### PR TITLE
feat(report): true matrix cross-tab + dataset drill-down (ADR-0021 D2)

### DIFF
--- a/.changeset/dataset-matrix-pivot-drill.md
+++ b/.changeset/dataset-matrix-pivot-drill.md
@@ -1,0 +1,10 @@
+---
+"@object-ui/plugin-report": minor
+"@object-ui/app-shell": minor
+---
+
+ADR-0021 D2: true matrix cross-tab + dataset-path drill-down.
+
+- DatasetReportRenderer pivots `type: 'matrix'` reports into a real rows × columns cross-tab (one dataset query over all dimensions, pivoted client-side; matrix without `columns` degrades to the flat grouped table). Joined blocks pivot too.
+- Drill-down: aggregated rows / matrix cells are clickable when the host passes `onDrill` (and the report doesn't set `drilldown: false`), emitting `{dataset, groupKey, runtimeFilter}`. ReportView resolves the dataset's object + dimension→field mapping (reverse-mapping select option labels back to stored values) and navigates to the object list scoped by `?filter[field]=value`.
+- Studio: the report inspector gains a Columns (across dimensions) list for matrix reports; ReportPreview renders through the same DatasetReportRenderer as the runtime, so the matrix preview is WYSIWYG.

--- a/packages/app-shell/src/chrome/CommandPalette.tsx
+++ b/packages/app-shell/src/chrome/CommandPalette.tsx
@@ -27,7 +27,6 @@ import {
   Sun,
   Monitor,
   Search,
-  Plus,
 } from 'lucide-react';
 import { useRecordSearch } from '@object-ui/react';
 import { useTheme } from './ThemeProvider';
@@ -319,13 +318,7 @@ export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSour
         {/* Full Search Page */}
         <CommandSeparator />
         <CommandGroup heading={t('console.commandPalette.actions')}>
-          <CommandItem
-            value="create new app application"
-            onSelect={() => runCommand(() => navigate(`${baseUrl}/create-app`))}
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            <span>{t('console.commandPalette.createApp')}</span>
-          </CommandItem>
+          {/* Manual "Create App" deprecated — AI-first builder is the path. */}
           <CommandItem
             value="search all results full page"
             onSelect={() => runCommand(() => navigate(`${baseUrl}/search`))}

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -27,7 +27,7 @@ import { AppCard } from './AppCard';
 import { RecentApps } from './RecentApps';
 import { StarredApps } from './StarredApps';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
-import { Plus, Settings, Sparkles, Star, Clock, ArrowDown, Store, LayoutGrid, ShieldAlert, X, UploadCloud } from 'lucide-react';
+import { Sparkles, Star, Clock, ArrowDown, Store, LayoutGrid, ShieldAlert, X, UploadCloud } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
 import { toast } from 'sonner';
@@ -250,35 +250,42 @@ export function HomePage() {
         <PendingDraftsBanner t={t} />
         <RecoveryPasswordReminder t={t} />
         <div className="flex flex-1 items-center justify-center p-6">
-        <Empty>
-          <EmptyTitle>{t('home.welcome', { defaultValue: 'Welcome to ObjectUI' })}</EmptyTitle>
-          <EmptyDescription>
-            {t('home.welcomeDescription', {
-              defaultValue:
-                'Get started by creating your first application or configure your system settings.',
-            })}
-          </EmptyDescription>
-          <div className="mt-6 flex flex-col sm:flex-row items-center gap-3">
-            {/*
-              AI-first magic moment: the primary CTA deep-links into the AI
-              workspace preselecting the metadata-authoring agent, so a brand-new
-              user goes straight from "describe your business" to a generated
-              backend. Manual create / settings stay as secondary paths.
-            */}
-            <Button onClick={() => navigate('/ai?agent=metadata_assistant')} data-testid="build-with-ai-btn">
-              <Sparkles className="mr-2 h-4 w-4" />
-              {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
-            </Button>
-            <Button variant="outline" onClick={() => navigate('/create-app')} data-testid="create-first-app-btn">
-              <Plus className="mr-2 h-4 w-4" />
-              {t('home.createFirstApp', { defaultValue: 'Create Your First App' })}
-            </Button>
-            <Button variant="outline" onClick={() => navigate('/apps/setup')} data-testid="go-to-settings-btn">
-              <Settings className="mr-2 h-4 w-4" />
-              {t('home.systemSettings', { defaultValue: 'System Settings' })}
-            </Button>
-          </div>
-        </Empty>
+        {/*
+          Role-aware empty state. ADMINS get the AI-first magic moment as the
+          single primary CTA — "describe your business" → generated backend.
+          System administration is one click away in the left "Administration"
+          nav (UnifiedSidebar), so we no longer crowd the center with a System
+          Settings button, and manual "Create App" is deprecated entirely.
+          NON-ADMINS can't author the workspace, so they get a quiet "no apps
+          yet — ask your admin" state instead of build CTAs they can't use.
+        */}
+        {isAdmin ? (
+          <Empty>
+            <EmptyTitle>{t('home.welcome', { defaultValue: 'Welcome to ObjectUI' })}</EmptyTitle>
+            <EmptyDescription>
+              {t('home.welcomeAdminDescription', {
+                defaultValue:
+                  'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or set things up yourself from the Administration menu on the left.',
+              })}
+            </EmptyDescription>
+            <div className="mt-6 flex flex-col sm:flex-row items-center gap-3">
+              <Button onClick={() => navigate('/ai?agent=metadata_assistant')} data-testid="build-with-ai-btn">
+                <Sparkles className="mr-2 h-4 w-4" />
+                {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
+              </Button>
+            </div>
+          </Empty>
+        ) : (
+          <Empty>
+            <EmptyTitle>{t('home.noAppsTitle', { defaultValue: 'No applications yet' })}</EmptyTitle>
+            <EmptyDescription>
+              {t('home.noAppsDescription', {
+                defaultValue:
+                  'There are no applications available to you yet. Please contact your workspace administrator.',
+              })}
+            </EmptyDescription>
+          </Empty>
+        )}
         </div>
       </div>
     );

--- a/packages/app-shell/src/console/home/QuickActions.tsx
+++ b/packages/app-shell/src/console/home/QuickActions.tsx
@@ -10,7 +10,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Card, CardContent } from '@object-ui/components';
-import { Plus, Settings, Database, ArrowUpRight } from 'lucide-react';
+import { Settings, Database, ArrowUpRight } from 'lucide-react';
 import { cn } from '@object-ui/components';
 
 interface QuickAction {
@@ -28,17 +28,9 @@ export function QuickActions() {
   const navigate = useNavigate();
   const { t } = useObjectTranslation();
 
+  // Manual "Create App" deprecated — the AI-first builder (Build with AI on
+  // /home) is the path to a new application.
   const actions: QuickAction[] = [
-    {
-      id: 'create-app',
-      label: t('home.quickActions.createApp', { defaultValue: 'Create App' }),
-      description: t('home.quickActions.createAppDesc', { defaultValue: 'Start with a new application' }),
-      icon: Plus,
-      href: '/create-app',
-      iconBg: 'bg-gradient-to-br from-blue-500/15 to-indigo-500/10 ring-blue-500/20',
-      iconText: 'text-blue-600 dark:text-blue-400',
-      hoverBorder: 'hover:border-blue-500/40',
-    },
     {
       id: 'manage-objects',
       label: t('home.quickActions.manageObjects', { defaultValue: 'Manage Objects' }),

--- a/packages/app-shell/src/layout/AppSidebar.tsx
+++ b/packages/app-shell/src/layout/AppSidebar.tsx
@@ -289,7 +289,9 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
       { id: 'sys-orgs', label: t('layout.systemNav.organizations', { defaultValue: 'Organizations' }), type: 'url' as const, url: '/apps/setup/system/organizations', icon: 'building-2' },
       { id: 'sys-roles', label: t('layout.systemNav.roles', { defaultValue: 'Roles' }), type: 'url' as const, url: '/apps/setup/system/roles', icon: 'shield' },
       { id: 'sys-config', label: t('layout.systemNav.configuration', { defaultValue: 'Configuration' }), type: 'url' as const, url: '/apps/setup/system/settings', icon: 'sliders-horizontal' },
-      { id: 'sys-create-app', label: t('layout.systemNav.createApp', { defaultValue: 'Create App' }), type: 'url' as const, url: '/create-app', icon: 'plus' },
+      // Manual "Create App" is deprecated in favour of the AI-first builder
+      // (Build with AI on /home). Entry point removed; the /create-app route
+      // remains reachable directly for any legacy deep links.
     );
     return items;
   }, [isWorkspaceAdmin, t]);

--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -43,7 +43,7 @@ import type { NavigationItem } from '@object-ui/types';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useExpressionContext, evaluateVisibility } from '../providers/ExpressionProvider';
 import { usePermissions } from '@object-ui/permissions';
-import { useAuth } from '@object-ui/auth';
+import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useRecentItems } from '../hooks/useRecentItems';
 import { useFavorites } from '../hooks/useFavorites';
 import { useNavPins } from '../hooks/useNavPins';
@@ -151,6 +151,7 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
   const { objectLabel: resolveNavObjectLabel, dashboardLabel: resolveNavDashboardLabel, navGroupLabel: resolveNavGroupLabel, viewLabel: resolveNavViewLabel } = useObjectLabel();
   const { context, currentAppName } = useNavigationContext();
   const { user } = useAuth();
+  const isWorkspaceAdmin = useIsWorkspaceAdmin();
 
   // Swipe-from-left-edge gesture to open sidebar on mobile
   React.useEffect(() => {
@@ -215,10 +216,37 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
     t,
   );
 
-  // Home navigation items
-  const homeNavigation: NavigationItem[] = React.useMemo(() => [
-    { id: 'home-dashboard', label: t('home.nav', { defaultValue: 'Home' }), type: 'url' as const, url: '/home', icon: 'home' },
-  ], [t]);
+  // Home navigation items. For workspace admins we surface the full system
+  // ("Administration") nav right here on /home — previously the home context
+  // showed ONLY a "Home" link, so a fresh env (no apps yet) rendered a bare
+  // centered page with the real menu nowhere in sight. Mirrors AppSidebar's
+  // `systemFallbackNavigation` (sans the deprecated manual "Create App").
+  // Non-admins get just Home — system administration is owner/admin-gated.
+  const homeNavigation: NavigationItem[] = React.useMemo(() => {
+    const items: NavigationItem[] = [
+      { id: 'home-dashboard', label: t('home.nav', { defaultValue: 'Home' }), type: 'url' as const, url: '/home', icon: 'home' },
+    ];
+    if (isWorkspaceAdmin) {
+      const adminItems: NavigationItem[] = [
+        { id: 'sys-settings', label: t('layout.systemNav.systemSettings', { defaultValue: 'System Settings' }), type: 'url' as const, url: '/apps/setup', icon: 'settings' },
+        { id: 'sys-apps', label: t('layout.systemNav.applications', { defaultValue: 'Applications' }), type: 'url' as const, url: '/apps/setup/system/apps', icon: 'layout-grid' },
+        { id: 'sys-marketplace', label: t('layout.systemNav.appMarketplace', { defaultValue: 'App Marketplace' }), type: 'url' as const, url: '/apps/setup/system/marketplace', icon: 'store' },
+        { id: 'sys-objects', label: t('layout.systemNav.objectManager', { defaultValue: 'Object Manager' }), type: 'url' as const, url: '/apps/setup/system/metadata/object', icon: 'database' },
+        { id: 'sys-users', label: t('layout.systemNav.users', { defaultValue: 'Users' }), type: 'url' as const, url: '/apps/setup/system/users', icon: 'users' },
+        { id: 'sys-orgs', label: t('layout.systemNav.organizations', { defaultValue: 'Organizations' }), type: 'url' as const, url: '/apps/setup/system/organizations', icon: 'building-2' },
+        { id: 'sys-roles', label: t('layout.systemNav.roles', { defaultValue: 'Roles' }), type: 'url' as const, url: '/apps/setup/system/roles', icon: 'shield' },
+        { id: 'sys-config', label: t('layout.systemNav.configuration', { defaultValue: 'Configuration' }), type: 'url' as const, url: '/apps/setup/system/settings', icon: 'sliders-horizontal' },
+      ];
+      items.push({
+        id: 'sys-administration',
+        label: t('layout.systemNav.administration', { defaultValue: 'Administration' }),
+        type: 'group' as const,
+        icon: 'shield',
+        children: adminItems,
+      });
+    }
+    return items;
+  }, [t, isWorkspaceAdmin]);
 
   // Determine which navigation to show based on context
   const navigationItems = context === 'home' ? homeNavigation : appNavigation;

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 const ReportViewer = lazy(() =>
   import('@object-ui/plugin-report').then((m) => ({ default: m.ReportViewer })),
 );
@@ -19,6 +19,7 @@ import { useMetadataClient } from './metadata-admin/useMetadata';
 import { persistRuntimeMetadata } from './runtime-metadata-persistence';
 import { useAuth } from '@object-ui/auth';
 import type { DataSource } from '@object-ui/types';
+import type { DatasetDrillArgs } from '@object-ui/plugin-report';
 
 // Fallback fields when no schema is available
 const FALLBACK_FIELDS = [
@@ -34,7 +35,8 @@ const FALLBACK_FIELDS = [
 
 export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   const { t } = useObjectTranslation();
-  const { reportName } = useParams<{ reportName: string }>();
+  const { appName, reportName } = useParams<{ appName?: string; reportName: string }>();
+  const navigate = useNavigate();
   const { showDebug } = useMetadataInspector();
   const adapter = useAdapter();
   // ADR-0034: report edits persist via the metadata draft/publish model.
@@ -79,6 +81,64 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
       }));
     },
     [objects],
+  );
+
+  // ADR-0021 D2 drill-down: a click on an aggregated row/cell emits dimension
+  // NAMES + bucket values; resolve them through the dataset definition
+  // (object + dimension→field) and open the object's list scoped by
+  // `?filter[<field>]=<value>` (the same equality-filter contract the
+  // related-list "View All" buttons use).
+  //
+  // The analytics service resolves dimension buckets to DISPLAY labels in
+  // place (select option label, lookup record name) — so the clicked value
+  // must be mapped back to the stored value before it can filter:
+  //   - select fields  → reverse-map label → option value
+  //   - lookup fields  → the label is a record name, not the FK id; skip the
+  //     dim (the drill lands on a superset rather than filtering wrongly)
+  //   - granularity-bucketed dates → need a range, not equality; skip too
+  const handleDatasetDrill = useCallback(
+    async ({ dataset, groupKey }: DatasetDrillArgs) => {
+      try {
+        const def = await metadataClient.get<Record<string, any>>('dataset', dataset);
+        const objectName = typeof def?.object === 'string' ? def.object : undefined;
+        if (!objectName) return;
+        const dims: Array<Record<string, any>> = Array.isArray(def?.dimensions) ? def.dimensions : [];
+        const dimByName = new Map(dims.filter((d) => d?.name).map((d) => [d.name as string, d]));
+
+        // Field defs of the dataset's object — the option value↔label source.
+        const objDef = objects?.find((o: any) => o.name === objectName);
+        const rawFields = objDef?.fields;
+        const fieldDef = (field: string): Record<string, any> | undefined => {
+          if (Array.isArray(rawFields)) return rawFields.find((f: any) => f?.name === field);
+          if (rawFields && typeof rawFields === 'object') return (rawFields as Record<string, any>)[field];
+          return undefined;
+        };
+
+        const params = new URLSearchParams();
+        for (const [dim, value] of Object.entries(groupKey)) {
+          if (value == null) continue;
+          const dimDef = dimByName.get(dim);
+          if (dimDef?.dateGranularity) continue;
+          const field = (dimDef?.field as string) || dim;
+          const fd = fieldDef(field);
+          if (fd?.type === 'lookup' || fd?.type === 'master_detail') continue;
+          let stored: unknown = value;
+          if (Array.isArray(fd?.options)) {
+            const opt = fd.options.find(
+              (o: any) => o?.label === value || o?.value === value,
+            );
+            if (opt && opt.value != null) stored = opt.value;
+          }
+          params.set(`filter[${field}]`, String(stored));
+        }
+        const qs = params.toString();
+        const base = appName ? `/apps/${appName}` : '';
+        navigate(`${base}/${objectName}${qs ? `?${qs}` : ''}`);
+      } catch (err) {
+        console.warn('ReportView: drill navigation failed', err);
+      }
+    },
+    [metadataClient, navigate, appName, objects],
   );
 
   // Derive available fields from object schema for filter/sort editors
@@ -471,7 +531,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
                  <Suspense fallback={<div className="p-8 text-sm text-muted-foreground">{t('common.loading', { defaultValue: 'Loading…' })}</div>}>
                    {useSpecRenderer ? (
                      <div className="p-4 sm:p-6">
-                       <ReportRenderer schema={previewReport} dataSource={dataSource as any} rows={reportRuntimeData} />
+                       <ReportRenderer schema={previewReport} dataSource={dataSource as any} rows={reportRuntimeData} onDrill={handleDatasetDrill} />
                      </div>
                    ) : (
                      <ReportViewer schema={viewerSchema} />

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -422,6 +422,8 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.report.valuesEmpty': 'No measures yet. Add one from the dataset below.',
   'engine.inspector.report.rows': 'Rows (dimensions)',
   'engine.inspector.report.rowsEmpty': 'No dimensions yet. Add one from the dataset below.',
+  'engine.inspector.report.columnsAcross': 'Columns (across dimensions)',
+  'engine.inspector.report.columnsAcrossEmpty': 'No across dimensions yet — the matrix pivots rows × columns.',
   'engine.inspector.report.noSchema': 'Spec schema unavailable — basic properties only.',
   // Trailing section for fields the live server has but the bundled spec lacks.
   'engine.inspector.moreFields': 'More fields',
@@ -1063,6 +1065,8 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.report.valuesEmpty': '还没有度量。从下方数据集中添加。',
   'engine.inspector.report.rows': '行（维度）',
   'engine.inspector.report.rowsEmpty': '还没有维度。从下方数据集中添加。',
+  'engine.inspector.report.columnsAcross': '列（横向维度）',
+  'engine.inspector.report.columnsAcrossEmpty': '还没有横向维度——矩阵按 行 × 列 透视。',
   'engine.inspector.report.noSchema': '规格 schema 不可用 —— 仅显示基础属性。',
   // Trailing section for fields the live server has but the bundled spec lacks.
   'engine.inspector.moreFields': '更多字段',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.test.tsx
@@ -112,6 +112,34 @@ describe('ReportDefaultInspector — dataset binding (9.0 single form)', () => {
     expect(onPatch).toHaveBeenCalledWith({ rows: [] });
   });
 
+  it('matrix reports get a Columns (across) editor fed by dataset dimensions', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        draft={{ ...datasetDraft, type: 'matrix', columns: ['close_quarter'] }}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    expect(screen.getByText('Columns (across dimensions)')).toBeInTheDocument();
+    expect(screen.getByText('close_quarter')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove close_quarter' }));
+    expect(onPatch).toHaveBeenCalledWith({ columns: [] });
+  });
+
+  it('non-matrix reports hide the Columns (across) editor', () => {
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        draft={{ ...datasetDraft }}
+        onPatch={vi.fn()}
+        readOnly={false}
+      />,
+    );
+    expect(screen.queryByText('Columns (across dimensions)')).not.toBeInTheDocument();
+  });
+
   it('falls back to a manual dataset input when the catalog is empty', () => {
     render(
       <ReportDefaultInspector

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
@@ -64,6 +64,7 @@ const REPORT_CURATED_FIELDS = new Set([
   'dataset',
   'values',
   'rows',
+  'columns', // matrix across-dimensions — dedicated list below
 ]);
 
 export interface ReportDefaultInspectorProps extends MetadataDefaultInspectorProps {
@@ -220,6 +221,7 @@ export function ReportDefaultInspector({
     typeof draft.dataset === 'string' ? (draft.dataset as string) : '';
   const values = React.useMemo(() => readNames(draft.values), [draft.values]);
   const rows = React.useMemo(() => readNames(draft.rows), [draft.rows]);
+  const columnsAcross = React.useMemo(() => readNames(draft.columns), [draft.columns]);
 
   // Dataset catalog (binding options) + the bound dataset's semantic layer
   // (measure/dimension picker options).
@@ -342,6 +344,19 @@ export function ReportDefaultInspector({
             readOnly={readOnly}
             onCommit={(next) => onPatch({ rows: next })}
           />
+          {reportType === 'matrix' && (
+            // ADR-0021 D2 — a matrix pivots rows × columns (across dimensions).
+            <DatasetNamesEditor
+              label={tr('engine.inspector.report.columnsAcross')}
+              emptyText={tr('engine.inspector.report.columnsAcrossEmpty')}
+              names={columnsAcross}
+              options={dimensionOptions}
+              loading={semantics.loading}
+              error={semantics.error}
+              readOnly={readOnly}
+              onCommit={(next) => onPatch({ columns: next })}
+            />
+          )}
         </>
       )}
 
@@ -351,7 +366,7 @@ export function ReportDefaultInspector({
             schema={schema}
             form={form}
             value={draft}
-            hiddenFields={['type', 'label', 'name', 'dataset', 'values', 'rows']}
+            hiddenFields={['type', 'label', 'name', 'dataset', 'values', 'rows', 'columns']}
             readOnly={readOnly}
             onChange={(next) => onPatch(next)}
           />

--- a/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx
@@ -25,22 +25,22 @@ const datasetReport = {
   values: ['revenue'],
 };
 
-describe('ReportPreview — dataset-bound report (ADR-0021 dual-form)', () => {
+describe('ReportPreview — dataset-bound report (ADR-0021 single-form)', () => {
   it('runs the bound dataset (rows→dimensions, values→measures) and renders a table', async () => {
     queryDataset.mockResolvedValue({ rows: [{ region: 'finance', revenue: 450000 }, { region: 'tech', revenue: 260000 }], fields: [] });
     render(<ReportPreview {...baseProps} draft={datasetReport} />);
 
     await waitFor(() =>
-      expect(queryDataset).toHaveBeenCalledWith('sales', { dimensions: ['region'], measures: ['revenue'], runtimeFilter: undefined }),
+      expect(queryDataset).toHaveBeenCalledWith('sales', { dimensions: ['region'], measures: ['revenue'] }),
     );
     expect(await screen.findByText('finance')).toBeInTheDocument();
     expect(screen.getByText('450000')).toBeInTheDocument();
     expect(screen.getByText('tech')).toBeInTheDocument();
   });
 
-  it('shows an empty state when no measures are selected', () => {
+  it('shows an empty state when no measures are selected', async () => {
     render(<ReportPreview {...baseProps} draft={{ ...datasetReport, values: [] }} />);
-    expect(screen.getByText(/Pick measures to show/)).toBeInTheDocument();
+    expect(await screen.findByText(/choose at least one measure/i)).toBeInTheDocument();
     expect(queryDataset).not.toHaveBeenCalled();
   });
 
@@ -48,6 +48,25 @@ describe('ReportPreview — dataset-bound report (ADR-0021 dual-form)', () => {
     queryDataset.mockRejectedValue(new Error('relationship "account" is not declared in the dataset'));
     render(<ReportPreview {...baseProps} draft={datasetReport} />);
     expect(await screen.findByText(/not declared in the dataset/)).toBeInTheDocument();
+  });
+
+  it('renders a matrix draft as the same cross-tab the runtime shows', async () => {
+    queryDataset.mockResolvedValue({
+      rows: [
+        { region: 'east', stage: 'won', revenue: 100 },
+        { region: 'east', stage: 'lost', revenue: 40 },
+        { region: 'west', stage: 'won', revenue: 70 },
+      ],
+      fields: [],
+    });
+    render(
+      <ReportPreview
+        {...baseProps}
+        draft={{ ...datasetReport, type: 'matrix', rows: ['region'], columns: ['stage'] }}
+      />,
+    );
+    expect(await screen.findByTestId('dataset-matrix')).toBeInTheDocument();
+    expect(queryDataset).toHaveBeenCalledWith('sales', expect.objectContaining({ dimensions: ['region', 'stage'] }));
   });
 
   it('forwards runtimeFilter to the dataset query', async () => {

--- a/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.tsx
@@ -1,117 +1,55 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * ReportPreview — runs the live Report draft through the dataset query path
- * (ADR-0021 single-form).
+ * ReportPreview — runs the live Report draft through the SAME dataset-bound
+ * renderer the runtime ReportView uses (ADR-0021 single-form).
  *
  * A 9.0 report binds a semantic-layer `dataset` and selects its measures
- * (`values`) grouped by dimensions (`rows`); the preview executes that
- * selection through `adapter.queryDataset`, so the numbers match every other
- * surface on the same dataset. A draft without a dataset binding (e.g. stored
- * pre-9.0 query-form JSON) gets an actionable empty state pointing at the
- * inspector's Dataset control instead of the retired legacy renderer.
+ * (`values`) grouped by dimensions (`rows`, plus `columns` across for a
+ * matrix); rendering through plugin-report's `ReportRenderer` keeps the
+ * studio preview pixel-equal with the runtime — including the matrix
+ * cross-tab — and the numbers consistent with every other surface on the
+ * same dataset (`adapter.queryDataset`). Drill-down stays inert here: the
+ * preview passes no `onDrill` sink.
  *
- * Uses the app-shell AdapterProvider's data source so previews see actual
- * rows.
+ * A draft without a dataset binding (e.g. stored pre-9.0 query-form JSON)
+ * gets an actionable empty state pointing at the inspector's Dataset control
+ * instead of the retired legacy renderer.
  */
 
 import * as React from 'react';
-import { Database, Loader2, Table2, AlertTriangle } from 'lucide-react';
+import { Database, Loader2 } from 'lucide-react';
 import { useAdapter } from '../../../providers/AdapterProvider';
 import type { MetadataPreviewProps } from '../preview-registry';
-import { PreviewShell, PreviewEmptyState } from './PreviewShell';
+import { PreviewShell, PreviewErrorBoundary, PreviewEmptyState } from './PreviewShell';
 
-/**
- * DatasetBoundReport — renders a report that binds to a semantic-layer
- * `dataset` (ADR-0021 single-form). The report
- * picks dimensions (`rows`) and measures (`values`) by NAME from the dataset;
- * we run them through the same `adapter.queryDataset` path the dataset preview
- * uses, so the numbers match every other surface on that dataset.
- */
-function DatasetBoundReport({ draft }: { draft: Record<string, unknown> }) {
-  const adapter = useAdapter();
-  const datasetName = String((draft as any).dataset);
-  const rows = React.useMemo(
-    () => (Array.isArray((draft as any).rows) ? ((draft as any).rows as string[]).filter(Boolean) : []),
-    [draft],
-  );
-  const values = React.useMemo(
-    () => (Array.isArray((draft as any).values) ? ((draft as any).values as string[]).filter(Boolean) : []),
-    [draft],
-  );
-  const runtimeFilter = (draft as any).runtimeFilter;
-
-  const [state, setState] = React.useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Array<Record<string, unknown>>; error?: string }>({ status: 'idle', rows: [] });
-
-  const signature = `${datasetName}|${rows.join(',')}|${values.join(',')}`;
-  React.useEffect(() => {
-    if (values.length === 0) { setState({ status: 'idle', rows: [] }); return; }
-    let cancelled = false;
-    setState({ status: 'loading', rows: [] });
-    (adapter as unknown as { queryDataset: (d: string, s: unknown) => Promise<{ rows: Array<Record<string, unknown>> }> })
-      .queryDataset(datasetName, { dimensions: rows, measures: values, runtimeFilter })
-      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [] }); })
-      .catch((e) => { if (!cancelled) setState({ status: 'error', rows: [], error: String((e as Error)?.message ?? e) }); });
-    return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [signature]);
-
-  if (values.length === 0) {
-    return (
-      <PreviewShell>
-        <PreviewEmptyState
-          icon={<Table2 className="h-8 w-8" />}
-          title="Pick measures to show"
-          description={`This report binds the "${datasetName}" dataset — choose at least one measure (values) to render.`}
-        />
-      </PreviewShell>
-    );
-  }
-
-  const columns = [...rows, ...values];
-  return (
-    <PreviewShell hint={`report · dataset "${datasetName}"${rows.length ? ' · by ' + rows.join(', ') : ''}`}>
-      <div className="p-3">
-        {state.status === 'loading' && (
-          <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Running report…</div>
-        )}
-        {state.status === 'error' && (
-          <div role="alert" className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" /><span className="break-words">{state.error}</span>
-          </div>
-        )}
-        {state.status === 'ok' && state.rows.length === 0 && (
-          <PreviewEmptyState icon={<Table2 className="h-8 w-8" />} title="No rows" description="The dataset returned no rows for this report's scope." />
-        )}
-        {state.rows.length > 0 && (
-          <div className="overflow-auto max-h-[70vh] rounded-md border">
-            <table className="w-full text-xs">
-              <thead className="bg-muted/40">
-                <tr>{columns.map((c) => <th key={c} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">{c}</th>)}</tr>
-              </thead>
-              <tbody>
-                {state.rows.map((row, i) => (
-                  <tr key={i} className="border-t">
-                    {columns.map((c) => {
-                      const v = row[c];
-                      const text = v == null ? '—' : typeof v === 'number' ? (Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 })) : String(v);
-                      return <td key={c} className="px-2 py-1 tabular-nums whitespace-nowrap">{text}</td>;
-                    })}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-    </PreviewShell>
-  );
-}
+const ReportRenderer = React.lazy(() =>
+  import('@object-ui/plugin-report').then((m) => ({ default: m.ReportRenderer })),
+);
 
 export function ReportPreview({ draft }: MetadataPreviewProps) {
+  const adapter = useAdapter();
+
   // ADR-0021 single-form: a report binds a semantic-layer dataset.
   if (typeof (draft as any).dataset === 'string' && (draft as any).dataset) {
-    return <DatasetBoundReport draft={draft as Record<string, unknown>} />;
+    const rows = Array.isArray((draft as any).rows) ? ((draft as any).rows as string[]).filter(Boolean) : [];
+    return (
+      <PreviewShell hint={`report · dataset "${(draft as any).dataset}"${rows.length ? ' · by ' + rows.join(', ') : ''}`}>
+        <PreviewErrorBoundary fallbackHint="The Report references a dataset/measure that doesn't resolve, or its config is incomplete.">
+          <React.Suspense
+            fallback={
+              <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Loading report renderer…
+              </div>
+            }
+          >
+            <div className="p-3 min-h-[200px] max-h-[70vh] overflow-auto">
+              <ReportRenderer schema={draft as any} dataSource={adapter as any} />
+            </div>
+          </React.Suspense>
+        </PreviewErrorBoundary>
+      </PreviewShell>
+    );
   }
 
   // No dataset bound — either a fresh draft or stored pre-9.0 query-form

--- a/packages/app-shell/src/views/metadata-admin/report-schema.ts
+++ b/packages/app-shell/src/views/metadata-admin/report-schema.ts
@@ -34,6 +34,7 @@ const FORM_FIELDS_OWNED_ELSEWHERE = new Set([
   'dataset', // dataset binding rendered as a dedicated picker
   'values', // managed by the dedicated measures list
   'rows', // managed by the dedicated dimensions list
+  'columns', // matrix across-dimensions — dedicated list (ADR-0021 D2)
   'name', // record identity — not user-editable here
 ]);
 

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -5,18 +5,28 @@
  *
  * Renders a spec `Report` that binds to a semantic-layer `dataset` (ADR-0021
  * single-form) instead of an inline `objectName` + `columns` query. The report
- * selects dimensions (`rows`) and measures (`values`) BY NAME and runs them
- * through `dataSource.queryDataset` — the same governed path dataset-bound
- * dashboard widgets and the dataset preview use, so the numbers (and the
- * server-resolved dimension display labels) match everywhere.
+ * selects dimensions (`rows`, and for matrix also `columns`) and measures
+ * (`values`) BY NAME and runs them through `dataSource.queryDataset` — the
+ * same governed path dataset-bound dashboard widgets and the dataset preview
+ * use, so the numbers (and the server-resolved dimension display labels)
+ * match everywhere.
  *
- * - `summary` / `matrix` / `tabular` → one grouped table (`rows` + `values`).
+ * - `summary` / `tabular` → one grouped table (`rows` + `values`).
+ * - `matrix` → a true cross-tab (ADR-0021 D2): `rows` down × `columns`
+ *   across, measures in the cells. One dataset query over all dimensions,
+ *   pivoted client-side. (No totals row/column: measures like `avg` cannot
+ *   be re-aggregated from bucketed values without drifting from the semantic
+ *   layer — the governance red line. A matrix without `columns` degrades to
+ *   the flat grouped table.)
  * - `joined` → a vertical stack of blocks, each its own dataset-bound table,
  *   with the report-level `runtimeFilter` merged into every block.
  *
- * This is the report-side counterpart to plugin-dashboard's `DatasetWidget`;
- * it replaces the legacy `useReportData` (objectName + client aggregation) path
- * for reports authored against a dataset.
+ * Drill-down (ADR-0021 D2): when the report's `drilldown` flag is not `false`
+ * and the host supplies `onDrill`, every aggregated row / matrix cell is
+ * clickable and emits `{ dataset, groupKey, runtimeFilter }`. The HOST owns
+ * navigation — it resolves the dataset's `object` and dimension→field mapping
+ * (this renderer only knows dimension NAMES) and routes to the underlying
+ * records.
  */
 
 import * as React from 'react';
@@ -36,12 +46,26 @@ interface DatasetReportLike {
   type?: string;
   dataset?: string;
   rows?: string[];
+  /** Dimension names across — matrix pivots `rows` × `columns` (ADR-0021 D2). */
+  columns?: string[];
   values?: string[];
   runtimeFilter?: Record<string, unknown>;
   filter?: Record<string, unknown>;
+  /** Click-through to underlying records (default true). */
+  drilldown?: boolean;
   label?: unknown;
   description?: unknown;
   blocks?: DatasetReportLike[];
+}
+
+/** What a drill click means — the host resolves names to a navigation target. */
+export interface DatasetDrillArgs {
+  /** Dataset the clicked aggregate was computed over. */
+  dataset: string;
+  /** Dimension NAME → clicked bucket value (row dims, plus across dims for a matrix cell). */
+  groupKey: Record<string, unknown>;
+  /** The effective render-time scope filter, if any. */
+  runtimeFilter?: Record<string, unknown>;
 }
 
 export interface DatasetReportRendererProps {
@@ -49,6 +73,11 @@ export interface DatasetReportRendererProps {
   dataSource?: unknown;
   /** Filter merged into the report (and every joined block) as `runtimeFilter`. */
   runtimeFilter?: Record<string, unknown>;
+  /**
+   * Drill-down sink. Rows/cells become clickable when provided (and the
+   * report doesn't set `drilldown: false`).
+   */
+  onDrill?: (args: DatasetDrillArgs) => void;
   className?: string;
 }
 
@@ -78,34 +107,32 @@ function formatCell(v: unknown): string {
   return String(v);
 }
 
-/** One dataset-bound table: fetch via `queryDataset`, render `rows` + `values`. */
-function DatasetReportTable({
-  dataset,
-  rows,
-  values,
-  runtimeFilter,
-  dataSource,
-}: {
-  dataset: string;
-  rows: string[];
-  values: string[];
-  runtimeFilter?: Record<string, unknown>;
-  dataSource?: unknown;
-}) {
+function readNames(value: unknown): string[] {
+  return Array.isArray(value) ? (value as unknown[]).filter((v): v is string => typeof v === 'string' && !!v) : [];
+}
+
+/** Shared fetch for one dataset selection. */
+function useDatasetRows(
+  dataset: string,
+  dimensions: string[],
+  measures: string[],
+  runtimeFilter: Record<string, unknown> | undefined,
+  dataSource: unknown,
+) {
   const [state, setState] = React.useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; error?: string }>({
     status: 'idle',
     rows: [],
   });
 
   const rfKey = JSON.stringify(runtimeFilter ?? null);
-  const signature = `${dataset}|${rows.join(',')}|${values.join(',')}|${rfKey}`;
+  const signature = `${dataset}|${dimensions.join(',')}|${measures.join(',')}|${rfKey}`;
   React.useEffect(() => {
     const src = dataSource as DatasetCapableSource | undefined;
     if (!src || typeof src.queryDataset !== 'function') {
       setState({ status: 'error', rows: [], error: 'This data source does not support dataset queries.' });
       return;
     }
-    if (!dataset || values.length === 0) {
+    if (!dataset || measures.length === 0) {
       setState({ status: 'idle', rows: [] });
       return;
     }
@@ -113,8 +140,8 @@ function DatasetReportTable({
     setState({ status: 'loading', rows: [] });
     src
       .queryDataset(dataset, {
-        dimensions: rows,
-        measures: values,
+        dimensions,
+        measures,
         ...(runtimeFilter && Object.keys(runtimeFilter).length > 0 ? { runtimeFilter } : {}),
       })
       .then((res) => {
@@ -129,35 +156,73 @@ function DatasetReportTable({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [signature]);
 
-  if (values.length === 0) {
-    return (
-      <div className="flex items-center justify-center rounded-md border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground">
-        This report binds the “{dataset}” dataset — choose at least one measure (values) to render.
-      </div>
-    );
-  }
-  if (state.status === 'loading' || state.status === 'idle') {
-    return (
-      <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
-        <Loader2 className="h-4 w-4 animate-spin" /> Running report…
-      </div>
-    );
-  }
-  if (state.status === 'error') {
+  return state;
+}
+
+function EmptyMeasures({ dataset }: { dataset: string }) {
+  return (
+    <div className="flex items-center justify-center rounded-md border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground">
+      This report binds the “{dataset}” dataset — choose at least one measure (values) to render.
+    </div>
+  );
+}
+
+function FetchStates({ status, error }: { status: 'idle' | 'loading' | 'error'; error?: string }) {
+  if (status === 'error') {
     return (
       <div role="alert" className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
         <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-        <span className="break-words">{state.error}</span>
+        <span className="break-words">{error}</span>
       </div>
     );
   }
-  if (state.rows.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed bg-muted/20 p-6 text-xs text-muted-foreground">
-        <Table2 className="h-6 w-6" /> The dataset returned no rows for this report’s scope.
-      </div>
-    );
-  }
+  return (
+    <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
+      <Loader2 className="h-4 w-4 animate-spin" /> Running report…
+    </div>
+  );
+}
+
+function NoRows() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed bg-muted/20 p-6 text-xs text-muted-foreground">
+      <Table2 className="h-6 w-6" /> The dataset returned no rows for this report’s scope.
+    </div>
+  );
+}
+
+const DRILL_CLASS = 'cursor-pointer hover:bg-accent/40';
+
+/** One dataset-bound table: fetch via `queryDataset`, render `rows` + `values`. */
+function DatasetReportTable({
+  dataset,
+  rows,
+  values,
+  runtimeFilter,
+  dataSource,
+  onDrill,
+}: {
+  dataset: string;
+  rows: string[];
+  values: string[];
+  runtimeFilter?: Record<string, unknown>;
+  dataSource?: unknown;
+  onDrill?: (args: DatasetDrillArgs) => void;
+}) {
+  const state = useDatasetRows(dataset, rows, values, runtimeFilter, dataSource);
+
+  if (values.length === 0) return <EmptyMeasures dataset={dataset} />;
+  if (state.status === 'loading' || state.status === 'idle') return <FetchStates status={state.status} />;
+  if (state.status === 'error') return <FetchStates status="error" error={state.error} />;
+  if (state.rows.length === 0) return <NoRows />;
+
+  // Drilling needs at least one dimension to scope by.
+  const canDrill = !!onDrill && rows.length > 0;
+  const drill = (row: Row) => {
+    const groupKey: Record<string, unknown> = {};
+    for (const dim of rows) groupKey[dim] = row[dim];
+    onDrill!({ dataset, groupKey, runtimeFilter });
+  };
 
   const columns = [...rows, ...values];
   return (
@@ -174,7 +239,12 @@ function DatasetReportTable({
         </thead>
         <tbody>
           {state.rows.map((row, i) => (
-            <tr key={i} className="border-t">
+            <tr
+              key={i}
+              className={`border-t${canDrill ? ` ${DRILL_CLASS}` : ''}`}
+              data-testid={canDrill ? 'dataset-drill-row' : undefined}
+              onClick={canDrill ? () => drill(row) : undefined}
+            >
               {columns.map((c) => (
                 <td key={c} className="px-2 py-1 tabular-nums whitespace-nowrap">
                   {formatCell(row[c])}
@@ -188,16 +258,147 @@ function DatasetReportTable({
   );
 }
 
+/** Stable bucket id for a dimension-value tuple. */
+function bucketId(dims: string[], row: Row): string {
+  return dims.map((d) => String(row[d] ?? '∅')).join('');
+}
+
+function bucketLabel(dims: string[], row: Row): string {
+  return dims.map((d) => formatCell(row[d])).join(' / ');
+}
+
+/**
+ * True cross-tab for `type: 'matrix'` — one dataset query over
+ * `[...rows, ...columns]`, pivoted client-side. Cells show every measure
+ * (single measure → one column per across-bucket; multiple → one column per
+ * across-bucket × measure).
+ */
+function DatasetMatrixTable({
+  dataset,
+  rows,
+  columnsAcross,
+  values,
+  runtimeFilter,
+  dataSource,
+  onDrill,
+}: {
+  dataset: string;
+  rows: string[];
+  columnsAcross: string[];
+  values: string[];
+  runtimeFilter?: Record<string, unknown>;
+  dataSource?: unknown;
+  onDrill?: (args: DatasetDrillArgs) => void;
+}) {
+  const state = useDatasetRows(dataset, [...rows, ...columnsAcross], values, runtimeFilter, dataSource);
+
+  const pivot = React.useMemo(() => {
+    if (state.status !== 'ok') return null;
+    const rowHeaders: Array<{ id: string; label: string; key: Row }> = [];
+    const colHeaders: Array<{ id: string; label: string; key: Row }> = [];
+    const seenRow = new Set<string>();
+    const seenCol = new Set<string>();
+    const cells = new Map<string, Row>();
+    for (const r of state.rows) {
+      const rid = bucketId(rows, r);
+      const cid = bucketId(columnsAcross, r);
+      if (!seenRow.has(rid)) {
+        seenRow.add(rid);
+        const key: Row = {};
+        for (const d of rows) key[d] = r[d];
+        rowHeaders.push({ id: rid, label: bucketLabel(rows, r), key });
+      }
+      if (!seenCol.has(cid)) {
+        seenCol.add(cid);
+        const key: Row = {};
+        for (const d of columnsAcross) key[d] = r[d];
+        colHeaders.push({ id: cid, label: bucketLabel(columnsAcross, r), key });
+      }
+      cells.set(`${rid} ${cid}`, r);
+    }
+    return { rowHeaders, colHeaders, cells };
+  }, [state, rows, columnsAcross]);
+
+  if (values.length === 0) return <EmptyMeasures dataset={dataset} />;
+  if (state.status === 'loading' || state.status === 'idle') return <FetchStates status={state.status} />;
+  if (state.status === 'error') return <FetchStates status="error" error={state.error} />;
+  if (!pivot || pivot.rowHeaders.length === 0) return <NoRows />;
+
+  const canDrill = !!onDrill;
+  const drillCell = (rowKey: Row, colKey: Row) => {
+    onDrill!({ dataset, groupKey: { ...rowKey, ...colKey }, runtimeFilter });
+  };
+
+  // Single measure → one column per across-bucket; multiple → bucket × measure.
+  const cellCols = pivot.colHeaders.flatMap((col) =>
+    values.map((measure) => ({
+      col,
+      measure,
+      header: values.length === 1 ? col.label : `${col.label} · ${measure}`,
+    })),
+  );
+
+  return (
+    <div className="overflow-auto max-h-[70vh] rounded-md border" data-testid="dataset-matrix">
+      <table className="w-full text-xs">
+        <thead className="bg-muted/40">
+          <tr>
+            {rows.map((d) => (
+              <th key={d} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">
+                {d}
+              </th>
+            ))}
+            {cellCols.map((cc) => (
+              <th key={`${cc.col.id}-${cc.measure}`} className="px-2 py-1.5 text-right font-medium whitespace-nowrap">
+                {cc.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {pivot.rowHeaders.map((rh) => (
+            <tr key={rh.id} className="border-t">
+              {rows.map((d) => (
+                <td key={d} className="px-2 py-1 whitespace-nowrap font-medium">
+                  {formatCell(rh.key[d])}
+                </td>
+              ))}
+              {cellCols.map((cc) => {
+                const cell = pivot.cells.get(`${rh.id} ${cc.col.id}`);
+                const value = cell?.[cc.measure];
+                const clickable = canDrill && cell != null;
+                return (
+                  <td
+                    key={`${cc.col.id}-${cc.measure}`}
+                    className={`px-2 py-1 text-right tabular-nums whitespace-nowrap${clickable ? ` ${DRILL_CLASS}` : ''}`}
+                    data-testid={clickable ? 'dataset-drill-cell' : undefined}
+                    onClick={clickable ? () => drillCell(rh.key, cc.col.key) : undefined}
+                  >
+                    {formatCell(value)}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
   report,
   dataSource,
   runtimeFilter,
+  onDrill,
   className,
 }) => {
   const outerFilter = mergeFilters(
     (report.runtimeFilter ?? report.filter) as Record<string, unknown> | undefined,
     runtimeFilter,
   );
+  // ADR-0021 D2: `drilldown` defaults on; the host must still supply a sink.
+  const drillSink = report.drilldown === false ? undefined : onDrill;
 
   // Joined → a vertical stack of dataset-bound blocks.
   if (report.type === 'joined' && Array.isArray(report.blocks)) {
@@ -210,6 +411,27 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
       >
         {report.blocks.map((block, index) => {
           const blockFilter = mergeFilters(outerFilter, (block.runtimeFilter ?? block.filter) as Record<string, unknown> | undefined);
+          const blockAcross = readNames(block.columns);
+          const blockTable = block.type === 'matrix' && blockAcross.length > 0 ? (
+            <DatasetMatrixTable
+              dataset={String(block.dataset ?? '')}
+              rows={readNames(block.rows)}
+              columnsAcross={blockAcross}
+              values={readNames(block.values)}
+              runtimeFilter={blockFilter}
+              dataSource={dataSource}
+              onDrill={drillSink}
+            />
+          ) : (
+            <DatasetReportTable
+              dataset={String(block.dataset ?? '')}
+              rows={readNames(block.rows)}
+              values={readNames(block.values)}
+              runtimeFilter={blockFilter}
+              dataSource={dataSource}
+              onDrill={drillSink}
+            />
+          );
           return (
             <section
               key={block.name ?? `block-${index}`}
@@ -223,13 +445,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
                   <p className="text-xs text-muted-foreground">{resolveText(block.description, '')}</p>
                 ) : null}
               </header>
-              <DatasetReportTable
-                dataset={String(block.dataset ?? '')}
-                rows={Array.isArray(block.rows) ? block.rows.filter(Boolean) : []}
-                values={Array.isArray(block.values) ? block.values.filter(Boolean) : []}
-                runtimeFilter={blockFilter}
-                dataSource={dataSource}
-              />
+              {blockTable}
             </section>
           );
         })}
@@ -237,15 +453,35 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
     );
   }
 
-  // summary / matrix / tabular → a single dataset-bound table.
+  const across = readNames(report.columns);
+  // Matrix with an across dimension → true cross-tab; without one it
+  // degrades to the flat grouped table (pre-`columns` stored JSON).
+  if (report.type === 'matrix' && across.length > 0) {
+    return (
+      <div className={className} data-testid="dataset-report" data-report-name={report.name}>
+        <DatasetMatrixTable
+          dataset={String(report.dataset ?? '')}
+          rows={readNames(report.rows)}
+          columnsAcross={across}
+          values={readNames(report.values)}
+          runtimeFilter={outerFilter}
+          dataSource={dataSource}
+          onDrill={drillSink}
+        />
+      </div>
+    );
+  }
+
+  // summary / tabular (and matrix without `columns`) → a single grouped table.
   return (
     <div className={className} data-testid="dataset-report" data-report-name={report.name}>
       <DatasetReportTable
         dataset={String(report.dataset ?? '')}
-        rows={Array.isArray(report.rows) ? report.rows.filter(Boolean) : []}
-        values={Array.isArray(report.values) ? report.values.filter(Boolean) : []}
+        rows={readNames(report.rows)}
+        values={readNames(report.values)}
         runtimeFilter={outerFilter}
         dataSource={dataSource}
+        onDrill={drillSink}
       />
     </div>
   );

--- a/packages/plugin-report/src/ReportRenderer.tsx
+++ b/packages/plugin-report/src/ReportRenderer.tsx
@@ -31,7 +31,7 @@ import {
 import { SchemaRendererContext } from '@object-ui/react';
 import { LegacyReportRenderer, type LegacyReportRendererProps } from './LegacyReportRenderer';
 import { ReportViewer } from './ReportViewer';
-import { DatasetReportRenderer, isDatasetReport } from './DatasetReportRenderer';
+import { DatasetReportRenderer, isDatasetReport, type DatasetDrillArgs } from './DatasetReportRenderer';
 
 export type ReportRendererSchema = SpecReport | LegacyReportRendererProps['schema'];
 
@@ -44,6 +44,12 @@ export interface ReportRendererProps {
   rows?: Array<Record<string, unknown>>;
   /** Runtime filter merged on top of the report's own scope filter. */
   runtimeFilter?: Record<string, unknown>;
+  /**
+   * Drill-down sink for dataset-bound reports (ADR-0021 D2) — rows/cells
+   * become clickable when provided. The host resolves the dataset's object
+   * and dimension→field mapping and navigates to the underlying records.
+   */
+  onDrill?: (args: DatasetDrillArgs) => void;
   /** Optional class for the outer container. */
   className?: string;
 }
@@ -53,6 +59,7 @@ export const ReportRenderer: React.FC<ReportRendererProps> = (props) => {
     dataSource: propDataSource,
     rows,
     runtimeFilter,
+    onDrill,
     className,
   } = props;
   // Fall back to the SchemaRenderer context when no dataSource prop is
@@ -86,6 +93,7 @@ export const ReportRenderer: React.FC<ReportRendererProps> = (props) => {
         report={schema as Parameters<typeof DatasetReportRenderer>[0]['report']}
         dataSource={dataSource}
         runtimeFilter={runtimeFilter}
+        onDrill={onDrill}
         className={className}
       />
     );

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -7,9 +7,11 @@
  *  - joined report → one dataset-bound table per block
  *  - report-level runtimeFilter merged into the dataset query
  *  - missing queryDataset → a clear error instead of a blank
+ *  - matrix → true rows × columns cross-tab (ADR-0021 D2)
+ *  - drill-down: clickable rows/cells emit {dataset, groupKey, runtimeFilter}
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { DatasetReportRenderer, isDatasetReport } from '../DatasetReportRenderer';
 
@@ -92,6 +94,99 @@ describe('DatasetReportRenderer', () => {
     );
     await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
     expect(src.calls[0].selection.runtimeFilter).toMatchObject({ owner: 'me' });
+  });
+
+  it('pivots a matrix report into a rows × columns cross-tab (ADR-0021 D2)', async () => {
+    const src = makeSource({
+      task_metrics: [
+        { status: 'Backlog', priority: 'High', est_hours: 10 },
+        { status: 'Backlog', priority: 'Low', est_hours: 20 },
+        { status: 'Done', priority: 'High', est_hours: 14 },
+      ],
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'task_metrics', rows: ['status'], columns: ['priority'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    // One query over ALL dimensions (down + across).
+    expect(src.queryDataset).toHaveBeenCalledWith('task_metrics', expect.objectContaining({
+      dimensions: ['status', 'priority'], measures: ['est_hours'],
+    }));
+    // Across buckets become column headers (single measure → bucket label only).
+    expect(screen.getByRole('columnheader', { name: 'High' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Low' })).toBeInTheDocument();
+    // Cells land at row × column intersections; missing pairs render '—'.
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+    expect(screen.getByText('14')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument(); // Done × Low has no bucket
+  });
+
+  it('matrix without `columns` degrades to the flat grouped table', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', priority: 'High', est_hours: 10 }] });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'task_metrics', rows: ['status', 'priority'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect(screen.queryByTestId('dataset-matrix')).not.toBeInTheDocument();
+  });
+
+  it('drill: clicking a grouped row emits dataset + dimension groupKey + scope filter', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+        runtimeFilter={{ owner: 'me' }}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-drill-row')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('dataset-drill-row'));
+    expect(onDrill).toHaveBeenCalledWith({
+      dataset: 'task_metrics',
+      groupKey: { status: 'Backlog' },
+      runtimeFilter: { owner: 'me' },
+    });
+  });
+
+  it('drill: clicking a matrix cell emits row + across dimension values', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', priority: 'High', est_hours: 10 }] });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'task_metrics', rows: ['status'], columns: ['priority'], values: ['est_hours'] }}
+        dataSource={src}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    fireEvent.click(screen.getAllByTestId('dataset-drill-cell')[0]);
+    expect(onDrill).toHaveBeenCalledWith(expect.objectContaining({
+      dataset: 'task_metrics',
+      groupKey: { status: 'Backlog', priority: 'High' },
+    }));
+  });
+
+  it('drilldown: false disables row clicks even with an onDrill sink', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'], drilldown: false }}
+        dataSource={src}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect(screen.queryByTestId('dataset-drill-row')).not.toBeInTheDocument();
   });
 
   it('shows an error when the data source cannot run dataset queries', async () => {

--- a/packages/plugin-report/src/index.tsx
+++ b/packages/plugin-report/src/index.tsx
@@ -15,7 +15,7 @@ import { DatasetReportRenderer, isDatasetReport } from './DatasetReportRenderer'
 export { ReportRenderer, LegacyReportRenderer, ReportViewer, DatasetReportRenderer, isDatasetReport };
 export type { ReportRendererProps, ReportRendererSchema } from './ReportRenderer';
 export type { LegacyReportRendererProps } from './LegacyReportRenderer';
-export type { DatasetReportRendererProps } from './DatasetReportRenderer';
+export type { DatasetReportRendererProps, DatasetDrillArgs } from './DatasetReportRenderer';
 export { formatValue } from './formatValue';
 export { exportReport, exportAsCSV, exportAsJSON, exportAsHTML, exportAsPDF, exportAsExcel } from './ReportExportEngine';
 export {


### PR DESCRIPTION
## Summary

Closes the two capability gaps left by the legacy-report-surface retirement ([#1645](https://github.com/objectstack-ai/objectui/pull/1645)), implementing the ADR-0021 D2 pivot grammar on the dataset path. Upstream prerequisite already merged + on framework main: [framework#1732](https://github.com/objectstack-ai/framework/pull/1732) (spec `Report.columns` across-dims + `drilldown` flag).

### True matrix cross-tab
- `DatasetReportRenderer` pivots `type: 'matrix'` into a real **rows × columns** cross-tab — one dataset query over all dimensions, pivoted client-side; empty intersections render `—`; multi-measure renders `bucket · measure` columns. Joined blocks pivot the same way.
- **No totals row/column by design**: re-aggregating bucketed `avg`-style measures client-side would drift from the semantic layer (the ADR-0021 governance red line).
- A matrix without `columns` (pre-9.1 stored JSON) degrades to the flat grouped table.

### Dataset-path drill-down
- Rows/cells clickable when the host passes `onDrill` (gated on the report's `drilldown` flag, default on) → emits `{dataset, groupKey, runtimeFilter}`; the renderer stays navigation-agnostic.
- `ReportView` resolves dataset → `object` + dimension→field and opens `/apps/:app/:object?filter[field]=value` (the related-list **View All** contract).
- **Label→value reverse mapping** (caught live in browser testing): the analytics service resolves dimension buckets to display labels *in place*, so `filter[status]="In Progress"` matched nothing — the stored value is `in_progress`. Select dims reverse-map via the object's field options; lookup + date-granularity dims are skipped (drill lands on a superset) rather than filtered wrongly.

### Studio
- Report inspector gains a **Columns (across dimensions)** list for matrix reports.
- `ReportPreview` now renders through the SAME `DatasetReportRenderer` as the runtime — parallel lightweight table deleted, matrix preview is WYSIWYG.

## Browser verification (app-showcase, live backend)
- `showcase_status_priority_matrix` renders status × Low/Medium/High/Urgent cross-tab in runtime **and** studio preview
- Clicking the **In Progress × High** cell (40h) navigates to `showcase_task?filter[status]=in_progress&filter[priority]=high` → exactly the 1 underlying record ("Build homepage")
- Inspector shows 值/行/列 editors fed by the dataset's semantic layer

## Test plan
- [x] `pnpm vitest run` — 3556 passed (new: 5 matrix/drill renderer cases, 2 inspector cases, 1 preview matrix case)
- [x] `pnpm --filter @object-ui/app-shell type-check` — clean; touched files lint 0 errors
- [x] `pnpm --filter @object-ui/console exec vite build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)