### PR TITLE
feat(flow-designer): server-driven node config form + reference-field pickers

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
@@ -19,6 +19,7 @@ import { Label } from '@object-ui/components';
 import { FlowKeyValueField } from './FlowKeyValueField';
 import { FlowStringListField } from './FlowStringListField';
 import { FlowObjectListField } from './FlowObjectListField';
+import { FlowReferenceField, type FlowReferenceContext } from './FlowReferenceField';
 
 export interface FlowNodeConfigFieldProps {
   field: FlowConfigField;
@@ -26,11 +27,23 @@ export interface FlowNodeConfigFieldProps {
   onCommit: (value: unknown) => void;
   disabled?: boolean;
   locale?: string;
+  /** Draft + node context so `reference` fields can resolve their options. */
+  context?: FlowReferenceContext;
 }
 
-export function FlowNodeConfigField({ field, value, onCommit, disabled, locale }: FlowNodeConfigFieldProps) {
+export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, context }: FlowNodeConfigFieldProps) {
   const control = (() => {
     switch (field.kind) {
+      case 'reference':
+        return (
+          <FlowReferenceField
+            field={field}
+            value={value}
+            onCommit={(v) => onCommit(v)}
+            disabled={disabled}
+            context={context}
+          />
+        );
       case 'keyValue':
         return (
           <FlowKeyValueField

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
@@ -31,6 +31,8 @@ import {
   configKeyOf,
   FLOW_NODE_TYPE_OPTIONS,
 } from './flow-node-config';
+import { jsonSchemaToFlowFields } from './json-schema-to-fields';
+import { useActionConfigSchemas } from '../previews/useFlowNodePalette';
 import { FlowNodeConfigField } from './FlowNodeConfigField';
 
 interface FlowNode {
@@ -73,7 +75,17 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
   const index = nodes.findIndex((n) => n?.id === selection.id);
   const node = index >= 0 ? nodes[index] : null;
 
-  const fields = fieldsForNodeType(node?.type);
+  // Server-driven property form: when the running engine publishes a config
+  // JSON Schema for this node type (ADR-0018 §configSchema — e.g. the ADR-0019
+  // approval node), derive the form from it so the designer stays in lock-step
+  // with the backend. Falls back to the hardcoded field group when no schema is
+  // published (offline / plugin absent / older backend).
+  const configSchemas = useActionConfigSchemas();
+  const fields = React.useMemo(() => {
+    const schema = node?.type ? configSchemas[node.type] : undefined;
+    const serverFields = schema !== undefined ? jsonSchemaToFlowFields(schema) : null;
+    return serverFields ?? fieldsForNodeType(node?.type);
+  }, [configSchemas, node?.type]);
   const config = asConfig(node);
   const visibleFields = fields.filter((f) => isFieldVisible(f, node, fields));
   // Only fields stored under `config` "own" a config key; spec-structured
@@ -202,6 +214,7 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
           onCommit={(v) => setField(field.path, v)}
           disabled={readOnly}
           locale={locale}
+          context={{ draft, node }}
         />
       ))}
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
@@ -1,0 +1,185 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * FlowReferenceField — an *editable combobox* for flow-node config values that
+ * are really references (an object's field, an object/flow/role by name, or
+ * another node in this flow) rather than free-form strings.
+ *
+ * Why a combobox and not a strict dropdown: the designer must never trap the
+ * author. The control suggests known values (fetched per {@link ReferenceKind})
+ * but always accepts free text, so a field that doesn't exist yet, a role the
+ * current tenant hasn't populated, or an empty catalog all still let the author
+ * type a value. Implemented with a native `<datalist>` for exactly that
+ * suggest-but-allow-anything behaviour, zero extra dependencies, and built-in
+ * accessibility.
+ *
+ * Data sources are resolved lazily from the running backend (the same source of
+ * truth as the rest of the designer); `object-field` additionally needs to know
+ * *which* object — resolved from the reference's `objectSource` against the
+ * flow draft (trigger object) or the node's sibling config.
+ */
+
+import * as React from 'react';
+import { Input, Label } from '@object-ui/components';
+import type { FlowConfigField, FlowReferenceSpec } from './flow-node-config';
+import { useMetadataClient } from '../useMetadata';
+import { useObjectFields } from '../previews/useObjectFields';
+
+/** Context the reference picker needs to resolve dynamic option sources. */
+export interface FlowReferenceContext {
+  /** The whole flow draft — used for `$trigger` object + the node list. */
+  draft: Record<string, unknown>;
+  /** The node currently being edited — used to resolve sibling config keys. */
+  node: Record<string, unknown> | null;
+}
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+/** Read `node.config[key]` as a non-empty string, else undefined. */
+function configString(node: Record<string, unknown> | null | undefined, key: string): string | undefined {
+  const cfg = node?.config;
+  if (!cfg || typeof cfg !== 'object' || Array.isArray(cfg)) return undefined;
+  const v = (cfg as Record<string, unknown>)[key];
+  return typeof v === 'string' && v ? v : undefined;
+}
+
+/** Resolve the target object name for an `object-field` reference. */
+function resolveObjectName(ref: FlowReferenceSpec | undefined, ctx: FlowReferenceContext): string | undefined {
+  if (!ref || ref.kind !== 'object-field') return undefined;
+  const src = ref.objectSource || '$trigger';
+  if (src === '$trigger') {
+    const nodes = Array.isArray(ctx.draft.nodes) ? (ctx.draft.nodes as Array<Record<string, unknown>>) : [];
+    const start = nodes.find((n) => n?.type === 'start');
+    return configString(start, 'objectName');
+  }
+  // A sibling config key on the same node (CRUD nodes carry their own objectName).
+  return configString(ctx.node, src);
+}
+
+/**
+ * Fetch a metadata type's items as combobox options. `type === undefined`
+ * disables the fetch (returns empty), so the hook can be called
+ * unconditionally regardless of the reference kind.
+ */
+function useMetadataListOptions(type: string | undefined): { options: Option[]; loading: boolean } {
+  const client = useMetadataClient();
+  const [state, setState] = React.useState<{ options: Option[]; loading: boolean }>({
+    options: [],
+    loading: !!type,
+  });
+  React.useEffect(() => {
+    if (!type) {
+      setState({ options: [], loading: false });
+      return;
+    }
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true }));
+    client
+      .list<{ name?: string; label?: string }>(type)
+      .then((rows) => {
+        if (cancelled) return;
+        const options = (Array.isArray(rows) ? rows : [])
+          .filter((r) => r && typeof r.name === 'string' && r.name)
+          .map((r) => ({
+            value: String(r.name),
+            label: typeof r.label === 'string' && r.label && r.label !== r.name ? `${r.label} (${r.name})` : String(r.name),
+          }));
+        setState({ options, loading: false });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ options: [], loading: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, type]);
+  return state;
+}
+
+export interface FlowReferenceFieldProps {
+  field: FlowConfigField;
+  value: unknown;
+  onCommit: (value: unknown) => void;
+  disabled?: boolean;
+  context?: FlowReferenceContext;
+}
+
+export function FlowReferenceField({ field, value, onCommit, disabled, context }: FlowReferenceFieldProps) {
+  const listId = React.useId();
+  const ref = field.ref;
+  const ctx: FlowReferenceContext = context ?? { draft: {}, node: null };
+  const kind = ref?.kind;
+
+  // object-field: resolve the target object, then its field catalog.
+  const objectName = resolveObjectName(ref, ctx);
+  const { fields: objectFields } = useObjectFields(kind === 'object-field' ? objectName : undefined);
+
+  // object / flow / role: list the metadata type.
+  const listType = kind === 'object' ? 'object' : kind === 'flow' ? 'flow' : kind === 'role' ? 'role' : undefined;
+  const { options: listOptions } = useMetadataListOptions(listType);
+
+  const options = React.useMemo<Option[]>(() => {
+    switch (kind) {
+      case 'object-field':
+        return objectFields.map((f) => ({
+          value: f.name,
+          label: f.label && f.label !== f.name ? `${f.label} (${f.name})` : f.name,
+        }));
+      case 'object':
+      case 'flow':
+      case 'role':
+        return listOptions;
+      case 'node': {
+        const nodes = Array.isArray(ctx.draft.nodes) ? (ctx.draft.nodes as Array<Record<string, unknown>>) : [];
+        const currentId = typeof ctx.node?.id === 'string' ? ctx.node.id : undefined;
+        return nodes
+          .filter((n) => typeof n?.id === 'string' && n.id && n.id !== currentId)
+          .map((n) => {
+            const id = String(n.id);
+            const lbl = typeof n.label === 'string' && n.label ? `${n.label} (${id})` : id;
+            return { value: id, label: lbl };
+          });
+      }
+      default:
+        return [];
+    }
+  }, [kind, objectFields, listOptions, ctx.draft, ctx.node]);
+
+  // For an object-field whose object can't be resolved, tell the author why the
+  // suggestions are empty — but still let them type a value.
+  const unresolvedObject = kind === 'object-field' && !objectName;
+
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs text-muted-foreground">{field.label}</Label>
+      <Input
+        list={options.length ? listId : undefined}
+        value={value != null ? String(value) : ''}
+        onChange={(e) => onCommit(e.target.value)}
+        placeholder={field.placeholder}
+        disabled={disabled}
+        className="h-8 text-sm"
+      />
+      {options.length > 0 && (
+        <datalist id={listId}>
+          {options.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </datalist>
+      )}
+      {kind === 'object-field' && objectName && (
+        <p className="text-[11px] leading-snug text-muted-foreground">Fields of {objectName}.</p>
+      )}
+      {unresolvedObject && (
+        <p className="text-[11px] leading-snug text-muted-foreground">
+          Set the flow’s trigger object (on the Start node) to list fields.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -33,7 +33,35 @@ export type FlowConfigFieldKind =
   | 'textarea'
   | 'keyValue'
   | 'stringList'
-  | 'objectList';
+  | 'objectList'
+  | 'reference';
+
+/**
+ * What a `reference` field points at — the picker's data source. The control
+ * is always an *editable* combobox (suggestions + free text), so an unknown /
+ * not-yet-created value is never rejected and an empty catalog degrades to a
+ * plain text box.
+ *
+ *   • `object`        → a business object, by API name (`client.list('object')`)
+ *   • `object-field`  → a field of some object; the object is resolved via
+ *                       {@link FlowReferenceSpec.objectSource}
+ *   • `flow`          → a flow, by name (`client.list('flow')`)
+ *   • `role`          → a security role (`client.list('role')`)
+ *   • `node`          → another node in *this* flow, by id (read from the draft)
+ */
+export type ReferenceKind = 'object' | 'object-field' | 'flow' | 'role' | 'node';
+
+export interface FlowReferenceSpec {
+  kind: ReferenceKind;
+  /**
+   * For `object-field` only: where to find the target object's name.
+   *   • `'$trigger'` (default) → the flow trigger object, read from the start
+   *     node's `config.objectName` (the record an approval / record node acts on).
+   *   • any other string       → a sibling config key on the *same* node holding
+   *     the object name (e.g. CRUD nodes resolve from their own `objectName`).
+   */
+  objectSource?: string;
+}
 
 /** Column descriptor for an `objectList` repeater row. */
 export interface FlowConfigColumn {
@@ -76,6 +104,8 @@ export interface FlowConfigField {
   showWhen?: { field: string; equals: string[] };
   /** Column schema for `objectList` fields (array-of-objects repeater). */
   columns?: FlowConfigColumn[];
+  /** Reference target for `reference` fields — drives the combobox data source. */
+  ref?: FlowReferenceSpec;
 }
 
 /** Convenience: a `['config', key]`-rooted field (the common case). */
@@ -129,7 +159,8 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
         { value: 'event', label: 'Platform event' },
       ],
     }),
-    cfg('objectName', 'Object', 'text', {
+    cfg('objectName', 'Object', 'reference', {
+      ref: { kind: 'object' },
       placeholder: 'crm_lead',
       help: 'Target object for record / scheduled-scan triggers.',
     }),
@@ -183,21 +214,21 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
     cfg('iteratorVariable', 'Item variable', 'text', { placeholder: 'currentItem' }),
   ],
   create_record: [
-    cfg('objectName', 'Object', 'text', { placeholder: 'contract' }),
+    cfg('objectName', 'Object', 'reference', { ref: { kind: 'object' }, placeholder: 'contract' }),
     cfg('fields', 'Field values', 'keyValue', { help: 'Field values to write on the new record.' }),
     cfg('outputVariable', 'Output variable', 'text', { placeholder: 'newRecord' }),
   ],
   update_record: [
-    cfg('objectName', 'Object', 'text', { placeholder: 'contract' }),
+    cfg('objectName', 'Object', 'reference', { ref: { kind: 'object' }, placeholder: 'contract' }),
     cfg('filter', 'Filter', 'keyValue', { help: 'Field/value pairs identifying the record(s) to update (e.g. id → {recordId}).' }),
     cfg('fields', 'Field values', 'keyValue', { help: 'Field values to write.' }),
   ],
   delete_record: [
-    cfg('objectName', 'Object', 'text', { placeholder: 'contract' }),
+    cfg('objectName', 'Object', 'reference', { ref: { kind: 'object' }, placeholder: 'contract' }),
     cfg('filter', 'Filter', 'keyValue', { help: 'Field/value pairs identifying the record(s) to delete.' }),
   ],
   get_record: [
-    cfg('objectName', 'Object', 'text', { placeholder: 'contract' }),
+    cfg('objectName', 'Object', 'reference', { ref: { kind: 'object' }, placeholder: 'contract' }),
     cfg('filter', 'Filter', 'keyValue', { help: 'Field/value pairs to match (e.g. status → active). Operator values like {"$ne": null} are preserved.' }),
     cfg('limit', 'Limit', 'number', { placeholder: '100' }),
     cfg('outputVariable', 'Output variable', 'text', { placeholder: 'records' }),
@@ -299,7 +330,8 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
     cfg('lockRecord', 'Lock record', 'boolean', {
       help: 'Lock the triggering record from edits while this node is pending.',
     }),
-    cfg('approvalStatusField', 'Status field', 'text', {
+    cfg('approvalStatusField', 'Status field', 'reference', {
+      ref: { kind: 'object-field', objectSource: '$trigger' },
       placeholder: 'approval_status',
       help: 'Business-object field to mirror request status onto (pending/approved/rejected). Should be readonly.',
     }),
@@ -350,7 +382,7 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
     }),
   ],
   subflow: [
-    cfg('flowName', 'Flow', 'text', { placeholder: 'escalation_flow' }),
+    cfg('flowName', 'Flow', 'reference', { ref: { kind: 'flow' }, placeholder: 'escalation_flow' }),
     cfg('input', 'Input mapping', 'keyValue', { help: 'Values passed to the subflow\u2019s input variables.' }),
     cfg('outputVariable', 'Output variable', 'text', { placeholder: 'subResult' }),
     { id: 'timeoutMs', path: ['timeoutMs'], label: 'Timeout (ms)', kind: 'number', placeholder: '60000' },
@@ -364,7 +396,7 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
   parallel_gateway: [],
   join_gateway: [],
   boundary_event: [
-    at('boundaryConfig', 'attachedToNodeId', 'Attached to', 'text', { placeholder: 'host node id', help: 'Host node this boundary event monitors.' }),
+    at('boundaryConfig', 'attachedToNodeId', 'Attached to', 'reference', { ref: { kind: 'node' }, placeholder: 'host node id', help: 'Host node this boundary event monitors.' }),
     at('boundaryConfig', 'eventType', 'Event type', 'select', {
       options: [
         { value: 'error', label: 'Error' },
@@ -397,7 +429,7 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
    */
   legacy_action: [
     cfg('action', 'Action', 'text', { placeholder: 'sendEmail · createTask · update · query' }),
-    cfg('objectName', 'Object', 'text', { placeholder: 'contract' }),
+    cfg('objectName', 'Object', 'reference', { ref: { kind: 'object' }, placeholder: 'contract' }),
     cfg('recordId', 'Record', 'expression', { placeholder: 'record.id' }),
     cfg('params', 'Parameters', 'keyValue', { help: 'Action inputs. Values auto-typed: 3 \u2192 number, true \u2192 boolean.' }),
     cfg('fields', 'Field values', 'keyValue' ),

--- a/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.test.ts
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { jsonSchemaToFlowFields, humanizeKey } from './json-schema-to-fields';
+
+/**
+ * The exact JSON Schema the engine publishes for the Approval node config
+ * (`z.toJSONSchema(ApprovalNodeConfigSchema, { io: 'input' })`), captured from
+ * `GET /api/v1/automation/actions`. Drives the server-driven property form.
+ */
+const APPROVAL_CONFIG_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  properties: {
+    approvers: {
+      minItems: 1,
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', enum: ['user', 'role', 'team', 'department', 'manager', 'field', 'queue'] },
+          value: { description: 'User id / role / team / department / field / queue — per `type`', type: 'string' },
+        },
+        required: ['type'],
+      },
+      description: 'Allowed approvers for this node',
+    },
+    behavior: {
+      default: 'first_response',
+      description: 'How to combine multiple approvers',
+      type: 'string',
+      enum: ['first_response', 'unanimous'],
+    },
+    lockRecord: { default: true, description: 'Lock the record from editing while pending', type: 'boolean' },
+    approvalStatusField: {
+      description: 'Business-object field to mirror request status onto',
+      type: 'string',
+      xRef: { kind: 'object-field', objectSource: '$trigger' },
+    },
+    escalation: {
+      description: 'Per-node SLA escalation',
+      type: 'object',
+      properties: {
+        enabled: { default: false, description: 'Enable SLA-based escalation for this node', type: 'boolean' },
+        timeoutHours: { type: 'number', minimum: 1, description: 'Hours before escalation triggers' },
+        action: { default: 'notify', description: 'Action on escalation timeout', type: 'string', enum: ['reassign', 'auto_approve', 'auto_reject', 'notify'] },
+        escalateTo: { description: 'User id, role, or manager level to escalate to', type: 'string' },
+        notifySubmitter: { default: true, description: 'Notify the original submitter on escalation', type: 'boolean' },
+      },
+      required: ['timeoutHours'],
+    },
+  },
+  required: ['approvers'],
+};
+
+describe('humanizeKey', () => {
+  it('title-cases camelCase and snake_case', () => {
+    expect(humanizeKey('approvalStatusField')).toBe('Approval Status Field');
+    expect(humanizeKey('first_response')).toBe('First Response');
+    expect(humanizeKey('lockRecord')).toBe('Lock Record');
+  });
+});
+
+describe('jsonSchemaToFlowFields', () => {
+  it('returns null for non-object schemas (caller falls back to hardcoded fields)', () => {
+    expect(jsonSchemaToFlowFields(undefined)).toBeNull();
+    expect(jsonSchemaToFlowFields({ type: 'string' })).toBeNull();
+    expect(jsonSchemaToFlowFields({ type: 'object' })).toBeNull(); // no properties
+  });
+
+  it('preserves property order from the schema', () => {
+    const fields = jsonSchemaToFlowFields(APPROVAL_CONFIG_SCHEMA)!;
+    expect(fields.map((f) => f.id)).toEqual([
+      'approvers',
+      'behavior',
+      'lockRecord',
+      'approvalStatusField',
+      // escalation flattens into config.escalation.* sub-fields
+      'escalation.enabled',
+      'escalation.timeoutHours',
+      'escalation.action',
+      'escalation.escalateTo',
+      'escalation.notifySubmitter',
+    ]);
+  });
+
+  it('maps an array-of-object into an objectList with columns', () => {
+    const fields = jsonSchemaToFlowFields(APPROVAL_CONFIG_SCHEMA)!;
+    const approvers = fields.find((f) => f.id === 'approvers')!;
+    expect(approvers.kind).toBe('objectList');
+    expect(approvers.path).toEqual(['config', 'approvers']);
+    expect(approvers.label).toBe('Approvers');
+    expect(approvers.help).toBe('Allowed approvers for this node');
+    const colKeys = approvers.columns!.map((c) => c.key);
+    expect(colKeys).toEqual(['type', 'value']);
+    const typeCol = approvers.columns!.find((c) => c.key === 'type')!;
+    expect(typeCol.kind).toBe('select');
+    expect(typeCol.options!.map((o) => o.value)).toEqual(['user', 'role', 'team', 'department', 'manager', 'field', 'queue']);
+    const valueCol = approvers.columns!.find((c) => c.key === 'value')!;
+    expect(valueCol.kind).toBe('text');
+    expect(valueCol.placeholder).toBe('User id / role / team / department / field / queue — per `type`');
+  });
+
+  it('maps an enum string into a select with humanized option labels + default', () => {
+    const fields = jsonSchemaToFlowFields(APPROVAL_CONFIG_SCHEMA)!;
+    const behavior = fields.find((f) => f.id === 'behavior')!;
+    expect(behavior.kind).toBe('select');
+    expect(behavior.defaultValue).toBe('first_response');
+    expect(behavior.options).toEqual([
+      { value: 'first_response', label: 'First Response' },
+      { value: 'unanimous', label: 'Unanimous' },
+    ]);
+  });
+
+  it('maps boolean scalars', () => {
+    const fields = jsonSchemaToFlowFields(APPROVAL_CONFIG_SCHEMA)!;
+    const lock = fields.find((f) => f.id === 'lockRecord')!;
+    expect(lock.kind).toBe('boolean');
+    expect(lock.defaultValue).toBe('true');
+  });
+
+  it('maps an xRef string into a reference field (picker, not free text)', () => {
+    const fields = jsonSchemaToFlowFields(APPROVAL_CONFIG_SCHEMA)!;
+    const statusField = fields.find((f) => f.id === 'approvalStatusField')!;
+    expect(statusField.kind).toBe('reference');
+    expect(statusField.path).toEqual(['config', 'approvalStatusField']);
+    expect(statusField.ref).toEqual({ kind: 'object-field', objectSource: '$trigger' });
+    // Description still flows through as help.
+    expect(statusField.help).toBe('Business-object field to mirror request status onto');
+  });
+
+  it('falls back to plain text for a string with no xRef', () => {
+    const fields = jsonSchemaToFlowFields({
+      type: 'object',
+      properties: { note: { type: 'string', description: 'free text' } },
+    })!;
+    const note = fields.find((f) => f.id === 'note')!;
+    expect(note.kind).toBe('text');
+    expect(note.ref).toBeUndefined();
+  });
+
+  it('ignores an xRef with an unknown kind (treats as plain text)', () => {
+    const fields = jsonSchemaToFlowFields({
+      type: 'object',
+      properties: { weird: { type: 'string', xRef: { kind: 'bogus' } } },
+    })!;
+    const weird = fields.find((f) => f.id === 'weird')!;
+    expect(weird.kind).toBe('text');
+    expect(weird.ref).toBeUndefined();
+  });
+
+  it('flattens a nested object and gates siblings behind its enabled toggle', () => {
+    const fields = jsonSchemaToFlowFields(APPROVAL_CONFIG_SCHEMA)!;
+    const enabled = fields.find((f) => f.id === 'escalation.enabled')!;
+    expect(enabled.kind).toBe('boolean');
+    expect(enabled.path).toEqual(['config', 'escalation', 'enabled']);
+    // The gate adopts the parent group's label, not "Enabled".
+    expect(enabled.label).toBe('Escalation');
+    expect(enabled.showWhen).toBeUndefined();
+
+    const timeout = fields.find((f) => f.id === 'escalation.timeoutHours')!;
+    expect(timeout.kind).toBe('number');
+    expect(timeout.showWhen).toEqual({ field: 'escalation.enabled', equals: ['true'] });
+
+    const action = fields.find((f) => f.id === 'escalation.action')!;
+    expect(action.kind).toBe('select');
+    expect(action.defaultValue).toBe('notify');
+    expect(action.options!.map((o) => o.value)).toEqual(['reassign', 'auto_approve', 'auto_reject', 'notify']);
+    expect(action.showWhen).toEqual({ field: 'escalation.enabled', equals: ['true'] });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.ts
@@ -1,0 +1,243 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * json-schema-to-fields — adapt an engine-published config JSON Schema into the
+ * inspector's {@link FlowConfigField} model, so the flow designer renders a
+ * node's property form **from the server** rather than a hardcoded client form.
+ *
+ * The automation engine owns each node type's config contract: built-in node
+ * packs and plugins publish an `ActionDescriptor` whose `configSchema` is the
+ * JSON Schema compiled from the executor's Zod (ADR-0018 §configSchema). The
+ * approval plugin (ADR-0019) is the first to publish one. Driving the inspector
+ * from that schema keeps the property form in lock-step with what the running
+ * backend actually validates — when a plugin evolves its config, the designer
+ * updates with no client release.
+ *
+ * We map onto `FlowConfigField[]` (rather than rendering JSON Schema directly)
+ * so the existing, polished field widgets — select, boolean, the `objectList`
+ * repeater (e.g. approvers), the optional Advanced-JSON escape hatch — are
+ * reused unchanged. Anything the mapping can't express (deeply nested objects,
+ * unions) is simply left off the form and remains editable in the Advanced
+ * block, so authors are never locked out.
+ *
+ * Scope mirrors what `z.toJSONSchema` emits for real node configs:
+ *   • string                      → text  (enum → select)
+ *   • number / integer            → number
+ *   • boolean                     → boolean
+ *   • array of string             → stringList
+ *   • array of object             → objectList (columns from item props)
+ *   • object (one level)          → flattened sub-fields under config.<key>.*
+ *                                   (a nested `enabled: boolean` makes the
+ *                                    group's other fields reveal when enabled)
+ */
+
+import type { FlowConfigField, FlowConfigColumn, FlowConfigFieldKind, FlowReferenceSpec, ReferenceKind } from './flow-node-config';
+
+/** Loose JSON Schema node shape — we only read the keys we map. */
+interface JsonSchemaNode {
+  type?: string | string[];
+  enum?: unknown[];
+  const?: unknown;
+  default?: unknown;
+  description?: string;
+  title?: string;
+  format?: string;
+  properties?: Record<string, JsonSchemaNode>;
+  items?: JsonSchemaNode;
+  required?: string[];
+  /**
+   * Reference annotation carried from the executor's Zod `.meta({ xRef })`
+   * (ADR-0018). Marks a string as a typed reference (object field, object,
+   * flow, role, node) so the inspector renders a picker instead of free text.
+   */
+  xRef?: { kind?: string; objectSource?: string };
+}
+
+const REFERENCE_KINDS: ReadonlySet<string> = new Set<ReferenceKind>([
+  'object',
+  'object-field',
+  'flow',
+  'role',
+  'node',
+]);
+
+/** Read a valid `xRef` annotation off a schema node, or undefined. */
+function refOf(node: JsonSchemaNode): FlowReferenceSpec | undefined {
+  const x = node.xRef;
+  if (!x || typeof x !== 'object' || typeof x.kind !== 'string' || !REFERENCE_KINDS.has(x.kind)) return undefined;
+  return {
+    kind: x.kind as ReferenceKind,
+    ...(typeof x.objectSource === 'string' && x.objectSource ? { objectSource: x.objectSource } : {}),
+  };
+}
+
+/** "approvalStatusField" → "Approval Status Field"; "approve" → "Approve". */
+export function humanizeKey(key: string): string {
+  const spaced = key
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim();
+  if (!spaced) return key;
+  return spaced
+    .split(/\s+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function isObject(v: unknown): v is JsonSchemaNode {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** The JSON Schema `type`, normalized to a single string (first non-null of a union). */
+function schemaType(node: JsonSchemaNode): string | undefined {
+  if (Array.isArray(node.type)) return node.type.find((t) => t !== 'null');
+  if (typeof node.type === 'string') return node.type;
+  // Infer from shape when `type` is omitted (common with enum-only schemas).
+  if (Array.isArray(node.enum)) return 'string';
+  if (node.properties) return 'object';
+  if (node.items) return 'array';
+  return undefined;
+}
+
+/** Build `{ value, label }` options from a string enum. */
+function enumOptions(values: unknown[]): Array<{ value: string; label: string }> {
+  return values
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => ({ value: v, label: humanizeKey(v) }));
+}
+
+/** Default coerced to the string form the inspector's `defaultValue` expects. */
+function defaultString(node: JsonSchemaNode): string | undefined {
+  if (node.default === undefined || node.default === null) return undefined;
+  if (typeof node.default === 'boolean') return String(node.default);
+  if (typeof node.default === 'number') return String(node.default);
+  if (typeof node.default === 'string') return node.default;
+  return undefined;
+}
+
+/** Scalar (non-object, non-array) → field kind. */
+function scalarKind(node: JsonSchemaNode): FlowConfigFieldKind | undefined {
+  if (Array.isArray(node.enum)) return 'select';
+  const t = schemaType(node);
+  if (t === 'boolean') return 'boolean';
+  if (t === 'number' || t === 'integer') return 'number';
+  if (t === 'string') return node.format === 'multiline' ? 'textarea' : 'text';
+  return undefined;
+}
+
+/** Derive `objectList` columns from an item object's properties. */
+function columnsFor(item: JsonSchemaNode): FlowConfigColumn[] {
+  const props = item.properties ?? {};
+  const cols: FlowConfigColumn[] = [];
+  for (const [key, prop] of Object.entries(props)) {
+    if (!isObject(prop)) continue;
+    const t = schemaType(prop);
+    let kind: FlowConfigColumn['kind'];
+    let options: Array<{ value: string; label: string }> | undefined;
+    if (Array.isArray(prop.enum)) {
+      kind = 'select';
+      options = enumOptions(prop.enum);
+    } else if (t === 'boolean') {
+      kind = 'boolean';
+    } else {
+      kind = 'text';
+    }
+    cols.push({
+      key,
+      label: prop.title || humanizeKey(key),
+      kind,
+      ...(options ? { options } : {}),
+      // Columns have no help slot — surface the schema description as a hint.
+      ...(prop.description ? { placeholder: prop.description } : {}),
+    });
+  }
+  return cols;
+}
+
+/** Common field metadata derived from a schema node. */
+function meta(node: JsonSchemaNode, key: string): { label: string; help?: string; defaultValue?: string } {
+  return {
+    label: node.title || humanizeKey(key),
+    ...(node.description ? { help: node.description } : {}),
+    ...(defaultString(node) ? { defaultValue: defaultString(node) } : {}),
+  };
+}
+
+/**
+ * Convert a published config JSON Schema (an object schema) into the inspector's
+ * `FlowConfigField[]`. Property order is preserved. Returns `null` when the
+ * schema is not a usable object schema, so callers fall back to their hardcoded
+ * field group.
+ */
+export function jsonSchemaToFlowFields(schema: unknown): FlowConfigField[] | null {
+  if (!isObject(schema) || schemaType(schema) !== 'object' || !isObject(schema.properties)) {
+    return null;
+  }
+  const fields: FlowConfigField[] = [];
+
+  for (const [key, prop] of Object.entries(schema.properties)) {
+    if (!isObject(prop)) continue;
+    const t = schemaType(prop);
+
+    // ── arrays ────────────────────────────────────────────────────────────
+    if (t === 'array') {
+      const item = isObject(prop.items) ? prop.items : undefined;
+      const itemType = item ? schemaType(item) : undefined;
+      if (item && itemType === 'object' && isObject(item.properties)) {
+        fields.push({ id: key, path: ['config', key], kind: 'objectList', columns: columnsFor(item), ...meta(prop, key) });
+      } else if (itemType === 'string') {
+        fields.push({ id: key, path: ['config', key], kind: 'stringList', ...meta(prop, key) });
+      }
+      // arrays of anything else fall through to the Advanced block.
+      continue;
+    }
+
+    // ── nested object → flatten one level under config.<key>.* ──────────────
+    if (t === 'object' && isObject(prop.properties)) {
+      const subProps = Object.entries(prop.properties).filter(([, p]) => isObject(p));
+      // A boolean `enabled` toggle gates the rest of the group (mirrors the SLA
+      // escalation UX): the group's other fields reveal only when it is on.
+      const hasEnabled = subProps.some(([k, p]) => k === 'enabled' && schemaType(p as JsonSchemaNode) === 'boolean');
+      for (const [subKey, subProp] of subProps) {
+        const sp = subProp as JsonSchemaNode;
+        const subRef = refOf(sp);
+        const kind = subRef ? 'reference' : scalarKind(sp);
+        if (!kind) continue; // deeper nesting / unsupported → Advanced block
+        const id = `${key}.${subKey}`;
+        const isGate = hasEnabled && subKey === 'enabled';
+        const field: FlowConfigField = {
+          id,
+          path: ['config', key, subKey],
+          kind,
+          // The gate adopts the parent group's label; siblings keep their own.
+          ...(isGate ? { label: prop.title || humanizeKey(key), ...(prop.description ? { help: prop.description } : {}), ...(defaultString(sp) ? { defaultValue: defaultString(sp) } : {}) } : meta(sp, subKey)),
+          ...(subRef ? { ref: subRef } : {}),
+          ...(kind === 'select' && Array.isArray(sp.enum) ? { options: enumOptions(sp.enum) } : {}),
+          ...(hasEnabled && !isGate ? { showWhen: { field: `${key}.enabled`, equals: ['true'] } } : {}),
+        };
+        fields.push(field);
+      }
+      continue;
+    }
+
+    // ── scalars ─────────────────────────────────────────────────────────────
+    // A reference annotation (xRef) wins over the plain scalar mapping — the
+    // string is really a typed reference and gets a picker.
+    const ref = refOf(prop);
+    if (ref) {
+      fields.push({ id: key, path: ['config', key], kind: 'reference', ref, ...meta(prop, key) });
+      continue;
+    }
+    const kind = scalarKind(prop);
+    if (!kind) continue; // unrepresentable → Advanced block
+    fields.push({
+      id: key,
+      path: ['config', key],
+      kind,
+      ...meta(prop, key),
+      ...(kind === 'select' && Array.isArray(prop.enum) ? { options: enumOptions(prop.enum) } : {}),
+    });
+  }
+
+  return fields;
+}

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -41,6 +41,7 @@ import {
   type Point,
 } from './flow-canvas-layout';
 import { NodeCard, NodePalette, defaultNodeLabel, defaultNodeExtras } from './flow-canvas-parts';
+import { useFlowNodePalette } from './useFlowNodePalette';
 
 const MIN_ZOOM = 0.4;
 const MAX_ZOOM = 1.6;
@@ -96,6 +97,11 @@ export function FlowCanvas({
   const [zoom, setZoom] = React.useState(1);
   const [pan, setPan] = React.useState<Point>({ x: 0, y: 0 });
   const [paletteOpen, setPaletteOpen] = React.useState(false);
+  // Node types offered by the add-node palette, driven by the engine's
+  // published descriptors (`GET /api/v1/automation/actions`) merged with the
+  // hardcoded base — so the palette reflects what the backend actually supports
+  // (e.g. the `approval` node, third-party connector actions).
+  const paletteItems = useFlowNodePalette();
 
   // Transient drag position override (commit-on-drop) so rapid pointer moves
   // never spam onPatch and never diverge from the persisted draft.
@@ -334,6 +340,7 @@ export function FlowCanvas({
             {paletteOpen && (
               <NodePalette
                 locale={locale}
+                items={paletteItems}
                 onClose={() => setPaletteOpen(false)}
                 onPick={(type) => addNode(type, { from: selectedId ?? undefined })}
               />

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -369,17 +369,19 @@ export function NodeCard({
 
 export interface NodePaletteProps {
   locale?: string;
+  /** Node types to offer. Defaults to the hardcoded {@link NODE_PALETTE}. */
+  items?: PaletteItem[];
   onPick: (type: string) => void;
   onClose: () => void;
 }
 
 /** Compact popover listing the node types an author can add. */
-export function NodePalette({ onPick, onClose }: NodePaletteProps) {
+export function NodePalette({ items = NODE_PALETTE, onPick, onClose }: NodePaletteProps) {
   return (
     <>
       <div className="fixed inset-0 z-20" onClick={onClose} aria-hidden />
-      <div className="absolute right-0 top-full z-30 mt-1 w-56 overflow-hidden rounded-lg border bg-popover p-1 shadow-lg">
-        {NODE_PALETTE.map((item) => {
+      <div className="absolute right-0 top-full z-30 mt-1 max-h-[60vh] w-56 overflow-y-auto rounded-lg border bg-popover p-1 shadow-lg">
+        {items.map((item) => {
           const tone = nodeTone(item.type);
           return (
             <button

--- a/packages/app-shell/src/views/metadata-admin/previews/useFlowNodePalette.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/useFlowNodePalette.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { mergePalette } from './useFlowNodePalette';
+import { NODE_PALETTE } from './flow-canvas-parts';
+
+describe('mergePalette', () => {
+  it('returns the base palette unchanged when no descriptors are given', () => {
+    expect(mergePalette(NODE_PALETTE, [])).toEqual(NODE_PALETTE);
+  });
+
+  it('overlays the engine label/description onto a matching base entry, keeping its position', () => {
+    const base = [
+      { type: 'decision', label: 'Decision', hint: 'Branch on a condition' },
+      { type: 'approval', label: 'Approval', hint: 'Pause for a human decision' },
+    ];
+    const merged = mergePalette(base, [
+      { type: 'approval', name: 'Approval (engine)', description: 'Route a record for human approval' },
+    ]);
+    // Same length + order — approval is overlaid in place, not appended.
+    expect(merged.map((i) => i.type)).toEqual(['decision', 'approval']);
+    expect(merged[1]).toEqual({
+      type: 'approval',
+      label: 'Approval (engine)',
+      hint: 'Route a record for human approval',
+    });
+  });
+
+  it('appends engine-only node types after the base', () => {
+    const base = [{ type: 'decision', label: 'Decision' }];
+    const merged = mergePalette(base, [
+      { type: 'decision', name: 'Decision' },
+      { type: 'assignment', name: 'Assignment', description: 'Set flow variables' },
+    ]);
+    expect(merged.map((i) => i.type)).toEqual(['decision', 'assignment']);
+    expect(merged[1]).toEqual({ type: 'assignment', label: 'Assignment', hint: 'Set flow variables' });
+  });
+
+  it('skips deprecated descriptors (the base entry, if any, is preserved)', () => {
+    const base = [{ type: 'screen', label: 'Screen' }];
+    const merged = mergePalette(base, [
+      { type: 'old_node', name: 'Old', deprecated: true },
+      { type: 'screen', name: 'Screen', deprecated: true },
+    ]);
+    expect(merged.map((i) => i.type)).toEqual(['screen']);
+    expect(merged[0]).toEqual({ type: 'screen', label: 'Screen' });
+  });
+
+  it('skips non-flow descriptors but keeps flow + paradigm-less ones', () => {
+    const merged = mergePalette([], [
+      { type: 'flow_node', name: 'Flow node', paradigms: ['flow'] },
+      { type: 'action_only', name: 'Action only', paradigms: ['action'] },
+      { type: 'no_paradigm', name: 'No paradigm' },
+    ]);
+    expect(merged.map((i) => i.type)).toEqual(['flow_node', 'no_paradigm']);
+  });
+
+  it('falls back to the descriptor type when no name is provided', () => {
+    const merged = mergePalette([], [{ type: 'custom_node' }]);
+    expect(merged[0]).toEqual({ type: 'custom_node', label: 'custom_node', hint: undefined });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/useFlowNodePalette.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/useFlowNodePalette.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * useFlowNodePalette — server-driven node palette for the flow designer.
+ *
+ * The set of node types a flow can use is owned by the automation **engine**,
+ * not the client: built-in node packs and plugins (e.g. the ADR-0019
+ * `approval` node contributed by the approvals plugin, or third-party
+ * `connector_action` providers) publish an `ActionDescriptor` that the engine
+ * exposes at `GET /api/v1/automation/actions` — the same registry that backs
+ * server-side flow validation. Driving the palette from that endpoint keeps the
+ * designer in lock-step with what the running backend actually supports.
+ *
+ * The hardcoded {@link NODE_PALETTE} stays as the base: it supplies the
+ * structural / control nodes the engine does not publish as actions (subflow,
+ * wait, end, connector_action) and acts as an offline fallback so the designer
+ * still works when the endpoint is unreachable or the plugin is not installed.
+ * Server descriptors are overlaid on top — keeping the base ordering, adopting
+ * the engine's labels/descriptions, and appending any engine-only node types
+ * (and future plugin nodes) the base doesn't list.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { NODE_PALETTE, type PaletteItem } from './flow-canvas-parts';
+
+/** Minimal shape of an engine action descriptor we consume. */
+interface ActionDescriptorLite {
+  type: string;
+  name?: string;
+  description?: string;
+  paradigms?: string[];
+  deprecated?: boolean;
+  /**
+   * JSON Schema for the node's `config` (ADR-0018 §configSchema). Present only
+   * for actions whose executor publishes one (e.g. the ADR-0019 approval node).
+   * Drives the inspector's server-rendered property form.
+   */
+  configSchema?: unknown;
+}
+
+function apiBase(): string {
+  const url = (import.meta as { env?: { VITE_SERVER_URL?: string } }).env?.VITE_SERVER_URL || '';
+  return `${String(url).replace(/\/$/, '')}/api/v1`;
+}
+
+/**
+ * Merge engine descriptors onto the hardcoded base. Base order is canonical;
+ * a descriptor overlays its base entry's label/hint (so the engine is the
+ * source of truth for naming), and engine-only types are appended.
+ */
+export function mergePalette(base: PaletteItem[], descriptors: ActionDescriptorLite[]): PaletteItem[] {
+  const byType = new Map<string, PaletteItem>();
+  for (const item of base) byType.set(item.type, item);
+
+  for (const d of descriptors) {
+    if (!d?.type) continue;
+    if (d.deprecated) continue;
+    // The flow designer only offers flow-capable nodes. Descriptors without a
+    // paradigm list are treated as flow-capable (conservative default).
+    if (Array.isArray(d.paradigms) && d.paradigms.length > 0 && !d.paradigms.includes('flow')) continue;
+    const existing = byType.get(d.type);
+    byType.set(d.type, {
+      type: d.type,
+      label: d.name || existing?.label || d.type,
+      hint: d.description || existing?.hint,
+    });
+  }
+
+  return [...byType.values()];
+}
+
+/**
+ * Fetch the running engine's published action descriptors from
+ * `GET /api/v1/automation/actions`. Returns `[]` while loading or on any error
+ * (offline / plugin absent / older backend), so consumers fall back to their
+ * hardcoded defaults. Shared by both the palette and the inspector's
+ * server-driven config form.
+ */
+export function useActionDescriptors(): ActionDescriptorLite[] {
+  const [descriptors, setDescriptors] = useState<ActionDescriptorLite[]>([]);
+  // Avoid a state update after unmount (the fetch resolves async).
+  const alive = useRef(true);
+
+  useEffect(() => {
+    alive.current = true;
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch(`${apiBase()}/automation/actions`, {
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          signal: controller.signal,
+        });
+        if (!res.ok) return; // keep fallbacks (404/501 when plugin absent)
+        const payload = (await res.json()) as { data?: { actions?: ActionDescriptorLite[] } };
+        const actions = payload?.data?.actions;
+        if (!Array.isArray(actions) || actions.length === 0) return;
+        if (alive.current) setDescriptors(actions);
+      } catch {
+        /* offline / aborted — keep the hardcoded fallback */
+      }
+    })();
+    return () => {
+      alive.current = false;
+      controller.abort();
+    };
+  }, []);
+
+  return descriptors;
+}
+
+/**
+ * Returns the node palette merged with the running engine's published
+ * descriptors. Falls back to {@link NODE_PALETTE} while loading or on any
+ * error, so the designer always has a usable palette.
+ */
+export function useFlowNodePalette(): PaletteItem[] {
+  const descriptors = useActionDescriptors();
+  return useMemo(
+    () => (descriptors.length ? mergePalette(NODE_PALETTE, descriptors) : NODE_PALETTE),
+    [descriptors],
+  );
+}
+
+/**
+ * Map of node `type` → published config JSON Schema, for the actions whose
+ * executor publishes one. Empty while loading / offline, so the inspector
+ * falls back to its hardcoded field group for every type.
+ */
+export function useActionConfigSchemas(): Record<string, unknown> {
+  const descriptors = useActionDescriptors();
+  return useMemo(() => {
+    const map: Record<string, unknown> = {};
+    for (const d of descriptors) {
+      if (d?.type && d.configSchema !== undefined && d.configSchema !== null) {
+        map[d.type] = d.configSchema;
+      }
+    }
+    return map;
+  }, [descriptors]);
+}


### PR DESCRIPTION
## Summary
Renders the flow node property form and the add-node palette from what the running automation engine publishes (`GET /api/v1/automation/actions`), instead of a hardcoded client form — so the Studio designer stays in lock-step with the backend (ADR-0018/0019). Companion to the framework PR that publishes the config schema + `xRef` annotations.

- **useFlowNodePalette**: merge the engine's published node descriptors with the hardcoded base palette; `NodePalette` accepts `items` and scrolls when long.
- **json-schema-to-fields**: adapt a published config JSON Schema into the inspector's `FlowConfigField` model (select / boolean / number / `objectList` / one-level nested), and map a string's `xRef` annotation to a typed `reference` field.
- **FlowReferenceField**: an editable combobox (native `<datalist>`) for reference values — `object`, `object-field` (resolved from the flow's `$trigger` object or a sibling config key), `flow`, `role`, and in-flow `node`. Always accepts free text and degrades to plain text on an empty catalog, so authors are never trapped.
- **flow-node-config**: add the `reference` kind + `ReferenceKind`/`FlowReferenceSpec`; convert `objectName` (start + CRUD), `subflow.flowName`, and boundary `attachedToNodeId` to references. `FlowNodeInspector` threads `{ draft, node }` context to the fields.

## Test plan
- `json-schema-to-fields.test.ts`: 10 passed. `useFlowNodePalette.test.ts`: 6 passed.
- `tsc --noEmit` on @object-ui/app-shell: clean.
- Verified live in the running designer (`crm_discount_approval`): the approval node's **Approval Status Field** renders as a field-picker combobox listing the trigger object's fields ("Fields of crm_opportunity."); the start node's **Object** renders as an object-catalog combobox. Both still accept free text.