### PR TITLE
feat(console): render SLA escalation on the approvals timeline

### DIFF
--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -1470,11 +1470,14 @@ export function ApprovalsInboxPage() {
                                   : a.action === 'remind' ? 'bg-amber-500'
                                   : a.action === 'request_info' ? 'bg-amber-500'
                                   : a.action === 'comment' ? 'bg-slate-400'
+                                  : a.action === 'escalate' ? 'bg-red-500'
                                   : 'bg-muted-foreground';
-                      const actorName = a.actor_name
-                        ?? (a.actor_id && a.actor_id === selected.submitter_id
-                          ? submitterDisplay(selected)
-                          : formatIdentity(a.actor_id));
+                      const actorName = a.actor_id === 'system:sla'
+                        ? tr('systemSlaActor', 'System (SLA)')
+                        : a.actor_name
+                          ?? (a.actor_id && a.actor_id === selected.submitter_id
+                            ? submitterDisplay(selected)
+                            : formatIdentity(a.actor_id));
                       const actionText = a.action === 'submit' ? tr('actSubmit', 'Submitted')
                         : a.action === 'approve' ? tr('actApprove', 'Approved')
                         : a.action === 'reject' ? tr('actReject', 'Rejected')
@@ -1483,6 +1486,7 @@ export function ApprovalsInboxPage() {
                         : a.action === 'remind' ? tr('actRemind', 'Reminder sent')
                         : a.action === 'request_info' ? tr('actRequestInfo', 'Requested more info')
                         : a.action === 'comment' ? tr('actComment', 'Commented')
+                        : a.action === 'escalate' ? tr('actEscalate', 'SLA escalated')
                         : a.action;
                       return (
                         <li key={a.id} className="relative text-xs">

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1750,6 +1750,8 @@ const ar = {
     },
   },
   approvalsInbox: {
+    actEscalate: 'تصعيد SLA',
+    systemSlaActor: 'النظام (SLA)',
     reassignBtn: 'إعادة إسناد',
     reassignTitle: 'تسليم هذه الموافقة لشخص آخر؟',
     reassignBody: 'ينتقل مقعدك كموافق إلى الشخص المختار — يتم إخطاره ويمكنه التصرف فورًا.',

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1750,6 +1750,8 @@ const de = {
     },
   },
   approvalsInbox: {
+    actEscalate: 'SLA eskaliert',
+    systemSlaActor: 'System (SLA)',
     reassignBtn: 'Übergeben',
     reassignTitle: 'Diese Genehmigung an jemand anderen übergeben?',
     reassignBody: 'Ihr Genehmiger-Platz geht an die gewählte Person — sie wird benachrichtigt und kann sofort handeln.',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1905,6 +1905,8 @@ const en = {
       },
     },
   approvalsInbox: {
+    actEscalate: 'SLA escalated',
+    systemSlaActor: 'System (SLA)',
     reassignBtn: 'Reassign',
     reassignTitle: 'Hand this approval to someone else?',
     reassignBody: 'Your approver slot moves to the person you pick — they are notified and can act immediately.',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1750,6 +1750,8 @@ const es = {
     },
   },
   approvalsInbox: {
+    actEscalate: 'SLA escalado',
+    systemSlaActor: 'Sistema (SLA)',
     reassignBtn: 'Reasignar',
     reassignTitle: '¿Pasar esta aprobación a otra persona?',
     reassignBody: 'Tu puesto de aprobador pasa a la persona elegida; se le notifica y puede actuar de inmediato.',

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1750,6 +1750,8 @@ const fr = {
     },
   },
   approvalsInbox: {
+    actEscalate: 'SLA escaladé',
+    systemSlaActor: 'Système (SLA)',
     reassignBtn: 'Réattribuer',
     reassignTitle: 'Confier cette approbation à quelqu\'un d\'autre ?',
     reassignBody: 'Votre place d\'approbateur passe à la personne choisie — elle est notifiée et peut agir immédiatement.',

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1750,6 +1750,8 @@ const ja = {
     },
   },
   approvalsInbox: {
+    actEscalate: 'SLAエスカレーション',
+    systemSlaActor: 'システム（SLA）',
     reassignBtn: '引き継ぎ',
     reassignTitle: 'この承認を他の人に引き継ぎますか？',
     reassignBody: 'あなたの承認枠は選択した相手に移ります。相手に通知され、すぐに対応できます。',

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1750,6 +1750,8 @@ const ko = {
     },
   },
   approvalsInbox: {
+    actEscalate: 'SLA 에스컬레이션',
+    systemSlaActor: '시스템(SLA)',
     reassignBtn: '재할당',
     reassignTitle: '이 승인을 다른 사람에게 넘길까요?',
     reassignBody: '승인 슬롯이 선택한 사람에게 이동하며, 상대는 알림을 받고 즉시 처리할 수 있습니다.',

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1750,6 +1750,8 @@ const pt = {
     },
   },
   approvalsInbox: {
+    actEscalate: 'SLA escalonado',
+    systemSlaActor: 'Sistema (SLA)',
     reassignBtn: 'Reatribuir',
     reassignTitle: 'Passar esta aprovação para outra pessoa?',
     reassignBody: 'Sua vaga de aprovador passa para a pessoa escolhida — ela é notificada e pode agir imediatamente.',

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1750,6 +1750,8 @@ const ru = {
     },
   },
   approvalsInbox: {
+    actEscalate: 'Эскалация SLA',
+    systemSlaActor: 'Система (SLA)',
     reassignBtn: 'Передать',
     reassignTitle: 'Передать согласование другому?',
     reassignBody: 'Ваше место согласующего перейдёт выбранному человеку — он получит уведомление и сможет действовать сразу.',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1913,6 +1913,8 @@ const zh = {
       },
     },
   approvalsInbox: {
+    actEscalate: 'SLA 升级',
+    systemSlaActor: '系统（SLA）',
     reassignBtn: '转签',
     reassignTitle: '将该审批转签给其他人？',
     reassignBody: '你的审批席位将转移给所选人员，对方会收到通知并可立即处理。',


### PR DESCRIPTION
Companion to objectstack-ai/framework#1749 (ADR-0042 SLA auto-escalation).

- Timeline renders `escalate` as a red entry ("SLA 升级") with the configured action in the comment.
- Reserved actor `system:sla` displays as localized "System (SLA)" / "系统（SLA）" — machine decisions stay visually distinct from human ones.
- 2 new `approvalsInbox.*` keys × 10 locales (parity test green).

Verified live against the showcase boot catch-up sweep: an overdue request shows `提交 → SLA 升级 · 系统（SLA）("auto_approve") → 通过 · 系统（SLA）`, step progress flips Manager Review to done, and pending rows show red "SLA 已超期 4h" chips.

Tests: i18n 100/100 ✅ · console 3518 passed ✅ · tsc clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)