### PR TITLE
fix(fields,dashboard): fill renderer registry gaps for field & chart types

### DIFF
--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1352,6 +1352,44 @@ export function resolveCellRendererType(fieldOrType: string | { type?: string; f
 }
 
 /**
+ * Renders structured/embedded values (json, object, composite, record,
+ * address, geolocation) as compact, readable JSON. Objects and arrays are
+ * stringified; primitives fall through to their string form.
+ */
+export function JsonCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  if (value == null || value === '') return <EmptyValue />;
+  let text: string;
+  if (typeof value === 'object') {
+    try {
+      text = JSON.stringify(value);
+    } catch {
+      text = String(value);
+    }
+  } else {
+    text = String(value);
+  }
+  return <span className="font-mono text-xs text-gray-600 truncate" title={text}>{text}</span>;
+}
+
+/**
+ * Renders a `color` value as a swatch alongside its hex/string value.
+ */
+export function ColorSwatchCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  if (value == null || value === '') return <EmptyValue />;
+  const color = String(value);
+  return (
+    <span className="inline-flex items-center gap-1.5 text-sm">
+      <span
+        className="h-3.5 w-3.5 rounded border border-black/10 shrink-0"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+      <span className="font-mono text-xs">{color}</span>
+    </span>
+  );
+}
+
+/**
  * Get the appropriate cell renderer for a field type
  */
 export function getCellRenderer(fieldType: string): React.FC<CellRendererProps> {
@@ -1366,30 +1404,59 @@ export function getCellRenderer(fieldType: string): React.FC<CellRendererProps> 
     textarea: TextCellRenderer,
     markdown: TextCellRenderer,
     html: TextCellRenderer,
+    richtext: TextCellRenderer,
+    code: TextCellRenderer,
+    qrcode: TextCellRenderer,
     number: NumberCellRenderer,
     currency: CurrencyCellRenderer,
     percent: PercentCellRenderer,
+    progress: PercentCellRenderer,
+    slider: NumberCellRenderer,
+    rating: NumberCellRenderer,
     boolean: BooleanCellRenderer,
+    toggle: BooleanCellRenderer,
     date: DateCellRenderer,
     datetime: DateTimeCellRenderer,
     time: TextCellRenderer,
     select: SelectCellRenderer,
     status: SelectCellRenderer,
+    multiselect: SelectCellRenderer,
+    radio: SelectCellRenderer,
+    checkboxes: SelectCellRenderer,
+    tags: SelectCellRenderer,
     lookup: LookupCellRenderer,
     master_detail: LookupCellRenderer,
+    tree: LookupCellRenderer,
     email: EmailCellRenderer,
     url: UrlCellRenderer,
     phone: PhoneCellRenderer,
     file: FileCellRenderer,
+    video: FileCellRenderer,
+    audio: FileCellRenderer,
     image: ImageCellRenderer,
+    avatar: ImageCellRenderer,
+    signature: ImageCellRenderer,
     formula: FormulaCellRenderer,
     summary: FormulaCellRenderer,
     auto_number: TextCellRenderer,
     user: UserCellRenderer,
     owner: UserCellRenderer,
     password: () => <span>••••••</span>,
+    secret: () => <span>••••••</span>,
     location: TextCellRenderer, // Default fallback
-    object: () => <span className="text-gray-500 italic">[Object]</span>,
+    geolocation: JsonCellRenderer,
+    address: JsonCellRenderer,
+    color: ColorSwatchCellRenderer,
+    json: JsonCellRenderer,
+    object: JsonCellRenderer,
+    composite: JsonCellRenderer,
+    record: JsonCellRenderer,
+    repeater: ({ value }: CellRendererProps) => {
+      const n = Array.isArray(value) ? value.length : 0;
+      return n > 0
+        ? <span className="text-gray-500 italic">{n} 项</span>
+        : <EmptyValue />;
+    },
     vector: () => <span className="text-gray-500 italic">[Vector]</span>,
     grid: () => <span className="text-gray-500 italic">[Grid]</span>,
   };
@@ -1430,38 +1497,66 @@ export function mapFieldTypeToFormType(fieldType: string): string {
     textarea: 'field:textarea',
     markdown: 'field:markdown', // Markdown editor (fallback to textarea)
     html: 'field:html', // Rich text editor (fallback to textarea)
-    
+    richtext: 'field:richtext', // WYSIWYG rich-text editor
+    secret: 'field:password', // encrypted-at-rest value — mask input like a password
+
     // Numeric fields
     number: 'field:number',
     currency: 'field:currency',
     percent: 'field:percent',
-    
+    slider: 'field:slider',
+    progress: 'field:slider', // bounded 0..100 progress — edit via slider
+    rating: 'field:rating',
+
     // Date/Time fields
     date: 'field:date',
     datetime: 'field:datetime',
     time: 'field:time',
-    
+
     // Boolean
     boolean: 'field:boolean',
-    
+    toggle: 'field:boolean', // toggle is a boolean rendered as a switch
+
     // Selection fields
     select: 'field:select',
+    multiselect: 'field:multiselect',
+    radio: 'field:radio',
+    checkboxes: 'field:checkboxes',
+    tags: 'field:tags',
     lookup: 'field:lookup',
     master_detail: 'field:master_detail',
-    
+    tree: 'field:lookup', // hierarchical reference — pick the parent via a lookup
+
     // Contact fields
     email: 'field:email',
     phone: 'field:phone',
     url: 'field:url',
-    
-    // File fields
+
+    // File / media fields
     file: 'field:file',
     image: 'field:image',
-    
-    // Special fields
+    avatar: 'field:avatar',
+    video: 'field:file', // uploads as a file
+    audio: 'field:file', // uploads as a file
+    signature: 'field:signature',
+
+    // Special / enhanced fields
     password: 'field:password',
     location: 'field:location', // Location/map field (fallback to input)
-    
+    geolocation: 'field:geolocation',
+    address: 'field:address',
+    color: 'field:color',
+    code: 'field:code',
+    json: 'field:code', // JSON edited in the code editor
+    qrcode: 'field:qrcode',
+    vector: 'field:vector',
+
+    // Embedded structured values (stored as JSON on the row)
+    object: 'field:object',
+    composite: 'field:object', // embedded object
+    record: 'field:object', // name-keyed map
+    repeater: 'field:grid', // embedded array of rows
+
     // Auto-generated/computed fields (typically read-only)
     formula: 'field:formula',
     summary: 'field:summary',
@@ -1693,12 +1788,19 @@ const fieldWidgetMap: Record<string, () => Promise<{ default: React.ComponentTyp
   'phone': () => import('./widgets/PhoneField').then(m => ({ default: m.PhoneField })),
   'url': () => import('./widgets/UrlField').then(m => ({ default: m.UrlField })),
   
+  // Selection fields (multi-value / option groups)
+  'multiselect': () => import('./widgets/MultiSelectField').then(m => ({ default: m.MultiSelectField })),
+  'radio': () => import('./widgets/RadioField').then(m => ({ default: m.RadioField })),
+  'checkboxes': () => import('./widgets/CheckboxesField').then(m => ({ default: m.CheckboxesField })),
+  'tags': () => import('./widgets/TagsField').then(m => ({ default: m.TagsField })),
+
   // Specialized fields
   'currency': () => import('./widgets/CurrencyField').then(m => ({ default: m.CurrencyField })),
   'percent': () => import('./widgets/PercentField').then(m => ({ default: m.PercentField })),
   'password': () => import('./widgets/PasswordField').then(m => ({ default: m.PasswordField })),
   'markdown': () => import('./widgets/RichTextField').then(m => ({ default: m.RichTextField })),
   'html': () => import('./widgets/RichTextField').then(m => ({ default: m.RichTextField })),
+  'richtext': () => import('./widgets/RichTextField').then(m => ({ default: m.RichTextField })),
   'lookup': () => import('./widgets/LookupField').then(m => ({ default: m.LookupField })),
   // master_detail represents the child-side FK to its parent. In create/edit forms it
   // must render as a single-value lookup picker (it is typically NOT NULL). The legacy
@@ -1908,6 +2010,10 @@ export * from './widgets/GeolocationField';
 export * from './widgets/SignatureField';
 export * from './widgets/QRCodeField';
 export * from './widgets/MasterDetailField';
+export * from './widgets/MultiSelectField';
+export * from './widgets/RadioField';
+export * from './widgets/CheckboxesField';
+export * from './widgets/TagsField';
 
 // Initialize registry
 registerAllFields();

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -1,0 +1,53 @@
+import React, { useId } from 'react';
+import { Checkbox, Label, EmptyValue, Badge } from '@object-ui/components';
+import { FieldWidgetProps } from './types';
+
+interface Option { label: string; value: string }
+
+/**
+ * CheckboxesField - select zero or more values from a fixed option set, rendered
+ * as a list of checkboxes. The stored value is a string[]. Used for the
+ * `checkboxes` field type.
+ */
+export function CheckboxesField({ value, onChange, field, readonly, className, ...props }: FieldWidgetProps<string[]>) {
+  const config = (field || (props as any).schema) as any;
+  const options: Option[] = config?.options || [];
+  const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
+  const groupId = useId();
+
+  if (readonly) {
+    if (selected.length === 0) return <EmptyValue />;
+    return (
+      <div className="flex flex-wrap gap-1">
+        {selected.map((v) => {
+          const opt = options.find((o) => o.value === v);
+          return <Badge key={v} variant="outline">{opt?.label || v}</Badge>;
+        })}
+      </div>
+    );
+  }
+
+  const toggle = (v: string, checked: boolean) => {
+    const next = checked ? [...selected.filter((x) => x !== v), v] : selected.filter((x) => x !== v);
+    onChange(next);
+  };
+
+  return (
+    <div className={className}>
+      {options.map((opt) => {
+        const id = `${groupId}-${opt.value}`;
+        return (
+          <div key={opt.value} className="flex items-center space-x-2 py-0.5">
+            <Checkbox
+              id={id}
+              checked={selected.includes(opt.value)}
+              onCheckedChange={(checked) => toggle(opt.value, !!checked)}
+              disabled={(props as any).disabled}
+            />
+            <Label htmlFor={id} className="font-normal">{opt.label}</Label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Badge, EmptyValue, cn } from '@object-ui/components';
+import { FieldWidgetProps } from './types';
+
+interface Option { label: string; value: string; color?: string }
+
+/**
+ * MultiSelectField - select zero or more values from a fixed option set.
+ *
+ * Renders the configured options as toggleable chips. The stored value is a
+ * string[] (the selected option values). Used for the `multiselect` field type.
+ */
+export function MultiSelectField({ value, onChange, field, readonly, className, ...props }: FieldWidgetProps<string[]>) {
+  const config = (field || (props as any).schema) as any;
+  const options: Option[] = config?.options || [];
+  const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
+
+  if (readonly) {
+    if (selected.length === 0) return <EmptyValue />;
+    return (
+      <div className="flex flex-wrap gap-1">
+        {selected.map((v) => {
+          const opt = options.find((o) => o.value === v);
+          return <Badge key={v} variant="outline">{opt?.label || v}</Badge>;
+        })}
+      </div>
+    );
+  }
+
+  const toggle = (v: string) => {
+    const next = selected.includes(v) ? selected.filter((x) => x !== v) : [...selected, v];
+    onChange(next);
+  };
+
+  return (
+    <div className={cn('flex flex-wrap gap-1.5', className)}>
+      {options.map((opt) => {
+        const active = selected.includes(opt.value);
+        return (
+          <button
+            type="button"
+            key={opt.value}
+            onClick={() => toggle(opt.value)}
+            disabled={(props as any).disabled}
+            aria-pressed={active}
+            className={cn(
+              'rounded-full border px-3 py-1 text-sm transition-colors',
+              active
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-input bg-background text-foreground hover:bg-accent',
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -1,0 +1,41 @@
+import React, { useId } from 'react';
+import { RadioGroup, RadioGroupItem, Label, EmptyValue } from '@object-ui/components';
+import { FieldWidgetProps } from './types';
+
+interface Option { label: string; value: string }
+
+/**
+ * RadioField - choose exactly one value from a fixed option set, rendered as a
+ * radio group. The stored value is the selected option value (string). Used for
+ * the `radio` field type.
+ */
+export function RadioField({ value, onChange, field, readonly, className, ...props }: FieldWidgetProps<string>) {
+  const config = (field || (props as any).schema) as any;
+  const options: Option[] = config?.options || [];
+  const groupId = useId();
+
+  if (readonly) {
+    if (value == null || value === '') return <EmptyValue />;
+    const opt = options.find((o) => o.value === value);
+    return <span className="text-sm">{opt?.label || String(value)}</span>;
+  }
+
+  return (
+    <RadioGroup
+      value={value ?? ''}
+      onValueChange={onChange}
+      disabled={(props as any).disabled}
+      className={className}
+    >
+      {options.map((opt) => {
+        const id = `${groupId}-${opt.value}`;
+        return (
+          <div key={opt.value} className="flex items-center space-x-2">
+            <RadioGroupItem value={opt.value} id={id} />
+            <Label htmlFor={id} className="font-normal">{opt.label}</Label>
+          </div>
+        );
+      })}
+    </RadioGroup>
+  );
+}

--- a/packages/fields/src/widgets/TagsField.tsx
+++ b/packages/fields/src/widgets/TagsField.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Badge, Input, EmptyValue, cn } from '@object-ui/components';
+import { FieldWidgetProps } from './types';
+
+/**
+ * TagsField - free-form list of string tags. Type a value and press Enter (or
+ * comma) to add it; click a tag's × to remove it. The stored value is a
+ * string[]. Used for the `tags` field type.
+ */
+export function TagsField({ value, onChange, field, readonly, className, ...props }: FieldWidgetProps<string[]>) {
+  const tags: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
+  const [draft, setDraft] = React.useState('');
+
+  if (readonly) {
+    if (tags.length === 0) return <EmptyValue />;
+    return (
+      <div className="flex flex-wrap gap-1">
+        {tags.map((t) => <Badge key={t} variant="secondary">{t}</Badge>)}
+      </div>
+    );
+  }
+
+  const addTag = (raw: string) => {
+    const t = raw.trim();
+    if (!t || tags.includes(t)) return;
+    onChange([...tags, t]);
+    setDraft('');
+  };
+
+  const removeTag = (t: string) => onChange(tags.filter((x) => x !== t));
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag(draft);
+    } else if (e.key === 'Backspace' && draft === '' && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-1.5 rounded-md border border-input bg-background p-1.5', className)}>
+      {tags.map((t) => (
+        <Badge key={t} variant="secondary" className="gap-1">
+          {t}
+          <button
+            type="button"
+            onClick={() => removeTag(t)}
+            className="ml-0.5 rounded-full text-muted-foreground hover:text-foreground"
+            aria-label={`Remove ${t}`}
+          >
+            ×
+          </button>
+        </Badge>
+      ))}
+      <Input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={() => addTag(draft)}
+        disabled={(props as any).disabled}
+        placeholder={tags.length === 0 ? '输入后回车添加…' : ''}
+        className="h-7 flex-1 border-0 bg-transparent p-0 px-1 shadow-none focus-visible:ring-0 min-w-[8ch]"
+      />
+    </div>
+  );
+}

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -96,6 +96,53 @@ const CHART_COLORS = [
 ];
 
 /**
+ * Spec-level `ChartType` families normalized to a base type that the chart
+ * implementation (plugin-charts/AdvancedChartImpl) actually renders. The
+ * widget `type` taxonomy is broader than the set of distinct visual renderers;
+ * several families collapse onto a shared renderer (e.g. stacked / grouped /
+ * column bars all render through the bar chart). Keeps the dashboard from
+ * surfacing a raw "Unknown component type" for a perfectly meaningful chart.
+ */
+const CHART_TYPE_ALIASES: Record<string, string> = {
+  column: 'bar',
+  'stacked-bar': 'bar',
+  'grouped-bar': 'bar',
+  'bi-polar-bar': 'bar',
+  spline: 'line',
+  'step-line': 'line',
+  'stacked-area': 'area',
+  pyramid: 'funnel',
+  bubble: 'scatter',
+};
+
+/**
+ * Chart types the renderer can draw (after alias normalization). Anything
+ * outside this set that is still a chart family renders a clean
+ * "not-yet-supported" placeholder instead of a raw error box.
+ */
+const SUPPORTED_CHART_TYPES = new Set([
+  'bar', 'horizontal-bar', 'line', 'area', 'pie', 'donut', 'scatter', 'funnel', 'radar',
+]);
+
+/**
+ * Single-value "performance" widgets that render as a metric card rather than
+ * a chart (gauge/kpi/bullet are all one number with optional target).
+ */
+const METRIC_LIKE_TYPES = new Set(['gauge', 'solid-gauge', 'kpi', 'bullet']);
+
+/**
+ * Chart families that have no dedicated renderer yet (Recharts cannot draw
+ * them and no approximation reads honestly). These render a labelled
+ * placeholder so the dashboard stays clean instead of dumping the widget JSON
+ * under a red "Unknown component type" error.
+ */
+const UNSUPPORTED_CHART_TYPES = new Set([
+  'heatmap', 'treemap', 'sunburst', 'sankey', 'waterfall',
+  'candlestick', 'stock', 'box-plot', 'violin',
+  'gl-map', 'choropleth', 'bubble-map', 'word-cloud',
+]);
+
+/**
  * Chart sub-types that have a meaningful drill-down interaction.
  * Mirrors WidgetConfigPanel.DRILL_DOWN_TYPES and the click-handler wiring
  * in plugin-charts/AdvancedChartImpl. Scatter and funnel are excluded
@@ -399,8 +446,9 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                 };
             }
 
-            // gauge / solid-gauge with object binding → render as object-metric
-            if ((widgetType === 'gauge' || widgetType === 'solid-gauge') && widget.object) {
+            // gauge / solid-gauge / kpi / bullet with object binding → render as
+            // object-metric (all are a single aggregated value, optionally vs a target).
+            if (METRIC_LIKE_TYPES.has(widgetType || '') && widget.object) {
                 const aggregate = widget.aggregate ? {
                     field: widget.valueField || 'value',
                     function: widget.aggregate,
@@ -425,11 +473,12 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                 };
             }
 
-            // 'horizontal-bar' uses BarChart with vertical layout; 'funnel' has its own renderer.
-            const chartTypeMap: Record<string, string> = {};
-            const resolvedWidgetType = (widgetType && chartTypeMap[widgetType]) || widgetType;
+            // Normalize spec-level chart families onto a renderer-supported base
+            // type (e.g. column→bar, spline→line). 'horizontal-bar' uses BarChart
+            // with vertical layout; 'funnel'/'radar' have their own renderers.
+            const resolvedWidgetType = (widgetType && CHART_TYPE_ALIASES[widgetType]) || widgetType;
 
-            if (resolvedWidgetType === 'bar' || resolvedWidgetType === 'horizontal-bar' || resolvedWidgetType === 'line' || resolvedWidgetType === 'area' || resolvedWidgetType === 'pie' || resolvedWidgetType === 'donut' || resolvedWidgetType === 'scatter' || resolvedWidgetType === 'funnel') {
+            if (resolvedWidgetType && SUPPORTED_CHART_TYPES.has(resolvedWidgetType)) {
                 // Support data at widget level or nested inside options
                 const widgetData = (widget as any).data || options.data;
                 // Widget-level fields (from config panel) override options-level fields
@@ -669,6 +718,19 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                 return {
                     type: 'text',
                     value: 'Custom widget — set `component` to a UIComponent schema.',
+                    variant: 'caption',
+                    align: 'center',
+                    className: 'flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-muted-foreground',
+                };
+            }
+
+            // Known chart family with no dedicated renderer yet → clean labelled
+            // placeholder instead of falling through to a raw "Unknown component
+            // type" error box that dumps the widget JSON.
+            if (widgetType && UNSUPPORTED_CHART_TYPES.has(widgetType)) {
+                return {
+                    type: 'text',
+                    value: `「${widgetType}」chart type is not supported yet`,
                     variant: 'caption',
                     align: 'center',
                     className: 'flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-muted-foreground',


### PR DESCRIPTION
## Problem
The Console silently fell back to a plain `<input type=text>` for ~25 field types, and showed a raw red **"Unknown component type"** JSON dump for most dashboard chart families — even though the server metadata carried the correct `type`. Surfaced while exercising the `example-showcase` Field Zoo + Chart Gallery.

## Fix
**Fields** (`packages/fields/src/index.tsx`)
- `mapFieldTypeToFormType`: route toggle, secret, richtext, multiselect, radio, checkboxes, tags, tree, video, audio, composite, record, repeater, progress, color, slider, rating, code, json, avatar, address, geolocation, signature, qrcode, vector, object to their (already-registered) `field:*` widgets instead of defaulting to `field:text`.
- New widgets: `MultiSelectField`, `RadioField`, `CheckboxesField`, `TagsField` (none existed) + registered via `fieldWidgetMap`.
- `getCellRenderer`: read/detail renderers for the above. **`toggle` now renders as a boolean (was "0.0").** New `JsonCellRenderer` / `ColorSwatchCellRenderer`.

**Dashboard** (`packages/plugin-dashboard/src/DashboardRenderer.tsx`)
- Normalize chart families onto supported base renderers (`column→bar`, `spline→line`, `pyramid→funnel`, `bubble→scatter`, …) and admit `radar`.
- `kpi`/`bullet`/`gauge`/`solid-gauge` → metric cards.
- Families with no Recharts renderer (heatmap, treemap, sunburst, sankey, candlestick, …) → clean labelled placeholder instead of a raw error box.

## Verification
Built `@object-ui/console`, ran against `example-showcase`:
- Field Zoo form: all 46 fields render correct widgets; toggle detail no longer "0.0".
- Chart Gallery: `Unknown component type` count 23 → **0**; charts render, 13 unsupported families show clean placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)