### PR TITLE
feat(console): standalone top-level API Console route

### DIFF
--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -12,7 +12,7 @@
  * with extra `<Route>` children.
  */
 
-import { type ReactNode } from 'react';
+import { lazy, Suspense, type ReactNode } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AuthProvider, AuthGuard, useAuth } from '@object-ui/auth';
 import {
@@ -48,6 +48,20 @@ import { SetupPage } from './pages/auth/SetupPage';
 import { OAuthConsentPage } from './pages/auth/OAuthConsentPage';
 import { DeviceAuthPage } from './pages/auth/DeviceAuthPage';
 import { AcceptInvitationPage } from './pages/auth/AcceptInvitationPage';
+
+/**
+ * Standalone API Console — a top-level, full-screen route
+ * (`/developer/api-console`) decoupled from the `/apps/:appName/*` inner
+ * shell. NOTE the path must NOT start with `/api`: the dev server and
+ * production reverse-proxy forward `/api*` to the backend, so a literal
+ * `/api-console` would 502 instead of serving the SPA. It only needs the
+ * adapter context (provided by ConnectedShell) and a signed-in user, so it
+ * renders bare — no ConsoleLayout sidebar, no active app / organization.
+ * Lazy-loaded so its bundle stays out of the auth-surface critical path.
+ */
+const ApiConsolePage = lazy(() =>
+  import('./pages/developer/ApiConsolePage').then(m => ({ default: m.ApiConsolePage })),
+);
 
 const AUTH_URL = `${import.meta.env.VITE_SERVER_URL || ''}/api/v1/auth`;
 
@@ -202,6 +216,22 @@ export function App() {
             <Route path="/ai/:conversationId" element={
               <ProtectedRoute>
                 <DefaultAiChatPage />
+              </ProtectedRoute>
+            } />
+            {/*
+              * Standalone API Console — full-screen, app-independent. Wrapped
+              * in a `h-screen flex-col` host because the page root is
+              * `flex flex-1 min-h-0` and needs a height-bearing flex parent
+              * (normally supplied by the inner shell's content area).
+              * requireOrganization={false}: the console is not org-scoped.
+              */}
+            <Route path="/developer/api-console" element={
+              <ProtectedRoute requireOrganization={false}>
+                <div className="flex h-screen flex-col">
+                  <Suspense fallback={<LoadingFallback />}>
+                    <ApiConsolePage />
+                  </Suspense>
+                </div>
               </ProtectedRoute>
             } />
             <Route path="/apps/:appName/*" element={

--- a/apps/console/src/AppContent.tsx
+++ b/apps/console/src/AppContent.tsx
@@ -26,7 +26,6 @@ const AuditLogPage = lazy(() => import('./pages/system/AuditLogPage').then(m => 
 const SettingsHub = lazy(() => import('./pages/settings/SettingsHub').then(m => ({ default: m.SettingsHub })));
 const SettingsView = lazy(() => import('./pages/settings/SettingsView').then(m => ({ default: m.SettingsView })));
 const DeveloperHubPage = lazy(() => import('./pages/developer/DeveloperHubPage').then(m => ({ default: m.DeveloperHubPage })));
-const ApiConsolePage = lazy(() => import('./pages/developer/ApiConsolePage').then(m => ({ default: m.ApiConsolePage })));
 const FlowRunsPage = lazy(() => import('./pages/developer/FlowRunsPage').then(m => ({ default: m.FlowRunsPage })));
 const PublicFormsPage = lazy(() => import('./pages/developer/PublicFormsPage').then(m => ({ default: m.PublicFormsPage })));
 
@@ -79,7 +78,7 @@ const systemRoutes = (
     <Route path="system/settings" element={<Suspense fallback={<LoadingScreen />}><SettingsHub /></Suspense>} />
     <Route path="system/settings/:namespace" element={<Suspense fallback={<LoadingScreen />}><SettingsView /></Suspense>} />
     <Route path="developer" element={<Suspense fallback={<LoadingScreen />}><DeveloperHubPage /></Suspense>} />
-    <Route path="developer/api-console" element={<Suspense fallback={<LoadingScreen />}><ApiConsolePage /></Suspense>} />
+    {/* API Console moved to the top-level standalone route `/developer/api-console` (see App.tsx). */}
     <Route path="developer/flow-runs" element={<Suspense fallback={<LoadingScreen />}><FlowRunsPage /></Suspense>} />
     <Route path="developer/public-forms" element={<Suspense fallback={<LoadingScreen />}><PublicFormsPage /></Suspense>} />
     {/* Legacy URL redirects → metadata-admin engine (zero-cost compatibility). */}

--- a/apps/console/src/pages/developer/DeveloperHubPage.tsx
+++ b/apps/console/src/pages/developer/DeveloperHubPage.tsx
@@ -32,7 +32,9 @@ export function DeveloperHubPage() {
       title: 'API Console',
       description: 'Inspect and exercise REST endpoints with auto-discovered services',
       icon: Terminal,
-      href: `${basePath}/developer/api-console`,
+      // Standalone top-level route — app-independent, opens full-screen.
+      // Must not start with `/api` (that prefix is proxied to the backend).
+      href: `/developer/api-console`,
     },
     {
       title: 'Flow Runs',


### PR DESCRIPTION
## What

Moves the **API Console** out of the `/apps/:appName/*` inner shell to a **top-level, full-screen route** at **`/developer/api-console`**, so it can be opened, bookmarked, and shared directly — no longer requires picking an app or organization first.

Before: only reachable at `/apps/{appName}/developer/api-console`, wrapped in the full ConsoleLayout shell, gated behind app + org selection.
After: a clean standalone URL, rendered bare (no sidebar), still behind login.

## Why

The console only depends on the adapter context (provided by `ConnectedShell`) and a signed-in user — not on an active app or org. So it can live as a first-class top-level route and render full-screen on its own.

## ⚠️ Path choice (reviewer note)

The route is `/developer/api-console`, **not** `/api-console`. The dev server and the production reverse-proxy forward every `/api*` path to the backend, so a literal `/api-console` returns **502** instead of serving the SPA (verified locally: `curl /api-console → 502`, `curl /developer/api-console → 200`). `/developer/api-console` avoids the prefix collision and happens to match the path the metadata **Tool preview** ("Open in API Console") already links to — that deep link now resolves for the first time.

## Changes

- **`App.tsx`** — add lazy-loaded `/developer/api-console` route under `ProtectedRoute` with `requireOrganization={false}` (login still required). Wrapped in a `h-screen flex-col` host because the page root is `flex flex-1 min-h-0` and needs a height-bearing flex parent normally supplied by the inner shell's content area.
- **`AppContent.tsx`** — remove the old nested `developer/api-console` route + its now-unused lazy import.
- **`DeveloperHubPage.tsx`** — point the "API Console" hub card at the new path.

## Notes

- The metadata-driven app-sidebar entry `developer:api-console` (`registerDeveloperComponents.tsx`, renders at `/apps/<app>/component/developer/api-console`) is a separate embedding mechanism and is intentionally left untouched — still works.

## Verification

- `tsc --noEmit` passes for `apps/console`.
- `curl`: `/developer/api-console` → 200 (SPA), old `/api-console` → 502 (confirms the proxy collision).
- Browser smoke (no local backend): the SPA boots with no console errors; visiting `/developer/api-console` while unauthenticated correctly redirects to `/login` — confirming the route is wired and the auth gate works. The page body render needs a logged-in session, which requires the :3000 backend not running in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)