### PR TITLE
chore(deps): bump @objectstack/spec to ^9.1.0 (matrix columns + drilldown)

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -87,7 +87,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/client": "^9.0.0",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/apps/console/src/services/approvalsApi.ts
+++ b/apps/console/src/services/approvalsApi.ts
@@ -45,6 +45,12 @@ export interface ApprovalRequestRow {
   record_title?: string;
   /** Display name of the submitter (`sys_user.name`), when resolvable. */
   submitter_name?: string;
+  /** Schema label of the target object (e.g. "Project"). */
+  object_label?: string;
+  /** Display names for user-id entries in `pending_approvers` (id → name). */
+  pending_approver_names?: Record<string, string>;
+  /** Display values for lookup fields in `payload` (field key → record title). */
+  payload_display?: Record<string, string>;
 }
 
 export interface ApprovalActionRow {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -31,7 +31,7 @@
     "@object-ui/plugin-view": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "fumadocs-core": "16.9.3",
     "fumadocs-mdx": "15.0.11",
     "fumadocs-ui": "16.9.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@eslint/js": "^10.0.1",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "@playwright/test": "^1.60.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -45,7 +45,7 @@
     "@object-ui/providers": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "@sentry/react": "^10.56.0",
     "jsonc-parser": "^3.3.1",
     "lucide-react": "^1.17.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@object-ui/types": "workspace:*",
     "@objectstack/formula": "^9.0.0",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "lodash": "^4.18.1",
     "zod": "^4.4.3"
   },

--- a/packages/plugin-gantt/package.json
+++ b/packages/plugin-gantt/package.json
@@ -37,7 +37,7 @@
     "@object-ui/plugin-detail": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "lucide-react": "^1.17.0"
   },
   "peerDependencies": {

--- a/packages/plugin-map/package.json
+++ b/packages/plugin-map/package.json
@@ -35,7 +35,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "lucide-react": "^1.17.0",
     "maplibre-gl": "^5.24.0",
     "react-map-gl": "^8.1.1",

--- a/packages/plugin-timeline/package.json
+++ b/packages/plugin-timeline/package.json
@@ -36,7 +36,7 @@
     "@object-ui/mobile": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "class-variance-authority": "^0.7.1",
     "zod": "^4.4.3"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
     "@object-ui/data-objectstack": "workspace:*",
     "@object-ui/i18n": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "react-hook-form": "^7.78.0"
   },
   "peerDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -90,7 +90,7 @@
     "directory": "packages/types"
   },
   "dependencies": {
-    "@objectstack/spec": "^9.0.1",
+    "@objectstack/spec": "^9.1.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -251,8 +251,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0(ai@6.0.198(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -380,8 +380,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/types
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       fumadocs-core:
         specifier: 16.9.3
         version: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
@@ -693,8 +693,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       '@sentry/react':
         specifier: ^10.56.0
         version: 10.56.0(react@19.2.7)
@@ -1034,8 +1034,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0(ai@6.0.198(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1837,8 +1837,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -2060,8 +2060,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -2231,8 +2231,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2360,8 +2360,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -2474,8 +2474,8 @@ importers:
   packages/types:
     dependencies:
       '@objectstack/spec':
-        specifier: ^9.0.1
-        version: 9.0.1(ai@6.0.198(zod@4.4.3))
+        specifier: ^9.1.0
+        version: 9.1.0(ai@6.0.198(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3836,8 +3836,8 @@ packages:
       ai:
         optional: true
 
-  '@objectstack/spec@9.0.1':
-    resolution: {integrity: sha512-tBoq2RcFaLp8lzqwBgNHVFcLHPgKoIB9acUTh29/Jcv7F4ovklc18dko3VkRX0I6N0t/7Qeqo0fUsPpdrLiKQA==}
+  '@objectstack/spec@9.1.0':
+    resolution: {integrity: sha512-KaWZUlKOCVzFfYb9xjsGMY2IoC6DQ/ylTJmRy5IxZL9hjkZaXflgW8QB0lApWMT5ojZDTsbA/qywyl9Wr4428w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -11584,7 +11584,7 @@ snapshots:
     optionalDependencies:
       ai: 6.0.198(zod@4.4.3)
 
-  '@objectstack/spec@9.0.1(ai@6.0.198(zod@4.4.3))':
+  '@objectstack/spec@9.1.0(ai@6.0.198(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:


### PR DESCRIPTION
9.1.0 ships the ADR-0021 D2 report fields from [framework#1732](https://github.com/objectstack-ai/framework/pull/1732) — the bundled `ReportSchema` / `reportForm` now carry `columns` (matrix across dimensions) and `drilldown` natively (verified: the installed reportForm's Dataset binding section declares `dataset, values, rows, columns, drilldown`). Recursive update (`pnpm -r`) so every workspace importer resolves 9.1.0.

## Test plan
- [x] `pnpm vitest run` — 3558 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)