### PR TITLE
feat(auth): standalone shell-less /set-password page for SSO recovery (#1544)

### DIFF
--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -42,6 +42,7 @@ import { LoginPage } from './pages/auth/LoginPage';
 import { RegisterPage } from './pages/auth/RegisterPage';
 import { ForgotPasswordPage } from './pages/auth/ForgotPasswordPage';
 import { ResetPasswordPage } from './pages/auth/ResetPasswordPage';
+import { SetPasswordPage } from './pages/auth/SetPasswordPage';
 import { VerifyEmailPage } from './pages/auth/VerifyEmailPage';
 import { VerifyEmailPromptPage } from './pages/auth/VerifyEmailPromptPage';
 import { SetupPage } from './pages/auth/SetupPage';
@@ -137,6 +138,14 @@ export function App() {
             <Route path="/register" element={<RegisterPage />} />
             <Route path="/forgot-password" element={<ForgotPasswordPage />} />
             <Route path="/reset-password" element={<ResetPasswordPage />} />
+            {/*
+              * Set an initial local password after SSO-as-owner entry on a
+              * per-environment runtime. Public (session cookie already set by
+              * the cloud sso-exchange) + shell-less, like the other auth
+              * surfaces — see SetPasswordPage. The cloud auth-proxy redirects
+              * here as `/set-password?next=…`.
+              */}
+            <Route path="/set-password" element={<SetPasswordPage />} />
             <Route path="/verify-email" element={<VerifyEmailPage />} />
             <Route path="/verify-email-prompt" element={<VerifyEmailPromptPage />} />
             <Route path="/setup" element={<SetupPage />} />

--- a/apps/console/src/pages/auth/SetPasswordPage.tsx
+++ b/apps/console/src/pages/auth/SetPasswordPage.tsx
@@ -1,0 +1,161 @@
+/**
+ * SetPasswordPage — standalone, shell-less "set a local password" surface.
+ *
+ * Reached when a user enters via SSO-as-owner on a per-environment runtime
+ * and has no `credential` account yet. The cloud `auth-proxy-plugin`
+ * `sso-exchange` mints a session cookie and redirects here with `?next=`.
+ *
+ * This is intentionally a sibling of LoginPage / ResetPasswordPage — rendered
+ * OUTSIDE ProtectedRoute and wrapped in <AuthLayout> (no console shell), which
+ * is the conventional shape for an auth surface. The session cookie is already
+ * present, so `setInitialPassword()` authenticates against it; the server
+ * (`POST /api/v1/auth/set-initial-password`) enforces the session and rejects
+ * with 409 if a local password already exists.
+ */
+
+import { useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import { useAuth } from '@object-ui/auth';
+import { useObjectTranslation } from '@object-ui/i18n';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@object-ui/components';
+import { AuthLayout } from './AuthLayout';
+
+/** Only same-origin app paths are safe redirect targets. */
+function safeNext(raw: string | null): string {
+  if (!raw) return '/';
+  // Reject absolute URLs and protocol-relative (`//host`) targets.
+  return raw.startsWith('/') && !raw.startsWith('//') ? raw : '/';
+}
+
+export function SetPasswordPage() {
+  const { t } = useObjectTranslation();
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const next = safeNext(params.get('next'));
+  const { user, isLoading, setInitialPassword } = useAuth();
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) {
+      toast.error(
+        t('auth.setPassword.passwordsMismatch', { defaultValue: 'Passwords do not match' }),
+      );
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await setInitialPassword(newPassword);
+      toast.success(
+        t('auth.setPassword.success', { defaultValue: 'Local password set' }),
+      );
+      navigate(next);
+    } catch (err) {
+      toast.error(
+        t('auth.setPassword.failed', { defaultValue: 'Could not set password' }),
+        { description: (err as Error).message },
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <Card className="border-border/60 shadow-sm shadow-primary/5 backdrop-blur supports-[backdrop-filter]:bg-card/95">
+        <CardHeader className="text-center">
+          <CardTitle className="text-xl tracking-tight">
+            {t('auth.setPassword.title', { defaultValue: 'Set a recovery password' })}
+          </CardTitle>
+          <CardDescription>
+            {t('auth.setPassword.description', {
+              defaultValue:
+                'You signed in via single sign-on. Set a local password so you can still sign in to this environment directly if SSO ever becomes unavailable.',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!isLoading && !user ? (
+            <p className="text-center text-sm text-muted-foreground">
+              {t('auth.setPassword.noSession', {
+                defaultValue: 'Your session has expired.',
+              })}{' '}
+              <Link
+                to="/login"
+                className="font-medium text-primary underline-offset-4 hover:underline"
+              >
+                {t('auth.setPassword.backToSignIn', { defaultValue: 'Sign in again' })}
+              </Link>
+            </p>
+          ) : (
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+              {user?.email ? (
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="set-password-email">
+                    {t('auth.setPassword.email', { defaultValue: 'Email' })}
+                  </Label>
+                  <Input
+                    id="set-password-email"
+                    type="email"
+                    autoComplete="username"
+                    value={user.email}
+                    disabled
+                    className="bg-muted text-muted-foreground"
+                  />
+                </div>
+              ) : null}
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="new-password">
+                  {t('auth.setPassword.newPassword', { defaultValue: 'New password' })}
+                </Label>
+                <Input
+                  id="new-password"
+                  type="password"
+                  autoComplete="new-password"
+                  required
+                  minLength={8}
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="confirm-password">
+                  {t('auth.setPassword.confirmPassword', { defaultValue: 'Confirm password' })}
+                </Label>
+                <Input
+                  id="confirm-password"
+                  type="password"
+                  autoComplete="new-password"
+                  required
+                  minLength={8}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                />
+              </div>
+              <Button type="submit" className="w-full" disabled={submitting}>
+                {submitting
+                  ? t('auth.setPassword.submitting', { defaultValue: 'Saving…' })
+                  : t('auth.setPassword.submit', { defaultValue: 'Set password' })}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </AuthLayout>
+  );
+}
+
+export default SetPasswordPage;

--- a/apps/console/src/pages/system/ProfilePage.tsx
+++ b/apps/console/src/pages/system/ProfilePage.tsx
@@ -22,35 +22,9 @@ import {
   Badge,
   Alert,
   AlertDescription,
-  AlertTitle,
 } from '@object-ui/components';
 import { useUpload } from '@object-ui/providers';
-import { CheckCircle2, AlertCircle, User, Lock, Upload, Loader2, X, ShieldAlert } from 'lucide-react';
-
-/**
- * `?recovery_needed=true` is set by the cloud `sso_as_owner` redirect when
- * the SSO-handoff lands a user that has no `credential` account on this
- * environment yet. We surface a prominent banner + scroll to the password
- * card so the operator can set a disaster-recovery local password before
- * the SSO bridge becomes unreachable. See `auth-proxy-plugin.ts` →
- * `sso-exchange` for the upstream redirect logic.
- */
-function useRecoveryNeededFlag(): { recoveryNeeded: boolean; clear: () => void } {
-  const [recoveryNeeded, setRecoveryNeeded] = useState(false);
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const params = new URLSearchParams(window.location.search);
-    setRecoveryNeeded(params.get('recovery_needed') === 'true');
-  }, []);
-  const clear = () => {
-    if (typeof window === 'undefined') return;
-    const url = new URL(window.location.href);
-    url.searchParams.delete('recovery_needed');
-    window.history.replaceState({}, '', url.toString());
-    setRecoveryNeeded(false);
-  };
-  return { recoveryNeeded, clear };
-}
+import { CheckCircle2, AlertCircle, User, Lock, Upload, Loader2, X } from 'lucide-react';
 
 export function ProfilePage() {
   const { user, updateUser, isLoading, changePassword, setInitialPassword, hasLocalPassword } = useAuth();
@@ -61,8 +35,6 @@ export function ProfilePage() {
   const avatarInputRef = useRef<HTMLInputElement>(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
   const [avatarError, setAvatarError] = useState<string | null>(null);
-  const passwordCardRef = useRef<HTMLDivElement>(null);
-  const { recoveryNeeded, clear: clearRecoveryFlag } = useRecoveryNeededFlag();
 
   // Sync local `name` state when the user object arrives or changes.
   // useState's initial value is only evaluated on first render, so when
@@ -72,16 +44,6 @@ export function ProfilePage() {
   useEffect(() => {
     setName(user?.name ?? '');
   }, [user?.name]);
-
-  // When the SSO-handoff dropped us here, jump straight to the password
-  // section so the operator can finish the recovery flow in one motion.
-  useEffect(() => {
-    if (!recoveryNeeded) return;
-    const t = setTimeout(() => {
-      passwordCardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }, 200);
-    return () => clearTimeout(t);
-  }, [recoveryNeeded]);
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -132,22 +94,6 @@ export function ProfilePage() {
         <h1 className="text-xl sm:text-2xl font-bold tracking-tight">Profile</h1>
         <p className="text-sm text-muted-foreground mt-1">Manage your account settings</p>
       </div>
-
-      {recoveryNeeded && (
-        <Alert
-          variant="default"
-          className="border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
-          data-testid="profile-recovery-banner"
-        >
-          <ShieldAlert className="h-4 w-4" />
-          <AlertTitle>Set a recovery password</AlertTitle>
-          <AlertDescription>
-            You signed in via single sign-on from the control plane. Set a local password
-            below so you can still sign in to this environment directly if SSO ever becomes
-            unavailable.
-          </AlertDescription>
-        </Alert>
-      )}
 
       {/* Avatar & Identity */}
       <Card>
@@ -281,15 +227,11 @@ export function ProfilePage() {
       </Card>
 
       {/* Password Change */}
-      <div ref={passwordCardRef}>
-        <PasswordCard
-          changePassword={changePassword}
-          setInitialPassword={setInitialPassword}
-          hasLocalPassword={hasLocalPassword}
-          highlight={recoveryNeeded}
-          onPasswordSet={clearRecoveryFlag}
-        />
-      </div>
+      <PasswordCard
+        changePassword={changePassword}
+        setInitialPassword={setInitialPassword}
+        hasLocalPassword={hasLocalPassword}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Why
After SSO-as-owner entry on a per-environment runtime, a user with no local `credential` account is sent to "set a recovery password". That affordance lived **inside the full-shell profile page** (`/system/profile?recovery_needed=true` — banner + auto-scroll to the password card). An auth surface should be **standalone and shell-less**, like `login` / `reset-password`. This makes it so.

## Changes
- **New `SetPasswordPage`** at `/set-password` — wrapped in `AuthLayout`, rendered **outside** `ProtectedRoute` (the cloud `sso-exchange` already set the session cookie). Reads `?next=`, calls `useAuth().setInitialPassword()`, and redirects to a **sanitised same-origin** `next` on success. Shows an expired-session fallback with a sign-in link.
- **`ProfilePage`** — drop the recovery banner, scroll-to-card effect, and `useRecoveryNeededFlag` hook (+ now-unused `AlertTitle` / `ShieldAlert` imports). Its `PasswordCard` still offers "set local password" for any credential-less user.

## Pairs with framework
objectstack-ai/framework#1577 — the cloud `auth-proxy` `sso-exchange` now redirects to `/_console/set-password?next=…` (instead of the profile page), and adds the missing `set-initial-password` endpoint on per-environment runtimes (the original 404).

## Verification
- `tsc --noEmit` clean (apps/console)
- No remaining refs to `recovery_needed` / `profile-recovery-banner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)