### PR TITLE
feat(chat): one-click Publish for AI-staged drafts

### DIFF
--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -31,6 +31,7 @@ import {
 } from '@object-ui/components';
 import { Share2, SquarePen } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
+import { toast } from 'sonner';
 import { useChatConversation, type HydratedUIMessage } from '../hooks';
 import { useAssistant, requestAssistantReview, type AssistantEditorContext } from '../assistant/assistantBus';
 
@@ -93,6 +94,9 @@ function buildChatLocale(
       newChat: '开启新对话',
       share: '分享对话',
       reviewDraft: (n: number) => `查看 ${n} 项变更`,
+      publishDrafts: '发布',
+      publishOk: '已发布，对象已生效。',
+      publishFailed: '发布失败',
       suggestions,
     };
   }
@@ -118,6 +122,9 @@ function buildChatLocale(
     newChat: 'New chat',
     share: 'Share conversation',
     reviewDraft: (n: number) => `Review ${n} change${n === 1 ? '' : 's'}`,
+    publishDrafts: 'Publish',
+    publishOk: 'Published — objects are now live.',
+    publishFailed: 'Publish failed',
     suggestions,
   };
 }
@@ -447,6 +454,34 @@ function ChatbotInner({
           if (items[0]) requestAssistantReview(items[0]);
         }}
         toolReviewLabel={locale.reviewDraft}
+        onPublishDrafts={async (packageId) => {
+          // ADR-0033 — promote the conversation's staged drafts to live in one
+          // click (the human still confirms here). Mirrors PackagesPage's
+          // publish-drafts call; cookie-authenticated like the rest of the SPA.
+          try {
+            const res = await fetch(
+              `/api/v1/packages/${encodeURIComponent(packageId)}/publish-drafts`,
+              {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+                body: '{}',
+              },
+            );
+            const payload = await res.json().catch(() => null);
+            if (!res.ok || payload?.success === false) {
+              throw new Error(payload?.error?.message || `HTTP ${res.status}`);
+            }
+            const failed = payload?.data?.failedCount ?? payload?.failedCount ?? 0;
+            if (failed) throw new Error(String(failed));
+            toast.success(locale.publishOk);
+          } catch (e) {
+            toast.error(locale.publishFailed, {
+              description: e instanceof Error ? e.message : undefined,
+            });
+          }
+        }}
+        publishDraftsLabel={locale.publishDrafts}
       />
       {conversationId && (
         <ShareDialog

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -19,7 +19,7 @@
  */
 import * as React from 'react';
 import { cn } from '@object-ui/components';
-import { AlertCircle, Copy, Check, RefreshCw, CornerDownLeft, Bot, GitCompareArrows } from 'lucide-react';
+import { AlertCircle, Copy, Check, RefreshCw, CornerDownLeft, Bot, GitCompareArrows, Rocket } from 'lucide-react';
 import type { ChatStatus } from 'ai';
 import {
   humanizeToolName,
@@ -134,7 +134,7 @@ export interface ChatToolInvocation {
    * change(s)" affordance that opens the designer's review/diff. Nothing is
    * live until the human publishes — this is the review entry point.
    */
-  draftReview?: { items: Array<{ type: string; name: string }>; summary?: string };
+  draftReview?: { items: Array<{ type: string; name: string }>; summary?: string; packageId?: string };
 }
 
 export interface ChatSource {
@@ -267,6 +267,16 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   onReviewDraft?: (items: Array<{ type: string; name: string }>) => void;
   /** Label for the review-draft button (default "Review {n} change(s)"). */
   toolReviewLabel?: (count: number) => string;
+  /**
+   * When provided AND the drafted tool result reported its owning `packageId`,
+   * tool parts render a one-click "Publish" button so the human can promote the
+   * staged drafts to live without leaving the conversation (the ADR-0033 gate
+   * stays — the human still clicks). The host wires this to
+   * `POST /api/v1/packages/:packageId/publish-drafts`.
+   */
+  onPublishDrafts?: (packageId: string) => void;
+  /** Label for the publish-drafts button (default "Publish"). */
+  publishDraftsLabel?: string;
 }
 
 export type ToolDecisionState =
@@ -344,6 +354,8 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       toolDecisions,
       onReviewDraft,
       toolReviewLabel = (n) => `Review ${n} change${n === 1 ? '' : 's'}`,
+      onPublishDrafts,
+      publishDraftsLabel = 'Publish',
       ...props
     },
     ref
@@ -600,16 +612,37 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                                       </button>
                                     </div>
                                   ) : null}
-                                  {tool.draftReview && tool.draftReview.items.length > 0 && onReviewDraft ? (
+                                  {tool.draftReview &&
+                                  tool.draftReview.items.length > 0 &&
+                                  (onReviewDraft ||
+                                    (onPublishDrafts && tool.draftReview.packageId)) ? (
                                     <div className="flex items-center gap-2 p-3 border-t bg-muted/30">
-                                      <button
-                                        type="button"
-                                        onClick={() => onReviewDraft(tool.draftReview!.items)}
-                                        className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
-                                      >
-                                        <GitCompareArrows className="size-3.5" />
-                                        {toolReviewLabel(tool.draftReview.items.length)}
-                                      </button>
+                                      {onPublishDrafts && tool.draftReview.packageId ? (
+                                        <button
+                                          type="button"
+                                          onClick={() =>
+                                            onPublishDrafts(tool.draftReview!.packageId!)
+                                          }
+                                          className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                                        >
+                                          <Rocket className="size-3.5" />
+                                          {publishDraftsLabel}
+                                        </button>
+                                      ) : null}
+                                      {onReviewDraft ? (
+                                        <button
+                                          type="button"
+                                          onClick={() => onReviewDraft(tool.draftReview!.items)}
+                                          className={
+                                            onPublishDrafts && tool.draftReview.packageId
+                                              ? 'inline-flex h-7 items-center gap-1.5 rounded-md border px-3 text-xs font-medium hover:bg-muted'
+                                              : 'inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90'
+                                          }
+                                        >
+                                          <GitCompareArrows className="size-3.5" />
+                                          {toolReviewLabel(tool.draftReview.items.length)}
+                                        </button>
+                                      ) : null}
                                       {tool.draftReview.summary ? (
                                         <span className="truncate text-xs text-muted-foreground">
                                           {tool.draftReview.summary}

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -128,7 +128,7 @@ function detectPendingApproval(
  */
 function detectDraftResult(
   result: unknown,
-): { items: Array<{ type: string; name: string }>; summary?: string } | undefined {
+): { items: Array<{ type: string; name: string }>; summary?: string; packageId?: string } | undefined {
   const obj = parseResultEnvelope(result);
   if (!obj || obj.status !== 'drafted') return undefined;
   const items: Array<{ type: string; name: string }> = [];
@@ -143,7 +143,15 @@ function detectDraftResult(
     items.push({ type: obj.type, name: obj.name });
   }
   if (items.length === 0) return undefined;
-  return { items, summary: typeof obj.summary === 'string' ? obj.summary : undefined };
+  // The owning package (when the staging tool reported it) lets the chat offer
+  // a one-click "publish" — POST /packages/:packageId/publish-drafts — so the
+  // ADR-0033 human gate is reachable from the conversation, not just a deep
+  // link into the designer.
+  return {
+    items,
+    summary: typeof obj.summary === 'string' ? obj.summary : undefined,
+    ...(typeof obj.packageId === 'string' && obj.packageId ? { packageId: obj.packageId } : {}),
+  };
 }
 
 function extractToolInvocations(parts: AnyPart[]): ChatToolInvocation[] {


### PR DESCRIPTION
## 背景(本地 dogfood 实测)
AI 助手能从一句话生成完整数据模型(实测宠物医院:owner/pet/appointment/treatment + 关系),但工具按 ADR-0033 只把对象 stage 成草稿、**发布步骤在聊天流里不可达** → 新用户拿到永不生效的草稿(data API 404),AI 还可能越权宣称"已启用 API"。手动 `POST /packages/:id/publish-drafts` 后对象立刻 live(data API 404→200)。

## 改动
- **mapMessages**:把草稿 envelope 的 `packageId`(cloud service-ai-studio 现已上报,见 objectstack-ai/cloud#130)提升进 `draftReview`。
- **ChatbotEnhanced**:草稿结果带 packageId + 接了 `onPublishDrafts` 时,在「Review」旁渲染一键「发布」按钮;放宽显隐门槛,使没传 onReviewDraft 时「发布」也显示。
- **ConsoleFloatingChatbot**:接 `onPublishDrafts` → `POST /api/v1/packages/:packageId/publish-drafts`(cookie 鉴权,镜像 PackagesPage),带成功/失败 toast + 中英文案。

人仍点一下「发布」(ADR-0033 人工门保留),只是从对话可达了。type-clean。

## 依赖 / 验证
- 需配合 cloud #130(envelope 带 packageId)部署后,发布按钮才会出现。
- 待 staging 验证:重跑"一句话搭后端"→ 聊天出现「发布」→ 点击 → 对象 live。