### PR TITLE
fix(react): repoint useClientNotifications to ADR-0030 client surface

### DIFF
--- a/.changeset/notifications-sdk-receipt-cutover.md
+++ b/.changeset/notifications-sdk-receipt-cutover.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/react': patch
+---
+
+Repoint `useClientNotifications` to the ADR-0030 `@objectstack/client` surface
+
+The `useClientNotifications` bridge hook called `client.notifications.*` with
+signatures that no longer exist on `@objectstack/client@7.x`:
+
+- `registerDevice(token, platform)` → the SDK takes a single
+  `RegisterDeviceRequest` object (`{ token, platform }`).
+- `markAsRead(id)` → there is no single-id method; the SDK exposes
+  `markRead(ids: string[])`. The hook keeps its friendly single-id API and
+  adapts to the batch call.
+
+These helpers are the stable transport contract for ADR-0030 (Notification
+Convergence): server-side they route to the L5 `sys_inbox_message`
+materialization and the `sys_notification_receipt` read-state spine — the
+re-modeled `sys_notification` L2 event no longer carries recipient/read
+columns. (The Console bell itself reads the inbox + receipts directly via the
+generic data API; see the `@object-ui/app-shell` bell cut-over.)
+
+## Cut-over sequence (operational — run in this order)
+
+The Console UI repoint must land together with the framework pipeline **and**
+the data migration so the bell is never blank and read-state is never lost:
+
+1. Deploy the framework ADR-0030 change (objects + `emit()` + producers). New
+   notifications now land in `sys_inbox_message` + `sys_notification_receipt`.
+2. Run the data migration **once** to carry existing notifications across —
+   `migrateSysNotificationToEvent({ driver, data })` from
+   `@objectstack/metadata/migrations`. It splits each legacy `sys_notification`
+   inbox row into a `sys_inbox_message` + receipt, rewrites the row to the event
+   shape, and clears the legacy columns. It is **idempotent** and reports
+   `not_applicable` on fresh installs. This runs against the ObjectStack
+   **server/data engine** — it is not a Console (frontend) step.
+3. Deploy the objectui repoint (this change + the `@object-ui/app-shell` bell
+   cut-over).

--- a/packages/react/src/hooks/useClientNotifications.ts
+++ b/packages/react/src/hooks/useClientNotifications.ts
@@ -12,6 +12,14 @@
  * Bridge hook between the @objectstack/client notifications API
  * and the local NotificationContext state. Fetches server-side
  * notifications and surfaces them through the existing provider.
+ *
+ * ADR-0030 (Notification Convergence): the `client.notifications.*` helpers
+ * are the stable transport contract — the server routes them to the L5
+ * `sys_inbox_message` materialization and the `sys_notification_receipt`
+ * read-state spine (the re-modeled `sys_notification` L2 event carries no
+ * recipient/read columns). This hook only needs to call the SDK with its
+ * current signatures: `list(options)`, `markRead(ids[])`, `markAllRead()`,
+ * and `registerDevice(request)`.
  */
 
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
@@ -158,7 +166,13 @@ export function useClientNotifications(
       if (!client?.notifications) return;
       setError(null);
       try {
-        await client.notifications.registerDevice(token, platform);
+        // ADR-0030 / @objectstack/client v7+: registerDevice takes a single
+        // RegisterDeviceRequest object (`{ token, platform }`), not positional
+        // args. `platform` is the device platform enum.
+        await client.notifications.registerDevice({
+          token,
+          platform: platform as 'ios' | 'android' | 'web',
+        });
       } catch (err) {
         const wrapped = err instanceof Error ? err : new Error('Failed to register device');
         setError(wrapped);
@@ -209,7 +223,11 @@ export function useClientNotifications(
       if (!client?.notifications) return;
       setError(null);
       try {
-        await client.notifications.markAsRead(id);
+        // ADR-0030 / @objectstack/client v7+: the SDK exposes `markRead(ids[])`
+        // (batch) — there is no single-id `markAsRead`. Server-side this writes
+        // the `read` state to the `sys_notification_receipt` spine. We keep the
+        // friendly single-id hook API and adapt to the batch call.
+        await client.notifications.markRead([id]);
       } catch (err) {
         const wrapped = err instanceof Error ? err : new Error('Failed to mark as read');
         setError(wrapped);


### PR DESCRIPTION
## What & why

Cross-repo cut-over for [framework ADR-0030 — Notification Convergence](../../framework/docs/handoff/adr-0030-notification-convergence.md). The objectui-side bell repoint (`sys_notification` → `sys_inbox_message` + `sys_notification_receipt`) and the receipt-upsert mark-read path already landed in #1429. This PR closes the remaining objectui item: the **SDK consumer**.

`useClientNotifications` (the only objectui surface that touches `client.notifications.*`) called the SDK with signatures that no longer exist on `@objectstack/client@7.x`, so it would throw at runtime:

- `registerDevice(token, platform)` → SDK takes a single `RegisterDeviceRequest` object → now `registerDevice({ token, platform })`.
- `markAsRead(id)` → no single-id method; SDK is `markRead(ids: string[])` → now `markRead([id])` (kept the friendly single-id hook API).

These helpers are the stable transport contract; server-side ADR-0030 routes them to the L5 `sys_inbox_message` materialization and the `sys_notification_receipt` read-state spine.

## Cut-over runbook (in the changeset)

objectui is frontend-only and cannot run the server-side data migration. The new changeset records the operational order so whoever deploys runs it:

1. Deploy framework ADR-0030 (objects + `emit()` + producers).
2. Run **`migrateSysNotificationToEvent({ driver, data })`** once (from `@objectstack/metadata/migrations`; idempotent, `not_applicable` on fresh installs) — server/data-engine step, not a Console step.
3. Deploy the objectui repoint (this PR + the #1429 bell cut-over).

## Verification

- `tsc --noEmit` + eslint clean on the changed package (remaining lint warnings are pre-existing in untouched lines).
- **Browser end-to-end** against a live ADR-0030 backend (showcase Console): seeded a `sys_inbox_message` + a `delivered` `sys_notification_receipt` for a test user →
  - bell badge showed **1**, popover rendered the row;
  - **Mark all read** flipped the *existing* receipt `delivered → read` in place (same row id, no duplicate) and cleared the badge to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)