### PR TITLE
fix(chatbot): stop dumping raw tool JSON on the consumer Build-with-AI panel

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -705,10 +705,15 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         processVisibility === 'debug' &&
         friendlyTitle &&
         friendlyTitle.toLowerCase() !== tool.toolName.toLowerCase();
+      // Raw PARAMETERS/RESULT JSON is developer detail — only in `debug` mode,
+      // or when a HITL approval needs the operator to see the exact payload.
+      // A drafting tool (create_object / apply_blueprint) is NOT a reason to dump
+      // JSON: the human summary + the Publish/Review affordance below already tell
+      // a Build-with-AI user what happened, so on the consumer surface (`summary`)
+      // the whole-app blueprint JSON and "status: drafted" envelopes stay hidden.
       const showPayload =
         processVisibility === 'debug' ||
-        isAwaitingApproval ||
-        Boolean(tool.draftReview?.items.length);
+        isAwaitingApproval;
       const titleNode = (
         <span className="inline-flex items-center gap-2">
           <span>{friendlyTitle || tool.toolName}</span>

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -176,6 +176,39 @@ describe('ChatbotEnhanced (AI Elements composition)', () => {
     expect(screen.getByText(/Picked the query_data tool/i)).toBeInTheDocument();
   });
 
+  it('hides raw tool JSON for drafting tools in summary mode but keeps the Review affordance', () => {
+    const draftTool: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: 'Built your sales CRM.',
+      toolInvocations: [
+        {
+          toolCallId: 'tc1',
+          toolName: 'apply_blueprint',
+          state: 'output-available',
+          args: { blueprint: { summary: 'sales', objects: [{ name: 'opportunity_secret_field' }] } },
+          result: { status: 'drafted', drafted: [{ type: 'object', name: 'opportunity' }] },
+          draftReview: { items: [{ type: 'object', name: 'opportunity' }], summary: 'drafted 1 artifact(s)' },
+        },
+      ],
+    };
+    const onReviewDraft = vi.fn();
+    const { rerender } = render(
+      <ChatbotEnhanced messages={[draftTool]} onReviewDraft={onReviewDraft} />,
+    );
+    // Consumer surface (summary): the friendly card + Review affordance render,
+    // but the raw blueprint PARAMETERS / drafted RESULT JSON stay hidden.
+    expect(screen.getByText(/Apply blueprint/i)).toBeInTheDocument();
+    expect(screen.queryByText('Parameters')).not.toBeInTheDocument();
+    expect(screen.queryByText('Result')).not.toBeInTheDocument();
+    expect(screen.queryByText(/opportunity_secret_field/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Review/i)).toBeInTheDocument();
+
+    // Developer surface (debug): the raw PARAMETERS JSON is revealed.
+    rerender(<ChatbotEnhanced processVisibility="debug" messages={[draftTool]} onReviewDraft={onReviewDraft} />);
+    expect(screen.getByText('Parameters')).toBeInTheDocument();
+  });
+
   it('renders a model picker and forwards changes', () => {
     const onModelChange = vi.fn();
     render(


### PR DESCRIPTION
## Problem

On the consumer **Build with AI** surface, the chat dumped the **raw tool-call JSON** for every drafting tool — the full `apply_blueprint` blueprint as `PARAMETERS`, and `{ "status": "drafted", … "note": "NOT LIVE…" }` as `RESULT`. For someone building an app from one sentence, that's developer noise sitting next to the friendly summary.

Root cause: a drafting tool (`create_object` / `apply_blueprint`) returns a `draftReview`, and that alone forced `showPayload` true — so the raw JSON rendered even in `summary` (consumer) mode, not just `debug`.

## Fix

Gate the raw `PARAMETERS`/`RESULT` JSON on `processVisibility === 'debug'` (or a HITL approval that genuinely needs the operator to see the exact payload). The friendly card, the `BuildProgressPanel` streaming tree, and the **Publish/Review** affordance still render in `summary` — only the JSON is withheld. Developers flip **Agent Process Visibility → debug** to see it. Errors still surface in any mode.

One-line behavioural change in `ChatbotEnhanced.tsx`; the `draftReview` affordance is rendered independently and is unaffected.

## Test

- New test: a drafting tool in `summary` mode renders the card + Review affordance but **not** the raw `Parameters`/`Result` JSON; in `debug` the JSON is revealed.
- `plugin-chatbot` suite green (53 tests) + `type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)