### PR TITLE
feat(chat): Publish & Open — land on the published app after publish

### DIFF
--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -32,6 +32,7 @@ import {
 import { Share2, SquarePen } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { toast } from 'sonner';
+import { useNavigate } from 'react-router-dom';
 import { useChatConversation, type HydratedUIMessage } from '../hooks';
 import { useAssistant, requestAssistantReview, type AssistantEditorContext } from '../assistant/assistantBus';
 
@@ -254,6 +255,7 @@ function ChatbotInner({
   initialMessages: persistedMessages,
 }: ChatbotInnerProps) {
   const { language } = useObjectTranslation();
+  const navigate = useNavigate();
 
   // What the user is currently editing in a designer (if any). Merged into
   // the agent context so "add a priority field" acts on the open object,
@@ -475,6 +477,14 @@ function ChatbotInner({
             const failed = payload?.data?.failedCount ?? payload?.failedCount ?? 0;
             if (failed) throw new Error(String(failed));
             toast.success(locale.publishOk);
+            // Publish & Open: land the user ON the thing they just built rather
+            // than leaving them on an empty home with only a toast. Prefer the
+            // published App (a full navigable surface); the bare-object case has
+            // no app to open yet, so the toast is the only feedback there.
+            const published: Array<{ type?: string; name?: string }> =
+              payload?.data?.published ?? payload?.published ?? [];
+            const app = published.find((p) => p?.type === 'app' && p?.name);
+            if (app?.name) navigate(`/apps/${encodeURIComponent(app.name)}`);
           } catch (e) {
             toast.error(locale.publishFailed, {
               description: e instanceof Error ? e.message : undefined,


### PR DESCRIPTION
P0 开发体验优化(见 cloud docs/strategy/dev-experience-optimization.md):用户点发布后,**直接落地到刚建好的 App**,而不是停在空主页只给 toast。publish-drafts 响应含 published 'app' 时导航到 /apps/<app>。加法式+安全:bare object(无 app)行为不变(仅 toast),不会回退已验证的 create_object 发布流程。type-clean。app 导航路径待 staging 确认。