### PR TITLE
ci(bundle-analysis): make PR comment step resilient to transient API 401s

### DIFF
--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -152,8 +152,13 @@ jobs:
 
       - name: Comment PR with results
         if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
+          # GitHub's API intermittently rejects valid run tokens with 401
+          # (seen on PR #1627), so 401/403 must stay retryable here.
+          retries: 3
+          retry-exempt-status-codes: 400,404,422
           script: |
             const fs = require('fs');
             const status = '${{ steps.budget.outputs.budget_status }}';
@@ -180,9 +185,14 @@ jobs:
               // Size report not generated
             }
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            });
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            } catch (error) {
+              core.warning(`Could not comment on PR: ${error.message}`);
+              await core.summary.addRaw(body).write();
+            }


### PR DESCRIPTION
## Summary

Both attempts of [run 27288401243](https://github.com/objectstack-ai/objectui/actions/runs/27288401243) (PR #1627) failed at the final "Comment PR with results" step with **401 Requires authentication**, even though the performance budget check itself passed.

Investigation showed this was a transient GitHub-side token rejection, not a workflow misconfiguration:
- the step received a non-empty `github-token` and the request carried an `authorization: bearer` header, yet GitHub's auth layer rejected it (401, not a 403 permission error)
- checkout authenticated with the same token minutes earlier in the same job
- the identical workflow commented successfully on PR #1626 just 38 minutes before

The workflow's real defects were that it turned this blip into a job failure:
1. `createComment` was un-awaited with no error handling → unhandled rejection fails the step
2. github-script retries were off, and its default retry-exempt list includes 401/403

## Changes

- enable `retries: 3` with `retry-exempt-status-codes: 400,404,422` so transient 401/403/5xx are retried
- `await` the `createComment` call in try/catch; on persistent failure, log a warning and write the report to the job summary instead so the data isn't lost
- `continue-on-error: true` as a backstop so the comment step can never fail the job (the budget check remains a separate, still-fatal step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)