### PR TITLE
fix(app-shell): resolve 51 rules-of-hooks errors in ObjectView

### DIFF
--- a/.changeset/objectview-rules-of-hooks.md
+++ b/.changeset/objectview-rules-of-hooks.md
@@ -1,0 +1,7 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(app-shell): resolve 51 react-hooks/rules-of-hooks errors in ObjectView
+
+ObjectView had a mid-component early return (`if (!objectDef) return …`) sitting before ~50 hooks, which violated the Rules of Hooks and risked a `Rendered fewer hooks than expected` crash if `objectDef` flipped present→absent→present on a live instance (object switch, metadata refresh, reload failure). Split the component so the missing-object empty state lives in a thin `ObjectView` wrapper, while `ObjectViewInner` (mounted only when the definition exists) calls all hooks unconditionally. Behavior is unchanged.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -107,6 +107,51 @@ function substituteFilterTokens(filter: any, currentUserId: string | undefined):
 }
 
 export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: any) {
+    const { objectName } = useParams();
+    const { t } = useObjectTranslation();
+
+    // Resolve the object definition up front. When it's missing we render the
+    // "object not found" empty state *here*, before the inner component mounts.
+    // This is the key to keeping the Rules of Hooks satisfied: ObjectViewInner
+    // holds ~50 hooks and must call them unconditionally, so the missing-object
+    // branch lives in this thin wrapper instead of as a mid-component early
+    // return. The inner subtree then mounts/unmounts as a whole (object exists
+    // ↔ doesn't) rather than toggling the number of hooks executed per render.
+    const objectDef = objects.find((o: any) => o.name === objectName);
+    if (!objectDef) {
+      return (
+        <div className="h-full p-4 flex items-center justify-center">
+          <Empty>
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <TableIcon className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <EmptyTitle>{t('console.objectView.objectNotFound')}</EmptyTitle>
+            <EmptyDescription>
+              {t('console.objectView.objectNotFoundDescription', { objectName })}
+              {' '}
+              {t('console.objectView.objectNotFoundHint')}
+            </EmptyDescription>
+          </Empty>
+        </div>
+      );
+    }
+
+    return (
+      <ObjectViewInner
+        dataSource={dataSource}
+        objects={objects}
+        onEdit={onEdit}
+        externalRefreshKey={externalRefreshKey}
+      />
+    );
+}
+
+/**
+ * Inner ObjectView body. Only mounted by {@link ObjectView} once the object
+ * definition is known to exist, so every hook below runs unconditionally on
+ * every render of this component — no early return sits between hook calls.
+ */
+function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: any) {
     const navigate = useNavigate();
     const { appName, objectName, viewId } = useParams();
     const [searchParams, setSearchParams] = useSearchParams();
@@ -259,26 +304,10 @@ export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: 
     const isAdmin = user?.role === 'admin';
     const { can } = usePermissions();
     
-    // Get Object Definition
+    // Get Object Definition. The outer ObjectView wrapper already guards the
+    // missing-object case, so this always resolves while this component is
+    // mounted — every hook below can therefore run unconditionally.
     const objectDef = objects.find((o: any) => o.name === objectName);
-
-    if (!objectDef) {
-      return (
-        <div className="h-full p-4 flex items-center justify-center">
-          <Empty>
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-              <TableIcon className="h-6 w-6 text-muted-foreground" />
-            </div>
-            <EmptyTitle>{t('console.objectView.objectNotFound')}</EmptyTitle>
-            <EmptyDescription>
-              {t('console.objectView.objectNotFoundDescription', { objectName })}
-              {' '}
-              {t('console.objectView.objectNotFoundHint')}
-            </EmptyDescription>
-          </Empty>
-        </div>
-      );
-    }
 
     // Refresh trigger — bumped after view CRUD or external data mutations.
     const [refreshKey, setRefreshKey] = useState(0);


### PR DESCRIPTION
## Problem

`packages/app-shell/src/views/ObjectView.tsx` had a mid-component **early return** (`if (!objectDef) return <empty state>`) sitting *before* ~50 hooks, producing **51 `react-hooks/rules-of-hooks` lint errors** — the only errors in the file (everything else is warnings).

Beyond lint, this was a latent bug. React identifies hooks by call order, requiring the same number/order of hook calls every render. On a single live instance:
- `objectDef` missing → early return → the trailing ~51 hooks **don't run**
- `objectDef` present → the trailing ~51 hooks **run**

If `objectDef` flips present → absent → present on a mounted instance (switching objects, a metadata refresh briefly clearing, a reload failure), React mismatches hook state → `Rendered fewer hooks than expected` crash, or stale/cross-wired state.

## Fix

Applied the canonical React split:

- A thin **`ObjectView`** wrapper (same public name/signature, so callers are unaffected) does the `objects.find` lookup and renders the "object not found" empty state.
- It mounts a new **`ObjectViewInner`** component only when `objectDef` exists. The inner component holds all the hooks and calls them **unconditionally** — no early return between hook calls.

The inner subtree now mounts/unmounts as a whole (object exists ↔ doesn't) instead of toggling the number of hooks executed per render. This is behavior-preserving and avoids sprinkling ~60 null-guards through the hook bodies.

## Verification

- `npx eslint ObjectView.tsx`: **51 errors → 0 errors** (warning count unchanged in kind — pre-existing `no-explicit-any` / `exhaustive-deps` / `no-unused-vars`).
- `pnpm --filter @object-ui/app-shell type-check`: clean (with workspace deps built).
- `vitest run` over app-shell + plugin-view ObjectView tests: **332 passed**.

Closes #1536

https://claude.ai/code/session_01Jk9LBuYfJdsnCrSusGvDtH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jk9LBuYfJdsnCrSusGvDtH)_