### PR TITLE
feat(home): content-first Linear-style home (drop ambient color wash)

### DIFF
--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -46,13 +46,9 @@ function GettingStartedHint({ t }: { t: (key: string, opts?: any) => string }) {
   return (
     <section
       data-testid="home-getting-started"
-      className="relative overflow-hidden rounded-2xl border border-border/60 bg-card/70 backdrop-blur-sm p-6 sm:p-8"
+      className="rounded-2xl border border-border bg-card p-6 sm:p-8 shadow-sm"
     >
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-fuchsia-500/5"
-      />
-      <div className="relative flex flex-col sm:flex-row sm:items-center gap-5">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-5">
         <div className="flex items-center gap-2 shrink-0">
           <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10 ring-1 ring-amber-500/20 text-amber-600 dark:text-amber-400">
             <Star className="h-5 w-5" />
@@ -98,7 +94,7 @@ function StatPill({
   tone: string;
 }) {
   return (
-    <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/70 px-3 py-1.5 text-sm backdrop-blur-sm">
+    <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-sm shadow-sm">
       <Icon className={`h-4 w-4 ${tone}`} />
       <span className="font-semibold tabular-nums">{value}</span>
       <span className="text-muted-foreground">{label}</span>
@@ -173,23 +169,19 @@ export function HomePage() {
   }
 
   return (
-    <div className="relative isolate min-h-full bg-background">
+    <div className="relative min-h-full bg-background">
       {/*
-        A single brand-hue glow (indigo→violet, adjacent hues so they never
-        muddy) anchored top-left, fading quickly into a clean neutral canvas.
-        Replaces the previous three-color blue/sky/fuchsia wash that smeared
-        into an uneven pastel haze in light mode.
+        Content-first neutral canvas (Linear/Vercel-console style): no ambient
+        color wash. Hierarchy comes from typography, spacing, and hairline
+        borders + micro-shadows on cards — the only brand-color highlight is
+        the gradient display name in the hero.
       */}
-      <div aria-hidden className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-80 overflow-hidden">
-        <div className="absolute -top-44 left-[-8%] h-[34rem] w-[46rem] rounded-full bg-gradient-to-br from-indigo-500/25 via-violet-500/20 to-transparent blur-3xl opacity-80 dark:from-indigo-500/20 dark:via-violet-600/15 dark:opacity-55" />
-        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-background/70 to-background" />
-      </div>
 
       {/* Hero */}
       <section className="px-4 sm:px-6 lg:px-8 pt-10 pb-6">
         <div className="max-w-7xl mx-auto">
           <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground mb-3">
-            <Sparkles className="h-3.5 w-3.5 text-primary" />
+            <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
             <span className="uppercase tracking-wider">{t('home.title', { defaultValue: 'Home' })}</span>
           </div>
           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-pretty">
@@ -248,7 +240,7 @@ export function HomePage() {
           <section>
             <div className="flex items-end justify-between mb-5">
               <div className="flex items-center gap-2.5">
-                <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-500/10 ring-1 ring-indigo-500/20 text-indigo-600 dark:text-indigo-400">
+                <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
                   <LayoutGrid className="h-4 w-4" />
                 </span>
                 <div>

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -173,13 +173,16 @@ export function HomePage() {
   }
 
   return (
-    <div className="relative isolate min-h-full bg-gradient-to-b from-background via-background to-muted/40">
-      {/* Decorative ambient blobs */}
-      <div aria-hidden className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[28rem] overflow-hidden">
-        <div className="absolute -top-32 -left-24 h-[28rem] w-[28rem] rounded-full bg-primary/30 blur-3xl opacity-70 dark:opacity-40" />
-        <div className="absolute -top-20 right-[-6rem] h-[26rem] w-[36rem] rounded-full bg-sky-400/30 blur-3xl opacity-70 dark:opacity-35" />
-        <div className="absolute top-32 left-1/3 h-[18rem] w-[24rem] rounded-full bg-fuchsia-400/25 blur-3xl opacity-60 dark:opacity-25" />
-        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-background/40 to-background" />
+    <div className="relative isolate min-h-full bg-background">
+      {/*
+        A single brand-hue glow (indigo→violet, adjacent hues so they never
+        muddy) anchored top-left, fading quickly into a clean neutral canvas.
+        Replaces the previous three-color blue/sky/fuchsia wash that smeared
+        into an uneven pastel haze in light mode.
+      */}
+      <div aria-hidden className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-80 overflow-hidden">
+        <div className="absolute -top-44 left-[-8%] h-[34rem] w-[46rem] rounded-full bg-gradient-to-br from-indigo-500/25 via-violet-500/20 to-transparent blur-3xl opacity-80 dark:from-indigo-500/20 dark:via-violet-600/15 dark:opacity-55" />
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-background/70 to-background" />
       </div>
 
       {/* Hero */}

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectPreview.tsx
@@ -70,23 +70,16 @@ export function ObjectPreview({
   name,
   draft,
   onPatch,
-  editing,
 }: MetadataPreviewProps) {
   const objectName = String((draft as any).name ?? name ?? '');
   const columns = React.useMemo(() => deriveColumns((draft as any).fields), [draft]);
   const label = String((draft as any).label ?? objectName);
   const pluralLabel = String((draft as any).pluralLabel ?? `${label}s`);
 
-  // Default to Designer when editing + writable; otherwise Data view
-  // keeps the run-time fidelity for read-only browsing.
-  const canDesign = !!onPatch && editing !== false;
-  const [mode, setMode] = React.useState<Mode>(canDesign ? 'designer' : 'data');
-
-  // If editing toggles to read-only, snap back to Data view to avoid
-  // showing an inert designer surface.
-  React.useEffect(() => {
-    if (!canDesign && mode === 'designer') setMode('data');
-  }, [canDesign, mode]);
+  // Default to Designer: even in read-only tiers, browsing the field
+  // definitions is more useful than an empty Data grid. FieldDesigner
+  // gracefully degrades via its `readOnly` prop when onPatch is absent.
+  const [mode, setMode] = React.useState<Mode>('designer');
 
   if (!objectName) {
     return (
@@ -107,7 +100,6 @@ export function ObjectPreview({
       <ModeButton
         active={mode === 'designer'}
         onClick={() => setMode('designer')}
-        disabled={!canDesign}
         icon={<Pencil className="h-3 w-3" />}
         label="Designer"
       />


### PR DESCRIPTION
## Summary
Redesigns the console **Home** page toward the current cutting-edge **product-interior** style (Linear / Vercel console / Stripe dashboard): a clean, neutral, content-first canvas where hierarchy comes from **typography, spacing, and hairline borders + micro-shadows** — not ambient color.

Ambient color glows are a marketing-landing-page device; inside a dense app surface they compete with content and read as generic. So the home surface now goes the other way.

### Changes (`packages/app-shell/src/console/home/HomePage.tsx`)
- **Removed the background glow entirely** — neutral `bg-background` canvas in both light and dark mode.
- **Flattened the stat pills** — dropped the glassy `backdrop-blur`/transparency (which only made sense over a glow) for a solid card + 1px border + subtle shadow.
- **Flattened the getting-started hint card** — removed its gradient overlay + blur.
- **Single brand-color highlight** — neutralized the "All Applications" header chip and the hero eyebrow icon, leaving the **gradient display name** as the page's one intentional brand accent.

> Note: this supersedes the earlier intermediate commit that added a single indigo→violet glow. A squash merge collapses it; the net result is the neutral redesign.

### Also included (independent commit)
`fix(studio): default object preview to Designer mode` — a self-contained Studio fix committed locally alongside this work: the object Preview tab defaults to the Designer view, with `FieldDesigner` degrading gracefully via `readOnly` when `onPatch` is absent.

## Testing
- Browser-verified in light and dark mode — clean neutral canvas, no muddy wash, no console errors.