### PR TITLE
ci: bound every job with timeout-minutes so a stalled runner fails fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   changeset-check:
     name: Changeset Fixed Group Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -37,6 +38,10 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # Bound the job so a stalled runner / non-exiting test worker fails fast and
+    # is retryable, instead of hanging up to GitHub's 6h default (the suite
+    # normally finishes in ~6 min).
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -94,6 +99,7 @@ jobs:
   e2e:
     name: Build & E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -177,6 +183,7 @@ jobs:
   docs:
     name: Build Docs
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -244,6 +251,7 @@ jobs:
   dev-server:
     name: Dev-server fixture build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Why

On PR #1433 the **Test** job hung `in_progress` for **~19 min**, and again for **~11 min** on re-run. Diagnosis:

- `vitest.config.mts` sets `testTimeout: 15000`, so a hanging *test* fails at 15s — a 19-min hang can't be a test body. It's a **stalled runner / non-exiting vitest worker**: the cancelled job's cleanup step terminated orphaned `turbo` + several `node`/`sh` (vitest) processes that never exited.
- **No job declares `timeout-minutes`**, so such a stall runs unbounded up to GitHub's **6-hour** default instead of failing fast.
- It's **intermittent** — the same suite passed on #1430 / #1432 — so it's not introduced by any one PR.

## What

Add per-job `timeout-minutes` to every job in `ci.yml`:

| Job | timeout | normal |
|---|---|---|
| Changeset Fixed Group Check | 10m | seconds |
| Test | 20m | ~6m |
| Build & E2E | 30m | ~4m |
| Build Docs | 15m | seconds |
| Dev-server fixture build | 15m | <1m |

A future stall now **fails quickly and is retryable** instead of blocking a PR for hours.

## Scope

This **bounds the symptom**. The underlying intermittent worker-exit hang (an open handle keeping a vitest worker alive under the turbo fan-out) is a separate follow-up — best pinpointed by running CI once with a hanging-process reporter (`why-is-node-running` / `--reporter=hanging-process`) to name the leaking package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)