### PR TITLE
feat(fields): render markdown/html/richtext read cells as formatted content

### DIFF
--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -39,6 +39,9 @@
     "@object-ui/types": "workspace:*",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",
+    "react-markdown": "^10.1.0",
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0"
   },
   "peerDependencies": {

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1389,6 +1389,46 @@ export function ColorSwatchCellRenderer({ value }: CellRendererProps): React.Rea
   );
 }
 
+const LazyMarkdownContent = React.lazy(() => import('./widgets/MarkdownContent'));
+
+/**
+ * Renders `markdown` / `richtext` values as formatted GFM markdown (lazy-loaded,
+ * sanitized) instead of the raw markup string.
+ */
+export function MarkdownCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  if (value == null || value === '') return <EmptyValue />;
+  return (
+    <React.Suspense fallback={<span className="text-sm text-muted-foreground">{String(value).slice(0, 80)}</span>}>
+      <LazyMarkdownContent value={String(value)} />
+    </React.Suspense>
+  );
+}
+
+/**
+ * Minimal HTML sanitizer for display: drops <script>/<style>/<iframe> blocks,
+ * inline event handlers, and javascript: URLs. Defense-in-depth — stored HTML
+ * is authored by users with write access, but is never trusted blindly.
+ */
+function sanitizeHtml(html: string): string {
+  return html
+    .replace(/<\s*(script|style|iframe|object|embed)[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, '')
+    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    .replace(/(href|src)\s*=\s*("javascript:[^"]*"|'javascript:[^']*')/gi, '$1="#"');
+}
+
+/**
+ * Renders an `html` value as sanitized, formatted HTML instead of raw markup.
+ */
+export function HtmlCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  if (value == null || value === '') return <EmptyValue />;
+  return (
+    <div
+      className="prose prose-sm max-w-none dark:prose-invert break-words"
+      dangerouslySetInnerHTML={{ __html: sanitizeHtml(String(value)) }}
+    />
+  );
+}
+
 /**
  * Renders a `location`/`geolocation` value as readable coordinates with a pin.
  * Accepts `{ lat, lng }` / `{ latitude, longitude }`, a `"lat,lng"` string,
@@ -1435,9 +1475,9 @@ export function getCellRenderer(fieldType: string): React.FC<CellRendererProps> 
   const standardMap: Record<string, React.FC<CellRendererProps>> = {
     text: TextCellRenderer,
     textarea: TextCellRenderer,
-    markdown: TextCellRenderer,
-    html: TextCellRenderer,
-    richtext: TextCellRenderer,
+    markdown: MarkdownCellRenderer,
+    html: HtmlCellRenderer,
+    richtext: MarkdownCellRenderer,
     code: TextCellRenderer,
     qrcode: TextCellRenderer,
     number: NumberCellRenderer,

--- a/packages/fields/src/widgets/MarkdownContent.tsx
+++ b/packages/fields/src/widgets/MarkdownContent.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+
+/**
+ * Heavy markdown renderer, split into its own module so it can be lazy-loaded
+ * by the cell/detail renderers (react-markdown pulls in ~100-200 KB). GitHub
+ * Flavored Markdown + sanitization (defense against XSS in stored content).
+ */
+export default function MarkdownContent({ value }: { value: string }) {
+  return (
+    <div className="prose prose-sm max-w-none dark:prose-invert break-words">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+        {value}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -780,7 +780,7 @@ importers:
         version: 9.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -801,7 +801,7 @@ importers:
         version: 4.1.1
       vite:
         specifier: ^8.0.14
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.25
@@ -820,7 +820,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/collaboration:
     dependencies:
@@ -1101,7 +1101,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/fields:
     dependencies:
@@ -1135,6 +1135,15 @@ importers:
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.15)(react@19.2.6)
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -13601,11 +13610,6 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       maplibre-gl: 5.24.0
-
-  '@vitejs/plugin-react@6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
## Problem
`markdown` / `richtext` / `html` fields rendered their **raw markup string** in grids and detail views (they fell through to the text cell renderer).

## Fix
- `MarkdownCellRenderer` (markdown, richtext): GitHub Flavored Markdown via a **lazy-loaded** `react-markdown` module (`MarkdownContent`), sanitized with `rehype-sanitize`.
- `HtmlCellRenderer` (html): sanitized `dangerouslySetInnerHTML` — strips `<script>/<style>/<iframe>` blocks, inline `on*` handlers, and `javascript:` URLs.
- Adds `react-markdown` / `remark-gfm` / `rehype-sanitize` to `@object-ui/fields` (react-markdown is lazy-loaded so it stays out of the initial chunk).

## Verification
Created a Field Zoo record with markdown/html/richtext content; detail view now renders headings, lists, links, code blocks, and bold/italic. Injected `<script>alert(1)</script>` is stripped (no XSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)