### PR TITLE
fix(list): localize row-action labels + honor visible CEL per row

### DIFF
--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1587,8 +1587,24 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
              * remains for back-compat where the action lives elsewhere.
              */
             rowActionDefs: (Array.isArray((objectDef as any)?.actions)
-                ? (objectDef as any).actions.filter((a: any) =>
-                    Array.isArray(a?.locations) && a.locations.includes('list_item'))
+                ? (objectDef as any).actions
+                    .filter((a: any) =>
+                      Array.isArray(a?.locations) && a.locations.includes('list_item'))
+                    // Localize label / confirm / success the same way the
+                    // record_header and list_toolbar paths do — the row kebab
+                    // previously rendered raw English `a.label`. The `visible`
+                    // CEL is forwarded untouched (spread) and evaluated per-row
+                    // at render time inside RowActionMenu.
+                    .map((a: any) => ({
+                      ...a,
+                      label: actionLabel(objectDef.name, a.name, a.label || a.name),
+                      ...(a.confirmText !== undefined && {
+                        confirmText: actionConfirm(objectDef.name, a.name, a.confirmText),
+                      }),
+                      ...(a.successMessage !== undefined && {
+                        successMessage: actionSuccess(objectDef.name, a.name, a.successMessage),
+                      }),
+                    }))
                 : []),
             bulkActions: viewDef.bulkActions ?? listSchema.bulkActions,
             bulkActionDefs: (viewDef as any).bulkActionDefs ?? (listSchema as any).bulkActionDefs,

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuTrigger,
 } from '@object-ui/components';
 import { Edit, Trash2, MoreVertical } from 'lucide-react';
-import { useObjectTranslation } from '@object-ui/react';
+import { useObjectTranslation, useCondition, toPredicateInput } from '@object-ui/react';
 
 const ROW_ACTION_FALLBACKS: Record<string, string> = {
   'grid.openMenu': 'Open menu',
@@ -75,6 +75,34 @@ export interface RowActionMenuProps {
   onActionDef?: (def: RowActionDef, row: any) => void;
 }
 
+/**
+ * One schema-driven row-action menu item. Extracted into its own component
+ * so the `visible` CEL predicate can be evaluated with a hook
+ * (`useCondition`) without violating the rules-of-hooks inside a `.map()`.
+ * Mirrors `ActionMenuItem` on the record_header path: when a `visible`
+ * predicate is present and evaluates false against the row, the item is
+ * hidden (so e.g. "Resume" no longer shows on a running record). Bare field
+ * references (`status == "active"`, `is_default != true`) resolve against
+ * the row record passed in as evaluation context.
+ */
+const RowActionMenuItem: React.FC<{
+  def: RowActionDef;
+  row: any;
+  onActionDef?: (def: RowActionDef, row: any) => void;
+}> = ({ def, row, onActionDef }) => {
+  const isVisible = useCondition(toPredicateInput(def.visible), row);
+  if (def.visible && !isVisible) return null;
+  return (
+    <DropdownMenuItem
+      onClick={() => onActionDef?.(def, row)}
+      data-testid={`row-action-${def.name}`}
+      className={def.variant === 'danger' ? 'text-destructive focus:text-destructive' : undefined}
+    >
+      {def.label ?? formatActionLabel(def.name)}
+    </DropdownMenuItem>
+  );
+};
+
 export const RowActionMenu: React.FC<RowActionMenuProps> = ({
   row,
   rowActions,
@@ -114,14 +142,12 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
           </DropdownMenuItem>
         )}
         {rowActionDefs?.map(def => (
-          <DropdownMenuItem
+          <RowActionMenuItem
             key={def.name}
-            onClick={() => onActionDef?.(def, row)}
-            data-testid={`row-action-${def.name}`}
-            className={def.variant === 'danger' ? 'text-destructive focus:text-destructive' : undefined}
-          >
-            {def.label ?? formatActionLabel(def.name)}
-          </DropdownMenuItem>
+            def={def}
+            row={row}
+            onActionDef={onActionDef}
+          />
         ))}
         {rowActions?.map(action => (
           <DropdownMenuItem


### PR DESCRIPTION
List/grid row action menus (`list_item` location) had two gaps vs the record_header path:

1. **Labels not localized** — the row kebab rendered raw English `action.label`; `record_header` and `list_toolbar` localize via `actionLabel()` but `rowActionDefs` did not. `ObjectView` now builds `rowActionDefs` through the same `actionLabel/actionConfirm/actionSuccess` pass.
2. **`visible` CEL ignored** — state-machine actions showed regardless of row state (e.g. both Suspend and Resume on an active row). `RowActionMenu` now evaluates each action's `visible` predicate against the row via a small `RowActionMenuItem` child (`useCondition`/`toPredicateInput`), mirroring `ActionMenuItem`.

Full `turbo run build` (42/42) passes including `@object-ui/console`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)