### PR TITLE
fix(app-shell): i18n managed-by empty states

### DIFF
--- a/.changeset/managed-by-empty-state-i18n.md
+++ b/.changeset/managed-by-empty-state-i18n.md
@@ -1,0 +1,8 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/i18n": patch
+---
+
+i18n the managed-by empty states for system / append-only / better-auth object lists.
+
+`resolveManagedByEmptyState` previously hardcoded English titles and messages (e.g. "No identity records", "No events recorded"), so list views for managed objects (identity, audit logs, system-generated records) rendered English regardless of locale. It now takes the `t` translator and resolves `list.managedBy.{system,appendOnly,betterAuth}.{title,message}` (English kept as `defaultValue` fallbacks); `ObjectView` passes its `t` through. Added the keys to the `en` and `zh` locale packs.

--- a/packages/app-shell/src/utils/managedByEmptyState.ts
+++ b/packages/app-shell/src/utils/managedByEmptyState.ts
@@ -27,30 +27,44 @@ export interface ManagedByEmptyState {
   icon: string;
 }
 
+/**
+ * Translator function, structurally compatible with the `t` returned by
+ * `useObjectTranslation()`. Accepts a key and optional options (including a
+ * `defaultValue` used as the English fallback when a locale lacks the key).
+ */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
+
 export function resolveManagedByEmptyState(
   managedBy: string | undefined | null,
+  t: TranslateFn,
 ): ManagedByEmptyState | undefined {
   switch (managedBy) {
     case 'system':
       return {
         icon: 'Lock',
-        title: 'Nothing here yet',
-        message:
-          'Entries appear automatically when their source action runs (e.g. Submit for Approval, Share, Invite). Trigger one of those on a source record to create a row.',
+        title: t('list.managedBy.system.title', { defaultValue: 'Nothing here yet' }),
+        message: t('list.managedBy.system.message', {
+          defaultValue:
+            'Entries appear automatically when their source action runs (e.g. Submit for Approval, Share, Invite). Trigger one of those on a source record to create a row.',
+        }),
       };
     case 'append-only':
       return {
         icon: 'Archive',
-        title: 'No events recorded',
-        message:
-          'This is an immutable audit log. Rows are written by the platform when events occur — you can export the history but cannot create entries from here.',
+        title: t('list.managedBy.appendOnly.title', { defaultValue: 'No events recorded' }),
+        message: t('list.managedBy.appendOnly.message', {
+          defaultValue:
+            'This is an immutable audit log. Rows are written by the platform when events occur — you can export the history but cannot create entries from here.',
+        }),
       };
     case 'better-auth':
       return {
         icon: 'ShieldAlert',
-        title: 'No identity records',
-        message:
-          'Identity rows are managed by the authentication provider. Use the dedicated identity workflows (Invite User, Reset Password, …) to create new entries.',
+        title: t('list.managedBy.betterAuth.title', { defaultValue: 'No identity records' }),
+        message: t('list.managedBy.betterAuth.message', {
+          defaultValue:
+            'Identity rows are managed by the authentication provider. Use the dedicated identity workflows (Invite User, Reset Password, …) to create new entries.',
+        }),
       };
     default:
       return undefined;

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1199,7 +1199,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                     viewDef.name || viewDef.id || '',
                     viewDef.emptyState
                         ?? listSchema.emptyState
-                        ?? resolveManagedByEmptyState((objectDef as any)?.managedBy),
+                        ?? resolveManagedByEmptyState((objectDef as any)?.managedBy, t),
                 ),
             aria: viewDef.aria ?? listSchema.aria,
             tabs: listSchema.tabs,

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -228,6 +228,23 @@ const en = {
     firstRunMessage: 'Create your first record to get started.',
     noMatches: 'No matching records',
     noMatchesMessage: 'No records match your current filters or search. Try adjusting or clearing them.',
+    managedBy: {
+      system: {
+        title: 'Nothing here yet',
+        message:
+          'Entries appear automatically when their source action runs (e.g. Submit for Approval, Share, Invite). Trigger one of those on a source record to create a row.',
+      },
+      appendOnly: {
+        title: 'No events recorded',
+        message:
+          'This is an immutable audit log. Rows are written by the platform when events occur — you can export the history but cannot create entries from here.',
+      },
+      betterAuth: {
+        title: 'No identity records',
+        message:
+          'Identity rows are managed by the authentication provider. Use the dedicated identity workflows (Invite User, Reset Password, …) to create new entries.',
+      },
+    },
     showAll: 'Show all',
     pullToRefresh: 'Pull to refresh',
     refreshing: 'Refreshing…',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -228,6 +228,23 @@ const zh = {
     firstRunMessage: '创建第一条记录即可开始。',
     noMatches: '没有匹配的记录',
     noMatchesMessage: '没有符合当前筛选或搜索条件的记录，试试调整或清除它们。',
+    managedBy: {
+      system: {
+        title: '这里还没有数据',
+        message:
+          '当其来源操作运行时（例如提交审批、共享、邀请），记录会自动出现。请在来源记录上触发其中一个操作来创建数据。',
+      },
+      appendOnly: {
+        title: '暂无事件记录',
+        message:
+          '这是一份不可变更的审计日志。记录由平台在事件发生时写入——你可以导出历史，但无法在此处创建条目。',
+      },
+      betterAuth: {
+        title: '暂无身份记录',
+        message:
+          '身份记录由认证提供方管理。请使用专门的身份流程（邀请用户、重置密码……）来创建新条目。',
+      },
+    },
     showAll: '显示全部',
     pullToRefresh: '下拉刷新',
     refreshing: '刷新中…',


### PR DESCRIPTION
## 问题

`/_console/apps/setup/sys_organization`(以及其他受管对象列表:身份、审计日志、系统生成记录)在空状态下显示**硬编码英文**,无论界面语言:

> No identity records
> Identity rows are managed by the authentication provider. Use the dedicated identity workflows (Invite User, Reset Password, …) to create new entries.

根因:`packages/app-shell/src/utils/managedByEmptyState.ts` 的 `resolveManagedByEmptyState` 对 `system` / `append-only` / `better-auth` 三种 `managedBy` 桶返回写死的英文 title/message。注意这与通用 ListView 空状态(`list.firstRunTitle` / `list.noMatches`,已在 #1555 国际化)是不同的代码路径——受管对象会用这个自定义空状态覆盖通用文案。

## 改动

- `resolveManagedByEmptyState(managedBy, t)` 新增 `t` 参数,改为解析 `list.managedBy.{system,appendOnly,betterAuth}.{title,message}`,英文保留为 `defaultValue` 兜底(缺 key 的语言行为不变)。
- `ObjectView.tsx` 在调用处传入其 `t`。
- `packages/i18n/src/locales/en.ts`、`zh.ts` 新增对应 key(其余语言走 fallback 链 = 英文,与现状一致)。

## 验证

在 framework showcase 控制台(zh 语言)本地重建 `@object-ui/console` dist 并实地访问组织列表页,空状态已渲染中文:

> 暂无身份记录
> 身份记录由认证提供方管理。请使用专门的身份流程(邀请用户、重置密码……)来创建新条目。

英文文案已完全消失。`@object-ui/console` 构建 32/32 通过;`@object-ui/i18n` `tsc` 干净;改动行未引入新的类型错误(app-shell 既有 tsc 噪音与本次无关)。

附 changeset(`@object-ui/app-shell` / `@object-ui/i18n` patch)。