### PR TITLE
feat(adr-0034): retire sys_view/sys_report/sys_dashboard (#1519)

### DIFF
--- a/packages/app-shell/src/views/DashboardConfigPanel.tsx
+++ b/packages/app-shell/src/views/DashboardConfigPanel.tsx
@@ -60,8 +60,7 @@ export interface DashboardConfigPanelProps<
   name?: string;
   /**
    * Studio metadata client — drives the ADR-0034 draft/publish chrome
-   * ({@link RuntimeDraftBar}). Only used when `VITE_RUNTIME_EDIT_VIA_META`
-   * is on; the chrome renders nothing otherwise.
+   * ({@link RuntimeDraftBar}).
    */
   metadataClient?: any;
 }

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -196,12 +196,10 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
   const saveSchema = useCallback(
     async (schema: DashboardSchema) => {
       try {
-        if (adapter) {
-          // ADR-0034 seam: flag OFF (default) reproduces the prior behaviour
-          // exactly — `adapter.updateDashboard(...)` when available, otherwise
-          // `adapter.update('sys_dashboard', …)`. Flag ON → metadata draft.
+        if (metadataClient) {
+          // ADR-0034: save stages a per-item draft; an explicit Publish
+          // promotes it (RuntimeDraftBar). `sys_dashboard` is retired.
           await persistRuntimeMetadata('dashboard', dashboardName!, schema, {
-            adapter,
             metadataClient,
           });
         }
@@ -216,7 +214,7 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
         toast.error(`Failed to save dashboard: ${message}`);
       }
     },
-    [adapter, metadataClient, dashboardName, refresh],
+    [metadataClient, dashboardName, refresh],
   );
 
   // ---- Open / close config panel ------------------------------------------

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -106,113 +106,6 @@ function substituteFilterTokens(filter: any, currentUserId: string | undefined):
     return filter.map(sub);
 }
 
-/**
- * Translate a NamedListView spec object (shape: `type`, `label`, `columns`,
- * `filter`, `sort`, `kanban`/`chart`/`gantt`/... sub-blocks, `bulkActions`,
- * `rowActions`, `pagination`, ...) into the `sys_view` storage shape that the
- * server's `sys_view` object schema actually exposes (snake_case scalars +
- * `*_json` text columns for complex shapes).
- *
- * The server rejects any other column name (`bulkActions`, `objectName`,
- * `isPinned`, ...) with `table sys_view has no column named …`, and knex
- * flattens raw arrays into positional bindings which mangles the SQL — so
- * every write path that targets `sys_view` MUST go through this helper.
- */
-function toSysViewPayload(
-    config: Record<string, any>,
-    objectName: string | undefined,
-    opts: { defaultColumns?: string[] } = {},
-): Record<string, any> {
-    const VIEW_TYPE_KEYS = [
-        'kanban', 'calendar', 'timeline', 'gantt',
-        'gallery', 'map', 'chart', 'grid',
-    ] as const;
-    // Fold view-type-specific sub-blocks plus any non-storage NamedListView
-    // fields into a single `config_json` blob so the round-trip preserves
-    // everything the renderer might need (bulkActions, rowActions, pagination,
-    // navigation, emptyState, exportOptions, rowHeight, isPinned, isDefault,
-    // visibility, sortOrder, …).
-    const subConfig: Record<string, any> = {};
-    for (const k of VIEW_TYPE_KEYS) {
-        if (config[k] && typeof config[k] === 'object') {
-            Object.assign(subConfig, config[k]);
-        }
-    }
-    const EXTRA_CONFIG_KEYS = [
-        'bulkActions', 'bulkActionDefs', 'rowActions', 'pagination', 'navigation',
-        'emptyState', 'exportOptions', 'rowHeight',
-        'isPinned', 'isDefault', 'visibility', 'sortOrder',
-        'showSort',
-    ];
-    for (const k of EXTRA_CONFIG_KEYS) {
-        if (config[k] !== undefined) subConfig[k] = config[k];
-    }
-
-    const incomingColumns = Array.isArray(config.columns) && config.columns.length > 0
-        ? config.columns
-        : (opts.defaultColumns ?? []);
-    const viewType = (config.type as string) || 'grid';
-    const baseLabel = (config.label as string) || (config.name as string) || 'Untitled View';
-    const slug = baseLabel
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '_')
-        .replace(/^_+|_+$/g, '')
-        .slice(0, 60) || 'view';
-
-    return {
-        name: `${slug}_${Date.now().toString(36)}`,
-        label: baseLabel,
-        object_name: objectName,
-        view_type: viewType,
-        columns_json: JSON.stringify(incomingColumns),
-        filters_json: config.filter ? JSON.stringify(config.filter) : null,
-        sort_json: config.sort ? JSON.stringify(config.sort) : null,
-        config_json: Object.keys(subConfig).length > 0
-            ? JSON.stringify(subConfig)
-            : null,
-        page_size: config.pageSize ?? 25,
-        show_search: config.showSearch !== false,
-        show_filters: config.showFilters !== false,
-        managed_by: 'user',
-    };
-}
-
-/**
- * Inverse of {@link toSysViewPayload}. Decodes a raw `sys_view` record
- * (snake_case fields + `*_json` text columns) back into the NamedListView
- * spec shape (`type`, `columns`, `filter`, `sort`, plus everything stashed
- * inside `config_json`) so the rest of the UI — ViewTabBar, ListView, the
- * grid renderer — can consume it without caring about the storage layer.
- *
- * Robust to fixtures/mocks that already store the spec shape directly
- * (older tests, the in-memory dev adapter): if `*_json` is missing we fall
- * back to `sv.columns` / `sv.filter` / `sv.sort` as-is.
- */
-function fromSysViewRecord(sv: Record<string, any>): Record<string, any> {
-    const parse = (raw: any): any => {
-        if (raw == null) return undefined;
-        if (typeof raw !== 'string') return raw;
-        try { return JSON.parse(raw); } catch { return undefined; }
-    };
-    const columns = parse(sv.columns_json) ?? sv.columns;
-    const filter = parse(sv.filters_json) ?? sv.filter;
-    const sort = parse(sv.sort_json) ?? sv.sort;
-    const extra = parse(sv.config_json) ?? {};
-    return {
-        ...sv,
-        ...extra,
-        type: sv.view_type ?? sv.type ?? 'grid',
-        objectName: sv.object_name ?? sv.objectName,
-        columns,
-        filter,
-        sort,
-        showSearch: sv.show_search ?? sv.showSearch,
-        showFilters: sv.show_filters ?? sv.showFilters,
-        pageSize: sv.page_size ?? sv.pageSize,
-    };
-}
-
-
 export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: any) {
     const navigate = useNavigate();
     const { appName, objectName, viewId } = useParams();
@@ -222,8 +115,8 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
     const { t } = useObjectTranslation();
     const { objectLabel, objectDescription: objectDesc, viewLabel, viewEmptyState, actionLabel, actionConfirm, actionSuccess, fieldLabel, fieldOptionLabel } = useObjectLabel();
     const { isFavorite, toggleFavorite } = useFavorites();
-    // ADR-0034 seam: used only when the runtime-via-/meta flag is ON; the
-    // flag-OFF default still calls `dataSource.updateViewConfig(...)`.
+    // ADR-0034: runtime view edits persist via the metadata draft/publish
+    // model (the `sys_view` table is retired).
     const metadataClient = useMetadataClient();
 
     // Inline view config panel state (Airtable-style right sidebar)
@@ -274,34 +167,23 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         setViewDraft(draft);
         setRefreshKey(k => k + 1);
 
-        // Persist to backend if dataSource supports it.
-        // ADR-0034 seam: flag OFF (default) → `dataSource.updateViewConfig(...)`
-        // exactly as before; flag ON → metadata draft. Behaviour unchanged
-        // while the flag is off (the seam's view branch calls updateViewConfig).
-        if (dataSource?.updateViewConfig) {
-            const objName = objectName;
-            const vid = draft.id;
-            if (objName && vid) {
-                persistRuntimeMetadata('view', vid, draft, {
-                    dataSource,
-                    metadataClient,
-                    objectName: objName,
-                }).catch((err: any) => {
-                    console.error('[ViewConfigPanel] Failed to persist view config:', err);
-                });
-            } else {
-                console.warn('[ViewConfigPanel] Cannot persist view config: missing objectName or viewId.');
-            }
+        // ADR-0034: stage a per-item draft via the metadata seam; an explicit
+        // Publish (RuntimeDraftBar) promotes it + records a version.
+        const vid = draft.id;
+        if (metadataClient && vid) {
+            persistRuntimeMetadata('view', vid, draft, { metadataClient }).catch((err: any) => {
+                console.error('[ViewConfigPanel] Failed to persist view config:', err);
+            });
         } else {
-            console.warn('[ViewConfigPanel] dataSource.updateViewConfig is not available. View config saved locally only.');
+            console.warn('[ViewConfigPanel] Cannot persist view config: missing metadataClient or viewId.');
         }
-    }, [dataSource, objectName, metadataClient]);
+    }, [metadataClient]);
 
     /** Create a new view via the config panel */
     const handleViewCreate = useCallback(async (config: Record<string, any>) => {
         try {
             let createdId: string | undefined;
-            if (dataSource?.create) {
+            if (metadataClient) {
                 // Prefill sensible defaults so the saved view renders rows
                 // immediately even if the user didn't pick columns yet.
                 const objectDef = objects?.find?.((o: any) => o.name === objectName);
@@ -340,22 +222,15 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                         spec.gallery = { ...existing, visibleFields: incomingColumns };
                     }
                 }
-                // ADR-0034 seam (#1517): route the create WRITE through the
-                // shared seam. flag OFF (default) reproduces today's path
-                // byte-for-byte — `createView` preferred, legacy `sys_view`
-                // insert via `toSysViewPayload` as fallback; flag ON saves the
-                // new view as an invisible per-item draft. UI-layer concerns
-                // (default columns, kanban/gallery massaging above, and the
-                // auto-activation below) stay here.
+                // ADR-0034: a new view is created as an invisible per-item
+                // draft via the metadata seam; an explicit Publish promotes it.
+                // UI-layer concerns (default columns, kanban/gallery massaging
+                // above, and the auto-activation below) stay here.
                 const draftName = String(
                     (config as any)?.name ?? (config as any)?.id ?? (spec as any)?.id ?? '',
                 );
                 createdId = await createRuntimeMetadata('view', draftName, spec, {
-                    dataSource,
                     metadataClient,
-                    objectName,
-                    toSysViewPayload: (cfg: any, obj?: string) =>
-                        toSysViewPayload(cfg, obj, { defaultColumns }),
                 });
             }
             setShowViewConfigPanel(false);
@@ -431,10 +306,11 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
     // Import wizard open/close state — toolbar entry triggers it.
     const [showImport, setShowImport] = useState(false);
 
-    // ─── User-defined views (sys_view) ──────────────────────────────────
-    // Saved views created via the ViewConfigPanel ("Add View") are persisted
-    // to the `sys_view` object. We fetch them here and merge into `views` so
-    // the ViewTabBar can render them alongside metadata-defined listViews.
+    // ─── User-defined views (metadata overlay) ──────────────────────────
+    // Saved views created via the ViewConfigPanel ("Add View") live in the
+    // metadata overlay (`/meta/view`). We fetch them via `listViews` and merge
+    // into `views` so the ViewTabBar renders them alongside metadata-defined
+    // listViews.
     const [savedViews, setSavedViews] = useState<any[]>([]);
     useEffect(() => {
         let cancelled = false;
@@ -442,10 +318,8 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
             setSavedViews([]);
             return;
         }
-        // ADR-0005: use the metadata overlay API instead of writing to
-        // the physical `sys_view` table (which has incompatible columns).
-        // Falls back to the legacy `find('sys_view', ...)` path only when
-        // the adapter doesn't expose `listViews` (e.g. test mocks).
+        // Read saved views from the metadata overlay (`/meta/view`) via the
+        // adapter's `listViews`. Adapters without it surface no saved views.
         if (typeof (dataSource as any)?.listViews === 'function') {
             (dataSource as any).listViews(objectName)
                 .then((rows: any[]) => {
@@ -470,39 +344,9 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                 });
             return () => { cancelled = true; };
         }
-        if (!dataSource?.find) {
-            setSavedViews([]);
-            return;
-        }
-        dataSource
-            .find('sys_view', {
-                $filter: ['object_name', '=', objectName],
-                $orderby: [{ field: 'created_at', order: 'asc' }],
-                $top: 200,
-            })
-            .then((res: any) => {
-                if (cancelled) return;
-                const rows: any[] = Array.isArray(res)
-                    ? res
-                    : Array.isArray(res?.data) ? res.data
-                    : Array.isArray(res?.records) ? res.records
-                    : Array.isArray(res?.value) ? res.value
-                    : [];
-                // Defensive client-side filter: only keep rows that look like
-                // sys_view records for *this* object. Adapters that don't
-                // honour $filter (or test mocks that ignore it) won't pollute
-                // the view list with arbitrary records. Match either casing —
-                // the storage column is `object_name`, but older mock fixtures
-                // and tests may still emit `objectName`.
-                const filtered = rows
-                    .filter(r => r && (r.object_name === objectName || r.objectName === objectName))
-                    .map(fromSysViewRecord);
-                setSavedViews(filtered);
-            })
-            .catch((err: any) => {
-                console.error('[ObjectView] Failed to load sys_view records:', err);
-                if (!cancelled) setSavedViews([]);
-            });
+        // No overlay API available (e.g. a minimal adapter / test mock) → no
+        // saved views. The retired `sys_view` table is no longer read.
+        setSavedViews([]);
         return () => { cancelled = true; };
     }, [dataSource, objectName, refreshKey]);
 
@@ -825,11 +669,9 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
             return;
         }
         try {
-            // ADR-0005 overlay path — `vid` is the view's `name` field
+            // Metadata overlay path — `vid` is the view's `name` field.
             if (typeof (dataSource as any)?.updateView === 'function') {
                 await (dataSource as any).updateView(objectName, vid, { label: newName });
-            } else if (dataSource?.update) {
-                await dataSource.update('sys_view', vid, { label: newName });
             }
             setRefreshKey(k => k + 1);
         } catch (err) {
@@ -898,8 +740,6 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         try {
             if (typeof (dataSource as any)?.deleteView === 'function') {
                 await (dataSource as any).deleteView(objectName, vid);
-            } else if (dataSource?.delete) {
-                await dataSource.delete('sys_view', vid);
             }
             // If we deleted the active view, fall back to the first remaining view.
             if (vid === activeViewId) {
@@ -922,8 +762,6 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         try {
             if (typeof (dataSource as any)?.updateView === 'function') {
                 await (dataSource as any).updateView(objectName, vid, { isPinned: pinned });
-            } else if (dataSource?.update) {
-                await dataSource.update('sys_view', vid, { isPinned: pinned });
             }
             setRefreshKey(k => k + 1);
         } catch (err) {
@@ -942,20 +780,12 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         }
         try {
             // Clear `isDefault` on all other saved views, then set this one.
-            const hasOverlay = typeof (dataSource as any)?.updateView === 'function';
+            if (typeof (dataSource as any)?.updateView !== 'function') return;
+            const updateView = (dataSource as any).updateView;
             const updates = savedViews
                 .filter((sv: any) => (sv.id || sv._id) !== vid && sv.isDefault)
-                .map((sv: any) => {
-                    const id = sv.id || sv._id;
-                    return hasOverlay
-                        ? (dataSource as any).updateView(objectName, id, { isDefault: false })
-                        : dataSource.update!('sys_view', id, { isDefault: false });
-                });
-            updates.push(
-                hasOverlay
-                    ? (dataSource as any).updateView(objectName, vid, { isDefault: true })
-                    : dataSource.update!('sys_view', vid, { isDefault: true }),
-            );
+                .map((sv: any) => updateView(objectName, sv.id || sv._id, { isDefault: false }));
+            updates.push(updateView(objectName, vid, { isDefault: true }));
             await Promise.all(updates);
             setRefreshKey(k => k + 1);
         } catch (err) {
@@ -975,15 +805,12 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
         } catch { /* ignore */ }
         // Best-effort: also persist `sortOrder` on each saved view so other
         // sessions / users can pick up the order from the backend.
-        if (dataSource) {
-            const hasOverlay = typeof (dataSource as any)?.updateView === 'function';
+        if (typeof (dataSource as any)?.updateView === 'function') {
+            const updateView = (dataSource as any).updateView;
             const savedIdSet = new Set(savedViews.map((sv: any) => sv.id || sv._id));
             const updates = orderedIds
                 .filter(id => savedIdSet.has(id))
-                .map((id, idx) => hasOverlay
-                    ? (dataSource as any).updateView(objectName, id, { sortOrder: idx })
-                    : dataSource.update?.('sys_view', id, { sortOrder: idx }))
-                .filter(Boolean);
+                .map((id, idx) => updateView(objectName, id, { sortOrder: idx }));
             try {
                 await Promise.all(updates);
             } catch (err) {

--- a/packages/app-shell/src/views/ReportConfigPanel.tsx
+++ b/packages/app-shell/src/views/ReportConfigPanel.tsx
@@ -59,8 +59,7 @@ export interface ReportConfigPanelProps {
   name?: string;
   /**
    * Studio metadata client — drives the draft/publish chrome
-   * ({@link RuntimeDraftBar}). Only used when `VITE_RUNTIME_EDIT_VIA_META`
-   * is on; the chrome renders nothing otherwise.
+   * ({@link RuntimeDraftBar}).
    */
   metadataClient?: any;
 }

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -94,12 +94,10 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   const saveSchema = useCallback(
     async (schema: any) => {
       try {
-        if (adapter) {
-          // ADR-0034 seam: flag OFF (default) → `adapter.update('sys_report',…)`
-          // exactly as before; flag ON → metadata draft. Behaviour unchanged
-          // while the flag is off.
+        if (metadataClient) {
+          // ADR-0034: save stages a per-item draft; an explicit Publish
+          // promotes it (RuntimeDraftBar). `sys_report` is retired.
           await persistRuntimeMetadata('report', reportName!, schema, {
-            adapter,
             metadataClient,
           });
           refresh().catch(() => {});
@@ -108,7 +106,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
         console.warn('[ReportView] Auto-save failed:', err);
       }
     },
-    [adapter, metadataClient, reportName, refresh],
+    [metadataClient, reportName, refresh],
   );
 
   // ---- Open / close config panel ------------------------------------------

--- a/packages/app-shell/src/views/RuntimeDraftBar.test.tsx
+++ b/packages/app-shell/src/views/RuntimeDraftBar.test.tsx
@@ -5,11 +5,11 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { RuntimeDraftBar } from './RuntimeDraftBar';
 
 /**
- * ADR-0034 step 3 (#1515) chrome tests.
+ * ADR-0034 draft/publish chrome tests.
  *
- * The bar is fully gated by the `VITE_RUNTIME_EDIT_VIA_META` flag (toggled via
- * `vi.stubEnv`). Flag OFF must render NOTHING and touch no network; flag ON
- * surfaces the draft indicator / publish / discard and resumes the draft.
+ * The bar reads the pending draft on open, surfaces the indicator + Publish +
+ * Discard when one exists, and resumes the draft into the editor. It renders
+ * nothing until there is a pending draft.
  */
 
 function makeMetadataClient(draftItem: unknown = null) {
@@ -22,186 +22,122 @@ function makeMetadataClient(draftItem: unknown = null) {
 
 describe('RuntimeDraftBar (ADR-0034)', () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
-  describe('flag OFF (default)', () => {
-    it('renders nothing and never reads the draft', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', '');
-      const metadataClient = makeMetadataClient({ item: { a: 1 } });
-
-      const { container } = render(
-        <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} />,
-      );
-
-      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
-      // No draft read fired — the legacy path must stay inert.
-      expect(metadataClient.get).not.toHaveBeenCalled();
+  it('shows the indicator + publish when a draft is pending, and resumes it', async () => {
+    const metadataClient = makeMetadataClient({
+      type: 'view',
+      name: 'my_view',
+      item: { columns: ['name'] },
     });
+    const onResume = vi.fn();
+
+    render(
+      <RuntimeDraftBar
+        type="view"
+        name="my_view"
+        metadataClient={metadataClient}
+        onResume={onResume}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy());
+    expect(screen.getByTestId('runtime-draft-publish')).toBeTruthy();
+    expect(screen.getByTestId('runtime-draft-discard')).toBeTruthy();
+    expect(metadataClient.get).toHaveBeenCalledWith('view', 'my_view', { state: 'draft' });
+    expect(onResume).toHaveBeenCalledWith({ columns: ['name'] });
   });
 
-  describe('flag ON', () => {
-    it('shows the indicator + publish when a draft is pending, and resumes it', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
-      const metadataClient = makeMetadataClient({
-        type: 'view',
-        name: 'my_view',
-        item: { columns: ['name'] },
-      });
-      const onResume = vi.fn();
-
-      render(
-        <RuntimeDraftBar
-          type="view"
-          name="my_view"
-          metadataClient={metadataClient}
-          onResume={onResume}
-        />,
-      );
-
-      await waitFor(() =>
-        expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy(),
-      );
-      expect(screen.getByTestId('runtime-draft-publish')).toBeTruthy();
-      expect(screen.getByTestId('runtime-draft-discard')).toBeTruthy();
-      expect(metadataClient.get).toHaveBeenCalledWith('view', 'my_view', {
-        state: 'draft',
-      });
-      expect(onResume).toHaveBeenCalledWith({ columns: ['name'] });
+  it('still shows the indicator when onResume throws (resume is best-effort)', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
+    const onResume = vi.fn(() => {
+      throw new Error('seed failed');
     });
 
-    it('still shows the indicator when onResume throws (resume is best-effort)', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
-      vi.spyOn(console, 'error').mockImplementation(() => {});
-      const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
-      const onResume = vi.fn(() => {
-        throw new Error('seed failed');
-      });
+    render(
+      <RuntimeDraftBar
+        type="view"
+        name="my_view"
+        metadataClient={metadataClient}
+        onResume={onResume}
+      />,
+    );
 
-      render(
-        <RuntimeDraftBar
-          type="view"
-          name="my_view"
-          metadataClient={metadataClient}
-          onResume={onResume}
-        />,
-      );
+    await waitFor(() => expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy());
+    expect(onResume).toHaveBeenCalled();
+  });
 
-      // A throwing resume must NOT hide the "unpublished changes" chrome —
-      // the draft still exists on the server.
-      await waitFor(() => expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy());
-      expect(onResume).toHaveBeenCalled();
-    });
+  it('renders nothing when there is no pending draft', async () => {
+    const metadataClient = makeMetadataClient(null);
 
-    it('renders nothing when there is no pending draft', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
-      const metadataClient = makeMetadataClient(null);
+    const { container } = render(
+      <RuntimeDraftBar type="report" name="my_report" metadataClient={metadataClient} />,
+    );
 
-      const { container } = render(
-        <RuntimeDraftBar type="report" name="my_report" metadataClient={metadataClient} />,
-      );
+    await waitFor(() => expect(metadataClient.get).toHaveBeenCalled());
+    expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
+  });
 
-      await waitFor(() => expect(metadataClient.get).toHaveBeenCalled());
-      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
-    });
+  it('publishes the pending draft on click', async () => {
+    const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
+    const onAfterChange = vi.fn();
 
-    it('publishes the pending draft on click', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
-      const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
-      const onAfterChange = vi.fn();
+    render(
+      <RuntimeDraftBar
+        type="dashboard"
+        name="my_dash"
+        metadataClient={metadataClient}
+        onAfterChange={onAfterChange}
+      />,
+    );
 
-      render(
-        <RuntimeDraftBar
-          type="dashboard"
-          name="my_dash"
-          metadataClient={metadataClient}
-          onAfterChange={onAfterChange}
-        />,
-      );
+    const publishBtn = await screen.findByTestId('runtime-draft-publish');
+    fireEvent.click(publishBtn);
 
-      const publishBtn = await screen.findByTestId('runtime-draft-publish');
-      fireEvent.click(publishBtn);
+    await waitFor(() =>
+      expect(metadataClient.publish).toHaveBeenCalledWith('dashboard', 'my_dash'),
+    );
+    expect(onAfterChange).toHaveBeenCalled();
+  });
 
-      await waitFor(() =>
-        expect(metadataClient.publish).toHaveBeenCalledWith('dashboard', 'my_dash'),
-      );
-      expect(onAfterChange).toHaveBeenCalled();
-    });
+  it('Publish is disabled while the panel has unsaved edits (dirty)', async () => {
+    const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
 
-    it('Publish is disabled while the panel has unsaved edits (dirty)', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
-      const metadataClient = makeMetadataClient({ item: { columns: ['name'] } });
+    render(
+      <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} dirty />,
+    );
 
-      render(
-        <RuntimeDraftBar
-          type="view"
-          name="my_view"
-          metadataClient={metadataClient}
-          dirty
-        />,
-      );
+    const publishBtn = await screen.findByTestId('runtime-draft-publish');
+    expect((publishBtn as HTMLButtonElement).disabled).toBe(true);
+  });
 
-      const publishBtn = await screen.findByTestId('runtime-draft-publish');
-      expect((publishBtn as HTMLButtonElement).disabled).toBe(true);
-    });
+  it('surfaces the indicator immediately when savedSignal bumps (no read race)', async () => {
+    const metadataClient = makeMetadataClient(null); // no draft on initial read
 
-    it('surfaces the indicator immediately when savedSignal bumps (no read race)', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
-      const metadataClient = makeMetadataClient(null); // no draft on initial read
+    const { rerender, container } = render(
+      <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} savedSignal={0} />,
+    );
 
-      const { rerender, container } = render(
-        <RuntimeDraftBar
-          type="view"
-          name="my_view"
-          metadataClient={metadataClient}
-          savedSignal={0}
-        />,
-      );
+    await waitFor(() => expect(metadataClient.get).toHaveBeenCalled());
+    expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
 
-      // No draft yet → nothing rendered.
-      await waitFor(() => expect(metadataClient.get).toHaveBeenCalled());
-      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
+    // Host saved a draft → bump the signal → indicator appears at once.
+    rerender(
+      <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} savedSignal={1} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy());
+  });
 
-      // Host saved a draft → bump the signal → indicator appears at once,
-      // without depending on a re-read.
-      rerender(
-        <RuntimeDraftBar
-          type="view"
-          name="my_view"
-          metadataClient={metadataClient}
-          savedSignal={1}
-        />,
-      );
-      await waitFor(() =>
-        expect(screen.getByTestId('runtime-draft-bar')).toBeTruthy(),
-      );
-    });
+  it('stays inert until a name is known', async () => {
+    const metadataClient = makeMetadataClient({ item: { a: 1 } });
 
-    it('savedSignal does nothing when the flag is off', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', '');
-      const metadataClient = makeMetadataClient(null);
+    const { container } = render(
+      <RuntimeDraftBar type="view" metadataClient={metadataClient} />,
+    );
 
-      const { rerender, container } = render(
-        <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} savedSignal={0} />,
-      );
-      rerender(
-        <RuntimeDraftBar type="view" name="my_view" metadataClient={metadataClient} savedSignal={1} />,
-      );
-
-      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
-    });
-
-    it('stays inert until a name is known', async () => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
-      const metadataClient = makeMetadataClient({ item: { a: 1 } });
-
-      const { container } = render(
-        <RuntimeDraftBar type="view" metadataClient={metadataClient} />,
-      );
-
-      expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
-      expect(metadataClient.get).not.toHaveBeenCalled();
-    });
+    expect(container.querySelector('[data-testid="runtime-draft-bar"]')).toBeNull();
+    expect(metadataClient.get).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-shell/src/views/RuntimeDraftBar.tsx
+++ b/packages/app-shell/src/views/RuntimeDraftBar.tsx
@@ -5,25 +5,16 @@
  * runtime config panels (ViewConfigPanel / ReportConfigPanel /
  * DashboardConfigPanel).
  *
- * It mirrors studio's `ResourceEditPage` affordances — an "unpublished
- * changes" indicator, a **Publish** button, and a **Discard draft** button —
- * but is **entirely gated by {@link isViaMeta}**:
- *
- *   • flag OFF (default) → renders `null`. Mounting it adds NO DOM, so the
- *     existing panel footers are byte-identical to before this change.
- *   • flag ON → on open it reads the pending draft (`?state=draft`), shows the
- *     indicator when one exists, optionally resumes it into the editor
- *     (`onResume`), and exposes Publish / Discard.
- *
- * Hooks are always called (no conditional hooks); only the rendered output and
- * the network effects are gated, so flipping the flag never changes hook order.
+ * It mirrors studio's `ResourceEditPage` affordances: on open it reads the
+ * pending draft (`?state=draft`), shows an "unpublished changes" indicator when
+ * one exists, resumes it into the editor (`onResume`), and exposes **Publish**
+ * and **Discard draft**. It renders nothing until there is a pending draft.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@object-ui/components';
 import { Loader2, Send, Undo2 } from 'lucide-react';
 import {
-  isViaMeta,
   publishRuntimeMetadata,
   discardRuntimeDraft,
   readRuntimeDraft,
@@ -69,7 +60,6 @@ export function RuntimeDraftBar({
   onAfterChange,
   savedSignal,
 }: RuntimeDraftBarProps) {
-  const enabled = isViaMeta();
   const locale = detectLocale();
   const [hasDraft, setHasDraft] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -78,7 +68,7 @@ export function RuntimeDraftBar({
   const resumedRef = useRef<string | null>(null);
 
   const refresh = useCallback(async () => {
-    if (!enabled || !name || !metadataClient) {
+    if (!name || !metadataClient) {
       setHasDraft(false);
       return;
     }
@@ -103,7 +93,7 @@ export function RuntimeDraftBar({
         console.error('[RuntimeDraftBar] Resume draft failed:', err);
       }
     }
-  }, [enabled, type, name, metadataClient, onResume]);
+  }, [type, name, metadataClient, onResume]);
 
   // Read the pending draft on open / when the edited item changes.
   useEffect(() => {
@@ -117,8 +107,8 @@ export function RuntimeDraftBar({
   useEffect(() => {
     if (savedSignal === lastSavedSignal.current) return;
     lastSavedSignal.current = savedSignal;
-    if (enabled && savedSignal) setHasDraft(true);
-  }, [savedSignal, enabled]);
+    if (savedSignal) setHasDraft(true);
+  }, [savedSignal]);
 
   const handlePublish = useCallback(async () => {
     if (!name) return;
@@ -155,7 +145,8 @@ export function RuntimeDraftBar({
   }, [type, name, metadataClient, onAfterChange, locale]);
 
   // flag OFF, or nothing pending → render nothing (zero DOM, zero layout shift).
-  if (!enabled || !hasDraft) return null;
+  // Nothing pending → render nothing (no indicator, no buttons).
+  if (!hasDraft) return null;
 
   return (
     <div

--- a/packages/app-shell/src/views/ViewConfigPanel.tsx
+++ b/packages/app-shell/src/views/ViewConfigPanel.tsx
@@ -72,9 +72,8 @@ export interface ViewConfigPanelProps {
     /** Called when create-mode view is created */
     onCreate?: (config: Record<string, any>) => void;
     /**
-     * Studio metadata client — drives the ADR-0034 draft/publish chrome
-     * ({@link RuntimeDraftBar}). Only used when `VITE_RUNTIME_EDIT_VIA_META`
-     * is on; the chrome renders nothing otherwise.
+     * Studio metadata client — drives saves and the ADR-0034 draft/publish
+     * chrome ({@link RuntimeDraftBar}).
      */
     metadataClient?: any;
 }

--- a/packages/app-shell/src/views/runtime-metadata-persistence.test.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   persistRuntimeMetadata,
   publishRuntimeMetadata,
@@ -8,24 +8,15 @@ import {
   readRuntimeDraft,
   discardRuntimeDraft,
   unwrapDraftBody,
-  isViaMeta,
 } from './runtime-metadata-persistence';
 
 /**
  * ADR-0034 seam tests.
  *
- * The flag is read live from `import.meta.env.VITE_RUNTIME_EDIT_VIA_META`
- * via `isViaMeta()`, so we toggle it with `vi.stubEnv`. Flag OFF is the
- * default and must reproduce the legacy `sys_*` writes; flag ON routes to
- * the metadata client's draft/publish.
+ * The seam is metadata-only: every call routes to the `MetadataClient`
+ * draft/publish API (`sys_*` tables retired). Saves stage a per-item draft;
+ * publish promotes it.
  */
-
-function makeAdapter() {
-  return {
-    update: vi.fn().mockResolvedValue(undefined),
-    updateDashboard: vi.fn().mockResolvedValue(undefined),
-  };
-}
 
 function makeMetadataClient() {
   return {
@@ -38,229 +29,85 @@ function makeMetadataClient() {
 
 describe('runtime-metadata-persistence seam (ADR-0034)', () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
-  describe('flag OFF (default — legacy sys_* path)', () => {
-    beforeEach(() => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', '');
-    });
+  it('persistRuntimeMetadata → save(type, name, body, { mode: "draft" })', async () => {
+    const metadataClient = makeMetadataClient();
+    const body = { title: 'Pipeline' };
 
-    it('isViaMeta() is false', () => {
-      expect(isViaMeta()).toBe(false);
-    });
+    await persistRuntimeMetadata('report', 'my_report', body, { metadataClient });
 
-    it('report → adapter.update("sys_report", name, body)', async () => {
-      const adapter = makeAdapter();
-      const metadataClient = makeMetadataClient();
-      const body = { title: 'Pipeline' };
-
-      await persistRuntimeMetadata('report', 'my_report', body, {
-        adapter,
-        metadataClient,
-      });
-
-      expect(adapter.update).toHaveBeenCalledTimes(1);
-      expect(adapter.update).toHaveBeenCalledWith('sys_report', 'my_report', body);
-      expect(metadataClient.save).not.toHaveBeenCalled();
-    });
-
-    it('dashboard → adapter.updateDashboard(name, body) when available', async () => {
-      const adapter = makeAdapter();
-      const body = { widgets: [] };
-
-      await persistRuntimeMetadata('dashboard', 'my_dash', body, { adapter });
-
-      expect(adapter.updateDashboard).toHaveBeenCalledTimes(1);
-      expect(adapter.updateDashboard).toHaveBeenCalledWith('my_dash', body);
-      expect(adapter.update).not.toHaveBeenCalled();
-    });
-
-    it('dashboard → falls back to adapter.update("sys_dashboard", …) when no updateDashboard', async () => {
-      const adapter = { update: vi.fn().mockResolvedValue(undefined) };
-      const body = { widgets: [] };
-
-      await persistRuntimeMetadata('dashboard', 'my_dash', body, { adapter });
-
-      expect(adapter.update).toHaveBeenCalledTimes(1);
-      expect(adapter.update).toHaveBeenCalledWith('sys_dashboard', 'my_dash', body);
-    });
-
-    it('view → dataSource.updateViewConfig(objectName, name, body)', async () => {
-      const dataSource = { updateViewConfig: vi.fn().mockResolvedValue(undefined) };
-      const body = { columns: ['name'] };
-
-      await persistRuntimeMetadata('view', 'my_view', body, {
-        dataSource,
-        objectName: 'crm_lead',
-      });
-
-      expect(dataSource.updateViewConfig).toHaveBeenCalledWith('crm_lead', 'my_view', body);
-    });
-
-    it('publishRuntimeMetadata is a no-op (no draft concept in legacy model)', async () => {
-      const metadataClient = makeMetadataClient();
-
-      await publishRuntimeMetadata('report', 'my_report', { metadataClient });
-
-      expect(metadataClient.publish).not.toHaveBeenCalled();
-    });
-
-    it('createRuntimeMetadata(view) → dataSource.createView(objectName, body), returns created name', async () => {
-      const dataSource = {
-        createView: vi.fn().mockResolvedValue({ name: 'srv_assigned_name' }),
-        create: vi.fn(),
-      };
-      const metadataClient = makeMetadataClient();
-      const body = { id: 'view_123', columns: ['name'] };
-
-      const id = await createRuntimeMetadata('view', 'view_123', body, {
-        dataSource,
-        metadataClient,
-        objectName: 'crm_lead',
-      });
-
-      expect(dataSource.createView).toHaveBeenCalledWith('crm_lead', body);
-      expect(id).toBe('srv_assigned_name');
-      expect(metadataClient.save).not.toHaveBeenCalled();
-    });
-
-    it('createRuntimeMetadata(view) → legacy sys_view insert via toSysViewPayload when no createView', async () => {
-      const created = { id: 'row_42' };
-      const dataSource = { create: vi.fn().mockResolvedValue(created) };
-      const toSysViewPayload = vi.fn((cfg: any) => ({ shaped: cfg }));
-      const body = { id: 'view_123', columns: ['name'] };
-
-      const id = await createRuntimeMetadata('view', 'view_123', body, {
-        dataSource,
-        objectName: 'crm_lead',
-        toSysViewPayload,
-      });
-
-      expect(toSysViewPayload).toHaveBeenCalledWith(body, 'crm_lead');
-      expect(dataSource.create).toHaveBeenCalledWith('sys_view', { shaped: body });
-      expect(id).toBe('row_42');
-    });
-
-    it('readRuntimeDraft is null (no draft concept in legacy model)', async () => {
-      const metadataClient = makeMetadataClient();
-
-      const draft = await readRuntimeDraft('view', 'my_view', { metadataClient });
-
-      expect(draft).toBeNull();
-      expect(metadataClient.get).not.toHaveBeenCalled();
-    });
-
-    it('discardRuntimeDraft is a no-op (nothing to discard in legacy model)', async () => {
-      const metadataClient = makeMetadataClient();
-
-      await discardRuntimeDraft('view', 'my_view', { metadataClient });
-
-      expect(metadataClient.reset).not.toHaveBeenCalled();
+    expect(metadataClient.save).toHaveBeenCalledTimes(1);
+    expect(metadataClient.save).toHaveBeenCalledWith('report', 'my_report', body, {
+      mode: 'draft',
     });
   });
 
-  describe('flag ON (/meta draft/publish path)', () => {
-    beforeEach(() => {
-      vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true');
+  it('persistRuntimeMetadata works for view / dashboard too', async () => {
+    const metadataClient = makeMetadataClient();
+
+    await persistRuntimeMetadata('view', 'my_view', { columns: ['name'] }, { metadataClient });
+    await persistRuntimeMetadata('dashboard', 'my_dash', { widgets: [] }, { metadataClient });
+
+    expect(metadataClient.save).toHaveBeenCalledWith('view', 'my_view', { columns: ['name'] }, {
+      mode: 'draft',
+    });
+    expect(metadataClient.save).toHaveBeenCalledWith('dashboard', 'my_dash', { widgets: [] }, {
+      mode: 'draft',
+    });
+  });
+
+  it('createRuntimeMetadata → save draft and returns the name', async () => {
+    const metadataClient = makeMetadataClient();
+    const body = { id: 'view_123', columns: ['name'] };
+
+    const id = await createRuntimeMetadata('view', 'view_123', body, { metadataClient });
+
+    expect(metadataClient.save).toHaveBeenCalledWith('view', 'view_123', body, {
+      mode: 'draft',
+    });
+    expect(id).toBe('view_123');
+  });
+
+  it('publishRuntimeMetadata → publish(type, name)', async () => {
+    const metadataClient = makeMetadataClient();
+
+    await publishRuntimeMetadata('report', 'my_report', { metadataClient });
+
+    expect(metadataClient.publish).toHaveBeenCalledWith('report', 'my_report');
+  });
+
+  it('readRuntimeDraft → unwraps get(type, name, { state: "draft" })', async () => {
+    const metadataClient = makeMetadataClient();
+    metadataClient.get.mockResolvedValue({
+      type: 'view',
+      name: 'my_view',
+      item: { columns: ['name', 'stage'] },
     });
 
-    it('isViaMeta() is true', () => {
-      expect(isViaMeta()).toBe(true);
-    });
+    const draft = await readRuntimeDraft('view', 'my_view', { metadataClient });
 
-    it('report → metadataClient.save("report", name, body, { mode: "draft" })', async () => {
-      const adapter = makeAdapter();
-      const metadataClient = makeMetadataClient();
-      const body = { title: 'Pipeline' };
+    expect(metadataClient.get).toHaveBeenCalledWith('view', 'my_view', { state: 'draft' });
+    expect(draft).toEqual({ columns: ['name', 'stage'] });
+  });
 
-      await persistRuntimeMetadata('report', 'my_report', body, {
-        adapter,
-        metadataClient,
-      });
+  it('readRuntimeDraft → null when no draft is pending', async () => {
+    const metadataClient = makeMetadataClient();
+    metadataClient.get.mockResolvedValue(null);
 
-      expect(metadataClient.save).toHaveBeenCalledTimes(1);
-      expect(metadataClient.save).toHaveBeenCalledWith('report', 'my_report', body, {
-        mode: 'draft',
-      });
-      // Legacy path must NOT run when the flag is on.
-      expect(adapter.update).not.toHaveBeenCalled();
-    });
+    const draft = await readRuntimeDraft('view', 'my_view', { metadataClient });
 
-    it('dashboard → metadataClient.save("dashboard", …, { mode: "draft" })', async () => {
-      const metadataClient = makeMetadataClient();
-      const body = { widgets: [] };
+    expect(draft).toBeNull();
+  });
 
-      await persistRuntimeMetadata('dashboard', 'my_dash', body, { metadataClient });
+  it('discardRuntimeDraft → reset(type, name, { state: "draft" })', async () => {
+    const metadataClient = makeMetadataClient();
 
-      expect(metadataClient.save).toHaveBeenCalledWith('dashboard', 'my_dash', body, {
-        mode: 'draft',
-      });
-    });
+    await discardRuntimeDraft('report', 'my_report', { metadataClient });
 
-    it('publishRuntimeMetadata → metadataClient.publish(type, name)', async () => {
-      const metadataClient = makeMetadataClient();
-
-      await publishRuntimeMetadata('report', 'my_report', { metadataClient });
-
-      expect(metadataClient.publish).toHaveBeenCalledTimes(1);
-      expect(metadataClient.publish).toHaveBeenCalledWith('report', 'my_report');
-    });
-
-    it('createRuntimeMetadata → metadataClient.save(..., { mode: "draft" }) and returns name', async () => {
-      const dataSource = { createView: vi.fn(), create: vi.fn() };
-      const metadataClient = makeMetadataClient();
-      const body = { id: 'view_123', columns: ['name'] };
-
-      const id = await createRuntimeMetadata('view', 'view_123', body, {
-        dataSource,
-        metadataClient,
-        objectName: 'crm_lead',
-      });
-
-      expect(metadataClient.save).toHaveBeenCalledWith('view', 'view_123', body, {
-        mode: 'draft',
-      });
-      expect(id).toBe('view_123');
-      // Legacy create path must NOT run when the flag is on.
-      expect(dataSource.createView).not.toHaveBeenCalled();
-      expect(dataSource.create).not.toHaveBeenCalled();
-    });
-
-    it('readRuntimeDraft → unwraps metadataClient.get(..., { state: "draft" })', async () => {
-      const metadataClient = makeMetadataClient();
-      metadataClient.get.mockResolvedValue({
-        type: 'view',
-        name: 'my_view',
-        item: { columns: ['name', 'stage'] },
-      });
-
-      const draft = await readRuntimeDraft('view', 'my_view', { metadataClient });
-
-      expect(metadataClient.get).toHaveBeenCalledWith('view', 'my_view', {
-        state: 'draft',
-      });
-      expect(draft).toEqual({ columns: ['name', 'stage'] });
-    });
-
-    it('readRuntimeDraft → null when no draft is pending', async () => {
-      const metadataClient = makeMetadataClient();
-      metadataClient.get.mockResolvedValue(null);
-
-      const draft = await readRuntimeDraft('view', 'my_view', { metadataClient });
-
-      expect(draft).toBeNull();
-    });
-
-    it('discardRuntimeDraft → metadataClient.reset(type, name, { state: "draft" })', async () => {
-      const metadataClient = makeMetadataClient();
-
-      await discardRuntimeDraft('report', 'my_report', { metadataClient });
-
-      expect(metadataClient.reset).toHaveBeenCalledWith('report', 'my_report', {
-        state: 'draft',
-      });
+    expect(metadataClient.reset).toHaveBeenCalledWith('report', 'my_report', {
+      state: 'draft',
     });
   });
 

--- a/packages/app-shell/src/views/runtime-metadata-persistence.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.ts
@@ -1,121 +1,40 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * ADR-0034 — Runtime metadata persistence seam (first code).
+ * ADR-0034 — Runtime metadata persistence seam.
  *
- * Runtime editing of **views / reports / dashboards** historically writes
- * to bespoke per-type tables (`sys_view` / `sys_report` / `sys_dashboard`)
- * with immediate, unversioned writes. ADR-0034 unifies this with studio's
- * `/meta` per-item **draft → publish → version** model.
+ * Runtime editing of **views / reports / dashboards** is unified with studio's
+ * `/meta` per-item **draft → publish → version** model. A runtime edit stages a
+ * per-item **draft** (invisible to other users, live in the editor's own
+ * preview); an explicit **publish** promotes it to the active overlay and
+ * records a version.
  *
- * This module is the single **seam** that both paths flow through, gated by
- * a feature flag:
+ * This module is the single seam every runtime persistence call flows through,
+ * so the call sites (ObjectView / ReportView / DashboardView / RuntimeDraftBar)
+ * stay decoupled from the `MetadataClient` shape.
  *
- *   • **flag OFF (default)** → reproduces today's behaviour exactly: writes
- *     to `sys_*` via the existing data-source / adapter. Zero behaviour
- *     change. Safe to merge and unit-test now.
- *   • **flag ON** → routes to `metadataClient.save(type, name, body,
- *     { mode: 'draft' })` (save-as-draft) and `metadataClient.publish(...)`.
- *
- * Scope of THIS change (deliberately small / low-risk):
- *   • The seam is wired into **ReportView** and **DashboardView** only.
- *   • **ObjectView (view)** is NOT wired yet — its `toSysViewPayload` +
- *     create-vs-update + debounce logic is more involved. The `view` branch
- *     below is written for the future, but ObjectView still runs its own
- *     legacy path today. See the `'view'` TODO in {@link persistRuntimeMetadata}.
- *   • No draft/publish UI is added here. No `sys_*` table is removed. No
- *     data migration is performed.
- *
- * The flag is read in exactly ONE place ({@link isViaMeta}) so the
- * mechanism can be swapped later (e.g. for a server-pushed runtime-config
- * capability) without touching call sites.
+ * The bespoke per-type tables (`sys_view` / `sys_report` / `sys_dashboard`) and
+ * their shape adapters have been retired — there is no longer a feature flag or
+ * a legacy write path here.
  */
-
-/**
- * Underlying flag value, read once at module init from the Vite-time env var
- * `VITE_RUNTIME_EDIT_VIA_META`. Exported as the canonical, documented name
- * for the ADR; consumers that only need the static value can read this.
- *
- * NOTE: prefer {@link isViaMeta} internally so tests can flip the flag via
- * `vi.stubEnv('VITE_RUNTIME_EDIT_VIA_META', 'true')` without relying on
- * module-load timing.
- *
- * Default: `false` (legacy `sys_*` path).
- */
-export const RUNTIME_EDIT_VIA_META: boolean =
-  readViaMetaEnv();
-
-/**
- * Read the raw env flag. Centralised so the source of truth is one place.
- *
- * In production the value comes from Vite's `import.meta.env` (inlined at
- * build time). We also consult `process.env` as a fallback so the flag is
- * togglable in Node/unit-test contexts (`vi.stubEnv`) where `import.meta.env`
- * is not patched.
- */
-function readViaMetaEnv(): boolean {
-  try {
-    if ((import.meta as any).env?.VITE_RUNTIME_EDIT_VIA_META === 'true') return true;
-  } catch {
-    // import.meta.env unavailable in this context — fall through.
-  }
-  try {
-    if (typeof process !== 'undefined' && process.env?.VITE_RUNTIME_EDIT_VIA_META === 'true') {
-      return true;
-    }
-  } catch {
-    // no process — ignore.
-  }
-  return false;
-}
-
-/**
- * Whether runtime edits should route through the `/meta` draft/publish
- * model. Reads the env flag live (not the captured constant) so unit tests
- * can toggle it with `vi.stubEnv`. This is the ONLY place the flag is
- * consulted — replace the body here to swap the flag mechanism later.
- */
-export function isViaMeta(): boolean {
-  return readViaMetaEnv();
-}
 
 /** The three runtime-editable artifact types ADR-0034 unifies. */
 export type RuntimeArtifactType = 'view' | 'report' | 'dashboard';
 
-/**
- * Everything the seam might need to persist any of the three artifact types,
- * passed by the call site. All optional so each call site only supplies what
- * its path needs (report/dashboard need `adapter`; view needs `dataSource` +
- * `toSysViewPayload`; the flag-on path needs `metadataClient`).
- */
+/** Everything the seam needs to persist any of the three artifact types. */
 export interface RuntimePersistCtx {
-  /** Studio metadata client — used by the flag-ON `/meta` path. */
-  metadataClient?: any;
-  /** Generic data source — used by the legacy `sys_view` path. */
-  dataSource?: any;
-  /** ObjectStack adapter — used by the legacy `sys_report`/`sys_dashboard` path. */
-  adapter?: any;
-  /** Object a view belongs to — first arg to `updateViewConfig`. */
-  objectName?: string;
-  /**
-   * View-only payload shaper for the CREATE legacy `sys_view` fallback. Used
-   * by {@link createRuntimeMetadata} when the data source has no `createView`.
-   * Kept as a call-site callback so the complex `toSysViewPayload` logic
-   * (default-column derivation, etc.) stays in ObjectView's UI layer; the seam
-   * only invokes it.
-   */
-  toSysViewPayload?: (cfg: any, obj?: string) => any;
+  /** Studio metadata client — the `/meta` draft/publish/version API. */
+  metadataClient: any;
 }
 
 /**
  * Unwrap a `?state=draft` GET response into its bare body, or `null` when
  * there is nothing pending.
  *
- * The framework wraps draft reads in a `{ type, name, item }` envelope (see
- * {@link MetadataClient.getDraft}); a published/legacy read is the bare body.
- * This accepts either shape and returns `null` for an empty/absent draft so
- * `!!readRuntimeDraft(...)` is a reliable "has pending changes" check. Mirrors
- * studio's `extractDraftBody` in `ResourceEditPage`.
+ * The framework wraps draft reads in a `{ type, name, item }` envelope; a
+ * published read is the bare body. This accepts either shape and returns
+ * `null` for an empty/absent draft so `!!readRuntimeDraft(...)` is a reliable
+ * "has pending changes" check. Mirrors studio's `extractDraftBody`.
  */
 export function unwrapDraftBody(
   resp: unknown,
@@ -133,111 +52,8 @@ export function unwrapDraftBody(
 }
 
 /**
- * Create a NEW runtime artifact, routed through the same seam as edits so the
- * flag controls create and update identically (ADR-0034 step / #1517).
- *
- * • flag OFF → reproduces ObjectView's legacy `handleViewCreate` write exactly:
- *   prefer the ADR-0005 overlay API (`dataSource.createView(objectName, body)`),
- *   else fall back to a physical `sys_view` insert
- *   (`dataSource.create('sys_view', toSysViewPayload(body, objectName))`).
- * • flag ON → `metadataClient.save(type, name, body, { mode: 'draft' })` — the
- *   new view is born as an invisible per-item draft, promoted by an explicit
- *   publish.
- *
- * Returns the created artifact's id/name (for auto-activation by the caller),
- * matching the legacy resolution: `created.name ?? name` for the overlay path,
- * `created.id ?? created._id` for the legacy `sys_view` insert.
- *
- * The UI-layer concerns the legacy path had (default-column derivation,
- * kanban/gallery sub-config massaging, auto-activation) stay in ObjectView;
- * only the final write call is centralised here.
- *
- * @param type artifact type (today only `view` has a create path)
- * @param name best-known identifier for the new item (the draft `:name` when
- *   flag ON; also the createView fallback id when the server omits one)
- * @param body the spec/config to persist
- * @param ctx  call-site capabilities (see {@link RuntimePersistCtx})
- */
-export async function createRuntimeMetadata(
-  type: RuntimeArtifactType,
-  name: string,
-  body: any,
-  ctx: RuntimePersistCtx,
-): Promise<string | undefined> {
-  if (isViaMeta()) {
-    // ── flag ON: create-as-draft via the unified /meta model ──
-    await ctx.metadataClient.save(type, name, body, { mode: 'draft' });
-    return name;
-  }
-
-  // ── flag OFF: legacy create write (today's `handleViewCreate` behaviour) ──
-  switch (type) {
-    case 'view': {
-      if (typeof ctx.dataSource?.createView === 'function') {
-        const created = await ctx.dataSource.createView(ctx.objectName, body);
-        return (created as any)?.name ?? name;
-      }
-      if (ctx.dataSource?.create) {
-        const payload = ctx.toSysViewPayload
-          ? ctx.toSysViewPayload(body, ctx.objectName)
-          : body;
-        const created = await ctx.dataSource.create('sys_view', payload);
-        return (created as any)?.id ?? (created as any)?._id;
-      }
-      return undefined;
-    }
-    // report/dashboard creation is not (yet) a runtime path — only update is.
-    default:
-      return undefined;
-  }
-}
-
-/**
- * Read the pending draft body for a runtime artifact (for the "unpublished
- * changes" indicator and resume-on-open). Returns the bare body, or `null`
- * when nothing is pending.
- *
- * • flag OFF → always `null`: the legacy `sys_*` model has no draft concept.
- * • flag ON  → `metadataClient.get(type, name, { state: 'draft' })`, unwrapped.
- */
-export async function readRuntimeDraft<T = Record<string, unknown>>(
-  type: RuntimeArtifactType,
-  name: string,
-  ctx: RuntimePersistCtx,
-): Promise<T | null> {
-  if (!isViaMeta()) return null;
-  const resp = await ctx.metadataClient.get(type, name, { state: 'draft' });
-  return unwrapDraftBody(resp) as T | null;
-}
-
-/**
- * Discard the pending draft of a runtime artifact (Studio's "Discard draft").
- * The published overlay is untouched.
- *
- * • flag OFF → **no-op**: there is no draft to discard in the legacy model.
- * • flag ON  → `metadataClient.reset(type, name, { state: 'draft' })`.
- */
-export async function discardRuntimeDraft(
-  type: RuntimeArtifactType,
-  name: string,
-  ctx: RuntimePersistCtx,
-): Promise<void> {
-  if (!isViaMeta()) return;
-  await ctx.metadataClient.reset(type, name, { state: 'draft' });
-}
-
-/**
- * Persist a runtime edit of a view / report / dashboard.
- *
- * • flag OFF → legacy `sys_*` write (behaviour identical to before this seam).
- * • flag ON  → `metadataClient.save(type, name, body, { mode: 'draft' })`
- *   (save-as-draft; an explicit publish promotes it — see
- *   {@link publishRuntimeMetadata}).
- *
- * @param type artifact type
- * @param name artifact name (the `:name` in `/meta/:type/:name`)
- * @param body the spec/schema/config to persist
- * @param ctx  call-site capabilities (see {@link RuntimePersistCtx})
+ * Persist a runtime edit of a view / report / dashboard as a per-item DRAFT
+ * (invisible to other users until {@link publishRuntimeMetadata}).
  */
 export async function persistRuntimeMetadata(
   type: RuntimeArtifactType,
@@ -245,60 +61,58 @@ export async function persistRuntimeMetadata(
   body: any,
   ctx: RuntimePersistCtx,
 ): Promise<void> {
-  if (isViaMeta()) {
-    // ── flag ON: unified studio path ──
-    // Default to a per-item DRAFT (invisible to other users until publish).
-    // `MetadataClient.save(type, name, item, { mode })` is the real write API
-    // (PUT /meta/:type/:name) — the same one studio's editor uses.
-    await ctx.metadataClient.save(type, name, body, { mode: 'draft' });
-    return;
-  }
-
-  // ── flag OFF: legacy per-type tables (today's behaviour) ──
-  switch (type) {
-    case 'view': {
-      // ObjectView's UPDATE path goes through the adapter's `updateViewConfig`
-      // (the ADR-0005 overlay API), NOT a raw `sys_view` write — only the
-      // CREATE legacy fallback touches the physical table. So the flag-OFF
-      // view branch mirrors that update call exactly. The view CREATE path
-      // (`createView` + default-columns / kanban / gallery massaging) is more
-      // involved and is NOT wired to the seam yet (see ADR-0034 rollout).
-      await ctx.dataSource.updateViewConfig(ctx.objectName, name, body);
-      return;
-    }
-    case 'report': {
-      await ctx.adapter.update('sys_report', name, body);
-      return;
-    }
-    case 'dashboard': {
-      if (ctx.adapter?.updateDashboard) {
-        await ctx.adapter.updateDashboard(name, body);
-      } else {
-        await ctx.adapter.update('sys_dashboard', name, body);
-      }
-      return;
-    }
-  }
+  await ctx.metadataClient.save(type, name, body, { mode: 'draft' });
 }
 
 /**
- * Publish a previously-staged runtime edit.
- *
- * • flag OFF → **no-op**: the legacy `sys_*` model has no draft concept;
- *   writes were already live, so there is nothing to publish.
- * • flag ON  → `metadataClient.publish(type, name)` promotes the pending
- *   draft to the active overlay and records a version.
- *
- * This change does NOT add publish UI — that is a later, flag-gated step.
+ * Create a NEW runtime artifact as a per-item draft. Returns its name (for the
+ * caller's auto-activation). UI-layer concerns (default columns, kanban/gallery
+ * sub-config, auto-activation) stay in the call site.
+ */
+export async function createRuntimeMetadata(
+  type: RuntimeArtifactType,
+  name: string,
+  body: any,
+  ctx: RuntimePersistCtx,
+): Promise<string | undefined> {
+  await ctx.metadataClient.save(type, name, body, { mode: 'draft' });
+  return name;
+}
+
+/**
+ * Read the pending draft body for a runtime artifact (for the "unpublished
+ * changes" indicator and resume-on-open). Returns the bare body, or `null`
+ * when nothing is pending.
+ */
+export async function readRuntimeDraft<T = Record<string, unknown>>(
+  type: RuntimeArtifactType,
+  name: string,
+  ctx: RuntimePersistCtx,
+): Promise<T | null> {
+  const resp = await ctx.metadataClient.get(type, name, { state: 'draft' });
+  return unwrapDraftBody(resp) as T | null;
+}
+
+/**
+ * Discard the pending draft of a runtime artifact (Studio's "Discard draft").
+ * The published overlay is untouched.
+ */
+export async function discardRuntimeDraft(
+  type: RuntimeArtifactType,
+  name: string,
+  ctx: RuntimePersistCtx,
+): Promise<void> {
+  await ctx.metadataClient.reset(type, name, { state: 'draft' });
+}
+
+/**
+ * Publish a previously-staged runtime edit: promote the pending draft to the
+ * active overlay and record a version.
  */
 export async function publishRuntimeMetadata(
   type: RuntimeArtifactType,
   name: string,
   ctx: RuntimePersistCtx,
 ): Promise<void> {
-  if (!isViaMeta()) {
-    // Legacy model: save was already live; nothing to publish.
-    return;
-  }
   await ctx.metadataClient.publish(type, name);
 }

--- a/packages/app-shell/src/views/view-config-adapter.ts
+++ b/packages/app-shell/src/views/view-config-adapter.ts
@@ -8,7 +8,7 @@
  *
  *   { id, label, type, columns, filter, sort, … }
  *
- * (already decoded from the `sys_view` record by `fromSysViewRecord`).
+ * (read from the metadata overlay via the adapter's `listViews`).
  *
  * The studio {@link ViewVariantInspector} authors a canonical ViewItem draft
  * (ADR-0017, "Object has-many View"):
@@ -19,9 +19,9 @@
  * bound object additionally lives at `config.data.object` for list views.
  *
  * This adapter converts both ways so the runtime panel can host the studio
- * inspector without changing the `sys_view` persistence path: edits are kept
- * as a ViewItem draft while the panel is open, then flattened back to the
- * runtime view shape on update / save / create.
+ * inspector: edits are kept as a ViewItem draft while the panel is open, then
+ * flattened back to the runtime view shape on update / save / create (which
+ * persist via the metadata draft/publish model).
  */
 
 /** View `type`s that belong to the FORM family (no column list). */


### PR DESCRIPTION
Closes the ADR-0034 rollout: runtime view/report/dashboard editing now persists **only** through the metadata **draft → publish → version** model. The bespoke per-type tables and the feature flag that fronted them are removed. System is pre-launch, so **no data migration** (per direction on #1516).

## What changed

**Seam (`runtime-metadata-persistence.ts`)** — dropped the `VITE_RUNTIME_EDIT_VIA_META` flag and every legacy branch. `persist`/`create`/`read`/`discard`/`publish` are thin wrappers over `MetadataClient`; ctx is just `{ metadataClient }`.

**Chrome (`RuntimeDraftBar`)** — no longer flag-gated; renders whenever a draft exists.

**ObjectView**
- Saved views read **only** via the metadata overlay (`listViews`); dropped `find('sys_view')`.
- Rename / delete / pin / set-default / reorder use `updateView`/`deleteView` only; dropped the `update/delete('sys_view')` fallbacks.
- Save/create persist via the seam; deleted the `toSysViewPayload` / `fromSysViewRecord` shape adapters.

**ReportView / DashboardView** — dropped the `adapter.update('sys_report'|'sys_dashboard', …)` fallback.

## Verification (real showcase backend)
- View list loads from metadata (no `sys_view`) ✅
- Edit → draft → **Publish** records a version ✅
- **Rename** persists to the overlay (`updateView`) ✅
- No active `sys_*` reference remains in `app-shell` ✅

## Checks
- `pnpm turbo build --filter=@object-ui/app-shell` green
- `vitest packages/app-shell/src/views` → **197 passing**
- lint: 0 new errors (ObjectView's pre-existing `rules-of-hooks` count went 52 → 51)

## Out of scope (separate framework-repo change)
Dropping the physical `sys_view` / `sys_report` / `sys_dashboard` **object schemas + auto CRUD endpoints** lives in the backend (`framework`) repo — the frontend no longer references them, so the tables are now dead and can be removed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)