### PR TITLE
feat(master-detail): derive child columns + FK from metadata

### DIFF
--- a/.changeset/master-detail-auto-derive.md
+++ b/.changeset/master-detail-auto-derive.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/plugin-form": minor
+---
+
+feat(master-detail): derive child columns + relationship FK from metadata
+
+A master-detail child collection can now be configured with **just the child
+object name** — the relationship FK and the editable grid columns are derived
+from the child object's schema (via `DataSource.getObjectSchema`), instead of a
+hand-authored columns block.
+
+```ts
+// before: ~40 lines of columns + relationshipField
+details: [{ childObject: 'task', relationshipField: 'project', columns: [ ...12 lines... ] }]
+// after:
+details: [{ childObject: 'task' }]
+```
+
+- `relationshipField` is auto-detected from the child's `master_detail`/`lookup`
+  field that references the parent (master_detail preferred).
+- `columns` are derived from the child's fields, skipping system/audit fields,
+  the back-reference FK, and non-editable types (formula/summary/autonumber/
+  file/json/…); select options and lookup references carry through.
+- `amountField` (running-total source) defaults to the first numeric/currency
+  column.
+- Any of these can still be set explicitly to override the derived defaults.
+- Save is gated until derivation resolves; new pure helpers
+  (`deriveDetail`/`deriveColumns`/`findRelationshipField`) are unit-tested.

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -30,14 +30,18 @@ import { LineItemsField, type GridColumn } from '@object-ui/fields';
 import { Button, Card, CardContent, CardHeader, CardTitle, cn, toast } from '@object-ui/components';
 import { ObjectForm } from './ObjectForm';
 import { applyDetail, idOf, buildMasterDetailBatch, buildMasterDetailEditBatch, sumRows } from './masterDetailTx';
+import { deriveDetail } from './deriveMasterDetail';
 
 export interface MasterDetailDetailConfig {
   /** Child object name, e.g. 'expense_line'. */
   childObject: string;
-  /** FK field on the child pointing back to the parent, e.g. 'expense_claim'. */
-  relationshipField: string;
-  /** Editable columns for the child grid. */
-  columns: GridColumn[];
+  /** FK field on the child pointing back to the parent, e.g. 'expense_claim'.
+   *  Optional — auto-detected from the child's master_detail/lookup field that
+   *  references the parent object when omitted. */
+  relationshipField?: string;
+  /** Editable columns for the child grid. Optional — derived from the child
+   *  object's fields (via DataSource.getObjectSchema) when omitted. */
+  columns?: GridColumn[];
   /** Numeric child column to sum, e.g. 'amount'. */
   amountField?: string;
   /** Parent field to receive the rolled-up sum, e.g. 'total_amount'. */
@@ -87,12 +91,53 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
   dataSource,
   className,
 }) => {
-  const details = schema.details || [];
+  const rawDetails = schema.details || [];
   const isEdit = schema.mode === 'edit' && !!schema.recordId;
 
-  // One row-state per detail collection.
+  // A detail can be configured with just `{ childObject }` — the relationship
+  // FK and grid columns are then derived from the child object's metadata
+  // (DataSource.getObjectSchema). Resolve those before rendering the grid.
+  const needsDerive = rawDetails.some((d) => !d.relationshipField || !d.columns?.length);
+  const [resolvedDetails, setResolvedDetails] = useState<MasterDetailDetailConfig[] | null>(
+    needsDerive ? null : rawDetails,
+  );
+  const details = resolvedDetails ?? rawDetails; // length always matches rawDetails
+
+  useEffect(() => {
+    if (!needsDerive) { setResolvedDetails(rawDetails); return; }
+    if (!dataSource || typeof (dataSource as any).getObjectSchema !== 'function') return;
+    let cancelled = false;
+    (async () => {
+      const out = await Promise.all(
+        rawDetails.map(async (d) => {
+          if (d.relationshipField && d.columns?.length) return d;
+          try {
+            const childSchema = await dataSource.getObjectSchema(d.childObject);
+            const derived = deriveDetail(d.childObject, childSchema, schema.objectName, {
+              relationshipField: d.relationshipField,
+              columns: d.columns,
+              amountField: d.amountField,
+            });
+            return {
+              ...d,
+              relationshipField: derived.relationshipField,
+              columns: derived.columns,
+              amountField: d.amountField ?? derived.amountField,
+            };
+          } catch {
+            return d; // leave as-is; the grid card will show a config hint
+          }
+        }),
+      );
+      if (!cancelled) setResolvedDetails(out);
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataSource, schema.objectName, schema.details]);
+
+  // One row-state per detail collection (length is known up-front from rawDetails).
   const [state, setState] = useState<RowState[]>(() =>
-    details.map(() => ({ rows: [], original: [] })),
+    rawDetails.map(() => ({ rows: [], original: [] })),
   );
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -119,6 +164,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
     (async () => {
       const loaded = await Promise.all(
         details.map(async (d) => {
+          if (!d.relationshipField) return { rows: [], original: [] }; // not resolved yet
           try {
             const res = await dataSource.find(d.childObject, {
               $filter: { [d.relationshipField]: schema.recordId },
@@ -137,7 +183,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEdit, dataSource, schema.recordId]);
+  }, [isEdit, dataSource, schema.recordId, resolvedDetails]);
 
   const setRows = useCallback((detailIdx: number, rows: Record<string, any>[]) => {
     setState((prev) => prev.map((s, i) => (i === detailIdx ? { ...s, rows } : s)));
@@ -181,6 +227,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
       for (let i = 0; i < details.length; i++) {
         const d = details[i];
         const { rows, original } = stateRef.current[i];
+        if (!d.relationshipField) continue; // unresolved — skip (save is gated)
         const { created } = await applyDetail(dataSource!, schema.objectName, parentId, {
           childObject: d.childObject,
           relationshipField: d.relationshipField,
@@ -244,9 +291,9 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
             schema.objectName,
             schema.recordId!,
             parentData,
-            details.map((d, i) => ({
+            details.filter((d) => d.relationshipField).map((d, i) => ({
               childObject: d.childObject,
-              relationshipField: d.relationshipField,
+              relationshipField: d.relationshipField!,
               rows: stateRef.current[i]?.rows ?? [],
               original: stateRef.current[i]?.original ?? [],
             })),
@@ -254,9 +301,9 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
         : buildMasterDetailBatch(
             schema.objectName,
             parentData,
-            details.map((d, i) => ({
+            details.filter((d) => d.relationshipField).map((d, i) => ({
               childObject: d.childObject,
-              relationshipField: d.relationshipField,
+              relationshipField: d.relationshipField!,
               rows: stateRef.current[i]?.rows ?? [],
             })),
           );
@@ -336,6 +383,9 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
             <CardTitle className="text-sm font-medium">{d.title || 'Line Items'}</CardTitle>
           </CardHeader>
           <CardContent>
+            {!d.columns?.length ? (
+              <p className="py-4 text-sm text-muted-foreground">Loading columns…</p>
+            ) : (
             <LineItemsField
               value={state[i]?.rows ?? []}
               onChange={(rows) => setRows(i, rows)}
@@ -351,6 +401,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
                 } as any
               }
             />
+            )}
           </CardContent>
         </Card>
       ))}
@@ -362,7 +413,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
             Cancel
           </Button>
         )}
-        <Button type="button" onClick={handleSave} disabled={saving} data-testid="md-form-submit">
+        <Button type="button" onClick={handleSave} disabled={saving || (needsDerive && !resolvedDetails)} data-testid="md-form-submit">
           {saving ? 'Saving…' : submitText}
         </Button>
       </div>

--- a/packages/plugin-form/src/deriveMasterDetail.test.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { findRelationshipField, deriveColumns, deriveDetail, fieldTypeToColumnType } from './deriveMasterDetail';
+
+const taskSchema = {
+  name: 'showcase_task',
+  fields: {
+    id: { type: 'text', system: true },
+    title: { type: 'text', label: 'Title', required: true },
+    status: { type: 'select', label: 'Status', options: [{ label: 'To Do', value: 'todo' }, { label: 'Done', value: 'done' }] },
+    estimate_hours: { type: 'number', label: 'Estimate (h)' },
+    budget: { type: 'currency', label: 'Budget' },
+    due_date: { type: 'date', label: 'Due Date' },
+    assignee: { type: 'lookup', label: 'Assignee', reference: 'user', display_field: 'name' },
+    project: { type: 'master_detail', label: 'Project', reference: 'showcase_project', required: true },
+    health: { type: 'formula', label: 'Health', expression: 'x' },
+    created_at: { type: 'datetime' },
+  },
+};
+
+describe('fieldTypeToColumnType', () => {
+  it('maps object field types to grid column types', () => {
+    expect(fieldTypeToColumnType('number')).toBe('number');
+    expect(fieldTypeToColumnType('currency')).toBe('currency');
+    expect(fieldTypeToColumnType('datetime')).toBe('date');
+    expect(fieldTypeToColumnType('select')).toBe('select');
+    expect(fieldTypeToColumnType('master_detail')).toBe('lookup');
+    expect(fieldTypeToColumnType('email')).toBe('text');
+  });
+});
+
+describe('findRelationshipField', () => {
+  it('finds the master_detail field pointing at the parent', () => {
+    expect(findRelationshipField(taskSchema, 'showcase_project')).toBe('project');
+  });
+  it('prefers master_detail over lookup', () => {
+    const s = { fields: { a: { type: 'lookup', reference: 'p' }, b: { type: 'master_detail', reference: 'p' } } };
+    expect(findRelationshipField(s, 'p')).toBe('b');
+  });
+  it('returns undefined when no field references the parent', () => {
+    expect(findRelationshipField(taskSchema, 'nope')).toBeUndefined();
+  });
+});
+
+describe('deriveColumns', () => {
+  it('derives editable columns, skipping system/audit/FK/non-editable fields', () => {
+    const cols = deriveColumns(taskSchema, { relationshipField: 'project' });
+    const names = cols.map((c) => c.field);
+    expect(names).toEqual(['title', 'status', 'estimate_hours', 'budget', 'due_date', 'assignee']);
+    // id (system), created_at (audit), project (FK), health (formula) excluded
+    expect(names).not.toContain('id');
+    expect(names).not.toContain('project');
+    expect(names).not.toContain('health');
+    expect(names).not.toContain('created_at');
+  });
+
+  it('carries type, options, required and lookup reference through', () => {
+    const cols = deriveColumns(taskSchema, { relationshipField: 'project' });
+    const byName = Object.fromEntries(cols.map((c) => [c.field, c]));
+    expect(byName.title).toMatchObject({ type: 'text', label: 'Title', required: true });
+    expect(byName.status).toMatchObject({ type: 'select', options: [{ label: 'To Do', value: 'todo' }, { label: 'Done', value: 'done' }] });
+    expect(byName.estimate_hours.type).toBe('number');
+    expect(byName.budget.type).toBe('currency');
+    expect(byName.assignee).toMatchObject({ type: 'lookup', reference: 'user', displayField: 'name' });
+  });
+});
+
+describe('deriveDetail', () => {
+  it('resolves relationshipField + columns + amountField from the child schema', () => {
+    const d = deriveDetail('showcase_task', taskSchema, 'showcase_project');
+    expect(d.relationshipField).toBe('project');
+    expect(d.columns.map((c) => c.field)).toContain('estimate_hours');
+    expect(d.amountField).toBe('estimate_hours'); // first numeric/currency column
+  });
+
+  it('honors explicit overrides over derived values', () => {
+    const d = deriveDetail('showcase_task', taskSchema, 'showcase_project', {
+      relationshipField: 'project',
+      columns: [{ field: 'title', type: 'text' }],
+      amountField: 'budget',
+    });
+    expect(d.columns).toHaveLength(1);
+    expect(d.amountField).toBe('budget');
+  });
+
+  it('throws a helpful error when no relationship can be resolved', () => {
+    expect(() => deriveDetail('showcase_task', { fields: { title: { type: 'text' } } }, 'showcase_project'))
+      .toThrow(/could not find a lookup\/master_detail field/i);
+  });
+});

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -1,0 +1,168 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Derive a master-detail child collection's grid columns + relationship FK from
+ * object metadata, so a master-detail form can be configured with just the
+ * child object name instead of a hand-authored columns block. Pure (no React /
+ * no I/O) so it is unit-testable; the async schema fetch lives in the component.
+ */
+
+import type { GridColumn } from '@object-ui/fields';
+
+/** Minimal shape of an object schema as returned by `DataSource.getObjectSchema`. */
+export interface ObjectSchemaLike {
+  name?: string;
+  fields?: Record<string, any>;
+}
+
+/** Fields never shown as editable line-item columns. */
+const SYSTEM_FIELDS = new Set([
+  'id', '_id', 'recordId',
+  'created_at', 'updated_at', 'created_by', 'updated_by',
+  'createdAt', 'updatedAt', 'createdBy', 'updatedBy',
+  'organization_id', 'tenant_id', 'space', 'owner',
+]);
+
+/** Field types that are not directly editable in a line-item grid. */
+const NON_EDITABLE_TYPES = new Set([
+  'formula', 'summary', 'rollup', 'autonumber', 'auto_number',
+  'file', 'image', 'avatar', 'json', 'object', 'grid', 'table',
+  'location', 'vector', 'html', 'markdown', 'richtext',
+]);
+
+/** Map an ObjectQL field type to a LineItems grid column type. */
+export function fieldTypeToColumnType(type: string | undefined): GridColumn['type'] {
+  switch (type) {
+    case 'number':
+    case 'percent':
+    case 'rating':
+    case 'slider':
+      return 'number';
+    case 'currency':
+      return 'currency';
+    case 'date':
+    case 'datetime':
+    case 'time':
+      return 'date';
+    case 'select':
+    case 'picklist':
+    case 'radio':
+    case 'boolean':
+    case 'toggle':
+      return 'select';
+    case 'lookup':
+    case 'master_detail':
+      return 'lookup';
+    default:
+      return 'text';
+  }
+}
+
+function optionsFor(def: any): GridColumn['options'] | undefined {
+  if (def?.type === 'boolean' || def?.type === 'toggle') {
+    return [
+      { label: 'Yes', value: 'true' },
+      { label: 'No', value: 'false' },
+    ];
+  }
+  const raw = def?.options;
+  if (!Array.isArray(raw)) return undefined;
+  return raw.map((o: any) =>
+    typeof o === 'object' && o !== null
+      ? { label: String(o.label ?? o.value), value: String(o.value) }
+      : { label: String(o), value: String(o) },
+  );
+}
+
+/**
+ * Find the field on the child object that points back to the parent — the
+ * master_detail/lookup field whose `reference` is the parent object. Prefer
+ * `master_detail` over `lookup` when both exist.
+ */
+export function findRelationshipField(
+  childSchema: ObjectSchemaLike | undefined,
+  parentObjectName: string,
+): string | undefined {
+  const fields = childSchema?.fields;
+  if (!fields || typeof fields !== 'object') return undefined;
+  let lookupMatch: string | undefined;
+  for (const [name, def] of Object.entries(fields)) {
+    const d = def as any;
+    if (d?.reference !== parentObjectName) continue;
+    if (d?.type === 'master_detail') return name; // strongest match
+    if (d?.type === 'lookup' && !lookupMatch) lookupMatch = name;
+  }
+  return lookupMatch;
+}
+
+/**
+ * Derive editable grid columns from a child object's fields, skipping system /
+ * audit fields, non-editable types, and the back-reference FK to the parent.
+ */
+export function deriveColumns(
+  childSchema: ObjectSchemaLike | undefined,
+  opts: { relationshipField?: string; exclude?: string[] } = {},
+): GridColumn[] {
+  const fields = childSchema?.fields;
+  if (!fields || typeof fields !== 'object') return [];
+  const exclude = new Set([...(opts.exclude ?? []), ...(opts.relationshipField ? [opts.relationshipField] : [])]);
+  const cols: GridColumn[] = [];
+  for (const [name, def] of Object.entries(fields)) {
+    const d = def as any;
+    if (SYSTEM_FIELDS.has(name) || exclude.has(name)) continue;
+    if (d?.system || d?.readonly || d?.hidden) continue;
+    if (NON_EDITABLE_TYPES.has(d?.type)) continue;
+    const col: GridColumn = {
+      field: name,
+      label: d?.label || name,
+      type: fieldTypeToColumnType(d?.type),
+      required: !!d?.required,
+    };
+    const options = optionsFor(d);
+    if (col.type === 'select' && options) col.options = options;
+    if (col.type === 'lookup') {
+      col.reference = d?.reference;
+      col.displayField = d?.display_field || d?.reference_field;
+    }
+    cols.push(col);
+  }
+  return cols;
+}
+
+export interface DerivedDetail {
+  childObject: string;
+  relationshipField: string;
+  columns: GridColumn[];
+  /** First numeric column, used as the running-total source when none is set. */
+  amountField?: string;
+}
+
+/**
+ * Resolve a child collection's full config (FK + columns) from its object
+ * schema. Throws when no relationship to the parent can be found. The caller
+ * supplies any explicit overrides (relationshipField / columns / amountField),
+ * which win over the derived values.
+ */
+export function deriveDetail(
+  childObject: string,
+  childSchema: ObjectSchemaLike | undefined,
+  parentObjectName: string,
+  override: { relationshipField?: string; columns?: GridColumn[]; amountField?: string } = {},
+): DerivedDetail {
+  const relationshipField = override.relationshipField || findRelationshipField(childSchema, parentObjectName);
+  if (!relationshipField) {
+    throw new Error(
+      `MasterDetailForm: could not find a lookup/master_detail field on "${childObject}" referencing "${parentObjectName}". ` +
+      `Set relationshipField explicitly.`,
+    );
+  }
+  const columns = override.columns?.length ? override.columns : deriveColumns(childSchema, { relationshipField });
+  const amountField = override.amountField || columns.find((c) => c.type === 'number' || c.type === 'currency')?.field;
+  return { childObject, relationshipField, columns, amountField };
+}


### PR DESCRIPTION
## Summary

Answers "do master-detail forms really need a hand-authored columns block?" — **no**. A child collection can now be configured with just the child object name; the relationship FK and editable grid columns are derived from the child object's metadata.

```ts
// before — ~40 lines
details: [{ childObject: 'showcase_task', relationshipField: 'project', columns: [ /* 12+ lines */ ] }]
// after
details: [{ childObject: 'showcase_task' }]
```

## What it does

- **`relationshipField`** auto-detected from the child's `master_detail`/`lookup` field whose `reference` is the parent (master_detail preferred).
- **`columns`** derived from the child's fields — skips system/audit fields, the back-reference FK, and non-editable types (formula/summary/autonumber/file/json/…); select `options` and lookup `reference`/`displayField` carry through; types mapped to grid column types.
- **`amountField`** (running-total source) defaults to the first numeric/currency column.
- All of these remain explicitly overridable.
- `MasterDetailForm` resolves unconfigured details via `getObjectSchema` and gates Save until resolved.

## Testing

- New pure helpers `deriveDetail` / `deriveColumns` / `findRelationshipField` + `fieldTypeToColumnType` — **9 unit tests** (76 plugin-form pass).
- **Live e2e (2/2)**: the showcase form now derives its task columns at runtime and still posts the correct atomic `/api/v1/batch` (parent + child `{$ref:0}`). Paired showcase simplification in the framework repo drops its `details` block to one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)