### PR TITLE
feat(master-detail): atomic parent+children create via cross-object batch

### DIFF
--- a/.changeset/master-detail-atomic-batch.md
+++ b/.changeset/master-detail-atomic-batch.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/data-objectstack": minor
+"@object-ui/plugin-form": minor
+"@object-ui/types": minor
+---
+
+Atomic master-detail create via the cross-object transactional batch endpoint (ObjectStack #1604).
+
+When the server exposes the transactional batch endpoint, a NEW parent record and its child line items are now persisted in ONE server transaction — commit all or roll back all — instead of the previous client-orchestrated "create parent → create children → best-effort cleanup on failure" sequence.
+
+**`@object-ui/data-objectstack` — `ObjectStackAdapter.batchTransaction(operations)`**
+
+- New method posting `{ operations }` to `POST /api/v1/batch`. Operations run in one server transaction. A field value of `{ $ref: <earlier op index> }` resolves to that op's generated id, so a child can reference its parent created earlier in the same batch (master-detail FK). Throws `ObjectStackError('BATCH_ERROR')` on a non-2xx response.
+
+**`@object-ui/plugin-form`**
+
+- `MasterDetailForm` now detects `dataSource.batchTransaction` and, on a NEW parent, builds one atomic batch (parent at index 0, each child FK set to `{ $ref: 0 }`) via the new pure helper `buildMasterDetailBatch`. Client-side total rollups are merged into the parent payload before the batch. Edit mode and adapters without `batchTransaction` keep the existing client-orchestrated path.
+- `ObjectForm` gained a `submitHandler` hook: when supplied, the form validates and hands the collected values to the host instead of calling `dataSource.create` / `dataSource.update`. `MasterDetailForm` uses it to own the atomic parent+children write while the parent fields are still rendered by `ObjectForm`.
+
+**`@object-ui/types`**
+
+- `ObjectFormSchema.submitHandler?: (values) => any | Promise<any>` — typed override for host-owned persistence.
+
+Pairs with the framework-side ambient-transaction fix (ObjectQL `AsyncLocalStorage` transaction propagation) and the `/api/v1/batch` endpoint added in `@objectstack/rest`.

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -857,6 +857,32 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * @param data - Array of records to process
    * @returns Promise resolving to array of results
    */
+  /**
+   * Cross-object transactional batch (ObjectStack #1604). Runs the operations
+   * in ONE server transaction — commit all or roll back all. A field value of
+   * `{ $ref: <earlier op index> }` resolves to that op's created id, so a child
+   * can reference its parent created earlier in the same batch (master-detail).
+   */
+  async batchTransaction(
+    operations: Array<{ object: string; action?: 'create' | 'update' | 'delete'; data?: any; id?: string }>,
+  ): Promise<{ results: any[] }> {
+    const url = `${this.baseUrl}/api/v1/batch`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },
+      body: JSON.stringify({ operations }),
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ message: response.statusText }));
+      throw new ObjectStackError(
+        error.error || error.message || `Batch failed with status ${response.status}`,
+        'BATCH_ERROR',
+        response.status,
+      );
+    }
+    return response.json();
+  }
+
   async bulk(resource: string, operation: 'create' | 'update' | 'delete', data: Partial<T>[]): Promise<T[]> {
     await this.connect();
 

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -29,7 +29,7 @@ import type { DataSource } from '@object-ui/types';
 import { LineItemsField, type GridColumn } from '@object-ui/fields';
 import { Button, Card, CardContent, CardHeader, CardTitle, cn } from '@object-ui/components';
 import { ObjectForm } from './ObjectForm';
-import { applyDetail, idOf } from './masterDetailTx';
+import { applyDetail, idOf, buildMasterDetailBatch, sumRows } from './masterDetailTx';
 
 export interface MasterDetailDetailConfig {
   /** Child object name, e.g. 'expense_line'. */
@@ -177,6 +177,36 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
     [dataSource, isEdit, persistDetails, schema],
   );
 
+  // When the server exposes the transactional batch endpoint, a NEW parent +
+  // its children are persisted in ONE atomic transaction (commit all or roll
+  // back all) — no client-side best-effort cleanup. Otherwise fall back to the
+  // client-orchestrated create (parent → children with FK).
+  const canBatch = !isEdit && typeof (dataSource as any)?.batchTransaction === 'function';
+
+  const submitViaBatch = useCallback(
+    async (parentValues: Record<string, any>) => {
+      const ds: any = dataSource;
+      const parentData: Record<string, any> = { ...parentValues };
+      // Client-side rollups merged into the parent payload (hooks can't do
+      // nested writes — see ADR-0001).
+      details.forEach((d, i) => {
+        if (d.totalField) parentData[d.totalField] = sumRows(stateRef.current[i]?.rows ?? [], d.amountField || 'amount');
+      });
+      const ops = buildMasterDetailBatch(
+        schema.objectName,
+        parentData,
+        details.map((d, i) => ({
+          childObject: d.childObject,
+          relationshipField: d.relationshipField,
+          rows: stateRef.current[i]?.rows ?? [],
+        })),
+      );
+      const res = await ds.batchTransaction(ops);
+      return res?.results?.[0];
+    },
+    [dataSource, details, schema.objectName],
+  );
+
   // The parent form renders WITHOUT its own submit button — the master-detail
   // form owns a single action bar at the bottom (header → lines → Save), the
   // layout every mainstream enterprise platform uses for header+line entry.
@@ -192,10 +222,12 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
       title: schema.title,
       showSubmit: false,
       showCancel: false,
-      onSuccess: handleParentSaved,
+      // Atomic path: ObjectForm validates + hands values to submitViaBatch
+      // (which persists parent+children in one transaction), then onSuccess.
+      ...(canBatch ? { submitHandler: submitViaBatch, onSuccess: schema.onSuccess } : { onSuccess: handleParentSaved }),
       onError: schema.onError,
     }),
-    [schema, handleParentSaved],
+    [schema, handleParentSaved, canBatch, submitViaBatch],
   );
 
   const formHostRef = useRef<HTMLDivElement>(null);

--- a/packages/plugin-form/src/ObjectForm.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { ObjectForm } from './ObjectForm';
 import { registerAllFields } from '@object-ui/fields';
 import React from 'react';
@@ -57,5 +57,59 @@ describe('ObjectForm Integration', () => {
         // Assert input exists
         // Since we don't have getByLabelText working reliably without full accessibility tree in happy-dom sometimes,
         // we can try looking for inputs.
+    });
+
+    it('delegates persistence to submitHandler instead of dataSource.create', async () => {
+        // When a host (e.g. MasterDetailForm batching parent+children into one
+        // atomic transaction) supplies a `submitHandler`, the form must validate
+        // and hand the values over WITHOUT creating/updating on its own.
+        const submitHandler = vi.fn().mockResolvedValue({ id: 'p1' });
+        const onSuccess = vi.fn();
+        const ds: any = {
+            getObjectSchema: vi.fn().mockResolvedValue({
+                name: 'test_object',
+                fields: { name: { type: 'text', label: 'Name' } },
+            }),
+            create: vi.fn(),
+            update: vi.fn(),
+        };
+
+        const { container } = render(
+            <ObjectForm
+                schema={{
+                    type: 'object-form',
+                    objectName: 'test_object',
+                    mode: 'create',
+                    submitHandler,
+                    onSuccess,
+                } as any}
+                dataSource={ds}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(ds.getObjectSchema).toHaveBeenCalledWith('test_object');
+        });
+
+        const input = await waitFor(() => {
+            const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+            if (!el) throw new Error('name input not yet rendered');
+            return el;
+        });
+        fireEvent.change(input, { target: { value: 'Atomic demo' } });
+
+        const form = container.querySelector('form') as HTMLFormElement;
+        fireEvent.submit(form);
+
+        await waitFor(() => {
+            expect(submitHandler).toHaveBeenCalledTimes(1);
+        });
+        expect(submitHandler).toHaveBeenCalledWith(expect.objectContaining({ name: 'Atomic demo' }));
+        // The form must NOT persist on its own when a submitHandler is present.
+        expect(ds.create).not.toHaveBeenCalled();
+        expect(ds.update).not.toHaveBeenCalled();
+        await waitFor(() => {
+            expect(onSuccess).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -551,8 +551,13 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
 
     try {
       let result;
-      
-      if (schema.mode === 'create') {
+
+      if (schema.submitHandler) {
+        // The host owns persistence (e.g. MasterDetailForm batching the parent
+        // + children into one atomic transaction). The form just validates and
+        // hands over the values; it does NOT create/update itself.
+        result = await schema.submitHandler(payload);
+      } else if (schema.mode === 'create') {
         result = await dataSource.create(schema.objectName, payload);
       } else if (schema.mode === 'edit' && schema.recordId) {
         result = await dataSource.update(schema.objectName, schema.recordId, payload);

--- a/packages/plugin-form/src/masterDetailTx.test.ts
+++ b/packages/plugin-form/src/masterDetailTx.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect, vi } from 'vitest';
-import { diffRows, sumRows, applyDetail, idOf } from './masterDetailTx';
+import { diffRows, sumRows, applyDetail, idOf, buildMasterDetailBatch } from './masterDetailTx';
+
+describe('buildMasterDetailBatch — atomic master-detail ops', () => {
+  it('puts the parent first and references it via $ref:0 on each child FK', () => {
+    const ops = buildMasterDetailBatch(
+      'expense_claim',
+      { title: 'Trip', total_amount: 42 },
+      [{ childObject: 'expense_line', relationshipField: 'expense_claim', rows: [{ amount: 10 }, { amount: 32 }] }],
+    );
+    expect(ops).toEqual([
+      { object: 'expense_claim', action: 'create', data: { title: 'Trip', total_amount: 42 } },
+      { object: 'expense_line', action: 'create', data: { amount: 10, expense_claim: { $ref: 0 } } },
+      { object: 'expense_line', action: 'create', data: { amount: 32, expense_claim: { $ref: 0 } } },
+    ]);
+  });
+
+  it('handles a parent with no children', () => {
+    const ops = buildMasterDetailBatch('p', { name: 'x' }, [{ childObject: 'c', relationshipField: 'p', rows: [] }]);
+    expect(ops).toHaveLength(1);
+    expect(ops[0].object).toBe('p');
+  });
+});
 
 describe('masterDetailTx — pure helpers', () => {
   it('idOf reads id / _id / recordId', () => {

--- a/packages/plugin-form/src/masterDetailTx.ts
+++ b/packages/plugin-form/src/masterDetailTx.ts
@@ -29,6 +29,38 @@ export interface RowDiff {
  * creates; rows with an id are updates; snapshot ids no longer present are
  * deletes.
  */
+export interface BatchDetailInput {
+  childObject: string;
+  relationshipField: string;
+  rows: Record<string, any>[];
+}
+
+export interface BatchOp {
+  object: string;
+  action: 'create';
+  data: Record<string, any>;
+}
+
+/**
+ * Build cross-object batch operations for an ATOMIC master-detail create:
+ * the parent at index 0, then each child with its relationship FK set to
+ * `{ $ref: 0 }` so the server resolves it to the parent's generated id inside
+ * one transaction (commit all or roll back all).
+ */
+export function buildMasterDetailBatch(
+  parentObject: string,
+  parentData: Record<string, any>,
+  details: BatchDetailInput[],
+): BatchOp[] {
+  const ops: BatchOp[] = [{ object: parentObject, action: 'create', data: parentData }];
+  for (const d of details) {
+    for (const row of d.rows) {
+      ops.push({ object: d.childObject, action: 'create', data: { ...row, [d.relationshipField]: { $ref: 0 } } });
+    }
+  }
+  return ops;
+}
+
 export function diffRows(
   original: Record<string, any>[],
   current: Record<string, any>[],

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -959,7 +959,16 @@ export interface ObjectFormSchema extends BaseSchema {
    * Callback on successful submission
    */
   onSuccess?: (data: any) => void | Promise<void>;
-  
+
+  /**
+   * Override persistence. When supplied, the form validates and hands the
+   * collected values to this handler INSTEAD of calling dataSource.create /
+   * dataSource.update — the host owns the write (e.g. MasterDetailForm batching
+   * the parent + child line items into one atomic server transaction). The
+   * returned record is passed on to `onSuccess`.
+   */
+  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+
   /**
    * Callback on error
    */


### PR DESCRIPTION
## Summary

Completes the front-end half of the atomic master-detail work (ObjectStack #1604). When the server exposes the transactional batch endpoint, a **new** parent record and its child line items are persisted in **one** server transaction — commit all or roll back all — replacing the previous client-orchestrated "create parent → create children → best-effort cleanup on failure" sequence.

This pairs with the already-merged framework changes:
- ObjectQL `AsyncLocalStorage` ambient-transaction propagation (fixes the multi-write deadlock).
- `POST /api/v1/batch` endpoint in `@objectstack/rest` with `{ $ref: <opIndex> }` intra-batch parent references.

## Changes

**`@object-ui/data-objectstack`**
- `ObjectStackAdapter.batchTransaction(operations)` — posts `{ operations }` to `POST /api/v1/batch`; one server transaction; `{ $ref: N }` resolves to op N's generated id. Throws `ObjectStackError('BATCH_ERROR')` on non-2xx.

**`@object-ui/plugin-form`**
- `ObjectForm` — new `submitHandler` hook: when present the form validates and hands values to the host instead of calling `dataSource.create`/`update`.
- `MasterDetailForm` — detects `batchTransaction`; on a new parent builds one atomic batch (parent at index 0, child FKs `{ $ref: 0 }`) via the new pure `buildMasterDetailBatch` helper, merging client-side total rollups into the parent payload. Edit mode + adapters without `batchTransaction` keep the existing client-orchestrated path.

**`@object-ui/types`**
- `ObjectFormSchema.submitHandler?` typed.

## Testing

- `buildMasterDetailBatch` unit tests (parent-first, child `$ref:0` FK, no-children case).
- `ObjectForm` `submitHandler` delegation test (asserts `dataSource.create`/`update` are NOT called and `onSuccess` still fires).
- Full `@object-ui/plugin-form` suite: **63 passing**.
- Server `/api/v1/batch` `$ref` path proven end-to-end earlier (atomic commit returns 200; rollback returns 400 with nothing persisted; backend healthy after).

**Note:** the live browser click-through of the showcase create form could not be completed because the required Radix Select ("状态/Status") would not bind its value to react-hook-form under test automation (synthetic + harness clicks alike) — a known test-automation quirk, not a product defect (real-user submission of the same form worked). The integration is therefore verified at the unit + adapter + server-e2e level rather than via a full live UI click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)