### PR TITLE
feat(chatbot): surface seed-apply results, fix stale Running badge, Open-app on build done

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -368,6 +368,7 @@ function ChatPane({
   onShare,
 }: ChatPaneProps) {
   const { t } = useObjectTranslation();
+  const navigate = useNavigate();
   const activeAgentLabel = useMemo<string>(() => {
     const found = agents.find((a) => a.name === activeAgent);
     return localizeAgentLabel(t, activeAgent, found?.label ?? activeAgent ?? t('console.ai.assistant'));

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -538,6 +538,9 @@ function ChatPane({
         toolApproveLabel="Approve & run"
         toolDenyLabel="Reject"
         toolDenyReason="Operator rejected from chat"
+        // Build-tree "Open app": jump straight into the app the agent just built.
+        onOpenBuiltApp={(appName) => navigate(`/apps/${encodeURIComponent(appName)}`)}
+        openBuiltAppLabel={t('console.ai.openBuiltApp', { defaultValue: 'Open app' })}
         onPublishDrafts={async (packageId) => {
           // Promote the conversation's staged drafts to live (ADR-0033 gate —
           // the human still clicks). Same call as the floating chat + PackagesPage.
@@ -557,7 +560,23 @@ function ChatPane({
             }
             const failed = payload?.data?.failedCount ?? payload?.failedCount ?? 0;
             if (failed) throw new Error(String(failed));
-            toast.success(t('console.ai.publishOk', { defaultValue: 'Published — objects are now live.' }));
+            // Surface a seed-load problem (reported under `seedApplied`, never
+            // thrown) so "Published!" can't hide silently empty tables.
+            const seedApplied = payload?.data?.seedApplied ?? payload?.seedApplied;
+            if (seedApplied && seedApplied.success === false) {
+              toast.warning(
+                t('console.ai.seedWarn', { defaultValue: 'Published, but some sample data failed to load.' }),
+                {
+                  description:
+                    seedApplied.error ??
+                    (Array.isArray(seedApplied.errors) && seedApplied.errors.length
+                      ? String(seedApplied.errors[0])
+                      : undefined),
+                },
+              );
+            } else {
+              toast.success(t('console.ai.publishOk', { defaultValue: 'Published — objects are now live.' }));
+            }
             return true;
           } catch (e) {
             toast.error(t('console.ai.publishFailed', { defaultValue: 'Publish failed' }), {

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -148,10 +148,30 @@ function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) 
             .filter((d) => d && typeof d.type === 'string' && typeof d.name === 'string')
             .map((d) => ({ type: d.type, name: d.name }));
       if (pending.length === 0) throw new Error('nothing to publish');
-      for (const d of pending) {
-        await client.publishDraft(d.type, d.name);
+      // Structure first, seeds LAST — a seed's rows can only land once its
+      // object's table exists. Publishing a `seed` also materializes its rows
+      // (reported under `seedApplied`, never thrown) — collect failures so
+      // "Published!" can't hide silently empty tables.
+      const ordered = [
+        ...pending.filter((d) => d.type !== 'seed'),
+        ...pending.filter((d) => d.type === 'seed'),
+      ];
+      const seedProblems: string[] = [];
+      for (const d of ordered) {
+        const res = await client.publishDraft(d.type, d.name);
+        const seedApplied = (res as any)?.seedApplied;
+        if (seedApplied && seedApplied.success === false) {
+          seedProblems.push(seedApplied.error ?? `${d.name}: sample data failed to load`);
+        }
       }
-      toast.success(t('home.pendingDrafts.published', { defaultValue: 'Published! Your changes are live.' }));
+      if (seedProblems.length > 0) {
+        toast.warning(
+          t('home.pendingDrafts.seedWarn', { defaultValue: 'Published, but some sample data failed to load.' }),
+          { description: seedProblems[0] },
+        );
+      } else {
+        toast.success(t('home.pendingDrafts.published', { defaultValue: 'Published! Your changes are live.' }));
+      }
       setDrafts([]);
       // Surface the now-live app — reload so the populated home shows it.
       setTimeout(() => { try { window.location.reload(); } catch { /* ignore */ } }, 700);

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -121,6 +121,8 @@ function buildChatLocale(
       published: '已发布',
       publishOk: '已发布，对象已生效。',
       publishFailed: '发布失败',
+      seedWarn: '已发布，但部分示例数据未能载入。',
+      openBuiltApp: '打开应用',
       suggestions,
     };
   }
@@ -165,6 +167,8 @@ function buildChatLocale(
     published: 'Published',
     publishOk: 'Published — objects are now live.',
     publishFailed: 'Publish failed',
+    seedWarn: 'Published, but some sample data failed to load.',
+    openBuiltApp: 'Open app',
     suggestions,
   };
 }
@@ -501,6 +505,10 @@ function ChatbotInner({
           if (items[0]) requestAssistantReview(items[0]);
         }}
         toolReviewLabel={locale.reviewDraft}
+        // Build-tree "Open app": jump straight into the app the agent just
+        // built (the panel only shows this once the build reports done).
+        onOpenBuiltApp={(appName) => navigate(`/apps/${encodeURIComponent(appName)}`)}
+        openBuiltAppLabel={locale.openBuiltApp}
         onPublishDrafts={async (packageId) => {
           // ADR-0033 — promote the conversation's staged drafts to live in one
           // click (the human still confirms here). Mirrors PackagesPage's
@@ -521,7 +529,22 @@ function ChatbotInner({
             }
             const failed = payload?.data?.failedCount ?? payload?.failedCount ?? 0;
             if (failed) throw new Error(String(failed));
-            toast.success(locale.publishOk);
+            // The protocol materializes published `seed` rows and reports under
+            // `seedApplied` — a data problem never fails the publish, so it
+            // must be surfaced HERE or the user lands on an app with silently
+            // empty tables (the staging "No rows" incident).
+            const seedApplied = payload?.data?.seedApplied ?? payload?.seedApplied;
+            if (seedApplied && seedApplied.success === false) {
+              toast.warning(locale.seedWarn, {
+                description:
+                  seedApplied.error ??
+                  (Array.isArray(seedApplied.errors) && seedApplied.errors.length
+                    ? String(seedApplied.errors[0])
+                    : undefined),
+              });
+            } else {
+              toast.success(locale.publishOk);
+            }
             // Publish & Open: land the user ON the thing they just built rather
             // than leaving them on an empty home with only a toast. Prefer the
             // published App (a full navigable surface); the bare-object case has

--- a/packages/data-objectstack/src/metadata-client.test.ts
+++ b/packages/data-objectstack/src/metadata-client.test.ts
@@ -177,4 +177,24 @@ describe('MetadataClient', () => {
     });
     await expect(c.publishDraft('view', 'x')).rejects.toBeTruthy();
   });
+
+  it('publishDraft returns the result (incl. seedApplied) and unwraps the {data} envelope', async () => {
+    // Flat shape (rest-server passes protocol result through).
+    const flat = new MetadataClient({
+      baseUrl: '',
+      fetch: mockFetch(async () =>
+        jsonResponse({ success: true, seedApplied: { success: false, error: 'no readable seed bodies' } })),
+    });
+    const r1 = await flat.publishDraft('seed', 'job_sample');
+    expect(r1.seedApplied).toEqual({ success: false, error: 'no readable seed bodies' });
+
+    // Dispatcher `{ success, data: {...} }` envelope.
+    const enveloped = new MetadataClient({
+      baseUrl: '',
+      fetch: mockFetch(async () =>
+        jsonResponse({ success: true, data: { success: true, seedApplied: { success: true, inserted: 6, updated: 0 } } })),
+    });
+    const r2 = await enveloped.publishDraft('seed', 'candidate_sample');
+    expect(r2.seedApplied).toEqual({ success: true, inserted: 6, updated: 0 });
+  });
 });

--- a/packages/data-objectstack/src/metadata-client.ts
+++ b/packages/data-objectstack/src/metadata-client.ts
@@ -474,8 +474,19 @@ export class MetadataClient {
    * draft, including ones with no `packageId` binding (which the package-scoped
    * `/packages/:id/publish-drafts` flow cannot reach). Use this to publish the
    * exact set returned by {@link listDrafts} without needing a package.
+   *
+   * Returns the server result. For `seed` drafts the protocol also materializes
+   * the rows and reports under `seedApplied` — a data problem never fails the
+   * publish, so callers should check `seedApplied?.success` and warn the user
+   * rather than assume the data went live.
    */
-  async publishDraft(type: string, name: string): Promise<void> {
+  async publishDraft(
+    type: string,
+    name: string,
+  ): Promise<{
+    success?: boolean;
+    seedApplied?: { success: boolean; inserted?: number; updated?: number; error?: string; errors?: unknown[] };
+  } & Record<string, unknown>> {
     const url = `${this.base}/${encodeURIComponent(type)}/${encodeURIComponent(name)}/publish`;
     const res = await this.fetchImpl(url, {
       method: 'POST',
@@ -483,6 +494,10 @@ export class MetadataClient {
       body: '{}',
     });
     if (!res.ok) throw await parseError(res);
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    // Tolerate the dispatcher's `{ success, data: {...} }` envelope.
+    const inner = (body as any)?.data && typeof (body as any).data === 'object' ? (body as any).data : body;
+    return inner as any;
   }
 
   /**

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -19,7 +19,7 @@
  */
 import * as React from 'react';
 import { cn } from '@object-ui/components';
-import { AlertCircle, Copy, Check, RefreshCw, CornerDownLeft, Bot, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import type { ChatStatus } from 'ai';
 import {
   humanizeToolName,
@@ -340,6 +340,15 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    * `POST /api/v1/packages/:packageId/publish-drafts`.
    */
   onPublishDrafts?: (packageId: string) => void | boolean | Promise<void | boolean>;
+  /**
+   * When provided, a finished build tree (`buildProgress.phase === 'done'`) that
+   * created an `app` renders an "Open app" action so the user can jump straight
+   * into what was just built. The host wires this to its router (e.g.
+   * `navigate('/apps/<name>')`).
+   */
+  onOpenBuiltApp?: (appName: string) => void;
+  /** Label for the open-built-app action (default "Open app"). */
+  openBuiltAppLabel?: string;
   /** Label for the publish-drafts button (default "Publish"). */
   publishDraftsLabel?: string;
   /** Label for the published-state badge that replaces the button (default "Published"). */
@@ -535,6 +544,8 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       onReviewDraft,
       toolReviewLabel = (n) => `Review ${n} change${n === 1 ? '' : 's'}`,
       onPublishDrafts,
+      onOpenBuiltApp,
+      openBuiltAppLabel = 'Open app',
       publishDraftsLabel = 'Publish',
       publishedLabel = 'Published',
       autoPublishDrafts = false,
@@ -977,7 +988,11 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                       >
                     <MessageContent>
                       {buildProgress ? (
-                        <BuildProgressPanel progress={buildProgress} />
+                        <BuildProgressPanel
+                          progress={buildProgress}
+                          onOpenBuiltApp={onOpenBuiltApp}
+                          openBuiltAppLabel={openBuiltAppLabel}
+                        />
                       ) : null}
                       {!isUser && processVisibility === 'debug' && reasoning ? (
                         <Reasoning
@@ -1265,9 +1280,19 @@ const BUILD_GROUP_LABEL: Record<string, string> = {
  * watches objects → views → dashboard → app → sample data appear instead of a
  * blank thinking spinner. Collapses to a "Built X" summary when done.
  */
-function BuildProgressPanel({ progress }: { progress: ChatBuildProgress }) {
+function BuildProgressPanel({
+  progress,
+  onOpenBuiltApp,
+  openBuiltAppLabel = 'Open app',
+}: {
+  progress: ChatBuildProgress;
+  onOpenBuiltApp?: (appName: string) => void;
+  openBuiltAppLabel?: string;
+}) {
   const { phase, appLabel, items, done, total } = progress;
   const isDone = phase === 'done';
+  // The created `app` artifact (navigation shell) — the natural "open it" target.
+  const builtApp = items.find((it) => it.type === 'app');
   const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : isDone ? 100 : 6;
   const groups = new Map<string, string[]>();
   for (const it of items) {
@@ -1313,6 +1338,19 @@ function BuildProgressPanel({ progress }: { progress: ChatBuildProgress }) {
           );
         })}
       </ul>
+      {isDone && builtApp && onOpenBuiltApp ? (
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => onOpenBuiltApp(builtApp.name)}
+            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+            data-testid="build-progress-open-app"
+          >
+            {openBuiltAppLabel}
+            <ArrowRight className="size-3.5" />
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -411,4 +411,30 @@ describe('ChatbotEnhanced — streaming build preview (live build tree)', () => 
     render(<ChatbotEnhanced messages={[buildMsg('done')]} />);
     expect(screen.getByText(/Built CRM/i)).toBeInTheDocument();
   });
+
+  it('offers "Open app" on a finished build that created an app, wired to onOpenBuiltApp', () => {
+    const onOpenBuiltApp = vi.fn();
+    const doneWithApp: ChatMessage = {
+      ...buildMsg('done'),
+      buildProgress: {
+        ...buildMsg('done').buildProgress!,
+        items: [...buildMsg('done').buildProgress!.items, { type: 'app', name: 'crm' }],
+      },
+    };
+    render(<ChatbotEnhanced messages={[doneWithApp]} onOpenBuiltApp={onOpenBuiltApp} />);
+    const btn = screen.getByTestId('build-progress-open-app');
+    fireEvent.click(btn);
+    expect(onOpenBuiltApp).toHaveBeenCalledWith('crm');
+  });
+
+  it('shows no Open-app action while streaming or without an app artifact', () => {
+    const onOpenBuiltApp = vi.fn();
+    const { rerender } = render(
+      <ChatbotEnhanced isLoading messages={[buildMsg('data')]} onOpenBuiltApp={onOpenBuiltApp} />,
+    );
+    expect(screen.queryByTestId('build-progress-open-app')).not.toBeInTheDocument();
+    // Done but no `app` item → still no button (nothing to open).
+    rerender(<ChatbotEnhanced messages={[buildMsg('done')]} onOpenBuiltApp={onOpenBuiltApp} />);
+    expect(screen.queryByTestId('build-progress-open-app')).not.toBeInTheDocument();
+  });
 });

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -62,6 +62,37 @@ describe('uiMessageToChatMessage', () => {
     });
   });
 
+  it('promotes a stale input-available state to output-available when an output is present (reloaded conversations)', () => {
+    // A conversation persisted mid-stream can carry `input-available` next to a
+    // present output (the terminal state was never snapshotted) — without the
+    // promotion a reloaded chat shows "Running" forever on a finished build.
+    const out = uiMessageToChatMessage({
+      id: 'm-reload',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-apply_blueprint',
+          toolCallId: 'call_b',
+          state: 'input-available',
+          input: { blueprint: {} },
+          output: { status: 'drafted', drafted: [{ type: 'object', name: 'job' }] },
+        },
+      ],
+    });
+    expect(out.toolInvocations?.[0]?.state).toBe('output-available');
+  });
+
+  it('keeps input-available when there is genuinely no output yet (live stream)', () => {
+    const out = uiMessageToChatMessage({
+      id: 'm-live',
+      role: 'assistant',
+      parts: [
+        { type: 'tool-apply_blueprint', toolCallId: 'call_c', state: 'input-available', input: {} },
+      ],
+    });
+    expect(out.toolInvocations?.[0]?.state).toBe('input-available');
+  });
+
   it('preserves legacy msg.toolInvocations when no tool-* parts are present', () => {
     const out = uiMessageToChatMessage({
       id: 'm4',

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -186,7 +186,16 @@ function extractToolInvocations(parts: AnyPart[]): ChatToolInvocation[] {
       const result = p.output ?? p.result;
       const pending = detectPendingApproval(result);
       const draftReview = detectDraftResult(result);
-      const baseState = p.state;
+      // A part persisted mid-stream can carry a stale `input-*` state next to a
+      // present output (the terminal state wasn't snapshotted) — a reloaded
+      // conversation would then show "Running" forever. Output present = the
+      // call finished; promote so the badge reads Completed.
+      const persistedState = p.state;
+      const baseState: ChatToolInvocation['state'] =
+        (persistedState === 'input-available' || persistedState === 'input-streaming') &&
+        result !== undefined
+          ? 'output-available'
+          : persistedState;
       // Promote pending HITL results to `approval-requested` so the UI
       // unlocks the inline approve/reject buttons. Once the operator
       // decides, `useHitlInChat` flips `state` back via the per-call


### PR DESCRIPTION
Three magic-moment polish items, companion to [framework#1686](https://github.com/objectstack-ai/framework/pull/1686):

## 1. Surface `seedApplied` (companion to framework#1686)
The framework now materializes published `seed` rows on **every** publish path and reports under `seedApplied` — never thrown, so the UI must check it. This PR surfaces a seed-load failure as a **warning toast** in all three publish surfaces (floating chat, AI chat page, home pending-drafts banner), so "Published!" can never again hide silently empty tables (the staging "No rows" incident). The banner also publishes structure before seeds, and `MetadataClient.publishDraft()` now returns the server result (envelope-tolerant).

## 2. Stale "Running" badge on reloaded conversations
A conversation persisted mid-stream can carry `input-available` next to a present output (the terminal state was never snapshotted) — reloading then showed a finished build as **Running** forever. `mapMessages` now promotes such parts to `output-available` (output present = the call finished). Live streams without output keep their state.

## 3. "Open app" on the finished build tree
A finished build that created an `app` now renders an **Open app →** action on the `BuildProgressPanel` (new optional `onOpenBuiltApp` prop), wired in both hosts to navigate straight into the just-built app.

## Test
plugin-chatbot **57**, data-objectstack **14**, app-shell **390** — all green; typechecks clean on all three packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)