### PR TITLE
feat(detail): derive related lists from relationships (read-side mirror of inlineEdit)

### DIFF
--- a/e2e/live/detail-related-list.spec.ts
+++ b/e2e/live/detail-related-list.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Live e2e for relationship-derived DETAIL-PAGE related lists — the read-side
+ * mirror of `inlineEdit`.
+ *
+ * `showcase_project.account` is a lookup → showcase_account, so the Account's
+ * record detail page must auto-render a "Projects" related list with NO page
+ * config (derived from the relationship by `deriveRelatedLists`). The list's
+ * title/columns come from `relatedListTitle` / `relatedListColumns` declared on
+ * the relationship. We open an Account record and assert the Projects related
+ * list is present.
+ */
+test('Account detail page auto-renders a relationship-derived Projects related list', async ({ page }) => {
+  // 1) Open the Accounts list and drill into the first record.
+  await page.goto('/apps/showcase_app/showcase_account');
+
+  // The data grid renders the primary (name) cell as a link. Clicking it opens
+  // the record (the list uses a split-pane drawer keyed by `?recordId=`). Grab
+  // the id and navigate to the canonical full-page detail route.
+  const firstRowNameLink = page.getByRole('row').nth(1).getByRole('link').first();
+  await firstRowNameLink.waitFor({ state: 'visible', timeout: 15_000 });
+  await firstRowNameLink.click();
+
+  await page.waitForURL(/[?&]recordId=/, { timeout: 15_000 });
+  const recordId = new URL(page.url()).searchParams.get('recordId');
+  expect(recordId).toBeTruthy();
+
+  // 2) Open the canonical full-page detail (synthesized record page).
+  await page.goto(`/apps/showcase_app/showcase_account/record/${recordId}`);
+  await expect(page).toHaveURL(/\/showcase_account\/record\//, { timeout: 15_000 });
+
+  // 3) The synthesized detail page groups related lists under a "Related" tab.
+  //    This tab only exists because `deriveRelatedLists` found the
+  //    showcase_project.account relationship — it's the read-side mirror at work.
+  const relatedTab = page.getByRole('tab', { name: /^Related$/i });
+  await relatedTab.waitFor({ state: 'visible', timeout: 15_000 });
+  await relatedTab.click();
+
+  // 4) The relationship-derived related list renders with the declared
+  //    `relatedListTitle` ("Projects") and the override columns. Assert the
+  //    list header and a derived column are present in the Related panel.
+  const relatedPanel = page.getByRole('tabpanel', { name: /Related/i });
+  await expect(relatedPanel.getByText('Projects', { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+  // `relatedListColumns` → the Health column header is one of the declared
+  // overrides (it would not appear in a naive all-fields derivation order).
+  await expect(relatedPanel.getByText(/Health/i).first()).toBeVisible({ timeout: 15_000 });
+});

--- a/packages/app-shell/src/utils/__tests__/deriveRelatedLists.test.ts
+++ b/packages/app-shell/src/utils/__tests__/deriveRelatedLists.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { deriveRelatedLists } from '../deriveRelatedLists';
+
+const project = { name: 'project', label: 'Project', fields: { name: { type: 'text' } } };
+
+describe('deriveRelatedLists', () => {
+  it('returns [] for missing object or empty registry', () => {
+    expect(deriveRelatedLists(undefined, [])).toEqual([]);
+    expect(deriveRelatedLists(project, [])).toEqual([]);
+    expect(deriveRelatedLists(project, null as any)).toEqual([]);
+  });
+
+  it('derives a related list from a master_detail child (owned)', () => {
+    const task = {
+      name: 'task',
+      label: 'Task',
+      fields: { project: { type: 'master_detail', reference: 'project' } },
+    };
+    const out = deriveRelatedLists(project, [project, task]);
+    expect(out).toEqual([
+      {
+        childObject: 'task',
+        childLabel: 'Task',
+        referenceField: 'project',
+        isOwned: true,
+      },
+    ]);
+  });
+
+  it('derives a related list from a lookup child', () => {
+    const note = {
+      name: 'note',
+      label: 'Note',
+      fields: { project_id: { type: 'lookup', reference: 'project' } },
+    };
+    const out = deriveRelatedLists(project, [project, note]);
+    expect(out[0]).toMatchObject({ childObject: 'note', referenceField: 'project_id', isOwned: false });
+  });
+
+  it('supports reference_to as well as reference', () => {
+    const task = {
+      name: 'task',
+      fields: { project: { type: 'master_detail', reference_to: 'project' } },
+    };
+    const out = deriveRelatedLists(project, [project, task]);
+    expect(out).toHaveLength(1);
+    expect(out[0].childObject).toBe('task');
+  });
+
+  it('orders owned (master_detail) children before lookup children', () => {
+    const note = { name: 'note', fields: { project_id: { type: 'lookup', reference: 'project' } } };
+    const task = { name: 'task', fields: { project: { type: 'master_detail', reference: 'project' } } };
+    // note declared before task, but task is owned → owned wins ordering
+    const out = deriveRelatedLists(project, [project, note, task]);
+    expect(out.map((r) => r.childObject)).toEqual(['task', 'note']);
+  });
+
+  it('suppresses a child when relatedList === false', () => {
+    const task = {
+      name: 'task',
+      fields: { project: { type: 'master_detail', reference: 'project', relatedList: false } },
+    };
+    expect(deriveRelatedLists(project, [project, task])).toEqual([]);
+  });
+
+  it('skips audit FKs (created_by/updated_by/owner_id)', () => {
+    const log = {
+      name: 'log',
+      fields: {
+        created_by: { type: 'lookup', reference: 'project' },
+        owner_id: { type: 'lookup', reference: 'project' },
+      },
+    };
+    expect(deriveRelatedLists(project, [project, log])).toEqual([]);
+  });
+
+  it('carries relatedListTitle and relatedListColumns overrides', () => {
+    const task = {
+      name: 'task',
+      label: 'Task',
+      fields: {
+        project: {
+          type: 'master_detail',
+          reference: 'project',
+          relatedListTitle: 'Project Tasks',
+          relatedListColumns: ['name', 'status'],
+        },
+      },
+    };
+    const out = deriveRelatedLists(project, [project, task]);
+    expect(out[0]).toMatchObject({
+      title: 'Project Tasks',
+      columns: ['name', 'status'],
+    });
+  });
+
+  it('dedupes to one related list per child object (first eligible FK wins)', () => {
+    const assignment = {
+      name: 'assignment',
+      fields: {
+        project: { type: 'master_detail', reference: 'project' },
+        secondary_project: { type: 'lookup', reference: 'project' },
+      },
+    };
+    const out = deriveRelatedLists(project, [project, assignment]);
+    expect(out).toHaveLength(1);
+    expect(out[0].referenceField).toBe('project');
+  });
+
+  it('skips a suppressed FK but still considers a sibling FK on the same child', () => {
+    const assignment = {
+      name: 'assignment',
+      fields: {
+        legacy_project: { type: 'lookup', reference: 'project', relatedList: false },
+        project: { type: 'master_detail', reference: 'project' },
+      },
+    };
+    const out = deriveRelatedLists(project, [project, assignment]);
+    expect(out).toHaveLength(1);
+    expect(out[0].referenceField).toBe('project');
+  });
+
+  it('ignores unrelated objects and self-references', () => {
+    const other = { name: 'other', fields: { foo: { type: 'lookup', reference: 'somethingelse' } } };
+    const selfRef = { name: 'project', fields: { parent: { type: 'tree', reference: 'project' } } };
+    expect(deriveRelatedLists(project, [project, other, selfRef])).toEqual([]);
+  });
+
+  it('handles array-shaped fields', () => {
+    const task = {
+      name: 'task',
+      label: 'Task',
+      fields: [{ name: 'project', type: 'master_detail', reference: 'project' }],
+    };
+    const out = deriveRelatedLists(project, [project, task]);
+    expect(out[0]).toMatchObject({ childObject: 'task', referenceField: 'project', isOwned: true });
+  });
+});

--- a/packages/app-shell/src/utils/deriveRelatedLists.ts
+++ b/packages/app-shell/src/utils/deriveRelatedLists.ts
@@ -1,0 +1,112 @@
+/**
+ * deriveRelatedLists — the read-side mirror of `attachInlineSubforms`.
+ *
+ * Where `inlineEdit: true` on a child's `master_detail`/`lookup` field pulls
+ * that child INTO the parent's entry form (write side), the detail-page
+ * RELATED LIST is the read-side counterpart: a child collection surfaced on the
+ * parent's record DETAIL page. Both intents live on the relationship in the
+ * data model — not in a hand-authored page.
+ *
+ * This helper scans every object for fields whose `reference`/`reference_to`
+ * points back at the parent object and produces one related-list descriptor per
+ * child collection. The detail page (`RecordDetailView`) feeds these into the
+ * `record:related_list` renderers (and the legacy `DetailView.related`).
+ *
+ * Rules (kept in lockstep with the relationship-level `relatedList` spec flag):
+ *   - Owned children (`master_detail`) and `lookup` children are SHOWN by
+ *     default. Set `relatedList: false` on the FK field to suppress a noisy
+ *     association/audit link.
+ *   - `relatedListTitle` / `relatedListColumns` on the FK field override the
+ *     derived title / columns.
+ *   - Audit FKs (`created_by` / `updated_by` / `owner_id`) are skipped — they
+ *     exist on virtually every object and would balloon the detail page into
+ *     dozens of duplicate cards.
+ *   - One related list per child object (deduped by child object name): the
+ *     first non-audit, non-suppressed FK wins.
+ *   - Owned (`master_detail`) children are ordered before plain `lookup`
+ *     children, preserving discovery order within each group.
+ */
+
+/** Audit/ownership FKs that exist on nearly every object — never related lists. */
+const AUDIT_FK_FIELDS = new Set(['created_by', 'updated_by', 'owner_id']);
+
+export interface DerivedRelatedList {
+  /** Child object name (the `api` for the related list query). */
+  childObject: string;
+  /** Best-effort human label for the child object. */
+  childLabel: string;
+  /** FK field on the child pointing back at this parent. */
+  referenceField: string;
+  /** Title override from `relatedListTitle` (else derive from the object label). */
+  title?: string;
+  /** Explicit columns override from `relatedListColumns` (else auto-derived by the renderer). */
+  columns?: any[];
+  /** True when the child→parent link is a `master_detail` (owned) relationship. */
+  isOwned: boolean;
+}
+
+interface ObjectLike {
+  name?: string;
+  label?: string;
+  fields?: Record<string, any> | any[];
+}
+
+/** Normalize an object's `fields` (record or array) into `[name, def]` pairs. */
+function fieldEntries(fields: ObjectLike['fields']): Array<[string, any]> {
+  if (!fields) return [];
+  if (Array.isArray(fields)) {
+    return fields
+      .filter((f) => f && (f.name != null))
+      .map((f) => [String(f.name), f] as [string, any]);
+  }
+  return Object.entries(fields);
+}
+
+/**
+ * Derive the detail-page related lists for `objectDef` from the full object
+ * registry. Returns owned (`master_detail`) children first, then `lookup`
+ * children; deterministic and side-effect free (safe to memoize).
+ */
+export function deriveRelatedLists(
+  objectDef: ObjectLike | null | undefined,
+  objects: ObjectLike[] | null | undefined,
+): DerivedRelatedList[] {
+  if (!objectDef?.name || !Array.isArray(objects) || objects.length === 0) return [];
+  const parentName = objectDef.name;
+  const owned: DerivedRelatedList[] = [];
+  const referenced: DerivedRelatedList[] = [];
+  const seenChild = new Set<string>();
+
+  for (const child of objects) {
+    if (!child?.name || child.name === parentName) continue;
+    for (const [fieldName, fieldDef] of fieldEntries(child.fields)) {
+      if (!fieldDef) continue;
+      const type = fieldDef.type;
+      if (type !== 'lookup' && type !== 'master_detail') continue;
+      if ((fieldDef.reference_to || fieldDef.reference) !== parentName) continue;
+      if (AUDIT_FK_FIELDS.has(fieldName)) continue;
+      // Explicit opt-out lives on the relationship.
+      if (fieldDef.relatedList === false) continue;
+      // One related list per child object — the first eligible FK wins.
+      if (seenChild.has(child.name)) continue;
+      seenChild.add(child.name);
+
+      const entry: DerivedRelatedList = {
+        childObject: child.name,
+        childLabel: child.label || child.name,
+        referenceField: fieldName,
+        isOwned: type === 'master_detail',
+        ...(typeof fieldDef.relatedListTitle === 'string' && fieldDef.relatedListTitle
+          ? { title: fieldDef.relatedListTitle }
+          : {}),
+        ...(Array.isArray(fieldDef.relatedListColumns) && fieldDef.relatedListColumns.length > 0
+          ? { columns: fieldDef.relatedListColumns }
+          : {}),
+      };
+      (entry.isOwned ? owned : referenced).push(entry);
+      break; // move on to the next child object
+    }
+  }
+
+  return [...owned, ...referenced];
+}

--- a/packages/app-shell/src/utils/index.ts
+++ b/packages/app-shell/src/utils/index.ts
@@ -10,6 +10,9 @@ export type {
   RecordFormTarget,
 } from './recordFormNavigation';
 
+export { deriveRelatedLists } from './deriveRelatedLists';
+export type { DerivedRelatedList } from './deriveRelatedLists';
+
 /**
  * Resolves an I18nLabel to a plain string.
  * I18nLabel can be either a string or an object { key, defaultValue?, params? }.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -20,6 +20,7 @@ import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
 import { SkeletonDetail } from '../skeletons';
 import { ManagedByBadge } from '../components/ManagedByBadge';
 import { resolveCrudAffordances } from '../utils/crudAffordances';
+import { deriveRelatedLists } from '../utils/deriveRelatedLists';
 import { hasExplicitDiscussion } from '../utils/pageSchemaIntrospect';
 import { ActionConfirmDialog, type ConfirmDialogState } from './ActionConfirmDialog';
 import { ActionParamDialog, type ParamDialogState } from './ActionParamDialog';
@@ -556,38 +557,17 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // tabs). The semantic owner field for a child record is its primary
   // `*_id` lookup; audit attribution belongs in audit views, not in the
   // related-records summary.
-  const childRelations = useMemo(() => {
-    if (!objectDef || !objects) return [];
-    const AUDIT_FIELDS = new Set(['created_by', 'updated_by', 'owner_id']);
-    const relations: Array<{ childObject: string; childLabel: string; referenceField: string }> = [];
-    // Dedupe by childObject — if a child has multiple non-audit FKs to this
-    // object (e.g. sys_user_permission_set with user_id + assigned_by + …),
-    // we only surface the first FK to keep the right rail / tabs from
-    // ballooning into N duplicate cards per child object. The primary
-    // semantic relation is almost always the canonical `<parent>_id` field
-    // (e.g. `user_id`), which is what most schemas declare first.
-    const seenChild = new Set<string>();
-    for (const obj of objects) {
-      if (obj.name === objectDef.name) continue;
-      for (const [fieldName, fieldDef] of Object.entries<any>(obj.fields || {})) {
-        if (AUDIT_FIELDS.has(fieldName)) continue;
-        if (
-          fieldDef &&
-          (fieldDef.type === 'lookup' || fieldDef.type === 'master_detail') &&
-          (fieldDef.reference_to || fieldDef.reference) === objectDef.name
-        ) {
-          if (seenChild.has(obj.name)) continue;
-          seenChild.add(obj.name);
-          relations.push({
-            childObject: obj.name,
-            childLabel: obj.label || obj.name,
-            referenceField: fieldName,
-          });
-        }
-      }
-    }
-    return relations;
-  }, [objectDef, objects]);
+  // Detail-page related lists — the read-side mirror of the form's inline
+  // master-detail. Derived purely from the relationship graph: every child
+  // object whose lookup/master_detail FK references this object becomes a
+  // related list (owned `master_detail` children first), unless its FK opts
+  // out via `relatedList: false`. `relatedListTitle` / `relatedListColumns`
+  // on the FK override the derived title / columns. Audit FKs are skipped and
+  // children deduped — see `deriveRelatedLists`.
+  const childRelations = useMemo(
+    () => deriveRelatedLists(objectDef, objects),
+    [objectDef, objects],
+  );
 
   // Fetch related child records for each reverse reference.
   //
@@ -1274,12 +1254,15 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     // surfaces as header `+ New` / `View All` buttons and per-row Edit /
     // Delete controls.
     const baseAppUrl = appName ? `/apps/${appName}` : '';
-    const related = childRelations.map(({ childObject, childLabel, referenceField }) => {
+    const related = childRelations.map(({ childObject, childLabel, referenceField, title: titleOverride, columns: columnsOverride }) => {
       const childObjectDef = objects.find((o: any) => o.name === childObject);
       const parentId = pureRecordId || '';
-      const localizedTitle = childObjectDef
-        ? objectLabel({ name: childObjectDef.name, label: childObjectDef.label || childLabel })
-        : childLabel;
+      // A `relatedListTitle` on the relationship wins; else fall back to the
+      // localized child-object label.
+      const localizedTitle = titleOverride
+        || (childObjectDef
+          ? objectLabel({ name: childObjectDef.name, label: childObjectDef.label || childLabel })
+          : childLabel);
 
       const buildNewUrl = () => {
         const qs = new URLSearchParams({ [referenceField]: parentId }).toString();
@@ -1345,6 +1328,12 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         api: childObject,
         data: childRelatedData[childObject] || [],
         referenceField,
+        // Explicit columns from `relatedListColumns` on the relationship; when
+        // absent the related-list renderer auto-derives them from the child
+        // object's fields.
+        ...(Array.isArray(columnsOverride) && columnsOverride.length > 0
+          ? { columns: columnsOverride }
+          : {}),
         icon: childObjectDef?.icon,
         // Surface the child object's canonical display field so the
         // right-rail can show meaningful labels (`user_agent`, `email`,


### PR DESCRIPTION
## Summary

The record **detail page** now derives its related lists from the relationship graph — the read-side counterpart to the form's inline master-detail (`inlineEdit`). Every child relationship (`master_detail`/`lookup` referencing the parent) is shown as a related list by default (owned children first); the new relationship-level `relatedList` flag opts a child out, and `relatedListTitle`/`relatedListColumns` override the derived title/columns.

| Side | Flag (on child FK) | Effect |
|---|---|---|
| Write | `inlineEdit: true` | editable child grid inside the parent's create/edit form |
| Read | `relatedList` (+ `relatedListTitle`/`relatedListColumns`) | related list on the parent's detail page |

## Changes
- **New** `deriveRelatedLists(objectDef, objects)` pure helper (`app-shell/utils`) — read-side analogue of `attachInlineSubforms`. Scans child FKs, skips audit FKs, dedupes one list per child, honors `relatedList*` flags, orders owned (`master_detail`) children first. Fully unit-tested (12 cases).
- Refactor `RecordDetailView.childRelations` onto the helper; thread `relatedListTitle`/`relatedListColumns` into both the synthesized page (`record:related_list`) and legacy `DetailView` paths.
- **Live e2e** (`e2e/live/detail-related-list.spec.ts`): the showcase Account detail page auto-renders a "Projects" related list with the override columns.

## Verification
- Unit: app-shell 330 ✓, plugin-detail 118 ✓
- Live browser e2e: full suite 9/9 ✓ (real backend on :3000, real console on :5180)

Pairs with framework#1623 (spec `relatedList` flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)