### PR TITLE
perf(detail/header): lazy + dedupe related-list fan-out, coalesce header polls

### DIFF
--- a/.changeset/perf-detail-rail-poller-fanout.md
+++ b/.changeset/perf-detail-rail-poller-fanout.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/plugin-detail': patch
+---
+
+perf(detail/header): lazy + dedupe related-list fan-out, coalesce header polls
+
+Opening a record detail fired ~50 concurrent `/api/v1` requests that
+head-of-line-blocked one another on a single control-plane container.
+
+- `RecordDetailView` no longer eager-preloads reverse-reference children
+  when the reference rail renders them (that data was discarded while the
+  rail re-fetched the same collections).
+- `record:reference_rail` now gates fetching on visibility
+  (`IntersectionObserver`; the rail is `hidden xl:flex`), caps concurrency
+  at 3, and fetches once per `(parentId + entries)` via a signature guard,
+  applying results through a mounted ref.
+- `AppHeader` inbox/notification, approvals, and activity pollers gained
+  in-flight guards so bootstrap effect re-runs coalesce to one request; the
+  approvals poll now sends one request with all identities comma-joined
+  instead of one per identity.
+
+Measured locally: opening an environment detail dropped from ~52 to ~17
+requests, related collections from ×3–5 each to ×1, approvals from ×9 to ≤3.

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -161,6 +161,27 @@ export function AppHeader({
   const activityUnavailableRef = useRef(false);
   const notificationsUnavailableRef = useRef(false);
 
+  // Tracks whether the component is still mounted. Used by the pollers to
+  // decide whether to apply an in-flight fetch's result, independent of any
+  // single effect run's `cancelled` flag — so a fetch that outlives the
+  // effect run that started it (because deps settled mid-flight during
+  // bootstrap) still populates state instead of being silently dropped.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    // Reset on (re)mount too, so StrictMode's mount→cleanup→mount cycle
+    // doesn't leave it latched false and silence the pollers.
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  // In-flight guards: during bootstrap the poller effects re-run several
+  // times as `dataSource` / `isApp` / `user.id` settle, and each run kicks
+  // an immediate fetch. Without these the same query fired 5× concurrently
+  // (nothing cached yet) and flooded the backend. They coalesce to one.
+  const notifInFlightRef = useRef(false);
+  const approvalsInFlightRef = useRef(false);
+  const activityInFlightRef = useRef(false);
+
   /** M11.C15: pending approvals count for the topbar shortcut. */
   const [pendingApprovalsCount, setPendingApprovalsCount] = useState(0);
   const approvalsUnavailableRef = useRef(false);
@@ -180,6 +201,11 @@ export function AppHeader({
     // transport-level provider (<PresenceProvider>) which is not yet
     // wired — see ROADMAP for the realtime plan.
     if (activityUnavailableRef.current) return;
+    // In-flight dedupe: this callback's identity changes as dataSource/isApp
+    // settle during bootstrap, re-firing the mount effect below; coalesce the
+    // immediate fetches into one instead of N (sys_activity fired 3×+).
+    if (activityInFlightRef.current) return;
+    activityInFlightRef.current = true;
     try {
       const activityResult = await dataSource
         .find('sys_activity', { $orderby: { timestamp: 'desc' }, $top: 20 })
@@ -193,7 +219,9 @@ export function AppHeader({
         );
         if (items.length) setApiActivities(items);
       }
-    } catch { /* fallback below */ }
+    } catch { /* fallback below */ } finally {
+      activityInFlightRef.current = false;
+    }
   }, [dataSource, isApp]);
 
   useEffect(() => { fetchPresenceAndActivities(); }, [fetchPresenceAndActivities]);
@@ -232,6 +260,8 @@ export function AppHeader({
       err?.httpStatus === 404 || err?.status === 404 || err?.code === 'object_not_found';
     const READ_STATES = new Set(['read', 'clicked', 'dismissed']);
     const fetchOnce = async () => {
+      if (notifInFlightRef.current) return;
+      notifInFlightRef.current = true;
       try {
         const [inboxRes, receiptRes] = await Promise.all([
           dataSource.find('sys_inbox_message', {
@@ -246,7 +276,7 @@ export function AppHeader({
             $top: 200,
           }) as Promise<any>).catch(() => ({ data: [] })),
         ]);
-        if (cancelled) return;
+        if (!mountedRef.current) return;
         const rows: any[] = Array.isArray(inboxRes?.data) ? inboxRes.data : [];
         const receipts: any[] = Array.isArray(receiptRes?.data) ? receiptRes.data : [];
         // notification_id → { id, state } (most-advanced receipt wins).
@@ -283,6 +313,8 @@ export function AppHeader({
           return;
         }
         backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+      } finally {
+        notifInFlightRef.current = false;
       }
     };
     const scheduleNext = () => {
@@ -319,6 +351,13 @@ export function AppHeader({
    * Hits the framework's `/api/v1/approvals/requests?status=pending`
    * endpoint with the user's identities (id, email, role:<r>). Degrades
    * silently to zero on 404 (approvals plugin not installed).
+   *
+   * The endpoint accepts a comma-separated `approverId` and matches a
+   * request when ANY identity is a pending approver, so this issues ONE
+   * request per poll. (It previously looped one fetch per identity, firing
+   * N near-simultaneous calls every cycle — the dominant duplicate-request
+   * offender on the control plane. Requires framework with multi-approverId
+   * support; ship the framework + console SHA bumps together.)
    */
   useEffect(() => {
     if (!isApp || !user?.id) return;
@@ -335,19 +374,25 @@ export function AppHeader({
     let timer: ReturnType<typeof setTimeout> | null = null;
     const POLL_MS = 30_000;
     const fetchOnce = async () => {
+      if (identities.length === 0) return;
+      // In-flight dedupe: bootstrap re-runs this effect a few times; coalesce
+      // the immediate fetches into one instead of firing them concurrently.
+      if (approvalsInFlightRef.current) return;
+      approvalsInFlightRef.current = true;
       try {
+        const qs = new URLSearchParams({ status: 'pending', approverId: identities.join(',') });
+        const res = await fetch(`${base}?${qs}`, { credentials: 'include' });
+        if (res.status === 404) { approvalsUnavailableRef.current = true; return; }
+        if (!res.ok) return;
+        const payload = await res.json().catch(() => null);
         const seen = new Set<string>();
-        if (identities.length === 0) return;
-        for (const id of identities) {
-          const qs = new URLSearchParams({ status: 'pending', approverId: id });
-          const res = await fetch(`${base}?${qs}`, { credentials: 'include' });
-          if (res.status === 404) { approvalsUnavailableRef.current = true; return; }
-          if (!res.ok) return;
-          const payload = await res.json().catch(() => null);
-          for (const row of (payload?.data || []) as { id: string }[]) seen.add(row.id);
-        }
-        if (!cancelled) setPendingApprovalsCount(seen.size);
-      } catch { /* transient — keep last value */ }
+        for (const row of (payload?.data || []) as { id: string }[]) seen.add(row.id);
+        // Apply if still mounted (not gated on this run's `cancelled`, so the
+        // single in-flight fetch survives a bootstrap re-run mid-flight).
+        if (mountedRef.current) setPendingApprovalsCount(seen.size);
+      } catch { /* transient — keep last value */ } finally {
+        approvalsInFlightRef.current = false;
+      }
     };
     const schedule = () => {
       if (cancelled || approvalsUnavailableRef.current) return;

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -584,9 +584,27 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     return relations;
   }, [objectDef, objects]);
 
-  // Fetch related child records for each reverse reference
+  // Fetch related child records for each reverse reference.
+  //
+  // PERF: skip this eager fan-out when the reference rail will render the
+  // related lists instead. `buildDefaultPageSchema` emits the rail (and
+  // hides the duplicate Related tab) whenever there are ≥2 related lists
+  // and the author hasn't opted out via `hideReferenceRail`. In that
+  // layout `childRelatedData` is never displayed — the rail fetches its
+  // own data lazily (on-visible + concurrency-capped, see
+  // record-reference-rail.tsx). Preloading every child here therefore
+  // produced ~N redundant concurrent queries on every record open that
+  // head-of-line-blocked the rail's real fetches (measured: opening a
+  // record with 8 related lists fired ~50 concurrent requests, all TTFB
+  // ~9s). When the rail is NOT emitted (≤1 related list, or
+  // hideReferenceRail), the Related tab consumes this data, so we still
+  // load it.
   useEffect(() => {
     if (!dataSource || !pureRecordId || childRelations.length === 0) return;
+    const railWillRender =
+      childRelations.length >= 2 &&
+      (objectDef as any)?.detail?.hideReferenceRail !== true;
+    if (railWillRender) return;
     let cancelled = false;
     Promise.all(
       childRelations.map(({ childObject, referenceField }) =>
@@ -611,7 +629,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       setChildRelatedData(data);
     });
     return () => { cancelled = true; };
-  }, [dataSource, pureRecordId, childRelations]);
+  }, [dataSource, pureRecordId, childRelations, objectDef]);
 
   // ── Audit history fetch ────────────────────────────────────────────
   // Loads recent sys_audit_log entries for this record so the DetailView can

--- a/packages/plugin-detail/src/renderers/record-reference-rail.tsx
+++ b/packages/plugin-detail/src/renderers/record-reference-rail.tsx
@@ -122,47 +122,114 @@ export const RecordReferenceRailRenderer: React.FC<RecordReferenceRailRendererPr
 
   const [states, setStates] = React.useState<Record<string, EntryState>>({});
 
+  // PERF: gate the rail's per-entry queries on visibility. The rail lives in
+  // an aside region that is `hidden xl:flex` (see buildDefaultPageSchema), so
+  // on sub-`xl` viewports (the common laptop width) it is `display:none` and
+  // the IntersectionObserver never reports intersection → zero queries on
+  // record open. On `xl`+ it fetches once the rail scrolls near the viewport.
+  // Without this, every related collection was fetched eagerly on mount,
+  // which (together with RecordDetailView's preload, now removed for this
+  // layout) produced ~50 concurrent requests that head-of-line-blocked one
+  // another on a single backend container.
+  const railRef = React.useRef<HTMLDivElement>(null);
+  const [railVisible, setRailVisible] = React.useState(false);
+  // Mounted latch: results are applied while mounted regardless of which
+  // effect run dispatched them, so a fetch that outlives a re-render isn't
+  // dropped (and then never retried because of the sig guard below).
+  const mountedRef = React.useRef(true);
   React.useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+  // Signature of the entry set already dispatched. The fetch effect re-runs
+  // whenever the record context hands down a new `dataSource` identity during
+  // the drawer's mount churn; without this guard each re-run re-drained the
+  // whole queue (every related collection fetched 3–5×). We fetch once per
+  // (parentId + entries) and skip identical re-runs.
+  const fetchedSigRef = React.useRef<string>('');
+  React.useEffect(() => {
+    if (railVisible) return; // latch: once visible, stop observing
+    const el = railRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      // No element yet or unsupported environment (SSR/tests): fall back to
+      // eager so behaviour never regresses to "never loads".
+      setRailVisible(true);
+      return;
+    }
+    const obs = new IntersectionObserver(
+      (records) => {
+        if (records.some((r) => r.isIntersecting)) setRailVisible(true);
+      },
+      { rootMargin: '200px' },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [railVisible]);
+
+  const entriesSig = JSON.stringify(entries.map((e) => `${e.objectName}:${e.relationshipField}:${e.limit ?? 3}`));
+  React.useEffect(() => {
+    if (!railVisible) return;
     if (!dataSource?.find || !parentId || entries.length === 0) return;
-    let cancelled = false;
-    entries.forEach((entry) => {
+    // Fetch once per (parentId + entries). Re-runs triggered purely by a new
+    // `dataSource` identity (drawer mount churn) are no-ops; navigating to a
+    // different record changes the signature and refetches.
+    const sig = `${parentId}::${entriesSig}`;
+    if (fetchedSigRef.current === sig) return;
+    fetchedSigRef.current = sig;
+    // Mark every entry as loading up front so the skeletons render.
+    setStates((prev) => {
+      const next = { ...prev };
+      for (const entry of entries) {
+        next[entry.objectName] = {
+          loading: true,
+          total: 0,
+          items: prev[entry.objectName]?.items || [],
+        };
+      }
+      return next;
+    });
+    const fetchEntry = async (entry: ReferenceRailEntry) => {
       const key = entry.objectName;
-      setStates((prev) => ({
-        ...prev,
-        [key]: { loading: true, total: 0, items: prev[key]?.items || [] },
-      }));
-      dataSource
-        .find(entry.objectName, {
+      try {
+        const res: any = await dataSource.find(entry.objectName, {
           $filter: { [entry.relationshipField]: parentId },
           $top: entry.limit ?? 3,
           $count: true,
-        })
-        .then((res: any) => {
-          if (cancelled) return;
-          const items = Array.isArray(res) ? res : res?.data || [];
-          const total =
-            typeof res?.total === 'number'
-              ? res.total
-              : typeof res?.count === 'number'
-                ? res.count
-                : items.length;
-          setStates((prev) => ({
-            ...prev,
-            [key]: { loading: false, total, items },
-          }));
-        })
-        .catch((err: any) => {
-          if (cancelled) return;
-          setStates((prev) => ({
-            ...prev,
-            [key]: { loading: false, total: 0, items: [], error: String(err?.message || err) },
-          }));
         });
-    });
-    return () => {
-      cancelled = true;
+        if (!mountedRef.current) return;
+        const items = Array.isArray(res) ? res : res?.data || [];
+        const total =
+          typeof res?.total === 'number'
+            ? res.total
+            : typeof res?.count === 'number'
+              ? res.count
+              : items.length;
+        setStates((prev) => ({ ...prev, [key]: { loading: false, total, items } }));
+      } catch (err: any) {
+        if (!mountedRef.current) return;
+        setStates((prev) => ({
+          ...prev,
+          [key]: { loading: false, total: 0, items: [], error: String(err?.message || err) },
+        }));
+      }
     };
-  }, [dataSource, parentId, JSON.stringify(entries.map((e) => `${e.objectName}:${e.relationshipField}:${e.limit ?? 3}`))]);
+    // Concurrency-capped pool: drain the entries a few at a time instead of
+    // firing all N at once, so the rail never floods the backend in a burst.
+    const MAX_CONCURRENCY = 3;
+    const queue = [...entries];
+    const runWorker = async () => {
+      while (mountedRef.current) {
+        const entry = queue.shift();
+        if (!entry) return;
+        await fetchEntry(entry);
+      }
+    };
+    const workers = Array.from(
+      { length: Math.min(MAX_CONCURRENCY, queue.length) },
+      () => runWorker(),
+    );
+    void Promise.all(workers);
+  }, [railVisible, dataSource, parentId, entriesSig]);
 
   if (entries.length === 0) return null;
 
@@ -195,7 +262,7 @@ export const RecordReferenceRailRenderer: React.FC<RecordReferenceRailRendererPr
     );
 
   return (
-    <div className={cn('flex flex-col gap-3', schema.className, className)} {...designer}>
+    <div ref={railRef} className={cn('flex flex-col gap-3', schema.className, className)} {...designer}>
       {visibleEntries.map((entry) => {
         const key = entry.objectName;
         const state = states[key] || { loading: true, total: 0, items: [] };


### PR DESCRIPTION
## Problem
Opening a record detail (e.g. an environment in the cloud control plane) fired ~50 concurrent `/api/v1` requests that head-of-line-blocked one another on the single control-plane container, making the page feel slow.

## Root causes (fixed at source)
- **RecordDetailView** eagerly preloaded *every* reverse-reference child even when the reference rail renders them (≥2 related lists) — that data was then discarded (the Related tab is hidden in that layout) while the rail re-fetched the same collections. Now skips the preload when the rail owns the related lists.
- **record-reference-rail** fetched every collection eagerly on mount, once per re-render. Now it (a) gates fetching on visibility via `IntersectionObserver` (the rail is `hidden xl:flex`), (b) caps concurrency at 3, and (c) fetches once per `(parentId + entries)` via a signature guard, applying results through a mounted-ref so a fetch that outlives a re-render isn't dropped.
- **AppHeader** inbox/notification, approvals, and activity pollers re-ran several times during bootstrap (deps settling), each firing an immediate fetch. Added in-flight guards so the bootstrap re-runs coalesce to one request; results apply via a mounted ref.
- The **approvals poll** now issues a single request with all identities comma-joined (pairs with the framework multi-approverId change) instead of one request per identity.

## Verification
Local rig (Vite live source against the cloud control-plane), opening an environment detail:
- total `/api/v1` requests on open: **~52 → ~17**
- related collections: **×3–5 each → ×1**
- `approvals/requests`: **×9 → ≤3**

Typecheck clean; `plugin-detail` (117) and `app-shell` (243) test suites pass.

## Deploy note
The approvals client change pairs with the framework multi-approverId endpoint — bump the cloud `.framework-sha` and `.objectui-sha` together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)