### PR TITLE
fix(app-shell): org-package Install routes by deployment shape

### DIFF
--- a/.changeset/org-install-local-mode.md
+++ b/.changeset/org-install-local-mode.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": patch
+---
+
+"Your organization" Install routes by deployment shape: install-local runtimes (runtime-config `features.installLocal`) install via `/marketplace/install-local` into their OWN kernel (the bound oscc_ credential fetches the org manifest — ADR-0008); cloud-managed environments keep the control-plane `/cloud-connection/install` path. Previously the org Install button always called the control-plane path, which 401s on self-hosted runtimes.

--- a/packages/app-shell/src/console/marketplace/MarketplacePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePage.tsx
@@ -31,10 +31,12 @@ import {
   listOrgPackages,
   listInstalledPackages,
   installPackage,
+  installLocal,
   type MarketplacePackageSummary,
   type LocalInstallEntry,
   type OrgPackageSummary,
 } from './marketplaceApi';
+import { getRuntimeConfig } from '../../runtime-config';
 
 /**
  * Format a published-at timestamp as a localized relative string.
@@ -118,13 +120,25 @@ export function MarketplacePage() {
   useEffect(() => { void load(); }, []);
 
   // Install an org package into the current environment (ADR-0007 step ②).
-  // The same-origin /cloud-connection/install route resolves the env by
-  // hostname, so we only need the package id.
+  //
+  // Two deployment shapes, two semantically-correct routes:
+  //   - install-local runtimes (single-env / self-hosted, runtime-config
+  //     features.installLocal=true): the runtime OWNS its desired state —
+  //     install merges into ITS kernel via /marketplace/install-local; the
+  //     bound oscc_ credential lets it fetch the org manifest (ADR-0008).
+  //     The control-plane /cloud-connection/install path would 401 here
+  //     (no env→cloud service key) and is the wrong semantics anyway.
+  //   - cloud-managed environments: desired state lives in the control
+  //     plane — /cloud-connection/install resolves the env by hostname.
   const doOrgInstall = async (pkg: OrgPackageSummary) => {
     setOrgInstalling(pkg.id);
     setOrgMsg(null);
     try {
-      await installPackage({ packageId: pkg.id, environmentId: '', seedSampleData: true });
+      if (getRuntimeConfig().features.installLocal) {
+        await installLocal({ packageId: pkg.manifest_id || pkg.id, versionId: 'latest' });
+      } else {
+        await installPackage({ packageId: pkg.id, environmentId: '', seedSampleData: true });
+      }
       setOrgMsg({ ok: true, text: t('marketplace.org.installed', { defaultValue: `Installed ${pkg.display_name}`, name: pkg.display_name }) });
       await load();
     } catch (e: any) {


### PR DESCRIPTION
自托管绑定 E2E 抓到的真 bug:「Your organization」的 Install 一律调控制面 `/cloud-connection/install` —— 自托管运行时(无服务键)401,且语义错误(自托管期望态在本地)。

修法:`runtime-config features.installLocal` 分流 —— install-local 运行时走 `/marketplace/install-local`(经绑定的 oscc_ 凭据取 org manifest,装进自己内核;E2E 已验 200);云托管环境保持原路径。

418/418 app-shell 测试过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)