### PR TITLE
feat(studio): edit nested sub-blocks inside container blocks (closes #1499)

### DIFF
--- a/.changeset/page-editor-nested.md
+++ b/.changeset/page-editor-nested.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": minor
+---
+
+The Studio page editor can now edit nested sub-blocks inside container blocks. A `page:tabs`/`page:accordion` tab's children, and a `page:card`/`page:section`'s body, are surfaced as indented, selectable sub-blocks — each one can be selected, configured (via the inspector and its object/field pickers), edited, removed, and new ones added — in both full and slotted pages. Addressing is handled by extending the block-path scheme to support object-key hops (e.g. `…components[0].properties.items[0].children[0]`) and a nested sub-path under slot ids. Closes the last gap so a container's contents are fully point-and-click instead of raw JSON.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
@@ -23,7 +23,6 @@ import {
   InspectorCheckboxField,
   InspectorRemoveButton,
   InspectorEmptyState,
-  spliceArray,
   moveArray,
 } from './_shared';
 import { BLOCK_CONFIG, blockHasConfig, type BlockPropField } from '../previews/block-config';
@@ -119,115 +118,109 @@ interface Block {
   [k: string]: unknown;
 }
 
+/**
+ * A path hop. `index < 0` means a plain object-property access (e.g.
+ * `properties`); `index >= 0` adds an array index after the key (e.g.
+ * `items[0]`). Supporting object hops lets us address nested container
+ * children at `…components[0].properties.items[0].children[0]` (issue #1499).
+ */
 type Hop = { key: string; index: number };
 
-function parsePath(id: string): Hop[] | null {
+export type PathSeg = string | number;
+const REMOVE: unique symbol = Symbol('remove');
+
+/** A segment is `key` (object) or `key[i]` (array). */
+export function parsePath(id: string): Hop[] | null {
   const segs = id.split('.');
   const hops: Hop[] = [];
   for (const s of segs) {
-    const m = /^([a-zA-Z_]\w*)\[(\d+)\]$/.exec(s);
+    const m = /^([a-zA-Z_]\w*)(?:\[(\d+)\])?$/.exec(s);
     if (!m) return null;
-    hops.push({ key: m[1], index: Number(m[2]) });
+    hops.push({ key: m[1], index: m[2] != null ? Number(m[2]) : -1 });
   }
   return hops.length > 0 ? hops : null;
 }
 
-function readAt(root: Record<string, unknown>, hops: Hop[]): Block | null {
-  let arr = (root as any)[hops[0].key] as Block[] | undefined;
-  if (!Array.isArray(arr)) return null;
-  let node: Block | null = arr[hops[0].index] ?? null;
-  for (let h = 1; h < hops.length; h++) {
-    if (!node) return null;
-    arr = (node as any)[hops[h].key] as Block[] | undefined;
-    if (!Array.isArray(arr)) return null;
-    node = arr[hops[h].index] ?? null;
+/** Flatten hops to a JSON-pointer-like path: object key, then index if any. */
+export function hopsToPath(hops: Hop[]): PathSeg[] {
+  const p: PathSeg[] = [];
+  for (const h of hops) {
+    p.push(h.key);
+    if (h.index >= 0) p.push(h.index);
   }
-  return node;
+  return p;
 }
 
-function writeAt(root: Record<string, unknown>, hops: Hop[], replacement: Block | null): Record<string, unknown> {
-  const rootKey = hops[0].key;
-  const rootArr = Array.isArray((root as any)[rootKey]) ? [...(root as any)[rootKey] as Block[]] : [];
-  if (hops.length === 1) {
-    return { [rootKey]: spliceArray(rootArr, hops[0].index, replacement) };
+export function getByPath(root: any, path: PathSeg[]): any {
+  let node = root;
+  for (const seg of path) {
+    if (node == null) return null;
+    node = node[seg as any];
   }
-  let arr = rootArr;
-  for (let h = 0; h < hops.length - 1; h++) {
-    const cur = { ...(arr[hops[h].index] ?? {}) } as Block;
-    const nextKey = hops[h + 1].key;
-    const childArr = Array.isArray((cur as any)[nextKey]) ? [...(cur as any)[nextKey] as Block[]] : [];
-    (cur as any)[nextKey] = childArr;
-    arr[hops[h].index] = cur;
-    arr = childArr;
-  }
-  spliceArray; // (silence unused if any optimizer)
-  const last = hops[hops.length - 1];
-  // Replace within the inner-most reference (already cloned above).
-  if (replacement === null) arr.splice(last.index, 1);
-  else arr[last.index] = replacement;
-  return { [rootKey]: rootArr };
+  return node ?? null;
 }
 
-/**
- * Read the sibling array containing the node at `hops` along with the
- * leaf index, so the inspector can offer reorder controls without
- * re-traversing the tree.
- */
-function readSiblings(root: Record<string, unknown>, hops: Hop[]): { siblings: Block[]; index: number } | null {
-  let arr = (root as any)[hops[0].key] as Block[] | undefined;
-  if (!Array.isArray(arr)) return null;
-  if (hops.length === 1) return { siblings: arr, index: hops[0].index };
-  let node: Block | null = arr[hops[0].index] ?? null;
-  for (let h = 1; h < hops.length - 1; h++) {
-    if (!node) return null;
-    arr = (node as any)[hops[h].key] as Block[] | undefined;
-    if (!Array.isArray(arr)) return null;
-    node = arr[hops[h].index] ?? null;
+/** Immutable set/remove along a path. `value === REMOVE` deletes the leaf. */
+export function setByPath(root: any, path: PathSeg[], value: any): any {
+  if (path.length === 0) return value;
+  const [head, ...rest] = path;
+  if (typeof head === 'number') {
+    const arr = Array.isArray(root) ? [...root] : [];
+    if (rest.length === 0) {
+      if (value === REMOVE) arr.splice(head, 1);
+      else arr[head] = value;
+    } else arr[head] = setByPath(arr[head], rest, value);
+    return arr;
   }
-  if (!node) return null;
-  const last = hops[hops.length - 1];
-  const sibs = (node as any)[last.key] as Block[] | undefined;
-  if (!Array.isArray(sibs)) return null;
-  return { siblings: sibs, index: last.index };
+  const obj = { ...(root || {}) };
+  if (rest.length === 0) {
+    if (value === REMOVE) delete (obj as any)[head];
+    else (obj as any)[head] = value;
+  } else (obj as any)[head] = setByPath((obj as any)[head], rest, value);
+  return obj;
 }
 
-/**
- * Replace the sibling array at `hops` (without the final index hop)
- * with `nextSiblings`. Used by reorder so we can hand back a freshly
- * permuted array.
- */
-function writeSiblings(root: Record<string, unknown>, hops: Hop[], nextSiblings: Block[]): Record<string, unknown> {
-  const rootKey = hops[0].key;
-  if (hops.length === 1) {
-    return { [rootKey]: nextSiblings };
-  }
-  const rootArr = Array.isArray((root as any)[rootKey]) ? [...(root as any)[rootKey] as Block[]] : [];
-  let arr = rootArr;
-  for (let h = 0; h < hops.length - 2; h++) {
-    const cur = { ...(arr[hops[h].index] ?? {}) } as Block;
-    const nextKey = hops[h + 1].key;
-    const childArr = Array.isArray((cur as any)[nextKey]) ? [...(cur as any)[nextKey] as Block[]] : [];
-    (cur as any)[nextKey] = childArr;
-    arr[hops[h].index] = cur;
-    arr = childArr;
-  }
-  // Replace the inner-most container's child array with the permuted siblings.
-  const parentHop = hops[hops.length - 2];
-  const lastKey = hops[hops.length - 1].key;
-  const parentCopy = { ...(arr[parentHop.index] ?? {}) } as Block;
-  (parentCopy as any)[lastKey] = nextSiblings;
-  arr[parentHop.index] = parentCopy;
-  return { [rootKey]: rootArr };
+export function readAt(root: Record<string, unknown>, hops: Hop[]): Block | null {
+  return getByPath(root, hopsToPath(hops)) as Block | null;
+}
+
+/** Returns a shallow patch `{ [topKey]: newValue }` for onPatch. */
+export function writeAt(root: Record<string, unknown>, hops: Hop[], replacement: Block | null): Record<string, unknown> {
+  const path = hopsToPath(hops);
+  const next = setByPath(root, path, replacement === null ? REMOVE : replacement);
+  const topKey = path[0] as string;
+  return { [topKey]: next[topKey] };
+}
+
+export function readSiblings(root: Record<string, unknown>, hops: Hop[]): { siblings: Block[]; index: number } | null {
+  const path = hopsToPath(hops);
+  const last = path[path.length - 1];
+  if (typeof last !== 'number') return null;
+  const siblings = getByPath(root, path.slice(0, -1));
+  if (!Array.isArray(siblings)) return null;
+  return { siblings: siblings as Block[], index: last };
+}
+
+export function writeSiblings(root: Record<string, unknown>, hops: Hop[], nextSiblings: Block[]): Record<string, unknown> {
+  const path = hopsToPath(hops);
+  const next = setByPath(root, path.slice(0, -1), nextSiblings);
+  const topKey = path[0] as string;
+  return { [topKey]: next[topKey] };
 }
 
 export function PageBlockInspector({ selection, draft, onPatch, onClearSelection, onSelectionChange, locale, readOnly }: MetadataInspectorProps) {
   // Slotted record page: selection ids are `slot:<name>:<index>` and address
   // `draft.slots.<name>` (a single component is normalised to a 1-element array).
-  const slotMatch = /^slot:([a-zA-Z_]+):(\d+)$/.exec(selection.id);
+  // `slot:<name>:<idx>` optionally followed by a nested sub-path within the
+  // slot's block (e.g. `slot:tabs:0.properties.items[0].children[0]`), so a
+  // block inside a slotted container is addressable too (issue #1499).
+  const slotMatch = /^slot:([a-zA-Z_]+):(\d+)(?:\.(.+))?$/.exec(selection.id);
   const hops = slotMatch ? null : parsePath(selection.id);
 
   const slotName = slotMatch ? slotMatch[1] : '';
   const slotIdx = slotMatch ? Number(slotMatch[2]) : -1;
+  const slotSub = slotMatch ? slotMatch[3] : undefined;
+  const subHops = slotSub ? parsePath(slotSub) : null;
   const slotsObj: Record<string, any> =
     (draft as any).slots && typeof (draft as any).slots === 'object' ? ((draft as any).slots as Record<string, any>) : {};
   const slotArr: Block[] = slotMatch
@@ -237,10 +230,26 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
         ? [slotsObj[slotName] as Block]
         : []
     : [];
+  const slotBase: Block | null = slotMatch ? (slotArr[slotIdx] ?? null) : null;
+  // Write the slot's whole array back (delete the base block when null).
   const writeSlot = (nextArr: Block[]) => onPatch({ slots: { ...slotsObj, [slotName]: nextArr } });
+  const writeSlotBase = (nextBase: Block | null) =>
+    writeSlot(nextBase === null ? slotArr.filter((_, i) => i !== slotIdx) : slotArr.map((b, i) => (i === slotIdx ? nextBase : b)));
 
-  const block: Block | null = slotMatch ? (slotArr[slotIdx] ?? null) : hops ? readAt(draft, hops) : null;
-  const sibInfo = slotMatch ? { siblings: slotArr, index: slotIdx } : hops ? readSiblings(draft, hops) : null;
+  const block: Block | null = slotMatch
+    ? subHops
+      ? readAt((slotBase || {}) as any, subHops)
+      : slotBase
+    : hops
+      ? readAt(draft, hops)
+      : null;
+  const sibInfo = slotMatch
+    ? subHops
+      ? readSiblings((slotBase || {}) as any, subHops)
+      : { siblings: slotArr, index: slotIdx }
+    : hops
+      ? readSiblings(draft, hops)
+      : null;
 
   if ((!slotMatch && !hops) || !block) {
     return (
@@ -250,10 +259,11 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
     );
   }
 
-  const patch = (updates: Partial<Block>) =>
-    slotMatch
-      ? writeSlot(slotArr.map((b, i) => (i === slotIdx ? { ...block, ...updates } : b)))
-      : onPatch(writeAt(draft, hops!, { ...block, ...updates }));
+  const patch = (updates: Partial<Block>) => {
+    if (!slotMatch) return onPatch(writeAt(draft, hops!, { ...block, ...updates }));
+    if (subHops) return writeSlotBase({ ...(slotBase as Block), ...writeAt((slotBase || {}) as any, subHops, { ...block, ...updates }) });
+    return writeSlotBase({ ...block, ...updates });
+  };
 
   // Per-block configurable properties (spec `properties`). The renderer hoists
   // `properties.*` to the top level, so we read from either and always write
@@ -384,22 +394,31 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
     }
   };
   const remove = () => {
-    if (slotMatch) writeSlot(slotArr.filter((_, i) => i !== slotIdx));
-    else onPatch(writeAt(draft, hops!, null));
+    if (slotMatch) {
+      if (subHops) writeSlotBase({ ...(slotBase as Block), ...writeAt((slotBase || {}) as any, subHops, null) });
+      else writeSlotBase(null);
+    } else onPatch(writeAt(draft, hops!, null));
     onClearSelection();
   };
+  // Re-serialise hops to an id, honouring object hops (index < 0 → no `[i]`).
+  const fmtHops = (hs: Hop[]) => hs.map((h) => (h.index >= 0 ? `${h.key}[${h.index}]` : h.key)).join('.');
   const move = (to: number) => {
     if (!sibInfo) return;
     if (slotMatch) {
-      writeSlot(moveArray(slotArr, slotIdx, to));
-      onSelectionChange?.({ kind: 'block', id: `slot:${slotName}:${to}`, label: String(block.id || block.type || to) });
+      if (subHops) {
+        const next = moveArray(sibInfo.siblings, sibInfo.index, to);
+        writeSlotBase({ ...(slotBase as Block), ...writeSiblings((slotBase || {}) as any, subHops, next) });
+        const newSub = fmtHops([...subHops.slice(0, -1), { key: subHops[subHops.length - 1].key, index: to }]);
+        onSelectionChange?.({ kind: 'block', id: `slot:${slotName}:${slotIdx}.${newSub}`, label: String(block.id || block.type || to) });
+      } else {
+        writeSlot(moveArray(slotArr, slotIdx, to));
+        onSelectionChange?.({ kind: 'block', id: `slot:${slotName}:${to}`, label: String(block.id || block.type || to) });
+      }
       return;
     }
     const next = moveArray(sibInfo.siblings, sibInfo.index, to);
     onPatch(writeSiblings(draft, hops!, next));
-    const prefix = hops!.slice(0, -1).map((h) => `${h.key}[${h.index}]`).join('.');
-    const lastKey = hops![hops!.length - 1].key;
-    const newId = prefix ? `${prefix}.${lastKey}[${to}]` : `${lastKey}[${to}]`;
+    const newId = fmtHops([...hops!.slice(0, -1), { key: hops![hops!.length - 1].key, index: to }]);
     onSelectionChange?.({ kind: 'block', id: newId, label: String(block.id || block.type || newId) });
   };
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/__tests__/page-block-path.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/__tests__/page-block-path.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { parsePath, readAt, writeAt, readSiblings, writeSiblings, getByPath, setByPath, hopsToPath } from '../PageBlockInspector';
+
+const draft = {
+  regions: [
+    {
+      name: 'main',
+      components: [
+        { type: 'element:text' },
+        {
+          type: 'page:tabs',
+          properties: {
+            items: [
+              { key: 'a', label: 'A', children: [{ type: 'record:line_items', properties: { childObject: 'showcase_task' } }] },
+              { key: 'b', label: 'B', children: [] },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe('PageBlockInspector path helpers (object-key + array hops)', () => {
+  it('parsePath accepts both key and key[index] segments', () => {
+    expect(parsePath('regions[0].components[1]')).toEqual([
+      { key: 'regions', index: 0 },
+      { key: 'components', index: 1 },
+    ]);
+    expect(parsePath('regions[0].components[1].properties.items[0].children[0]')).toEqual([
+      { key: 'regions', index: 0 },
+      { key: 'components', index: 1 },
+      { key: 'properties', index: -1 },
+      { key: 'items', index: 0 },
+      { key: 'children', index: 0 },
+    ]);
+    expect(parsePath('not a path!')).toBeNull();
+  });
+
+  it('readAt resolves a deeply nested block under properties.items[].children', () => {
+    const hops = parsePath('regions[0].components[1].properties.items[0].children[0]')!;
+    expect(readAt(draft as any, hops)).toEqual({ type: 'record:line_items', properties: { childObject: 'showcase_task' } });
+  });
+
+  it('writeAt immutably patches a nested block and returns a top-level patch', () => {
+    const hops = parsePath('regions[0].components[1].properties.items[0].children[0]')!;
+    const patch = writeAt(draft as any, hops, { type: 'record:line_items', properties: { childObject: 'edited' } });
+    expect(Object.keys(patch)).toEqual(['regions']);
+    const newChild = (patch as any).regions[0].components[1].properties.items[0].children[0];
+    expect(newChild.properties.childObject).toBe('edited');
+    // original draft untouched (immutability)
+    expect((draft as any).regions[0].components[1].properties.items[0].children[0].properties.childObject).toBe('showcase_task');
+  });
+
+  it('writeAt removes a nested block when replacement is null', () => {
+    const hops = parsePath('regions[0].components[1].properties.items[0].children[0]')!;
+    const patch = writeAt(draft as any, hops, null);
+    expect((patch as any).regions[0].components[1].properties.items[0].children).toHaveLength(0);
+  });
+
+  it('appends a block into a nested children array (the add-nested path)', () => {
+    const path = hopsToPath(parsePath('regions[0].components[1].properties.items[1].children')!);
+    const cur = getByPath(draft as any, path) || [];
+    expect(cur).toHaveLength(0);
+    const next = setByPath(draft as any, path, [...cur, { type: 'element:text' }]);
+    expect(next.regions[0].components[1].properties.items[1].children).toEqual([{ type: 'element:text' }]);
+    // original untouched
+    expect((draft as any).regions[0].components[1].properties.items[1].children).toHaveLength(0);
+  });
+
+  it('readSiblings / writeSiblings operate on the nested children array', () => {
+    const hops = parsePath('regions[0].components[1].properties.items[0].children[0]')!;
+    const sib = readSiblings(draft as any, hops)!;
+    expect(sib.index).toBe(0);
+    expect(sib.siblings).toHaveLength(1);
+    const patch = writeSiblings(draft as any, hops, [{ type: 'x' }, { type: 'y' }]);
+    expect((patch as any).regions[0].components[1].properties.items[0].children).toEqual([{ type: 'x' }, { type: 'y' }]);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/PageBlockCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PageBlockCanvas.tsx
@@ -34,6 +34,31 @@ import {
   resolveBlockTone,
   type BlockTypeId,
 } from './block-types';
+import { parsePath, hopsToPath, getByPath, setByPath } from '../inspectors/PageBlockInspector';
+
+/** Container blocks expose nested child arrays (issue #1499). Returns each
+ *  group's display label, the path suffix to its children array (relative to
+ *  the block), and the current children. */
+function childGroups(block: Block): Array<{ label: string; pathSuffix: string; children: Block[] }> {
+  const props = (block?.properties as any) || {};
+  switch (block?.type) {
+    case 'page:tabs':
+    case 'page:accordion': {
+      const items = Array.isArray(props.items) ? props.items : [];
+      return items.map((it: any, i: number) => ({
+        label: it?.label || it?.key || `Item ${i + 1}`,
+        pathSuffix: `properties.items[${i}].children`,
+        children: Array.isArray(it?.children) ? it.children : [],
+      }));
+    }
+    case 'page:card':
+      return [{ label: 'Body', pathSuffix: 'properties.body', children: Array.isArray(props.body) ? props.body : [] }];
+    case 'page:section':
+      return [{ label: 'Content', pathSuffix: 'properties.children', children: Array.isArray(props.children) ? props.children : [] }];
+    default:
+      return [];
+  }
+}
 
 interface Block {
   type?: string;
@@ -238,6 +263,41 @@ export function PageBlockCanvas({
     writeRegions(next);
   }, [onPatch, regions, writeRegions]);
 
+  // Append a block into a container's nested child array (issue #1499).
+  // `baseId` is the container's selection id (`regions[r].components[c]` or
+  // `slot:<name>:<idx>`); `pathSuffix` locates the children array within it.
+  const addNestedBlock = React.useCallback(
+    (baseId: string, pathSuffix: string, type: BlockTypeId) => {
+      if (!onPatch) return;
+      const slot = /^slot:([a-zA-Z_]+):(\d+)$/.exec(baseId);
+      const subHops = parsePath(pathSuffix);
+      if (!subHops) return;
+      const subPath = hopsToPath(subHops);
+      if (slot) {
+        const name = slot[1];
+        const idx = Number(slot[2]);
+        const slots = ((draft as any).slots || {}) as Record<string, any>;
+        const v = slots[name];
+        const arr = Array.isArray(v) ? [...v] : v != null ? [v] : [];
+        const base = arr[idx];
+        if (!base) return;
+        const cur = getByPath(base, subPath) || [];
+        arr[idx] = setByPath(base, subPath, [...cur, { type }]);
+        onPatch({ slots: { ...slots, [name]: arr } });
+        onSelectionChange?.({ kind: 'block', id: `${baseId}.${pathSuffix}[${cur.length}]`, label: type });
+      } else {
+        const fullHops = parsePath(`${baseId}.${pathSuffix}`);
+        if (!fullHops) return;
+        const fullPath = hopsToPath(fullHops);
+        const cur = getByPath(draft, fullPath) || [];
+        const next = setByPath(draft, fullPath, [...cur, { type }]);
+        onPatch({ [fullPath[0] as string]: next[fullPath[0]] });
+        onSelectionChange?.({ kind: 'block', id: `${baseId}.${pathSuffix}[${cur.length}]`, label: type });
+      }
+    },
+    [onPatch, draft, onSelectionChange],
+  );
+
   const handleBgClick = React.useCallback(
     (e: React.MouseEvent) => {
       if (e.target === e.currentTarget && selectedId) onSelectionChange?.(null);
@@ -290,6 +350,9 @@ export function PageBlockCanvas({
             onMoveBlock={moveBlock}
             onAddBlock={addBlock}
             onRenameLabel={renameLabel}
+            baseIdOf={(compIdx) => selectionId(shape, regionIdx, compIdx, region.name)}
+            onSelectId={(sid, lbl) => onSelectionChange?.({ kind: 'block', id: sid, label: lbl })}
+            onAddNested={addNestedBlock}
           />
         ))}
         {!readOnly && shape === 'regions' && (
@@ -317,6 +380,9 @@ function RegionSection({
   onMoveBlock,
   onAddBlock,
   onRenameLabel,
+  baseIdOf,
+  onSelectId,
+  onAddNested,
 }: {
   region: Region;
   regionIdx: number;
@@ -332,6 +398,9 @@ function RegionSection({
   ) => void;
   onAddBlock: (regionIdx: number, type: BlockTypeId) => void;
   onRenameLabel: (regionIdx: number, compIdx: number, nextLabel: string) => void;
+  baseIdOf: (compIdx: number) => string;
+  onSelectId: (id: string, label: string) => void;
+  onAddNested: (baseId: string, pathSuffix: string, type: BlockTypeId) => void;
 }) {
   const comps = Array.isArray(region.components) ? region.components : [];
   const [active, setActive] = React.useState(false);
@@ -389,17 +458,26 @@ function RegionSection({
           comps.map((blk, compIdx) => {
             const id = selectionId(shape, regionIdx, compIdx, region.name);
             return (
-              <BlockRow
-                key={`${regionIdx}:${compIdx}`}
-                block={blk}
-                regionIdx={regionIdx}
-                compIdx={compIdx}
-                selected={id === selectedId}
-                readOnly={readOnly}
-                onClick={() => onSelectBlock(compIdx, blk)}
-                onMoveBlock={onMoveBlock}
-                onRenameLabel={(v) => onRenameLabel(regionIdx, compIdx, v)}
-              />
+              <React.Fragment key={`${regionIdx}:${compIdx}`}>
+                <BlockRow
+                  block={blk}
+                  regionIdx={regionIdx}
+                  compIdx={compIdx}
+                  selected={id === selectedId}
+                  readOnly={readOnly}
+                  onClick={() => onSelectBlock(compIdx, blk)}
+                  onMoveBlock={onMoveBlock}
+                  onRenameLabel={(v) => onRenameLabel(regionIdx, compIdx, v)}
+                />
+                <NestedChildren
+                  block={blk}
+                  baseId={id}
+                  selectedId={selectedId}
+                  readOnly={readOnly}
+                  onSelectId={onSelectId}
+                  onAddNested={onAddNested}
+                />
+              </React.Fragment>
             );
           })
         )}
@@ -566,6 +644,66 @@ function BlockRow({
       {dropZone === 'after' && (
         <div className="absolute left-0 right-0 -bottom-1 h-0.5 bg-primary rounded-full" />
       )}
+    </div>
+  );
+}
+
+/* ─────────────── Nested container children (issue #1499) ─────────────── */
+
+function NestedChildren({
+  block,
+  baseId,
+  selectedId,
+  readOnly,
+  onSelectId,
+  onAddNested,
+}: {
+  block: Block;
+  baseId: string;
+  selectedId: string | null;
+  readOnly: boolean;
+  onSelectId: (id: string, label: string) => void;
+  onAddNested: (baseId: string, pathSuffix: string, type: BlockTypeId) => void;
+}) {
+  const groups = childGroups(block);
+  if (groups.length === 0) return null;
+  return (
+    <div className="ml-5 mt-1.5 space-y-2.5 border-l border-dashed border-border pl-3">
+      {groups.map((g, gi) => (
+        <div key={gi} className="space-y-1.5">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{g.label}</div>
+          {g.children.length === 0 ? (
+            <div className="rounded border border-dashed bg-background/40 py-2 px-3 text-[11px] text-muted-foreground">
+              Empty — add a block.
+            </div>
+          ) : (
+            g.children.map((child, ci) => {
+              const cid = `${baseId}.${g.pathSuffix}[${ci}]`;
+              const typeStr = String(child?.type ?? '');
+              const meta = BLOCK_TYPE_META[typeStr as BlockTypeId];
+              const Icon = meta?.Icon ?? UnknownBlockIcon;
+              return (
+                <button
+                  key={ci}
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); onSelectId(cid, blockLabel(child)); }}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded border px-2.5 py-1.5 text-left text-xs transition-colors',
+                    cid === selectedId
+                      ? 'border-primary bg-primary/5 ring-1 ring-primary/30'
+                      : 'border-border bg-background hover:bg-muted/40',
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="flex-1 truncate">{blockLabel(child)}</span>
+                  <span className="font-mono text-[10px] text-muted-foreground/60">{typeStr}</span>
+                </button>
+              );
+            })
+          )}
+          {!readOnly && <AddBlockButton onPick={(type) => onAddNested(baseId, g.pathSuffix, type)} />}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
Closes #1499 — the last gap in the page editor. Blocks NESTED inside a container (a page:tabs/page:accordion tab's children, a page:card/page:section body) are now surfaced as indented, selectable sub-blocks: select → configure (inspector + object/field pickers) → edit → remove → add — in both full and slotted pages.

Foundation: the block-path helpers now support object-key hops (so …components[0].properties.items[0].children[0] is addressable), built on a generic immutable getByPath/setByPath. Slot ids gain an optional nested sub-path (slot:tabs:0.properties.items[0].children[0]). The canvas renders each container's child groups with per-group Add block.

Verified e2e on app-showcase showcase_project_detail (a slotted page — the hardest case): the tabs slot's page:tabs surfaces its nested children (record:details / record:line_items); selecting record:details configures it via the inspector with field pickers resolving showcase_project fields; a section-label edit round-trips through the nested slot path; adding a nested block works. 149 metadata-admin tests pass (incl. nested-path unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)