### PR TITLE
feat(studio): polish metadata designers — consolidate lock banner, color-code field types

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -1321,9 +1321,9 @@ function MetadataResourceEditPageImpl({
               </div>
             )}
             {isLocked && (
-              <div className="text-xs text-amber-900 border border-amber-300 bg-amber-50 rounded p-3 dark:text-amber-200 dark:border-amber-700/50 dark:bg-amber-950/30 flex items-start gap-3">
-                <Lock className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                <div className="flex-1">
+              <div className="text-xs text-amber-900 border border-amber-300/70 bg-amber-50/70 rounded-md px-3 py-2.5 dark:text-amber-200 dark:border-amber-700/40 dark:bg-amber-950/20 flex items-start gap-2.5">
+                <Lock className="h-3.5 w-3.5 mt-0.5 shrink-0 opacity-80" />
+                <div className="flex-1 min-w-0">
                   <div className="font-medium">
                     {layered?.lock === 'full' && t('engine.edit.lockFull', locale)}
                     {layered?.lock === 'no-overlay' && t('engine.edit.lockNoOverlay', locale)}
@@ -1336,6 +1336,20 @@ function MetadataResourceEditPageImpl({
                     </div>
                   )}
                 </div>
+                {/* When this locked item ships from a code package the
+                    user can still author their own copy — fold that CTA
+                    into the lock banner instead of stacking a second,
+                    near-identical amber notice below it. */}
+                {showArtifactLockedBanner && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="shrink-0 h-7 bg-background/60"
+                    onClick={() => navigate(`../new`, { relative: 'path' })}
+                  >
+                    {t('engine.list.create', locale)}
+                  </Button>
+                )}
               </div>
             )}
             {hasDraft && !createMode && (
@@ -1369,8 +1383,12 @@ function MetadataResourceEditPageImpl({
                 )}
               </div>
             )}
-            {readOnly && (
-              <div className="text-xs text-amber-800 border border-amber-300 bg-amber-50 rounded p-3 dark:text-amber-200 dark:border-amber-700/50 dark:bg-amber-950/30 flex items-start gap-3">
+            {/* When the item is already flagged via the lock banner above,
+                this read-only notice is redundant (and its CTA has been
+                folded into the lock banner). Only render it for the
+                non-locked read-only cases. */}
+            {readOnly && !isLocked && (
+              <div className="text-xs text-amber-800 border border-amber-300/70 bg-amber-50/70 rounded-md px-3 py-2.5 dark:text-amber-200 dark:border-amber-700/40 dark:bg-amber-950/20 flex items-start gap-3">
                 <div className="flex-1">
                   {showArtifactLockedBanner ? (
                     /* Type allows runtime-create but THIS item ships from

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.tsx
@@ -39,6 +39,7 @@ import {
   FIELD_TYPE_META,
   TYPES_BY_CATEGORY,
   CATEGORY_LABEL_EN,
+  CATEGORY_TONE,
   type FieldTypeId,
 } from './field-types';
 import { FieldStub } from './FieldStub';
@@ -310,6 +311,7 @@ function FieldRow({
   const typeStr = typeof def.type === 'string' ? (def.type as string) : 'text';
   const meta = FIELD_TYPE_META[typeStr as FieldTypeId];
   const Icon = meta?.Icon;
+  const tone = CATEGORY_TONE[meta?.category ?? 'advanced'];
   const label = typeof def.label === 'string' ? (def.label as string) : entry.name;
   const required = !!def.required;
   const description = typeof def.description === 'string' ? (def.description as string) : null;
@@ -405,7 +407,7 @@ function FieldRow({
                 aria-hidden="true"
               />
             )}
-            {Icon && <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />}
+            {Icon && <Icon className={cn('h-3.5 w-3.5 shrink-0', tone.icon)} />}
             {editingLabel ? (
               <input
                 autoFocus
@@ -432,7 +434,7 @@ function FieldRow({
             {required && <span className="text-destructive text-sm">*</span>}
             <code className="text-[10px] text-muted-foreground/70 font-mono truncate">{entry.name}</code>
           </div>
-          <Badge variant="outline" className="text-[10px] shrink-0">
+          <Badge variant="outline" className={cn('text-[10px] shrink-0 font-medium', tone.badge)}>
             {meta?.label ?? typeStr}
           </Badge>
         </div>
@@ -537,7 +539,7 @@ function AddFieldButton({ onPick }: { onPick: (type: FieldTypeId) => void }) {
                         }}
                         className="flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs hover:bg-accent"
                       >
-                        <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        <Icon className={cn('h-3.5 w-3.5 shrink-0', CATEGORY_TONE[m.category].icon)} />
                         <span className="truncate">{m.label}</span>
                       </button>
                     );

--- a/packages/app-shell/src/views/metadata-admin/previews/field-types.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/field-types.ts
@@ -123,6 +123,41 @@ export const CATEGORY_LABEL_EN: Record<FieldTypeCategory, string> = {
   calculated: 'Calculated', advanced: 'Advanced',
 };
 
+/**
+ * Per-category color tone. Lets the canvas, type badges, and type
+ * picker tint a field by its category so the form is scannable at a
+ * glance (text vs number vs relation vs media …) instead of a wall of
+ * neutral-grey rows. Colour is used purely as a category *signal* —
+ * subtle tints, never loud fills — consistent with the console's
+ * content-first visual language.
+ *
+ * Class strings are written out in full (not composed) so Tailwind's
+ * JIT can see and emit every variant.
+ */
+export interface CategoryTone {
+  /** Icon stroke colour. */
+  icon: string;
+  /** Tinted type-badge classes (border + bg + text), light & dark. */
+  badge: string;
+}
+
+export const CATEGORY_TONE: Record<FieldTypeCategory, CategoryTone> = {
+  text:       { icon: 'text-slate-500 dark:text-slate-400',     badge: 'border-slate-200 bg-slate-50 text-slate-600 dark:border-slate-700/50 dark:bg-slate-800/40 dark:text-slate-300' },
+  number:     { icon: 'text-blue-600 dark:text-blue-400',       badge: 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800/50 dark:bg-blue-950/40 dark:text-blue-300' },
+  date:       { icon: 'text-violet-600 dark:text-violet-400',   badge: 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-800/50 dark:bg-violet-950/40 dark:text-violet-300' },
+  logic:      { icon: 'text-amber-600 dark:text-amber-400',     badge: 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800/50 dark:bg-amber-950/40 dark:text-amber-300' },
+  selection:  { icon: 'text-teal-600 dark:text-teal-400',       badge: 'border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-800/50 dark:bg-teal-950/40 dark:text-teal-300' },
+  relation:   { icon: 'text-indigo-600 dark:text-indigo-400',   badge: 'border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-800/50 dark:bg-indigo-950/40 dark:text-indigo-300' },
+  media:      { icon: 'text-pink-600 dark:text-pink-400',       badge: 'border-pink-200 bg-pink-50 text-pink-700 dark:border-pink-800/50 dark:bg-pink-950/40 dark:text-pink-300' },
+  calculated: { icon: 'text-emerald-600 dark:text-emerald-400', badge: 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800/50 dark:bg-emerald-950/40 dark:text-emerald-300' },
+  advanced:   { icon: 'text-zinc-500 dark:text-zinc-400',       badge: 'border-zinc-200 bg-zinc-50 text-zinc-600 dark:border-zinc-700/50 dark:bg-zinc-800/40 dark:text-zinc-300' },
+};
+
+/** Resolve the colour tone for any field-type string (unknown → advanced). */
+export function resolveCategoryTone(type: unknown): CategoryTone {
+  return CATEGORY_TONE[resolveFieldTypeMeta(type).category];
+}
+
 export const CATEGORY_LABEL_ZH: Record<FieldTypeCategory, string> = {
   text: '文本', number: '数值', date: '日期/时间', logic: '逻辑',
   selection: '选择', relation: '关系', media: '媒体',


### PR DESCRIPTION
## Studio metadata-designer polish (round 1)

A restrained, visual-only pass over the Studio (metadata-admin) designers, picking up the shared-chrome + per-canvas direction. No behavior/logic changes.

### Shared chrome — benefits every designer
- **Consolidated the locked / read-only banner stack.** Locked code-package items (e.g. the `object/sys_user` designer) previously stacked *two* near-identical amber banners (~140px), pushing the canvas below the fold. They're now a single banner: the lock notice carries the "新建" CTA inline, and the redundant read-only banner is suppressed when the item is already shown as locked (the non-locked read-only cases are unchanged). Also lightened the amber tone (`/70` bg + softer border) so it informs without dominating.

### Per-canvas — Object form designer + field-type picker
- **Color-coded field types by category.** Added `CATEGORY_TONE` to the field-type catalog (`field-types.ts`) — a subtle per-category tint (text=slate, number=blue, date=violet, logic=amber, selection=teal, relation=indigo, media=pink, calculated=emerald, advanced=zinc). Applied to the field-card **icon** + **type badge** and the **type-picker** icons, so the form is scannable at a glance instead of a wall of neutral-grey rows. Colour is used purely as a category signal (no loud fills), consistent with the console's content-first language. Class strings are written out in full so Tailwind's JIT emits every variant.

### Verification
- Verified in-browser at `/apps/setup/metadata/object/sys_user` in **light + dark**: single consolidated banner, canvas starts ~80px higher, type badges/icons tinted correctly in both themes.
- No new compile or runtime errors. (Pre-existing, unrelated: backend `analytics/query` 500s referencing a missing `amount_sum` column, and a `<button>`-in-`<button>` hydration warning from `FieldStub` rendering an interactive preview inside the card button — flagged separately.)

### Follow-up (flagged separately)
- `FieldStub` renders a Switch (`<button>`) inside the field-card `<button>` → hydration/a11y error. Pre-existing; needs a structural fix (card → `div role=button`), out of scope for this visual pass.
