### PR TITLE
fix(app-shell): stateless hydrated tool parts render Completed + unified 'Assistant' label

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -83,11 +83,18 @@ function partToolState(part: HydratedUIMessagePart): ChatbotEnhancedToolInvocati
     case 'output-denied':
       return state;
     default:
-      return undefined;
+      // No state at all: server-side conversations persist ModelMessage
+      // `tool-call` content entries, which carry no UI state — contentToParts
+      // passes them through as `tool-call` parts verbatim. In hydrated
+      // history that turn has ended too, so stateless ≡ completed; returning
+      // undefined here leaves the invocation state-less and the chip renders
+      // "Running" forever (the live-verified gap left by the first fix).
+      return 'output-available';
   }
 }
 
-function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): ChatMessage[] {
+/** Exported for tests — maps persisted/cached history to renderable messages. */
+export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): ChatMessage[] {
   return messages.map((message) => {
     const toolInvocations: ChatbotEnhancedToolInvocation[] = [];
     const content = message.parts
@@ -130,7 +137,7 @@ function firstUserMessageText(messages: HydratedUIMessage[]): string | undefined
 }
 
 const PLATFORM_AGENT_LABEL_KEYS: Record<string, { key: string; defaultValue: string }> = {
-  data_chat: { key: 'console.ai.agentLabels.dataChat', defaultValue: 'Data Assistant' },
+  data_chat: { key: 'console.ai.agentLabels.dataChat', defaultValue: 'Assistant' },
   metadata_assistant: { key: 'console.ai.agentLabels.metadataAssistant', defaultValue: 'Metadata Assistant' },
 };
 

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { hydratedMessagesToChatMessages } from '../AiChatPage';
+import type { HydratedUIMessage } from '../../../hooks/useChatConversation';
+
+function assistantWith(parts: HydratedUIMessage['parts']): HydratedUIMessage[] {
+  return [{ id: 'm1', role: 'assistant', parts }];
+}
+
+describe('AiChatPage hydration — tool invocation states', () => {
+  it('promotes STATELESS tool parts to output-available (server ModelMessage tool-call entries)', () => {
+    // Server conversations persist ModelMessage content: `tool-call` entries
+    // carry toolName/toolCallId but NO UI state. Hydrated history has ended,
+    // so stateless must render Completed — not an eternal "Running" chip.
+    const [msg] = hydratedMessagesToChatMessages(
+      assistantWith([
+        { type: 'tool-call', toolCallId: 't1', toolName: 'propose_blueprint' },
+      ]),
+    );
+    expect(msg.toolInvocations).toEqual([
+      { toolCallId: 't1', toolName: 'propose_blueprint', state: 'output-available' },
+    ]);
+  });
+
+  it('promotes dangling mid-stream states to output-available', () => {
+    const [msg] = hydratedMessagesToChatMessages(
+      assistantWith([
+        { type: 'tool-add_field', toolCallId: 't1', toolName: 'add_field', state: 'input-available' },
+        { type: 'tool-create_metadata', toolCallId: 't2', toolName: 'create_metadata', state: 'input-streaming' },
+      ]),
+    );
+    expect(msg.toolInvocations?.map((t) => t.state)).toEqual(['output-available', 'output-available']);
+  });
+
+  it('preserves genuine terminal states', () => {
+    const [msg] = hydratedMessagesToChatMessages(
+      assistantWith([
+        { type: 'tool-add_field', toolCallId: 't1', toolName: 'add_field', state: 'output-error', errorText: 'boom' },
+        { type: 'tool-verify_build', toolCallId: 't2', toolName: 'verify_build', state: 'output-denied' },
+      ]),
+    );
+    expect(msg.toolInvocations).toEqual([
+      { toolCallId: 't1', toolName: 'add_field', state: 'output-error', errorText: 'boom' },
+      { toolCallId: 't2', toolName: 'verify_build', state: 'output-denied' },
+    ]);
+  });
+});

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -51,7 +51,7 @@ import { getRuntimeConfig } from '../runtime-config';
  * to whatever label the backend provides.
  */
 const PLATFORM_AGENT_LABELS: Record<string, { zh: string; en: string }> = {
-  data_chat: { zh: '数据助手', en: 'Data Assistant' },
+  data_chat: { zh: '智能助手', en: 'Assistant' },
   metadata_assistant: { zh: '元数据开发助手', en: 'Metadata Assistant' },
 };
 

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1029,7 +1029,7 @@ const en = {
       hoursAgo: '{{count}}h ago',
       daysAgo: '{{count}}d ago',
       agentLabels: {
-        dataChat: 'Data Assistant',
+        dataChat: 'Assistant',
         metadataAssistant: 'Metadata Assistant',
       },
       suggestions: {

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1029,7 +1029,7 @@ const zh = {
       hoursAgo: '{{count}} 小时前',
       daysAgo: '{{count}} 天前',
       agentLabels: {
-        dataChat: '数据助手',
+        dataChat: '智能助手',
         metadataAssistant: '元数据开发助手',
       },
       suggestions: {


### PR DESCRIPTION
Found during browser verification on jack-test staging after the [cloud#244](https://github.com/objectstack-ai/cloud/pull/244) pin landed.

## Gap 1 — stateless tool parts spin forever (the third hydration path)

#1648 fixed `mapMessages` (floating chat), #1655 fixed dangling `input-*` states in AiChatPage — but server-persisted conversations store **ModelMessage content**, whose `tool-call` entries carry **no UI state at all**. `contentToParts` passes them through verbatim (`type: 'tool-call'`, no `state`), `partToolState`'s default branch returned `undefined`, and the chip rendered "Running" forever — exactly what conv_584c… still showed after deploy.

Fix: in hydrated history the turn has ended, so **stateless ≡ completed** — the default branch now promotes to `output-available`. Genuine terminal states (`output-error`, `output-denied`, approvals) are preserved.

## Gap 2 — client hardcodes override the unified assistant label

The server-side `data_chat` agent now reports `label: 'Assistant'` (verified live: `GET /api/v1/ai/agents`), but three client spots still hardcoded the old name and overrode it:
- `AiChatPage` i18n `defaultValue: 'Data Assistant'` → `'Assistant'`
- `en.ts` / `zh.ts` locale catalogs → `'Assistant'` / `'智能助手'`
- `ConsoleFloatingChatbot` fallback map → same

## Tests
- New `AiChatPage.hydration.test.ts`: stateless tool-call → Completed; dangling mid-stream → promoted; terminal states preserved. (`hydratedMessagesToChatMessages` exported for tests.)
- app-shell suite: 415/415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)