### PR TITLE
Refine Studio package scope navigation

### DIFF
--- a/.changeset/studio-package-scope-home.md
+++ b/.changeset/studio-package-scope-home.md
@@ -1,0 +1,8 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/i18n': patch
+---
+
+Refine Studio package-scoped navigation and home overview.
+
+Studio now treats the selected package as the home overview scope, flattens the root Overview sidebar group, hides the duplicate all-metadata sidebar entry, redirects the invalid package metadata route to package management, preserves the selected package across package-management navigation, and adds a localized package-management sidebar label.

--- a/content/docs/guide/console.md
+++ b/content/docs/guide/console.md
@@ -28,6 +28,7 @@ The console opens at **http://localhost:5175** with MSW (Mock Service Worker) pr
 | **Expression Visibility** | Show/hide navigation items using `visible: "${data.role === 'admin'}"`. |
 | **Branding** | Per-app colors, favicons, and logos via `AppShell` branding. |
 | **Command Palette** | `⌘+K` opens a searchable command bar for quick navigation. |
+| **Studio Package Scope** | Studio home, metadata counts, quick-create links, and diagnostics follow the selected package. |
 | **App Creation Wizard** | 4-step wizard (Basic Info → Objects → Navigation → Branding) to create or edit apps. |
 | **Error Boundary** | Graceful error handling with a retry button. |
 

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -147,6 +147,18 @@ for each metadata type. Every type has a pure-renderer **preview** that doubles
 as its **designer** when given `editing` + `onPatch` props — no backend round
 trip is required to edit a draft.
 
+### Studio package scope
+
+Studio treats the selected package as the authoring scope. The package selector
+is mandatory, and Studio repairs missing `?package=` query parameters from the
+last selected package or the first project package so scoped pages do not drift
+out of sync with the sidebar. The Studio home overview, quick-create links,
+metadata counts, and diagnostics all follow that active package. The dedicated
+package-management page remains the global place to create, import, publish,
+enable, or disable packages; direct `/metadata/package` links redirect there.
+The Studio sidebar also flattens the root Overview group so Home and package
+navigation sit directly under the package selector.
+
 ### Visual flow canvas
 
 The `flow` designer (`FlowPreview` → `FlowCanvas`) renders an automation as an

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -173,6 +173,17 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
     launcherApps.find((a: any) => a.isDefault === true) ||
     launcherApps[0];
 
+  useEffect(() => {
+    if (!activeApp?.name) return;
+    const packageMetadataPath = `/apps/${activeApp.name}/metadata/package`;
+    if (
+      location.pathname === packageMetadataPath ||
+      location.pathname.startsWith(`${packageMetadataPath}/`)
+    ) {
+      navigate(`/apps/${activeApp.name}/component/developer/packages`, { replace: true });
+    }
+  }, [activeApp?.name, location.pathname, navigate]);
+
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingRecord, setEditingRecord] = useState<any>(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -415,6 +426,10 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
                     wins React Router's score tiebreaker (both
                     `metadata/:type/:name` and `:objectName/view/:viewId`
                     score 16; declaration order breaks the tie). */}
+                <Route
+                  path="metadata/package/*"
+                  element={<Navigate to={`/apps/${activeApp.name}/component/developer/packages`} replace />}
+                />
                 <Route path="metadata">
                   <Route index element={<MetadataDirectoryPage />} />
                   <Route path="_diagnostics" element={<MetadataDiagnosticsPage />} />
@@ -670,4 +685,3 @@ function RouteNotFound() {
     </div>
   );
 }
-

--- a/packages/app-shell/src/hooks/__tests__/useResponsiveSidebar.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useResponsiveSidebar.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SidebarProvider, useSidebar } from '@object-ui/components';
+import { describe, expect, it } from 'vitest';
+import { useResponsiveSidebar } from '../useResponsiveSidebar';
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+function Harness() {
+  useResponsiveSidebar();
+  const { open, setOpen } = useSidebar();
+
+  return (
+    <>
+      <div data-testid="sidebar-open">{String(open)}</div>
+      <button type="button" onClick={() => setOpen(true)}>
+        Expand sidebar
+      </button>
+    </>
+  );
+}
+
+describe('useResponsiveSidebar', () => {
+  it('auto-collapses at tablet width without overriding a manual expand', async () => {
+    setViewportWidth(970);
+
+    render(
+      <SidebarProvider defaultOpen>
+        <Harness />
+      </SidebarProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-open')).toHaveTextContent('false');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand sidebar' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-open')).toHaveTextContent('true');
+    });
+  });
+});

--- a/packages/app-shell/src/hooks/useResponsiveSidebar.ts
+++ b/packages/app-shell/src/hooks/useResponsiveSidebar.ts
@@ -6,7 +6,7 @@
  * @module
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSidebar } from '@object-ui/components';
 
 /** Tablet breakpoint range: 768px <= width < 1024px */
@@ -15,14 +15,25 @@ const TABLET_MAX = 1024;
 
 export function useResponsiveSidebar() {
   const { setOpen, isMobile } = useSidebar();
+  const setOpenRef = useRef(setOpen);
 
   useEffect(() => {
+    setOpenRef.current = setOpen;
+  }, [setOpen]);
+
+  useEffect(() => {
+    if (isMobile) return undefined;
+
+    let wasTablet = false;
+
     function handleResize() {
       const width = window.innerWidth;
-      if (width >= TABLET_MIN && width < TABLET_MAX) {
-        // Tablet: auto-collapse sidebar
-        setOpen(false);
+      const isTablet = width >= TABLET_MIN && width < TABLET_MAX;
+      if (isTablet && !wasTablet) {
+        // Auto-collapse once when entering tablet width, then preserve manual toggles.
+        setOpenRef.current(false);
       }
+      wasTablet = isTablet;
     }
 
     // Run on mount to set initial state
@@ -30,5 +41,5 @@ export function useResponsiveSidebar() {
 
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [setOpen, isMobile]);
+  }, [isMobile]);
 }

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -574,8 +574,9 @@ export function AppHeader({
 
         {isApp && (
           <>
-            {/* Mobile sidebar trigger */}
-            <SidebarTrigger className="md:hidden shrink-0 ml-1" aria-label={t('common.toggleSidebar') || 'Toggle sidebar'} />
+            {/* Keep the sidebar trigger visible through narrow desktop widths,
+                where the sidebar may already be collapsed into icon mode. */}
+            <SidebarTrigger className="lg:hidden shrink-0 ml-1" aria-label={t('common.toggleSidebar') || 'Toggle sidebar'} />
 
             {/* App dropdown — desktop/tablet only. On mobile the sidebar
                 already shows the active app at its top, so a second app

--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -148,13 +148,10 @@ export function useAppContextSelectors(
   // more "sidebar says A while the list shows B" drift.
   const params = new URLSearchParams(location.search);
 
-  // Re-apply a remembered scope once, on first mount, so a selection
-  // survives a full page reload (when the URL comes back without the
-  // query param). Subsequent navigation is driven purely by the URL.
-  const seededRef = React.useRef(false);
+  // Re-apply a remembered scope whenever navigation drops the query param.
+  // The selector is mandatory for Studio: package-scoped pages should never
+  // sit at a blank package value just because a nav link omitted `?package=`.
   React.useEffect(() => {
-    if (seededRef.current) return;
-    seededRef.current = true;
     const p = new URLSearchParams(location.search);
     let changed = false;
     for (const sel of list) {
@@ -168,8 +165,7 @@ export function useAppContextSelectors(
     if (changed) {
       navigate({ pathname: location.pathname, search: p.toString() }, { replace: true });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [appName, list, location.pathname, location.search, navigate]);
 
   const setValue = React.useCallback((sel: ContextSelectorDef, raw: string) => {
     const value = raw === ALL_SENTINEL ? (sel.allValue ?? '') : raw;
@@ -190,7 +186,11 @@ export function useAppContextSelectors(
 
   const contextValues: Record<string, string> = {};
   for (const sel of list) {
-    contextValues[sel.id] = params.get('package') ?? (sel.allValue ?? '');
+    let saved = '';
+    try {
+      saved = sessionStorage.getItem(`objectui-ctx-${appName}-${sel.id}`) ?? '';
+    } catch { /* storage disabled */ }
+    contextValues[sel.id] = (params.get('package') ?? saved) || (sel.allValue ?? '');
   }
 
   const element = list.length === 0 ? null : (
@@ -238,19 +238,14 @@ function SelectorControl({
   // `includeAll`, never render an "All" row, and auto-select the first option
   // as soon as the list resolves when nothing concrete is selected yet.
   const hasConcrete = !!value && value !== (def.allValue ?? '');
-  const seededRef = React.useRef(false);
   React.useEffect(() => {
-    if (seededRef.current) return;
     if (hasConcrete) {
-      seededRef.current = true;
       return;
     }
     if (options.length > 0) {
-      seededRef.current = true;
       onChange(options[0].value);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options, hasConcrete]);
+  }, [hasConcrete, onChange, options]);
 
   const current = hasConcrete ? value : '';
 
@@ -258,14 +253,16 @@ function SelectorControl({
     <Select value={current} onValueChange={onChange}>
       <SelectTrigger
         aria-label={label}
-        className="h-8 w-full gap-1.5 rounded-md border-sidebar-border/60 bg-sidebar-accent/40 px-2 text-xs font-medium text-sidebar-foreground shadow-none hover:bg-sidebar-accent focus:ring-1 focus:ring-sidebar-ring data-[state=open]:bg-sidebar-accent"
+        className="h-9 w-full gap-2 rounded-md border-sidebar-border/70 bg-sidebar/80 px-2 text-xs font-medium text-sidebar-foreground shadow-none transition-colors hover:bg-sidebar-accent focus:ring-1 focus:ring-sidebar-ring data-[state=open]:bg-sidebar-accent [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:shrink-0"
       >
-        <span className="flex min-w-0 items-center gap-1.5 truncate">
-          <Icon className="h-3.5 w-3.5 shrink-0 opacity-60" />
-          <SelectValue placeholder={placeholder} />
-        </span>
+        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded border border-sidebar-border/70 bg-sidebar-accent text-sidebar-foreground/70">
+            <Icon className="h-3 w-3" />
+          </span>
+          <SelectValue placeholder={placeholder} className="truncate" />
+        </div>
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className="w-[var(--radix-select-trigger-width)]">
         {options.map((opt) => (
           <SelectItem key={opt.value} value={opt.value}>
             {opt.label}

--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -38,7 +38,6 @@ import {
   ChevronRight,
   Home,
   Layers,
-  Package,
 } from 'lucide-react';
 import { NavigationRenderer } from '@object-ui/layout';
 import type { NavigationItem } from '@object-ui/types';
@@ -130,6 +129,21 @@ interface UnifiedSidebarProps {
   onAppChange?: (name: string) => void;
 }
 
+function isMetadataDirectoryItem(item: NavigationItem): boolean {
+  return (item as any).componentRef === 'metadata:directory';
+}
+
+function isPackagesItem(item: NavigationItem): boolean {
+  return (item as any).componentRef === 'developer:packages';
+}
+
+function isOverviewGroup(item: NavigationItem): boolean {
+  if (item.type !== 'group') return false;
+  const id = String(item.id ?? '').toLowerCase();
+  const label = typeof item.label === 'string' ? item.label.toLowerCase() : '';
+  return id === 'overview' || label === 'overview';
+}
+
 export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
   const { isMobile, setOpenMobile } = useSidebar();
   const location = useLocation();
@@ -208,12 +222,49 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
 
   // Determine which navigation to show based on context
   const navigationItems = context === 'home' ? homeNavigation : appNavigation;
+  const basePath = context === 'app' && activeApp ? `/apps/${activeApp.name}` : '';
+  const isStudioApp = context === 'app' && activeApp?.name === 'studio';
+  const studioHomeSearch = React.useMemo(() => {
+    if (!isStudioApp) return '';
+    const packageId = new URLSearchParams(location.search).get('package') || contextValues.active_package;
+    return packageId ? `?package=${encodeURIComponent(packageId)}` : '';
+  }, [contextValues.active_package, isStudioApp, location.search]);
+
+  const studioNavigationItems = React.useMemo(() => {
+    if (context !== 'app' || activeApp?.name !== 'studio') return navigationItems;
+    const packageManagementLabel = t('sidebar.packageManagement', {
+      defaultValue: 'Package management',
+    });
+    const walk = (items: NavigationItem[]): NavigationItem[] =>
+      items.flatMap((item) => {
+        if (isMetadataDirectoryItem(item)) return [];
+        const children = item.children?.length ? walk(item.children) : item.children;
+        if (item.type === 'group' && children?.length === 0) return [];
+        if (isPackagesItem(item)) {
+          return [{
+            ...item,
+            type: 'url' as const,
+            label: packageManagementLabel,
+            url: `${basePath}/component/developer/packages${studioHomeSearch}`,
+            children,
+          }];
+        }
+        if (children !== item.children) {
+          return [{ ...item, children }];
+        }
+        return [item];
+      });
+    return walk(navigationItems).flatMap((item) => {
+      if (!isOverviewGroup(item)) return [item];
+      return item.children ?? [];
+    });
+  }, [activeApp?.name, basePath, context, navigationItems, studioHomeSearch, t]);
 
   // Apply saved order and pin state
   const processedNavigation = React.useMemo(() => {
-    const ordered = applyOrder(navigationItems);
+    const ordered = applyOrder(studioNavigationItems);
     return applyPins(ordered);
-  }, [navigationItems, applyOrder, applyPins]);
+  }, [studioNavigationItems, applyOrder, applyPins]);
 
   // Recent section collapsed by default
   const [recentExpanded, setRecentExpanded] = React.useState(false);
@@ -255,7 +306,7 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
     [registeredObjectNames],
   );
 
-  const basePath = context === 'app' && activeApp ? `/apps/${activeApp.name}` : '';
+  const isStudioHomeActive = isStudioApp && location.pathname.replace(/\/+$/, '') === basePath;
 
   return (
     <>
@@ -287,13 +338,32 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
            <>
           {/* App-level context selectors (e.g. package scope) */}
           {contextSelectorsUI && (
-            <SidebarGroup className="group-data-[state=collapsed]:hidden">
-              <SidebarGroupLabel className="flex items-center gap-1.5">
-                <Package className="h-3.5 w-3.5" />
-                {t('sidebar.scope', { defaultValue: '范围' })}
-              </SidebarGroupLabel>
+            <SidebarGroup className="group-data-[state=collapsed]:hidden px-2 pb-1">
+              <div className="rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 p-1.5 shadow-xs">
+                <SidebarGroupContent>
+                  {contextSelectorsUI}
+                </SidebarGroupContent>
+              </div>
+            </SidebarGroup>
+          )}
+
+          {isStudioApp && (
+            <SidebarGroup>
               <SidebarGroupContent>
-                {contextSelectorsUI}
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={isStudioHomeActive}
+                      tooltip={t('home.nav', { defaultValue: 'Home' })}
+                    >
+                      <Link to={{ pathname: basePath, search: studioHomeSearch }}>
+                        <Home className="h-4 w-4" />
+                        <span>{t('home.nav', { defaultValue: 'Home' })}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
               </SidebarGroupContent>
             </SidebarGroup>
           )}
@@ -342,7 +412,11 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
              resolveObjectLabel={(objectName, fallback) => resolveNavObjectLabel({ name: objectName, label: fallback })}
              resolveDashboardLabel={(dashboardName, fallback) => resolveNavDashboardLabel({ name: dashboardName, label: fallback })}
              resolveGroupLabel={activeApp ? (groupId, fallback) => resolveNavGroupLabel(activeApp.name, groupId, fallback) : undefined}
-             resolveItemLabel={activeApp ? (itemId, fallback) => resolveNavGroupLabel(activeApp.name, itemId, fallback) : undefined}
+             resolveItemLabel={activeApp ? (itemId, fallback) => (
+               activeApp.name === 'studio' && fallback === t('sidebar.packageManagement', { defaultValue: 'Package management' })
+                 ? fallback
+                 : resolveNavGroupLabel(activeApp.name, itemId, fallback)
+             ) : undefined}
              resolveViewLabel={(objectName, viewName, fallback) => resolveNavViewLabel(objectName, viewName, fallback)}
              t={t}
              templateContext={{ currentUserId: user?.id ?? null, contextValues }}

--- a/packages/app-shell/src/views/metadata-admin/DirectoryPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/DirectoryPage.tsx
@@ -67,8 +67,12 @@ const DOMAIN_ORDER = [
  * `field` is managed in-context via the parent object's edit form
  * (master-detail widget). A flat global list of every field across
  * every object is rarely useful and clutters the admin surface.
+ *
+ * `package` is the Studio scope container itself. It has a dedicated
+ * management surface for create/publish/import/export flows, so exposing it
+ * as scoped metadata would mean "view packages inside a package".
  */
-const HIDDEN_TYPES = new Set(['field']);
+const HIDDEN_TYPES = new Set(['field', 'package']);
 
 export function MetadataDirectoryPage() {
   const client = useMetadataClient();

--- a/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
@@ -13,7 +13,7 @@
  */
 
 import * as React from 'react';
-import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { Plus, Search, RefreshCw, AlertTriangle, Lock } from 'lucide-react';
 import { Button } from '@object-ui/components';
 import { Input } from '@object-ui/components';
@@ -85,8 +85,13 @@ function classifyProvenance(item: Record<string, unknown>, rawSource?: string): 
 }
 
 export function MetadataResourceListPage({ type: typeProp }: MetadataResourceListPageProps) {
-  const params = useParams<{ type?: string }>();
+  const params = useParams<{ appName?: string; type?: string }>();
   const type = typeProp ?? params.type ?? '';
+
+  if (type === 'package') {
+    const appName = params.appName ?? 'studio';
+    return <Navigate to={`/apps/${appName}/component/developer/packages`} replace />;
+  }
 
   // If a fully custom ListPage is registered, render it and bail.
   // Done before any other hooks so hook count stays stable across type

--- a/packages/app-shell/src/views/metadata-admin/StudioHomePage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/StudioHomePage.tsx
@@ -22,7 +22,7 @@
  */
 
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import {
   Search,
   Database,
@@ -60,7 +60,7 @@ import {
   detectLocale,
 } from './i18n';
 
-const HIDDEN_TYPES = new Set(['field']);
+const HIDDEN_TYPES = new Set(['field', 'package']);
 
 const DOMAIN_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   data: Database,
@@ -126,11 +126,78 @@ function relativeTime(iso: string, locale: string): string {
 export function StudioHomePage() {
   const client = useMetadataClient();
   const { loading, entries } = useMetadataTypes(client);
-  const { summary: diagSummary, countsByType, allPackages } = useGlobalDiagnostics(client, 'warning');
   const { recentItems } = useRecentItems();
   const locale = React.useMemo(() => detectLocale(), []);
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const visible = React.useMemo(() => entries.filter((e) => !HIDDEN_TYPES.has(e.type)), [entries]);
+  const [projectPackages, setProjectPackages] = React.useState<
+    { id: string; name: string }[] | null
+  >(null);
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await client.list<any>('package');
+        if (cancelled) return;
+        const SYSTEM_SCOPES = new Set(['system', 'cloud']);
+        const rows = (list ?? [])
+          .map((raw) => {
+            const item =
+              raw && typeof raw === 'object' && 'item' in raw ? raw.item : raw;
+            const m = ((item as any)?.manifest ?? item ?? {}) as Record<string, unknown>;
+            return {
+              id: m.id as string,
+              scope: m.scope as string,
+              name: (m.name as string) || (m.id as string),
+            };
+          })
+          .filter((p) => p.id && !SYSTEM_SCOPES.has(p.scope));
+        rows.sort((a, b) => a.name.localeCompare(b.name));
+        setProjectPackages(rows.map((p) => ({ id: p.id, name: p.name })));
+      } catch {
+        if (!cancelled) setProjectPackages([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const urlPackage = searchParams.get('package');
+  const activePackage = React.useMemo(() => {
+    if (!projectPackages) return null;
+    if (urlPackage && projectPackages.some((p) => p.id === urlPackage)) return urlPackage;
+    return projectPackages[0]?.id ?? null;
+  }, [projectPackages, urlPackage]);
+
+  React.useEffect(() => {
+    if (!projectPackages || projectPackages.length === 0) return;
+    if (urlPackage && projectPackages.some((p) => p.id === urlPackage)) return;
+    const next = new URLSearchParams(searchParams);
+    next.set('package', projectPackages[0].id);
+    setSearchParams(next, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectPackages, urlPackage]);
+
+  const packageSuffix = activePackage ? `?package=${encodeURIComponent(activePackage)}` : '';
+  const metadataHref = `metadata${packageSuffix}`;
+  const packagesHref = `component/developer/packages${packageSuffix}`;
+  const {
+    summary: diagSummary,
+    countsByType,
+    packagesByType,
+    loading: diagLoading,
+  } = useGlobalDiagnostics(client, 'warning', activePackage ?? undefined);
+
+  const visible = React.useMemo(
+    () =>
+      entries.filter((e) => {
+        if (HIDDEN_TYPES.has(e.type)) return false;
+        if (!activePackage) return false;
+        return (packagesByType[e.type] ?? []).includes(activePackage);
+      }),
+    [activePackage, entries, packagesByType],
+  );
   const writable = React.useMemo(
     () => visible.filter((e) => e.allowOrgOverride || e.allowRuntimeCreate),
     [visible],
@@ -156,9 +223,9 @@ export function StudioHomePage() {
   }, [writable]);
 
   const issues = diagSummary.total;
-  const healthy = !loading && issues === 0;
+  const healthy = !loading && !diagLoading && issues === 0;
 
-  if (loading) {
+  if (loading || projectPackages === null || (activePackage && diagLoading)) {
     return (
       <div className="flex h-full items-center justify-center p-8 text-sm text-muted-foreground">
         {t('engine.home.loading', locale)}
@@ -195,9 +262,10 @@ export function StudioHomePage() {
                 <Button
                   asChild
                   size="sm"
-                  className="bg-white text-violet-700 shadow-sm hover:bg-white/90"
+                  variant="ghost"
+                  className="bg-white/10 text-white shadow-sm ring-1 ring-white/25 hover:bg-white/20 hover:text-white"
                 >
-                  <Link to="metadata">
+                  <Link to={metadataHref}>
                     <Layers className="mr-1.5 h-4 w-4" />
                     {t('engine.home.browseAll', locale)}
                   </Link>
@@ -213,7 +281,7 @@ export function StudioHomePage() {
             <div className="grid grid-cols-3 gap-3">
               <HeroPill value={visible.length} label={t('engine.home.statTypes', locale)} />
               <HeroPill value={writable.length} label={t('engine.home.statWritable', locale)} />
-              <HeroPill value={allPackages.length} label={t('engine.home.statPackages', locale)} />
+              <HeroPill value={projectPackages.length} label={t('engine.home.statPackages', locale)} />
             </div>
           </div>
         </section>
@@ -226,7 +294,7 @@ export function StudioHomePage() {
             to="to-violet-600"
             value={visible.length}
             label={t('engine.home.statTypes', locale)}
-            to_link="metadata"
+            to_link={metadataHref}
           />
           <StatCard
             icon={CheckCircle2}
@@ -234,19 +302,19 @@ export function StudioHomePage() {
             to="to-blue-600"
             value={writable.length}
             label={t('engine.home.statWritable', locale)}
-            to_link="metadata"
+            to_link={metadataHref}
           />
           <StatCard
             icon={PackageIcon}
             from="from-emerald-500"
             to="to-teal-600"
-            value={allPackages.length}
+            value={projectPackages.length}
             label={t('engine.home.statPackages', locale)}
-            to_link="metadata"
+            to_link={packagesHref}
           />
           {/* Health card — swaps colour + meaning based on diagnostics. */}
           <Link
-            to={healthy ? 'metadata' : 'metadata/_diagnostics'}
+            to={healthy ? metadataHref : `metadata/_diagnostics${packageSuffix}`}
             className={
               'group relative flex flex-col justify-between overflow-hidden rounded-2xl border p-4 transition-all hover:-translate-y-0.5 hover:shadow-lg ' +
               (healthy
@@ -295,7 +363,7 @@ export function StudioHomePage() {
                   size="sm"
                   className="group rounded-full border-dashed hover:border-solid hover:border-primary hover:bg-primary/5"
                 >
-                  <Link to={`metadata/${encodeURIComponent(e.type)}/new`}>
+                  <Link to={`metadata/${encodeURIComponent(e.type)}/new${packageSuffix}`}>
                     <Plus className="mr-1 h-3.5 w-3.5 text-primary transition-transform group-hover:rotate-90" />
                     {tFormat('engine.home.newItem', locale, {
                       label: translateMetadataType(e.type, locale, e.label),
@@ -318,7 +386,14 @@ export function StudioHomePage() {
             />
             <div className="mt-3 grid gap-4 sm:grid-cols-2">
               {grouped.map(([domain, group]) => (
-                <DomainCard key={domain} domain={domain} group={group} countsByType={countsByType} locale={locale} />
+                <DomainCard
+                  key={domain}
+                  domain={domain}
+                  group={group}
+                  countsByType={countsByType}
+                  locale={locale}
+                  packageSuffix={packageSuffix}
+                />
               ))}
             </div>
           </section>
@@ -436,11 +511,13 @@ function DomainCard({
   group,
   countsByType,
   locale,
+  packageSuffix,
 }: {
   domain: string;
   group: RichMetadataTypeEntry[];
   countsByType: Record<string, number>;
   locale: string;
+  packageSuffix: string;
 }) {
   const Icon = DOMAIN_ICONS[domain] ?? Box;
   const accent = DOMAIN_ACCENT[domain] ?? DOMAIN_ACCENT.other;
@@ -463,7 +540,7 @@ function DomainCard({
         {top.map((e) => (
           <Link
             key={e.type}
-            to={`metadata/${encodeURIComponent(e.type)}`}
+            to={`metadata/${encodeURIComponent(e.type)}${packageSuffix}`}
             className="inline-flex items-center gap-1.5 rounded-lg border bg-background px-2 py-1 text-xs transition-colors hover:border-primary/50 hover:bg-accent"
           >
             <span className="truncate max-w-[10rem]">{translateMetadataType(e.type, locale, e.label)}</span>
@@ -472,7 +549,7 @@ function DomainCard({
         ))}
         {more > 0 && (
           <Link
-            to="metadata"
+            to={`metadata${packageSuffix}`}
             className={`inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium ${accent.text} hover:underline`}
           >
             +{more}

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1351,6 +1351,7 @@ const en = {
     inboxAriaLabel: 'Open inbox',
     area: 'Area',
     scope: 'Scope',
+    packageManagement: 'Package management',
     recent: 'Recent',
     favorites: 'Favorites',
     starred: 'Starred',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1350,6 +1350,7 @@ const zh = {
     inboxAriaLabel: '打开消息中心',
     area: '区域',
     scope: '范围',
+    packageManagement: '软件包管理',
     recent: '最近使用',
     favorites: '收藏',
     starred: '已收藏',


### PR DESCRIPTION
## Summary
- Treat Studio's selected package as the scoped home/metadata context and preserve/repair the package query across navigation.
- Remove duplicate package-as-metadata and all-metadata sidebar concepts, flatten the root Overview sidebar group, and route package metadata URLs to package management.
- Keep the sidebar trigger usable at tablet-width layouts and add regression coverage for manual expand.

## Verification
- pnpm --filter @object-ui/app-shell type-check
- pnpm --filter @object-ui/i18n type-check
- pnpm --filter @object-ui/app-shell test
- pnpm --filter @object-ui/console build
- Browser smoke: Studio home at 970px preserves 报销管理, hides Overview/全部元数据类型, opens 软件包管理 with package query, redirects /metadata/package, and expands sidebar from 48px to 256px after clicking the top trigger.