### PR TITLE
fix(app-shell): align flow designer with engine vocabulary + runs panel

### DIFF
--- a/.changeset/flow-designer-engine-alignment.md
+++ b/.changeset/flow-designer-engine-alignment.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/app-shell": minor
+---
+
+Flow designer ↔ automation engine alignment + run history panel.
+
+- **Palette/type-picker:** replace the BPMN `parallel_gateway` / `join_gateway`
+  (and `boundary_event` in the picker) with the structured `parallel` and
+  `try_catch` constructs the engine actually executes (ADR-0031 keeps the BPMN
+  gateway types as import/export interop only — they have no executor, so
+  flows authored with them failed at runtime with `NO_EXECUTOR`). Legacy
+  gateway nodes still render for imported flows.
+- **Runs panel:** new `FlowRunsPanel` fetches `GET /api/v1/automation/{name}/runs`
+  and surfaces run status / duration / per-node step logs in the FlowPreview
+  side panel (Variables / Debug / Runs), degrading quietly when the engine is
+  offline.
+- **Simulator:** structured containers (`parallel`, `try_catch`) pass through
+  honestly as unsupported instead of faking their semantics.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -451,6 +451,20 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
     at('connectorConfig', 'input', 'Input', 'keyValue', { help: 'Mapped inputs for the connector action.' }),
     { id: 'timeoutMs', path: ['timeoutMs'], label: 'Timeout (ms)', kind: 'number', placeholder: '30000' },
   ],
+  // ADR-0031 structured constructs. Their bodies are nested regions
+  // (config.branches / config.try / config.catch) — sub-graphs the flat field
+  // kinds can't model; authors edit them in the JSON source editor. Only the
+  // scalar knobs surface here.
+  parallel: [],
+  try_catch: [
+    cfg('errorVariable', 'Error variable', 'text', {
+      placeholder: '$error',
+      help: 'Variable the caught error is bound to inside the catch region.',
+    }),
+  ],
+  // Legacy BPMN interop pair — kept so imported flows still render an
+  // inspector, but no longer offered by the palette / type picker (the engine
+  // has no executor; ADR-0031 makes them import/export-only).
   parallel_gateway: [],
   join_gateway: [],
   boundary_event: [
@@ -518,7 +532,6 @@ const TYPE_ALIASES: Record<string, string> = {
   signal: 'boundary_event',
   webhook: 'connector_action',
   for_each: 'loop',
-  parallel: 'parallel_gateway',
 };
 
 /** Resolve the config fields for a node type (alias-aware). */
@@ -591,8 +604,9 @@ export const FLOW_NODE_TYPE_OPTIONS = [
   'wait',
   'subflow',
   'connector_action',
-  'parallel_gateway',
-  'join_gateway',
-  'boundary_event',
+  // ADR-0031: structured constructs replace the BPMN gateway/boundary types in
+  // the picker — those remain import/export-only (no engine executor).
+  'parallel',
+  'try_catch',
   'end',
 ] as const;

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -23,6 +23,7 @@ import {
   Bug,
   CircleDot,
   GitBranch,
+  History,
   PanelRight,
   Plus,
   Settings2,
@@ -36,6 +37,7 @@ import { t as tr } from '../i18n';
 import { FlowCanvas } from './FlowCanvas';
 import { edgeKey } from './flow-canvas-layout';
 import { FlowSimulatorPanel } from './FlowSimulatorPanel';
+import { FlowRunsPanel } from './FlowRunsPanel';
 
 interface FlowNode {
   id: string;
@@ -78,6 +80,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
 
   const [showDebug, setShowDebug] = React.useState(false);
   const [showVars, setShowVars] = React.useState(true);
+  const [showRuns, setShowRuns] = React.useState(false);
   const [runHL, setRunHL] = React.useState<{
     activeNodeId: string | null;
     visitedNodeIds: string[];
@@ -96,6 +99,8 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
     onSelectionChange?.({ kind: 'node', id: newNode.id, label: newNode.label || newNode.id });
   }, [canEdit, nodes, onPatch, onSelectionChange]);
 
+  // Run history needs the published flow name (the engine keys runs by it).
+  const flowName = typeof d.name === 'string' && d.name ? d.name : '';
   const flowType = String(d.type ?? 'autolaunched');
   const status = String(d.status ?? (d.active ? 'active' : 'draft'));
   const runAs = String(d.runAs ?? 'user');
@@ -128,7 +133,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
       <PreviewErrorBoundary fallbackHint="One of the flow nodes or edges is malformed.">
         <div className={
           'grid gap-0 h-full min-h-[440px] ' +
-          (showDebug || showVars ? 'lg:grid-cols-[1fr_240px]' : 'grid-cols-1')
+          (showDebug || showVars || showRuns ? 'lg:grid-cols-[1fr_240px]' : 'grid-cols-1')
         }>
           {/* Visual canvas */}
           <div className="flex flex-col min-w-0 min-h-0">
@@ -139,7 +144,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
               {version && <Pill label="v" value={version} />}
               {errorStrategy && <Pill icon={GitBranch} label="On error" value={errorStrategy} />}
               <div className="ml-auto flex items-center gap-1.5">
-                {!showDebug && (
+                {!showDebug && !showRuns && (
                   <button
                     type="button"
                     onClick={() => setShowVars((v) => !v)}
@@ -154,9 +159,30 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                     <PanelRight className="h-3 w-3" /> Variables
                   </button>
                 )}
+                {flowName && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowRuns((v) => !v);
+                      setShowDebug(false);
+                    }}
+                    className={
+                      'inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] font-medium transition-colors ' +
+                      (showRuns
+                        ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
+                        : 'border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground')
+                    }
+                    title="Run history from the automation engine"
+                  >
+                    <History className="h-3 w-3" /> Runs
+                  </button>
+                )}
                 <button
                   type="button"
-                  onClick={() => setShowDebug((v) => !v)}
+                  onClick={() => {
+                    setShowDebug((v) => !v);
+                    setShowRuns(false);
+                  }}
                   className={
                     'inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] font-medium transition-colors ' +
                     (showDebug
@@ -195,8 +221,9 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
             </div>
           </div>
 
-          {/* Right side panel: Variables (default) or the debug simulator.
-              Collapsible so the canvas can use the full width. */}
+          {/* Right side panel: Variables (default), the debug simulator, or
+              the engine run history. Collapsible so the canvas can use the
+              full width. */}
           {showDebug ? (
             <div className="border-l bg-muted/20">
               <FlowSimulatorPanel
@@ -205,6 +232,10 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                 variables={variables}
                 onRunStateChange={setRunHL}
               />
+            </div>
+          ) : showRuns && flowName ? (
+            <div className="border-l bg-muted/20">
+              <FlowRunsPanel flowName={flowName} />
             </div>
           ) : showVars ? (
             <div className="border-l bg-muted/20 p-3 text-xs space-y-2">

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchFlowRuns } from './FlowRunsPanel';
+
+const RUN = {
+  id: 'run-1',
+  status: 'completed',
+  startedAt: '2026-06-01T10:00:00Z',
+  durationMs: 42,
+  steps: [{ nodeId: 'start', nodeType: 'start', status: 'success' }],
+};
+
+function mockFetch(impl: (url: string) => Promise<Response> | Response) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => impl(String(url))));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchFlowRuns', () => {
+  it('parses the dispatcher envelope ({ data: { runs } })', async () => {
+    mockFetch(() => new Response(JSON.stringify({ success: true, data: { runs: [RUN] } }), { status: 200 }));
+    const runs = await fetchFlowRuns('escalation_flow');
+    expect(runs).toEqual([RUN]);
+  });
+
+  it('accepts a bare { runs } payload (older backend)', async () => {
+    mockFetch(() => new Response(JSON.stringify({ runs: [RUN] }), { status: 200 }));
+    expect(await fetchFlowRuns('escalation_flow')).toEqual([RUN]);
+  });
+
+  it('URL-encodes the flow name and requests the automation runs route', async () => {
+    let requested = '';
+    mockFetch((url) => {
+      requested = url;
+      return new Response(JSON.stringify({ data: { runs: [] } }), { status: 200 });
+    });
+    await fetchFlowRuns('my flow/v2');
+    expect(requested).toContain('/automation/my%20flow%2Fv2/runs');
+  });
+
+  it('returns null (degrade, not throw) on 404/501 and on network failure', async () => {
+    mockFetch(() => new Response('not found', { status: 404 }));
+    expect(await fetchFlowRuns('missing')).toBeNull();
+
+    mockFetch(() => Promise.reject(new Error('offline')));
+    expect(await fetchFlowRuns('missing')).toBeNull();
+  });
+
+  it('returns null when the payload has no runs array', async () => {
+    mockFetch(() => new Response(JSON.stringify({ data: {} }), { status: 200 }));
+    expect(await fetchFlowRuns('empty')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
@@ -1,0 +1,212 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * FlowRunsPanel — run history for a flow, fetched from the automation engine
+ * (`GET /api/v1/automation/{name}/runs`, the observability surface next to
+ * resume/screen). Renders each run's status / start time / duration with an
+ * expandable per-node step log (the `ExecutionLog.steps` ADR-0019/#1479 shape),
+ * so authors can see where a run paused or failed without leaving the Studio.
+ *
+ * Degrades like the palette fetch: offline / plugin-absent / older backend →
+ * a quiet "history unavailable" note, never an error state that blocks the
+ * designer.
+ */
+
+import * as React from 'react';
+import { AlertCircle, CheckCircle2, ChevronDown, ChevronRight, Clock, Loader2, PauseCircle, RefreshCw, SkipForward } from 'lucide-react';
+import { cn } from '@object-ui/components';
+import { apiBase } from './useFlowNodePalette';
+
+/** Step entry of a run log (spec `ExecutionStepLogSchema`, fields we render). */
+interface RunStep {
+  nodeId: string;
+  nodeType?: string;
+  status: 'success' | 'failure' | 'skipped' | string;
+  durationMs?: number;
+  error?: { code?: string; message?: string };
+}
+
+/** Run log entry (spec `ExecutionLogSchema`, fields we render). */
+export interface FlowRun {
+  id: string;
+  status: 'completed' | 'failed' | 'paused' | 'running' | 'cancelled' | string;
+  startedAt?: string;
+  completedAt?: string;
+  durationMs?: number;
+  trigger?: { type?: string; userId?: string; object?: string };
+  steps?: RunStep[];
+  error?: { message?: string };
+}
+
+type LoadState = 'loading' | 'ready' | 'unavailable';
+
+/** Fetch a flow's run history. Exposed for tests. */
+export async function fetchFlowRuns(flowName: string, signal?: AbortSignal): Promise<FlowRun[] | null> {
+  try {
+    const res = await fetch(
+      `${apiBase()}/automation/${encodeURIComponent(flowName)}/runs?limit=25`,
+      { credentials: 'include', headers: { 'Content-Type': 'application/json' }, signal },
+    );
+    if (!res.ok) return null; // 404/501 — plugin absent or older backend
+    const payload = (await res.json()) as { data?: { runs?: FlowRun[] }; runs?: FlowRun[] };
+    const runs = payload?.data?.runs ?? payload?.runs;
+    return Array.isArray(runs) ? runs : null;
+  } catch {
+    return null; // offline / aborted
+  }
+}
+
+const STATUS_META: Record<string, { icon: React.ComponentType<{ className?: string }>; cls: string; label: string }> = {
+  completed: { icon: CheckCircle2, cls: 'text-emerald-600 dark:text-emerald-400', label: 'Completed' },
+  failed: { icon: AlertCircle, cls: 'text-rose-600 dark:text-rose-400', label: 'Failed' },
+  paused: { icon: PauseCircle, cls: 'text-amber-600 dark:text-amber-400', label: 'Paused' },
+  running: { icon: Loader2, cls: 'text-sky-600 dark:text-sky-400', label: 'Running' },
+  cancelled: { icon: SkipForward, cls: 'text-muted-foreground', label: 'Cancelled' },
+};
+
+function statusMeta(status: string) {
+  return STATUS_META[status] ?? { icon: Clock, cls: 'text-muted-foreground', label: status };
+}
+
+function fmtTime(iso?: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+function fmtDuration(ms?: number): string | null {
+  if (ms == null) return null;
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.round(ms / 60_000)}m`;
+}
+
+function StepRow({ step }: { step: RunStep }) {
+  const cls =
+    step.status === 'success'
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : step.status === 'failure'
+        ? 'text-rose-600 dark:text-rose-400'
+        : 'text-muted-foreground';
+  return (
+    <li className="flex items-baseline gap-1.5 py-0.5">
+      <span className={cn('shrink-0 text-[9px] font-semibold uppercase', cls)}>{step.status}</span>
+      <span className="truncate font-mono text-[10px]" title={step.nodeId}>{step.nodeId}</span>
+      {step.nodeType && <span className="shrink-0 text-[9px] uppercase text-muted-foreground">{step.nodeType}</span>}
+      {fmtDuration(step.durationMs) && (
+        <span className="ml-auto shrink-0 text-[9px] text-muted-foreground">{fmtDuration(step.durationMs)}</span>
+      )}
+      {step.error?.message && (
+        <span className="min-w-0 truncate text-[9px] text-rose-600" title={step.error.message}>
+          {step.error.message}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function RunRow({ run }: { run: FlowRun }) {
+  const [open, setOpen] = React.useState(false);
+  const meta = statusMeta(run.status);
+  const Icon = meta.icon;
+  const steps = Array.isArray(run.steps) ? run.steps : [];
+  return (
+    <li className="rounded border bg-background">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-1.5 p-1.5 text-left"
+        aria-expanded={open}
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+        )}
+        <Icon className={cn('h-3.5 w-3.5 shrink-0', meta.cls, run.status === 'running' && 'animate-spin')} />
+        <span className={cn('shrink-0 text-[10px] font-semibold', meta.cls)}>{meta.label}</span>
+        <span className="min-w-0 truncate text-[10px] text-muted-foreground" title={run.id}>
+          {fmtTime(run.startedAt)}
+        </span>
+        {fmtDuration(run.durationMs) && (
+          <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{fmtDuration(run.durationMs)}</span>
+        )}
+      </button>
+      {open && (
+        <div className="border-t px-2 py-1.5">
+          <div className="pb-1 font-mono text-[9px] text-muted-foreground" title={run.id}>
+            run {run.id}
+            {run.trigger?.type && ` · trigger ${run.trigger.type}`}
+          </div>
+          {run.error?.message && (
+            <div className="pb-1 text-[10px] text-rose-600">{run.error.message}</div>
+          )}
+          {steps.length === 0 ? (
+            <div className="text-[10px] italic text-muted-foreground">No step log recorded.</div>
+          ) : (
+            <ul className="divide-y divide-border/50">
+              {steps.map((s, i) => (
+                <StepRow key={`${s.nodeId}#${i}`} step={s} />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function FlowRunsPanel({ flowName }: { flowName: string }) {
+  const [runs, setRuns] = React.useState<FlowRun[]>([]);
+  const [state, setState] = React.useState<LoadState>('loading');
+  const [reloadKey, setReloadKey] = React.useState(0);
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    let alive = true;
+    setState('loading');
+    (async () => {
+      const result = await fetchFlowRuns(flowName, controller.signal);
+      if (!alive) return;
+      if (result === null) setState('unavailable');
+      else {
+        setRuns(result);
+        setState('ready');
+      }
+    })();
+    return () => {
+      alive = false;
+      controller.abort();
+    };
+  }, [flowName, reloadKey]);
+
+  return (
+    <div className="flex h-full flex-col p-3 text-xs">
+      <div className="flex items-center gap-1.5 pb-2 font-medium text-muted-foreground">
+        <Clock className="h-3 w-3" /> Runs
+        <button
+          type="button"
+          onClick={() => setReloadKey((k) => k + 1)}
+          title="Refresh run history"
+          aria-label="Refresh run history"
+          className="ml-auto rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+        >
+          <RefreshCw className={cn('h-3 w-3', state === 'loading' && 'animate-spin')} />
+        </button>
+      </div>
+      {state === 'unavailable' ? (
+        <div className="italic text-muted-foreground">
+          Run history unavailable — the automation engine is offline or this flow hasn’t been published.
+        </div>
+      ) : state === 'ready' && runs.length === 0 ? (
+        <div className="italic text-muted-foreground">No runs yet.</div>
+      ) : (
+        <ul className="min-h-0 flex-1 space-y-1.5 overflow-y-auto">
+          {runs.map((r) => (
+            <RunRow key={r.id} run={r} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -23,6 +23,7 @@ import {
   Plug,
   Plus,
   Repeat,
+  ShieldAlert,
   TimerReset,
   UserCheck,
   Variable,
@@ -84,6 +85,8 @@ export function nodeIcon(type: string): LucideIcon {
     case 'join_gateway':
     case 'parallel':
       return GitFork;
+    case 'try_catch':
+      return ShieldAlert;
     default:
       return CircleDot;
   }
@@ -200,6 +203,7 @@ export function nodeTone(type: string): NodeTone {
       return TONES.wait;
     case 'boundary_event':
     case 'signal':
+    case 'try_catch':
       return TONES.signal;
     case 'subflow':
     case 'flow':
@@ -275,6 +279,7 @@ export function nodeCategory(type: string): NodeCategory {
     case 'parallel_gateway':
     case 'join_gateway':
     case 'parallel':
+    case 'try_catch':
       return 'Logic';
     case 'approval':
     case 'screen':
@@ -302,8 +307,11 @@ export const NODE_PALETTE: PaletteItem[] = [
   { type: 'decision', label: 'Decision', hint: 'Branch on a condition', category: 'Logic' },
   { type: 'loop', label: 'Loop', hint: 'Iterate over a collection', category: 'Logic' },
   { type: 'assignment', label: 'Set variables', hint: 'Assign flow variables', category: 'Logic' },
-  { type: 'parallel_gateway', label: 'Parallel split', hint: 'Fork into concurrent branches', category: 'Logic' },
-  { type: 'join_gateway', label: 'Parallel join', hint: 'Wait for concurrent branches', category: 'Logic' },
+  // ADR-0031: authors get the structured constructs (well-formed by
+  // construction); the BPMN `parallel_gateway` / `join_gateway` pair is an
+  // import/export representation only — the engine has no executor for it.
+  { type: 'parallel', label: 'Parallel', hint: 'Run branches concurrently, join at end', category: 'Logic' },
+  { type: 'try_catch', label: 'Try / Catch', hint: 'Protect steps with error handling and retry', category: 'Logic' },
   { type: 'approval', label: 'Approval', hint: 'Pause for a human decision', category: 'Human' },
   { type: 'screen', label: 'Screen', hint: 'Collect input from a user', category: 'Human' },
   { type: 'http_request', label: 'HTTP request', hint: 'Call an external API', category: 'Integration' },

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-simulator.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-simulator.ts
@@ -9,8 +9,10 @@
  * end. `wait` and `screen` PAUSE for manual continuation. `loop` resolves its
  * collection and exposes the iterator but is a labelled single pass (the edge
  * model has no separate body/exit edge). `parallel_gateway` fans out WITHOUT
- * join synchronization; `join_gateway`, `subflow` and `boundary_event` are
- * marked unsupported rather than faked. A hard step ceiling guards cycles.
+ * join synchronization; the ADR-0031 structured containers (`parallel`,
+ * `try_catch` — nested body regions), `join_gateway`, `subflow` and
+ * `boundary_event` are marked unsupported rather than faked. A hard step
+ * ceiling guards cycles.
  */
 
 import type {
@@ -35,7 +37,9 @@ const MOCKED_SIDE_EFFECT = new Set([
   'http_request',
   'connector_action',
 ]);
-const UNSUPPORTED = new Set(['join_gateway', 'subflow', 'boundary_event']);
+// `parallel` / `try_catch` carry nested body regions (ADR-0031) the flat
+// stepper can't walk — pass through honestly instead of faking their semantics.
+const UNSUPPORTED = new Set(['join_gateway', 'subflow', 'boundary_event', 'parallel', 'try_catch']);
 
 const edgeId = (e: SimEdge, i: number): string => e.id || `${e.source}->${e.target}#${i}`;
 const condStr = (c: SimEdge['condition']): string | undefined => (typeof c === 'string' ? c : undefined);

--- a/packages/app-shell/src/views/metadata-admin/previews/useFlowNodePalette.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/useFlowNodePalette.ts
@@ -38,7 +38,8 @@ interface ActionDescriptorLite {
   configSchema?: unknown;
 }
 
-function apiBase(): string {
+/** Server API base — shared by the palette fetch and the runs panel. */
+export function apiBase(): string {
   const url = (import.meta as { env?: { VITE_SERVER_URL?: string } }).env?.VITE_SERVER_URL || '';
   return `${String(url).replace(/\/$/, '')}/api/v1`;
 }


### PR DESCRIPTION
## Summary
- **Palette / type-picker fix (runtime bug):** the hardcoded palette offered BPMN `parallel_gateway` / `join_gateway` — node types the automation engine has **no executor** for (ADR-0031 keeps them as import/export interop only), so flows authored with them registered fine and then failed at runtime with `NO_EXECUTOR`. Replaced with the structured `parallel` + `try_catch` constructs the engine actually executes. Legacy gateway nodes still render for imported flows; `boundary_event` also dropped from the type picker (same no-executor issue), its inspector group retained for legacy display.
- **Run history in Studio:** new `FlowRunsPanel` fetches `GET /api/v1/automation/{name}/runs` and shows run status / duration / expandable per-node step logs as a third FlowPreview side-panel mode (Variables / Debug / **Runs**). Degrades quietly (offline / plugin absent / older backend) like the palette fetch.
- **Simulator honesty:** structured containers (`parallel`, `try_catch` — nested body regions) pass through as unsupported instead of faking semantics.

## Test plan
- [x] `pnpm vitest run` previews + simulator suites green (incl. 5 new `fetchFlowRuns` parse/degrade tests)
- [x] `@object-ui/app-shell` `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)