### PR TITLE
fix(plugin-list): translate ListView empty-state title and message

### DIFF
--- a/.changeset/listview-empty-state-i18n.md
+++ b/.changeset/listview-empty-state-i18n.md
@@ -1,0 +1,9 @@
+---
+"@object-ui/plugin-list": patch
+---
+
+fix(plugin-list): translate ListView empty-state title and message
+
+The empty-state heading and body in `ListView` hardcoded their English fallback (`'No items found'` / `'There are no records to display. Try adjusting your filters or adding new data.'`) instead of going through the i18n `t()` helper like every other label in the component. As a result the empty state always rendered in English even when the active locale (e.g. `zh-CN`) had translations.
+
+Route the fallbacks through `t('list.noItems')` / `t('list.noItemsMessage')`. A user-supplied `schema.emptyState.title`/`message` still takes precedence; only the default text now localizes. The translation keys already exist in every shipped locale, so no new strings are needed.

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1669,10 +1669,10 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
               <div className="flex flex-col items-center justify-center h-full min-h-[200px] text-center p-8" data-testid="empty-state">
                 <ResolvedIcon className="h-12 w-12 text-muted-foreground/50 mb-4" />
                 <h3 className="text-lg font-medium text-foreground mb-1">
-                  {(typeof schema.emptyState?.title === 'string' ? schema.emptyState.title : undefined) ?? 'No items found'}
+                  {(typeof schema.emptyState?.title === 'string' ? schema.emptyState.title : undefined) ?? t('list.noItems')}
                 </h3>
                 <p className="text-sm text-muted-foreground max-w-md">
-                  {(typeof schema.emptyState?.message === 'string' ? schema.emptyState.message : undefined) ?? 'There are no records to display. Try adjusting your filters or adding new data.'}
+                  {(typeof schema.emptyState?.message === 'string' ? schema.emptyState.message : undefined) ?? t('list.noItemsMessage')}
                 </p>
                 {toolbarFlags.showAddRecord && (
                   <Button


### PR DESCRIPTION
## Problem

The empty-state heading and body in `ListView` rendered in English even when the active locale (e.g. `zh-CN`) had translations:

> **No items found**
> There are no records to display. Try adjusting your filters or adding new data.

## Root cause

Every other label in `ListView` goes through the i18n `t()` helper, but the empty-state title/message hardcoded their English fallback:

```tsx
{schema.emptyState?.title   ?? 'No items found'}                                           // ❌
{schema.emptyState?.message ?? 'There are no records to display. Try adjusting your...'}   // ❌
```

The translation keys `list.noItems` / `list.noItemsMessage` already exist in **every** shipped locale (`packages/i18n/src/locales/{en,zh,ja,ko,de,es,fr,pt,ru,ar}.ts`) — they just weren't being used here.

## Fix

Route the fallbacks through `t()`:

```tsx
{schema.emptyState?.title   ?? t('list.noItems')}
{schema.emptyState?.message ?? t('list.noItemsMessage')}
```

A user-supplied `schema.emptyState.title`/`message` still takes precedence; only the default text now localizes. No new strings needed.

## Testing

- `pnpm vitest run src/__tests__/ListView.test.tsx` → **117 passed**. The existing empty-state assertion (`getByText('No items found')`) still passes because, without an `I18nProvider`, `t()` falls back to the English default — behavior is unchanged in the default locale.

A changeset (`@object-ui/plugin-list`: patch) is included.
