### PR TITLE
feat(studio): schema-driven object/field pickers in block inspector

### DIFF
--- a/.changeset/block-config-pickers.md
+++ b/.changeset/block-config-pickers.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": minor
+---
+
+Schema-driven object/field pickers in the page-editor block inspector. Data-reference block properties are now dropdowns populated from the live metadata instead of free-text: an object picker (e.g. `record:related_list` object, `element:number` object) and cascading field pickers that list the chosen object's actual fields (e.g. `record:related_list` relationship field, `element:number` field, `record:path` status field, `record:highlights`/`record:details` field lists). Resolves the object from the record page's bound object or a sibling block property; degrades gracefully to a text input when the metadata can't be fetched.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
@@ -27,8 +27,88 @@ import {
   moveArray,
 } from './_shared';
 import { BLOCK_CONFIG, blockHasConfig, type BlockPropField } from '../previews/block-config';
-import { Button, Input, Label } from '@object-ui/components';
+import { useObjectOptions } from '../previews/useObjectOptions';
+import { useObjectFields } from '../previews/useObjectFields';
+import {
+  Button, Input, Label,
+  Select, SelectTrigger, SelectContent, SelectItem, SelectValue,
+} from '@object-ui/components';
 import { Plus, X, Trash2 } from 'lucide-react';
+
+// ── Schema-driven picker fields ──────────────────────────────────────────────
+
+/** Field options for an object (visible fields), as {value,label}. */
+function useFieldOptions(objectName: string | undefined): Array<{ value: string; label: string }> {
+  const { fields } = useObjectFields(objectName);
+  return React.useMemo(
+    () =>
+      fields
+        .filter((f) => !f.hidden)
+        .map((f) => ({ value: f.name, label: f.label && f.label !== f.name ? `${f.label} (${f.name})` : f.name })),
+    [fields],
+  );
+}
+
+/** Object dropdown; falls back to a free-text input when the list is empty. */
+function ObjectPickerField({ label, value, onCommit, disabled }: {
+  label: string; value: string | undefined; onCommit: (v: string) => void; disabled?: boolean;
+}) {
+  const { options } = useObjectOptions();
+  if (options.length === 0) {
+    return <InspectorTextField label={label} value={value ?? ''} placeholder="snake_case object" onCommit={onCommit} disabled={disabled} mono />;
+  }
+  return <InspectorSelectField label={label} value={value || undefined} options={options} onCommit={onCommit} disabled={disabled} />;
+}
+
+/** Field dropdown for `objectName`; falls back to free text when unresolved. */
+function FieldPickerField({ label, objectName, value, onCommit, disabled }: {
+  label: string; objectName: string | undefined; value: string | undefined; onCommit: (v: string) => void; disabled?: boolean;
+}) {
+  const options = useFieldOptions(objectName);
+  if (!objectName || options.length === 0) {
+    return <InspectorTextField label={label} value={value ?? ''} onCommit={onCommit} disabled={disabled} mono />;
+  }
+  return <InspectorSelectField label={label} value={value || undefined} options={options} onCommit={onCommit} disabled={disabled} />;
+}
+
+/** Editable list of field names — each row a field dropdown (or text fallback). */
+function FieldListField({ label, objectName, value, onChange, disabled }: {
+  label: string; objectName: string | undefined; value: unknown; onChange: (v: string[]) => void; disabled?: boolean;
+}) {
+  const options = useFieldOptions(objectName);
+  const arr: string[] = Array.isArray(value) ? (value as string[]) : [];
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      {arr.map((s, i) => (
+        <div key={i} className="flex items-center gap-1.5">
+          {options.length > 0 ? (
+            <div className="flex-1">
+              <Select value={s ? String(s) : ''} onValueChange={(v) => { const n = [...arr]; n[i] = v; onChange(n); }} disabled={disabled}>
+                <SelectTrigger className="h-8"><SelectValue placeholder="—" /></SelectTrigger>
+                <SelectContent>
+                  {options.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <Input className="h-8 text-sm" value={String(s ?? '')} placeholder="field name" disabled={disabled}
+              onChange={(e) => { const n = [...arr]; n[i] = e.target.value; onChange(n); }} />
+          )}
+          <Button type="button" variant="ghost" size="icon" className="h-8 w-8" disabled={disabled} aria-label="Remove"
+            onClick={() => onChange(arr.filter((_, j) => j !== i))}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+      {!disabled && (
+        <Button type="button" variant="outline" size="sm" onClick={() => onChange([...arr, ''])}>
+          <Plus className="mr-1 h-3.5 w-3.5" /> Add
+        </Button>
+      )}
+    </div>
+  );
+}
 
 interface Block {
   type?: string;
@@ -159,6 +239,15 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
   // `properties.*` to the top level, so we read from either and always write
   // back to `properties` (the canonical shape).
   const blockProps = (block.properties as Record<string, unknown>) || {};
+  // The record page's bound object — drives `field-picker`/`field-list` with
+  // objectFrom:'page'. (objectFrom:'self' reads a sibling block property.)
+  const pageObject = typeof (draft as any)?.object === 'string' ? ((draft as any).object as string) : undefined;
+  const resolveObject = (src: BlockPropField & { objectFrom?: string; objectProp?: string }): string | undefined =>
+    src.objectFrom === 'page'
+      ? pageObject
+      : src.objectProp != null && blockProps[src.objectProp] != null
+        ? String(blockProps[src.objectProp])
+        : undefined;
   const readProp = (name: string): unknown => blockProps[name] ?? (block as any)[name];
   const patchProp = (name: string, value: unknown) =>
     patch({ properties: { ...blockProps, [name]: value } } as Partial<Block>);
@@ -249,11 +338,28 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
           </div>
         );
       }
+      case 'object-picker':
+        return (
+          <ObjectPickerField key={k} label={f.label}
+            value={read(f.name) != null ? String(read(f.name)) : undefined}
+            onCommit={(v) => write(f.name, v)} disabled={readOnly} />
+        );
+      case 'field-picker':
+        return (
+          <FieldPickerField key={k} label={f.label} objectName={resolveObject(f)}
+            value={read(f.name) != null ? String(read(f.name)) : undefined}
+            onCommit={(v) => write(f.name, v)} disabled={readOnly} />
+        );
+      case 'field-list':
+        return (
+          <FieldListField key={k} label={f.label} objectName={resolveObject(f)}
+            value={read(f.name)} onChange={(v) => write(f.name, v)} disabled={readOnly} />
+        );
       default:
         return (
           <InspectorTextField key={k} label={f.label}
             value={read(f.name) != null ? String(read(f.name)) : ''}
-            placeholder={f.placeholder} onCommit={(v) => write(f.name, v)} disabled={readOnly} />
+            placeholder={(f as any).placeholder} onCommit={(v) => write(f.name, v)} disabled={readOnly} />
         );
     }
   };

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -36,7 +36,10 @@ describe('block-config', () => {
   });
 
   it('every field (incl. nested array items) has a name, label and valid kind', () => {
-    const kinds = new Set(['text', 'number', 'boolean', 'select', 'string-list', 'array']);
+    const kinds = new Set([
+      'text', 'number', 'boolean', 'select', 'string-list', 'array',
+      'object-picker', 'field-picker', 'field-list',
+    ]);
     const check = (f: any, path: string) => {
       expect(f.name, `${path}.name`).toBeTruthy();
       expect(f.label, `${path}.label`).toBeTruthy();

--- a/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
@@ -14,13 +14,22 @@
  *   array (+ itemFields)              — an array of objects (e.g. tab items)
  */
 
+/** Where a field/field-list picker resolves its object from:
+ *  - 'page' — the record page's bound object (draft.object)
+ *  - 'self' — a sibling property on the same block (objectProp) */
+export type ObjectSource = { objectFrom: 'page' } | { objectFrom: 'self'; objectProp: string };
+
 export type BlockPropField =
   | { name: string; label: string; kind: 'text'; placeholder?: string }
   | { name: string; label: string; kind: 'number'; placeholder?: string }
   | { name: string; label: string; kind: 'boolean' }
   | { name: string; label: string; kind: 'select'; options: Array<{ value: string; label: string }> }
   | { name: string; label: string; kind: 'string-list'; placeholder?: string }
-  | { name: string; label: string; kind: 'array'; itemFields: BlockPropField[]; addLabel?: string };
+  | { name: string; label: string; kind: 'array'; itemFields: BlockPropField[]; addLabel?: string }
+  // Schema-driven pickers — dropdowns populated from the live metadata.
+  | { name: string; label: string; kind: 'object-picker'; placeholder?: string }
+  | ({ name: string; label: string; kind: 'field-picker'; placeholder?: string } & ObjectSource)
+  | ({ name: string; label: string; kind: 'field-list'; placeholder?: string } & ObjectSource);
 
 const ALIGN_OPTS = [
   { value: 'left', label: 'Left' },
@@ -60,8 +69,8 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
     },
   ],
   'element:number': [
-    { name: 'object', label: 'Object', kind: 'text', placeholder: 'snake_case object' },
-    { name: 'field', label: 'Field', kind: 'text' },
+    { name: 'object', label: 'Object', kind: 'object-picker' },
+    { name: 'field', label: 'Field', kind: 'field-picker', objectFrom: 'self', objectProp: 'object' },
     {
       name: 'aggregate',
       label: 'Aggregate',
@@ -153,13 +162,13 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
 
   // ── Record context ────────────────────────────────────────────────────────
   'record:related_list': [
-    { name: 'objectName', label: 'Object', kind: 'text', placeholder: 'snake_case object' },
-    { name: 'relationshipField', label: 'Relationship field', kind: 'text' },
+    { name: 'objectName', label: 'Object', kind: 'object-picker' },
+    { name: 'relationshipField', label: 'Relationship field', kind: 'field-picker', objectFrom: 'self', objectProp: 'objectName' },
     { name: 'title', label: 'Title', kind: 'text' },
     { name: 'limit', label: 'Limit', kind: 'number', placeholder: '10' },
   ],
   'record:highlights': [
-    { name: 'fields', label: 'Fields', kind: 'string-list', placeholder: 'field name' },
+    { name: 'fields', label: 'Fields', kind: 'field-list', objectFrom: 'page' },
   ],
   'record:details': [
     {
@@ -170,7 +179,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
       itemFields: [
         { name: 'label', label: 'Label', kind: 'text' },
         { name: 'columns', label: 'Columns', kind: 'number', placeholder: '2' },
-        { name: 'fields', label: 'Fields', kind: 'string-list', placeholder: 'field name' },
+        { name: 'fields', label: 'Fields', kind: 'field-list', objectFrom: 'page' },
       ],
     },
   ],
@@ -192,7 +201,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
     { name: 'dismissible', label: 'Dismissible', kind: 'boolean' },
   ],
   'record:path': [
-    { name: 'statusField', label: 'Status field', kind: 'text', placeholder: 'e.g. stage' },
+    { name: 'statusField', label: 'Status field', kind: 'field-picker', objectFrom: 'page' },
     {
       name: 'stages',
       label: 'Stages',

--- a/packages/app-shell/src/views/metadata-admin/previews/useObjectOptions.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/useObjectOptions.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * useObjectOptions — the list of objects (name + label) for object pickers in
+ * the page-editor block inspector. Async; degrades to an empty list (the
+ * picker then falls back to a free-text input).
+ */
+import * as React from 'react';
+import { useMetadataClient } from '../useMetadata';
+
+export interface ObjectOption {
+  value: string;
+  label: string;
+}
+
+export function useObjectOptions(): { options: ObjectOption[]; loading: boolean } {
+  const client = useMetadataClient();
+  const [options, setOptions] = React.useState<ObjectOption[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    client
+      .list<{ name?: string; label?: string }>('object')
+      .then((items) => {
+        if (cancelled) return;
+        const mapped = (items ?? [])
+          .map((raw) => (raw && typeof raw === 'object' && 'item' in raw ? (raw as any).item : raw))
+          .filter((i: any) => typeof i?.name === 'string' && i.name)
+          .map((i: any) => ({
+            value: i.name as string,
+            label: i.label ? `${i.label} (${i.name})` : (i.name as string),
+          }))
+          .sort((a: ObjectOption, b: ObjectOption) => a.value.localeCompare(b.value));
+        setOptions(mapped);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setOptions([]);
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  return { options, loading };
+}


### PR DESCRIPTION
Turns data-reference block properties in the page editor into dropdowns populated from the live metadata (the hallmark of low-code), instead of free-text strings.

- object-picker: record:related_list object, element:number object.
- field-picker (cascading): lists the chosen object's real fields — record:related_list relationship field, element:number field, record:path status field. Resolves the object from the page's bound object (objectFrom:'page') or a sibling block prop (objectFrom:'self').
- field-list: a list of field dropdowns (record:highlights fields, record:details section fields).
- Graceful fallback to a free-text input when metadata can't be fetched.

Reuses the existing useObjectFields hook + a new useObjectOptions hook (client.list('object')).

Browser-verified: Object dropdown listed 84 objects; picking showcase_task populated Relationship field with its real fields (title/project/assignee/status/…) with localized labels. 140 metadata-admin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)