### PR TITLE
feat(form): standard New/Edit modal renders form-view subforms (Tier 0)

### DIFF
--- a/.changeset/tier0-console-subforms.md
+++ b/.changeset/tier0-console-subforms.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/plugin-form": minor
+"@object-ui/app-shell": minor
+---
+
+feat(form): standard New/Edit modal renders form-view subforms (Tier 0)
+
+The console's standard create/edit record modal now renders inline child
+collections when the object's form view declares `subforms` — master-detail
+entry with **no bespoke page**, persisted as one atomic transaction.
+
+- `ModalForm` (and the create/edit modal in app-shell `AppContent`) detects
+  `subforms` and renders `MasterDetailForm` inside the dialog (it owns its Save
+  bar; the modal footer is suppressed); on success the modal closes + refreshes.
+- `AppContent` sources `subforms` from the object's default form view
+  (`form.subforms` / `formViews.default.subforms`).
+- `ModalFormSchema` gains `subforms`.
+
+With this, declaring `formViews.default.subforms: [{ childObject }]` is enough
+to make an object's standard New/Edit screen a master-detail form — completing
+the config-driven master-detail story (Tier 0 → derive everything from the
+relationship + child metadata).

--- a/e2e/live/form-view-subforms.spec.ts
+++ b/e2e/live/form-view-subforms.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { selectOption, fillLookup, addLineItem } from './helpers';
+
+/**
+ * Tier 0 live e2e: an object's standard New/Edit modal renders inline child
+ * collections purely from `formViews.default.subforms` (no bespoke page). Here
+ * the showcase_project form view declares { childObject: 'showcase_task' }, so
+ * "New Project" opens a master-detail modal that submits parent + children in
+ * one atomic /api/v1/batch.
+ */
+test('New <object> modal renders form-view subforms and submits an atomic batch', async ({ page }) => {
+  const batches: any[] = [];
+  page.on('request', (r) => {
+    if (r.method() === 'POST' && r.url().includes('/api/v1/batch')) {
+      try { batches.push(r.postDataJSON()); } catch { /* ignore */ }
+    }
+  });
+
+  await page.goto('/apps/showcase_app/showcase_project');
+  await page.getByRole('button', { name: /^New$/i }).first().click();
+
+  // The standard create modal is now a master-detail form (no custom page).
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByTestId('md-form-submit')).toBeVisible();
+  await expect(dialog.getByText('Tasks', { exact: false })).toBeVisible();
+
+  const name = `Tier0 ${Date.now()}`;
+  await dialog.locator('input[name="name"]').fill(name);
+  await fillLookup(page, 'account', 'North');
+  await selectOption(page, 'status', 'planned');
+  await expect(dialog.getByText('Northwind', { exact: false }).first()).toBeVisible();
+
+  const row = await addLineItem(page);
+  await row.getByRole('textbox').first().fill('Tier0 Task');
+
+  await Promise.all([
+    page.waitForRequest((r) => r.url().includes('/api/v1/batch'), { timeout: 15_000 }).catch(() => null),
+    dialog.getByTestId('md-form-submit').click(),
+  ]);
+  await page.waitForTimeout(500);
+
+  expect(batches.length).toBeGreaterThan(0);
+  const ops = batches[0].operations;
+  expect(ops[0]).toMatchObject({ object: 'showcase_project', action: 'create' });
+  expect(ops[0].data.name).toBe(name);
+  expect(ops[0].data.status).toBe('planned');
+  const child = ops.find((o: any) => o.object === 'showcase_task');
+  expect(child?.data?.project).toEqual({ $ref: 0 });
+});

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -495,6 +495,11 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
                 objectName: currentObjectDef.name,
                 mode: editingRecord ? 'edit' : 'create',
                 recordId: editingRecord?.id,
+                // Master-detail by config: if the object's form view declares
+                // inline child collections, the standard New/Edit modal renders
+                // them as an atomic master-detail form (no bespoke page).
+                subforms: (currentObjectDef as any).form?.subforms
+                  ?? (currentObjectDef as any).formViews?.default?.subforms,
                 title: editingRecord
                   ? t('form.editTitle', { object: objectLabel(currentObjectDef as any) })
                   : t('form.createTitle', { object: objectLabel(currentObjectDef as any) }),

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -27,6 +27,7 @@ import {
 } from '@object-ui/components';
 import { Loader2 } from 'lucide-react';
 import { FormSection } from './FormSection';
+import { MasterDetailForm } from './MasterDetailForm';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { mapFieldTypeToFormType, buildValidationRules, evaluateCondition } from '@object-ui/fields';
 import { applyAutoLayout, inferModalSize } from './autoLayout';
@@ -90,6 +91,19 @@ export interface ModalFormSchema {
   onError?: (error: Error) => void;
   onCancel?: () => void;
   className?: string;
+  /** Inline child collections — renders the modal as an atomic master-detail
+   *  form. Each entry needs only `childObject` (FK + columns derived). */
+  subforms?: Array<{
+    childObject: string;
+    relationshipField?: string;
+    columns?: any[];
+    amountField?: string;
+    totalField?: string;
+    title?: string;
+    addLabel?: string;
+    minRows?: number;
+    maxRows?: number;
+  }>;
 }
 
 export interface ModalFormProps {
@@ -479,6 +493,47 @@ export const ModalForm: React.FC<ModalFormProps> = ({
       />
     );
   };
+
+  // Master-detail in a modal: when the schema declares inline child collections,
+  // render the master-detail form inside the dialog (it owns its own Save/Cancel
+  // action bar, so the modal footer is suppressed). Persisted atomically.
+  const subforms = (schema as any).subforms as any[] | undefined;
+  if (subforms?.length && schema.mode !== 'view') {
+    return (
+      <Dialog open={isOpen} onOpenChange={schema.onOpenChange}>
+        <MobileDialogContent className={cn(sizeClass, 'flex flex-col h-[100dvh] sm:h-auto sm:max-h-[90vh] overflow-hidden p-0', className, schema.className)}>
+          {(schema.title || schema.description) && (
+            <DialogHeader className="shrink-0 px-4 pt-4 sm:px-6 sm:pt-6 pb-2 border-b">
+              {schema.title && <DialogTitle>{schema.title}</DialogTitle>}
+              {schema.description ? (
+                <DialogDescription>{schema.description}</DialogDescription>
+              ) : (
+                <DialogDescription className="sr-only">Enter the record and its line items, then save.</DialogDescription>
+              )}
+            </DialogHeader>
+          )}
+          <div className="@container flex-1 overflow-y-auto px-4 sm:px-6 py-4">
+            <MasterDetailForm
+              schema={{
+                type: 'object-master-detail-form',
+                objectName: schema.objectName,
+                mode: schema.mode === 'edit' ? 'edit' : 'create',
+                recordId: schema.recordId,
+                fields: schema.fields as any,
+                sections: schema.sections as any,
+                submitText: submitLabel,
+                details: subforms as any,
+                onSuccess: async (rec: any) => { await schema.onSuccess?.(rec); schema.onOpenChange?.(false); },
+                onError: schema.onError,
+                onCancel: () => schema.onOpenChange?.(false),
+              }}
+              dataSource={dataSource}
+            />
+          </div>
+        </MobileDialogContent>
+      </Dialog>
+    );
+  }
 
   const hasFooter = !loading && !error && (showSubmit || showCancel);
 


### PR DESCRIPTION
## Summary

Completes the config-driven master-detail story (**Tier 0**): the console's **standard New/Edit record modal** now renders inline child collections when the object's form view declares `subforms` — master-detail entry with **no bespoke page**, saved as one atomic transaction.

```ts
// object form view — that's the whole config:
formViews: { default: { sections: [...], subforms: [{ childObject: 'showcase_task' }] } }
```
→ clicking **New <object>** opens a modal with the object's fields + an inline child grid + one Save.

## Changes

- **`ModalForm`**: when `schema.subforms?.length`, renders `MasterDetailForm` inside the dialog (it owns its Save/Cancel bar, so the modal footer is suppressed); on success the modal closes + the list refreshes. `ModalFormSchema` gains `subforms`.
- **app-shell `AppContent`**: the standard create/edit modal sources `subforms` from the object's default form view (`form.subforms` / `formViews.default.subforms`).

Builds on: `ObjectFormSchema.subforms` + `ObjectForm` delegation (#1527), metadata derivation (#1526), `@objectstack/spec` `FormViewSchema.subforms` (#1613), `ObjectView` pass-through (#1528).

## Testing

- `plugin-form` 77 unit tests pass; `plugin-form` + `app-shell` build clean (the `ModalForm → MasterDetailForm → ObjectForm → ModalForm` references are render-time only).
- **Live e2e** (`e2e/live/form-view-subforms.spec.ts`, green): "New Project" opens a master-detail modal (project fields + inline **Tasks** grid), fills + submits, and posts exactly one `POST /api/v1/batch` with the populated parent (`name`/`status`) and a child op referencing the parent via `{$ref:0}`. Pairs with the showcase form-view change in the framework repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)