### PR TITLE
feat(studio): designer ↔ global-chat context + Ask AI entry point (P1)

### DIFF
--- a/packages/app-shell/src/assistant/assistantBus.test.ts
+++ b/packages/app-shell/src/assistant/assistantBus.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { assistantBus } from './assistantBus';
+
+// The bus is a module singleton, so tests share state — assertions are
+// relative (before/after) rather than absolute where openSeq is involved.
+
+describe('assistantBus — editor channel', () => {
+  it('setEditor updates the snapshot and notifies subscribers', () => {
+    let notifications = 0;
+    const unsub = assistantBus.subscribe(() => {
+      notifications += 1;
+    });
+    assistantBus.setEditor({ type: 'object', name: 'account', label: 'Account' });
+    expect(assistantBus.getSnapshot().editor).toMatchObject({ type: 'object', name: 'account' });
+    expect(notifications).toBe(1);
+    unsub();
+  });
+
+  it('setEditor is a no-op when the content is unchanged', () => {
+    assistantBus.setEditor({ type: 'object', name: 'a', label: 'A' });
+    let notifications = 0;
+    const unsub = assistantBus.subscribe(() => {
+      notifications += 1;
+    });
+    assistantBus.setEditor({ type: 'object', name: 'a', label: 'A' }); // identical
+    expect(notifications).toBe(0);
+    assistantBus.setEditor(null); // different → notifies
+    expect(notifications).toBe(1);
+    expect(assistantBus.getSnapshot().editor).toBeNull();
+    unsub();
+  });
+});
+
+describe('assistantBus — open channel', () => {
+  it('requestOpen bumps openSeq monotonically', () => {
+    const before = assistantBus.getSnapshot().openSeq;
+    assistantBus.requestOpen();
+    assistantBus.requestOpen();
+    expect(assistantBus.getSnapshot().openSeq).toBe(before + 2);
+  });
+});
+
+describe('assistantBus — snapshot stability', () => {
+  it('returns a stable reference until a real change (safe for useSyncExternalStore)', () => {
+    assistantBus.setEditor(null);
+    const s1 = assistantBus.getSnapshot();
+    const s2 = assistantBus.getSnapshot();
+    expect(s1).toBe(s2);
+    assistantBus.requestOpen();
+    expect(assistantBus.getSnapshot()).not.toBe(s1);
+  });
+
+  it('unsubscribed listeners stop receiving updates', () => {
+    let n = 0;
+    const unsub = assistantBus.subscribe(() => {
+      n += 1;
+    });
+    assistantBus.requestOpen();
+    expect(n).toBe(1);
+    unsub();
+    assistantBus.requestOpen();
+    expect(n).toBe(1);
+  });
+});

--- a/packages/app-shell/src/assistant/assistantBus.ts
+++ b/packages/app-shell/src/assistant/assistantBus.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Assistant bus — a tiny framework-agnostic singleton that connects the
+ * metadata designers to the global AI chat (`ConsoleFloatingChatbot`).
+ *
+ * Two channels:
+ *   1. **Editor context** — a designer publishes *what the user is
+ *      currently editing* (`{ type, name, label, fields }`). The chatbot
+ *      reads it and merges it into the `context` it sends the agent, so
+ *      "add a priority field" acts on the open object without the user
+ *      restating which object they mean.
+ *   2. **Open signal** — a designer can ask the global chat to open (e.g.
+ *      an "Ask AI" button). The lazy chat FAB arms + opens on the signal.
+ *
+ * Why a singleton bus instead of React context? The chat FAB is
+ * lazy-mounted on a different branch of the tree from the designers, and
+ * the open-signal must cross that boundary without a shared Provider
+ * being threaded through every layout. A module singleton + (subscribe,
+ * getSnapshot) reads cleanly via `useSyncExternalStore`.
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+
+export interface AssistantEditorField {
+  name: string;
+  type?: string;
+  label?: string;
+  required?: boolean;
+}
+
+export interface AssistantEditorContext {
+  /** Metadata type, e.g. 'object'. */
+  type: string;
+  /** Item primary-key name (may be empty in create mode). */
+  name: string;
+  label?: string;
+  /** Lightweight field summary — enough for the agent to reason, not the full draft. */
+  fields?: AssistantEditorField[];
+}
+
+export interface AssistantSnapshot {
+  /** What the user is currently editing, or null when no designer is active. */
+  editor: AssistantEditorContext | null;
+  /** Monotonic counter — bumped each time a surface requests the chat to open. */
+  openSeq: number;
+}
+
+let editor: AssistantEditorContext | null = null;
+let openSeq = 0;
+// Cached snapshot — its reference only changes on a real state change so
+// useSyncExternalStore doesn't loop.
+let snapshot: AssistantSnapshot = { editor, openSeq };
+
+const listeners = new Set<() => void>();
+
+function commit(): void {
+  snapshot = { editor, openSeq };
+  for (const l of listeners) l();
+}
+
+function sameEditor(a: AssistantEditorContext | null, b: AssistantEditorContext | null): boolean {
+  if (a === b) return true;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export const assistantBus = {
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  getSnapshot(): AssistantSnapshot {
+    return snapshot;
+  },
+  /** Publish the currently-edited item (or null to clear). No-op if unchanged. */
+  setEditor(next: AssistantEditorContext | null): void {
+    if (sameEditor(editor, next)) return;
+    editor = next;
+    commit();
+  },
+  /** Ask the global chat to open (and warm/mount the lazy FAB). */
+  requestOpen(): void {
+    openSeq += 1;
+    commit();
+  },
+};
+
+/** Subscribe a component to the assistant bus snapshot. */
+export function useAssistant(): AssistantSnapshot {
+  return useSyncExternalStore(
+    assistantBus.subscribe,
+    assistantBus.getSnapshot,
+    assistantBus.getSnapshot,
+  );
+}
+
+/**
+ * Publish the currently-edited item to the assistant for the lifetime of
+ * the calling component (auto-clears on unmount). Pass `null` to register
+ * nothing. Stable across renders with equal content.
+ */
+export function useRegisterAssistantEditor(ctx: AssistantEditorContext | null): void {
+  // Serialize for a cheap, content-based effect dependency.
+  const key = ctx ? JSON.stringify(ctx) : '';
+  useEffect(() => {
+    assistantBus.setEditor(ctx);
+    return () => assistantBus.setEditor(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+}
+
+/** Open the global AI chat from anywhere (e.g. an "Ask AI" button). */
+export function requestAssistantOpen(): void {
+  assistantBus.requestOpen();
+}

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -214,3 +214,16 @@ export type {
   MetadataInspector,
   MetadataInspectorProps,
 } from './views/metadata-admin';
+
+// AI assistant bus — connects the metadata designers to the global chat.
+export {
+  assistantBus,
+  useAssistant,
+  useRegisterAssistantEditor,
+  requestAssistantOpen,
+} from './assistant/assistantBus';
+export type {
+  AssistantSnapshot,
+  AssistantEditorContext,
+  AssistantEditorField,
+} from './assistant/assistantBus';

--- a/packages/app-shell/src/layout/ConsoleChatbotFab.tsx
+++ b/packages/app-shell/src/layout/ConsoleChatbotFab.tsx
@@ -15,7 +15,8 @@
  *
  * @module
  */
-import React, { Suspense, lazy, useState } from 'react';
+import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
+import { useAssistant } from '../assistant/assistantBus';
 
 const ConsoleFloatingChatbot = lazy(() => import('./ConsoleFloatingChatbot'));
 const prefetchChatbot = () => {
@@ -28,6 +29,18 @@ export type ConsoleChatbotFabProps = ConsoleFloatingChatbotProps;
 
 export function ConsoleChatbotFab(props: ConsoleChatbotFabProps) {
   const [armed, setArmed] = useState(false);
+
+  // A designer surface can ask the assistant to open (e.g. an "Ask AI"
+  // button) via the assistant bus — arming the lazy chatbot just like a
+  // click does. Once armed, the chatbot's own trigger owns open/close.
+  const { openSeq } = useAssistant();
+  const seenOpenSeq = useRef(openSeq);
+  useEffect(() => {
+    if (openSeq !== seenOpenSeq.current) {
+      seenOpenSeq.current = openSeq;
+      setArmed(true);
+    }
+  }, [openSeq]);
 
   if (armed) {
     return (

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -32,6 +32,7 @@ import {
 import { Share2, SquarePen } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useChatConversation, type HydratedUIMessage } from '../hooks';
+import { useAssistant, type AssistantEditorContext } from '../assistant/assistantBus';
 
 /**
  * Display names for the built-in platform agents. The backend ships English
@@ -177,6 +178,23 @@ function resolveApiBase(explicit?: string): string {
  * the active agent changes so `useObjectChat`'s first-render mode lock
  * (api vs local) picks up the new endpoint.
  */
+/**
+ * Starter prompts tailored to the metadata item currently open in a
+ * designer. Returns null when nothing relevant is being edited, so the
+ * caller falls back to the generic agent suggestions.
+ */
+function buildEditorSuggestions(
+  editor: AssistantEditorContext | null,
+  language: string,
+): string[] | null {
+  if (!editor || editor.type !== 'object') return null;
+  const subject = editor.label || editor.name || 'this object';
+  const zh = (language ?? '').toLowerCase().startsWith('zh');
+  return zh
+    ? [`为「${subject}」补充字段`, `为「${subject}」建议校验规则`, '添加一个状态选项字段']
+    : [`Add fields to ${subject}`, `Suggest validations for ${subject}`, 'Add a status picklist field'];
+}
+
 interface ChatbotInnerProps {
   appLabel: string;
   appName?: string;
@@ -228,6 +246,11 @@ function ChatbotInner({
 }: ChatbotInnerProps) {
   const { language } = useObjectTranslation();
 
+  // What the user is currently editing in a designer (if any). Merged into
+  // the agent context so "add a priority field" acts on the open object,
+  // and drives context-aware starter suggestions.
+  const { editor } = useAssistant();
+
   // Replay persisted history when present.
   const hydratedHistory = React.useMemo<ChatMessage[]>(() => {
     if (!persistedMessages || persistedMessages.length === 0) return [];
@@ -249,6 +272,12 @@ function ChatbotInner({
     [language, appLabel, activeAgent, activeAgentLabel, objects],
   );
 
+  // When a designer is open, prefer starter prompts about that item.
+  const editorSuggestions = React.useMemo(
+    () => buildEditorSuggestions(editor, language),
+    [editor, language],
+  );
+
   const {
     messages,
     isLoading,
@@ -266,6 +295,9 @@ function ChatbotInner({
         appName,
         objects: objects.map((o) => ({ name: o.name, label: o.label })),
         agentName: activeAgent,
+        // The metadata item currently open in a designer, so the agent
+        // can act on "this object/view/…" without the user restating it.
+        ...(editor ? { editing: editor } : {}),
       },
     },
     // Start empty so the modern empty-state + starter prompts render. We no
@@ -385,7 +417,7 @@ function ChatbotInner({
         showAvatars
         hideClearBar
         assistantAvatarFallback={locale.agentLabel}
-        suggestions={messages.length === 0 ? locale.suggestions : undefined}
+        suggestions={messages.length === 0 ? (editorSuggestions ?? locale.suggestions) : undefined}
         placeholder={
           activeAgent
             ? locale.placeholder

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -96,6 +96,8 @@ import { MetadataDetailDrawer } from './MetadataDetailDrawer';
 import { HistoryPanel } from './ResourceHistoryPage';
 import { AuditPanel } from './AuditPanel';
 import { getMetadataPreview, type MetadataSelection } from './preview-registry';
+import { readFields } from './previews/object-fields-io';
+import { useRegisterAssistantEditor, type AssistantEditorContext } from '../../assistant/assistantBus';
 import { getMetadataInspector } from './inspector-registry';
 import { getMetadataDefaultInspector } from './default-inspector-registry';
 import { detectLocale, t, tFormat } from './i18n';
@@ -1070,6 +1072,31 @@ function MetadataResourceEditPageImpl({
     document.addEventListener('click', handler, true);
     return () => document.removeEventListener('click', handler, true);
   }, [isDirty, locale]);
+
+  // Publish "what's being edited" to the global AI chat so the agent can
+  // act on the open item (and offer item-specific starter prompts). Kept
+  // to a light summary — the agent can `describe_object` for full detail.
+  // Declared above the early returns to satisfy the Rules of Hooks.
+  const assistantEditorCtx = React.useMemo<AssistantEditorContext | null>(() => {
+    if (embedded) return null;
+    const itemName = String((draft as any).name ?? name ?? '');
+    if (!itemName) return null;
+    const ctx: AssistantEditorContext = {
+      type,
+      name: itemName,
+      label: typeof (draft as any).label === 'string' ? (draft as any).label : undefined,
+    };
+    if (type === 'object') {
+      ctx.fields = readFields((draft as any).fields).entries.slice(0, 60).map((e) => ({
+        name: e.name,
+        type: typeof e.def.type === 'string' ? (e.def.type as string) : undefined,
+        label: typeof e.def.label === 'string' ? (e.def.label as string) : undefined,
+        required: !!e.def.required || undefined,
+      }));
+    }
+    return ctx;
+  }, [embedded, type, name, draft]);
+  useRegisterAssistantEditor(assistantEditorCtx);
 
   if (loading) {
     return (

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -597,6 +597,9 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'designer.canvas.diffChanged': 'Changed',
   'designer.canvas.diffRemoved': 'Removed',
   'designer.canvas.diffChangedKeys': 'Changed: {keys}',
+  // AI assistant entry points
+  'designer.canvas.askAi': 'Ask AI',
+  'designer.canvas.askAiGenerate': 'Generate fields with AI',
 };
 
 const ENGINE_STRINGS_ZH: Record<string, string> = {
@@ -1053,6 +1056,9 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'designer.canvas.diffChanged': '修改',
   'designer.canvas.diffRemoved': '删除',
   'designer.canvas.diffChangedKeys': '变更：{keys}',
+  // AI assistant entry points
+  'designer.canvas.askAi': '问 AI',
+  'designer.canvas.askAiGenerate': '用 AI 生成字段',
 };
 
 function pickTable(

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.test.tsx
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
 import { ObjectFormCanvas } from './ObjectFormCanvas';
+import { assistantBus } from '../../../assistant/assistantBus';
 
 afterEach(cleanup);
 
@@ -309,5 +310,37 @@ describe('ObjectFormCanvas — review/diff mode', () => {
     expect(screen.getByText('Review changes')).toBeInTheDocument();
     // The removed-field ghost only exists in review mode.
     expect(screen.queryByText('Legacy')).not.toBeInTheDocument();
+  });
+});
+
+describe('ObjectFormCanvas — Ask AI entry point', () => {
+  it('footer "Ask AI" opens the assistant via the bus', () => {
+    const before = assistantBus.getSnapshot().openSeq;
+    render(
+      <ObjectFormCanvas
+        objectName="x"
+        draft={{ name: 'x', fields: { a: { type: 'text', label: 'A' } } }}
+        onPatch={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Ask AI'));
+    expect(assistantBus.getSnapshot().openSeq).toBe(before + 1);
+  });
+
+  it('empty-state "Generate fields with AI" opens the assistant', () => {
+    const before = assistantBus.getSnapshot().openSeq;
+    render(<ObjectFormCanvas objectName="x" draft={{ name: 'x', fields: {} }} onPatch={vi.fn()} />);
+    fireEvent.click(screen.getByText('Generate fields with AI'));
+    expect(assistantBus.getSnapshot().openSeq).toBe(before + 1);
+  });
+
+  it('hides the Ask AI affordance when read-only', () => {
+    render(
+      <ObjectFormCanvas
+        objectName="x"
+        draft={{ name: 'x', fields: { a: { type: 'text', label: 'A' } } }}
+      />,
+    );
+    expect(screen.queryByText('Ask AI')).not.toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.tsx
@@ -39,9 +39,11 @@ import {
   ChevronsUpDown,
   CheckSquare,
   GitCompareArrows,
+  Sparkles,
   X,
 } from 'lucide-react';
 import type { MetadataSelection } from '../preview-registry';
+import { requestAssistantOpen } from '../../../assistant/assistantBus';
 import {
   readFields,
   writeFields,
@@ -541,6 +543,15 @@ export function ObjectFormCanvas({
             >
               <FolderPlus className="h-3.5 w-3.5" />
               {t('designer.canvas.addSection', locale)}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 ml-auto text-primary/80 hover:text-primary"
+              onClick={() => requestAssistantOpen()}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              {t('designer.canvas.askAi', locale)}
             </Button>
           </div>
         )}
@@ -1205,8 +1216,17 @@ function EmptyCanvas({ onAdd, locale }: { onAdd?: (type: FieldTypeId) => void; l
         {t('designer.canvas.noFieldsHint', locale)}
       </div>
       {onAdd && (
-        <div className="pt-2">
+        <div className="pt-2 flex items-center justify-center gap-2">
           <AddFieldButton onPick={onAdd} locale={locale} />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-primary/80 hover:text-primary"
+            onClick={() => requestAssistantOpen()}
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            {t('designer.canvas.askAiGenerate', locale)}
+          </Button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
P1 of "centralize AI metadata gen/mod in the global chat." Instead of forking a bespoke "generate" UI into each designer, this **connects the designers to the existing global chat** (which already binds Studio to the `metadata_assistant` agent with real metadata tools).

- **`assistantBus`** (new singleton in app-shell): a designer publishes *what's being edited* (`{type, name, label, fields}`) and can *request the chat to open*. It crosses the lazy-FAB boundary without Provider plumbing; components read it via `useSyncExternalStore`.
- **`ResourceEditPage`** publishes a light editor context (objects include a field summary; the agent can `describe_object` for full detail).
- **`ConsoleFloatingChatbot`** merges that context into the agent `context` body (the chat transport rebuilds on body change, so the next turn carries it) — "add a priority field" now acts on the open object. Starter suggestions become **item-specific** when a designer is active.
- **`ConsoleChatbotFab`** arms/opens the lazy chatbot on the open signal.
- The object canvas gains **"Ask AI"** (toolbar) + **"Generate fields with AI"** (empty state) buttons that open the chat. All localized (en-US / zh-CN).

## Why this shape (from the architecture eval)
The AI "brain" is already centralized (one agent + tools + global chat). This PR adds the **thin connective tissue** (context + entry point) so the chat actually serves the designers — no duplicated AI logic. It's **frontend-only**.

## Out of scope (P2/P3)
- **P2 — review-gated apply:** route AI changes through the designer **draft** so they surface in the **review/diff mode** (#1456) for confirm/publish. Needs a small framework-side "write-to-draft / propose" change (today the metadata tools persist immediately).
- **P3 — more types + server approval gate.**

## Tests
+5 `assistantBus` (editor channel, open channel, snapshot stability, unsubscribe), +3 canvas Ask-AI (footer + empty-state open the bus, hidden when read-only). app-shell metadata/assistant/layout suites green (**128**); `tsc` clean; no new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)