### PR TITLE
fix(charts): angle + truncate crowded bar-chart x-axis labels

### DIFF
--- a/.changeset/chart-axis-label-crowding.md
+++ b/.changeset/chart-axis-label-crowding.md
@@ -1,0 +1,7 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+Bar-chart X-axis labels no longer overlap on narrow widgets. When a chart has
+many categories (>4) or any long label (>8 chars), the tick labels are angled
+(-32°) and truncated with a hover `title`; few short labels stay horizontal.

--- a/packages/plugin-charts/src/ChartImpl.tsx
+++ b/packages/plugin-charts/src/ChartImpl.tsx
@@ -17,6 +17,36 @@ export interface ChartImplProps {
   color?: string;
 }
 
+/** Truncate a long axis label, keeping the full text available on hover. */
+function truncate(s: string, max = 14): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+/**
+ * Angled, truncated X-axis tick — used when categories are many or wide so the
+ * labels don't overlap on a narrow widget. A `<title>` exposes the full label
+ * on hover when truncated.
+ */
+function AngledTick({ x, y, payload }: any) {
+  const raw = String(payload?.value ?? '');
+  const label = truncate(raw);
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        dy={10}
+        textAnchor="end"
+        transform="rotate(-32)"
+        fill="hsl(var(--muted-foreground))"
+        fontSize={11}
+        fontFamily="monospace"
+      >
+        {raw !== label && <title>{raw}</title>}
+        {label}
+      </text>
+    </g>
+  );
+}
+
 /**
  * ChartImpl - The heavy implementation that imports Recharts
  * This component is lazy-loaded to avoid including Recharts in the initial bundle
@@ -30,10 +60,14 @@ export default function ChartImpl({
   // Default to standard primary color
   color = 'hsl(var(--primary))',
 }: ChartImplProps) {
+  // Angle + truncate the category labels when they would crowd a narrow widget:
+  // many categories, or any label long enough to collide with its neighbour.
+  const labels = data.map((d) => String(d?.[xAxisKey] ?? ''));
+  const needAngle = labels.length > 4 || labels.some((l) => l.length > 8);
   return (
     <div className={`p-2 sm:p-3 md:p-4 rounded-xl border border-border bg-card/40 backdrop-blur-sm shadow-lg shadow-background/5 ${className}`}>
       <ResponsiveContainer width="100%" height={height}>
-        <BarChart data={data} margin={{ top: 10, right: 10, left: 10, bottom: 5 }}>
+        <BarChart data={data} margin={{ top: 10, right: 10, left: 10, bottom: needAngle ? 24 : 5 }}>
           <defs>
             <linearGradient id="barGradient" x1="0" y1="0" x2="0" y2="1">
               <stop offset="0%" stopColor={color} stopOpacity={1} />
@@ -52,12 +86,14 @@ export default function ChartImpl({
             </filter>
           </defs>
           <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
-          <XAxis 
-            dataKey={xAxisKey} 
-            tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12, fontFamily: 'monospace' }} 
+          <XAxis
+            dataKey={xAxisKey}
+            tick={needAngle ? <AngledTick /> : { fill: 'hsl(var(--muted-foreground))', fontSize: 12, fontFamily: 'monospace' }}
             tickLine={false}
             axisLine={{ stroke: 'hsl(var(--border))' }}
-            dy={10}
+            interval={needAngle ? 0 : 'preserveStartEnd'}
+            height={needAngle ? 56 : undefined}
+            dy={needAngle ? undefined : 10}
           />
           <YAxis 
             tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12, fontFamily: 'monospace' }} 


### PR DESCRIPTION
## Problem

On narrow dashboard widgets, categorical X-axis labels (`Backlog`, `In Progress`, `In Review`, `To Do`) overlapped — `ChartImpl` rendered them horizontally with no tick management. (From the Chart Gallery dashboard review.)

## Fix

`ChartImpl` now angles the tick labels (-32°) and truncates long ones (with a hover `<title>` for the full text) **when the axis would crowd** — heuristic: more than 4 categories, or any label longer than 8 chars. Few short labels (e.g. `High` / `Low` / `Urgent`) stay horizontal. Bottom margin + axis height grow in the angled case so nothing clips.

## Verification

Browser-tested on the showcase Chart Gallery:
- **Tasks by Status / Hours by Status** (5 categories) → labels angled, readable, no overlap.
- **Tasks by Priority** (3 short labels) → stays horizontal (not over-angled).

plugin-charts tests green.

> After merge, framework bumps `.objectui-sha` to vendor it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)