### PR TITLE
chore(deps): upgrade @objectstack/spec from ^7.8.0 to ^8.0.1

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -87,7 +87,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/client": "^7.8.0",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -16,7 +16,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/example-schema-catalog": "workspace:*",
     "@object-ui/fields": "workspace:*",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "@object-ui/plugin-calendar": "workspace:*",
     "@object-ui/plugin-charts": "workspace:*",
     "@object-ui/plugin-chatbot": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@eslint/js": "^10.0.1",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "@playwright/test": "^1.60.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -44,7 +44,7 @@
     "@object-ui/providers": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "@monaco-editor/react": "^4.7.0",
     "@sentry/react": "^10.56.0",
     "jsonc-parser": "^3.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@object-ui/types": "workspace:*",
     "@objectstack/formula": "^7.9.0",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "lodash": "^4.18.1",
     "zod": "^4.4.3"
   },

--- a/packages/plugin-gantt/package.json
+++ b/packages/plugin-gantt/package.json
@@ -37,7 +37,7 @@
     "@object-ui/plugin-detail": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "lucide-react": "^1.17.0"
   },
   "peerDependencies": {

--- a/packages/plugin-map/package.json
+++ b/packages/plugin-map/package.json
@@ -35,7 +35,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "lucide-react": "^1.17.0",
     "maplibre-gl": "^5.24.0",
     "react-map-gl": "^8.1.1",

--- a/packages/plugin-timeline/package.json
+++ b/packages/plugin-timeline/package.json
@@ -36,7 +36,7 @@
     "@object-ui/mobile": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "class-variance-authority": "^0.7.1",
     "zod": "^4.4.3"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
     "@object-ui/data-objectstack": "workspace:*",
     "@object-ui/i18n": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "react-hook-form": "^7.78.0"
   },
   "peerDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -90,7 +90,7 @@
     "directory": "packages/types"
   },
   "dependencies": {
-    "@objectstack/spec": "^7.8.0",
+    "@objectstack/spec": "^8.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -251,8 +251,8 @@ importers:
         specifier: ^7.8.0
         version: 7.8.0(ai@6.0.197(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -380,8 +380,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/types
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       fumadocs-core:
         specifier: 16.9.3
         version: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
@@ -693,8 +693,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       '@sentry/react':
         specifier: ^10.56.0
         version: 10.56.0(react@19.2.7)
@@ -1034,8 +1034,8 @@ importers:
         specifier: ^7.9.0
         version: 7.9.0(ai@6.0.197(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1837,8 +1837,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -2060,8 +2060,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -2231,8 +2231,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2412,8 +2412,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -2526,8 +2526,8 @@ importers:
   packages/types:
     dependencies:
       '@objectstack/spec':
-        specifier: ^7.8.0
-        version: 7.8.0(ai@6.0.197(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.197(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3900,6 +3900,15 @@ packages:
 
   '@objectstack/spec@7.9.0':
     resolution: {integrity: sha512-B/tEB4Xggdwck9v4d97dB+K3dOjgjjm/TALcRqSFotRmBs3hbsiLXxKYMsyhl71E57/DNxwwikaZ3inwOi+ZUA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      ai: ^6.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+
+  '@objectstack/spec@8.0.1':
+    resolution: {integrity: sha512-ZTHxY0TJIGDGNNd+i5Jzl8KQEA4wxgm46WTICrrYEybdsUnSkuOEKSW3lH0IBB8vI9Dx8/yUtKw77Di9NDfkAw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -12156,6 +12165,12 @@ snapshots:
       ai: 6.0.197(zod@4.4.3)
 
   '@objectstack/spec@7.9.0(ai@6.0.197(zod@4.4.3))':
+    dependencies:
+      zod: 4.4.3
+    optionalDependencies:
+      ai: 6.0.197(zod@4.4.3)
+
+  '@objectstack/spec@8.0.1(ai@6.0.197(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Upgrade `@objectstack/spec` from `^7.8.0` to `^8.0.1` across all 10 packages
- Updated `pnpm-lock.yaml` accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)