### PR TITLE
feat(console): MCP connect surface on Integrations page — show-once key + skill (closes #1550)

### DIFF
--- a/apps/console/src/pages/developer/AgentConnectSection.tsx
+++ b/apps/console/src/pages/developer/AgentConnectSection.tsx
@@ -1,0 +1,273 @@
+/**
+ * AgentConnectSection (ADR-0036 Phase 2b)
+ *
+ * Surfaces "connect an AI agent to this environment over MCP" on the
+ * Integrations page: shows the env's MCP endpoint (from /discovery, opt-in via
+ * OS_MCP_SERVER_ENABLED), mints a show-once API key (POST /api/v1/keys), offers
+ * a one-click portable Skill download, and gives copy-paste connect steps.
+ *
+ * One connection per ENVIRONMENT (not per app) — the agent discovers apps/
+ * objects live via the MCP tools, so a new app needs no reinstall.
+ */
+
+import { useEffect, useState, type ChangeEvent } from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  Button,
+  Input,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  Alert,
+  AlertTitle,
+  AlertDescription,
+} from '@object-ui/components';
+import { Bot, KeyRound, Copy, Check, Download, ShieldAlert } from 'lucide-react';
+
+import { renderObjectStackSkill } from './objectstack-skill';
+
+interface GeneratedKey {
+  id?: string;
+  name?: string;
+  prefix?: string;
+  key: string;
+}
+
+function useCopy(): [boolean, (v: string) => void] {
+  const [copied, setCopied] = useState(false);
+  const copy = (v: string) => {
+    void navigator.clipboard?.writeText(v);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return [copied, copy];
+}
+
+function InlineCopy({ value, label }: { value: string; label?: string }) {
+  const [copied, copy] = useCopy();
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-7 gap-1.5 px-2 text-xs"
+      onClick={() => copy(value)}
+      aria-label={`Copy ${label ?? 'value'}`}
+    >
+      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+      {copied ? 'Copied' : 'Copy'}
+    </Button>
+  );
+}
+
+export function AgentConnectSection() {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  const [mcpUrl, setMcpUrl] = useState<string | null>(null);
+  const [mcpEnabled, setMcpEnabled] = useState<boolean | null>(null);
+
+  const [keyName, setKeyName] = useState('Agent key');
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [generated, setGenerated] = useState<GeneratedKey | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [keyCopied, copyKey] = useCopy();
+
+  // Discover whether MCP is enabled + its URL.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/v1/discovery', { credentials: 'include' });
+        const json = await res.json().catch(() => ({}));
+        const route: string | undefined = json?.data?.routes?.mcp ?? json?.routes?.mcp;
+        if (cancelled) return;
+        if (route) {
+          setMcpUrl(route.startsWith('http') ? route : `${origin}${route}`);
+          setMcpEnabled(true);
+        } else {
+          setMcpEnabled(false);
+        }
+      } catch {
+        if (!cancelled) setMcpEnabled(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [origin]);
+
+  const generateKey = async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/v1/keys', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: keyName.trim() || 'Agent key' }),
+      });
+      const json = await res.json().catch(() => ({}));
+      const data = json?.data;
+      if (!res.ok || !data?.key) {
+        throw new Error(json?.error?.message || `Request failed (${res.status})`);
+      }
+      setGenerated(data as GeneratedKey);
+      setDialogOpen(true);
+    } catch (e) {
+      setError((e as Error)?.message ?? 'Failed to generate key');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const downloadSkill = () => {
+    const md = renderObjectStackSkill({ mcpUrl: mcpUrl ?? undefined });
+    const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'SKILL.md';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+  };
+
+  const effectiveUrl = mcpUrl ?? `${origin}/api/v1/mcp`;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Bot className="size-4" /> Connect an AI agent (MCP)
+        </CardTitle>
+        <CardDescription className="text-xs">
+          Every app in this environment is an agent-ready toolset. Connect Claude, Cursor, Codex or
+          any MCP client — one connection covers all your apps (new ones appear automatically).
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {/* MCP endpoint */}
+        <div>
+          <div className="mb-1 text-xs font-medium text-muted-foreground">MCP endpoint</div>
+          {mcpEnabled === false ? (
+            <Alert>
+              <ShieldAlert className="size-4" />
+              <AlertTitle>MCP is not enabled for this environment</AlertTitle>
+              <AlertDescription className="text-xs">
+                Connecting agents is opt-in. An admin can enable it by setting{' '}
+                <code className="font-mono">OS_MCP_SERVER_ENABLED=true</code>. You can still
+                generate a key and download the skill below.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <div className="flex items-center gap-2">
+              <code className="flex-1 truncate rounded bg-muted px-2 py-1.5 font-mono text-xs">
+                {effectiveUrl}
+              </code>
+              <InlineCopy value={effectiveUrl} label="MCP URL" />
+            </div>
+          )}
+        </div>
+
+        {/* Generate key */}
+        <div>
+          <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+            <KeyRound className="size-3.5" /> API key
+          </div>
+          <div className="flex items-center gap-2">
+            <Input
+              value={keyName}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setKeyName(e.target.value)}
+              placeholder="Key name (e.g. Claude desktop)"
+              className="h-8 max-w-xs text-sm"
+            />
+            <Button type="button" size="sm" onClick={generateKey} disabled={generating}>
+              {generating ? 'Generating…' : 'Generate key'}
+            </Button>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            The key acts as you (your permissions + row-level security). Shown once — copy it
+            immediately. Revoke anytime from the API Keys list.
+          </p>
+          {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+        </div>
+
+        {/* Skill */}
+        <div>
+          <div className="mb-1 text-xs font-medium text-muted-foreground">Agent skill (portable)</div>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={downloadSkill}>
+              <Download className="size-4" /> Download SKILL.md
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              Works with any skills-capable agent (Claude, Codex, Gemini, Cursor…).
+            </span>
+          </div>
+        </div>
+
+        {/* Connect steps */}
+        <div className="rounded-lg border bg-muted/30 p-3 text-xs leading-relaxed">
+          <div className="mb-1 font-medium">Connect in 3 steps</div>
+          <ol className="list-decimal space-y-0.5 pl-4 text-muted-foreground">
+            <li>Add a remote MCP server pointing at the endpoint above.</li>
+            <li>
+              Set the header <code className="font-mono">x-api-key: &lt;your key&gt;</code> (a
+              session Bearer is <em>not</em> an API key).
+            </li>
+            <li>Drop in <code className="font-mono">SKILL.md</code> so the agent knows how to drive your data.</li>
+          </ol>
+        </div>
+      </CardContent>
+
+      {/* Show-once key dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <KeyRound className="size-4" /> Your new API key
+            </DialogTitle>
+            <DialogDescription>
+              Copy this now — for your security it will <strong>not be shown again</strong>.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <code className="flex-1 break-all rounded bg-muted px-2 py-2 font-mono text-xs">
+                {generated?.key}
+              </code>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="gap-1.5"
+                onClick={() => generated && copyKey(generated.key)}
+              >
+                {keyCopied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                {keyCopied ? 'Copied' : 'Copy'}
+              </Button>
+            </div>
+            <Alert>
+              <ShieldAlert className="size-4" />
+              <AlertDescription className="text-xs">
+                Send it as <code className="font-mono">x-api-key</code>. It carries your
+                permissions — store it like a password and revoke it if leaked.
+              </AlertDescription>
+            </Alert>
+          </div>
+          <DialogFooter>
+            <Button type="button" onClick={() => setDialogOpen(false)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/apps/console/src/pages/developer/IntegrationsPage.tsx
+++ b/apps/console/src/pages/developer/IntegrationsPage.tsx
@@ -5,11 +5,14 @@
  * API: shows this environment's base URL, the auto-generated CRUD endpoints per
  * object, a jump to the interactive API Console, and copy-paste samples.
  *
- * Read-only surfacing of shipped endpoints — no runtime change. Self-serve API
- * keys for external (non-browser) callers land with ADR-0036 Phase 1a
- * (better-auth apiKey auth); until then the in-console API Console (which uses
- * the logged-in session) is the way to exercise the API, and that is called out
- * honestly below.
+ * Also the env's agent surface (ADR-0036 Phase 2b): the <AgentConnectSection>
+ * shows the MCP endpoint, mints a show-once `sys_api_key`, and offers a portable
+ * Skill download — one connection per environment covers every app.
+ *
+ * Self-serve API keys are live (Phase 1a hand-rolled `sys_api_key` auth + the
+ * generation endpoint); send them as the `x-api-key` header (a session Bearer is
+ * not an API key). The in-console API Console (session-authed) remains for
+ * interactive exploration.
  */
 
 import { useEffect, useMemo, useState } from 'react';
@@ -24,6 +27,8 @@ import {
   Badge,
 } from '@object-ui/components';
 import { Terminal, Copy, Check, Plug, Database, KeyRound } from 'lucide-react';
+
+import { AgentConnectSection } from './AgentConnectSection';
 
 interface ConsoleObjectMeta {
   name: string;
@@ -96,7 +101,7 @@ export function IntegrationsPage() {
     () =>
       `# List ${sampleObject} records\n` +
       `curl "${baseUrl}/api/v1/data/${sampleObject}?$top=10" \\\n` +
-      `  -H "Authorization: Bearer <YOUR_API_KEY>"`,
+      `  -H "x-api-key: <YOUR_API_KEY>"`,
     [baseUrl, sampleObject],
   );
 
@@ -130,6 +135,9 @@ export function IntegrationsPage() {
           <CopyButton value={`${baseUrl}/api/v1`} label="base URL" />
         </CardContent>
       </Card>
+
+      {/* Connect an AI agent (MCP) — ADR-0036 Phase 2b */}
+      <AgentConnectSection />
 
       {/* Endpoints per object */}
       <Card>
@@ -184,8 +192,10 @@ export function IntegrationsPage() {
             In the console you're already authenticated — use <strong>Open API Console</strong> above to call these endpoints now.
           </p>
           <p>
-            For external programs and AI agents, <strong>self-serve API keys</strong> (a Bearer token scoped to your permissions)
-            are coming next (ADR-0036). Until then, treat the samples below as the shape to expect.
+            For external programs and AI agents, generate a <strong>self-serve API key</strong> in
+            the <strong>Connect an AI agent</strong> section above. Send it as the{' '}
+            <code className="font-mono text-xs">x-api-key</code> header; it runs under your
+            permissions and row-level security, and is revocable.
           </p>
         </CardContent>
       </Card>

--- a/apps/console/src/pages/developer/objectstack-skill.test.ts
+++ b/apps/console/src/pages/developer/objectstack-skill.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  renderObjectStackSkill,
+  OBJECTSTACK_SKILL_NAME,
+  OBJECTSTACK_SKILL_DESCRIPTION,
+} from './objectstack-skill';
+
+function frontmatter(md: string): Record<string, string> {
+  const m = md.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) throw new Error('no frontmatter');
+  const out: Record<string, string> = {};
+  for (const line of m[1].split('\n')) {
+    const i = line.indexOf(':');
+    if (i > 0) out[line.slice(0, i).trim()] = line.slice(i + 1).trim();
+  }
+  return out;
+}
+
+describe('renderObjectStackSkill', () => {
+  it('emits valid SKILL.md frontmatter (name + description)', () => {
+    const fm = frontmatter(renderObjectStackSkill());
+    expect(fm.name).toBe(OBJECTSTACK_SKILL_NAME);
+    expect(fm.description).toBe(OBJECTSTACK_SKILL_DESCRIPTION);
+  });
+
+  it('slots the env MCP URL and drops the placeholder', () => {
+    const md = renderObjectStackSkill({ mcpUrl: 'https://acme.objectos.app/api/v1/mcp' });
+    expect(md).toContain('https://acme.objectos.app/api/v1/mcp');
+    expect(md).not.toContain('<YOUR_ENV_MCP_URL>');
+  });
+
+  it('falls back to a placeholder when no URL is given', () => {
+    expect(renderObjectStackSkill()).toContain('<YOUR_ENV_MCP_URL>');
+  });
+
+  it('documents x-api-key auth, not Bearer', () => {
+    const md = renderObjectStackSkill();
+    expect(md).toContain('x-api-key');
+    expect(md).not.toMatch(/Authorization:\s*Bearer/);
+  });
+
+  it('lists all object-CRUD tools and instructs live discovery', () => {
+    const md = renderObjectStackSkill();
+    for (const t of [
+      'list_objects',
+      'describe_object',
+      'query_records',
+      'get_record',
+      'create_record',
+      'update_record',
+      'delete_record',
+    ]) {
+      expect(md).toContain(t);
+    }
+    expect(md).toContain('discovered live');
+  });
+
+  it('includes the env name when provided', () => {
+    expect(renderObjectStackSkill({ envName: 'Acme CRM' })).toContain('**Acme CRM**');
+  });
+});

--- a/apps/console/src/pages/developer/objectstack-skill.ts
+++ b/apps/console/src/pages/developer/objectstack-skill.ts
@@ -1,0 +1,120 @@
+/**
+ * objectstack-skill — client-side renderer for the portable ObjectStack Agent
+ * Skill (`SKILL.md`), used by the Integrations page "Download skill" button.
+ *
+ * CANONICAL SOURCE: `renderSkillMarkdown` in `@objectstack/mcp` (framework).
+ * That package pulls in the MCP SDK and is not browser-friendly to import here,
+ * so this is a faithful mirror for the download UX. Keep the two in sync — the
+ * unit test asserts the structural invariants (frontmatter, URL slot, tools).
+ *
+ * Per ADR-0036 Amendment C this is ONE generic skill: it never enumerates a
+ * tenant's schema (the agent discovers live via list_objects/describe_object);
+ * only the connection URL is environment-specific.
+ */
+
+export interface RenderSkillOptions {
+  /** The env's MCP endpoint, e.g. https://acme.objectos.app/api/v1/mcp */
+  mcpUrl?: string;
+  /** Optional human label for the environment. */
+  envName?: string;
+}
+
+export const OBJECTSTACK_SKILL_NAME = 'objectstack';
+export const OBJECTSTACK_SKILL_DESCRIPTION =
+  'Query and modify data in an ObjectStack app over MCP — discover objects, ' +
+  'read and filter records, and create/update/delete under your own ' +
+  'permissions and row-level security. Use when the user wants to inspect or ' +
+  'change data in their ObjectStack environment.';
+
+const URL_PLACEHOLDER = '<YOUR_ENV_MCP_URL>';
+
+export function renderObjectStackSkill(options: RenderSkillOptions = {}): string {
+  const url = options.mcpUrl?.trim() || URL_PLACEHOLDER;
+  const envLabel = options.envName?.trim();
+  const intro = envLabel
+    ? `This skill connects you to the **${envLabel}** ObjectStack environment.`
+    : 'This skill connects you to an ObjectStack environment.';
+
+  return `---
+name: ${OBJECTSTACK_SKILL_NAME}
+description: ${OBJECTSTACK_SKILL_DESCRIPTION}
+---
+
+# ObjectStack
+
+${intro} An ObjectStack environment exposes its data **objects** (tables) as
+tools over the Model Context Protocol (MCP). Every operation runs **as you** —
+under your account's permissions and row-level security — so you may see a
+subset of rows, or get a permission error on a write. That is expected
+governance, not a failure.
+
+## When to use
+
+Use these tools whenever the user wants to **inspect or change data** in their
+ObjectStack app: look up records, filter/report, create or update entries, or
+clean up data. Prefer these tools over guessing — the environment is the source
+of truth.
+
+## Connect
+
+This skill drives the MCP server at:
+
+\`\`\`
+${url}
+\`\`\`
+
+Authenticate with an ObjectStack API key sent as a request header (the key is
+shown to you once when created; treat it like a password):
+
+\`\`\`
+x-api-key: <YOUR_API_KEY>
+\`\`\`
+
+(The header \`Authorization: ApiKey <YOUR_API_KEY>\` is also accepted.) If your
+MCP client supports custom headers on a remote server, set the header there.
+
+## Discover before you act
+
+The schema is **not** baked into this skill — it is discovered live, so it is
+always current even as the app evolves:
+
+1. \`list_objects\` — see what objects exist.
+2. \`describe_object({ objectName })\` — get an object's fields (name, type,
+   required) before querying or writing it.
+
+Always discover the relevant object's shape before constructing a filter or a
+create/update payload.
+
+## Tools
+
+- **list_objects()** — list available objects (system \`sys_*\` objects are hidden).
+- **describe_object({ objectName })** — an object's fields and features.
+- **query_records({ objectName, where?, fields?, limit?, offset?, orderBy? })** —
+  read records. \`where\` is a field→value match, e.g. \`{ "status": "open" }\`.
+  Results are page-capped; use \`limit\`/\`offset\` to page.
+- **get_record({ objectName, recordId })** — fetch one record by id.
+- **create_record({ objectName, data })** — create a record.
+- **update_record({ objectName, recordId, data })** — change fields on a record.
+- **delete_record({ objectName, recordId })** — delete a record (destructive —
+  confirm with the user first).
+
+## Conventions & gotchas
+
+- **Permissions/RLS apply to every call.** Fewer rows than expected, or a
+  write that's rejected, usually means your key isn't authorized — don't retry
+  blindly; tell the user.
+- **Discover, don't assume.** Object and field names vary per app; always
+  \`list_objects\` / \`describe_object\` first.
+- **Writes are real and immediate.** There is no implicit dry-run. Confirm
+  destructive actions (\`delete_record\`, bulk updates) with the user.
+- **Page large reads.** Use \`limit\`/\`offset\` rather than asking for everything.
+
+## Recommended workflow
+
+1. \`list_objects\` to orient.
+2. \`describe_object\` on the target object.
+3. \`query_records\` to read / verify current state.
+4. \`create_record\` / \`update_record\` / \`delete_record\` to make changes,
+   confirming destructive steps with the user.
+`;
+}


### PR DESCRIPTION
Closes #1550.

## What

ADR-0036 **Phase 2b surfacing** — a "Connect an AI agent (MCP)" section on the Integrations page so a user connects their environment to Claude / Cursor / Codex / any MCP client in one flow. **One connection per environment** covers every app (agents discover apps/objects live, so a new app needs no reinstall).

## Changes

- **`AgentConnectSection.tsx`** (new):
  - **MCP endpoint** — read from `GET /api/v1/discovery` → `routes.mcp` (opt-in via `OS_MCP_SERVER_ENABLED`; shows an enable hint when off).
  - **Generate key (show-once)** — `POST /api/v1/keys` → reveals the raw key in a dialog with copy + a "won't be shown again" warning. The key acts as the user (permissions + RLS) and is revocable.
  - **Download SKILL.md** — one-click portable skill (works with any skills-capable agent).
  - **3-step connect** instructions (set `x-api-key` header — a session Bearer is *not* an API key).
- **`objectstack-skill.ts`** (new): client-side renderer mirroring `@objectstack/mcp`'s `renderSkillMarkdown` (canonical source noted in a comment; importing the framework package into the browser bundle isn't viable). Generic, schema-discovered-live, `x-api-key` auth. **6 unit tests** assert the invariants (frontmatter, URL slot, tools, discover-first, no-Bearer).
- **`IntegrationsPage.tsx`**: renders the section; refreshes the now-stale "Authentication" copy (keys are live); **fixes the cURL sample** `Authorization: Bearer` → `x-api-key` (our resolver treats Bearer as session auth, so a `sys_api_key` must go in `x-api-key`).

## Consumes (framework, all merged/landing)

`discovery.routes.mcp` (#1626), `renderSkillMarkdown` (#1628), `POST /api/v1/keys` (#1630).

## Verification

My 3 files typecheck clean (remaining repo tsc errors are an unbuilt `@object-ui/app-shell` in the isolated worktree, present on untouched files too). `objectstack-skill.test.ts` — 6 green. Live browser e2e awaits a staging deploy of the framework changes (discovery.mcp + /keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
