### PR TITLE
feat(form): subforms in DrawerForm + full-page record form (Tier 0 everywhere)

### DIFF
--- a/.changeset/drawer-recordpage-subforms.md
+++ b/.changeset/drawer-recordpage-subforms.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/plugin-form": patch
+"@object-ui/app-shell": patch
+---
+
+feat(form): subforms in DrawerForm + full-page record form (Tier 0 everywhere)
+
+Completes config-driven master-detail across all standard create/edit entry
+points (after the modal in the previous change):
+
+- `DrawerForm` now hosts `MasterDetailForm` inside the drawer when the schema
+  declares `subforms` (its own Save bar; closes + refreshes on success).
+- `RecordFormPage` (full-page New/Edit) sources `subforms` from the object's
+  form view, so the full-page form renders inline child collections too.
+- `ObjectForm`'s subforms shortcut now defers to the drawer/modal variants for
+  those formTypes (so they keep their envelope), and only renders the
+  master-detail form directly for inline/simple forms.
+
+Declaring `formViews.default.subforms: [{ childObject }]` now yields a
+master-detail experience in the modal, drawer, AND full-page form — no bespoke
+page anywhere.

--- a/packages/app-shell/src/views/RecordFormPage.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.tsx
@@ -288,6 +288,11 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
                       }),
                 layout: 'vertical',
                 fields,
+                // Master-detail by config: if the object's form view declares
+                // inline child collections, ObjectForm renders them as an atomic
+                // master-detail form on this page — no bespoke page needed.
+                subforms: (objectDef as any).form?.subforms
+                  ?? (objectDef as any).formViews?.default?.subforms,
                 onSuccess: handleSuccess,
                 onCancel: handleCancel,
                 showSubmit: true,

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -25,6 +25,7 @@ import {
 } from '@object-ui/components';
 
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
+import { MasterDetailForm } from './MasterDetailForm';
 import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
 import { applyAutoLayout } from './autoLayout';
 import { sanitizeFormData } from './sanitize';
@@ -101,6 +102,19 @@ export interface DrawerFormSchema {
   onError?: (error: Error) => void;
   onCancel?: () => void;
   className?: string;
+  /** Inline child collections — renders the drawer as an atomic master-detail
+   *  form. Each entry needs only `childObject` (FK + columns derived). */
+  subforms?: Array<{
+    childObject: string;
+    relationshipField?: string;
+    columns?: any[];
+    amountField?: string;
+    totalField?: string;
+    title?: string;
+    addLabel?: string;
+    minRows?: number;
+    maxRows?: number;
+  }>;
 }
 
 export interface DrawerFormProps {
@@ -410,6 +424,30 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
     );
   };
 
+  // Master-detail in a drawer: render the master-detail form (it owns its Save
+  // bar) when the schema declares inline child collections; saved atomically.
+  const subforms = (schema as any).subforms as any[] | undefined;
+  const drawerBody = subforms?.length && schema.mode !== 'view' ? (
+    <MasterDetailForm
+      schema={{
+        type: 'object-master-detail-form',
+        objectName: schema.objectName,
+        mode: schema.mode === 'edit' ? 'edit' : 'create',
+        recordId: schema.recordId,
+        fields: schema.fields as any,
+        sections: schema.sections as any,
+        submitText: schema.submitText,
+        details: subforms as any,
+        onSuccess: async (rec: any) => { await schema.onSuccess?.(rec); schema.onOpenChange?.(false); },
+        onError: schema.onError,
+        onCancel: () => schema.onOpenChange?.(false),
+      }}
+      dataSource={dataSource}
+    />
+  ) : (
+    renderContent()
+  );
+
   return (
     <Sheet open={isOpen} onOpenChange={schema.onOpenChange}>
       <SheetContent
@@ -431,7 +469,7 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
         )}
 
         <div className="@container py-4">
-          {renderContent()}
+          {drawerBody}
         </div>
       </SheetContent>
     </Sheet>

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -104,7 +104,10 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
   // a master-detail form (parent fields + child grids, persisted atomically).
   // This lets a plain form view become master-detail by config — no bespoke
   // page. Skipped in view mode (read-only detail uses related lists instead).
-  if ((schema as any).subforms?.length && schema.mode !== 'view') {
+  // For drawer/modal formTypes we fall through to DrawerForm/ModalForm, which
+  // host the master-detail form INSIDE their envelope.
+  if ((schema as any).subforms?.length && schema.mode !== 'view'
+      && schema.formType !== 'drawer' && schema.formType !== 'modal') {
     return (
       <MasterDetailForm
         schema={{


### PR DESCRIPTION
## Summary

Completes config-driven master-detail across **all** standard create/edit entry points (the modal landed in #1529; this finishes the drawer + full-page paths):

- **`DrawerForm`** hosts `MasterDetailForm` inside the drawer when the schema declares `subforms` (it owns its Save bar; closes + refreshes on success). `DrawerFormSchema` gains `subforms`.
- **`RecordFormPage`** (full-page New/Edit) sources `subforms` from the object's form view, so the full-page form renders inline child collections too.
- **`ObjectForm`**'s subforms shortcut now defers to the drawer/modal variants for those `formType`s (so they keep their envelope), rendering the master-detail form directly only for inline/simple forms.

Net result: declaring `formViews.default.subforms: [{ childObject }]` yields a master-detail experience in the **modal, drawer, and full-page** form — no bespoke page anywhere, regardless of the object's navigation mode.

## Testing

- `plugin-form` 77 unit tests pass; `plugin-form` + `app-shell` build clean.
- **Live e2e 3/3** (`form-view-subforms` + `master-detail`) after the change — no regression; the New Project modal still renders the inline Tasks subtable and posts one atomic `/api/v1/batch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)