### PR TITLE
feat(studio): dark-aware Validation/Approval tones + color-coded page blocks

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/ApprovalPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ApprovalPreview.tsx
@@ -162,11 +162,11 @@ export function ApprovalPreview({ draft, editing, selection, onSelectionChange, 
 
           {/* Escalation callout */}
           {escalation?.enabled && (
-            <div className="rounded border border-amber-200 bg-amber-50 p-2.5 text-xs">
-              <div className="flex items-center gap-1.5 font-medium text-amber-900">
+            <div className="rounded border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/40 p-2.5 text-xs">
+              <div className="flex items-center gap-1.5 font-medium text-amber-900 dark:text-amber-200">
                 <AlarmClock className="h-3.5 w-3.5" /> SLA escalation enabled
               </div>
-              <div className="mt-1 text-amber-900">
+              <div className="mt-1 text-amber-900 dark:text-amber-200">
                 After <code className="font-mono">{escalation.timeoutHours}h</code> on a pending step →{' '}
                 <span className="font-medium">{escalation.action ?? 'notify'}</span>
                 {escalation.escalateTo && <> → <code className="font-mono">{escalation.escalateTo}</code></>}
@@ -262,7 +262,7 @@ function StepRow({ step, index, onClick, selected }: { step: ApprovalStep; index
             <Users className="h-3 w-3 mt-0.5 text-muted-foreground shrink-0" />
             <span className="text-muted-foreground shrink-0">Approvers:</span>
             {approvers.length === 0 ? (
-              <span className="text-amber-700">none</span>
+              <span className="text-amber-700 dark:text-amber-400">none</span>
             ) : (
               <div className="flex flex-wrap gap-1">
                 {approvers.map((a, i) => (
@@ -315,7 +315,7 @@ function ActionLine({
   label: string;
   actions: ApprovalAction[];
 }) {
-  const cls = tone === 'green' ? 'text-emerald-700' : 'text-red-700';
+  const cls = tone === 'green' ? 'text-emerald-700 dark:text-emerald-400' : 'text-red-700 dark:text-red-400';
   return (
     <div className="flex items-start gap-1.5">
       <Icon className={`h-3 w-3 mt-0.5 ${cls}`} />
@@ -345,9 +345,9 @@ function Hook({
 }) {
   const cls =
     tone === 'green'
-      ? 'text-emerald-700'
+      ? 'text-emerald-700 dark:text-emerald-400'
       : tone === 'red'
-        ? 'text-red-700'
+        ? 'text-red-700 dark:text-red-400'
         : 'text-muted-foreground';
   return (
     <span className={`inline-flex items-center gap-1 ${cls}`}>
@@ -370,7 +370,7 @@ function Pill({
   mono?: boolean;
 }) {
   const cls =
-    tone === 'green' ? 'text-emerald-700' : tone === 'amber' ? 'text-amber-700' : 'text-foreground';
+    tone === 'green' ? 'text-emerald-700 dark:text-emerald-400' : tone === 'amber' ? 'text-amber-700 dark:text-amber-400' : 'text-foreground';
   return (
     <span className="inline-flex items-center gap-1">
       {Icon && <Icon className="h-3 w-3 text-muted-foreground" />}

--- a/packages/app-shell/src/views/metadata-admin/previews/PageBlockCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PageBlockCanvas.tsx
@@ -31,6 +31,7 @@ import {
   TYPES_BY_CATEGORY,
   CATEGORY_LABEL_EN,
   UnknownBlockIcon,
+  resolveBlockTone,
   type BlockTypeId,
 } from './block-types';
 
@@ -404,6 +405,7 @@ function BlockRow({
   const typeStr = String(block.type ?? '');
   const meta = BLOCK_TYPE_META[typeStr as BlockTypeId];
   const Icon = meta?.Icon ?? UnknownBlockIcon;
+  const tone = resolveBlockTone(typeStr);
   const label = blockLabel(block);
   const draggable = !readOnly;
   const [dropZone, setDropZone] = React.useState<'before' | 'after' | null>(null);
@@ -491,7 +493,7 @@ function BlockRow({
                 aria-hidden="true"
               />
             )}
-            <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <Icon className={cn('h-3.5 w-3.5 shrink-0', tone.icon)} />
             {editingLabel ? (
               <input
                 autoFocus
@@ -519,7 +521,7 @@ function BlockRow({
               <code className="text-[10px] text-muted-foreground/70 font-mono truncate">#{block.id}</code>
             )}
           </div>
-          <Badge variant="outline" className="text-[10px] shrink-0 font-mono">
+          <Badge variant="outline" className={cn('text-[10px] shrink-0 font-mono', tone.badge)}>
             {typeStr}
           </Badge>
         </div>
@@ -581,6 +583,7 @@ function AddBlockButton({ onPick }: { onPick: (type: BlockTypeId) => void }) {
                 {g.types.map((id) => {
                   const m = BLOCK_TYPE_META[id];
                   const Icon = m.Icon;
+                  const tone = resolveBlockTone(id);
                   return (
                     <button
                       key={id}
@@ -588,7 +591,7 @@ function AddBlockButton({ onPick }: { onPick: (type: BlockTypeId) => void }) {
                       onClick={() => { onPick(id); setOpen(false); setFilter(''); }}
                       className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-sm hover:bg-accent text-left"
                     >
-                      <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                      <Icon className={cn('h-3.5 w-3.5 shrink-0', tone.icon)} />
                       <span className="truncate">{m.label}</span>
                       <code className="ml-auto text-[10px] text-muted-foreground/70 font-mono truncate">{id}</code>
                     </button>

--- a/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.tsx
@@ -55,12 +55,24 @@ function celText(c: unknown): string | undefined {
 function severityTone(s: Severity) {
   switch (s) {
     case 'error':
-      return { ring: 'border-red-200 bg-red-50', text: 'text-red-700', icon: XOctagon };
+      return {
+        ring: 'border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/40',
+        text: 'text-red-700 dark:text-red-300',
+        icon: XOctagon,
+      };
     case 'warning':
-      return { ring: 'border-amber-200 bg-amber-50', text: 'text-amber-800', icon: AlertTriangle };
+      return {
+        ring: 'border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/40',
+        text: 'text-amber-800 dark:text-amber-300',
+        icon: AlertTriangle,
+      };
     case 'info':
     default:
-      return { ring: 'border-blue-200 bg-blue-50', text: 'text-blue-800', icon: Info };
+      return {
+        ring: 'border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/40',
+        text: 'text-blue-800 dark:text-blue-300',
+        icon: Info,
+      };
   }
 }
 
@@ -174,7 +186,7 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
           <Section title={`Unique on ${fields.length} field${fields.length === 1 ? '' : 's'}`} icon={Fingerprint}>
             <div className="flex flex-wrap gap-1">
               {fields.length === 0 ? (
-                <span className="text-xs text-amber-700">no fields set</span>
+                <span className="text-xs text-amber-700 dark:text-amber-400">no fields set</span>
               ) : (
                 fields.map((f) => (
                   <span key={f} className="rounded border bg-muted/40 px-1.5 py-0.5 text-[11px] font-mono">
@@ -201,7 +213,7 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
       return (
         <Section title={`Transitions${field ? ` on ${field}` : ''}`} icon={Workflow}>
           {transitions.length === 0 ? (
-            <div className="text-xs text-amber-700">No transitions declared.</div>
+            <div className="text-xs text-amber-700 dark:text-amber-400">No transitions declared.</div>
           ) : (
             <ul className="rounded border bg-background divide-y text-xs">
               {transitions.map((t, i) => (
@@ -210,7 +222,7 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
                     {Array.isArray(t.from) ? t.from.join(' | ') : (t.from ?? '*')}
                   </span>
                   <ArrowRight className="h-3 w-3 text-muted-foreground" />
-                  <span className="font-mono text-emerald-700">{t.to ?? '?'}</span>
+                  <span className="font-mono text-emerald-700 dark:text-emerald-400">{t.to ?? '?'}</span>
                 </li>
               ))}
             </ul>
@@ -237,7 +249,7 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
                 <code className="font-mono break-all">{pattern}</code>
               </div>
             )}
-            {!format && !pattern && <span className="text-amber-700">No format or regex set.</span>}
+            {!format && !pattern && <span className="text-amber-700 dark:text-amber-400">No format or regex set.</span>}
           </div>
         </Section>
       );
@@ -289,7 +301,7 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
       return (
         <Section title="Custom handler" icon={Code2}>
           <div className="rounded border bg-background px-2.5 py-1.5 text-xs">
-            {handler ? <code className="font-mono break-all">{handler}</code> : <span className="text-amber-700">No handler set.</span>}
+            {handler ? <code className="font-mono break-all">{handler}</code> : <span className="text-amber-700 dark:text-amber-400">No handler set.</span>}
           </div>
         </Section>
       );
@@ -308,7 +320,7 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
 
 function CelBlock({ value }: { value: string | undefined }) {
   if (!value) {
-    return <div className="text-xs text-amber-700">No expression set.</div>;
+    return <div className="text-xs text-amber-700 dark:text-amber-400">No expression set.</div>;
   }
   return (
     <pre className="rounded border bg-background p-2.5 text-xs font-mono whitespace-pre-wrap break-words">
@@ -348,7 +360,7 @@ function Pill({
   tone?: 'gray' | 'green';
   mono?: boolean;
 }) {
-  const cls = tone === 'green' ? 'text-emerald-700' : 'text-foreground';
+  const cls = tone === 'green' ? 'text-emerald-700 dark:text-emerald-400' : 'text-foreground';
   return (
     <span className="inline-flex items-center gap-1">
       {Icon && <Icon className="h-3 w-3 text-muted-foreground" />}

--- a/packages/app-shell/src/views/metadata-admin/previews/block-types.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-types.ts
@@ -147,3 +147,48 @@ export const TYPES_BY_CATEGORY: Array<{ category: BlockCategory; types: BlockTyp
 
 /** Fallback icon for unknown block types. */
 export const UnknownBlockIcon = Box;
+
+/**
+ * Per-category color tone — keeps block kinds scannable in the page
+ * canvas and picker, mirroring the field-type / nav-kind / node-type
+ * tinting used across the other Studio designers. Class strings are
+ * written out in full so Tailwind's JIT emits them, with light + dark
+ * variants (the app defaults to dark).
+ */
+export interface BlockCategoryTone {
+  icon: string;
+  badge: string;
+}
+
+export const BLOCK_CATEGORY_TONE: Record<BlockCategory, BlockCategoryTone> = {
+  layout: {
+    icon: 'text-slate-500 dark:text-slate-400',
+    badge: 'border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300',
+  },
+  record: {
+    icon: 'text-blue-500 dark:text-blue-400',
+    badge: 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-300',
+  },
+  navigation: {
+    icon: 'text-indigo-500 dark:text-indigo-400',
+    badge: 'border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300',
+  },
+  element: {
+    icon: 'text-teal-500 dark:text-teal-400',
+    badge: 'border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-900 dark:bg-teal-950/40 dark:text-teal-300',
+  },
+  ai: {
+    icon: 'text-violet-500 dark:text-violet-400',
+    badge: 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300',
+  },
+  misc: {
+    icon: 'text-zinc-500 dark:text-zinc-400',
+    badge: 'border-zinc-200 bg-zinc-50 text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-400',
+  },
+};
+
+/** Resolve a category tone for any block `type` string (handles unknowns). */
+export function resolveBlockTone(type: string): BlockCategoryTone {
+  const meta = BLOCK_TYPE_META[type as BlockTypeId];
+  return BLOCK_CATEGORY_TONE[meta?.category ?? 'misc'];
+}


### PR DESCRIPTION
## What

Extends the scannable per-type color language (from #1412/#1413) to the last two designer gaps.

### Validation / Approval previews — dark-aware tones
Severity & status callouts (error/warning/info, escalation, approved/rejected) only had light-mode classes, so they washed out in the app's default dark theme. Added `dark:` variants throughout so every tone reads correctly in both themes.

### Page designer — color-coded blocks
- `block-types.ts`: new `BLOCK_CATEGORY_TONE` map + `resolveBlockTone()` helper, keyed by block category (layout / record / navigation / element / ai / misc), with full light + dark Tailwind class strings.
- `PageBlockCanvas.tsx`: tint the block-card **icon** and **type badge**, plus the **add-block picker** icons, by category — instead of the previous uniform `text-muted-foreground` gray.

This makes page composition scannable at a glance: layout = slate, record = blue, navigation = indigo, element = teal, ai = violet.

## Verification
- `tsc --noEmit` clean on `@object-ui/app-shell`.
- Verified in-browser (Studio › 页面 › sys_organization_detail) in dark theme: add-block picker shows all six categories with distinct tints; placed `ai:chat_window` (violet) and `record:details` (blue) blocks render tinted icon + badge. Throwaway draft discarded — seeded page untouched.