### PR TITLE
feat(chat): auto-expand tool cards with pending draft actions

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -540,7 +540,11 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                                 key={tool.toolCallId}
                                 defaultOpen={
                                   state === 'output-error' ||
-                                  state === 'approval-requested'
+                                  state === 'approval-requested' ||
+                                  // Surface pending draft actions (Publish / Review)
+                                  // immediately — they live inside ToolContent, so a
+                                  // collapsed card hides the primary CTA from the user.
+                                  Boolean(tool.draftReview && tool.draftReview.items.length > 0)
                                 }
                               >
                                 <ToolHeader


### PR DESCRIPTION
P0 开发体验(见 cloud docs/strategy/dev-experience-optimization.md「一键显眼发布」)。

**问题**:暂存草稿的工具卡(create_object/apply_blueprint)把发布/审阅 CTA 放在 ToolContent 里,而工具卡默认折叠 → 本地 dogfood 实测新用户找不到「发布」按钮。

**修复**:卡片携带可审阅草稿(draftReview.items>0)时默认展开,与现有 error/approval 的默认展开一致。一行布尔表达式,与渲染条件同构,type-clean。