### PR TITLE
feat(charts): treemap & sankey via Recharts + field-type coverage guard

### DIFF
--- a/packages/fields/src/field-type-coverage.test.ts
+++ b/packages/fields/src/field-type-coverage.test.ts
@@ -1,0 +1,65 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression guard for the field-type → renderer registries. These mappings
+ * regressed once already: ~25 specialized field types silently fell back to a
+ * plain text input (form) and the raw text cell renderer (read), because the
+ * mapping tables were incomplete. This test locks them in so a dropped entry
+ * fails CI instead of shipping a broken widget.
+ */
+import { describe, it, expect } from 'vitest';
+import { mapFieldTypeToFormType, getCellRenderer, TextCellRenderer } from './index';
+
+/**
+ * Field types that MUST resolve to a dedicated form widget — never the
+ * `field:text` fallback. (Plain text-ish types like text/textarea are
+ * intentionally excluded.)
+ */
+const FORM_WIDGET_TYPES = [
+  'textarea', 'email', 'url', 'phone', 'password', 'secret',
+  'markdown', 'html', 'richtext',
+  'number', 'currency', 'percent', 'slider', 'progress', 'rating',
+  'date', 'datetime', 'time',
+  'boolean', 'toggle',
+  'select', 'multiselect', 'radio', 'checkboxes', 'tags',
+  'lookup', 'master_detail', 'tree',
+  'file', 'image', 'avatar', 'video', 'audio', 'signature',
+  'location', 'geolocation', 'address', 'color', 'code', 'json', 'qrcode', 'vector',
+  'object', 'composite', 'record', 'repeater',
+  'formula', 'summary', 'auto_number',
+];
+
+/**
+ * Field types that MUST resolve to a dedicated read/cell renderer — never the
+ * generic text cell renderer. (markdown/html/richtext render formatted;
+ * code/qrcode/time legitimately stay textual and are excluded.)
+ */
+const CELL_RENDERER_TYPES = [
+  'email', 'url', 'phone', 'number', 'currency', 'percent', 'progress',
+  'boolean', 'toggle', 'date', 'datetime',
+  'select', 'multiselect', 'radio', 'checkboxes', 'tags',
+  'lookup', 'master_detail', 'tree',
+  'file', 'video', 'audio', 'image', 'avatar', 'signature',
+  'markdown', 'html', 'richtext',
+  'location', 'geolocation', 'address', 'color', 'json',
+  'formula', 'summary', 'user', 'owner',
+];
+
+describe('field-type renderer coverage (regression guard)', () => {
+  it.each(FORM_WIDGET_TYPES)('maps "%s" to a dedicated form widget (not field:text)', (type) => {
+    const widget = mapFieldTypeToFormType(type);
+    expect(widget).toMatch(/^field:/);
+    expect(widget).not.toBe('field:text');
+  });
+
+  it.each(CELL_RENDERER_TYPES)('resolves "%s" to a dedicated cell renderer (not TextCellRenderer)', (type) => {
+    const renderer = getCellRenderer(type);
+    expect(renderer).toBeTypeOf('function');
+    expect(renderer).not.toBe(TextCellRenderer);
+  });
+
+  it('falls back to field:text for unknown types', () => {
+    expect(mapFieldTypeToFormType('something-unknown')).toBe('field:text');
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -31,6 +31,9 @@ import {
   Funnel,
   FunnelChart,
   LabelList,
+  Treemap,
+  Sankey,
+  Tooltip,
 } from 'recharts';
 import {
   ChartContainer,
@@ -87,7 +90,7 @@ const comparisonStyle = (s: any, kind: 'line' | 'area' | 'bar' | 'scatter') => {
 };
 
 export interface AdvancedChartImplProps {
-  chartType?: 'bar' | 'column' | 'horizontal-bar' | 'line' | 'area' | 'pie' | 'donut' | 'radar' | 'scatter' | 'funnel' | 'combo';
+  chartType?: 'bar' | 'column' | 'horizontal-bar' | 'line' | 'area' | 'pie' | 'donut' | 'radar' | 'scatter' | 'funnel' | 'combo' | 'treemap' | 'sankey';
   data?: Array<Record<string, any>>;
   config?: ChartConfig;
   xAxisKey?: string;
@@ -162,6 +165,10 @@ export default function AdvancedChartImpl({
     scatter: ScatterChart,
     funnel: FunnelChart as any,
     combo: BarChart,
+    // treemap/sankey return from their own branches above; mapped here only so
+    // the index type stays exhaustive.
+    treemap: BarChart,
+    sankey: BarChart,
   }[chartType] || BarChart;
 
   // Format ISO date strings into compact "MMM D" / "MMM YYYY" labels for X-axis ticks.
@@ -335,6 +342,64 @@ export default function AdvancedChartImpl({
             ))}
           </Funnel>
         </FunnelChart>
+      </ChartContainer>
+    );
+  }
+
+  // Treemap — composition by relative size. Recharts <Treemap> is itself the
+  // chart root (no wrapping cartesian chart); a custom content paints each
+  // leaf with a palette color + label.
+  if (chartType === 'treemap') {
+    const dataKey = series[0]?.dataKey || 'value';
+    const palette = getPalette();
+    const tmData = data.map((row, idx) => ({
+      name: String(row?.[xAxisKey] ?? ''),
+      size: Number(row?.[dataKey]) || 0,
+      fill: resolveColor(palette[idx % palette.length]),
+    }));
+    const TreemapCell = (props: any) => {
+      const { x, y, width, height, name, fill } = props;
+      if (width <= 0 || height <= 0) return null;
+      return (
+        <g>
+          <rect x={x} y={y} width={width} height={height} fill={fill} stroke="hsl(var(--background))" strokeWidth={2} />
+          {width > 48 && height > 18 ? (
+            <text x={x + 6} y={y + 18} fill="#fff" fontSize={12} className="pointer-events-none">{name}</text>
+          ) : null}
+        </g>
+      );
+    };
+    return (
+      <ChartContainer config={config} className={className}>
+        <Treemap data={tmData} dataKey="size" nameKey="name" isAnimationActive content={<TreemapCell />}>
+          <Tooltip />
+        </Treemap>
+      </ChartContainer>
+    );
+  }
+
+  // Sankey — flow from a single root node to each category, weighted by value.
+  // (The dashboard aggregate yields one value per category; a real multi-stage
+  // flow needs richer data, but this honestly renders the sankey family.)
+  if (chartType === 'sankey') {
+    const dataKey = series[0]?.dataKey || 'value';
+    const rootName = series[0]?.label || dataKey;
+    const rows = data.filter((r) => (Number(r?.[dataKey]) || 0) > 0);
+    const nodes = [{ name: rootName }, ...rows.map((r) => ({ name: String(r?.[xAxisKey] ?? '') }))];
+    const links = rows.map((r, i) => ({ source: 0, target: i + 1, value: Number(r?.[dataKey]) || 0 }));
+    if (links.length === 0) {
+      return <div className={className} />;
+    }
+    return (
+      <ChartContainer config={config} className={className}>
+        <Sankey
+          data={{ nodes, links }}
+          nodePadding={24}
+          link={{ stroke: 'hsl(var(--muted-foreground))', strokeOpacity: 0.25 }}
+          node={{ fill: 'hsl(var(--chart-1))' } as any}
+        >
+          <Tooltip />
+        </Sankey>
       </ChartContainer>
     );
   }

--- a/packages/plugin-charts/src/ChartRenderer.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.tsx
@@ -43,7 +43,7 @@ export interface ChartRendererProps {
     type: string;
     id?: string;
     className?: string;
-    chartType?: 'bar' | 'column' | 'horizontal-bar' | 'line' | 'area' | 'pie' | 'donut' | 'radar' | 'scatter' | 'funnel' | 'combo';
+    chartType?: 'bar' | 'column' | 'horizontal-bar' | 'line' | 'area' | 'pie' | 'donut' | 'radar' | 'scatter' | 'funnel' | 'combo' | 'treemap' | 'sankey';
     data?: Array<Record<string, any>>;
     config?: Record<string, any>;
     xAxisKey?: string;

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -122,6 +122,7 @@ const CHART_TYPE_ALIASES: Record<string, string> = {
  */
 const SUPPORTED_CHART_TYPES = new Set([
   'bar', 'horizontal-bar', 'line', 'area', 'pie', 'donut', 'scatter', 'funnel', 'radar',
+  'treemap', 'sankey',
 ]);
 
 /**
@@ -137,9 +138,12 @@ const METRIC_LIKE_TYPES = new Set(['gauge', 'solid-gauge', 'kpi', 'bullet']);
  * under a red "Unknown component type" error.
  */
 const UNSUPPORTED_CHART_TYPES = new Set([
-  'heatmap', 'treemap', 'sunburst', 'sankey', 'waterfall',
-  'candlestick', 'stock', 'box-plot', 'violin',
-  'gl-map', 'choropleth', 'bubble-map', 'word-cloud',
+  // Safety net: chart families dropped from the ChartType protocol (they need
+  // richer data — OHLC / per-record distributions — or a geo dependency).
+  // Kept here so any stale dashboard still referencing them renders a clean
+  // placeholder rather than a raw "Unknown component type" error.
+  'sunburst', 'word-cloud', 'choropleth', 'bubble-map', 'gl-map',
+  'heatmap', 'waterfall', 'box-plot', 'violin', 'candlestick', 'stock',
 ]);
 
 /**


### PR DESCRIPTION
## Summary
Two things:

1. **treemap & sankey via Recharts** (no new charting dependency — these were going to need ECharts, but Recharts 3.8 ships `Treemap`/`Sankey`):
   - `AdvancedChartImpl`: treemap (palette-colored leaves + labels) and sankey (single-root flow weighted by value) branches.
   - `DashboardRenderer`: move `treemap`/`sankey` into `SUPPORTED_CHART_TYPES`. Remaining geo / OHLC / distribution families (heatmap, sunburst, candlestick, box-plot, geo maps, word-cloud, …) stay as clean placeholders.

2. **Regression guard** (`fields/field-type-coverage.test.ts`): asserts every specialized field type resolves to a dedicated form widget (never the `field:text` fallback) and a dedicated cell renderer (never `TextCellRenderer`). This locks in the field-renderer fixes so the registry can't silently regress again. 87 cases.

## Verification
- Chart Gallery: treemap renders 5 colored cells, sankey renders root→category flows; 0 "Unknown component type"; placeholders down from 13 → 11.
- `vitest run field-type-coverage.test.ts` → 87 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)