### PR TITLE
fix(marketplace): detect installed state via same-origin proxy on tenant runtimes

### DIFF
--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -598,7 +598,12 @@ export function MarketplacePackagePage() {
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          {!localInstall && cloudInstall && (
+          {/* Reseed / purge still POST cross-origin to the control plane, which
+              the browser blocks on a tenant subdomain. Only offer them when the
+              runtime IS the cloud (same-origin). On tenants the install state is
+              still detected — the CTA flips to "Installed" — we just hide the
+              sample-data actions until they route through a same-origin proxy. */}
+          {!localInstall && cloudInstall && !getRuntimeConfig().cloudUrl && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="outline" size="lg" className="px-2.5" aria-label={t('marketplace.detail.moreOptions') || 'More options'}>

--- a/packages/app-shell/src/console/marketplace/marketplaceApi.ts
+++ b/packages/app-shell/src/console/marketplace/marketplaceApi.ts
@@ -364,8 +364,42 @@ export async function getCloudInstallationInfo(
   packageId: string,
   environmentId: string,
 ): Promise<CloudInstallationInfo | null> {
-  if (!packageId || !environmentId) return null;
-  const base = getCloudBase() || SERVER_URL;
+  if (!packageId) return null;
+
+  // ── In-environment (tenant runtime) path ──────────────────────────────
+  // When `getCloudBase()` is non-empty we're a tenant runtime browsing a
+  // *separate* cloud origin. A direct `${cloudBase}/api/v1/data/...` read is
+  // a cross-origin, cross-site-cookie request the browser blocks — the exact
+  // reason `installPackage()` routes through the same-origin proxy. Mirror it
+  // here: the cloud-owned runtime plugin's `/cloud-connection/installation`
+  // route resolves the env by hostname and queries the control plane
+  // server-to-server. Without this, the "Installed" CTA never flips and an
+  // already-installed package keeps inviting another install.
+  const cloudBase = getCloudBase();
+  if (cloudBase) {
+    try {
+      const res = await fetch(
+        `/api/v1/cloud-connection/installation?package_id=${encodeURIComponent(packageId)}`,
+        { credentials: 'include', headers: { 'Accept': 'application/json' } },
+      );
+      if (!res.ok) return null;
+      const payload: any = await res.json().catch(() => ({}));
+      const data: any = payload?.data ?? payload ?? {};
+      if (!data.installed) return null;
+      return {
+        installationId: String(data.installationId ?? ''),
+        version: String(data.version ?? 'installed'),
+        withSampleData: data.withSampleData === true,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Cloud control-plane path (runtime IS cloud) ───────────────────────
+  // Same-origin read against the control plane's data API.
+  if (!environmentId) return null;
+  const base = SERVER_URL;
   const filter = JSON.stringify([
     'and',
     ['package_id', '=', packageId],


### PR DESCRIPTION
## Problem

On a tenant runtime (e.g. `crm.objectos.app`) the marketplace SPA browses a **separate** cloud control plane. `getCloudInstallationInfo()` read `sys_package_installation` directly from the cloud origin — a cross-origin, cross-site-cookie request the browser blocks (the same reason install was moved to the same-origin `/api/v1/cloud-connection/install` proxy). The probe returned null, so the primary CTA never flipped to **Installed**: an already-installed app kept showing "安装到云端 / Install to cloud" and re-inviting installs (which then appeared to "hang" because re-install upserts silently and the button never changes).

## Fix

- Route the installed-state probe through the cloud-owned runtime plugin's new same-origin `GET /api/v1/cloud-connection/installation?package_id=` endpoint (resolves env by hostname, queries the control plane server-to-server). Falls back to the existing same-origin path when the runtime *is* the cloud.
- Hide the cloud reseed/purge dropdown on tenant runtimes — those actions still POST cross-origin (follow-up: proxy them too) — so fixing detection doesn't surface buttons that can't work yet.

## Pairs with

cloud PR adding `GET /api/v1/cloud-connection/installation`. Ship needs `.objectui-sha` bump to this PR's merge SHA.

## Tests

`app-shell` suite green (243 passed); typecheck clean. No marketplace-specific tests exist for these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)