### PR TITLE
feat(packages): "Discard changes" + "Delete app" buttons (AI-build review loop)

### DIFF
--- a/.changeset/package-discard-delete-buttons.md
+++ b/.changeset/package-discard-delete-buttons.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/app-shell': minor
+---
+
+feat(packages): "Discard changes" and "Delete app" buttons in the package detail sheet
+
+Adds two one-click package-lifecycle actions next to the existing "Publish app", mirroring the new backend endpoints:
+
+- **Discard changes (N)** — next to "Publish app" in the Pending changes block. Drops every pending draft via `POST /packages/:id/discard-drafts`, reverting the app to its last published baseline. Non-destructive (published metadata + data untouched), then refreshes the pending list.
+- **Delete app** — in the Actions row. Removes the whole package via `DELETE /packages/:id` (active + draft metadata + drops each object's table). Confirms first ("this cannot be undone"); closes the sheet on success, keeps it open and shows the error on failure.
+
+Together with "Publish app", this gives the full AI-build review loop a UI: publish to preview → keep, **discard all changes**, or **delete the app**.

--- a/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
@@ -31,6 +31,7 @@ import {
   PowerOff,
   ExternalLink,
   AlertTriangle,
+  Trash2,
 } from 'lucide-react';
 import {
   Button,
@@ -392,6 +393,57 @@ function PackageDetailSheet({
       'Reverted to last published state.',
     );
 
+  // ADR-0033 — discard every pending draft of this app in one shot, reverting
+  // it to the last published baseline. NON-destructive: published metadata and
+  // data are untouched. Distinct from the metadata-service `/revert` above —
+  // this hits the robust `/discard-drafts` (sys_metadata) path.
+  const discardDrafts = () =>
+    run(
+      'discard-drafts',
+      () =>
+        apiJson<{ discardedCount?: number; failedCount?: number }>(
+          `${API}/${encodeURIComponent(id)}/discard-drafts`,
+          { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) },
+        ).then(async (r) => {
+          try {
+            const fresh = await apiJson<{ drafts?: Array<{ type: string; name: string }> }>(
+              `/api/v1/meta/_drafts?packageId=${encodeURIComponent(id)}`,
+            );
+            setDrafts(fresh?.drafts ?? []);
+          } catch {
+            setDrafts([]);
+          }
+          if (r?.failedCount) {
+            throw new Error(`Discarded ${r.discardedCount ?? 0}; ${r.failedCount} failed.`);
+          }
+          return r;
+        }),
+      'All pending changes discarded — back to the published version.',
+    );
+
+  // ADR-0033 — delete the WHOLE package: every metadata row (active + draft)
+  // plus each object's physical table (DESTRUCTIVE). Confirmed, then closes the
+  // sheet on success. Errors stay visible (sheet kept open).
+  const deleteApp = async () => {
+    const ok = window.confirm(
+      `Delete "${pkg?.manifest.name || id}" and all its data?\n\n` +
+        `This removes every object, view, dashboard and app in the package AND ` +
+        `drops the database tables those objects created. This cannot be undone.`,
+    );
+    if (!ok) return;
+    setBusy('delete');
+    setMsg(null);
+    try {
+      await apiJson(`${API}/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      onChanged();
+      onOpenChange(false);
+    } catch (e: any) {
+      setMsg({ kind: 'err', text: e?.message ?? 'Delete failed' });
+    } finally {
+      setBusy(null);
+    }
+  };
+
   const toggleEnable = () =>
     run(
       'toggle',
@@ -470,10 +522,16 @@ function PackageDetailSheet({
                 Drafted, not yet published. Publish the whole app, or review each below.
               </p>
               {!isKernel && (
-                <Button size="sm" onClick={publishDrafts} disabled={!!busy}>
-                  <Upload className="mr-1.5 h-3.5 w-3.5" />
-                  {busy === 'publish-drafts' ? 'Publishing…' : `Publish app (${drafts.length})`}
-                </Button>
+                <div className="flex flex-wrap gap-2">
+                  <Button size="sm" onClick={publishDrafts} disabled={!!busy}>
+                    <Upload className="mr-1.5 h-3.5 w-3.5" />
+                    {busy === 'publish-drafts' ? 'Publishing…' : `Publish app (${drafts.length})`}
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={discardDrafts} disabled={!!busy}>
+                    <Undo2 className="mr-1.5 h-3.5 w-3.5" />
+                    {busy === 'discard-drafts' ? 'Discarding…' : `Discard changes (${drafts.length})`}
+                  </Button>
+                </div>
               )}
               <ul className="space-y-1">
                 {drafts.map((d) => (
@@ -526,6 +584,16 @@ function PackageDetailSheet({
               <Button size="sm" variant="outline" onClick={exportPkg} disabled={!!busy}>
                 <Download className="mr-1.5 h-3.5 w-3.5" />
                 {busy === 'export' ? 'Exporting…' : 'Export'}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={deleteApp}
+                disabled={!!busy}
+                className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                {busy === 'delete' ? 'Deleting…' : 'Delete app'}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
Adds the two package-lifecycle buttons to the package detail sheet, mirroring the existing **Publish app**, so the AI-build review loop has a UI.

Pairs with framework PR objectstack-ai/framework#1569 (the `discard-drafts` / `delete-package` backend).

## Buttons

- **Discard changes (N)** — beside "Publish app" in the *Pending changes* block. `POST /packages/:id/discard-drafts`: drops every pending draft, reverting the app to its last published baseline. Non-destructive (published metadata + data untouched); refreshes the pending list after.
- **Delete app** — in the *Actions* row (destructive styling). `DELETE /packages/:id`: removes the whole package (active + draft metadata) and drops each object's table. Confirms first; closes the sheet on success, keeps it open + shows the error on failure.

## The loop this completes

```
AI builds app → Publish app (preview with real data)
                ├─ keep it
                ├─ Discard changes → back to last published
                └─ Delete app → gone, tables dropped, no residue
```

## Notes
- Both reuse the existing `run()` helper / busy-state / message pattern; `Delete app` uses a `window.confirm` guard.
- Backend endpoints ship in framework#1569 — until that merges+deploys, the buttons surface the backend error (e.g. 501) via the existing message banner.
- `@object-ui/app-shell` typechecks clean (0 errors after building workspace deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
