### PR TITLE
test(components): refresh Accordion snapshots for Radix 1.2.x aria-controls

### DIFF
--- a/packages/components/src/__tests__/__snapshots__/snapshot-critical.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/snapshot-critical.test.tsx.snap
@@ -72,7 +72,6 @@ exports[`Accordion snapshots > renders accordion with first item expanded 1`] = 
       data-state="closed"
     >
       <button
-        aria-controls="radix-_r_j_"
         aria-expanded="false"
         class="flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180"
         data-orientation="vertical"
@@ -130,7 +129,6 @@ exports[`Accordion snapshots > renders accordion with multiple items 1`] = `
       data-state="closed"
     >
       <button
-        aria-controls="radix-_r_b_"
         aria-expanded="false"
         class="flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180"
         data-orientation="vertical"
@@ -181,7 +179,6 @@ exports[`Accordion snapshots > renders accordion with multiple items 1`] = `
       data-state="closed"
     >
       <button
-        aria-controls="radix-_r_d_"
         aria-expanded="false"
         class="flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180"
         data-orientation="vertical"
@@ -232,7 +229,6 @@ exports[`Accordion snapshots > renders accordion with multiple items 1`] = `
       data-state="closed"
     >
       <button
-        aria-controls="radix-_r_f_"
         aria-expanded="false"
         class="flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180"
         data-orientation="vertical"


### PR DESCRIPTION
## Problem

The `snapshot-critical` **Accordion** snapshots are stale and fail on **every** objectui PR (they block CI on unrelated branches).

## Cause — a Radix a11y improvement, not a regression

`@radix-ui/react-accordion@^1.2.13` no longer emits `aria-controls` on a trigger whose content panel is **unmounted** (a collapsed item). Older Radix pointed `aria-controls` at a **non-existent** id — a dangling ARIA reference. The new behaviour is correct: `aria-controls` is present only when the panel exists (verified — expanded triggers keep theirs; only collapsed ones drop it).

## Fix

Regenerated the two stale snapshots. The diff is **purely** the removal of 4 dangling `aria-controls` attributes on collapsed triggers — no component change, no behaviour change.

Unblocks [#1616](https://github.com/objectstack-ai/objectui/pull/1616) (and any other PR currently red on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)