### PR TITLE
fix(app-shell): resolve recordId from grid selection for list_toolbar flow/script actions

### DIFF
--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -117,6 +117,158 @@ describe('useConsoleActionRuntime — authenticated handlers', () => {
   });
 });
 
+describe('flowHandler — list_toolbar selection fallback', () => {
+  // Toolbar-invoked flow actions carry no `_rowRecord` (that's a list_item /
+  // row-menu concept). The grid publishes its checkbox selection into the
+  // shared ActionRunner context as `selectedRecords`; with exactly one row
+  // selected the flow must receive that row's id as recordId, otherwise a
+  // record-bound flow node fails ("Update requires an ID or options.multi=true").
+  it('uses the single selected row from the runner context as recordId', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'inv' }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.flowHandler(
+        { type: 'flow', name: 'showcase_bulk_reassign', target: 'showcase_reassign_wizard' } as any,
+        { selectedRecords: [{ id: 'rec_42', name: 'Acme' }] } as any,
+      );
+    });
+
+    expect(res).toMatchObject({ success: true });
+    const [url, init] = authFetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/api/v1/automation/showcase_reassign_wizard/trigger');
+    const body = JSON.parse(init.body);
+    expect(body.recordId).toBe('rec_42');
+    expect(body.params.recordId).toBe('rec_42');
+  });
+
+  it('blocks with an error (no trigger call) when multiple rows are selected', async () => {
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [] }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.flowHandler(
+        { type: 'flow', target: 'showcase_reassign_wizard' } as any,
+        { selectedRecords: [{ id: 'a' }, { id: 'b' }] } as any,
+      );
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/single record/i);
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('an explicit _rowRecord (list_item invocation) still wins over the selection', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [] }),
+    );
+
+    await act(async () => {
+      await result.current.flowHandler(
+        { type: 'flow', target: 'f', params: { _rowRecord: { id: 'row_1' } } } as any,
+        { selectedRecords: [{ id: 'other_1' }, { id: 'other_2' }] } as any,
+      );
+    });
+
+    expect(JSON.parse(authFetchSpy.mock.calls[0][1].body).recordId).toBe('row_1');
+  });
+
+  it('end-to-end: selection published via updateContext reaches the flow trigger', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+
+    // Mirrors the real wiring: ObjectGrid calls `updateContext({ selectedRecords })`
+    // on the shared runner; the toolbar button then executes the flow action.
+    function Probe() {
+      const { execute, updateContext } = useAction();
+      return (
+        <button
+          onClick={() => {
+            updateContext({ selectedRecords: [{ id: 'sel_1' }] });
+            void execute({ type: 'flow', name: 'showcase_bulk_reassign', target: 'showcase_reassign_wizard' } as any);
+          }}
+        >
+          run-flow
+        </button>
+      );
+    }
+
+    render(
+      <ConsoleActionRuntimeProvider dataSource={{}} objects={[]}>
+        <Probe />
+      </ConsoleActionRuntimeProvider>,
+    );
+
+    fireEvent.click(screen.getByText('run-flow'));
+
+    await waitFor(() => expect(authFetchSpy).toHaveBeenCalled());
+    const [url, init] = authFetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/api/v1/automation/showcase_reassign_wizard/trigger');
+    expect(JSON.parse(init.body).recordId).toBe('sel_1');
+  });
+});
+
+describe('serverActionHandler — list_toolbar selection fallback', () => {
+  it('uses the single selected row from the runner context as recordId', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'inv' }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.serverActionHandler(
+        { type: 'script', name: 'archive' } as any,
+        { selectedRecords: [{ id: 'rec_7' }] } as any,
+      );
+    });
+
+    expect(res).toMatchObject({ success: true });
+    const [url, init] = authFetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/api/v1/actions/inv/archive');
+    expect(JSON.parse(init.body).recordId).toBe('rec_7');
+  });
+
+  it('honors a custom recordIdField when resolving from the selection', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'inv' }),
+    );
+
+    await act(async () => {
+      await result.current.serverActionHandler(
+        { type: 'script', name: 'archive', recordIdField: 'code' } as any,
+        { selectedRecords: [{ id: 'rec_7', code: 'INV-001' }] } as any,
+      );
+    });
+
+    expect(JSON.parse(authFetchSpy.mock.calls[0][1].body).recordId).toBe('INV-001');
+  });
+
+  it('blocks with an error (no API call) when multiple rows are selected', async () => {
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'inv' }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.serverActionHandler(
+        { type: 'script', name: 'archive' } as any,
+        { selectedRecords: [{ id: 'a' }, { id: 'b' }] } as any,
+      );
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/single record/i);
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('ConsoleActionRuntimeProvider — page-level action execution', () => {
   function Probe() {
     const { execute } = useAction();

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -28,6 +28,7 @@ import { useObjectLabel } from '@object-ui/i18n';
 import { ActionProvider } from '@object-ui/react';
 import { toast } from 'sonner';
 import type {
+  ActionContext,
   ActionDef,
   ActionParamDef,
   ActionResult,
@@ -64,8 +65,8 @@ export interface ConsoleActionRuntime {
   paramCollectionHandler: ParamCollectionHandler;
   resultDialogHandler: ResultDialogHandler;
   apiHandler: (action: ActionDef) => Promise<ActionResult>;
-  flowHandler: (action: ActionDef) => Promise<ActionResult>;
-  serverActionHandler: (action: ActionDef) => Promise<ActionResult>;
+  flowHandler: (action: ActionDef, context?: ActionContext) => Promise<ActionResult>;
+  serverActionHandler: (action: ActionDef, context?: ActionContext) => Promise<ActionResult>;
   /** Authenticated fetch wrapper (Bearer + tenant + cookies). */
   authFetch: ReturnType<typeof createAuthenticatedFetch>;
   /** Props to spread onto `<ActionProvider>`. */
@@ -263,7 +264,9 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   }, [dataSource, objApiName, authFetch, activeOrganization, refresh]);
 
   // Flow action handler — POST to /api/v1/automation/{name}/trigger.
-  const flowHandler = useCallback(async (action: ActionDef): Promise<ActionResult> => {
+  // `context` is the shared ActionRunner context (registered handlers are
+  // invoked as `handler(action, runnerContext)`).
+  const flowHandler = useCallback(async (action: ActionDef, context?: ActionContext): Promise<ActionResult> => {
     const flowName = action.target || action.name;
     if (!flowName) {
       return { success: false, error: 'No flow target provided for flow action' };
@@ -273,7 +276,20 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       const params = { ...(action.params || {}) } as Record<string, any>;
       const rowRecord = params._rowRecord as Record<string, any> | undefined;
       delete params._rowRecord;
-      const recordId = params.recordId ?? rowRecord?.id;
+      let recordId = params.recordId ?? rowRecord?.id;
+      // list_toolbar invocations carry no `_rowRecord` — fall back to the
+      // grid's checkbox selection, which ObjectGrid publishes into the runner
+      // context as `selectedRecords`. Flows take a single `recordId` input
+      // variable, so a multi-row selection is ambiguous: block with a message
+      // instead of triggering a run that fails at its first record-bound node.
+      if (recordId == null) {
+        const selected = Array.isArray(context?.selectedRecords) ? context!.selectedRecords : [];
+        if (selected.length === 1) {
+          recordId = selected[0]?.id;
+        } else if (selected.length > 1) {
+          return { success: false, error: 'This flow runs on a single record — select exactly one row.' };
+        }
+      }
       if (recordId != null && params.recordId == null) params.recordId = recordId;
       const res = await authFetch(
         `${baseUrl}/api/v1/automation/${encodeURIComponent(flowName)}/trigger`,
@@ -308,7 +324,9 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   }, [authFetch, objApiName, refresh]);
 
   // Server-side action handler — POST to /api/v1/actions/{object}/{action}.
-  const serverActionHandler = useCallback(async (action: ActionDef): Promise<ActionResult> => {
+  // `context` is the shared ActionRunner context (registered handlers are
+  // invoked as `handler(action, runnerContext)`).
+  const serverActionHandler = useCallback(async (action: ActionDef, context?: ActionContext): Promise<ActionResult> => {
     const targetName = action.target || action.name;
     if (!targetName) {
       return { success: false, error: 'No action target provided' };
@@ -319,7 +337,20 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     const _rowRecord = (params as any)._rowRecord as Record<string, any> | undefined;
     delete (params as any)._rowRecord;
     const recordIdField = (action as any).recordIdField || 'id';
-    const resolvedRecordId = (params as any).recordId ?? _rowRecord?.[recordIdField];
+    let resolvedRecordId = (params as any).recordId ?? _rowRecord?.[recordIdField];
+    // Same list_toolbar fallback as flowHandler: no `_rowRecord` means the
+    // action came from the toolbar — resolve the recordId from the grid's
+    // checkbox selection (published as `selectedRecords`). Multi-select is
+    // ambiguous for a single-record action, so block with a message.
+    if (resolvedRecordId == null) {
+      const selected = Array.isArray(context?.selectedRecords) ? context!.selectedRecords : [];
+      if (selected.length === 1) {
+        resolvedRecordId = selected[0]?.[recordIdField];
+      } else if (selected.length > 1) {
+        // The runner's post-execution hook surfaces `error` as a toast.
+        return { success: false, error: 'This action runs on a single record — select exactly one row.' };
+      }
+    }
 
     // Re-entrancy guard.
     const inflightKey = `${targetName}:${resolvedRecordId ?? ''}`;

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -534,7 +534,17 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   });
 
   // --- Action support for action columns ---
-  const { execute: executeAction } = useAction();
+  const { execute: executeAction, updateContext: updateActionContext } = useAction();
+
+  // Publish the checkbox selection into the shared ActionRunner context so
+  // actions rendered OUTSIDE the grid but inside the same <ActionProvider>
+  // (e.g. `list_toolbar` flow buttons in the ObjectView header) can resolve a
+  // recordId from the selected rows. Cleared on unmount / selection change so
+  // a stale selection never leaks into later invocations.
+  React.useEffect(() => {
+    updateActionContext({ selectedRecords: selectedRows });
+    return () => { updateActionContext({ selectedRecords: [] }); };
+  }, [selectedRows, updateActionContext]);
 
   // --- Row color support ---
   const getRowClassName = useRowColor(schema.rowColor);


### PR DESCRIPTION
## Problem

A `type: 'flow'` (or script/modal) action placed in **`list_toolbar`** never receives a `recordId`: the handler only resolves it from `params.recordId` or `_rowRecord`, and `_rowRecord` is only attached by `list_item` (row-menu) invocations. Selecting a row via checkbox and clicking the toolbar button triggered the flow without a recordId, so record-bound nodes failed with:

> Update requires an ID or options.multi=true

Reproduced with the showcase `showcase_bulk_reassign` action targeting flow `showcase_reassign_wizard` (framework repo, `examples/app-showcase`): trigger paused at the screen node as normal, resume failed at node `apply`.

## Fix

- **ObjectGrid** publishes its checkbox selection into the shared `ActionRunner` context (`updateContext({ selectedRecords })`), clearing it on unmount. The toolbar action bar renders outside the grid but inside the same `<ActionProvider>`, so the runner context is the natural channel — no prop plumbing.
- **`flowHandler` / `serverActionHandler`** accept the runner context as their second argument (registered handlers are already invoked as `handler(action, context)` by `ActionRunner.execute`). When neither `params.recordId` nor `_rowRecord` resolves an id:
  - exactly **one** selected row → its id is sent as `recordId` (`serverActionHandler` honors the action's `recordIdField`);
  - **multiple** rows → blocked with `success: false` and a clear error (surfaced once as a toast by the runner's post-execution hook), since screen flows take a single `recordId` input variable;
  - **zero** rows → unchanged (flows that need no record still trigger).

## Tests

7 new regression tests in `useConsoleActionRuntime.test.tsx`: single-selection fallback (flow + script), custom `recordIdField`, multi-select blocking with no API call (flow + script), `_rowRecord` precedence over selection, and an end-to-end test through `ConsoleActionRuntimeProvider` mirroring the real grid→toolbar wiring.

- app-shell suite: 401/401 passing
- plugin-grid suite: 53/53 passing

## Manual verification (framework `examples/app-showcase`)

Ran `objectstack dev --fresh` + local console dev server:

- ✅ Select one task → toolbar **Reassign…** → screen form opens → submit → resume succeeds, `assignee` written to the record (verified via data API)
- ✅ Select two tasks → toolbar **Reassign…** → blocked with a single toast, no trigger request, no FlowRunner

🤖 Generated with [Claude Code](https://claude.com/claude-code)