### PR TITLE
feat(form): parent-scoped conditional rules in inline grids (#1581)

### DIFF
--- a/.changeset/md-parent-scoped-line-rules.md
+++ b/.changeset/md-parent-scoped-line-rules.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/plugin-form": patch
+---
+
+B2 follow-up (#1581): parent-scoped conditional rules in inline grids — "paid invoice → lock lines". `MasterDetailForm` now binds the live header record to every line-item grid as `parent`, so a column's `readonlyWhen` / `requiredWhen` CEL rule can react to the header (e.g. `parent.status == 'paid'` locks quantity / unit price / product when the invoice is paid). The line grids + document totals moved into a dedicated `<MasterDetailLines>` child that owns the scraped header record, so a header edit re-renders only the lines and never resets the header `ObjectForm`'s react-hook-form state mid-edit; the scrape is deduped by value to avoid needless churn. (`@object-ui/fields`' `GridField.contextRecord` and column-rule derivation already existed — this wires the last link.)

--- a/e2e/live/grid-conditional-rules.spec.ts
+++ b/e2e/live/grid-conditional-rules.spec.ts
@@ -7,9 +7,9 @@ import { test, expect } from '@playwright/test';
  * line must carry a description — so a row whose quantity crosses the threshold
  * flags its (empty) Description cell required inline, and clears once filled.
  *
- * (This is the row-scoped generalization of B2 to grid cells. A header-driven
- * lock — "paid invoice → lock lines", referencing `parent` — is a separate
- * deferred capability; see ADR-0036.)
+ * (This is the row-scoped generalization of B2 to grid cells. The header-driven
+ * lock — "paid invoice → lock lines", referencing `parent` — is covered by
+ * grid-parent-rules.spec.ts; see ADR-0036 and #1581.)
  */
 test('a line cell flags required per row from a row-scoped requiredWhen', async ({ page }) => {
   await page.goto('/apps/showcase_app/showcase_invoice');

--- a/e2e/live/grid-parent-rules.spec.ts
+++ b/e2e/live/grid-parent-rules.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { selectOption } from './helpers';
+
+/**
+ * B2 follow-up (#1581): parent-scoped conditional rules in inline grids —
+ * "paid invoice → lock lines". An invoice line column declares
+ * `readonlyWhen: "parent.status == 'paid'"` on quantity / unit price / product;
+ * the cell evaluates that CEL per row against the live header as `parent`, so
+ * flipping the header status to "paid" locks the lines, and flipping it back
+ * unlocks them.
+ *
+ * This is the header-driven generalization of B2 to grid cells (the row-scoped
+ * variant — `record.*` — is covered by grid-conditional-rules.spec.ts). The
+ * live header record is scraped from the form host and bound as `parent` by
+ * <MasterDetailForm>/<MasterDetailLines>, isolated so the lock never re-renders
+ * (and thus never resets) the header form.
+ */
+test('a line locks when the header status becomes "paid" and unlocks when it changes back', async ({ page }) => {
+  await page.goto('/apps/showcase_app/showcase_invoice');
+  await page.getByRole('button', { name: /^(New|新建)$/i }).first().click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByTestId('md-form-submit')).toBeVisible();
+
+  const grid = dialog.getByTestId('line-items');
+  const qty = grid.locator('input[aria-label="Qty"]').first();
+  const unitPrice = grid.locator('input[aria-label="Unit Price"]').first();
+  await expect(qty).toBeVisible();
+
+  // Give the line some data so the lock is observable on a real row.
+  await qty.fill('3');
+
+  // Default (non-paid) status leaves the line editable.
+  await selectOption(dialog, 'status', 'draft');
+  await expect(qty).toBeEnabled();
+  await expect(unitPrice).toBeEnabled();
+
+  // Header → paid: quantity and unit price lock (parent.status == 'paid').
+  await selectOption(dialog, 'status', 'paid');
+  await expect(qty).toBeDisabled();
+  await expect(unitPrice).toBeDisabled();
+  // The locking re-render must not have wiped the typed quantity.
+  await expect(qty).toHaveValue('3');
+
+  // Header back to draft: the line is editable again.
+  await selectOption(dialog, 'status', 'draft');
+  await expect(qty).toBeEnabled();
+  await expect(unitPrice).toBeEnabled();
+});

--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -247,4 +247,63 @@ describe('GridField / LineItemsField — editable line items', () => {
   it('sumColumn ignores blanks and NaN', () => {
     expect(sumColumn([{ amount: 1 }, { amount: 2 }, { amount: null }], 'amount')).toBe(3);
   });
+
+  describe('parent-scoped conditional rules (B2 follow-up — "paid invoice → lock lines")', () => {
+    const lockField = {
+      columns: [
+        { field: 'product', label: 'Product', type: 'text' as const },
+        { field: 'qty', label: 'Qty', type: 'number' as const, readonlyWhen: "parent.status == 'paid'" },
+        { field: 'unit_price', label: 'Unit Price', type: 'currency' as const, readonlyWhen: "parent.status == 'paid'" },
+      ],
+    } as any;
+
+    it('leaves cells editable when the parent rule is FALSE', () => {
+      render(
+        <GridField
+          value={[{ product: 'Widget', qty: 2, unit_price: 10 }]}
+          onChange={() => {}}
+          field={lockField}
+          contextRecord={{ status: 'draft' }}
+        />,
+      );
+      expect((screen.getAllByLabelText('Qty')[0] as HTMLInputElement).disabled).toBe(false);
+      expect((screen.getAllByLabelText('Unit Price')[0] as HTMLInputElement).disabled).toBe(false);
+    });
+
+    it('locks cells whose readonlyWhen references the parent header', () => {
+      render(
+        <GridField
+          value={[{ product: 'Widget', qty: 2, unit_price: 10 }]}
+          onChange={() => {}}
+          field={lockField}
+          contextRecord={{ status: 'paid' }}
+        />,
+      );
+      // The header is paid → quantity / unit price lock; product (no rule) stays editable.
+      expect((screen.getAllByLabelText('Qty')[0] as HTMLInputElement).disabled).toBe(true);
+      expect((screen.getAllByLabelText('Unit Price')[0] as HTMLInputElement).disabled).toBe(true);
+      expect((screen.getAllByLabelText('Product')[0] as HTMLInputElement).disabled).toBe(false);
+    });
+
+    it('re-evaluates per row, mixing the parent header with row data', () => {
+      const rowRule = {
+        columns: [
+          { field: 'qty', label: 'Qty', type: 'number' as const },
+          // Locks only when the header is paid AND this row is already invoiced.
+          { field: 'note', label: 'Note', type: 'text' as const, readonlyWhen: "parent.status == 'paid' && record.invoiced == true" },
+        ],
+      } as any;
+      render(
+        <GridField
+          value={[{ qty: 1, note: 'a', invoiced: true }, { qty: 2, note: 'b', invoiced: false }]}
+          onChange={() => {}}
+          field={rowRule}
+          contextRecord={{ status: 'paid' }}
+        />,
+      );
+      const notes = screen.getAllByLabelText('Note') as HTMLInputElement[];
+      expect(notes[0].disabled).toBe(true);  // invoiced row → locked
+      expect(notes[1].disabled).toBe(false); // not-yet-invoiced row → editable
+    });
+  });
 });

--- a/packages/plugin-form/src/MasterDetailForm.test.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.test.tsx
@@ -107,3 +107,76 @@ describe('MasterDetailForm — submit feedback (never silent)', () => {
     expect(toastSuccess).not.toHaveBeenCalled();
   });
 });
+
+describe('MasterDetailForm — parent-scoped line rules ("paid invoice → lock lines", #1581)', () => {
+  // Parent header carries a `status` text field (a real <select> can't be driven
+  // by synthetic events in jsdom — that path is covered by the live e2e spec).
+  const invSchema = { name: 'inv', fields: { status: { type: 'text', label: 'Status' } } };
+
+  function lockDataSource(overrides: any = {}) {
+    return {
+      getObjectSchema: vi.fn().mockResolvedValue(invSchema),
+      find: vi.fn().mockResolvedValue({ data: [] }),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      bulk: vi.fn(),
+      ...overrides,
+    } as any;
+  }
+
+  const schema = {
+    objectName: 'inv',
+    mode: 'create',
+    fields: ['status'],
+    details: [
+      {
+        childObject: 'inv_line',
+        relationshipField: 'inv',
+        columns: [
+          { field: 'product', label: 'Product', type: 'text' },
+          { field: 'qty', label: 'Qty', type: 'number', readonlyWhen: "parent.status == 'paid'" },
+        ],
+      },
+    ],
+  } as any;
+
+  it('locks a line cell when the header makes its readonlyWhen TRUE, and unlocks on change', async () => {
+    const { container } = render(<MasterDetailForm schema={schema} dataSource={lockDataSource()} />);
+
+    const status = await waitFor(() => {
+      const el = container.querySelector('input[name="status"]') as HTMLInputElement | null;
+      if (!el) throw new Error('header not ready');
+      return el;
+    });
+    const qty = () => screen.getAllByLabelText('Qty')[0] as HTMLInputElement;
+
+    // Header not paid → the Qty cell is editable.
+    await waitFor(() => expect(qty().disabled).toBe(false));
+
+    // Header becomes paid → the Qty cell locks (parent.status == 'paid').
+    fireEvent.change(status, { target: { value: 'paid' } });
+    await waitFor(() => expect(qty().disabled).toBe(true));
+    // A column without a rule stays editable regardless of the header.
+    expect((screen.getAllByLabelText('Product')[0] as HTMLInputElement).disabled).toBe(false);
+
+    // Header moves off paid → the cell unlocks again.
+    fireEvent.change(status, { target: { value: 'draft' } });
+    await waitFor(() => expect(qty().disabled).toBe(false));
+  });
+
+  it('does not reset the header form when a line locks (isolated re-render)', async () => {
+    const { container } = render(<MasterDetailForm schema={schema} dataSource={lockDataSource()} />);
+
+    const status = await waitFor(() => {
+      const el = container.querySelector('input[name="status"]') as HTMLInputElement | null;
+      if (!el) throw new Error('header not ready');
+      return el;
+    });
+
+    fireEvent.change(status, { target: { value: 'paid' } });
+    // The scrape-driven lock must NOT wipe the value the user just typed.
+    await waitFor(() => expect((screen.getAllByLabelText('Qty')[0] as HTMLInputElement).disabled).toBe(true));
+    expect((container.querySelector('input[name="status"]') as HTMLInputElement).value).toBe('paid');
+  });
+});

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -94,6 +94,189 @@ interface RowState {
   original: Record<string, any>[];
 }
 
+/**
+ * Read the live header record from the rendered parent-form host by scraping its
+ * named controls. The header is owned by react-hook-form (inside <ObjectForm>),
+ * which exposes no values callback here; rather than couple into its internals
+ * we read the DOM the same way the tax-rate stack does. Radix <Select> renders a
+ * visually-hidden native `<select name=...>` for form participation, so selects
+ * (e.g. an invoice `status`) are captured too, and a user's pick dispatches a
+ * bubbling `change` the host listener catches.
+ */
+function scrapeHeaderRecord(host: HTMLElement | null): Record<string, unknown> {
+  if (!host) return {};
+  const out: Record<string, unknown> = {};
+  const els = host.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>('[name]');
+  els.forEach((el) => {
+    const name = el.getAttribute('name');
+    if (!name) return;
+    if (el.tagName === 'INPUT') {
+      const input = el as HTMLInputElement;
+      if (input.type === 'checkbox') { out[name] = input.checked; return; }
+      if (input.type === 'radio') { if (input.checked) out[name] = input.value; return; }
+      if (input.type === 'number' || input.type === 'range') {
+        if (input.value === '') { out[name] = null; return; }
+        const n = Number(input.value);
+        out[name] = Number.isFinite(n) ? n : input.value;
+        return;
+      }
+      out[name] = input.value;
+      return;
+    }
+    // <select> (incl. Radix's hidden native select) and <textarea>.
+    out[name] = (el as HTMLSelectElement | HTMLTextAreaElement).value;
+  });
+  return out;
+}
+
+interface MasterDetailLinesProps {
+  details: MasterDetailDetailConfig[];
+  state: RowState[];
+  setRows: (detailIdx: number, rows: Record<string, any>[]) => void;
+  /** Host wrapping the header <ObjectForm> — scraped for the live parent record. */
+  formHostRef: React.RefObject<HTMLDivElement | null>;
+  taxRateField: string;
+  /** Bumped when the header form remounts (after create) so the lines re-scrape. */
+  formKey: number;
+  onRowExpand: (detailIdx: number, rowIdx: number) => void;
+  onAddViaForm: (detailIdx: number) => void;
+}
+
+/**
+ * The line-item grids + document totals, isolated from the header form.
+ *
+ * It owns `parentRecord` — the live header values, scraped from the form host —
+ * and binds it to every grid as `contextRecord`, so a column's `readonlyWhen` /
+ * `requiredWhen` CEL rule can react to the header (the "paid invoice → lock
+ * lines" case, `parent.status == 'paid'`; see #1581 / ADR-0036).
+ *
+ * Holding `parentRecord` HERE rather than in <MasterDetailForm> is the whole
+ * point: a header keystroke re-renders only these lines, never the header
+ * <ObjectForm> whose react-hook-form state would otherwise reset mid-edit. The
+ * scrape is deduped by value so an identical re-read causes no state churn.
+ */
+const MasterDetailLines: React.FC<MasterDetailLinesProps> = ({
+  details,
+  state,
+  setRows,
+  formHostRef,
+  taxRateField,
+  formKey,
+  onRowExpand,
+  onAddViaForm,
+}) => {
+  const [parentRecord, setParentRecord] = useState<Record<string, unknown>>({});
+  const parentKeyRef = useRef<string>('');
+
+  useEffect(() => {
+    const host = formHostRef.current;
+    if (!host) return;
+    const read = () => {
+      const next = scrapeHeaderRecord(host);
+      let key: string;
+      try { key = JSON.stringify(next); } catch { key = String(Math.random()); }
+      if (key === parentKeyRef.current) return; // value-identical → no re-render
+      parentKeyRef.current = key;
+      setParentRecord(next);
+    };
+    read();
+    const onEvt = () => read();
+    host.addEventListener('input', onEvt);
+    host.addEventListener('change', onEvt);
+    // The header populates asynchronously (schema fetch → edit-mode load → RHF
+    // reset), none of which fire input events, so re-read on a few ticks to
+    // capture the initial record (e.g. an already-paid invoice loads locked).
+    const timers = [120, 360, 800].map((ms) => setTimeout(read, ms));
+    return () => {
+      host.removeEventListener('input', onEvt);
+      host.removeEventListener('change', onEvt);
+      timers.forEach(clearTimeout);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formHostRef, formKey, details.length]);
+
+  // Document totals: Subtotal (Σ line amounts) → Tax (header rate %) → Total.
+  // Shown only when the header carries the tax-rate field AND a detail has an
+  // amount column; otherwise each grid keeps its own footer total.
+  const taxRaw = parentRecord[taxRateField];
+  const taxRate = taxRaw === undefined ? null : (Number.isFinite(Number(taxRaw)) ? Number(taxRaw) : 0);
+  const subtotal = details.reduce((acc, d, i) => acc + sumRows(state[i]?.rows ?? [], d.amountField || 'amount'), 0);
+  const showTaxStack = taxRate !== null && details.some((d) => !!d.amountField);
+  const taxPct = taxRate ?? 0;
+  const taxAmount = subtotal * (taxPct / 100);
+  const grandTotal = subtotal + taxAmount;
+  const money = (n: number) => `¥${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+  return (
+    <>
+      {/* Line items below the header. Rendered as a light section (label + the
+          grid's own bordered table) rather than a heavy Card — a Card here would
+          double-frame the grid and its p-6 padding wastes the width the line
+          table needs. */}
+      {details.map((d, i) => (
+        <section key={`${d.childObject}-${i}`} className="space-y-2">
+          <h3 className="text-sm font-medium text-foreground">{d.title || 'Line Items'}</h3>
+          {!d.columns?.length ? (
+            <p className="py-4 text-sm text-muted-foreground">Loading columns…</p>
+          ) : (
+            <LineItemsField
+              value={state[i]?.rows ?? []}
+              onChange={(rows) => setRows(i, rows)}
+              // The live header record — a line cell's readonlyWhen/requiredWhen
+              // CEL rule evaluates against it as `parent` (e.g. lock when
+              // parent.status == 'paid').
+              contextRecord={parentRecord}
+              // Per-row "expand to full form" is offered when it adds something:
+              // always in form mode (it IS the editor), and in grid mode only
+              // when the full form has fields the grid omits. A thin grid whose
+              // columns already cover every field (e.g. invoice lines) shows no
+              // redundant expand button.
+              {...((d.inlineMode === 'form' || (d.formFields?.length ?? 0) > (d.columns?.length ?? 0))
+                ? { onRowExpand: (rowIdx: number) => onRowExpand(i, rowIdx) }
+                : {})}
+              displayMode={d.inlineMode === 'form' ? 'list' : 'grid'}
+              {...(d.inlineMode === 'form' ? { onAdd: () => onAddViaForm(i) } : {})}
+              field={
+                {
+                  columns: d.columns,
+                  // Show the per-grid running total whenever an amount column is
+                  // set — unless the document totals stack below subsumes it.
+                  total_field: showTaxStack ? undefined : (d.amountField || (d.totalField ? 'amount' : undefined)),
+                  sort_field: d.sortField,
+                  min_rows: d.minRows,
+                  max_rows: d.maxRows,
+                  add_label: d.inlineMode === 'form' ? (d.addLabel || 'Add') : d.addLabel,
+                } as any
+              }
+            />
+          )}
+        </section>
+      ))}
+
+      {/* Document totals stack (Subtotal / Tax / Total) — the right-aligned block
+          every invoicing tool shows. Live as lines and the header tax rate change. */}
+      {showTaxStack && (
+        <div className="flex justify-end">
+          <dl className="w-64 space-y-1.5 text-sm" data-testid="md-totals">
+            <div className="flex items-center justify-between">
+              <dt className="text-muted-foreground">Subtotal</dt>
+              <dd className="tabular-nums" data-testid="md-subtotal">{money(subtotal)}</dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-muted-foreground">Tax ({taxPct}%)</dt>
+              <dd className="tabular-nums" data-testid="md-tax">{money(taxAmount)}</dd>
+            </div>
+            <div className="flex items-center justify-between border-t border-border pt-1.5 text-base font-semibold">
+              <dt>Total</dt>
+              <dd className="tabular-nums" data-testid="md-grand-total">{money(grandTotal)}</dd>
+            </div>
+          </dl>
+        </div>
+      )}
+    </>
+  );
+};
+
 export interface MasterDetailFormProps {
   schema: MasterDetailFormSchema;
   dataSource?: DataSource;
@@ -206,35 +389,9 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
     setState((prev) => prev.map((s, i) => (i === detailIdx ? { ...s, rows } : s)));
   }, []);
 
-  // Live header tax rate, read from the parent form's `tax_rate` input via
-  // scoped event delegation on the form host (no coupling into ObjectForm's
-  // internals). Drives the Subtotal / Tax / Total stack under the lines.
+  // Header tax-rate field name — the live value is read by <MasterDetailLines>
+  // (which scrapes the header record) and drives the Subtotal / Tax / Total stack.
   const taxRateField = schema.taxRateField || 'tax_rate';
-  const [taxRate, setTaxRate] = useState<number | null>(null);
-  useEffect(() => {
-    const host = formHostRef.current;
-    if (!host) return;
-    const read = () => {
-      const el = host.querySelector(`[name="${taxRateField}"]`) as HTMLInputElement | null;
-      if (!el) { setTaxRate(null); return; }
-      const n = Number(el.value);
-      setTaxRate(Number.isFinite(n) ? n : 0);
-    };
-    read();
-    const onInput = (e: Event) => {
-      const t = e.target as HTMLInputElement | null;
-      if (t && t.name === taxRateField) read();
-    };
-    host.addEventListener('input', onInput);
-    host.addEventListener('change', onInput);
-    const t = setTimeout(read, 300); // re-read once the form has mounted its fields
-    return () => {
-      host.removeEventListener('input', onInput);
-      host.removeEventListener('change', onInput);
-      clearTimeout(t);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [taxRateField, formKey, details.length]);
 
   // Per-row "expand to full form": opens the child's complete form (all business
   // fields, incl. rich types the grid omits) in a drawer, pre-filled with the
@@ -462,16 +619,6 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
 
   useEffect(() => () => { if (saveGuardTimer.current) clearTimeout(saveGuardTimer.current); }, []);
 
-  // Document totals: Subtotal (Σ line amounts) → Tax (header rate %) → Total.
-  // Shown only when the parent has the tax-rate field AND a detail has an
-  // amount column; otherwise each grid keeps its own footer total.
-  const subtotal = details.reduce((acc, d, i) => acc + sumRows(state[i]?.rows ?? [], d.amountField || 'amount'), 0);
-  const showTaxStack = taxRate !== null && details.some((d) => !!d.amountField);
-  const taxPct = taxRate ?? 0;
-  const taxAmount = subtotal * (taxPct / 100);
-  const grandTotal = subtotal + taxAmount;
-  const money = (n: number) => `¥${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-
   return (
     <div className={cn('space-y-6', className, schema.className)}>
       {/* 1) Header fields on top */}
@@ -479,66 +626,19 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
         <ObjectForm key={formKey} schema={parentSchema as any} dataSource={dataSource} />
       </div>
 
-      {/* 2) Line items below the header. Rendered as a light section (label +
-          the grid's own bordered table) rather than a heavy Card — a Card here
-          would double-frame the grid and its p-6 padding wastes the width the
-          line table needs. */}
-      {details.map((d, i) => (
-        <section key={`${d.childObject}-${i}`} className="space-y-2">
-          <h3 className="text-sm font-medium text-foreground">{d.title || 'Line Items'}</h3>
-            {!d.columns?.length ? (
-              <p className="py-4 text-sm text-muted-foreground">Loading columns…</p>
-            ) : (
-            <LineItemsField
-              value={state[i]?.rows ?? []}
-              onChange={(rows) => setRows(i, rows)}
-              // Per-row "expand to full form" is offered when it adds something:
-              // always in form mode (it IS the editor), and in grid mode only
-              // when the full form has fields the grid omits. A thin grid whose
-              // columns already cover every field (e.g. invoice lines) shows no
-              // redundant expand button.
-              {...((d.inlineMode === 'form' || (d.formFields?.length ?? 0) > (d.columns?.length ?? 0))
-                ? { onRowExpand: (rowIdx: number) => setExpanded({ detailIdx: i, rowIdx }) }
-                : {})}
-              displayMode={d.inlineMode === 'form' ? 'list' : 'grid'}
-              {...(d.inlineMode === 'form' ? { onAdd: () => addRowViaForm(i) } : {})}
-              field={
-                {
-                  columns: d.columns,
-                  // Show the per-grid running total whenever an amount column is
-                  // set — unless the document totals stack below subsumes it.
-                  total_field: showTaxStack ? undefined : (d.amountField || (d.totalField ? 'amount' : undefined)),
-                  sort_field: d.sortField,
-                  min_rows: d.minRows,
-                  max_rows: d.maxRows,
-                  add_label: d.inlineMode === 'form' ? (d.addLabel || 'Add') : d.addLabel,
-                } as any
-              }
-            />
-            )}
-        </section>
-      ))}
-
-      {/* Document totals stack (Subtotal / Tax / Total) — the right-aligned block
-          every invoicing tool shows. Live as lines and the header tax rate change. */}
-      {showTaxStack && (
-        <div className="flex justify-end">
-          <dl className="w-64 space-y-1.5 text-sm" data-testid="md-totals">
-            <div className="flex items-center justify-between">
-              <dt className="text-muted-foreground">Subtotal</dt>
-              <dd className="tabular-nums" data-testid="md-subtotal">{money(subtotal)}</dd>
-            </div>
-            <div className="flex items-center justify-between">
-              <dt className="text-muted-foreground">Tax ({taxPct}%)</dt>
-              <dd className="tabular-nums" data-testid="md-tax">{money(taxAmount)}</dd>
-            </div>
-            <div className="flex items-center justify-between border-t border-border pt-1.5 text-base font-semibold">
-              <dt>Total</dt>
-              <dd className="tabular-nums" data-testid="md-grand-total">{money(grandTotal)}</dd>
-            </div>
-          </dl>
-        </div>
-      )}
+      {/* 2) Line items + document totals, in a sibling component that owns the
+          live header record (scraped from the form host) so header edits never
+          re-render — and thus never reset — the header <ObjectForm> (see #1581). */}
+      <MasterDetailLines
+        details={details}
+        state={state}
+        setRows={setRows}
+        formHostRef={formHostRef}
+        taxRateField={taxRateField}
+        formKey={formKey}
+        onRowExpand={(detailIdx, rowIdx) => setExpanded({ detailIdx, rowIdx })}
+        onAddViaForm={addRowViaForm}
+      />
 
       {/* Per-row "expand to full form": an inline editor panel for the selected
           row. Rendered INLINE (not a portaled drawer) so it behaves identically


### PR DESCRIPTION
Closes #1581 — B2 follow-up: parent-scoped conditional rules in inline grids ("paid invoice → lock lines").

## What

Wire the live header record into master-detail line grids as `parent`, so a column's `readonlyWhen` / `requiredWhen` CEL rule can react to the header — e.g. `readonlyWhen: "parent.status == 'paid'"` locks quantity / unit price / product when the invoice is paid.

The CEL engine `parent` scope, `GridField.contextRecord`, and column-rule derivation already existed; this wires the missing link in `MasterDetailForm`.

## How (the #1581 reset fix)

The line grids + document totals move into a dedicated `<MasterDetailLines>` child that **owns** the scraped header record. A header edit therefore re-renders only the lines and never resets the header `ObjectForm`'s react-hook-form state mid-edit. The scrape is **deduped by value** to avoid needless churn. Header `<select>` values are captured via Radix's hidden native select (whose change bubbles to the form host).

## Tests

- `GridField.test.tsx` — parent-FALSE editable, parent-TRUE locks, per-row `parent`+`record` mix.
- `MasterDetailForm.test.tsx` — scrape→lock/unlock as status toggles, and header value survives the locking re-render (no reset).
- `e2e/live/grid-parent-rules.spec.ts` — new live e2e (pairs with the showcase backend rules).

Verified in a real browser (real Radix `<select>`): Paid → Qty/Unit Price lock, Product stays editable, values preserved; Draft → unlock.

Backend counterpart (showcase `invoice_line` rules) is a separate PR in the framework repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)