### PR TITLE
fix(plugin-list): make ListView viewType-normalization test order-independent (fixes red main CI)

### DIFF
--- a/.changeset/registry-unregister.md
+++ b/.changeset/registry-unregister.md
@@ -1,0 +1,9 @@
+---
+"@object-ui/core": patch
+---
+
+Add `ComponentRegistry.unregister(type, namespace?)` — the inverse of
+`register()`. Clears the namespaced key and the bare-name fallback (when it
+still resolves to that registration) plus any matching lazy stub, and notifies
+subscribers only when something was removed. Lets callers (and tests) restore
+prior registry state cleanly.

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -150,6 +150,30 @@ export class Registry<T = any> {
   }
 
   /**
+   * Remove a previously registered component. Mirrors {@link register} by
+   * clearing both the namespaced key and the bare-name fallback (when the
+   * fallback still points at this registration), plus any matching lazy stub.
+   * Notifies subscribers only when something was actually removed.
+   *
+   * Mainly used by tests that install a stub renderer and need to restore the
+   * prior registry state on teardown, since the registry is a process-level
+   * singleton shared across test files.
+   */
+  unregister(type: string, namespace?: string): boolean {
+    const fullType = namespace ? `${namespace}:${type}` : type;
+    const removed = this.components.delete(fullType);
+    // Only drop the bare fallback if it still resolves to this registration.
+    if (namespace) {
+      const bare = this.components.get(type);
+      if (bare && bare.type === fullType) this.components.delete(type);
+    }
+    this.lazyEntries.delete(fullType);
+    this.lazyEntries.delete(type);
+    if (removed) this.notify();
+    return removed;
+  }
+
+  /**
    * Register a lazy-loaded component. The `loader` is a function returning a
    * dynamic `import()` whose target module performs `register()` calls for
    * the given `type` as a top-level side effect.

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ListView, evaluateConditionalFormatting } from '../ListView';
@@ -2196,11 +2196,25 @@ describe('ListView — viewType normalization (AI-authored views)', () => {
   // viewType must normalize to the grid renderer — never reach the typeless
   // default branch, which SchemaRenderer used to surface as a red
   // "Unknown component type" box dumping the raw config at the user.
+  // The real object-grid lives in @object-ui/plugin-grid (not a test dep);
+  // register a stub so "did we emit a typed grid schema" is observable.
+  //
+  // Register UNCONDITIONALLY (and restore on teardown): ComponentRegistry is a
+  // process-level singleton shared across test files, so another suite
+  // (plugin-grid/plugin-view/react) may already have registered a real
+  // object-grid. The old `if (!get('object-grid'))` guard then skipped our stub
+  // and the 'bogus' case rendered the real grid instead of `grid-stub` — making
+  // this test pass in isolation but fail in the full suite (order-dependent).
+  let prevObjectGrid: ReturnType<typeof ComponentRegistry.get>;
   beforeAll(() => {
-    // The real object-grid lives in @object-ui/plugin-grid (not a test dep);
-    // register a stub so "did we emit a typed grid schema" is observable.
-    if (!ComponentRegistry.get('object-grid')) {
-      ComponentRegistry.register('object-grid', () => <div data-testid="grid-stub" />);
+    prevObjectGrid = ComponentRegistry.get('object-grid');
+    ComponentRegistry.register('object-grid', () => <div data-testid="grid-stub" />);
+  });
+  afterAll(() => {
+    if (prevObjectGrid) {
+      ComponentRegistry.register('object-grid', prevObjectGrid);
+    } else {
+      ComponentRegistry.unregister('object-grid');
     }
   });
   const base = { type: 'list-view', objectName: 'expense', fields: ['title', 'amount'] };


### PR DESCRIPTION
## Problem
`main` CI (`Test`) is red on a single test:
`plugin-list/ListView.test.tsx > ListView — viewType normalization > an unrecognized viewType degrades to a TYPED grid schema`.

It **passes in isolation but fails in the full suite** — a test-ordering/global-state leak, not a product bug.

## Root cause
The test's `beforeAll` installed its `object-grid` stub only `if (!ComponentRegistry.get('object-grid'))`. `ComponentRegistry` is a process-level singleton shared across test files, so when another suite (`plugin-grid`/`plugin-view`/`react`) registered a **real** `object-grid` first, the guard skipped the stub and the `'bogus'` case rendered the real grid instead of `grid-stub` → `findByTestId('grid-stub')` timed out.

Reproduced deterministically:
```
vitest run --no-isolate packages/plugin-grid/src/index.test.tsx packages/plugin-list/src/__tests__/ListView.test.tsx
# → 1 failed (grid-stub timeout), matching CI
```

## Fix
- `ListView.test.tsx`: register the stub **unconditionally** and **restore the prior registration in `afterAll`** (re-register what was there, or `unregister` if nothing was) — order-independent.
- `core/registry/Registry.ts`: add `unregister(type, namespace?)` — `register()` had no inverse. Clears the namespaced key + bare fallback (when it still resolves to that entry) + lazy stub, and notifies only when something was removed.

## Verification
- Repro command above now passes with the fix.
- `type-check` clean (core + plugin-list); plugin-list standalone 129/129.
- **Full suite (`pnpm test`, the CI command): 3583 passed / 0 failed** (was 3582 / 1 failed on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)