### PR TITLE
fix(chatbot): terminalize tool states on historical turns — no more permanent 'Running'

### DIFF
--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -82,15 +82,52 @@ describe('uiMessageToChatMessage', () => {
     expect(out.toolInvocations?.[0]?.state).toBe('output-available');
   });
 
-  it('keeps input-available when there is genuinely no output yet (live stream)', () => {
+  it('keeps input-available when there is genuinely no output yet AND this is the live streaming tail', () => {
+    const out = uiMessageToChatMessage(
+      {
+        id: 'm-live',
+        role: 'assistant',
+        parts: [
+          { type: 'tool-apply_blueprint', toolCallId: 'call_c', state: 'input-available', input: {} },
+        ],
+      },
+      { streaming: true },
+    );
+    expect(out.toolInvocations?.[0]?.state).toBe('input-available');
+  });
+
+  it('promotes a dangling input-available to Completed on a NON-streaming (historical) message, even without an output', () => {
+    // The real staging incident: a reloaded build conversation showed every
+    // tool stuck on "Running" because the server never snapshotted terminal
+    // tool states. A tool in a turn that has ENDED cannot still be running.
     const out = uiMessageToChatMessage({
-      id: 'm-live',
+      id: 'm-history',
       role: 'assistant',
       parts: [
-        { type: 'tool-apply_blueprint', toolCallId: 'call_c', state: 'input-available', input: {} },
+        { type: 'tool-add_field', toolCallId: 'call_d', state: 'input-available', input: {} },
+        { type: 'tool-verify_build', toolCallId: 'call_e', state: 'input-streaming', input: {} },
       ],
     });
-    expect(out.toolInvocations?.[0]?.state).toBe('input-available');
+    expect(out.toolInvocations?.[0]?.state).toBe('output-available');
+    expect(out.toolInvocations?.[1]?.state).toBe('output-available');
+  });
+
+  it('uiMessagesToChatMessages: only the streaming tail keeps a tool Running; prior messages terminalize', () => {
+    const msgs = [
+      {
+        id: 'm-prior',
+        role: 'assistant',
+        parts: [{ type: 'tool-create_object', toolCallId: 'c1', state: 'input-available', input: {} }],
+      },
+      {
+        id: 'm-tail',
+        role: 'assistant',
+        parts: [{ type: 'tool-add_field', toolCallId: 'c2', state: 'input-available', input: {} }],
+      },
+    ];
+    const out = uiMessagesToChatMessages(msgs as never, { isStreaming: true });
+    expect(out[0].toolInvocations?.[0]?.state).toBe('output-available'); // prior turn → terminalized
+    expect(out[1].toolInvocations?.[0]?.state).toBe('input-available');  // live tail → still Running
   });
 
   it('preserves legacy msg.toolInvocations when no tool-* parts are present', () => {

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -170,7 +170,10 @@ function detectDraftResult(
   };
 }
 
-function extractToolInvocations(parts: AnyPart[]): ChatToolInvocation[] {
+function extractToolInvocations(
+  parts: AnyPart[],
+  opts: { liveTail?: boolean } = {},
+): ChatToolInvocation[] {
   return parts
     .filter((p) => {
       if (p.type === 'dynamic-tool') return true;
@@ -186,14 +189,19 @@ function extractToolInvocations(parts: AnyPart[]): ChatToolInvocation[] {
       const result = p.output ?? p.result;
       const pending = detectPendingApproval(result);
       const draftReview = detectDraftResult(result);
-      // A part persisted mid-stream can carry a stale `input-*` state next to a
-      // present output (the terminal state wasn't snapshotted) — a reloaded
-      // conversation would then show "Running" forever. Output present = the
-      // call finished; promote so the badge reads Completed.
+      // Promote a dangling `input-*` state to a terminal one so a reloaded
+      // conversation never shows "Running" forever (the server doesn't always
+      // snapshot the terminal tool state). Two cases:
+      //   1. output present → the call finished → Completed.
+      //   2. NOT the live streaming tail → the turn that drove this tool has
+      //      ENDED, so it cannot still be running, output-snapshot or not.
+      // Only the actively-streaming trailing assistant message (`liveTail`)
+      // may legitimately keep a tool spinning; everything else is history.
       const persistedState = p.state;
+      const isDanglingInput =
+        persistedState === 'input-available' || persistedState === 'input-streaming';
       const baseState: ChatToolInvocation['state'] =
-        (persistedState === 'input-available' || persistedState === 'input-streaming') &&
-        result !== undefined
+        isDanglingInput && (result !== undefined || !opts.liveTail)
           ? 'output-available'
           : persistedState;
       // Promote pending HITL results to `approval-requested` so the UI
@@ -266,7 +274,9 @@ export function uiMessageToChatMessage(
   opts: { streaming?: boolean } = {},
 ): ChatMessage {
   const parts = Array.isArray(msg.parts) ? msg.parts : [];
-  const tools = extractToolInvocations(parts);
+  // Only the live streaming tail may keep tools in a "Running" state; for any
+  // other (historical) message a dangling tool state is stale by definition.
+  const tools = extractToolInvocations(parts, { liveTail: opts.streaming });
   const legacyTools = Array.isArray(msg.toolInvocations) ? msg.toolInvocations : [];
   return {
     id: (msg.id ?? `msg-${Math.random().toString(36).slice(2, 8)}`) as string,


### PR DESCRIPTION
User-reported on staging: a reloaded build conversation showed **every tool stuck on "Running"** — Propose blueprint, Create object, Add field, Verify build, all 16+ of them — making a finished (if messy) build look completely hung.

## Root cause
The server doesn't always snapshot the *terminal* tool state, so persisted parts keep their mid-stream `input-available`/`input-streaming` state. `mapMessages` only promoted those to Completed **when an output was also present** — but many persisted parts have no output snapshot either, so they showed the live "Running" spinner forever.

## Fix
A tool whose turn has **ended** cannot still be running, output or not. Only the **live streaming tail** (`opts.streaming` — the trailing assistant message during an in-flight stream) may legitimately keep a tool spinning; every other message is history. `extractToolInvocations` now takes `liveTail` and terminalizes a dangling `input-*` to `output-available` whenever it's *not* the live tail (or an output is present).

## Tests
The prior "keeps input-available with no output (live stream)" test was actually asserting the bug — it never passed the streaming flag. Updated to a genuine live-tail case, plus new historical-message and multi-message (only-the-tail-spins) cases. plugin-chatbot 67/67, build green.

Note: this fixes the *display*. The underlying server-side terminal-state persistence gap remains (tracked separately); this makes the client honest regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)