### PR TITLE
chore(changeset): changelog entry for chart ResponsiveContainer fix (#1634)

### DIFF
--- a/.changeset/fix-chart-responsive-container-width.md
+++ b/.changeset/fix-chart-responsive-container-width.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+Dashboard charts no longer render blank on first paint. Recharts'
+`ResponsiveContainer` was a child of a `flex … justify-center` box, so it
+collapsed to content width (0) on first paint inside react-grid-layout,
+measured `width(-1)` and skipped drawing until a later resize fired its
+ResizeObserver. The chart wrapper is now a definite-width block in both the
+dashboard chart container (`plugin-charts/ChartContainerImpl`) and the shadcn
+base (`components/ui/chart`). Follow-up changeset for #1634.


### PR DESCRIPTION
Follow-up to #1634, which fixed dashboard charts rendering blank on first paint (Recharts `ResponsiveContainer` measuring `width(-1)` inside a width-collapsing `flex … justify-center` box) but was merged **without a changeset**.

This adds a `patch` changeset so the fix gets a changelog entry in the next release.

Note: `@object-ui/plugin-charts` and `@object-ui/components` are both in the changesets **fixed** version group, so the fix already ships with the next release regardless — this is purely for changelog accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)