### PR TITLE
fix(app-shell): New chat — URL mirror bounced on in-SPA ?new=1 navigation (stale-closure race)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -221,10 +221,29 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     [apiBase],
   );
 
+  // New-conversation race guard. On an IN-SPA `/ai?new=1` navigation the
+  // URL-mirroring effect below fires in the SAME commit as the hook's effect,
+  // with this render's (stale) `conversationId` still in its closure — the
+  // hook's setConversationId(undefined) hasn't re-rendered yet. Unguarded, it
+  // bounced straight back to `/ai/:oldId` and stripped the flag before the
+  // fresh conversation existed (the New button looked like a no-op; a full
+  // page load on the same URL worked because state starts empty). Snapshot
+  // the id visible when the flag appears — a RENDER-phase ref write, so it's
+  // set before any effect of this commit runs — and refuse to mirror that
+  // exact id while the flag is up. The fresh id differs, mirrors normally,
+  // and the navigation strips `?new=1`, which resets the snapshot.
+  const staleNewTargetRef = useRef<{ id: string | undefined } | null>(null);
+  if (forceNewConversation) {
+    if (staleNewTargetRef.current === null) staleNewTargetRef.current = { id: conversationId };
+  } else {
+    staleNewTargetRef.current = null;
+  }
+
   // After the hook resolves a real id for a fresh `/ai` visit, mirror it into
   // the URL so the sidebar's active-row + share/refresh both work.
   useEffect(() => {
     if (!urlConversationId && conversationId) {
+      if (staleNewTargetRef.current && staleNewTargetRef.current.id === conversationId) return;
       navigate(`/ai/${conversationId}`, { replace: true });
     }
   }, [urlConversationId, conversationId, navigate]);


### PR DESCRIPTION
User-reproduced on staging: clicking **New** in the chat sidebar bounced straight back to the previous conversation (`/_console/ai/conv_…`). [#1638](https://github.com/objectstack-ai/objectui/pull/1638)'s fix held for full page loads (state starts empty) but not the button's in-SPA navigation: at the `/ai?new=1` commit, the URL-mirroring effect still holds the **stale** `conversationId` in its render closure — the hook's `setConversationId(undefined)` hasn't re-rendered yet — so it rewrote `/ai/:oldId` and stripped the flag before the fresh conversation existed.

**Fix:** snapshot the id visible at the moment the flag appears (a render-phase ref write — set before any effect of that commit runs) and refuse to mirror that exact id while `?new=1` is up. The fresh id differs → mirrors normally → navigation strips the flag → snapshot resets. Covers repeat-New and direct-URL cases.

app-shell suite 409/409, build green. Will verify on staging with the user's exact repro after the pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)