### PR TITLE
feat: ADR-0037 P3 client + P2.5 — preview dataset queries + same-document live refresh

### DIFF
--- a/packages/app-shell/src/assistant/assistantBus.ts
+++ b/packages/app-shell/src/assistant/assistantBus.ts
@@ -113,6 +113,35 @@ export const assistantBus = {
   },
 };
 
+// ── ADR-0037 P2.5 — canvas invalidations ───────────────────────────────────
+// The chat announces "this draft artifact just changed"; preview surfaces in
+// the SAME document (a page open on ?preview=draft while the floating chat
+// edits) subscribe and refetch the affected type. Kept OFF the snapshot bus:
+// invalidations are fire-and-forget events, not state — putting them in the
+// snapshot would re-render every useAssistant consumer per artifact.
+
+export interface CanvasInvalidation {
+  type: string;
+  name: string;
+}
+
+const invalidateListeners = new Set<(inv: CanvasInvalidation) => void>();
+
+/** Announce that a draft artifact changed (chat hosts call this). */
+export function emitCanvasInvalidate(inv: CanvasInvalidation): void {
+  for (const l of invalidateListeners) l(inv);
+}
+
+/** Subscribe to draft-artifact invalidations; returns an unsubscriber. */
+export function subscribeCanvasInvalidate(
+  listener: (inv: CanvasInvalidation) => void,
+): () => void {
+  invalidateListeners.add(listener);
+  return () => {
+    invalidateListeners.delete(listener);
+  };
+}
+
 /** Subscribe a component to the assistant bus snapshot. */
 export function useAssistant(): AssistantSnapshot {
   return useSyncExternalStore(

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -41,7 +41,7 @@ import {
   writeConversationMessagesCache,
   type HydratedUIMessage,
 } from '../hooks';
-import { useAssistant, requestAssistantReview, type AssistantEditorContext } from '../assistant/assistantBus';
+import { useAssistant, requestAssistantReview, emitCanvasInvalidate, type AssistantEditorContext } from '../assistant/assistantBus';
 import { getRuntimeConfig } from '../runtime-config';
 
 /**
@@ -513,6 +513,11 @@ function ChatbotInner({
         // ADR-0037: see the drafted app as-if-published before Publish — same
         // route, draft overlay, watermark bar on top.
         onPreviewDraftApp={(appName) => navigate(`/apps/${encodeURIComponent(appName)}?preview=draft`)}
+        // ADR-0037 P2.5: announce drafted artifacts so an open ?preview=draft
+        // page (same document) drops its cache and refetches the new draft.
+        onDraftArtifacts={(artifacts) => {
+          for (const a of artifacts) emitCanvasInvalidate(a);
+        }}
         onPublishDrafts={async (packageId) => {
           // ADR-0033 — promote the conversation's staged drafts to live in one
           // click (the human still confirms here). Mirrors PackagesPage's

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -10,6 +10,7 @@ import { MetadataClient, type ObjectStackAdapter } from '@object-ui/data-objects
 import { resolveInlineMode } from '@object-ui/plugin-form';
 import { MetadataCtx, useMetadata, type MetadataContextValue, type MetadataState } from '@object-ui/react';
 import { usePreviewDrafts } from '../preview/PreviewModeContext';
+import { subscribeCanvasInvalidate } from '../assistant/assistantBus';
 
 export type { MetadataState, MetadataContextValue };
 export { useMetadataItem } from '@object-ui/react';
@@ -515,6 +516,17 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
     },
     [bump],
   );
+
+  // ADR-0037 P2.5 — same-document live refresh: while this tree renders the
+  // draft overlay, chat hosts announce each drafted artifact on the assistant
+  // bus; drop that type's cache entry so the next read refetches the updated
+  // draft world. Published-mode trees ignore the events entirely.
+  useEffect(() => {
+    if (!previewDrafts) return;
+    return subscribeCanvasInvalidate(({ type }) => {
+      invalidate(type);
+    });
+  }, [previewDrafts, invalidate]);
 
   const [initialLoading, setInitialLoading] = useState(true);
   const [initialError, setInitialError] = useState<Error | null>(null);

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1827,9 +1827,18 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     await this.connect();
     const base = (this.baseUrl || '').replace(/\/$/, '');
     const url = `${base}/api/v1/analytics/dataset/query`;
+    // ADR-0037 P3 — draft data preview. Preview mode is URL-keyed by design
+    // (`?preview=draft` flips the whole document, incl. the Live Canvas
+    // iframe), so the adapter reads it straight off the location rather than
+    // threading a React context down through every widget package. When set,
+    // the server overlays the pending seed draft's rows on the dataset query
+    // and resolves draft-overlaid dataset definitions.
+    const previewDrafts =
+      typeof window !== 'undefined' &&
+      new URLSearchParams(window.location.search).get('preview') === 'draft';
     const requestBody = typeof dataset === 'string'
-      ? { datasetName: dataset, selection }
-      : { dataset, selection };
+      ? { datasetName: dataset, selection, ...(previewDrafts ? { previewDrafts: true } : {}) }
+      : { dataset, selection, ...(previewDrafts ? { previewDrafts: true } : {}) };
 
     const res = await this.fetchImpl(url, {
       method: 'POST',


### PR DESCRIPTION
Client half of [framework#1726](https://github.com/objectstack-ai/framework/pull/1726) (ADR-0037 Phase 3) + the P2.5 follow-up from [#1639](https://github.com/objectstack-ai/objectui/pull/1639).

## P3 — preview dataset queries
`queryDataset` (data-objectstack adapter) sends `previewDrafts: true` when the document is in draft-preview mode. Read straight off `window.location.search` — preview is **URL-keyed by design** (one flag flips the whole document, including the Live Canvas iframe), so every `DatasetWidget` in any preview surface sends it automatically with zero context-threading through widget packages. Server side (framework#1726) overlays the pending seed draft's rows → **drafted dashboards chart real numbers before publish**, continuous across the gate.

## P2.5 — same-document live refresh
- `assistantBus`: `emitCanvasInvalidate` / `subscribeCanvasInvalidate` — fire-and-forget events kept OFF the snapshot (no useAssistant re-render storms).
- `ConsoleFloatingChatbot` announces every drafted artifact (reusing `onDraftArtifacts` from #1639).
- `MetadataProvider` (draft-preview mode ONLY) drops the announced type's cache → the open `?preview=draft` page refetches in place while you talk to the floating chat. Published-mode trees ignore the events.

## Tests
Suites green: app-shell 404/404, data-objectstack 164/164; workspace build green. (The seed-overlay math itself is covered by framework#1726's 9 cases.)

Activation: cloud pin bump for BOTH framework + objectui follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)