### PR TITLE
fix(grid/app-shell): inline primary row actions + popup-safe opensInNewTab

### DIFF
--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1256,8 +1256,30 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
             return { success: false, error: 'No action target provided' };
         }
         const params = (action.params && !Array.isArray(action.params))
-            ? (action.params as Record<string, unknown>)
+            ? { ...(action.params as Record<string, unknown>) }
             : {};
+        // Row-action path stashes the row under `_rowRecord` (ObjectGrid →
+        // onRowAction) but ActionRunner doesn't set `recordId` for `script`
+        // handlers — derive it from the row so list_item actions (e.g. "Open"
+        // on an environment row) resolve their target record. Strip
+        // `_rowRecord` from the sent body.
+        const _rowRecord = (params as any)._rowRecord as Record<string, any> | undefined;
+        delete (params as any)._rowRecord;
+        const recordIdField = (action as any).recordIdField || 'id';
+        const resolvedRecordId = (params as any).recordId ?? _rowRecord?.[recordIdField];
+
+        // ── Popup-blocker workaround (mirrors RecordDetailView) ───────────
+        // When `action.opensInNewTab` is set, the handler returns
+        // `{ redirectUrl }` for the UI to navigate to. Pre-open `about:blank`
+        // synchronously *before* the await so the user-gesture context is
+        // preserved and Chrome/Safari don't block the eventual navigation —
+        // without this, the post-await window.open() on the row-action path
+        // is dropped as an unsolicited popup. Falls back to navigating the
+        // current tab if the pre-open is itself blocked.
+        let preOpenedTab: Window | null = null;
+        if ((action as any).opensInNewTab) {
+            try { preOpenedTab = window.open('about:blank', '_blank', 'noopener,noreferrer'); } catch { preOpenedTab = null; }
+        }
         try {
             const baseUrl = import.meta.env.VITE_SERVER_URL || '';
             const obj = action.objectName || objectDef.name || 'global';
@@ -1266,18 +1288,44 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                 {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ recordId: (params as any).recordId, params }),
+                    body: JSON.stringify({ recordId: resolvedRecordId, params }),
                 },
             );
             const json = await res.json().catch(() => null);
             if (!res.ok || (json && json.success === false)) {
                 const errMsg = json?.error || `Action "${targetName}" failed (HTTP ${res.status})`;
+                if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
                 return { success: false, error: errMsg };
             }
             const shouldRefresh = action.refreshAfter !== false;
             if (shouldRefresh) setRefreshKey(k => k + 1);
-            return { success: true, data: json?.data, reload: shouldRefresh };
+            const data = json?.data;
+            // `{ redirectUrl }` convention: drive the pre-opened tab to it
+            // (popup-safe); otherwise open lazily, falling back to the current
+            // tab if blocked so the user always reaches the destination.
+            const redirectUrl = (data && typeof data === 'object' && typeof (data as any).redirectUrl === 'string')
+                ? (data as any).redirectUrl as string
+                : null;
+            if (redirectUrl) {
+                if (preOpenedTab) {
+                    try { preOpenedTab.location.href = redirectUrl; }
+                    catch {
+                        try { preOpenedTab.close(); } catch { /* ignore */ }
+                        window.location.href = redirectUrl;
+                    }
+                } else {
+                    let popup: Window | null = null;
+                    try { popup = window.open(redirectUrl, '_blank', 'noopener,noreferrer'); } catch { popup = null; }
+                    if (!popup) window.location.href = redirectUrl;
+                }
+            } else if (preOpenedTab) {
+                // opensInNewTab declared but no redirectUrl came back — don't
+                // leave a dangling blank tab.
+                try { preOpenedTab.close(); } catch { /* ignore */ }
+            }
+            return { success: true, data, reload: shouldRefresh };
         } catch (error) {
+            if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
             return { success: false, error: (error as Error).message };
         }
     }, [authFetch, objectDef.name]);

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -103,6 +103,44 @@ const RowActionMenuItem: React.FC<{
   );
 };
 
+/** Map a schema action variant onto a Button variant. `primary` is the
+ * accent ("default") button so the action reads as the row's main CTA. */
+function toButtonVariant(v: RowActionDef['variant']): 'default' | 'secondary' | 'destructive' | 'ghost' | 'link' {
+  switch (v) {
+    case 'danger': return 'destructive';
+    case 'secondary': return 'secondary';
+    case 'ghost': return 'ghost';
+    case 'link': return 'link';
+    default: return 'default'; // 'primary' (and unset) → accent button
+  }
+}
+
+/**
+ * A `variant: 'primary'` row action rendered as an inline button (not folded
+ * into the "⋮" overflow), so the row's main CTA — e.g. "Open" on an
+ * environment — is immediately visible and clickable. Hook-safe per item so
+ * the `visible` CEL predicate is honored just like the menu path.
+ */
+const RowActionInlineButton: React.FC<{
+  def: RowActionDef;
+  row: any;
+  onActionDef?: (def: RowActionDef, row: any) => void;
+}> = ({ def, row, onActionDef }) => {
+  const isVisible = useCondition(toPredicateInput(def.visible), row);
+  if (def.visible && !isVisible) return null;
+  return (
+    <Button
+      variant={toButtonVariant(def.variant)}
+      size="sm"
+      className="h-8"
+      data-testid={`row-action-inline-${def.name}`}
+      onClick={(e) => { e.stopPropagation(); onActionDef?.(def, row); }}
+    >
+      {def.label ?? formatActionLabel(def.name)}
+    </Button>
+  );
+};
+
 export const RowActionMenu: React.FC<RowActionMenuProps> = ({
   row,
   rowActions,
@@ -115,50 +153,72 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
   onActionDef,
 }) => {
   const t = useRowActionTranslation();
+  // Surface `variant: 'primary'` row actions inline (as the row's main CTA);
+  // everything else stays in the "⋮" overflow menu.
+  const inlineDefs = (rowActionDefs ?? []).filter(d => d.variant === 'primary');
+  const menuDefs = (rowActionDefs ?? []).filter(d => d.variant !== 'primary');
+  const hasMenu = Boolean(
+    (canEdit && onEdit) ||
+    (canDelete && onDelete) ||
+    menuDefs.length > 0 ||
+    (rowActions?.length ?? 0) > 0,
+  );
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
-          data-testid="row-action-trigger"
-        >
-          <MoreVertical className="h-4 w-4" />
-          <span className="sr-only">{t('grid.openMenu')}</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
-        {canEdit && onEdit && (
-          <DropdownMenuItem onClick={() => onEdit(row)}>
-            <Edit className="mr-2 h-4 w-4" />
-            {t('grid.edit')}
-          </DropdownMenuItem>
-        )}
-        {canDelete && onDelete && (
-          <DropdownMenuItem onClick={() => onDelete(row)}>
-            <Trash2 className="mr-2 h-4 w-4" />
-            {t('grid.delete')}
-          </DropdownMenuItem>
-        )}
-        {rowActionDefs?.map(def => (
-          <RowActionMenuItem
-            key={def.name}
-            def={def}
-            row={row}
-            onActionDef={onActionDef}
-          />
-        ))}
-        {rowActions?.map(action => (
-          <DropdownMenuItem
-            key={action}
-            onClick={() => onAction?.(action, row)}
-            data-testid={`row-action-${action}`}
-          >
-            {formatActionLabel(action)}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+      {inlineDefs.map(def => (
+        <RowActionInlineButton
+          key={def.name}
+          def={def}
+          row={row}
+          onActionDef={onActionDef}
+        />
+      ))}
+      {hasMenu && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
+              data-testid="row-action-trigger"
+            >
+              <MoreVertical className="h-4 w-4" />
+              <span className="sr-only">{t('grid.openMenu')}</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+            {canEdit && onEdit && (
+              <DropdownMenuItem onClick={() => onEdit(row)}>
+                <Edit className="mr-2 h-4 w-4" />
+                {t('grid.edit')}
+              </DropdownMenuItem>
+            )}
+            {canDelete && onDelete && (
+              <DropdownMenuItem onClick={() => onDelete(row)}>
+                <Trash2 className="mr-2 h-4 w-4" />
+                {t('grid.delete')}
+              </DropdownMenuItem>
+            )}
+            {menuDefs.map(def => (
+              <RowActionMenuItem
+                key={def.name}
+                def={def}
+                row={row}
+                onActionDef={onActionDef}
+              />
+            ))}
+            {rowActions?.map(action => (
+              <DropdownMenuItem
+                key={action}
+                onClick={() => onAction?.(action, row)}
+                data-testid={`row-action-${action}`}
+              >
+                {formatActionLabel(action)}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
   );
 };


### PR DESCRIPTION
The environment list's **"Open"** action (`sso_as_owner`) had two issues: the button was buried in the row **"⋮" overflow** (should be a primary CTA), and clicking it got **blocked by Chrome's popup blocker**.

- **RowActionMenu**: render `variant: 'primary'` row actions as **inline buttons** (the row's main CTA) instead of folding every action into the "⋮". Hook-safe per item so the `visible` CEL predicate is still honored; the overflow menu only renders when it still has items.
- **ObjectView.serverActionHandler**: honor `opensInNewTab` on the **list** path too (was only on `record_header` / RecordDetailView). Pre-open `about:blank` synchronously before the await so the user-gesture context survives → drive that tab to the returned `redirectUrl` (popup-safe), falling back to the current tab if blocked. Also derive `recordId` from the row's `_rowRecord` for `script` row actions (ActionRunner doesn't inject it for the script handler), so list_item script actions resolve their target record.

Verified: `@object-ui/app-shell` `tsc` clean + `@object-ui/plugin-grid` builds.

Pairs with cloud adding `'list_item'` to the `sso_as_owner` action's locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)