### PR TITLE
feat(fields): lookup cells in line-item grids

### DIFF
--- a/.changeset/line-items-lookup-cells.md
+++ b/.changeset/line-items-lookup-cells.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/fields": minor
+---
+
+Lookup cells in line-item grids. `LineItemsField` columns now support `type: 'lookup'` (with `reference` / `displayField` / `idField`), rendering a real lookup picker per cell that resolves display labels and stores the foreign-key id — so master-detail line grids can reference other objects (category, account, assignee, …) instead of only plain selects.

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -18,6 +18,7 @@ import { AuthProvider, AuthGuard, useAuth } from '@object-ui/auth';
 import { DevMasterDetail } from './dev/DevMasterDetail';
 import { DevLists } from './dev/DevLists';
 import { DevModal } from './dev/DevModal';
+import { DevLookup } from './dev/DevLookup';
 import {
   ConsoleShell,
   ConnectedShell,
@@ -198,6 +199,12 @@ export function App() {
             <Route path="/dev/modal" element={
               <ProtectedRoute>
                 <DevModal />
+              </ProtectedRoute>
+            } />
+            {/* Dev-only: line-item grid with a lookup cell. */}
+            <Route path="/dev/lookup" element={
+              <ProtectedRoute>
+                <DevLookup />
               </ProtectedRoute>
             } />
             <Route path="/organizations" element={

--- a/apps/console/src/dev/DevLookup.tsx
+++ b/apps/console/src/dev/DevLookup.tsx
@@ -1,0 +1,33 @@
+/**
+ * Dev-only harness for lookup cells in line-item grids (SDUI follow-up):
+ * a LineItemsField whose first column is a real lookup picker bound to live
+ * showcase_account. Not part of the product nav.
+ */
+import React from 'react';
+import { LineItemsField } from '@object-ui/fields';
+
+export const DevLookup: React.FC = () => {
+  const [rows, setRows] = React.useState<Record<string, any>[]>([{}, {}]);
+  const field = {
+    columns: [
+      { field: 'account', label: 'Account', type: 'lookup', reference: 'showcase_account', displayField: 'name' },
+      { field: 'note', label: 'Note', type: 'text' },
+      { field: 'amount', label: 'Amount', type: 'currency' },
+    ],
+    total_field: 'amount',
+  } as any;
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-6">
+      <h1 className="text-lg font-semibold">Dev · Line-item grid with a lookup cell</h1>
+      <p className="text-sm text-muted-foreground">
+        The <code>Account</code> column is a real lookup picker bound to live <code>showcase_account</code>.
+      </p>
+      <LineItemsField value={rows} onChange={setRows} field={field} />
+      <pre className="rounded bg-muted p-3 text-xs" data-testid="rows-json">
+        {JSON.stringify(rows)}
+      </pre>
+    </div>
+  );
+};
+
+export default DevLookup;

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@object-ui/components';
 import { Plus, Trash2 } from 'lucide-react';
+import { LookupField } from './LookupField';
 
 /**
  * GridField / LineItemsField — editable child-grid ("line items") widget.
@@ -32,12 +33,17 @@ import { Plus, Trash2 } from 'lucide-react';
 export interface GridColumn {
   field: string;
   label?: string;
-  type?: 'text' | 'number' | 'currency' | 'date' | 'select';
+  type?: 'text' | 'number' | 'currency' | 'date' | 'select' | 'lookup';
   options?: Array<{ label: string; value: string }>;
   width?: number;
   required?: boolean;
   prefix?: string;
   step?: number;
+  /** For `type: 'lookup'` — the referenced object and label/id fields. */
+  reference?: string;
+  displayField?: string;
+  idField?: string;
+  multiple?: boolean;
 }
 
 type Row = Record<string, any>;
@@ -89,14 +95,19 @@ export function GridField({
     [onChange],
   );
 
-  const setCell = useCallback(
-    (rowIdx: number, col: GridColumn, raw: string) => {
-      const next = rows.map((r, i) =>
-        i === rowIdx ? { ...r, [col.field]: coerce(col.type, raw) } : r,
-      );
-      emit(next);
+  /** Set a cell to an already-typed value (lookup ids, etc.) without coercion. */
+  const setCellValue = useCallback(
+    (rowIdx: number, field: string, value: any) => {
+      emit(rows.map((r, i) => (i === rowIdx ? { ...r, [field]: value } : r)));
     },
     [rows, emit],
+  );
+
+  const setCell = useCallback(
+    (rowIdx: number, col: GridColumn, raw: string) => {
+      setCellValue(rowIdx, col.field, coerce(col.type, raw));
+    },
+    [setCellValue],
   );
 
   const addRow = useCallback(() => {
@@ -164,9 +175,18 @@ export function GridField({
                       key={c.field}
                       className={cn('px-3 py-2 text-foreground', isNumeric(c.type) && 'text-right tabular-nums')}
                     >
-                      {row[c.field] != null && row[c.field] !== ''
-                        ? String(row[c.field])
-                        : '—'}
+                      {c.type === 'lookup' && row[c.field] != null && row[c.field] !== '' ? (
+                        <LookupField
+                          value={row[c.field]}
+                          onChange={() => {}}
+                          readonly
+                          field={{ reference: c.reference, display_field: c.displayField, id_field: c.idField } as any}
+                        />
+                      ) : row[c.field] != null && row[c.field] !== '' ? (
+                        String(row[c.field])
+                      ) : (
+                        '—'
+                      )}
                     </td>
                   ))}
                 </tr>
@@ -239,7 +259,23 @@ export function GridField({
                   )}
                   {columns.map((c) => (
                     <td key={c.field} className="px-2 py-1.5 align-top">
-                      {c.type === 'select' ? (
+                      {c.type === 'lookup' ? (
+                        <LookupField
+                          value={row[c.field]}
+                          onChange={(v: any) => setCellValue(rowIdx, c.field, v)}
+                          field={
+                            {
+                              reference: c.reference,
+                              display_field: c.displayField,
+                              id_field: c.idField,
+                              multiple: c.multiple,
+                              options: c.options,
+                              placeholder: '—',
+                            } as any
+                          }
+                          disabled={disabled}
+                        />
+                      ) : c.type === 'select' ? (
                         <Select
                           value={row[c.field] != null ? String(row[c.field]) : ''}
                           onValueChange={(v) => setCell(rowIdx, c, v)}


### PR DESCRIPTION
Line-item grids (`LineItemsField`) now support `type: 'lookup'` columns: each cell renders the existing `LookupField` picker (search + record picker), resolves the display label, and stores the foreign-key id. Read-only mode shows the resolved label. So master-detail line grids can reference other objects (category, account, assignee…) instead of plain selects.

Verified end-to-end at `/dev/lookup` against live `showcase_account` (picked Contoso → row stores the account id, cell shows the label). Unit tests unchanged (8 pass, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)