### PR TITLE
feat(metadata-admin): curated forms graft server-only fields (skew root-cure, last piece)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -2019,6 +2019,7 @@ function MetadataResourceEditPageImpl({
                             onSelectionChange={setSelection}
                             readOnly={formReadOnly}
                             locale={locale}
+                            serverSchema={entry?.schema as Record<string, unknown> | undefined}
                           />
                         ) : (
                           <SchemaForm

--- a/packages/app-shell/src/views/metadata-admin/default-inspector-registry.ts
+++ b/packages/app-shell/src/views/metadata-admin/default-inspector-registry.ts
@@ -37,6 +37,15 @@ export interface MetadataDefaultInspectorProps {
   readOnly: boolean;
   /** Active UI locale for i18n. */
   locale: SupportedLocale;
+  /**
+   * The live server JSONSchema for this type (`RichMetadataTypeEntry.schema`,
+   * from `/meta/types`). Curated inspectors graft any server-only top-level
+   * fields onto the bundled-spec form so new server fields (e.g. a report's
+   * `dataset`/`rows`/`values`) are directly editable even when objectui's
+   * bundled `@objectstack/spec` lags the running server. Undefined when no
+   * server schema is available (offline / older server).
+   */
+  serverSchema?: Record<string, unknown>;
 }
 
 export type MetadataDefaultInspector = ComponentType<MetadataDefaultInspectorProps>;

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -416,6 +416,8 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.report.columns': 'Columns',
   'engine.inspector.report.columnsEmpty': 'No columns yet. Add a field below.',
   'engine.inspector.report.noSchema': 'Spec schema unavailable — basic properties only.',
+  // Trailing section for fields the live server has but the bundled spec lacks.
+  'engine.inspector.moreFields': 'More fields',
   // Dashboard default (home) inspector
   'engine.inspector.dashboard.kind': 'Dashboard',
   'engine.inspector.dashboard.close': 'Close dashboard',
@@ -1050,6 +1052,8 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.report.columns': '列',
   'engine.inspector.report.columnsEmpty': '还没有列。在下方添加字段。',
   'engine.inspector.report.noSchema': '规格 schema 不可用 —— 仅显示基础属性。',
+  // Trailing section for fields the live server has but the bundled spec lacks.
+  'engine.inspector.moreFields': '更多字段',
   // Dashboard default (home) inspector
   'engine.inspector.dashboard.kind': '仪表盘',
   'engine.inspector.dashboard.close': '关闭仪表盘',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardDefaultInspector.tsx
@@ -43,9 +43,22 @@ import { WIDGET_TYPE_META, UnknownWidgetIcon } from '../previews/widget-types';
 import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
 import { SchemaForm } from '../SchemaForm';
 import { getDashboardForm, getDashboardSchema } from '../dashboard-schema';
+import { mergeServerFields } from '../mergeServerFields';
 import { t } from '../i18n';
 
 type DashboardWidget = DashboardWidgetSchema & { id: string };
+
+/**
+ * Top-level dashboard fields rendered by this inspector's own controls (or by
+ * the dedicated widgets list), pruned from the spec-form graft so they are not
+ * double-rendered. Mirrors the `hiddenFields` passed to SchemaForm.
+ */
+const DASHBOARD_CURATED_FIELDS = new Set([
+  'name',
+  'label',
+  'description',
+  'widgets',
+]);
 
 export function DashboardDefaultInspector({
   draft,
@@ -53,6 +66,7 @@ export function DashboardDefaultInspector({
   readOnly,
   locale,
   onSelectionChange,
+  serverSchema,
 }: MetadataDefaultInspectorProps) {
   const tr = React.useCallback((key: string) => t(key, locale), [locale]);
 
@@ -99,8 +113,19 @@ export function DashboardDefaultInspector({
   const [dragIndex, setDragIndex] = React.useState<number | null>(null);
   const [overIndex, setOverIndex] = React.useState<number | null>(null);
 
-  const schema = getDashboardSchema();
-  const form = getDashboardForm();
+  // Graft any server-only top-level dashboard fields onto the bundled-spec
+  // form so they are editable even when the bundled spec lags the server.
+  const { schema, form } = React.useMemo(
+    () =>
+      mergeServerFields({
+        bundledSchema: getDashboardSchema(),
+        bundledForm: getDashboardForm(),
+        serverSchema,
+        excludeFields: DASHBOARD_CURATED_FIELDS,
+        sectionTitle: t('engine.inspector.moreFields', locale),
+      }),
+    [serverSchema, locale],
+  );
 
   return (
     <InspectorShell

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
@@ -41,7 +41,21 @@ import type { MetadataDefaultInspectorProps } from '../default-inspector-registr
 import { SchemaForm } from '../SchemaForm';
 import { useObjectFields, type ObjectFieldInfo } from '../previews/useObjectFields';
 import { getReportForm, getReportSchema } from '../report-schema';
+import { mergeServerFields } from '../mergeServerFields';
 import { t } from '../i18n';
+
+/**
+ * Top-level report fields this inspector renders with its own dedicated
+ * controls (type / object / columns + identity), so the spec-form graft
+ * never double-renders them. Mirrors the `hiddenFields` passed to SchemaForm.
+ */
+const REPORT_CURATED_FIELDS = new Set([
+  'type',
+  'objectName',
+  'label',
+  'name',
+  'columns',
+]);
 
 export interface ReportDefaultInspectorProps extends MetadataDefaultInspectorProps {
   /**
@@ -97,6 +111,7 @@ export function ReportDefaultInspector({
   locale,
   onSelectionChange,
   objectFieldsOverride,
+  serverSchema,
 }: ReportDefaultInspectorProps) {
   const tr = React.useCallback((key: string) => t(key, locale), [locale]);
 
@@ -176,8 +191,20 @@ export function ReportDefaultInspector({
   const [dragIndex, setDragIndex] = React.useState<number | null>(null);
   const [overIndex, setOverIndex] = React.useState<number | null>(null);
 
-  const schema = getReportSchema();
-  const form = getReportForm();
+  // Graft any server-only top-level fields (e.g. dataset/rows/values) onto
+  // the bundled-spec form so they are directly editable here even when the
+  // bundled `@objectstack/spec` lags the running server (skew root-cure).
+  const { schema, form } = React.useMemo(
+    () =>
+      mergeServerFields({
+        bundledSchema: getReportSchema(),
+        bundledForm: getReportForm(),
+        serverSchema,
+        excludeFields: REPORT_CURATED_FIELDS,
+        sectionTitle: t('engine.inspector.moreFields', locale),
+      }),
+    [serverSchema, locale],
+  );
 
   return (
     <InspectorShell

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.tsx
@@ -42,7 +42,16 @@ import {
   getFormVariantSchema,
 } from '../view-schema';
 import { isFormFamilyKey } from '../view-variant-model';
+import { mergeServerFields } from '../mergeServerFields';
 import { t } from '../i18n';
+
+/**
+ * Variant-body fields this inspector renders with its own controls, pruned
+ * from the spec-form graft so they are not double-rendered. Mirrors the
+ * `hiddenFields` passed to SchemaForm (`type`/`object`/`label`) plus the
+ * canvas-owned `columns`.
+ */
+const VIEW_CURATED_FIELDS = new Set(['type', 'object', 'label', 'columns']);
 
 export interface ViewVariantInspectorProps extends MetadataDefaultInspectorProps {
   /**
@@ -148,6 +157,7 @@ export function ViewVariantInspector({
   onSelectionChange,
   objectFieldsOverride,
   locale,
+  serverSchema,
 }: ViewVariantInspectorProps) {
   const variant = (draft[variantKey] as Record<string, unknown> | undefined) ?? {};
 
@@ -188,8 +198,27 @@ export function ViewVariantInspector({
     [objectFields],
   );
 
-  const form = isFormFamily ? undefined : getViewForm();
-  const schema = isFormFamily ? getFormVariantSchema() : getListVariantSchema();
+  // Graft server-only fields onto the bundled variant form so new server
+  // fields are editable even when the bundled spec lags (skew root-cure). A
+  // View is a nested document: the variant body lives under
+  // `serverSchema.properties.{list|form}`, so we pass that sub-schema.
+  const serverVariantSchema = (() => {
+    const props = (serverSchema?.properties as Record<string, any> | undefined);
+    return (isFormFamily ? props?.form : props?.list) as
+      | Record<string, unknown>
+      | undefined;
+  })();
+  const { schema, form } = React.useMemo(
+    () =>
+      mergeServerFields({
+        bundledSchema: isFormFamily ? getFormVariantSchema() : getListVariantSchema(),
+        bundledForm: isFormFamily ? undefined : getViewForm(),
+        serverSchema: serverVariantSchema,
+        excludeFields: VIEW_CURATED_FIELDS,
+        sectionTitle: t('engine.inspector.moreFields', locale),
+      }),
+    [isFormFamily, serverVariantSchema, locale],
+  );
 
   /** Shallow-write a curated patch onto the variant. */
   const writeVariant = (patch: Record<string, unknown>) => {

--- a/packages/app-shell/src/views/metadata-admin/mergeServerFields.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/mergeServerFields.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * mergeServerFields — the curated-form half of the cross-repo spec-skew
+ * root-cure. Grafts server-only top-level fields onto the bundled-spec form
+ * so new server fields (e.g. a report's dataset/rows/values) are directly
+ * editable even when the bundled @objectstack/spec lags the running server.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mergeServerFields } from './mergeServerFields';
+
+const bundledSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    label: { type: 'string' },
+    objectName: { type: 'string' },
+    columns: { type: 'array' },
+    type: { type: 'string' },
+  },
+} as Record<string, any>;
+
+const bundledForm = {
+  type: 'simple' as const,
+  sections: [{ label: 'Basics', fields: [{ field: 'label' }, { field: 'type' }] }],
+};
+
+// Newer server: adds dataset/rows/values/runtimeFilter on top of the bundle.
+const serverSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    label: { type: 'string' },
+    objectName: { type: 'string' },
+    columns: { type: 'array' },
+    type: { type: 'string' },
+    dataset: { type: 'string' },
+    rows: { type: 'array', items: { type: 'string' } },
+    values: { type: 'array', items: { type: 'string' } },
+    runtimeFilter: { type: 'object' },
+  },
+} as Record<string, any>;
+
+const CURATED = new Set(['type', 'objectName', 'label', 'name', 'columns']);
+
+describe('mergeServerFields', () => {
+  it('grafts server-only fields into BOTH schema.properties and a trailing form section', () => {
+    const { schema, form } = mergeServerFields({
+      bundledSchema,
+      bundledForm,
+      serverSchema,
+      excludeFields: CURATED,
+      sectionTitle: 'More fields',
+    });
+
+    // schema gains the new props…
+    expect(schema!.properties).toHaveProperty('dataset');
+    expect(schema!.properties).toHaveProperty('rows');
+    expect(schema!.properties).toHaveProperty('values');
+    expect(schema!.properties).toHaveProperty('runtimeFilter');
+
+    // …and a trailing section declares exactly those new fields so SchemaForm
+    // (which renders only declared fields when a form is present) shows them.
+    const sections = form!.sections!;
+    expect(sections).toHaveLength(2);
+    const added = sections[1];
+    expect(added.label).toBe('More fields');
+    const fieldNames = added.fields.map((f) => (typeof f === 'string' ? f : f.field));
+    expect(fieldNames).toEqual(['dataset', 'rows', 'values', 'runtimeFilter']);
+  });
+
+  it('does not graft curated-owned fields even if the server still has them', () => {
+    const { schema, form } = mergeServerFields({
+      bundledSchema,
+      bundledForm,
+      serverSchema,
+      excludeFields: CURATED,
+      sectionTitle: 'More fields',
+    });
+    const added = form!.sections![1];
+    const fieldNames = added.fields.map((f) => (typeof f === 'string' ? f : f.field));
+    expect(fieldNames).not.toContain('objectName');
+    expect(fieldNames).not.toContain('columns');
+    // bundled props/sections are untouched (additive only)
+    expect(form!.sections![0]).toEqual(bundledForm.sections[0]);
+    expect(schema!.properties.label).toEqual(bundledSchema.properties.label);
+  });
+
+  it('is a no-op when the server schema has no extra fields', () => {
+    const { schema, form } = mergeServerFields({
+      bundledSchema,
+      bundledForm,
+      serverSchema: bundledSchema, // identical shape — nothing new
+      excludeFields: CURATED,
+      sectionTitle: 'More fields',
+    });
+    expect(schema).toBe(bundledSchema);
+    expect(form).toBe(bundledForm);
+  });
+
+  it('is a no-op when no server schema is provided (offline / older server)', () => {
+    const { schema, form } = mergeServerFields({
+      bundledSchema,
+      bundledForm,
+      serverSchema: undefined,
+      excludeFields: CURATED,
+      sectionTitle: 'More fields',
+    });
+    expect(schema).toBe(bundledSchema);
+    expect(form).toBe(bundledForm);
+  });
+
+  it('does not re-add a field once the bundle catches up', () => {
+    // Bundle now ALSO has dataset → it must not be grafted again.
+    const caughtUp = {
+      ...bundledSchema,
+      properties: { ...bundledSchema.properties, dataset: { type: 'string' } },
+    };
+    const { schema, form } = mergeServerFields({
+      bundledSchema: caughtUp,
+      bundledForm,
+      serverSchema,
+      excludeFields: CURATED,
+      sectionTitle: 'More fields',
+    });
+    const added = form!.sections![1];
+    const fieldNames = added.fields.map((f) => (typeof f === 'string' ? f : f.field));
+    expect(fieldNames).not.toContain('dataset');
+    expect(fieldNames).toEqual(['rows', 'values', 'runtimeFilter']);
+    expect(schema!.properties.dataset).toEqual(caughtUp.properties.dataset);
+  });
+
+  it('grafts schema props but synthesises no form when the bundle ships none (flat render)', () => {
+    const { schema, form } = mergeServerFields({
+      bundledSchema,
+      bundledForm: undefined,
+      serverSchema,
+      excludeFields: CURATED,
+      sectionTitle: 'More fields',
+    });
+    // Flat SchemaForm renders every property, so the schema graft alone surfaces them.
+    expect(schema!.properties).toHaveProperty('dataset');
+    expect(form).toBeUndefined();
+  });
+
+  it('skips fields the bundled form already declares (no duplicate render)', () => {
+    const formWithDataset = {
+      type: 'simple' as const,
+      sections: [{ label: 'Basics', fields: [{ field: 'label' }, { field: 'dataset' }] }],
+    };
+    const { form } = mergeServerFields({
+      bundledSchema,
+      bundledForm: formWithDataset,
+      serverSchema,
+      excludeFields: CURATED,
+      sectionTitle: 'More fields',
+    });
+    const added = form!.sections![1];
+    const fieldNames = added.fields.map((f) => (typeof f === 'string' ? f : f.field));
+    expect(fieldNames).not.toContain('dataset');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/mergeServerFields.ts
+++ b/packages/app-shell/src/views/metadata-admin/mergeServerFields.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * mergeServerFields — completes the cross-repo spec-skew root-cure for the
+ * CURATED inspectors (report / dashboard / view).
+ *
+ * Background: the curated "home" inspectors derive their authoring form from
+ * the BUNDLED `@objectstack/spec` (`getReportForm()`/`getReportSchema()` …).
+ * When the running server adds new fields to a metadata type (e.g. report's
+ * `dataset`/`rows`/`values`) before objectui bumps its bundled spec, those
+ * fields exist in the live server schema (`/meta/types` → `entry.schema`) but
+ * NOT in the bundled one — so the curated form can't render them. They were
+ * only reachable via the raw "source" tab / API.
+ *
+ * `clientValidation.ts` already stopped the bundled spec from being STRICTER
+ * than the server (no more false "required" banners). This is the symmetric
+ * other half: let the bundled-derived FORM be a SUPERSET of the bundled spec
+ * by grafting in any server-only top-level properties, so new fields become
+ * directly editable in the right-hand curated form.
+ *
+ * It is purely ADDITIVE and lag-tolerant:
+ *   - Only fields the server has and the bundle lacks are added; existing
+ *     bundled fields, ordering, sections and `visibleOn` predicates are
+ *     untouched.
+ *   - When the bundle catches up (the field appears in `bundledSchema`), the
+ *     merge becomes a no-op for that field automatically — no shim to remove.
+ *   - When no server schema is available (offline/older server), it returns
+ *     the bundled `{schema, form}` verbatim.
+ *
+ * SchemaForm renders ONLY the fields a `form` declares (see SchemaForm's
+ * sectioned path), so new properties must be added to BOTH the schema's
+ * `properties` AND the form (as a trailing section) to actually surface.
+ */
+
+import type { FormViewSpec } from './SchemaForm';
+
+type JsonSchema = Record<string, any>;
+
+export interface MergeServerFieldsArgs {
+  /** Bundled-spec JSONSchema for the whole document (may be undefined). */
+  bundledSchema: JsonSchema | undefined;
+  /** Bundled-spec authoring FormView (may be undefined). */
+  bundledForm: FormViewSpec | undefined;
+  /**
+   * Live server JSONSchema for this type (`RichMetadataTypeEntry.schema`).
+   * For nested documents (view), pass the relevant sub-schema (e.g.
+   * `serverSchema.properties.list`).
+   */
+  serverSchema: JsonSchema | undefined;
+  /**
+   * Top-level fields the curated inspector renders itself (e.g. report's
+   * `objectName`/`columns`/`label`) plus identity (`name`). These are never
+   * grafted into the spec form even if the server adds/keeps them, so they
+   * are not double-edited.
+   */
+  excludeFields: Set<string>;
+  /** Localized title for the trailing "new server fields" section. */
+  sectionTitle: string;
+}
+
+export interface MergeServerFieldsResult {
+  schema: JsonSchema | undefined;
+  form: FormViewSpec | undefined;
+}
+
+/** Collect every field name a FormView's sections already declare. */
+function formDeclaredFields(form: FormViewSpec | undefined): Set<string> {
+  const out = new Set<string>();
+  for (const s of form?.sections ?? []) {
+    for (const f of s.fields ?? []) {
+      out.add(typeof f === 'string' ? f : (f as any)?.field);
+    }
+  }
+  return out;
+}
+
+/**
+ * Return `{schema, form}` with server-only top-level properties grafted onto
+ * the bundled pair. No-op (returns the bundled pair) when there is nothing to
+ * add or no server schema to read.
+ */
+export function mergeServerFields({
+  bundledSchema,
+  bundledForm,
+  serverSchema,
+  excludeFields,
+  sectionTitle,
+}: MergeServerFieldsArgs): MergeServerFieldsResult {
+  if (!bundledSchema) return { schema: bundledSchema, form: bundledForm };
+
+  const serverProps = serverSchema?.properties as
+    | Record<string, JsonSchema>
+    | undefined;
+  if (!serverProps || typeof serverProps !== 'object') {
+    return { schema: bundledSchema, form: bundledForm };
+  }
+
+  const bundledProps = (bundledSchema.properties ?? {}) as Record<string, JsonSchema>;
+  const alreadyShown = formDeclaredFields(bundledForm);
+
+  // Server-only fields = on the server, absent from the bundled schema, not
+  // curated-owned, and not already declared by the bundled form.
+  const newKeys = Object.keys(serverProps).filter(
+    (k) =>
+      !(k in bundledProps) &&
+      !excludeFields.has(k) &&
+      !alreadyShown.has(k),
+  );
+  if (newKeys.length === 0) return { schema: bundledSchema, form: bundledForm };
+
+  // ── additive schema merge (shallow clone; bundled defs win on conflict) ──
+  const mergedSchema: JsonSchema = {
+    ...bundledSchema,
+    properties: { ...bundledProps },
+  };
+  for (const k of newKeys) {
+    if (!(k in mergedSchema.properties)) mergedSchema.properties[k] = serverProps[k];
+  }
+
+  // ── additive form merge — append a trailing section with the new fields ──
+  // When the bundle ships no form at all, SchemaForm falls back to a flat
+  // property list (which already renders every property), so we only need to
+  // synthesise a form when one exists to preserve its curated layout.
+  let mergedForm = bundledForm;
+  if (bundledForm && typeof bundledForm === 'object') {
+    const clone = JSON.parse(JSON.stringify(bundledForm)) as FormViewSpec;
+    clone.sections = [
+      ...(clone.sections ?? []),
+      { label: sectionTitle, fields: newKeys.map((field) => ({ field })) },
+    ];
+    mergedForm = clone;
+  }
+
+  return { schema: mergedSchema, form: mergedForm };
+}


### PR DESCRIPTION
Completes the cross-repo spec-skew root-cure. The curated home inspectors (report/dashboard/view) derive their form from the **bundled** `@objectstack/spec`; when the server adds fields (e.g. a report's `dataset`/`rows`/`values`) before objectui bumps the bundled spec, those fields existed in the live server schema but were only editable via the raw *source* tab.

`clientValidation` already stopped the bundled spec from being **stricter** than the server (no false 'required' banners). This is the symmetric other half: let the bundled-derived **form** be a **superset** by grafting server-only top-level properties in.

## What
- new `mergeServerFields()` — additive, lag-tolerant: grafts server-only props into **both** `schema.properties` **and** the form (trailing *More fields* section, since SchemaForm renders only form-declared fields). No-op offline / when nothing's new / once the bundle catches up — no per-field shim to remove.
- thread `serverSchema` (`entry.schema`) through `MetadataDefaultInspectorProps` from `ResourceEditPage` into the report/dashboard/view default inspectors.
- report surfaces `dataset`/`rows`/`values`/`runtimeFilter` directly; dashboard + view use the same generic path.
- i18n `engine.inspector.moreFields` (en + zh-CN).

## Tests
- `mergeServerFields.test.ts` (7): graft, exclude-curated, no-op paths, bundle-catch-up, flat-render, already-declared.
- existing inspector + schema suites green (69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)