### PR TITLE
fix(plugin-charts,components): dashboard charts blank on first paint (ResponsiveContainer width(-1))

### DIFF
--- a/packages/components/src/ui/chart.tsx
+++ b/packages/components/src/ui/chart.tsx
@@ -60,7 +60,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "block aspect-video w-full text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
         {...props}

--- a/packages/plugin-charts/src/ChartContainerImpl.tsx
+++ b/packages/plugin-charts/src/ChartContainerImpl.tsx
@@ -64,14 +64,19 @@ function ChartContainer({
         data-slot="chart"
         data-chart={chartId}
         className={cn(
-          "flex w-full h-[350px] justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground",
+          // Block (not flex) so Recharts' ResponsiveContainer child fills the
+          // box. Under `flex ... justify-center` the container collapsed to its
+          // content width (0) on first paint inside react-grid-layout, so
+          // Recharts measured width(-1) and rendered nothing until a later
+          // resize fired its ResizeObserver — leaving dashboard charts blank.
+          "block w-full h-[350px] text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground",
           className
         )}
-        // Guarantee a non-zero box for Recharts' ResponsiveContainer even
-        // when the consumer-supplied className overrides our h-[350px] (e.g.
-        // dashboard widgets that wrap the chart in flex/grid layouts without
-        // an explicit child height). Without this minHeight the chart
-        // computes width/height = -1 and renders invisibly.
+        // Guarantee a non-zero box for Recharts' ResponsiveContainer even when
+        // the consumer-supplied className overrides our h-[350px] (e.g. dashboard
+        // widgets that wrap the chart in flex/grid layouts without an explicit
+        // child height). Without this min-size the chart computes
+        // width/height = -1 and renders invisibly.
         style={{ minHeight: 280, minWidth: 0, ...props.style }}
         {...props}
       >


### PR DESCRIPTION
## Problem
Dashboard charts (funnel, donut, area, …) render **blank on initial load** and only appear after a window resize / layout change. The console is flooded with:

```
The width(-1) and height(-1) of chart should be greater than 0 …
```

## Root cause
Every dashboard chart renders through `AdvancedChartImpl` → `ChartContainer` in `packages/plugin-charts/src/ChartContainerImpl.tsx`. That container was `flex w-full h-[350px] justify-center`, and Recharts' `<ResponsiveContainer width="100%" height="100%">` was its **flex child**. In a `justify-center` flex row the child is sized to its content on the main axis, so on first paint inside `react-grid-layout` (before the grid applies column widths) it collapsed to width 0 → Recharts measured `width(-1)` and skipped drawing. It only recovered when a later resize fired `ResponsiveContainer`'s `ResizeObserver`. The existing `minHeight: 280` guard fixed height but not the width collapse.

The shadcn base `packages/components/src/ui/chart.tsx` (`flex aspect-video justify-center`, dimensionless `<ResponsiveContainer>`) has the same latent issue.

## Fix
Give `ResponsiveContainer` a definite-width **block** parent instead of a width-collapsing centered flexbox:

- `plugin-charts/ChartContainerImpl.tsx`: `flex … justify-center` → `block w-full h-[350px]` (min-size guard kept).
- `components/ui/chart.tsx`: `flex aspect-video justify-center` → `block aspect-video w-full`.

The `"No rows"` empty state is a separate component (`plugin-dashboard/DatasetWidget.tsx`) and is unaffected; flex-centering was vestigial for the chart path (the only child is `ResponsiveContainer`, which fills 100%).

## Verification
- `@object-ui/plugin-charts` `type-check` ✅ and `test` ✅ (11/11).
- Full suite: 3582 passed; the only failure is an unrelated pre-existing `plugin-list/ListView.test.tsx` (viewType normalization, #1632 / `fix/listview-default-grid`) — untouched by this change.
- Reproduced originally in a HotCRM dashboard: funnel/donut blank on load, `recharts-trapezoid` count = 0; after any resize the same charts paint correctly (data was always present). This change makes them paint on first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)