### PR TITLE
docs(adr): ADR-0034 unify runtime metadata persistence

### DIFF
--- a/.changeset/adr-0034-unified-metadata-persistence.md
+++ b/.changeset/adr-0034-unified-metadata-persistence.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(adr): ADR-0034 — propose unifying runtime metadata persistence (retire `sys_view`/`sys_report`/`sys_dashboard` in favour of a `user`-scoped metadata overlay). Documentation only; no package changes.

--- a/docs/adr/0034-unified-runtime-metadata-persistence.md
+++ b/docs/adr/0034-unified-runtime-metadata-persistence.md
@@ -1,0 +1,124 @@
+# ADR-0034: Unify runtime metadata persistence (retire `sys_view` / `sys_report` / `sys_dashboard` in favour of a scoped metadata overlay)
+
+**Status**: Proposed (2026-06-06)
+**Author**: ObjectUI renderer team
+**Consumers**: `@object-ui/app-shell` (ObjectView / ReportView / DashboardView + the metadata-admin inspectors), `@object-ui/data-objectstack` (metadata client), `@object-ui/plugin-view` / `plugin-report` / `plugin-dashboard`, and the ObjectStack backend (`/api/v1/meta/*`, the overlay store and its history).
+
+---
+
+## TL;DR
+
+The console edits the same conceptual artifacts — **views, reports, dashboards** — in **two unrelated storage systems**:
+
+- **Design time (studio)** → the unified metadata overlay system: `GET/PUT /api/v1/meta/:type/:name`, layered `code artifact ← org/env overlay ← draft`, with `draft → publish`, validation, history and rollback. The canonical, packaged, versioned definition.
+- **Runtime (the right-rail editors)** → bespoke per-type data tables `sys_view`, `sys_report`, `sys_dashboard`: plain rows, immediate writes, no draft/publish/history, each with its **own column layout** (`toSysViewPayload` snake_cases scalars and stuffs the rest into `*_json` blobs).
+
+PRs #1496 / #1504 / #1505 unified the **editing UI** (both layers now render the same spec-driven inspector from `@objectstack/spec`), but the **persistence stayed split**: every runtime panel still flattens the spec draft back into a bespoke `sys_*` row.
+
+This ADR argues the split should be along **lifecycle/scope (design-time vs runtime)**, not along **artifact type**, and proposes collapsing the three bespoke tables into the existing metadata overlay system by adding a **`user` (runtime personalization) scope** below the org/env overlay. The frontend is already most of the way there: the inspectors speak the spec shape, so the remaining change is to repoint each panel's `onSave` from `sys_*` writes to a scoped `metadataClient.put(...)`.
+
+---
+
+## Context: how we got two stores
+
+The separation is not unmotivated. Runtime-authored artifacts (a user's personal filtered view of Leads, an admin's quick dashboard) legitimately differ from packaged metadata:
+
+1. **Lifecycle / ownership** — packaged metadata is authored by designers, shipped in packages, versioned and published; runtime artifacts are end-user/admin content that must **not** pollute the app package and cannot be "published".
+2. **Immediacy** — a runtime save must take effect instantly; it should not go through `draft → publish`.
+3. **Permissions** — saving a personal view is a *data* operation, not a *metadata authoring* one; it must not require publish rights.
+4. **Scale / write frequency** — user-scoped instances are numerous and written often; the overlay system (layering + validation + history) is heavier per write.
+
+So **the design-time vs runtime distinction is correct.** What is suboptimal is implementing it as **one bespoke table per artifact type**.
+
+## Problem: "a table per type" is technical debt
+
+1. **Two sources of truth.** A "view" can exist both as packaged metadata (a `ViewItem`) *and* as a `sys_view` row; the runtime merges them. Same for reports/dashboards. This is confusing and a recurring source of bugs.
+2. **Shape drift.** `sys_view` has its own columns + `*_json` blobs that must be hand-kept in sync with the `NamedListView` spec. `toSysViewPayload` / `fromSysViewRecord` are pure maintenance burden and have been a bug source.
+3. **Capability asymmetry.** The `sys_*` path has no history / rollback / draft / validation; studio has all of it. The same artifact gets two different levels of care.
+4. **Not portable.** `sys_*` rows are not part of any package, so `export` / `publish` / environment promotion silently drop them.
+5. **N toolchains.** Studio has one editor; runtime has another. PRs #1496/#1504/#1505 only just papered over the *shape* difference with per-panel adapters.
+
+## Decision (proposed)
+
+Unify on the metadata system, and model runtime personalization as a **scope layer**, not a parallel table.
+
+### 1. View / report / dashboard are first-class metadata types
+
+All three are authored, read and written through `/api/v1/meta/:type/:name` in their **spec shape** (`ViewItem` is already one; `report` and `dashboard` schemas already exist in `@objectstack/spec` — they back the studio inspectors today). Retire `sys_view`, `sys_report`, `sys_dashboard`.
+
+### 2. Add a `user` (runtime) scope to the overlay stack
+
+Extend the existing layered overlay with one more, lowest layer:
+
+```
+code artifact (package)
+   ←  org / env overlay        (studio: draft → publish, history)
+        ←  user overlay         (runtime: immediate, no publish)   ← NEW
+```
+
+The **scope decides the behaviour**, uniformly:
+
+| Scope | Write path | Publish | History | Visibility |
+|-------|-----------|---------|---------|------------|
+| `package` / `org` | studio | `draft → publish` | yes | everyone (once published) |
+| `user` | runtime panels | immediate (active on write) | off by default | the owning user/role |
+
+This preserves every reason the split existed (immediacy, no-publish, data-style permissions, write throughput for the `user` scope) **without** a bespoke per-type table.
+
+### 3. Personalization metadata, not personalization tables
+
+Record-style attributes the `sys_*` tables carry today (owner, shared-with, pinned, sort order, default-for-user) become **fields on the user-scoped overlay**, addressed by `type + name + ownerScope`. The runtime "merge metadata-defined + user-defined views" becomes the overlay resolver's existing **layering** (effective = artifact ← org ← user), which already exists for the other layers.
+
+### 4. Frontend: one save seam
+
+Each runtime panel's persistence collapses to one call, e.g.:
+
+```ts
+// today (three shapes, three tables)
+dataSource.create('sys_view', toSysViewPayload(draft, objectName))
+adapter.update('sys_report', name, draft)
+adapter.updateDashboard(name, draft)
+
+// target (one shape, one path)
+metadataClient.put(type, name, draft, { scope: 'user' })
+```
+
+`toSysViewPayload` / `fromSysViewRecord` / the report+dashboard adapters are deleted. Because the inspectors already emit the spec draft (post #1496/#1504/#1505), this is a localized change at the `onSave` boundary.
+
+## Consequences
+
+**Positive**
+- One store, one shape, one toolchain for an artifact's whole life.
+- Personalization gains, for free, the overlay system's diffing ("my view vs the app default"), validation, optional history, export/promotion.
+- Deletes the `sys_*` schemas and all the shape-conversion code (a meaningful net reduction).
+- The "two sources of truth / merge" class of bugs disappears.
+
+**Costs / risks**
+- **Backend-led.** Requires the `/meta` API + overlay store to learn a `user` scope (resolution order, write path, per-scope history toggle, throughput for high write volume). This ADR's frontend is ready; the backend is the gating work.
+- **Data migration.** Existing `sys_view` / `sys_report` / `sys_dashboard` rows must be migrated into user-scoped overlays (with a back-compat dual-read window).
+- **Write performance.** The `user` scope needs a lightweight write path (skip history/validation by default) so personalization stays cheap.
+- **Permissions model.** A new "edit own user-scoped overlay" permission, distinct from metadata publish rights.
+
+## Rollout (phased, back-compat throughout)
+
+1. **(done)** Unify the editing UI on the spec-driven inspectors — #1496 (view), #1504 (report), #1505 (dashboard), #1503 (i18n). Runtime panels already produce spec drafts.
+2. **Backend**: add `scope: 'user'` to `/meta` write/read + overlay resolution (artifact ← org ← user); lightweight user-scope write (no publish/history by default).
+3. **Frontend seam**: introduce a single `persistRuntimeMetadata(type, name, draft)` helper; today it routes to the existing `sys_*` writes, so the switch in step 4 is one line per panel.
+4. **Cutover**: repoint `persistRuntimeMetadata` to `metadataClient.put(..., { scope: 'user' })` behind a flag; dual-read `sys_*` for a window.
+5. **Migrate** `sys_*` rows → user overlays; **retire** the tables and delete `toSysViewPayload` / adapters.
+
+## Alternatives considered
+
+- **Keep the status quo (per-type tables).** Rejected: it is the technical debt this ADR documents — two sources of truth, shape drift, capability asymmetry, non-portability.
+- **Push everything (incl. personalization) through `draft → publish`.** Rejected: breaks runtime immediacy and forces publish permissions onto end-user personalization.
+- **One generic `sys_user_metadata` table (type + name + owner + spec JSON), separate from the overlay system.** A reasonable middle ground (one table, spec shape, no per-type drift), but it still keeps personalization *outside* the overlay resolver, so it forgoes free layering/diffing against the app default and re-implements a parallel resolver. The scoped-overlay approach is preferred; this is the fallback if extending the overlay store proves too costly.
+
+---
+
+## Appendix: current persistence call sites (for the step-3 seam)
+
+| Runtime panel | Today | File |
+|---|---|---|
+| ObjectView (view) | `dataSource.create/update('sys_view', toSysViewPayload(...))` | `packages/app-shell/src/views/ObjectView.tsx` |
+| ReportView | `adapter.update('sys_report', name, schema)` | `packages/app-shell/src/views/ReportView.tsx` |
+| DashboardView | `adapter.updateDashboard(name, schema)` / `adapter.update('sys_dashboard', ...)` | `packages/app-shell/src/views/DashboardView.tsx` |

--- a/docs/adr/0034-unified-runtime-metadata-persistence.md
+++ b/docs/adr/0034-unified-runtime-metadata-persistence.md
@@ -1,4 +1,4 @@
-# ADR-0034: Unify runtime metadata persistence (retire `sys_view` / `sys_report` / `sys_dashboard` in favour of a scoped metadata overlay)
+# ADR-0034: Unify runtime metadata persistence (admin-edits-the-shared-definition first; retire `sys_view` / `sys_report` / `sys_dashboard`)
 
 **Status**: Proposed (2026-06-06)
 **Author**: ObjectUI renderer team
@@ -10,68 +10,65 @@
 
 The console edits the same conceptual artifacts — **views, reports, dashboards** — in **two unrelated storage systems**:
 
-- **Design time (studio)** → the unified metadata overlay system: `GET/PUT /api/v1/meta/:type/:name`, layered `code artifact ← org/env overlay ← draft`, with `draft → publish`, validation, history and rollback. The canonical, packaged, versioned definition.
+- **Design time (studio)** → the unified metadata overlay: `GET/PUT /api/v1/meta/:type/:name`, layered `code artifact ← org/env overlay ← draft`, with `draft → publish`, validation, history and rollback. The canonical, packaged, versioned definition.
 - **Runtime (the right-rail editors)** → bespoke per-type data tables `sys_view`, `sys_report`, `sys_dashboard`: plain rows, immediate writes, no draft/publish/history, each with its **own column layout** (`toSysViewPayload` snake_cases scalars and stuffs the rest into `*_json` blobs).
 
-PRs #1496 / #1504 / #1505 unified the **editing UI** (both layers now render the same spec-driven inspector from `@objectstack/spec`), but the **persistence stayed split**: every runtime panel still flattens the spec draft back into a bespoke `sys_*` row.
+PRs #1496 / #1504 / #1505 unified the **editing UI** (both layers now render the same spec-driven inspector from `@objectstack/spec`), but the **persistence stayed split**.
 
-This ADR argues the split should be along **lifecycle/scope (design-time vs runtime)**, not along **artifact type**, and proposes collapsing the three bespoke tables into the existing metadata overlay system by adding a **`user` (runtime personalization) scope** below the org/env overlay. The frontend is already most of the way there: the inspectors speak the spec shape, so the remaining change is to repoint each panel's `onSave` from `sys_*` writes to a scoped `metadataClient.put(...)`.
+**Key finding (verified in code):** *none of the runtime editors do per-user personalization today.* They all write the **shared** record. View editing is already **admin-gated**; report/dashboard editing is **un-gated** (any user who clicks "edit" mutates the shared report/dashboard for everyone). So in practice these buttons are an **admin quick-edit entry point to the shared definition**, not a personalization feature.
+
+This ADR therefore proposes a **v1 that matches that reality and removes the debt now**, with personalization deferred to v2:
+
+- **v1 (this version, mostly frontend):** treat every runtime edit button as an **admin** quick-edit that writes the **shared definition through the existing `/meta` org/env overlay**. Retire `sys_view`/`sys_report`/`sys_dashboard` and their shape adapters. Add the missing admin gate to report/dashboard.
+- **v2 (backend-led, when there's demand):** add **per-user personalization to views only**, as an additive `user` overlay layer below org/env. Reports/dashboards/pages stay shared (governed by ownership + visibility, not per-user overlays).
+
+The frontend is already positioned for both: post #1496/#1504/#1505 the inspectors emit the spec draft, so v1 is mostly repointing each panel's `onSave`.
 
 ---
 
 ## Context: how we got two stores
 
-The separation is not unmotivated. Runtime-authored artifacts (a user's personal filtered view of Leads, an admin's quick dashboard) legitimately differ from packaged metadata:
+The split is not unmotivated. Runtime-authored artifacts *could* legitimately differ from packaged metadata (immediacy, no-publish, data-style permissions, write throughput). So the **design-time vs runtime distinction is sound.** What is suboptimal is implementing it as **one bespoke table per artifact type** — and, as the finding below shows, the runtime tables aren't even being used for the personalization that would justify them.
 
-1. **Lifecycle / ownership** — packaged metadata is authored by designers, shipped in packages, versioned and published; runtime artifacts are end-user/admin content that must **not** pollute the app package and cannot be "published".
-2. **Immediacy** — a runtime save must take effect instantly; it should not go through `draft → publish`.
-3. **Permissions** — saving a personal view is a *data* operation, not a *metadata authoring* one; it must not require publish rights.
-4. **Scale / write frequency** — user-scoped instances are numerous and written often; the overlay system (layering + validation + history) is heavier per write.
+## Current reality (verified)
 
-So **the design-time vs runtime distinction is correct.** What is suboptimal is implementing it as **one bespoke table per artifact type**.
+| Runtime editor | Permission gate today | Writes to | Per-user? |
+|---|---|---|---|
+| **View** (`ObjectView`) | **admin-gated** (`onConfigView={isAdmin ? … : undefined}`, panel `open={… && isAdmin}`) | shared `sys_view` row | **no** (the row is shared; the comment "user-defined views" notwithstanding) |
+| **Report** (`ReportView`) | **un-gated** (`report-edit-button` shown to everyone) | shared `sys_report` | no |
+| **Dashboard** (`DashboardView`) | **un-gated** | shared `sys_dashboard` | no |
+| **Page** (`PageView`) | — (render only; authored in studio) | metadata | n/a |
+
+Takeaways: (1) there is **no per-user data to preserve**; (2) view editing is **already** admin-only; (3) report/dashboard editing is an **un-gated shared mutation** — arguably a defect this ADR also fixes.
 
 ## Problem: "a table per type" is technical debt
 
-1. **Two sources of truth.** A "view" can exist both as packaged metadata (a `ViewItem`) *and* as a `sys_view` row; the runtime merges them. Same for reports/dashboards. This is confusing and a recurring source of bugs.
-2. **Shape drift.** `sys_view` has its own columns + `*_json` blobs that must be hand-kept in sync with the `NamedListView` spec. `toSysViewPayload` / `fromSysViewRecord` are pure maintenance burden and have been a bug source.
-3. **Capability asymmetry.** The `sys_*` path has no history / rollback / draft / validation; studio has all of it. The same artifact gets two different levels of care.
-4. **Not portable.** `sys_*` rows are not part of any package, so `export` / `publish` / environment promotion silently drop them.
-5. **N toolchains.** Studio has one editor; runtime has another. PRs #1496/#1504/#1505 only just papered over the *shape* difference with per-panel adapters.
+1. **Two sources of truth.** A "view" can exist both as packaged metadata (a `ViewItem`) *and* as a `sys_view` row; the runtime merges them. Same for reports/dashboards. Confusing and bug-prone.
+2. **Shape drift.** `sys_view` has bespoke columns + `*_json` blobs hand-kept in sync with the `NamedListView` spec via `toSysViewPayload` / `fromSysViewRecord` — pure maintenance burden and a known bug source.
+3. **Capability asymmetry.** The `sys_*` path has no history / rollback / draft / validation; studio has all of it.
+4. **Not portable.** `sys_*` rows aren't part of any package, so `export` / `publish` / environment promotion silently drop them.
+5. **N toolchains.** #1496/#1504/#1505 only just papered over the *shape* difference with per-panel adapters.
 
-## Decision (proposed)
+## The architectural crux: two different kinds of "personal"
 
-Unify on the metadata system, and model runtime personalization as a **scope layer**, not a parallel table.
+When personalization *is* wanted, it comes in two shapes — and conflating them is the main design risk:
 
-### 1. View / report / dashboard are first-class metadata types
+| Kind | Semantics | Right for |
+|------|-----------|-----------|
+| **(A) Personal overlay (delta)** | "the org has a Leads grid; I layer my own columns/filter on top of it" — a *delta over a shared definition* | **views** (Airtable personal-vs-collaborative views; Salesforce per-user list columns/filters; ServiceNow list personalization; Dataverse `userquery`) |
+| **(B) Owned instance (ownership + visibility)** | "I built my own report/dashboard; it's mine, optionally shared" — a *standalone artifact I own* | **reports / dashboards** (Salesforce report/dashboard folders; Metabase personal collections; Tableau) |
 
-All three are authored, read and written through `/api/v1/meta/:type/:name` in their **spec shape** (`ViewItem` is already one; `report` and `dashboard` schemas already exist in `@objectstack/spec` — they back the studio inspectors today). Retire `sys_view`, `sys_report`, `sys_dashboard`.
+A per-user *overlay of a specific org report* is the wrong model; a report's "personal-ness" is **ownership + visibility**, which in most orgs simply manifests as *shared*. Pages are shared metadata everywhere (Salesforce Lightning pages, Retool, ServiceNow) — no personalization.
 
-### 2. Add a `user` (runtime) scope to the overlay stack
+## Decision
 
-Extend the existing layered overlay with one more, lowest layer:
+### Storage: one system, retire the bespoke tables
 
-```
-code artifact (package)
-   ←  org / env overlay        (studio: draft → publish, history)
-        ←  user overlay         (runtime: immediate, no publish)   ← NEW
-```
+View / report / dashboard are authored, read and written through `/api/v1/meta/:type/:name` in their **spec shape** (`ViewItem` already is; `report`/`dashboard` schemas already exist in `@objectstack/spec` and back the studio inspectors). Retire `sys_view`, `sys_report`, `sys_dashboard`.
 
-The **scope decides the behaviour**, uniformly:
+### v1 — admin edits the shared definition (mostly frontend, no new backend)
 
-| Scope | Write path | Publish | History | Visibility |
-|-------|-----------|---------|---------|------------|
-| `package` / `org` | studio | `draft → publish` | yes | everyone (once published) |
-| `user` | runtime panels | immediate (active on write) | off by default | the owning user/role |
-
-This preserves every reason the split existed (immediacy, no-publish, data-style permissions, write throughput for the `user` scope) **without** a bespoke per-type table.
-
-### 3. Personalization metadata, not personalization tables
-
-Record-style attributes the `sys_*` tables carry today (owner, shared-with, pinned, sort order, default-for-user) become **fields on the user-scoped overlay**, addressed by `type + name + ownerScope`. The runtime "merge metadata-defined + user-defined views" becomes the overlay resolver's existing **layering** (effective = artifact ← org ← user), which already exists for the other layers.
-
-### 4. Frontend: one save seam
-
-Each runtime panel's persistence collapses to one call, e.g.:
+The runtime edit buttons become explicit **admin quick-edit** affordances that write the **org/env overlay** via the **existing** `/meta` PUT (the same write studio already uses), taking effect immediately (overlay write / `mode: 'publish'`, not a pending draft, to preserve the quick-edit feel):
 
 ```ts
 // today (three shapes, three tables)
@@ -79,43 +76,71 @@ dataSource.create('sys_view', toSysViewPayload(draft, objectName))
 adapter.update('sys_report', name, draft)
 adapter.updateDashboard(name, draft)
 
-// target (one shape, one path)
-metadataClient.put(type, name, draft, { scope: 'user' })
+// v1 (one shape, one path — existing org/env overlay)
+metadataClient.put(type, name, draft /* spec shape */)   // gated by admin
 ```
 
-`toSysViewPayload` / `fromSysViewRecord` / the report+dashboard adapters are deleted. Because the inspectors already emit the spec draft (post #1496/#1504/#1505), this is a localized change at the `onSave` boundary.
+- Add the missing **admin gate** to the report/dashboard edit buttons.
+- Delete `toSysViewPayload` / `fromSysViewRecord` and the report/dashboard adapters.
+- Migrate existing `sys_*` rows → org/env overlays, with a back-compat dual-read window; then drop the tables.
+
+Because the inspectors already emit the spec draft, this is a localized change at each `onSave` boundary plus a read-path switch to the overlay's effective value.
+
+### v2 — per-user personalization, views only (backend-led, on demand)
+
+Add one more, lowest overlay layer **scoped to a user**, used **only by views**:
+
+```
+code artifact (package)
+   ←  org / env overlay        (admin quick-edit + studio: immediate or draft→publish)
+        ←  user overlay         (per-user view personalization: immediate, no publish)   ← v2, views only
+```
+
+Reports/dashboards do **not** get a per-user overlay; if "personal" ones are ever wanted they are modelled as **owned, shareable** metadata (ownership + visibility), defaulting to shared. Pages stay shared-only.
+
+### Target model per artifact
+
+| Artifact | Storage | Personalization model | Default | Precedent |
+|---|---|---|---|---|
+| **Object views** (grid / **kanban** / calendar / gallery / list / …) | unified metadata | **v2: personal overlay** (artifact ← org ← user delta) | org-shared default + optional personal | Airtable personal/collaborative views, Dataverse `userquery`, SF personal list views |
+| **Reports / Dashboards** | unified metadata | **ownership + visibility** (private / role / org); no per-user overlay | **shared** (optionally restrict who can create) | SF report/dashboard folders, Metabase collections, Tableau |
+| **Custom pages** | unified metadata | **none** (shared only) | shared | SF Lightning pages, Retool, ServiceNow |
+
+> Note: in ObjectUI a **kanban** is a *view kind* of an object (like grid), so it sits in the "object views" row — it personalizes like any other view, not like a standalone dashboard.
 
 ## Consequences
 
 **Positive**
-- One store, one shape, one toolchain for an artifact's whole life.
-- Personalization gains, for free, the overlay system's diffing ("my view vs the app default"), validation, optional history, export/promotion.
-- Deletes the `sys_*` schemas and all the shape-conversion code (a meaningful net reduction).
-- The "two sources of truth / merge" class of bugs disappears.
+- One store, one shape, one toolchain per artifact's whole life; the "two sources of truth / merge" bug class disappears.
+- Runtime admin edits gain the overlay system's validation, optional history and env-promotion **for free**, and report/dashboard editing gets a proper permission gate.
+- Deletes the `sys_*` schemas and all shape-conversion code (a meaningful net reduction).
+- **v1 needs no new backend** — it reuses the existing `/meta` org/env overlay.
+- Personalization stays a clean, additive, demand-driven v2 (views only), not a blocker.
 
 **Costs / risks**
-- **Backend-led.** Requires the `/meta` API + overlay store to learn a `user` scope (resolution order, write path, per-scope history toggle, throughput for high write volume). This ADR's frontend is ready; the backend is the gating work.
-- **Data migration.** Existing `sys_view` / `sys_report` / `sys_dashboard` rows must be migrated into user-scoped overlays (with a back-compat dual-read window).
-- **Write performance.** The `user` scope needs a lightweight write path (skip history/validation by default) so personalization stays cheap.
-- **Permissions model.** A new "edit own user-scoped overlay" permission, distinct from metadata publish rights.
+- **Immediacy vs governance.** Quick-edit must feel instant → write the env overlay / `mode:'publish'` rather than leaving a draft. (Draft→publish remains available for governed changes.)
+- **Read-path switch.** Runtime read moves from "`sys_*` + metadata merge" to the overlay's effective value (the metadata read path is already partly there).
+- **Data migration.** Existing `sys_*` rows → overlays, behind a dual-read window.
+- **v2 backend.** The `user` scope needs overlay resolution (artifact ← org ← user), a lightweight write path (no publish/history by default) and an "edit own personalization" permission distinct from publish rights.
 
 ## Rollout (phased, back-compat throughout)
 
 1. **(done)** Unify the editing UI on the spec-driven inspectors — #1496 (view), #1504 (report), #1505 (dashboard), #1503 (i18n). Runtime panels already produce spec drafts.
-2. **Backend**: add `scope: 'user'` to `/meta` write/read + overlay resolution (artifact ← org ← user); lightweight user-scope write (no publish/history by default).
-3. **Frontend seam**: introduce a single `persistRuntimeMetadata(type, name, draft)` helper; today it routes to the existing `sys_*` writes, so the switch in step 4 is one line per panel.
-4. **Cutover**: repoint `persistRuntimeMetadata` to `metadataClient.put(..., { scope: 'user' })` behind a flag; dual-read `sys_*` for a window.
-5. **Migrate** `sys_*` rows → user overlays; **retire** the tables and delete `toSysViewPayload` / adapters.
+2. **v1 — frontend seam**: introduce `persistRuntimeMetadata(type, name, draft)`; initially routes to the existing `sys_*` writes so the switch is one line per panel.
+3. **v1 — cutover**: repoint `persistRuntimeMetadata` to `metadataClient.put(type, name, draft)` (org/env overlay, immediate) behind a flag; add admin gating to report/dashboard; dual-read `sys_*` for a window.
+4. **v1 — retire**: migrate `sys_*` rows → overlays; drop the tables; delete `toSysViewPayload` / adapters.
+5. **v2 — backend**: add the `user` scope (views only) for per-user personalization, additive and flagged.
 
 ## Alternatives considered
 
-- **Keep the status quo (per-type tables).** Rejected: it is the technical debt this ADR documents — two sources of truth, shape drift, capability asymmetry, non-portability.
-- **Push everything (incl. personalization) through `draft → publish`.** Rejected: breaks runtime immediacy and forces publish permissions onto end-user personalization.
-- **One generic `sys_user_metadata` table (type + name + owner + spec JSON), separate from the overlay system.** A reasonable middle ground (one table, spec shape, no per-type drift), but it still keeps personalization *outside* the overlay resolver, so it forgoes free layering/diffing against the app default and re-implements a parallel resolver. The scoped-overlay approach is preferred; this is the fallback if extending the overlay store proves too costly.
+- **Keep the status quo (per-type tables).** Rejected: it is the technical debt this ADR documents, and the tables aren't even serving the personalization that would justify them.
+- **One uniform `user` overlay for all three types (the first draft of this ADR).** Rejected: a per-user overlay is right for views but wrong for reports/dashboards, whose "personal-ness" is ownership+visibility. Conflating them bakes in the wrong model.
+- **Ship per-user personalization in v1.** Rejected for v1: there is no per-user data today and view editing is already admin-only, so personalization is pure new scope (backend) with no current consumer — classic YAGNI. Deferred to v2.
+- **One generic `sys_user_metadata` table (type + name + owner + spec JSON).** A reasonable v2 fallback if extending the overlay store proves too costly, but it keeps personalization outside the overlay resolver (forgoing free layering/diffing against the app default).
 
 ---
 
-## Appendix: current persistence call sites (for the step-3 seam)
+## Appendix: current persistence call sites (for the step-2 seam)
 
 | Runtime panel | Today | File |
 |---|---|---|


### PR DESCRIPTION
## 背景

回答"为什么运行时编辑保存到 `sys_view`/`sys_report`/`sys_dashboard` 三张专用表、而非统一元数据系统",并给出经多轮讨论收敛的推荐架构。

## 核实到的现状(已写进 ADR)

**今天没有任何运行时编辑器做 per-user 个性化——全是共享编辑:**
- 视图编辑:**已 isAdmin 门控**,写共享 `sys_view`
- 报表/仪表盘编辑:**无门控**(任何用户保存即改所有人的),写共享 `sys_report`/`sys_dashboard`
- 页面:仅渲染,studio 编辑

即:这些"编辑"按钮本质是**管理员对共享定义的快速编辑入口**,不是个性化功能。

## 决策(v1-first)

- **存储统一**:view/report/dashboard 升为一等元数据类型,统一走 `/meta`,退役 `sys_*` 异形表。
- **v1(本期,基本前端、无需新后端)**:运行时编辑按钮 = **管理员快速编辑** → 写**现有 `/meta` org/env 覆盖层**(即时生效);给报表/仪表盘**补 admin 门控**;删 `toSysViewPayload` 等转换;`sys_*` 数据迁移到覆盖层(双读过渡)。
- **v2(后端配合、按需)**:**仅视图**加 `user` 覆盖层做 per-user 个性化;报表/仪表盘走"归属+可见性"(默认共享);页面仅共享。

含**两种"个人化"的关键区分**(视图=覆盖增量 / 报表+仪表盘=归属可见性)、各制品目标模型对照(附主流平台先例)、分阶段向后兼容 rollout、备选方案、当前 `sys_*` 调用点清单。

## 性质

**纯文档(Status: Proposed),零运行时/包改动。** 供你和后端评审决策——接受后再按 rollout 落地。

https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL