### PR TITLE
feat(view): forward form-view subforms to ObjectForm

### DIFF
--- a/.changeset/view-subforms-passthrough.md
+++ b/.changeset/view-subforms-passthrough.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/plugin-view": patch
+---
+
+feat(view): pass form-view `subforms` through to ObjectForm
+
+`ObjectView`'s form schema now forwards `form.subforms` to `ObjectForm`, so a
+form view that declares inline child collections renders as a master-detail
+form (parent fields + child grids, atomic save) in ObjectView's own
+create/edit form — no bespoke page. Pairs with `@objectstack/spec`
+`FormViewSchema.subforms` and ObjectForm's existing `subforms` rendering.

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -821,6 +821,10 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
       initialValues: schema.form?.initialValues,
       readOnly: schema.form?.readOnly || formMode === 'view',
       className: schema.form?.className,
+      // Master-detail by config: a form view can declare inline child
+      // collections; ObjectForm renders them as an atomic master-detail form
+      // (no bespoke page). ObjectForm skips them in view mode.
+      subforms: schema.form?.subforms,
       onSuccess: handleFormSuccess,
       onCancel: handleFormCancel,
     };


### PR DESCRIPTION
`ObjectView.buildFormSchema` now forwards `form.subforms` to `ObjectForm`. A form view that declares inline child collections renders as a master-detail form (parent fields + child grids, atomic save) in ObjectView's own create/edit form — no bespoke page.

Pairs with `@objectstack/spec` `FormViewSchema.subforms` and ObjectForm's existing `subforms` rendering (#1527).

**Scope note (honest):** this covers the **ObjectView**-rendered form path. The console's standard "New/Edit" modal is built separately (app-shell `AppContent` → `ModalForm`, which renders its body via `SchemaRenderer` and does not go through the ObjectForm dispatcher). Making that path render subforms needs `ModalForm`/`DrawerForm` to host `MasterDetailForm` inside the dialog + `AppContent` to source `subforms` from the object's form view — tracked as a follow-up (it carries a UX decision: master-detail inside a modal vs a full page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)