### PR TITLE
chore(adr-0034): mark ADR Implemented + refresh runtime read after publish

### DIFF
--- a/docs/adr/0034-unified-runtime-metadata-persistence.md
+++ b/docs/adr/0034-unified-runtime-metadata-persistence.md
@@ -1,6 +1,6 @@
 # ADR-0034: Runtime editing reuses studio's per-item draft → publish → version model (retire `sys_view` / `sys_report` / `sys_dashboard`)
 
-**Status**: Proposed (2026-06-06)
+**Status**: Implemented (2026-06-06) — see [#1533](https://github.com/objectstack-ai/objectui/pull/1533) (chrome + view-create seam) and [#1534](https://github.com/objectstack-ai/objectui/pull/1534) (retire `sys_*`, drop the flag).
 **Author**: ObjectUI renderer team
 **Consumers**: `@object-ui/app-shell` (ObjectView / ReportView / DashboardView + metadata-admin), `@object-ui/data-objectstack` (metadata client), and the ObjectStack backend (`/api/v1/meta/*`).
 
@@ -53,10 +53,10 @@ Runtime panels gain a small **draft/publish chrome** (Save draft · Publish · "
 ## Rollout (flagged, reversible, back-compat)
 
 1. **(done)** Unify the editing UI (#1496/#1503/#1504/#1505) and gate report/dashboard editing (#1508).
-2. **Seam (this ADR's first code):** a single `persistRuntimeMetadata(type, name, draft, …)` (+ `publishRuntimeMetadata`). Behind a flag (default **off**) it routes to the existing `sys_*` writes — **zero behaviour change** — so it is safe to merge and unit-test now. Flag **on** routes to `metadataClient` draft/publish.
-3. **UI:** add the draft/publish chrome to the runtime panels, flag-gated.
-4. **Verify in a real environment** (this sandbox has no backend; the save→draft→publish→read round trip cannot be verified here). Then flip the default.
-5. **Retire:** migrate existing `sys_*` rows → published overlays (dual-read window), drop the tables, delete the shape adapters.
+2. **(done)** Seam — `persistRuntimeMetadata` / `publishRuntimeMetadata` (#1513/#1514), behind the `VITE_RUNTIME_EDIT_VIA_META` flag (default off) routing to the legacy `sys_*` writes; flag on → `metadataClient` draft/publish.
+3. **(done)** UI — the draft/publish chrome on the runtime panels (#1515), plus the view-create path through the seam (#1517).
+4. **(done)** Verified in a real environment (the app-showcase backend): save→draft→publish→version, resume-on-open, discard, and rename-via-overlay all confirmed end-to-end (#1518).
+5. **(done)** Retire — the flag and all legacy `sys_*` write/read/fallback paths + shape adapters were removed (#1534); runtime editing is now metadata-only. The system was pre-launch, so **no data migration** was needed. Note: the physical `sys_view`/`sys_report`/`sys_dashboard` tables/object-schemas turned out **never to have existed** on this backend (only the metadata overlay + `sys_metadata` were ever used), so there were no tables to drop.
 
 ## Risks
 

--- a/packages/app-shell/src/views/DashboardConfigPanel.tsx
+++ b/packages/app-shell/src/views/DashboardConfigPanel.tsx
@@ -63,6 +63,8 @@ export interface DashboardConfigPanelProps<
    * ({@link RuntimeDraftBar}).
    */
   metadataClient?: any;
+  /** Called after a publish / discard so the host can refresh its read. */
+  onAfterChange?: () => void;
 }
 
 export function DashboardConfigPanel<
@@ -78,6 +80,7 @@ export function DashboardConfigPanel<
   onRemoveWidget,
   name: artifactName,
   metadataClient,
+  onAfterChange,
 }: DashboardConfigPanelProps<T>) {
   const { t } = useObjectTranslation();
   const locale = useMemo(() => detectLocale(), []);
@@ -220,6 +223,7 @@ export function DashboardConfigPanel<
           dirty={dirty}
           onResume={handleResumeDraft}
           savedSignal={savedSignal}
+          onAfterChange={onAfterChange}
         />
         <Button
           size="sm"

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -95,8 +95,7 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
   const { dashboardName } = useParams<{ dashboardName: string }>();
   const { showDebug } = useMetadataInspector();
   const adapter = useAdapter();
-  // ADR-0034 seam: used only when the runtime-via-/meta flag is ON; the
-  // flag-OFF default still writes to `sys_dashboard` via the adapter below.
+  // ADR-0034: dashboard edits persist via the metadata draft/publish model.
   const metadataClient = useMetadataClient();
   const { t } = useObjectTranslation();
   const { dashboardLabel, dashboardDescription } = useObjectLabel();
@@ -436,6 +435,7 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
            onRemoveWidget={removeWidget}
            name={dashboardName}
            metadataClient={metadataClient}
+           onAfterChange={() => refresh().catch(() => {})}
          />
 
          <MetadataPanel

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -2001,6 +2001,7 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
                         onViewUpdate={handleViewUpdate}
                         onCreate={handleViewCreate}
                         metadataClient={metadataClient}
+                        onAfterChange={() => setRefreshKey(k => k + 1)}
                     />
                 </div>
                 <CreateViewDialog

--- a/packages/app-shell/src/views/ReportConfigPanel.tsx
+++ b/packages/app-shell/src/views/ReportConfigPanel.tsx
@@ -62,6 +62,8 @@ export interface ReportConfigPanelProps {
    * ({@link RuntimeDraftBar}).
    */
   metadataClient?: any;
+  /** Called after a publish / discard so the host can refresh its read. */
+  onAfterChange?: () => void;
 }
 
 /** Map the host's `{ value, label, type }` fields into the inspector's catalog. */
@@ -84,6 +86,7 @@ export function ReportConfigPanel({
   availableFields,
   name,
   metadataClient,
+  onAfterChange,
 }: ReportConfigPanelProps) {
   const { t } = useObjectTranslation();
   const locale = useMemo(() => detectLocale(), []);
@@ -186,6 +189,7 @@ export function ReportConfigPanel({
           metadataClient={metadataClient}
           dirty={dirty}
           onResume={handleResumeDraft}
+          onAfterChange={onAfterChange}
         />
         <Button variant="ghost" size="sm" onClick={handleDiscard} data-testid="report-config-discard">
           {t('common.cancel', { defaultValue: 'Cancel' })}

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -37,8 +37,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   const { reportName } = useParams<{ reportName: string }>();
   const { showDebug } = useMetadataInspector();
   const adapter = useAdapter();
-  // ADR-0034 seam: used only when the runtime-via-/meta flag is ON; the
-  // flag-OFF default still writes to `sys_report` via the adapter below.
+  // ADR-0034: report edits persist via the metadata draft/publish model.
   const metadataClient = useMetadataClient();
   // Editing a report mutates the SHARED definition, so it is an admin-only
   // quick-edit affordance (mirrors ObjectView's view-config gate).
@@ -481,6 +480,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
            getFieldsForObject={getFieldsForObject}
            name={reportName}
            metadataClient={metadataClient}
+           onAfterChange={() => refresh().catch(() => {})}
          />
 
          <MetadataPanel

--- a/packages/app-shell/src/views/ViewConfigPanel.tsx
+++ b/packages/app-shell/src/views/ViewConfigPanel.tsx
@@ -76,6 +76,8 @@ export interface ViewConfigPanelProps {
      * chrome ({@link RuntimeDraftBar}).
      */
     metadataClient?: any;
+    /** Called after a publish / discard so the host can refresh its read. */
+    onAfterChange?: () => void;
 }
 
 /**
@@ -97,7 +99,7 @@ function mapObjectFields(objectDef: ViewConfigPanelProps['objectDef']): ObjectFi
     });
 }
 
-export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, objectDef, onViewUpdate, onSave, onCreate, metadataClient }: ViewConfigPanelProps) {
+export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, objectDef, onViewUpdate, onSave, onCreate, metadataClient, onAfterChange }: ViewConfigPanelProps) {
     const { t } = useObjectTranslation();
     const panelRef = useRef<HTMLDivElement>(null);
     const locale = useMemo(() => detectLocale(), []);
@@ -255,6 +257,7 @@ export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, obje
                         dirty={isDirty}
                         onResume={handleResumeDraft}
                         savedSignal={savedSignal}
+                        onAfterChange={onAfterChange}
                     />
                 )}
                 <Button


### PR DESCRIPTION
Final tidy-up after the ADR-0034 epic (#1533, #1534).

## 1. ADR-0034 status → Implemented
`docs/adr/0034-…md`: **Proposed → Implemented**; rollout steps 2–5 marked done with as-built notes (verified on app-showcase; flag + `sys_*` paths removed; the physical `sys_view`/`sys_report`/`sys_dashboard` tables turned out never to have existed on this backend, so there was nothing to migrate or drop).

## 2. Refresh runtime read after Publish/Discard
Wire `onAfterChange` from each runtime config panel's `RuntimeDraftBar` to the host's refresh:
- **ObjectView** → `setRefreshKey(k+1)`
- **ReportView / DashboardView** → `refresh()`

Before this, after publishing a view edit the **tab label only updated on reopen**. Now the runtime re-reads the artifact in place.

### Verified (showcase backend)
Edit view label → Save (draft) → **Publish** → the active view tab updates **"All Leads" → "All Leads (refresh test)" in place, no reopen** ✅ (then restored).

## Checks
- `pnpm turbo build --filter=@object-ui/app-shell` green
- `vitest packages/app-shell/src/views` → **197 passing**
- lint: 0 new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)