### PR TITLE
fix(app-shell,view): chart list-view rendered empty

### DIFF
--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1474,20 +1474,36 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
 
         if (viewDef.type === 'chart') {
             const chartConfig = viewDef.chart || {};
+            // ObjectChart consumes a structured `aggregate` ({ field, function,
+            // groupBy }) + `xAxisKey` + `series`, NOT the flat spec-level
+            // `xAxisField`/`yAxisFields`/`aggregation` keys. Translate here so the
+            // chart actually runs its aggregate query (otherwise it renders empty).
+            const categoryField = chartConfig.xAxisField || 'name';
+            const valueField =
+                (Array.isArray(chartConfig.yAxisFields) && chartConfig.yAxisFields[0]) || 'value';
+            const aggFn = chartConfig.aggregation || 'count';
+            const series =
+                chartConfig.series && chartConfig.series.length > 0
+                    ? chartConfig.series
+                    : [{ dataKey: valueField, label: valueField }];
             return (
                 <Suspense key={key} fallback={<div className="p-4 text-sm text-muted-foreground">Loading chart…</div>}>
-                    <ObjectChart 
+                    <ObjectChart
                         dataSource={ds}
                         schema={{
                             type: 'object-chart',
                             objectName: objectDef.name,
-                            chartType: chartConfig.chartType,
-                            xAxisField: chartConfig.xAxisField,
-                            yAxisFields: chartConfig.yAxisFields,
-                            aggregation: chartConfig.aggregation,
-                            series: chartConfig.series,
+                            chartType: chartConfig.chartType || 'bar',
+                            aggregate: {
+                                field: valueField,
+                                function: aggFn,
+                                groupBy: categoryField,
+                            },
+                            xAxisKey: categoryField,
+                            series,
                             config: chartConfig.config,
                             filter: chartConfig.filter,
+                            className: 'h-[400px] w-full',
                         } as any}
                     />
                 </Suspense>

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1066,8 +1066,8 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     }
     
     // Always allow switching back to the viewType defined in schema if it's one of the supported types
-    if (schema.viewType && !views.includes(schema.viewType as ViewType) && 
-       ['grid', 'kanban', 'calendar', 'timeline', 'gantt', 'map', 'gallery'].includes(schema.viewType)) {
+    if (schema.viewType && !views.includes(schema.viewType as ViewType) &&
+       ['grid', 'kanban', 'calendar', 'timeline', 'gantt', 'map', 'gallery', 'chart'].includes(schema.viewType)) {
       views.push(schema.viewType as ViewType);
     }
     
@@ -1303,6 +1303,29 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           locationField: schema.options?.map?.locationField || 'location',
           ...(schema.options?.map || {}),
         };
+      case 'chart': {
+        // A `chart` list view renders an aggregated chart of the object's
+        // records (e.g. sum of estimate_hours grouped by status), delegating
+        // to the same object-chart component the dashboard uses.
+        const chartCfg = (schema as any).chart || schema.options?.chart || {};
+        const valueField = (Array.isArray(chartCfg.yAxisFields) && chartCfg.yAxisFields[0])
+          || chartCfg.valueField || 'value';
+        const categoryField = chartCfg.xAxisField || chartCfg.categoryField || 'name';
+        return {
+          type: 'object-chart',
+          objectName: schema.objectName,
+          chartType: chartCfg.chartType || 'bar',
+          filters: schema.filters,
+          aggregate: {
+            field: valueField,
+            function: chartCfg.aggregation || 'count',
+            groupBy: categoryField,
+          },
+          xAxisKey: categoryField,
+          series: [{ dataKey: valueField, label: valueField }],
+          className: 'h-[400px] w-full',
+        };
+      }
       default:
         return baseProps;
     }

--- a/packages/plugin-list/src/ViewSwitcher.tsx
+++ b/packages/plugin-list/src/ViewSwitcher.tsx
@@ -16,16 +16,18 @@ import {
   Activity,  // timeline
   GanttChartSquare, // gantt
   Map,        // map
+  BarChart3,  // chart
 } from 'lucide-react';
 
-export type ViewType = 
-  | 'grid' 
-  | 'kanban' 
-  | 'gallery' 
-  | 'calendar' 
+export type ViewType =
+  | 'grid'
+  | 'kanban'
+  | 'gallery'
+  | 'calendar'
   | 'timeline'
   | 'gantt'
-  | 'map';
+  | 'map'
+  | 'chart';
 
 export interface ViewSwitcherProps {
   currentView: ViewType;
@@ -44,6 +46,7 @@ const VIEW_ICONS: Record<ViewType, React.ReactNode> = {
   timeline: <Activity className="h-4 w-4" />,
   gantt: <GanttChartSquare className="h-4 w-4" />,
   map: <Map className="h-4 w-4" />,
+  chart: <BarChart3 className="h-4 w-4" />,
 };
 
 const VIEW_LABELS: Record<ViewType, string> = {
@@ -54,6 +57,7 @@ const VIEW_LABELS: Record<ViewType, string> = {
   timeline: 'Timeline',
   gantt: 'Gantt',
   map: 'Map',
+  chart: 'Chart',
 };
 
 export const ViewSwitcher: React.FC<ViewSwitcherProps> = ({

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -535,6 +535,7 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           grid: 'table',
           list: 'list',
           detail: 'file-text',
+          chart: 'bar-chart-3',
         };
         return {
           type: v.type as ViewType,
@@ -747,6 +748,27 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           locationField: viewOptions.map?.locationField || 'location',
           ...(viewOptions.map || {}),
         };
+      case 'chart': {
+        // Aggregated chart of the object's records, delegating to the same
+        // object-chart component the dashboard uses.
+        const chartCfg = viewOptions.chart || {};
+        const valueField = (Array.isArray(chartCfg.yAxisFields) && chartCfg.yAxisFields[0])
+          || chartCfg.valueField || 'value';
+        const categoryField = chartCfg.xAxisField || chartCfg.categoryField || 'name';
+        return {
+          type: 'object-chart',
+          objectName: schema.objectName,
+          chartType: chartCfg.chartType || 'bar',
+          aggregate: {
+            field: valueField,
+            function: chartCfg.aggregation || 'count',
+            groupBy: categoryField,
+          },
+          xAxisKey: categoryField,
+          series: [{ dataKey: valueField, label: valueField }],
+          className: 'h-[400px] w-full',
+        };
+      }
       default:
         return null;
     }

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -25,7 +25,7 @@ import type { SelectOptionMetadata } from './field-types';
 /**
  * View Type
  */
-export type ViewType = 'list' | 'detail' | 'grid' | 'kanban' | 'calendar' | 'timeline' | 'map' | 'gallery' | 'gantt';
+export type ViewType = 'list' | 'detail' | 'grid' | 'kanban' | 'calendar' | 'timeline' | 'map' | 'gallery' | 'gantt' | 'chart';
 
 /**
  * Detail View Field Configuration


### PR DESCRIPTION
## Problem
A list view declared with `type: 'chart'` (one of the 8 list-view types) rendered an empty plot — axes drew but no bars. app-shell's `ObjectView` passed the flat spec-level chart keys (`xAxisField` / `yAxisFields` / `aggregation`) straight through to `ObjectChart`, but `ObjectChart` runs its aggregate query from a **structured** `aggregate: { field, function, groupBy }` + `xAxisKey` + `series`. With no `aggregate`, no query ran → no data.

Found while sweeping the `example-showcase` Task view gallery (the `chart` list-view type).

## Fix
- **`app-shell/views/ObjectView`**: translate the chart config into the `aggregate` / `xAxisKey` / `series` shape `ObjectChart` consumes (the same shape the dashboard uses).
- **`plugin-view/ObjectView`** & **`plugin-list/ListView`**: add the missing `case 'chart'` so the chart view type is handled through those render paths too (emit an `object-chart` schema).
- **`plugin-list/ViewSwitcher`** + **`types/ViewType`**: add `'chart'` to the view-type union, icon map (`BarChart3`) and label map.

## Verification
Built the console and opened the showcase Task → "Hours by Status (Chart)" view: now renders a correct bar chart (Done 24 / In Review 54 / In Progress 100 / To Do 36 / Backlog 30), matching the Hours-by-Status report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)