### PR TITLE
fix(app-shell): probed package publish from the banner + working New-chat button

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -169,6 +169,11 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   // query string — so reading it lazily would lose the agent before the
   // selection effect runs. The initializer snapshots it before that race.
   const [agentParam] = useState<string | undefined>(() => searchParams.get('agent') ?? undefined);
+  // Explicit new-conversation intent (`/ai?new=1`, the sidebar's New button).
+  // Read LIVE (not snapshotted): the button can be clicked again later from an
+  // existing conversation, and the flag is stripped once the fresh id is
+  // mirrored into the URL.
+  const forceNewConversation = searchParams.get('new') !== null;
   const navigate = useNavigate();
   const { setContext } = useNavigationContext();
 
@@ -203,6 +208,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     scope: activeAgent,
     apiBase,
     activeId: urlConversationId,
+    forceNew: forceNewConversation,
   });
 
   const [refreshKey, setRefreshKey] = useState(0);

--- a/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
+++ b/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
@@ -89,7 +89,10 @@ export function ConversationsSidebar({
   }, [decoratedConversations, filter]);
 
   const handleNew = useCallback(() => {
-    navigate('/ai');
+    // `?new=1` is the explicit new-conversation intent. A bare `/ai` resumes
+    // the last cached conversation (by design), so without the flag this
+    // button silently landed back on the current chat.
+    navigate('/ai?new=1');
     onNavigate?.();
   }, [navigate, onNavigate]);
 

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -29,6 +29,7 @@ import { StarredApps } from './StarredApps';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
 import { Plus, Settings, Sparkles, Star, Clock, ArrowDown, Store, LayoutGrid, ShieldAlert, X, UploadCloud } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
+import { publishHealthFromResponse, type PublishHealth } from '@object-ui/plugin-chatbot';
 import { toast } from 'sonner';
 
 function pickGreetingKey(hour: number): string {
@@ -115,7 +116,7 @@ function StatPill({
  */
 function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) {
   const client = useMetadataClient();
-  const [drafts, setDrafts] = useState<Array<{ type: string; name: string }>>([]);
+  const [drafts, setDrafts] = useState<Array<{ type: string; name: string; packageId: string | null }>>([]);
   const [publishing, setPublishing] = useState(false);
   const count = drafts.length;
 
@@ -127,18 +128,22 @@ function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) 
         setDrafts(
           rows
             .filter((d: any) => d && typeof d.type === 'string' && typeof d.name === 'string')
-            .map((d: any) => ({ type: d.type, name: d.name })),
+            .map((d: any) => ({ type: d.type, name: d.name, packageId: typeof d.packageId === 'string' && d.packageId ? d.packageId : null })),
         );
       })
       .catch(() => { /* drafts unsupported / error → don't show */ });
     return () => { cancelled = true; };
   }, [client]);
 
-  // One-click publish: promote every pending draft BY REFERENCE so a brand-new
-  // user reaches "it's live" without hunting for a designer. (Pre-PMF activation
-  // > the draft-review gate.) Publishing per-(type,name) — not per-package —
-  // means a draft with no `packageId` binding still publishes, instead of the
-  // banner dead-ending with "no draft packages" while the count stays stuck.
+  // One-click publish. Package-bound drafts go through the package endpoint
+  // (`POST /packages/:id/publish-drafts`) — the governed path that orders
+  // structure-before-seeds server-side AND runs the ADR-0038 L3 runtime probes
+  // (seed rows landed? views read? widget queries return data?), so this
+  // banner can no longer say "Published!" over an app that is silently empty
+  // (the gym_management incident: a mid-publish container crash ate every
+  // seed row and the per-ref path had nothing checking). Drafts with no
+  // `packageId` keep the legacy by-reference fallback so they still publish
+  // instead of dead-ending the banner.
   const publish = async () => {
     setPublishing(true);
     try {
@@ -146,17 +151,45 @@ function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) 
         ? drafts
         : (((await client.listDrafts?.({})) as any[]) || [])
             .filter((d) => d && typeof d.type === 'string' && typeof d.name === 'string')
-            .map((d) => ({ type: d.type, name: d.name }));
+            .map((d) => ({ type: d.type, name: d.name, packageId: typeof d.packageId === 'string' && d.packageId ? d.packageId : null }));
       if (pending.length === 0) throw new Error('nothing to publish');
-      // Structure first, seeds LAST — a seed's rows can only land once its
-      // object's table exists. Publishing a `seed` also materializes its rows
-      // (reported under `seedApplied`, never thrown) — collect failures so
-      // "Published!" can't hide silently empty tables.
-      const ordered = [
-        ...pending.filter((d) => d.type !== 'seed'),
-        ...pending.filter((d) => d.type === 'seed'),
-      ];
+
+      const packageIds = [...new Set(pending.map((d) => d.packageId).filter((p): p is string => p !== null))];
+      const orphans = pending.filter((d) => d.packageId === null);
+
       const seedProblems: string[] = [];
+      const probeProblems: string[] = [];
+      let seededRows = 0;
+      const recordHealth = (health: PublishHealth | undefined) => {
+        if (!health) return;
+        if (health.seedError) seedProblems.push(health.seedError);
+        if (typeof health.seededRows === 'number') seededRows += health.seededRows;
+        for (const issue of health.issues ?? []) {
+          if (issue.severity === 'error') probeProblems.push(issue.message);
+        }
+      };
+
+      for (const packageId of packageIds) {
+        const res = await fetch(`/api/v1/packages/${encodeURIComponent(packageId)}/publish-drafts`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: '{}',
+        });
+        const payload = await res.json().catch(() => null);
+        if (!res.ok || (payload as any)?.success === false) {
+          throw new Error((payload as any)?.error?.message || `HTTP ${res.status}`);
+        }
+        recordHealth(publishHealthFromResponse(payload));
+      }
+
+      // Package-less stragglers: by reference, structure first, seeds LAST —
+      // a seed's rows can only land once its object's table exists. Publishing
+      // a `seed` also materializes its rows (reported under `seedApplied`).
+      const ordered = [
+        ...orphans.filter((d) => d.type !== 'seed'),
+        ...orphans.filter((d) => d.type === 'seed'),
+      ];
       for (const d of ordered) {
         const res = await client.publishDraft(d.type, d.name);
         const seedApplied = (res as any)?.seedApplied;
@@ -164,13 +197,27 @@ function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) 
           seedProblems.push(seedApplied.error ?? `${d.name}: sample data failed to load`);
         }
       }
-      if (seedProblems.length > 0) {
+
+      if (probeProblems.length > 0) {
+        // Runtime probes found the published app broken — say so, loudly.
+        toast.warning(
+          t('home.pendingDrafts.probeWarn', { defaultValue: 'Published, but verification found problems.' }),
+          { description: probeProblems[0] },
+        );
+      } else if (seedProblems.length > 0) {
         toast.warning(
           t('home.pendingDrafts.seedWarn', { defaultValue: 'Published, but some sample data failed to load.' }),
           { description: seedProblems[0] },
         );
       } else {
-        toast.success(t('home.pendingDrafts.published', { defaultValue: 'Published! Your changes are live.' }));
+        toast.success(
+          seededRows > 0
+            ? t('home.pendingDrafts.publishedVerified', {
+                count: seededRows,
+                defaultValue: 'Published & verified — {{count}} sample row(s) live.',
+              })
+            : t('home.pendingDrafts.published', { defaultValue: 'Published! Your changes are live.' }),
+        );
       }
       setDrafts([]);
       // Surface the now-live app — reload so the populated home shows it.

--- a/packages/app-shell/src/hooks/__tests__/useChatConversation.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useChatConversation.test.tsx
@@ -231,3 +231,70 @@ describe('useChatConversation', () => {
     expect(result.current.initialMessages).toEqual([]);
   });
 });
+
+describe('useChatConversation — forceNew (the sidebar New button)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('skips the cached conversation and creates a fresh one', async () => {
+    localStorage.setItem('objectstack:ai-chat-conversation-id:u1', 'conv-cached');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'conv-fresh', messages: [] }));
+
+    const { result } = renderHook(() =>
+      useChatConversation({ userId: 'u1', apiBase: API_BASE, forceNew: true }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.conversationId).toBe('conv-fresh');
+    // ONE call — the create; the cached id was never even fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE}/conversations`);
+    expect(fetchMock.mock.calls[0][1]?.method).toBe('POST');
+    // Cache now points at the fresh conversation.
+    expect(localStorage.getItem('objectstack:ai-chat-conversation-id:u1')).toBe('conv-fresh');
+  });
+
+  it('overrides the resolved-once guard when flipping forceNew on an open page', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 'conv-a', messages: [] }));
+
+    const { result, rerender } = renderHook(
+      ({ forceNew }: { forceNew: boolean }) =>
+        useChatConversation({ userId: 'u1', apiBase: API_BASE, forceNew }),
+      { initialProps: { forceNew: false } },
+    );
+    await waitFor(() => expect(result.current.conversationId).toBe('conv-a'));
+
+    // The user clicks New: same mount, forceNew flips true. The stale id must
+    // clear immediately (so the URL-mirroring host can't bounce back), then a
+    // fresh conversation resolves.
+    fetchMock.mockResolvedValue(jsonResponse({ id: 'conv-b', messages: [] }));
+    rerender({ forceNew: true });
+    await waitFor(() => expect(result.current.conversationId).toBe('conv-b'));
+    const createCalls = fetchMock.mock.calls.filter(
+      (c) => c[0] === `${API_BASE}/conversations` && c[1]?.method === 'POST',
+    );
+    expect(createCalls.length).toBe(2);
+  });
+
+  it('is ignored while an explicit activeId is set (deep link wins)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'conv-x', messages: [] }));
+
+    const { result } = renderHook(() =>
+      useChatConversation({ userId: 'u1', apiBase: API_BASE, activeId: 'conv-x', forceNew: true }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.conversationId).toBe('conv-x');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE}/conversations/conv-x`);
+  });
+});

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -44,6 +44,16 @@ export interface UseChatConversationOptions {
    * original cache-first / create-on-miss behaviour.
    */
   activeId?: string;
+  /**
+   * Explicit "start a NEW conversation" intent (the sidebar's New button,
+   * `/ai?new=1`). Without it a bare `/ai` visit resumes the last cached
+   * conversation — which is right for a plain visit but made the New button a
+   * no-op: the resolved-once guard kept the current id and the URL-mirroring
+   * effect immediately rewrote `/ai` back to `/ai/:currentId`. When true (and
+   * no `activeId`), the cache and the guard are skipped and a fresh
+   * conversation is created. Ignored while `activeId` is set.
+   */
+  forceNew?: boolean;
 }
 
 export interface UseChatConversationReturn {
@@ -265,7 +275,7 @@ async function deleteConversation(apiBase: string, id: string): Promise<void> {
 export function useChatConversation(
   options: UseChatConversationOptions,
 ): UseChatConversationReturn {
-  const { userId, scope, apiBase, activeId } = options;
+  const { userId, scope, apiBase, activeId, forceNew } = options;
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
   const [initialMessages, setInitialMessages] = useState<HydratedUIMessage[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(Boolean(userId));
@@ -292,11 +302,21 @@ export function useChatConversation(
     }
     // Already resolved a conversation for this user during the no-activeId
     // window — don't re-create just because `scope` or another dep changed.
-    if (!activeId && resolvedForUserRef.current === userId && conversationId) {
+    // An explicit new-conversation intent (`forceNew`) overrides the guard.
+    if (!activeId && !forceNew && resolvedForUserRef.current === userId && conversationId) {
       return;
     }
     let cancelled = false;
     const key = cacheKey(userId, scope);
+    // Explicit new-conversation intent: drop the previous id NOW, before the
+    // async create. The host page mirrors `conversationId` into the URL the
+    // moment `activeId` is empty — with the stale id still in state it would
+    // bounce straight back to `/ai/:oldId` and strip the `?new=1` flag before
+    // the fresh conversation ever existed.
+    if (!activeId && forceNew) {
+      setConversationId(undefined);
+      setInitialMessages([]);
+    }
     setIsLoading(true);
 
     (async () => {
@@ -315,7 +335,7 @@ export function useChatConversation(
           // Requested id is gone — fall through to create a fresh one.
           writeCache(key, undefined);
           writeConversationMessagesCache(activeId, []);
-        } else {
+        } else if (!forceNew) {
           const cached = readCache(key);
           if (cached) {
             const existing = await fetchConversation(apiBase, cached);
@@ -354,7 +374,7 @@ export function useChatConversation(
     // short-circuit guard, which is governed by the ref. Including it would
     // re-run the effect after we successfully resolved an id.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userId, scope, apiBase, activeId]);
+  }, [userId, scope, apiBase, activeId, forceNew]);
 
   const reset = useCallback(async () => {
     if (!userId) return;


### PR DESCRIPTION
Closes out the two UI leftovers from the 2026-06-11 BVL staging E2E.

## 1. Pending-drafts banner → probed publish path
The Home banner published every draft **by reference** — no ADR-0038 L3 probes anywhere on that path. In the staging test, a mid-publish container crash ate every seed row of `gym_management` and the banner still toasted *Published!* over an app whose dashboard was all zeros.

Now: drafts are grouped by `packageId` and each package goes through `POST /packages/:id/publish-drafts` ([framework#1715](https://github.com/objectstack-ai/framework/pull/1715)'s probed + seed-ordered path). Probe findings reuse `publishHealthFromResponse` from [#1637](https://github.com/objectstack-ai/objectui/pull/1637):
- runtime errors → ⚠ *Published, but verification found problems* + first finding
- seed failure → existing seed warning
- clean → *Published & verified — N sample row(s) live*

Package-less drafts keep the legacy by-ref fallback (structure first, seeds last) so they never dead-end.

## 2. New-chat button was a no-op
`New` navigated to `/ai`; `useChatConversation`'s resolved-once guard kept the current id and the URL-mirror effect bounced straight back to `/ai/:currentId`. Confirmed live on staging — every message landed in the same conversation, and the granular-precedent context steered later builds away from `apply_blueprint`.

Now: `New` → `/ai?new=1`; the hook's new `forceNew` option skips the guard + cache, clears the stale id synchronously (so the mirror effect can't bounce while the create is in flight), and creates a fresh conversation. Flag self-strips when the fresh id is mirrored into the URL.

## Tests
- 3 new `useChatConversation` cases: fresh-create skips cache, mid-mount `forceNew` flip overrides the guard, explicit `activeId` wins over `forceNew`
- app-shell suite 404/404, workspace build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)