### PR TITLE
test(e2e): live specs for Studio page editor + action modals

### DIFF
--- a/e2e/live/action-modal.spec.ts
+++ b/e2e/live/action-modal.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Live e2e for action modals — a row action opens its modal envelope (Dialog),
+ * renders the target form, and closes cleanly. Guards the action-modal
+ * transport (drawer/modal/fullscreen) wiring end-to-end.
+ */
+test('a row Edit action opens a modal form and closes', async ({ page }) => {
+  await page.goto('/apps/showcase_app/showcase_task');
+  await page.locator('[data-testid="row-action-trigger"]').first().waitFor();
+  await page.locator('[data-testid="row-action-trigger"]').first().click();
+  await page.getByRole('menuitem', { name: /^Edit$/i }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole('heading', { name: /Edit Task/i })).toBeVisible();
+  await expect(page.getByTestId('modal-form-footer')).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+});

--- a/e2e/live/studio-editor.spec.ts
+++ b/e2e/live/studio-editor.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Live e2e for the Studio metadata page editor — guards the "Add block works
+ * and blocks are configurable" contract the SDUI runtime depends on. Drives the
+ * real editor at /apps/:app/metadata/page/:name against the running stack.
+ */
+const EDIT = '/apps/showcase_app/metadata/page/showcase_project_workspace';
+
+test('the page editor loads with its config sections', async ({ page }) => {
+  await page.goto(EDIT);
+  await expect(page.getByTestId('metadata-edit-page')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Basics' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Layout' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Add block/i }).first()).toBeVisible();
+});
+
+test('Add block opens a block-type picker with configurable block kinds', async ({ page }) => {
+  await page.goto(EDIT);
+  await expect(page.getByTestId('metadata-edit-page')).toBeVisible();
+
+  await page.getByRole('button', { name: /Add block/i }).first().click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  // The picker offers selectable, schema-backed block kinds (SDUI slots).
+  await expect(dialog.getByRole('button', { name: /Card/i })).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Section/i })).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Record details/i })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Extends the live Playwright harness (real backend :3000 + console :5180) to two more SDUI surfaces, turning it into a broader regression net:

- **`studio-editor.spec.ts`** — the Studio metadata **page editor** (`/apps/:app/metadata/page/:name`) loads with its config sections (Basics / Layout / …) and **"Add block"** opens a block-type **picker** offering configurable block kinds (Card / Section / Record details / Tabs / …). Directly guards the "add block works and each block is configurable" contract.
- **`action-modal.spec.ts`** — a row **Edit** action opens its modal envelope (Dialog titled "Edit Task" + `modal-form-footer`) and closes cleanly on Escape. Guards the action-modal transport wiring.

## Testing

- `pnpm test:e2e:live` → studio-editor (2) + action-modal (1), green across 2 repeats against the live stack.
- Excluded from the mocked CI run by the default config's `testIgnore: ['**/live/**']` (added in #1523).

Builds on the harness from #1521 (config + auth global-setup + Radix/lookup/grid helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)