### PR TITLE
feat(studio): "Publish app" button — publish all package drafts (ADR-0033)

### DIFF
--- a/.changeset/adr-0033-publish-app-button.md
+++ b/.changeset/adr-0033-publish-app-button.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/app-shell': minor
+---
+
+feat(studio): add "Publish app" button to publish all package drafts (ADR-0033)
+
+The package detail's Pending changes section gains a primary **Publish app (N)** button that calls `POST /api/v1/packages/:id/publish-drafts` to promote every drafted item of the app in one shot, then refreshes the pending list. Complements the per-item review/publish links — so after an AI builds an app you can review item-by-item or publish the whole thing at once.

--- a/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
@@ -358,6 +358,33 @@ function PackageDetailSheet({
       'Package published.',
     );
 
+  // ADR-0033 — publish every pending draft of this app in one shot, then
+  // refresh the pending list (it should now be empty). Distinct from the
+  // registry-based `publish` above; this hits `/publish-drafts`.
+  const publishDrafts = () =>
+    run(
+      'publish-drafts',
+      () =>
+        apiJson<{ publishedCount?: number; failedCount?: number; failed?: Array<{ name?: string }> }>(
+          `${API}/${encodeURIComponent(id)}/publish-drafts`,
+          { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) },
+        ).then(async (r) => {
+          try {
+            const fresh = await apiJson<{ drafts?: Array<{ type: string; name: string }> }>(
+              `/api/v1/meta/_drafts?packageId=${encodeURIComponent(id)}`,
+            );
+            setDrafts(fresh?.drafts ?? []);
+          } catch {
+            setDrafts([]);
+          }
+          if (r?.failedCount) {
+            throw new Error(`Published ${r.publishedCount ?? 0}; ${r.failedCount} failed.`);
+          }
+          return r;
+        }),
+      'App published — all drafts are now live.',
+    );
+
   const revert = () =>
     run(
       'revert',
@@ -440,8 +467,14 @@ function PackageDetailSheet({
                 <Badge variant="secondary">{drafts.length}</Badge>
               </p>
               <p className="text-xs text-muted-foreground">
-                Drafted, not yet published. Review and publish each to make it live.
+                Drafted, not yet published. Publish the whole app, or review each below.
               </p>
+              {!isKernel && (
+                <Button size="sm" onClick={publishDrafts} disabled={!!busy}>
+                  <Upload className="mr-1.5 h-3.5 w-3.5" />
+                  {busy === 'publish-drafts' ? 'Publishing…' : `Publish app (${drafts.length})`}
+                </Button>
+              )}
               <ul className="space-y-1">
                 {drafts.map((d) => (
                   <li key={`${d.type}/${d.name}`}>


### PR DESCRIPTION
## Context

Companion to framework #1553 (`POST /api/v1/packages/:id/publish-drafts`). After an AI builds an app, its metadata is drafted and bound to the app package. The package detail already lists pending drafts (objectstack-ai/objectui#1469) with per-item review/publish links; this adds a one-click "publish the whole app".

## Change

- In the package detail's **Pending changes** section, a primary **Publish app (N)** button calls `POST /api/v1/packages/:id/publish-drafts`, then refreshes the pending list (which empties on success). On partial failure it surfaces `Published X; Y failed.`
- Complements the existing per-item review links — review item-by-item, or publish everything at once.

## Verification

- Backend live-verified (framework #1553): an AI-built `app.asset_management` (4 drafts) published in one call → all promoted to active, drafts cleared.
- `@object-ui/app-shell` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)