### PR TITLE
fix(app-shell): gate the runtime report/dashboard editors behind admin

### DIFF
--- a/.changeset/gate-runtime-editors-admin.md
+++ b/.changeset/gate-runtime-editors-admin.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Gate the runtime report and dashboard editors behind an admin check. Editing a report or dashboard mutates the **shared** definition (it writes the single `sys_report` / `sys_dashboard` record, not a per-user copy), but the edit buttons were shown to every user — so any viewer could change a report/dashboard for everyone. The "Edit" affordance (and its config panel) is now admin-only, matching ObjectView's existing view-config gate. This is the first step of ADR-0034 (runtime edits are an admin quick-edit of the shared definition).

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -11,6 +11,7 @@ import { useParams } from 'react-router-dom';
 import { DashboardRenderer } from '@object-ui/plugin-dashboard';
 import { ModalForm } from '@object-ui/plugin-form';
 import { DashboardConfigPanel } from './DashboardConfigPanel';
+import { useAuth } from '@object-ui/auth';
 import { toast } from 'sonner';
 import type { ModalHandler, ActionDef, ActionContext, ActionResult } from '@object-ui/core';
 import {
@@ -94,6 +95,10 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
   const adapter = useAdapter();
   const { t } = useObjectTranslation();
   const { dashboardLabel, dashboardDescription } = useObjectLabel();
+  // Editing a dashboard mutates the SHARED definition, so it is an admin-only
+  // quick-edit affordance (mirrors ObjectView's view-config gate).
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
   const [isLoading, setIsLoading] = useState(true);
   const [configPanelOpen, setConfigPanelOpen] = useState(false);
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
@@ -382,6 +387,7 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
               ))}
             </div>
           )}
+          {isAdmin && (
           <button
             type="button"
             onClick={handleOpenConfigPanel}
@@ -391,6 +397,7 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
             <Pencil className="h-3.5 w-3.5" />
             {t('common.edit', { defaultValue: 'Edit' })}
           </button>
+          )}
         </div>
       </div>
 
@@ -413,7 +420,7 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
          {/* Right-side config panel — one controlled panel that switches
              between the dashboard-level and widget-level studio inspectors. */}
          <DashboardConfigPanel
-           open={configPanelOpen}
+           open={configPanelOpen && isAdmin}
            onClose={handleCloseConfigPanel}
            schema={panelSchema}
            selectedWidgetId={selectedWidgetId}

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -15,6 +15,7 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useAdapter } from '../providers/AdapterProvider';
+import { useAuth } from '@object-ui/auth';
 import type { DataSource } from '@object-ui/types';
 
 // Fallback fields when no schema is available
@@ -34,6 +35,10 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   const { reportName } = useParams<{ reportName: string }>();
   const { showDebug } = useMetadataInspector();
   const adapter = useAdapter();
+  // Editing a report mutates the SHARED definition, so it is an admin-only
+  // quick-edit affordance (mirrors ObjectView's view-config gate).
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
   const [configPanelOpen, setConfigPanelOpen] = useState(false);
   // Version counter — incremented on save to refresh the stable config reference
   const [configVersion, setConfigVersion] = useState(0);
@@ -426,6 +431,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
            )}
         </div>
         <div className="shrink-0 flex items-center gap-1.5">
+           {isAdmin && (
            <button
              type="button"
              onClick={handleOpenConfigPanel}
@@ -435,6 +441,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
              <Pencil className="h-3.5 w-3.5" />
              {t('common.edit')}
            </button>
+           )}
         </div>
       </div>
 
@@ -456,7 +463,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
          {/* Right-side config panel — studio's spec-driven report inspector,
              hosted locally in app-shell (see ReportConfigPanel). */}
          <ReportConfigPanel
-           open={configPanelOpen}
+           open={configPanelOpen && isAdmin}
            onClose={handleCloseConfigPanel}
            config={reportConfig}
            onSave={handleReportConfigSave}


### PR DESCRIPTION
## 背景

ADR-0034 调研中核实到一个**独立的真实缺陷**:运行时**报表/仪表盘**的编辑按钮**无任何权限门控**——而它们写的是**共享**记录(`sys_report`/`sys_dashboard` 单条),所以**任何普通用户点"编辑"保存,就改了所有人的报表/仪表盘**。视图编辑早已是 isAdmin 门控,这两处却没有。

## 改动

给 `ReportView` 与 `DashboardView` 的编辑入口补上管理员门控(对齐 `ObjectView`):
- `useAuth().user?.role === 'admin'` 计算 `isAdmin`。
- 编辑按钮仅管理员可见(`{isAdmin && <button .../>}`)。
- 配置面板 `open` 加 `&& isAdmin` 防御。

这是 **ADR-0034 v1 的第一步**(运行时编辑 = 管理员对共享定义的快速编辑),小、安全、独立可上线,不依赖后端。

## 验证
- `pnpm turbo run build --filter=@object-ui/app-shell`:27/27 通过。
- `app-shell/src/views` 测试:179 全过。
- lint 改动文件 0 error。

https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL)_