### PR TITLE
chore: scrub stale apps/studio references

### DIFF
--- a/apps/console/src/pages/developer/ApiConsolePage.tsx
+++ b/apps/console/src/pages/developer/ApiConsolePage.tsx
@@ -1,10 +1,10 @@
 /**
  * API Console — REST endpoint debugger with auto-discovery.
  *
- * Ported from apps/studio: console is not project-scoped, so the projectId
- * prop, scope toggle (Project API / System API), and the `Server`/`FolderOpen`
- * icons are dropped. The discovery hook is the console-local copy under
- * `./hooks/useApiDiscovery`. UI primitives come from `@object-ui/components`.
+ * Console is not project-scoped, so there is no projectId prop, no scope
+ * toggle (Project API / System API), and no `Server`/`FolderOpen` icons. The
+ * discovery hook is the console-local copy under `./hooks/useApiDiscovery`.
+ * UI primitives come from `@object-ui/components`.
  */
 
 import { useState, useCallback, useMemo } from 'react';

--- a/apps/console/src/pages/developer/FlowRunsPage.tsx
+++ b/apps/console/src/pages/developer/FlowRunsPage.tsx
@@ -2,10 +2,9 @@
  * Flow Runs — pick a flow, trigger a test run with sample inputs, and
  * inspect recent run history.
  *
- * Ported from apps/studio's FlowTestRunner + FlowRunsPanel. Console is not
- * project-scoped: there is no useScopedClient and no projectId param. The
- * client comes from `useAdapter().getClient()` (which exposes `.automation`
- * and `.meta`). Studio's `JsonTree` is replaced with a plain `<pre>` block.
+ * Console is not project-scoped: there is no useScopedClient and no projectId
+ * param. The client comes from `useAdapter().getClient()` (which exposes
+ * `.automation` and `.meta`). Run output renders as a plain `<pre>` block.
  */
 
 import { useEffect, useMemo, useState, useCallback } from 'react';

--- a/apps/console/src/pages/developer/PublicFormsPage.tsx
+++ b/apps/console/src/pages/developer/PublicFormsPage.tsx
@@ -3,10 +3,9 @@
  * `sharing.allowAnonymous === true && sharing.publicLink`, and lets devs
  * publish a non-public FormView or tweak sharing / submitBehavior.
  *
- * Ported from apps/studio's `$package.forms.index.tsx`. Console is not
- * project-scoped, so this drops `useParams().package`, the `<Link>` to the
- * legacy metadata editor, and the `useMetadataHmr` polling — refresh is
- * driven by the explicit Refresh button.
+ * Console is not project-scoped, so there is no `useParams().package`, no
+ * `<Link>` to the legacy metadata editor, and no `useMetadataHmr` polling —
+ * refresh is driven by the explicit Refresh button.
  */
 
 import { useEffect, useState } from 'react';

--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
@@ -2,8 +2,8 @@
  * useApiDiscovery — fetches the API discovery payload and builds a flat list
  * of REST endpoint definitions grouped by service / metadata type / object.
  *
- * Ported from apps/studio: console is not project-scoped, so this drops the
- * `projectId` parameter and the `/projects/:projectId/...` URL rewriting.
+ * Console is not project-scoped, so there is no `projectId` parameter and no
+ * `/projects/:projectId/...` URL rewriting.
  */
 
 import { useState, useEffect, useCallback } from 'react';

--- a/content/docs/guide/metadata-diagnostics.md
+++ b/content/docs/guide/metadata-diagnostics.md
@@ -88,7 +88,7 @@ Use this as a CI gate too — `total === 0` is the green-build condition.
 
 ### 1. Directory page badges
 
-`/apps/studio/metadata` — the directory is **scoped to the active project
+`/apps/<app>/metadata` — the directory is **scoped to the active project
 software package** (the sidebar `active_package` selector, published as
 `?package=`). Only metadata types that the selected project package
 contributes are listed — system/cloud types never appear, and there is no
@@ -110,7 +110,7 @@ governance page.
 
 ### 2. Resource list rows
 
-`/apps/studio/metadata/<type>` — invalid rows get a red ⚠ icon next to
+`/apps/<app>/metadata/<type>` — invalid rows get a red ⚠ icon next to
 the name and a destructive-tinted background; warning-only rows get an
 amber ⚠ and amber tint. The list header shows aggregate "Invalid N" and
 "Warnings N" chips. Hover the ⚠ for the first three messages.
@@ -128,7 +128,7 @@ scope is owned solely by the sidebar selector.)
 
 ### 3. Resource edit banners
 
-`/apps/studio/metadata/<type>/<name>` — a destructive banner at the top
+`/apps/<app>/metadata/<type>/<name>` — a destructive banner at the top
 of the edit page lists the first three errors with their paths; the
 same errors are also threaded into the form so the offending fields
 get inline messages **without** the user having to click Save first.
@@ -140,7 +140,7 @@ on save.
 
 ### 4. Governance overview page
 
-`/apps/studio/metadata/_diagnostics` — a single sortable table of every
+`/apps/<app>/metadata/_diagnostics` — a single sortable table of every
 invalid item across every type, grouped by type, with deep-links to the
 offending edit page. Toggle the severity tab to include
 warning-only items. This is the page to open during a release readiness

--- a/packages/app-shell/src/hooks/__tests__/useTrackRouteAsRecent.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useTrackRouteAsRecent.test.tsx
@@ -90,44 +90,44 @@ describe('useTrackRouteAsRecent', () => {
 
   it('records a Studio metadata item route', () => {
     const { result } = renderHook(
-      () => useHarness('/apps/studio/metadata/object/sys_user', 'studio'),
+      () => useHarness('/apps/admin/metadata/object/sys_user', 'admin'),
       { wrapper },
     );
     expect(result.current[0]).toMatchObject({
       id: 'metadata:object:sys_user',
       label: 'sys_user',
-      href: '/apps/studio/metadata/object/sys_user',
+      href: '/apps/admin/metadata/object/sys_user',
       type: 'metadata',
     });
   });
 
   it('records the metadata item when on its history sub-route', () => {
     const { result } = renderHook(
-      () => useHarness('/apps/studio/metadata/view/account_grid/history', 'studio'),
+      () => useHarness('/apps/admin/metadata/view/account_grid/history', 'admin'),
       { wrapper },
     );
     expect(result.current[0]).toMatchObject({
       id: 'metadata:view:account_grid',
-      href: '/apps/studio/metadata/view/account_grid',
+      href: '/apps/admin/metadata/view/account_grid',
       type: 'metadata',
     });
   });
 
   it('skips metadata list, directory and create routes', () => {
     const { result: list } = renderHook(
-      () => useHarness('/apps/studio/metadata/object', 'studio'),
+      () => useHarness('/apps/admin/metadata/object', 'admin'),
       { wrapper },
     );
     expect(list.current).toEqual([]);
 
     const { result: dir } = renderHook(
-      () => useHarness('/apps/studio/metadata', 'studio'),
+      () => useHarness('/apps/admin/metadata', 'admin'),
       { wrapper },
     );
     expect(dir.current).toEqual([]);
 
     const { result: create } = renderHook(
-      () => useHarness('/apps/studio/metadata/object/new', 'studio'),
+      () => useHarness('/apps/admin/metadata/object/new', 'admin'),
       { wrapper },
     );
     expect(create.current).toEqual([]);

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -11,8 +11,8 @@
  * those don't reflect the runtime the SPA is actually attached to (e.g.
  * a tenant ObjectOS runtime pointing at a separate cloud control plane).
  *
- * Mirrors `apps/studio/src/lib/config.ts` but lives in app-shell because
- * the Console SPA in `apps/console` consumes app-shell code.
+ * The runtime-config shape lives in app-shell because the Console SPA in
+ * `apps/console` consumes app-shell code.
  *
  * Server-side: see
  *   cloud/packages/service-cloud/src/multi-environment-plugins.ts

--- a/packages/plugin-chatbot/README.md
+++ b/packages/plugin-chatbot/README.md
@@ -291,12 +291,13 @@ mapping logic stays consistent across direct and managed usage.
 This package depends on `streamdown`, `shiki`, `mermaid`, and `katex`
 for code/markdown rendering. Together they weigh ~20 MB minified.
 
-In host apps that don't always show the chat panel (e.g. Studio's
+In host apps that don't always show the chat panel (e.g. Console's
 opt-in AI sidebar), import this package via `React.lazy` so the heavy
 chunks only download when the panel actually opens. See
-`apps/studio/src/routes/__root.tsx` for the reference pattern, and
-`apps/studio/vite.config.ts` for the `manualChunks` rules that keep
-the chat-only deps in dedicated, lazy-loadable chunks.
+`packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx` for the
+reference lazy-load pattern, and `apps/console/vite.config.ts` for the
+`manualChunks` rules that keep the chat-only deps in dedicated,
+lazy-loadable chunks.
 
 ## License
 


### PR DESCRIPTION
## What

Update comments, docs, and tests that still pointed at the old `apps/studio` paths to reference the current `apps/<app>` / Console locations instead.

## Files

- `apps/console/src/pages/developer/{ApiConsolePage,FlowRunsPage,PublicFormsPage}.tsx` + `hooks/useApiDiscovery.ts` — drop "Ported from apps/studio" wording in header comments
- `content/docs/guide/metadata-diagnostics.md` — `/apps/studio/...` → `/apps/<app>/...`
- `packages/app-shell/src/runtime-config.ts` — remove stale `apps/studio/src/lib/config.ts` reference in comment
- `packages/app-shell/src/hooks/__tests__/useTrackRouteAsRecent.test.tsx` — use `apps/admin` paths in test fixtures
- `packages/plugin-chatbot/README.md` — point lazy-load reference at Console's components

Docs/comments/test-fixture only; no runtime behavior change.