### PR TITLE
feat(app-shell): pass auto-publish posture to the agent for consistent narration

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -397,6 +397,9 @@ function ChatPane({
       context: {
         activeApp: 'AI',
         agentName: activeAgent,
+        // Tell the agent the environment's publish posture so its narration
+        // matches reality (an auto-published build is live, not "to publish").
+        autoPublishAiBuilds: getRuntimeConfig().features.autoPublishAiBuilds,
       },
     },
     initialMessages: hydrated,

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -341,6 +341,9 @@ function ChatbotInner({
         appName,
         objects: objects.map((o) => ({ name: o.name, label: o.label })),
         agentName: activeAgent,
+        // Publish posture, so the agent's narration matches reality (an
+        // auto-published build is live, not "to publish").
+        autoPublishAiBuilds: getRuntimeConfig().features.autoPublishAiBuilds,
         // The metadata item currently open in a designer, so the agent
         // can act on "this object/view/…" without the user restating it.
         ...(editor ? { editing: editor } : {}),


### PR DESCRIPTION
## What
Forward `features.autoPublishAiBuilds` in the chat context so the agent's prose matches reality — when builds auto-publish, it says the app is live instead of "publish it to make it live". Consumed by [framework service-ai](https://github.com/objectstack-ai/framework)'s `buildSystemMessages`. Both chat surfaces (AiChatPage + ConsoleFloatingChatbot).

Optional polish on top of [#1613](https://github.com/objectstack-ai/objectui/pull/1613) (auto-publish magic moment). typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)