### PR TITLE
fix(plugin-list): normalize viewType 'list'/missing/unknown to the grid renderer

### DIFF
--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -324,12 +324,20 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   const { fieldLabel: resolveFieldLabel, actionLabel: resolveActionLabel } = useListFieldLabel();
   const { translateOptions } = useSafeFieldLabel();
 
-  // Kernel level default: Ensure viewType is always defined (default to 'grid').
-  // Perf: only allocate a new object when the default is actually needed,
+  // Kernel level default: Ensure viewType is always a RENDERABLE kind.
+  // Two inputs must land on 'grid': a missing viewType, and the view-metadata
+  // kind `'list'` (AI-authored views store `type/viewKind: 'list'`, which hosts
+  // forward verbatim) — 'list' names the view CATEGORY, not a renderer, and
+  // letting it through used to hit the typeless default branch below and
+  // render as a red "Unknown component type" box.
+  // Perf: only allocate a new object when normalization is actually needed,
   // otherwise return propSchema as-is so downstream useMemos see a stable
-  // reference when callers already provide viewType (the common case).
+  // reference when callers already provide a renderable viewType (the common case).
   const schema = React.useMemo(
-    () => (propSchema.viewType ? propSchema : { ...propSchema, viewType: 'grid' }),
+    () =>
+      propSchema.viewType && (propSchema.viewType as string) !== 'list'
+        ? propSchema
+        : { ...propSchema, viewType: 'grid' },
     [propSchema],
   );
 
@@ -1202,6 +1210,10 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     };
 
     switch (currentView) {
+      // `default` deliberately shares the grid branch: an unrecognized
+      // viewType must degrade to a working table, never to a typeless schema
+      // (SchemaRenderer shows those as a red "Unknown component type" box).
+      default:
       case 'grid':
         return {
           type: 'object-grid',
@@ -1332,8 +1344,6 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           className: 'h-[400px] w-full',
         };
       }
-      default:
-        return baseProps;
     }
   }, [currentView, schema, currentSort, effectiveFields, groupingConfig, rowColorConfig, navigation.handleClick, density.mode, galleryCardSize]);
 

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ListView, evaluateConditionalFormatting } from '../ListView';
 import type { ListViewSchema } from '@object-ui/types';
@@ -2186,5 +2187,39 @@ describe('ListView', () => {
       const filterButton = screen.getByRole('button', { name: /filter/i });
       expect(filterButton).toBeInTheDocument();
     });
+  });
+});
+
+describe('ListView — viewType normalization (AI-authored views)', () => {
+  // AI-authored view metadata carries the view KIND ('list'), not a renderer
+  // name; hosts forward it verbatim as viewType. Both 'list' and a missing
+  // viewType must normalize to the grid renderer — never reach the typeless
+  // default branch, which SchemaRenderer used to surface as a red
+  // "Unknown component type" box dumping the raw config at the user.
+  beforeAll(() => {
+    // The real object-grid lives in @object-ui/plugin-grid (not a test dep);
+    // register a stub so "did we emit a typed grid schema" is observable.
+    if (!ComponentRegistry.get('object-grid')) {
+      ComponentRegistry.register('object-grid', () => <div data-testid="grid-stub" />);
+    }
+  });
+  const base = { type: 'list-view', objectName: 'expense', fields: ['title', 'amount'] };
+
+  it("normalizes viewType:'list' to grid — renders the friendly empty state, not the red box", async () => {
+    renderWithProvider(<ListView schema={{ ...base, viewType: 'list' } as unknown as ListViewSchema} />);
+    expect(await screen.findByTestId('empty-state')).toBeInTheDocument();
+    expect(screen.queryByText(/Unknown component type/i)).not.toBeInTheDocument();
+  });
+
+  it('normalizes a MISSING viewType to grid — same friendly empty state', async () => {
+    renderWithProvider(<ListView schema={{ ...base } as unknown as ListViewSchema} />);
+    expect(await screen.findByTestId('empty-state')).toBeInTheDocument();
+    expect(screen.queryByText(/Unknown component type/i)).not.toBeInTheDocument();
+  });
+
+  it('an unrecognized viewType degrades to a TYPED grid schema (default branch is never typeless)', async () => {
+    renderWithProvider(<ListView schema={{ ...base, viewType: 'bogus' } as unknown as ListViewSchema} />);
+    expect(await screen.findByTestId('grid-stub')).toBeInTheDocument();
+    expect(screen.queryByText(/Unknown component type/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes the red **"Unknown component type"** box on every AI-built list view (live on staging: `/apps/expense_tracking/expense/view/all_expenses`).

AI-authored view metadata stores the view **kind** (`type: 'list'`) which hosts forward verbatim as `viewType` — it names a category, not a renderer. ListView's normalization only defaulted a *missing* viewType, so `'list'` (truthy) slipped through to the switch's `default:` branch, which returned a **typeless** schema → SchemaRenderer error box dumping the raw config at the user.

- normalization now maps `'list'` → `'grid'` (single normalization point);
- the switch `default` shares the grid branch — an unrecognized viewType degrades to a working table, never a typeless schema.

plugin-list **122** green (3 new: 'list' / missing / unknown all render without the red box — the first two land on the friendly empty state with no data, the third proves the default branch emits a typed grid schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)