### PR TITLE
fix(studio): unwrap expanded ViewItem config in the view editor + list cleanup

### DIFF
--- a/packages/app-shell/src/services/builtinComponents.tsx
+++ b/packages/app-shell/src/services/builtinComponents.tsx
@@ -23,6 +23,10 @@ import {
 } from '../views/metadata-admin';
 import { PermissionMatrixEditPage } from '../views/metadata-admin/PermissionMatrixEditor';
 import { PackagesPage } from '../views/metadata-admin/PackagesPage';
+import {
+  viewItemToDraft,
+  draftToViewItem,
+} from '../views/metadata-admin/view-item-normalize';
 
 /* -------------------------------------------------------------------------- */
 /* 1) Top-level admin pages — bound to `metadata:directory` + `metadata:resource` */
@@ -121,6 +125,12 @@ registerMetadataResource({
     { key: 'type', label: 'Type', width: '15%' },
     { key: 'label', label: 'Label' },
   ],
+  // ADR-0017 — the framework expands each per-object aggregated view
+  // container into independent ViewItems whose real single-view spec is
+  // nested under `config`. Unwrap it into the `{ list | form }` family key
+  // the View inspector + preview read, and fold it back on save.
+  toDraft: viewItemToDraft,
+  fromDraft: draftToViewItem,
 });
 
 registerMetadataResource({

--- a/packages/app-shell/src/services/builtinComponents.tsx
+++ b/packages/app-shell/src/services/builtinComponents.tsx
@@ -26,6 +26,8 @@ import { PackagesPage } from '../views/metadata-admin/PackagesPage';
 import {
   viewItemToDraft,
   draftToViewItem,
+  isAggregatedViewContainer,
+  viewDisplayType,
 } from '../views/metadata-admin/view-item-normalize';
 
 /* -------------------------------------------------------------------------- */
@@ -122,7 +124,15 @@ registerMetadataResource({
   listColumns: [
     { key: 'name', label: 'Name', width: '30%' },
     { key: 'object', label: 'Object', width: '20%' },
-    { key: 'type', label: 'Type', width: '15%' },
+    {
+      key: 'type',
+      label: 'Type',
+      width: '15%',
+      // Expanded ViewItems keep their display type under `config.type`
+      // and only the list/form family at the top level — derive it so the
+      // column shows "calendar" / "grid" / "form" instead of "—".
+      render: (_v, item) => viewDisplayType(item) ?? '—',
+    },
     { key: 'label', label: 'Label' },
   ],
   // ADR-0017 — the framework expands each per-object aggregated view
@@ -131,6 +141,9 @@ registerMetadataResource({
   // the View inspector + preview read, and fold it back on save.
   toDraft: viewItemToDraft,
   fromDraft: draftToViewItem,
+  // Hide the bare aggregated container the framework keeps for runtime
+  // dual-read — its views are already listed as expanded ViewItems.
+  listFilter: (item) => !isAggregatedViewContainer(item),
 });
 
 registerMetadataResource({

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -471,10 +471,14 @@ function MetadataResourceEditPageImpl({
         // Prefer the pending draft as the editing baseline — the
         // operator is mid-flight on this item and should see their
         // own in-progress state, not the last published version.
-        const initial = (draftReal
+        const rawInitial = (draftReal
           ?? lay.effective
           ?? lay.code
           ?? {}) as Record<string, unknown>;
+        // Normalise the wire shape into the editor's draft shape (e.g.
+        // `view` unwraps an expanded ViewItem's `config` into a
+        // `{ list | form }` family key). No-op for types without a hook.
+        const initial = config.toDraft ? config.toDraft(rawInitial) : rawInitial;
         setDraft(initial);
         draftSnapshotRef.current = initial;
         setHasDraft(!!draftReal);
@@ -717,7 +721,10 @@ function MetadataResourceEditPageImpl({
         ? (config.createBuildBody
             ? config.createBuildBody(draft)
             : { ...(config.createDefaults ?? {}), ...draft })
-        : draft;
+        // Edit mode: serialise the editor draft back to the wire shape
+        // (inverse of `toDraft` — e.g. `view` folds the `{ list | form }`
+        // family key back into the ViewItem `config` wrapper).
+        : (config.fromDraft ? config.fromDraft(draft) : draft);
       const savedName = String(
         (builtBody as Record<string, unknown>)[identityField] ?? draft[identityField] ?? name,
       );
@@ -758,7 +765,11 @@ function MetadataResourceEditPageImpl({
       setLayered(lay);
       const draftReal = extractDraftBody(draftResp);
       setHasDraft(!!draftReal);
-      const fresh = (draftReal ?? lay.effective ?? itemToSave) as Record<string, unknown>;
+      const rawFresh = (draftReal ?? lay.effective ?? itemToSave) as Record<string, unknown>;
+      // Re-normalise the refreshed wire shape so the editor keeps showing
+      // the canonical draft shape after a save (e.g. the backend re-expands
+      // a view into the ViewItem `config` wrapper).
+      const fresh = config.toDraft ? config.toDraft(rawFresh) : rawFresh;
       setDraft(fresh);
       draftSnapshotRef.current = fresh;
       setLastSavedAt(new Date());

--- a/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
@@ -216,6 +216,9 @@ function DefaultMetadataList({ type }: { type: string }) {
 
   const searchableFields = config.searchableFields ?? ['name', 'label', 'description'];
   const filtered = items.filter((row) => {
+    // Per-type hide hook (e.g. `view` drops the bare aggregated container
+    // that the framework keeps for runtime dual-read).
+    if (config.listFilter && !config.listFilter(row.item)) return false;
     if (!matchesQuery(row.item, query, searchableFields)) return false;
     if (sourceFilter !== 'all' && row.source !== sourceFilter) return false;
     // Mandatory project-package scope: show nothing until a concrete project

--- a/packages/app-shell/src/views/metadata-admin/registry.ts
+++ b/packages/app-shell/src/views/metadata-admin/registry.ts
@@ -90,6 +90,16 @@ export interface MetadataResourceConfig {
   primaryKey?: string;
   /** Fields searched by the free-text filter. Default `['name','label','description']`. */
   searchableFields?: string[];
+  /**
+   * Optional client-side list predicate — return `false` to HIDE a row
+   * from the resource list page. Runs against the unwrapped item shape
+   * after search / source / package filters. Use this to drop back-compat
+   * or synthetic rows (e.g. `view` hides the bare aggregated container the
+   * framework keeps for runtime dual-read, since its views are listed
+   * individually as expanded ViewItems). Pure function; keep it cheap.
+   */
+  listFilter?: (item: Record<string, unknown>) => boolean;
+
   /** Columns rendered in the list page. */
   listColumns?: Array<{
     key: string;

--- a/packages/app-shell/src/views/metadata-admin/registry.ts
+++ b/packages/app-shell/src/views/metadata-admin/registry.ts
@@ -181,6 +181,27 @@ export interface MetadataResourceConfig {
   createBuildBody?: (draft: Record<string, unknown>) => Record<string, unknown>;
 
   /**
+   * Optional load-time normaliser: the wire item returned by the server
+   * (`layered.effective` / a pending draft) → the draft shape the editor
+   * (SchemaForm / inspector / preview) expects. Applied on initial load
+   * AND after every save-refresh, so the editor always sees the canonical
+   * draft shape. Must be a pure function and a no-op for shapes it does
+   * not recognise. Pair with {@link fromDraft} for the save round-trip.
+   *
+   * Example: `view` unwraps an expanded ViewItem's `config` into the
+   * `{ list | form }` family key the View inspector reads.
+   */
+  toDraft?: (item: Record<string, unknown>) => Record<string, unknown>;
+
+  /**
+   * Optional save-time serialiser — the inverse of {@link toDraft}. The
+   * editor draft → the wire shape PUT back to the server. Applied to the
+   * body just before save (edit mode). Must be a pure function and a
+   * no-op for drafts it does not recognise.
+   */
+  fromDraft?: (draft: Record<string, unknown>) => Record<string, unknown>;
+
+  /**
    * Optional schema override for create mode only. When present, the
    * engine uses this schema (instead of the server's edit schema) to
    * render the create form and validate the draft. The saved body still

--- a/packages/app-shell/src/views/metadata-admin/view-item-normalize.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/view-item-normalize.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import {
+  isExpandedViewItem,
+  viewItemToDraft,
+  draftToViewItem,
+} from './view-item-normalize';
+
+const calendarItem = {
+  name: 'crm_campaign.campaign_calendar',
+  object: 'crm_campaign',
+  viewKind: 'list',
+  label: 'Launch Calendar',
+  scope: 'package',
+  _provenance: 'package',
+  config: {
+    name: 'campaign_calendar',
+    label: 'Launch Calendar',
+    type: 'calendar',
+    data: { provider: 'object', object: 'crm_campaign' },
+    columns: ['name', 'channel', 'status'],
+    calendar: {
+      startDateField: 'start_date',
+      endDateField: 'end_date',
+      titleField: 'name',
+      colorField: 'name',
+    },
+  },
+};
+
+const formItem = {
+  name: 'crm_lead.intake_form',
+  object: 'crm_lead',
+  viewKind: 'form',
+  label: 'Intake',
+  scope: 'shared',
+  config: { type: 'simple', data: { object: 'crm_lead' }, sections: [] },
+};
+
+describe('isExpandedViewItem', () => {
+  it('accepts list-family expanded items', () => {
+    expect(isExpandedViewItem(calendarItem)).toBe(true);
+  });
+  it('accepts form-family expanded items', () => {
+    expect(isExpandedViewItem(formItem)).toBe(true);
+  });
+  it('rejects the bare aggregated container (no viewKind/config)', () => {
+    expect(isExpandedViewItem({ name: 'crm_lead', list: {}, listViews: [] })).toBe(false);
+  });
+  it('rejects a legacy flat view (top-level type, no viewKind)', () => {
+    expect(isExpandedViewItem({ name: 'x', type: 'grid', columns: [] })).toBe(false);
+  });
+  it('rejects viewKind present but config missing/non-object', () => {
+    expect(isExpandedViewItem({ name: 'x', viewKind: 'list' })).toBe(false);
+    expect(isExpandedViewItem({ name: 'x', viewKind: 'list', config: [] })).toBe(false);
+  });
+  it('rejects non-objects', () => {
+    expect(isExpandedViewItem(null)).toBe(false);
+    expect(isExpandedViewItem('view')).toBe(false);
+  });
+});
+
+describe('viewItemToDraft', () => {
+  it('unwraps a list-family config under the `list` family key', () => {
+    const draft = viewItemToDraft(calendarItem);
+    expect(draft.list).toEqual(calendarItem.config);
+    expect((draft as any).config).toBeUndefined();
+    // Identity / provenance preserved at top level.
+    expect(draft.name).toBe('crm_campaign.campaign_calendar');
+    expect(draft.object).toBe('crm_campaign');
+    expect(draft.viewKind).toBe('list');
+    expect(draft.label).toBe('Launch Calendar');
+    expect(draft.scope).toBe('package');
+  });
+
+  it('unwraps a form-family config under the `form` family key', () => {
+    const draft = viewItemToDraft(formItem);
+    expect(draft.form).toEqual(formItem.config);
+    expect(draft.list).toBeUndefined();
+  });
+
+  it('leaves a non-expanded item unchanged', () => {
+    const legacy = { name: 'x', type: 'grid', columns: ['a'] };
+    expect(viewItemToDraft(legacy)).toBe(legacy);
+  });
+
+  it('coerces nullish input to an empty object', () => {
+    expect(viewItemToDraft(null)).toEqual({});
+  });
+});
+
+describe('draftToViewItem', () => {
+  it('is the inverse of viewItemToDraft for a list view', () => {
+    const draft = viewItemToDraft(calendarItem);
+    const back = draftToViewItem(draft);
+    expect(back).toEqual(calendarItem);
+  });
+
+  it('is the inverse for a form view', () => {
+    expect(draftToViewItem(viewItemToDraft(formItem))).toEqual(formItem);
+  });
+
+  it('folds back edits made to the family variant', () => {
+    const draft = viewItemToDraft(calendarItem) as any;
+    draft.list = { ...draft.list, columns: ['name', 'channel'] };
+    const back = draftToViewItem(draft) as any;
+    expect(back.config.columns).toEqual(['name', 'channel']);
+    expect(back.viewKind).toBe('list');
+  });
+
+  it('no-ops on a draft without the viewKind discriminant', () => {
+    const legacy = { name: 'x', type: 'grid', columns: ['a'] };
+    expect(draftToViewItem(legacy)).toBe(legacy);
+  });
+
+  it('no-ops when the family object is absent', () => {
+    const d = { name: 'x', viewKind: 'list' };
+    expect(draftToViewItem(d)).toBe(d);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/view-item-normalize.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/view-item-normalize.test.ts
@@ -5,6 +5,8 @@ import {
   isExpandedViewItem,
   viewItemToDraft,
   draftToViewItem,
+  isAggregatedViewContainer,
+  viewDisplayType,
 } from './view-item-normalize';
 
 const calendarItem = {
@@ -117,5 +119,40 @@ describe('draftToViewItem', () => {
   it('no-ops when the family object is absent', () => {
     const d = { name: 'x', viewKind: 'list' };
     expect(draftToViewItem(d)).toBe(d);
+  });
+});
+
+describe('isAggregatedViewContainer', () => {
+  it('accepts a bare container with listViews/formViews', () => {
+    expect(isAggregatedViewContainer({ name: 'crm_lead', listViews: {}, formViews: {} })).toBe(true);
+    expect(isAggregatedViewContainer({ name: 'crm_lead', list: {} })).toBe(true);
+    expect(isAggregatedViewContainer({ name: 'crm_lead', form: {} })).toBe(true);
+  });
+  it('rejects an expanded ViewItem (carries viewKind)', () => {
+    expect(isAggregatedViewContainer(calendarItem)).toBe(false);
+    expect(isAggregatedViewContainer({ name: 'x', viewKind: 'list', list: {} })).toBe(false);
+  });
+  it('rejects an item with none of the aggregate buckets', () => {
+    expect(isAggregatedViewContainer({ name: 'x' })).toBe(false);
+    expect(isAggregatedViewContainer(null)).toBe(false);
+  });
+});
+
+describe('viewDisplayType', () => {
+  it('reads config.type for an expanded list item', () => {
+    expect(viewDisplayType(calendarItem)).toBe('calendar');
+  });
+  it('reads config.type for an expanded form item', () => {
+    expect(viewDisplayType(formItem)).toBe('simple');
+  });
+  it('reads a flat legacy view`s top-level type', () => {
+    expect(viewDisplayType({ name: 'x', type: 'grid' })).toBe('grid');
+  });
+  it('falls back to the family when only viewKind is present', () => {
+    expect(viewDisplayType({ name: 'x', viewKind: 'list', config: {} })).toBe('list');
+    expect(viewDisplayType({ name: 'x', viewKind: 'form', config: {} })).toBe('form');
+  });
+  it('returns undefined for an aggregated container', () => {
+    expect(viewDisplayType({ name: 'crm_lead', listViews: {} })).toBeUndefined();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/view-item-normalize.ts
+++ b/packages/app-shell/src/views/metadata-admin/view-item-normalize.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * view-item-normalize — bridge the backend's **expanded ViewItem** shape
+ * (ADR-0017, "Object has-many View") into the draft shape the Studio View
+ * editor (inspector + preview) already understands, and back again on save.
+ *
+ * ## Why
+ *
+ * The framework expands each per-object aggregated `*.view.ts` container
+ * into independent first-class ViewItems addressed as `<object>.<viewKey>`.
+ * `GET /meta/view/<object>.<viewKey>` returns:
+ *
+ *   {
+ *     name: "crm_campaign.campaign_calendar",
+ *     object: "crm_campaign",
+ *     viewKind: "list",            // list-family | form-family discriminant
+ *     label: "Launch Calendar",
+ *     scope: "package",
+ *     config: {                    // ← the REAL single-view spec lives here
+ *       type: "calendar",
+ *       data: { object: "crm_campaign" },
+ *       columns: ["name", "channel", "status"],
+ *       calendar: { startDateField: "start_date", … },
+ *     },
+ *   }
+ *
+ * The View editor, however, models a view *document* whose single-view spec
+ * sits under a **family key** (`list` for list-family, `form` for
+ * form-family) — that is what `ViewVariantInspector` reads (`draft.list`,
+ * `draft.form`) and what `ViewPreview.detectVariants` scans for. It has no
+ * knowledge of the `config` wrapper, so an expanded ViewItem rendered as-is
+ * shows a blank "Table / List" with 0 columns — the user opens a calendar
+ * view but sees nothing of it.
+ *
+ * These two pure transforms unwrap `config` → `{ [familyKey]: config }` on
+ * load and fold it back on save, leaving every NON-expanded shape (legacy
+ * overlay views, the bare aggregated `<object>` container, freshly-created
+ * drafts) untouched.
+ */
+
+const FAMILY_KEYS = ['list', 'form'] as const;
+type FamilyKey = (typeof FAMILY_KEYS)[number];
+
+function familyKeyFor(viewKind: unknown): FamilyKey {
+  return viewKind === 'form' ? 'form' : 'list';
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * True when `item` is an **expanded ViewItem** — it carries the
+ * `viewKind` discriminant AND a nested `config` object holding the real
+ * single-view spec. Legacy/aggregated/create shapes lack both and are
+ * left alone.
+ */
+export function isExpandedViewItem(item: unknown): item is Record<string, unknown> {
+  if (!isPlainObject(item)) return false;
+  const viewKind = item.viewKind;
+  if (viewKind !== 'list' && viewKind !== 'form') return false;
+  return isPlainObject(item.config);
+}
+
+/**
+ * Load-time: expanded ViewItem → editor draft.
+ *
+ *   { name, object, viewKind:'list', label, scope, config:{…} }
+ *     → { name, object, viewKind:'list', label, scope, list:{…} }
+ *
+ * Identity / provenance metadata (`name`, `object`, `viewKind`, `label`,
+ * `scope`, `_provenance`, `_diagnostics`, …) is preserved verbatim at the
+ * top level so read-only detection, the header, and the round-trip back to
+ * {@link draftToViewItem} all keep working. Non-expanded items pass through.
+ */
+export function viewItemToDraft(item: unknown): Record<string, unknown> {
+  if (!isExpandedViewItem(item)) {
+    return isPlainObject(item) ? item : {};
+  }
+  const { config, ...meta } = item;
+  const familyKey = familyKeyFor(item.viewKind);
+  // A non-expanded view document might *also* already carry a `list`/`form`
+  // key; the expansion contract guarantees expanded items do not, so a
+  // straight assignment is safe.
+  return { ...meta, [familyKey]: config };
+}
+
+/**
+ * Save-time: editor draft → expanded ViewItem.
+ *
+ * The inverse of {@link viewItemToDraft}. Only fires when the draft still
+ * carries the top-level `viewKind` discriminant AND the matching family
+ * object — i.e. it originated from an expanded ViewItem. Every other draft
+ * (create flow, legacy overlay, aggregated container) is returned unchanged
+ * so this transform is a no-op outside the expanded-ViewItem round-trip.
+ */
+export function draftToViewItem(draft: unknown): Record<string, unknown> {
+  if (!isPlainObject(draft)) return {};
+  const viewKind = draft.viewKind;
+  if (viewKind !== 'list' && viewKind !== 'form') return draft;
+  const familyKey = familyKeyFor(viewKind);
+  const config = draft[familyKey];
+  if (!isPlainObject(config)) return draft;
+  const rest = { ...draft };
+  delete rest[familyKey];
+  return { ...rest, config };
+}

--- a/packages/app-shell/src/views/metadata-admin/view-item-normalize.ts
+++ b/packages/app-shell/src/views/metadata-admin/view-item-normalize.ts
@@ -87,6 +87,40 @@ export function viewItemToDraft(item: unknown): Record<string, unknown> {
 }
 
 /**
+ * True when `item` is a **bare aggregated view container** — the legacy
+ * per-object `defineView({ list, form, listViews, formViews })` document
+ * the framework still registers under the bare `<object>` key for runtime
+ * back-compat (dual-read). It carries NO `viewKind` discriminant and holds
+ * at least one of the aggregate buckets.
+ *
+ * Studio expands every such container into independent `<object>.<viewKey>`
+ * ViewItems (including the defaults), so the container row is fully
+ * redundant in the metadata list and should be hidden there.
+ */
+export function isAggregatedViewContainer(item: unknown): boolean {
+  if (!isPlainObject(item)) return false;
+  if (item.viewKind) return false; // already an independent ViewItem
+  return Boolean(item.list || item.form || item.listViews || item.formViews);
+}
+
+/**
+ * Derive the display "type" of a view list row. Expanded ViewItems keep
+ * their display type under `config.type` (`grid` / `calendar` / `kanban`
+ * / …) and only the list/form *family* at the top level (`viewKind`); a
+ * legacy flat view carries `type` directly. Returns `undefined` when
+ * nothing is resolvable (e.g. an aggregated container).
+ */
+export function viewDisplayType(item: unknown): string | undefined {
+  if (!isPlainObject(item)) return undefined;
+  const config = item.config;
+  if (isPlainObject(config) && typeof config.type === 'string') return config.type;
+  if (typeof item.type === 'string') return item.type;
+  if (item.viewKind === 'form') return 'form';
+  if (item.viewKind === 'list') return 'list';
+  return undefined;
+}
+
+/**
  * Save-time: editor draft → expanded ViewItem.
  *
  * The inverse of {@link viewItemToDraft}. Only fires when the draft still


### PR DESCRIPTION
## What

Fixes the Studio **view editor** showing a blank "Table / List" (0 columns) instead of the actual view when opening an expanded ViewItem — e.g. `/apps/studio/metadata/view/crm_campaign.campaign_calendar`. Also cleans up the view **list** for the new expanded-ViewItem model.

## Why

Under the "Object has-many View" model (ADR-0017), the framework expands each per-object aggregated view container into independent first-class ViewItems addressed as `<object>.<viewKey>`. `GET /meta/view/<object>.<viewKey>` returns the real single-view spec nested under a `config` key with a `viewKind` (`list` | `form`) discriminant at the top level:

```jsonc
{
  "name": "crm_campaign.campaign_calendar",
  "object": "crm_campaign",
  "viewKind": "list",
  "label": "Launch Calendar",
  "config": { "type": "calendar", "columns": ["name","channel","status"], "calendar": { … } }
}
```

The Studio view editor models a view *document* whose single-view spec sits under a **family key** (`list` for list-family, `form` for form-family) — that's what `ViewVariantInspector` reads and `ViewPreview.detectVariants` scans. It has no knowledge of the `config` wrapper, so an expanded ViewItem rendered as-is shows a blank "Table / List" with 0 columns. A naive flatten collides (`config.calendar` settings object vs. the `calendar` VARIANT_KEY), so the bridge has to be `config`-aware.

## How

A pair of pure transforms (`view-item-normalize.ts`) unwrap `config` → `{ [familyKey]: config }` on load and fold it back on save, leaving every non-expanded shape (legacy overlay views, the bare aggregated container, freshly-created drafts) untouched. They are wired through three new generic registry hooks, mirroring the existing `createBuildBody` pattern:

- `toDraft?(item)` — applied when loading the editor and after a save refresh.
- `fromDraft?(draft)` — applied in the edit-mode save branch.
- `listFilter?(item)` — return `false` to hide a list row.

The `view` resource registration uses these to: unwrap/fold the `config` (`toDraft: viewItemToDraft`, `fromDraft: draftToViewItem`), hide the now-redundant bare aggregated container rows (`listFilter: (item) => !isAggregatedViewContainer(item)`), and populate the **Type** column from `config.type` (`viewDisplayType`) so it reads `calendar` / `grid` / `form` instead of `—`.

## Changed files

- `view-item-normalize.ts` (new) — pure `isExpandedViewItem` / `viewItemToDraft` / `draftToViewItem` / `isAggregatedViewContainer` / `viewDisplayType`. Single source of ViewItem shape logic.
- `view-item-normalize.test.ts` (new) — 23 tests across all 5 functions, incl. round-trip identity.
- `registry.ts` — adds `toDraft` / `fromDraft` / `listFilter` to `MetadataResourceConfig`; preserved through `resolveResourceConfig`.
- `ResourceEditPage.tsx` — applies `toDraft` on load + post-save refresh, `fromDraft` on save.
- `ResourceListPage.tsx` — applies `listFilter` first in the row filter.
- `builtinComponents.tsx` — wires the hooks + Type column on the `view` resource.

## Testing

- `npx vitest run --config vitest.config.mts packages/app-shell/src/views/metadata-admin/view-item-normalize.test.ts` — 23 passing.
- Verified live on both the Vite dev server (`:5180`, app-shell from source) and the deployed console (`:3000`):
  - Calendar view (`crm_campaign.campaign_calendar`) now shows type=Calendar, object=crm_campaign, 3 columns (name/channel/status), label=Launch Calendar, calendar field config, and the canvas renders a real calendar with campaign events.
  - Grid views (e.g. `crm_lead.all_leads`) unaffected.
  - View list: 92 → 80 rows (12 redundant aggregated-container rows hidden); Type column populated.

## Notes for the reviewer

- All transforms are **pure and non-expanded-safe** — they no-op on legacy/overlay/create shapes, so there's no risk to existing view documents.
- Scope is intentionally limited to the Studio metadata-admin surface. The separate **runtime adapter** (`data-objectstack`) wiring to the `sys_view_definition` ObjectQL object (the runtime "create a view anytime" persistence path) is **not** part of this PR — it's a larger follow-up tracked under the broader "Object has-many View" work.
