### PR TITLE
docs(agents): multi-agent working discipline in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,16 @@
 - 任务结束:停后台服务(`lsof -i :PORT -t`)、清 `.playwright-mcp/`。
 - 改完代码提交时:功能改进(feature)需写 changeset(`pnpm changeset`);纯 bug 修复不需要。
 
+## 多 agent 协作纪律(并行修改本仓库,务必遵守)
+
+本仓库有**多个 agent 并行**修改 —— 分支会被切换、共享文件会在你工作时被改动(正常现象,不是 bug):
+
+- **只改你任务需要的文件**;别去"修"无关的 diff、回退或别人的在途编辑,也别管整棵工作树。
+- **一个任务一个 feature 分支 + 一个 PR**;**绝不**把任务改动直接提交到 `main`。
+- **绝不 `git push --force`/`--force-with-lease`,绝不推 `main`**(会覆盖并行 agent 的工作;`main` 共享,一律走 PR)。
+- **每次 commit/push 前先确认当前分支**(`git rev-parse --abbrev-ref HEAD`);HEAD 可能被别的 agent 切走 —— 不是你的分支就停下重新 checkout。
+- 改**共享文件**(barrel/注册表):编辑→`git add`→commit 一气呵成,并核验提交确实含你的改动(`git show HEAD:<file> | grep <你的改动>`);真冲突只重加*你自己*那几行,其余交给 PR 合并。
+
 ## Local dev — console UI ↔ backend (read before debugging UI)
 
 - **启动前端**:仓根 `pnpm --filter @object-ui/console dev`(Vite,固定 **:5180**,见 `apps/console/vite.config.ts`)。


### PR DESCRIPTION
Adds the parallel-agent git/workflow rules to AGENTS.md (Chinese, matching the file): only touch your task's files; one feature branch + PR per task; never force-push or push main; verify the current branch before every commit/push; edit+commit shared files atomically and verify your lines are in the commit. Docs-only.