### PR TITLE
perf(detail): make reference rail opt-in, drop eager related-list fan-out

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -586,25 +586,18 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
 
   // Fetch related child records for each reverse reference.
   //
-  // PERF: skip this eager fan-out when the reference rail will render the
-  // related lists instead. `buildDefaultPageSchema` emits the rail (and
-  // hides the duplicate Related tab) whenever there are ≥2 related lists
-  // and the author hasn't opted out via `hideReferenceRail`. In that
-  // layout `childRelatedData` is never displayed — the rail fetches its
-  // own data lazily (on-visible + concurrency-capped, see
-  // record-reference-rail.tsx). Preloading every child here therefore
-  // produced ~N redundant concurrent queries on every record open that
-  // head-of-line-blocked the rail's real fetches (measured: opening a
-  // record with 8 related lists fired ~50 concurrent requests, all TTFB
-  // ~9s). When the rail is NOT emitted (≤1 related list, or
-  // hideReferenceRail), the Related tab consumes this data, so we still
-  // load it.
+  // PERF: only the legacy `DetailView` path consumes `childRelatedData`
+  // (it's threaded into `detailSchema.related[].data`). The default
+  // schema path renders each related list via `record:related_list`,
+  // whose `RelatedList` self-fetches lazily when its tab is shown — so
+  // preloading here would just fire ~N redundant concurrent queries on
+  // every record open (measured: a record with 8 related lists fired ~50
+  // concurrent requests, all TTFB ~9s) for data the schema path never
+  // reads. Skip the fan-out entirely whenever the schema page renders;
+  // load eagerly only for the legacy fallback that needs it.
   useEffect(() => {
+    if (effectivePage) return;
     if (!dataSource || !pureRecordId || childRelations.length === 0) return;
-    const railWillRender =
-      childRelations.length >= 2 &&
-      (objectDef as any)?.detail?.hideReferenceRail !== true;
-    if (railWillRender) return;
     let cancelled = false;
     Promise.all(
       childRelations.map(({ childObject, referenceField }) =>
@@ -629,7 +622,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       setChildRelatedData(data);
     });
     return () => { cancelled = true; };
-  }, [dataSource, pureRecordId, childRelations, objectDef]);
+  }, [dataSource, pureRecordId, childRelations, objectDef, effectivePage]);
 
   // ── Audit history fetch ────────────────────────────────────────────
   // Loads recent sys_audit_log entries for this record so the DetailView can
@@ -1610,6 +1603,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           // Per-object opt-outs read from `objectDef.detail.*`. Lets
           // catalog/atomic objects (product, task, ...) keep a focused
           // single-column layout instead of inheriting the rail.
+          showReferenceRail:
+            (objectDef as any)?.detail?.showReferenceRail === true || undefined,
           hideReferenceRail:
             (objectDef as any)?.detail?.hideReferenceRail === true || undefined,
           hideRelatedTab:

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -288,10 +288,9 @@ describe('buildDefaultPageSchema', () => {
 
     it('emits Related tab with one record:related_list per entry', () => {
       const page = buildDefaultPageSchema(leadDef, {
-        // Force the Related tab to appear even with 2+ related lists,
-        // which would otherwise trigger the Reference Rail and suppress
-        // the duplicate Related tab.
-        hideReferenceRail: true,
+        // The Related tab is the default home for related lists. The
+        // Reference Rail is opt-in (`showReferenceRail`), so it stays off
+        // here and the Related tab renders even with 2+ related lists.
         related: [
           {
             objectName: 'task',
@@ -315,8 +314,24 @@ describe('buildDefaultPageSchema', () => {
       expect(tabs.items[1].children[0].limit).toBe(10);
     });
 
-    it('auto-emits a Reference Rail aside region and suppresses the duplicate Related tab when 2+ related lists are present', () => {
+    it('does NOT emit a Reference Rail by default, keeping the Related tab', () => {
       const page = buildDefaultPageSchema(leadDef, {
+        related: [
+          { objectName: 'task', relationshipField: 'lead_id' },
+          { objectName: 'note', relationshipField: 'parent_id' },
+        ],
+      });
+      // No aside region — the rail is opt-in.
+      expect(page.regions.find((r: any) => r.name === 'aside')).toBeUndefined();
+      // Related tab survives (Details + Related).
+      const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
+      const labels = tabs.items.map((t: any) => t.label);
+      expect(labels).toContain('Related');
+    });
+
+    it('emits a Reference Rail aside region and suppresses the duplicate Related tab when showReferenceRail is on and 2+ related lists are present', () => {
+      const page = buildDefaultPageSchema(leadDef, {
+        showReferenceRail: true,
         related: [
           { objectName: 'task', relationshipField: 'lead_id' },
           { objectName: 'note', relationshipField: 'parent_id' },
@@ -352,6 +367,7 @@ describe('buildDefaultPageSchema', () => {
 
     it('appends slots.rightRail after the auto-emitted reference rail', () => {
       const page = buildDefaultPageSchema(leadDef, {
+        showReferenceRail: true,
         related: [
           { objectName: 'task', relationshipField: 'lead_id' },
           { objectName: 'note', relationshipField: 'parent_id' },

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -65,9 +65,17 @@ export interface BuildPageOptions {
   /** Suppress the auto-prepended `record:path` stepper. */
   hidePath?: boolean;
   /**
-   * Suppress the auto-emitted Reference Rail (aside region with
-   * `record:reference_rail`). The rail is auto-emitted only when
-   * `related` has at least 2 entries.
+   * Opt in to the Reference Rail (aside region with
+   * `record:reference_rail`). The rail is OFF by default — it fans out a
+   * collection query per related list, which is wasteful on records the
+   * author never intended to summarize. Set `showReferenceRail: true`
+   * (per object via `detail.showReferenceRail`) to surface it; it then
+   * emits only when `related` has at least 2 entries.
+   */
+  showReferenceRail?: boolean;
+  /**
+   * Force-suppress the Reference Rail even when `showReferenceRail` is on.
+   * Retained for callers that toggle the rail off contextually.
    */
   hideReferenceRail?: boolean;
   /**
@@ -493,6 +501,7 @@ export function buildDefaultPageSchema(
   // (HubSpot/Dynamics convention). Authors can opt out of either via
   // `hideReferenceRail` / `hideRelatedTab`.
   const willEmitRail =
+    options.showReferenceRail === true &&
     !options.hideReferenceRail &&
     Array.isArray(options.related) &&
     options.related.length >= 2;


### PR DESCRIPTION
## 背景 / Problem

记录详情页右侧会**自动生成相关列表面板**（reference rail），只要记录有 ≥2 个反向关联就出现。同时详情页还在打开时**预加载每一个**关联子对象的记录——实测一个有 8 个相关列表的记录，打开瞬间并发约 50 个请求、TTFB 约 9s。这个面板对常见布局并无必要，且明显拖慢首屏。

The detail page auto-emitted a right-side reference rail whenever a record had ≥2 reverse references, and separately preloaded every related child on open (~50 concurrent queries / ~9s TTFB on a record with 8 related lists).

## 改动 / Changes

- **`buildDefaultPageSchema`**: 相关列表面板改为**按需开启**——需 `showReferenceRail === true`（每对象通过 `detail.showReferenceRail` 开启）；`hideReferenceRail` 仍可强制隐藏。默认情况下相关列表保留在 “Related” 标签页。
- **`RecordDetailView`**: schema 渲染路径下跳过预加载 (`if (effectivePage) return;`)。默认路径的 `record:related_list` 会自己懒加载，只有旧版 `DetailView` 兜底路径才需要预加载的 `childRelatedData`。
- 更新 synth 测试以匹配新默认值，新增 “默认不出现面板” 用例。

## 影响 / Impact

这是**框架级默认行为变更**：所有对象详情页默认不再显示该面板。需要的对象可设 `detail.showReferenceRail = true` 重新开启。

This flips a framework-wide default — all object detail pages lose the rail unless they opt in via `detail.showReferenceRail = true`.

## 验证 / Verification

- ✅ `plugin-detail` 单元测试 118 个全部通过
- ✅ `plugin-detail` 与 `app-shell` 类型检查通过
- ⚠️ 浏览器验证因登录拦截未完成（preview 为独立会话）

🤖 Generated with [Claude Code](https://claude.com/claude-code)