### PR TITLE
fix(master-detail): never silent on save — toast + reset + duplicate-submit guard

### DIFF
--- a/.changeset/master-detail-submit-feedback.md
+++ b/.changeset/master-detail-submit-feedback.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/plugin-form": patch
+"@object-ui/components": patch
+---
+
+fix(master-detail): never silent on save — feedback, reset, and a duplicate-submit guard
+
+`MasterDetailForm`'s "Create" submitted successfully but gave **no feedback**: no toast, no form reset, no navigation. A successful create looked broken, and re-clicking created duplicate records.
+
+- On success: a `toast.success`, and on create the form clears (line items reset + parent `<ObjectForm>` remounts) ready for the next entry. A page-supplied `onSuccess` still runs afterwards (e.g. to navigate).
+- On failure (validation / network / atomic rollback): a `toast.error` surfaces the message instead of failing silently.
+- In-flight guard: the Create button shows "Saving…" and is disabled while a submit is running, preventing duplicate submissions, with a safety release if client-side validation blocks the submit.
+- `@object-ui/components` now re-exports `toast` (alongside `Toaster`) from its sonner wrapper.
+
+Tests: two new `MasterDetailForm` tests assert success → toast + form clear, and failure → error toast.

--- a/packages/components/src/ui/sonner.tsx
+++ b/packages/components/src/ui/sonner.tsx
@@ -16,7 +16,7 @@ import {
   TriangleAlert,
 } from "lucide-react"
 import { useTheme } from "next-themes"
-import { Toaster as Sonner } from "sonner"
+import { Toaster as Sonner, toast } from "sonner"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
@@ -50,4 +50,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster }
+export { Toaster, toast }

--- a/packages/plugin-form/src/MasterDetailForm.test.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { registerAllFields } from '@object-ui/fields';
+import { MasterDetailForm } from './MasterDetailForm';
+
+// Capture toast calls so we can assert the form is never a silent no-op.
+const { toastSuccess, toastError } = vi.hoisted(() => ({ toastSuccess: vi.fn(), toastError: vi.fn() }));
+vi.mock('@object-ui/components', async (orig) => {
+  const actual = await (orig as any)();
+  return { ...actual, toast: { success: toastSuccess, error: toastError } };
+});
+
+registerAllFields();
+
+// Parent object with a single non-required text field so a jsdom submit can
+// actually validate + succeed (no Radix selects in the test surface).
+const parentSchema = { name: 'po', fields: { ref: { type: 'text', label: 'Ref' } } };
+
+function makeDataSource(overrides: any = {}) {
+  return {
+    getObjectSchema: vi.fn().mockResolvedValue(parentSchema),
+    find: vi.fn().mockResolvedValue({ data: [] }),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    bulk: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+describe('MasterDetailForm — submit feedback (never silent)', () => {
+  beforeEach(() => {
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  it('atomic path: shows a success toast + clears the form on create', async () => {
+    const batchTransaction = vi.fn().mockResolvedValue({ results: [{ id: 'po1' }] });
+    const onSuccess = vi.fn();
+    const ds = makeDataSource({ batchTransaction });
+
+    const { container } = render(
+      <MasterDetailForm
+        schema={{
+          objectName: 'po',
+          mode: 'create',
+          fields: ['ref'],
+          onSuccess,
+          details: [
+            { childObject: 'po_line', relationshipField: 'po', columns: [{ key: 'qty', label: 'Qty', type: 'number' } as any] },
+          ],
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+    const input = await waitFor(() => {
+      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+      if (!el) throw new Error('parent form not ready');
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'PO-1' } });
+
+    // Drive the bottom action bar's Create button.
+    const createBtn = screen.getByRole('button', { name: /create/i });
+    fireEvent.click(createBtn);
+
+    await waitFor(() => expect(batchTransaction).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled()); // <- never silent
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    // Parent form remounted (cleared) for the next entry.
+    await waitFor(() => {
+      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+      expect(el && el.value).toBeFalsy();
+    });
+  });
+
+  it('shows an error toast when the atomic write fails (rollback)', async () => {
+    const batchTransaction = vi.fn().mockRejectedValue(new Error('BATCH_ERROR: rolled back'));
+    const ds = makeDataSource({ batchTransaction });
+
+    const { container } = render(
+      <MasterDetailForm
+        schema={{
+          objectName: 'po',
+          mode: 'create',
+          fields: ['ref'],
+          details: [
+            { childObject: 'po_line', relationshipField: 'po', columns: [{ key: 'qty', label: 'Qty', type: 'number' } as any] },
+          ],
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+    const input = await waitFor(() => {
+      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+      if (!el) throw new Error('parent form not ready');
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'PO-2' } });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => expect(batchTransaction).toHaveBeenCalled());
+    await waitFor(() => expect(toastError).toHaveBeenCalled()); // <- failure is surfaced
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -27,7 +27,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DataSource } from '@object-ui/types';
 import { LineItemsField, type GridColumn } from '@object-ui/fields';
-import { Button, Card, CardContent, CardHeader, CardTitle, cn } from '@object-ui/components';
+import { Button, Card, CardContent, CardHeader, CardTitle, cn, toast } from '@object-ui/components';
 import { ObjectForm } from './ObjectForm';
 import { applyDetail, idOf, buildMasterDetailBatch, sumRows } from './masterDetailTx';
 
@@ -97,6 +97,21 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
   const stateRef = useRef(state);
   stateRef.current = state;
 
+  // Bumped after a successful CREATE to remount the parent <ObjectForm> (which
+  // owns react-hook-form state) so its fields clear for the next entry.
+  const [formKey, setFormKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const savingRef = useRef(false);
+  const saveGuardTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const releaseSave = useCallback(() => {
+    savingRef.current = false;
+    setSaving(false);
+    if (saveGuardTimer.current) {
+      clearTimeout(saveGuardTimer.current);
+      saveGuardTimer.current = null;
+    }
+  }, []);
+
   // Edit mode: load existing children for each detail collection.
   useEffect(() => {
     let cancelled = false;
@@ -127,6 +142,36 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
   const setRows = useCallback((detailIdx: number, rows: Record<string, any>[]) => {
     setState((prev) => prev.map((s, i) => (i === detailIdx ? { ...s, rows } : s)));
   }, []);
+
+  /**
+   * Built-in feedback so a save is NEVER silent (a silent success looks broken
+   * and invites duplicate submits). Shows a toast, and on CREATE clears the
+   * form for the next entry by resetting the line items + remounting the parent
+   * form. A page-supplied `onSuccess` still runs afterwards (e.g. to navigate).
+   */
+  const handleSaved = useCallback(
+    async (parent: any) => {
+      releaseSave();
+      toast.success(isEdit ? (schema.title ? `${schema.title} saved` : 'Saved') : 'Created');
+      if (!isEdit) {
+        setState(details.map(() => ({ rows: [], original: [] })));
+        setFormKey((k) => k + 1);
+      }
+      await schema.onSuccess?.(parent);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isEdit, schema.onSuccess, schema.title, details.length, releaseSave],
+  );
+
+  /** Surface failures (validation / network / atomic rollback) to the user. */
+  const handleError = useCallback(
+    (err: Error) => {
+      releaseSave();
+      toast.error(err?.message || 'Save failed');
+      schema.onError?.(err);
+    },
+    [schema, releaseSave],
+  );
 
   /** Persist all child collections for a known parent id. Returns created ids
    *  (create mode) so the caller can clean up on a later failure. */
@@ -172,9 +217,9 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
         }
         throw err;
       }
-      await schema.onSuccess?.(parent);
+      await handleSaved(parent);
     },
-    [dataSource, isEdit, persistDetails, schema],
+    [dataSource, isEdit, persistDetails, schema, handleSaved],
   );
 
   // When the server exposes the transactional batch endpoint, a NEW parent +
@@ -223,11 +268,13 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
       showSubmit: false,
       showCancel: false,
       // Atomic path: ObjectForm validates + hands values to submitViaBatch
-      // (which persists parent+children in one transaction), then onSuccess.
-      ...(canBatch ? { submitHandler: submitViaBatch, onSuccess: schema.onSuccess } : { onSuccess: handleParentSaved }),
-      onError: schema.onError,
+      // (which persists parent+children in one transaction), then handleSaved
+      // (toast + reset + page onSuccess). The non-atomic path persists children
+      // in handleParentSaved, which also ends in handleSaved.
+      ...(canBatch ? { submitHandler: submitViaBatch, onSuccess: handleSaved } : { onSuccess: handleParentSaved }),
+      onError: handleError,
     }),
-    [schema, handleParentSaved, canBatch, submitViaBatch],
+    [schema, handleParentSaved, canBatch, submitViaBatch, handleSaved, handleError],
   );
 
   const formHostRef = useRef<HTMLDivElement>(null);
@@ -236,15 +283,25 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
   const handleSave = useCallback(() => {
     // Drive the (button-less) parent form's submit so its validation + RHF
     // onSubmit fire; success chains into child persistence via onSuccess.
+    if (savingRef.current) return; // guard against duplicate submits
     const form = formHostRef.current?.querySelector('form') as HTMLFormElement | null;
-    if (form) form.requestSubmit();
-  }, []);
+    if (!form) return;
+    savingRef.current = true;
+    setSaving(true);
+    form.requestSubmit();
+    // Safety net: react-hook-form blocks invalid submits without firing
+    // onSuccess/onError, which would otherwise leave the button stuck. Release
+    // the guard after a beat so the user can correct fields and retry.
+    saveGuardTimer.current = setTimeout(() => releaseSave(), 1500);
+  }, [releaseSave]);
+
+  useEffect(() => () => { if (saveGuardTimer.current) clearTimeout(saveGuardTimer.current); }, []);
 
   return (
     <div className={cn('space-y-6', className, schema.className)}>
       {/* 1) Header fields on top */}
       <div ref={formHostRef}>
-        <ObjectForm schema={parentSchema as any} dataSource={dataSource} />
+        <ObjectForm key={formKey} schema={parentSchema as any} dataSource={dataSource} />
       </div>
 
       {/* 2) Line items below the header */}
@@ -276,12 +333,12 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
       {/* 3) Single action bar at the bottom */}
       <div className="flex items-center justify-end gap-2 border-t border-border pt-4">
         {schema.onCancel && (
-          <Button type="button" variant="outline" onClick={schema.onCancel}>
+          <Button type="button" variant="outline" onClick={schema.onCancel} disabled={saving}>
             Cancel
           </Button>
         )}
-        <Button type="button" onClick={handleSave}>
-          {submitText}
+        <Button type="button" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving…' : submitText}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Found via live browser E2E: `MasterDetailForm`'s **Create** button POSTed `/api/v1/batch` and the server returned **200 (record created)** — but the UI gave **zero feedback**: no toast, no form reset, no navigation. To the user it looked like nothing happened, so they clicked again… and again. Evidence: the showcase DB ended up with the same project (`得到的`) created **5 times**.

This is the real-world bug behind "我点最下面的创建还是没反应".

## Fix (`@object-ui/plugin-form` `MasterDetailForm`)

- **Success** → `toast.success`, and on *create* the form clears for the next entry (line-item state reset + parent `<ObjectForm>` remounts via a bumped `key`). Any page-supplied `onSuccess` still runs afterwards (e.g. navigation).
- **Failure** (validation / network / atomic rollback) → `toast.error` with the message, instead of failing silently.
- **In-flight guard** → the Create button shows **"Saving…"** and is disabled while a submit runs, blocking the duplicate submissions that produced the 5× duplicates. A safety timer releases the guard if react-hook-form blocks an invalid submit (which doesn't fire success/error).

`@object-ui/components` now re-exports `toast` (next to `Toaster`) from its sonner wrapper so plugin-form can use it without a new dependency.

## Testing

- **2 new `MasterDetailForm` tests**: success → `toast.success` called + parent field cleared; failure → `toast.error` called and no success toast. `@object-ui/plugin-form` suite: **65 pass**.
- `@object-ui/components` + `@object-ui/plugin-form` build type-clean.
- **Live (rebuilt backend on :3000 + front-end on :5180)**: confirmed the Create button now enters the **"Saving…"** disabled state on click and the parent form clears after a submit. Full live toast screenshot was gated by the known react-hook-form/Radix-Select automation flakiness when driving the remounted form programmatically — a real user filling the form normally sees the toast + reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)