### PR TITLE
feat(studio): add list primitives to palette, prune dead element blocks

### DIFF
--- a/.changeset/block-config-elements.md
+++ b/.changeset/block-config-elements.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": minor
+---
+
+Align the page-editor element palette with reality. Adds the real lightweight-list primitives — `element:definition-list` (compact key/value `<dl>`) and `element:repeater` (data-bound, chrome-free list) — to the block palette with full config panels (object/field pickers for the repeater), and removes three palette entries that have no renderer (`element:form`, `element:filter`, `element:record_picker`) so the palette only offers blocks that actually render.

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -9,6 +9,7 @@ describe('block-config', () => {
       'page:header', 'page:card', 'page:tabs', 'page:accordion',
       'record:related_list', 'record:highlights', 'record:details', 'record:alert',
       'record:path', 'record:quick_actions', 'ai:chat_window', 'ai:input',
+      'element:definition-list', 'element:repeater',
     ]) {
       expect(blockHasConfig(type), type).toBe(true);
       expect(BLOCK_CONFIG[type].length).toBeGreaterThan(0);
@@ -21,12 +22,17 @@ describe('block-config', () => {
     expect(blockHasConfig(undefined)).toBe(false);
   });
 
-  it('prunes shell-singleton blocks from the page palette', () => {
-    for (const type of ['app:launcher', 'global:notifications', 'user:profile']) {
+  it('prunes shell-singleton and unimplemented blocks from the page palette', () => {
+    for (const type of [
+      'app:launcher', 'global:notifications', 'user:profile', // shell singletons
+      'element:form', 'element:filter', 'element:record_picker', // no renderer
+    ]) {
       expect((BLOCK_TYPE_META as any)[type]).toBeUndefined();
     }
-    // page-content navigation stays
+    // page-content navigation stays; the real list primitives are now in the palette
     expect((BLOCK_TYPE_META as any)['nav:menu']).toBeTruthy();
+    expect((BLOCK_TYPE_META as any)['element:definition-list']).toBeTruthy();
+    expect((BLOCK_TYPE_META as any)['element:repeater']).toBeTruthy();
   });
 
   it('also exposes the array-valued blocks', () => {

--- a/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
@@ -68,6 +68,30 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
       ],
     },
   ],
+
+  // ── Lightweight lists (compact, for simple data) ──────────────────────────
+  'element:definition-list': [
+    {
+      name: 'items',
+      label: 'Items',
+      kind: 'array',
+      addLabel: 'Add item',
+      itemFields: [
+        { name: 'label', label: 'Label', kind: 'text' },
+        { name: 'value', label: 'Value', kind: 'text' },
+      ],
+    },
+    { name: 'columns', label: 'Columns (1 or 2)', kind: 'number', placeholder: '1' },
+    { name: 'inline', label: 'Inline (label · value)', kind: 'boolean' },
+  ],
+  'element:repeater': [
+    { name: 'object', label: 'Object', kind: 'object-picker' },
+    { name: 'titleField', label: 'Title field', kind: 'field-picker', objectFrom: 'self', objectProp: 'object' },
+    { name: 'fields', label: 'Fields', kind: 'field-list', objectFrom: 'self', objectProp: 'object' },
+    { name: 'limit', label: 'Limit', kind: 'number', placeholder: '10' },
+    { name: 'emptyText', label: 'Empty text', kind: 'text' },
+    { name: 'divided', label: 'Dividers between rows', kind: 'boolean' },
+  ],
   'element:number': [
     { name: 'object', label: 'Object', kind: 'object-picker' },
     { name: 'field', label: 'Field', kind: 'field-picker', objectFrom: 'self', objectProp: 'object' },

--- a/packages/app-shell/src/views/metadata-admin/previews/block-types.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-types.ts
@@ -38,9 +38,8 @@ import {
   Image as ImageIcon,
   Minus,
   MousePointerClick,
-  Filter,
-  ClipboardList,
-  Target,
+  List,
+  Rows3,
   Box,
   type LucideIcon,
 } from 'lucide-react';
@@ -62,7 +61,7 @@ export type BlockTypeId =
   | 'ai:chat_window' | 'ai:suggestion'
   // element:*
   | 'element:text' | 'element:number' | 'element:image' | 'element:divider'
-  | 'element:button' | 'element:filter' | 'element:form' | 'element:record_picker';
+  | 'element:button' | 'element:definition-list' | 'element:repeater';
 
 export type BlockCategory = 'layout' | 'record' | 'navigation' | 'element' | 'ai' | 'misc';
 
@@ -110,9 +109,8 @@ export const BLOCK_TYPE_META: Record<BlockTypeId, Omit<BlockTypeMeta, 'id'>> = {
   'element:image':          { label: 'Image',           category: 'element', Icon: ImageIcon },
   'element:divider':        { label: 'Divider',         category: 'element', Icon: Minus },
   'element:button':         { label: 'Button',          category: 'element', Icon: MousePointerClick },
-  'element:filter':         { label: 'Filter',          category: 'element', Icon: Filter },
-  'element:form':           { label: 'Form',            category: 'element', Icon: ClipboardList },
-  'element:record_picker':  { label: 'Record picker',   category: 'element', Icon: Target },
+  'element:definition-list': { label: 'Definition list', category: 'element', Icon: List },
+  'element:repeater':       { label: 'Repeater',        category: 'element', Icon: Rows3 },
 };
 
 export const CATEGORY_LABEL_EN: Record<BlockCategory, string> = {


### PR DESCRIPTION
Aligns the page-editor element palette with what actually renders.

- Adds the real lightweight-list primitives to the palette with config: element:definition-list (items/columns/inline) and element:repeater (object/titleField/fields/limit/emptyText/divided, using the object/field pickers). These were built for the 'simple data lists are too heavy' case but weren't addable in the editor.
- Removes element:form / element:filter / element:record_picker from the palette — they have no renderer (dead entries that would render as 'unknown component').

Browser-verified: palette now lists Definition list + Repeater and no longer lists Form/Filter/Record picker; Repeater's Object prop is an object dropdown with Title field + Fields pickers. 143 metadata-admin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)