### PR TITLE
feat(adr-0034): runtime draft/publish UI chrome + view-create seam (#1515, #1517)

### DIFF
--- a/packages/app-shell/src/views/DashboardConfigPanel.tsx
+++ b/packages/app-shell/src/views/DashboardConfigPanel.tsx
@@ -85,6 +85,8 @@ export function DashboardConfigPanel<
   // Unsaved-edits flag — gates Publish (mirrors studio's "save first"). The
   // panel unmounts on close, so this resets to false on each open.
   const [dirty, setDirty] = useState(false);
+  // Bumped on save so the draft chrome surfaces the indicator immediately.
+  const [savedSignal, setSavedSignal] = useState(0);
 
   // Controlled: merge an inspector patch into the current schema and bubble it
   // back up. No local draft state — `schema` is the single source of truth.
@@ -218,12 +220,14 @@ export function DashboardConfigPanel<
           metadataClient={metadataClient}
           dirty={dirty}
           onResume={handleResumeDraft}
+          savedSignal={savedSignal}
         />
         <Button
           size="sm"
           onClick={() => {
             onSave((schema ?? {}) as T);
             setDirty(false);
+            setSavedSignal((s) => s + 1);
           }}
           data-testid="dashboard-config-save"
         >

--- a/packages/app-shell/src/views/DashboardConfigPanel.tsx
+++ b/packages/app-shell/src/views/DashboardConfigPanel.tsx
@@ -27,12 +27,13 @@
  * draft, the runtime's old flatten / unflatten / extract adapters are gone.
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Button } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { ArrowLeft, Trash2, X } from 'lucide-react';
 import { DashboardDefaultInspector } from './metadata-admin/inspectors/DashboardDefaultInspector';
 import { DashboardWidgetInspector } from './metadata-admin/inspectors/DashboardWidgetInspector';
+import { RuntimeDraftBar } from './RuntimeDraftBar';
 import { detectLocale } from './metadata-admin/i18n';
 import type { MetadataSelection } from './metadata-admin/preview-registry';
 
@@ -55,6 +56,14 @@ export interface DashboardConfigPanelProps<
   onChange: (schema: T) => void;
   /** Remove the given widget (used by the widget-level header trash button). */
   onRemoveWidget?: (id: string) => void;
+  /** Dashboard artifact name — the `:name` for the draft/publish chrome. */
+  name?: string;
+  /**
+   * Studio metadata client — drives the ADR-0034 draft/publish chrome
+   * ({@link RuntimeDraftBar}). Only used when `VITE_RUNTIME_EDIT_VIA_META`
+   * is on; the chrome renders nothing otherwise.
+   */
+  metadataClient?: any;
 }
 
 export function DashboardConfigPanel<
@@ -68,17 +77,35 @@ export function DashboardConfigPanel<
   onSave,
   onChange,
   onRemoveWidget,
+  name: artifactName,
+  metadataClient,
 }: DashboardConfigPanelProps<T>) {
   const { t } = useObjectTranslation();
   const locale = useMemo(() => detectLocale(), []);
+  // Unsaved-edits flag — gates Publish (mirrors studio's "save first"). The
+  // panel unmounts on close, so this resets to false on each open.
+  const [dirty, setDirty] = useState(false);
 
   // Controlled: merge an inspector patch into the current schema and bubble it
   // back up. No local draft state — `schema` is the single source of truth.
   const handlePatch = useCallback(
     (patch: Record<string, unknown>) => {
+      setDirty(true);
       onChange({ ...(schema ?? {}), ...patch } as T);
     },
     [schema, onChange],
+  );
+
+  // ADR-0034 (#1515): resume a pending draft into the editor on open
+  // (flag-ON only). The dashboard document IS the controlled schema, so push
+  // it up as a live edit (preview only — no save) and treat it as the clean
+  // baseline.
+  const handleResumeDraft = useCallback(
+    (body: Record<string, unknown>) => {
+      onChange(body as T);
+      setDirty(false);
+    },
+    [onChange],
   );
 
   const handleSelectionChange = useCallback(
@@ -185,9 +212,19 @@ export function DashboardConfigPanel<
         data-testid="dashboard-config-footer"
         className="flex items-center justify-end gap-2 border-t px-4 py-2.5 shrink-0"
       >
+        <RuntimeDraftBar
+          type="dashboard"
+          name={artifactName || name || undefined}
+          metadataClient={metadataClient}
+          dirty={dirty}
+          onResume={handleResumeDraft}
+        />
         <Button
           size="sm"
-          onClick={() => onSave((schema ?? {}) as T)}
+          onClick={() => {
+            onSave((schema ?? {}) as T);
+            setDirty(false);
+          }}
           data-testid="dashboard-config-save"
         >
           {t('common.save', { defaultValue: 'Save' })}

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -436,6 +436,8 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
            onSave={saveSchema}
            onChange={setEditSchema}
            onRemoveWidget={removeWidget}
+           name={dashboardName}
+           metadataClient={metadataClient}
          />
 
          <MetadataPanel

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -38,7 +38,7 @@ import type { ListViewSchema, ViewNavigationConfig, FeedItem } from '@object-ui/
 import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
 import { ViewConfigPanel } from './ViewConfigPanel';
 import { useMetadataClient } from './metadata-admin/useMetadata';
-import { persistRuntimeMetadata } from './runtime-metadata-persistence';
+import { persistRuntimeMetadata, createRuntimeMetadata } from './runtime-metadata-persistence';
 import { CreateViewDialog } from './CreateViewDialog';
 import { PageHeader } from '../layout/PageHeader';
 import { useMobileViewSwitcherRegistration } from '../layout/MobileViewSwitcherContext';
@@ -340,15 +340,23 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                         spec.gallery = { ...existing, visibleFields: incomingColumns };
                     }
                 }
-                if (typeof (dataSource as any)?.createView === 'function') {
-                    const created = await (dataSource as any).createView(objectName, spec);
-                    createdId = (created as any)?.name || (config as any)?.name;
-                } else if (dataSource?.create) {
-                    // Legacy fallback for adapters that don't expose createView.
-                    const payload = toSysViewPayload(spec, objectName, { defaultColumns });
-                    const created = await dataSource.create('sys_view', payload);
-                    createdId = created?.id ?? created?._id;
-                }
+                // ADR-0034 seam (#1517): route the create WRITE through the
+                // shared seam. flag OFF (default) reproduces today's path
+                // byte-for-byte — `createView` preferred, legacy `sys_view`
+                // insert via `toSysViewPayload` as fallback; flag ON saves the
+                // new view as an invisible per-item draft. UI-layer concerns
+                // (default columns, kanban/gallery massaging above, and the
+                // auto-activation below) stay here.
+                const draftName = String(
+                    (config as any)?.name ?? (config as any)?.id ?? (spec as any)?.id ?? '',
+                );
+                createdId = await createRuntimeMetadata('view', draftName, spec, {
+                    dataSource,
+                    metadataClient,
+                    objectName,
+                    toSysViewPayload: (cfg: any, obj?: string) =>
+                        toSysViewPayload(cfg, obj, { defaultColumns }),
+                });
             }
             setShowViewConfigPanel(false);
             setViewConfigPanelMode('edit');
@@ -366,7 +374,7 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         } catch (err) {
             console.error('[ViewConfigPanel] Failed to create view:', err);
         }
-    }, [dataSource, objectName, objects, navigate, viewId]);
+    }, [dataSource, objectName, objects, navigate, viewId, metadataClient]);
     
     // Record count tracking for footer
     const [recordCount, setRecordCount] = useState<number | undefined>(undefined);
@@ -905,54 +913,6 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         }
     }, [dataSource, isSavedView, activeViewId, views, viewId, navigate, t, confirmHandler]);
 
-    const handleDuplicateView = useCallback(async (vid: string) => {
-        if (!dataSource) return;
-        const source = views.find((v: any) => v.id === vid);
-        if (!source) return;
-        try {
-            // ADR-0005 overlay path — store the full NamedListView spec
-            // shape directly under a unique `name`. No legacy sys_view
-            // column-flattening required.
-            const baseName = String(source.name || vid).toLowerCase()
-                .replace(/[^a-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || 'view';
-            const newName = `${baseName}_copy_${Date.now().toString(36)}`;
-            // Drop `id` so the overlay row is keyed purely by `name`; copying
-            // the source's `id` would collide with the source view in the
-            // tab-bar dedup logic and silently shadow it.
-            const { id: _omitId, ...rest } = source as any;
-            const spec = {
-                ...rest,
-                name: newName,
-                label: `${source.label || vid} (Copy)`,
-                isDefault: false,
-                isPinned: false,
-                data: source.data || { provider: 'object', object: objectName },
-                object: source.object || objectName,
-            };
-            let newId: string | undefined;
-            if (typeof (dataSource as any)?.createView === 'function') {
-                const created = await (dataSource as any).createView(objectName, spec);
-                newId = (created as any)?.name || newName;
-            } else if (dataSource?.create) {
-                const payload = toSysViewPayload(spec, objectName);
-                const created = await dataSource.create('sys_view', payload);
-                newId = created?.id ?? created?._id;
-            }
-            setRefreshKey(k => k + 1);
-            // Auto-activate the duplicate (Airtable parity).
-            if (newId) {
-                if (viewId) {
-                    navigate(`../${newId}`, { relative: 'path' });
-                } else {
-                    navigate(`view/${newId}`);
-                }
-            }
-        } catch (err) {
-            console.error('[ViewTabBar] Failed to duplicate view:', err);
-            toast.error('Failed to duplicate view');
-        }
-    }, [dataSource, views, objectName, navigate, viewId]);
-
     const handlePinView = useCallback(async (vid: string, pinned: boolean) => {
         if (!dataSource) return;
         if (!isSavedView(vid)) {
@@ -976,7 +936,7 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         if (!isSavedView(vid)) {
             toast.error(
                 t('console.objectView.cannotEditMetaView')
-                || 'System view — duplicate it to mark a default.',
+                || 'System view — it cannot be set as a default.',
             );
             return;
         }
@@ -1036,11 +996,11 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
     const handleConfigView = useCallback((vid: string) => {
         // System (metadata-defined) views are read-only — opening the
         // ViewConfigPanel against one would let the user save changes that
-        // never persist. Steer them to "Duplicate view" instead.
+        // never persist.
         if (!isSavedView(vid)) {
             toast.error(
                 t('console.objectView.cannotEditMetaView')
-                || 'System view — duplicate it to make changes.',
+                || 'System view — it cannot be edited.',
             );
             return;
         }
@@ -1836,7 +1796,6 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         viewActions: isAdmin ? [
             { type: 'settings' as const },
             { type: 'share' as const },
-            { type: 'duplicate' as const },
             { type: 'delete' as const },
         ] : [],
         onNavigate: (recordId: string | number, mode: 'view' | 'edit') => {
@@ -2065,7 +2024,7 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                    readonly: isSystem,
                    readonlyReason: isSystem
                      ? (t('console.objectView.systemViewReadonly')
-                       || 'System view defined in code — duplicate to customize.')
+                       || 'System view defined in code — read-only.')
                      : undefined,
                  } as ViewTabItem;
                });
@@ -2086,7 +2045,6 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                    onAddView={isAdmin ? handleAddView : undefined}
                    onRenameView={isAdmin ? handleRenameView : undefined}
                    onDeleteView={isAdmin ? handleDeleteView : undefined}
-                   onDuplicateView={isAdmin ? handleDuplicateView : undefined}
                    onPinView={isAdmin ? handlePinView : undefined}
                    onSetDefaultView={isAdmin ? handleSetDefaultView : undefined}
                    onConfigView={isAdmin ? handleConfigView : undefined}
@@ -2101,7 +2059,6 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                      viewTypeIcons={VIEW_TYPE_ICONS}
                      onRename={handleRenameView}
                      onDelete={handleDeleteView}
-                     onDuplicate={handleDuplicateView}
                      onSetDefault={handleSetDefaultView}
                      onSetPinned={handlePinView}
                      onReorder={handleReorderViews}
@@ -2216,6 +2173,7 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                         onSave={handleViewConfigSave}
                         onViewUpdate={handleViewUpdate}
                         onCreate={handleViewCreate}
+                        metadataClient={metadataClient}
                     />
                 </div>
                 <CreateViewDialog

--- a/packages/app-shell/src/views/ReportConfigPanel.tsx
+++ b/packages/app-shell/src/views/ReportConfigPanel.tsx
@@ -29,6 +29,7 @@ import { Button } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { X } from 'lucide-react';
 import { ReportDefaultInspector } from './metadata-admin/inspectors/ReportDefaultInspector';
+import { RuntimeDraftBar } from './RuntimeDraftBar';
 import { detectLocale } from './metadata-admin/i18n';
 import type { ObjectFieldInfo } from './metadata-admin/previews/useObjectFields';
 
@@ -54,6 +55,14 @@ export interface ReportConfigPanelProps {
   availableFields?: AvailableField[];
   /** Reserved for parity with the legacy panel; unused by the inspector. */
   getFieldsForObject?: (objectName: string | undefined) => AvailableField[] | undefined;
+  /** Report artifact name — the `:name` for the ADR-0034 draft/publish chrome. */
+  name?: string;
+  /**
+   * Studio metadata client — drives the draft/publish chrome
+   * ({@link RuntimeDraftBar}). Only used when `VITE_RUNTIME_EDIT_VIA_META`
+   * is on; the chrome renders nothing otherwise.
+   */
+  metadataClient?: any;
 }
 
 /** Map the host's `{ value, label, type }` fields into the inspector's catalog. */
@@ -74,10 +83,14 @@ export function ReportConfigPanel({
   onSave,
   onFieldChange,
   availableFields,
+  name,
+  metadataClient,
 }: ReportConfigPanelProps) {
   const { t } = useObjectTranslation();
   const locale = useMemo(() => detectLocale(), []);
   const objectFields = useMemo(() => toObjectFields(availableFields), [availableFields]);
+  // Unsaved-edits flag — gates Publish (mirrors studio's "save first").
+  const [dirty, setDirty] = useState(false);
 
   // Draft state seeded from `config`. Rebuilt only when the source identity
   // changes (the host stabilizes `config` and bumps it on open / save) — never
@@ -90,6 +103,7 @@ export function ReportConfigPanel({
     lastSourceRef.current = initialDraft;
     draftRef.current = initialDraft;
     setDraft(initialDraft);
+    setDirty(false);
   }
 
   // Shallow-merge an inspector patch into the draft, then mirror each changed
@@ -98,6 +112,7 @@ export function ReportConfigPanel({
     const next = { ...draftRef.current, ...patch };
     draftRef.current = next;
     setDraft(next);
+    setDirty(true);
     if (onFieldChange) {
       for (const [key, value] of Object.entries(patch)) {
         onFieldChange(key, value, next);
@@ -107,8 +122,19 @@ export function ReportConfigPanel({
 
   const handleSave = useCallback(() => {
     onSave(draftRef.current);
+    setDirty(false);
     onClose();
   }, [onSave, onClose]);
+
+  // ADR-0034 (#1515): resume a pending draft into the inspector on open
+  // (flag-ON only). The report document IS the inspector draft, so seed it
+  // directly.
+  const handleResumeDraft = useCallback((body: Record<string, unknown>) => {
+    const next = { ...body };
+    draftRef.current = next;
+    setDraft(next);
+    setDirty(false);
+  }, []);
 
   const handleDiscard = useCallback(() => {
     onClose();
@@ -155,6 +181,13 @@ export function ReportConfigPanel({
         data-testid="report-config-footer"
         className="flex items-center justify-end gap-2 border-t px-4 py-2.5 shrink-0"
       >
+        <RuntimeDraftBar
+          type="report"
+          name={name}
+          metadataClient={metadataClient}
+          dirty={dirty}
+          onResume={handleResumeDraft}
+        />
         <Button variant="ghost" size="sm" onClick={handleDiscard} data-testid="report-config-discard">
           {t('common.cancel', { defaultValue: 'Cancel' })}
         </Button>

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -481,6 +481,8 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
            onFieldChange={handleReportFieldChange}
            availableFields={availableFields}
            getFieldsForObject={getFieldsForObject}
+           name={reportName}
+           metadataClient={metadataClient}
          />
 
          <MetadataPanel

--- a/packages/app-shell/src/views/RuntimeDraftBar.test.tsx
+++ b/packages/app-shell/src/views/RuntimeDraftBar.test.tsx
@@ -1,0 +1,161 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { RuntimeDraftBar } from './RuntimeDraftBar';
+
+/**
+ * ADR-0034 step 3 (#1515) chrome tests.
+ *
+ * The bar is fully gated by the `VITE_RUNTIME_EDIT_VIA_META` flag (toggled via
+ * `vi.stubEnv`). Flag OFF must render NOTHING and touch no network; flag ON
+ * surfaces the draft indicator / publish / discard and resumes the draft.
+ */
+
+function makeMetadataClient(draftItem: unknown = null) {
+  return {
+    get: vi.fn().mockResolvedValue(draftItem),
+    publish: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('RuntimeDraftBar (ADR-0034)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe('flag OFF (default)', () => {
+    it('renders nothing and never reads the draft', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', '');
+      const metadataClient = makeMetadataClient({ item: { a: 1 } });
+
+      const { container } = render(
+        <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} />,
+      );
+
+      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
+      // No draft read fired — the legacy path must stay inert.
+      expect(metadataClient.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flag ON', () => {
+    it('shows the indicator + publish when a draft is pending, and resumes it', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+      const metadataClient = makeMetadataClient({
+        type: 'view',
+        name: 'my_view',
+        item: { columns: ['name'] },
+      });
+      const onResume = vi.fn();
+
+      render(
+        <RuntimeDraftBar
+          type="view"
+          name="my_view"
+          metadataClient={metadataClient}
+          onResume={onResume}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy(),
+      );
+      expect(screen.getByTestId('runtime-draft-publish')).toBeTruthy();
+      expect(screen.getByTestId('runtime-draft-discard')).toBeTruthy();
+      expect(metadataClient.get).toHaveBeenCalledWith('view', 'my_view', {
+        state: 'draft',
+      });
+      expect(onResume).toHaveBeenCalledWith({ columns: ['name'] });
+    });
+
+    it('still shows the indicator when onResume throws (resume is best-effort)', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
+      const onResume = vi.fn(() => {
+        throw new Error('seed failed');
+      });
+
+      render(
+        <RuntimeDraftBar
+          type="view"
+          name="my_view"
+          metadataClient={metadataClient}
+          onResume={onResume}
+        />,
+      );
+
+      // A throwing resume must NOT hide the "unpublished changes" chrome —
+      // the draft still exists on the server.
+      await waitFor(() => expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy());
+      expect(onResume).toHaveBeenCalled();
+    });
+
+    it('renders nothing when there is no pending draft', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+      const metadataClient = makeMetadataClient(null);
+
+      const { container } = render(
+        <RuntimeDraftBar type="report" name="my_report" metadataClient={metadataClient} />,
+      );
+
+      await waitFor(() => expect(metadataClient.get).toHaveBeenCalled());
+      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
+    });
+
+    it('publishes the pending draft on click', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+      const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
+      const onAfterChange = vi.fn();
+
+      render(
+        <RuntimeDraftBar
+          type="dashboard"
+          name="my_dash"
+          metadataClient={metadataClient}
+          onAfterChange={onAfterChange}
+        />,
+      );
+
+      const publishBtn = await screen.findByTestId('runtime-draft-publish');
+      fireEvent.click(publishBtn);
+
+      await waitFor(() =>
+        expect(metadataClient.publish).toHaveBeenCalledWith('dashboard', 'my_dash'),
+      );
+      expect(onAfterChange).toHaveBeenCalled();
+    });
+
+    it('Publish is disabled while the panel has unsaved edits (dirty)', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+      const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
+
+      render(
+        <RuntimeDraftBar
+          type="view"
+          name="my_view"
+          metadataClient={metadataClient}
+          dirty
+        />,
+      );
+
+      const publishBtn = await screen.findByTestId('runtime-draft-publish');
+      expect((publishBtn as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('stays inert until a name is known', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+      const metadataClient = makeMetadataClient({ item: { a: 1 } });
+
+      const { container } = render(
+        <RuntimeDraftBar type="view" metadataClient={metadataClient} />,
+      );
+
+      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
+      expect(metadataClient.get).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/app-shell/src/views/RuntimeDraftBar.test.tsx
+++ b/packages/app-shell/src/views/RuntimeDraftBar.test.tsx
@@ -146,6 +146,52 @@ describe('RuntimeDraftBar (ADR-0034)', () => {
       expect((publishBtn as HTMLButtonElement).disabled).toBe(true);
     });
 
+    it('surfaces the indicator immediately when savedSignal bumps (no read race)', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+      const metadataClient = makeMetadataClient(null); // no draft on initial read
+
+      const { rerender, container } = render(
+        <RuntimeDraftBar
+          type="view"
+          name="my_view"
+          metadataClient={metadataClient}
+          savedSignal={0}
+        />,
+      );
+
+      // No draft yet → nothing rendered.
+      await waitFor(() => expect(metadataClient.get).toHaveBeenCalled());
+      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
+
+      // Host saved a draft → bump the signal → indicator appears at once,
+      // without depending on a re-read.
+      rerender(
+        <RuntimeDraftBar
+          type="view"
+          name="my_view"
+          metadataClient={metadataClient}
+          savedSignal={1}
+        />,
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy(),
+      );
+    });
+
+    it('savedSignal does nothing when the flag is off', async () => {
+      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', '');
+      const metadataClient = makeMetadataClient(null);
+
+      const { rerender, container } = render(
+        <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} savedSignal={0} />,
+      );
+      rerender(
+        <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} savedSignal={1} />,
+      );
+
+      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
+    });
+
     it('stays inert until a name is known', async () => {
       vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
       const metadataClient = makeMetadataClient({ item: { a: 1 } });

--- a/packages/app-shell/src/views/RuntimeDraftBar.tsx
+++ b/packages/app-shell/src/views/RuntimeDraftBar.tsx
@@ -1,0 +1,188 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * RuntimeDraftBar — ADR-0034 step 3 (#1515): the draft/publish chrome for the
+ * runtime config panels (ViewConfigPanel / ReportConfigPanel /
+ * DashboardConfigPanel).
+ *
+ * It mirrors studio's `ResourceEditPage` affordances — an "unpublished
+ * changes" indicator, a **Publish** button, and a **Discard draft** button —
+ * but is **entirely gated by {@link isViaMeta}**:
+ *
+ *   • flag OFF (default) → renders `null`. Mounting it adds NO DOM, so the
+ *     existing panel footers are byte-identical to before this change.
+ *   • flag ON → on open it reads the pending draft (`?state=draft`), shows the
+ *     indicator when one exists, optionally resumes it into the editor
+ *     (`onResume`), and exposes Publish / Discard.
+ *
+ * Hooks are always called (no conditional hooks); only the rendered output and
+ * the network effects are gated, so flipping the flag never changes hook order.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@object-ui/components';
+import { Loader2, Send, Undo2 } from 'lucide-react';
+import {
+  isViaMeta,
+  publishRuntimeMetadata,
+  discardRuntimeDraft,
+  readRuntimeDraft,
+  type RuntimeArtifactType,
+} from './runtime-metadata-persistence';
+import { detectLocale, t, tFormat } from './metadata-admin/i18n';
+
+export interface RuntimeDraftBarProps {
+  /** Artifact type — the `:type` in `/meta/:type/:name`. */
+  type: RuntimeArtifactType;
+  /** Artifact name — the `:name`. Chrome stays inert until this is known. */
+  name?: string;
+  /** Studio metadata client (flag-ON path). */
+  metadataClient: any;
+  /**
+   * Disable Publish while the panel has unsaved local edits, mirroring
+   * studio's "save first, then publish" rule.
+   */
+  dirty?: boolean;
+  /**
+   * Seed an existing draft back into the editor when the panel opens, so a
+   * half-finished edit is restored. Called at most once per `name` per mount.
+   */
+  onResume?: (body: Record<string, unknown>) => void;
+  /** Called after a successful publish / discard so the host can refresh. */
+  onAfterChange?: () => void;
+}
+
+export function RuntimeDraftBar({
+  type,
+  name,
+  metadataClient,
+  dirty,
+  onResume,
+  onAfterChange,
+}: RuntimeDraftBarProps) {
+  const enabled = isViaMeta();
+  const locale = detectLocale();
+  const [hasDraft, setHasDraft] = useState(false);
+  const [busy, setBusy] = useState(false);
+  // Track the `name` we've already resumed so reopening the same item doesn't
+  // clobber in-flight edits with the stored draft on every effect run.
+  const resumedRef = useRef<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!enabled || !name || !metadataClient) {
+      setHasDraft(false);
+      return;
+    }
+    let body: Record<string, unknown> | null;
+    try {
+      body = await readRuntimeDraft<Record<string, unknown>>(type, name, {
+        metadataClient,
+      });
+    } catch {
+      // A failed draft read must not break the editor — treat as "no draft".
+      setHasDraft(false);
+      return;
+    }
+    setHasDraft(!!body);
+    // Resume is best-effort: a failure to seed the editor must NOT hide the
+    // "unpublished changes" indicator (the draft still exists on the server).
+    if (body && onResume && resumedRef.current !== name) {
+      resumedRef.current = name;
+      try {
+        onResume(body);
+      } catch (err) {
+        console.error('[RuntimeDraftBar] Resume draft failed:', err);
+      }
+    }
+  }, [enabled, type, name, metadataClient, onResume]);
+
+  // Read the pending draft on open / when the edited item changes.
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handlePublish = useCallback(async () => {
+    if (!name) return;
+    setBusy(true);
+    try {
+      await publishRuntimeMetadata(type, name, { metadataClient });
+      setHasDraft(false);
+      onAfterChange?.();
+    } catch (err) {
+      console.error('[RuntimeDraftBar] Publish failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  }, [type, name, metadataClient, onAfterChange]);
+
+  const handleDiscard = useCallback(async () => {
+    if (!name) return;
+    if (
+      typeof confirm === 'function' &&
+      !confirm(tFormat('engine.edit.discardDraftConfirm', locale, { type, name }))
+    ) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await discardRuntimeDraft(type, name, { metadataClient });
+      setHasDraft(false);
+      onAfterChange?.();
+    } catch (err) {
+      console.error('[RuntimeDraftBar] Discard draft failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  }, [type, name, metadataClient, onAfterChange, locale]);
+
+  // flag OFF, or nothing pending → render nothing (zero DOM, zero layout shift).
+  if (!enabled || !hasDraft) return null;
+
+  return (
+    <div
+      className="mr-auto flex items-center gap-2"
+      data-testid="runtime-draft-bar"
+    >
+      <span
+        className="text-xs text-amber-700 dark:text-amber-400"
+        title={t('engine.edit.draftPending', locale)}
+        data-testid="runtime-draft-indicator"
+      >
+        ● {t('engine.edit.draftPending', locale)}
+      </span>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleDiscard}
+        disabled={busy}
+        className="h-7 w-7 p-0 text-muted-foreground"
+        title={t('engine.edit.discardDraft', locale)}
+        aria-label={t('engine.edit.discardDraft', locale)}
+        data-testid="runtime-draft-discard"
+      >
+        <Undo2 className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        size="sm"
+        onClick={handlePublish}
+        disabled={busy || dirty}
+        className="h-7 px-2 bg-emerald-600 hover:bg-emerald-700 text-emerald-50"
+        title={
+          dirty
+            ? t('engine.edit.publishBlockedDirty', locale)
+            : t('engine.edit.publish', locale)
+        }
+        data-testid="runtime-draft-publish"
+      >
+        {busy ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <>
+            <Send className="h-3.5 w-3.5 mr-1" />
+            {t('engine.edit.publish', locale)}
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/RuntimeDraftBar.tsx
+++ b/packages/app-shell/src/views/RuntimeDraftBar.tsx
@@ -50,6 +50,14 @@ export interface RuntimeDraftBarProps {
   onResume?: (body: Record<string, unknown>) => void;
   /** Called after a successful publish / discard so the host can refresh. */
   onAfterChange?: () => void;
+  /**
+   * Monotonic counter the host bumps right after it saves a draft. The bar
+   * reads the pending draft only on open, so without this a save in an
+   * already-open panel wouldn't surface the indicator until reopen. Bumping
+   * this marks the indicator immediately (a save just created a draft) — no
+   * dependence on the fire-and-forget write's timing.
+   */
+  savedSignal?: number;
 }
 
 export function RuntimeDraftBar({
@@ -59,6 +67,7 @@ export function RuntimeDraftBar({
   dirty,
   onResume,
   onAfterChange,
+  savedSignal,
 }: RuntimeDraftBarProps) {
   const enabled = isViaMeta();
   const locale = detectLocale();
@@ -100,6 +109,16 @@ export function RuntimeDraftBar({
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // A host save just wrote a draft → surface the indicator immediately,
+  // without waiting for a reopen or racing the fire-and-forget write.
+  // Skip the initial mount (savedSignal === 0 / undefined).
+  const lastSavedSignal = useRef(savedSignal);
+  useEffect(() => {
+    if (savedSignal === lastSavedSignal.current) return;
+    lastSavedSignal.current = savedSignal;
+    if (enabled && savedSignal) setHasDraft(true);
+  }, [savedSignal, enabled]);
 
   const handlePublish = useCallback(async () => {
     if (!name) return;

--- a/packages/app-shell/src/views/ViewConfigPanel.tsx
+++ b/packages/app-shell/src/views/ViewConfigPanel.tsx
@@ -132,6 +132,9 @@ export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, obje
     );
     const [draft, setDraft] = useState<InspectorViewDraft>(initialDraft);
     const [isDirty, setIsDirty] = useState(false);
+    // Bumped on each edit-mode save so the draft/publish chrome surfaces the
+    // "unpublished changes" indicator immediately (the save writes a draft).
+    const [savedSignal, setSavedSignal] = useState(0);
     // Mirror the committed draft into a ref so `handlePatch` can compute the
     // next draft synchronously without a side-effecting state updater.
     const draftRef = useRef(draft);
@@ -183,6 +186,7 @@ export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, obje
             onCreate?.(flat);
         } else {
             onSave?.(flat);
+            setSavedSignal((s) => s + 1);
         }
         setIsDirty(false);
     }, [draft, onSave, onCreate, mode]);
@@ -251,6 +255,7 @@ export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, obje
                         metadataClient={metadataClient}
                         dirty={isDirty}
                         onResume={handleResumeDraft}
+                        savedSignal={savedSignal}
                     />
                 )}
                 <Button

--- a/packages/app-shell/src/views/ViewConfigPanel.tsx
+++ b/packages/app-shell/src/views/ViewConfigPanel.tsx
@@ -23,6 +23,7 @@ import { useMemo, useEffect, useRef, useCallback, useState } from 'react';
 import { Button } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { ViewVariantInspector } from './metadata-admin/inspectors/ViewVariantInspector';
+import { RuntimeDraftBar } from './RuntimeDraftBar';
 import { isFormFamilyKey } from './metadata-admin/view-variant-model';
 import { detectLocale } from './metadata-admin/i18n';
 import type { ObjectFieldInfo } from './metadata-admin/previews/useObjectFields';
@@ -70,6 +71,12 @@ export interface ViewConfigPanelProps {
     onSave?: (draft: Record<string, any>) => void;
     /** Called when create-mode view is created */
     onCreate?: (config: Record<string, any>) => void;
+    /**
+     * Studio metadata client — drives the ADR-0034 draft/publish chrome
+     * ({@link RuntimeDraftBar}). Only used when `VITE_RUNTIME_EDIT_VIA_META`
+     * is on; the chrome renders nothing otherwise.
+     */
+    metadataClient?: any;
 }
 
 /**
@@ -91,7 +98,7 @@ function mapObjectFields(objectDef: ViewConfigPanelProps['objectDef']): ObjectFi
     });
 }
 
-export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, objectDef, onViewUpdate, onSave, onCreate }: ViewConfigPanelProps) {
+export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, objectDef, onViewUpdate, onSave, onCreate, metadataClient }: ViewConfigPanelProps) {
     const { t } = useObjectTranslation();
     const panelRef = useRef<HTMLDivElement>(null);
     const locale = useMemo(() => detectLocale(), []);
@@ -189,6 +196,17 @@ export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, obje
         setIsDirty(false);
     }, [initialDraft, mode, onClose]);
 
+    // ADR-0034 (#1515): resume a pending draft into the inspector when the
+    // panel reopens (flag-ON only; the bar never fires this when the flag is
+    // off). The stored body is the flat runtime view, so adapt it back to the
+    // inspector draft shape before seeding.
+    const handleResumeDraft = useCallback((body: Record<string, unknown>) => {
+        const resumed = runtimeViewToInspectorDraft(body as RuntimeView, objectDef.name);
+        draftRef.current = resumed;
+        setDraft(resumed);
+        setIsDirty(false);
+    }, [objectDef.name]);
+
     const panelTitle = mode === 'create'
         ? t('console.objectView.createView')
         : t('console.objectView.configureView');
@@ -226,6 +244,15 @@ export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, obje
                 data-testid="view-config-footer"
                 className="flex items-center justify-end gap-2 border-t px-4 py-2.5"
             >
+                {mode === 'edit' && (
+                    <RuntimeDraftBar
+                        type="view"
+                        name={activeView.id}
+                        metadataClient={metadataClient}
+                        dirty={isDirty}
+                        onResume={handleResumeDraft}
+                    />
+                )}
                 <Button
                     variant="ghost"
                     size="sm"

--- a/packages/app-shell/src/views/metadata-admin/useMetadata.ts
+++ b/packages/app-shell/src/views/metadata-admin/useMetadata.ts
@@ -80,10 +80,22 @@ export interface RichMetadataTypeEntry {
   ui?: Record<string, unknown>;
 }
 
-/** Use a single MetadataClient for the whole admin engine. */
+/**
+ * Use a single MetadataClient for the whole admin engine.
+ *
+ * The base resolves to `VITE_SERVER_URL` so `/meta/*` writes reach the backend
+ * even when the SPA and API are served from different origins (the split-origin
+ * `pnpm dev` setup: SPA on :5180, backend on :3000). In same-origin production
+ * `VITE_SERVER_URL` is unset → falls back to `''` (relative, current origin),
+ * matching every other client in the app (see `apps/console/src/main.tsx`).
+ */
 export function useMetadataClient(environmentId?: string): MetadataClient {
   return useMemo(() => {
-    const c = new MetadataClient({ baseUrl: '' });
+    const baseUrl =
+      (typeof import.meta !== 'undefined' &&
+        (import.meta as any).env?.VITE_SERVER_URL) ||
+      '';
+    const c = new MetadataClient({ baseUrl });
     return environmentId ? c.withEnvironment(environmentId) : c;
   }, [environmentId]);
 }

--- a/packages/app-shell/src/views/runtime-metadata-persistence.test.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.test.ts
@@ -4,6 +4,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   persistRuntimeMetadata,
   publishRuntimeMetadata,
+  createRuntimeMetadata,
+  readRuntimeDraft,
+  discardRuntimeDraft,
+  unwrapDraftBody,
   isViaMeta,
 } from './runtime-metadata-persistence';
 
@@ -27,6 +31,8 @@ function makeMetadataClient() {
   return {
     save: vi.fn().mockResolvedValue(undefined),
     publish: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue(null),
+    reset: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -100,6 +106,59 @@ describe('runtime-metadata-persistence seam (ADR-0034)', () => {
 
       expect(metadataClient.publish).not.toHaveBeenCalled();
     });
+
+    it('createRuntimeMetadata(view) → dataSource.createView(objectName, body), returns created name', async () => {
+      const dataSource = {
+        createView: vi.fn().mockResolvedValue({ name: 'srv_assigned_name' }),
+        create: vi.fn(),
+      };
+      const metadataClient = makeMetadataClient();
+      const body = { id: 'view_123', columns: ['name'] };
+
+      const id = await createRuntimeMetadata('view', 'view_123', body, {
+        dataSource,
+        metadataClient,
+        objectName: 'crm_lead',
+      });
+
+      expect(dataSource.createView).toHaveBeenCalledWith('crm_lead', body);
+      expect(id).toBe('srv_assigned_name');
+      expect(metadataClient.save).not.toHaveBeenCalled();
+    });
+
+    it('createRuntimeMetadata(view) → legacy sys_view insert via toSysViewPayload when no createView', async () => {
+      const created = { id: 'row_42' };
+      const dataSource = { create: vi.fn().mockResolvedValue(created) };
+      const toSysViewPayload = vi.fn((cfg: any) => ({ shaped: cfg }));
+      const body = { id: 'view_123', columns: ['name'] };
+
+      const id = await createRuntimeMetadata('view', 'view_123', body, {
+        dataSource,
+        objectName: 'crm_lead',
+        toSysViewPayload,
+      });
+
+      expect(toSysViewPayload).toHaveBeenCalledWith(body, 'crm_lead');
+      expect(dataSource.create).toHaveBeenCalledWith('sys_view', { shaped: body });
+      expect(id).toBe('row_42');
+    });
+
+    it('readRuntimeDraft is null (no draft concept in legacy model)', async () => {
+      const metadataClient = makeMetadataClient();
+
+      const draft = await readRuntimeDraft('view', 'my_view', { metadataClient });
+
+      expect(draft).toBeNull();
+      expect(metadataClient.get).not.toHaveBeenCalled();
+    });
+
+    it('discardRuntimeDraft is a no-op (nothing to discard in legacy model)', async () => {
+      const metadataClient = makeMetadataClient();
+
+      await discardRuntimeDraft('view', 'my_view', { metadataClient });
+
+      expect(metadataClient.reset).not.toHaveBeenCalled();
+    });
   });
 
   describe('flag ON (/meta draft/publish path)', () => {
@@ -147,6 +206,84 @@ describe('runtime-metadata-persistence seam (ADR-0034)', () => {
 
       expect(metadataClient.publish).toHaveBeenCalledTimes(1);
       expect(metadataClient.publish).toHaveBeenCalledWith('report', 'my_report');
+    });
+
+    it('createRuntimeMetadata → metadataClient.save(..., { mode: "draft" }) and returns name', async () => {
+      const dataSource = { createView: vi.fn(), create: vi.fn() };
+      const metadataClient = makeMetadataClient();
+      const body = { id: 'view_123', columns: ['name'] };
+
+      const id = await createRuntimeMetadata('view', 'view_123', body, {
+        dataSource,
+        metadataClient,
+        objectName: 'crm_lead',
+      });
+
+      expect(metadataClient.save).toHaveBeenCalledWith('view', 'view_123', body, {
+        mode: 'draft',
+      });
+      expect(id).toBe('view_123');
+      // Legacy create path must NOT run when the flag is on.
+      expect(dataSource.createView).not.toHaveBeenCalled();
+      expect(dataSource.create).not.toHaveBeenCalled();
+    });
+
+    it('readRuntimeDraft → unwraps metadataClient.get(..., { state: "draft" })', async () => {
+      const metadataClient = makeMetadataClient();
+      metadataClient.get.mockResolvedValue({
+        type: 'view',
+        name: 'my_view',
+        item: { columns: ['name', 'stage'] },
+      });
+
+      const draft = await readRuntimeDraft('view', 'my_view', { metadataClient });
+
+      expect(metadataClient.get).toHaveBeenCalledWith('view', 'my_view', {
+        state: 'draft',
+      });
+      expect(draft).toEqual({ columns: ['name', 'stage'] });
+    });
+
+    it('readRuntimeDraft → null when no draft is pending', async () => {
+      const metadataClient = makeMetadataClient();
+      metadataClient.get.mockResolvedValue(null);
+
+      const draft = await readRuntimeDraft('view', 'my_view', { metadataClient });
+
+      expect(draft).toBeNull();
+    });
+
+    it('discardRuntimeDraft → metadataClient.reset(type, name, { state: "draft" })', async () => {
+      const metadataClient = makeMetadataClient();
+
+      await discardRuntimeDraft('report', 'my_report', { metadataClient });
+
+      expect(metadataClient.reset).toHaveBeenCalledWith('report', 'my_report', {
+        state: 'draft',
+      });
+    });
+  });
+
+  describe('unwrapDraftBody', () => {
+    it('unwraps the { type, name, item } envelope', () => {
+      expect(unwrapDraftBody({ type: 'view', name: 'v', item: { a: 1 } })).toEqual({
+        a: 1,
+      });
+    });
+
+    it('returns a bare body as-is', () => {
+      expect(unwrapDraftBody({ a: 1 })).toEqual({ a: 1 });
+    });
+
+    it('returns null for an empty envelope item', () => {
+      expect(unwrapDraftBody({ type: 'view', name: 'v', item: {} })).toBeNull();
+    });
+
+    it('returns null for null / non-object / empty', () => {
+      expect(unwrapDraftBody(null)).toBeNull();
+      expect(unwrapDraftBody(undefined)).toBeNull();
+      expect(unwrapDraftBody('x')).toBeNull();
+      expect(unwrapDraftBody({})).toBeNull();
     });
   });
 });

--- a/packages/app-shell/src/views/runtime-metadata-persistence.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.ts
@@ -98,12 +98,132 @@ export interface RuntimePersistCtx {
   /** Object a view belongs to — first arg to `updateViewConfig`. */
   objectName?: string;
   /**
-   * View-only payload shaper. NOT used by the view UPDATE path (which goes
-   * through `updateViewConfig` with the raw draft); reserved for wiring the
-   * view CREATE legacy `sys_view` fallback through the seam later, so the
-   * complex `toSysViewPayload` logic can stay in ObjectView.
+   * View-only payload shaper for the CREATE legacy `sys_view` fallback. Used
+   * by {@link createRuntimeMetadata} when the data source has no `createView`.
+   * Kept as a call-site callback so the complex `toSysViewPayload` logic
+   * (default-column derivation, etc.) stays in ObjectView's UI layer; the seam
+   * only invokes it.
    */
   toSysViewPayload?: (cfg: any, obj?: string) => any;
+}
+
+/**
+ * Unwrap a `?state=draft` GET response into its bare body, or `null` when
+ * there is nothing pending.
+ *
+ * The framework wraps draft reads in a `{ type, name, item }` envelope (see
+ * {@link MetadataClient.getDraft}); a published/legacy read is the bare body.
+ * This accepts either shape and returns `null` for an empty/absent draft so
+ * `!!readRuntimeDraft(...)` is a reliable "has pending changes" check. Mirrors
+ * studio's `extractDraftBody` in `ResourceEditPage`.
+ */
+export function unwrapDraftBody(
+  resp: unknown,
+): Record<string, unknown> | null {
+  if (!resp || typeof resp !== 'object') return null;
+  const env = resp as Record<string, unknown>;
+  if ('item' in env) {
+    const body = env.item;
+    if (!body || typeof body !== 'object') return null;
+    return Object.keys(body as object).length > 0
+      ? (body as Record<string, unknown>)
+      : null;
+  }
+  return Object.keys(env).length > 0 ? env : null;
+}
+
+/**
+ * Create a NEW runtime artifact, routed through the same seam as edits so the
+ * flag controls create and update identically (ADR-0034 step / #1517).
+ *
+ * • flag OFF → reproduces ObjectView's legacy `handleViewCreate` write exactly:
+ *   prefer the ADR-0005 overlay API (`dataSource.createView(objectName, body)`),
+ *   else fall back to a physical `sys_view` insert
+ *   (`dataSource.create('sys_view', toSysViewPayload(body, objectName))`).
+ * • flag ON → `metadataClient.save(type, name, body, { mode: 'draft' })` — the
+ *   new view is born as an invisible per-item draft, promoted by an explicit
+ *   publish.
+ *
+ * Returns the created artifact's id/name (for auto-activation by the caller),
+ * matching the legacy resolution: `created.name ?? name` for the overlay path,
+ * `created.id ?? created._id` for the legacy `sys_view` insert.
+ *
+ * The UI-layer concerns the legacy path had (default-column derivation,
+ * kanban/gallery sub-config massaging, auto-activation) stay in ObjectView;
+ * only the final write call is centralised here.
+ *
+ * @param type artifact type (today only `view` has a create path)
+ * @param name best-known identifier for the new item (the draft `:name` when
+ *   flag ON; also the createView fallback id when the server omits one)
+ * @param body the spec/config to persist
+ * @param ctx  call-site capabilities (see {@link RuntimePersistCtx})
+ */
+export async function createRuntimeMetadata(
+  type: RuntimeArtifactType,
+  name: string,
+  body: any,
+  ctx: RuntimePersistCtx,
+): Promise<string | undefined> {
+  if (isViaMeta()) {
+    // ── flag ON: create-as-draft via the unified /meta model ──
+    await ctx.metadataClient.save(type, name, body, { mode: 'draft' });
+    return name;
+  }
+
+  // ── flag OFF: legacy create write (today's `handleViewCreate` behaviour) ──
+  switch (type) {
+    case 'view': {
+      if (typeof ctx.dataSource?.createView === 'function') {
+        const created = await ctx.dataSource.createView(ctx.objectName, body);
+        return (created as any)?.name ?? name;
+      }
+      if (ctx.dataSource?.create) {
+        const payload = ctx.toSysViewPayload
+          ? ctx.toSysViewPayload(body, ctx.objectName)
+          : body;
+        const created = await ctx.dataSource.create('sys_view', payload);
+        return (created as any)?.id ?? (created as any)?._id;
+      }
+      return undefined;
+    }
+    // report/dashboard creation is not (yet) a runtime path — only update is.
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Read the pending draft body for a runtime artifact (for the "unpublished
+ * changes" indicator and resume-on-open). Returns the bare body, or `null`
+ * when nothing is pending.
+ *
+ * • flag OFF → always `null`: the legacy `sys_*` model has no draft concept.
+ * • flag ON  → `metadataClient.get(type, name, { state: 'draft' })`, unwrapped.
+ */
+export async function readRuntimeDraft<T = Record<string, unknown>>(
+  type: RuntimeArtifactType,
+  name: string,
+  ctx: RuntimePersistCtx,
+): Promise<T | null> {
+  if (!isViaMeta()) return null;
+  const resp = await ctx.metadataClient.get(type, name, { state: 'draft' });
+  return unwrapDraftBody(resp) as T | null;
+}
+
+/**
+ * Discard the pending draft of a runtime artifact (Studio's "Discard draft").
+ * The published overlay is untouched.
+ *
+ * • flag OFF → **no-op**: there is no draft to discard in the legacy model.
+ * • flag ON  → `metadataClient.reset(type, name, { state: 'draft' })`.
+ */
+export async function discardRuntimeDraft(
+  type: RuntimeArtifactType,
+  name: string,
+  ctx: RuntimePersistCtx,
+): Promise<void> {
+  if (!isViaMeta()) return;
+  await ctx.metadataClient.reset(type, name, { state: 'draft' });
 }
 
 /**

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -300,7 +300,7 @@ const en = {
     defaultView: 'Default view',
     tabActionsFor: 'View actions for {{name}}',
     readonlyAriaLabel: 'Read-only view',
-    readonlyTooltip: 'System view — duplicate to customize.',
+    readonlyTooltip: 'System view — defined in code, read-only.',
   },
   detail: {
     back: 'Back',
@@ -1031,7 +1031,7 @@ const en = {
       objectNotFound: 'Object Not Found',
       objectNotFoundDescription: 'The object "{{objectName}}" does not exist in the current configuration.',
       objectNotFoundHint: 'Check your app navigation settings or select a different object from the sidebar.',
-      systemViewReadonly: 'System view defined in code — duplicate to customize.',
+      systemViewReadonly: 'System view defined in code — read-only.',
       expandToPage: 'Open as full page',
       allRecords: 'All Records',
       exitDesignMode: 'Exit Design Mode',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -300,7 +300,7 @@ const zh = {
     defaultView: '默认视图',
     tabActionsFor: '{{name}} 的视图操作',
     readonlyAriaLabel: '只读视图',
-    readonlyTooltip: '系统视图 — 复制后可自定义。',
+    readonlyTooltip: '系统视图 — 由代码定义，只读。',
   },
   designer: {
     undo: 'Undo',
@@ -1028,7 +1028,7 @@ const zh = {
       system: '系统',
     },
     objectView: {
-      systemViewReadonly: '系统视图由代码定义，请复制后再自定义。',
+      systemViewReadonly: '系统视图由代码定义，只读。',
       expandToPage: '以完整页面打开',
       objectNotFound: '未找到对象',
       objectNotFoundDescription: '对象"{{objectName}}"在当前配置中不存在。',


### PR DESCRIPTION
Part of **ADR-0034** (`docs/adr/0034-unified-runtime-metadata-persistence.md`). Implements **#1515** (draft/publish UI chrome) and **#1517** (view-create path → seam). Flag-gated by `VITE_RUNTIME_EDIT_VIA_META` — **default OFF = zero behaviour change**.

## #1515 — draft/publish chrome
New `RuntimeDraftBar` (mirrors studio's `ResourceEditPage` affordances), wired into all three runtime panels:
- **"Unpublished changes"** indicator, **Publish**, **Discard draft**, **resume-on-open**.
- Entirely gated by `isViaMeta()` → renders `null` when the flag is off (no DOM, no layout shift).
- Hosts thread the metadata client + artifact name + dirty state. Publish is gated on unsaved edits ("save first"), matching studio.
- Seam gains `readRuntimeDraft` / `discardRuntimeDraft` / `unwrapDraftBody`.

## #1517 — view-create through the seam
- `handleViewCreate`'s write routed through new `createRuntimeMetadata`: flag-OFF reproduces `createView` / legacy `sys_view` **byte-for-byte**; flag-ON creates a per-item draft. UI-layer concerns (default columns, kanban/gallery, auto-activate) stay in `ObjectView`.

## Also
- Remove the runtime **"Duplicate view"** feature (deferred to per-user personalisation, #1520) and fix the now-misleading "duplicate to customize" system-view copy (en/zh + hardcoded fallbacks).

## Verification
Verified against a **real backend** (app-showcase), the round trip that CI/sandbox can't exercise:
- ✅ flag-ON: Save → per-item draft → indicator shows → **Publish promotes the overlay + records a version** (history `op=publish`) → resume-on-open restores the draft.
- ✅ flag-OFF: zero chrome renders; "Duplicate view" gone from the menu.
- Fixed one bug found during browser verification: a throwing `onResume` was hiding the chrome — resume is now best-effort and isolated (regression test added).

## Checks
- `pnpm turbo build --filter=@object-ui/app-shell` + `@object-ui/i18n` green
- `vitest packages/app-shell/src/views` → **208 passing** (29 new: seam + chrome)
- lint: 0 new errors in changed files

## Out of scope (pre-existing, found during verification — follow-up)
1. `useMetadataClient` uses `baseUrl: ''` → `/meta` writes 404 in split-origin dev (SPA :5180 / backend :3000); affects studio editing too. Same-origin prod is fine.
2. `handleViewConfigSave` skips persistence when `draft.id` is empty (package views resolve an empty inspector `draft.name`) — pre-existing #1514 wiring, flag-on/off identical.

> ⚠️ Per ADR-0034 / #1518: do **not** flip the default or migrate `sys_*` until the flag-on path is signed off in a real environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)