### PR TITLE
feat(marketplace): Installed view reads the control-plane list when cloud-bound (ADR-0007 ①)

### DIFF
--- a/packages/app-shell/src/console/marketplace/MarketplaceInstalledPage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplaceInstalledPage.tsx
@@ -31,6 +31,7 @@ import { useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import {
   listLocalInstalls,
+  listInstalledPackages,
   uninstallLocal,
   type LocalInstallEntry,
 } from './marketplaceApi';
@@ -44,6 +45,9 @@ export function MarketplaceInstalledPage() {
   const basePath = appName ? `/apps/${appName}` : '';
 
   const [items, setItems] = useState<LocalInstallEntry[]>([]);
+  // 'cloud' = list comes from the control plane (CLI/marketplace/REST installs,
+  // ADR-0007 step ①); 'local' = self-hosted install-local cache.
+  const [source, setSource] = useState<'cloud' | 'local'>('local');
   const [loading, setLoading] = useState(true);
   const [working, setWorking] = useState<string | null>(null);
   const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
@@ -51,8 +55,16 @@ export function MarketplaceInstalledPage() {
   const load = async () => {
     setLoading(true);
     try {
-      const list = await listLocalInstalls();
-      setItems(list);
+      // Cloud-connected env → authoritative installed list is the control
+      // plane's. Self-hosted (not bound) → fall back to the local cache.
+      const cloud = await listInstalledPackages();
+      if (cloud.connected) {
+        setSource('cloud');
+        setItems(cloud.items);
+      } else {
+        setSource('local');
+        setItems(await listLocalInstalls());
+      }
     } finally {
       setLoading(false);
     }
@@ -163,25 +175,29 @@ export function MarketplaceInstalledPage() {
                     <ExternalLink className="h-4 w-4 mr-1.5" aria-hidden="true" />
                     {t('marketplace.action.details')}
                   </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void doUninstall(entry)}
-                    disabled={working === entry.manifestId}
-                  >
-                    <Trash2 className="h-4 w-4 mr-1.5" aria-hidden="true" />
-                    {working === entry.manifestId ? t('marketplace.action.uninstalling') : t('marketplace.action.uninstall')}
-                  </Button>
+                  {source === 'local' && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void doUninstall(entry)}
+                      disabled={working === entry.manifestId}
+                    >
+                      <Trash2 className="h-4 w-4 mr-1.5" aria-hidden="true" />
+                      {working === entry.manifestId ? t('marketplace.action.uninstalling') : t('marketplace.action.uninstall')}
+                    </Button>
+                  )}
                 </div>
               </CardHeader>
-              <CardContent
-                className="pt-0 text-xs text-muted-foreground"
-                dangerouslySetInnerHTML={{
-                  __html: t('marketplace.cachedAs', {
-                    path: `.objectstack/installed-packages/${entry.manifestId.replace(/[^a-zA-Z0-9._-]/g, '_')}.json`,
-                  }),
-                }}
-              />
+              {source === 'local' && (
+                <CardContent
+                  className="pt-0 text-xs text-muted-foreground"
+                  dangerouslySetInnerHTML={{
+                    __html: t('marketplace.cachedAs', {
+                      path: `.objectstack/installed-packages/${entry.manifestId.replace(/[^a-zA-Z0-9._-]/g, '_')}.json`,
+                    }),
+                  }}
+                />
+              )}
             </Card>
           ))}
         </div>

--- a/packages/app-shell/src/console/marketplace/marketplaceApi.ts
+++ b/packages/app-shell/src/console/marketplace/marketplaceApi.ts
@@ -568,6 +568,52 @@ export async function listLocalInstalls(): Promise<LocalInstallEntry[]> {
   }
 }
 
+/**
+ * Cloud-managed installed list (ADR-0007 step ①).
+ *
+ * For a cloud-connected environment, the authoritative "what's installed"
+ * lives in the control plane's `sys_package_installation`, NOT the runtime's
+ * local `.objectstack/installed-packages/` cache. A tenant SPA can't read the
+ * control plane cross-origin, so the env's own runtime proxies it at the
+ * same-origin `/api/v1/cloud-connection/installed` route. This surfaces
+ * packages installed via ANY path (CLI `--env --install`, marketplace, REST).
+ *
+ * `connected: false` means this runtime is self-hosted / not cloud-bound — the
+ * caller should fall back to {@link listLocalInstalls}.
+ */
+export interface InstalledPackagesResult {
+  connected: boolean;
+  items: LocalInstallEntry[];
+}
+
+export async function listInstalledPackages(): Promise<InstalledPackagesResult> {
+  try {
+    const res = await fetch(`${SERVER_URL}/api/v1/cloud-connection/installed`, {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return { connected: false, items: [] };
+    const payload: any = await res.json().catch(() => ({}));
+    const data: any = payload?.data ?? {};
+    const pkgs: any[] = Array.isArray(data.packages) ? data.packages : [];
+    const items: LocalInstallEntry[] = pkgs.map((p) => {
+      const manifestId = String(p.packageId ?? p.package_id ?? '');
+      return {
+        packageId: manifestId,
+        versionId: String(p.package_version_id ?? ''),
+        manifestId,
+        version: String(p.version ?? 'installed'),
+        installedAt: String(p.installed_at ?? p.installedAt ?? ''),
+        installedBy: (p.installed_by ?? p.installedBy ?? null) as string | null,
+        withSampleData: p.with_sample_data === true || p.withSampleData === true,
+      };
+    });
+    return { connected: data.connected === true, items };
+  } catch {
+    return { connected: false, items: [] };
+  }
+}
+
 export async function uninstallLocal(manifestId: string): Promise<void> {
   const res = await fetch(`${API_BASE}/install-local/${encodeURIComponent(manifestId)}`, {
     method: 'DELETE',


### PR DESCRIPTION
ADR-0007 migration **step ①** (objectui half).

The Console "Installed" page read only the runtime's local `install-local` cache, so a **cloud-managed** environment showed nothing even though packages were installed via the control plane (CLI `os package publish --env --install`, marketplace, REST).

- `listInstalledPackages()` calls the env runtime's same-origin `GET /api/v1/cloud-connection/installed` proxy (control-plane truth).
- The page prefers that list when cloud-connected; falls back to the local cache when self-hosted/unbound.
- For control-plane entries the local-only Uninstall + `.objectstack/...` cache note are hidden (don't apply); cloud uninstall is a later step.

Pairs with cloud [#188](https://github.com/objectstack-ai/cloud/pull/188) (the proxy route). `tsc` clean for the marketplace files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)