### PR TITLE
fix(app-shell): NavigationSyncEffect baseline race — readiness gate, sys_ filter, ADR-0010 lock filter

### DIFF
--- a/.changeset/navigation-sync-baseline-race.md
+++ b/.changeset/navigation-sync-baseline-race.md
@@ -1,0 +1,6 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/react": patch
+---
+
+Fix the NavigationSyncEffect baseline race: lazily-loaded `page`/`dashboard` metadata (and the empty cache during `invalidate()` refetch) could seed a partial diff baseline, making platform `sys_` pages look "user added" — the effect then wrote them into every app's navigation, 403ing on ADR-0010 locked apps (red "Failed to update navigation" toasts) and polluting writable apps. The effect now diffs only while both types are `status === 'ready'` (new optional `MetadataContextValue.getTypeStatus`), never treats `sys_`-prefixed artifacts as user creations, and skips apps whose `_lock`/`protection.lock` is `full`/`no-overlay`.

--- a/packages/app-shell/src/hooks/__tests__/useNavigationSync.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useNavigationSync.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * NavigationSyncEffect baseline race — the regression that motivated this
+ * suite: `page` / `dashboard` metadata is lazily loaded, so the effect's
+ * first baseline could be seeded from a partial (or, after `invalidate()`,
+ * emptied) list. When the full list landed, platform pages
+ * (sys_organization_detail, sys_user_detail, …) diffed as "user added" and
+ * the effect PUT them into every app's navigation — including write-protected
+ * system apps (ADR-0010 `_lock`), which 403'd into red failure toasts while
+ * writable apps got polluted with sys_ nav entries (and a green toast).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MetadataCtx, AdapterCtx, type MetadataContextValue, type MetadataTypeStatus } from '@object-ui/react';
+import {
+  NavigationSyncEffect,
+  isSystemArtifactName,
+  isNavigationSyncableApp,
+} from '../useNavigationSync';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('isSystemArtifactName', () => {
+  it('flags sys_-prefixed names and nothing else', () => {
+    expect(isSystemArtifactName('sys_organization_detail')).toBe(true);
+    expect(isSystemArtifactName('sys_user_detail')).toBe(true);
+    expect(isSystemArtifactName('my_page')).toBe(false);
+    expect(isSystemArtifactName('system_overview')).toBe(false); // not the sys_ prefix
+    expect(isSystemArtifactName('')).toBe(false);
+    expect(isSystemArtifactName(undefined)).toBe(false);
+    expect(isSystemArtifactName(42)).toBe(false);
+  });
+});
+
+describe('isNavigationSyncableApp', () => {
+  it('rejects apps whose lock forbids PUT (ADR-0010)', () => {
+    expect(isNavigationSyncableApp({ name: 'setup', _lock: 'full' })).toBe(false);
+    expect(isNavigationSyncableApp({ name: 'studio', _lock: 'no-overlay' })).toBe(false);
+    expect(isNavigationSyncableApp({ name: 'setup', protection: { lock: 'full' } })).toBe(false);
+  });
+
+  it('accepts writable apps (no lock, or locks that still allow PUT)', () => {
+    expect(isNavigationSyncableApp({ name: 'crm' })).toBe(true);
+    expect(isNavigationSyncableApp({ name: 'crm', _lock: 'none' })).toBe(true);
+    expect(isNavigationSyncableApp({ name: 'crm', _lock: 'no-delete' })).toBe(true);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isNavigationSyncableApp(null)).toBe(false);
+    expect(isNavigationSyncableApp('crm')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NavigationSyncEffect
+// ---------------------------------------------------------------------------
+
+interface World {
+  apps: any[];
+  pages: any[];
+  dashboards: any[];
+  status: Partial<Record<string, MetadataTypeStatus>>;
+}
+
+function metaValue(world: World): MetadataContextValue {
+  return {
+    apps: world.apps,
+    objects: [],
+    dashboards: world.dashboards,
+    reports: [],
+    pages: world.pages,
+    loading: false,
+    error: null,
+    refresh: async () => {},
+    invalidate: () => {},
+    ensureType: async () => [],
+    getItem: async () => null,
+    getItemsByType: () => [],
+    getTypeStatus: (type: string) => world.status[type] ?? 'ready',
+  };
+}
+
+function makeAdapter(saveItem: ReturnType<typeof vi.fn>) {
+  return { getClient: () => ({ meta: { saveItem } }) } as any;
+}
+
+function renderEffect(saveItem: ReturnType<typeof vi.fn>, world: World) {
+  const utils = render(
+    <AdapterCtx.Provider value={makeAdapter(saveItem)}>
+      <MetadataCtx.Provider value={metaValue(world)}>
+        <NavigationSyncEffect />
+      </MetadataCtx.Provider>
+    </AdapterCtx.Provider>,
+  );
+  const setWorld = (next: World) =>
+    utils.rerender(
+      <AdapterCtx.Provider value={makeAdapter(saveItem)}>
+        <MetadataCtx.Provider value={metaValue(next)}>
+          <NavigationSyncEffect />
+        </MetadataCtx.Provider>
+      </AdapterCtx.Provider>,
+    );
+  return { ...utils, setWorld };
+}
+
+/** Flush the effect's fire-and-forget async sync loop. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const crm = { name: 'crm', label: 'CRM', navigation: [] };
+
+describe('NavigationSyncEffect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not seed the baseline until page AND dashboard types are ready', async () => {
+    const saveItem = vi.fn().mockResolvedValue({});
+    // Lazy types still loading — pages reads as [] even though the server
+    // has sys_ pages plus a user page.
+    const { setWorld } = renderEffect(saveItem, {
+      apps: [crm],
+      pages: [],
+      dashboards: [],
+      status: { page: 'loading', dashboard: 'loading' },
+    });
+
+    // Full load lands. If the empty not-ready snapshot had been used as the
+    // baseline, every page here would now diff as "user added".
+    setWorld({
+      apps: [crm],
+      pages: [{ name: 'sys_organization_detail' }, { name: 'sys_user_detail' }, { name: 'home' }],
+      dashboards: [{ name: 'sales' }],
+      status: {},
+    });
+    await flush();
+    expect(saveItem).not.toHaveBeenCalled();
+
+    // A page created AFTER the ready baseline does sync.
+    setWorld({
+      apps: [crm],
+      pages: [{ name: 'sys_organization_detail' }, { name: 'sys_user_detail' }, { name: 'home' }, { name: 'my_page' }],
+      dashboards: [{ name: 'sales' }],
+      status: {},
+    });
+    await waitFor(() => expect(saveItem).toHaveBeenCalledTimes(1));
+    const [type, name, schema] = saveItem.mock.calls[0];
+    expect(type).toBe('app');
+    expect(name).toBe('crm');
+    expect(schema.navigation.map((i: any) => i.pageName)).toEqual(['my_page']);
+  });
+
+  it('ignores the invalidate dip (status leaves ready, items empty out)', async () => {
+    const saveItem = vi.fn().mockResolvedValue({});
+    const ready: World = {
+      apps: [crm],
+      pages: [{ name: 'home' }],
+      dashboards: [],
+      status: {},
+    };
+    const { setWorld } = renderEffect(saveItem, ready);
+    await flush();
+
+    // invalidate('page') → status 'idle'/'loading', items []. Without the
+    // ready gate this read as "home deleted" …
+    setWorld({ apps: [crm], pages: [], dashboards: [], status: { page: 'loading' } });
+    await flush();
+    // … and the refetch landing (now including a late sys_ page) as
+    // "home + sys_* created".
+    setWorld({
+      apps: [crm],
+      pages: [{ name: 'home' }, { name: 'sys_organization_detail' }],
+      dashboards: [],
+      status: {},
+    });
+    await flush();
+
+    expect(saveItem).not.toHaveBeenCalled();
+  });
+
+  it('never treats sys_ pages/dashboards as user creations or deletions', async () => {
+    const saveItem = vi.fn().mockResolvedValue({});
+    const { setWorld } = renderEffect(saveItem, {
+      apps: [crm],
+      pages: [{ name: 'home' }],
+      dashboards: [{ name: 'sys_metrics' }],
+      status: {},
+    });
+    await flush();
+
+    // sys_ artifacts appear and disappear (package install/uninstall) —
+    // neither direction may touch app navigation.
+    setWorld({
+      apps: [crm],
+      pages: [{ name: 'home' }, { name: 'sys_user_detail' }],
+      dashboards: [],
+      status: {},
+    });
+    await flush();
+    expect(saveItem).not.toHaveBeenCalled();
+  });
+
+  it('skips write-protected apps (ADR-0010 _lock) when syncing', async () => {
+    const saveItem = vi.fn().mockResolvedValue({});
+    const apps = [
+      crm,
+      { name: 'setup', label: 'Setup', navigation: [], _lock: 'full' },
+      { name: 'studio', label: 'Studio', navigation: [], protection: { lock: 'no-overlay' } },
+    ];
+    const { setWorld } = renderEffect(saveItem, {
+      apps,
+      pages: [],
+      dashboards: [],
+      status: {},
+    });
+    await flush();
+
+    setWorld({ apps, pages: [{ name: 'my_page' }], dashboards: [], status: {} });
+    await waitFor(() => expect(saveItem).toHaveBeenCalledTimes(1));
+    await flush();
+
+    // Exactly one write — to the writable app; no 403-bound PUTs attempted.
+    expect(saveItem).toHaveBeenCalledTimes(1);
+    expect(saveItem.mock.calls[0][1]).toBe('crm');
+    const { toast } = await import('sonner');
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('treats a context without getTypeStatus as always ready (back-compat)', async () => {
+    const saveItem = vi.fn().mockResolvedValue({});
+    const base = metaValue({ apps: [crm], pages: [{ name: 'home' }], dashboards: [], status: {} });
+    delete (base as any).getTypeStatus;
+    const next = metaValue({
+      apps: [crm],
+      pages: [{ name: 'home' }, { name: 'p2' }],
+      dashboards: [],
+      status: {},
+    });
+    delete (next as any).getTypeStatus;
+
+    const adapter = makeAdapter(saveItem);
+    const utils = render(
+      <AdapterCtx.Provider value={adapter}>
+        <MetadataCtx.Provider value={base}>
+          <NavigationSyncEffect />
+        </MetadataCtx.Provider>
+      </AdapterCtx.Provider>,
+    );
+    utils.rerender(
+      <AdapterCtx.Provider value={adapter}>
+        <MetadataCtx.Provider value={next}>
+          <NavigationSyncEffect />
+        </MetadataCtx.Provider>
+      </AdapterCtx.Provider>,
+    );
+    await waitFor(() => expect(saveItem).toHaveBeenCalledTimes(1));
+    expect(saveItem.mock.calls[0][1]).toBe('crm');
+  });
+});

--- a/packages/app-shell/src/hooks/__tests__/useNavigationSync.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useNavigationSync.test.tsx
@@ -23,6 +23,7 @@ import { MetadataCtx, AdapterCtx, type MetadataContextValue, type MetadataTypeSt
 import {
   NavigationSyncEffect,
   isSystemArtifactName,
+  isPlatformArtifact,
   isNavigationSyncableApp,
 } from '../useNavigationSync';
 
@@ -43,6 +44,23 @@ describe('isSystemArtifactName', () => {
     expect(isSystemArtifactName('')).toBe(false);
     expect(isSystemArtifactName(undefined)).toBe(false);
     expect(isSystemArtifactName(42)).toBe(false);
+  });
+});
+
+describe('isPlatformArtifact', () => {
+  it('flags package-provenance items regardless of name (ADR-0010 stamps)', () => {
+    // Third-party plugin pages are NOT sys_-prefixed — provenance is the
+    // primary signal, the name prefix only a fallback.
+    expect(isPlatformArtifact({ name: 'crm_dashboard', _packageId: 'com.acme.crm' })).toBe(true);
+    expect(isPlatformArtifact({ name: 'billing_home', _provenance: 'package' })).toBe(true);
+    expect(isPlatformArtifact({ name: 'sys_user_detail' })).toBe(true); // prefix fallback
+  });
+
+  it('accepts user-authored items', () => {
+    expect(isPlatformArtifact({ name: 'my_page' })).toBe(false);
+    expect(isPlatformArtifact({ name: 'my_page', _provenance: 'org' })).toBe(false);
+    expect(isPlatformArtifact(null)).toBe(false);
+    expect(isPlatformArtifact('my_page')).toBe(false);
   });
 });
 
@@ -206,6 +224,29 @@ describe('NavigationSyncEffect', () => {
     setWorld({
       apps: [crm],
       pages: [{ name: 'home' }, { name: 'sys_user_detail' }],
+      dashboards: [],
+      status: {},
+    });
+    await flush();
+    expect(saveItem).not.toHaveBeenCalled();
+  });
+
+  it('ignores package-provenance pages from a mid-session install (not sys_-prefixed)', async () => {
+    const saveItem = vi.fn().mockResolvedValue({});
+    const { setWorld } = renderEffect(saveItem, {
+      apps: [crm],
+      pages: [{ name: 'home' }],
+      dashboards: [],
+      status: {},
+    });
+    await flush();
+
+    // Installing a package adds its pages to the metadata list between two
+    // ready snapshots — a name-set diff reads that exactly like user CRUD.
+    // The package ships its own navigation; auto-sync must stay out.
+    setWorld({
+      apps: [crm],
+      pages: [{ name: 'home' }, { name: 'crm_dashboard', _packageId: 'com.acme.crm' }],
       dashboards: [],
       status: {},
     });

--- a/packages/app-shell/src/hooks/useNavigationSync.ts
+++ b/packages/app-shell/src/hooks/useNavigationSync.ts
@@ -106,6 +106,33 @@ export function navigationEqual(a: NavigationItem[], b: NavigationItem[]): boole
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
+/**
+ * `sys_`-prefixed pages/dashboards are platform-shipped artifacts
+ * (sys_organization_detail, sys_user_detail, …) that appear in metadata once
+ * their lazily-loaded type finishes fetching — they are never something the
+ * user just created, so they must not trigger navigation sync.
+ */
+export function isSystemArtifactName(name: unknown): boolean {
+  return typeof name === 'string' && name.startsWith('sys_');
+}
+
+/**
+ * Whether an app may be targeted by automatic navigation writes.
+ *
+ * ADR-0010 metadata protection: the loader stamps a `_lock` envelope on
+ * packaged artifacts (translated from the author-facing `protection` block,
+ * e.g. the `setup` app ships `protection.lock = 'full'`). Locks 'full' and
+ * 'no-overlay' reject PUT with 403 — a navigation write into such an app can
+ * never succeed, so don't attempt it (each attempt surfaced as a red
+ * "Failed to update navigation" toast).
+ */
+export function isNavigationSyncableApp(app: unknown): boolean {
+  if (!app || typeof app !== 'object') return false;
+  const a = app as { _lock?: string; protection?: { lock?: string } };
+  const lock = a._lock ?? a.protection?.lock;
+  return lock !== 'full' && lock !== 'no-overlay';
+}
+
 // ============================================================================
 // React Hook
 // ============================================================================
@@ -411,7 +438,7 @@ export function useNavigationSync(): UseNavigationSyncReturn {
     async (pageName: string, label?: string) => {
       for (const app of apps) {
         const name = getAppName(app);
-        if (!name) continue;
+        if (!name || !isNavigationSyncableApp(app)) continue;
         await syncPageCreated(name, pageName, label);
       }
     },
@@ -423,7 +450,7 @@ export function useNavigationSync(): UseNavigationSyncReturn {
     async (dashboardName: string, label?: string) => {
       for (const app of apps) {
         const name = getAppName(app);
-        if (!name) continue;
+        if (!name || !isNavigationSyncableApp(app)) continue;
         await syncDashboardCreated(name, dashboardName, label);
       }
     },
@@ -435,7 +462,7 @@ export function useNavigationSync(): UseNavigationSyncReturn {
     async (pageName: string) => {
       for (const app of apps) {
         const name = getAppName(app);
-        if (!name) continue;
+        if (!name || !isNavigationSyncableApp(app)) continue;
         await syncPageDeleted(name, pageName);
       }
     },
@@ -447,7 +474,7 @@ export function useNavigationSync(): UseNavigationSyncReturn {
     async (dashboardName: string) => {
       for (const app of apps) {
         const name = getAppName(app);
-        if (!name) continue;
+        if (!name || !isNavigationSyncableApp(app)) continue;
         await syncDashboardDeleted(name, dashboardName);
       }
     },
@@ -459,7 +486,7 @@ export function useNavigationSync(): UseNavigationSyncReturn {
     async (oldName: string, newName: string) => {
       for (const app of apps) {
         const name = getAppName(app);
-        if (!name) continue;
+        if (!name || !isNavigationSyncableApp(app)) continue;
         await syncPageRenamed(name, oldName, newName);
       }
     },
@@ -471,7 +498,7 @@ export function useNavigationSync(): UseNavigationSyncReturn {
     async (oldName: string, newName: string) => {
       for (const app of apps) {
         const name = getAppName(app);
-        if (!name) continue;
+        if (!name || !isNavigationSyncableApp(app)) continue;
         await syncDashboardRenamed(name, oldName, newName);
       }
     },
@@ -510,7 +537,7 @@ export function useNavigationSync(): UseNavigationSyncReturn {
  * > should invoke `syncPageRenamed` / `syncDashboardRenamed` explicitly.
  */
 export function NavigationSyncEffect(): null {
-  const { pages, dashboards, apps } = useMetadata();
+  const { pages, dashboards, apps, getTypeStatus } = useMetadata();
   const adapter = useAdapter();
   const adapterRef = useRef(adapter);
   adapterRef.current = adapter;
@@ -553,11 +580,31 @@ export function NavigationSyncEffect(): null {
       return;
     }
 
+    // `page` and `dashboard` are lazily-loaded metadata types: their arrays
+    // are empty (or stale) until the fetch lands, and `invalidate()` empties
+    // them again mid-session (e.g. the New-record flow reloads meta). Diffing
+    // a not-ready snapshot misreads that dip as mass deletion / re-creation —
+    // notably flagging system pages as "user added" once the full list
+    // arrives. Only seed the baseline and diff while both types are 'ready'.
+    // (Contexts without getTypeStatus — hand-rolled test values — are
+    // treated as always ready.)
+    if (
+      getTypeStatus &&
+      (getTypeStatus('page') !== 'ready' || getTypeStatus('dashboard') !== 'ready')
+    ) {
+      return;
+    }
+
+    const isUserArtifactName = (n: unknown): n is string =>
+      typeof n === 'string' && n.length > 0 && !isSystemArtifactName(n);
+    // System (sys_*) artifacts never participate in the diff: they ship with
+    // the platform, not from user CRUD, so their appearance must not write
+    // them into app navigation (nor their disappearance delete nav entries).
     const currentPageNames = new Set(
-      (pages ?? []).map((p: any) => p.name).filter(Boolean) as string[],
+      (pages ?? []).map((p: any) => p.name).filter(isUserArtifactName),
     );
     const currentDashNames = new Set(
-      (dashboards ?? []).map((d: any) => d.name).filter(Boolean) as string[],
+      (dashboards ?? []).map((d: any) => d.name).filter(isUserArtifactName),
     );
 
     const prevPages = prevPageNamesRef.current;
@@ -599,7 +646,9 @@ export function NavigationSyncEffect(): null {
         for (const app of apps) {
           if (cancelled || syncVersionRef.current !== version) break;
           const appName = getAppName(app);
-          if (!appName) continue;
+          // Write-protected apps (ADR-0010 `_lock`) would 403 every PUT —
+          // skip them instead of spraying failure toasts.
+          if (!appName || !isNavigationSyncableApp(app)) continue;
 
           for (const pageName of addedPages) {
             if (cancelled) break;
@@ -631,7 +680,7 @@ export function NavigationSyncEffect(): null {
     return () => {
       cancelled = true;
     };
-  }, [pages, dashboards, apps, previewDrafts, syncPageCreated, syncDashboardCreated, syncPageDeleted, syncDashboardDeleted]);
+  }, [pages, dashboards, apps, previewDrafts, getTypeStatus, syncPageCreated, syncDashboardCreated, syncPageDeleted, syncDashboardDeleted]);
 
   return null;
 }

--- a/packages/app-shell/src/hooks/useNavigationSync.ts
+++ b/packages/app-shell/src/hooks/useNavigationSync.ts
@@ -107,13 +107,34 @@ export function navigationEqual(a: NavigationItem[], b: NavigationItem[]): boole
 }
 
 /**
- * `sys_`-prefixed pages/dashboards are platform-shipped artifacts
- * (sys_organization_detail, sys_user_detail, …) that appear in metadata once
- * their lazily-loaded type finishes fetching — they are never something the
- * user just created, so they must not trigger navigation sync.
+ * `sys_` is the platform-reserved metadata namespace (sys_organization_detail,
+ * sys_user_detail, …). Fallback signal only — see isPlatformArtifact.
  */
 export function isSystemArtifactName(name: unknown): boolean {
   return typeof name === 'string' && name.startsWith('sys_');
+}
+
+/**
+ * Package/platform-shipped pages and dashboards are never "something the user
+ * just created", so they must not trigger navigation sync no matter when they
+ * appear in (or vanish from) the metadata lists — package install/uninstall
+ * mid-session looks exactly like user CRUD to a name-set diff. A package that
+ * ships pages also ships (or contributes to) the navigation that exposes
+ * them; auto-syncing on top of that would duplicate entries at best and write
+ * into apps the package never intended at worst.
+ *
+ * Provenance is the primary signal: ADR-0010's applyProtection stamps
+ * `_packageId` + `_provenance: 'package'` on artifacts registered with
+ * package coords (the engine manifest path passes them). The `sys_` name
+ * prefix is only a fallback for registration paths that don't stamp
+ * provenance yet — third-party plugin pages are NOT guaranteed to carry it,
+ * which is why the field check comes first.
+ */
+export function isPlatformArtifact(item: unknown): boolean {
+  if (!item || typeof item !== 'object') return false;
+  const a = item as { name?: unknown; _packageId?: unknown; _provenance?: unknown };
+  if (a._packageId != null || a._provenance === 'package') return true;
+  return isSystemArtifactName(a.name);
 }
 
 /**
@@ -595,17 +616,19 @@ export function NavigationSyncEffect(): null {
       return;
     }
 
-    const isUserArtifactName = (n: unknown): n is string =>
-      typeof n === 'string' && n.length > 0 && !isSystemArtifactName(n);
-    // System (sys_*) artifacts never participate in the diff: they ship with
-    // the platform, not from user CRUD, so their appearance must not write
-    // them into app navigation (nor their disappearance delete nav entries).
-    const currentPageNames = new Set(
-      (pages ?? []).map((p: any) => p.name).filter(isUserArtifactName),
-    );
-    const currentDashNames = new Set(
-      (dashboards ?? []).map((d: any) => d.name).filter(isUserArtifactName),
-    );
+    // Platform/package artifacts never participate in the diff: they ship
+    // with the platform or arrive via package install, not from user CRUD,
+    // so their appearance must not write them into app navigation (nor
+    // their disappearance delete nav entries). See isPlatformArtifact.
+    const userArtifactNames = (items: any[]): Set<string> =>
+      new Set(
+        items
+          .filter((it: any) => !isPlatformArtifact(it))
+          .map((it: any) => it?.name)
+          .filter((n: any): n is string => typeof n === 'string' && n.length > 0),
+      );
+    const currentPageNames = userArtifactNames(pages ?? []);
+    const currentDashNames = userArtifactNames(dashboards ?? []);
 
     const prevPages = prevPageNamesRef.current;
     const prevDash = prevDashNamesRef.current;

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -614,6 +614,9 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
       ensureType,
       getItem,
       getItemsByType,
+      // Pure read — must NOT kick a fetch, so render-phase status checks
+      // can't recurse into ensureType.
+      getTypeStatus: (type: string) => getEntry(type).status,
     };
 
     return base;

--- a/packages/react/src/context/AppShellContext.tsx
+++ b/packages/react/src/context/AppShellContext.tsx
@@ -25,12 +25,23 @@ export interface MetadataState {
   error: Error | null;
 }
 
+export type MetadataTypeStatus = 'idle' | 'loading' | 'ready' | 'error';
+
 export interface MetadataContextValue extends MetadataState {
   refresh: (type?: string) => Promise<void>;
   invalidate: (type: string, name?: string) => void;
   ensureType: (type: string) => Promise<any[]>;
   getItem: (type: string, name: string) => Promise<any | null>;
   getItemsByType: (type: string) => any[];
+  /**
+   * Per-type load status. Lazy types ('page', 'dashboard', …) return their
+   * items array immediately — empty or stale while a (re)fetch is in flight —
+   * so consumers that DIFF the list over time (e.g. NavigationSyncEffect)
+   * must distinguish "empty because unloaded" from "actually empty" and only
+   * trust snapshots taken while the type is 'ready'. Optional so hand-rolled
+   * context values in tests keep working; absent means "always ready".
+   */
+  getTypeStatus?: (type: string) => MetadataTypeStatus;
 }
 
 export const MetadataCtx = createContext<MetadataContextValue | null>(null);
@@ -55,6 +66,7 @@ export function useMetadata(): MetadataContextValue {
       ensureType: async () => [],
       getItem: async () => null,
       getItemsByType: () => [],
+      getTypeStatus: () => 'ready',
     };
   }
   return ctx;


### PR DESCRIPTION
## Problem

`page`/`dashboard` metadata types load lazily (`ensureType`), so `NavigationSyncEffect` could seed its diff baseline from a partial list — and `invalidate()` empties the cache mid-session (e.g. the New-record flow reloads meta). When the full list landed, platform pages (`sys_organization_detail`, `sys_user_detail`) diffed as "user added": the effect PUT them into every app's navigation — 403 on the write-protected `setup` app (red "Failed to update navigation" toasts ×2) while writable apps' navigation got polluted with sys_ entries (the lying green "Navigation updated" toast — that write actually succeeded, into the wrong app).

The same misread applies beyond the load race: a **mid-session package install** adds its pages between two ready snapshots, which a name-set diff reads exactly like user CRUD — and third-party plugin pages are not `sys_`-prefixed.

## Fix (three layers)

1. **Readiness gate** — `MetadataContextValue` grows optional `getTypeStatus(type)`; the app-shell provider exposes its cache entry status. The effect only seeds its baseline and diffs while both `page` and `dashboard` are `status === 'ready'` — the initial partial load and the invalidate dip never enter the diff. Contexts without `getTypeStatus` (hand-rolled test values) are treated as always-ready.
2. **Platform/package artifacts excluded** — items carrying the ADR-0010 provenance stamps (`_packageId` / `_provenance: 'package'`) never participate in the diff; the `sys_` namespace prefix is kept only as a fallback for registration paths that don't stamp provenance yet (the metadata-service path registers without package coords — framework-side gap, flagged separately). Packages ship their own navigation; auto-sync must stay out.
3. **ADR-0010 lock filter** — apps whose `_lock`/`protection.lock` is `full`/`no-overlay` are skipped by the effect and the `*AllApps` sync methods; a PUT there can only 403.

Success toasts were already only fired after a successful save (the SDK throws on non-2xx) — the green toast in the report was a *successful* write of a sys_ page into a writable app, which layer 2 now prevents.

Preserves the ADR-0037 preview-mode guard from #1659 (baseline reset under `usePreviewDrafts`).

## Verification

- 12 unit tests (`useNavigationSync.test.tsx`): readiness gate, invalidate dip, sys_ filter both directions, package-provenance filter (mid-session install, non-sys_ names), lock filter, no-getTypeStatus back-compat, helper edge cases. Full app-shell suite green.
- **Browser A/B on the full local stack** (cloud + objectos, prod-like, seeded): on the unfixed bundle, Setup → Role → New reproduced `PUT /api/v1/meta/app/setup → 403`; on the fixed bundle the same flow issues **zero** `PUT /meta/app/*` and shows zero toasts, with the meta reload confirmed and the live page list containing exactly `sys_organization_detail`/`sys_user_detail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)