### PR TITLE
feat(studio): AI-draft review/diff mode in the object designer (v1)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -1750,6 +1750,11 @@ function MetadataResourceEditPageImpl({
                           type={type}
                           name={name}
                           draft={draft}
+                          baseline={
+                            !createMode
+                              ? ((layered?.effective as Record<string, unknown> | undefined) ?? undefined)
+                              : undefined
+                          }
                           editing={editing && !previewOnly}
                           selection={previewOnly ? null : selection}
                           onSelectionChange={setSelection}

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -589,6 +589,14 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'designer.canvas.bulkDelete': 'Delete',
   'designer.canvas.bulkClear': 'Clear',
   'designer.canvas.bulkHint': 'Ctrl/⌘-click or Shift-click to select multiple fields.',
+  // Review / diff mode (Tier 3 — AI-draft review)
+  'designer.canvas.reviewChanges': 'Review changes',
+  'designer.canvas.reviewExit': 'Exit review',
+  'designer.canvas.reviewVsPublished': 'vs last published',
+  'designer.canvas.diffAdded': 'Added',
+  'designer.canvas.diffChanged': 'Changed',
+  'designer.canvas.diffRemoved': 'Removed',
+  'designer.canvas.diffChangedKeys': 'Changed: {keys}',
 };
 
 const ENGINE_STRINGS_ZH: Record<string, string> = {
@@ -1037,6 +1045,14 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'designer.canvas.bulkDelete': '删除',
   'designer.canvas.bulkClear': '取消选择',
   'designer.canvas.bulkHint': '按住 Ctrl/⌘ 单击或 Shift 单击可多选字段。',
+  // Review / diff mode (Tier 3 — AI-draft review)
+  'designer.canvas.reviewChanges': '查看变更',
+  'designer.canvas.reviewExit': '退出查看',
+  'designer.canvas.reviewVsPublished': '对比已发布版本',
+  'designer.canvas.diffAdded': '新增',
+  'designer.canvas.diffChanged': '修改',
+  'designer.canvas.diffRemoved': '删除',
+  'designer.canvas.diffChangedKeys': '变更：{keys}',
 };
 
 function pickTable(

--- a/packages/app-shell/src/views/metadata-admin/preview-registry.ts
+++ b/packages/app-shell/src/views/metadata-admin/preview-registry.ts
@@ -57,6 +57,13 @@ export interface MetadataPreviewProps {
    */
   onPatch?: (patch: Record<string, unknown>) => void;
   /**
+   * Optional: the last *published* version of this item, for previews
+   * that offer a review/diff mode (e.g. the object designer diffing an
+   * AI-authored draft against what's live). Undefined in create mode or
+   * when no published baseline exists.
+   */
+  baseline?: Record<string, unknown>;
+  /**
    * Optional: whether the host is in edit mode. Previews that ship
    * editing affordances should render them in a disabled/hidden state
    * when `editing === false`.

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.test.tsx
@@ -1,10 +1,27 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
 import { ObjectFormCanvas } from './ObjectFormCanvas';
 
 afterEach(cleanup);
+
+/* shared fixtures for the review/diff tests */
+const REVIEW_BASELINE = {
+  name: 'account',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    legacy: { type: 'text', label: 'Legacy' },
+  },
+};
+const REVIEW_DRAFT = {
+  name: 'account',
+  fields: {
+    name: { type: 'text', label: 'Full Name' }, // changed (label)
+    phone: { type: 'phone', label: 'Mobile' }, // added (label ≠ type, avoids badge clash)
+    // legacy removed
+  },
+};
 
 /** Draft with three fields, two declared sections (one empty). */
 function draftWithGroups() {
@@ -251,5 +268,46 @@ describe('ObjectFormCanvas — bulk multi-select', () => {
     // Popover lists Ungrouped + the declared sections; pick "Metadata" (key 'meta').
     fireEvent.click(screen.getByRole('button', { name: 'Metadata' }));
     expect(onPatch.mock.calls.at(-1)![0].fields.notes.group).toBe('meta');
+  });
+});
+
+describe('ObjectFormCanvas — review/diff mode', () => {
+  const rowFor = (label: string) => screen.getByText(label).closest('[role="button"]') as HTMLElement;
+
+  it('offers a Review changes toggle only when a baseline differs', () => {
+    render(<ObjectFormCanvas objectName="account" draft={REVIEW_DRAFT} baseline={REVIEW_BASELINE} onPatch={vi.fn()} />);
+    expect(screen.getByText('Review changes')).toBeInTheDocument();
+  });
+
+  it('hides the toggle when there is no baseline', () => {
+    render(<ObjectFormCanvas objectName="account" draft={REVIEW_DRAFT} onPatch={vi.fn()} />);
+    expect(screen.queryByText('Review changes')).not.toBeInTheDocument();
+  });
+
+  it('hides the toggle when the draft equals the baseline', () => {
+    render(<ObjectFormCanvas objectName="account" draft={REVIEW_BASELINE} baseline={REVIEW_BASELINE} onPatch={vi.fn()} />);
+    expect(screen.queryByText('Review changes')).not.toBeInTheDocument();
+  });
+
+  it('shows per-field badges and a removed ghost when reviewing', () => {
+    render(<ObjectFormCanvas objectName="account" draft={REVIEW_DRAFT} baseline={REVIEW_BASELINE} onPatch={vi.fn()} />);
+    fireEvent.click(screen.getByText('Review changes'));
+    // Added badge scoped to the new field's row.
+    expect(within(rowFor('Mobile')).getByText('Added')).toBeInTheDocument();
+    // Changed badge scoped to the edited field's row.
+    expect(within(rowFor('Full Name')).getByText('Changed')).toBeInTheDocument();
+    // Removed field shows as a ghost (its label survives only in review mode).
+    expect(screen.getByText('Legacy')).toBeInTheDocument();
+  });
+
+  it('Exit review removes the diff chrome (incl. the removed ghost)', () => {
+    render(<ObjectFormCanvas objectName="account" draft={REVIEW_DRAFT} baseline={REVIEW_BASELINE} onPatch={vi.fn()} />);
+    fireEvent.click(screen.getByText('Review changes'));
+    expect(screen.getByText('Exit review')).toBeInTheDocument();
+    expect(screen.getByText('Legacy')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Exit review'));
+    expect(screen.getByText('Review changes')).toBeInTheDocument();
+    // The removed-field ghost only exists in review mode.
+    expect(screen.queryByText('Legacy')).not.toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.tsx
@@ -38,6 +38,7 @@ import {
   ChevronsDownUp,
   ChevronsUpDown,
   CheckSquare,
+  GitCompareArrows,
   X,
 } from 'lucide-react';
 import type { MetadataSelection } from '../preview-registry';
@@ -53,8 +54,11 @@ import {
   removeGroup,
   moveGroup,
   clearFieldGroup,
+  diffFields,
   type FieldEntry,
   type FieldGroup,
+  type FieldsDiff,
+  type FieldDiffStatus,
 } from './object-fields-io';
 import {
   FIELD_TYPE_META,
@@ -80,6 +84,8 @@ const categoryLabel = (cat: FieldTypeCategory, locale?: string): string =>
 export interface ObjectFormCanvasProps {
   objectName: string;
   draft: Record<string, unknown>;
+  /** Last published version, for the review/diff mode. */
+  baseline?: Record<string, unknown>;
   onPatch?: (patch: Record<string, unknown>) => void;
   selection?: MetadataSelection | null;
   onSelectionChange?: (next: MetadataSelection | null) => void;
@@ -89,6 +95,7 @@ export interface ObjectFormCanvasProps {
 export function ObjectFormCanvas({
   objectName,
   draft,
+  baseline,
   onPatch,
   selection,
   onSelectionChange,
@@ -97,6 +104,25 @@ export function ObjectFormCanvas({
   const readOnly = !onPatch;
 
   const view = React.useMemo(() => readFields((draft as any).fields), [draft]);
+
+  /* ─── Review/diff mode — draft vs last published ─── */
+  const diff = React.useMemo<FieldsDiff | null>(
+    () => (baseline ? diffFields((baseline as any).fields, (draft as any).fields) : null),
+    [baseline, draft],
+  );
+  const changeCount = diff
+    ? diff.counts.added + diff.counts.changed + diff.counts.removed
+    : 0;
+  const [reviewMode, setReviewMode] = React.useState(false);
+  // Auto-exit review when nothing differs anymore (e.g. user reverted edits).
+  React.useEffect(() => {
+    if (reviewMode && changeCount === 0) setReviewMode(false);
+  }, [reviewMode, changeCount]);
+  const reviewing = reviewMode && changeCount > 0;
+  const statusOf = (name: string): FieldDiffStatus | undefined =>
+    reviewing ? diff?.byName[name]?.status : undefined;
+  const changedKeysOf = (name: string): string[] =>
+    reviewing ? diff?.byName[name]?.changedKeys ?? [] : [];
   const declaredGroups = React.useMemo<FieldGroup[]>(
     () => readGroups((draft as any).fieldGroups),
     [draft],
@@ -429,6 +455,10 @@ export function ObjectFormCanvas({
             sectionCount={declaredGroups.length}
             allCollapsed={allCollapsed}
             onToggleAll={showSectionChrome ? () => setAllCollapsed(!allCollapsed) : undefined}
+            reviewAvailable={changeCount > 0}
+            reviewing={reviewing}
+            diffCounts={diff?.counts}
+            onToggleReview={() => setReviewMode((v) => !v)}
             locale={locale}
           />
         )}
@@ -466,6 +496,8 @@ export function ObjectFormCanvas({
                       entry={entry}
                       selected={entry.name === selectedName}
                       multiSelected={multiSel.has(entry.name)}
+                      diffStatus={statusOf(entry.name)}
+                      changedKeys={changedKeysOf(entry.name)}
                       readOnly={readOnly}
                       locale={locale}
                       onClick={(e) => handleRowClick(entry, e)}
@@ -484,6 +516,17 @@ export function ObjectFormCanvas({
                 </GroupSection>
               );
             })}
+          </div>
+        )}
+
+        {reviewing && diff && diff.removed.length > 0 && (
+          <div className="space-y-2.5">
+            <div className="text-[11px] font-medium uppercase tracking-wider text-destructive/80 pl-1">
+              {t('designer.canvas.diffRemoved', locale)}
+            </div>
+            {diff.removed.map((entry) => (
+              <GhostFieldRow key={entry.name} entry={entry} locale={locale} />
+            ))}
           </div>
         )}
 
@@ -514,6 +557,10 @@ function CanvasToolbar({
   sectionCount,
   allCollapsed,
   onToggleAll,
+  reviewAvailable,
+  reviewing,
+  diffCounts,
+  onToggleReview,
   locale,
 }: {
   fieldCount: number;
@@ -521,40 +568,85 @@ function CanvasToolbar({
   sectionCount: number;
   allCollapsed: boolean;
   onToggleAll?: () => void;
+  reviewAvailable?: boolean;
+  reviewing?: boolean;
+  diffCounts?: { added: number; changed: number; removed: number };
+  onToggleReview?: () => void;
   locale?: string;
 }) {
   return (
     <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
-      <div className="flex items-center gap-1.5">
-        <span className="font-medium text-foreground/80">{fieldCount}</span>{' '}
-        {t('designer.canvas.fields', locale)}
-        <span className="text-muted-foreground/50">·</span>
-        <span className="font-medium text-foreground/80">{requiredCount}</span>{' '}
-        {t('designer.canvas.required', locale)}
-        {sectionCount > 0 && (
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {reviewing && diffCounts ? (
           <>
+            <span className="font-medium text-emerald-600 dark:text-emerald-400">
+              {diffCounts.added}
+            </span>{' '}
+            {t('designer.canvas.diffAdded', locale)}
             <span className="text-muted-foreground/50">·</span>
-            <span className="font-medium text-foreground/80">{sectionCount}</span>{' '}
-            {t('designer.canvas.sections', locale)}
+            <span className="font-medium text-amber-600 dark:text-amber-400">
+              {diffCounts.changed}
+            </span>{' '}
+            {t('designer.canvas.diffChanged', locale)}
+            <span className="text-muted-foreground/50">·</span>
+            <span className="font-medium text-destructive">{diffCounts.removed}</span>{' '}
+            {t('designer.canvas.diffRemoved', locale)}
+            <span className="text-muted-foreground/40 normal-case ml-1">
+              {t('designer.canvas.reviewVsPublished', locale)}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="font-medium text-foreground/80">{fieldCount}</span>{' '}
+            {t('designer.canvas.fields', locale)}
+            <span className="text-muted-foreground/50">·</span>
+            <span className="font-medium text-foreground/80">{requiredCount}</span>{' '}
+            {t('designer.canvas.required', locale)}
+            {sectionCount > 0 && (
+              <>
+                <span className="text-muted-foreground/50">·</span>
+                <span className="font-medium text-foreground/80">{sectionCount}</span>{' '}
+                {t('designer.canvas.sections', locale)}
+              </>
+            )}
           </>
         )}
       </div>
-      {onToggleAll && (
-        <button
-          type="button"
-          onClick={onToggleAll}
-          className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-accent hover:text-foreground transition-colors"
-        >
-          {allCollapsed ? (
-            <ChevronsUpDown className="h-3 w-3" />
-          ) : (
-            <ChevronsDownUp className="h-3 w-3" />
-          )}
-          {allCollapsed
-            ? t('designer.canvas.expandAll', locale)
-            : t('designer.canvas.collapseAll', locale)}
-        </button>
-      )}
+      <div className="flex items-center gap-1 shrink-0">
+        {reviewAvailable && onToggleReview && (
+          <button
+            type="button"
+            onClick={onToggleReview}
+            className={cn(
+              'inline-flex items-center gap-1 rounded px-1.5 py-0.5 transition-colors',
+              reviewing
+                ? 'bg-primary/10 text-primary hover:bg-primary/15'
+                : 'hover:bg-accent hover:text-foreground',
+            )}
+          >
+            <GitCompareArrows className="h-3 w-3" />
+            {reviewing
+              ? t('designer.canvas.reviewExit', locale)
+              : t('designer.canvas.reviewChanges', locale)}
+          </button>
+        )}
+        {onToggleAll && (
+          <button
+            type="button"
+            onClick={onToggleAll}
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-accent hover:text-foreground transition-colors"
+          >
+            {allCollapsed ? (
+              <ChevronsUpDown className="h-3 w-3" />
+            ) : (
+              <ChevronsDownUp className="h-3 w-3" />
+            )}
+            {allCollapsed
+              ? t('designer.canvas.expandAll', locale)
+              : t('designer.canvas.collapseAll', locale)}
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -859,10 +951,39 @@ function SectionHeader({
   );
 }
 
+/** Read-only ghost of a field that exists in the baseline but was removed. */
+function GhostFieldRow({ entry, locale }: { entry: FieldEntry; locale?: string }) {
+  const def = entry.def;
+  const typeStr = typeof def.type === 'string' ? (def.type as string) : 'text';
+  const meta = FIELD_TYPE_META[typeStr as FieldTypeId];
+  const Icon = meta?.Icon;
+  const label = typeof def.label === 'string' ? (def.label as string) : entry.name;
+  return (
+    <div className="rounded-md border border-dashed border-destructive/30 bg-destructive/[0.03] px-3.5 py-2.5 opacity-80">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {Icon && <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />}
+          <span className="text-sm font-medium truncate line-through text-muted-foreground">
+            {label}
+          </span>
+          <code className="text-[10px] text-muted-foreground/60 font-mono truncate line-through">
+            {entry.name}
+          </code>
+        </div>
+        <Badge className="text-[10px] font-medium border-transparent bg-destructive/15 text-destructive shrink-0">
+          {t('designer.canvas.diffRemoved', locale)}
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
 function FieldRow({
   entry,
   selected,
   multiSelected,
+  diffStatus,
+  changedKeys,
   readOnly,
   locale,
   onClick,
@@ -873,6 +994,9 @@ function FieldRow({
   entry: FieldEntry;
   selected: boolean;
   multiSelected?: boolean;
+  /** Review mode: how this field differs from the published baseline. */
+  diffStatus?: FieldDiffStatus;
+  changedKeys?: string[];
   readOnly: boolean;
   locale?: string;
   /** Receives the mouse event so the host can branch on Ctrl/⌘/Shift. */
@@ -985,6 +1109,8 @@ function FieldRow({
           'hover:border-primary/40 hover:bg-card outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
           selected ? 'border-primary ring-2 ring-primary/30 shadow-sm' : 'border-border',
           multiSelected && 'border-primary/60 ring-2 ring-primary/40 bg-primary/[0.04]',
+          diffStatus === 'added' && 'border-l-[3px] border-l-emerald-500',
+          diffStatus === 'changed' && 'border-l-[3px] border-l-amber-500',
           readOnly && 'cursor-default',
           draggable && 'cursor-grab active:cursor-grabbing',
         )}
@@ -1028,9 +1154,28 @@ function FieldRow({
             {required && <span className="text-destructive text-sm">*</span>}
             <code className="text-[10px] text-muted-foreground/70 font-mono truncate">{entry.name}</code>
           </div>
-          <Badge variant="outline" className={cn('text-[10px] shrink-0 font-medium', tone.badge)}>
-            {typeLabel(meta, locale) ?? typeStr}
-          </Badge>
+          <div className="flex items-center gap-1.5 shrink-0">
+            {diffStatus === 'added' && (
+              <Badge className="text-[10px] font-medium border-transparent bg-emerald-500/15 text-emerald-700 dark:text-emerald-300">
+                {t('designer.canvas.diffAdded', locale)}
+              </Badge>
+            )}
+            {diffStatus === 'changed' && (
+              <Badge
+                className="text-[10px] font-medium border-transparent bg-amber-500/15 text-amber-700 dark:text-amber-300"
+                title={
+                  changedKeys && changedKeys.length
+                    ? tFormat('designer.canvas.diffChangedKeys', locale, { keys: changedKeys.join(', ') })
+                    : undefined
+                }
+              >
+                {t('designer.canvas.diffChanged', locale)}
+              </Badge>
+            )}
+            <Badge variant="outline" className={cn('text-[10px] font-medium', tone.badge)}>
+              {typeLabel(meta, locale) ?? typeStr}
+            </Badge>
+          </div>
         </div>
         {description && (
           <div className="text-[11px] text-muted-foreground mb-1.5 line-clamp-1">{description}</div>

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectPreview.tsx
@@ -22,6 +22,7 @@ import { t } from '../i18n';
 export function ObjectPreview({
   name,
   draft,
+  baseline,
   onPatch,
   selection,
   onSelectionChange,
@@ -45,6 +46,7 @@ export function ObjectPreview({
         <ObjectFormCanvas
           objectName={objectName}
           draft={draft}
+          baseline={baseline}
           onPatch={onPatch}
           selection={selection}
           onSelectionChange={onSelectionChange}

--- a/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.test.ts
@@ -12,6 +12,7 @@ import {
   moveGroup,
   clearFieldGroup,
   groupEntries,
+  diffFields,
   type FieldsView,
 } from './object-fields-io';
 
@@ -199,5 +200,63 @@ describe('group ops preserve the fields round-trip shape', () => {
     expect(out[0].name).toBe('a');
     expect(out[0].customExtra).toBe(1);
     expect(out[0].group).toBeUndefined();
+  });
+});
+
+/* ─────────────── diffFields (review mode) ─────────────── */
+
+describe('diffFields', () => {
+  const baseline = {
+    name: { type: 'text', label: 'Name' },
+    email: { type: 'email', label: 'Email' },
+    legacy: { type: 'text', label: 'Legacy' },
+  };
+  const current = {
+    name: { type: 'text', label: 'Name' }, // unchanged
+    email: { type: 'email', label: 'Email Address', required: true }, // changed
+    phone: { type: 'phone', label: 'Phone' }, // added
+    // legacy removed
+  };
+
+  it('classifies added / changed / removed / unchanged', () => {
+    const d = diffFields(baseline, current);
+    expect(d.byName.name.status).toBe('unchanged');
+    expect(d.byName.email.status).toBe('changed');
+    expect(d.byName.phone.status).toBe('added');
+    expect(d.counts).toEqual({ added: 1, changed: 1, removed: 1 });
+  });
+
+  it('reports the changed def keys (sorted)', () => {
+    const d = diffFields(baseline, current);
+    expect(d.byName.email.changedKeys).toEqual(['label', 'required']);
+  });
+
+  it('surfaces removed fields as entries for ghost rendering', () => {
+    const d = diffFields(baseline, current);
+    expect(d.removed.map((e) => e.name)).toEqual(['legacy']);
+    expect(d.removed[0].def).toMatchObject({ type: 'text', label: 'Legacy' });
+  });
+
+  it('treats a missing/empty baseline as everything-added', () => {
+    const d = diffFields(undefined, { a: { type: 'text' }, b: { type: 'text' } });
+    expect(d.counts).toEqual({ added: 2, changed: 0, removed: 0 });
+  });
+
+  it('is shape-agnostic (array baseline vs record current)', () => {
+    const d = diffFields(
+      [{ name: 'a', type: 'text' }, { name: 'b', type: 'text' }],
+      { a: { type: 'text' } }, // b removed
+    );
+    expect(d.byName.a.status).toBe('unchanged');
+    expect(d.counts.removed).toBe(1);
+    expect(d.removed[0].name).toBe('b');
+  });
+
+  it('order-insensitive equality does not flag re-ordered identical defs', () => {
+    const d = diffFields(
+      { a: { type: 'text', label: 'A' } },
+      { a: { label: 'A', type: 'text' } },
+    );
+    expect(d.byName.a.status).toBe('unchanged');
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts
@@ -225,3 +225,70 @@ export function groupEntries(
   // it never shows empty.
   return Array.from(buckets.values()).filter((b) => b.entries.length > 0 || (includeEmpty && b.key !== null));
 }
+
+/* ─────────────── Review diff (current draft vs a baseline) ─────────────── */
+
+export type FieldDiffStatus = 'added' | 'removed' | 'changed' | 'unchanged';
+
+export interface FieldDiffEntry {
+  name: string;
+  status: FieldDiffStatus;
+  /** Sorted def keys that differ (only for `changed`). */
+  changedKeys: string[];
+}
+
+export interface FieldsDiff {
+  /** Per current-field status, keyed by field name. */
+  byName: Record<string, FieldDiffEntry>;
+  /** Baseline fields absent from the current draft (rendered as ghosts). */
+  removed: FieldEntry[];
+  counts: { added: number; changed: number; removed: number };
+}
+
+/** Stable equality for field-def values (small JSON — order-sensitive is fine). */
+function valueEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+/** Def keys whose values differ between two field definitions, sorted. */
+function changedDefKeys(a: Record<string, unknown>, b: Record<string, unknown>): string[] {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  const out: string[] = [];
+  for (const k of keys) if (!valueEqual(a[k], b[k])) out.push(k);
+  return out.sort();
+}
+
+/**
+ * Diff the current `fields` against a `baseline` (e.g. the last published
+ * version). Drives the canvas review mode: added / changed / removed
+ * per field. Shape-agnostic — both inputs are read via {@link readFields}.
+ */
+export function diffFields(baselineInput: unknown, currentInput: unknown): FieldsDiff {
+  const base = readFields(baselineInput);
+  const cur = readFields(currentInput);
+  const baseByName = new Map(base.entries.map((e) => [e.name, e] as const));
+  const curNames = new Set(cur.entries.map((e) => e.name));
+
+  const byName: Record<string, FieldDiffEntry> = {};
+  let added = 0;
+  let changed = 0;
+  for (const e of cur.entries) {
+    const b = baseByName.get(e.name);
+    if (!b) {
+      byName[e.name] = { name: e.name, status: 'added', changedKeys: [] };
+      added += 1;
+      continue;
+    }
+    const keys = changedDefKeys(b.def, e.def);
+    if (keys.length) {
+      byName[e.name] = { name: e.name, status: 'changed', changedKeys: keys };
+      changed += 1;
+    } else {
+      byName[e.name] = { name: e.name, status: 'unchanged', changedKeys: [] };
+    }
+  }
+
+  const removed = base.entries.filter((e) => !curNames.has(e.name));
+  return { byName, removed, counts: { added, changed, removed: removed.length } };
+}


### PR DESCRIPTION
## Summary
The headline feature for the **"AI writes the object, human confirms"** workflow: a read-only **review/diff mode** that compares the current (AI-authored) draft against the **last published version**.

- A **"Review changes"** toggle appears in the canvas toolbar whenever the draft differs from the published baseline (`layered.effective`). Hidden in create mode and when nothing changed; auto-exits once the draft matches the baseline again.
- In review mode:
  - Each field row gets an **Added** / **Changed** badge and a colored left accent. Changed rows tooltip the exact def keys that differ (e.g. *Changed: label, required*).
  - Fields **removed** vs the baseline render as dimmed, struck-through **ghost rows** so nothing silently disappears.
  - The toolbar summarizes **"N added · M changed · K removed — vs last published"**.

Per the design discussion: **baseline = last published** (`layered.effective`), **v1 = read-only diff** (no accept/reject yet), **surface = inline on the canvas**.

## Plumbing
- New optional `baseline` on `MetadataPreviewProps`, passed from `ResourceEditPage` (`layered.effective`, non-create) and forwarded through `ObjectPreview`.
- Diff is a pure, shape-agnostic `diffFields(baseline, current)` in `object-fields-io` → `{ byName, removed, counts }`.

## Tests
+6 `diffFields` cases (added/changed/removed/unchanged, changed-keys, removed entries, empty baseline, shape-agnostic, order-insensitive) and +5 canvas review cases (toggle gating ×3, badges + ghost, exit). `metadata-admin` suite green (**120**); `tsc` clean; no new lint errors.

## Next (not in this PR)
- v2: **accept/reject per field** (revert a changed/added field to baseline).
- A contextual **"generate fields with AI"** entry point in the empty state/toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)