### PR TITLE
ci: speed up e2e console build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # Build + E2E merged into one job: avoids artifact upload/download (~30s)
-  # and a duplicate `pnpm install` (~60s). Turbo cache makes the build
-  # essentially free on subsequent runs.
+  # and a duplicate `pnpm install` (~60s). This job only needs the console SPA
+  # artifact for Playwright; package build and package-size checks are covered
+  # by the Bundle Analysis workflow for package / console changes.
   e2e:
     name: Build & E2E
     runs-on: ubuntu-latest
@@ -111,36 +112,30 @@ jobs:
           node-version: '20.x'
           cache: 'pnpm'
 
-      - name: Turbo Cache
-        uses: actions/cache@v5
-        with:
-          path: node_modules/.cache/turbo
-          key: turbo-${{ runner.os }}-build-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-build-
-            turbo-${{ runner.os }}-
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Core & Console
+      - name: Build Console for E2E
         # Pin VITE_BASE_PATH so the E2E suite (which mounts the SPA at
         # /console/) gets an absolute-base build whose asset URLs resolve
         # under that prefix. The default ('./') is correct for embedded
         # deployments but breaks vite preview's SPA fallback.
+        #
+        # Use Vite directly instead of `pnpm --filter @object-ui/console build`:
+        # the package build runs `tsc` and `build:plugin`, which need built
+        # workspace declaration files. The Vite bundle aliases workspace
+        # packages to `src/` and is the only artifact Playwright consumes.
         env:
           VITE_BASE_PATH: /console/
-        run: |
-          pnpm turbo run build --filter='./packages/*'
-          pnpm --filter @object-ui/console build
+        run: pnpm --filter @object-ui/console exec vite build
 
       - name: Verify build artifacts
         run: |
-          if [ ! -d "packages/core/dist" ]; then
-            echo "Protocol package build failed"
+          if [ ! -f "apps/console/dist/index.html" ]; then
+            echo "Console build failed"
             exit 1
           fi
-          echo "All packages built successfully"
+          echo "Console build artifact is ready"
 
       - name: Get Playwright version
         id: playwright-version


### PR DESCRIPTION
## Summary
- build only the console SPA artifact in the CI Build & E2E job
- remove the package-wide turbo build and cache from that job
- keep package build and package-size coverage in the Bundle Analysis workflow

## Validation
- `CI=1 VITE_BASE_PATH=/console/ pnpm --filter @object-ui/console exec vite build` completed locally in 3.8s
- old `pnpm turbo run build --filter='./packages/*' --dry=json` schedules 38 package build tasks
- `git diff --check` passed