### PR TITLE
feat(studio): curated ObjectDefaultInspector for the no-selection panel

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -555,6 +555,21 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'designer.field.min': 'Min',
   'designer.field.max': 'Max',
   'designer.field.maxLength': 'Max length',
+  // Object basics (no-selection default inspector)
+  'designer.object.kind': 'Object',
+  'designer.object.section.basic': 'Basic info',
+  'designer.object.section.basicHint': 'Identity, display names & classification',
+  'designer.object.name': 'Name',
+  'designer.object.nameHint': 'snake_case unique identifier (cannot change after create)',
+  'designer.object.namePlaceholder': 'account',
+  'designer.object.label': 'Label',
+  'designer.object.labelPlaceholder': 'e.g. Account',
+  'designer.object.pluralLabel': 'Plural label',
+  'designer.object.pluralPlaceholder': 'e.g. Accounts',
+  'designer.object.icon': 'Icon',
+  'designer.object.iconHint': 'Lucide icon name (e.g. “building”, “users”)',
+  'designer.object.description': 'Description',
+  'designer.object.descriptionPlaceholder': 'What this object represents',
 };
 
 const ENGINE_STRINGS_ZH: Record<string, string> = {
@@ -969,6 +984,21 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'designer.field.min': '最小值',
   'designer.field.max': '最大值',
   'designer.field.maxLength': '最大长度',
+  // Object basics (no-selection default inspector)
+  'designer.object.kind': '对象',
+  'designer.object.section.basic': '基础信息',
+  'designer.object.section.basicHint': '标识、显示名与分类',
+  'designer.object.name': '名称',
+  'designer.object.nameHint': 'snake_case 唯一标识符（创建后不可修改）',
+  'designer.object.namePlaceholder': 'account',
+  'designer.object.label': '显示名',
+  'designer.object.labelPlaceholder': '如：客户',
+  'designer.object.pluralLabel': '复数显示名',
+  'designer.object.pluralPlaceholder': '如：客户列表',
+  'designer.object.icon': '图标',
+  'designer.object.iconHint': 'Lucide 图标名称（如 “building”、“users”）',
+  'designer.object.description': '描述',
+  'designer.object.descriptionPlaceholder': '该对象代表什么',
 };
 
 function pickTable(

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.test.tsx
@@ -1,0 +1,151 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ObjectDefaultInspector } from './ObjectDefaultInspector';
+
+afterEach(cleanup);
+
+const baseProps = {
+  type: 'object',
+  onSelectionChange: vi.fn(),
+  locale: 'en-US' as const,
+};
+
+function labelledInput(label: string): HTMLInputElement {
+  // The shared field renders <Label>{text}</Label> followed by the input
+  // inside the same wrapper div.
+  const lab = screen.getByText(label);
+  const input = lab.parentElement!.querySelector('input, textarea');
+  return input as HTMLInputElement;
+}
+
+describe('ObjectDefaultInspector — basics', () => {
+  it('renders curated object basics (no raw fields JSON)', () => {
+    const { container } = render(
+      <ObjectDefaultInspector
+        {...baseProps}
+        name="account"
+        draft={{ name: 'account', label: 'Account', pluralLabel: 'Accounts', fields: { a: { type: 'text' } } }}
+        onPatch={vi.fn()}
+        readOnly={false}
+      />,
+    );
+    expect(screen.getByText('Basic info')).toBeInTheDocument();
+    expect((labelledInput('Label')).value).toBe('Account');
+    expect((labelledInput('Plural label')).value).toBe('Accounts');
+    // The fields JSON must NOT leak into this panel.
+    expect(container.textContent).not.toContain('object-fields');
+    expect(container.querySelector('textarea')).toBeTruthy(); // description only
+  });
+
+  it('commits edits via onPatch', () => {
+    const onPatch = vi.fn();
+    render(
+      <ObjectDefaultInspector
+        {...baseProps}
+        name="account"
+        draft={{ name: 'account', label: 'Account' }}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Plural label'), { target: { value: 'Accounts' } });
+    expect(onPatch).toHaveBeenCalledWith({ pluralLabel: 'Accounts' });
+    fireEvent.change(labelledInput('Icon'), { target: { value: 'building' } });
+    expect(onPatch).toHaveBeenCalledWith({ icon: 'building' });
+  });
+});
+
+describe('ObjectDefaultInspector — name editability', () => {
+  it('locks the name in edit mode (existing object)', () => {
+    render(
+      <ObjectDefaultInspector
+        {...baseProps}
+        name="account"
+        draft={{ name: 'account', label: 'Account' }}
+        onPatch={vi.fn()}
+        readOnly={false}
+      />,
+    );
+    expect(labelledInput('Name')).toBeDisabled();
+  });
+
+  it('allows editing the name in create mode (empty host name)', () => {
+    const onPatch = vi.fn();
+    render(
+      <ObjectDefaultInspector
+        {...baseProps}
+        name=""
+        draft={{ name: '' }}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    const nameInput = labelledInput('Name');
+    expect(nameInput).not.toBeDisabled();
+    fireEvent.change(nameInput, { target: { value: 'My Thing' } });
+    expect(onPatch).toHaveBeenCalledWith({ name: 'my_thing' });
+  });
+});
+
+describe('ObjectDefaultInspector — create-mode name derivation', () => {
+  it('auto-derives a snake_case name from the label until name is edited', () => {
+    const onPatch = vi.fn();
+    render(
+      <ObjectDefaultInspector
+        {...baseProps}
+        name=""
+        draft={{ name: '' }}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    // Typing a label derives name.
+    fireEvent.change(labelledInput('Label'), { target: { value: 'Sales Order' } });
+    expect(onPatch).toHaveBeenCalledWith({ label: 'Sales Order', name: 'sales_order' });
+
+    onPatch.mockClear();
+    // Once the user edits name, label changes no longer overwrite it.
+    fireEvent.change(labelledInput('Name'), { target: { value: 'so' } });
+    expect(onPatch).toHaveBeenCalledWith({ name: 'so' });
+    onPatch.mockClear();
+    fireEvent.change(labelledInput('Label'), { target: { value: 'Sales Orders' } });
+    expect(onPatch).toHaveBeenCalledWith({ label: 'Sales Orders' }); // no name key
+  });
+});
+
+describe('ObjectDefaultInspector — i18n', () => {
+  it('renders Chinese labels under zh-CN', () => {
+    render(
+      <ObjectDefaultInspector
+        {...baseProps}
+        locale={'zh-CN'}
+        name="account"
+        draft={{ name: 'account', label: '客户' }}
+        onPatch={vi.fn()}
+        readOnly={false}
+      />,
+    );
+    expect(screen.getByText('基础信息')).toBeInTheDocument();
+    expect(screen.getByText('显示名')).toBeInTheDocument();
+    expect(screen.getByText('复数显示名')).toBeInTheDocument();
+  });
+});
+
+describe('ObjectDefaultInspector — read-only', () => {
+  it('disables all inputs when readOnly', () => {
+    render(
+      <ObjectDefaultInspector
+        {...baseProps}
+        name="account"
+        draft={{ name: 'account', label: 'Account' }}
+        onPatch={vi.fn()}
+        readOnly
+      />,
+    );
+    expect(labelledInput('Label')).toBeDisabled();
+    expect(labelledInput('Plural label')).toBeDisabled();
+    expect(labelledInput('Icon')).toBeDisabled();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ObjectDefaultInspector — the "home" panel for the object designer,
+ * shown when no field is selected.
+ *
+ * Without it, deselecting a field falls back to the generic whole-draft
+ * SchemaForm, which (a) exposes a raw `fields` JSON editor the canvas
+ * already owns, and (b) only renders whatever properties the server's
+ * `/meta/types` schema happens to declare (often just `name`). This
+ * curated panel instead edits the object-level basics directly, in the
+ * active locale, in both create and edit.
+ *
+ * Create-mode niceties:
+ *   • `name` is editable only while creating (it's the immutable PK once
+ *     saved) and auto-derives a snake_case slug from the label until the
+ *     author edits it directly — mirroring the protocol create form.
+ *
+ * All edits flow through `onPatch` as shallow draft patches.
+ */
+
+import * as React from 'react';
+import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
+import { InspectorShell, InspectorTextField } from './_shared';
+import { Label } from '@object-ui/components';
+import { toFieldName } from '../previews/object-fields-io';
+import { t } from '../i18n';
+
+export function ObjectDefaultInspector({
+  name,
+  draft,
+  onPatch,
+  readOnly,
+  locale,
+}: MetadataDefaultInspectorProps) {
+  const tr = React.useCallback((key: string) => t(key, locale), [locale]);
+  // The host passes an empty `name` only while creating a new object.
+  const createMode = !name;
+  const str = (key: string) => (typeof draft[key] === 'string' ? (draft[key] as string) : '');
+
+  // Auto-derive name from label until the user edits name directly.
+  const nameTouched = React.useRef(false);
+
+  const setLabel = (v: string) => {
+    const patch: Record<string, unknown> = { label: v || undefined };
+    if (createMode && !nameTouched.current) patch.name = toFieldName(v);
+    onPatch(patch);
+  };
+  const setName = (v: string) => {
+    nameTouched.current = true;
+    onPatch({ name: toFieldName(v) });
+  };
+
+  const nameValue = createMode ? str('name') : name || str('name');
+  const title = str('label') || name || tr('designer.object.kind');
+
+  return (
+    <InspectorShell
+      kindLabel={tr('designer.object.kind')}
+      title={title}
+      onClose={() => {}}
+      hideClose
+    >
+      <Section
+        title={tr('designer.object.section.basic')}
+        hint={tr('designer.object.section.basicHint')}
+      >
+        <Field hint={tr('designer.object.nameHint')}>
+          <InspectorTextField
+            label={tr('designer.object.name')}
+            value={nameValue}
+            onCommit={setName}
+            disabled={readOnly || !createMode}
+            mono
+            placeholder={tr('designer.object.namePlaceholder')}
+          />
+        </Field>
+        <InspectorTextField
+          label={tr('designer.object.label')}
+          value={str('label')}
+          onCommit={setLabel}
+          disabled={readOnly}
+          placeholder={tr('designer.object.labelPlaceholder')}
+        />
+        <InspectorTextField
+          label={tr('designer.object.pluralLabel')}
+          value={str('pluralLabel')}
+          onCommit={(v) => onPatch({ pluralLabel: v || undefined })}
+          disabled={readOnly}
+          placeholder={tr('designer.object.pluralPlaceholder')}
+        />
+        <Field hint={tr('designer.object.iconHint')}>
+          <InspectorTextField
+            label={tr('designer.object.icon')}
+            value={str('icon')}
+            onCommit={(v) => onPatch({ icon: v || undefined })}
+            disabled={readOnly}
+            mono
+            placeholder="building"
+          />
+        </Field>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">{tr('designer.object.description')}</Label>
+          <textarea
+            value={str('description')}
+            disabled={readOnly}
+            rows={2}
+            placeholder={tr('designer.object.descriptionPlaceholder')}
+            onChange={(e) => onPatch({ description: e.target.value || undefined })}
+            className="w-full text-sm rounded-md border bg-background px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+      </Section>
+    </InspectorShell>
+  );
+}
+
+/* ─────────────── Sub-components ─────────────── */
+
+function Section({
+  title,
+  hint,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="border-b pb-1">
+        <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {title}
+        </div>
+        {hint && <div className="text-[10px] normal-case text-muted-foreground/70 mt-0.5">{hint}</div>}
+      </div>
+      <div className="space-y-2">{children}</div>
+    </div>
+  );
+}
+
+/** Wraps a field with a small help line below it. */
+function Field({ hint, children }: { hint?: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      {children}
+      {hint && <p className="text-[11px] text-muted-foreground/80 px-0.5 leading-snug">{hint}</p>}
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/index.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/index.ts
@@ -14,6 +14,7 @@ import { ViewInspector, ViewDefaultInspector } from './ViewInspector';
 import { PageBlockInspector } from './PageBlockInspector';
 import { ReportColumnInspector } from './ReportColumnInspector';
 import { ObjectFieldInspector } from './ObjectFieldInspector';
+import { ObjectDefaultInspector } from './ObjectDefaultInspector';
 
 export function registerBuiltinInspectors(): void {
   registerMetadataInspector('dashboard', DashboardWidgetInspector);
@@ -30,4 +31,5 @@ export function registerBuiltinInspectors(): void {
   registerMetadataInspector('page', PageBlockInspector);
   registerMetadataInspector('report', ReportColumnInspector);
   registerMetadataInspector('object', ObjectFieldInspector);
+  registerMetadataDefaultInspector('object', ObjectDefaultInspector);
 }


### PR DESCRIPTION
## Summary
Follow-up to #1441. Gives the object designer a dedicated **no-selection "home" inspector** so deselecting a field no longer falls back to the generic whole-draft `SchemaForm`.

Previously that fallback (a) exposed a raw `fields` JSON editor the canvas already owns, and (b) only rendered whatever properties the server's `/meta/types` schema declared — often just `name`.

`ObjectDefaultInspector` (mirrors the existing `ViewDefaultInspector`) renders curated, **localized** object basics — Name / Label / Plural label / Icon / Description — editing the draft directly via `onPatch`, independent of server-schema completeness. In create mode `name` is editable and auto-derives a snake_case slug from the label until the author edits it; in edit mode `name` is locked (immutable PK).

## Tests
7 RTL cases: renders basics without leaking `fields` JSON, commits patches, name editability (create vs edit), label→name derivation, zh-CN labels, read-only. Full `metadata-admin` suite green (**86**); `tsc` clean; 0 lint errors.

## Note
Live browser re-confirmation of this panel was blocked by a framework-side auth issue in the local dev backend (`/api/v1/auth/get-session` 404 → the console SPA can't restore a session), unrelated to this change. The i18n wiring and the "no fields JSON on deselect" behavior were verified live earlier in the same designer; this component is otherwise fully covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)