### PR TITLE
fix(app-shell): drop noopener on opensInNewTab pre-open (double-navigation)

### DIFF
--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1278,7 +1278,12 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         // current tab if the pre-open is itself blocked.
         let preOpenedTab: Window | null = null;
         if ((action as any).opensInNewTab) {
-            try { preOpenedTab = window.open('about:blank', '_blank', 'noopener,noreferrer'); } catch { preOpenedTab = null; }
+            // NOTE: no 'noopener' — per spec it forces window.open to return
+            // null even when the tab opens, losing the handle so we'd fall
+            // through to the popup branch and navigate the *current* (list)
+            // tab to the redirectUrl (double-navigation bug). We need the
+            // reference to drive the pre-opened tab to the SSO redirect.
+            try { preOpenedTab = window.open('about:blank', '_blank'); } catch { preOpenedTab = null; }
         }
         try {
             const baseUrl = import.meta.env.VITE_SERVER_URL || '';
@@ -1315,7 +1320,10 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                     }
                 } else {
                     let popup: Window | null = null;
-                    try { popup = window.open(redirectUrl, '_blank', 'noopener,noreferrer'); } catch { popup = null; }
+                    // No 'noopener' so a successful open returns a truthy
+                    // handle; with it the null return would always trip the
+                    // current-tab fallback below.
+                    try { popup = window.open(redirectUrl, '_blank'); } catch { popup = null; }
                     if (!popup) window.location.href = redirectUrl;
                 }
             } else if (preOpenedTab) {

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -447,7 +447,13 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     // the user always gets there.
     let preOpenedTab: Window | null = null;
     if ((action as any).opensInNewTab) {
-      try { preOpenedTab = window.open('about:blank', '_blank', 'noopener,noreferrer'); } catch { preOpenedTab = null; }
+      // NOTE: do NOT pass 'noopener' here — per spec it forces window.open to
+      // return null even when the tab opens, so we'd lose the handle, fall
+      // through to the popup branch below, and end up navigating the *current*
+      // tab to the redirectUrl (the double-navigation bug: env opens in a new
+      // tab AND the list/detail page jumps to the now-consumed SSO URL). We
+      // need the reference to drive the pre-opened tab to the SSO redirect.
+      try { preOpenedTab = window.open('about:blank', '_blank'); } catch { preOpenedTab = null; }
     }
 
     try {
@@ -486,7 +492,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           }
         } else {
           let popup: Window | null = null;
-          try { popup = window.open(redirectUrl, '_blank', 'noopener,noreferrer'); } catch { popup = null; }
+          // No 'noopener' so a successful open returns a truthy handle; with
+          // it, the null return would always trip the current-tab fallback.
+          try { popup = window.open(redirectUrl, '_blank'); } catch { popup = null; }
           if (!popup) { window.location.href = redirectUrl; }
         }
       } else if (preOpenedTab) {


### PR DESCRIPTION
Browser-reproduced: clicking **Open environment** (sso_as_owner) opened the env in a new tab but ALSO navigated the current list/detail page to the single-use-consumed SSO URL → error page.

**Root cause**: the popup-safe pre-open used `window.open('about:blank','_blank','noopener,noreferrer')`. Per spec, `noopener` makes window.open return **null** even when the tab opens → `preOpenedTab` null → falls through to the popup branch → that open also returns null → `if(!popup) window.location.href = redirectUrl` navigates the **current** tab.

**Fix**: pre-open (and popup-detection open) **without** `noopener` so we get a usable handle and drive that one tab; the current tab is never navigated. Safe — these tabs only load our own cloud→env SSO URL. Fixes both RecordDetailView (record_header) and ObjectView (list_item) paths.

Verified: `@object-ui/app-shell` tsc/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)