### PR TITLE
docs(plugin-view): Duplicate-view = intentional opt-in; fix stale tooltip

### DIFF
--- a/packages/plugin-view/src/ManageViewsDialog.tsx
+++ b/packages/plugin-view/src/ManageViewsDialog.tsx
@@ -77,6 +77,11 @@ export interface ManageViewsDialogProps {
   // --- Action callbacks (reuse the same handlers from ObjectView) ---
   onRename?: (viewId: string, newName: string) => void;
   onDelete?: (viewId: string) => void;
+  /**
+   * Opt-in duplicate action — the row's "Duplicate" button renders only when
+   * wired. Deliberate generic affordance (not dead code); the console defers
+   * view duplication to per-user personalisation (objectui#1520). Omit to hide.
+   */
   onDuplicate?: (viewId: string) => void;
   onSetDefault?: (viewId: string) => void;
   onSetPinned?: (viewId: string, pinned: boolean) => void;

--- a/packages/plugin-view/src/ViewTabBar.tsx
+++ b/packages/plugin-view/src/ViewTabBar.tsx
@@ -164,7 +164,14 @@ export interface ViewTabBarProps {
   onAddView?: () => void;
   /** Called when a view is renamed via context menu or double-click */
   onRenameView?: (viewId: string, newName: string) => void;
-  /** Called when a view is duplicated */
+  /**
+   * Called when a view is duplicated. **Opt-in**: the Duplicate menu item
+   * renders only when a host wires this. It is a deliberate generic affordance
+   * of this reusable tab bar (duplicate = a fresh override, even for read-only
+   * views) — not dead code. The console currently does not wire it (runtime
+   * view duplication is deferred to the per-user personalisation work,
+   * objectui#1520); omit the prop to hide the affordance.
+   */
   onDuplicateView?: (viewId: string) => void;
   /** Called when a view is deleted */
   onDeleteView?: (viewId: string) => void;
@@ -477,7 +484,7 @@ export const ViewTabBar: React.FC<ViewTabBarProps> = ({
               />
             </TooltipTrigger>
             <TooltipContent side="bottom" className="text-xs">
-              {view.readonlyReason || viewTabLabel('view.readonlyTooltip', 'System view — duplicate to customize.')}
+              {view.readonlyReason || viewTabLabel('view.readonlyTooltip', 'System view — defined in code, read-only.')}
             </TooltipContent>
           </Tooltip>
         )}


### PR DESCRIPTION
Follow-up cleanup after the ADR-0034 work, covering two loose ends.

## 3. plugin-view "Duplicate view" — keep as intentional opt-in (not dead code)
After the console removed its view-duplication wiring (#1533, deferred to per-user personalisation #1520), the `Duplicate` UI in `ViewTabBar` / `ManageViewsDialog` / `ViewSwitcher` had no consumer.

**Decision: keep it.** `plugin-view` is a generic, reusable view-switcher; Duplicate is a deliberate affordance (produces a *fresh override*, even for read-only views — already documented on `readonly`). Deleting a library's opt-in capability because the one app stopped wiring it would couple the library to a product decision. No consumer/test uses it today, but that's true of many optional library props.

- Documented `onDuplicateView` / `onDuplicate` as intentional **opt-in** (with a pointer to #1520) so they aren't mistaken for dead code.
- Fixed the one genuinely-misleading string: the `view.readonlyTooltip` hardcoded fallback no longer says "duplicate to customize" → now "System view — defined in code, read-only." (matches the i18n value).

## 4. Doc audit (sys_* references) — no change needed
The only **design** doc referencing `sys_view`/`sys_report`/`sys_dashboard` is ADR-0034, already annotated **Implemented** with the "these tables never existed on this backend" note. CHANGELOG / ROADMAP / changesets are append-only **historical records** that correctly describe the work as-done — left unchanged.

## Checks
- `pnpm turbo build --filter=@object-ui/plugin-view` green
- lint: 0 new errors (ViewTabBar's 3 `rules-of-hooks` are pre-existing, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)