### PR TITLE
fix(app-shell): extractItems accepts bare arrays — preview-mode list reads were silently empty

### DIFF
--- a/packages/app-shell/src/providers/MetadataProvider.extract.test.ts
+++ b/packages/app-shell/src/providers/MetadataProvider.extract.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { extractItems } from './MetadataProvider';
+
+/**
+ * The provider consumes TWO metadata sources with different envelope shapes:
+ * the adapter SDK resolves `{ items: [...] }`, while MetadataClient.list()
+ * (the `?preview=draft` path, ADR-0037) unwraps internally and resolves a
+ * BARE ARRAY. Both must normalize identically — the missing array branch
+ * silently emptied every preview-mode list read, so a draft-built app
+ * rendered "No Apps Configured" in the Live Canvas.
+ */
+describe('extractItems', () => {
+  const apps = [{ name: 'procurement_system' }, { name: 'crm' }];
+
+  it('unwraps the adapter SDK `{items}` envelope', () => {
+    expect(extractItems({ items: apps })).toEqual(apps);
+  });
+
+  it('passes through a bare array (MetadataClient.list / preview-draft path)', () => {
+    expect(extractItems(apps)).toEqual(apps);
+  });
+
+  it('returns [] for malformed responses', () => {
+    expect(extractItems(null)).toEqual([]);
+    expect(extractItems({ data: apps })).toEqual([]);
+    expect(extractItems('nope')).toEqual([]);
+  });
+});

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -82,7 +82,14 @@ function debug(...args: unknown[]) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function extractItems(res: unknown): any[] {
+/** Exported for tests — both metadata sources must normalize identically. */
+export function extractItems(res: unknown): any[] {
+  // MetadataClient.list() (the preview-draft path) unwraps `{items}` itself
+  // and resolves a BARE ARRAY; the adapter SDK path resolves `{items}`.
+  // Missing this branch silently turned every preview-mode list read into []
+  // — a draft-built app rendered the launcher's "No Apps Configured" empty
+  // state in the Live Canvas (live-verified on staging).
+  if (Array.isArray(res)) return res;
   if (res && typeof res === 'object' && 'items' in res && Array.isArray((res as { items: unknown[] }).items)) {
     return (res as { items: unknown[] }).items;
   }


### PR DESCRIPTION
Final piece of the Live Canvas draft-app chain, found by elimination on staging after [framework#1763](https://github.com/objectstack-ai/framework/pull/1763) deployed:

- `GET /meta/app?preview=draft` now correctly returns 13 apps **including the draft-built one** (server side fixed) —
- — but the canvas still showed **"No Apps Configured"**: `MetadataClient.list()` resolves a **bare array** (it unwraps `{items}` itself), while `extractItems` only handled the adapter SDK's `{items}` envelope and returned `[]` for arrays. Every preview-mode list read was silently empty; published mode was unaffected (different source, different shape).

One-line branch + regression tests (`extractItems` exported for tests): bare array passes through, `{items}` envelope unwraps, malformed → `[]`.

app-shell suite 418/418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)