### PR TITLE
feat(chatbot): ADR-0038 L3 — build-health line under the Published card

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -39,6 +39,7 @@ import {
   useObjectChat,
   useHitlInChat,
   resolveDefaultAgentName,
+  publishHealthFromResponse,
   type AgentDescriptor,
   type ChatbotEnhancedToolInvocation,
   type ChatMessage,
@@ -578,7 +579,10 @@ function ChatPane({
             } else {
               toast.success(t('console.ai.publishOk', { defaultValue: 'Published — objects are now live.' }));
             }
-            return true;
+            // ADR-0038 L3 — hand the runtime verification (seedApplied +
+            // probes) back to the chat so the Published card grows a
+            // build-health line instead of claiming bare success.
+            return { ok: true, health: publishHealthFromResponse(payload) };
           } catch (e) {
             toast.error(t('console.ai.publishFailed', { defaultValue: 'Publish failed' }), {
               description: e instanceof Error ? e.message : undefined,

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -18,6 +18,7 @@ import {
   useHitlInChat,
   resolveDefaultAgentName,
   uiMessagesToChatMessages,
+  publishHealthFromResponse,
   type ChatMessage,
   type AgentDescriptor,
 } from '@object-ui/plugin-chatbot';
@@ -553,7 +554,10 @@ function ChatbotInner({
               payload?.data?.published ?? payload?.published ?? [];
             const app = published.find((p) => p?.type === 'app' && p?.name);
             if (app?.name) navigate(`/apps/${encodeURIComponent(app.name)}`);
-            return true;
+            // ADR-0038 L3 — hand the runtime verification (seedApplied +
+            // probes) back to the chat so the Published card grows a
+            // build-health line instead of claiming bare success.
+            return { ok: true, health: publishHealthFromResponse(payload) };
           } catch (e) {
             toast.error(locale.publishFailed, {
               description: e instanceof Error ? e.message : undefined,

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -338,8 +338,17 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    * staged drafts to live without leaving the conversation (the ADR-0033 gate
    * stays — the human still clicks). The host wires this to
    * `POST /api/v1/packages/:packageId/publish-drafts`.
+   *
+   * Return value (all forms accepted, `false`/`{ok:false}` = failure):
+   * - `boolean | void` — legacy success flag;
+   * - `{ ok: boolean; health?: PublishHealth }` — ADR-0038 L3: the publish
+   *   response's `seedApplied` + runtime `probes`, rendered as a build-health
+   *   line under the Published badge so "Published" and "actually works" are
+   *   two separately-verified statements.
    */
-  onPublishDrafts?: (packageId: string) => void | boolean | Promise<void | boolean>;
+  onPublishDrafts?: (
+    packageId: string,
+  ) => void | boolean | PublishOutcome | Promise<void | boolean | PublishOutcome>;
   /**
    * When provided, a finished build tree (`buildProgress.phase === 'done'`) that
    * created an `app` renders an "Open app" action so the user can jump straight
@@ -382,6 +391,77 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    * @default 'card'
    */
   surface?: ChatbotSurface;
+}
+
+/**
+ * ADR-0038 L3 — what a publish actually did at runtime. Hosts extract this
+ * from the publish-drafts response (`seedApplied` + `probes`) so the chat can
+ * render a build-health line: "Published" and "actually works" are two
+ * separately-verified statements, and the second one must be visible too.
+ */
+export interface PublishHealth {
+  /** Rows materialized by published seeds (`seedApplied` inserted+updated). */
+  seededRows?: number;
+  /** Seed-load failure detail when sample data did NOT land. */
+  seedError?: string;
+  /** How many runtime probes ran per plane (`probes.checked`). */
+  checked?: { seeds: number; views: number; widgets: number };
+  /** Runtime findings (`probes.issues`), already human-readable. */
+  issues?: Array<{ severity: 'error' | 'warning'; code: string; message: string }>;
+}
+
+/** Structured result of `onPublishDrafts` — richer alternative to a bare boolean. */
+export interface PublishOutcome {
+  ok: boolean;
+  health?: PublishHealth;
+}
+
+/**
+ * Extract {@link PublishHealth} from a publish-drafts response body (tolerant
+ * of the dispatcher's `{ success, data }` envelope). Shared by the hosts that
+ * wire `onPublishDrafts` so they all read `seedApplied` + `probes` the same
+ * way; returns undefined when the server reported neither (older runtimes).
+ */
+export function publishHealthFromResponse(payload: unknown): PublishHealth | undefined {
+  const root = (payload ?? {}) as Record<string, unknown>;
+  const data = (root.data && typeof root.data === 'object' ? root.data : root) as Record<string, unknown>;
+  const seedApplied = data.seedApplied as
+    | { success?: boolean; inserted?: number; updated?: number; error?: string; errors?: unknown[] }
+    | undefined;
+  const probes = data.probes as
+    | {
+        checked?: { seeds?: number; views?: number; widgets?: number };
+        issues?: Array<{ severity?: string; code?: string; message?: string }>;
+      }
+    | undefined;
+  if (!seedApplied && !probes) return undefined;
+  const health: PublishHealth = {};
+  if (seedApplied) {
+    if (seedApplied.success === false) {
+      health.seedError =
+        seedApplied.error ??
+        (Array.isArray(seedApplied.errors) && seedApplied.errors.length
+          ? String(seedApplied.errors[0])
+          : 'Sample data failed to load.');
+    } else {
+      health.seededRows = (seedApplied.inserted ?? 0) + (seedApplied.updated ?? 0);
+    }
+  }
+  if (probes) {
+    health.checked = {
+      seeds: probes.checked?.seeds ?? 0,
+      views: probes.checked?.views ?? 0,
+      widgets: probes.checked?.widgets ?? 0,
+    };
+    health.issues = (probes.issues ?? [])
+      .filter((i) => i && typeof i.message === 'string')
+      .map((i) => ({
+        severity: i.severity === 'error' ? 'error' : 'warning',
+        code: String(i.code ?? 'runtime_issue'),
+        message: String(i.message),
+      }));
+  }
+  return health;
 }
 
 export type ToolDecisionState =
@@ -503,6 +583,61 @@ function summarizeTools(tools: ChatToolInvocation[]): ToolSummaryGroup[] {
   });
 }
 
+/**
+ * ADR-0038 L3 — the build-health line under a Published badge. Reads the
+ * publish's `seedApplied` + runtime-probe results and answers the question
+ * the badge alone can't: did the published app actually work when exercised?
+ * Renders nothing without health data (older hosts return a bare boolean).
+ */
+function PublishHealthLine({ health }: { health: PublishHealth | undefined }) {
+  if (!health) return null;
+  const issues = health.issues ?? [];
+  const errors = issues.filter((i) => i.severity === 'error');
+  const warnings = issues.filter((i) => i.severity !== 'error');
+  const checked = health.checked;
+  const probesRan = !!checked && checked.seeds + checked.views + checked.widgets > 0;
+  const okParts: string[] = [];
+  if (typeof health.seededRows === 'number' && health.seededRows > 0 && !health.seedError) {
+    okParts.push(`${health.seededRows} sample row${health.seededRows === 1 ? '' : 's'} live`);
+  }
+  if (probesRan && errors.length === 0) {
+    const planes: string[] = [];
+    if (checked!.views > 0) planes.push(`${checked!.views} view${checked!.views === 1 ? '' : 's'}`);
+    if (checked!.widgets > 0) planes.push(`${checked!.widgets} widget${checked!.widgets === 1 ? '' : 's'}`);
+    if (checked!.seeds > 0) planes.push(`${checked!.seeds} seed${checked!.seeds === 1 ? '' : 's'}`);
+    if (planes.length) okParts.push(`${planes.join(' · ')} verified`);
+  }
+  if (okParts.length === 0 && !health.seedError && issues.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1 border-t bg-muted/20 px-3 py-2" data-testid="publish-health">
+      {okParts.length > 0 ? (
+        <div className="flex items-center gap-1.5 text-xs text-emerald-700">
+          <CheckCircle2 className="size-3.5 shrink-0" />
+          <span>{okParts.join(' · ')}</span>
+        </div>
+      ) : null}
+      {health.seedError ? (
+        <div className="flex items-start gap-1.5 text-xs text-red-600">
+          <XCircle className="mt-0.5 size-3.5 shrink-0" />
+          <span>{health.seedError}</span>
+        </div>
+      ) : null}
+      {errors.map((i, idx) => (
+        <div key={`e${idx}`} className="flex items-start gap-1.5 text-xs text-red-600">
+          <XCircle className="mt-0.5 size-3.5 shrink-0" />
+          <span>{i.message}</span>
+        </div>
+      ))}
+      {warnings.map((i, idx) => (
+        <div key={`w${idx}`} className="flex items-start gap-1.5 text-xs text-amber-600">
+          <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+          <span>{i.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
   (
     {
@@ -599,10 +734,17 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
     const [publishedToolCalls, setPublishedToolCalls] = React.useState<ReadonlySet<string>>(
       () => new Set(),
     );
+    // ADR-0038 L3 — per published card, what the publish actually did at
+    // runtime (rows seeded, probes run, findings). Rendered under the
+    // Published badge as the build-health line.
+    const [publishHealthByToolCall, setPublishHealthByToolCall] = React.useState<
+      ReadonlyMap<string, PublishHealth>
+    >(() => new Map());
     // Publish a package's drafts and reflect success on exactly the cards that
     // were pending for it at publish time. The host's onPublishDrafts returns
-    // `false` on failure (and surfaces its own error); any other outcome (incl.
-    // void) counts as success.
+    // `false` / `{ok:false}` on failure (and surfaces its own error); any other
+    // outcome (incl. void) counts as success. A structured outcome may carry
+    // `health` (seedApplied + runtime probes) for the health line.
     const handlePublishDrafts = React.useCallback(
       async (packageId: string) => {
         if (!onPublishDrafts) return;
@@ -616,13 +758,24 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             }
           }
         }
-        const ok = await onPublishDrafts(packageId);
-        if (ok !== false && promoted.length > 0) {
+        const res = await onPublishDrafts(packageId);
+        const outcome: PublishOutcome | undefined =
+          res && typeof res === 'object' ? (res as PublishOutcome) : undefined;
+        const ok = outcome ? outcome.ok !== false : res !== false;
+        if (ok && promoted.length > 0) {
           setPublishedToolCalls((prev) => {
             const next = new Set(prev);
             for (const id of promoted) next.add(id);
             return next;
           });
+          const health = outcome?.health;
+          if (health) {
+            setPublishHealthByToolCall((prev) => {
+              const next = new Map(prev);
+              for (const id of promoted) next.set(id, health);
+              return next;
+            });
+          }
         }
       },
       [onPublishDrafts, messages],
@@ -812,49 +965,57 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             tool.draftReview.items.length > 0 &&
             (onReviewDraft ||
               (onPublishDrafts && tool.draftReview.packageId)) ? (
-              <div className="flex items-center gap-2 p-3 border-t bg-muted/30">
-                {onPublishDrafts && tool.draftReview.packageId ? (
-                  publishedToolCalls.has(tool.toolCallId) ? (
-                    // Published (auto or manual): a stable status badge, not a
-                    // stale button. Keeps the card honest about lifecycle state.
-                    <span className="inline-flex h-7 items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-3 text-xs font-medium text-emerald-700">
-                      <CheckCircle2 className="size-3.5" />
-                      {publishedLabel}
-                      {tool.draftReview.failedCount
-                        ? ` · ${tool.draftReview.failedCount} need${tool.draftReview.failedCount === 1 ? 's' : ''} attention`
-                        : ''}
-                    </span>
-                  ) : (
+              <>
+                <div className="flex items-center gap-2 p-3 border-t bg-muted/30">
+                  {onPublishDrafts && tool.draftReview.packageId ? (
+                    publishedToolCalls.has(tool.toolCallId) ? (
+                      // Published (auto or manual): a stable status badge, not a
+                      // stale button. Keeps the card honest about lifecycle state.
+                      <span className="inline-flex h-7 items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-3 text-xs font-medium text-emerald-700">
+                        <CheckCircle2 className="size-3.5" />
+                        {publishedLabel}
+                        {tool.draftReview.failedCount
+                          ? ` · ${tool.draftReview.failedCount} need${tool.draftReview.failedCount === 1 ? 's' : ''} attention`
+                          : ''}
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => void handlePublishDrafts(tool.draftReview!.packageId!)}
+                        className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                      >
+                        <Rocket className="size-3.5" />
+                        {publishDraftsLabel}
+                      </button>
+                    )
+                  ) : null}
+                  {onReviewDraft ? (
                     <button
                       type="button"
-                      onClick={() => void handlePublishDrafts(tool.draftReview!.packageId!)}
-                      className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                      onClick={() => onReviewDraft(tool.draftReview!.items)}
+                      className={
+                        onPublishDrafts && tool.draftReview.packageId
+                          ? 'inline-flex h-7 items-center gap-1.5 rounded-md border px-3 text-xs font-medium hover:bg-muted'
+                          : 'inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90'
+                      }
                     >
-                      <Rocket className="size-3.5" />
-                      {publishDraftsLabel}
+                      <GitCompareArrows className="size-3.5" />
+                      {toolReviewLabel(tool.draftReview.items.length)}
                     </button>
-                  )
+                  ) : null}
+                  {tool.draftReview.summary ? (
+                    <span className="truncate text-xs text-muted-foreground">
+                      {tool.draftReview.summary}
+                    </span>
+                  ) : null}
+                </div>
+                {/* ADR-0038 L3 — build-health line: what the publish actually
+                    did at runtime. Renders only when the host supplied health
+                    data; "Published" alone never implies "verified". */}
+                {publishedToolCalls.has(tool.toolCallId) ? (
+                  <PublishHealthLine health={publishHealthByToolCall.get(tool.toolCallId)} />
                 ) : null}
-                {onReviewDraft ? (
-                  <button
-                    type="button"
-                    onClick={() => onReviewDraft(tool.draftReview!.items)}
-                    className={
-                      onPublishDrafts && tool.draftReview.packageId
-                        ? 'inline-flex h-7 items-center gap-1.5 rounded-md border px-3 text-xs font-medium hover:bg-muted'
-                        : 'inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90'
-                    }
-                  >
-                    <GitCompareArrows className="size-3.5" />
-                    {toolReviewLabel(tool.draftReview.items.length)}
-                  </button>
-                ) : null}
-                {tool.draftReview.summary ? (
-                  <span className="truncate text-xs text-muted-foreground">
-                    {tool.draftReview.summary}
-                  </span>
-                ) : null}
-              </div>
+              </>
             ) : null}
           </ToolContent>
         </Tool>

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -438,3 +438,140 @@ describe('ChatbotEnhanced — streaming build preview (live build tree)', () => 
     expect(screen.queryByTestId('build-progress-open-app')).not.toBeInTheDocument();
   });
 });
+
+/**
+ * ADR-0038 L3 — the build-health line under a Published card: the host's
+ * onPublishDrafts may return `{ ok, health }` (seedApplied + runtime probes)
+ * and the chat must show what the publish ACTUALLY did, not just "Published".
+ */
+describe('ChatbotEnhanced — publish build-health line (ADR-0038)', () => {
+  const userMsg: ChatMessage = { id: 'u1', role: 'user', content: 'build it' };
+  const draftMsg = (packageId: string): ChatMessage => ({
+    id: 'a1',
+    role: 'assistant',
+    content: 'Built your app.',
+    toolInvocations: [
+      {
+        toolCallId: 'tc-health',
+        toolName: 'apply_blueprint',
+        state: 'output-available',
+        draftReview: { items: [{ type: 'object', name: 'task' }], packageId, autoPublishable: true },
+      },
+    ],
+  });
+
+  it('renders rows-seeded + verified counts and runtime issues from a structured outcome', async () => {
+    const onPublishDrafts = vi.fn().mockResolvedValue({
+      ok: true,
+      health: {
+        seededRows: 12,
+        checked: { seeds: 2, views: 3, widgets: 4 },
+        issues: [
+          { severity: 'error', code: 'empty_query', message: 'widget "w1" returns NO data' },
+          { severity: 'warning', code: 'probes_unavailable', message: '1 widget not probed' },
+        ],
+      },
+    });
+    const { rerender } = render(
+      <ChatbotEnhanced autoPublishDrafts isLoading messages={[userMsg]} onPublishDrafts={onPublishDrafts} />,
+    );
+    rerender(
+      <ChatbotEnhanced autoPublishDrafts isLoading={false} messages={[userMsg, draftMsg('app.todo')]} onPublishDrafts={onPublishDrafts} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('publish-health')).toBeInTheDocument());
+    expect(screen.getByText(/12 sample rows live/i)).toBeInTheDocument();
+    // Errors present → the "verified" claim is withheld; the findings show instead.
+    expect(screen.queryByText(/verified/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/returns NO data/i)).toBeInTheDocument();
+    expect(screen.getByText(/not probed/i)).toBeInTheDocument();
+  });
+
+  it('claims "verified" only when the probes ran clean', async () => {
+    const onPublishDrafts = vi.fn().mockResolvedValue({
+      ok: true,
+      health: { seededRows: 6, checked: { seeds: 1, views: 2, widgets: 3 }, issues: [] },
+    });
+    const { rerender } = render(
+      <ChatbotEnhanced autoPublishDrafts isLoading messages={[userMsg]} onPublishDrafts={onPublishDrafts} />,
+    );
+    rerender(
+      <ChatbotEnhanced autoPublishDrafts isLoading={false} messages={[userMsg, draftMsg('app.todo')]} onPublishDrafts={onPublishDrafts} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('publish-health')).toBeInTheDocument());
+    expect(screen.getByText(/6 sample rows live · 2 views · 3 widgets · 1 seed verified/i)).toBeInTheDocument();
+  });
+
+  it('renders the seed-load failure loudly', async () => {
+    const onPublishDrafts = vi.fn().mockResolvedValue({
+      ok: true,
+      health: { seedError: 'no readable seed bodies' },
+    });
+    const { rerender } = render(
+      <ChatbotEnhanced autoPublishDrafts isLoading messages={[userMsg]} onPublishDrafts={onPublishDrafts} />,
+    );
+    rerender(
+      <ChatbotEnhanced autoPublishDrafts isLoading={false} messages={[userMsg, draftMsg('app.todo')]} onPublishDrafts={onPublishDrafts} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('publish-health')).toBeInTheDocument());
+    expect(screen.getByText(/no readable seed bodies/i)).toBeInTheDocument();
+  });
+
+  it('stays silent (no health element) for legacy boolean outcomes', async () => {
+    const onPublishDrafts = vi.fn().mockResolvedValue(true);
+    const { rerender } = render(
+      <ChatbotEnhanced autoPublishDrafts isLoading messages={[userMsg]} onPublishDrafts={onPublishDrafts} />,
+    );
+    rerender(
+      <ChatbotEnhanced autoPublishDrafts isLoading={false} messages={[userMsg, draftMsg('app.todo')]} onPublishDrafts={onPublishDrafts} />,
+    );
+    // Publish resolves → Published badge, but no health line.
+    await waitFor(() => expect(screen.getByText('Published')).toBeInTheDocument());
+    expect(screen.queryByTestId('publish-health')).not.toBeInTheDocument();
+  });
+
+  it('treats {ok:false} as failure — no Published badge', async () => {
+    const onPublishDrafts = vi.fn().mockResolvedValue({ ok: false });
+    const { rerender } = render(
+      <ChatbotEnhanced autoPublishDrafts isLoading messages={[userMsg]} onPublishDrafts={onPublishDrafts} />,
+    );
+    rerender(
+      <ChatbotEnhanced autoPublishDrafts isLoading={false} messages={[userMsg, draftMsg('app.todo')]} onPublishDrafts={onPublishDrafts} />,
+    );
+    await waitFor(() => expect(onPublishDrafts).toHaveBeenCalled());
+    expect(screen.queryByText('Published')).not.toBeInTheDocument();
+  });
+});
+
+describe('publishHealthFromResponse', () => {
+  it('maps seedApplied + probes through the {success,data} envelope', async () => {
+    const { publishHealthFromResponse } = await import('../ChatbotEnhanced');
+    const health = publishHealthFromResponse({
+      success: true,
+      data: {
+        seedApplied: { success: true, inserted: 10, updated: 2 },
+        probes: {
+          checked: { seeds: 2, views: 1, widgets: 3 },
+          issues: [{ severity: 'error', code: 'empty_query', message: 'm' }],
+        },
+      },
+    });
+    expect(health).toEqual({
+      seededRows: 12,
+      checked: { seeds: 2, views: 1, widgets: 3 },
+      issues: [{ severity: 'error', code: 'empty_query', message: 'm' }],
+    });
+  });
+
+  it('maps a failed seedApplied to seedError and tolerates a flat body', async () => {
+    const { publishHealthFromResponse } = await import('../ChatbotEnhanced');
+    const health = publishHealthFromResponse({
+      seedApplied: { success: false, errors: ['row 3 rejected'] },
+    });
+    expect(health).toEqual({ seedError: 'row 3 rejected' });
+  });
+
+  it('returns undefined when the server reported neither (older runtimes)', async () => {
+    const { publishHealthFromResponse } = await import('../ChatbotEnhanced');
+    expect(publishHealthFromResponse({ success: true, data: { publishedCount: 3 } })).toBeUndefined();
+  });
+});

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -276,7 +276,7 @@ export * from './renderer';
 
 // Shared composition layer over the vendored AI Elements (used by both
 // Studio's sidebar panel and Console's floating chatbot).
-export { ChatbotEnhanced } from './ChatbotEnhanced';
+export { ChatbotEnhanced, publishHealthFromResponse } from './ChatbotEnhanced';
 export type {
   ChatbotEnhancedProps,
   ChatMessage as ChatbotEnhancedMessage,
@@ -284,6 +284,8 @@ export type {
   ChatSource as ChatbotEnhancedSource,
   ChatbotLabels,
   ToolDecisionState,
+  PublishHealth,
+  PublishOutcome,
 } from './ChatbotEnhanced';
 
 // Re-export the vendored Vercel AI Elements (MIT, src/elements/) so app


### PR DESCRIPTION
Second half of BVL Phase 2 ([ADR-0038](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0038-build-verification-loop.md)), pairing with [framework#1715](https://github.com/objectstack-ai/framework/pull/1715) (post-publish runtime probes): the chat now shows what a publish **actually did at runtime**, so "Published" and "actually works" are two separately-verified statements.

## What

- `onPublishDrafts` may return `{ ok, health }` — `PublishHealth` carries the publish response's `seedApplied` + `probes` (framework#1715). Legacy `boolean`/`void` returns keep working; `{ok:false}` counts as failure (no Published badge).
- `ChatbotEnhanced` renders a **build-health line** under the Published badge:
  - ✓ `12 sample rows live · 3 views · 4 widgets verified` — the "verified" claim appears **only when probes ran clean**;
  - ✗ each runtime error (`empty_query`, `seed_not_applied`, `view_read_failed`, …) and the seed-load failure rendered loudly;
  - ⚠ warnings (e.g. `probes_unavailable`) so silence never reads as "probed and passed".
- `publishHealthFromResponse`: shared, dispatcher-envelope-tolerant extractor; both hosts (ConsoleFloatingChatbot + AiChatPage) wired to return structured outcomes.

No health data → no element (older runtimes degrade silently).

## Tests
- Health line: errors-present withholds "verified"; clean probes claim it; seed failure loud; legacy boolean → no element; `{ok:false}` → no Published badge.
- `publishHealthFromResponse`: envelope tolerance, seedError mapping, undefined for older runtimes.
- plugin-chatbot 65/65, app-shell 401/401, tsc green.

Staging note: this card would have flagged today's live incident (publish reported success; the published app was unreadable minutes later — kernel-eviction metadata loss, diagnosed separately) as soon as L3 probes flow through a cloud .framework-sha bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)