### PR TITLE
feat(dashboard): measure label + format + consistent metric card (dataset widgets)

### DIFF
--- a/.changeset/dataset-widget-measure-label-format.md
+++ b/.changeset/dataset-widget-measure-label-format.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/plugin-dashboard": minor
+---
+
+Dataset-bound dashboard widgets now use the measure's display label + format and
+render metric widgets with a consistent card.
+
+- KPI value and chart legend use the measure `label` (carried on the analytics
+  result `fields`) instead of the raw measure name — "Tasks" not "task_count".
+- The KPI value is formatted via the measure `format` hint ("$0,0" → "$616,000").
+- A dataset-bound `metric` widget takes the shared Card wrapper (title + border)
+  like kpi/gauge, instead of rendering as bare untitled text.
+
+Requires `AnalyticsResult.fields[].label`/`format` (objectstack-ai/framework#1683).

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -755,7 +755,12 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
         };
         
         const componentSchema = getComponentSchema();
-        const isSelfContained = widget.type === 'metric';
+        // A `metric` widget renders its own card chrome ONLY in the inline
+        // (object-metric) path. A dataset-bound metric uses DatasetWidget, which
+        // renders just the value — so it must take the shared Card wrapper to get
+        // a title + border like the kpi/gauge widgets (otherwise it shows as bare
+        // text with no title, inconsistent with its neighbours).
+        const isSelfContained = widget.type === 'metric' && !datasetBound;
         const resolvedTitle = tWidgetTitle(widget);
         const resolvedDescription = tWidgetDescription(widget);
         const widgetKey = widget.id || resolvedTitle || `widget-${index}`;

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -23,8 +23,30 @@ import { Loader2, BarChart3, AlertTriangle } from 'lucide-react';
 import { resolveDateMacros } from './utils';
 
 type Row = Record<string, unknown>;
+/** Measure column metadata from the analytics result (ADR-0021). */
+interface ResultField { name: string; type?: string; label?: string; format?: string }
 interface DatasetCapableSource {
-  queryDataset?: (dataset: string, selection: unknown) => Promise<{ rows: Row[] }>;
+  queryDataset?: (dataset: string, selection: unknown) => Promise<{ rows: Row[]; fields?: ResultField[] }>;
+}
+
+/**
+ * Format a measure value using its dataset `format` hint (numeral-style, e.g.
+ * "$0,0", "0.0", "0.0%"). Falls back to a thousand-separated number. The format
+ * can't be baked into the numeric row value server-side (charts need the raw
+ * number), so it is applied here at render time.
+ */
+function formatMeasure(v: unknown, format?: string): string {
+  if (v == null) return '—';
+  if (typeof v !== 'number') return String(v);
+  if (!format) {
+    // No format hint → preserve the plain rendering (integers verbatim).
+    return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  const isPercent = format.includes('%');
+  const isCurrency = format.includes('$');
+  const decimals = format.split('.')[1]?.match(/0/g)?.length ?? 0;
+  const body = v.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+  return `${isCurrency ? '$' : ''}${body}${isPercent ? '%' : ''}`;
 }
 
 function formatValue(v: unknown): string {
@@ -59,7 +81,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     [rawFilter],
   );
 
-  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; error?: string }>({ status: 'idle', rows: [] });
+  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: ResultField[]; error?: string }>({ status: 'idle', rows: [] });
 
   // Signature uses the RAW filter (stable) — the resolved one carries a
   // render-time `now` and would otherwise force a refetch loop.
@@ -79,7 +101,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       ...(runtimeFilter ? { runtimeFilter } : {}),
       ...(compareTo ? { compareTo } : {}),
     })
-      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [] }); })
+      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [], fields: Array.isArray(res?.fields) ? res.fields : [] }); })
       .catch((e) => { if (!cancelled) setState({ status: 'error', rows: [], error: String((e as Error)?.message ?? e) }); });
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -102,23 +124,35 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground"><BarChart3 className="mr-2 h-4 w-4" />No rows</div>;
   }
 
-  // Metric / KPI — show the single measure value of the first row.
+  // Measure metadata (label + format) carried on the result fields, keyed by name.
+  const fieldByName = new Map((state.fields ?? []).map((f) => [f.name, f]));
+  const measureField = (name: string) => fieldByName.get(name);
+
+  // Metric / KPI — show the single measure value of the first row, using the
+  // measure's display label (not the raw name) and its format (e.g. "$616,000").
   if (isMetric) {
+    const f = measureField(values[0]);
     const value = state.rows[0]?.[values[0]];
     return (
       <div className="flex h-full w-full flex-col items-start justify-center gap-1 p-2">
-        <span className="text-2xl font-semibold tabular-nums">{formatValue(value)}</span>
-        <span className="text-xs text-muted-foreground">{values[0]}</span>
+        <span className="text-2xl font-semibold tabular-nums">{formatMeasure(value, f?.format)}</span>
+        <span className="text-xs text-muted-foreground">{f?.label ?? values[0]}</span>
       </div>
     );
   }
 
   // Chart — bar chart of the first measure over the first dimension, via the
-  // shared chart registry (`bar-chart`).
+  // shared chart registry (`bar-chart`). Remap the measure column to its display
+  // label so the legend/tooltip read "Tasks" rather than "task_count".
+  const measureLabel = measureField(values[0])?.label;
+  const dataKey = measureLabel && measureLabel !== values[0] ? measureLabel : values[0];
+  const chartRows = dataKey === values[0]
+    ? state.rows
+    : state.rows.map((r) => ({ ...r, [dataKey]: r[values[0]] }));
   return (
     <div className={cn('h-full w-full min-h-[220px]')}>
       <SchemaRenderer
-        schema={{ type: 'bar-chart', data: state.rows, xAxisKey: dimensions[0], dataKey: values[0] } as any}
+        schema={{ type: 'bar-chart', data: chartRows, xAxisKey: dimensions[0], dataKey } as any}
       />
     </div>
   );

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -16,6 +16,16 @@ describe('DatasetWidget', () => {
     expect(src.queryDataset).toHaveBeenCalledWith('sales', { dimensions: [], measures: ['revenue'] });
   });
 
+  it('renders the measure label + formatted value from the result fields', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ spent_sum: 616000 }],
+      fields: [{ name: 'spent_sum', type: 'number', label: 'Total Spent', format: '$0,0' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'sales', values: ['spent_sum'] }} dataSource={src} />);
+    expect(await screen.findByText('$616,000')).toBeInTheDocument();
+    expect(screen.getByText('Total Spent')).toBeInTheDocument();
+  });
+
   it('runs the dataset query for a dimensioned (chart) widget — rows→dimensions, values→measures', async () => {
     const src = makeSource(async () => ({ rows: [{ stage: 'won', revenue: 100 }, { stage: 'lost', revenue: 20 }] }));
     render(<DatasetWidget widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);


### PR DESCRIPTION
Three fixes for dataset-bound dashboard widgets, from the Chart Gallery review:

1. **Measure labels** — KPI value + chart legend use the measure's display `label` (carried on the analytics result `fields`) instead of the raw measure name: **`Tasks`** not `task_count`. The chart series is remapped to the label so the legend reads it too.
2. **Number formatting** — KPI value formatted via the measure `format` hint: `$0,0` → **`$616,000`**, `0.0` → `47.0`. A no-format measure renders verbatim (unchanged).
3. **Consistent metric card** — a dataset-bound `metric` widget now takes the shared Card wrapper (title + border) like kpi/gauge. Previously `isSelfContained` rendered it as **bare untitled text**, inconsistent with its neighbours.

> Requires framework [#1683](https://github.com/objectstack-ai/framework/pull/1683) (`AnalyticsResult.fields[].label`/`format`). After both merge, framework bumps `.objectui-sha`.

## Verification

Browser-tested on the showcase Chart Gallery: KPIs read `Total Tasks → Tasks`, `Budget vs Spend → $616,000 / Total Spent`, and "Total Tasks" now has a card like its neighbours. Chart legends show `Tasks` / `Estimated Hours` (0 raw names). New test for label+format rendering; plugin-dashboard suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)