### PR TITLE
feat(app-shell): repoint Console bell to sys_inbox_message + receipts (ADR-0030)

### DIFF
--- a/.changeset/bell-inbox-message-cutover.md
+++ b/.changeset/bell-inbox-message-cutover.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Repoint the Console bell to `sys_inbox_message` + `sys_notification_receipt` (ADR-0030)
+
+The notification bell read the legacy `sys_notification` object's
+`recipient_id`/`is_read`/`title`/`body` columns. ADR-0030 re-modeled
+`sys_notification` into the L2 *event* (no recipient/read-state), so the bell
+returned nothing — every notification the new pipeline produced was invisible.
+
+The bell now reads the L5 in-app materialization instead:
+
+- **List**: `sys_inbox_message` filtered by `user_id` (the `mine` scope), 20
+  most-recent, ordered by `created_at`.
+- **Read-state**: joins `sys_notification_receipt` (filtered by `user_id` +
+  `channel:'inbox'`). A message is unread until its event has a
+  `read`/`clicked`/`dismissed` receipt; the unread count drives the badge.
+- **Mark-read**: `UPDATE`s the existing `delivered` receipt to `read`
+  (keyed `(notification_id, user_id, channel)`), inserting only as a fallback
+  when no receipt exists. Replaces the old `sys_notification.is_read` write.
+- **Navigation**: follows the materialization's `action_url` (absolute,
+  `/apps/...`, or app-relative `/{object}/{id}`), falling back to the legacy
+  `source_object`/`source_id` pointer.
+- **"View all"**: routes to `/apps/setup/sys_inbox_message?view=mine`.
+
+Pairs with the framework ADR-0030 pipeline (`@objectstack/service-messaging`).
+Verified in-browser (showcase Console): a materialized inbox message + its
+`delivered` receipt lit the bell badge; the popover rendered the row;
+"mark all read" flipped the receipt to `read` in place (no duplicate) and
+cleared the badge.

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -131,12 +131,23 @@ export function AppHeader({
   const mobileSwitcher = useMobileViewSwitcher();
 
   const [apiActivities, setApiActivities] = useState<ActivityItem[] | null>(null);
-  /** M10.8: in-header notifications. Polled from sys_notification scoped to current user. */
+  /**
+   * In-header notifications (ADR-0030). Polled from `sys_inbox_message` (the L5
+   * in-app materialization, `mine` scope) joined with `sys_notification_receipt`
+   * for read-state — the bell no longer reads the re-modeled `sys_notification`
+   * L2 event (which carries no recipient/read columns).
+   */
   const [notifications, setNotifications] = useState<Array<{
     id: string;
+    /** FK → sys_notification (L2 event); keys the read-state receipt. */
+    notification_id?: string | null;
+    /** Existing receipt row id (if any) — lets mark-read UPDATE in place. */
+    receipt_id?: string | null;
     type: string;
     title: string;
     body?: string | null;
+    /** Deep-link target carried by the materialization (action_url). */
+    action_url?: string | null;
     source_object?: string | null;
     source_id?: string | null;
     actor_name?: string | null;
@@ -187,22 +198,25 @@ export function AppHeader({
   useEffect(() => { fetchPresenceAndActivities(); }, [fetchPresenceAndActivities]);
 
   /**
-   * M10.8 + M11.B3: poll sys_notification for the signed-in user.
+   * Poll the signed-in user's in-app inbox (ADR-0030 L5).
    *
-   * - Limited to the 20 most-recent entries; unread count drives the bell badge.
-   * - Adaptive interval: 10s while the tab is foregrounded (was 30s) so the
-   *   bell reflects mentions / assignments within seconds without requiring a
-   *   server-push transport.
-   * - Immediate refetch on `visibilitychange` when the user returns to the
-   *   tab, so a backgrounded tab catches up the moment it regains focus.
-   * - On transient errors, switches to exponential backoff (cap 2 min) and
-   *   resets on the first successful fetch.
-   * - Tolerates 404 so deployments without sys_notification degrade silently.
+   * Two scoped reads, joined client-side:
+   *   - `sys_inbox_message` filtered by `user_id` (the `mine` materialization),
+   *     20 most-recent — the notification rows themselves.
+   *   - `sys_notification_receipt` filtered by `user_id` + `channel:'inbox'` —
+   *     the read-state spine. A message is unread until its event has a
+   *     `read`/`clicked`/`dismissed` receipt; the unread count drives the badge.
    *
-   * Full server-push (SSE / WebSocket) is tracked separately as a M12
-   * enhancement; this adaptive poll already reduces perceived latency from
-   * ~15s (average half of the old 30s window) to ~5s and is sufficient for
-   * pilots up to ~50 concurrent users.
+   * - Adaptive interval: 10s while the tab is foregrounded so the bell reflects
+   *   mentions / assignments within seconds without a server-push transport.
+   * - Immediate refetch on `visibilitychange` when the user returns to the tab.
+   * - On transient errors, exponential backoff (cap 2 min), reset on success.
+   * - Tolerates 404 so deployments without the messaging pipeline degrade
+   *   silently.
+   *
+   * Full server-push (SSE / WebSocket) is tracked separately; this adaptive
+   * poll keeps perceived latency ~5s and is sufficient for pilots up to ~50
+   * concurrent users.
    */
   useEffect(() => {
     if (!dataSource || !isApp || !user?.id) return;
@@ -215,15 +229,52 @@ export function AppHeader({
     let backoffMs = ACTIVE_INTERVAL_MS;
     const isMissingResource = (err: any): boolean =>
       err?.httpStatus === 404 || err?.status === 404 || err?.code === 'object_not_found';
+    const READ_STATES = new Set(['read', 'clicked', 'dismissed']);
     const fetchOnce = async () => {
       try {
-        const res: any = await dataSource.find('sys_notification', {
-          $filter: { recipient_id: user.id },
-          $orderby: { created_at: 'desc' },
-          $top: 20,
-        });
+        const [inboxRes, receiptRes] = await Promise.all([
+          dataSource.find('sys_inbox_message', {
+            $filter: { user_id: user.id },
+            $orderby: { created_at: 'desc' },
+            $top: 20,
+          }) as Promise<any>,
+          // Read-state spine. Best-effort: if receipts are unavailable the
+          // inbox still renders (everything shows unread) rather than erroring.
+          (dataSource.find('sys_notification_receipt', {
+            $filter: { user_id: user.id, channel: 'inbox' },
+            $top: 200,
+          }) as Promise<any>).catch(() => ({ data: [] })),
+        ]);
         if (cancelled) return;
-        if (Array.isArray(res?.data)) setNotifications(res.data);
+        const rows: any[] = Array.isArray(inboxRes?.data) ? inboxRes.data : [];
+        const receipts: any[] = Array.isArray(receiptRes?.data) ? receiptRes.data : [];
+        // notification_id → { id, state } (most-advanced receipt wins).
+        const receiptByNotif = new Map<string, { id: string; state: string }>();
+        for (const r of receipts) {
+          const nid = r?.notification_id != null ? String(r.notification_id) : '';
+          if (!nid) continue;
+          const prev = receiptByNotif.get(nid);
+          // Prefer a read/clicked/dismissed receipt over a plain delivered one.
+          if (!prev || (!READ_STATES.has(prev.state) && READ_STATES.has(r.state))) {
+            receiptByNotif.set(nid, { id: String(r.id), state: String(r.state) });
+          }
+        }
+        const merged = rows.map((m) => {
+          const nid = m?.notification_id != null ? String(m.notification_id) : null;
+          const rec = nid ? receiptByNotif.get(nid) : undefined;
+          return {
+            id: String(m.id),
+            notification_id: nid,
+            receipt_id: rec?.id ?? null,
+            type: m.topic ?? 'notification',
+            title: m.title ?? '',
+            body: m.body_md ?? null,
+            action_url: m.action_url ?? null,
+            is_read: rec ? READ_STATES.has(rec.state) : false,
+            created_at: m.created_at,
+          };
+        });
+        setNotifications(merged);
         backoffMs = ACTIVE_INTERVAL_MS;
       } catch (err: any) {
         if (isMissingResource(err)) {
@@ -307,39 +358,42 @@ export function AppHeader({
 
   const unreadCount = notifications.reduce((n, x) => n + (x.is_read ? 0 : 1), 0);
 
-  const markNotificationRead = useCallback(async (id: string) => {
-    setNotifications(prev => prev.map(n => n.id === id ? { ...n, is_read: true } : n));
-    if (!dataSource) return;
-    try {
-      await dataSource.update('sys_notification', id, {
-        is_read: true,
-        read_at: new Date().toISOString(),
+  // Read-state lives in `sys_notification_receipt`, keyed
+  // (notification_id, user_id, channel) — ADR-0030. Marking read UPDATEs the
+  // existing `delivered` receipt to `read` (the inbox channel always writes one
+  // on materialization); we INSERT only as a fallback for the rare row whose
+  // receipt is missing. Rows without a `notification_id` (legacy/synthetic)
+  // can't be keyed, so they update optimistically but don't persist.
+  const writeReadReceipt = useCallback(async (n: { notification_id?: string | null; receipt_id?: string | null }, now: string) => {
+    if (!dataSource || !n.notification_id) return;
+    if (n.receipt_id) {
+      await dataSource.update('sys_notification_receipt', n.receipt_id, { state: 'read', at: now });
+    } else {
+      await dataSource.create('sys_notification_receipt', {
+        notification_id: n.notification_id,
+        user_id: user?.id,
+        channel: 'inbox',
+        state: 'read',
+        at: now,
+        created_at: now,
       });
-    } catch { /* best-effort */ }
-  }, [dataSource]);
+    }
+  }, [dataSource, user?.id]);
+
+  const markNotificationRead = useCallback(async (id: string) => {
+    const target = notifications.find(n => n.id === id);
+    setNotifications(prev => prev.map(n => n.id === id ? { ...n, is_read: true } : n));
+    if (!target) return;
+    try { await writeReadReceipt(target, new Date().toISOString()); } catch { /* best-effort */ }
+  }, [notifications, writeReadReceipt]);
 
   const markAllRead = useCallback(async () => {
     const unread = notifications.filter(n => !n.is_read);
     if (!unread.length) return;
     setNotifications(prev => prev.map(n => ({ ...n, is_read: true })));
-    if (!dataSource) return;
     const now = new Date().toISOString();
-    const ids = unread.map(n => n.id);
-    // Prefer the bulk endpoint — one HTTP/auth/RLS round-trip instead of
-    // N parallel PATCHes, which previously caused noticeable hitching
-    // (Slack-style "mark all read" jank) on inboxes with 50+ unread.
-    // Fall back to the per-id loop on adapters that don't implement it.
-    const ds: any = dataSource as any;
-    if (typeof ds.bulkUpdate === 'function') {
-      try {
-        await ds.bulkUpdate('sys_notification', ids, { is_read: true, read_at: now });
-        return;
-      } catch { /* fall through to per-id loop */ }
-    }
-    await Promise.all(unread.map(n =>
-      dataSource.update('sys_notification', n.id, { is_read: true, read_at: now }).catch(() => {}),
-    ));
-  }, [dataSource, notifications]);
+    await Promise.all(unread.map(n => writeReadReceipt(n, now).catch(() => {})));
+  }, [notifications, writeReadReceipt]);
 
   const tenantPresence = useTenantPresence();
   const activeUsers = presenceUsers ?? (tenantPresence.length > 0 ? tenantPresence : EMPTY_PRESENCE_USERS);

--- a/packages/app-shell/src/layout/InboxPopover.tsx
+++ b/packages/app-shell/src/layout/InboxPopover.tsx
@@ -33,9 +33,14 @@ import { useNavigationContext } from '../context/NavigationContext';
 
 export interface InboxNotification {
   id: string;
+  /** FK → sys_notification (L2 event) — keys the read-state receipt (ADR-0030). */
+  notification_id?: string | null;
+  receipt_id?: string | null;
   type: string;
   title: string;
   body?: string | null;
+  /** Deep-link target carried by the inbox materialization. */
+  action_url?: string | null;
   source_object?: string | null;
   source_id?: string | null;
   actor_name?: string | null;
@@ -115,11 +120,11 @@ export function InboxPopover({
 
   const goToAllNotifications = () => {
     setOpen(false);
-    // Always route through the setup app's sys_notification list view —
-    // it's the canonical full-page inbox and lives outside per-app sidebars.
-    // The `?view=mine` query selects the "Mine" tab so the user sees their
-    // own notifications by default (matching the popover scope).
-    navigate('/apps/setup/sys_notification?view=mine');
+    // Route through the setup app's sys_inbox_message list view — the
+    // canonical full-page inbox (ADR-0030 L5), outside per-app sidebars. The
+    // `?view=mine` query selects the user-scoped "Notifications" view, matching
+    // the popover scope.
+    navigate('/apps/setup/sys_inbox_message?view=mine');
   };
 
   const goToAllActivity = () => {
@@ -132,9 +137,28 @@ export function InboxPopover({
 
   const handleNotificationClick = (n: InboxNotification) => {
     onMarkRead(n.id);
+    const app = currentAppName ?? params.appName;
+    // Prefer the materialization's action_url (ADR-0030). The messaging
+    // pipeline synthesizes an app-relative `/{object}/{id}` link from the
+    // event's source when a producer didn't set an explicit url.
+    if (n.action_url) {
+      setOpen(false);
+      const url = n.action_url;
+      if (/^https?:\/\//i.test(url)) {
+        window.open(url, '_blank', 'noopener,noreferrer');
+        return;
+      }
+      if (url.startsWith('/apps/')) {
+        navigate(url);
+        return;
+      }
+      const rel = url.startsWith('/') ? url : `/${url}`;
+      navigate(app ? `/apps/${app}${rel}` : rel);
+      return;
+    }
+    // Back-compat fallback: explicit source object/record pointer.
     if (n.source_object && n.source_id) {
       setOpen(false);
-      const app = currentAppName ?? params.appName;
       const target = app
         ? `/apps/${app}/${n.source_object}/${n.source_id}`
         : `/objects/${n.source_object}/${n.source_id}`;
@@ -289,7 +313,7 @@ export function InboxPopover({
                 </ul>
               );
             })()}
-            {/* Footer link to dedicated /sys_notification list. The popover
+            {/* Footer link to the dedicated /sys_inbox_message list. The popover
                 only shows the 20 most-recent rows; users need a path to the
                 full inbox for bulk operations and older history. */}
             <div className="border-t px-3 py-2 text-center">

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -926,11 +926,12 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
 
   /**
    * Note: comment-mention → notification fan-out lives on the server
-   * (`@objectstack/plugin-audit` registers a `sys_comment` afterInsert
-   * hook that parses the `mentions` JSON and writes one `sys_notification`
-   * row per recipient). The client's only job is to ensure
+   * (`@objectstack/plugin-audit` registers a `sys_comment` afterInsert hook
+   * that parses the `mentions` JSON and calls `messaging.emit('collab.mention')`
+   * — ADR-0030 single ingress — which materializes one `sys_inbox_message` per
+   * recipient that the bell then reads). The client's only job is to ensure
    * `sys_comment.mentions` carries the real id list (see handleAddComment
-   * /handleAddReply below). Deployments without plugin-audit will not
+   * /handleAddReply below). Deployments without the messaging pipeline will not
    * deliver bell notifications, which is the expected degradation.
    */
 


### PR DESCRIPTION
## What

The notification bell read the legacy `sys_notification` object's `recipient_id` / `is_read` / `title` / `body` columns. ADR-0030 re-modeled `sys_notification` into the **L2 event** (topic/payload/severity/dedup_key/source — **no recipient, no read-state**), so the bell's `recipient_id` query returned nothing: every notification the new pipeline produced (`@mention`, assignment, `notify` flows, email/preference pipeline) was **invisible in the UI**. This is the user-facing half of the ADR-0030 cut-over.

The bell now reads the **L5 in-app materialization**:

- **List** — `sys_inbox_message` filtered by `user_id` (the `mine` scope), 20 most-recent, `created_at desc`.
- **Read-state** — joins `sys_notification_receipt` (filtered by `user_id` + `channel:'inbox'`). A message is unread until its event carries a `read`/`clicked`/`dismissed` receipt; the unread count drives the badge.
- **Mark-read** — `UPDATE`s the existing `delivered` receipt to `read` (keyed `(notification_id, user_id, channel)`), inserting only as a fallback when no receipt exists. Replaces the old `sys_notification.is_read` write (and drops the `sys_notification` bulk path).
- **Navigation** — follows the materialization's `action_url` (absolute URL, `/apps/...`, or app-relative `/{object}/{id}`), falling back to the legacy `source_object`/`source_id`.
- **"View all"** — routes to `/apps/setup/sys_inbox_message?view=mine`.

Stale doc comments in `RecordDetailView` updated to describe the `emit()` single-ingress path.

## Pairs with

Framework PR `objectstack-ai/framework#1456` (synthesizes `action_url` from the event `source` so collaboration notifications stay deep-linkable). The cut-over works against the already-shipped ADR-0030 P0–P3 pipeline.

## Verification (showcase Console, live)

Fresh sqlite backend, full messaging pipeline. Seeded one `sys_inbox_message` for the signed-in user + its `delivered` receipt (exactly what the inbox channel materializes):

1. Bell badge showed **1** (was empty before — regression reproduced & fixed).
2. Popover rendered the row ("You were mentioned on Demo Task", unread dot, relative time) with the 未读/全部 filter and "view all" footer.
3. **Mark all read** → the existing `delivered` receipt flipped to `read` **in place** (same id, fresh `at`, **no duplicate** — unique index respected) and the badge cleared.

`tsc --noEmit` clean on `@object-ui/app-shell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)