### PR TITLE
feat(preview): make ADR-0037 draft preview honest end-to-end — sticky mode, real empty states, live publish truth, changeset panel

### DIFF
--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -20,6 +20,8 @@ import type { ConnectionState } from '@object-ui/data-objectstack';
 import { useAuth } from '@object-ui/auth';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useAdapter } from '../providers/AdapterProvider';
+import { usePreviewDrafts } from '../preview/PreviewModeContext';
+import { PreviewDraftEmptyState } from '../preview/PreviewDraftEmptyState';
 import { ExpressionProvider, evaluateVisibility } from '../providers/ExpressionProvider';
 import { useTrackRouteAsRecent } from '../hooks/useTrackRouteAsRecent';
 import { resolveRecordFormTarget, resolveNavigateCreateUrl, resolveNavigateEditUrl } from '../utils/recordFormNavigation';
@@ -135,7 +137,8 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
   const navigate = useNavigate();
   const location = useLocation();
   const { appName } = useParams();
-  const { apps, objects: allObjects, loading: metadataLoading, ensureType } = useMetadata();
+  const { apps, objects: allObjects, loading: metadataLoading, ensureType, error: metadataError, refresh: refreshMetadata } = useMetadata();
+  const previewDrafts = usePreviewDrafts();
   const { t } = useObjectTranslation();
   const { objectLabel } = useObjectLabel();
 
@@ -172,6 +175,13 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
     apps.find((a: any) => a.name === appName) ||
     launcherApps.find((a: any) => a.isDefault === true) ||
     launcherApps[0];
+
+  // ADR-0037 — a draft preview is a window onto ONE requested app. When the
+  // overlay doesn't (yet) carry it, the default-app fallback above would
+  // silently preview the WRONG app; treat the request as "not ready" instead
+  // and let the preview-specific empty state below say so.
+  const requestedAppMissing =
+    previewDrafts && !!appName && !apps.some((a: any) => a.name === appName);
 
   useEffect(() => {
     if (!activeApp?.name) return;
@@ -343,6 +353,21 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
   );
 
   if (!dataSource || metadataLoading || !scopeMetaReady) return <LoadingScreen />;
+
+  // ADR-0037 — preview mode renders its OWN empty/error states and never
+  // falls through to the generic "No Apps Configured" guard below: inside a
+  // draft preview (the Live Canvas iframe, or a hand-opened ?preview=draft
+  // URL) that screen both lies ("nothing has been registered") and misdirects
+  // ("Create Your First App") about an app the AI may have just drafted.
+  if (previewDrafts && (requestedAppMissing || !activeApp)) {
+    return (
+      <PreviewDraftEmptyState
+        appName={appName}
+        error={metadataError}
+        onRetry={() => void refreshMetadata()}
+      />
+    );
+  }
 
   const isCreateAppRoute = location.pathname.endsWith('/create-app');
   const isSystemRoute = location.pathname.includes('/system');

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -46,6 +46,7 @@ import {
 } from '@object-ui/plugin-chatbot';
 
 import { AppHeader } from '../../layout/AppHeader';
+import { fetchPendingDraftCount } from '../../preview/draftStatus';
 import { getRuntimeConfig } from '../../runtime-config';
 import { useNavigationContext } from '../../context/NavigationContext';
 import {
@@ -632,6 +633,9 @@ function ChatPane({
         // Build-tree "Open app": jump straight into the app the agent just built.
         onOpenBuiltApp={(appName) => navigate(`/apps/${encodeURIComponent(appName)}`)}
         openBuiltAppLabel={t('console.ai.openBuiltApp', { defaultValue: 'Open app' })}
+        // Live lifecycle truth for draft cards: the server's pending count per
+        // package, so reloaded conversations show Published/Publish honestly.
+        fetchPendingDraftCount={fetchPendingDraftCount}
         onPublishDrafts={async (packageId) => {
           // Promote the conversation's staged drafts to live (ADR-0033 gate —
           // the human still clicks). Same call as the floating chat + PackagesPage.

--- a/packages/app-shell/src/hooks/useNavigationSync.ts
+++ b/packages/app-shell/src/hooks/useNavigationSync.ts
@@ -15,6 +15,7 @@ import type { NavigationItem, AppSchema } from '@object-ui/types';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useAdapter } from '../providers/AdapterProvider';
 import { useMetadata } from '../providers/MetadataProvider';
+import { usePreviewDrafts } from '../preview/PreviewModeContext';
 
 // ============================================================================
 // Pure utility helpers (exported for testing)
@@ -513,6 +514,13 @@ export function NavigationSyncEffect(): null {
   const adapter = useAdapter();
   const adapterRef = useRef(adapter);
   adapterRef.current = adapter;
+  // ADR-0037 — preview is read-only by design. Entering/leaving
+  // `?preview=draft` swaps the entire metadata source, so the page/dashboard
+  // sets legitimately DIFFER from the previous render; diffing across that
+  // swap would misread draft-only (or published-only) items as user
+  // creations/deletions and WRITE navigation changes back to the real app
+  // metadata from inside a preview. Disabled for the whole preview session.
+  const previewDrafts = usePreviewDrafts();
 
   const {
     syncPageCreated,
@@ -537,6 +545,13 @@ export function NavigationSyncEffect(): null {
 
   useEffect(() => {
     if (syncingRef.current) return;
+    if (previewDrafts) {
+      // Drop the baseline so leaving preview re-seeds instead of diffing the
+      // published world against the draft world it just stopped rendering.
+      prevPageNamesRef.current = null;
+      prevDashNamesRef.current = null;
+      return;
+    }
 
     const currentPageNames = new Set(
       (pages ?? []).map((p: any) => p.name).filter(Boolean) as string[],
@@ -616,7 +631,7 @@ export function NavigationSyncEffect(): null {
     return () => {
       cancelled = true;
     };
-  }, [pages, dashboards, apps, syncPageCreated, syncDashboardCreated, syncPageDeleted, syncDashboardDeleted]);
+  }, [pages, dashboards, apps, previewDrafts, syncPageCreated, syncDashboardCreated, syncPageDeleted, syncDashboardDeleted]);
 
   return null;
 }

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -42,6 +42,7 @@ import {
   type HydratedUIMessage,
 } from '../hooks';
 import { useAssistant, requestAssistantReview, emitCanvasInvalidate, type AssistantEditorContext } from '../assistant/assistantBus';
+import { fetchPendingDraftCount } from '../preview/draftStatus';
 import { getRuntimeConfig } from '../runtime-config';
 
 /**
@@ -525,6 +526,9 @@ function ChatbotInner({
         onDraftArtifacts={(artifacts) => {
           for (const a of artifacts) emitCanvasInvalidate(a);
         }}
+        // Live lifecycle truth for draft cards: the server's pending count per
+        // package, so reloaded conversations show Published/Publish honestly.
+        fetchPendingDraftCount={fetchPendingDraftCount}
         onPublishDrafts={async (packageId) => {
           // ADR-0033 — promote the conversation's staged drafts to live in one
           // click (the human still confirms here). Mirrors PackagesPage's

--- a/packages/app-shell/src/preview/DraftChangesPanel.tsx
+++ b/packages/app-shell/src/preview/DraftChangesPanel.tsx
@@ -1,0 +1,212 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * "What will publishing change?" — the draft changeset, answered before the
+ * user commits. Lists every pending ADR-0033 draft grouped by metadata type,
+ * and classifies each as NEW (no published version exists — publishing adds
+ * it) or UPDATE (a published version exists — publishing overwrites it).
+ * This is the review surface that turns Publish from a leap of faith into an
+ * informed click; the per-item designer diff remains the deep-dive.
+ *
+ * Read-only: fetches `_drafts` + per-item `/published` probes on open, and
+ * never writes. Publishing stays with the caller (DraftPreviewBar / chat).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { FilePlus2, FilePen, Loader2 } from 'lucide-react';
+import {
+  Badge,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@object-ui/components';
+import { useObjectTranslation } from '@object-ui/i18n';
+
+export interface DraftChangeEntry {
+  type: string;
+  name: string;
+  packageId: string | null;
+  /** `new` = no published version; `update` = overwrites one; undefined = probing. */
+  kind?: 'new' | 'update';
+}
+
+/** Pending drafts straight from the ADR-0033 `_drafts` endpoint. */
+async function listPendingDrafts(): Promise<DraftChangeEntry[]> {
+  const res = await fetch('/api/v1/meta/_drafts', {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`_drafts HTTP ${res.status}`);
+  const data = (await res.json()) as
+    | Array<Record<string, unknown>>
+    | { drafts?: Array<Record<string, unknown>> };
+  const list = Array.isArray(data) ? data : data?.drafts ?? [];
+  return list
+    .filter((d) => typeof d?.type === 'string' && typeof d?.name === 'string')
+    .map((d) => ({
+      type: d.type as string,
+      name: d.name as string,
+      packageId: typeof d.packageId === 'string' && d.packageId ? (d.packageId as string) : null,
+    }));
+}
+
+/**
+ * Names that exist in the PUBLISHED world for a type — the plain (no
+ * `preview=draft`) list. One request classifies every draft of that type:
+ * a draft whose name is absent here is NEW; present means publish UPDATES it.
+ * (A per-item `/published` probe would be O(drafts) requests, and the REST
+ * tree has no such sub-route — the generic :name handler answers anything.)
+ */
+async function publishedNamesOf(type: string): Promise<Set<string>> {
+  const res = await fetch(`/api/v1/meta/${encodeURIComponent(type)}`, {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`published list HTTP ${res.status}`);
+  const data = (await res.json()) as unknown[] | { items?: unknown[] };
+  const list = Array.isArray(data) ? data : data?.items ?? [];
+  return new Set(
+    (list as Array<{ name?: unknown }>)
+      .map((it) => (typeof it?.name === 'string' ? it.name : null))
+      .filter((n): n is string => n !== null),
+  );
+}
+
+export interface DraftChangesPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DraftChangesPanel({ open, onOpenChange }: DraftChangesPanelProps) {
+  const { t } = useObjectTranslation();
+  const [entries, setEntries] = useState<DraftChangeEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setEntries(null);
+    setError(null);
+    try {
+      const drafts = await listPendingDrafts();
+      setEntries(drafts);
+      // Classify new-vs-update per TYPE: one published-list read covers every
+      // draft of that type. A type whose read fails stays unclassified
+      // (rendered neutrally) rather than failing the whole panel.
+      const types = [...new Set(drafts.map((d) => d.type))];
+      await Promise.all(
+        types.map(async (type) => {
+          let published: Set<string> | null = null;
+          try {
+            published = await publishedNamesOf(type);
+          } catch {
+            return;
+          }
+          setEntries((prev) =>
+            prev
+              ? prev.map((entry) =>
+                  entry.type === type
+                    ? { ...entry, kind: published!.has(entry.name) ? 'update' : 'new' }
+                    : entry,
+                )
+              : prev,
+          );
+        }),
+      );
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [open, load]);
+
+  const byType = new Map<string, DraftChangeEntry[]>();
+  for (const entry of entries ?? []) {
+    const bucket = byType.get(entry.type) ?? [];
+    bucket.push(entry);
+    byType.set(entry.type, bucket);
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-[420px] sm:max-w-[420px]" data-testid="draft-changes-panel">
+        <SheetHeader>
+          <SheetTitle>
+            {t('preview.changes.title', { defaultValue: 'Pending changes' })}
+          </SheetTitle>
+          <SheetDescription>
+            {t('preview.changes.description', {
+              defaultValue: 'What publishing will change. New items are added; updates overwrite the live version.',
+            })}
+          </SheetDescription>
+        </SheetHeader>
+        <div className="mt-4 flex flex-col gap-4 overflow-y-auto px-4 pb-6">
+          {error ? (
+            <p className="text-sm text-destructive">
+              {t('preview.changes.loadFailed', { defaultValue: 'Could not load pending changes:' })}{' '}
+              {error}
+            </p>
+          ) : entries === null ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t('preview.changes.loading', { defaultValue: 'Loading pending changes…' })}
+            </div>
+          ) : entries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t('preview.changes.empty', { defaultValue: 'Nothing pending — every draft has been published.' })}
+            </p>
+          ) : (
+            [...byType.entries()].map(([type, items]) => (
+              <div key={type}>
+                <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {type} · {items.length}
+                </h4>
+                <ul className="flex flex-col gap-1">
+                  {items.map((entry) => (
+                    <li
+                      key={`${entry.type}:${entry.name}`}
+                      className="flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm"
+                    >
+                      {entry.kind === 'new' ? (
+                        <FilePlus2 className="h-3.5 w-3.5 shrink-0 text-emerald-600" />
+                      ) : entry.kind === 'update' ? (
+                        <FilePen className="h-3.5 w-3.5 shrink-0 text-amber-600" />
+                      ) : (
+                        <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate font-mono text-xs">{entry.name}</span>
+                      {entry.kind ? (
+                        <Badge
+                          variant="outline"
+                          className={
+                            entry.kind === 'new'
+                              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                              : 'border-amber-200 bg-amber-50 text-amber-700'
+                          }
+                        >
+                          {entry.kind === 'new'
+                            ? t('preview.changes.kindNew', { defaultValue: 'New' })
+                            : t('preview.changes.kindUpdate', { defaultValue: 'Update' })}
+                        </Badge>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/app-shell/src/preview/DraftPreviewBar.tsx
+++ b/packages/app-shell/src/preview/DraftPreviewBar.tsx
@@ -14,12 +14,14 @@
  * keeps a read-only preview from ever being confused with the live app.
  */
 
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Eye, X, Rocket } from 'lucide-react';
+import { Eye, X, Rocket, GitCompareArrows } from 'lucide-react';
 import { Button } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
-import { usePreviewDrafts, PREVIEW_QUERY_FLAG } from './PreviewModeContext';
+import { usePreviewDrafts, markPreviewExit, PREVIEW_QUERY_FLAG } from './PreviewModeContext';
 import { usePublishAllDrafts } from './usePublishAllDrafts';
+import { DraftChangesPanel } from './DraftChangesPanel';
 
 export function DraftPreviewBar() {
   const preview = usePreviewDrafts();
@@ -27,10 +29,39 @@ export function DraftPreviewBar() {
   const navigate = useNavigate();
   const { t } = useObjectTranslation();
   const { publishAll, publishing } = usePublishAllDrafts(t);
+  const [changesOpen, setChangesOpen] = useState(false);
+  // Pending-draft count for the Changes button label — what Publish will
+  // actually promote. Refreshed per pathname so drafts staged while the
+  // preview is open (the chat keeps building) update the count.
+  const [pendingCount, setPendingCount] = useState<number | null>(null);
+  useEffect(() => {
+    if (!preview) return;
+    let cancelled = false;
+    void fetch('/api/v1/meta/_drafts', {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const list = Array.isArray(data) ? data : data?.drafts ?? [];
+        setPendingCount(Array.isArray(list) ? list.length : null);
+      })
+      .catch(() => {
+        /* count is decorative — the panel itself reports errors */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [preview, location.pathname]);
 
   if (!preview) return null;
 
   const exit = () => {
+    // Tell the sticky preview keeper this is an INTENTIONAL exit, or it
+    // would immediately re-apply the flag we are about to remove.
+    markPreviewExit();
     const params = new URLSearchParams(location.search);
     params.delete(PREVIEW_QUERY_FLAG);
     const qs = params.toString();
@@ -57,12 +88,23 @@ export function DraftPreviewBar() {
           defaultValue: 'Draft preview — you are seeing unpublished changes. Nothing here is live until you publish.',
         })}
       </p>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => setChangesOpen(true)}
+        data-testid="draft-preview-changes"
+      >
+        <GitCompareArrows className="mr-1 h-3.5 w-3.5" />
+        {t('preview.draftBar.changes', { defaultValue: 'Changes' })}
+        {typeof pendingCount === 'number' ? ` (${pendingCount})` : ''}
+      </Button>
       <Button size="sm" onClick={publish} disabled={publishing} data-testid="draft-preview-publish">
         <Rocket className="mr-1 h-3.5 w-3.5" />
         {publishing
           ? t('preview.draftBar.publishing', { defaultValue: 'Publishing…' })
           : t('preview.draftBar.publish', { defaultValue: 'Publish' })}
       </Button>
+      <DraftChangesPanel open={changesOpen} onOpenChange={setChangesOpen} />
       <Button size="sm" variant="outline" onClick={exit} data-testid="draft-preview-exit">
         <X className="mr-1 h-3.5 w-3.5" />
         {t('preview.draftBar.exit', { defaultValue: 'Exit preview' })}

--- a/packages/app-shell/src/preview/PreviewDraftEmptyState.tsx
+++ b/packages/app-shell/src/preview/PreviewDraftEmptyState.tsx
@@ -1,0 +1,79 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0037 — the draft preview's own empty/error states.
+ *
+ * A `?preview=draft` tree (the Live Canvas iframe, or a hand-opened preview
+ * URL) must NEVER fall through to the console's generic "No Apps Configured"
+ * screen: that screen tells the user nothing exists and offers "Create Your
+ * First App" — both wrong and disorienting inside a preview of an app the AI
+ * just drafted. Preview has exactly three honest non-happy states, all
+ * rendered here:
+ *
+ *  - loading failed   → say so, offer Retry (the overlay read errored);
+ *  - app not in draft → the build likely failed or hasn't run — point the
+ *                       user back to the conversation, never to "create app";
+ *  - nothing drafted  → same message, generic (no app name in the URL).
+ *
+ * Deliberately CTA-free beyond Retry: the preview is a window owned by the
+ * build conversation; every corrective action lives there.
+ */
+
+import { Eye, RefreshCw, TriangleAlert } from 'lucide-react';
+import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
+import { useObjectTranslation } from '@object-ui/i18n';
+
+export interface PreviewDraftEmptyStateProps {
+  /** The app the URL asked to preview (`/apps/:appName?preview=draft`). */
+  appName?: string;
+  /** Why the draft world failed to load, when it errored (null = loaded fine). */
+  error?: Error | null;
+  /** Re-read the draft overlay (MetadataProvider.refresh). */
+  onRetry: () => void;
+}
+
+export function PreviewDraftEmptyState({ appName, error, onRetry }: PreviewDraftEmptyStateProps) {
+  const { t } = useObjectTranslation();
+  const failed = Boolean(error);
+  return (
+    <div className="flex h-screen items-center justify-center" data-testid="preview-draft-empty-state">
+      <Empty>
+        <div className="mb-2 flex justify-center text-muted-foreground" aria-hidden="true">
+          {failed ? <TriangleAlert className="h-8 w-8" /> : <Eye className="h-8 w-8" />}
+        </div>
+        <EmptyTitle>
+          {failed
+            ? t('preview.empty.loadFailedTitle', { defaultValue: 'Draft preview failed to load' })
+            : appName
+              ? t('preview.empty.notReadyTitle', {
+                  app: appName,
+                  defaultValue: '“{{app}}” isn’t in the draft yet',
+                })
+              : t('preview.empty.nothingTitle', { defaultValue: 'Nothing to preview yet' })}
+        </EmptyTitle>
+        <EmptyDescription>
+          {failed
+            ? t('preview.empty.loadFailedDescription', {
+                defaultValue: 'The draft overlay could not be read. Retry, or check your connection.',
+              })
+            : t('preview.empty.notReadyDescription', {
+                defaultValue:
+                  'The build may still be running, or it may have failed before this app was staged. Check the conversation for the build status — this pane refreshes as drafts land.',
+              })}
+        </EmptyDescription>
+        <div className="mt-4 flex justify-center">
+          <Button variant="outline" onClick={onRetry} data-testid="preview-draft-retry">
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            {t('preview.empty.retry', { defaultValue: 'Retry' })}
+          </Button>
+        </div>
+      </Empty>
+    </div>
+  );
+}

--- a/packages/app-shell/src/preview/PreviewModeContext.test.tsx
+++ b/packages/app-shell/src/preview/PreviewModeContext.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0037 sticky preview — the regression that motivated it: in-app
+ * navigation (landing redirect, sidebar links) builds URLs without the query
+ * string, so a `?preview=draft` session used to silently flip back to the
+ * published world for one render. That flicker swapped the metadata source
+ * mid-session and once fed a cross-world diff into NavigationSyncEffect,
+ * which WROTE navigation changes from inside a read-only preview.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import {
+  PreviewModeProvider,
+  usePreviewDrafts,
+  markPreviewExit,
+  isPreviewSearch,
+} from './PreviewModeContext';
+
+function Probe() {
+  const preview = usePreviewDrafts();
+  const location = useLocation();
+  return (
+    <div>
+      <span data-testid="preview">{String(preview)}</span>
+      <span data-testid="search">{location.search}</span>
+    </div>
+  );
+}
+
+/** Navigates once (like the app's landing redirect) WITHOUT the query string. */
+function DropFlagOnce({ to }: { to: string }) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate(to, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+}
+
+/** Exits preview explicitly, the way DraftPreviewBar's Exit button does. */
+function ExplicitExitButton() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  return (
+    <button
+      type="button"
+      data-testid="exit"
+      onClick={() => {
+        markPreviewExit();
+        navigate(location.pathname, { replace: true });
+      }}
+    >
+      exit
+    </button>
+  );
+}
+
+function App({ children, initialEntry }: { children?: React.ReactNode; initialEntry: string }) {
+  return (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <PreviewModeProvider>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <>
+                <Probe />
+                {children}
+              </>
+            }
+          />
+        </Routes>
+      </PreviewModeProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('isPreviewSearch', () => {
+  it('detects the flag and rejects other values', () => {
+    expect(isPreviewSearch('?preview=draft')).toBe(true);
+    expect(isPreviewSearch('?preview=published')).toBe(false);
+    expect(isPreviewSearch('')).toBe(false);
+  });
+});
+
+describe('PreviewModeProvider (sticky)', () => {
+  it('is on when the URL carries the flag', () => {
+    render(<App initialEntry="/apps/crm?preview=draft" />);
+    expect(screen.getByTestId('preview').textContent).toBe('true');
+  });
+
+  it('stays on and restores the flag when navigation drops the query string', async () => {
+    render(
+      <App initialEntry="/apps/crm?preview=draft">
+        <DropFlagOnce to="/apps/crm/lead" />
+      </App>,
+    );
+    // The context value must never read false mid-flight, and the URL must
+    // come back with the flag restored.
+    await waitFor(() => {
+      expect(screen.getByTestId('search').textContent).toBe('?preview=draft');
+    });
+    expect(screen.getByTestId('preview').textContent).toBe('true');
+  });
+
+  it('turns off (and stays off) after an explicit markPreviewExit()', async () => {
+    render(
+      <App initialEntry="/apps/crm?preview=draft">
+        <ExplicitExitButton />
+      </App>,
+    );
+    expect(screen.getByTestId('preview').textContent).toBe('true');
+    fireEvent.click(screen.getByTestId('exit'));
+    await waitFor(() => {
+      expect(screen.getByTestId('preview').textContent).toBe('false');
+    });
+    // The flag is gone and the keeper did NOT re-apply it.
+    expect(screen.getByTestId('search').textContent).toBe('');
+  });
+
+  it('is off for a tree that never entered preview', () => {
+    render(<App initialEntry="/apps/crm" />);
+    expect(screen.getByTestId('preview').textContent).toBe('false');
+    expect(screen.getByTestId('search').textContent).toBe('');
+  });
+});

--- a/packages/app-shell/src/preview/PreviewModeContext.tsx
+++ b/packages/app-shell/src/preview/PreviewModeContext.tsx
@@ -19,8 +19,8 @@
  * writes, and Publish remains the single commit gate.
  */
 
-import { createContext, useContext, useMemo, type ReactNode } from 'react';
-import { useLocation } from 'react-router-dom';
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const PreviewModeContext = createContext<boolean>(false);
 
@@ -33,18 +33,68 @@ export function isPreviewSearch(search: string): boolean {
   return new URLSearchParams(search).get(PREVIEW_QUERY_FLAG) === PREVIEW_QUERY_VALUE;
 }
 
+// Set by markPreviewExit() for exactly one navigation: the user explicitly
+// left preview (DraftPreviewBar's Exit / post-publish), so the keeper below
+// must NOT re-stick the flag onto the next location.
+let previewExitRequested = false;
+
+/**
+ * Declare that the NEXT navigation is an intentional exit from draft preview.
+ * Call right before navigating away (e.g. the preview bar's Exit button);
+ * without it, the sticky keeper re-applies `?preview=draft` to in-app
+ * navigation so a click inside the previewed app can't silently drop the
+ * draft world mid-session.
+ */
+export function markPreviewExit(): void {
+  previewExitRequested = true;
+}
+
 /**
  * Provides the preview-mode flag to the tree. Reads the router location
  * LIVE, so entering/leaving `?preview=draft` flips consumers without a
  * remount. `force` overrides the URL — the Live Canvas mounts its embedded
  * renderer subtree with `force` so the canvas is always a draft window
  * regardless of the host page's own URL.
+ *
+ * STICKY by design: preview is URL-keyed, but in-app navigation (the app's
+ * landing redirect, sidebar links, row clicks) builds URLs without the
+ * query string. Once the tree is in preview, this provider re-applies the
+ * flag (history REPLACE, no extra entry) to any same-session navigation
+ * that lost it — so the only way out of the draft world is the explicit
+ * Exit affordance ({@link markPreviewExit}), never an accidental click.
  */
 export function PreviewModeProvider({ force, children }: { force?: boolean; children: ReactNode }) {
   const location = useLocation();
+  const navigate = useNavigate();
   const fromUrl = useMemo(() => isPreviewSearch(location.search), [location.search]);
+  // Sticky state: stays true across the flag-less navigation window so the
+  // CONTEXT VALUE never flickers false mid-session. A flicker is not benign —
+  // it swaps the whole metadata source to published for one render, which
+  // (a) wastes a full refetch and (b) feeds cross-world diffs to effects
+  // like NavigationSyncEffect that must never see the two worlds as one
+  // timeline (that misread once WROTE nav changes from inside a preview).
+  const [sticky, setSticky] = useState(fromUrl);
+  useEffect(() => {
+    if (fromUrl) {
+      setSticky(true);
+      previewExitRequested = false;
+      return;
+    }
+    if (!sticky) return;
+    if (previewExitRequested) {
+      previewExitRequested = false;
+      setSticky(false);
+      return;
+    }
+    // In-app navigation lost the flag without an explicit exit — restore it
+    // in place (history REPLACE, no extra entry) so a refresh/share of the
+    // URL stays in the draft world too.
+    const params = new URLSearchParams(location.search);
+    params.set(PREVIEW_QUERY_FLAG, PREVIEW_QUERY_VALUE);
+    navigate(`${location.pathname}?${params.toString()}${location.hash}`, { replace: true });
+  }, [fromUrl, sticky, location.pathname, location.search, location.hash, navigate]);
   return (
-    <PreviewModeContext.Provider value={force ?? fromUrl}>
+    <PreviewModeContext.Provider value={force ?? (fromUrl || sticky)}>
       {children}
     </PreviewModeContext.Provider>
   );

--- a/packages/app-shell/src/preview/draftStatus.ts
+++ b/packages/app-shell/src/preview/draftStatus.ts
@@ -1,0 +1,32 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Live draft-status read for the chat's draft cards (panel-as-source-of-truth,
+ * made literal): how many drafts are still PENDING in a package, straight from
+ * the ADR-0033 `_drafts` endpoint. The chat passes this to
+ * `fetchPendingDraftCount` so a card's Publish/Published affordance reflects
+ * the server's CURRENT state — across conversation reloads, other sessions'
+ * publishes, and later edits into the same package — instead of replaying the
+ * tool-result snapshot it was born with.
+ *
+ * Cookie-authenticated like every other console call; tolerant of both
+ * response shapes (`[...]` and `{ drafts: [...] }`).
+ */
+export async function fetchPendingDraftCount(packageId: string): Promise<number> {
+  const res = await fetch(
+    `/api/v1/meta/_drafts?packageId=${encodeURIComponent(packageId)}`,
+    { credentials: 'include', headers: { Accept: 'application/json' }, cache: 'no-store' },
+  );
+  if (!res.ok) throw new Error(`_drafts HTTP ${res.status}`);
+  const data = (await res.json()) as
+    | unknown[]
+    | { drafts?: unknown[]; data?: { drafts?: unknown[] } };
+  const list = Array.isArray(data) ? data : data?.drafts ?? data?.data?.drafts ?? [];
+  return Array.isArray(list) ? list.length : 0;
+}

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -84,11 +84,11 @@ function debug(...args: unknown[]) {
 
 /** Exported for tests — both metadata sources must normalize identically. */
 export function extractItems(res: unknown): any[] {
-  // MetadataClient.list() (the preview-draft path) unwraps `{items}` itself
-  // and resolves a BARE ARRAY; the adapter SDK path resolves `{items}`.
-  // Missing this branch silently turned every preview-mode list read into []
-  // — a draft-built app rendered the launcher's "No Apps Configured" empty
-  // state in the Live Canvas (live-verified on staging).
+  // Both source shapes must parse: the adapter SDK returns the wrapped
+  // `{ type, items: [...] }` envelope, while the ADR-0037 preview path's
+  // MetadataClient.list() returns the already-unwrapped array. Dropping the
+  // bare-array shape silently emptied the ENTIRE draft-preview world (every
+  // type read 0 items), stranding the Live Canvas on "No Apps Configured".
   if (Array.isArray(res)) return res;
   if (res && typeof res === 'object' && 'items' in res && Array.isArray((res as { items: unknown[] }).items)) {
     return (res as { items: unknown[] }).items;

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1616,6 +1616,32 @@ const en = {
     systemSettings: 'System Settings',
     back: 'Back',
   },
+  preview: {
+    empty: {
+      loadFailedTitle: 'Draft preview failed to load',
+      loadFailedDescription: 'The draft overlay could not be read. Retry, or check your connection.',
+      notReadyTitle: '“{{app}}” isn’t in the draft yet',
+      notReadyDescription: 'The build may still be running, or it may have failed before this app was staged. Check the conversation for the build status — this pane refreshes as drafts land.',
+      nothingTitle: 'Nothing to preview yet',
+      retry: 'Retry',
+    },
+    draftBar: {
+      message: 'Draft preview — you are seeing unpublished changes. Nothing here is live until you publish.',
+      publish: 'Publish',
+      publishing: 'Publishing…',
+      exit: 'Exit preview',
+      changes: 'Changes',
+    },
+    changes: {
+      title: 'Pending changes',
+      description: 'What publishing will change. New items are added; updates overwrite the live version.',
+      loading: 'Loading pending changes…',
+      loadFailed: 'Could not load pending changes:',
+      empty: 'Nothing pending — every draft has been published.',
+      kindNew: 'New',
+      kindUpdate: 'Update',
+    },
+  },
   renderer: {
     noPageSchema: 'No page schema provided',
     noFormSchema: 'No form schema provided',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1628,6 +1628,32 @@ const zh = {
     systemSettings: '系统设置',
     back: '返回',
   },
+  preview: {
+    empty: {
+      loadFailedTitle: '草稿预览加载失败',
+      loadFailedDescription: '无法读取草稿数据。请重试，或检查网络连接。',
+      notReadyTitle: '“{{app}}” 尚未进入草稿',
+      notReadyDescription: '构建可能仍在进行，或在该应用落稿前失败了。请回到对话查看构建状态 —— 草稿就绪后此窗口会自动刷新。',
+      nothingTitle: '暂无可预览的内容',
+      retry: '重试',
+    },
+    draftBar: {
+      message: '草稿预览 —— 您看到的是未发布的更改，发布前不会生效。',
+      publish: '发布',
+      publishing: '发布中…',
+      exit: '退出预览',
+      changes: '变更',
+    },
+    changes: {
+      title: '待发布的变更',
+      description: '发布将带来以下变更。“新增”为全新内容，“更新”将覆盖线上版本。',
+      loading: '正在加载待发布变更…',
+      loadFailed: '无法加载待发布变更：',
+      empty: '没有待发布的内容 —— 所有草稿均已发布。',
+      kindNew: '新增',
+      kindUpdate: '更新',
+    },
+  },
   renderer: {
     noPageSchema: '未提供页面 schema',
     noFormSchema: '未提供表单 schema',

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -19,7 +19,7 @@
  */
 import * as React from 'react';
 import { cn } from '@object-ui/components';
-import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, Eye, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, Eye, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2, ShieldCheck, TriangleAlert } from 'lucide-react';
 import type { ChatStatus } from 'ai';
 import {
   humanizeToolName,
@@ -172,6 +172,12 @@ export interface ChatToolInvocation {
      * open the REAL app URL, not the draft overlay.
      */
     materialized?: boolean;
+    /**
+     * ADR-0038 L1 graph-lint verdict for the staged build. Rendered as a
+     * verified/issues chip so "drafted" and "verified" read as the two
+     * separate statements they are. Absent on older tool output.
+     */
+    verification?: { errors: number; warnings: number };
   };
 }
 
@@ -393,6 +399,18 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   publishDraftsLabel?: string;
   /** Label for the published-state badge that replaces the button (default "Published"). */
   publishedLabel?: string;
+  /** Label for the clean ADR-0038 verification chip (default "Verified"). */
+  verifiedLabel?: string;
+  /**
+   * Live draft-status resolver: how many drafts are still PENDING in a
+   * package (e.g. `GET /metadata/_drafts?packageId=` count). When provided,
+   * each draft card's Publish/Published affordance reflects the SERVER's
+   * current state instead of this component's in-memory publish history —
+   * so a reloaded conversation shows "Published" for work that went live,
+   * and a card whose package gained new drafts offers Publish again. The
+   * in-memory snapshot remains the fallback when the prop is absent.
+   */
+  fetchPendingDraftCount?: (packageId: string) => Promise<number>;
   /**
    * Auto-fire `onPublishDrafts` the moment a turn finishes drafting an app —
    * the self-use "magic moment" where the user refreshes and the app is already
@@ -718,6 +736,8 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       onBuildMaterialized,
       publishDraftsLabel = 'Publish',
       publishedLabel = 'Published',
+      verifiedLabel = 'Verified',
+      fetchPendingDraftCount,
       autoPublishDrafts = false,
       processVisibility = 'summary',
       surface = 'card',
@@ -775,6 +795,57 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
     const [publishHealthByToolCall, setPublishHealthByToolCall] = React.useState<
       ReadonlyMap<string, PublishHealth>
     >(() => new Map());
+
+    // Live publish-state (panel-as-source-of-truth, made literal): the server's
+    // CURRENT pending-draft count per package, when the host wires
+    // `fetchPendingDraftCount`. The in-memory `publishedToolCalls` snapshot
+    // above is an optimistic overlay for THIS session; this map is what keeps a
+    // RELOADED conversation honest — published work shows "Published" (count
+    // 0), and a package that gained new drafts offers Publish again, no matter
+    // which session staged them.
+    const [pendingByPackage, setPendingByPackage] = React.useState<
+      ReadonlyMap<string, number>
+    >(() => new Map());
+    const pendingFetchedRef = React.useRef<Set<string>>(new Set());
+    const refreshPendingCount = React.useCallback(
+      async (packageId: string) => {
+        if (!fetchPendingDraftCount) return;
+        try {
+          const count = await fetchPendingDraftCount(packageId);
+          setPendingByPackage((prev) => {
+            if (prev.get(packageId) === count) return prev;
+            const next = new Map(prev);
+            next.set(packageId, count);
+            return next;
+          });
+        } catch {
+          // Leave the package unknown — the card falls back to the
+          // in-memory snapshot rather than guessing.
+        }
+      },
+      [fetchPendingDraftCount],
+    );
+    // Resolve the live count as draft cards appear (incl. on mount for
+    // reloaded conversations). Keyed by the card's toolCallId — a NEW build
+    // into an already-seen package must refresh that package's count, or the
+    // older card would keep claiming "Published" while drafts are pending.
+    // Waits for the turn to finish so a mid-build fetch doesn't race the
+    // still-staging drafts.
+    React.useEffect(() => {
+      if (!fetchPendingDraftCount || isLoading) return;
+      const due = new Set<string>();
+      for (const message of messages) {
+        for (const tool of message.toolInvocations ?? []) {
+          const pkg = tool.draftReview?.packageId;
+          const key = tool.toolCallId;
+          if (pkg && key && !pendingFetchedRef.current.has(key)) {
+            pendingFetchedRef.current.add(key);
+            due.add(pkg);
+          }
+        }
+      }
+      for (const pkg of due) void refreshPendingCount(pkg);
+    }, [messages, isLoading, fetchPendingDraftCount, refreshPendingCount]);
     // Publish a package's drafts and reflect success on exactly the cards that
     // were pending for it at publish time. The host's onPublishDrafts returns
     // `false` / `{ok:false}` on failure (and surfaces its own error); any other
@@ -812,8 +883,12 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             });
           }
         }
+        // Re-read the server's pending count so every card bound to this
+        // package reflects the post-publish truth (0 on success; unchanged
+        // on failure — the button stays).
+        void refreshPendingCount(packageId);
       },
-      [onPublishDrafts, messages],
+      [onPublishDrafts, messages, refreshPendingCount],
     );
 
     // Auto-publish "magic moment": when the environment enables autoPublishDrafts
@@ -961,6 +1036,18 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       const showPayload =
         processVisibility === 'debug' ||
         isAwaitingApproval;
+      // Lifecycle truth for this card's draft package, in precedence order:
+      // the server's live pending-draft count (host wired
+      // `fetchPendingDraftCount`), else this session's in-memory publish
+      // history. The live count is what keeps reloaded conversations and
+      // cross-session edits honest.
+      const draftPackageId = tool.draftReview?.packageId;
+      const livePendingCount = draftPackageId !== undefined
+        ? pendingByPackage.get(draftPackageId)
+        : undefined;
+      const draftIsPublished = livePendingCount !== undefined
+        ? livePendingCount === 0
+        : publishedToolCalls.has(tool.toolCallId);
       const titleNode = (
         <span className="inline-flex items-center gap-2">
           <span>{friendlyTitle || tool.toolName}</span>
@@ -1051,7 +1138,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
               <>
                 <div className="flex items-center gap-2 p-3 border-t bg-muted/30">
                   {onPublishDrafts && tool.draftReview.packageId ? (
-                    publishedToolCalls.has(tool.toolCallId) ? (
+                    draftIsPublished ? (
                       // Published (auto or manual): a stable status badge, not a
                       // stale button. Keeps the card honest about lifecycle state.
                       <span className="inline-flex h-7 items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-3 text-xs font-medium text-emerald-700">
@@ -1066,9 +1153,13 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                         type="button"
                         onClick={() => void handlePublishDrafts(tool.draftReview!.packageId!)}
                         className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                        data-testid="draft-publish"
                       >
                         <Rocket className="size-3.5" />
                         {publishDraftsLabel}
+                        {typeof livePendingCount === 'number' && livePendingCount > 0
+                          ? ` (${livePendingCount})`
+                          : ''}
                       </button>
                     )
                   ) : null}
@@ -1088,8 +1179,10 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                   ) : null}
                   {/* ADR-0037: drafted-app preview — see it as-if-published
                       without publishing. Only when the draft set includes an
-                      app (the canvas previews whole apps, not single items). */}
-                  {onPreviewDraftApp && !publishedToolCalls.has(tool.toolCallId)
+                      app (the canvas previews whole apps, not single items).
+                      Hidden once the package has no pending drafts (live
+                      count when available, else this session's history). */}
+                  {onPreviewDraftApp && !draftIsPublished
                     ? (() => {
                         const app = tool.draftReview!.items.find((i) => i.type === 'app');
                         return app ? (
@@ -1105,6 +1198,29 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                         ) : null;
                       })()
                     : null}
+                  {/* ADR-0038 L1 chip: the graph-lint verdict, so the user sees
+                      WHY a build did or didn't auto-publish without reading
+                      tool JSON. Green = referentially clean; amber = blocking
+                      issues, the build stays draft until the agent repairs. */}
+                  {tool.draftReview.verification ? (
+                    tool.draftReview.verification.errors > 0 ? (
+                      <span
+                        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-2.5 text-xs font-medium text-amber-700"
+                        data-testid="draft-verification-chip"
+                      >
+                        <TriangleAlert className="size-3.5" />
+                        {`${tool.draftReview.verification.errors} issue${tool.draftReview.verification.errors === 1 ? '' : 's'}`}
+                      </span>
+                    ) : (
+                      <span
+                        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-2.5 text-xs font-medium text-emerald-700"
+                        data-testid="draft-verification-chip"
+                      >
+                        <ShieldCheck className="size-3.5" />
+                        {verifiedLabel}
+                      </span>
+                    )
+                  ) : null}
                   {tool.draftReview.summary ? (
                     <span className="truncate text-xs text-muted-foreground">
                       {tool.draftReview.summary}

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -137,6 +137,7 @@ function detectDraftResult(
   autoPublishable?: boolean;
   failedCount?: number;
   materialized?: boolean;
+  verification?: { errors: number; warnings: number };
 } | undefined {
   const obj = parseResultEnvelope(result);
   if (!obj || obj.status !== 'drafted') return undefined;
@@ -162,6 +163,19 @@ function detectDraftResult(
   // incremental edits omit it and stay drafts for explicit review. `failedCount`
   // surfaces partial build failures so the UI never hides them.
   const failedCount = Array.isArray(obj.failed) ? obj.failed.length : 0;
+  // ADR-0038 L1 — the build's graph-lint verdict (`verification: {errors,
+  // warnings}` on apply_blueprint results). Lifted so the chat can render a
+  // verified/issues chip; absent on older tool output → no chip.
+  const rawVerification = (obj as { verification?: unknown }).verification;
+  const verification =
+    rawVerification && typeof rawVerification === 'object' &&
+    typeof (rawVerification as { errors?: unknown }).errors === 'number' &&
+    typeof (rawVerification as { warnings?: unknown }).warnings === 'number'
+      ? {
+          errors: (rawVerification as { errors: number }).errors,
+          warnings: (rawVerification as { warnings: number }).warnings,
+        }
+      : undefined;
   return {
     items,
     summary: typeof obj.summary === 'string' ? obj.summary : undefined,
@@ -171,6 +185,7 @@ function detectDraftResult(
     // ADR-0045: the build was materialized in-turn (real tables + data, app
     // hidden). The canvas then previews the REAL app URL, not the draft overlay.
     ...(obj.materialized === true ? { materialized: true } : {}),
+    ...(verification ? { verification } : {}),
   };
 }
 


### PR DESCRIPTION
## Why

The Live Canvas / draft preview chain had a compound failure: an AI-built app's preview pane rendered the console's generic **"No Apps Configured" + "Create Your First App"** screen — lying about work that existed and misdirecting the user. Reproduced on the full local stack (cloud+objectos, prod-like, drafts staged via the same `saveMetaItem mode=draft` path `apply_blueprint` uses) and fixed link by link, browser-verified at each step.

Pairs with framework#1763 (REST `/meta` routes now forward `?preview=draft`); this PR is the client half plus the UX hardening around it.

## Fixes

1. **`extractItems` dropped the bare-array shape** (`MetadataProvider`): `MetadataClient.list()` returns an unwrapped array, the parser only accepted the adapter SDK's `{items}` envelope → **every preview-mode read collapsed to 0 items**, every type, always. This was the proximate cause of the empty canvas.
2. **Sticky preview mode** (`PreviewModeContext`): in-app navigation (the app landing redirect, sidebar links) drops the query string. The context value flickered `false`, swapping the whole metadata source mid-session; the URL silently left the draft world. Preview now stays on until an explicit `markPreviewExit()` (Exit button), restores the flag via history-replace, and never flickers. Unit-tested (5 cases).
3. **`NavigationSyncEffect` wrote from inside a preview**: the preview source-swap legitimately changes the page/dashboard sets; diffing across the swap misread draft items as user creations and issued real `PUT /meta/app/*` writes (observed live: 403s + "Failed to update navigation" toasts). Sync is now disabled for the whole preview session and re-seeds its baseline on exit.
4. **Preview-specific empty states** (`PreviewDraftEmptyState`): inside preview, a missing app no longer falls back to a *different* app, and the generic console empty state never renders — replaced by honest not-ready / load-failed / retry states pointing back to the build conversation.

## Features

5. **Live publish truth on chat draft cards**: new `fetchPendingDraftCount` prop (wired in both chat hosts via the ADR-0033 `_drafts` endpoint). Publish/Published now reflects the server's current state — reloaded conversations stop replaying their birth snapshot; the button shows the real pending count; the ADR-0038 L1 `verification` verdict renders as a **Verified / N issues** chip.
6. **Changeset panel** (`DraftChangesPanel`): the preview bar gains **Changes (N)** → a sheet listing every pending draft grouped by type, classified **New** (publishing adds) vs **Update** (publishing overwrites live), one published-list read per type.

## Verification

- Full-stack browser run: staged a 6-artifact production-management app as drafts → preview renders the drafted app (watermark bar, kanban/list views), sticky across navigation, zero stray writes on the wire → Changes (6) panel classifies all entries New → Publish promotes everything, auto-exits preview, app live with real kanban columns → `_drafts` count 0.
- `vitest`: app-shell preview/hooks/chatbot suites green (111 + 142 + new 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)