### PR TITLE
fix(marketplace): detail CTA reflects installed state on tenant runtimes

### DIFF
--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -112,14 +112,18 @@ export function MarketplacePackagePage() {
     return () => { cancelled = true; };
   }, [packageId, localResult]);
 
-  // Seed cloud-install state: when the runtime advertises a default
-  // environment (per-subdomain ObjectOS), check whether this package is
-  // already installed in that env so the primary CTA renders as
-  // "Installed" on first paint instead of inviting another install.
+  // Seed cloud-install state so the primary CTA renders as "Installed" on
+  // first paint instead of inviting another install.
+  // NOTE: a tenant runtime (per-subdomain ObjectOS) has NO
+  // `defaultEnvironmentId` — but getCloudInstallationInfo's same-origin
+  // `/cloud-connection/installation` path resolves the env by hostname and
+  // does not need an explicit id (only the cloud-control-plane path needs
+  // one, and it no-ops on an empty id internally). So do NOT gate the probe
+  // on `currentEnvId` — that left the detail CTA stuck on "Install to
+  // cloud…" for every already-installed package in an env console.
   useEffect(() => {
     if (!packageId) return;
-    const currentEnvId = getRuntimeConfig().defaultEnvironmentId;
-    if (!currentEnvId) return;
+    const currentEnvId = getRuntimeConfig().defaultEnvironmentId ?? '';
     let cancelled = false;
     (async () => {
       const info = await getCloudInstallationInfo(packageId, currentEnvId);

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1705,6 +1705,7 @@ const en = {
         reinstall: 'Reinstall',
         working: 'Working…',
         installToCloud: 'Install to cloud…',
+        installed: 'Installed',
         installing: 'Installing…',
         uninstall: 'Uninstall',
         uninstalling: 'Uninstalling…',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1699,6 +1699,7 @@ const zh = {
         reinstall: '重新安装',
         working: '处理中…',
         installToCloud: '安装到云端…',
+        installed: '已安装',
         installing: '安装中…',
         uninstall: '卸载',
         uninstalling: '卸载中…',


### PR DESCRIPTION
The in-env marketplace package-DETAIL CTA stayed **'安装到云端… / Install to cloud…'** even when the package was already installed in the current env. Root cause: the installed-state probe was gated on `getRuntimeConfig().defaultEnvironmentId`, which is **empty on a per-subdomain tenant runtime**, so the probe never fired. `getCloudInstallationInfo`'s same-origin `/cloud-connection/installation` path resolves the env by hostname and needs no explicit id (pairs with cloud #88 which made that probe return correct data). Drop the guard → CTA flips to **'已安装 / Installed'**. Also adds the missing `marketplace.action.installed` key (was relying on a defaultValue fallback, so zh rendered English).

Verified locally: `/cloud-connection/installation?package_id=…` returns `{installed:true}` with the env session; with this change the detail CTA reads '已安装'.