### PR TITLE
feat(app-shell): ADR-0032 author-time condition validation in flow inspectors

### DIFF
--- a/.changeset/adr-0032-condition-validation.md
+++ b/.changeset/adr-0032-condition-validation.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/app-shell": minor
+---
+
+ADR-0032: author-time condition validation in the flow inspectors.
+
+Flow node and edge condition editors now flag a malformed predicate **as you
+type** — most importantly the `{record.x}` template-brace-in-CEL mistake (#1491),
+which `{…}` parses as a CEL map literal and silently fails — with the same
+corrective message the build and the `validate_expression` agent tool emit.
+Client-side check for now (no CEL parser in the browser); swaps to
+`@objectstack/formula`'s shared `validateExpression` once it is published.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
@@ -27,6 +27,7 @@ import {
 } from './_shared';
 import { Label } from '@object-ui/components';
 import { edgeKey, conditionText } from '../previews/flow-canvas-layout';
+import { validateExpressionClient } from './expression-validate';
 
 interface FlowEdge {
   id?: string;
@@ -127,6 +128,16 @@ export function FlowEdgeInspector({ selection, draft, onPatch, onClearSelection,
         disabled={readOnly || isDefault}
         mono
       />
+      {(() => {
+        // ADR-0032 — flag a malformed edge guard (e.g. `{record.x}` brace-in-CEL)
+        // inline, with the same corrective message as build/agent validation.
+        const issue = isDefault ? null : validateExpressionClient('predicate', edge.condition);
+        return issue ? (
+          <p className="text-[11px] leading-snug text-destructive" role="alert">
+            {issue.message}
+          </p>
+        ) : null;
+      })()}
       <InspectorCheckboxField
         label={t('engine.inspector.flowEdge.isDefault', locale)}
         value={isDefault}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
@@ -20,6 +20,7 @@ import { FlowKeyValueField } from './FlowKeyValueField';
 import { FlowStringListField } from './FlowStringListField';
 import { FlowObjectListField } from './FlowObjectListField';
 import { FlowReferenceField, type FlowReferenceContext } from './FlowReferenceField';
+import { validateExpressionClient } from './expression-validate';
 
 export interface FlowNodeConfigFieldProps {
   field: FlowConfigField;
@@ -144,10 +145,23 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
     }
   })();
 
+  // ADR-0032 — surface a malformed condition (e.g. the `{record.x}` brace-in-CEL
+  // mistake) inline, as the author types, with the same corrective message the
+  // build and the agent tool emit. Only checked for expression-bearing fields.
+  const exprIssue =
+    field.kind === 'expression' ? validateExpressionClient('predicate', value) : null;
+
   return (
     <div className="space-y-1">
       {control}
-      {field.help && <p className="text-[11px] leading-snug text-muted-foreground">{field.help}</p>}
+      {exprIssue && (
+        <p className="text-[11px] leading-snug text-destructive" role="alert">
+          {exprIssue.message}
+        </p>
+      )}
+      {field.help && !exprIssue && (
+        <p className="text-[11px] leading-snug text-muted-foreground">{field.help}</p>
+      )}
     </div>
   );
 }

--- a/packages/app-shell/src/views/metadata-admin/inspectors/expression-validate.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/expression-validate.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { validateExpressionClient } from './expression-validate';
+
+describe('validateExpressionClient (ADR-0032 author-time)', () => {
+  it('accepts a clean bare-CEL predicate', () => {
+    expect(validateExpressionClient('predicate', 'record.rating >= 4')).toBeNull();
+  });
+
+  it('accepts an empty / absent value', () => {
+    expect(validateExpressionClient('predicate', '')).toBeNull();
+    expect(validateExpressionClient('predicate', null)).toBeNull();
+    expect(validateExpressionClient('predicate', undefined)).toBeNull();
+  });
+
+  it('flags the #1491 brace-in-CEL mistake with a corrective message', () => {
+    const issue = validateExpressionClient('predicate', '{record.rating} >= 4');
+    expect(issue).not.toBeNull();
+    expect(issue!.message).toMatch(/map literal/);
+    expect(issue!.message).toContain('record.rating');
+  });
+
+  it('reads an Expression envelope, not just a string', () => {
+    expect(validateExpressionClient('predicate', { dialect: 'cel', source: '{x} > 1' })).not.toBeNull();
+    expect(validateExpressionClient('predicate', { dialect: 'cel', source: 'x > 1' })).toBeNull();
+  });
+
+  it('flags unbalanced parentheses', () => {
+    expect(validateExpressionClient('predicate', '(record.a > 1')!.message).toMatch(/parenthes/i);
+  });
+
+  it('templates: flags single-brace and suggests {{ }}', () => {
+    const issue = validateExpressionClient('template', 'Hi {record.name}');
+    expect(issue).not.toBeNull();
+    expect(issue!.message).toMatch(/\{\{ record\.name \}\}|double braces/);
+  });
+
+  it('templates: accepts {{ path }}', () => {
+    expect(validateExpressionClient('template', 'Hi {{ record.name }}')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/expression-validate.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/expression-validate.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Author-time expression validation for the metadata inspectors (ADR-0032).
+ *
+ * The GUI is a first-class author surface, so the same rule the build and the
+ * `validate_expression` agent tool enforce must surface *here, as you type* —
+ * not only on save/build. The #1 mistake (human or AI) is wrapping a field
+ * reference in single `{…}` braces inside a CEL condition: `{x}` parses as a
+ * CEL map literal and silently fails (issue #1491). We catch that and a couple
+ * of other obvious shape errors, with the **same corrective message** the
+ * server-side validator emits.
+ *
+ * NOTE: this is an intentionally small client-side check (no CEL parser in the
+ * browser). Once `@objectstack/formula` is published, swap the body of
+ * {@link validateExpressionClient} for a call to its shared `validateExpression`
+ * so the GUI, SDK, and CLI share one validator verbatim.
+ */
+
+export type ExprFieldRole = 'predicate' | 'value' | 'template';
+
+export interface ExprClientIssue {
+  /** Self-correcting message: what is wrong + the correct form. */
+  message: string;
+}
+
+/** A bare `{x}` that is NOT part of a `{{x}}` mustache hole. */
+const SINGLE_BRACE_RE = /(?:^|[^{])\{\s*([A-Za-z_$][\w.$]*)\s*\}(?!\})/;
+
+function balanced(src: string, open: string, close: string): boolean {
+  let depth = 0;
+  for (const ch of src) {
+    if (ch === open) depth++;
+    else if (ch === close) { depth--; if (depth < 0) return false; }
+  }
+  return depth === 0;
+}
+
+/**
+ * Validate one expression for a field role. Returns `null` when clean, or an
+ * issue with a corrective message. Empty/absent input is always clean.
+ */
+export function validateExpressionClient(role: ExprFieldRole, raw: unknown): ExprClientIssue | null {
+  // Accept a bare string or an Expression envelope ({ dialect, source }).
+  let source = '';
+  let dialect: string | undefined;
+  if (typeof raw === 'string') source = raw;
+  else if (raw && typeof raw === 'object') {
+    const env = raw as { dialect?: string; source?: string };
+    dialect = env.dialect;
+    source = env.source ?? '';
+  }
+  if (!source.trim()) return null;
+
+  if (role === 'template') {
+    if (dialect && dialect !== 'template') {
+      return { message: `Expected a text template but got a \`${dialect}\` expression.` };
+    }
+    if (!balanced(source.replace(/\{\{/g, '').replace(/\}\}/g, ''), '{', '}')) {
+      // crude: only flag obviously single-brace mustache misuse below
+    }
+    const m = SINGLE_BRACE_RE.exec(source);
+    if (m) {
+      return { message: `Single-brace \`{${m[1]}}\` is not a valid template hole — use double braces: \`{{ ${m[1]} }}\`.` };
+    }
+    return null;
+  }
+
+  // predicate | value → CEL
+  if (dialect && dialect !== 'cel') {
+    return { message: `Expected a CEL expression but got a \`${dialect}\` dialect.` };
+  }
+  const m = SINGLE_BRACE_RE.exec(source);
+  if (m) {
+    return {
+      message:
+        `It looks like a \`{${m[1]}}\` template brace was used inside a condition — ` +
+        `\`{…}\` parses as a CEL map literal and fails. Write the bare reference instead, e.g. \`${m[1]}\`. ` +
+        `Conditions are bare CEL (e.g. \`record.rating >= 4\`).`,
+    };
+  }
+  if (!balanced(source, '(', ')')) {
+    return { message: `Unbalanced parentheses in \`${source}\`.` };
+  }
+  if (!balanced(source, '[', ']')) {
+    return { message: `Unbalanced brackets in \`${source}\`.` };
+  }
+  return null;
+}


### PR DESCRIPTION
## What

ADR-0032 (Step 7, frontend): the Studio flow inspectors now validate **conditions as you type**, so a malformed predicate is caught at author time — not at save/build. Most importantly it flags the `{record.x}` template-brace-in-CEL mistake (#1491) — `{…}` parses as a CEL map literal and silently fails — with the **same corrective message** the framework build and the `validate_expression` agent tool emit.

## Changes

- New `expression-validate.ts` — a small client-side checker (`validateExpressionClient(role, value)`) for `predicate` / `value` / `template` roles: detects brace-in-CEL, unbalanced parens/brackets, and single-brace-in-template (suggests `{{ }}`). Reads both a bare string and an `{ dialect, source }` envelope.
- `FlowNodeConfigField` (expression fields) and `FlowEdgeInspector` (edge guards) render an inline error under the field when invalid.

## Note on the dependency

This is intentionally a small client-side check — there is no CEL parser in the browser, and `@objectstack/formula`'s shared `validateExpression` isn't published yet. Once it ships, swap the body of `validateExpressionClient` for a call to the shared validator so GUI / SDK / CLI share one validator verbatim (ADR-0032 §5). The message wording already matches.

## Verification

`type-check` ✓, `build` ✓, app-shell test suite **238 passed** (incl. new `expression-validate.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
