### PR TITLE
test(e2e): live summary-rollup spec + exclude live specs from default config

### DIFF
--- a/e2e/live/summary-rollup.spec.ts
+++ b/e2e/live/summary-rollup.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+/**
+ * Live e2e for server-side roll-up SUMMARY fields (ObjectQL).
+ *
+ * showcase_project.total_estimate = SUM(showcase_task.estimate_hours) and
+ * .task_count = COUNT(showcase_task) are recomputed by the engine whenever a
+ * child task is inserted / updated / deleted — here exercised end-to-end
+ * against the real SQL driver via the atomic /api/v1/batch endpoint.
+ */
+const API = process.env.LIVE_API_URL || 'http://localhost:3000';
+
+async function anAccountId(request: APIRequestContext): Promise<string> {
+  const body = await (await request.get(`${API}/api/v1/data/showcase_account?$top=1`)).json();
+  const id = (body.data ?? body.records ?? body)[0]?.id;
+  expect(id, 'a seeded showcase_account').toBeTruthy();
+  return id;
+}
+
+async function getProject(request: APIRequestContext, id: string) {
+  const r = await (await request.get(`${API}/api/v1/data/showcase_project/${id}`)).json();
+  return r.record ?? r.data ?? r;
+}
+
+test('SUM/COUNT roll-up is computed server-side on atomic create', async ({ request }) => {
+  const account = await anAccountId(request);
+  const res = await request.post(`${API}/api/v1/batch`, {
+    data: { operations: [
+      { object: 'showcase_project', action: 'create', data: { name: `Rollup ${Date.now()}`, status: 'planned', account } },
+      { object: 'showcase_task', action: 'create', data: { title: 'T1', status: 'backlog', estimate_hours: 3, project: { $ref: 0 } } },
+      { object: 'showcase_task', action: 'create', data: { title: 'T2', status: 'backlog', estimate_hours: 5, project: { $ref: 0 } } },
+    ] },
+  });
+  expect(res.status()).toBe(200);
+  const projectId = (await res.json()).results[0].id;
+
+  const proj = await getProject(request, projectId);
+  expect(Number(proj.total_estimate)).toBe(8);
+  expect(Number(proj.task_count)).toBe(2);
+});
+
+test('roll-up recomputes when a child is added then deleted', async ({ request }) => {
+  const account = await anAccountId(request);
+  const created = await (await request.post(`${API}/api/v1/batch`, {
+    data: { operations: [
+      { object: 'showcase_project', action: 'create', data: { name: `Rollup2 ${Date.now()}`, status: 'planned', account } },
+      { object: 'showcase_task', action: 'create', data: { title: 'T1', status: 'backlog', estimate_hours: 4, project: { $ref: 0 } } },
+    ] },
+  })).json();
+  const projectId = created.results[0].id;
+  const taskId = created.results[1].id;
+  expect(Number((await getProject(request, projectId)).total_estimate)).toBe(4);
+
+  // delete the only task → rollup falls back to 0
+  const del = await request.delete(`${API}/api/v1/data/showcase_task/${taskId}`);
+  expect(del.ok()).toBeTruthy();
+  const proj = await getProject(request, projectId);
+  expect(Number(proj.total_estimate)).toBe(0);
+  expect(Number(proj.task_count)).toBe(0);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,11 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
+  // Live specs (e2e/live/**) drive the REAL running stack (backend :3000 +
+  // console :5180) via playwright.live.config.ts + an auth global-setup.
+  // Exclude them from the default/CI run, which serves a mocked production
+  // build with no backend.
+  testIgnore: ['**/live/**'],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code */


### PR DESCRIPTION
## Summary

- Adds **`e2e/live/summary-rollup.spec.ts`** — verifies the new server-side roll-up `summary` fields (framework PR #1610) end-to-end against the **real SQL driver** via `/api/v1/batch`: `showcase_project.total_estimate` (SUM) + `task_count` (COUNT) computed on atomic create, and recomputed to `0` when the child is deleted. **2 passing** against the live stack.
- Adds `testIgnore: ['**/live/**']` to the **default** `playwright.config.ts` so the mocked CI run (vite preview on :4173, no backend) skips the live specs. Live specs need the real stack (backend :3000 + console :5180) and the live config's auth global-setup; run them with `pnpm test:e2e:live`. This also retroactively keeps the master-detail live spec (added in #1521) out of the CI run.

## Testing

- `pnpm test:e2e:live` → master-detail (2) + summary-rollup (2) all green against the live stack.
- `npx playwright test --list` (default) confirms live specs are excluded; smoke/console specs unaffected.

Pairs with framework PR #1610 (server-side summary computation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)