### PR TITLE
feat(chatbot): live build tree for streaming app builds

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -19,7 +19,7 @@
  */
 import * as React from 'react';
 import { cn } from '@object-ui/components';
-import { AlertCircle, Copy, Check, RefreshCw, CornerDownLeft, Bot, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle } from 'lucide-react';
+import { AlertCircle, Copy, Check, RefreshCw, CornerDownLeft, Bot, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import type { ChatStatus } from 'ai';
 import {
   humanizeToolName,
@@ -96,6 +96,26 @@ export interface ChatMessage {
   sources?: ChatSource[];
   /** Optional backend trace id (e.g. `ai_traces.id`) for debugging. */
   traceId?: string;
+  /**
+   * Live build progress from a long-running tool (apply_blueprint), lifted from
+   * the stream's reconciled `data-build-progress` part. When present, the chat
+   * renders a growing "build tree" so the user watches the app take shape
+   * instead of staring at a thinking spinner.
+   */
+  buildProgress?: ChatBuildProgress;
+}
+
+/** A reconciled snapshot of an in-flight app build (apply_blueprint). */
+export interface ChatBuildProgress {
+  /** Coarse phase: drafting structure, generating sample data, or finished. */
+  phase: 'structure' | 'data' | 'done';
+  /** Human label for the app being built (for the panel header). */
+  appLabel?: string;
+  /** Artifacts drafted so far, cumulative. */
+  items: Array<{ type: string; name: string }>;
+  /** Count of artifacts done and the rough total (for the progress bar). */
+  done: number;
+  total: number;
 }
 
 export interface ChatToolInvocation {
@@ -907,12 +927,14 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                 const tools = message.toolInvocations ?? [];
                 const reasoning = message.reasoning?.trim();
                 const sources = message.sources ?? [];
+                const buildProgress = !isUser ? message.buildProgress : undefined;
                 const isEmptyAssistantStreaming =
                   !isUser &&
                   Boolean(message.streaming) &&
                   !message.content &&
                   tools.length === 0 &&
-                  !reasoning;
+                  !reasoning &&
+                  !buildProgress; // a streaming build shows its tree, not the dots
                 const summaryTools =
                   !isUser && processVisibility === 'summary'
                     ? tools.filter((tool) => !shouldRenderDetailedTool(tool))
@@ -949,6 +971,9 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                         )}
                       >
                     <MessageContent>
+                      {buildProgress ? (
+                        <BuildProgressPanel progress={buildProgress} />
+                      ) : null}
                       {!isUser && processVisibility === 'debug' && reasoning ? (
                         <Reasoning
                           isStreaming={Boolean(message.streaming) && !message.content}
@@ -1217,6 +1242,73 @@ function ThinkingDots() {
         <span className="size-1.5 rounded-full bg-current animate-pulse" />
       </span>
     </>
+  );
+}
+
+const BUILD_GROUP_ORDER = ['object', 'view', 'dashboard', 'app', 'seed'];
+const BUILD_GROUP_LABEL: Record<string, string> = {
+  object: 'Objects',
+  view: 'Views',
+  dashboard: 'Dashboards',
+  app: 'App',
+  seed: 'Sample data',
+};
+
+/**
+ * Live "build tree" for an in-flight app build (apply_blueprint). Renders the
+ * artifacts as they stream in (via the message's `buildProgress`), so the user
+ * watches objects → views → dashboard → app → sample data appear instead of a
+ * blank thinking spinner. Collapses to a "Built X" summary when done.
+ */
+function BuildProgressPanel({ progress }: { progress: ChatBuildProgress }) {
+  const { phase, appLabel, items, done, total } = progress;
+  const isDone = phase === 'done';
+  const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : isDone ? 100 : 6;
+  const groups = new Map<string, string[]>();
+  for (const it of items) {
+    const arr = groups.get(it.type) ?? [];
+    arr.push(it.name.replace(/_sample$/, ''));
+    groups.set(it.type, arr);
+  }
+  const orderedTypes = [
+    ...BUILD_GROUP_ORDER.filter((t) => groups.has(t)),
+    ...[...groups.keys()].filter((t) => !BUILD_GROUP_ORDER.includes(t)),
+  ];
+  return (
+    <div className="rounded-lg border bg-muted/30 p-3 text-sm" data-testid="build-progress">
+      <div className="mb-2 flex items-center gap-2 font-medium">
+        {isDone ? (
+          <CheckCircle2 className="size-4 shrink-0 text-emerald-600" />
+        ) : (
+          <Loader2 className="size-4 shrink-0 animate-spin text-primary" />
+        )}
+        <span>{isDone ? `Built ${appLabel ?? 'your app'}` : `Building ${appLabel ?? 'your app'}…`}</span>
+        {!isDone && phase === 'data' ? (
+          <span className="text-xs font-normal text-muted-foreground">adding sample data</span>
+        ) : null}
+      </div>
+      <div className="mb-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn('h-full rounded-full transition-all duration-500', isDone ? 'bg-emerald-500' : 'bg-primary')}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <ul className="space-y-1">
+        {orderedTypes.map((type) => {
+          const names = groups.get(type)!;
+          return (
+            <li key={type} className="flex items-start gap-2">
+              <CheckCircle2 className="mt-0.5 size-3.5 shrink-0 text-emerald-600" />
+              <span className="min-w-0 text-muted-foreground">
+                <span className="font-medium text-foreground">{BUILD_GROUP_LABEL[type] ?? type}</span>{' '}
+                {names.slice(0, 6).join(', ')}
+                {names.length > 6 ? ` +${names.length - 6} more` : ''}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }
 

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -342,3 +342,40 @@ describe('ChatbotEnhanced — auto-publish drafts (self-use magic moment)', () =
     expect(onPublishDrafts).toHaveBeenLastCalledWith('com.workspace');
   });
 });
+
+describe('ChatbotEnhanced — streaming build preview (live build tree)', () => {
+  const buildMsg = (phase: 'structure' | 'data' | 'done'): ChatMessage => ({
+    id: 'a1',
+    role: 'assistant',
+    content: '',
+    streaming: phase !== 'done',
+    buildProgress: {
+      phase,
+      appLabel: 'CRM',
+      items: [
+        { type: 'object', name: 'customer' },
+        { type: 'view', name: 'customer.list' },
+        { type: 'seed', name: 'customer_sample' },
+      ],
+      done: 3,
+      total: 6,
+    },
+  });
+
+  it('renders a live build tree (not thinking dots) while a build streams', () => {
+    render(<ChatbotEnhanced isLoading messages={[buildMsg('data')]} />);
+    expect(screen.getByTestId('build-progress')).toBeInTheDocument();
+    expect(screen.getByText(/Building CRM/i)).toBeInTheDocument();
+    // Artifacts are grouped by type with friendly labels.
+    expect(screen.getByText('Objects')).toBeInTheDocument();
+    expect(screen.getByText('Views')).toBeInTheDocument();
+    expect(screen.getByText('Sample data')).toBeInTheDocument();
+    // The artifact names render (seeds without the _sample suffix).
+    expect(screen.getAllByText(/customer/).length).toBeGreaterThan(0);
+  });
+
+  it('collapses to a "Built" summary when the build is done', () => {
+    render(<ChatbotEnhanced messages={[buildMsg('done')]} />);
+    expect(screen.getByText(/Built CRM/i)).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -82,6 +82,38 @@ describe('uiMessageToChatMessage', () => {
     );
     expect(out.streaming).toBe(true);
   });
+
+  it('lifts a reconciled data-build-progress part into buildProgress', () => {
+    const out = uiMessageToChatMessage({
+      id: 'm6',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'data-build-progress',
+          id: 'build-progress',
+          data: {
+            phase: 'data',
+            appLabel: 'CRM',
+            items: [{ type: 'object', name: 'customer' }, { type: 'view', name: 'customer.list' }],
+            done: 2,
+            total: 6,
+          },
+        },
+      ],
+    });
+    expect(out.buildProgress).toEqual({
+      phase: 'data',
+      appLabel: 'CRM',
+      items: [{ type: 'object', name: 'customer' }, { type: 'view', name: 'customer.list' }],
+      done: 2,
+      total: 6,
+    });
+  });
+
+  it('leaves buildProgress undefined when there is no build-progress part', () => {
+    const out = uiMessageToChatMessage({ id: 'm7', role: 'assistant', parts: [{ type: 'text', text: 'hi' }] });
+    expect(out.buildProgress).toBeUndefined();
+  });
 });
 
 // ADR-0033 Phase B — the chat lifts draft envelopes onto the invocation so a

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -14,7 +14,7 @@
  * apps that drive `useChat` themselves (e.g. Studio, which needs a custom
  * `prepareSendMessagesRequest` transport).
  */
-import type { ChatMessage, ChatToolInvocation, ChatSource } from './ChatbotEnhanced';
+import type { ChatMessage, ChatToolInvocation, ChatSource, ChatBuildProgress } from './ChatbotEnhanced';
 
 interface AnyPart {
   type?: string;
@@ -31,6 +31,8 @@ interface AnyPart {
   url?: string;
   href?: string;
   title?: string;
+  /** Payload of a Vercel custom data part (`data-*`), e.g. build progress. */
+  data?: unknown;
 }
 
 interface AnyUIMessage {
@@ -218,6 +220,31 @@ function extractSources(parts: AnyPart[]): ChatSource[] | undefined {
 }
 
 /**
+ * Lift the live build progress from the stream's reconciled `data-build-progress`
+ * part (emitted by apply_blueprint via `ctx.onProgress`). With a stable id the
+ * SDK keeps a single, in-place-updated part, so we just read the latest one.
+ */
+function extractBuildProgress(parts: AnyPart[]): ChatBuildProgress | undefined {
+  const part = parts.filter((p) => p.type === 'data-build-progress').pop();
+  const data = part?.data;
+  if (!data || typeof data !== 'object') return undefined;
+  const d = data as Record<string, unknown>;
+  const items = Array.isArray(d.items)
+    ? (d.items as Array<Record<string, unknown>>)
+        .filter((i) => typeof i?.type === 'string' && typeof i?.name === 'string')
+        .map((i) => ({ type: i.type as string, name: i.name as string }))
+    : [];
+  const phase = d.phase === 'data' || d.phase === 'done' ? d.phase : 'structure';
+  return {
+    phase,
+    ...(typeof d.appLabel === 'string' ? { appLabel: d.appLabel } : {}),
+    items,
+    done: typeof d.done === 'number' ? d.done : items.length,
+    total: typeof d.total === 'number' ? d.total : items.length,
+  };
+}
+
+/**
  * Map a single Vercel AI SDK v6 `UIMessage` to the `ChatMessage` shape that
  * `<ChatbotEnhanced>` renders.
  *
@@ -239,6 +266,7 @@ export function uiMessageToChatMessage(
     reasoning: extractReasoning(parts),
     toolInvocations: tools.length > 0 ? tools : legacyTools,
     sources: extractSources(parts),
+    buildProgress: extractBuildProgress(parts),
     streaming: opts.streaming,
   };
 }


### PR DESCRIPTION
Lift the stream's data-build-progress part into ChatMessage.buildProgress and render a growing build tree (objects to views to dashboard to app to sample data with a progress bar) as apply_blueprint streams them, replacing the blank thinking spinner. Pairs with framework + cloud. plugin-chatbot 52 tests; verified live.

Generated with Claude Code