### PR TITLE
feat(forms): field-level conditional rules — visibleWhen/readonlyWhen/requiredWhen (B2 client)

### DIFF
--- a/.changeset/b2-client-field-rules.md
+++ b/.changeset/b2-client-field-rules.md
@@ -1,0 +1,8 @@
+---
+"@object-ui/core": minor
+"@object-ui/types": minor
+"@object-ui/components": patch
+"@object-ui/plugin-form": patch
+---
+
+B2 step 3: client-side field-level conditional rules (`visibleWhen` / `readonlyWhen` / `requiredWhen`). The form renderer now evaluates these CEL predicates reactively against the live record and gates each field's visibility, read-only state, and required-ness accordingly. Evaluation delegates to the canonical `@objectstack/formula` `ExpressionEngine` — the *same* dialect the server enforces (`requiredWhen` in the rule-validator, `readonlyWhen` in `stripReadonlyWhenFields`) — so the UX and the persisted verdict always agree. New core helpers `evalFieldPredicate` / `resolveFieldRuleState` (zero-React, fail-open). `FormField` gains `visibleWhen` / `readonlyWhen` / `requiredWhen` (+ deprecated `conditionalRequired` alias), and `ObjectForm` carries them through from object metadata.

--- a/docs/adr/0036-field-conditional-rules.md
+++ b/docs/adr/0036-field-conditional-rules.md
@@ -1,0 +1,117 @@
+# ADR-0036: Field-level conditional rules (visibleWhen / readonlyWhen / requiredWhen)
+
+**Status**: Accepted — implementing (2026-06-07)
+**Author**: ObjectUI renderer team
+**Consumers**: `@object-ui/core`, `@object-ui/components` (form renderer), `@object-ui/plugin-form`, `@objectstack/spec`, `@objectstack/objectql`, every app whose forms need a field to appear / lock / become mandatory based on other field values
+
+---
+
+## TL;DR
+
+A field's visibility, read-only state, and required-ness are frequently
+**conditional on the rest of the record**: an invoice's `paid_on` is only
+relevant once `status == 'paid'`; its `tax_rate` is locked once paid; a "send"
+flow requires `issued_on` only when the invoice leaves draft. These are not
+widget concerns — they are **data-model rules**, authored once on the field and
+honored everywhere the object is edited.
+
+We express them as three optional CEL predicates on `Field`:
+
+| Prop           | When the predicate is TRUE                          | Enforced on        |
+| -------------- | --------------------------------------------------- | ------------------ |
+| `visibleWhen`  | the field is shown (else hidden)                    | client (UX only)   |
+| `readonlyWhen` | the field is read-only                              | **client + server**|
+| `requiredWhen` | the field is required                               | **client + server**|
+
+`conditionalRequired` is a back-compat **alias of `requiredWhen`**.
+
+## Why CEL, and why the *same* engine on both ends
+
+The whole point of a dual-side rule is that the **client UX and the persisted
+server verdict agree** for any given record. To guarantee that, both ends
+evaluate the predicate with the canonical ObjectStack expression engine —
+`@objectstack/formula`'s `ExpressionEngine` (CEL via `@marcbachmann/cel-js`) —
+rather than a parallel evaluator. Same dialect, same stdlib, same null/missing
+semantics. The alternative (a bespoke client-side condition DSL) is exactly the
+drift hazard this avoids: it would agree on `record.status == 'paid'` today and
+silently diverge the first time a predicate used `has()`, a string function, or
+a list membership test.
+
+`@objectstack/formula` is browser-safe — its only deps are
+`@marcbachmann/cel-js` and `@objectstack/spec`, and `@object-ui/core` already
+depends on the latter — so there is no new runtime surface and no node-only
+import dragged into the bundle.
+
+## Server enforcement (framework)
+
+- **`requiredWhen`** — `@objectstack/objectql`'s rule-validator evaluates the
+  predicate over the *merged* record (`{ ...previous, ...patch }`) and pushes a
+  `{ field, code: 'required' }` violation when it is TRUE and the value is
+  missing. `conditionalRequired` is treated identically.
+- **`readonlyWhen`** — `stripReadonlyWhenFields` drops any field from an UPDATE
+  payload whose predicate is TRUE for the merged record: the incoming change is
+  **ignored** (the persisted value is kept), not rejected. Update paths fetch
+  the prior record only when an object actually declares conditional fields
+  (`needsPriorRecord`).
+- A predicate that fails to evaluate is **fail-open** and logged (a broken rule
+  must never block a legitimate write).
+- `visibleWhen` is **not** a server concept — visibility is purely a client UX
+  affordance. The server's `requiredWhen` / `readonlyWhen` are the real guards,
+  so hiding a field client-side never weakens enforcement.
+
+## Client enforcement (objectui)
+
+- **`@object-ui/core`** exposes two zero-React helpers:
+  - `evalFieldPredicate(pred, record, fallback, previous?)` — wraps the engine,
+    returns `fallback` on an absent/broken predicate.
+  - `resolveFieldRuleState(rules, record, statics, previous?)` → `{ visible,
+    readonly, required }`. A static `required: true` / `readonly: true` is a
+    **floor** — a FALSE predicate never weakens it; `visibleWhen` is
+    authoritative when present.
+- **The form renderer** (`@object-ui/components`) watches the live record
+  (`form.watch()`) and re-evaluates every field's rules **reactively** as the
+  user types. A field whose `visibleWhen` is FALSE is not rendered; `readonly`
+  feeds the field's `disabled`; `required` drives both the asterisk and the RHF
+  validation rule.
+- **`ObjectForm`** (`@object-ui/plugin-form`) carries the three props through
+  from object metadata onto the generated `FormField`s.
+
+### The missing-key gotcha
+
+CEL **throws** on a *missing* map key (`record.status` when `status` isn't in
+the record) but compares cleanly against `null`. On a fresh create form,
+react-hook-form hasn't registered every field yet, so a naïve `form.watch()`
+omits them — and a `visibleWhen` referencing an unregistered field would fault
+and fail *open* (flash visible). The renderer therefore seeds every declared
+field to `null` before overlaying the *defined* watched values, so an
+unregistered field reads as present-null (clean predicate result) rather than
+missing (fault). This mirrors the server, which always evaluates over the full
+merged record.
+
+`evalFieldPredicate`'s fallbacks are chosen so a fault is *safe*: `true` for
+visibility (don't hide content on error), `false` for required/readonly (don't
+block submit or lock a field on error) — the same posture as the server.
+
+## Showcase
+
+`showcase_invoice` demonstrates all three:
+
+```ts
+issued_on: Field.date({ requiredWhen: "record.status in ['sent', 'paid']" }),
+tax_rate:  Field.number({ readonlyWhen: "record.status == 'paid'" }),
+paid_on:   Field.date({
+  visibleWhen:  "record.status == 'paid'",   // UX-only: hide until paid
+  requiredWhen: "record.status == 'paid'",   // dual-side
+}),
+```
+
+Covered by the `field-conditional-rules` live e2e (drives Status →
+paid/sent/draft and asserts each dependent field re-gates).
+
+## Consequences
+
+- Authors express conditional UX once, on the field, in the same CEL they
+  already use for validation rules and formulas — no widget-level wiring.
+- Client and server cannot drift: identical engine, identical dialect.
+- `visibleWhen` is intentionally client-only; never rely on it for security —
+  use `readonlyWhen` / `requiredWhen` (or a full validation rule) for guarantees.

--- a/e2e/live/field-conditional-rules.spec.ts
+++ b/e2e/live/field-conditional-rules.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, type Locator } from '@playwright/test';
+import { selectOption } from './helpers';
+
+/**
+ * B2 live e2e: field-level conditional rules (visibleWhen / readonlyWhen /
+ * requiredWhen), authored as CEL on the object's fields and enforced
+ * client-side by the form renderer via the canonical @objectstack/formula
+ * engine — the SAME dialect the server enforces, so the UX and the persisted
+ * verdict agree.
+ *
+ * The showcase Invoice header declares:
+ *   • issued_on.requiredWhen = "record.status in ['sent', 'paid']"
+ *   • tax_rate.readonlyWhen  = "record.status == 'paid'"
+ *   • paid_on.visibleWhen    = "record.status == 'paid'"   (UX-only)
+ *     paid_on.requiredWhen   = "record.status == 'paid'"
+ *
+ * Driving the Status select must reactively re-gate every dependent field.
+ */
+
+/** True when the field's <label> carries the required asterisk. */
+async function isRequired(dialog: Locator, labelText: string): Promise<boolean> {
+  const marker = dialog
+    .locator('label', { hasText: labelText })
+    .locator('span[aria-label="required"]');
+  return (await marker.count()) > 0;
+}
+
+test('header fields react to Status via CEL visibleWhen / readonlyWhen / requiredWhen', async ({ page }) => {
+  await page.goto('/apps/showcase_app/showcase_invoice');
+  await page.getByRole('button', { name: /^(New|新建)$/i }).first().click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByTestId('md-form-submit')).toBeVisible();
+
+  const paidOn = dialog.locator('[name="paid_on"]');
+  const taxRate = dialog.locator('[name="tax_rate"]');
+
+  // --- Initial (status unset / draft): paid_on hidden, tax_rate editable,
+  //     issued_on not yet required. ---
+  await expect(paidOn).toHaveCount(0);
+  await expect(taxRate).toBeEnabled();
+  expect(await isRequired(dialog, 'Issued On')).toBe(false);
+
+  // --- Paid: tax_rate locks (readonlyWhen), paid_on appears + required,
+  //     issued_on required. ---
+  await selectOption(dialog, 'status', 'paid');
+  await expect(paidOn).toHaveCount(1);
+  await expect(taxRate).toBeDisabled();
+  expect(await isRequired(dialog, 'Paid On')).toBe(true);
+  expect(await isRequired(dialog, 'Issued On')).toBe(true);
+
+  // --- Sent: tax_rate editable again, paid_on hidden again, issued_on still
+  //     required. ---
+  await selectOption(dialog, 'status', 'sent');
+  await expect(paidOn).toHaveCount(0);
+  await expect(taxRate).toBeEnabled();
+  expect(await isRequired(dialog, 'Issued On')).toBe(true);
+
+  // --- Draft: everything relaxes — tax_rate editable, paid_on hidden,
+  //     issued_on optional. ---
+  await selectOption(dialog, 'status', 'draft');
+  await expect(paidOn).toHaveCount(0);
+  await expect(taxRate).toBeEnabled();
+  expect(await isRequired(dialog, 'Issued On')).toBe(false);
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ComponentRegistry } from '@object-ui/core';
+import { ComponentRegistry, resolveFieldRuleState } from '@object-ui/core';
 import type { FormSchema, FormField as FormFieldConfig, ValidationRule, FieldCondition, SelectOption } from '@object-ui/types';
 import { useForm } from 'react-hook-form';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from '../../ui/form';
@@ -223,6 +223,12 @@ ComponentRegistry.register('form',
     const [isSubmitting, setIsSubmitting] = React.useState(false);
     const [submitError, setSubmitError] = React.useState<string | null>(null);
 
+    // Live snapshot of all form values — subscribes to every change so
+    // field-level CEL rules (visibleWhen/readonlyWhen/requiredWhen) re-evaluate
+    // reactively as the user edits. Evaluated below via the canonical
+    // `@objectstack/formula` engine (same dialect the server enforces).
+    const recordValues = form.watch() as Record<string, unknown>;
+
     // Read DataSource from SchemaRendererContext and propagate it to field
     // widgets as a prop so they can dynamically load related records.
     const schemaCtx = React.useContext(SchemaRendererContext);
@@ -412,7 +418,7 @@ ComponentRegistry.register('form',
                   label,
                   description,
                   type = 'input',
-                  required = false,
+                  required: staticRequired = false,
                   disabled: fieldDisabled = false,
                   validation = {},
                   condition,
@@ -420,7 +426,11 @@ ComponentRegistry.register('form',
                   hidden,
                   widget,
                   visibleOn,
-                  readonly,
+                  readonly: staticReadonly,
+                  visibleWhen,
+                  readonlyWhen,
+                  requiredWhen,
+                  conditionalRequired,
                   ...fieldProps
                 } = field;
 
@@ -431,10 +441,10 @@ ComponentRegistry.register('form',
                 if (condition) {
                   const watchField = condition.field;
                   const watchValue = form.watch(watchField);
-                  
+
                   // Check for null/undefined before evaluating conditions
                   const hasValue = watchValue !== undefined && watchValue !== null;
-                  
+
                   if (condition.equals !== undefined && watchValue !== condition.equals) {
                     return null;
                   }
@@ -445,6 +455,20 @@ ComponentRegistry.register('form',
                     return null;
                   }
                 }
+
+                // Field-level CEL conditional rules (B2). Evaluated reactively
+                // against the live record via the canonical engine — same
+                // dialect the server enforces (requiredWhen / readonlyWhen), so
+                // the UX and the persisted verdict agree. A field with no rules
+                // resolves to its static flags unchanged.
+                const ruleState = resolveFieldRuleState(
+                  { visibleWhen, readonlyWhen, requiredWhen, conditionalRequired },
+                  recordValues,
+                  { required: staticRequired, readonly: staticReadonly === true },
+                );
+                if (!ruleState.visible) return null;
+                const required = ruleState.required;
+                const readonly = ruleState.readonly;
 
                 // Section divider — renders a collapsible FormSection header inline
                 // so all fields share the same form instance (enables cross-section conditions).

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -226,8 +226,26 @@ ComponentRegistry.register('form',
     // Live snapshot of all form values — subscribes to every change so
     // field-level CEL rules (visibleWhen/readonlyWhen/requiredWhen) re-evaluate
     // reactively as the user edits. Evaluated below via the canonical
-    // `@objectstack/formula` engine (same dialect the server enforces).
-    const recordValues = form.watch() as Record<string, unknown>;
+    // `@objectstack/formula` engine (same dialect the server enforces). We seed
+    // every declared field name to `null` first so a predicate that references
+    // a field react-hook-form hasn't registered yet (e.g. on initial mount,
+    // before defaults populate) evaluates against a present-but-null value
+    // rather than faulting — mirroring the server, which evaluates over the
+    // full merged record.
+    const watched = form.watch() as Record<string, unknown>;
+    const ruleRecord = React.useMemo(() => {
+      // Seed every declared field to `null` so a predicate referencing a field
+      // that's absent / not-yet-registered evaluates against a present-null
+      // value. The canonical CEL engine throws "No such key" on a *missing*
+      // field (which would fail the predicate open), but compares cleanly
+      // against `null`. Overlay only DEFINED watched values so an unregistered
+      // field (value `undefined`) doesn't clobber its null seed back to missing.
+      const out: Record<string, unknown> = {};
+      for (const f of fields) if (f?.name) out[f.name] = null;
+      for (const k of Object.keys(watched)) if (watched[k] !== undefined) out[k] = watched[k];
+      return out;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [fields, JSON.stringify(watched)]);
 
     // Read DataSource from SchemaRendererContext and propagate it to field
     // widgets as a prop so they can dynamically load related records.
@@ -463,7 +481,7 @@ ComponentRegistry.register('form',
                 // resolves to its static flags unchanged.
                 const ruleState = resolveFieldRuleState(
                   { visibleWhen, readonlyWhen, requiredWhen, conditionalRequired },
-                  recordValues,
+                  ruleRecord,
                   { required: staticRequired, readonly: staticReadonly === true },
                 );
                 if (!ruleState.visible) return null;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@object-ui/types": "workspace:*",
+    "@objectstack/formula": "^7.9.0",
     "@objectstack/spec": "^7.8.0",
     "lodash": "^4.18.1",
     "zod": "^4.4.3"

--- a/packages/core/src/evaluator/__tests__/fieldRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/fieldRules.test.ts
@@ -1,0 +1,110 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evalFieldPredicate, resolveFieldRuleState } from '../fieldRules';
+
+describe('evalFieldPredicate', () => {
+  it('evaluates a bare-string CEL predicate as TRUE', () => {
+    expect(evalFieldPredicate("record.status == 'paid'", { status: 'paid' }, false)).toBe(true);
+  });
+
+  it('evaluates a bare-string CEL predicate as FALSE', () => {
+    expect(evalFieldPredicate("record.status == 'paid'", { status: 'draft' }, false)).toBe(false);
+  });
+
+  it('accepts an { dialect, source } object predicate', () => {
+    expect(
+      evalFieldPredicate({ dialect: 'cel', source: 'record.amount > 100' }, { amount: 250 }, false),
+    ).toBe(true);
+  });
+
+  it('returns the fallback for an absent predicate', () => {
+    expect(evalFieldPredicate(undefined, { status: 'paid' }, true)).toBe(true);
+    expect(evalFieldPredicate(null, { status: 'paid' }, false)).toBe(false);
+    expect(evalFieldPredicate('   ', { status: 'paid' }, true)).toBe(true);
+  });
+
+  it('fails open to the fallback on a broken predicate', () => {
+    // Unparseable / type-faulting CEL must not throw — it returns fallback.
+    expect(evalFieldPredicate('record.status ===', { status: 'paid' }, false)).toBe(false);
+    expect(evalFieldPredicate('record.status ===', { status: 'paid' }, true)).toBe(true);
+  });
+
+  it('exposes previous.* for transition predicates', () => {
+    expect(
+      evalFieldPredicate("record.status == 'paid' && previous.status != 'paid'", { status: 'paid' }, false, {
+        status: 'sent',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('resolveFieldRuleState', () => {
+  it('hides a field whose visibleWhen is FALSE', () => {
+    const s = resolveFieldRuleState({ visibleWhen: "record.status == 'sent'" }, { status: 'draft' }, {});
+    expect(s.visible).toBe(false);
+  });
+
+  it('shows a field whose visibleWhen is TRUE', () => {
+    const s = resolveFieldRuleState({ visibleWhen: "record.status == 'sent'" }, { status: 'sent' }, {});
+    expect(s.visible).toBe(true);
+  });
+
+  it('shows a field with no visibleWhen (default visible)', () => {
+    expect(resolveFieldRuleState({}, {}, {}).visible).toBe(true);
+  });
+
+  it('locks a field whose readonlyWhen is TRUE', () => {
+    const s = resolveFieldRuleState({ readonlyWhen: "record.status == 'paid'" }, { status: 'paid' }, {});
+    expect(s.readonly).toBe(true);
+  });
+
+  it('keeps a static readonly even when readonlyWhen is FALSE', () => {
+    const s = resolveFieldRuleState(
+      { readonlyWhen: "record.status == 'paid'" },
+      { status: 'draft' },
+      { readonly: true },
+    );
+    expect(s.readonly).toBe(true);
+  });
+
+  it('requires a field whose requiredWhen is TRUE', () => {
+    const s = resolveFieldRuleState({ requiredWhen: "record.status == 'sent'" }, { status: 'sent' }, {});
+    expect(s.required).toBe(true);
+  });
+
+  it('honors conditionalRequired as a requiredWhen alias', () => {
+    const s = resolveFieldRuleState({ conditionalRequired: "record.status == 'sent'" }, { status: 'sent' }, {});
+    expect(s.required).toBe(true);
+  });
+
+  it('prefers requiredWhen over conditionalRequired when both present', () => {
+    const s = resolveFieldRuleState(
+      { requiredWhen: "record.status == 'sent'", conditionalRequired: 'record.amount > 0' },
+      { status: 'draft', amount: 5 },
+      {},
+    );
+    // requiredWhen (status=='sent') is FALSE → not required; the alias is ignored.
+    expect(s.required).toBe(false);
+  });
+
+  it('keeps a static required even when requiredWhen is FALSE', () => {
+    const s = resolveFieldRuleState(
+      { requiredWhen: "record.status == 'sent'" },
+      { status: 'draft' },
+      { required: true },
+    );
+    expect(s.required).toBe(true);
+  });
+
+  it('fails open: broken visibleWhen keeps the field visible', () => {
+    const s = resolveFieldRuleState({ visibleWhen: 'record.status ===' }, { status: 'x' }, {});
+    expect(s.visible).toBe(true);
+  });
+});

--- a/packages/core/src/evaluator/__tests__/fieldRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/fieldRules.test.ts
@@ -36,6 +36,17 @@ describe('evalFieldPredicate', () => {
     expect(evalFieldPredicate('record.status ===', { status: 'paid' }, true)).toBe(true);
   });
 
+  it('fails open when a referenced field is MISSING from the record (CEL "No such key")', () => {
+    // CEL throws on a missing map key (vs. comparing cleanly against null). A
+    // predicate referencing an absent field must fall back, not surface the
+    // fault — the renderer seeds declared fields to null to avoid this, but the
+    // helper must be safe on its own.
+    expect(evalFieldPredicate("record.status == 'paid'", {}, true)).toBe(true);
+    expect(evalFieldPredicate("record.status == 'paid'", {}, false)).toBe(false);
+    // Present-but-null compares cleanly to a real boolean (no fault).
+    expect(evalFieldPredicate("record.status == 'paid'", { status: null }, true)).toBe(false);
+  });
+
   it('exposes previous.* for transition predicates', () => {
     expect(
       evalFieldPredicate("record.status == 'paid' && previous.status != 'paid'", { status: 'paid' }, false, {

--- a/packages/core/src/evaluator/fieldRules.ts
+++ b/packages/core/src/evaluator/fieldRules.ts
@@ -1,0 +1,104 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Client-side evaluation of field-level conditional rules
+ * (`visibleWhen` / `readonlyWhen` / `requiredWhen`).
+ *
+ * These predicates are authored as CEL — the *same* dialect the server
+ * enforces in `@objectstack/objectql`'s rule-validator (`requiredWhen`) and
+ * `stripReadonlyWhenFields` (`readonlyWhen`). To guarantee the client UX and
+ * the server enforcement reach the *identical* verdict for a given record we
+ * delegate to the canonical engine, `@objectstack/formula`'s
+ * `ExpressionEngine`, rather than re-implementing a parallel evaluator. See
+ * ADR-0036 (field-level conditional rules) and the framework's
+ * `packages/formula` "No private expression DSL" note.
+ *
+ * A predicate is `string | { dialect, source }`. A bare string is treated as
+ * CEL (mirrors the server's `toExpression`). Evaluation is *fail-open* for
+ * visibility/required (a broken predicate must not hide a field or wrongly
+ * block submit) and *fail-open* for readonly (a broken predicate leaves the
+ * field editable) — matching the server, which logs and allows the change
+ * through.
+ */
+import { ExpressionEngine } from '@objectstack/formula';
+import type { Expression } from '@objectstack/spec';
+
+/** A field-rule predicate as authored in metadata. */
+export type FieldRulePredicate = string | { dialect?: string; source: string };
+
+/** Normalize a predicate into the `Expression` shape the engine expects. */
+function toExpression(pred: FieldRulePredicate): Expression {
+  if (typeof pred === 'string') return { dialect: 'cel', source: pred };
+  return { dialect: (pred.dialect ?? 'cel') as Expression['dialect'], source: pred.source };
+}
+
+/**
+ * Evaluate a field-rule CEL predicate against a record.
+ *
+ * @param pred      The `visibleWhen` / `readonlyWhen` / `requiredWhen` predicate.
+ * @param record    The live form values (overlays prior persisted record).
+ * @param fallback  Value to return when the predicate is absent or fails to
+ *                  evaluate. Pick the *safe* default for the caller:
+ *                  `false` for readonly/required (don't lock/block on error),
+ *                  `true` for visibility (don't hide on error).
+ * @param previous  The prior persisted record, if any (for `previous.*` refs).
+ */
+export function evalFieldPredicate(
+  pred: FieldRulePredicate | undefined | null,
+  record: Record<string, unknown>,
+  fallback: boolean,
+  previous?: Record<string, unknown>,
+): boolean {
+  if (pred == null || (typeof pred === 'string' && !pred.trim())) return fallback;
+  try {
+    const res = ExpressionEngine.evaluate<boolean>(toExpression(pred), { record, previous });
+    if (!res.ok) return fallback;
+    return res.value === true;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Resolve the effective `{ visible, readonly, required }` state for a field
+ * given its conditional rules and the live record. Each `*When` rule, when
+ * present, *overrides* the static flag. A static `true` is never weakened by a
+ * `false` predicate result for required/readonly — but `visibleWhen` is
+ * authoritative when present (so a field can be conditionally shown/hidden).
+ */
+export function resolveFieldRuleState(
+  rules: {
+    visibleWhen?: FieldRulePredicate;
+    readonlyWhen?: FieldRulePredicate;
+    requiredWhen?: FieldRulePredicate;
+    /** Back-compat alias of `requiredWhen` (spec @deprecated). */
+    conditionalRequired?: FieldRulePredicate;
+  },
+  record: Record<string, unknown>,
+  statics: { required?: boolean; readonly?: boolean },
+  previous?: Record<string, unknown>,
+): { visible: boolean; readonly: boolean; required: boolean } {
+  const visible =
+    rules.visibleWhen != null
+      ? evalFieldPredicate(rules.visibleWhen, record, true, previous)
+      : true;
+
+  const readonly =
+    statics.readonly === true ||
+    (rules.readonlyWhen != null
+      ? evalFieldPredicate(rules.readonlyWhen, record, false, previous)
+      : false);
+
+  const requiredPred = rules.requiredWhen ?? rules.conditionalRequired;
+  const required =
+    statics.required === true ||
+    (requiredPred != null ? evalFieldPredicate(requiredPred, record, false, previous) : false);
+
+  return { visible, readonly, required };
+}

--- a/packages/core/src/evaluator/index.ts
+++ b/packages/core/src/evaluator/index.ts
@@ -8,6 +8,7 @@
 
 export * from './ExpressionContext.js';
 export * from './ExpressionEvaluator.js';
+export * from './fieldRules.js';
 export * from './ExpressionCache.js';
 export * from './FormulaFunctions.js';
 export * from './SafeExpressionParser.js';

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -454,8 +454,14 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
           placeholder: field.placeholder,
           description: field.help || field.description,
           validation: buildValidationRules(field),
+          // Field-level CEL conditional rules (B2). Carried through verbatim so
+          // the form renderer evaluates them reactively via the canonical
+          // engine (same dialect the server enforces). Undefined when absent.
+          visibleWhen: field.visibleWhen,
+          readonlyWhen: field.readonlyWhen,
+          requiredWhen: field.requiredWhen ?? field.conditionalRequired,
           // Important: Pass the original field metadata so widgets can access properties like precision, currency, etc.
-          field: field, 
+          field: field,
         };
 
         // Add field-specific properties

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -852,6 +852,34 @@ export interface FormField {
    */
   readonly?: boolean;
   /**
+   * CEL predicate: when it evaluates TRUE for the live record the field is
+   * shown, when FALSE it is hidden. Aligns with @objectstack/spec
+   * Field.visibleWhen and is enforced client-side via the canonical
+   * `@objectstack/formula` engine (same dialect the server uses). A broken
+   * predicate fails open (field stays visible).
+   * @example "record.status == 'sent'"
+   */
+  visibleWhen?: string | { dialect?: string; source: string };
+  /**
+   * CEL predicate: when TRUE the field becomes read-only (the server also
+   * strips matching writes via `stripReadonlyWhenFields`). Aligns with
+   * @objectstack/spec Field.readonlyWhen. Fails open (field stays editable).
+   * @example "record.status == 'paid'"
+   */
+  readonlyWhen?: string | { dialect?: string; source: string };
+  /**
+   * CEL predicate: when TRUE the field is required (the server enforces the
+   * same rule in its rule-validator). Aligns with @objectstack/spec
+   * Field.requiredWhen. Fails open (field is not required).
+   * @example "record.status == 'sent'"
+   */
+  requiredWhen?: string | { dialect?: string; source: string };
+  /**
+   * @deprecated Back-compat alias of {@link requiredWhen}. Aligns with
+   * @objectstack/spec Field.conditionalRequired.
+   */
+  conditionalRequired?: string | { dialect?: string; source: string };
+  /**
    * Additional field-specific props
    */
   [key: string]: any;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1030,6 +1030,9 @@ importers:
       '@object-ui/types':
         specifier: workspace:*
         version: link:../types
+      '@objectstack/formula':
+        specifier: ^7.9.0
+        version: 7.9.0(ai@6.0.194(zod@4.4.3))
       '@objectstack/spec':
         specifier: ^7.8.0
         version: 7.8.0(ai@6.0.194(zod@4.4.3))
@@ -3735,6 +3738,11 @@ packages:
   '@maplibre/vt-pbf@4.3.0':
     resolution: {integrity: sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==}
 
+  '@marcbachmann/cel-js@7.6.1':
+    resolution: {integrity: sha512-YyY8yiDU07ByKb2rJUoNgMAkYeeDvkdrONBREV2MP9siAW7yNft0KfbIoonWTIMY0fGtv8og0EhzKx3Xsi1Nmg==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -3882,8 +3890,20 @@ packages:
     resolution: {integrity: sha512-Whvubqw2nSZeSf6s6JEHheszq+zwBhSKdiOTCfDa9MZdamtHrCztBH90DnFBkUiNQHzrvHbaUag6KxGie3DuOA==}
     engines: {node: '>=18.0.0'}
 
+  '@objectstack/formula@7.9.0':
+    resolution: {integrity: sha512-58RShr27FiB/zNydIRi+pEkmnnR/lQe3uWlS/5o6J5UHtLERSRTPv0qqHiMIjHvLGVtx3qUeSnnGBVrFQJeqPA==}
+
   '@objectstack/spec@7.8.0':
     resolution: {integrity: sha512-eOdt6KVi8D52mGxV1slwzEqvnejW5teDhDk20lBWVAvn4XVN5DT0NVGjSPfABaKvoFKItk0lS+7Ur/p0NgIEQA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      ai: ^6.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+
+  '@objectstack/spec@7.9.0':
+    resolution: {integrity: sha512-B/tEB4Xggdwck9v4d97dB+K3dOjgjjm/TALcRqSFotRmBs3hbsiLXxKYMsyhl71E57/DNxwwikaZ3inwOi+ZUA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -11579,6 +11599,8 @@ snapshots:
       pbf: 4.0.1
       supercluster: 8.0.1
 
+  '@marcbachmann/cel-js@7.6.1': {}
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
@@ -11771,7 +11793,20 @@ snapshots:
     transitivePeerDependencies:
       - ai
 
+  '@objectstack/formula@7.9.0(ai@6.0.194(zod@4.4.3))':
+    dependencies:
+      '@marcbachmann/cel-js': 7.6.1
+      '@objectstack/spec': 7.9.0(ai@6.0.194(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+
   '@objectstack/spec@7.8.0(ai@6.0.194(zod@4.4.3))':
+    dependencies:
+      zod: 4.4.3
+    optionalDependencies:
+      ai: 6.0.194(zod@4.4.3)
+
+  '@objectstack/spec@7.9.0(ai@6.0.194(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -193,6 +193,48 @@ The `On` variants accept raw expressions without `${}` wrapping — the entire s
 { "disabledOn": "!data.canPerformAction || data.isLocked" }
 ```
 
+## Field-level conditional rules (CEL — `visibleWhen` / `readonlyWhen` / `requiredWhen`)
+
+> **Different engine, different layer.** The `${}` / `On` conditions above are
+> the *schema/widget* tier and run on the recursive-descent
+> `SafeExpressionParser`. The three rules below are the **data-model tier**:
+> they live on the **object's field metadata**, are written in **CEL**, and are
+> evaluated by the canonical `@objectstack/formula` engine — the *same* engine
+> the server uses. Use these when the rule belongs to the field itself and must
+> hold everywhere the object is edited (and, for `readonlyWhen`/`requiredWhen`,
+> be enforced server-side too). See ADR-0036.
+
+```ts
+// On the object's Field definition (server-side metadata):
+issued_on: Field.date({ requiredWhen: "record.status in ['sent', 'paid']" }),
+tax_rate:  Field.number({ readonlyWhen: "record.status == 'paid'" }),
+paid_on:   Field.date({
+  visibleWhen:  "record.status == 'paid'",   // UX-only — hide until paid
+  requiredWhen: "record.status == 'paid'",   // enforced client AND server
+}),
+```
+
+| Rule           | Predicate TRUE ⇒          | Where it's enforced     |
+| -------------- | ------------------------- | ----------------------- |
+| `visibleWhen`  | field shown (else hidden) | client only (UX)        |
+| `readonlyWhen` | field read-only           | **client + server**     |
+| `requiredWhen` | field required            | **client + server**     |
+
+- Predicate scope is `record` (the live/merged record) and `previous` (the
+  prior persisted record, for transition rules like
+  `"record.status == 'paid' && previous.status != 'paid'"`).
+- A predicate is `string` (treated as CEL) or `{ dialect: 'cel', source }`.
+- `conditionalRequired` is a **deprecated alias** of `requiredWhen`.
+- The form renderer re-evaluates these **reactively** as the user edits, via
+  `resolveFieldRuleState` (`@object-ui/core`). Static `required: true` /
+  `readonly: true` is a floor a FALSE predicate can't weaken.
+- **Gotchas:** CEL throws on a *missing* map key but compares cleanly against
+  `null` — author predicates against fields that exist (the renderer seeds
+  declared fields to `null` so unregistered fields don't fault). Evaluation is
+  **fail-open**: a broken predicate never hides content, never blocks submit,
+  never locks a field. `visibleWhen` is client-only — never rely on it for
+  security; use `readonlyWhen`/`requiredWhen` (or a validation rule) for guarantees.
+
 ## Data binding with `bind`
 
 The `bind` field is NOT expression-evaluated. It's a path string resolved by `useDataScope()`:


### PR DESCRIPTION
## What

Client-side enforcement of field-level **conditional rules** so a form field can be conditionally **shown/hidden** (`visibleWhen`), made **read-only** (`readonlyWhen`), or made **required** (`requiredWhen`) based on a CEL predicate over the live record. Evaluated **reactively** as the user types.

This is the client half of B2. The server half (framework PR #1649) enforces `requiredWhen` in the rule-validator and strips `readonlyWhen` writes in `stripReadonlyWhenFields`. The showcase example lives in a framework PR (see below). See **ADR-0036**.

## Why delegate to `@objectstack/formula`

The point of dual-side rules is that the **client UX and the persisted server verdict agree**. The client evaluates with the *exact same* engine + dialect the server uses — `@objectstack/formula`'s `ExpressionEngine` (CEL via `@marcbachmann/cel-js`) — rather than a parallel evaluator, so there is zero drift risk. The package is browser-safe (deps: `@marcbachmann/cel-js` + `@objectstack/spec`, which `@object-ui/core` already depends on).

## Changes

- **core**: `evalFieldPredicate` + `resolveFieldRuleState` — zero-React, **fail-open** (a broken/absent predicate never hides a field, blocks submit, or locks a field). Static `required`/`readonly` is a floor a FALSE predicate can't weaken.
- **types**: `FormField` gains `visibleWhen` / `readonlyWhen` / `requiredWhen` (+ `@deprecated conditionalRequired` alias).
- **components**: the form renderer watches the live record and gates `visible`/`readonly`/`required` per field. It seeds every declared field to `null` before overlaying *defined* watched values, so a predicate referencing a not-yet-registered field compares against `null` rather than faulting on a missing CEL key (mirrors the server's full-record merge).
- **plugin-form**: `ObjectForm` carries the rule props through from object metadata.

## Tests

- 17 unit tests (`packages/core/.../fieldRules.test.ts`) — predicate eval, object form, `previous.*`, fail-open, **missing-key** contract, alias precedence, static-flag floor.
- `e2e/live/field-conditional-rules.spec.ts` — drives the showcase Invoice Status through paid/sent/draft and asserts `paid_on` visibility, `tax_rate` lock, and `issued_on` required all re-gate reactively. **Passes** (full live suite 11/11 green).

## Docs

- `docs/adr/0036-field-conditional-rules.md`
- `skills/objectui/guides/schema-expressions.md` — new CEL field-rules section (distinguishing the data-model CEL tier from the `${}`/`On` widget tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)