### PR TITLE
feat(home): vibrant gradient hero, stat pills & section icon chip

### DIFF
--- a/apps/console/src/pages/auth/LoginPage.tsx
+++ b/apps/console/src/pages/auth/LoginPage.tsx
@@ -16,7 +16,7 @@
  *    `emailPassword.disableSignUp === true`.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth, LoginForm } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
@@ -201,13 +201,16 @@ function LoginFormCard({
   const { t } = useObjectTranslation();
   const navigate = useNavigate();
   // LoginForm doesn't expose the submitted email, so we capture it here
-  // to forward into the verify-email-prompt redirect.
-  const [lastEmail, setLastEmail] = useState('');
+  // to forward into the verify-email-prompt redirect. A ref is used instead
+  // of state so capturing each keystroke doesn't re-render this subtree
+  // (which would otherwise recompute every translated label and re-render
+  // <LoginForm> on every character typed into the email field).
+  const lastEmailRef = useRef('');
 
   useEffect(() => {
     const handler = (e: Event) => {
       const target = e.target as HTMLInputElement;
-      if (target?.id === 'login-email') setLastEmail(target.value);
+      if (target?.id === 'login-email') lastEmailRef.current = target.value;
     };
     document.addEventListener('input', handler, true);
     return () => document.removeEventListener('input', handler, true);
@@ -225,7 +228,7 @@ function LoginFormCard({
             (lower.includes('verif') || lower.includes('not verified')));
         if (isEmailUnverified) {
           const sp = new URLSearchParams();
-          if (lastEmail) sp.set('email', lastEmail);
+          if (lastEmailRef.current) sp.set('email', lastEmailRef.current);
           if (redirect) sp.set('redirect', redirect);
           navigate(`/verify-email-prompt?${sp.toString()}`);
         }

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -16,7 +16,7 @@
  * @module
  */
 
-import { useMemo } from 'react';
+import { useMemo, type ComponentType } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMetadata } from '../../providers/MetadataProvider';
 import { useRecentItems } from '../../hooks/useRecentItems';
@@ -27,7 +27,7 @@ import { AppCard } from './AppCard';
 import { RecentApps } from './RecentApps';
 import { StarredApps } from './StarredApps';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
-import { Plus, Settings, Sparkles, Star, Clock, ArrowDown, Store } from 'lucide-react';
+import { Plus, Settings, Sparkles, Star, Clock, ArrowDown, Store, LayoutGrid } from 'lucide-react';
 
 function pickGreetingKey(hour: number): string {
   if (hour < 5) return 'home.greetingNight';
@@ -78,6 +78,31 @@ function GettingStartedHint({ t }: { t: (key: string, opts?: any) => string }) {
         </div>
       </div>
     </section>
+  );
+}
+
+/**
+ * Compact at-a-glance metric pill shown under the hero greeting — gives
+ * the workspace a sense of scale ("3 apps · 6 recent · 2 starred") the
+ * moment the page loads.
+ */
+function StatPill({
+  icon: Icon,
+  value,
+  label,
+  tone,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  value: number;
+  label: string;
+  tone: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/70 px-3 py-1.5 text-sm backdrop-blur-sm">
+      <Icon className={`h-4 w-4 ${tone}`} />
+      <span className="font-semibold tabular-nums">{value}</span>
+      <span className="text-muted-foreground">{label}</span>
+    </span>
   );
 }
 
@@ -165,15 +190,46 @@ export function HomePage() {
             <span className="uppercase tracking-wider">{t('home.title', { defaultValue: 'Home' })}</span>
           </div>
           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-pretty">
-            <span className="bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent">
+            <span className="text-foreground">
               {greeting}
-              {displayName ? `, ${displayName}` : ''}
+              {displayName ? ', ' : ''}
             </span>
+            {displayName && (
+              <span className="bg-gradient-to-r from-indigo-600 via-violet-600 to-fuchsia-600 bg-clip-text text-transparent dark:from-indigo-400 dark:via-violet-400 dark:to-fuchsia-400">
+                {displayName}
+              </span>
+            )}
             <span className="text-foreground/40">.</span>
           </h1>
           <p className="text-base sm:text-lg text-muted-foreground mt-2 max-w-2xl">
             {t('home.heroTagline', { defaultValue: 'Pick up where you left off, or explore something new.' })}
           </p>
+
+          {/* At-a-glance stat pills */}
+          <div className="mt-5 flex flex-wrap items-center gap-2.5">
+            <StatPill
+              icon={LayoutGrid}
+              tone="text-indigo-600 dark:text-indigo-400"
+              value={activeApps.length}
+              label={t('home.stats.apps', { defaultValue: 'Applications' })}
+            />
+            {recentItems.length > 0 && (
+              <StatPill
+                icon={Clock}
+                tone="text-sky-600 dark:text-sky-400"
+                value={recentItems.length}
+                label={t('home.recentApps.title', { defaultValue: 'Recently Accessed' })}
+              />
+            )}
+            {favorites.length > 0 && (
+              <StatPill
+                icon={Star}
+                tone="text-amber-500 dark:text-amber-400"
+                value={favorites.length}
+                label={t('home.starredApps.title', { defaultValue: 'Starred' })}
+              />
+            )}
+          </div>
         </div>
       </section>
 
@@ -188,15 +244,20 @@ export function HomePage() {
 
           <section>
             <div className="flex items-end justify-between mb-5">
-              <div>
-                <h2 className="text-2xl font-semibold tracking-tight">
-                  {t('home.allApps', { defaultValue: 'All Applications' })}
-                </h2>
-                <p className="text-sm text-muted-foreground mt-1">
-                  {activeApps.length}
-                  {' · '}
-                  {t('home.stats.apps', { defaultValue: 'Applications' })}
-                </p>
+              <div className="flex items-center gap-2.5">
+                <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-500/10 ring-1 ring-indigo-500/20 text-indigo-600 dark:text-indigo-400">
+                  <LayoutGrid className="h-4 w-4" />
+                </span>
+                <div>
+                  <h2 className="text-2xl font-semibold tracking-tight">
+                    {t('home.allApps', { defaultValue: 'All Applications' })}
+                  </h2>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    {activeApps.length}
+                    {' · '}
+                    {t('home.stats.apps', { defaultValue: 'Applications' })}
+                  </p>
+                </div>
               </div>
               {isAdmin && (
                 <Button


### PR DESCRIPTION
## Summary
Polishes the console **Home** page (`/home`, the app launcher) to feel more design-forward and alive, matching the brand vibrancy direction.

### Home page enhancements (`packages/app-shell/src/console/home/HomePage.tsx`)
- **Gradient hero name** — the user's display name now renders with an indigo→violet→fuchsia gradient (dark-mode aware), giving the greeting a striking focal point.
- **At-a-glance stat pills** — a row under the tagline surfaces workspace scale: Applications (always), Recently Accessed and Starred (only when > 0), each with a tinted icon.
- **Section icon chip** — an indigo icon chip sits beside the "All Applications" header for stronger visual hierarchy.

All new copy uses `t(key, { defaultValue })`, so **no i18n catalog files were touched** — existing locales fall back gracefully and translators can add keys later.

### Drive-by fix (`apps/console/src/pages/auth/LoginPage.tsx`)
- Capture the submitted email in a `useRef` instead of `useState`. The previous `setLastEmail` on every keystroke re-rendered the whole login subtree (recomputing translated labels and re-rendering `<LoginForm>` per character). The ref keeps the verify-email redirect working without the per-keystroke churn.

## Testing
- Browser-verified the Home page in both light and dark mode — no console errors.
- Stat pills correctly hide when recent/starred counts are zero.