### PR TITLE
fix(app-shell): terminalize dangling tool states in hydrated /ai history (missed path of #1648)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -68,8 +68,14 @@ function partString(part: HydratedUIMessagePart, key: string): string | undefine
 function partToolState(part: HydratedUIMessagePart): ChatbotEnhancedToolInvocation['state'] | undefined {
   const state = partString(part, 'state');
   switch (state) {
+    // Hydrated history is never a live stream: the turn that drove these
+    // tools has ENDED, so a dangling mid-stream state means the terminal
+    // state was never snapshotted server-side — promote to Completed or a
+    // reloaded build conversation shows every tool "Running" forever (the
+    // same incident mapMessages fixed for the floating-chat path).
     case 'input-streaming':
     case 'input-available':
+      return 'output-available';
     case 'approval-requested':
     case 'approval-responded':
     case 'output-available':


### PR DESCRIPTION
Staging verification of [#1648](https://github.com/objectstack-ai/objectui/pull/1648) caught a second code path: the `/ai` full page hydrates conversation history through its **own** `partToolState` in `AiChatPage` (not `mapMessages`), so the library-build conversation still showed every tool permanently 'Running' after a hard reload.

Hydrated history is never a live stream — `useObjectChat` owns live turns — so a dangling `input-streaming`/`input-available` on a hydrated part means the terminal state was never snapshotted server-side. Promote to `output-available`, mirroring #1648's rule.

app-shell 412/412, build green. Will re-verify on the exact staging conversation after the pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)