### PR TITLE
fix(console): DeviceAuthPage keeps device context through the login redirect

### DIFF
--- a/.changeset/device-redirect-context.md
+++ b/.changeset/device-redirect-context.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/console": patch
+---
+
+DeviceAuthPage preserves the full query string (runtime_name / runtime_version device context) through the login redirect — previously only user_code survived, so a signed-out approver never saw what device they were authorizing.

--- a/apps/console/src/pages/auth/DeviceAuthPage.tsx
+++ b/apps/console/src/pages/auth/DeviceAuthPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState } from 'react';
-import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { CheckCircle2, GalleryVerticalEnd } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@object-ui/auth';
@@ -42,6 +42,7 @@ function PageShell({ children }: { children: React.ReactNode }) {
 
 export function DeviceAuthPage() {
   const { t } = useObjectTranslation();
+  const location = useLocation();
   const [params] = useSearchParams();
   const code = params.get('user_code') ?? params.get('code') ?? '';
   // Device context appended by the requesting runtime's bind/start (ADR
@@ -92,11 +93,12 @@ export function DeviceAuthPage() {
   }
 
   if (!user) {
+    // Preserve the FULL query string through the login round-trip — it
+    // carries the device context (runtime_name / runtime_version) the
+    // approval card displays, not just the user code.
     return (
       <Navigate
-        to={`/login?redirect=${encodeURIComponent(
-          `/auth/device?user_code=${encodeURIComponent(code)}`,
-        )}`}
+        to={`/login?redirect=${encodeURIComponent(`/auth/device${location.search}`)}`}
         replace
       />
     );


### PR DESCRIPTION
Found in the runtime-identity-binding E2E: the signed-out branch of `DeviceAuthPage` rebuilt the login redirect from `user_code` alone, dropping the `runtime_name`/`runtime_version` params [objectui#1673](https://github.com/objectstack-ai/objectui/pull/1673) added — so a signed-out approver (the common first-bind case) never saw the device context card. Preserve the full query string through the round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)