### PR TITLE
fix(app-shell): close FlowRunner on terminal resume failure

### DIFF
--- a/.changeset/flowrunner-terminal-failure-reset.md
+++ b/.changeset/flowrunner-terminal-failure-reset.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/app-shell": patch
+---
+
+FlowRunner: close the runner when a resume ends in a terminal flow failure.
+
+The engine consumes a run's suspension before executing downstream nodes
+(resume-once semantics), so a resume whose `AutomationResult` is
+`success: false` can never be retried — the old behavior left the dialog open
+and a second Submit hit "No suspended run". Transport-level failures (network
+/ 5xx) still keep the dialog open for retry.

--- a/packages/app-shell/src/views/FlowRunner.tsx
+++ b/packages/app-shell/src/views/FlowRunner.tsx
@@ -107,14 +107,21 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete }: F
       );
       const json = await res.json().catch(() => null);
       if (!res.ok || json?.success === false) {
+        // Transport / envelope failure — possibly transient (network, 5xx), so
+        // keep the dialog open and let the user retry the same run.
         toast.error(json?.error || `Resume failed (HTTP ${res.status})`);
         return;
       }
       const data = json?.data ?? {};
       // The HTTP envelope is `{ success:true, data: AutomationResult }`; a flow
-      // that errored downstream surfaces as `data.success === false`.
+      // that errored downstream surfaces as `data.success === false`. That is
+      // TERMINAL: the engine consumes the suspension before running downstream
+      // nodes (resume-once), so this run can never be resumed again — a retry
+      // would only hit "No suspended run". Close the runner instead of leaving
+      // a dead form open.
       if (data.success === false || data.status === 'failed') {
         toast.error(data.error || 'The flow failed to complete.');
+        onClose();
         return;
       }
       if (data.status === 'paused' && data.screen) {

--- a/packages/app-shell/src/views/__tests__/FlowRunner.test.tsx
+++ b/packages/app-shell/src/views/__tests__/FlowRunner.test.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FlowRunner, type ScreenFlowState } from '../FlowRunner';
+
+const STATE: ScreenFlowState = {
+  flowName: 'reassign_wizard',
+  runId: 'run-1',
+  screen: {
+    nodeId: 'collect',
+    title: 'New Assignee',
+    fields: [{ name: 'new_assignee', label: 'New Assignee', type: 'text', required: true }],
+  },
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function setup(authFetch: (url: string, init?: RequestInit) => Promise<Response>) {
+  const onClose = vi.fn();
+  const onComplete = vi.fn();
+  render(
+    <FlowRunner state={STATE} authFetch={authFetch} baseUrl="" onClose={onClose} onComplete={onComplete} />,
+  );
+  return { onClose, onComplete };
+}
+
+async function fillAndSubmit() {
+  const user = userEvent.setup();
+  // The screen title and the field label share the same text — target the
+  // input by role instead of label text.
+  await user.type(screen.getAllByRole('textbox')[0], 'linus@example.com');
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
+}
+
+beforeEach(() => vi.restoreAllMocks());
+
+describe('FlowRunner resume outcomes', () => {
+  it('closes the runner on a TERMINAL flow failure (suspension already consumed)', async () => {
+    const authFetch = vi.fn(async () =>
+      jsonResponse({ success: true, data: { success: false, error: "Node 'apply' failed: Update requires an ID" } }),
+    );
+    const { onClose, onComplete } = setup(authFetch);
+    await fillAndSubmit();
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('stays open on a transport-level failure so the user can retry', async () => {
+    const authFetch = vi.fn(async () => jsonResponse({ success: false, error: 'gateway timeout' }, 502));
+    const { onClose, onComplete } = setup(authFetch);
+    await fillAndSubmit();
+    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+    // The form is still interactive for a retry.
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled();
+  });
+
+  it('renders the next screen on a multi-step pause', async () => {
+    const authFetch = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        data: {
+          status: 'paused',
+          runId: 'run-1',
+          screen: { nodeId: 'confirm', title: 'Confirm Change', fields: [{ name: 'note', label: 'Note', type: 'text' }] },
+        },
+      }),
+    );
+    const { onClose, onComplete } = setup(authFetch);
+    await fillAndSubmit();
+    await waitFor(() => expect(screen.getByText('Confirm Change')).toBeInTheDocument());
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('completes (host refresh) on a successful terminal result', async () => {
+    const authFetch = vi.fn(async () => jsonResponse({ success: true, data: { success: true, durationMs: 5 } }));
+    const { onComplete } = setup(authFetch);
+    await fillAndSubmit();
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+  });
+});


### PR DESCRIPTION
## Summary
Found by browser E2E against the framework showcase app: when a screen-flow resume ends in a **terminal** flow failure (`{ success:true, data:{ success:false, error } }`), the FlowRunner dialog stayed open with stale state. The engine consumes the suspension before running downstream nodes (resume-once semantics), so a second Submit re-posted the dead runId and surfaced `No suspended run 'run_…'`.

- Terminal `AutomationResult` failure (`data.success === false` / `status === 'failed'`) → error toast + **close the runner** (the run can never be resumed again)
- Transport-level failure (network / 5xx envelope) → unchanged: keep the dialog open for retry
- Multi-screen `paused` and successful-completion paths unchanged

## Test plan
- [x] New `FlowRunner.test.tsx` covering all four resume outcomes (terminal failure closes; transport failure stays open & re-submittable; next-screen pause renders; success calls onComplete) — 4/4 green
- [x] Browser re-verification against the live showcase backend: failure toast shows and the dialog now closes instead of allowing a dead resubmit

🤖 Generated with [Claude Code](https://claude.com/claude-code)