### PR TITLE
fix: keep form-family views out of the object list-view switcher

### DIFF
--- a/.changeset/data-objectstack-listviews-form-family.md
+++ b/.changeset/data-objectstack-listviews-form-family.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+fix(datasource): exclude form-family views from `listViews()`
+
+`OBJECTSTACKDataSource.listViews(objectName)` feeds the object list-view
+switcher (`ObjectView` → `ViewTabBar`), but returned **every** view bound to
+the object — including form-family ones. With the backend now exposing each
+view as an independent **ViewItem** carrying a `viewKind` discriminant
+(ADR-0017, "Object has-many View"), a form view such as `crm_activity.default`
+(expanded from `formViews.default`) leaked in as a spurious switcher tab and,
+when opened, fell back to the default grid.
+
+`listViews()` now filters out `viewKind` `form`/`detail` items so only
+list-family views reach the switcher. Bare view specs without a `viewKind`
+(legacy artifacts and user-saved views) are still treated as list views.

--- a/.changeset/runtime-viewkind-form-family.md
+++ b/.changeset/runtime-viewkind-form-family.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/app-shell': patch
+---
+
+fix(metadata): keep form-family views out of the runtime list-view switcher
+
+The backend now exposes each view as an independent **ViewItem** (ADR-0017,
+"Object has-many View"): `{ name: '<object>.<key>', object, viewKind:
+'list' | 'form', config }`. The Studio preview was already taught this shape,
+but the runtime console path was not — `MetadataProvider.mergeViewsIntoObjects`
+only understood the legacy aggregated container (`{ list, form, listViews,
+formViews }`) and ignored `viewKind` entirely. As a result a form-family view
+(e.g. `crm_activity.default`, expanded from `formViews.default`) was neither
+recognized nor excluded: navigating to its `/view/<name>` URL silently fell
+back to the default grid list instead of being treated as a record form.
+
+`mergeViewsIntoObjects` now recognizes the ViewItem shape and routes by
+`viewKind` — `'list'` → `objectDef.listViews`, `'form'` → `objectDef.formViews`
+— so FORM-family views never enter the list-view switcher (which reads only
+`listViews`). Each item's `config` body is flattened to the renderer shape so
+`type`/`columns`/`calendar`/… survive, the canonical `<object>.<key>` name is
+used as the view id (so `/view/<name>` resolves), and the legacy container is
+skipped for any object that already has expanded ViewItems (no double-listing).
+Objects served only as a legacy container are unaffected.

--- a/packages/app-shell/src/providers/MetadataProvider.merge.test.ts
+++ b/packages/app-shell/src/providers/MetadataProvider.merge.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { mergeViewsIntoObjects } from './MetadataProvider';
+
+/**
+ * `mergeViewsIntoObjects` folds the `view` metadata type into object
+ * definitions. The backend returns BOTH expanded first-class ViewItems
+ * (`{ name: '<obj>.<key>', object, viewKind, config }`, ADR-0017) AND the
+ * legacy aggregated container — these tests pin the routing so FORM-family
+ * views stay out of the list-view switcher (`objectDef.listViews`).
+ */
+describe('mergeViewsIntoObjects', () => {
+  const objects = [{ name: 'crm_activity', fields: {} }];
+
+  // The crm_activity view set, as the framework expands it (examples/app-crm).
+  const listAll = {
+    name: 'crm_activity.all',
+    object: 'crm_activity',
+    viewKind: 'list',
+    isDefault: true,
+    label: 'All Activities',
+    config: { type: 'grid', data: { object: 'crm_activity' }, columns: [{ field: 'subject' }] },
+  };
+  const listCalendar = {
+    name: 'crm_activity.calendar',
+    object: 'crm_activity',
+    viewKind: 'list',
+    label: 'Activity Calendar',
+    config: { type: 'calendar', data: { object: 'crm_activity' }, calendar: { startDateField: 'due_date' } },
+  };
+  const formDefault = {
+    name: 'crm_activity.default',
+    object: 'crm_activity',
+    viewKind: 'form',
+    label: 'Activity',
+    config: { type: 'simple', sections: [{ label: 'Details', fields: [{ field: 'subject' }] }] },
+  };
+
+  it('routes form-family ViewItems into formViews, not listViews', () => {
+    const [obj] = mergeViewsIntoObjects(objects, [listAll, listCalendar, formDefault]);
+    // List-family views populate the switcher…
+    expect(Object.keys(obj.listViews).sort()).toEqual(['crm_activity.all', 'crm_activity.calendar']);
+    // …and the form view is NOT among them (the original bug).
+    expect(obj.listViews['crm_activity.default']).toBeUndefined();
+    // Form view is available separately for the record-form renderer.
+    expect(obj.formViews['crm_activity.default']).toBeTruthy();
+  });
+
+  it('flattens `config` to the renderer shape and preserves type/label/isDefault', () => {
+    const [obj] = mergeViewsIntoObjects(objects, [listAll, listCalendar, formDefault]);
+    const calendar = obj.listViews['crm_activity.calendar'];
+    expect(calendar.type).toBe('calendar'); // type comes from config, not defaulted to grid
+    expect(calendar.calendar.startDateField).toBe('due_date');
+    expect(calendar.label).toBe('Activity Calendar');
+    // The default list becomes the promoted primary, with a `name` that matches
+    // its listViews key so ObjectView's primary-promotion dedups instead of
+    // appending a duplicate tab.
+    expect(obj.list.name).toBe('crm_activity.all');
+    expect(obj.listViews['crm_activity.all'].isDefault).toBe(true);
+  });
+
+  it('skips the legacy aggregated container when expanded ViewItems exist', () => {
+    const container = {
+      name: 'crm_activity',
+      list: { type: 'grid', columns: [{ field: 'subject' }] },
+      listViews: { all: { type: 'grid' } },
+      formViews: { default: { type: 'simple' } },
+    };
+    const [obj] = mergeViewsIntoObjects(objects, [listAll, listCalendar, formDefault, container]);
+    // Only the canonical `<obj>.<key>` ids — the container's short `all`/`list`
+    // keys must NOT also appear (no double-listing).
+    expect(Object.keys(obj.listViews).sort()).toEqual(['crm_activity.all', 'crm_activity.calendar']);
+  });
+
+  it('still consumes the legacy container for objects without ViewItems', () => {
+    const container = {
+      name: 'crm_activity',
+      list: { name: 'list', type: 'grid' },
+      listViews: { all: { type: 'grid' } },
+      formViews: { default: { type: 'simple' } },
+    };
+    const [obj] = mergeViewsIntoObjects(objects, [container]);
+    expect(Object.keys(obj.listViews).sort()).toEqual(['all', 'list']);
+    expect(obj.formViews.default).toBeTruthy();
+    expect(obj.formViews.list).toBeUndefined();
+  });
+});

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -104,13 +104,27 @@ function isNamedItem(item: unknown): item is { name: string } {
 }
 
 /**
- * Merge `view` metadata (the @objectstack/spec View container, keyed by
- * target object name) into object definitions so that `objectDef.listViews`
+ * Merge `view` metadata into object definitions so that `objectDef.listViews`
  * is populated for the renderer (`@object-ui/plugin-view`) which expects it.
  *
- * Each View has shape `{ list?, form?, listViews?, formViews? }`. We collapse:
- *   - `view.list`      → `listViews[view.list.name || 'default']`
- *   - `view.listViews` → spread into `listViews`
+ * Two view shapes coexist in the `view` metadata type (the backend returns
+ * both for back-compat — see framework `objectql/engine.ts` registration):
+ *
+ *  1. Independent **ViewItem** (ADR-0017, "Object has-many View") — the
+ *     canonical first-class shape, one entry per named view:
+ *       { name: '<object>.<key>', object, viewKind: 'list' | 'form',
+ *         label, isDefault?, config: { type, data, columns, … } }
+ *     `viewKind` is the family discriminant and the view body lives under
+ *     `config`. We route `viewKind: 'list'` items into `listViews` and
+ *     `viewKind: 'form'` items into `formViews` — so FORM-family views never
+ *     surface in the list-view switcher (which only reads `listViews`).
+ *
+ *  2. Legacy aggregated **container** `{ list?, form?, listViews?, formViews? }`
+ *     keyed by the bare object name. Kept for adapters/fixtures that don't
+ *     expand into ViewItems. When an object already has expanded ViewItems the
+ *     container is skipped, since it restates the same views (and keying both
+ *     would list every view twice — once under its short key, once under its
+ *     canonical `<object>.<key>` name).
  *
  * Existing `obj.listViews` / `obj.list_views` win to preserve overrides.
  */
@@ -121,12 +135,47 @@ interface ViewBucket {
   formViews: Record<string, any>;
 }
 
-function mergeViewsIntoObjects(objects: any[], views: any[]): any[] {
+/** A first-class ViewItem carries a `viewKind` discriminant + `object` binding. */
+function isViewItem(view: any): boolean {
+  return !!view && typeof view === 'object' && !!view.viewKind && !!view.object;
+}
+
+export function mergeViewsIntoObjects(objects: any[], views: any[]): any[] {
   if (!objects.length || !views.length) return objects;
   const byObject: Record<string, ViewBucket> = {};
+  // Objects that received expanded ViewItems — their legacy aggregated
+  // container (also present in the `view` list) is superseded and skipped.
+  const hasViewItems = new Set<string>();
   for (const view of views) {
+    if (isViewItem(view)) hasViewItems.add(view.object);
+  }
+  for (const view of views) {
+    // ── New protocol: independent ViewItem ({ name, object, viewKind, config }) ──
+    if (isViewItem(view)) {
+      const bucket = (byObject[view.object] ||= { listViews: {}, formViews: {} });
+      // Canonical `<object>.<key>` name doubles as the view id, so `/view/<name>`
+      // URLs resolve directly against the switcher tab ids.
+      const key = view.name || `${view.object}.${view.viewKind}`;
+      const body = view.config && typeof view.config === 'object' ? view.config : {};
+      // Flatten `config` to the legacy NamedListView/FormView shape the
+      // renderer consumes (type/data/columns/sections at top level); carry the
+      // item-level label/isDefault and stamp `name` so primary-view promotion
+      // (which matches on `list.name`) finds this entry by its listViews key.
+      const entry = { ...body, name: key, label: view.label ?? (body as any).label, isDefault: !!view.isDefault };
+      if (view.viewKind === 'form') {
+        bucket.formViews[key] = entry;
+        if (view.isDefault || !bucket.form) bucket.form = entry;
+      } else {
+        bucket.listViews[key] = entry;
+        if (view.isDefault) bucket.primary = entry;
+      }
+      continue;
+    }
+    // ── Legacy aggregated container ({ list, form, listViews, formViews }) ──
     const objName = view?.name || view?.list?.data?.object || view?.form?.data?.object;
     if (!objName) continue;
+    // Expanded ViewItems supersede the bare container for this object.
+    if (hasViewItems.has(objName)) continue;
     const bucket = (byObject[objName] ||= { listViews: {}, formViews: {} });
     if (view.list) {
       // Preserve the primary list view as `obj.list` per @objectstack/spec

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1432,12 +1432,22 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       const items: any[] = Array.isArray(result?.items)
         ? result.items
         : Array.isArray(result) ? result : [];
+      // This feeds the list-view switcher (ViewTabBar), so it must return
+      // LIST-family views only. The backend now exposes each view as an
+      // independent ViewItem carrying a `viewKind` discriminant (ADR-0017);
+      // form-family views (`form`/`detail`) are record forms, not list tabs,
+      // and must be excluded — otherwise e.g. `crm_activity.default` (a form)
+      // leaks in as a spurious switcher tab. Bare specs without `viewKind`
+      // (legacy artifacts / saved views) are kept as list views.
+      const FORM_FAMILY = new Set(['form', 'detail']);
       return items.filter((v: any) => {
         if (!v) return false;
         // Handle both bare view spec and `{list: {...}}` artifact wrapper
         const spec = v.list ?? v;
         const obj = spec?.data?.object ?? spec?.object ?? spec?.objectName;
-        return obj === objectName;
+        if (obj !== objectName) return false;
+        const viewKind = v.viewKind ?? spec?.viewKind;
+        return !(viewKind && FORM_FAMILY.has(viewKind));
       }).map((v: any) => v.list ?? v);
     } catch (err) {
       console.warn('[OBJECTSTACKDataSource] listViews failed:', err);

--- a/packages/data-objectstack/src/listViews.test.ts
+++ b/packages/data-objectstack/src/listViews.test.ts
@@ -1,0 +1,78 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackAdapter } from './index';
+
+/**
+ * `listViews(object)` feeds the list-view switcher (ObjectView → ViewTabBar),
+ * so it must return LIST-family views only. The backend exposes each view as
+ * an independent ViewItem carrying a `viewKind` discriminant (ADR-0017); a
+ * form-family view (e.g. `crm_activity.default`) must NOT leak in as a tab.
+ */
+function makeDS(items: any[]) {
+  const ds: any = new ObjectStackAdapter({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () =>
+      new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })),
+  });
+  ds.connected = true;
+  ds.connectionState = 'connected';
+  ds.client = { meta: { getItems: vi.fn(async () => ({ items })) } };
+  return ds;
+}
+
+describe('ObjectStackDataSource.listViews', () => {
+  // The crm_activity view set as the framework expands it.
+  const listAll = {
+    name: 'crm_activity.all', object: 'crm_activity', viewKind: 'list', isDefault: true,
+    label: 'All Activities', config: { type: 'grid', data: { object: 'crm_activity' } },
+  };
+  const listCalendar = {
+    name: 'crm_activity.calendar', object: 'crm_activity', viewKind: 'list',
+    label: 'Activity Calendar', config: { type: 'calendar', data: { object: 'crm_activity' } },
+  };
+  const formDefault = {
+    name: 'crm_activity.default', object: 'crm_activity', viewKind: 'form',
+    label: 'Activity', config: { type: 'simple' },
+  };
+
+  it('excludes form-family ViewItems from the list-view switcher', async () => {
+    const ds = makeDS([listAll, listCalendar, formDefault]);
+    const views = await ds.listViews('crm_activity');
+    const names = views.map((v: any) => v.name).sort();
+    expect(names).toEqual(['crm_activity.all', 'crm_activity.calendar']);
+    // The form view is the original leak — it must be gone.
+    expect(views.find((v: any) => v.name === 'crm_activity.default')).toBeUndefined();
+  });
+
+  it('excludes detail-family views too', async () => {
+    const detail = { name: 'crm_activity.detail', object: 'crm_activity', viewKind: 'detail', config: {} };
+    const ds = makeDS([listAll, detail]);
+    const views = await ds.listViews('crm_activity');
+    expect(views.map((v: any) => v.name)).toEqual(['crm_activity.all']);
+  });
+
+  it('filters by object binding', async () => {
+    const otherList = { name: 'crm_lead.all', object: 'crm_lead', viewKind: 'list', config: {} };
+    const ds = makeDS([listAll, otherList]);
+    const views = await ds.listViews('crm_activity');
+    expect(views.map((v: any) => v.name)).toEqual(['crm_activity.all']);
+  });
+
+  it('keeps legacy bare specs without a viewKind (saved/list views)', async () => {
+    const legacy = { name: 'saved_grid', object: 'crm_activity', type: 'grid' };
+    const wrapped = { list: { name: 'wrapped_grid', object: 'crm_activity', type: 'grid' } };
+    const ds = makeDS([legacy, wrapped]);
+    const views = await ds.listViews('crm_activity');
+    expect(views.map((v: any) => v.name).sort()).toEqual(['saved_grid', 'wrapped_grid']);
+  });
+});


### PR DESCRIPTION
## Problem

Navigating to `crm_activity` showed a third tab in the list-view switcher: **`crm_activity.default`** — which is actually a **form** view (`viewKind: 'form'`, expanded from `formViews.default`), not a list view. It should never appear in the list switcher, and opening its URL silently fell back to the grid.

The backend now exposes each view as an independent **ViewItem** carrying a `viewKind` discriminant (ADR-0017, "Object has-many View"). The runtime console path never read `viewKind`, so form-family views were not categorized:

```
crm_activity.all       viewKind=list  config.type=grid      isDefault=true
crm_activity.calendar  viewKind=list  config.type=calendar
crm_activity.default   viewKind=form  config.type=simple    ← leaked into the switcher
```

## Fix

Two runtime paths ignored `viewKind`; both are now `viewKind`-aware:

1. **`MetadataProvider.mergeViewsIntoObjects`** — recognizes the first-class ViewItem shape and routes by `viewKind` (`list` → `listViews`, `form`/`detail` → `formViews`), flattens `config` to the renderer shape, and skips the legacy aggregated container for objects that already have expanded ViewItems.
2. **`OBJECTSTACKDataSource.listViews()`** — this is what actually feeds the switcher (`ObjectView` → `ViewTabBar`) and returned *every* view bound to the object. It now filters out `viewKind` `form`/`detail`. This was the real leak: the form tab survived path #1 because `listViews()` re-added it from the overlay endpoint. Legacy bare specs without a `viewKind` are still kept as list views.

## Verification

Ran the framework backend + objectui console locally against the new view protocol, logged in, and opened `/apps/crm_app/crm_activity`:

- **Before:** tabs were `All Activities`, `Activity Calendar`, **`crm_activity.default`**
- **After:** tabs are `All Activities`, `Activity Calendar` only — the form tab is gone, list still renders all records.

## Tests

- `@object-ui/data-objectstack`: +4 tests (`listViews.test.ts`), 144 pass, type-check clean.
- `@object-ui/app-shell`: `MetadataProvider.merge.test.ts`, 131 pass.
- Changesets added for both packages.

## Follow-up (out of scope)

Navigating directly to `/view/crm_activity.default` now falls back to the grid (it's excluded from the switcher). Rendering form-kind view URLs as a record form is a separate enhancement.