### PR TITLE
feat(studio): scannable per-type color-coding across designer previews

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
@@ -38,6 +38,7 @@ import {
   Sparkles,
   Wrench,
 } from 'lucide-react';
+import { cn } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell';
 
@@ -141,11 +142,20 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
             {/* Capabilities */}
             <Section title="Capabilities" icon={Wrench}>
               <div className="space-y-2">
-                <ChipList label="Skills" emptyHint="Attach skills (preferred)" items={skills.map((s) => ({ key: s, label: s }))} mono />
+                <ChipList
+                  label="Skills"
+                  emptyHint="Attach skills (preferred)"
+                  items={skills.map((s) => ({ key: s, label: s }))}
+                  icon={Sparkles}
+                  tone="violet"
+                  mono
+                />
                 <ChipList
                   label="Tools"
                   emptyHint="No direct tools (skills can provide them)"
                   items={tools.map((t, i) => ({ key: `${t.type ?? ''}:${t.name ?? i}`, label: t.name ?? String(t), hint: t.type }))}
+                  icon={Wrench}
+                  tone="blue"
                   mono
                 />
               </div>
@@ -254,17 +264,38 @@ function Empty({ children }: { children: React.ReactNode }) {
   return <div className="text-xs text-muted-foreground italic">{children}</div>;
 }
 
+/**
+ * Tone presets for capability chips — keep skills and tools visually
+ * distinct at a glance. Full Tailwind class strings (JIT) with light +
+ * dark variants.
+ */
+const CHIP_TONE = {
+  violet: {
+    chip: 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300',
+    icon: 'text-violet-500 dark:text-violet-400',
+  },
+  blue: {
+    chip: 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-300',
+    icon: 'text-blue-500 dark:text-blue-400',
+  },
+} as const;
+
 function ChipList({
   label,
   emptyHint,
   items,
+  icon: Icon,
+  tone,
   mono = false,
 }: {
   label: string;
   emptyHint: string;
   items: Array<{ key: string; label: string; hint?: string }>;
+  icon?: React.ComponentType<{ className?: string }>;
+  tone?: keyof typeof CHIP_TONE;
   mono?: boolean;
 }) {
+  const t = tone ? CHIP_TONE[tone] : null;
   return (
     <div>
       <div className="text-[10px] uppercase text-muted-foreground tracking-wider mb-1">{label}</div>
@@ -275,10 +306,15 @@ function ChipList({
           {items.map((it) => (
             <span
               key={it.key}
-              className={`inline-flex items-center gap-1 rounded border bg-background px-1.5 py-0.5 text-[11px] ${mono ? 'font-mono' : ''}`}
+              className={cn(
+                'inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[11px]',
+                t ? t.chip : 'bg-background',
+                mono && 'font-mono',
+              )}
             >
+              {Icon && <Icon className={cn('h-3 w-3 shrink-0', t?.icon)} />}
               {it.label}
-              {it.hint && <span className="text-[9px] uppercase text-muted-foreground">{it.hint}</span>}
+              {it.hint && <span className="text-[9px] uppercase opacity-70">{it.hint}</span>}
             </span>
           ))}
         </div>

--- a/packages/app-shell/src/views/metadata-admin/previews/AppNavCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AppNavCanvas.tsx
@@ -30,7 +30,7 @@ import {
   Trash2,
   type LucideIcon,
 } from 'lucide-react';
-import { Badge } from '@object-ui/components';
+import { Badge, cn } from '@object-ui/components';
 import { appendArray, moveArray, spliceArray } from '../inspectors/_shared';
 
 const DND_MIME = 'text/x-objectui-nav';
@@ -83,6 +83,51 @@ function kindIcon(kind: string): LucideIcon {
     default:
       return Compass;
   }
+}
+
+/**
+ * Per-kind color tone — keeps nav kinds scannable at a glance and
+ * mirrors the field-type category tinting used elsewhere in Studio.
+ * Class strings are written out in full so Tailwind's JIT emits them.
+ */
+interface KindTone {
+  icon: string;
+  badge: string;
+}
+
+const KIND_TONE: Record<string, KindTone> = {
+  object: {
+    icon: 'text-blue-500',
+    badge: 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-300',
+  },
+  page: {
+    icon: 'text-violet-500',
+    badge: 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300',
+  },
+  dashboard: {
+    icon: 'text-teal-500',
+    badge: 'border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-900 dark:bg-teal-950/40 dark:text-teal-300',
+  },
+  report: {
+    icon: 'text-amber-500',
+    badge: 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300',
+  },
+  link: {
+    icon: 'text-indigo-500',
+    badge: 'border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300',
+  },
+  group: {
+    icon: 'text-slate-500',
+    badge: 'border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300',
+  },
+  item: {
+    icon: 'text-zinc-500',
+    badge: 'border-zinc-200 bg-zinc-50 text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-400',
+  },
+};
+
+function kindTone(kind: string): KindTone {
+  return KIND_TONE[kind] ?? KIND_TONE.item;
 }
 
 function navLabel(it: RawNav, i: number): string {
@@ -349,6 +394,7 @@ function NavCard({
 }) {
   const kind = inferKind(item);
   const Icon = kindIcon(kind);
+  const tone = kindTone(kind);
   const path0 = navPath(item);
   const [editing, setEditing] = React.useState(false);
   const [draft, setDraft] = React.useState(navLabel(item, index));
@@ -403,7 +449,7 @@ function NavCard({
         ) : (
           <span className="w-3.5" />
         )}
-        <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <Icon className={cn('h-3.5 w-3.5 shrink-0', tone.icon)} />
         {editing ? (
           <input
             autoFocus
@@ -439,7 +485,7 @@ function NavCard({
             {navLabel(item, index)}
           </span>
         )}
-        <Badge variant="outline" className="text-[10px]">
+        <Badge variant="outline" className={cn('text-[10px] font-medium', tone.badge)}>
           {kind}
         </Badge>
         {path0 && (

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -33,6 +33,7 @@ import {
   Workflow,
   Zap,
 } from 'lucide-react';
+import { cn } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell';
 import { uniqueId, appendArray } from '../inspectors/_shared';
@@ -85,6 +86,73 @@ function nodeIcon(type: string) {
       return Workflow;
     default:
       return CircleDot;
+  }
+}
+
+/**
+ * Per-node-type color tone — makes step kinds scannable in the list
+ * and mirrors the field-type / nav-kind tinting used elsewhere in
+ * Studio. Class strings are written in full for Tailwind's JIT.
+ */
+interface NodeTone {
+  /** Icon + type-label text color. */
+  icon: string;
+  /** Step-number chip (border + bg + text). */
+  chip: string;
+}
+
+const NODE_TONE: Record<string, NodeTone> = {
+  start: {
+    icon: 'text-emerald-600 dark:text-emerald-400',
+    chip: 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300',
+  },
+  end: {
+    icon: 'text-rose-600 dark:text-rose-400',
+    chip: 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-300',
+  },
+  decision: {
+    icon: 'text-amber-600 dark:text-amber-400',
+    chip: 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300',
+  },
+  wait: {
+    icon: 'text-blue-600 dark:text-blue-400',
+    chip: 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-300',
+  },
+  signal: {
+    icon: 'text-violet-600 dark:text-violet-400',
+    chip: 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300',
+  },
+  subflow: {
+    icon: 'text-indigo-600 dark:text-indigo-400',
+    chip: 'border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300',
+  },
+  task: {
+    icon: 'text-slate-500 dark:text-slate-400',
+    chip: 'border-slate-200 bg-slate-100 text-slate-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300',
+  },
+};
+
+function nodeTone(type: string): NodeTone {
+  switch (type) {
+    case 'start':
+      return NODE_TONE.start;
+    case 'end':
+      return NODE_TONE.end;
+    case 'decision':
+    case 'branch':
+    case 'gateway':
+      return NODE_TONE.decision;
+    case 'wait':
+    case 'timer':
+      return NODE_TONE.wait;
+    case 'boundary_event':
+    case 'signal':
+      return NODE_TONE.signal;
+    case 'subflow':
+    case 'flow':
+      return NODE_TONE.subflow;
+    default:
+      return NODE_TONE.task;
   }
 }
 
@@ -202,6 +270,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
             <ol className="space-y-2">
               {ordered.map((node, idx) => {
                 const Icon = nodeIcon(node.type);
+                const tone = nodeTone(node.type);
                 const outs = outgoingByNode.get(node.id) ?? [];
                 const isBranch = node.type === 'decision' || node.type === 'branch' || node.type === 'gateway';
                 return (
@@ -211,15 +280,15 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                     onClick={designMode ? (e) => { e.stopPropagation(); selectNode(node); } : undefined}
                   >
                     <div className="flex items-start gap-2 p-2.5">
-                      <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-mono">
+                      <span className={cn('mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-mono', tone.chip)}>
                         {idx + 1}
                       </span>
-                      <Icon className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+                      <Icon className={cn('h-4 w-4 mt-0.5 shrink-0', tone.icon)} />
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-baseline gap-x-2">
                           <span className="text-sm font-medium truncate">{node.label || node.id}</span>
                           <span className="font-mono text-[10px] text-muted-foreground">{node.id}</span>
-                          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <span className={cn('text-[10px] uppercase tracking-wider font-medium', tone.icon)}>
                             {node.type}
                           </span>
                         </div>

--- a/packages/app-shell/src/views/metadata-admin/previews/WorkflowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/WorkflowPreview.tsx
@@ -32,6 +32,7 @@ import {
   Power,
   Workflow as WorkflowIcon,
 } from 'lucide-react';
+import { cn } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell';
 import { appendArray } from '../inspectors/_shared';
@@ -70,6 +71,75 @@ function actionIcon(type: string) {
       return Plug;
     default:
       return Bot;
+  }
+}
+
+/**
+ * Per-action-type color tone — mirrors the flow node-type tinting so
+ * action kinds are scannable in the rule's action list. Full Tailwind
+ * class strings (JIT) with light + dark variants.
+ */
+interface ActionTone {
+  /** Icon color. */
+  icon: string;
+  /** Icon chip (border + bg). */
+  chip: string;
+}
+
+const ACTION_TONE: Record<string, ActionTone> = {
+  field_update: {
+    icon: 'text-blue-600 dark:text-blue-400',
+    chip: 'border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/40',
+  },
+  email_alert: {
+    icon: 'text-violet-600 dark:text-violet-400',
+    chip: 'border-violet-200 bg-violet-50 dark:border-violet-900 dark:bg-violet-950/40',
+  },
+  http_call: {
+    icon: 'text-indigo-600 dark:text-indigo-400',
+    chip: 'border-indigo-200 bg-indigo-50 dark:border-indigo-900 dark:bg-indigo-950/40',
+  },
+  task_creation: {
+    icon: 'text-emerald-600 dark:text-emerald-400',
+    chip: 'border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/40',
+  },
+  push_notification: {
+    icon: 'text-amber-600 dark:text-amber-400',
+    chip: 'border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/40',
+  },
+  custom_script: {
+    icon: 'text-teal-600 dark:text-teal-400',
+    chip: 'border-teal-200 bg-teal-50 dark:border-teal-900 dark:bg-teal-950/40',
+  },
+  connector_action: {
+    icon: 'text-rose-600 dark:text-rose-400',
+    chip: 'border-rose-200 bg-rose-50 dark:border-rose-900 dark:bg-rose-950/40',
+  },
+  default: {
+    icon: 'text-slate-500 dark:text-slate-400',
+    chip: 'border-slate-200 bg-slate-100 dark:border-slate-800 dark:bg-slate-900/60',
+  },
+};
+
+function actionTone(type: string): ActionTone {
+  switch (type) {
+    case 'field_update':
+      return ACTION_TONE.field_update;
+    case 'email_alert':
+      return ACTION_TONE.email_alert;
+    case 'http_call':
+    case 'webhook':
+      return ACTION_TONE.http_call;
+    case 'task_creation':
+      return ACTION_TONE.task_creation;
+    case 'push_notification':
+      return ACTION_TONE.push_notification;
+    case 'custom_script':
+      return ACTION_TONE.custom_script;
+    case 'connector_action':
+      return ACTION_TONE.connector_action;
+    default:
+      return ACTION_TONE.default;
   }
 }
 
@@ -254,6 +324,7 @@ export function WorkflowPreview({ draft, editing, selection, onSelectionChange, 
 
 function ActionRow({ action, onClick, selected }: { action: WorkflowAction; onClick?: () => void; selected?: boolean }) {
   const Icon = actionIcon(action.type);
+  const tone = actionTone(action.type);
   const summary = summarizeAction(action);
   const aName = (action as any).name as string | undefined;
   return (
@@ -261,7 +332,9 @@ function ActionRow({ action, onClick, selected }: { action: WorkflowAction; onCl
       className={`flex items-start gap-2 px-3 py-2 text-xs ${onClick ? 'cursor-pointer hover:bg-accent/40' : ''} ${selected ? 'bg-primary/5 ring-1 ring-primary' : ''}`}
       onClick={onClick ? (e) => { e.stopPropagation(); onClick(); } : undefined}
     >
-      <Icon className="h-3.5 w-3.5 mt-0.5 text-muted-foreground shrink-0" />
+      <span className={cn('mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border', tone.chip)}>
+        <Icon className={cn('h-3 w-3', tone.icon)} />
+      </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2 flex-wrap">
           <span className="font-medium">{prettyActionType(action.type)}</span>


### PR DESCRIPTION
## What

Extends the scannable per-type color tinting introduced for field types (#1412) across four more metadata designers in Studio, so type/kind variety reads at a glance instead of a wall of muted gray. All tones are dark-aware (the app defaults to dark mode).

### AppNavCanvas (App designer)
Each nav entry's inferred **kind** gets a matching icon + badge tone: object=blue, page=violet, dashboard=teal, report=amber, link=indigo, group=slate, item=zinc.

### FlowPreview (Flow designer)
Each step's **node type** tints the icon, type label, and numbered step chip: start=emerald, end=rose, decision/branch/gateway=amber, wait/timer=blue, boundary_event/signal=violet, subflow/flow=indigo, task=slate.

### WorkflowPreview (Workflow Rule designer)
Each action row's icon sits in a tone-matched chip keyed by **action type**: field_update=blue, email_alert=violet, http_call/webhook=indigo, task_creation=emerald, push_notification=amber, custom_script=teal, connector_action=rose, default=slate.

### AgentPreview (AI Agent designer)
Capability chips were uniform gray; **skills** and **tools** now carry distinct leading icons + tones (skills=violet/Sparkles, tools=blue/Wrench) so the two classes are instantly distinguishable.

## Notes
- Tone maps use full Tailwind class strings (JIT-safe) with light + dark variants.
- **Pure visual** — no behavior, data, or API change.
- Verified in-browser (dark mode): `crm_app` nav, `lead_qualification_conversion` flow, `crm_stale_opportunity_alert` workflow, `metadata_assistant`/`data_chat` agents. (Agent *tools* chips share the verified skills code path; no seed agent declares direct tools to screenshot.)