### PR TITLE
feat(app-shell): render the map node in the flow designer

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -246,6 +246,15 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
     cfg('collection', 'Collection', 'expression', { placeholder: '{leadList}', help: 'Expression resolving to the items to iterate.' }),
     cfg('iteratorVariable', 'Item variable', 'text', { placeholder: 'currentItem' }),
   ],
+  // Sequential multi-instance (ADR-0037 A2): a per-item subflow, one at a time;
+  // each item may durably pause (e.g. a per-item approval).
+  map: [
+    cfg('collection', 'Collection', 'expression', { placeholder: '{items}', help: 'Expression resolving to the array to process, one item at a time.' }),
+    cfg('flowName', 'Per-item flow', 'reference', { ref: { kind: 'flow' }, placeholder: 'one_task_signoff', help: 'Subflow run for each item — it may pause (e.g. an approval).' }),
+    cfg('iteratorVariable', 'Item variable', 'text', { placeholder: 'item' }),
+    cfg('itemObject', 'Item object', 'reference', { ref: { kind: 'object' }, placeholder: 'showcase_task', help: 'When items are records, the object they belong to (exposes each item as the child’s record).' }),
+    cfg('outputVariable', 'Output variable', 'text', { placeholder: 'results', help: 'Each item’s subflow output, collected in order.' }),
+  ],
   create_record: [
     cfg('objectName', 'Object', 'reference', { ref: { kind: 'object' }, placeholder: 'contract' }),
     cfg('fields', 'Field values', 'keyValue', { help: 'Field values to write on the new record.' }),
@@ -603,6 +612,7 @@ export const FLOW_NODE_TYPE_OPTIONS = [
   'approval',
   'wait',
   'subflow',
+  'map',
   'connector_action',
   // ADR-0031: structured constructs replace the BPMN gateway/boundary types in
   // the picker — those remain import/export-only (no engine executor).

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -18,6 +18,7 @@ import {
   FileX,
   GitFork,
   Globe,
+  ListChecks,
   MonitorSmartphone,
   Play,
   Plug,
@@ -81,6 +82,8 @@ export function nodeIcon(type: string): LucideIcon {
     case 'loop':
     case 'for_each':
       return Repeat;
+    case 'map':
+      return ListChecks;
     case 'parallel_gateway':
     case 'join_gateway':
     case 'parallel':
@@ -212,6 +215,7 @@ export function nodeTone(type: string): NodeTone {
       return TONES.approval;
     case 'loop':
     case 'for_each':
+    case 'map':
       return TONES.loop;
     case 'screen':
     case 'user_task':
@@ -275,6 +279,7 @@ export function nodeCategory(type: string): NodeCategory {
     case 'gateway':
     case 'loop':
     case 'for_each':
+    case 'map':
     case 'assignment':
     case 'parallel_gateway':
     case 'join_gateway':


### PR DESCRIPTION
## Summary
The framework's new `map` node (sequential batch approval, ADR-0037 A2 — framework #1709) rendered in the Studio flow designer with the generic fallback icon. The server-driven palette already picked it up (label + description from the engine action descriptor), but the static icon/tone/category map in `flow-canvas-parts.tsx` had no `map` case, and the inspector had no config group.

- `flow-canvas-parts`: `map` → `ListChecks` icon, loop/sky tone, Logic category (consistent with loop / parallel / try_catch).
- `flow-node-config`: a `map` inspector group (collection / per-item flow / item variable / item object / output variable) + `map` in the type picker, so the property panel renders a form instead of falling back to JSON.

## Test plan
- [x] Browser-verified against `showcase_release_signoff`: the map node renders with the `list-checks` icon + sky tone (`lucide-list-checks text-sky-600`), appears under Logic in the add-node palette with the engine description, and the Runs panel shows the sequential re-entries (`signoffs MAP` ×3 in one completed run).
- [x] `pnpm vitest run` metadata-admin previews: 96 green. (The two pre-existing app-shell type-check errors are in unrelated AI/chatbot files, not these.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)