### PR TITLE
feat(master-detail): column chooser instead of hard column cap (no data loss)

### DIFF
--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -29,6 +29,36 @@ describe('GridField / LineItemsField — editable line items', () => {
     expect(onChange).toHaveBeenCalledWith([{ description: null, amount: null }]);
   });
 
+  describe('column chooser (defaultHidden columns)', () => {
+    const withHidden = {
+      columns: [
+        { field: 'title', label: 'Title', type: 'text' as const, required: true },
+        { field: 'amount', label: 'Amount', type: 'currency' as const },
+        { field: 'notes', label: 'Notes', type: 'text' as const, defaultHidden: true },
+      ],
+    } as any;
+
+    it('hides defaultHidden columns by default but keeps required/visible ones', () => {
+      render(<GridField value={[]} onChange={() => {}} field={withHidden} />);
+      expect(screen.getByText('Title')).toBeTruthy();
+      expect(screen.getByText('Amount')).toBeTruthy();
+      expect(screen.queryByText('Notes')).toBeNull(); // collapsed into the chooser
+      expect(screen.getByTestId('line-items-columns')).toBeTruthy();
+    });
+
+    it('reveals an optional column when toggled in the chooser', () => {
+      render(<GridField value={[]} onChange={() => {}} field={withHidden} />);
+      fireEvent.click(screen.getByTestId('line-items-columns'));
+      fireEvent.click(screen.getByLabelText('Notes'));
+      expect(screen.getAllByText('Notes').length).toBeGreaterThan(0);
+    });
+
+    it('shows no chooser when there are no optional columns', () => {
+      render(<GridField value={[]} onChange={() => {}} field={field} />);
+      expect(screen.queryByTestId('line-items-columns')).toBeNull();
+    });
+  });
+
   it('editing a text cell emits the raw string', () => {
     const onChange = vi.fn();
     render(<GridField value={[{ description: '', amount: null }]} onChange={onChange} field={field} />);

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -9,8 +9,13 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  Checkbox,
+  Label,
 } from '@object-ui/components';
-import { Plus, Trash2 } from 'lucide-react';
+import { Plus, Trash2, SlidersHorizontal } from 'lucide-react';
 import { LookupField } from './LookupField';
 
 /**
@@ -44,11 +49,31 @@ export interface GridColumn {
   displayField?: string;
   idField?: string;
   multiple?: boolean;
+  /**
+   * Hidden from the grid by default but revealable via the column chooser.
+   * Set by `deriveColumns` for fields beyond the default-visible budget — the
+   * data is NOT dropped (it's just collapsed, like Odoo's `optional` columns /
+   * Salesforce column personalization), so business-critical fields stay
+   * reachable. Required columns are never default-hidden.
+   */
+  defaultHidden?: boolean;
 }
 
 type Row = Record<string, any>;
 
 const isNumeric = (t?: string) => t === 'number' || t === 'currency';
+
+/** Comfortable minimum widths per column type so cells never get crushed; the
+ *  grid scrolls horizontally instead. Authors can still pin a `width`. */
+const MIN_WIDTH_BY_TYPE: Record<string, number> = {
+  text: 160,
+  select: 132,
+  lookup: 168,
+  number: 104,
+  currency: 116,
+  date: 150,
+};
+const minWidthFor = (c: GridColumn): number => c.width ?? MIN_WIDTH_BY_TYPE[c.type ?? 'text'] ?? 132;
 
 function coerce(type: string | undefined, raw: string): any {
   if (isNumeric(type)) {
@@ -78,8 +103,25 @@ export function GridField({
   ...props
 }: FieldWidgetProps<Row[]>) {
   const cfg = (field || (props as any).schema || {}) as any;
-  const columns: GridColumn[] = cfg.columns || [];
+  const allColumns: GridColumn[] = cfg.columns || [];
   const rows: Row[] = Array.isArray(value) ? value : [];
+
+  // Column visibility — a curated default-visible set with the rest revealable
+  // via the column chooser (mainstream "personalize columns" pattern). Required
+  // columns are always visible; nothing is ever silently dropped.
+  const [extraShown, setExtraShown] = React.useState<Set<string>>(() => new Set());
+  const optionalColumns = allColumns.filter((c) => c.defaultHidden && !c.required);
+  const columns: GridColumn[] = allColumns.filter(
+    (c) => !c.defaultHidden || c.required || extraShown.has(c.field),
+  );
+  const toggleColumn = useCallback((fieldName: string) => {
+    setExtraShown((prev) => {
+      const next = new Set(prev);
+      if (next.has(fieldName)) next.delete(fieldName);
+      else next.add(fieldName);
+      return next;
+    });
+  }, []);
 
   const allowAdd = cfg.allow_add !== false && !readonly && !disabled;
   const allowDelete = cfg.allow_delete !== false && !readonly && !disabled;
@@ -131,13 +173,58 @@ export function GridField({
   // last column). The label sits right-aligned immediately to its left.
   const totalColIndex = showTotal ? Math.max(0, columns.findIndex((c) => c.field === totalField)) : -1;
 
+  // Column chooser — reveal/hide the optional (default-hidden) columns. Only
+  // rendered when there are optional columns to manage.
+  const columnChooser = optionalColumns.length > 0 ? (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 text-xs text-muted-foreground"
+          data-testid="line-items-columns"
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          Columns
+          {extraShown.size > 0 && (
+            <span className="rounded-full bg-primary/10 px-1.5 text-[10px] font-medium text-primary">
+              +{extraShown.size}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 p-2">
+        <div className="px-1 pb-1.5 text-xs font-medium text-muted-foreground">Optional columns</div>
+        <div className="max-h-64 space-y-0.5 overflow-y-auto">
+          {optionalColumns.map((c) => {
+            const id = `col-toggle-${c.field}`;
+            return (
+              <Label
+                key={c.field}
+                htmlFor={id}
+                className="flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1.5 text-sm font-normal hover:bg-muted"
+              >
+                <Checkbox
+                  id={id}
+                  checked={extraShown.has(c.field)}
+                  onCheckedChange={() => toggleColumn(c.field)}
+                />
+                <span className="truncate">{c.label || c.field}</span>
+              </Label>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  ) : null;
+
   // ── Read-only / view rendering ────────────────────────────────────────────
   if (readonly) {
     return (
-      <div
-        className={cn('border border-border rounded-lg overflow-hidden', className)}
-        data-testid="line-items-readonly"
-      >
+      <div className={cn('space-y-2', className)}>
+        {columnChooser && <div className="flex justify-end">{columnChooser}</div>}
+        <div className="border border-border rounded-lg overflow-x-auto" data-testid="line-items-readonly">
         <table className="w-full text-sm">
           <thead className="bg-muted border-b border-border">
             <tr>
@@ -147,8 +234,9 @@ export function GridField({
               {columns.map((c) => (
                 <th
                   key={c.field}
+                  style={{ minWidth: minWidthFor(c) }}
                   className={cn(
-                    'px-3 py-2 text-xs font-medium text-muted-foreground',
+                    'px-3 py-2 text-xs font-medium text-muted-foreground whitespace-nowrap',
                     isNumeric(c.type) ? 'text-right' : 'text-left',
                   )}
                 >
@@ -215,6 +303,7 @@ export function GridField({
             </tfoot>
           )}
         </table>
+        </div>
       </div>
     );
   }
@@ -222,6 +311,7 @@ export function GridField({
   // ── Editable rendering ──────────────────────────────────────────────────────
   return (
     <div className={cn('space-y-2', className)} data-testid="line-items">
+      {columnChooser && <div className="flex justify-end">{columnChooser}</div>}
       <div className="border border-border rounded-lg overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="bg-muted border-b border-border">
@@ -233,10 +323,10 @@ export function GridField({
                 <th
                   key={c.field}
                   className={cn(
-                    'px-3 py-2 text-xs font-medium text-muted-foreground',
+                    'px-3 py-2 text-xs font-medium text-muted-foreground whitespace-nowrap',
                     isNumeric(c.type) ? 'text-right' : 'text-left',
                   )}
-                  style={c.width ? { width: c.width } : undefined}
+                  style={{ width: c.width, minWidth: minWidthFor(c) }}
                 >
                   {c.label || c.field}
                   {c.required && <span className="text-destructive"> *</span>}

--- a/packages/plugin-form/src/deriveMasterDetail.test.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.test.ts
@@ -84,24 +84,30 @@ describe('deriveColumns curation (column budget)', () => {
     },
   };
 
-  it('caps to the default budget (6) when a child has many editable fields', () => {
+  const visible = (cols: any[]) => cols.filter((c) => !c.defaultHidden).map((c) => c.field);
+
+  it('returns ALL columns — none dropped — and defaults a focused 6 visible', () => {
     const cols = deriveColumns(wideSchema, { relationshipField: 'parent' });
-    expect(cols.length).toBe(6);
+    expect(cols.length).toBe(12);              // every editable column kept (parent FK excluded)
+    expect(visible(cols).length).toBe(6);      // default-visible budget
+    expect(cols.some((c) => c.defaultHidden)).toBe(true); // the rest collapsed, not gone
   });
 
-  it('always keeps required columns even under the cap', () => {
-    const names = deriveColumns(wideSchema, { relationshipField: 'parent' }).map((c) => c.field);
-    expect(names).toContain('title');  // name-like + required
-    expect(names).toContain('status'); // required
+  it('always keeps required columns visible (never default-hidden)', () => {
+    const cols = deriveColumns(wideSchema, { relationshipField: 'parent' });
+    expect(visible(cols)).toContain('title');  // name-like + required
+    expect(visible(cols)).toContain('status'); // required
   });
 
-  it('drops low-signal text columns before keeping them all', () => {
-    const names = deriveColumns(wideSchema, { relationshipField: 'parent' }).map((c) => c.field);
-    expect(names).not.toContain('notes');
-    expect(names).not.toContain('labels');
+  it('collapses low-signal text columns into the chooser (hidden, not dropped)', () => {
+    const cols = deriveColumns(wideSchema, { relationshipField: 'parent' });
+    const byName = Object.fromEntries(cols.map((c) => [c.field, c]));
+    expect(byName.notes).toBeDefined();
+    expect(byName.notes.defaultHidden).toBe(true);
+    expect(byName.labels.defaultHidden).toBe(true);
   });
 
-  it('preserves schema order in the curated output', () => {
+  it('preserves schema order (including hidden columns)', () => {
     const names = deriveColumns(wideSchema, { relationshipField: 'parent' }).map((c) => c.field);
     const sorted = [...names].sort(
       (a, b) => Object.keys(wideSchema.fields).indexOf(a) - Object.keys(wideSchema.fields).indexOf(b),
@@ -109,12 +115,13 @@ describe('deriveColumns curation (column budget)', () => {
     expect(names).toEqual(sorted);
   });
 
-  it('maxColumns: 0 disables curation and returns every editable column', () => {
+  it('maxColumns: 0 marks no column hidden (all visible)', () => {
     const cols = deriveColumns(wideSchema, { relationshipField: 'parent', maxColumns: 0 });
-    expect(cols.length).toBe(12); // all editable (parent FK excluded)
+    expect(cols.length).toBe(12);
+    expect(cols.every((c) => !c.defaultHidden)).toBe(true);
   });
 
-  it('keeps all required columns even if more than the budget', () => {
+  it('keeps all required columns visible even if more than the budget', () => {
     const reqHeavy = {
       fields: {
         a: { type: 'text', required: true },
@@ -128,8 +135,10 @@ describe('deriveColumns curation (column budget)', () => {
         parent: { type: 'master_detail', reference: 'p', required: true },
       },
     };
-    const names = deriveColumns(reqHeavy, { relationshipField: 'parent' }).map((c) => c.field);
-    expect(names).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']); // 7 required kept, non-required 'h' dropped
+    const cols = deriveColumns(reqHeavy, { relationshipField: 'parent' });
+    expect(visible(cols)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']); // 7 required visible
+    expect(cols.find((c) => c.field === 'h')?.defaultHidden).toBe(true); // non-required collapsed
+    expect(cols.length).toBe(8); // nothing dropped
   });
 });
 

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -102,11 +102,13 @@ export function findRelationshipField(
 }
 
 /**
- * Default cap on auto-derived inline columns. An inline line-item grid lives in
- * a constrained width (modal / detail card); dumping *every* editable child
- * field crushes inputs and forces horizontal scroll. We curate down to a
- * focused set by default (authors can override with explicit `columns` /
- * `inlineColumns`, which bypass curation entirely).
+ * Default-visible column budget for an auto-derived inline grid. An inline
+ * line-item grid lives in a constrained width (modal / detail card), so we show
+ * a focused set by default and mark the rest `defaultHidden` — they are NOT
+ * dropped: the grid's column chooser reveals them on demand (the mainstream
+ * "personalize columns" pattern; cf. Odoo `optional` / Salesforce column
+ * personalization). Required columns are always visible. Authors can override
+ * with explicit `columns` / `inlineColumns` (no curation), or `maxColumns: 0`.
  */
 export const DEFAULT_MAX_INLINE_COLUMNS = 6;
 
@@ -124,33 +126,37 @@ const TYPE_FILL_PRIORITY: Record<string, number> = {
 };
 
 /**
- * Curate a full column list down to `max`, always keeping the primary
- * (name-like) column and every required column, then filling the remaining
- * budget by type usefulness. Output preserves the original schema order so the
- * grid still reads naturally.
+ * Choose the default-visible subset of `max` columns — always keeping the
+ * primary (name-like) column and every required column, then filling the
+ * remaining budget by type usefulness. Columns NOT in the visible set are
+ * marked `defaultHidden` (revealable via the grid's column chooser); none are
+ * dropped, so business-critical fields stay reachable. Output preserves the
+ * original schema order so the grid still reads naturally.
  */
 function curateColumns(cols: GridColumn[], max: number): GridColumn[] {
   if (max <= 0 || cols.length <= max) return cols;
-  const keep = new Set<string>();
+  const visible = new Set<string>();
   const primary = cols.find((c) => NAME_LIKE_FIELDS.includes(c.field)) ?? cols[0];
-  if (primary) keep.add(primary.field);
-  for (const c of cols) if (c.required) keep.add(c.field); // required is non-negotiable
+  if (primary) visible.add(primary.field);
+  for (const c of cols) if (c.required) visible.add(c.field); // required is always visible
   const remaining = cols
     .map((c, i) => ({ c, i }))
-    .filter(({ c }) => !keep.has(c.field))
+    .filter(({ c }) => !visible.has(c.field))
     .sort((a, b) => (TYPE_FILL_PRIORITY[a.c.type] ?? 5) - (TYPE_FILL_PRIORITY[b.c.type] ?? 5) || a.i - b.i);
   for (const { c } of remaining) {
-    if (keep.size >= max) break;
-    keep.add(c.field);
+    if (visible.size >= max) break;
+    visible.add(c.field);
   }
-  return cols.filter((c) => keep.has(c.field));
+  // Keep every column; collapse the overflow into the chooser.
+  return cols.map((c) => (visible.has(c.field) ? c : { ...c, defaultHidden: true }));
 }
 
 /**
  * Derive editable grid columns from a child object's fields, skipping system /
  * audit fields, non-editable types, and the back-reference FK to the parent.
- * By default the result is curated to {@link DEFAULT_MAX_INLINE_COLUMNS} (pass
- * `maxColumns: 0` to disable curation and return every editable column).
+ * Every editable column is returned; those beyond {@link DEFAULT_MAX_INLINE_COLUMNS}
+ * are flagged `defaultHidden` (collapsed into the grid's column chooser, not
+ * dropped). Pass `maxColumns: 0` to flag none.
  */
 export function deriveColumns(
   childSchema: ObjectSchemaLike | undefined,


### PR DESCRIPTION
## Why
Follow-up to the inline-grid column budget. A **hard cap silently dropped** non-required editable fields with no end-user recourse — wrong for real business entry (e.g. an order line's `discount`/`warehouse` that isn't `required`). 

**How mainstream enterprise grids do it:** Salesforce line editor, Dynamics editable subgrids, Odoo `optional` columns, NetSuite/SAP sublists — all show a **curated default set + let users reveal the rest**, with horizontal scroll. They never silently drop data.

## Change
- **`deriveColumns`**: columns beyond the default-visible budget (6) are flagged `defaultHidden` **instead of dropped**. Every editable column is returned; primary (name/title) + all required columns stay visible. `maxColumns: 0` flags none.
- **`GridField`**: renders the curated default + a **"Columns" chooser popover** to toggle optional columns; per-type **min-widths + horizontal scroll** so cells are never crushed. New `GridColumn.defaultHidden`.

## Verification
- In-browser (HMR): New Project Tasks grid shows 6 columns + "Columns +N" chooser revealing Assignee/Progress/Start Date/End Date/Labels/Notes; grid scrolls horizontally with comfortable widths.
- Unit: deriveColumns (plugin-form **86**), GridField incl. chooser (fields **3428**); live e2e **9/9**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)