### PR TITLE
fix: title action param dialog as the action (not generic 'Action parameters')

### DIFF
--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -36,6 +36,11 @@ import { LookupField } from '@object-ui/fields';
 export interface ParamDialogState {
   open: boolean;
   params: ActionParamDef[];
+  /** Dialog title — defaults to the generic "Action parameters" label when
+   *  absent. Callers pass the action's own label (e.g. "Create environment")
+   *  so the dialog reads as the task, not a generic param prompt. */
+  title?: string;
+  description?: string;
   resolve?: (value: Record<string, any> | null) => void;
 }
 
@@ -104,9 +109,9 @@ export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProp
     }}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t('actionDialog.title')}</DialogTitle>
+          <DialogTitle>{state.title || t('actionDialog.title')}</DialogTitle>
           <DialogDescription>
-            {t('actionDialog.description')}
+            {state.description || t('actionDialog.description')}
           </DialogDescription>
         </DialogHeader>
 

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -744,7 +744,15 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 fieldOptionLabel,
                 row,
             });
-            setParamState({ open: true, params: resolved, resolve });
+            setParamState({
+                open: true,
+                params: resolved,
+                // Title the dialog as the action ("Create environment") rather
+                // than the generic "Action parameters".
+                title: action?.label || action?.title,
+                description: action?.description,
+                resolve,
+            });
         });
     }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel]);
 

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -316,7 +316,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     });
   }, []);
 
-  const paramCollectionHandler = useCallback((params: ActionParamDef[]) => {
+  const paramCollectionHandler = useCallback((params: ActionParamDef[], action?: any) => {
     return new Promise<Record<string, any> | null>((resolve) => {
       const resolved = resolveActionParams(params as any, {
         objectName: objectName || objectDef?.name || '',
@@ -324,7 +324,14 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         fieldLabel,
         fieldOptionLabel,
       });
-      setParamState({ open: true, params: resolved, resolve });
+      setParamState({
+        open: true,
+        params: resolved,
+        // Title the dialog as the action rather than the generic "Action parameters".
+        title: action?.label || action?.title,
+        description: action?.description,
+        resolve,
+      });
     });
   }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel]);
 

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -77,6 +77,11 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
         await execute({
           type: schema.actionType || schema.type,
           name: schema.name,
+          // Forward the human label/description so a param-collection dialog
+          // can title itself as the action ("Create Environment") instead of a
+          // generic "Action parameters" prompt.
+          label: schema.label,
+          description: (schema as any).description,
           target: schema.target,
           execute: schema.execute,
           endpoint: schema.endpoint,


### PR DESCRIPTION
The action param-collection dialog always showed a generic '操作参数 / Action parameters' header — so the cloud control plane's **Create Environment** button (and any action with params) opened a developer-y, contextless dialog on the new-user funnel.

Root cause: `action-button` dropped the action's label/description when calling `execute()`, so the param handler had no human title. Fix: forward label+description through action-button → ActionParamDialog now titles itself as the action ('创建环境' / localized), with the generic copy preserved as fallback. Benefits every param-collection dialog.

Browser-verified: Create Environment dialog now reads '创建环境'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)