### PR TITLE
feat: master-detail subform + lightweight list primitives (SDUI)

### DIFF
--- a/.changeset/master-detail-subform.md
+++ b/.changeset/master-detail-subform.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/plugin-form": minor
+"@object-ui/fields": minor
+"@object-ui/components": minor
+---
+
+Master-detail subform + lightweight list primitives (SDUI).
+
+- `MasterDetailForm` (`object-master-detail-form`): enter a parent record and its child line items together; client-orchestrated transactional create (parent → FK → bulk children → rollup → cleanup). Enterprise-convention layout (header on top, line grid, single Save bar at the bottom).
+- `LineItemsField` editable child grid (line numbers, right-aligned numerics, running total) and `LineItemsPanel` (`record:line_items`) for detail-page inline edit.
+- `element:definition-list` and `element:repeater` — lightweight, low-chrome list primitives for simple data.

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -15,6 +15,7 @@
 import { type ReactNode } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AuthProvider, AuthGuard, useAuth } from '@object-ui/auth';
+import { DevMasterDetail } from './dev/DevMasterDetail';
 import {
   ConsoleShell,
   ConnectedShell,
@@ -177,6 +178,12 @@ export function App() {
             <Route path="/home" element={
               <ProtectedRoute>
                 <HomeRoute />
+              </ProtectedRoute>
+            } />
+            {/* Dev-only: ADR-0001 master-detail subform verification harness. */}
+            <Route path="/dev/master-detail" element={
+              <ProtectedRoute>
+                <DevMasterDetail />
               </ProtectedRoute>
             } />
             <Route path="/organizations" element={

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -16,6 +16,7 @@ import { type ReactNode } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AuthProvider, AuthGuard, useAuth } from '@object-ui/auth';
 import { DevMasterDetail } from './dev/DevMasterDetail';
+import { DevLists } from './dev/DevLists';
 import {
   ConsoleShell,
   ConnectedShell,
@@ -184,6 +185,12 @@ export function App() {
             <Route path="/dev/master-detail" element={
               <ProtectedRoute>
                 <DevMasterDetail />
+              </ProtectedRoute>
+            } />
+            {/* Dev-only: lightweight list primitives (definition-list, repeater). */}
+            <Route path="/dev/lists" element={
+              <ProtectedRoute>
+                <DevLists />
               </ProtectedRoute>
             } />
             <Route path="/organizations" element={

--- a/apps/console/src/dev/DevLists.tsx
+++ b/apps/console/src/dev/DevLists.tsx
@@ -1,0 +1,51 @@
+/**
+ * Dev-only harness for the lightweight list primitives (SDUI opt #1):
+ * element:definition-list (compact key/value) and element:repeater (chrome-free
+ * data-bound list). Bound to live showcase_category — the "simple data shouldn't
+ * need a full data-grid" case. Not part of the product nav.
+ */
+import React from 'react';
+import { SchemaRenderer } from '@object-ui/react';
+
+const defList = {
+  type: 'element:definition-list',
+  properties: {
+    columns: 2,
+    items: [
+      { term: 'Status', description: 'Active' },
+      { term: 'Owner', description: 'Ada Lovelace' },
+      { term: 'Plan', description: 'Enterprise' },
+      { term: 'Renewal', description: '2026-12-01' },
+    ],
+  },
+};
+
+const repeater = {
+  type: 'element:repeater',
+  properties: {
+    object: 'showcase_category',
+    titleField: 'name',
+    fields: ['color'],
+    limit: 10,
+    emptyText: 'No categories',
+  },
+};
+
+export const DevLists: React.FC = () => (
+  <div className="mx-auto max-w-2xl space-y-8 p-6">
+    <div>
+      <h1 className="mb-3 text-lg font-semibold">Dev · element:definition-list</h1>
+      <div className="rounded-lg border p-4">
+        <SchemaRenderer schema={defList as any} />
+      </div>
+    </div>
+    <div>
+      <h1 className="mb-3 text-lg font-semibold">Dev · element:repeater (showcase_category)</h1>
+      <div className="rounded-lg border p-4">
+        <SchemaRenderer schema={repeater as any} />
+      </div>
+    </div>
+  </div>
+);
+
+export default DevLists;

--- a/apps/console/src/dev/DevMasterDetail.tsx
+++ b/apps/console/src/dev/DevMasterDetail.tsx
@@ -1,0 +1,57 @@
+/**
+ * Dev-only harness for ADR-0001 (master-detail subform). Renders the
+ * `object-master-detail-form` SDUI component against the live backend's
+ * expense_claim (parent) + expense_line (child, master_detail) so the
+ * capability can be verified end-to-end. Not part of the product nav.
+ */
+import React from 'react';
+import { SchemaRenderer } from '@object-ui/react';
+
+const schema = {
+  type: 'object-master-detail-form',
+  objectName: 'expense_claim',
+  mode: 'create',
+  formType: 'simple',
+  title: 'New Expense Claim',
+  submitText: 'Create Claim',
+  fields: ['title', 'applicant', 'department', 'reason', 'currency', 'claim_status', 'payment_status', 'remarks'],
+  details: [
+    {
+      title: 'Expense Lines',
+      childObject: 'expense_line',
+      relationshipField: 'expense_claim',
+      amountField: 'amount',
+      totalField: 'total_amount',
+      columns: [
+        { field: 'expense_date', label: 'Date', type: 'date' },
+        {
+          field: 'category',
+          label: 'Category',
+          type: 'select',
+          options: [
+            { label: 'Travel & Transport', value: 'travel_transport' },
+            { label: 'Lodging', value: 'lodging' },
+            { label: 'Meals & Entertainment', value: 'meals_entertainment' },
+            { label: 'Office Supplies', value: 'office_supplies' },
+            { label: 'Communications', value: 'communications' },
+            { label: 'Training & Conference', value: 'training_conference' },
+            { label: 'Client / Project', value: 'client_project' },
+            { label: 'Other', value: 'other' },
+          ],
+        },
+        { field: 'description', label: 'Description', type: 'text' },
+        { field: 'merchant_vendor', label: 'Merchant', type: 'text' },
+        { field: 'amount', label: 'Amount', type: 'currency' },
+      ],
+    },
+  ],
+};
+
+export const DevMasterDetail: React.FC = () => (
+  <div className="mx-auto max-w-3xl p-6">
+    <h1 className="mb-4 text-lg font-semibold">Dev · Master-Detail Form (ADR-0001)</h1>
+    <SchemaRenderer schema={schema as any} />
+  </div>
+);
+
+export default DevMasterDetail;

--- a/docs/adr/0001-master-detail-subform.md
+++ b/docs/adr/0001-master-detail-subform.md
@@ -1,0 +1,276 @@
+# ADR-0001: Master-Detail Subform (parent + line items, entered and viewed together)
+
+**Status**: Accepted — implementing (2026-06-05)
+**Author**: ObjectUI renderer team
+**Consumers**: `@object-ui/fields`, `@object-ui/plugin-form`, `@object-ui/plugin-detail`, every app that ships a header→lines object pair (expense claim + lines, purchase order + lines, contract + obligations, order + items, …)
+
+---
+
+## TL;DR
+
+ObjectStack apps constantly model a **parent record with a set of child line
+items** — an expense claim with expense lines, a purchase order with order
+lines, an invoice with invoice items. Users expect to **enter the header and
+its lines in one screen**, and to **see (and inline-edit) the lines on the
+record page**.
+
+Today the ObjectUI renderer cannot do this. The protocol already expresses the
+relationship (`master_detail` field with `deleteBehavior: 'cascade'`), but the
+renderer is missing the UI primitive:
+
+- `GridField` is a **read-only stub** (shows `"N rows"` in edit mode).
+- There is **no editable child-grid / subform** component.
+- `dataSource.create()` writes a **single object**; there is no parent+children
+  transactional create, and the backend exposes **no `/batch` endpoint**
+  (verified: `POST /api/v1/batch` → 404).
+- `RelatedList` (detail page) is **read-only** — no inline create/edit.
+
+This ADR introduces a **master-detail subform** capability, entirely
+**renderer-side** (no protocol change):
+
+1. **`LineItemsField`** — a controlled, editable child-grid widget (array of
+   row objects; per-cell field widgets; add/delete/edit; running total).
+2. **`MasterDetailForm`** — composes parent fields + `LineItemsField` and
+   orchestrates a **client-side transactional create**: create parent → set FK
+   on each child → bulk-create children → roll the line total up onto the
+   parent. Best-effort rollback if children fail.
+3. **`record:line_items`** — the same grid bound to an **existing** parent on a
+   record/detail page (loads children by FK and persists inline edits
+   immediately).
+
+---
+
+## Context
+
+### The requirement (from the user)
+
+> 录入报销单的时候需要同时录入明细，查看的时候也是这样。
+> ("When entering an expense claim I need to enter the line items at the same
+> time, and view them the same way.")
+
+This is the canonical **master-detail** (a.k.a. header/lines) pattern. It is
+not specific to expenses — `../templates` and `../hotcrm` are full of it:
+
+| App | Parent | Child | Modeling today |
+| --- | --- | --- | --- |
+| expense (templates) | `expense_report` | `expense_line` | FK lookup, **two-step** entry (create report, navigate to add lines) |
+| expense (live backend) | `expense_claim` | `expense_line` | **`master_detail`** FK (`deleteBehavior: cascade`) |
+| procurement | `procurement_order` | lines | **JSON array** on the parent (no per-line query) |
+| contracts | `contracts_contract` | `contracts_obligation` | FK lookup, separate forms |
+
+The templates resort to two workarounds, both documented in their own source as
+compromises: **(a)** a separate child object with a FK, entered on its own form
+and shown as a read-only related list; or **(b)** a `Field.json()` array on the
+parent, edited as raw JSON. Neither delivers "enter header + lines together".
+
+### What the protocol already supports (no change needed)
+
+`@objectstack/spec` `data/field.zod.ts` defines `master_detail` as a first-class
+field type with cascade semantics:
+
+```
+'lookup', 'master_detail',  // Dynamic reference
+...
+// For `master_detail` fields, the parent record controls the lifecycle of
+// child records (e.g., cascade delete).
+deleteBehavior: 'set_null' | 'cascade' | 'restrict'   // default 'set_null'
+Field.masterDetail(reference, config)  // → { type: 'master_detail', ... }
+```
+
+`ui/view.zod.ts` even references a `master-detail` widget and `split`
+(master-detail) form/list layouts. **The gap is the renderer, not the
+protocol** — consistent with the project's broader SDUI posture.
+
+### Live verification target
+
+The running backend (`:3000`) has a real master-detail pair with **no UI and no
+data yet**, making it the ideal end-to-end verification target:
+
+```
+expense_claim (parent)
+  claim_number, title, applicant, department, reason, submitted_at,
+  total_amount, currency, claim_status, manager_approver, finance_reviewer,
+  payment_status, remarks
+
+expense_line (child)
+  expense_claim  → master_detail(expense_claim)   ← the relationship
+  expense_date, category, description, merchant_vendor, amount,
+  tax_amount, receipt_file, billable_to_client
+```
+
+### Runtime constraint that shapes the design
+
+Lifecycle **hooks cannot perform nested writes** — the QuickJS hook sandbox
+crashes on re-entrant `ctx.api.object(...).update(...)`. Both the expense and
+procurement templates state this explicitly and therefore treat the header
+total as a **stored field maintained by the client**, not a hook-computed
+rollup. Two consequences for this design:
+
+1. The **line total rollup must happen client-side** (the subform computes it
+   and writes it onto the parent), not in a child hook.
+2. There is no server-side transaction spanning parent+children, and no
+   `/batch` endpoint. The renderer must **orchestrate the multi-object write on
+   the client** and degrade gracefully on partial failure.
+
+---
+
+## Decision
+
+Build three renderer-side pieces. **No `@objectstack/spec` change.**
+
+### 1. `LineItemsField` (`@object-ui/fields`)
+
+A controlled component — `value: Row[]`, `onChange(rows)` — that finishes what
+the dormant `GridFieldMetadata` type promised.
+
+- Renders an editable table: one column per configured child field, one row per
+  line, an "Add row" affordance, and a per-row delete.
+- Each cell dispatches to the **existing field widgets** by column type
+  (`text | number | currency | select | date | lookup`), so we reuse validation
+  and formatting rather than reinventing inputs.
+- Computes and displays a **running total** of a configured numeric column
+  (e.g. `amount`).
+- Honors `min_rows` / `max_rows` / `allow_add` / `allow_delete` from the
+  existing `GridFieldMetadata`.
+- Read-only mode renders the same table without inputs (replaces the
+  `"N rows"` stub) — this is the **view** half of the requirement.
+
+Column config (reuses the existing `GridColumnDefinition` shape):
+
+```ts
+{
+  field: 'amount',
+  label: 'Amount',
+  type: 'currency',        // text | number | currency | select | date | lookup
+  options?: [...],         // for select
+  reference?: 'category',  // for lookup
+  width?: number,
+  required?: boolean,
+}
+```
+
+### 2. `MasterDetailForm` (`@object-ui/plugin-form`)
+
+Composes the **parent form fields** and one or more `LineItemsField`s for child
+collections, owning a **single submit**:
+
+```
+submit():
+  1. validate parent + every line
+  2. parentId = parentId ?? (await dataSource.create(parentObject, parentValues)).id
+  3. rows' = rows.map(r => ({ ...r, [relationshipField]: parentId }))
+  4. created = dataSource.bulk?.(childObject,'create',rows')          // preferred
+              ?? Promise.all(rows'.map(r => dataSource.create(childObject, r)))
+  5. if (totalField) dataSource.update(parentObject, parentId, { [totalField]: sum })
+  6. on child failure → best-effort cleanup of the just-created parent/children,
+     surface the error, keep the form open with entered data intact
+```
+
+Edit mode (existing parent) diffs current vs. original rows and issues
+create / update / delete per line.
+
+Rationale for **client orchestration** over a server batch: no `/batch`
+endpoint exists, hooks can't do the cross-object write, and the templates
+already maintain rollups client-side. This matches the platform's actual
+contract instead of inventing one.
+
+### 3. `record:line_items` component (`@object-ui/plugin-detail`)
+
+Registers `record:line_items` so a **record/detail page** (or a `slotted` page
+slot) can drop in the children grid bound to the current record:
+
+```jsonc
+{
+  "type": "record:line_items",
+  "properties": {
+    "childObject": "expense_line",
+    "relationshipField": "expense_claim",
+    "totalField": "total_amount",
+    "columns": [
+      { "field": "expense_date", "type": "date" },
+      { "field": "category", "type": "lookup", "reference": "expense_category" },
+      { "field": "description", "type": "text" },
+      { "field": "amount", "type": "currency" }
+    ]
+  }
+}
+```
+
+With `parentId` from record context it loads children by FK and persists inline
+edits immediately — covering "查看的时候也是这样" (view + inline edit). This also
+addresses the templates' documented "add a Files/lines panel to a slotted page"
+fork point: the children grid is now a registered slot component instead of
+forcing the page to `kind: 'full'`.
+
+### Schema surface (additive, renderer-internal types only)
+
+`MasterDetailForm` schema (extends the existing object-form schema):
+
+```ts
+{
+  type: 'object-master-detail-form',
+  objectName: 'expense_claim',         // parent
+  mode: 'create' | 'edit',
+  recordId?: string,                   // edit mode
+  sections: [...],                     // parent fields (unchanged)
+  details: [{
+    childObject: 'expense_line',
+    relationshipField: 'expense_claim',
+    totalField: 'total_amount',        // optional rollup target on parent
+    title: 'Line Items',
+    columns: GridColumnDefinition[],
+    minRows?, maxRows?,
+  }]
+}
+```
+
+---
+
+## Consequences
+
+**Positive**
+
+- The header+lines pattern becomes **declarative SDUI** — apps describe it in
+  metadata; no bespoke React per app.
+- The dormant `GridFieldMetadata` type finally has a renderer; `GridField` edit
+  mode stops being a stub.
+- Slotted record pages gain an "add a child grid" path without going
+  `kind: 'full'`.
+- Zero protocol change; works against the existing data API.
+
+**Negative / risks**
+
+- **Non-atomic writes.** Without a server transaction, a partial failure
+  (parent created, child N fails) is possible. Mitigation: validate everything
+  before writing, create children via `bulk` (one call), best-effort cleanup,
+  and keep the form populated so the user can retry. A future server `/batch`
+  endpoint can make this atomic without changing the component API.
+- **Client-side rollup** can drift if lines are edited by another client.
+  Acceptable: matches the platform's current "stored header field" contract; a
+  server aggregation in a fork supersedes it transparently.
+- Lookup-in-grid cells add fetch volume; mitigated by batch label resolution
+  (the pattern `RelatedList` already uses).
+
+**Out of scope (follow-ups)**
+
+- Atomic server `/batch` create (separate, server-side ADR).
+- Drag reorder of lines (`allow_reorder`), grouping/subtotal rows.
+- A `master_detail` *field widget* auto-selected from object metadata (this ADR
+  drives the grid from explicit column config first).
+
+---
+
+## Rollout plan
+
+1. `LineItemsField` editable grid + unit tests (add/delete/edit/total).  ← core
+2. `MasterDetailForm` + submit orchestration + unit tests (parent→children FK,
+   bulk path, failure cleanup) with a mock dataSource.
+3. Register `record:line_items` (detail/view, inline CRUD against existing
+   parent).
+4. **End-to-end browser verification** against the live `expense_claim` /
+   `expense_line`: enter a claim header + 2 lines, submit, confirm parent and
+   both children exist via the data API, and the total rolled up.
+5. Follow-ups (atomic batch, reorder) tracked separately.
+
+Verification is the gate: the feature is "done" only when a claim with lines is
+created end-to-end through the running console.

--- a/packages/components/src/__tests__/data-list.test.tsx
+++ b/packages/components/src/__tests__/data-list.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+
+beforeAll(async () => {
+  await import('../renderers');
+}, 30000);
+
+function renderType(schema: any) {
+  const Component = ComponentRegistry.get(schema.type);
+  if (!Component) throw new Error(`Component "${schema.type}" is not registered`);
+  return render(<Component schema={schema} />);
+}
+
+describe('element:definition-list', () => {
+  it('is registered', () => {
+    expect(ComponentRegistry.get('element:definition-list')).toBeTruthy();
+  });
+
+  it('renders a term/description pair per item', () => {
+    const { getByText, getByTestId } = renderType({
+      type: 'element:definition-list',
+      properties: {
+        items: [
+          { term: 'Status', description: 'Active' },
+          { term: 'Owner', description: 'Ada' },
+        ],
+      },
+    });
+    expect(getByTestId('definition-list')).toBeTruthy();
+    expect(getByText('Status')).toBeTruthy();
+    expect(getByText('Active')).toBeTruthy();
+    expect(getByText('Owner')).toBeTruthy();
+  });
+
+  it('renders an em dash for empty descriptions', () => {
+    const { getByText } = renderType({
+      type: 'element:definition-list',
+      properties: { items: [{ term: 'Notes', description: '' }] },
+    });
+    expect(getByText('—')).toBeTruthy();
+  });
+
+  it('shows a friendly message when there are no items', () => {
+    const { getByText } = renderType({ type: 'element:definition-list', properties: { items: [] } });
+    expect(getByText(/No details/i)).toBeTruthy();
+  });
+});
+
+describe('element:repeater', () => {
+  it('is registered', () => {
+    expect(ComponentRegistry.get('element:repeater')).toBeTruthy();
+  });
+
+  it('renders an empty message when no object/adapter is available', () => {
+    // Without an adapter the repeater resolves to its empty state rather than
+    // throwing — safe to drop into any page.
+    const { getByText } = renderType({
+      type: 'element:repeater',
+      properties: { object: 'showcase_category', fields: ['name'], emptyText: 'Nothing here' },
+    });
+    expect(getByText('Nothing here')).toBeTruthy();
+  });
+});

--- a/packages/components/src/renderers/basic/data-list.tsx
+++ b/packages/components/src/renderers/basic/data-list.tsx
@@ -1,0 +1,179 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Lightweight list primitives for SIMPLE data — the antidote to dropping a
+ * full data-grid (toolbar + filters + pagination + selection) on a handful of
+ * reference rows. Two presentational/low-chrome components:
+ *
+ *   - element:definition-list — a compact key/value `<dl>` for a single record.
+ *   - element:repeater        — a data-bound, chrome-free list: one line per
+ *                               row, no toolbar/card/pagination.
+ *
+ * Props are read off `schema.properties` (spec convention) with a `schema.props`
+ * fallback, matching the other `element:*` renderers.
+ */
+
+import * as React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { useAdapter } from '@object-ui/react';
+import { cn } from '../../lib/utils';
+
+function readProps<T extends Record<string, any>>(schema: any): T {
+  const fromProperties = (schema?.properties ?? {}) as T;
+  const fromProps = (schema?.props ?? {}) as T;
+  return { ...fromProps, ...fromProperties };
+}
+
+function toText(v: unknown): string {
+  if (v == null || v === '') return '—';
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+// ---------------------------------------------------------------------------
+// element:definition-list — compact key/value display
+// ---------------------------------------------------------------------------
+
+interface DefinitionItem {
+  term: string;
+  description?: unknown;
+}
+
+function DefinitionListRenderer({ schema }: { schema: any }) {
+  const props = readProps<{
+    items?: DefinitionItem[];
+    columns?: 1 | 2;
+    inline?: boolean;
+    className?: string;
+  }>(schema);
+  const items = Array.isArray(props.items) ? props.items : [];
+  const cols = props.columns === 2 ? 'sm:grid-cols-2' : 'grid-cols-1';
+
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">No details</p>;
+  }
+
+  return (
+    <dl
+      className={cn('grid gap-x-6 gap-y-3', cols, schema?.className, props.className)}
+      data-testid="definition-list"
+    >
+      {items.map((it, i) => (
+        <div
+          key={i}
+          className={cn(props.inline ? 'flex items-baseline justify-between gap-3' : 'flex flex-col gap-0.5')}
+        >
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {it.term}
+          </dt>
+          <dd className="text-sm text-foreground">{toText(it.description)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+ComponentRegistry.register('element:definition-list', DefinitionListRenderer, {
+  namespace: 'element',
+  label: 'Definition List',
+  category: 'content',
+});
+
+// ---------------------------------------------------------------------------
+// element:repeater — data-bound, chrome-free list
+// ---------------------------------------------------------------------------
+
+interface RepeaterColumn {
+  field: string;
+  label?: string;
+}
+
+function RepeaterRenderer({ schema }: { schema: any }) {
+  const props = readProps<{
+    object?: string;
+    titleField?: string;
+    fields?: Array<string | RepeaterColumn>;
+    filter?: unknown;
+    sort?: any;
+    limit?: number;
+    emptyText?: string;
+    divided?: boolean;
+    className?: string;
+  }>(schema);
+
+  const adapter = useAdapter() as any;
+  const [rows, setRows] = React.useState<any[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const filterKey = React.useMemo(() => (props.filter ? JSON.stringify(props.filter) : ''), [props.filter]);
+
+  const cols: RepeaterColumn[] = React.useMemo(
+    () => (props.fields ?? []).map((f) => (typeof f === 'string' ? { field: f } : f)),
+    [props.fields],
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!adapter || !props.object || typeof adapter.find !== 'function') {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const query: any = {};
+        if (props.filter) query.$filter = props.filter;
+        if (props.sort) query.$orderby = props.sort;
+        if (props.limit) query.$top = props.limit;
+        const res = await adapter.find(props.object, query);
+        const data: any[] = res?.data ?? res?.records ?? (Array.isArray(res) ? res : []);
+        if (!cancelled) setRows(data);
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message ?? 'Failed to load');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [adapter, props.object, filterKey, props.limit]);
+
+  if (loading) return <p className="py-2 text-sm text-muted-foreground">Loading…</p>;
+  if (error) return <p className="py-2 text-sm text-destructive">{error}</p>;
+  if (rows.length === 0) {
+    return <p className="py-2 text-sm text-muted-foreground">{props.emptyText ?? 'No records'}</p>;
+  }
+
+  return (
+    <ul
+      className={cn(props.divided !== false && 'divide-y divide-border', schema?.className, props.className)}
+      data-testid="repeater"
+    >
+      {rows.map((row, i) => (
+        <li key={row?.id ?? i} className="flex items-baseline gap-3 py-2">
+          {props.titleField && (
+            <span className="text-sm font-medium text-foreground">{toText(row[props.titleField])}</span>
+          )}
+          {cols.map((c) => (
+            <span key={c.field} className="text-sm text-muted-foreground">
+              {toText(row[c.field])}
+            </span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+ComponentRegistry.register('element:repeater', RepeaterRenderer, {
+  namespace: 'element',
+  label: 'Repeater',
+  category: 'content',
+});

--- a/packages/components/src/renderers/basic/index.ts
+++ b/packages/components/src/renderers/basic/index.ts
@@ -17,3 +17,4 @@ import './button-group';
 import './pagination';
 import './navigation-menu';
 import './elements';
+import './data-list';

--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -19,13 +19,13 @@ describe('GridField / LineItemsField — editable line items', () => {
     render(<GridField value={[]} onChange={() => {}} field={field} />);
     expect(screen.getByText('Description')).toBeTruthy();
     expect(screen.getByText('Amount')).toBeTruthy();
-    expect(screen.getByRole('button', { name: /Add row/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Add line/i })).toBeTruthy();
   });
 
-  it('Add row appends a blank row keyed by columns', () => {
+  it('Add line appends a blank row keyed by columns', () => {
     const onChange = vi.fn();
     render(<GridField value={[]} onChange={onChange} field={field} />);
-    fireEvent.click(screen.getByRole('button', { name: /Add row/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Add line/i }));
     expect(onChange).toHaveBeenCalledWith([{ description: null, amount: null }]);
   });
 

--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { GridField, LineItemsField, sumColumn } from './GridField';
+
+const columns = [
+  { field: 'description', label: 'Description', type: 'text' as const },
+  { field: 'amount', label: 'Amount', type: 'currency' as const },
+];
+
+const field = { columns, total_field: 'amount' } as any;
+
+describe('GridField / LineItemsField — editable line items', () => {
+  it('is exported under both names', () => {
+    expect(LineItemsField).toBe(GridField);
+  });
+
+  it('renders a column header per config and an empty hint', () => {
+    render(<GridField value={[]} onChange={() => {}} field={field} />);
+    expect(screen.getByText('Description')).toBeTruthy();
+    expect(screen.getByText('Amount')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Add row/i })).toBeTruthy();
+  });
+
+  it('Add row appends a blank row keyed by columns', () => {
+    const onChange = vi.fn();
+    render(<GridField value={[]} onChange={onChange} field={field} />);
+    fireEvent.click(screen.getByRole('button', { name: /Add row/i }));
+    expect(onChange).toHaveBeenCalledWith([{ description: null, amount: null }]);
+  });
+
+  it('editing a text cell emits the raw string', () => {
+    const onChange = vi.fn();
+    render(<GridField value={[{ description: '', amount: null }]} onChange={onChange} field={field} />);
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Taxi' } });
+    expect(onChange).toHaveBeenCalledWith([{ description: 'Taxi', amount: null }]);
+  });
+
+  it('editing a currency cell coerces to a number', () => {
+    const onChange = vi.fn();
+    render(<GridField value={[{ description: 'Taxi', amount: null }]} onChange={onChange} field={field} />);
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '42.5' } });
+    expect(onChange).toHaveBeenCalledWith([{ description: 'Taxi', amount: 42.5 }]);
+  });
+
+  it('removing a row emits the array without it', () => {
+    const onChange = vi.fn();
+    render(
+      <GridField
+        value={[{ description: 'A', amount: 1 }, { description: 'B', amount: 2 }]}
+        onChange={onChange}
+        field={field}
+      />,
+    );
+    const removeButtons = screen.getAllByLabelText('Remove row');
+    fireEvent.click(removeButtons[0]);
+    expect(onChange).toHaveBeenCalledWith([{ description: 'B', amount: 2 }]);
+  });
+
+  it('readonly mode shows values and a summed total footer', () => {
+    render(
+      <GridField
+        value={[{ description: 'A', amount: 10 }, { description: 'B', amount: 20 }]}
+        onChange={() => {}}
+        field={field}
+        readonly
+      />,
+    );
+    expect(screen.getByTestId('line-items-readonly')).toBeTruthy();
+    expect(screen.getByText('Total')).toBeTruthy();
+    expect(screen.getByText('30')).toBeTruthy();
+  });
+
+  it('sumColumn ignores blanks and NaN', () => {
+    expect(sumColumn([{ amount: 1 }, { amount: 2 }, { amount: null }], 'amount')).toBe(3);
+  });
+});

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -77,6 +77,8 @@ export function GridField({
 
   const allowAdd = cfg.allow_add !== false && !readonly && !disabled;
   const allowDelete = cfg.allow_delete !== false && !readonly && !disabled;
+  // Enterprise line grids (NetSuite/SAP/Salesforce) show a line-number column.
+  const showLineNumbers = cfg.show_line_numbers !== false;
   const minRows: number = cfg.min_rows ?? 0;
   const maxRows: number | undefined = cfg.max_rows;
   const totalField: string | undefined =
@@ -125,10 +127,16 @@ export function GridField({
         <table className="w-full text-sm">
           <thead className="bg-muted border-b border-border">
             <tr>
+              {showLineNumbers && (
+                <th className="w-10 px-2 py-2 text-right text-xs font-medium text-muted-foreground">#</th>
+              )}
               {columns.map((c) => (
                 <th
                   key={c.field}
-                  className="px-3 py-2 text-left text-xs font-medium text-muted-foreground"
+                  className={cn(
+                    'px-3 py-2 text-xs font-medium text-muted-foreground',
+                    isNumeric(c.type) ? 'text-right' : 'text-left',
+                  )}
                 >
                   {c.label || c.field}
                 </th>
@@ -139,7 +147,7 @@ export function GridField({
             {rows.length === 0 ? (
               <tr>
                 <td
-                  colSpan={Math.max(columns.length, 1)}
+                  colSpan={Math.max(columns.length + (showLineNumbers ? 1 : 0), 1)}
                   className="px-3 py-6 text-center text-muted-foreground"
                 >
                   No items
@@ -148,8 +156,14 @@ export function GridField({
             ) : (
               rows.map((row, rowIdx) => (
                 <tr key={rowIdx}>
+                  {showLineNumbers && (
+                    <td className="px-2 py-2 text-right text-muted-foreground tabular-nums">{rowIdx + 1}</td>
+                  )}
                   {columns.map((c) => (
-                    <td key={c.field} className="px-3 py-2 text-foreground">
+                    <td
+                      key={c.field}
+                      className={cn('px-3 py-2 text-foreground', isNumeric(c.type) && 'text-right tabular-nums')}
+                    >
                       {row[c.field] != null && row[c.field] !== ''
                         ? String(row[c.field])
                         : '—'}
@@ -163,12 +177,12 @@ export function GridField({
             <tfoot className="border-t border-border bg-muted/40">
               <tr>
                 <td
-                  colSpan={Math.max(columns.length - 1, 1)}
+                  colSpan={Math.max((showLineNumbers ? 1 : 0) + columns.length - 1, 1)}
                   className="px-3 py-2 text-right text-xs font-medium text-muted-foreground"
                 >
                   Total
                 </td>
-                <td className="px-3 py-2 font-medium text-foreground">
+                <td className="px-3 py-2 text-right font-medium text-foreground tabular-nums">
                   {total.toLocaleString()}
                 </td>
               </tr>
@@ -186,10 +200,16 @@ export function GridField({
         <table className="w-full text-sm">
           <thead className="bg-muted border-b border-border">
             <tr>
+              {showLineNumbers && (
+                <th className="w-10 px-2 py-2 text-right text-xs font-medium text-muted-foreground">#</th>
+              )}
               {columns.map((c) => (
                 <th
                   key={c.field}
-                  className="px-3 py-2 text-left text-xs font-medium text-muted-foreground"
+                  className={cn(
+                    'px-3 py-2 text-xs font-medium text-muted-foreground',
+                    isNumeric(c.type) ? 'text-right' : 'text-left',
+                  )}
                   style={c.width ? { width: c.width } : undefined}
                 >
                   {c.label || c.field}
@@ -203,15 +223,20 @@ export function GridField({
             {rows.length === 0 ? (
               <tr>
                 <td
-                  colSpan={columns.length + (allowDelete ? 1 : 0)}
+                  colSpan={columns.length + (allowDelete ? 1 : 0) + (showLineNumbers ? 1 : 0)}
                   className="px-3 py-6 text-center text-muted-foreground"
                 >
-                  No items yet — click “Add row” to begin.
+                  No items yet — click “{cfg.add_label || 'Add line'}” to begin.
                 </td>
               </tr>
             ) : (
               rows.map((row, rowIdx) => (
                 <tr key={rowIdx} className="hover:bg-muted/30">
+                  {showLineNumbers && (
+                    <td className="px-2 py-1.5 text-right align-middle text-muted-foreground tabular-nums">
+                      {rowIdx + 1}
+                    </td>
+                  )}
                   {columns.map((c) => (
                     <td key={c.field} className="px-2 py-1.5 align-top">
                       {c.type === 'select' ? (
@@ -239,7 +264,7 @@ export function GridField({
                             </span>
                           )}
                           <Input
-                            className={cn('h-8', c.type === 'currency' && 'pl-6')}
+                            className={cn('h-8', c.type === 'currency' && 'pl-6', isNumeric(c.type) && 'text-right')}
                             type={
                               c.type === 'date'
                                 ? 'date'
@@ -280,12 +305,12 @@ export function GridField({
             <tfoot className="border-t border-border bg-muted/40">
               <tr>
                 <td
-                  colSpan={Math.max(columns.length - 1, 1)}
+                  colSpan={Math.max((showLineNumbers ? 1 : 0) + columns.length - 1, 1)}
                   className="px-3 py-2 text-right text-xs font-medium text-muted-foreground"
                 >
                   Total
                 </td>
-                <td className="px-3 py-2 font-medium text-foreground" data-testid="line-items-total">
+                <td className="px-3 py-2 text-right font-medium text-foreground tabular-nums" data-testid="line-items-total">
                   {total.toLocaleString()}
                 </td>
                 {allowDelete && <td />}
@@ -304,7 +329,7 @@ export function GridField({
           disabled={maxRows != null && rows.length >= maxRows}
         >
           <Plus className="mr-1.5 h-4 w-4" />
-          {cfg.add_label || 'Add row'}
+          {cfg.add_label || 'Add line'}
         </Button>
       )}
     </div>

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -1,63 +1,315 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { FieldWidgetProps } from './types';
-import { cn, EmptyValue } from '@object-ui/components';
+import {
+  cn,
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@object-ui/components';
+import { Plus, Trash2 } from 'lucide-react';
 
 /**
- * GridField - Sub-table/grid data display
- * Shows tabular data in a simplified format
- * For full editing capabilities, use the grid plugin
+ * GridField / LineItemsField — editable child-grid ("line items") widget.
+ *
+ * A controlled component: `value` is an array of row objects, `onChange`
+ * receives the next array. It renders one editable cell per configured
+ * column, supports add / delete row, and shows a running total of a numeric
+ * column. This is the renderer for the `field:grid` widget and the cell
+ * engine behind the master-detail subform (see ADR-0001).
+ *
+ * Column config (a subset of `GridColumnDefinition`):
+ *   { field, label?, type?, options?, width?, required?, prefix?, step? }
+ *   type ∈ 'text' | 'number' | 'currency' | 'date' | 'select'
+ *
+ * Field-level config (from `GridFieldMetadata`):
+ *   columns, min_rows, max_rows, allow_add, allow_delete, total_field
  */
-export function GridField({ value, field, readonly, ...props }: FieldWidgetProps<any[]>) {
-  const gridField = (field || (props as any).schema) as any;
-  const columns = gridField?.columns || [];
 
-  if (!value || !Array.isArray(value)) {
-    return <EmptyValue />;
+export interface GridColumn {
+  field: string;
+  label?: string;
+  type?: 'text' | 'number' | 'currency' | 'date' | 'select';
+  options?: Array<{ label: string; value: string }>;
+  width?: number;
+  required?: boolean;
+  prefix?: string;
+  step?: number;
+}
+
+type Row = Record<string, any>;
+
+const isNumeric = (t?: string) => t === 'number' || t === 'currency';
+
+function coerce(type: string | undefined, raw: string): any {
+  if (isNumeric(type)) {
+    if (raw === '' || raw == null) return null;
+    const n = Number(raw);
+    return Number.isNaN(n) ? raw : n;
   }
+  return raw;
+}
 
+/** Sum a numeric column across rows (ignoring blanks/NaN). */
+export function sumColumn(rows: Row[], field: string): number {
+  if (!Array.isArray(rows)) return 0;
+  return rows.reduce((acc, r) => {
+    const v = Number(r?.[field]);
+    return acc + (Number.isFinite(v) ? v : 0);
+  }, 0);
+}
+
+export function GridField({
+  value,
+  onChange,
+  field,
+  readonly,
+  disabled,
+  className,
+  ...props
+}: FieldWidgetProps<Row[]>) {
+  const cfg = (field || (props as any).schema || {}) as any;
+  const columns: GridColumn[] = cfg.columns || [];
+  const rows: Row[] = Array.isArray(value) ? value : [];
+
+  const allowAdd = cfg.allow_add !== false && !readonly && !disabled;
+  const allowDelete = cfg.allow_delete !== false && !readonly && !disabled;
+  const minRows: number = cfg.min_rows ?? 0;
+  const maxRows: number | undefined = cfg.max_rows;
+  const totalField: string | undefined =
+    cfg.total_field || cfg.amount_field || cfg.amountField;
+
+  const emit = useCallback(
+    (next: Row[]) => onChange?.(next),
+    [onChange],
+  );
+
+  const setCell = useCallback(
+    (rowIdx: number, col: GridColumn, raw: string) => {
+      const next = rows.map((r, i) =>
+        i === rowIdx ? { ...r, [col.field]: coerce(col.type, raw) } : r,
+      );
+      emit(next);
+    },
+    [rows, emit],
+  );
+
+  const addRow = useCallback(() => {
+    if (maxRows != null && rows.length >= maxRows) return;
+    const blank: Row = {};
+    for (const c of columns) blank[c.field] = null;
+    emit([...rows, blank]);
+  }, [rows, columns, maxRows, emit]);
+
+  const removeRow = useCallback(
+    (rowIdx: number) => {
+      if (rows.length <= minRows) return;
+      emit(rows.filter((_, i) => i !== rowIdx));
+    },
+    [rows, minRows, emit],
+  );
+
+  const showTotal = !!totalField;
+  const total = showTotal ? sumColumn(rows, totalField!) : 0;
+
+  // ── Read-only / view rendering ────────────────────────────────────────────
   if (readonly) {
     return (
-      <div className={cn("text-sm", props.className)}>
-        <span className="text-foreground">{value.length} rows</span>
-      </div>
-    );
-  }
-
-  // Simple read-only table view
-  return (
-    <div className={cn("border border-border rounded-lg overflow-hidden", props.className)}>
-      <div className="overflow-auto max-h-60">
+      <div
+        className={cn('border border-border rounded-lg overflow-hidden', className)}
+        data-testid="line-items-readonly"
+      >
         <table className="w-full text-sm">
           <thead className="bg-muted border-b border-border">
             <tr>
-              {columns.map((col: any, idx: number) => (
+              {columns.map((c) => (
                 <th
-                  key={idx}
+                  key={c.field}
                   className="px-3 py-2 text-left text-xs font-medium text-muted-foreground"
                 >
-                  {col.label || col.name}
+                  {c.label || c.field}
                 </th>
               ))}
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
-            {value.slice(0, 5).map((row: any, rowIdx: number) => (
-              <tr key={rowIdx} className="hover:bg-muted/50 transition-colors">
-                {columns.map((col: any, colIdx: number) => (
-                  <td key={colIdx} className="px-3 py-2 text-foreground">
-                    {row[col.name] != null ? String(row[col.name]) : <EmptyValue />}
-                  </td>
-                ))}
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={Math.max(columns.length, 1)}
+                  className="px-3 py-6 text-center text-muted-foreground"
+                >
+                  No items
+                </td>
               </tr>
-            ))}
+            ) : (
+              rows.map((row, rowIdx) => (
+                <tr key={rowIdx}>
+                  {columns.map((c) => (
+                    <td key={c.field} className="px-3 py-2 text-foreground">
+                      {row[c.field] != null && row[c.field] !== ''
+                        ? String(row[c.field])
+                        : '—'}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
           </tbody>
+          {showTotal && (
+            <tfoot className="border-t border-border bg-muted/40">
+              <tr>
+                <td
+                  colSpan={Math.max(columns.length - 1, 1)}
+                  className="px-3 py-2 text-right text-xs font-medium text-muted-foreground"
+                >
+                  Total
+                </td>
+                <td className="px-3 py-2 font-medium text-foreground">
+                  {total.toLocaleString()}
+                </td>
+              </tr>
+            </tfoot>
+          )}
         </table>
       </div>
-      {value.length > 5 && (
-        <div className="bg-muted px-3 py-2 text-xs text-muted-foreground border-t border-border">
-          Showing 5 of {value.length} rows
-        </div>
+    );
+  }
+
+  // ── Editable rendering ──────────────────────────────────────────────────────
+  return (
+    <div className={cn('space-y-2', className)} data-testid="line-items">
+      <div className="border border-border rounded-lg overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-muted border-b border-border">
+            <tr>
+              {columns.map((c) => (
+                <th
+                  key={c.field}
+                  className="px-3 py-2 text-left text-xs font-medium text-muted-foreground"
+                  style={c.width ? { width: c.width } : undefined}
+                >
+                  {c.label || c.field}
+                  {c.required && <span className="text-destructive"> *</span>}
+                </th>
+              ))}
+              {allowDelete && <th className="w-10" />}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length + (allowDelete ? 1 : 0)}
+                  className="px-3 py-6 text-center text-muted-foreground"
+                >
+                  No items yet — click “Add row” to begin.
+                </td>
+              </tr>
+            ) : (
+              rows.map((row, rowIdx) => (
+                <tr key={rowIdx} className="hover:bg-muted/30">
+                  {columns.map((c) => (
+                    <td key={c.field} className="px-2 py-1.5 align-top">
+                      {c.type === 'select' ? (
+                        <Select
+                          value={row[c.field] != null ? String(row[c.field]) : ''}
+                          onValueChange={(v) => setCell(rowIdx, c, v)}
+                          disabled={disabled}
+                        >
+                          <SelectTrigger className="h-8" aria-label={c.label || c.field}>
+                            <SelectValue placeholder="—" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {(c.options || []).map((o) => (
+                              <SelectItem key={o.value} value={o.value}>
+                                {o.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <div className="relative">
+                          {c.type === 'currency' && (
+                            <span className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
+                              {c.prefix || '¥'}
+                            </span>
+                          )}
+                          <Input
+                            className={cn('h-8', c.type === 'currency' && 'pl-6')}
+                            type={
+                              c.type === 'date'
+                                ? 'date'
+                                : isNumeric(c.type)
+                                  ? 'number'
+                                  : 'text'
+                            }
+                            step={isNumeric(c.type) ? c.step ?? 'any' : undefined}
+                            aria-label={c.label || c.field}
+                            value={row[c.field] != null ? String(row[c.field]) : ''}
+                            onChange={(e) => setCell(rowIdx, c, e.target.value)}
+                            disabled={disabled}
+                          />
+                        </div>
+                      )}
+                    </td>
+                  ))}
+                  {allowDelete && (
+                    <td className="px-2 py-1.5 text-center align-middle">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                        aria-label="Remove row"
+                        onClick={() => removeRow(rowIdx)}
+                        disabled={disabled || rows.length <= minRows}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </td>
+                  )}
+                </tr>
+              ))
+            )}
+          </tbody>
+          {showTotal && (
+            <tfoot className="border-t border-border bg-muted/40">
+              <tr>
+                <td
+                  colSpan={Math.max(columns.length - 1, 1)}
+                  className="px-3 py-2 text-right text-xs font-medium text-muted-foreground"
+                >
+                  Total
+                </td>
+                <td className="px-3 py-2 font-medium text-foreground" data-testid="line-items-total">
+                  {total.toLocaleString()}
+                </td>
+                {allowDelete && <td />}
+              </tr>
+            </tfoot>
+          )}
+        </table>
+      </div>
+
+      {allowAdd && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addRow}
+          disabled={maxRows != null && rows.length >= maxRows}
+        >
+          <Plus className="mr-1.5 h-4 w-4" />
+          {cfg.add_label || 'Add row'}
+        </Button>
       )}
     </div>
   );
 }
+
+/** Semantic alias — the master-detail subform's child grid. */
+export const LineItemsField = GridField;

--- a/packages/plugin-form/src/LineItemsPanel.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.tsx
@@ -1,0 +1,166 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * LineItemsPanel — the `record:line_items` component. Renders a child "line
+ * items" grid bound to an EXISTING parent record (on a record/detail page or
+ * a slotted page slot). Loads children by FK, lets the user add/edit/delete
+ * rows, and persists the diff on Save. See ADR-0001.
+ *
+ * Parent id is taken from the component props (`recordId`/`parentId`) or from
+ * the surrounding <RecordContextProvider>. dataSource comes from the
+ * SchemaRenderer context.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  cn,
+} from '@object-ui/components';
+import { LineItemsField, type GridColumn } from '@object-ui/fields';
+import { useSchemaContext, useRecordContext } from '@object-ui/react';
+import { applyDetail } from './masterDetailTx';
+
+export interface LineItemsPanelSchema {
+  type?: 'record:line_items';
+  childObject: string;
+  relationshipField: string;
+  columns: GridColumn[];
+  parentObject?: string;
+  parentId?: string;
+  recordId?: string;
+  amountField?: string;
+  totalField?: string;
+  title?: string;
+  readonly?: boolean;
+  minRows?: number;
+  maxRows?: number;
+}
+
+export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ schema }) => {
+  const ctx = useSchemaContext() as any;
+  const dataSource = ctx?.dataSource;
+  let record: any;
+  try {
+    // useRecordContext throws outside a provider in some builds; guard it.
+    record = useRecordContext();
+  } catch {
+    record = undefined;
+  }
+
+  const parentObject = schema.parentObject || record?.objectName;
+  const parentId =
+    schema.parentId || schema.recordId || (record?.recordId as string | undefined);
+
+  const [rows, setRows] = useState<Record<string, any>[]>([]);
+  const [original, setOriginal] = useState<Record<string, any>[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!dataSource || !parentId) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await dataSource.find(schema.childObject, {
+        $filter: { [schema.relationshipField]: parentId },
+        $top: 500,
+      });
+      const data = (res?.data ?? []) as Record<string, any>[];
+      setRows(data.map((r) => ({ ...r })));
+      setOriginal(data.map((r) => ({ ...r })));
+      setDirty(false);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load line items');
+    } finally {
+      setLoading(false);
+    }
+  }, [dataSource, parentId, schema.childObject, schema.relationshipField]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onChange = useCallback((next: Record<string, any>[]) => {
+    setRows(next);
+    setDirty(true);
+  }, []);
+
+  const save = useCallback(async () => {
+    if (!dataSource || !parentId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await applyDetail(dataSource, parentObject || schema.childObject, parentId, {
+        childObject: schema.childObject,
+        relationshipField: schema.relationshipField,
+        rows,
+        original,
+        amountField: schema.amountField,
+        // only roll up when we know the parent object to write the total onto
+        totalField: parentObject ? schema.totalField : undefined,
+      });
+      await load();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to save line items');
+    } finally {
+      setSaving(false);
+    }
+  }, [dataSource, parentId, rows, original, schema, parentObject, load]);
+
+  const gridField = useMemo(
+    () =>
+      ({
+        columns: schema.columns,
+        total_field: schema.totalField ? schema.amountField || 'amount' : undefined,
+        min_rows: schema.minRows,
+        max_rows: schema.maxRows,
+        allow_add: !schema.readonly,
+        allow_delete: !schema.readonly,
+      }) as any,
+    [schema],
+  );
+
+  return (
+    <Card className={cn('shadow-none')}>
+      <CardHeader className="flex-row items-center justify-between gap-2 pb-2">
+        <CardTitle className="text-sm font-medium">{schema.title || 'Line Items'}</CardTitle>
+        {!schema.readonly && (
+          <Button
+            type="button"
+            size="sm"
+            onClick={save}
+            disabled={saving || loading || !dirty || !parentId}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent>
+        {error && <p className="mb-2 text-sm text-destructive">{error}</p>}
+        {loading ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">Loading…</p>
+        ) : !parentId ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            Save the record first to add line items.
+          </p>
+        ) : (
+          <LineItemsField value={rows} onChange={onChange} field={gridField} readonly={schema.readonly} />
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -27,7 +27,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DataSource } from '@object-ui/types';
 import { LineItemsField, type GridColumn } from '@object-ui/fields';
-import { Card, CardContent, CardHeader, CardTitle, cn } from '@object-ui/components';
+import { Button, Card, CardContent, CardHeader, CardTitle, cn } from '@object-ui/components';
 import { ObjectForm } from './ObjectForm';
 import { applyDetail, idOf } from './masterDetailTx';
 
@@ -65,6 +65,7 @@ export interface MasterDetailFormSchema {
   details: MasterDetailDetailConfig[];
   onSuccess?: (parent: any) => void | Promise<void>;
   onError?: (err: Error) => void;
+  onCancel?: () => void;
   className?: string;
 }
 
@@ -176,6 +177,9 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
     [dataSource, isEdit, persistDetails, schema],
   );
 
+  // The parent form renders WITHOUT its own submit button — the master-detail
+  // form owns a single action bar at the bottom (header → lines → Save), the
+  // layout every mainstream enterprise platform uses for header+line entry.
   const parentSchema = useMemo(
     () => ({
       type: 'object-form',
@@ -186,21 +190,36 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
       sections: schema.sections,
       fields: schema.fields,
       title: schema.title,
-      submitText: schema.submitText ?? (isEdit ? 'Save' : 'Create'),
+      showSubmit: false,
+      showCancel: false,
       onSuccess: handleParentSaved,
       onError: schema.onError,
     }),
-    [schema, isEdit, handleParentSaved],
+    [schema, handleParentSaved],
   );
 
+  const formHostRef = useRef<HTMLDivElement>(null);
+  const submitText = schema.submitText ?? (isEdit ? 'Save' : 'Create');
+
+  const handleSave = useCallback(() => {
+    // Drive the (button-less) parent form's submit so its validation + RHF
+    // onSubmit fire; success chains into child persistence via onSuccess.
+    const form = formHostRef.current?.querySelector('form') as HTMLFormElement | null;
+    if (form) form.requestSubmit();
+  }, []);
+
   return (
-    <div className={cn('space-y-4', className, schema.className)}>
+    <div className={cn('space-y-6', className, schema.className)}>
+      {/* 1) Header fields on top */}
+      <div ref={formHostRef}>
+        <ObjectForm schema={parentSchema as any} dataSource={dataSource} />
+      </div>
+
+      {/* 2) Line items below the header */}
       {details.map((d, i) => (
         <Card key={`${d.childObject}-${i}`} className="shadow-none">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">
-              {d.title || 'Line Items'}
-            </CardTitle>
+            <CardTitle className="text-sm font-medium">{d.title || 'Line Items'}</CardTitle>
           </CardHeader>
           <CardContent>
             <LineItemsField
@@ -222,8 +241,17 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
         </Card>
       ))}
 
-      {/* Parent fields + the single submit button live here. */}
-      <ObjectForm schema={parentSchema as any} dataSource={dataSource} />
+      {/* 3) Single action bar at the bottom */}
+      <div className="flex items-center justify-end gap-2 border-t border-border pt-4">
+        {schema.onCancel && (
+          <Button type="button" variant="outline" onClick={schema.onCancel}>
+            Cancel
+          </Button>
+        )}
+        <Button type="button" onClick={handleSave}>
+          {submitText}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -209,7 +209,9 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
               field={
                 {
                   columns: d.columns,
-                  total_field: d.totalField ? d.amountField || 'amount' : undefined,
+                  // Show the running total whenever an amount column is set,
+                  // independent of whether it also rolls up onto the parent.
+                  total_field: d.amountField || (d.totalField ? 'amount' : undefined),
                   min_rows: d.minRows,
                   max_rows: d.maxRows,
                   add_label: d.addLabel,

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -1,0 +1,227 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * MasterDetailForm — enter a parent record together with its child "line
+ * items" in a single screen, and persist them as one client-orchestrated
+ * transaction (see ADR-0001).
+ *
+ * The parent fields are rendered by the existing <ObjectForm>; the child
+ * collection(s) by <LineItemsField>. On submit we:
+ *   1. create/update the parent (ObjectForm owns this, via its `onSuccess`),
+ *   2. set the relationship FK on each line and bulk-create them,
+ *   3. (optional) roll the line total up onto a parent field,
+ *   4. on child failure, best-effort delete the just-created parent and rethrow
+ *      so the form surfaces the error with the user's input intact.
+ *
+ * No `@objectstack/spec` change: the relationship is a `master_detail` (or
+ * `lookup`) FK on the child object; there is no server batch endpoint, so the
+ * multi-object write is orchestrated here.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { DataSource } from '@object-ui/types';
+import { LineItemsField, type GridColumn } from '@object-ui/fields';
+import { Card, CardContent, CardHeader, CardTitle, cn } from '@object-ui/components';
+import { ObjectForm } from './ObjectForm';
+import { applyDetail, idOf } from './masterDetailTx';
+
+export interface MasterDetailDetailConfig {
+  /** Child object name, e.g. 'expense_line'. */
+  childObject: string;
+  /** FK field on the child pointing back to the parent, e.g. 'expense_claim'. */
+  relationshipField: string;
+  /** Editable columns for the child grid. */
+  columns: GridColumn[];
+  /** Numeric child column to sum, e.g. 'amount'. */
+  amountField?: string;
+  /** Parent field to receive the rolled-up sum, e.g. 'total_amount'. */
+  totalField?: string;
+  /** Section title. */
+  title?: string;
+  minRows?: number;
+  maxRows?: number;
+  addLabel?: string;
+}
+
+export interface MasterDetailFormSchema {
+  type?: 'object-master-detail-form';
+  /** Parent object name, e.g. 'expense_claim'. */
+  objectName: string;
+  mode?: 'create' | 'edit';
+  recordId?: string;
+  /** Parent form sections/fields — passed straight through to ObjectForm. */
+  sections?: any[];
+  fields?: any[];
+  formType?: 'simple' | 'tabbed';
+  title?: string;
+  submitText?: string;
+  /** One or more child collections. */
+  details: MasterDetailDetailConfig[];
+  onSuccess?: (parent: any) => void | Promise<void>;
+  onError?: (err: Error) => void;
+  className?: string;
+}
+
+/** Rows keyed by their persisted id (when known), for edit-mode diffing. */
+interface RowState {
+  rows: Record<string, any>[];
+  /** Snapshot of the persisted rows (edit mode) for diffing on submit. */
+  original: Record<string, any>[];
+}
+
+export interface MasterDetailFormProps {
+  schema: MasterDetailFormSchema;
+  dataSource?: DataSource;
+  className?: string;
+}
+
+export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
+  schema,
+  dataSource,
+  className,
+}) => {
+  const details = schema.details || [];
+  const isEdit = schema.mode === 'edit' && !!schema.recordId;
+
+  // One row-state per detail collection.
+  const [state, setState] = useState<RowState[]>(() =>
+    details.map(() => ({ rows: [], original: [] })),
+  );
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  // Edit mode: load existing children for each detail collection.
+  useEffect(() => {
+    let cancelled = false;
+    if (!isEdit || !dataSource) return;
+    (async () => {
+      const loaded = await Promise.all(
+        details.map(async (d) => {
+          try {
+            const res = await dataSource.find(d.childObject, {
+              $filter: { [d.relationshipField]: schema.recordId },
+              $top: 500,
+            });
+            const rows = (res?.data ?? []) as Record<string, any>[];
+            return { rows: rows.map((r) => ({ ...r })), original: rows.map((r) => ({ ...r })) };
+          } catch {
+            return { rows: [], original: [] };
+          }
+        }),
+      );
+      if (!cancelled) setState(loaded);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEdit, dataSource, schema.recordId]);
+
+  const setRows = useCallback((detailIdx: number, rows: Record<string, any>[]) => {
+    setState((prev) => prev.map((s, i) => (i === detailIdx ? { ...s, rows } : s)));
+  }, []);
+
+  /** Persist all child collections for a known parent id. Returns created ids
+   *  (create mode) so the caller can clean up on a later failure. */
+  const persistDetails = useCallback(
+    async (parentId: string) => {
+      const createdIds: Array<{ object: string; id: string }> = [];
+      for (let i = 0; i < details.length; i++) {
+        const d = details[i];
+        const { rows, original } = stateRef.current[i];
+        const { created } = await applyDetail(dataSource!, schema.objectName, parentId, {
+          childObject: d.childObject,
+          relationshipField: d.relationshipField,
+          rows,
+          // edit mode diffs against the loaded snapshot; create mode creates all.
+          original: isEdit ? original : undefined,
+          amountField: d.amountField,
+          totalField: d.totalField,
+        });
+        createdIds.push(...created);
+      }
+      return createdIds;
+    },
+    [details, isEdit, dataSource, schema.objectName],
+  );
+
+  /** Chained after the parent ObjectForm create/update succeeds. */
+  const handleParentSaved = useCallback(
+    async (parent: any) => {
+      const parentId = idOf(parent) ?? schema.recordId;
+      if (!parentId) throw new Error('MasterDetailForm: parent record has no id after save');
+      if (!dataSource) throw new Error('MasterDetailForm: dataSource is required');
+
+      let created: Array<{ object: string; id: string }> = [];
+      try {
+        created = await persistDetails(parentId);
+      } catch (err) {
+        // Best-effort cleanup so we don't leave an orphan parent on create.
+        if (!isEdit) {
+          await Promise.allSettled([
+            ...created.map((c) => dataSource.delete(c.object, c.id)),
+            dataSource.delete(schema.objectName, parentId),
+          ]);
+        }
+        throw err;
+      }
+      await schema.onSuccess?.(parent);
+    },
+    [dataSource, isEdit, persistDetails, schema],
+  );
+
+  const parentSchema = useMemo(
+    () => ({
+      type: 'object-form',
+      objectName: schema.objectName,
+      mode: schema.mode ?? 'create',
+      recordId: schema.recordId,
+      formType: schema.formType,
+      sections: schema.sections,
+      fields: schema.fields,
+      title: schema.title,
+      submitText: schema.submitText ?? (isEdit ? 'Save' : 'Create'),
+      onSuccess: handleParentSaved,
+      onError: schema.onError,
+    }),
+    [schema, isEdit, handleParentSaved],
+  );
+
+  return (
+    <div className={cn('space-y-4', className, schema.className)}>
+      {details.map((d, i) => (
+        <Card key={`${d.childObject}-${i}`} className="shadow-none">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">
+              {d.title || 'Line Items'}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <LineItemsField
+              value={state[i]?.rows ?? []}
+              onChange={(rows) => setRows(i, rows)}
+              field={
+                {
+                  columns: d.columns,
+                  total_field: d.totalField ? d.amountField || 'amount' : undefined,
+                  min_rows: d.minRows,
+                  max_rows: d.maxRows,
+                  add_label: d.addLabel,
+                } as any
+              }
+            />
+          </CardContent>
+        </Card>
+      ))}
+
+      {/* Parent fields + the single submit button live here. */}
+      <ObjectForm schema={parentSchema as any} dataSource={dataSource} />
+    </div>
+  );
+};

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -40,6 +40,14 @@ export { EmbeddableForm } from './EmbeddableForm';
 export type { EmbeddableFormProps, EmbeddableFormConfig, EmbeddableFormTexts } from './EmbeddableForm';
 export { FormAnalytics } from './FormAnalytics';
 export type { FormAnalyticsProps, FormSubmissionMetric } from './FormAnalytics';
+export { MasterDetailForm } from './MasterDetailForm';
+export type {
+  MasterDetailFormProps,
+  MasterDetailFormSchema,
+  MasterDetailDetailConfig,
+} from './MasterDetailForm';
+export { LineItemsPanel } from './LineItemsPanel';
+export type { LineItemsPanelSchema } from './LineItemsPanel';
 
 // Register object-form component
 const ObjectFormRenderer: React.FC<{ schema: any }> = ({ schema }) => {
@@ -140,4 +148,48 @@ ComponentRegistry.register('form-analytics', FormAnalyticsRenderer, {
     { name: 'formTitle', type: 'string', label: 'Form Title' },
     { name: 'metrics', type: 'object', label: 'Submission Metrics' },
   ]
+});
+
+// Register master-detail composite form (parent + child line items, entered
+// together — see ADR-0001).
+import { MasterDetailForm } from './MasterDetailForm';
+
+const MasterDetailFormRenderer: React.FC<{ schema: any }> = ({ schema }) => {
+  const ctx = useContext(SchemaRendererContext as React.Context<any>);
+  const dataSource = ctx?.dataSource ?? undefined;
+  return <MasterDetailForm schema={schema} dataSource={dataSource} />;
+};
+
+ComponentRegistry.register('object-master-detail-form', MasterDetailFormRenderer, {
+  namespace: 'plugin-form',
+  label: 'Master-Detail Form',
+  category: 'plugin',
+  inputs: [
+    { name: 'objectName', type: 'string', label: 'Parent Object', required: true },
+    { name: 'mode', type: 'enum', label: 'Mode', enum: ['create', 'edit'] },
+    { name: 'sections', type: 'array', label: 'Parent Sections' },
+    { name: 'details', type: 'array', label: 'Detail Collections', required: true },
+  ],
+});
+
+// Register record:line_items — child grid bound to an existing parent record,
+// usable on a record/detail page or slotted slot.
+import { LineItemsPanel } from './LineItemsPanel';
+
+const LineItemsPanelRenderer: React.FC<{ schema: any }> = ({ schema }) => (
+  <LineItemsPanel schema={schema} />
+);
+
+ComponentRegistry.register('line_items', LineItemsPanelRenderer, {
+  namespace: 'record',
+  skipFallback: true,
+  label: 'Line Items',
+  category: 'record',
+  inputs: [
+    { name: 'childObject', type: 'string', label: 'Child Object', required: true },
+    { name: 'relationshipField', type: 'string', label: 'Relationship Field', required: true },
+    { name: 'columns', type: 'array', label: 'Columns', required: true },
+    { name: 'totalField', type: 'string', label: 'Parent Total Field' },
+    { name: 'amountField', type: 'string', label: 'Amount Column' },
+  ],
 });

--- a/packages/plugin-form/src/masterDetailTx.test.ts
+++ b/packages/plugin-form/src/masterDetailTx.test.ts
@@ -62,6 +62,28 @@ describe('applyDetail — client-orchestrated child write', () => {
     ]);
   });
 
+  it('tolerates a bulk() that returns {records:[...]} instead of an array', async () => {
+    // Mirrors the real ObjectStack adapter, whose createMany can resolve to a
+    // wrapped shape rather than a bare array (regression: "newRecords is not iterable").
+    const ds = mockDataSource({
+      bulk: vi.fn(async (_o: string, _op: string, rows: any[]) => ({
+        records: rows.map((r, i) => ({ id: 'w' + i, ...r })),
+      })),
+    });
+    const res = await applyDetail(ds, 'expense_claim', 'claim_1', {
+      childObject: 'expense_line',
+      relationshipField: 'expense_claim',
+      rows: [{ amount: 10 }, { amount: 5 }],
+      amountField: 'amount',
+      totalField: 'total_amount',
+    });
+    expect(res.created).toEqual([
+      { object: 'expense_line', id: 'w0' },
+      { object: 'expense_line', id: 'w1' },
+    ]);
+    expect(ds.update).toHaveBeenCalledWith('expense_claim', 'claim_1', { total_amount: 15 });
+  });
+
   it('create mode without bulk falls back to per-row create', async () => {
     const ds = mockDataSource({ bulk: undefined });
     await applyDetail(ds, 'po', 'po_1', {

--- a/packages/plugin-form/src/masterDetailTx.test.ts
+++ b/packages/plugin-form/src/masterDetailTx.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { diffRows, sumRows, applyDetail, idOf } from './masterDetailTx';
+
+describe('masterDetailTx — pure helpers', () => {
+  it('idOf reads id / _id / recordId', () => {
+    expect(idOf({ id: 'a' })).toBe('a');
+    expect(idOf({ _id: 'b' })).toBe('b');
+    expect(idOf({ recordId: 'c' })).toBe('c');
+    expect(idOf({})).toBeUndefined();
+    expect(idOf(null)).toBeUndefined();
+  });
+
+  it('sumRows sums a numeric column, ignoring blanks/NaN', () => {
+    expect(sumRows([{ amount: 10 }, { amount: 20.5 }, { amount: null }, { amount: 'x' }], 'amount')).toBe(30.5);
+    expect(sumRows([], 'amount')).toBe(0);
+    expect(sumRows(undefined as any, 'amount')).toBe(0);
+  });
+
+  it('diffRows classifies create / update / delete', () => {
+    const original = [{ id: 'l1', amount: 10 }, { id: 'l2', amount: 20 }];
+    const current = [{ id: 'l1', amount: 15 }, { amount: 30 }]; // l2 removed, one new
+    const d = diffRows(original, current);
+    expect(d.toUpdate).toEqual([{ id: 'l1', amount: 15 }]);
+    expect(d.toCreate).toEqual([{ amount: 30 }]);
+    expect(d.toDelete).toEqual(['l2']);
+  });
+});
+
+function mockDataSource(overrides: any = {}) {
+  return {
+    create: vi.fn(async (_obj: string, data: any) => ({ id: 'new-' + Math.random().toString(36).slice(2, 7), ...data })),
+    update: vi.fn(async (_obj: string, id: string, data: any) => ({ id, ...data })),
+    delete: vi.fn(async () => true),
+    bulk: vi.fn(async (_obj: string, _op: string, rows: any[]) => rows.map((r, i) => ({ id: 'b' + i, ...r }))),
+    ...overrides,
+  } as any;
+}
+
+describe('applyDetail — client-orchestrated child write', () => {
+  it('create mode: sets FK, bulk-creates children, rolls up the total', async () => {
+    const ds = mockDataSource();
+    const res = await applyDetail(ds, 'expense_claim', 'claim_1', {
+      childObject: 'expense_line',
+      relationshipField: 'expense_claim',
+      rows: [{ amount: 10 }, { amount: 32.5 }],
+      amountField: 'amount',
+      totalField: 'total_amount',
+    });
+
+    // FK injected on every row, single bulk call
+    expect(ds.bulk).toHaveBeenCalledTimes(1);
+    expect(ds.bulk).toHaveBeenCalledWith('expense_line', 'create', [
+      { amount: 10, expense_claim: 'claim_1' },
+      { amount: 32.5, expense_claim: 'claim_1' },
+    ]);
+    // rollup written onto the parent
+    expect(ds.update).toHaveBeenCalledWith('expense_claim', 'claim_1', { total_amount: 42.5 });
+    // created ids surfaced for cleanup
+    expect(res.created).toEqual([
+      { object: 'expense_line', id: 'b0' },
+      { object: 'expense_line', id: 'b1' },
+    ]);
+  });
+
+  it('create mode without bulk falls back to per-row create', async () => {
+    const ds = mockDataSource({ bulk: undefined });
+    await applyDetail(ds, 'po', 'po_1', {
+      childObject: 'po_line',
+      relationshipField: 'po',
+      rows: [{ qty: 1 }, { qty: 2 }],
+    });
+    expect(ds.create).toHaveBeenCalledTimes(2);
+    expect(ds.create).toHaveBeenCalledWith('po_line', { qty: 1, po: 'po_1' });
+    expect(ds.create).toHaveBeenCalledWith('po_line', { qty: 2, po: 'po_1' });
+  });
+
+  it('edit mode: creates new, updates changed, deletes removed', async () => {
+    const ds = mockDataSource();
+    await applyDetail(ds, 'expense_claim', 'claim_1', {
+      childObject: 'expense_line',
+      relationshipField: 'expense_claim',
+      original: [{ id: 'l1', amount: 10 }, { id: 'l2', amount: 20 }],
+      rows: [{ id: 'l1', amount: 15 }, { amount: 30 }], // edit l1, drop l2, add one
+      amountField: 'amount',
+      totalField: 'total_amount',
+    });
+
+    // new row created (with FK)
+    expect(ds.bulk).toHaveBeenCalledWith('expense_line', 'create', [{ amount: 30, expense_claim: 'claim_1' }]);
+    // changed row updated (with FK)
+    expect(ds.update).toHaveBeenCalledWith('expense_line', 'l1', { id: 'l1', amount: 15, expense_claim: 'claim_1' });
+    // removed row deleted
+    expect(ds.delete).toHaveBeenCalledWith('expense_line', 'l2');
+    // rollup reflects the current rows (15 + 30 = 45)
+    expect(ds.update).toHaveBeenCalledWith('expense_claim', 'claim_1', { total_amount: 45 });
+  });
+
+  it('skips rollup when no totalField is configured', async () => {
+    const ds = mockDataSource();
+    await applyDetail(ds, 'expense_claim', 'claim_1', {
+      childObject: 'expense_line',
+      relationshipField: 'expense_claim',
+      rows: [{ amount: 10 }],
+    });
+    // only the bulk create — no parent update
+    expect(ds.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-form/src/masterDetailTx.ts
+++ b/packages/plugin-form/src/masterDetailTx.ts
@@ -52,6 +52,20 @@ export function sumRows(rows: Record<string, any>[], field: string): number {
   }, 0);
 }
 
+/**
+ * Normalize whatever a create/bulk call resolves to into an array of records.
+ * Adapters vary: some return `T[]`, others `{ records: [...] }` / `{ data: [...] }`
+ * or a single record. We only use the result to collect ids for cleanup, so a
+ * best-effort coercion keeps the happy path from throwing on an odd shape.
+ */
+function toRecordArray(res: any): any[] {
+  if (Array.isArray(res)) return res;
+  if (res && Array.isArray(res.records)) return res.records;
+  if (res && Array.isArray(res.data)) return res.data;
+  if (res && (res.id || res._id)) return [res];
+  return [];
+}
+
 /** Create child rows, preferring a single bulk call when the adapter has one. */
 async function createMany(
   dataSource: DataSource,
@@ -60,9 +74,10 @@ async function createMany(
 ): Promise<any[]> {
   if (rows.length === 0) return [];
   if (typeof dataSource.bulk === 'function') {
-    return await dataSource.bulk(childObject, 'create', rows);
+    return toRecordArray(await dataSource.bulk(childObject, 'create', rows));
   }
-  return await Promise.all(rows.map((r) => dataSource.create(childObject, r)));
+  const created = await Promise.all(rows.map((r) => dataSource.create(childObject, r)));
+  return toRecordArray(created);
 }
 
 export interface ApplyDetailOptions {

--- a/packages/plugin-form/src/masterDetailTx.ts
+++ b/packages/plugin-form/src/masterDetailTx.ts
@@ -1,0 +1,123 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pure helpers for the master-detail (parent + line items) client-orchestrated
+ * write. Kept free of React so the transaction logic is unit-testable in
+ * isolation (see ADR-0001). Both <MasterDetailForm> and <LineItemsPanel>
+ * delegate their child persistence here.
+ */
+
+import type { DataSource } from '@object-ui/types';
+
+export const idOf = (rec: any): string | undefined =>
+  rec == null ? undefined : (rec.id ?? rec._id ?? rec.recordId);
+
+export interface RowDiff {
+  toCreate: Record<string, any>[];
+  toUpdate: Record<string, any>[];
+  toDelete: string[];
+}
+
+/**
+ * Diff the current rows against a loaded snapshot. Rows without an id are
+ * creates; rows with an id are updates; snapshot ids no longer present are
+ * deletes.
+ */
+export function diffRows(
+  original: Record<string, any>[],
+  current: Record<string, any>[],
+): RowDiff {
+  const currentIds = new Set(current.map(idOf).filter(Boolean) as string[]);
+  return {
+    toCreate: current.filter((r) => !idOf(r)),
+    toUpdate: current.filter((r) => idOf(r)),
+    toDelete: (original || [])
+      .map(idOf)
+      .filter((id): id is string => !!id && !currentIds.has(id)),
+  };
+}
+
+/** Sum a numeric column across rows (blanks/NaN ignored). */
+export function sumRows(rows: Record<string, any>[], field: string): number {
+  if (!Array.isArray(rows)) return 0;
+  return rows.reduce((acc, r) => {
+    const v = Number(r?.[field]);
+    return acc + (Number.isFinite(v) ? v : 0);
+  }, 0);
+}
+
+/** Create child rows, preferring a single bulk call when the adapter has one. */
+async function createMany(
+  dataSource: DataSource,
+  childObject: string,
+  rows: Record<string, any>[],
+): Promise<any[]> {
+  if (rows.length === 0) return [];
+  if (typeof dataSource.bulk === 'function') {
+    return await dataSource.bulk(childObject, 'create', rows);
+  }
+  return await Promise.all(rows.map((r) => dataSource.create(childObject, r)));
+}
+
+export interface ApplyDetailOptions {
+  childObject: string;
+  relationshipField: string;
+  rows: Record<string, any>[];
+  /** Loaded snapshot — when present we diff (edit mode); otherwise create-all. */
+  original?: Record<string, any>[];
+  /** Numeric child column to sum. */
+  amountField?: string;
+  /** Parent field to receive the rolled-up sum. */
+  totalField?: string;
+}
+
+export interface ApplyDetailResult {
+  /** Child object + id pairs created in this call (for cleanup on failure). */
+  created: Array<{ object: string; id: string }>;
+}
+
+/**
+ * Persist one child collection for a known parent id. Sets the relationship FK
+ * on every row, then creates / updates / deletes, then (optionally) rolls the
+ * line total up onto the parent. Hooks can't do nested writes, so the rollup
+ * happens here on the client.
+ */
+export async function applyDetail(
+  dataSource: DataSource,
+  parentObject: string,
+  parentId: string,
+  opts: ApplyDetailOptions,
+): Promise<ApplyDetailResult> {
+  const created: Array<{ object: string; id: string }> = [];
+  const withFk = opts.rows.map((r) => ({ ...r, [opts.relationshipField]: parentId }));
+
+  if (opts.original !== undefined) {
+    const { toCreate, toUpdate, toDelete } = diffRows(opts.original, withFk);
+    const newRecords = await createMany(dataSource, opts.childObject, toCreate);
+    for (const rec of newRecords) {
+      const id = idOf(rec);
+      if (id) created.push({ object: opts.childObject, id });
+    }
+    await Promise.all(toUpdate.map((r) => dataSource.update(opts.childObject, idOf(r)!, r)));
+    await Promise.all(toDelete.map((id) => dataSource.delete(opts.childObject, id)));
+  } else {
+    const newRecords = await createMany(dataSource, opts.childObject, withFk);
+    for (const rec of newRecords) {
+      const id = idOf(rec);
+      if (id) created.push({ object: opts.childObject, id });
+    }
+  }
+
+  if (opts.totalField) {
+    const total = sumRows(opts.rows, opts.amountField || 'amount');
+    await dataSource.update(parentObject, parentId, { [opts.totalField]: total });
+  }
+
+  return { created };
+}


### PR DESCRIPTION
## Summary
Turns ObjectUI into a true SDUI runtime for two common enterprise needs, plus the dev harnesses that verified them.

### Master-detail subform (parent + line items) — ADR-0001
- `LineItemsField` (editable child grid): add/delete rows, per-cell widgets (text/number/currency/date/select), line-number column, right-aligned numerics, running total.
- `MasterDetailForm` (`object-master-detail-form`): enter a parent + its line items together; client-orchestrated transaction (create parent → set FK → bulk-create children → roll up total → best-effort cleanup). **Enterprise-convention layout**: header on top → line grid → single Save bar at the bottom (Salesforce/SAP/NetSuite/Odoo style).
- `LineItemsPanel` (`record:line_items`): child grid bound to an existing parent for detail/view + inline edit.
- `masterDetailTx`: pure, tested orchestration helpers (diff/sum/applyDetail; tolerant of varied adapter `bulk()` shapes).

### Lightweight list primitives (SDUI opt #1 — simple data shouldn't need a full data-grid)
- `element:definition-list` (compact key/value), `element:repeater` (chrome-free data-bound list).

## Verification
- Unit tests: 74 passing across plugin-form/fields/components.
- Browser-verified end-to-end against the app-showcase backend: created a Project + Tasks together via the showcase "New Project + Tasks" page (children persisted with the `master_detail` FK); lightweight lists rendered against live `showcase_category`.

## Notes
- Dev-only routes `/dev/master-detail` and `/dev/lists` are included for verification (removable).
- Pairs with framework PR (objectql cascade-delete + autonumber fixes) — required for full master-detail lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)