### PR TITLE
fix(app-shell): Live Canvas iframe carries the SPA basename (draft preview 404 on /_console)

### DIFF
--- a/packages/app-shell/src/console/ai/LiveCanvas.tsx
+++ b/packages/app-shell/src/console/ai/LiveCanvas.tsx
@@ -32,6 +32,16 @@ export interface LiveCanvasProps {
   onClose: () => void;
 }
 
+/**
+ * The SPA's mount prefix for ABSOLUTE urls (the iframe bypasses the router's
+ * basename, unlike navigate()). The console ships under `/_console`; bare
+ * mounts (tests, custom hosts) fall back to ''.
+ */
+function spaBase(): string {
+  if (typeof window === 'undefined') return '';
+  return window.location.pathname.startsWith('/_console') ? '/_console' : '';
+}
+
 export function LiveCanvas({ appName, refreshKey, onClose }: LiveCanvasProps) {
   const { t } = useObjectTranslation();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -65,7 +75,7 @@ export function LiveCanvas({ appName, refreshKey, onClose }: LiveCanvasProps) {
       <iframe
         ref={iframeRef}
         title={`Draft preview: ${appName}`}
-        src={`/apps/${encodeURIComponent(appName)}?preview=draft`}
+        src={`${spaBase()}/apps/${encodeURIComponent(appName)}?preview=draft`}
         className="h-full w-full flex-1 border-0 bg-background"
         data-testid="live-canvas-frame"
       />


### PR DESCRIPTION
Staging acceptance of [#1639](https://github.com/objectstack-ai/objectui/pull/1639) caught this: the canvas pane opened correctly when the agent drafted an app, but rendered `{"error":"Not found"}` — the iframe's ABSOLUTE `src` (`/apps/:name?preview=draft`) bypasses the router basename, so on the standard `/_console` mount it hit the server raw. In-chat `navigate()` calls were unaffected (router-relative).

Fix: prefix the iframe src with the SPA mount (`/_console` detected from `location.pathname`, `''` on bare mounts). app-shell suite 404/404, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)