### PR TITLE
feat(app-shell): add admin "Edit in studio" deep-link to PageView

### DIFF
--- a/.changeset/page-edit-in-studio.md
+++ b/.changeset/page-edit-in-studio.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Add an admin-only "Edit in studio" affordance to the runtime PageView. Custom pages are authored in the metadata studio (canvas + inspector), not at runtime — so instead of embedding the heavyweight page canvas, PageView now shows a lightweight top-right button (admins only) that deep-links to the page's studio editor (`/apps/:app/metadata/page/:name`). This gives view/report/dashboard/page a consistent runtime admin edit entry point.

--- a/packages/app-shell/src/views/PageView.tsx
+++ b/packages/app-shell/src/views/PageView.tsx
@@ -1,16 +1,20 @@
 /**
  * Page View Component
  *
- * Renders a custom page based on the pageName parameter. Page authoring
- * happens via the metadata admin (JSON form / preview tabs); no bespoke
- * canvas editor is offered here.
+ * Renders a custom page based on the pageName parameter. Page *authoring*
+ * happens in the metadata studio (canvas + inspector), not here — runtime is
+ * pure rendering. For parity with the view/report/dashboard runtime editors,
+ * admins get a lightweight "Edit in studio" affordance that deep-links to the
+ * page's studio editor (`/apps/:app/metadata/page/:name`) rather than
+ * embedding the heavyweight page canvas in the runtime.
  */
 
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import { SchemaRenderer } from '@object-ui/react';
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
-import { FileText } from 'lucide-react';
+import { FileText, Pencil } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
+import { useAuth } from '@object-ui/auth';
 import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
 import { useMetadata } from '../providers/MetadataProvider';
 
@@ -19,6 +23,12 @@ export function PageView() {
   const { pageName } = useParams<{ pageName: string }>();
   const [searchParams] = useSearchParams();
   const { showDebug } = useMetadataInspector();
+  const navigate = useNavigate();
+  const location = useLocation();
+  // Editing a page mutates the shared metadata definition, so the entry point
+  // is admin-only (mirrors the view/report/dashboard runtime editors).
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
 
   const { pages } = useMetadata();
   const page = pages?.find((p: any) => p.name === pageName);
@@ -41,9 +51,30 @@ export function PageView() {
 
   const params = Object.fromEntries(searchParams.entries());
 
+  // Resolve the app slug from the path (`/apps/:app/page/:name`) so the deep
+  // link survives whatever Router basename the host mounts under.
+  const appName = location.pathname.match(/\/apps\/([^/]+)/)?.[1];
+  const canEditInStudio = isAdmin && !!appName && !!pageName;
+  const openInStudio = () => {
+    if (!canEditInStudio) return;
+    navigate(`/apps/${appName}/metadata/page/${encodeURIComponent(pageName!)}`);
+  };
+
   return (
     <div className="flex flex-row h-full w-full overflow-hidden relative">
       <div className="flex-1 overflow-auto h-full relative">
+        {canEditInStudio && (
+          <button
+            type="button"
+            onClick={openInStudio}
+            className="absolute right-3 top-3 z-30 inline-flex items-center gap-1.5 rounded-md border border-input bg-background/90 px-2.5 py-1.5 text-xs font-medium text-muted-foreground shadow-sm backdrop-blur hover:bg-accent hover:text-accent-foreground"
+            data-testid="page-edit-in-studio-button"
+            title={t('common.editInStudio', { defaultValue: 'Edit in studio' })}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            {t('common.editInStudio', { defaultValue: 'Edit in studio' })}
+          </button>
+        )}
         <SchemaRenderer
           schema={{
             ...page,


### PR DESCRIPTION
## 背景

view/report/dashboard 的运行时编辑都已统一并补了 admin 门控。自定义 **page** 不同:它本就是"studio 创作、运行时纯渲染"(`PageView` 只用 `SchemaRenderer`),没有也不该内嵌重型页面画布。为补齐"四类制品在运行时有一致的管理员编辑入口"这一致性,给 PageView 加一个**轻量深链按钮**。

## 改动

`PageView`:
- 管理员专属(`useAuth().role==='admin'`)的右上角浮动按钮「Edit in studio」。
- 点击深链到该页在 studio 的编辑器:`/apps/:app/metadata/page/:name`(与 QuickFind/PackagesPage 等既有拼法一致)。
- app slug 从 `location.pathname` 解析,**不依赖 useParams**,可适配任何 Router basename。
- 非管理员/无法解析 app 时不渲染按钮。

不内嵌画布——页面编辑仍在 studio,符合既有设计意图(`PageView` 注释也相应更新)。

## 验证
- `pnpm turbo run build --filter=@object-ui/app-shell`:27/27。
- `app-shell/src/views` 测试:179 全过。
- lint 改动文件 0 error。

https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL)_