### PR TITLE
feat(metadata): relationship inlineEdit auto-renders master-detail

### DIFF
--- a/.changeset/relationship-inline-edit.md
+++ b/.changeset/relationship-inline-edit.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(metadata): relationship-level `inlineEdit` auto-renders master-detail
+
+A child object's `master_detail`/`lookup` field can declare `inlineEdit: true`
+(in the data model) to mean "edit me inline within my parent's form". The
+metadata layer now scans for these and merges the resulting child collections
+into each parent object's form view as `subforms` — so the parent's **standard**
+New/Edit form auto-renders an atomic master-detail form with **no view config
+and no bespoke page**. The intent lives once in the data model (where e.g. an AI
+modelling the schema naturally sets it); forms derive the UI.
+
+`master_detail` children WITHOUT `inlineEdit` are not inlined (so associations
+like comments/attachments stay out of the entry form). An explicit
+`form.subforms` entry overrides the derived one. Optional
+`inlineTitle`/`inlineColumns`/`inlineAmountField` tune the grid.

--- a/e2e/live/form-view-subforms.spec.ts
+++ b/e2e/live/form-view-subforms.spec.ts
@@ -3,12 +3,13 @@ import { selectOption, fillLookup, addLineItem } from './helpers';
 
 /**
  * Tier 0 live e2e: an object's standard New/Edit modal renders inline child
- * collections purely from `formViews.default.subforms` (no bespoke page). Here
- * the showcase_project form view declares { childObject: 'showcase_task' }, so
- * "New Project" opens a master-detail modal that submits parent + children in
- * one atomic /api/v1/batch.
+ * collections derived from the DATA MODEL (no view config, no bespoke page).
+ * `showcase_task.project` declares `inlineEdit: true`, so every standard
+ * Project form auto-renders a Tasks subtable; "New Project" opens a
+ * master-detail modal that submits parent + children in one atomic
+ * /api/v1/batch. (An explicit `form.subforms` would override the derived one.)
  */
-test('New <object> modal renders form-view subforms and submits an atomic batch', async ({ page }) => {
+test('New <object> modal renders relationship-derived subforms and submits an atomic batch', async ({ page }) => {
   const batches: any[] = [];
   page.on('request', (r) => {
     if (r.method() === 'POST' && r.url().includes('/api/v1/batch')) {

--- a/packages/app-shell/src/providers/MetadataProvider.merge.test.ts
+++ b/packages/app-shell/src/providers/MetadataProvider.merge.test.ts
@@ -86,3 +86,57 @@ describe('mergeViewsIntoObjects', () => {
     expect(obj.formViews.list).toBeUndefined();
   });
 });
+
+import { attachInlineSubforms } from './MetadataProvider';
+
+describe('attachInlineSubforms — relationship-level inlineEdit', () => {
+  const objects = [
+    { name: 'invoice', fields: { number: { type: 'text' } } },
+    {
+      name: 'invoice_line',
+      fields: {
+        amount: { type: 'number' },
+        invoice: { type: 'master_detail', reference: 'invoice', inlineEdit: true, inlineTitle: 'Lines' },
+      },
+    },
+    {
+      name: 'comment',
+      // master_detail but NOT inlineEdit → must NOT be inlined
+      fields: { body: { type: 'text' }, invoice: { type: 'master_detail', reference: 'invoice' } },
+    },
+  ];
+
+  it('merges inlineEdit children into the parent form as subforms', () => {
+    const out = attachInlineSubforms(objects);
+    const invoice = out.find((o) => o.name === 'invoice')!;
+    expect(invoice.form?.subforms).toEqual([
+      { childObject: 'invoice_line', relationshipField: 'invoice', title: 'Lines' },
+    ]);
+  });
+
+  it('does not inline master_detail children without inlineEdit', () => {
+    const out = attachInlineSubforms(objects);
+    const invoice = out.find((o) => o.name === 'invoice')!;
+    const children = (invoice.form?.subforms ?? []).map((s: any) => s.childObject);
+    expect(children).not.toContain('comment');
+  });
+
+  it('lets an explicit form.subforms entry override the derived one', () => {
+    const withExplicit = objects.map((o) =>
+      o.name === 'invoice'
+        ? { ...o, form: { type: 'simple', subforms: [{ childObject: 'invoice_line', columns: [{ field: 'amount' }] }] } }
+        : o,
+    );
+    const out = attachInlineSubforms(withExplicit);
+    const invoice = out.find((o) => o.name === 'invoice')!;
+    // single entry for invoice_line, and it's the explicit one (has columns)
+    const lineSubforms = invoice.form.subforms.filter((s: any) => s.childObject === 'invoice_line');
+    expect(lineSubforms).toHaveLength(1);
+    expect(lineSubforms[0].columns).toBeTruthy();
+  });
+
+  it('returns objects unchanged when no inlineEdit relationships exist', () => {
+    const plain = [{ name: 'a', fields: { x: { type: 'text' } } }];
+    expect(attachInlineSubforms(plain)).toBe(plain);
+  });
+});

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -222,6 +222,58 @@ export function mergeViewsIntoObjects(objects: any[], views: any[]): any[] {
   });
 }
 
+/**
+ * Relationship-driven master-detail: a child object's `master_detail`/`lookup`
+ * field can carry `inlineEdit: true` to declare "edit me inline within my
+ * parent's form". This pass scans every object for such fields and merges the
+ * resulting child collections into each parent object's form view as
+ * `subforms` — so the parent's standard create/edit form renders an atomic
+ * master-detail form with NO view config and NO bespoke page. The intent lives
+ * in the data model (where it's defined once, e.g. by an AI modelling the
+ * schema); forms just follow. An explicit `form.subforms` entry for the same
+ * child overrides the model-derived one.
+ */
+export function attachInlineSubforms(objects: any[]): any[] {
+  if (!objects?.length) return objects;
+  const inlineByParent: Record<string, any[]> = {};
+  for (const child of objects) {
+    const fields = child?.fields;
+    if (!fields) continue;
+    const entries: Array<[string, any]> = Array.isArray(fields)
+      ? fields.map((f: any) => [f?.name, f])
+      : Object.entries(fields);
+    for (const [fname, fdef] of entries) {
+      const d: any = fdef;
+      if (!fname || !d?.inlineEdit) continue;
+      if (d.type !== 'master_detail' && d.type !== 'lookup') continue;
+      const parent = d.reference;
+      if (!parent) continue;
+      (inlineByParent[parent] ||= []).push({
+        childObject: child.name,
+        relationshipField: fname,
+        ...(d.inlineTitle ? { title: d.inlineTitle } : {}),
+        ...(Array.isArray(d.inlineColumns) ? { columns: d.inlineColumns } : {}),
+        ...(typeof d.inlineAmountField === 'string' ? { amountField: d.inlineAmountField } : {}),
+      });
+    }
+  }
+  if (!Object.keys(inlineByParent).length) return objects;
+  return objects.map((obj) => {
+    const derived = inlineByParent[obj.name];
+    if (!derived?.length) return obj;
+    const form: any = { ...(obj.form || { type: 'simple' }) };
+    const explicit: any[] = Array.isArray(form.subforms) ? form.subforms : [];
+    const explicitChildren = new Set(explicit.map((s: any) => s.childObject));
+    // Model-derived first; an explicit view subform for the same child wins.
+    form.subforms = [...derived.filter((d) => !explicitChildren.has(d.childObject)), ...explicit];
+    const next: any = { ...obj, form };
+    if (obj.formViews?.default) {
+      next.formViews = { ...obj.formViews, default: { ...obj.formViews.default, subforms: form.subforms } };
+    }
+    return next;
+  });
+}
+
 function emptyEntry(): TypeCacheEntry {
   return {
     status: 'idle',
@@ -485,7 +537,8 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
       get objects() {
         const objs = readType(TYPE_BY_STATE_KEY.objects);
         const views = readType('view');
-        return views.length ? mergeViewsIntoObjects(objs, views) : objs;
+        const merged = views.length ? mergeViewsIntoObjects(objs, views) : objs;
+        return attachInlineSubforms(merged);
       },
       get dashboards() {
         return readType(TYPE_BY_STATE_KEY.dashboards);


### PR DESCRIPTION
## Summary

The capstone of config-driven master-detail: declare the inline-editing intent **once on the relationship** (in the data model) and **every** standard form derives it — no form view config, no bespoke page.

`attachInlineSubforms` (in `MetadataProvider`) scans objects for `master_detail`/`lookup` fields with `inlineEdit: true` and merges the resulting child collections into each parent object's form view as `subforms`. Because every form host already reads the object's `form.subforms` (#1528/#1529/#1530), the modal, drawer, full-page, and ObjectView forms all auto-render the atomic master-detail — for free.

- Children **without** `inlineEdit` are not inlined (associations like comments/attachments stay out).
- An explicit `form.subforms` entry **overrides** the derived one (view can still tune columns/order).

## Why this shape

The relationship (`master_detail`) already encodes the structure + ownership in the data model. The inline-edit intent belongs there too — defined once where the schema is modelled (e.g. by an AI), with forms following — rather than re-declared per form view. This makes master-detail truly zero-config for the common case.

## Testing

- +4 unit tests for `attachInlineSubforms` (inline merge, no-inline-without-flag, explicit override wins, no-op when none). **app-shell 310 pass.**
- **Live e2e (green):** with the view's `subforms` removed and `showcase_task.project` declaring `inlineEdit`, "New Project" still renders the Tasks subtable and submits one atomic `/api/v1/batch` (parent + child `{$ref:0}`).

Pairs with `@objectstack/spec` `field.inlineEdit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)