### PR TITLE
feat: ADR-0037 Live Canvas Phases 1+2 — draft preview mode + split-view canvas

### DIFF
--- a/packages/app-shell/src/console/ConsoleShell.tsx
+++ b/packages/app-shell/src/console/ConsoleShell.tsx
@@ -18,6 +18,7 @@ import { SchemaRendererProvider } from '@object-ui/react';
 import { createObjectStackUserStateAdapter } from '@object-ui/data-objectstack';
 import { AdapterProvider, useAdapter } from '../providers/AdapterProvider';
 import { MetadataProvider, useMetadata } from '../providers/MetadataProvider';
+import { PreviewModeProvider } from '../preview/PreviewModeContext';
 import { NavigationProvider } from '../context/NavigationContext';
 import { FavoritesProvider } from '../context/FavoritesProvider';
 import { RecentItemsProvider } from '../context/RecentItemsProvider';
@@ -73,7 +74,12 @@ export function ConsoleShell({ children }: { children: ReactNode }) {
 export function ConnectedShell({ children }: { children: ReactNode }) {
   return (
     <AdapterProvider>
-      <ConnectedShellInner>{children}</ConnectedShellInner>
+      {/* ADR-0037: one URL flag (?preview=draft) flips the whole metadata
+          tree below into the draft-overlaid world. Above MetadataProvider so
+          the provider itself reads through the right source. */}
+      <PreviewModeProvider>
+        <ConnectedShellInner>{children}</ConnectedShellInner>
+      </PreviewModeProvider>
     </AdapterProvider>
   );
 }

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -56,6 +56,7 @@ import {
   type HydratedUIMessagePart,
 } from '../../hooks/useChatConversation';
 import { ConversationsSidebar } from './ConversationsSidebar';
+import { LiveCanvas } from './LiveCanvas';
 
 const DEFAULT_AI_PATH = '/api/v1/ai';
 
@@ -376,6 +377,29 @@ function ChatPane({
 }: ChatPaneProps) {
   const { t } = useObjectTranslation();
   const navigate = useNavigate();
+
+  // ── ADR-0037 Live Canvas ────────────────────────────────────────────────
+  // When a build session drafts an `app`, open the split-view canvas: the
+  // drafted app rendered as-if-published (`?preview=draft`) beside the chat.
+  // Per-artifact signals coalesce (800 ms) into one pane refresh so a
+  // whole-app build doesn't trigger an invalidation storm.
+  const [canvasApp, setCanvasApp] = useState<string | null>(null);
+  const [canvasRefreshKey, setCanvasRefreshKey] = useState(0);
+  const canvasTimerRef = useRef<number | null>(null);
+  useEffect(() => () => {
+    if (canvasTimerRef.current) window.clearTimeout(canvasTimerRef.current);
+  }, []);
+  const handleDraftArtifacts = useCallback((artifacts: Array<{ type: string; name: string }>) => {
+    const app = artifacts.find((a) => a.type === 'app');
+    if (app) setCanvasApp((prev) => prev ?? app.name);
+    if (canvasTimerRef.current) window.clearTimeout(canvasTimerRef.current);
+    canvasTimerRef.current = window.setTimeout(() => setCanvasRefreshKey((k) => k + 1), 800);
+  }, []);
+  // A different conversation is a different build session — close the pane.
+  useEffect(() => {
+    setCanvasApp(null);
+  }, [conversationId]);
+
   const activeAgentLabel = useMemo<string>(() => {
     const found = agents.find((a) => a.name === activeAgent);
     return localizeAgentLabel(t, activeAgent, found?.label ?? activeAgent ?? t('console.ai.assistant'));
@@ -497,7 +521,14 @@ function ChatPane({
   );
 
   return (
-    <div className="flex min-h-0 flex-1 justify-center px-0">
+    <div className="flex min-h-0 flex-1 px-0">
+      <div
+        className={
+          canvasApp
+            ? 'flex min-h-0 w-[42%] min-w-[380px] max-w-[640px] shrink-0 justify-center'
+            : 'flex min-h-0 flex-1 justify-center'
+        }
+      >
       <ChatbotEnhanced
         className="min-h-0 flex-1 bg-background md:max-w-5xl"
         surface="plain"
@@ -602,8 +633,21 @@ function ChatPane({
         // app automatically the moment the agent finishes — no manual click; the
         // user refreshes and sees it live WITH data. Same governed endpoint.
         autoPublishDrafts={getRuntimeConfig().features.autoPublishAiBuilds}
+        // ADR-0037 Live Canvas: open/refresh the draft-preview pane as the
+        // agent's artifacts land; Preview buttons deep-link the same route.
+        onDraftArtifacts={handleDraftArtifacts}
+        onPreviewDraftApp={(appName) => setCanvasApp(appName)}
+        previewDraftLabel={t('console.ai.previewDraft', { defaultValue: 'Preview' })}
         data-testid="ai-chat-panel"
       />
+      </div>
+      {canvasApp ? (
+        <LiveCanvas
+          appName={canvasApp}
+          refreshKey={canvasRefreshKey}
+          onClose={() => setCanvasApp(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/app-shell/src/console/ai/LiveCanvas.tsx
+++ b/packages/app-shell/src/console/ai/LiveCanvas.tsx
@@ -1,0 +1,74 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0037 Live Canvas — the result pane of a build session. Chat on the
+ * left, the user's app rendered from the DRAFT overlay on the right, taking
+ * shape while they talk.
+ *
+ * Deliberately an iframe onto `/apps/:name?preview=draft`: the canvas mounts
+ * the EXISTING app renderers in preview mode through the same route a user
+ * could open by hand — no second renderer, no canvas-only store (ADR-0037
+ * boundary rules: one truth, the canvas never edits in place). Per-artifact
+ * invalidations from the chat coalesce into a reload of the pane, so during
+ * an `apply_blueprint` the app grows step-by-step with the build tree.
+ */
+
+import { useEffect, useRef } from 'react';
+import { X, Eye } from 'lucide-react';
+import { Button } from '@object-ui/components';
+import { useObjectTranslation } from '@object-ui/i18n';
+
+export interface LiveCanvasProps {
+  /** The drafted app to render (its `app` metadata name). */
+  appName: string;
+  /** Bump to reload the pane (the host coalesces invalidation storms). */
+  refreshKey: number;
+  onClose: () => void;
+}
+
+export function LiveCanvas({ appName, refreshKey, onClose }: LiveCanvasProps) {
+  const { t } = useObjectTranslation();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  // Refresh in place (src reload) instead of remounting the iframe — keeps
+  // the pane from flashing white on every invalidation.
+  useEffect(() => {
+    if (refreshKey > 0) {
+      try {
+        iframeRef.current?.contentWindow?.location.reload();
+      } catch {
+        /* cross-origin or not ready — the next mount picks it up */
+      }
+    }
+  }, [refreshKey]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col border-l" data-testid="live-canvas">
+      <div className="flex shrink-0 items-center gap-2 border-b bg-muted/30 px-3 py-1.5 text-xs text-muted-foreground">
+        <Eye className="h-3.5 w-3.5" />
+        <span className="min-w-0 flex-1 truncate">
+          {t('console.ai.liveCanvas', {
+            app: appName,
+            defaultValue: 'Live preview — {{app}} (draft)',
+          })}
+        </span>
+        <Button size="sm" variant="ghost" onClick={onClose} data-testid="live-canvas-close">
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <iframe
+        ref={iframeRef}
+        title={`Draft preview: ${appName}`}
+        src={`/apps/${encodeURIComponent(appName)}?preview=draft`}
+        className="h-full w-full flex-1 border-0 bg-background"
+        data-testid="live-canvas-frame"
+      />
+    </div>
+  );
+}

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -29,7 +29,7 @@ import { StarredApps } from './StarredApps';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
 import { Plus, Settings, Sparkles, Star, Clock, ArrowDown, Store, LayoutGrid, ShieldAlert, X, UploadCloud } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
-import { publishHealthFromResponse, type PublishHealth } from '@object-ui/plugin-chatbot';
+import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
 import { toast } from 'sonner';
 
 function pickGreetingKey(hour: number): string {
@@ -116,8 +116,11 @@ function StatPill({
  */
 function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) {
   const client = useMetadataClient();
-  const [drafts, setDrafts] = useState<Array<{ type: string; name: string; packageId: string | null }>>([]);
-  const [publishing, setPublishing] = useState(false);
+  const [drafts, setDrafts] = useState<Array<{ type: string; name: string }>>([]);
+  // Shared one-click publish (also used by the ADR-0037 draft-preview bar):
+  // packages via the probed publish-drafts path, orphans by reference, health
+  // surfaced in toasts. See usePublishAllDrafts for the full story.
+  const { publishAll, publishing } = usePublishAllDrafts(t);
   const count = drafts.length;
 
   useEffect(() => {
@@ -128,104 +131,19 @@ function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) 
         setDrafts(
           rows
             .filter((d: any) => d && typeof d.type === 'string' && typeof d.name === 'string')
-            .map((d: any) => ({ type: d.type, name: d.name, packageId: typeof d.packageId === 'string' && d.packageId ? d.packageId : null })),
+            .map((d: any) => ({ type: d.type, name: d.name })),
         );
       })
       .catch(() => { /* drafts unsupported / error → don't show */ });
     return () => { cancelled = true; };
   }, [client]);
 
-  // One-click publish. Package-bound drafts go through the package endpoint
-  // (`POST /packages/:id/publish-drafts`) — the governed path that orders
-  // structure-before-seeds server-side AND runs the ADR-0038 L3 runtime probes
-  // (seed rows landed? views read? widget queries return data?), so this
-  // banner can no longer say "Published!" over an app that is silently empty
-  // (the gym_management incident: a mid-publish container crash ate every
-  // seed row and the per-ref path had nothing checking). Drafts with no
-  // `packageId` keep the legacy by-reference fallback so they still publish
-  // instead of dead-ending the banner.
   const publish = async () => {
-    setPublishing(true);
-    try {
-      const pending = drafts.length
-        ? drafts
-        : (((await client.listDrafts?.({})) as any[]) || [])
-            .filter((d) => d && typeof d.type === 'string' && typeof d.name === 'string')
-            .map((d) => ({ type: d.type, name: d.name, packageId: typeof d.packageId === 'string' && d.packageId ? d.packageId : null }));
-      if (pending.length === 0) throw new Error('nothing to publish');
-
-      const packageIds = [...new Set(pending.map((d) => d.packageId).filter((p): p is string => p !== null))];
-      const orphans = pending.filter((d) => d.packageId === null);
-
-      const seedProblems: string[] = [];
-      const probeProblems: string[] = [];
-      let seededRows = 0;
-      const recordHealth = (health: PublishHealth | undefined) => {
-        if (!health) return;
-        if (health.seedError) seedProblems.push(health.seedError);
-        if (typeof health.seededRows === 'number') seededRows += health.seededRows;
-        for (const issue of health.issues ?? []) {
-          if (issue.severity === 'error') probeProblems.push(issue.message);
-        }
-      };
-
-      for (const packageId of packageIds) {
-        const res = await fetch(`/api/v1/packages/${encodeURIComponent(packageId)}/publish-drafts`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-          body: '{}',
-        });
-        const payload = await res.json().catch(() => null);
-        if (!res.ok || (payload as any)?.success === false) {
-          throw new Error((payload as any)?.error?.message || `HTTP ${res.status}`);
-        }
-        recordHealth(publishHealthFromResponse(payload));
-      }
-
-      // Package-less stragglers: by reference, structure first, seeds LAST —
-      // a seed's rows can only land once its object's table exists. Publishing
-      // a `seed` also materializes its rows (reported under `seedApplied`).
-      const ordered = [
-        ...orphans.filter((d) => d.type !== 'seed'),
-        ...orphans.filter((d) => d.type === 'seed'),
-      ];
-      for (const d of ordered) {
-        const res = await client.publishDraft(d.type, d.name);
-        const seedApplied = (res as any)?.seedApplied;
-        if (seedApplied && seedApplied.success === false) {
-          seedProblems.push(seedApplied.error ?? `${d.name}: sample data failed to load`);
-        }
-      }
-
-      if (probeProblems.length > 0) {
-        // Runtime probes found the published app broken — say so, loudly.
-        toast.warning(
-          t('home.pendingDrafts.probeWarn', { defaultValue: 'Published, but verification found problems.' }),
-          { description: probeProblems[0] },
-        );
-      } else if (seedProblems.length > 0) {
-        toast.warning(
-          t('home.pendingDrafts.seedWarn', { defaultValue: 'Published, but some sample data failed to load.' }),
-          { description: seedProblems[0] },
-        );
-      } else {
-        toast.success(
-          seededRows > 0
-            ? t('home.pendingDrafts.publishedVerified', {
-                count: seededRows,
-                defaultValue: 'Published & verified — {{count}} sample row(s) live.',
-              })
-            : t('home.pendingDrafts.published', { defaultValue: 'Published! Your changes are live.' }),
-        );
-      }
-      setDrafts([]);
-      // Surface the now-live app — reload so the populated home shows it.
-      setTimeout(() => { try { window.location.reload(); } catch { /* ignore */ } }, 700);
-    } catch (e) {
-      toast.error(`${t('home.pendingDrafts.publishFailed', { defaultValue: 'Publish failed' })}: ${(e as Error).message}`);
-      setPublishing(false);
-    }
+    const result = await publishAll();
+    if (!result.ok) return;
+    setDrafts([]);
+    // Surface the now-live app — reload so the populated home shows it.
+    setTimeout(() => { try { window.location.reload(); } catch { /* ignore */ } }, 700);
   };
 
   if (count <= 0) return null;

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -510,6 +510,9 @@ function ChatbotInner({
         // built (the panel only shows this once the build reports done).
         onOpenBuiltApp={(appName) => navigate(`/apps/${encodeURIComponent(appName)}`)}
         openBuiltAppLabel={locale.openBuiltApp}
+        // ADR-0037: see the drafted app as-if-published before Publish — same
+        // route, draft overlay, watermark bar on top.
+        onPreviewDraftApp={(appName) => navigate(`/apps/${encodeURIComponent(appName)}?preview=draft`)}
         onPublishDrafts={async (packageId) => {
           // ADR-0033 — promote the conversation's staged drafts to live in one
           // click (the human still confirms here). Mirrors PackagesPage's

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -16,6 +16,7 @@ import { useDiscovery } from '@object-ui/react';
 // shiki, streamdown, mermaid, @ai-sdk, ~20MB) only downloads on first
 // hover/click. See ConsoleChatbotFab.tsx.
 import { ConsoleChatbotFab } from './ConsoleChatbotFab';
+import { DraftPreviewBar } from '../preview/DraftPreviewBar';
 import { UnifiedSidebar } from './UnifiedSidebar';
 import { AppHeader } from './AppHeader';
 import { MobileViewSwitcherProvider } from './MobileViewSwitcherContext';
@@ -121,6 +122,9 @@ export function ConsoleLayout({
       }
     >
       <ConsoleLayoutInner>
+        {/* ADR-0037: unmistakable watermark while rendering the draft overlay
+            (?preview=draft) — with one-click exit and one-click Publish. */}
+        <DraftPreviewBar />
         {children}
       </ConsoleLayoutInner>
 

--- a/packages/app-shell/src/preview/DraftPreviewBar.tsx
+++ b/packages/app-shell/src/preview/DraftPreviewBar.tsx
@@ -1,0 +1,72 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0037 — the persistent "Draft preview" watermark. Renders only while the
+ * tree is in preview mode (`?preview=draft`); makes the mode unmistakable and
+ * offers the only two actions that matter: leave the preview, or make it real
+ * (the same governed one-click publish the Home banner uses). The bar is what
+ * keeps a read-only preview from ever being confused with the live app.
+ */
+
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Eye, X, Rocket } from 'lucide-react';
+import { Button } from '@object-ui/components';
+import { useObjectTranslation } from '@object-ui/i18n';
+import { usePreviewDrafts, PREVIEW_QUERY_FLAG } from './PreviewModeContext';
+import { usePublishAllDrafts } from './usePublishAllDrafts';
+
+export function DraftPreviewBar() {
+  const preview = usePreviewDrafts();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { t } = useObjectTranslation();
+  const { publishAll, publishing } = usePublishAllDrafts(t);
+
+  if (!preview) return null;
+
+  const exit = () => {
+    const params = new URLSearchParams(location.search);
+    params.delete(PREVIEW_QUERY_FLAG);
+    const qs = params.toString();
+    navigate(`${location.pathname}${qs ? `?${qs}` : ''}${location.hash}`, { replace: true });
+  };
+
+  const publish = async () => {
+    const result = await publishAll();
+    if (!result.ok) return;
+    // The draft world just became the real world — exit preview and reload so
+    // every renderer re-reads the published registry.
+    exit();
+    setTimeout(() => { try { window.location.reload(); } catch { /* ignore */ } }, 300);
+  };
+
+  return (
+    <div
+      className="sticky top-0 z-40 flex items-center gap-3 border-b border-amber-300/70 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-200"
+      data-testid="draft-preview-bar"
+    >
+      <Eye className="h-4 w-4 shrink-0" />
+      <p className="min-w-0 flex-1 truncate">
+        {t('preview.draftBar.message', {
+          defaultValue: 'Draft preview — you are seeing unpublished changes. Nothing here is live until you publish.',
+        })}
+      </p>
+      <Button size="sm" onClick={publish} disabled={publishing} data-testid="draft-preview-publish">
+        <Rocket className="mr-1 h-3.5 w-3.5" />
+        {publishing
+          ? t('preview.draftBar.publishing', { defaultValue: 'Publishing…' })
+          : t('preview.draftBar.publish', { defaultValue: 'Publish' })}
+      </Button>
+      <Button size="sm" variant="outline" onClick={exit} data-testid="draft-preview-exit">
+        <X className="mr-1 h-3.5 w-3.5" />
+        {t('preview.draftBar.exit', { defaultValue: 'Exit preview' })}
+      </Button>
+    </div>
+  );
+}

--- a/packages/app-shell/src/preview/PreviewModeContext.tsx
+++ b/packages/app-shell/src/preview/PreviewModeContext.tsx
@@ -1,0 +1,60 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0037 Live Canvas — preview mode plumbing.
+ *
+ * One URL flag (`?preview=draft`) flips the whole renderer tree into
+ * "as-if-published" mode: metadata reads overlay pending ADR-0033 drafts on
+ * the active registry, so an unpublished app/view/dashboard renders exactly
+ * what Publish would make real. The canvas (and the Preview button in chat)
+ * navigate with this flag; everything below just reads the context.
+ *
+ * Read-only by design: preview changes the SOURCE of metadata reads, never
+ * writes, and Publish remains the single commit gate.
+ */
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const PreviewModeContext = createContext<boolean>(false);
+
+/** Query flag that switches the console into draft-preview mode. */
+export const PREVIEW_QUERY_FLAG = 'preview';
+export const PREVIEW_QUERY_VALUE = 'draft';
+
+/** True when `search` (a `location.search` string) carries `preview=draft`. */
+export function isPreviewSearch(search: string): boolean {
+  return new URLSearchParams(search).get(PREVIEW_QUERY_FLAG) === PREVIEW_QUERY_VALUE;
+}
+
+/**
+ * Provides the preview-mode flag to the tree. Reads the router location
+ * LIVE, so entering/leaving `?preview=draft` flips consumers without a
+ * remount. `force` overrides the URL — the Live Canvas mounts its embedded
+ * renderer subtree with `force` so the canvas is always a draft window
+ * regardless of the host page's own URL.
+ */
+export function PreviewModeProvider({ force, children }: { force?: boolean; children: ReactNode }) {
+  const location = useLocation();
+  const fromUrl = useMemo(() => isPreviewSearch(location.search), [location.search]);
+  return (
+    <PreviewModeContext.Provider value={force ?? fromUrl}>
+      {children}
+    </PreviewModeContext.Provider>
+  );
+}
+
+/**
+ * Whether the current tree renders the draft-overlaid world. Defaults to
+ * false outside a provider, so surfaces that never mount preview (login,
+ * bare pages) keep reading published metadata only.
+ */
+export function usePreviewDrafts(): boolean {
+  return useContext(PreviewModeContext);
+}

--- a/packages/app-shell/src/preview/usePublishAllDrafts.ts
+++ b/packages/app-shell/src/preview/usePublishAllDrafts.ts
@@ -1,0 +1,126 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * One-click "publish everything pending" — shared by the Home pending-drafts
+ * banner and the ADR-0037 draft-preview bar, so both surfaces publish through
+ * the SAME governed path and report the SAME health.
+ *
+ * Package-bound drafts go through `POST /packages/:id/publish-drafts` — the
+ * path that orders structure-before-seeds server-side and runs the ADR-0038
+ * L3 runtime probes; findings surface as a loud warning toast instead of a
+ * blind "Published!". Package-less drafts fall back to by-reference publish
+ * (structure first, seeds last) so they never dead-end.
+ */
+
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import { publishHealthFromResponse, type PublishHealth } from '@object-ui/plugin-chatbot';
+import { useMetadataClient } from '../views/metadata-admin/useMetadata';
+
+type TranslateFn = (key: string, opts?: Record<string, unknown>) => string;
+
+export interface PublishAllResult {
+  ok: boolean;
+  /** Count of drafts the call attempted to publish. */
+  attempted: number;
+}
+
+export function usePublishAllDrafts(t: TranslateFn) {
+  const client = useMetadataClient();
+  const [publishing, setPublishing] = useState(false);
+
+  const publishAll = useCallback(async (): Promise<PublishAllResult> => {
+    setPublishing(true);
+    try {
+      const pending = (((await client.listDrafts?.({})) as any[]) || [])
+        .filter((d) => d && typeof d.type === 'string' && typeof d.name === 'string')
+        .map((d) => ({
+          type: d.type as string,
+          name: d.name as string,
+          packageId: typeof d.packageId === 'string' && d.packageId ? (d.packageId as string) : null,
+        }));
+      if (pending.length === 0) {
+        toast.info(t('home.pendingDrafts.nothing', { defaultValue: 'Nothing to publish.' }));
+        return { ok: true, attempted: 0 };
+      }
+
+      const packageIds = [...new Set(pending.map((d) => d.packageId).filter((p): p is string => p !== null))];
+      const orphans = pending.filter((d) => d.packageId === null);
+
+      const seedProblems: string[] = [];
+      const probeProblems: string[] = [];
+      let seededRows = 0;
+      const recordHealth = (health: PublishHealth | undefined) => {
+        if (!health) return;
+        if (health.seedError) seedProblems.push(health.seedError);
+        if (typeof health.seededRows === 'number') seededRows += health.seededRows;
+        for (const issue of health.issues ?? []) {
+          if (issue.severity === 'error') probeProblems.push(issue.message);
+        }
+      };
+
+      for (const packageId of packageIds) {
+        const res = await fetch(`/api/v1/packages/${encodeURIComponent(packageId)}/publish-drafts`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: '{}',
+        });
+        const payload = await res.json().catch(() => null);
+        if (!res.ok || (payload as any)?.success === false) {
+          throw new Error((payload as any)?.error?.message || `HTTP ${res.status}`);
+        }
+        recordHealth(publishHealthFromResponse(payload));
+      }
+
+      const ordered = [
+        ...orphans.filter((d) => d.type !== 'seed'),
+        ...orphans.filter((d) => d.type === 'seed'),
+      ];
+      for (const d of ordered) {
+        const res = await client.publishDraft(d.type, d.name);
+        const seedApplied = (res as any)?.seedApplied;
+        if (seedApplied && seedApplied.success === false) {
+          seedProblems.push(seedApplied.error ?? `${d.name}: sample data failed to load`);
+        }
+      }
+
+      if (probeProblems.length > 0) {
+        toast.warning(
+          t('home.pendingDrafts.probeWarn', { defaultValue: 'Published, but verification found problems.' }),
+          { description: probeProblems[0] },
+        );
+      } else if (seedProblems.length > 0) {
+        toast.warning(
+          t('home.pendingDrafts.seedWarn', { defaultValue: 'Published, but some sample data failed to load.' }),
+          { description: seedProblems[0] },
+        );
+      } else {
+        toast.success(
+          seededRows > 0
+            ? t('home.pendingDrafts.publishedVerified', {
+                count: seededRows,
+                defaultValue: 'Published & verified — {{count}} sample row(s) live.',
+              })
+            : t('home.pendingDrafts.published', { defaultValue: 'Published! Your changes are live.' }),
+        );
+      }
+      return { ok: true, attempted: pending.length };
+    } catch (e) {
+      toast.error(
+        `${t('home.pendingDrafts.publishFailed', { defaultValue: 'Publish failed' })}: ${(e as Error).message}`,
+      );
+      return { ok: false, attempted: 0 };
+    } finally {
+      setPublishing(false);
+    }
+  }, [client, t]);
+
+  return { publishAll, publishing };
+}

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -6,9 +6,10 @@ import {
   useMemo,
   type ReactNode,
 } from 'react';
-import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { MetadataClient, type ObjectStackAdapter } from '@object-ui/data-objectstack';
 import { resolveInlineMode } from '@object-ui/plugin-form';
 import { MetadataCtx, useMetadata, type MetadataContextValue, type MetadataState } from '@object-ui/react';
+import { usePreviewDrafts } from '../preview/PreviewModeContext';
 
 export type { MetadataState, MetadataContextValue };
 export { useMetadataItem } from '@object-ui/react';
@@ -320,6 +321,21 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
   const adapterRef = useRef(adapter);
   adapterRef.current = adapter;
 
+  // ADR-0037 Live Canvas: when the tree is in draft-preview mode, metadata
+  // reads come from the REST `?preview=draft` overlay (pending ADR-0033
+  // drafts win over active) instead of the adapter SDK. The MetadataClient
+  // is used because the SDK's meta API doesn't carry the preview flag; same
+  // endpoints, same cookie auth. Reads only — every write path is unchanged.
+  const previewDrafts = usePreviewDrafts();
+  const previewClient = useMemo(() => {
+    if (!previewDrafts) return null;
+    const baseUrl =
+      (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_SERVER_URL) || '';
+    return new MetadataClient({ baseUrl, previewDrafts: true });
+  }, [previewDrafts]);
+  const previewClientRef = useRef(previewClient);
+  previewClientRef.current = previewClient;
+
   const [version, setVersion] = useState(0);
   // Defer state bumps so they never occur synchronously during a consumer's
   // render phase. `ensureType` may be invoked from inside `useMemo` getters
@@ -333,6 +349,15 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
       Promise.resolve().then(() => setVersion(v => v + 1));
     }
   }, []);
+
+  // Entering/leaving preview swaps the entire metadata source — the published
+  // and draft-overlaid worlds must never mix in one cache. Drop everything and
+  // let consumers refetch through the new source.
+  useEffect(() => {
+    cacheRef.current.clear();
+    itemPromisesRef.current.clear();
+    bump();
+  }, [previewDrafts, bump]);
 
   const getEntry = useCallback((type: string): TypeCacheEntry => {
     let entry = cacheRef.current.get(type);
@@ -357,9 +382,13 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
       const started = Date.now();
       entry.status = 'loading';
       entry.error = null;
-      const client = adapterRef.current.getClient();
-      const promise = client.meta
-        .getItems(type)
+      // Preview mode reads the draft-overlaid world (`?preview=draft`);
+      // normal mode reads the adapter SDK as before.
+      const preview = previewClientRef.current;
+      const fetchItems: Promise<unknown> = preview
+        ? preview.list(type)
+        : adapterRef.current.getClient().meta.getItems(type);
+      const promise = fetchItems
         .then((res: unknown) => {
           const items = extractItems(res);
           entry.items = items;
@@ -373,7 +402,9 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
               entry.byName.set(it.name, it);
             }
           }
-          if (type === 'app') saveToSession(type, items);
+          // Never let the draft-overlaid world poison the published session
+          // cache — preview is ephemeral by design.
+          if (type === 'app' && !preview) saveToSession(type, items);
           debug(`fetched type=${type} items=${items.length} in ${Date.now() - started}ms`);
           bump();
           return items;
@@ -416,9 +447,11 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
       if (existing) return existing;
 
       const started = Date.now();
-      const client = adapterRef.current.getClient();
-      const promise = client.meta
-        .getItem(type, name)
+      const preview = previewClientRef.current;
+      const fetchItem: Promise<unknown> = preview
+        ? preview.get(type, name)
+        : adapterRef.current.getClient().meta.getItem(type, name);
+      const promise = fetchItem
         .then((res: unknown) => {
           const item = extractItem(res);
           if (item) entry.byName.set(name, item);
@@ -489,7 +522,9 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
   useEffect(() => {
     let cancelled = false;
 
-    const cached = loadFromSession('app');
+    // Session-cached apps are PUBLISHED-world data — seeding them while in
+    // draft preview would flash the wrong universe before the fetch lands.
+    const cached = previewDrafts ? null : loadFromSession('app');
     if (cached) {
       const entry = getEntry('app');
       entry.items = cached;
@@ -521,7 +556,7 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
     return () => {
       cancelled = true;
     };
-  }, [adapter, ensureType, getEntry, bump]);
+  }, [adapter, ensureType, getEntry, bump, previewDrafts]);
 
   const value = useMemo<MetadataContextValue>(() => {
     void version;

--- a/packages/app-shell/src/views/metadata-admin/useMetadata.ts
+++ b/packages/app-shell/src/views/metadata-admin/useMetadata.ts
@@ -17,6 +17,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { MetadataClient, type MetadataDiagnosticsSummary, type MetadataDiagnosticsEntry } from '@object-ui/data-objectstack';
+import { usePreviewDrafts } from '../../preview/PreviewModeContext';
 
 /**
  * A declarative **type-level** action surfaced on a metadata type by the
@@ -90,14 +91,17 @@ export interface RichMetadataTypeEntry {
  * matching every other client in the app (see `apps/console/src/main.tsx`).
  */
 export function useMetadataClient(environmentId?: string): MetadataClient {
+  // ADR-0037: inside a draft-preview tree (?preview=draft), reads overlay
+  // pending drafts on the active registry. Writes are unaffected.
+  const previewDrafts = usePreviewDrafts();
   return useMemo(() => {
     const baseUrl =
       (typeof import.meta !== 'undefined' &&
         (import.meta as any).env?.VITE_SERVER_URL) ||
       '';
-    const c = new MetadataClient({ baseUrl });
+    const c = new MetadataClient({ baseUrl, previewDrafts });
     return environmentId ? c.withEnvironment(environmentId) : c;
-  }, [environmentId]);
+  }, [environmentId, previewDrafts]);
 }
 
 /**

--- a/packages/data-objectstack/src/metadata-client.test.ts
+++ b/packages/data-objectstack/src/metadata-client.test.ts
@@ -198,3 +198,68 @@ describe('MetadataClient', () => {
     expect(r2.seedApplied).toEqual({ success: true, inserted: 6, updated: 0 });
   });
 });
+
+describe('MetadataClient — ADR-0037 previewDrafts', () => {
+  function previewClient(opts: { previewDrafts?: boolean; environmentId?: string } = {}) {
+    const urls: string[] = [];
+    const c = new MetadataClient({
+      baseUrl: 'http://localhost:3000',
+      ...opts,
+      fetch: mockFetch(async (url) => {
+        urls.push(url);
+        return jsonResponse([{ name: 'account' }]);
+      }),
+    });
+    return { c, urls };
+  }
+
+  it('list() and get() append ?preview=draft when enabled', async () => {
+    const { c, urls } = previewClient({ previewDrafts: true });
+    await c.list('object');
+    await c.get('object', 'account');
+    expect(urls[0]).toBe('http://localhost:3000/api/v1/meta/object?preview=draft');
+    expect(urls[1]).toBe('http://localhost:3000/api/v1/meta/object/account?preview=draft');
+  });
+
+  it('combines preview with the package filter on list()', async () => {
+    const { c, urls } = previewClient({ previewDrafts: true });
+    await c.list('object', { packageId: 'app.crm' });
+    expect(urls[0]).toBe('http://localhost:3000/api/v1/meta/object?package=app.crm&preview=draft');
+  });
+
+  it('an explicit state=draft read wins over the overlay flag', async () => {
+    const { c, urls } = previewClient({ previewDrafts: true });
+    await c.get('object', 'account', { state: 'draft' });
+    expect(urls[0]).toBe('http://localhost:3000/api/v1/meta/object/account?state=draft');
+  });
+
+  it('default client never sends the flag', async () => {
+    const { c, urls } = previewClient();
+    await c.list('object');
+    await c.get('object', 'account');
+    expect(urls[0]).not.toContain('preview');
+    expect(urls[1]).not.toContain('preview');
+  });
+
+  it('withPreviewDrafts derives a preview client and PRESERVES the environment scope', async () => {
+    const { c } = previewClient({ environmentId: 'env_1' });
+    const p = c.withPreviewDrafts(true);
+    expect(p.previewDrafts).toBe(true);
+    // Same instance back when the flag already matches.
+    expect(p.withPreviewDrafts(true)).toBe(p);
+    // Environment-scoped path survives the derivation (regression guard:
+    // a naive rebuild dropped /environments/:id from the base).
+    const urls: string[] = [];
+    const scoped = new MetadataClient({
+      baseUrl: 'http://localhost:3000',
+      environmentId: 'env_1',
+      previewDrafts: false,
+      fetch: mockFetch(async (url) => {
+        urls.push(url);
+        return jsonResponse([]);
+      }),
+    }).withPreviewDrafts(true);
+    await scoped.list('object');
+    expect(urls[0]).toBe('http://localhost:3000/api/v1/environments/env_1/meta/object?preview=draft');
+  });
+});

--- a/packages/data-objectstack/src/metadata-client.ts
+++ b/packages/data-objectstack/src/metadata-client.ts
@@ -46,6 +46,15 @@ export interface MetadataClientConfig {
   fetch?: typeof fetch;
   /** Additional headers (e.g. auth) included on every request. */
   headers?: Record<string, string>;
+  /**
+   * ADR-0037 Live Canvas — render the world **as-if-published**. When true,
+   * `list()` and `get()` append `?preview=draft`, which the framework
+   * dispatcher maps to `getMetaItems/getMetaItem({ previewDrafts: true })`:
+   * pending ADR-0033 drafts overlay the active registry (draft wins by name,
+   * draft-only items surface). Reads only — writes are unaffected, and
+   * nothing the preview shows is live until Publish.
+   */
+  previewDrafts?: boolean;
 }
 
 export interface MetadataListOptions {
@@ -322,11 +331,14 @@ export class MetadataClient {
   private readonly base: string;
   private readonly fetchImpl: typeof fetch;
   private readonly headers: Record<string, string>;
+  /** ADR-0037: when true, reads render the draft-overlaid world. */
+  readonly previewDrafts: boolean;
 
   constructor(config: MetadataClientConfig) {
     this.base = buildBase(config);
     this.fetchImpl = config.fetch ?? globalThis.fetch.bind(globalThis);
     this.headers = { Accept: 'application/json', ...(config.headers ?? {}) };
+    this.previewDrafts = config.previewDrafts === true;
   }
 
   /** Update the client's environment scope at runtime. */
@@ -338,6 +350,28 @@ export class MetadataClient {
       environmentId,
       fetch: this.fetchImpl,
       headers: this.headers,
+      previewDrafts: this.previewDrafts,
+    });
+  }
+
+  /**
+   * Derive a client whose reads render the draft-overlaid world (or not).
+   * Same base/fetch/headers; used by the app-shell to switch the whole
+   * renderer tree into ADR-0037 preview mode off one URL flag.
+   */
+  withPreviewDrafts(previewDrafts: boolean): MetadataClient {
+    if (previewDrafts === this.previewDrafts) return this;
+    // Preserve the environment scope baked into the base path (unlike
+    // `withEnvironment`, which exists to REPLACE it).
+    const envMatch = this.base.match(/\/api\/v\d+\/environments\/([^/]+)\/meta$/);
+    return new MetadataClient({
+      baseUrl: this.base
+        .replace(/\/api\/v\d+(?:\/environments\/[^/]+)?\/meta$/, '')
+        .replace(/\/+$/, ''),
+      ...(envMatch ? { environmentId: decodeURIComponent(envMatch[1]) } : {}),
+      fetch: this.fetchImpl,
+      headers: this.headers,
+      previewDrafts,
     });
   }
 
@@ -362,9 +396,10 @@ export class MetadataClient {
 
   /** List items of a metadata type (e.g. `object`, `field`, `view`). */
   async list<T = unknown>(type: string, options: MetadataListOptions = {}): Promise<T[]> {
-    const qs = options.packageId
-      ? `?package=${encodeURIComponent(options.packageId)}`
-      : '';
+    const params: string[] = [];
+    if (options.packageId) params.push(`package=${encodeURIComponent(options.packageId)}`);
+    if (this.previewDrafts) params.push('preview=draft');
+    const qs = params.length ? `?${params.join('&')}` : '';
     const url = `${this.base}/${encodeURIComponent(type)}${qs}`;
     const res = await this.fetchImpl(url, { method: 'GET', headers: this.headers, cache: 'no-store' });
     if (!res.ok) throw await parseError(res);
@@ -411,7 +446,12 @@ export class MetadataClient {
     name: string,
     options: MetadataGetOptions = {},
   ): Promise<T | null> {
-    const qs = options.state === 'draft' ? '?state=draft' : '';
+    const params: string[] = [];
+    if (options.state === 'draft') params.push('state=draft');
+    // `state=draft` reads the raw draft row explicitly; the overlay flag is
+    // redundant (and the dispatcher resolves `state` first), so skip it.
+    else if (this.previewDrafts) params.push('preview=draft');
+    const qs = params.length ? `?${params.join('&')}` : '';
     const url = `${this.base}/${encodeURIComponent(type)}/${encodeURIComponent(name)}${qs}`;
     const res = await this.fetchImpl(url, { method: 'GET', headers: this.headers, cache: 'no-store' });
     if (res.status === 404) return null;

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -19,7 +19,7 @@
  */
 import * as React from 'react';
 import { cn } from '@object-ui/components';
-import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, Eye, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import type { ChatStatus } from 'ai';
 import {
   humanizeToolName,
@@ -358,6 +358,22 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   onOpenBuiltApp?: (appName: string) => void;
   /** Label for the open-built-app action (default "Open app"). */
   openBuiltAppLabel?: string;
+  /**
+   * ADR-0037 Live Canvas: preview the drafted app *before* it is published.
+   * Rendered next to the build tree's Open-app action and on draft chips
+   * whose items include an `app`. The host wires this to its router with the
+   * preview flag (e.g. `navigate('/apps/<name>?preview=draft')`).
+   */
+  onPreviewDraftApp?: (appName: string) => void;
+  /** Label for the preview-draft action (default "Preview"). */
+  previewDraftLabel?: string;
+  /**
+   * ADR-0037 Live Canvas: notifies the host whenever AI-authored draft
+   * artifacts land in the conversation (build-progress items + drafted
+   * envelopes), with the cumulative deduped set. Hosts use it to open and
+   * refresh the live draft-preview pane while the agent builds.
+   */
+  onDraftArtifacts?: (artifacts: Array<{ type: string; name: string }>) => void;
   /** Label for the publish-drafts button (default "Publish"). */
   publishDraftsLabel?: string;
   /** Label for the published-state badge that replaces the button (default "Published"). */
@@ -681,6 +697,9 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       onPublishDrafts,
       onOpenBuiltApp,
       openBuiltAppLabel = 'Open app',
+      onPreviewDraftApp,
+      previewDraftLabel = 'Preview',
+      onDraftArtifacts,
       publishDraftsLabel = 'Publish',
       publishedLabel = 'Published',
       autoPublishDrafts = false,
@@ -822,6 +841,35 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       // One publish per distinct package, even if a turn made several build calls.
       for (const pkg of [...new Set(fresh.map((b) => b.packageId))]) void handlePublishDrafts(pkg);
     }, [messages, isLoading, autoPublishDrafts, onPublishDrafts, handlePublishDrafts]);
+
+    // ADR-0037 Live Canvas: surface every AI-authored draft artifact to the
+    // host as it lands — both the streaming build tree's items and drafted
+    // envelopes. Deduped cumulatively; the callback fires only when the set
+    // actually grows, so hosts can refresh a preview pane without storms.
+    const draftArtifactKeysRef = React.useRef<Set<string>>(new Set());
+    React.useEffect(() => {
+      if (!onDraftArtifacts) return;
+      const artifacts = new Map<string, { type: string; name: string }>();
+      for (const message of messages) {
+        for (const item of message.buildProgress?.items ?? []) {
+          if (item?.type && item?.name) artifacts.set(`${item.type}:${item.name}`, item);
+        }
+        for (const tool of message.toolInvocations ?? []) {
+          for (const item of tool.draftReview?.items ?? []) {
+            if (item?.type && item?.name) artifacts.set(`${item.type}:${item.name}`, item);
+          }
+        }
+      }
+      const seen = draftArtifactKeysRef.current;
+      let grew = false;
+      for (const key of artifacts.keys()) {
+        if (!seen.has(key)) {
+          seen.add(key);
+          grew = true;
+        }
+      }
+      if (grew) onDraftArtifacts([...artifacts.values()]);
+    }, [messages, onDraftArtifacts]);
 
     const handleSubmit = React.useCallback(
       (payload: PromptInputMessage) => {
@@ -1003,6 +1051,25 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                       {toolReviewLabel(tool.draftReview.items.length)}
                     </button>
                   ) : null}
+                  {/* ADR-0037: drafted-app preview — see it as-if-published
+                      without publishing. Only when the draft set includes an
+                      app (the canvas previews whole apps, not single items). */}
+                  {onPreviewDraftApp && !publishedToolCalls.has(tool.toolCallId)
+                    ? (() => {
+                        const app = tool.draftReview!.items.find((i) => i.type === 'app');
+                        return app ? (
+                          <button
+                            type="button"
+                            onClick={() => onPreviewDraftApp(app.name)}
+                            className="inline-flex h-7 items-center gap-1.5 rounded-md border px-3 text-xs font-medium hover:bg-muted"
+                            data-testid="draft-preview-app"
+                          >
+                            <Eye className="size-3.5" />
+                            {previewDraftLabel}
+                          </button>
+                        ) : null;
+                      })()
+                    : null}
                   {tool.draftReview.summary ? (
                     <span className="truncate text-xs text-muted-foreground">
                       {tool.draftReview.summary}
@@ -1153,6 +1220,8 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                           progress={buildProgress}
                           onOpenBuiltApp={onOpenBuiltApp}
                           openBuiltAppLabel={openBuiltAppLabel}
+                          onPreviewDraftApp={onPreviewDraftApp}
+                          previewDraftLabel={previewDraftLabel}
                         />
                       ) : null}
                       {!isUser && processVisibility === 'debug' && reasoning ? (
@@ -1445,10 +1514,14 @@ function BuildProgressPanel({
   progress,
   onOpenBuiltApp,
   openBuiltAppLabel = 'Open app',
+  onPreviewDraftApp,
+  previewDraftLabel = 'Preview',
 }: {
   progress: ChatBuildProgress;
   onOpenBuiltApp?: (appName: string) => void;
   openBuiltAppLabel?: string;
+  onPreviewDraftApp?: (appName: string) => void;
+  previewDraftLabel?: string;
 }) {
   const { phase, appLabel, items, done, total } = progress;
   const isDone = phase === 'done';
@@ -1499,17 +1572,31 @@ function BuildProgressPanel({
           );
         })}
       </ul>
-      {isDone && builtApp && onOpenBuiltApp ? (
-        <div className="mt-3">
-          <button
-            type="button"
-            onClick={() => onOpenBuiltApp(builtApp.name)}
-            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
-            data-testid="build-progress-open-app"
-          >
-            {openBuiltAppLabel}
-            <ArrowRight className="size-3.5" />
-          </button>
+      {isDone && builtApp && (onOpenBuiltApp || onPreviewDraftApp) ? (
+        <div className="mt-3 flex items-center gap-2">
+          {onOpenBuiltApp ? (
+            <button
+              type="button"
+              onClick={() => onOpenBuiltApp(builtApp.name)}
+              className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+              data-testid="build-progress-open-app"
+            >
+              {openBuiltAppLabel}
+              <ArrowRight className="size-3.5" />
+            </button>
+          ) : null}
+          {/* ADR-0037: see the drafted app as-if-published, before Publish. */}
+          {onPreviewDraftApp ? (
+            <button
+              type="button"
+              onClick={() => onPreviewDraftApp(builtApp.name)}
+              className="inline-flex h-7 items-center gap-1.5 rounded-md border px-3 text-xs font-medium hover:bg-muted"
+              data-testid="build-progress-preview-app"
+            >
+              <Eye className="size-3.5" />
+              {previewDraftLabel}
+            </button>
+          ) : null}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Implements [ADR-0037](https://github.com/objectstack-ai/framework/pull/1694) Phases 1+2: the magic moment stops being a progress bar and becomes **the app itself, taking shape on screen while you talk** — rendered from the ADR-0033 draft overlay, so what you see is exactly what Publish will make real.

## Phase 1 — static draft preview
- `MetadataClient.previewDrafts` → `list()`/`get()` append `?preview=draft` (both dispatcher endpoints already honor it); `withPreviewDrafts()` derives a preview client **preserving environment scope** (regression-tested).
- `PreviewModeContext` keyed off the URL; mounted in `ConnectedShell` ABOVE `MetadataProvider` so the whole renderer tree flips with one flag. `force` prop reserved for embedded canvas subtrees.
- `MetadataProvider`: preview reads go through the overlay endpoints (SDK meta API doesn't carry the flag); the published and draft worlds never mix — full cache clear on mode flip, draft apps never written to the published session cache.
- `DraftPreviewBar`: unmistakable amber watermark with one-click **Exit** and one-click **Publish** — publish logic extracted from the Home banner into shared `usePublishAllDrafts` (probed package path + by-ref fallback + health toasts), so both surfaces stay in lockstep.
- Chat entry: **Preview** button on the finished build tree and on draft chips whose items include an `app`.

## Phase 2 — event-driven live canvas
- `ChatbotEnhanced.onDraftArtifacts`: deduped cumulative signal of every draft artifact (streaming `buildProgress` items + `drafted` envelopes) — fires only when the set grows.
- `LiveCanvas` split view in `AiChatPage`: chat left (~42%), the drafted app right, rendered via an **iframe onto `/apps/:name?preview=draft`** — the existing renderers in preview mode through a route a user could open by hand. No second renderer, no canvas-only store, canvas never edits in place (ADR-0037 boundary rules). Pane opens automatically when a build drafts an `app`; invalidations coalesce (800 ms) into an in-place frame reload, so the app grows artifact-by-artifact during `apply_blueprint`.

## Tests
- 5 new `MetadataClient` preview cases (flag on list/get, package-filter combination, `state=draft` precedence, default-off, env-scope preservation through `withPreviewDrafts`)
- Suites green: data-objectstack 164/164, plugin-chatbot 65/65, app-shell 404/404; workspace build green

## Known follow-ups (Phase 2.5 / 3 per ADR)
- assistantBus canvas-invalidate → MetadataProvider for the floating-chat-while-previewing case (same-document refresh without reload)
- Phase 3 draft **data** preview (framework: seed-overlay dataset queries) — unpublished objects currently render with empty tables (structure-WYSIWYG, by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)