### PR TITLE
fix(fields): render reference/lookup cells as labels, not raw JSON

### DIFF
--- a/.changeset/grid-reference-cell-render.md
+++ b/.changeset/grid-reference-cell-render.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/fields': patch
+---
+
+Render reference/lookup cells as labels, not raw JSON
+
+A `lookup` / `master_detail` value can arrive as a JSON-encoded object string —
+e.g. an unresolved external-id reference `{"externalId":"Website Relaunch"}`.
+`LookupCellRenderer` treated the whole JSON string as an opaque id, failed to
+resolve it, and fell through to `String(value)`, leaking raw JSON into the grid
+cell (and detail/kanban surfaces).
+
+- `LookupCellRenderer` now parses a JSON-object-looking string value and renders
+  a human label (`name` → `label` → `externalId` → `id`).
+- `coerceToSafeValue` (the shared safe-render helper used by 8 cell renderers)
+  gains the same JSON-string parsing, and `externalId` is added to the
+  reference-label precedence for plain object values and arrays.
+
+Verified in the browser (showcase task grid: Project column shows "Website
+Relaunch" instead of `{"externalId":"Website Relaunch"}`) and by unit tests.

--- a/packages/fields/src/coerce-safe-value.test.ts
+++ b/packages/fields/src/coerce-safe-value.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { coerceToSafeValue } from './index';
+
+describe('coerceToSafeValue — reference / lookup values', () => {
+  it('extracts a label from a JSON-string reference (unresolved external-id ref)', () => {
+    // Regression: a master_detail/lookup value can arrive as a JSON-encoded
+    // string; it must render a label, not raw '{"externalId":"..."}'.
+    expect(coerceToSafeValue('{"externalId":"Website Relaunch"}')).toBe('Website Relaunch');
+  });
+
+  it('extracts a label from a reference object, name > label > externalId > id', () => {
+    expect(coerceToSafeValue({ externalId: 'X' })).toBe('X');
+    expect(coerceToSafeValue({ name: 'N', externalId: 'X' })).toBe('N');
+    expect(coerceToSafeValue({ label: 'L', externalId: 'X' })).toBe('L');
+    expect(coerceToSafeValue({ id: 'id1' })).toBe('id1');
+  });
+
+  it('handles a JSON-string array of references', () => {
+    expect(coerceToSafeValue('[{"name":"A"},{"externalId":"B"}]')).toBe('A, B');
+  });
+
+  it('leaves plain strings and non-JSON-looking strings untouched', () => {
+    expect(coerceToSafeValue('Website Relaunch')).toBe('Website Relaunch');
+    expect(coerceToSafeValue('{not valid json')).toBe('{not valid json');
+    expect(coerceToSafeValue('hello')).toBe('hello');
+  });
+
+  it('passes through primitives and null/undefined', () => {
+    expect(coerceToSafeValue(42)).toBe(42);
+    expect(coerceToSafeValue(true)).toBe(true);
+    expect(coerceToSafeValue(null)).toBe(null);
+    expect(coerceToSafeValue(undefined)).toBe(undefined);
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -222,13 +222,23 @@ export interface CellRendererProps {
  */
 export function coerceToSafeValue(value: unknown): string | number | boolean | null | undefined {
   if (value == null) return value as null | undefined;
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    // A reference/expanded value can arrive as a JSON-encoded object string —
+    // e.g. an unresolved external-id reference '{"externalId":"Website Relaunch"}'.
+    // Parse and extract a human label instead of leaking raw JSON into the cell.
+    const s = value.trim();
+    if ((s.startsWith('{') && s.endsWith('}')) || (s.startsWith('[') && s.endsWith(']'))) {
+      try { return coerceToSafeValue(JSON.parse(s)); } catch { /* not JSON — fall through */ }
+    }
+    return value;
+  }
   if (value instanceof Date) return value.toISOString();
   if (Array.isArray(value)) {
     return value.map((v) => {
       if (v != null && typeof v === 'object') {
         const obj = v as Record<string, unknown>;
-        return String(obj.name || obj.label || obj.id || obj._id || '[Object]');
+        return String(obj.name || obj.label || obj.externalId || obj.id || obj._id || '[Object]');
       }
       return String(v);
     }).join(', ');
@@ -241,8 +251,8 @@ export function coerceToSafeValue(value: unknown): string | number | boolean | n
     if ('$oid' in obj) return String(obj.$oid);
     // MongoDB date wrapper: { $date: "2024-01-01T00:00:00Z" }
     if ('$date' in obj) return String(obj.$date);
-    // Expanded reference / general object: extract name/label/id
-    return String(obj.name || obj.label || obj.id || obj._id || '[Object]');
+    // Expanded reference / general object: extract name/label/externalId/id
+    return String(obj.name || obj.label || obj.externalId || obj.id || obj._id || '[Object]');
   }
   return String(value);
 }
@@ -1111,6 +1121,24 @@ export function LookupCellRenderer({ value, field }: CellRendererProps): React.R
   const resolvedName = useLookupName(referenceTo, primaryPrimitiveId);
 
   if (value == null || value === '') return <EmptyValue />;
+
+  // A reference can arrive as a JSON-encoded object string — e.g. an
+  // unresolved external-id reference '{"externalId":"Website Relaunch"}'.
+  // Parse it and render a label instead of leaking raw JSON into the cell.
+  if (typeof value === 'string') {
+    const s = value.trim();
+    if (s.startsWith('{') && s.endsWith('}')) {
+      try {
+        const parsed = JSON.parse(s) as Record<string, unknown>;
+        if (parsed && typeof parsed === 'object') {
+          const display =
+            pickRecordDisplayName(parsed) ||
+            String(parsed.externalId ?? parsed.id ?? parsed._id ?? '');
+          if (display) return <span className="truncate">{display}</span>;
+        }
+      } catch { /* not JSON — fall through to normal resolution */ }
+    }
+  }
 
   // Server-side $expand returns the related record as a nested object
   // (e.g. { id, name }). Render its display name directly — no fetch needed.


### PR DESCRIPTION
## Problem
A `lookup` / `master_detail` value can arrive as a **JSON-encoded object string** — e.g. an unresolved external-id reference `{"externalId":"Website Relaunch"}`. `LookupCellRenderer` treated the whole string as an opaque id, failed to resolve it via `useLookupName`, and fell through to `String(value)`, leaking raw JSON into the grid cell.

## Fix
- **`LookupCellRenderer`** now parses a JSON-object-looking string value and renders a human label (`name` → `label` → `externalId` → `id`).
- **`coerceToSafeValue`** (the shared safe-render helper used by 8 cell renderers) gains the same JSON-string parsing, and `externalId` is added to the reference-label precedence for object values and arrays.

## Verification
- **Browser** (showcase task grid): Project column now shows **"Website Relaunch" / "Data Platform" / "Compliance Audit" / "Mobile App"** instead of `{"externalId":"…"}`.
- **Unit tests**: new `coerce-safe-value.test.ts` (5 cases); full `@object-ui/fields` suite green (3103 passed).

### Before / After
Before: `{"externalId":"Website Relaunch"}`  →  After: `Website Relaunch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)