### PR TITLE
feat(master-detail): per-row expand → full inline form (hybrid grid + form)

### DIFF
--- a/e2e/live/row-expand.spec.ts
+++ b/e2e/live/row-expand.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { selectOption } from './helpers';
+
+/**
+ * Live e2e for the master-detail inline grid's per-row "expand to full form"
+ * (the mainstream hybrid: a quick grid + a rich per-row form). Adding a line
+ * then clicking its expand button reveals the child's COMPLETE form inline
+ * (rich types the grid omits live here; the parent FK is excluded). Applying
+ * writes the values back into the grid row — no separate backend write; the
+ * atomic batch still persists everything on the parent Save.
+ *
+ * The editor is rendered inline (not a portaled drawer) precisely so it stays
+ * interactive + accessible when this form is itself inside the create-record
+ * modal (a nested portaled overlay would inherit the host modal's
+ * pointer-events / aria-hidden lock and be unclickable).
+ */
+test('a grid row expands into a full inline form and writes values back', async ({ page }) => {
+  await page.goto('/apps/showcase_app/showcase_project');
+  await page.getByRole('button', { name: /^New$/i }).first().click();
+
+  const dialog = page.getByRole('dialog').first();
+  await expect(dialog.getByTestId('md-form-submit')).toBeVisible();
+
+  // Add a task line, then expand it into the full form.
+  await dialog.getByTestId('line-items-add').click();
+  await dialog.getByTestId('line-items-expand-0').click();
+
+  const editor = page.getByTestId('md-row-form');
+  await expect(editor).toBeVisible();
+
+  // Richer than the grid: includes fields the grid omits (Notes) and excludes
+  // the parent relationship FK (Project).
+  await expect(editor.getByText('Notes', { exact: false }).first()).toBeVisible();
+  await expect(editor.getByText(/^Project$/)).toHaveCount(0);
+
+  // Fill the required fields (Title + Status) in the full form, then Apply.
+  await editor.locator('input[name="title"]').fill('Deep task A');
+  await selectOption(editor, 'status', 'todo');
+  await editor.getByRole('button', { name: 'Apply', exact: true }).click();
+
+  // Editor closes and the value is written back into the grid row.
+  await expect(editor).toBeHidden();
+  await expect(dialog.getByTestId('line-items').getByRole('textbox').first()).toHaveValue('Deep task A');
+});

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -15,7 +15,7 @@ import {
   Checkbox,
   Label,
 } from '@object-ui/components';
-import { Plus, Trash2, SlidersHorizontal } from 'lucide-react';
+import { Plus, Trash2, SlidersHorizontal, Maximize2 } from 'lucide-react';
 import { LookupField } from './LookupField';
 
 /**
@@ -100,8 +100,15 @@ export function GridField({
   readonly,
   disabled,
   className,
+  onRowExpand,
   ...props
-}: FieldWidgetProps<Row[]>) {
+}: FieldWidgetProps<Row[]> & {
+  /** When provided, each row shows an "expand" button that opens the row in a
+   *  full form (the host — e.g. MasterDetailForm — renders the drawer/modal and
+   *  writes the edited values back). Lets a "fat" child be edited in a real form
+   *  while the grid stays a quick at-a-glance editor. */
+  onRowExpand?: (rowIndex: number) => void;
+}) {
   const cfg = (field || (props as any).schema || {}) as any;
   const allColumns: GridColumn[] = cfg.columns || [];
   const rows: Row[] = Array.isArray(value) ? value : [];
@@ -125,6 +132,9 @@ export function GridField({
 
   const allowAdd = cfg.allow_add !== false && !readonly && !disabled;
   const allowDelete = cfg.allow_delete !== false && !readonly && !disabled;
+  // Per-row "expand to full form" (mainstream hybrid: quick grid + rich form).
+  const showExpand = typeof onRowExpand === 'function' && !readonly;
+  const hasRowActions = showExpand || allowDelete;
   // Enterprise line grids (NetSuite/SAP/Salesforce) show a line-number column.
   const showLineNumbers = cfg.show_line_numbers !== false;
   const minRows: number = cfg.min_rows ?? 0;
@@ -332,14 +342,14 @@ export function GridField({
                   {c.required && <span className="text-destructive"> *</span>}
                 </th>
               ))}
-              {allowDelete && <th className="w-10" />}
+              {hasRowActions && <th style={{ width: showExpand && allowDelete ? 84 : 44 }} />}
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
             {rows.length === 0 ? (
               <tr>
                 <td
-                  colSpan={columns.length + (allowDelete ? 1 : 0) + (showLineNumbers ? 1 : 0)}
+                  colSpan={columns.length + (hasRowActions ? 1 : 0) + (showLineNumbers ? 1 : 0)}
                   className="px-3 py-6 text-center text-muted-foreground"
                 >
                   No items yet — click “{cfg.add_label || 'Add line'}” to begin.
@@ -414,19 +424,35 @@ export function GridField({
                       )}
                     </td>
                   ))}
-                  {allowDelete && (
-                    <td className="px-2 py-1.5 text-center align-middle">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                        aria-label="Remove row"
-                        onClick={() => removeRow(rowIdx)}
-                        disabled={disabled || rows.length <= minRows}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                  {hasRowActions && (
+                    <td className="px-2 py-1.5 text-center align-middle whitespace-nowrap">
+                      {showExpand && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                          aria-label="Open row"
+                          title="Open full form"
+                          data-testid={`line-items-expand-${rowIdx}`}
+                          onClick={() => onRowExpand!(rowIdx)}
+                        >
+                          <Maximize2 className="h-3.5 w-3.5" />
+                        </Button>
+                      )}
+                      {allowDelete && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                          aria-label="Remove row"
+                          onClick={() => removeRow(rowIdx)}
+                          disabled={disabled || rows.length <= minRows}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
                     </td>
                   )}
                 </tr>
@@ -445,8 +471,8 @@ export function GridField({
                 <td className="px-3 py-2 text-right font-semibold text-foreground tabular-nums" data-testid="line-items-total">
                   {total.toLocaleString()}
                 </td>
-                {(columns.length - totalColIndex - 1 + (allowDelete ? 1 : 0)) > 0 && (
-                  <td colSpan={columns.length - totalColIndex - 1 + (allowDelete ? 1 : 0)} />
+                {(columns.length - totalColIndex - 1 + (hasRowActions ? 1 : 0)) > 0 && (
+                  <td colSpan={columns.length - totalColIndex - 1 + (hasRowActions ? 1 : 0)} />
                 )}
               </tr>
             </tfoot>

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -42,6 +42,9 @@ export interface MasterDetailDetailConfig {
   /** Editable columns for the child grid. Optional — derived from the child
    *  object's fields (via DataSource.getObjectSchema) when omitted. */
   columns?: GridColumn[];
+  /** Field names for the per-row expand form. Optional — derived from the child
+   *  object's fields (broader than `columns`: includes rich types) when omitted. */
+  formFields?: string[];
   /** Numeric child column to sum, e.g. 'amount'. */
   amountField?: string;
   /** Parent field to receive the rolled-up sum, e.g. 'total_amount'. */
@@ -122,6 +125,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
               ...d,
               relationshipField: derived.relationshipField,
               columns: derived.columns,
+              formFields: d.formFields ?? derived.formFields,
               amountField: d.amountField ?? derived.amountField,
             };
           } catch {
@@ -188,6 +192,28 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
   const setRows = useCallback((detailIdx: number, rows: Record<string, any>[]) => {
     setState((prev) => prev.map((s, i) => (i === detailIdx ? { ...s, rows } : s)));
   }, []);
+
+  // Per-row "expand to full form": opens the child's complete form (all business
+  // fields, incl. rich types the grid omits) in a drawer, pre-filled with the
+  // row. Saving writes back into the in-memory row — the atomic batch still
+  // persists everything on the parent Save (no separate backend write here).
+  const [expanded, setExpanded] = useState<{ detailIdx: number; rowIdx: number } | null>(null);
+  const expandedRow =
+    expanded ? state[expanded.detailIdx]?.rows?.[expanded.rowIdx] : undefined;
+  const expandedDetail = expanded ? details[expanded.detailIdx] : undefined;
+
+  const applyRowEdit = useCallback(
+    (detailIdx: number, rowIdx: number, values: Record<string, any>) => {
+      setState((prev) =>
+        prev.map((s, i) =>
+          i === detailIdx
+            ? { ...s, rows: s.rows.map((r, j) => (j === rowIdx ? { ...r, ...values } : r)) }
+            : s,
+        ),
+      );
+    },
+    [],
+  );
 
   /**
    * Built-in feedback so a save is NEVER silent (a silent success looks broken
@@ -389,6 +415,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
             <LineItemsField
               value={state[i]?.rows ?? []}
               onChange={(rows) => setRows(i, rows)}
+              onRowExpand={(rowIdx) => setExpanded({ detailIdx: i, rowIdx })}
               field={
                 {
                   columns: d.columns,
@@ -406,7 +433,57 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
         </Card>
       ))}
 
-      {/* 3) Single action bar at the bottom */}
+      {/* Per-row "expand to full form": an inline editor panel for the selected
+          row. Rendered INLINE (not a portaled drawer) so it behaves identically
+          whether this form is itself inside a modal (New-from-list) or a full
+          page — nested portaled overlays inherit the host modal's
+          pointer-events / aria-hidden lock and become unclickable. Edits the
+          row in the child's COMPLETE form (rich types the grid omits) and writes
+          the values back into the in-memory row; the atomic batch persists
+          everything on the parent Save. */}
+      {expanded && expandedDetail && (
+        <Card className="border-primary/40 shadow-none ring-1 ring-primary/10" data-testid="md-row-form">
+          <CardHeader className="pb-2 flex flex-row items-center justify-between gap-2 space-y-0">
+            <CardTitle className="text-sm font-medium">
+              {(expandedDetail.title || 'Line item')} — row {expanded.rowIdx + 1}
+            </CardTitle>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-muted-foreground"
+              onClick={() => setExpanded(null)}
+            >
+              Close
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <ObjectForm
+              key={`row-${expanded.detailIdx}-${expanded.rowIdx}`}
+              schema={{
+                type: 'object-form',
+                objectName: expandedDetail.childObject,
+                mode: 'edit',
+                // No recordId → ObjectForm uses initialData (no backend fetch).
+                initialData: expandedRow ?? {},
+                ...(expandedDetail.formFields?.length ? { fields: expandedDetail.formFields } : {}),
+                submitText: 'Apply',
+                // Non-persisting: return the values; the atomic batch on the
+                // parent Save does the real write.
+                submitHandler: async (values: any) => values,
+                onSuccess: (values: any) => {
+                  applyRowEdit(expanded.detailIdx, expanded.rowIdx, values);
+                  setExpanded(null);
+                },
+                onCancel: () => setExpanded(null),
+              } as any}
+              dataSource={dataSource}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Single action bar at the bottom */}
       <div className="flex items-center justify-end gap-2 border-t border-border pt-4">
         {schema.onCancel && (
           <Button type="button" variant="outline" onClick={schema.onCancel} disabled={saving} data-testid="md-form-cancel">

--- a/packages/plugin-form/src/deriveMasterDetail.test.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findRelationshipField, deriveColumns, deriveDetail, fieldTypeToColumnType } from './deriveMasterDetail';
+import { findRelationshipField, deriveColumns, deriveDetail, deriveFormFields, fieldTypeToColumnType } from './deriveMasterDetail';
 
 const taskSchema = {
   name: 'showcase_task',
@@ -139,6 +139,43 @@ describe('deriveColumns curation (column budget)', () => {
     expect(visible(cols)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']); // 7 required visible
     expect(cols.find((c) => c.field === 'h')?.defaultHidden).toBe(true); // non-required collapsed
     expect(cols.length).toBe(8); // nothing dropped
+  });
+});
+
+describe('deriveFormFields (per-row expand form)', () => {
+  it('returns business fields, excluding system/audit/FK/computed', () => {
+    const fields = deriveFormFields(taskSchema, { relationshipField: 'project' });
+    expect(fields).toContain('title');
+    expect(fields).toContain('status');
+    expect(fields).toContain('assignee');
+    expect(fields).not.toContain('id');         // system
+    expect(fields).not.toContain('created_at'); // audit
+    expect(fields).not.toContain('project');    // back-reference FK
+    expect(fields).not.toContain('health');     // formula (computed)
+  });
+
+  it('keeps rich input types the grid omits (textarea/file/etc.)', () => {
+    const rich = {
+      fields: {
+        title: { type: 'text', required: true },
+        parent: { type: 'master_detail', reference: 'p', required: true },
+        notes: { type: 'textarea' },
+        cover: { type: 'image' },
+        attachment: { type: 'file' },
+        total: { type: 'summary' }, // computed → excluded
+      },
+    };
+    const fields = deriveFormFields(rich, { relationshipField: 'parent' });
+    expect(fields).toEqual(expect.arrayContaining(['title', 'notes', 'cover', 'attachment']));
+    expect(fields).not.toContain('total');
+    expect(fields).not.toContain('parent');
+  });
+
+  it('is surfaced on deriveDetail output', () => {
+    const d = deriveDetail('showcase_task', taskSchema, 'showcase_project');
+    expect(Array.isArray(d.formFields)).toBe(true);
+    expect(d.formFields).toContain('title');
+    expect(d.formFields).not.toContain('project');
   });
 });
 

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -189,10 +189,41 @@ export function deriveColumns(
   return curateColumns(cols, maxColumns);
 }
 
+/** Computed / non-input field types — excluded from the row form (read-only,
+ *  server-derived). Unlike grid columns we DO keep rich inputs (textarea,
+ *  richtext, file, image, json…) since the row form has room for them. */
+const NON_INPUT_TYPES = new Set(['formula', 'summary', 'rollup', 'autonumber', 'auto_number']);
+
+/**
+ * Field names for a child's full "row form" (the per-row expand editor) — every
+ * editable business field, skipping system/audit fields, the back-reference FK,
+ * and computed types. Broader than {@link deriveColumns} (which only returns
+ * grid-friendly types): the form has room for textarea/richtext/file/etc.
+ */
+export function deriveFormFields(
+  childSchema: ObjectSchemaLike | undefined,
+  opts: { relationshipField?: string; exclude?: string[] } = {},
+): string[] {
+  const fields = childSchema?.fields;
+  if (!fields || typeof fields !== 'object') return [];
+  const exclude = new Set([...(opts.exclude ?? []), ...(opts.relationshipField ? [opts.relationshipField] : [])]);
+  const out: string[] = [];
+  for (const [name, def] of Object.entries(fields)) {
+    const d = def as any;
+    if (SYSTEM_FIELDS.has(name) || exclude.has(name)) continue;
+    if (d?.system || d?.hidden) continue;
+    if (NON_INPUT_TYPES.has(d?.type)) continue;
+    out.push(name);
+  }
+  return out;
+}
+
 export interface DerivedDetail {
   childObject: string;
   relationshipField: string;
   columns: GridColumn[];
+  /** Field names for the per-row expand form (broader than `columns`). */
+  formFields: string[];
   /** First numeric column, used as the running-total source when none is set. */
   amountField?: string;
 }
@@ -218,5 +249,6 @@ export function deriveDetail(
   }
   const columns = override.columns?.length ? override.columns : deriveColumns(childSchema, { relationshipField });
   const amountField = override.amountField || columns.find((c) => c.type === 'number' || c.type === 'currency')?.field;
-  return { childObject, relationshipField, columns, amountField };
+  const formFields = deriveFormFields(childSchema, { relationshipField });
+  return { childObject, relationshipField, columns, formFields, amountField };
 }


### PR DESCRIPTION
## Summary
Implements the mainstream master-detail hybrid (Airtable expand-record, Odoo open-form, Salesforce/Dynamics): a quick inline grid for common columns **+ a per-row "expand" into the child's COMPLETE form** for the rich/long fields the grid can't host.

## Changes
- **GridField**: each row gets an expand (⤢) action when `onRowExpand` is provided; expand + delete share one trailing actions column. The fields package only emits the intent (stays layer-clean).
- **deriveMasterDetail**: new `deriveFormFields()` — the child's full business-field list for the row form (keeps `textarea`/`file`/`image`/etc. the grid omits; drops system/audit/computed + the parent FK). Surfaced on `deriveDetail`.
- **MasterDetailForm**: expand opens an **inline editor panel** rendering the child's complete `ObjectForm` (`initialData` = the row; `submitHandler` returns values → no backend write; the atomic batch still persists on parent Save). Apply writes back into the in-memory row.

## Why inline, not a drawer
This form is often inside the create-record modal. A nested portaled drawer (Radix Sheet) inherits the host modal's `react-remove-scroll` **pointer-events + aria-hidden lock** — verified in-browser that the drawer's buttons were *unclickable* and the panel *aria-hidden*. Rendering inline keeps it interactive **and** accessible in both modal and full-page contexts.

## Verification
- Live in-browser end-to-end: expand → fill Title/Status in the full form → Apply → values written back to the grid row (Title "Deep task A", Status "To Do").
- e2e `row-expand.spec.ts`; full live suite **10/10**.
- Unit: `deriveFormFields` (plugin-form **89**), GridField (fields **3434**); fields typecheck clean.

Step 1 of the hybrid plan. Step 2 (relationship-level `inlineEdit: 'grid' | 'form'` + smart default + ADR/skills) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)