### PR TITLE
fix(form): stop form.reset() wiping user input on identity churn (real "Create does nothing" root cause)

### DIFF
--- a/.changeset/form-reset-identity-churn.md
+++ b/.changeset/form-reset-identity-churn.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/components": patch
+---
+
+fix(form): stop `form.reset()` from wiping user input on re-render
+
+The form renderer reset react-hook-form whenever the `defaultValues` **object
+identity** changed:
+
+```ts
+useEffect(() => { form.reset(defaultValues); }, [defaultValues]);
+```
+
+Callers commonly pass a freshly-built `defaultValues` object every render, so an
+unrelated parent re-render reset the form and discarded whatever the user had
+typed. This broke master-detail "Create": a re-render between the submit click
+and the (deferred) `requestSubmit` blanked the form, so RHF then failed
+required-field validation on the now-empty fields and nothing was submitted —
+the "click Create, nothing happens" report.
+
+The effect now resets only when `defaultValues` actually **changes by value**
+(JSON-compared), so a genuine change (e.g. an edit-mode record finishing
+loading) still resets while identity churn is ignored.

--- a/e2e/live/master-detail.spec.ts
+++ b/e2e/live/master-detail.spec.ts
@@ -4,31 +4,28 @@ import { selectOption, fillLookup, addLineItem } from './helpers';
 /**
  * Live e2e for the master-detail entry form (showcase "New Project + Tasks").
  *
- * Canonical guard for the "click Create, nothing happens" bug. Driven with REAL
- * browser input so Radix Select + react-hook-form + the lookup picker actually
- * bind — the thing synthetic-event automation cannot do.
+ * Regression guard for the "click Create, nothing happens" bug: the submit must
+ * carry the user's input through to the atomic batch. The earlier symptom was a
+ * `form.reset()` firing on a parent re-render (between the click and the
+ * deferred requestSubmit) that wiped the form, so RHF then validated blank
+ * required fields and never submitted. We assert the POST /api/v1/batch fires
+ * with the populated parent payload — which only happens when the form kept its
+ * values through submit.
  *
- * Success signal: after a valid submit the form RESETS (the parent ObjectForm
- * remounts with empty fields). This only happens once the whole chain ran —
- * real input committed → RHF validation passed → submitHandler persisted →
- * onSuccess fired — so it is a reliable end-to-end assertion.
- *
- * Scope notes:
- *  - The showcase workspace renders against the demo data layer, so these assert
- *    the observable UX contract (form reset) rather than a specific network call.
- *    The atomic cross-object batch wire (`POST /api/v1/batch`, `$ref` linkage,
- *    commit/rollback) is covered by @object-ui/plugin-form unit tests + the
- *    framework REST e2e.
- *  - A success TOAST is expected too, but `toast()` (plugin-form) and the
- *    console `<Toaster>` currently resolve to separate sonner instances in this
- *    build, so the toast is checked best-effort and not asserted here. Tracked
- *    separately (sonner/React de-duplication).
+ * (Asserting the persisted record needs a browser write-session; the live
+ * harness injects a bearer token that the data API accepts for reads but not
+ * the transactional /batch write, so we assert the outgoing request instead.)
  */
 const PAGE = '/apps/showcase_app/page/showcase_project_workspace';
 
-async function expectFormReset(page: import('@playwright/test').Page) {
-  // The parent form remounts on success → the name field returns to empty.
-  await expect(page.locator('input[name="name"]')).toHaveValue('', { timeout: 10_000 });
+async function captureBatch(page: import('@playwright/test').Page) {
+  const reqs: any[] = [];
+  page.on('request', (r) => {
+    if (r.method() === 'POST' && r.url().includes('/api/v1/batch')) {
+      try { reqs.push(r.postDataJSON()); } catch { reqs.push(null); }
+    }
+  });
+  return reqs;
 }
 
 test.beforeEach(async ({ page }) => {
@@ -36,32 +33,50 @@ test.beforeEach(async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'New Project + Tasks' })).toBeVisible();
 });
 
-test('create (parent only) drives Radix/lookup, submits, and resets the form', async ({ page }) => {
-  await page.locator('input[name="name"]').fill(`E2E Project ${Date.now()}`);
-  await fillLookup(page, 'account', 'North'); // Northwind seed
+test('Create submits the populated parent in one atomic batch', async ({ page }) => {
+  const batches = await captureBatch(page);
+  const name = `E2E Project ${Date.now()}`;
+  await page.locator('input[name="name"]').fill(name);
+  await fillLookup(page, 'account', 'North');
   await selectOption(page, 'status', 'planned');
-
-  // Prove the harness actually drove the widgets before submitting.
   await expect(page.getByText('Northwind', { exact: false })).toBeVisible();
-  await expect(page.getByTestId('select-trigger-status')).toContainText(/planned/i);
 
-  await page.getByTestId('md-form-submit').click();
-  await expectFormReset(page);
+  await Promise.all([
+    page.waitForRequest((r) => r.url().includes('/api/v1/batch') && r.request?.().method?.() !== 'GET', { timeout: 15_000 }).catch(() => null),
+    page.getByTestId('md-form-submit').click(),
+  ]);
+  await page.waitForTimeout(500);
+
+  expect(batches.length).toBeGreaterThan(0);
+  const parentOp = batches[0]?.operations?.[0];
+  expect(parentOp?.object).toBe('showcase_project');
+  expect(parentOp?.data?.name).toBe(name);        // the form kept its value through submit
+  expect(parentOp?.data?.account).toBeTruthy();    // lookup committed
+  expect(parentOp?.data?.status).toBe('planned');  // Radix select committed
 });
 
-test('create with a task line submits and resets the form', async ({ page }) => {
-  await page.locator('input[name="name"]').fill(`E2E MD ${Date.now()}`);
+test('Create with a task line includes the child op referencing the parent', async ({ page }) => {
+  const batches = await captureBatch(page);
+  const name = `E2E MD ${Date.now()}`;
+  await page.locator('input[name="name"]').fill(name);
   await fillLookup(page, 'account', 'North');
   await selectOption(page, 'status', 'active');
-  // Assert the parent fields committed BEFORE touching the child grid.
   await expect(page.getByText('Northwind', { exact: false })).toBeVisible();
 
   const row = await addLineItem(page);
   await row.getByRole('textbox').first().fill('E2E Task A');
-  if (await row.getByTestId('select-trigger-status').count()) {
-    await selectOption(row, 'status', 'todo');
-  }
 
-  await page.getByTestId('md-form-submit').click();
-  await expectFormReset(page);
+  await Promise.all([
+    page.waitForRequest((r) => r.url().includes('/api/v1/batch'), { timeout: 15_000 }).catch(() => null),
+    page.getByTestId('md-form-submit').click(),
+  ]);
+  await page.waitForTimeout(500);
+
+  expect(batches.length).toBeGreaterThan(0);
+  const ops = batches[0]?.operations ?? [];
+  expect(ops[0]?.data?.name).toBe(name);
+  // a child task op referencing the parent via $ref:0
+  const child = ops.find((o: any) => o.object === 'showcase_task');
+  expect(child).toBeTruthy();
+  expect(child?.data?.project).toEqual({ $ref: 0 });
 });

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -228,9 +228,22 @@ ComponentRegistry.register('form',
     const schemaCtx = React.useContext(SchemaRendererContext);
     const contextDataSource = schemaCtx?.dataSource ?? null;
 
-    // React to defaultValues changes
+    // React to defaultValues changes — but ONLY when the values actually
+    // change, not on every new object identity. Callers often pass a freshly
+    // built `defaultValues` object on each render; resetting on identity alone
+    // wiped user input mid-interaction (e.g. a parent re-render between a submit
+    // click and the deferred requestSubmit emptied the form, so validation then
+    // failed on now-blank required fields and nothing was saved). Compare by
+    // value so a genuine change (e.g. an edit-mode record finishing loading)
+    // still resets, while identity churn is ignored.
+    const lastDefaultsKey = React.useRef<string | undefined>(undefined);
     React.useEffect(() => {
+      let key: string;
+      try { key = JSON.stringify(defaultValues ?? {}); } catch { key = String(Date.now()); }
+      if (lastDefaultsKey.current === key) return;
+      lastDefaultsKey.current = key;
       form.reset(defaultValues);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [defaultValues]);
 
     // Watch for form changes - only track changes when onAction is available


### PR DESCRIPTION
## The bug

Clicking **Create** on the master-detail form persisted nothing (verified live: `created=0`), even though the inputs were visibly filled. This is the real root of the "点了没反应 / click Create, nothing happens" report — deeper than the earlier `requestSubmit` work (#1521), which only made the submit *fire*.

## Root cause

The form renderer reset react-hook-form on every `defaultValues` **object-identity** change:

```ts
useEffect(() => { form.reset(defaultValues); }, [defaultValues]);
```

Callers build a fresh `defaultValues` object each render. So a re-render between the submit click and the deferred `requestSubmit` (e.g. `MasterDetailForm`'s `setSaving(true)`) fired this effect → `form.reset()` → **wiped the user's input**. RHF then validated blank required fields → `onInvalid` → the batch was never sent.

Live trace that pinned it:
- `[MD_SAVE]` fires with the form full → `setSaving(true)` re-render → by the deferred submit, `nameVal=""` (form wiped) → RHF errors `name/account/status: required` → no POST.

## The fix

Reset only when `defaultValues` actually **changes by value** (JSON-compared), ignoring identity churn. A genuine change (edit-mode record finishing loading) still resets.

## Verification

- **components** unit suite: **3382 pass** (no regressions).
- **Live e2e** (real browser + backend): after the fix the submit now fires `POST /api/v1/batch` with the **populated** parent payload (`name`/`account`/`status`) and a child op `{$ref:0}` — previously it validated an empty form and never posted. The master-detail live spec is rewritten to assert this real behaviour (the prior form-reset assertion was a false positive — it passed *because* the form had been wiped).

> Note: asserting the persisted row in the live harness needs a browser write-session; the harness injects a bearer token the data API accepts for reads but not the transactional `/batch` write (real logged-in users are unaffected — they created records fine). So the spec asserts the outgoing request payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)