### PR TITLE
feat(i18n): localize action-parameter labels

### DIFF
--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -158,7 +158,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     const location = useLocation();
     const { showDebug } = useMetadataInspector();
     const { t } = useObjectTranslation();
-    const { objectLabel, objectDescription: objectDesc, viewLabel, viewEmptyState, actionLabel, actionConfirm, actionSuccess, fieldLabel, fieldOptionLabel } = useObjectLabel();
+    const { objectLabel, objectDescription: objectDesc, viewLabel, viewEmptyState, actionLabel, actionConfirm, actionSuccess, actionParamText, fieldLabel, fieldOptionLabel } = useObjectLabel();
     const { isFavorite, toggleFavorite } = useFavorites();
     // ADR-0034: runtime view edits persist via the metadata draft/publish
     // model (the `sys_view` table is retired).
@@ -744,9 +744,20 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 fieldOptionLabel,
                 row,
             });
+            // Localize each param's label/placeholder/helpText via the
+            // `_actions.<action>.params.<param>.<attr>` convention, falling back
+            // to the metadata literal. Without this, action params (e.g. the
+            // "Name" field on Create Environment) render untranslated.
+            const objForI18n = objectName || objectDef?.name;
+            const localized = (resolved as any[]).map((p: any) => ({
+                ...p,
+                label: actionParamText(objForI18n, action?.name, p.name, 'label', p.label) ?? p.label,
+                placeholder: actionParamText(objForI18n, action?.name, p.name, 'placeholder', p.placeholder) ?? p.placeholder,
+                helpText: actionParamText(objForI18n, action?.name, p.name, 'helpText', p.helpText) ?? p.helpText,
+            }));
             setParamState({
                 open: true,
-                params: resolved,
+                params: localized,
                 // Title the dialog as the action ("Create environment") rather
                 // than the generic "Action parameters".
                 title: action?.label || action?.title,
@@ -754,7 +765,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 resolve,
             });
         });
-    }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel]);
+    }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel, actionParamText]);
 
     const handleDeleteView = useCallback(async (vid: string) => {
         if (!dataSource) return;

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -119,7 +119,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   const location = useLocation();
   const originFrom = (location.state as any)?.from as { pathname?: string; label?: string } | undefined;
   const { t } = useObjectTranslation();
-  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, fieldLabel, fieldOptionLabel } = useObjectLabel();
+  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, fieldLabel, fieldOptionLabel } = useObjectLabel();
   const { isFavorite, toggleFavorite, refreshLabel: refreshFavoriteLabel } = useFavorites();
   const { addRecentItem } = useRecentItems();
   const [isLoading, setIsLoading] = useState(true);
@@ -324,16 +324,25 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         fieldLabel,
         fieldOptionLabel,
       });
+      // Localize param label/placeholder/helpText (see ObjectView for the
+      // convention); falls back to the metadata literal.
+      const objForI18n = objectName || objectDef?.name;
+      const localized = (resolved as any[]).map((p: any) => ({
+        ...p,
+        label: actionParamText(objForI18n, action?.name, p.name, 'label', p.label) ?? p.label,
+        placeholder: actionParamText(objForI18n, action?.name, p.name, 'placeholder', p.placeholder) ?? p.placeholder,
+        helpText: actionParamText(objForI18n, action?.name, p.name, 'helpText', p.helpText) ?? p.helpText,
+      }));
       setParamState({
         open: true,
-        params: resolved,
+        params: localized,
         // Title the dialog as the action rather than the generic "Action parameters".
         title: action?.label || action?.title,
         description: action?.description,
         resolve,
       });
     });
-  }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel]);
+  }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel, actionParamText]);
 
   const toastHandler = useCallback((message: string, options?: { type?: string }) => {
     if (options?.type === 'error') toast.error(message);

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -384,6 +384,29 @@ export function useObjectLabel() {
       const resolved = resolve(suffixes, fb);
       return resolved || undefined;
     },
+
+    /**
+     * Resolve translated action-PARAMETER text (label / placeholder / helpText).
+     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.params.{paramName}.{attr}`.
+     * Falls back to the provided value (the metadata's literal string) when no
+     * translation exists, so untranslated params keep rendering as authored.
+     */
+    actionParamText: (
+      objectName: string | undefined,
+      actionName: string | undefined,
+      paramName: string,
+      attr: 'label' | 'placeholder' | 'helpText',
+      fallback?: string,
+    ) => {
+      const fb = fallback ?? '';
+      if (!actionName || !paramName) return fb || undefined;
+      const suffix = `_actions.${actionName}.params.${paramName}.${attr}`;
+      const suffixes = objectName
+        ? objectSuffixes(objectName, suffix)
+        : `globalActions.${actionName}.params.${paramName}.${attr}`;
+      const resolved = resolve(suffixes, fb);
+      return resolved || undefined;
+    },
   };
   }, [t, i18n]);
 }


### PR DESCRIPTION
Action *labels* localized but action *params* didn't — Create Environment's dialog title was '创建环境' while its field stayed 'Name'. Adds an `actionParamText` probe (`objects.<obj>._actions.<action>.params.<param>.<attr>`) applied in the param-collection handlers, falling back to the metadata literal. Browser-verified with the cloud zh keys (field → '名称'). Benefits every action with collected params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)