### PR TITLE
fix(console): claim the device code before approve/deny

### DIFF
--- a/.changeset/device-approve-claim.md
+++ b/.changeset/device-approve-claim.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/console": patch
+---
+
+DeviceAuthPage claims the device code (GET /device?user_code=…) before approve/deny — better-auth's device-authorization plugin rejects both with 400 "not been claimed by a verifying session" otherwise, so approval silently failed.

--- a/apps/console/src/pages/auth/DeviceAuthPage.tsx
+++ b/apps/console/src/pages/auth/DeviceAuthPage.tsx
@@ -143,10 +143,21 @@ export function DeviceAuthPage() {
     );
   }
 
+  // better-auth's device-authorization plugin requires the verifying
+  // session to CLAIM the code (GET /device?user_code=…) before it will
+  // accept approve/deny — without it both return 400 "not been claimed
+  // by a verifying session". Idempotent, so claim right before acting.
+  const claimDevice = async () => {
+    await fetch(`${AUTH_BASE}/device?user_code=${encodeURIComponent(code)}`, {
+      credentials: 'include',
+    }).catch(() => { /* approve below surfaces the real error */ });
+  };
+
   const handleApprove = async () => {
     setError('');
     setSubmitting(true);
     try {
+      await claimDevice();
       const res = await fetch(`${AUTH_BASE}/device/approve`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -186,6 +197,7 @@ export function DeviceAuthPage() {
     setError('');
     setDenying(true);
     try {
+      await claimDevice();
       await fetch(`${AUTH_BASE}/device/deny`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Found in the runtime-identity-binding E2E (pre-existing — not introduced by #1673): better-auth's device-authorization plugin requires the verifying session to **claim** the code via `GET /device?user_code=…` before it accepts approve/deny; both returned 400 `not been claimed by a verifying session`, so the Approve button silently failed. Claim (idempotent) right before acting.

Verified live against a local control plane: claim=200 → approve=200 → runtime bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)