### PR TITLE
docs(agents): document console dev server ↔ backend loop + gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,16 @@
 - 任务结束:停后台服务(`lsof -i :PORT -t`)、清 `.playwright-mcp/`。
 - 改完代码提交时:功能改进(feature)需写 changeset(`pnpm changeset`);纯 bug 修复不需要。
 
+## Local dev — console UI ↔ backend (read before debugging UI)
+
+- **启动前端**:仓根 `pnpm --filter @object-ui/console dev`(Vite,固定 **:5180**,见 `apps/console/vite.config.ts`)。
+- **后端默认连 `:3000`**:vite `/api` proxy → `DEV_PROXY_TARGET || http://localhost:3000`。**要测哪个后端就把它跑在 :3000**(framework 仓:`PORT=3000 pnpm dev:crm`,或 `PORT=3000 pnpm dev` = showcase)。经 `pnpm --filter` 传 `DEV_PROXY_TARGET` env 不一定透传到 vite 子进程——优先把后端跑在 :3000,别依赖 env 覆盖。
+- `framework` 的 `:3001/_console` 服务的是**已发布的** console(`packages/console/dist`),**不是本仓 src**;改 src 必须用上面的 :5180 dev 服务验证(或在 framework 跑 `pnpm objectui:refresh` 重新拉构建——慢)。
+- 路由用 app 的 **`name`**(如 `showcase_app`,不是 `showcase`);直接 URL 进对象可能落到 Setup「对象不存在」——先经启动台/应用切换进入该 app 设好 currentApp。
+- **清 localStorage 会登出**(session token 存 localStorage;首页应用磁贴也读 localStorage 缓存,跨会话会显示过期的 app 列表)。
+- better-auth 用 `localhost`(非 `127.0.0.1`)否则 Invalid origin。
+- 浏览器验证:优先用桌面 preview(`preview_*`,`.claude/launch.json` 里配 `showcase-console`);chrome-devtools MCP 掉线时切 preview。
+
 ## Important
 
 do not make big edits of more than ~20000 bytes or so. If it fails, break one edit down to multiple smaller ones.


### PR DESCRIPTION
Fleshes out the AGENTS.md stub with a 'Local dev — console UI ↔ backend' section: console dev on :5180; the /api proxy defaults to :3000 (run the backend under test there; don't rely on DEV_PROXY_TARGET through `pnpm --filter`); backend-served `_console` is the published build, not src; routes use the app `name` (e.g. `showcase_app`); clearing localStorage logs you out; better-auth needs `localhost`; prefer desktop preview for verification. Captures the gotchas that caused avoidable thrash this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)