### PR TITLE
feat(studio): edit slotted record pages in the page editor (closes #1495)

### DIFF
--- a/.changeset/page-editor-slotted.md
+++ b/.changeset/page-editor-slotted.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": minor
+---
+
+The Studio page editor can now edit slotted record pages. A `kind:'slotted'` page surfaces its 7 canonical slots (header / actions / alerts / highlights / details / tabs / discussion) as editable regions — overridden slots show their blocks (selectable + configurable via the inspector and its object/field pickers), and unoverridden slots show an "inherited — add a block to override" placeholder. Edits write back to `slots`; empty slots are omitted so they keep inheriting the synthesized default. This closes the loop for the most common low-code task — customizing a business object's detail page (highlights/tabs/details) point-and-click instead of by hand-editing JSON.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
@@ -221,11 +221,28 @@ function writeSiblings(root: Record<string, unknown>, hops: Hop[], nextSiblings:
 }
 
 export function PageBlockInspector({ selection, draft, onPatch, onClearSelection, onSelectionChange, locale, readOnly }: MetadataInspectorProps) {
-  const hops = parsePath(selection.id);
-  const block = hops ? readAt(draft, hops) : null;
-  const sibInfo = hops ? readSiblings(draft, hops) : null;
+  // Slotted record page: selection ids are `slot:<name>:<index>` and address
+  // `draft.slots.<name>` (a single component is normalised to a 1-element array).
+  const slotMatch = /^slot:([a-zA-Z_]+):(\d+)$/.exec(selection.id);
+  const hops = slotMatch ? null : parsePath(selection.id);
 
-  if (!hops || !block) {
+  const slotName = slotMatch ? slotMatch[1] : '';
+  const slotIdx = slotMatch ? Number(slotMatch[2]) : -1;
+  const slotsObj: Record<string, any> =
+    (draft as any).slots && typeof (draft as any).slots === 'object' ? ((draft as any).slots as Record<string, any>) : {};
+  const slotArr: Block[] = slotMatch
+    ? Array.isArray(slotsObj[slotName])
+      ? (slotsObj[slotName] as Block[])
+      : slotsObj[slotName] != null
+        ? [slotsObj[slotName] as Block]
+        : []
+    : [];
+  const writeSlot = (nextArr: Block[]) => onPatch({ slots: { ...slotsObj, [slotName]: nextArr } });
+
+  const block: Block | null = slotMatch ? (slotArr[slotIdx] ?? null) : hops ? readAt(draft, hops) : null;
+  const sibInfo = slotMatch ? { siblings: slotArr, index: slotIdx } : hops ? readSiblings(draft, hops) : null;
+
+  if ((!slotMatch && !hops) || !block) {
     return (
       <InspectorShell kindLabel={t('engine.inspector.pageBlock.kind', locale)} title={selection.label ?? selection.id} onClose={onClearSelection} closeLabel={t('engine.inspector.pageBlock.close', locale)}>
         <InspectorEmptyState message={selection.id} />
@@ -233,7 +250,10 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
     );
   }
 
-  const patch = (updates: Partial<Block>) => onPatch(writeAt(draft, hops, { ...block, ...updates }));
+  const patch = (updates: Partial<Block>) =>
+    slotMatch
+      ? writeSlot(slotArr.map((b, i) => (i === slotIdx ? { ...block, ...updates } : b)))
+      : onPatch(writeAt(draft, hops!, { ...block, ...updates }));
 
   // Per-block configurable properties (spec `properties`). The renderer hoists
   // `properties.*` to the top level, so we read from either and always write
@@ -363,13 +383,22 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
         );
     }
   };
-  const remove = () => { onPatch(writeAt(draft, hops, null)); onClearSelection(); };
+  const remove = () => {
+    if (slotMatch) writeSlot(slotArr.filter((_, i) => i !== slotIdx));
+    else onPatch(writeAt(draft, hops!, null));
+    onClearSelection();
+  };
   const move = (to: number) => {
     if (!sibInfo) return;
+    if (slotMatch) {
+      writeSlot(moveArray(slotArr, slotIdx, to));
+      onSelectionChange?.({ kind: 'block', id: `slot:${slotName}:${to}`, label: String(block.id || block.type || to) });
+      return;
+    }
     const next = moveArray(sibInfo.siblings, sibInfo.index, to);
-    onPatch(writeSiblings(draft, hops, next));
-    const prefix = hops.slice(0, -1).map((h) => `${h.key}[${h.index}]`).join('.');
-    const lastKey = hops[hops.length - 1].key;
+    onPatch(writeSiblings(draft, hops!, next));
+    const prefix = hops!.slice(0, -1).map((h) => `${h.key}[${h.index}]`).join('.');
+    const lastKey = hops![hops!.length - 1].key;
     const newId = prefix ? `${prefix}.${lastKey}[${to}]` : `${lastKey}[${to}]`;
     onSelectionChange?.({ kind: 'block', id: newId, label: String(block.id || block.type || newId) });
   };

--- a/packages/app-shell/src/views/metadata-admin/previews/PageBlockCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PageBlockCanvas.tsx
@@ -57,9 +57,41 @@ export interface PageBlockCanvasProps {
   onSelectionChange?: (next: MetadataSelection | null) => void;
 }
 
+/** Canonical record-page slots, in render order. A `kind:'slotted'` page
+ *  overrides individual slots; unoverridden ones are filled by the synthesizer.
+ *  We surface all of them so an author can override an inherited slot too. */
+export const SLOT_ORDER = ['header', 'actions', 'alerts', 'highlights', 'details', 'tabs', 'discussion'] as const;
+
+/** slots object → one region per slot (single component normalised to array). */
+export function slotsToRegions(slots: Record<string, unknown> | undefined): Region[] {
+  const s = slots || {};
+  return SLOT_ORDER.map((name) => {
+    const v = (s as any)[name];
+    const components = Array.isArray(v) ? (v as Block[]) : v != null ? [v as Block] : [];
+    return { name, components };
+  });
+}
+
+/** regions (one per slot) → slots object; empty slots are omitted (= inherited). */
+export function regionsToSlots(regions: Region[]): Record<string, unknown> {
+  const slots: Record<string, unknown> = {};
+  for (const r of regions) {
+    const comps = Array.isArray(r.components) ? r.components : [];
+    if (comps.length === 0 || !r.name) continue; // omit empty → inherit the default
+    slots[r.name] = comps;
+  }
+  return slots;
+}
+
 function readRegions(
   draft: Record<string, unknown>,
-): { regions: Region[]; shape: 'regions' | 'children' } {
+): { regions: Region[]; shape: 'regions' | 'children' | 'slots' } {
+  // Slotted record page — edit the named slots (must win over an empty
+  // `regions: []`, which slotted pages carry).
+  const slots = (draft as any).slots;
+  if ((draft as any).kind === 'slotted' && slots && typeof slots === 'object' && !Array.isArray(slots)) {
+    return { regions: slotsToRegions(slots), shape: 'slots' };
+  }
   const raw = (draft as any).regions;
   if (Array.isArray(raw)) return { regions: raw as Region[], shape: 'regions' };
   const kids = (draft as any).children;
@@ -75,13 +107,14 @@ function readRegions(
  *  - children shape: children[j]  (flat, no nesting)
  */
 function selectionId(
-  shape: 'regions' | 'children',
+  shape: 'regions' | 'children' | 'slots',
   regionIdx: number,
   compIdx: number,
+  slotName?: string,
 ): string {
-  return shape === 'children'
-    ? `children[${compIdx}]`
-    : `regions[${regionIdx}].components[${compIdx}]`;
+  if (shape === 'children') return `children[${compIdx}]`;
+  if (shape === 'slots') return `slot:${slotName}:${compIdx}`;
+  return `regions[${regionIdx}].components[${compIdx}]`;
 }
 
 function blockLabel(b: Block): string {
@@ -111,6 +144,8 @@ export function PageBlockCanvas({
       if (shape === 'children') {
         const comps = next.flatMap((r) => (Array.isArray(r.components) ? r.components : []));
         onPatch?.({ children: comps });
+      } else if (shape === 'slots') {
+        onPatch?.({ slots: regionsToSlots(next) });
       } else {
         onPatch?.({ regions: next });
       }
@@ -153,10 +188,10 @@ export function PageBlockCanvas({
       dstComps.splice(insertAt, 0, moved);
       writeRegions(next);
       // Re-issue selection so inspector follows the move.
-      const newId = `regions[${dst.region}].components[${insertAt}]`;
+      const newId = selectionId(shape, dst.region, insertAt, next[dst.region]?.name);
       onSelectionChange?.({ kind: 'block', id: newId, label: blockLabel(moved) });
     },
-    [onPatch, onSelectionChange, regions, writeRegions],
+    [onPatch, onSelectionChange, regions, writeRegions, shape],
   );
 
   const addBlock = React.useCallback(
@@ -175,11 +210,11 @@ export function PageBlockCanvas({
       const idx = next[regionIdx].components!.length - 1;
       onSelectionChange?.({
         kind: 'block',
-        id: `regions[${regionIdx}].components[${idx}]`,
+        id: selectionId(shape, regionIdx, idx, next[regionIdx]?.name),
         label: blockLabel(newBlock),
       });
     },
-    [onPatch, onSelectionChange, regions, writeRegions],
+    [onPatch, onSelectionChange, regions, writeRegions, shape],
   );
 
   const renameLabel = React.useCallback(
@@ -248,7 +283,7 @@ export function PageBlockCanvas({
             onSelectBlock={(compIdx, blk) =>
               onSelectionChange?.({
                 kind: 'block',
-                id: `regions[${regionIdx}].components[${compIdx}]`,
+                id: selectionId(shape, regionIdx, compIdx, region.name),
                 label: blockLabel(blk),
               })
             }
@@ -285,7 +320,7 @@ function RegionSection({
 }: {
   region: Region;
   regionIdx: number;
-  shape: 'regions' | 'children';
+  shape: 'regions' | 'children' | 'slots';
   selectedId: string | null;
   readOnly: boolean;
   onSelectBlock: (compIdx: number, blk: Block) => void;
@@ -346,11 +381,13 @@ function RegionSection({
       <div className="space-y-2.5">
         {comps.length === 0 ? (
           <div className="rounded border border-dashed bg-background/50 py-6 px-4 text-center text-xs text-muted-foreground">
-            Empty region — drop a block here or use the add button below.
+            {shape === 'slots'
+              ? 'Inherited from the default page — add a block to override this slot.'
+              : 'Empty region — drop a block here or use the add button below.'}
           </div>
         ) : (
           comps.map((blk, compIdx) => {
-            const id = selectionId(shape, regionIdx, compIdx);
+            const id = selectionId(shape, regionIdx, compIdx, region.name);
             return (
               <BlockRow
                 key={`${regionIdx}:${compIdx}`}

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/slots-canvas.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/slots-canvas.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { SLOT_ORDER, slotsToRegions, regionsToSlots } from '../PageBlockCanvas';
+
+describe('slotted page ↔ canvas regions', () => {
+  it('surfaces all 7 canonical slots in order, normalising single components to arrays', () => {
+    const slots = {
+      highlights: { type: 'record:highlights' },
+      alerts: [{ type: 'record:alert' }, { type: 'record:alert' }],
+      tabs: { type: 'page:tabs' },
+    };
+    const regions = slotsToRegions(slots);
+    expect(regions.map((r) => r.name)).toEqual([...SLOT_ORDER]);
+    const byName = Object.fromEntries(regions.map((r) => [r.name, r.components]));
+    expect(byName.highlights).toEqual([{ type: 'record:highlights' }]); // single → [single]
+    expect(byName.alerts).toHaveLength(2); // array stays
+    expect(byName.tabs).toEqual([{ type: 'page:tabs' }]);
+    expect(byName.header).toEqual([]); // unoverridden slot → empty (inherited)
+    expect(byName.discussion).toEqual([]);
+  });
+
+  it('regionsToSlots omits empty slots (inherited) and keeps filled ones as arrays', () => {
+    const regions = [
+      { name: 'header', components: [] },
+      { name: 'highlights', components: [{ type: 'record:highlights' }] },
+      { name: 'details', components: [] },
+      { name: 'tabs', components: [{ type: 'page:tabs' }] },
+    ];
+    const slots = regionsToSlots(regions);
+    expect(Object.keys(slots).sort()).toEqual(['highlights', 'tabs']); // empty omitted
+    expect(slots.highlights).toEqual([{ type: 'record:highlights' }]);
+  });
+
+  it('round-trips: regionsToSlots(slotsToRegions(x)) keeps the overridden slots', () => {
+    const slots = { highlights: { type: 'record:highlights' }, tabs: { type: 'page:tabs' } };
+    const out = regionsToSlots(slotsToRegions(slots));
+    expect(Object.keys(out).sort()).toEqual(['highlights', 'tabs']);
+    expect(out.tabs).toEqual([{ type: 'page:tabs' }]);
+  });
+});


### PR DESCRIPTION
Closes #1495. Adds a 'slots' shape to PageBlockCanvas so a kind:'slotted' record page surfaces its 7 canonical slots (header/actions/alerts/highlights/details/tabs/discussion) as editable regions. Overridden slots show their blocks (configurable via the inspector + object/field pickers); inherited slots show an 'add a block to override' placeholder. Selection ids slot:<name>:<idx> handled by PageBlockInspector; edits write to draft.slots, omitting empty slots (keep inheriting the synth default).

Verified e2e on showcase_project_detail: 7 slots surfaced; record:highlights selectable; Fields picker lists showcase_project fields; account→owner edit round-trips. 3 unit tests + 143 metadata-admin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)