### PR TITLE
feat(app-shell): ADR-0034 step 2 — route ObjectView save through the seam

### DIFF
--- a/.changeset/adr-0034-objectview-seam.md
+++ b/.changeset/adr-0034-objectview-seam.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": patch
+---
+
+ADR-0034 step 2: route ObjectView's view-config save through the runtime persistence seam, completing the seam's coverage of all three runtime editors (view/report/dashboard). Corrects the seam's `view` branch to mirror ObjectView's real update path (`dataSource.updateViewConfig(...)`, the ADR-0005 overlay API) rather than a raw `sys_view` write. Behaviour is unchanged while the `VITE_RUNTIME_EDIT_VIA_META` flag is off; flag on routes the view update to the studio `/meta` draft. The view CREATE path (`createView` + default-column/kanban/gallery massaging) and the draft/publish UI remain deferred.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -37,6 +37,8 @@ import { getIcon } from '../utils/getIcon';
 import type { ListViewSchema, ViewNavigationConfig, FeedItem } from '@object-ui/types';
 import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
 import { ViewConfigPanel } from './ViewConfigPanel';
+import { useMetadataClient } from './metadata-admin/useMetadata';
+import { persistRuntimeMetadata } from './runtime-metadata-persistence';
 import { CreateViewDialog } from './CreateViewDialog';
 import { PageHeader } from '../layout/PageHeader';
 import { useMobileViewSwitcherRegistration } from '../layout/MobileViewSwitcherContext';
@@ -220,7 +222,10 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
     const { t } = useObjectTranslation();
     const { objectLabel, objectDescription: objectDesc, viewLabel, viewEmptyState, actionLabel, actionConfirm, actionSuccess, fieldLabel, fieldOptionLabel } = useObjectLabel();
     const { isFavorite, toggleFavorite } = useFavorites();
-    
+    // ADR-0034 seam: used only when the runtime-via-/meta flag is ON; the
+    // flag-OFF default still calls `dataSource.updateViewConfig(...)`.
+    const metadataClient = useMetadataClient();
+
     // Inline view config panel state (Airtable-style right sidebar)
     const [showViewConfigPanel, setShowViewConfigPanel] = useState(false);
     const [viewConfigPanelMode, setViewConfigPanelMode] = useState<'create' | 'edit'>('edit');
@@ -269,12 +274,19 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         setViewDraft(draft);
         setRefreshKey(k => k + 1);
 
-        // Persist to backend if dataSource supports it
+        // Persist to backend if dataSource supports it.
+        // ADR-0034 seam: flag OFF (default) → `dataSource.updateViewConfig(...)`
+        // exactly as before; flag ON → metadata draft. Behaviour unchanged
+        // while the flag is off (the seam's view branch calls updateViewConfig).
         if (dataSource?.updateViewConfig) {
             const objName = objectName;
             const vid = draft.id;
             if (objName && vid) {
-                dataSource.updateViewConfig(objName, vid, draft).catch((err: any) => {
+                persistRuntimeMetadata('view', vid, draft, {
+                    dataSource,
+                    metadataClient,
+                    objectName: objName,
+                }).catch((err: any) => {
                     console.error('[ViewConfigPanel] Failed to persist view config:', err);
                 });
             } else {
@@ -283,7 +295,7 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         } else {
             console.warn('[ViewConfigPanel] dataSource.updateViewConfig is not available. View config saved locally only.');
         }
-    }, [dataSource, objectName]);
+    }, [dataSource, objectName, metadataClient]);
 
     /** Create a new view via the config panel */
     const handleViewCreate = useCallback(async (config: Record<string, any>) => {

--- a/packages/app-shell/src/views/runtime-metadata-persistence.test.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.test.ts
@@ -81,22 +81,16 @@ describe('runtime-metadata-persistence seam (ADR-0034)', () => {
       expect(adapter.update).toHaveBeenCalledWith('sys_dashboard', 'my_dash', body);
     });
 
-    it('view → dataSource.update("sys_view", …) with toSysViewPayload', async () => {
-      const dataSource = { update: vi.fn().mockResolvedValue(undefined) };
-      const toSysViewPayload = vi.fn((cfg: any, obj?: string) => ({ ...cfg, obj }));
+    it('view → dataSource.updateViewConfig(objectName, name, body)', async () => {
+      const dataSource = { updateViewConfig: vi.fn().mockResolvedValue(undefined) };
       const body = { columns: ['name'] };
 
       await persistRuntimeMetadata('view', 'my_view', body, {
         dataSource,
         objectName: 'crm_lead',
-        toSysViewPayload,
       });
 
-      expect(toSysViewPayload).toHaveBeenCalledWith(body, 'crm_lead');
-      expect(dataSource.update).toHaveBeenCalledWith('sys_view', 'my_view', {
-        columns: ['name'],
-        obj: 'crm_lead',
-      });
+      expect(dataSource.updateViewConfig).toHaveBeenCalledWith('crm_lead', 'my_view', body);
     });
 
     it('publishRuntimeMetadata is a no-op (no draft concept in legacy model)', async () => {

--- a/packages/app-shell/src/views/runtime-metadata-persistence.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.ts
@@ -95,11 +95,13 @@ export interface RuntimePersistCtx {
   dataSource?: any;
   /** ObjectStack adapter — used by the legacy `sys_report`/`sys_dashboard` path. */
   adapter?: any;
-  /** Object name a view belongs to (for `toSysViewPayload`). */
+  /** Object a view belongs to — first arg to `updateViewConfig`. */
   objectName?: string;
   /**
-   * View-only payload shaper. Passed as a callback so the complex
-   * `toSysViewPayload` logic stays in ObjectView and isn't duplicated here.
+   * View-only payload shaper. NOT used by the view UPDATE path (which goes
+   * through `updateViewConfig` with the raw draft); reserved for wiring the
+   * view CREATE legacy `sys_view` fallback through the seam later, so the
+   * complex `toSysViewPayload` logic can stay in ObjectView.
    */
   toSysViewPayload?: (cfg: any, obj?: string) => any;
 }
@@ -135,15 +137,13 @@ export async function persistRuntimeMetadata(
   // ── flag OFF: legacy per-type tables (today's behaviour) ──
   switch (type) {
     case 'view': {
-      // NOTE: ObjectView is NOT wired to this seam yet (TODO, ADR-0034
-      // step 2/3). The view legacy branch is written here for the future
-      // so the contract is complete, but today ObjectView runs its own
-      // `create`-vs-`update` + debounce path. The seam only takes over the
-      // view write when ObjectView is migrated.
-      const payload = ctx.toSysViewPayload
-        ? ctx.toSysViewPayload(body, ctx.objectName)
-        : body;
-      await ctx.dataSource.update('sys_view', name, payload);
+      // ObjectView's UPDATE path goes through the adapter's `updateViewConfig`
+      // (the ADR-0005 overlay API), NOT a raw `sys_view` write — only the
+      // CREATE legacy fallback touches the physical table. So the flag-OFF
+      // view branch mirrors that update call exactly. The view CREATE path
+      // (`createView` + default-columns / kanban / gallery massaging) is more
+      // involved and is NOT wired to the seam yet (see ADR-0034 rollout).
+      await ctx.dataSource.updateViewConfig(ctx.objectName, name, body);
       return;
     }
     case 'report': {


### PR DESCRIPTION
## 背景

延续 ADR-0034(#1513)。第 1 步把 report/dashboard 的保存接入了 flag 化 seam;本 PR 把 **ObjectView 的视图保存**也接进来,完成三个运行时编辑器对 seam 的统一覆盖。

## 关键修正(避免回归)

调研发现:ObjectView 的视图**更新**实际走 `dataSource.updateViewConfig(objName, vid, draft)`(ADR-0005 的 overlay API),**不是** `dataSource.update('sys_view', toSysViewPayload(...))`——后者只是**创建**路径的 legacy 兜底。第 1 步 seam 里的 `view` 分支建模错了(写成了 `update('sys_view')`)。本 PR **改正 seam 的 view 分支为真实的 `updateViewConfig`**,从而 flag-off 逐字节一致。

## 改动

- `runtime-metadata-persistence.ts`:`view` 分支 flag-off → `ctx.dataSource.updateViewConfig(objectName, name, body)`(真实更新路径);flag-on → `metadataClient.save('view', …, {mode:'draft'})`。
- `ObjectView.tsx`:`handleViewConfigSave` 的持久化改为 `persistRuntimeMetadata('view', vid, draft, { dataSource, metadataClient, objectName })`,**保留原有 `if (dataSource?.updateViewConfig)` 守卫与告警**,flag-off 行为不变。
- 更新 seam 单测的 view 分支断言。

**仍有意未做**:视图**创建**路径(`createView` + 默认列/kanban/gallery 处理,较复杂)、草稿/发布 UI、翻默认、`sys_*` 迁移。

## 验证

- `pnpm turbo run build --filter=@object-ui/app-shell`:27/27。
- seam 单测 10/10;`app-shell/src/views` 全套 **189 全过**。
- seam 文件 lint 0 error(ObjectView 既有的大文件 lint 警告与本次无关)。

## ⚠️ 边界

flag 默认**关**、行为零变化、可单测/构建验证、安全合并。flag-on 的 `/meta` 真实往返仍需**有后端的环境**验证。

https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZW3fVCCbijEibXtEH3ZGL)_