### PR TITLE
feat(app-shell): ADR-0034 step 1 — flag-gated runtime persistence seam (+ finalized ADR)

### DIFF
--- a/.changeset/adr-0034-runtime-persistence-seam.md
+++ b/.changeset/adr-0034-runtime-persistence-seam.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": patch
+---
+
+ADR-0034 step 1: introduce a flag-gated runtime metadata persistence seam. `persistRuntimeMetadata` / `publishRuntimeMetadata` centralise where the runtime view/report/dashboard editors save. Behind the `VITE_RUNTIME_EDIT_VIA_META` flag (default **off**) they reproduce today's `sys_*` writes exactly (zero behaviour change); flag **on** routes to the studio `/meta` per-item draft/publish model (`MetadataClient.save(..., { mode: 'draft' })` + `publish`). ReportView and DashboardView now save through the seam; ObjectView (view) and the draft/publish UI are deliberately deferred. No `sys_*` table is removed and no data is migrated. Also adds the finalized ADR-0034.

--- a/docs/adr/0034-unified-runtime-metadata-persistence.md
+++ b/docs/adr/0034-unified-runtime-metadata-persistence.md
@@ -1,0 +1,79 @@
+# ADR-0034: Runtime editing reuses studio's per-item draft → publish → version model (retire `sys_view` / `sys_report` / `sys_dashboard`)
+
+**Status**: Proposed (2026-06-06)
+**Author**: ObjectUI renderer team
+**Consumers**: `@object-ui/app-shell` (ObjectView / ReportView / DashboardView + metadata-admin), `@object-ui/data-objectstack` (metadata client), and the ObjectStack backend (`/api/v1/meta/*`).
+
+---
+
+## TL;DR
+
+The console edits the same artifacts — **views, reports, dashboards** — in **two unrelated stores**:
+
+- **Studio** → the metadata overlay: `PUT /meta/:type/:name` with `mode: 'draft' | 'publish'`, plus `publish()`, history and rollback. Drafts are **per item** and invisible to runtime until published; publish is available **per item** (`client.publish(type, name)`) and as a batch **app publish** (`/packages/:id/publish-drafts`).
+- **Runtime** → bespoke per-type tables `sys_view` / `sys_report` / `sys_dashboard`: immediate writes, no draft/publish/history, each with its own column layout (`toSysViewPayload`).
+
+PRs #1496/#1504/#1505 unified the **editing UI** (both render the same spec-driven inspector); #1508 gave the report/dashboard editors the admin gate that view editing already had. **Persistence is still split.**
+
+**Decision:** make the runtime editors reuse studio's model exactly. A runtime edit **saves a per-item draft** (invisible to other users, visible in the editor's own live preview), and an explicit **Publish** promotes it to the active overlay and records a version. No bespoke tables, no new scope dimension. Because the runtime panels already emit the spec draft and the runtime already *reads* views/reports/dashboards from the metadata layer (`MetadataProvider.readType('view'|'report'|'dashboard')`), this is mostly a write-path switch.
+
+`sys_view`/`sys_report`/`sys_dashboard` are retired. Per-user personalization (a `user` overlay for **views only**) is explicitly **out of scope** here — a later, additive change.
+
+## Why this model (low-code rationale)
+
+- **One system, one mental model.** A view/report/dashboard behaves identically whether edited in studio or at runtime: same draft, same publish, same version/history/rollback.
+- **Solves the real use case.** "I'm editing a dashboard, only half done — stage it, don't publish, don't let users see it." A **per-item draft** does exactly this: invisible to users, resumable by the editor (`GET …?state=draft`).
+- **Immediacy *and* staging coexist.** The editing admin sees their own changes live in the panel's preview (driven by the local draft); other users keep seeing the **published** value until Publish. Per-item publish means staging one dashboard blocks nothing else.
+- **Governance upgrade.** Runtime edits gain validation, history and rollback they never had.
+- **No new backend for v1.** Reuses `/meta` draft/publish as-is.
+
+### Draft vs publish — a property of the change, not the screen
+
+`draft → publish` exists for **staging** and **atomic multi-item app releases**; forcing the two-step onto a trivial one-field tweak is friction (studio already mitigates with auto-save). So:
+
+- **Default = save-as-draft + explicit Publish** (matches studio; satisfies the "stage half-done work" need). The editor's live preview keeps it feeling immediate.
+- Batch **app publish** stays available for releasing many items together.
+- **Always versioned** on publish.
+
+This unifies the UX in *both* surfaces rather than making runtime a special case.
+
+## What changes (before → after)
+
+| | Before | After |
+|---|---|---|
+| Save (view) | `dataSource.create/update('sys_view', toSysViewPayload(...))` | `metadataClient.save('view', name, draft, { mode:'draft' })` |
+| Save (report/dashboard) | `adapter.update('sys_report'|'sys_dashboard', name, schema)` | `metadataClient.save(type, name, draft, { mode:'draft' })` |
+| Publish | — (writes were immediately live) | `metadataClient.publish(type, name)` → active overlay + version |
+| Read (others) | `sys_*` merged with metadata | metadata **active** value (already the read path) |
+| Read (editor, resume) | n/a | `metadataClient.get(type, name, { state:'draft' })` |
+| Shape adapters | `toSysViewPayload` / `fromSysViewRecord` / report+dashboard adapters | deleted |
+
+Runtime panels gain a small **draft/publish chrome** (Save draft · Publish · "unpublished changes" indicator · discard draft) — the same affordances studio's `ResourceEditPage` already has, reused.
+
+## Rollout (flagged, reversible, back-compat)
+
+1. **(done)** Unify the editing UI (#1496/#1503/#1504/#1505) and gate report/dashboard editing (#1508).
+2. **Seam (this ADR's first code):** a single `persistRuntimeMetadata(type, name, draft, …)` (+ `publishRuntimeMetadata`). Behind a flag (default **off**) it routes to the existing `sys_*` writes — **zero behaviour change** — so it is safe to merge and unit-test now. Flag **on** routes to `metadataClient` draft/publish.
+3. **UI:** add the draft/publish chrome to the runtime panels, flag-gated.
+4. **Verify in a real environment** (this sandbox has no backend; the save→draft→publish→read round trip cannot be verified here). Then flip the default.
+5. **Retire:** migrate existing `sys_*` rows → published overlays (dual-read window), drop the tables, delete the shape adapters.
+
+## Risks
+
+- 🔴 **Not verifiable in CI/sandbox.** This changes *where* edits persist and *how* they are read; there is no running backend here, so the round trip must be verified in a real environment. Mitigation: feature flag (default off) + per-item, reversible steps.
+- 🔴 **Data migration.** Existing `sys_*` rows must move to published overlays without loss; dual-read window + rollback.
+- 🟡 **Immediacy expectation.** Editors must understand Save = draft, Publish = live; the live preview and a clear "unpublished changes" indicator cover this.
+- 🟡 **Permissions.** Writing/publishing metadata requires admin/publish rights — already aligned with the #1508 admin gate.
+- 🟡 **Multi-tenant.** Writes/migration must stay correctly scoped to the org/env overlay.
+
+## Out of scope
+
+- **Per-user personalization** (a `user` overlay for views) — a later, additive change. v1 is admin editing of the shared definition only.
+
+## Appendix: persistence call sites (the seam targets)
+
+| Panel | Today | File |
+|---|---|---|
+| ObjectView | `dataSource.create/update('sys_view', toSysViewPayload(...))` (`handleViewConfigSave` / `handleViewCreate`; `persistViewPatch` for incremental toolbar state) | `packages/app-shell/src/views/ObjectView.tsx` |
+| ReportView | `adapter.update('sys_report', name, schema)` (`saveSchema`) | `packages/app-shell/src/views/ReportView.tsx` |
+| DashboardView | `adapter.updateDashboard(name, schema)` / `adapter.update('sys_dashboard', …)` (`saveSchema`) | `packages/app-shell/src/views/DashboardView.tsx` |

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -42,6 +42,8 @@ import { SkeletonDashboard } from '../skeletons';
 import { useMetadata } from '../providers/MetadataProvider';
 import { resolveI18nLabel } from '../utils';
 import { useAdapter } from '../providers/AdapterProvider';
+import { useMetadataClient } from './metadata-admin/useMetadata';
+import { persistRuntimeMetadata } from './runtime-metadata-persistence';
 import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import type { DashboardSchema, DashboardWidgetSchema } from '@object-ui/types';
 
@@ -93,6 +95,9 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
   const { dashboardName } = useParams<{ dashboardName: string }>();
   const { showDebug } = useMetadataInspector();
   const adapter = useAdapter();
+  // ADR-0034 seam: used only when the runtime-via-/meta flag is ON; the
+  // flag-OFF default still writes to `sys_dashboard` via the adapter below.
+  const metadataClient = useMetadataClient();
   const { t } = useObjectTranslation();
   const { dashboardLabel, dashboardDescription } = useObjectLabel();
   // Editing a dashboard mutates the SHARED definition, so it is an admin-only
@@ -191,11 +196,14 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
   const saveSchema = useCallback(
     async (schema: DashboardSchema) => {
       try {
-        if (adapter && (adapter as any).updateDashboard) {
-          await (adapter as any).updateDashboard(dashboardName!, schema);
-        } else if (adapter) {
-          // Fallback for adapters that don't expose updateDashboard
-          await adapter.update('sys_dashboard', dashboardName!, schema);
+        if (adapter) {
+          // ADR-0034 seam: flag OFF (default) reproduces the prior behaviour
+          // exactly — `adapter.updateDashboard(...)` when available, otherwise
+          // `adapter.update('sys_dashboard', …)`. Flag ON → metadata draft.
+          await persistRuntimeMetadata('dashboard', dashboardName!, schema, {
+            adapter,
+            metadataClient,
+          });
         }
         // Refresh metadata cache so closing the config panel shows saved data
         refresh().catch(() => {});
@@ -208,7 +216,7 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
         toast.error(`Failed to save dashboard: ${message}`);
       }
     },
-    [adapter, dashboardName, refresh],
+    [adapter, metadataClient, dashboardName, refresh],
   );
 
   // ---- Open / close config panel ------------------------------------------

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -15,6 +15,8 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useAdapter } from '../providers/AdapterProvider';
+import { useMetadataClient } from './metadata-admin/useMetadata';
+import { persistRuntimeMetadata } from './runtime-metadata-persistence';
 import { useAuth } from '@object-ui/auth';
 import type { DataSource } from '@object-ui/types';
 
@@ -35,6 +37,9 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   const { reportName } = useParams<{ reportName: string }>();
   const { showDebug } = useMetadataInspector();
   const adapter = useAdapter();
+  // ADR-0034 seam: used only when the runtime-via-/meta flag is ON; the
+  // flag-OFF default still writes to `sys_report` via the adapter below.
+  const metadataClient = useMetadataClient();
   // Editing a report mutates the SHARED definition, so it is an admin-only
   // quick-edit affordance (mirrors ObjectView's view-config gate).
   const { user } = useAuth();
@@ -90,14 +95,20 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
     async (schema: any) => {
       try {
         if (adapter) {
-          await adapter.update('sys_report', reportName!, schema);
+          // ADR-0034 seam: flag OFF (default) → `adapter.update('sys_report',…)`
+          // exactly as before; flag ON → metadata draft. Behaviour unchanged
+          // while the flag is off.
+          await persistRuntimeMetadata('report', reportName!, schema, {
+            adapter,
+            metadataClient,
+          });
           refresh().catch(() => {});
         }
       } catch (err) {
         console.warn('[ReportView] Auto-save failed:', err);
       }
     },
-    [adapter, reportName, refresh],
+    [adapter, metadataClient, reportName, refresh],
   );
 
   // ---- Open / close config panel ------------------------------------------

--- a/packages/app-shell/src/views/runtime-metadata-persistence.test.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  persistRuntimeMetadata,
+  publishRuntimeMetadata,
+  isViaMeta,
+} from './runtime-metadata-persistence';
+
+/**
+ * ADR-0034 seam tests.
+ *
+ * The flag is read live from `import.meta.env.VITE_RUNTIME_EDIT_VIA_META`
+ * via `isViaMeta()`, so we toggle it with `vi.stubEnv`. Flag OFF is the
+ * default and must reproduce the legacy `sys_*` writes; flag ON routes to
+ * the metadata client's draft/publish.
+ */
+
+function makeAdapter() {
+  return {
+    update: vi.fn().mockResolvedValue(undefined),
+    updateDashboard: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeMetadataClient() {
+  return {
+    save: vi.fn().mockResolvedValue(undefined),
+    publish: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('runtime-metadata-persistence seam (ADR-0034)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe('flag OFF (default — legacy sys_* path)', () => {
+    beforeEach(() => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', '');
+    });
+
+    it('isViaMeta() is false', () => {
+      expect(isViaMeta()).toBe(false);
+    });
+
+    it('report → adapter.update("sys_report", name, body)', async () => {
+      const adapter = makeAdapter();
+      const metadataClient = makeMetadataClient();
+      const body = { title: 'Pipeline' };
+
+      await persistRuntimeMetadata('report', 'my_report', body, {
+        adapter,
+        metadataClient,
+      });
+
+      expect(adapter.update).toHaveBeenCalledTimes(1);
+      expect(adapter.update).toHaveBeenCalledWith('sys_report', 'my_report', body);
+      expect(metadataClient.save).not.toHaveBeenCalled();
+    });
+
+    it('dashboard → adapter.updateDashboard(name, body) when available', async () => {
+      const adapter = makeAdapter();
+      const body = { widgets: [] };
+
+      await persistRuntimeMetadata('dashboard', 'my_dash', body, { adapter });
+
+      expect(adapter.updateDashboard).toHaveBeenCalledTimes(1);
+      expect(adapter.updateDashboard).toHaveBeenCalledWith('my_dash', body);
+      expect(adapter.update).not.toHaveBeenCalled();
+    });
+
+    it('dashboard → falls back to adapter.update("sys_dashboard", …) when no updateDashboard', async () => {
+      const adapter = { update: vi.fn().mockResolvedValue(undefined) };
+      const body = { widgets: [] };
+
+      await persistRuntimeMetadata('dashboard', 'my_dash', body, { adapter });
+
+      expect(adapter.update).toHaveBeenCalledTimes(1);
+      expect(adapter.update).toHaveBeenCalledWith('sys_dashboard', 'my_dash', body);
+    });
+
+    it('view → dataSource.update("sys_view", …) with toSysViewPayload', async () => {
+      const dataSource = { update: vi.fn().mockResolvedValue(undefined) };
+      const toSysViewPayload = vi.fn((cfg: any, obj?: string) => ({ ...cfg, obj }));
+      const body = { columns: ['name'] };
+
+      await persistRuntimeMetadata('view', 'my_view', body, {
+        dataSource,
+        objectName: 'crm_lead',
+        toSysViewPayload,
+      });
+
+      expect(toSysViewPayload).toHaveBeenCalledWith(body, 'crm_lead');
+      expect(dataSource.update).toHaveBeenCalledWith('sys_view', 'my_view', {
+        columns: ['name'],
+        obj: 'crm_lead',
+      });
+    });
+
+    it('publishRuntimeMetadata is a no-op (no draft concept in legacy model)', async () => {
+      const metadataClient = makeMetadataClient();
+
+      await publishRuntimeMetadata('report', 'my_report', { metadataClient });
+
+      expect(metadataClient.publish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flag ON (/meta draft/publish path)', () => {
+    beforeEach(() => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+    });
+
+    it('isViaMeta() is true', () => {
+      expect(isViaMeta()).toBe(true);
+    });
+
+    it('report → metadataClient.save("report", name, body, { mode: "draft" })', async () => {
+      const adapter = makeAdapter();
+      const metadataClient = makeMetadataClient();
+      const body = { title: 'Pipeline' };
+
+      await persistRuntimeMetadata('report', 'my_report', body, {
+        adapter,
+        metadataClient,
+      });
+
+      expect(metadataClient.save).toHaveBeenCalledTimes(1);
+      expect(metadataClient.save).toHaveBeenCalledWith('report', 'my_report', body, {
+        mode: 'draft',
+      });
+      // Legacy path must NOT run when the flag is on.
+      expect(adapter.update).not.toHaveBeenCalled();
+    });
+
+    it('dashboard → metadataClient.save("dashboard", …, { mode: "draft" })', async () => {
+      const metadataClient = makeMetadataClient();
+      const body = { widgets: [] };
+
+      await persistRuntimeMetadata('dashboard', 'my_dash', body, { metadataClient });
+
+      expect(metadataClient.save).toHaveBeenCalledWith('dashboard', 'my_dash', body, {
+        mode: 'draft',
+      });
+    });
+
+    it('publishRuntimeMetadata → metadataClient.publish(type, name)', async () => {
+      const metadataClient = makeMetadataClient();
+
+      await publishRuntimeMetadata('report', 'my_report', { metadataClient });
+
+      expect(metadataClient.publish).toHaveBeenCalledTimes(1);
+      expect(metadataClient.publish).toHaveBeenCalledWith('report', 'my_report');
+    });
+  });
+});

--- a/packages/app-shell/src/views/runtime-metadata-persistence.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.ts
@@ -1,0 +1,184 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0034 — Runtime metadata persistence seam (first code).
+ *
+ * Runtime editing of **views / reports / dashboards** historically writes
+ * to bespoke per-type tables (`sys_view` / `sys_report` / `sys_dashboard`)
+ * with immediate, unversioned writes. ADR-0034 unifies this with studio's
+ * `/meta` per-item **draft → publish → version** model.
+ *
+ * This module is the single **seam** that both paths flow through, gated by
+ * a feature flag:
+ *
+ *   • **flag OFF (default)** → reproduces today's behaviour exactly: writes
+ *     to `sys_*` via the existing data-source / adapter. Zero behaviour
+ *     change. Safe to merge and unit-test now.
+ *   • **flag ON** → routes to `metadataClient.save(type, name, body,
+ *     { mode: 'draft' })` (save-as-draft) and `metadataClient.publish(...)`.
+ *
+ * Scope of THIS change (deliberately small / low-risk):
+ *   • The seam is wired into **ReportView** and **DashboardView** only.
+ *   • **ObjectView (view)** is NOT wired yet — its `toSysViewPayload` +
+ *     create-vs-update + debounce logic is more involved. The `view` branch
+ *     below is written for the future, but ObjectView still runs its own
+ *     legacy path today. See the `'view'` TODO in {@link persistRuntimeMetadata}.
+ *   • No draft/publish UI is added here. No `sys_*` table is removed. No
+ *     data migration is performed.
+ *
+ * The flag is read in exactly ONE place ({@link isViaMeta}) so the
+ * mechanism can be swapped later (e.g. for a server-pushed runtime-config
+ * capability) without touching call sites.
+ */
+
+/**
+ * Underlying flag value, read once at module init from the Vite-time env var
+ * `VITE_RUNTIME_EDIT_VIA_META`. Exported as the canonical, documented name
+ * for the ADR; consumers that only need the static value can read this.
+ *
+ * NOTE: prefer {@link isViaMeta} internally so tests can flip the flag via
+ * `vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true')` without relying on
+ * module-load timing.
+ *
+ * Default: `false` (legacy `sys_*` path).
+ */
+export const RUNTIME_EDIT_VIA_META: boolean =
+  readViaMetaEnv();
+
+/**
+ * Read the raw env flag. Centralised so the source of truth is one place.
+ *
+ * In production the value comes from Vite's `import.meta.env` (inlined at
+ * build time). We also consult `process.env` as a fallback so the flag is
+ * togglable in Node/unit-test contexts (`vi.stubEnv`) where `import.meta.env`
+ * is not patched.
+ */
+function readViaMetaEnv(): boolean {
+  try {
+    if ((import.meta as any).env?.VITE_RUNTIME_EDIT_VIA_META === 'true') return true;
+  } catch {
+    // import.meta.env unavailable in this context — fall through.
+  }
+  try {
+    if (typeof process !== 'undefined' && process.env?.VITE_RUNTIME_EDIT_VIA_META === 'true') {
+      return true;
+    }
+  } catch {
+    // no process — ignore.
+  }
+  return false;
+}
+
+/**
+ * Whether runtime edits should route through the `/meta` draft/publish
+ * model. Reads the env flag live (not the captured constant) so unit tests
+ * can toggle it with `vi.stubEnv`. This is the ONLY place the flag is
+ * consulted — replace the body here to swap the flag mechanism later.
+ */
+export function isViaMeta(): boolean {
+  return readViaMetaEnv();
+}
+
+/** The three runtime-editable artifact types ADR-0034 unifies. */
+export type RuntimeArtifactType = 'view' | 'report' | 'dashboard';
+
+/**
+ * Everything the seam might need to persist any of the three artifact types,
+ * passed by the call site. All optional so each call site only supplies what
+ * its path needs (report/dashboard need `adapter`; view needs `dataSource` +
+ * `toSysViewPayload`; the flag-on path needs `metadataClient`).
+ */
+export interface RuntimePersistCtx {
+  /** Studio metadata client — used by the flag-ON `/meta` path. */
+  metadataClient?: any;
+  /** Generic data source — used by the legacy `sys_view` path. */
+  dataSource?: any;
+  /** ObjectStack adapter — used by the legacy `sys_report`/`sys_dashboard` path. */
+  adapter?: any;
+  /** Object name a view belongs to (for `toSysViewPayload`). */
+  objectName?: string;
+  /**
+   * View-only payload shaper. Passed as a callback so the complex
+   * `toSysViewPayload` logic stays in ObjectView and isn't duplicated here.
+   */
+  toSysViewPayload?: (cfg: any, obj?: string) => any;
+}
+
+/**
+ * Persist a runtime edit of a view / report / dashboard.
+ *
+ * • flag OFF → legacy `sys_*` write (behaviour identical to before this seam).
+ * • flag ON  → `metadataClient.save(type, name, body, { mode: 'draft' })`
+ *   (save-as-draft; an explicit publish promotes it — see
+ *   {@link publishRuntimeMetadata}).
+ *
+ * @param type artifact type
+ * @param name artifact name (the `:name` in `/meta/:type/:name`)
+ * @param body the spec/schema/config to persist
+ * @param ctx  call-site capabilities (see {@link RuntimePersistCtx})
+ */
+export async function persistRuntimeMetadata(
+  type: RuntimeArtifactType,
+  name: string,
+  body: any,
+  ctx: RuntimePersistCtx,
+): Promise<void> {
+  if (isViaMeta()) {
+    // ── flag ON: unified studio path ──
+    // Default to a per-item DRAFT (invisible to other users until publish).
+    // `MetadataClient.save(type, name, item, { mode })` is the real write API
+    // (PUT /meta/:type/:name) — the same one studio's editor uses.
+    await ctx.metadataClient.save(type, name, body, { mode: 'draft' });
+    return;
+  }
+
+  // ── flag OFF: legacy per-type tables (today's behaviour) ──
+  switch (type) {
+    case 'view': {
+      // NOTE: ObjectView is NOT wired to this seam yet (TODO, ADR-0034
+      // step 2/3). The view legacy branch is written here for the future
+      // so the contract is complete, but today ObjectView runs its own
+      // `create`-vs-`update` + debounce path. The seam only takes over the
+      // view write when ObjectView is migrated.
+      const payload = ctx.toSysViewPayload
+        ? ctx.toSysViewPayload(body, ctx.objectName)
+        : body;
+      await ctx.dataSource.update('sys_view', name, payload);
+      return;
+    }
+    case 'report': {
+      await ctx.adapter.update('sys_report', name, body);
+      return;
+    }
+    case 'dashboard': {
+      if (ctx.adapter?.updateDashboard) {
+        await ctx.adapter.updateDashboard(name, body);
+      } else {
+        await ctx.adapter.update('sys_dashboard', name, body);
+      }
+      return;
+    }
+  }
+}
+
+/**
+ * Publish a previously-staged runtime edit.
+ *
+ * • flag OFF → **no-op**: the legacy `sys_*` model has no draft concept;
+ *   writes were already live, so there is nothing to publish.
+ * • flag ON  → `metadataClient.publish(type, name)` promotes the pending
+ *   draft to the active overlay and records a version.
+ *
+ * This change does NOT add publish UI — that is a later, flag-gated step.
+ */
+export async function publishRuntimeMetadata(
+  type: RuntimeArtifactType,
+  name: string,
+  ctx: RuntimePersistCtx,
+): Promise<void> {
+  if (!isViaMeta()) {
+    // Legacy model: save was already live; nothing to publish.
+    return;
+  }
+  await ctx.metadataClient.publish(type, name);
+}


### PR DESCRIPTION
## 背景

回答"为什么运行时编辑保存到独立 `sys_*` 表、能否与 studio 统一",并落地第一段代码。经讨论确定的最终模型:**运行时编辑复用 studio 的 per-item 草稿→发布→版本**(保存=暂存草稿、用户看不到、编辑者实时预览;显式发布才生效),退役 `sys_*`,per-user 个性化划出范围外。

> 本 PR 取代纯 ADR 的 #1507(其内容已并入这里的最终 ADR),#1507 将关闭。

## 改动(ADR-0034 第 1 步:flag 化 seam,默认关、行为零变化)

- **新增** `docs/adr/0034-...md`:最终决策稿(模型、before→after、风险、分阶段 rollout)。
- **新增** `runtime-metadata-persistence.ts`:统一 seam。
  - `VITE_RUNTIME_EDIT_VIA_META`(默认 **关**)→ 完全复刻现有 `sys_*` 写入,**行为逐字节不变**。
  - flag **开** → `MetadataClient.save(type,name,body,{mode:'draft'})` + `publish(type,name)`(studio 同款 `/meta` 草稿/发布)。
  - flag 只在一处读取,便于将来替换机制。
- **接线** `ReportView`/`DashboardView` 的保存走 seam(flag 关时与改动前一致)。
- **新增** seam 单测(10 例,覆盖 flag 开/关两条路径)。

**有意未做**:ObjectView(view)接线(其 `toSysViewPayload`+防抖复杂,留下个 PR;seam 里已写好 view 分支)、草稿/发布 UI、删除 `sys_*`、数据迁移。

## 验证

- `pnpm turbo run build --filter=@object-ui/app-shell`:27/27。
- seam 单测 10/10;`app-shell/src/views` 全套 189 全过。
- lint 改动文件 0 error。

## ⚠️ 诚实边界(必读)

**flag-on 的 `/meta` 真实"保存→草稿→发布→读回"在此环境无法 e2e 验证**(沙箱无后端)。本 PR **默认关、行为零变化、可单测/构建验证、可安全合并**;真实验证需在**有后端的环境开 flag** 跑通后,再翻默认值,并按 ADR 后续步骤补 UI、迁移 `sys_*`。

https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL)_