### PR TITLE
feat(form): inline master-detail in a plain ObjectForm via subforms

### DIFF
--- a/.changeset/objectform-subforms.md
+++ b/.changeset/objectform-subforms.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/plugin-form": minor
+"@object-ui/types": minor
+---
+
+feat(form): inline master-detail in a plain ObjectForm via `subforms`
+
+`ObjectFormSchema` gains a `subforms` array. When set, a regular `object-form`
+renders as a master-detail form — the object's own fields on top, an editable
+grid per child collection below, persisted together in one atomic transaction —
+without a bespoke `object-master-detail-form` page.
+
+```ts
+{ type: 'object-form', objectName: 'expense_claim',
+  subforms: [{ childObject: 'expense_line' }] }   // FK + columns auto-derived
+```
+
+Each subform needs only `childObject` (relationship FK and columns are derived
+from the child object's metadata; override with `relationshipField`/`columns`).
+This is the config-driven, page-less way to express master-detail entry — a form
+view can declare its child collections directly.

--- a/packages/plugin-form/src/ObjectForm.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.test.tsx
@@ -112,4 +112,38 @@ describe('ObjectForm Integration', () => {
             expect(onSuccess).toHaveBeenCalled();
         });
     });
+
+    it('renders as a master-detail form when schema.subforms is set', async () => {
+        // A plain object form becomes master-detail by config (no bespoke page):
+        // parent fields on top + an editable child grid + a single Save action.
+        const ds: any = {
+            getObjectSchema: vi.fn().mockResolvedValue({
+                name: 'test_object',
+                fields: { name: { type: 'text', label: 'Name' } },
+            }),
+            batchTransaction: vi.fn(),
+        };
+
+        render(
+            <ObjectForm
+                schema={{
+                    type: 'object-form',
+                    objectName: 'test_object',
+                    mode: 'create',
+                    subforms: [
+                        { childObject: 'test_line', relationshipField: 'parent', title: 'Lines',
+                          columns: [{ field: 'qty', type: 'number' }] },
+                    ],
+                } as any}
+                dataSource={ds}
+            />,
+        );
+
+        // MasterDetailForm renders its single action bar (md-form-submit) and the
+        // child section title — proof we delegated to the master-detail form.
+        await waitFor(() => {
+            expect(screen.getByTestId('md-form-submit')).toBeTruthy();
+        });
+        expect(screen.getByText('Lines')).toBeTruthy();
+    });
 });

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -24,6 +24,7 @@ import { WizardForm } from './WizardForm';
 import { SplitForm } from './SplitForm';
 import { DrawerForm } from './DrawerForm';
 import { ModalForm } from './ModalForm';
+import { MasterDetailForm } from './MasterDetailForm';
 import { FormSection } from './FormSection';
 import { applyAutoLayout } from './autoLayout';
 
@@ -98,6 +99,35 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
   const { sectionLabel } = useSafeFieldLabel();
   const tSec = (s: any) =>
     s?.name ? sectionLabel(schema.objectName, s.name, s.label || s.name) : s?.label;
+
+  // Master-detail: when the schema declares inline child collections, render as
+  // a master-detail form (parent fields + child grids, persisted atomically).
+  // This lets a plain form view become master-detail by config — no bespoke
+  // page. Skipped in view mode (read-only detail uses related lists instead).
+  if ((schema as any).subforms?.length && schema.mode !== 'view') {
+    return (
+      <MasterDetailForm
+        schema={{
+          type: 'object-master-detail-form',
+          objectName: schema.objectName,
+          mode: schema.mode === 'edit' ? 'edit' : 'create',
+          recordId: schema.recordId,
+          formType: schema.formType === 'tabbed' ? 'tabbed' : 'simple',
+          sections: schema.sections as any,
+          fields: schema.fields as any,
+          title: schema.title,
+          submitText: schema.submitText,
+          details: (schema as any).subforms,
+          onSuccess: schema.onSuccess,
+          onError: schema.onError,
+          onCancel: schema.onCancel,
+          className: schema.className,
+        }}
+        dataSource={dataSource}
+      />
+    );
+  }
+
   // Route to specialized form variant based on formType
   if (schema.formType === 'tabbed' && schema.sections?.length) {
     return (

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -970,6 +970,27 @@ export interface ObjectFormSchema extends BaseSchema {
   submitHandler?: (values: Record<string, any>) => any | Promise<any>;
 
   /**
+   * Inline child collections (master-detail). When present, the form renders as
+   * a master-detail form: the object's own fields on top, then an editable grid
+   * per child collection, persisted together in one atomic transaction. Each
+   * entry needs only `childObject` — the relationship FK and grid columns are
+   * derived from the child object's metadata (override with
+   * `relationshipField` / `columns`). This lets a regular form view declare
+   * master-detail without a bespoke page.
+   */
+  subforms?: Array<{
+    childObject: string;
+    relationshipField?: string;
+    columns?: any[];
+    amountField?: string;
+    totalField?: string;
+    title?: string;
+    addLabel?: string;
+    minRows?: number;
+    maxRows?: number;
+  }>;
+
+  /**
    * Callback on error
    */
   onError?: (error: Error) => void;


### PR DESCRIPTION
## Summary

Completes the "master-detail without a bespoke page" story. `ObjectFormSchema` gains a **`subforms`** array; when present, a regular `object-form` renders as a master-detail form (object fields on top, an editable child grid per collection, persisted together in one atomic transaction) by delegating to `MasterDetailForm`.

```ts
{ type: 'object-form', objectName: 'expense_claim',
  subforms: [{ childObject: 'expense_line' }] }   // FK + columns auto-derived (#1526)
```

Each subform needs only `childObject` — the relationship FK and grid columns are derived from the child object's metadata (override with `relationshipField` / `columns`). A form view can now declare its child collections directly instead of composing a custom `object-master-detail-form` page.

## Tiers, recapped

- **Tier 1** (#1526): `object-master-detail-form` with `{ childObject }` — columns/FK derived.
- **Tier 2** (this PR): any `object-form` becomes master-detail by adding `subforms`.

## Testing

- +1 unit test: `ObjectForm` with `subforms` renders the master-detail UI (`md-form-submit` + child section). **77 plugin-form tests pass.**
- `@object-ui/types` + `@object-ui/plugin-form` build clean — the mutual `ObjectForm ↔ MasterDetailForm` reference is render-time only (no circular-init issue).
- The underlying master-detail/atomic path is already covered by the live e2e (#1521/#1526).

Note: wiring object **form-view metadata** to populate `subforms` automatically (so the standard New/Edit screen includes children with zero page authoring) is a natural follow-up on top of this capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)