### PR TITLE
fix(marketplace): send Bearer token on cloud-connection install/probe

### DIFF
--- a/packages/app-shell/src/console/marketplace/marketplaceApi.ts
+++ b/packages/app-shell/src/console/marketplace/marketplaceApi.ts
@@ -14,9 +14,29 @@
  */
 
 import { getCloudBase } from '../../runtime-config';
+import { TokenStorage } from '@object-ui/auth';
 
 const SERVER_URL = (import.meta.env.VITE_SERVER_URL || '').replace(/\/$/, '');
 const API_BASE = `${SERVER_URL}/api/v1/marketplace`;
+
+/**
+ * Attach the Bearer token to same-origin `/api/v1/cloud-connection/*` calls.
+ *
+ * objectui authenticates with a Bearer token (better-auth, stored in
+ * localStorage by `@object-ui/auth` and normally injected by the app's
+ * `createAuthenticatedFetch` wrapper). These marketplace routes use raw
+ * `fetch()` and so bypass that wrapper — relying on `credentials: 'include'`
+ * (the session cookie) alone is NOT enough on a tenant runtime: after
+ * platform SSO the env's session cookie is not reliably presented, so the
+ * cloud-connection route's `resolveEnvSession` finds no session and returns
+ * 401 "Sign in to this environment." even though the user is signed in.
+ * Injecting the Bearer (which the server's `getSession` accepts) fixes it.
+ * `credentials: 'include'` is kept so the cookie still rides along when set.
+ */
+function withEnvAuth(headers: Record<string, string>): Record<string, string> {
+  const token = TokenStorage.get();
+  return token ? { ...headers, Authorization: `Bearer ${token}` } : headers;
+}
 
 /**
  * Per-locale overrides for translatable package fields. Mirrors
@@ -188,7 +208,7 @@ export async function installPackage(input: {
     const res = await fetch(`/api/v1/cloud-connection/install`, {
       method: 'POST',
       credentials: 'include',
-      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      headers: withEnvAuth({ 'Accept': 'application/json', 'Content-Type': 'application/json' }),
       body: JSON.stringify({
         package_id: input.packageId,
         seed_sample_data: !!input.seedSampleData,
@@ -380,7 +400,7 @@ export async function getCloudInstallationInfo(
     try {
       const res = await fetch(
         `/api/v1/cloud-connection/installation?package_id=${encodeURIComponent(packageId)}`,
-        { credentials: 'include', headers: { 'Accept': 'application/json' } },
+        { credentials: 'include', headers: withEnvAuth({ 'Accept': 'application/json' }) },
       );
       if (!res.ok) return null;
       const payload: any = await res.json().catch(() => ({}));


### PR DESCRIPTION
## Symptom

After SSO into a tenant environment, opening a marketplace package or clicking Install fails:

```json
{"success":false,"error":{"code":"unauthenticated","message":"Sign in to this environment."}}
```

…even though the user is signed in (valid, non-expired session in the env DB).

## Root cause

objectui authenticates with a **Bearer token** (better-auth; token in localStorage, normally injected on every `/api/` call by `createAuthenticatedFetch` / `createBearerFetch`). The in-environment marketplace calls in `marketplaceApi.ts` use **raw `fetch()` with `credentials: 'include'` and no `Authorization` header**, so they bypass that wrapper and rely on the session **cookie** alone.

On a tenant runtime the env session cookie is not reliably presented after platform SSO, so the server route's `resolveEnvSession` (`apps/objectos/cloud-runtime-plugins.ts`) finds no session → 401.

**Verified**: the same server route returns `200` when the session is supplied as `Authorization: Bearer <token>` — so the server already accepts the Bearer; the client just wasn't sending it.

## Fix

Inject the Bearer token (from `@object-ui/auth` `TokenStorage`) on the two same-origin cloud-connection calls — `/install` and `/installation` — via a small `withEnvAuth()` helper. `credentials: 'include'` is kept so the cookie still rides along when present.

## Test plan

- [ ] CI typecheck/build
- [ ] After deploy: SSO into a tenant env → marketplace package page loads installed-state (no 401), Install succeeds
- [x] Verified server-side that `/api/v1/cloud-connection/installation` returns 200 with `Authorization: Bearer <session-token>`

## Deploy note

Reaching prod requires: merge → bump `cloud/.objectui-sha` to this commit → rebuild + deploy the objectos image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)