### PR TITLE
fix(view-editor): render form-family views as forms in Studio preview

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx
@@ -11,6 +11,13 @@
  * object's *other* views are independent ViewItems surfaced by the view
  * switcher (a query), not nested here.
  *
+ * The render path forks on `viewKind`:
+ *   - list-family (grid / kanban / calendar / …) → `object-view`, with the
+ *     draft body injected as a named listView (below);
+ *   - form-family (simple / drawer / …) → `object-form`, with the draft's
+ *     sections mapped onto the form schema (a form view binds a record layout,
+ *     not a list, so the list renderer would just fall back to a bare grid).
+ *
  * A raw single-schema draft (a bare `{ type, … }` with no `config` wrapper,
  * e.g. an ad-hoc preview) is rendered straight through SchemaRenderer.
  */
@@ -37,6 +44,51 @@ function resolveObjectName(
     if (typeof c === 'string' && c) return c;
   }
   return undefined;
+}
+
+// Form layouts that render inline. `drawer` / `modal` render as overlays that
+// need a trigger to open, so the preview coerces them to `simple` — the point
+// of the preview pane is to show the section/field layout, not the chrome.
+const INLINE_FORM_TYPES = new Set(['simple', 'tabbed', 'wizard', 'split']);
+
+// A ViewItem form section uses the spec's `{ field, readonly, … }` shape, but
+// `object-form` selects fields by `name` and reads `readOnly`. Normalize so the
+// section's fields resolve (otherwise every section comes up empty).
+function toFormFieldEntry(f: unknown): string | Record<string, unknown> {
+  if (typeof f === 'string') return f;
+  if (f && typeof f === 'object') {
+    const o = f as Record<string, unknown>;
+    const name = (o.field ?? o.name) as string | undefined;
+    if (!name) return o;
+    return { ...o, name, readOnly: o.readOnly ?? o.readonly };
+  }
+  return String(f);
+}
+
+function buildFormPreviewSchema(
+  objectName: string,
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const rawType = typeof body.type === 'string' ? body.type : 'simple';
+  const formType = INLINE_FORM_TYPES.has(rawType) ? rawType : 'simple';
+  const sections = Array.isArray(body.sections)
+    ? (body.sections as any[]).map((s) => ({
+        ...s,
+        fields: Array.isArray(s?.fields) ? s.fields.map(toFormFieldEntry) : [],
+      }))
+    : undefined;
+  return {
+    type: 'object-form',
+    objectName,
+    // A blank create-mode form: the preview shows the layout without needing a
+    // sample record to be selected.
+    mode: 'create',
+    formType,
+    sections,
+    fields: Array.isArray(body.fields) ? body.fields : undefined,
+    showSubmit: false,
+    showCancel: false,
+  };
 }
 
 export function ViewPreview({ name, draft, editing }: MetadataPreviewProps) {
@@ -94,6 +146,25 @@ export function ViewPreview({ name, draft, editing }: MetadataPreviewProps) {
           This view has no object binding yet. Set the bound <code>Object</code> in
           the right panel to fetch live data and field options.
         </PreviewMessage>
+      </PreviewShell>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Form-family view (`viewKind: 'form'`): render the record form layout via
+  // `object-form`. The list renderer (`object-view`) has no form layout, so a
+  // form view routed through it just falls back to a bare grid.
+  // -------------------------------------------------------------------------
+  if ((draft as any).viewKind === 'form' && body) {
+    const rawType = String((body as any).type ?? 'simple');
+    const formSchema = buildFormPreviewSchema(objectName, body as Record<string, unknown>);
+    return (
+      <PreviewShell hint={`view · ${rawType} · form${designMode ? ' · design' : ''}`}>
+        <PreviewErrorBoundary fallbackHint="The form view references an object or field that doesn't resolve.">
+          <div className="min-h-[300px] max-h-[75vh] overflow-auto">
+            <SchemaRenderer schema={formSchema as any} />
+          </div>
+        </PreviewErrorBoundary>
       </PreviewShell>
     );
   }

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRendererContext } from '@object-ui/react';
 import { ObjectForm } from './ObjectForm';
 
 export { ObjectForm };
@@ -42,7 +43,13 @@ export type { FormAnalyticsProps, FormSubmissionMetric } from './FormAnalytics';
 
 // Register object-form component
 const ObjectFormRenderer: React.FC<{ schema: any }> = ({ schema }) => {
-  return <ObjectForm schema={schema} />;
+  // Resolve dataSource from the SchemaRendererProvider context (same as
+  // object-view): ObjectForm needs a dataSource to fetch the object schema and
+  // auto-generate its fields. Without this, an `object-form` rendered straight
+  // through SchemaRenderer (e.g. the Studio view preview) has no fields.
+  const ctx = useContext(SchemaRendererContext as React.Context<any>);
+  const dataSource = ctx?.dataSource ?? undefined;
+  return <ObjectForm schema={schema} dataSource={dataSource} />;
 };
 
 ComponentRegistry.register('object-form', ObjectFormRenderer, {


### PR DESCRIPTION
## What

In the Studio metadata view editor, form-family view drafts (`viewKind: 'form'`) now render as an actual record form in the preview pane, instead of falling back to a bare grid.

## Why

Form-family drafts were always routed through the `object-view` list renderer. `ObjectView.generateViewSchema` only handles list-family layouts (grid/kanban/calendar/…) and returns `null` for form types, so the preview hit the `ObjectGrid` fallback — a form view showed up as an empty grid.

## Changes

- **`packages/app-shell/.../previews/ViewPreview.tsx`** — fork the render path on `viewKind`:
  - list-family → `object-view` (unchanged);
  - form-family → build an `object-form` schema.
  - Overlay form types (`drawer` / `modal`) are coerced to `simple` for the inline preview (the pane shows the section/field layout, not the open-trigger chrome).
  - Map the ViewItem section field shape `{ field, readonly }` onto the `object-form` shape `{ name, readOnly }` — otherwise every section comes up empty (ObjectForm selects fields by `name`).
- **`packages/plugin-form/src/index.tsx`** — `ObjectFormRenderer` now resolves `dataSource` from `SchemaRendererContext` (mirroring `ObjectViewRenderer`). A standalone `object-form` rendered straight through `SchemaRenderer` previously had no dataSource, so it couldn't fetch the object schema or auto-generate fields.

No dependency cycle introduced: `plugin-form` already depends on `@object-ui/react`, which does not depend on `plugin-form` (`plugin-view` is the working precedent).

## Verification

Verified live in the Studio view editor:
- **simple** form (`crm_lead.default`): Lead Information / Qualification sections render with real field widgets (Lead Name*, 邮箱, Phone, 公司, Title, 来源, 状态*).
- **drawer** form (`ai_pending_actions.detail`): renders inline (drawer→simple) with the Proposal section fields populated.
- Fiber scan confirms `hasDataSource: true` on the mounted ObjectForm.
- List-family types (grid/kanban/calendar/gallery/timeline/gantt/map) and the view creation flow re-tested — unchanged and working.