### PR TITLE
fix(report): render dataset-form reports (ADR-0021 single-form)

### DIFF
--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -408,7 +408,19 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   // and drill protocol end-to-end. The legacy ReportViewer is only used as a
   // last resort for fully-legacy schemas that lack `objectName` (e.g. inline
   // `fields` + `data` arrays from older app code).
-  const useSpecRenderer = Boolean(
+  // ADR-0021 single-form: a report bound to a semantic-layer `dataset` (no
+  // `objectName`/`columns`) still routes through the spec ReportRenderer, which
+  // dispatches it to the dataset path (queryDataset + grouped table / joined
+  // blocks). Without this it would fall to the legacy ReportViewer, which has no
+  // data source to fetch from → a blank page.
+  const isDatasetBound = Boolean(
+    previewReport &&
+      (typeof previewReport.dataset === 'string' ||
+        (previewReport.type === 'joined' &&
+          Array.isArray(previewReport.blocks) &&
+          previewReport.blocks.some((b: any) => typeof b?.dataset === 'string'))),
+  );
+  const useSpecRenderer = isDatasetBound || Boolean(
     previewReport &&
       previewReport.objectName &&
       (previewReport.type === 'matrix' ||

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * DatasetReportRenderer
+ *
+ * Renders a spec `Report` that binds to a semantic-layer `dataset` (ADR-0021
+ * single-form) instead of an inline `objectName` + `columns` query. The report
+ * selects dimensions (`rows`) and measures (`values`) BY NAME and runs them
+ * through `dataSource.queryDataset` — the same governed path dataset-bound
+ * dashboard widgets and the dataset preview use, so the numbers (and the
+ * server-resolved dimension display labels) match everywhere.
+ *
+ * - `summary` / `matrix` / `tabular` → one grouped table (`rows` + `values`).
+ * - `joined` → a vertical stack of blocks, each its own dataset-bound table,
+ *   with the report-level `runtimeFilter` merged into every block.
+ *
+ * This is the report-side counterpart to plugin-dashboard's `DatasetWidget`;
+ * it replaces the legacy `useReportData` (objectName + client aggregation) path
+ * for reports authored against a dataset.
+ */
+
+import * as React from 'react';
+import { Loader2, AlertTriangle, Table2 } from 'lucide-react';
+import { mergeFilters } from './hooks/useReportData';
+
+type Row = Record<string, unknown>;
+
+interface DatasetCapableSource {
+  queryDataset?: (dataset: string, selection: unknown) => Promise<{ rows: Row[] }>;
+}
+
+/** A report (or joined block) bound to a dataset. Field access is permissive — */
+/** the bundled spec types lag the runtime schema across the repo boundary.     */
+interface DatasetReportLike {
+  name?: string;
+  type?: string;
+  dataset?: string;
+  rows?: string[];
+  values?: string[];
+  runtimeFilter?: Record<string, unknown>;
+  filter?: Record<string, unknown>;
+  label?: unknown;
+  description?: unknown;
+  blocks?: DatasetReportLike[];
+}
+
+export interface DatasetReportRendererProps {
+  report: DatasetReportLike;
+  dataSource?: unknown;
+  /** Filter merged into the report (and every joined block) as `runtimeFilter`. */
+  runtimeFilter?: Record<string, unknown>;
+  className?: string;
+}
+
+/** `true` when this report should render through the dataset path. */
+export function isDatasetReport(value: unknown): value is DatasetReportLike {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as DatasetReportLike;
+  if (typeof v.dataset === 'string' && v.dataset.length > 0) return true;
+  // A joined report whose blocks are dataset-bound.
+  return v.type === 'joined' && Array.isArray(v.blocks) && v.blocks.some((b) => typeof b?.dataset === 'string');
+}
+
+function resolveText(label: unknown, fallback: string): string {
+  if (!label) return fallback;
+  if (typeof label === 'string') return label;
+  if (typeof label === 'object' && typeof (label as { default?: unknown }).default === 'string') {
+    return (label as { default: string }).default;
+  }
+  return fallback;
+}
+
+function formatCell(v: unknown): string {
+  if (v == null) return '—';
+  if (typeof v === 'number') {
+    return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  return String(v);
+}
+
+/** One dataset-bound table: fetch via `queryDataset`, render `rows` + `values`. */
+function DatasetReportTable({
+  dataset,
+  rows,
+  values,
+  runtimeFilter,
+  dataSource,
+}: {
+  dataset: string;
+  rows: string[];
+  values: string[];
+  runtimeFilter?: Record<string, unknown>;
+  dataSource?: unknown;
+}) {
+  const [state, setState] = React.useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; error?: string }>({
+    status: 'idle',
+    rows: [],
+  });
+
+  const rfKey = JSON.stringify(runtimeFilter ?? null);
+  const signature = `${dataset}|${rows.join(',')}|${values.join(',')}|${rfKey}`;
+  React.useEffect(() => {
+    const src = dataSource as DatasetCapableSource | undefined;
+    if (!src || typeof src.queryDataset !== 'function') {
+      setState({ status: 'error', rows: [], error: 'This data source does not support dataset queries.' });
+      return;
+    }
+    if (!dataset || values.length === 0) {
+      setState({ status: 'idle', rows: [] });
+      return;
+    }
+    let cancelled = false;
+    setState({ status: 'loading', rows: [] });
+    src
+      .queryDataset(dataset, {
+        dimensions: rows,
+        measures: values,
+        ...(runtimeFilter && Object.keys(runtimeFilter).length > 0 ? { runtimeFilter } : {}),
+      })
+      .then((res) => {
+        if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [] });
+      })
+      .catch((e) => {
+        if (!cancelled) setState({ status: 'error', rows: [], error: String((e as Error)?.message ?? e) });
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signature]);
+
+  if (values.length === 0) {
+    return (
+      <div className="flex items-center justify-center rounded-md border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground">
+        This report binds the “{dataset}” dataset — choose at least one measure (values) to render.
+      </div>
+    );
+  }
+  if (state.status === 'loading' || state.status === 'idle') {
+    return (
+      <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Running report…
+      </div>
+    );
+  }
+  if (state.status === 'error') {
+    return (
+      <div role="alert" className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+        <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <span className="break-words">{state.error}</span>
+      </div>
+    );
+  }
+  if (state.rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed bg-muted/20 p-6 text-xs text-muted-foreground">
+        <Table2 className="h-6 w-6" /> The dataset returned no rows for this report’s scope.
+      </div>
+    );
+  }
+
+  const columns = [...rows, ...values];
+  return (
+    <div className="overflow-auto max-h-[70vh] rounded-md border">
+      <table className="w-full text-xs">
+        <thead className="bg-muted/40">
+          <tr>
+            {columns.map((c) => (
+              <th key={c} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {state.rows.map((row, i) => (
+            <tr key={i} className="border-t">
+              {columns.map((c) => (
+                <td key={c} className="px-2 py-1 tabular-nums whitespace-nowrap">
+                  {formatCell(row[c])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
+  report,
+  dataSource,
+  runtimeFilter,
+  className,
+}) => {
+  const outerFilter = mergeFilters(
+    (report.runtimeFilter ?? report.filter) as Record<string, unknown> | undefined,
+    runtimeFilter,
+  );
+
+  // Joined → a vertical stack of dataset-bound blocks.
+  if (report.type === 'joined' && Array.isArray(report.blocks)) {
+    return (
+      <div
+        className={className}
+        data-testid="dataset-joined-report"
+        data-report-name={report.name}
+        style={{ display: 'flex', flexDirection: 'column', gap: 24 }}
+      >
+        {report.blocks.map((block, index) => {
+          const blockFilter = mergeFilters(outerFilter, (block.runtimeFilter ?? block.filter) as Record<string, unknown> | undefined);
+          return (
+            <section
+              key={block.name ?? `block-${index}`}
+              data-testid="dataset-report-block"
+              data-block-id={block.name ?? `block-${index}`}
+              className="flex flex-col gap-2 rounded-lg border bg-card p-4"
+            >
+              <header className="flex flex-col gap-0.5">
+                <h3 className="text-sm font-semibold">{resolveText(block.label, block.name ?? `Block ${index + 1}`)}</h3>
+                {block.description ? (
+                  <p className="text-xs text-muted-foreground">{resolveText(block.description, '')}</p>
+                ) : null}
+              </header>
+              <DatasetReportTable
+                dataset={String(block.dataset ?? '')}
+                rows={Array.isArray(block.rows) ? block.rows.filter(Boolean) : []}
+                values={Array.isArray(block.values) ? block.values.filter(Boolean) : []}
+                runtimeFilter={blockFilter}
+                dataSource={dataSource}
+              />
+            </section>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // summary / matrix / tabular → a single dataset-bound table.
+  return (
+    <div className={className} data-testid="dataset-report" data-report-name={report.name}>
+      <DatasetReportTable
+        dataset={String(report.dataset ?? '')}
+        rows={Array.isArray(report.rows) ? report.rows.filter(Boolean) : []}
+        values={Array.isArray(report.values) ? report.values.filter(Boolean) : []}
+        runtimeFilter={outerFilter}
+        dataSource={dataSource}
+      />
+    </div>
+  );
+};

--- a/packages/plugin-report/src/ReportRenderer.tsx
+++ b/packages/plugin-report/src/ReportRenderer.tsx
@@ -32,6 +32,7 @@ import { LegacyReportRenderer, type LegacyReportRendererProps } from './LegacyRe
 import { SpecReportGrid } from './SpecReportGrid';
 import { MatrixRenderer } from './MatrixRenderer';
 import { JoinedReportRenderer } from './JoinedReportRenderer';
+import { DatasetReportRenderer, isDatasetReport } from './DatasetReportRenderer';
 import type { DrillOpenIn, DrillView } from './drill';
 
 export type ReportRendererSchema = SpecReport | LegacyReportRendererProps['schema'];
@@ -96,6 +97,22 @@ export const ReportRenderer: React.FC<ReportRendererProps> = (props) => {
     && typeof (schema as Record<string, unknown>).report === 'object'
   ) {
     schema = (schema as Record<string, unknown>).report as ReportRendererSchema;
+  }
+  // ADR-0021 single-form: a report bound to a semantic-layer `dataset` (rather
+  // than an inline `objectName` + `columns` query) renders through the dataset
+  // path — `queryDataset` + a grouped table — exactly like a dataset-bound
+  // dashboard widget. Checked BEFORE the legacy `isSpecReport` guards, which
+  // require `objectName`/`columns` and would otherwise drop a dataset report
+  // into the legacy renderer (→ blank).
+  if (isDatasetReport(schema)) {
+    return (
+      <DatasetReportRenderer
+        report={schema as Parameters<typeof DatasetReportRenderer>[0]['report']}
+        dataSource={dataSource}
+        runtimeFilter={runtimeFilter}
+        className={className}
+      />
+    );
   }
   if (isSpecReport(schema)) {
     const reportType = schema.type ?? 'tabular';

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * DatasetReportRenderer tests (ADR-0021 single-form).
+ *
+ * Covers:
+ *  - isDatasetReport guard (dataset-bound report / joined-with-dataset-blocks)
+ *  - summary report → grouped table via dataSource.queryDataset
+ *  - joined report → one dataset-bound table per block
+ *  - report-level runtimeFilter merged into the dataset query
+ *  - missing queryDataset → a clear error instead of a blank
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DatasetReportRenderer, isDatasetReport } from '../DatasetReportRenderer';
+
+function makeSource(rowsByDataset: Record<string, Array<Record<string, unknown>>>) {
+  const calls: Array<{ dataset: string; selection: any }> = [];
+  return {
+    calls,
+    queryDataset: vi.fn(async (dataset: string, selection: unknown) => {
+      calls.push({ dataset, selection: selection as any });
+      return { rows: rowsByDataset[dataset] ?? [] };
+    }),
+  };
+}
+
+describe('isDatasetReport', () => {
+  it('matches a report bound to a dataset', () => {
+    expect(isDatasetReport({ name: 'r', dataset: 'task_metrics', values: ['c'] })).toBe(true);
+  });
+  it('matches a joined report whose blocks are dataset-bound', () => {
+    expect(isDatasetReport({ type: 'joined', blocks: [{ dataset: 'task_metrics', values: ['c'] }] })).toBe(true);
+  });
+  it('does not match a legacy object-bound report', () => {
+    expect(isDatasetReport({ name: 'r', objectName: 'task', columns: [{ field: 'x' }] })).toBe(false);
+    expect(isDatasetReport(null)).toBe(false);
+  });
+});
+
+describe('DatasetReportRenderer', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders a summary report as a grouped table', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }, { status: 'Done', est_hours: 24 }] });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'hours', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect(screen.getByText('Done')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+    // headers are the row + value names
+    expect(screen.getByText('status')).toBeInTheDocument();
+    expect(screen.getByText('est_hours')).toBeInTheDocument();
+    expect(src.queryDataset).toHaveBeenCalledWith('task_metrics', expect.objectContaining({
+      dimensions: ['status'], measures: ['est_hours'],
+    }));
+  });
+
+  it('renders a joined report as one table per block', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'To Do', task_count: 4 }] });
+    render(
+      <DatasetReportRenderer
+        report={{
+          name: 'overview', type: 'joined',
+          blocks: [
+            { name: 'open_block', label: 'Open Tasks', dataset: 'task_metrics', rows: ['status'], values: ['task_count'], runtimeFilter: { done: false } },
+            { name: 'done_block', label: 'Completed Tasks', dataset: 'task_metrics', rows: ['status'], values: ['task_count'], runtimeFilter: { done: true } },
+          ],
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Open Tasks')).toBeInTheDocument());
+    expect(screen.getByText('Completed Tasks')).toBeInTheDocument();
+    expect(screen.getAllByTestId('dataset-report-block')).toHaveLength(2);
+    // each block forwards its own runtimeFilter
+    expect(src.queryDataset).toHaveBeenCalledWith('task_metrics', expect.objectContaining({ runtimeFilter: { done: false } }));
+    expect(src.queryDataset).toHaveBeenCalledWith('task_metrics', expect.objectContaining({ runtimeFilter: { done: true } }));
+  });
+
+  it('merges the report-level runtimeFilter into the dataset query', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', task_count: 1 }] });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['task_count'] }}
+        dataSource={src}
+        runtimeFilter={{ owner: 'me' }}
+      />,
+    );
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    expect(src.calls[0].selection.runtimeFilter).toMatchObject({ owner: 'me' });
+  });
+
+  it('shows an error when the data source cannot run dataset queries', async () => {
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['task_count'] }}
+        dataSource={{}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText(/does not support dataset queries/i)).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-report/src/index.tsx
+++ b/packages/plugin-report/src/index.tsx
@@ -15,13 +15,15 @@ import { ReportConfigPanel } from './ReportConfigPanel';
 import { SpecReportGrid } from './SpecReportGrid';
 import { MatrixRenderer } from './MatrixRenderer';
 import { JoinedReportRenderer } from './JoinedReportRenderer';
+import { DatasetReportRenderer, isDatasetReport } from './DatasetReportRenderer';
 
-export { ReportRenderer, LegacyReportRenderer, ReportViewer, ReportBuilder, ReportConfigPanel, SpecReportGrid, MatrixRenderer, JoinedReportRenderer };
+export { ReportRenderer, LegacyReportRenderer, ReportViewer, ReportBuilder, ReportConfigPanel, SpecReportGrid, MatrixRenderer, JoinedReportRenderer, DatasetReportRenderer, isDatasetReport };
 export type { ReportRendererProps, ReportRendererSchema } from './ReportRenderer';
 export type { LegacyReportRendererProps } from './LegacyReportRenderer';
 export type { SpecReportGridProps } from './SpecReportGrid';
 export type { MatrixRendererProps, MatrixCellClickArgs } from './MatrixRenderer';
 export type { JoinedReportRendererProps } from './JoinedReportRenderer';
+export type { DatasetReportRendererProps } from './DatasetReportRenderer';
 export {
   buildDrillAction,
   createDrillHandler,


### PR DESCRIPTION
## Problem

After the framework's ADR-0021 single-form cutover, reports bind a semantic **`dataset`** + `rows`/`values` and no longer carry `objectName`/`columns`. The console's report stack still assumed the inline shape, so **every dataset-bound report rendered blank** (the dashboard `DatasetWidget` was migrated, but the report side was not).

Two gates dropped dataset reports into the legacy (no-data) path:
- `ReportView` computed `useSpecRenderer` from `previewReport.objectName` → dataset reports fell to the legacy `ReportViewer`, which has no source to fetch from → empty.
- `ReportRenderer`'s `isSpecReport` guard requires `objectName` + `columns` → even if reached, dropped to `LegacyReportRenderer`.

## Fix

New **`DatasetReportRenderer`** — the report-side counterpart to plugin-dashboard's `DatasetWidget`:
- runs `dataSource.queryDataset(dataset, { dimensions: rows, measures: values, runtimeFilter })` and renders a grouped table;
- a `joined` report renders one dataset-bound table per block, with the report-level filter merged into each block.

Wiring:
- `ReportRenderer` dispatches dataset-bound reports here (`isDatasetReport`) **before** the legacy guards.
- `ReportView` routes dataset reports through the spec renderer.

Because it uses the governed `queryDataset` path, server-resolved dimension display labels (select option labels, lookup names — framework PR #1680) flow through automatically.

## Verification

Browser-tested on the showcase reports against a live backend:

| Report | Type | Result |
|---|---|---|
| Task Overview | joined | both blocks render (Open Tasks / Completed Tasks) ✅ |
| Hours by Status | summary | `status \| est_hours` table ✅ |
| Status × Priority | matrix | `status \| priority \| est_hours`, both dims labelled ✅ |

All with resolved labels (`Backlog`/`In Progress`/`To Do`, `Low`/`Urgent`). 9 new tests; plugin-report 118/118 green.

> Pairs with framework PR #1680 (dimension labels). After merge, framework bumps `.objectui-sha` to vendor this console build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)