### PR TITLE
feat(app-shell): zero-roundtrip newTabUrl fast path for opensInNewTab actions

### DIFF
--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -373,6 +373,41 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     }
     try {
       const baseUrl = import.meta.env.VITE_SERVER_URL || '';
+      // ── Zero-roundtrip fast path ────────────────────────────────────────
+      // `newTabUrl` names a GET endpoint that performs ALL auth/authz itself
+      // (e.g. /sso-open re-runs every check the POST half would have done),
+      // so the POST round trip would add nothing but click latency. Drive the
+      // pre-opened tab there immediately — the spinner page stays painted
+      // until the (possibly slow) endpoint commits its redirect.
+      const newTabUrl = typeof (action as any).newTabUrl === 'string' ? (action as any).newTabUrl as string : '';
+      if ((action as any).opensInNewTab && newTabUrl) {
+        if (resolvedRecordId == null) {
+          if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
+          return { success: false, error: 'This action runs on a single record — no record id available.' };
+        }
+        // Absolute URL required: the pre-opened tab is an about:blank document,
+        // so a bare-relative href has no reliable resolution base.
+        const directUrl = `${baseUrl || window.location.origin}${newTabUrl.replace('{recordId}', encodeURIComponent(String(resolvedRecordId)))}`;
+        if (preOpenedTab) {
+          try { preOpenedTab.location.href = directUrl; }
+          catch {
+            try { preOpenedTab.close(); } catch { /* ignore */ }
+            window.location.href = directUrl;
+          }
+        } else {
+          let popup: Window | null = null;
+          try { popup = window.open(directUrl, '_blank'); } catch { popup = null; }
+          if (!popup) {
+            toast('浏览器拦截了弹窗 / Popup blocked', {
+              description: '点击在新标签页打开环境',
+              action: { label: '打开环境', onClick: () => { try { window.open(directUrl, '_blank'); } catch { window.location.href = directUrl; } } },
+              duration: 10000,
+            });
+          }
+        }
+        if (action.refreshAfter === true) refresh();
+        return { success: true };
+      }
       const obj = action.objectName || objApiName || 'global';
       const res = await authFetch(
         `${baseUrl}/api/v1/actions/${encodeURIComponent(obj)}/${encodeURIComponent(targetName)}`,

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -496,6 +496,41 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
 
     try {
       const baseUrl = import.meta.env.VITE_SERVER_URL || '';
+      // ── Zero-roundtrip fast path ────────────────────────────────────────
+      // `newTabUrl` names a GET endpoint that performs ALL auth/authz itself
+      // (e.g. /sso-open re-runs every check the POST half would have done),
+      // so the POST round trip would add nothing but click latency. Drive the
+      // pre-opened tab there immediately — the spinner page stays painted
+      // until the (possibly slow) endpoint commits its redirect.
+      const newTabUrl = typeof (action as any).newTabUrl === 'string' ? (action as any).newTabUrl as string : '';
+      if ((action as any).opensInNewTab && newTabUrl) {
+        if (pureRecordId == null) {
+          if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
+          return { success: false, error: 'This action runs on a single record — no record id available.' };
+        }
+        // Absolute URL required: the pre-opened tab is an about:blank document,
+        // so a bare-relative href has no reliable resolution base.
+        const directUrl = `${baseUrl || window.location.origin}${newTabUrl.replace('{recordId}', encodeURIComponent(String(pureRecordId)))}`;
+        if (preOpenedTab) {
+          try { preOpenedTab.location.href = directUrl; }
+          catch {
+            try { preOpenedTab.close(); } catch { /* ignore */ }
+            window.location.href = directUrl;
+          }
+        } else {
+          let popup: Window | null = null;
+          try { popup = window.open(directUrl, '_blank'); } catch { popup = null; }
+          if (!popup) {
+            toast('浏览器拦截了弹窗 / Popup blocked', {
+              description: '点击在新标签页打开环境',
+              action: { label: '打开环境', onClick: () => { try { window.open(directUrl, '_blank'); } catch { window.location.href = directUrl; } } },
+              duration: 10000,
+            });
+          }
+        }
+        if (action.refreshAfter === true) setActionRefreshKey(k => k + 1);
+        return { success: true };
+      }
       const obj = action.objectName || objectName || 'global';
       const res = await authFetch(
         `${baseUrl}/api/v1/actions/${encodeURIComponent(obj)}/${encodeURIComponent(targetName)}`,

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -127,6 +127,12 @@ export interface ActionDef {
    *  handler can drive it to a returned `redirectUrl` after an awaited fetch
    *  without tripping popup blockers. Used by actions like `sso_as_owner`. */
   opensInNewTab?: boolean;
+  /** Zero-roundtrip new-tab target: a path template (`{recordId}` placeholder)
+   *  the handler navigates the pre-opened tab to IMMEDIATELY on click, skipping
+   *  the action POST entirely. Only valid with `opensInNewTab`; the endpoint
+   *  must perform all auth/authz itself (e.g. the cloud `/sso-open` endpoint,
+   *  which re-runs every check the POST half would have done). */
+  newTabUrl?: string;
   /** Any additional properties */
   [key: string]: any;
 }


### PR DESCRIPTION
## Summary
- `ActionDef` gains `newTabUrl`: a direct new-tab URL template (`{recordId}` placeholder)
- Both server-action paths (list rows via `useConsoleActionRuntime`, record header via `RecordDetailView`) get a fast path: when an `opensInNewTab` action also declares `newTabUrl`, the pre-opened popup is navigated **straight to that URL on click — no action POST**
- The spinner page stays painted until the endpoint commits its redirect; URL is resolved absolute (about:blank gives bare-relative hrefs no reliable base); popup-blocked fallback keeps the existing toast pattern

## Motivation
The cloud console's environment **Open** button paid a full POST round trip before the popup started navigating, even though `GET /sso-open` re-runs every auth/authz check itself (defense in depth). Spec contract: framework#1787; first consumer: cloud `sys_environment.sso_as_owner`. Actions without `newTabUrl` keep the existing POST → `redirectUrl` flow — fully backward compatible.

## Test plan
- `pnpm --filter @object-ui/core build` ✓
- `pnpm --filter @object-ui/app-shell build` ✓ (after rebuilding stale workspace dists: plugin-chatbot, data-objectstack, providers, react — pre-existing breakage unrelated to this change)
- Staging contract check: cookie-authed direct `GET /sso-open` with no prior POST 302s into the env console ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)