### PR TITLE
feat(console): ADR-0046 P2 — /docs/:name package-documentation route

### DIFF
--- a/.changeset/adr-0046-docs-route.md
+++ b/.changeset/adr-0046-docs-route.md
@@ -1,0 +1,7 @@
+---
+"@object-ui/console": minor
+---
+
+ADR-0046 P2: `/docs/:name` package-documentation route.
+
+One authenticated route renders any installed `doc` metadata item (flat Markdown docs compiled from a package's `src/docs/*.md`): fetches the item via the standard metadata API (`meta.getItem('doc', name)`), renders the sanitized body through `@object-ui/plugin-markdown`, and rewrites relative cross-references `[x](./other_doc.md#anchor)` → `/docs/other_doc#anchor` (fenced/inline code untouched, SPA navigation on click). Unknown names degrade to a "Documentation not found" notice per the ADR — never a hard failure.

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -42,6 +42,7 @@ import { CloudAwareRootRedirect } from './components/CloudAwareRootRedirect';
 import { FormPage } from './components/FormPage';
 import { MetadataHmrReloader } from './components/MetadataHmrReloader';
 import SharedRecordPage from './pages/SharedRecordPage';
+import DocPage from './pages/DocPage';
 import { LoginPage } from './pages/auth/LoginPage';
 import { RegisterPage } from './pages/auth/RegisterPage';
 import { ForgotPasswordPage } from './pages/auth/ForgotPasswordPage';
@@ -176,6 +177,14 @@ export function App() {
             <Route path="/forms/:name" element={
               <ProtectedRoute>
                 <FormPage mode="internal" />
+              </ProtectedRoute>
+            } />
+            {/* Package documentation (ADR-0046): one route renders any
+              * installed `doc` metadata item; cross-references between docs
+              * resolve to this same route. */}
+            <Route path="/docs/:name" element={
+              <ProtectedRoute>
+                <DocPage />
               </ProtectedRoute>
             } />
             <Route path="/home" element={

--- a/apps/console/src/pages/DocPage.tsx
+++ b/apps/console/src/pages/DocPage.tsx
@@ -1,0 +1,131 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { AlertCircle, FileQuestion, Loader2 } from 'lucide-react';
+import { useAdapter } from '@object-ui/app-shell';
+import { MarkdownRenderer } from '@object-ui/plugin-markdown';
+import { rewriteDocLinks } from './doc-links';
+
+interface DocItem {
+  name: string;
+  label?: string;
+  content: string;
+}
+
+/**
+ * `/docs/:name` — render one package-doc metadata item (ADR-0046).
+ *
+ * Docs are inert `doc` metadata compiled from a package's flat
+ * `src/docs/*.md`; this page fetches the item by name through the
+ * standard metadata API and renders the sanitized Markdown body,
+ * rewriting relative `[x](./other_doc.md)` references to `/docs/<name>`
+ * routes (see doc-links.ts).
+ *
+ * Per the ADR, an unresolvable doc (bad URL, or a cross-package link
+ * whose target was removed in a newer dependency version) degrades to a
+ * "not found" notice — never an install-time or hard failure.
+ */
+export default function DocPage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const adapter = useAdapter();
+  const [doc, setDoc] = useState<DocItem | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'missing' | 'error'>('loading');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!name || !adapter) return;
+      setState('loading');
+      try {
+        const raw: any = await adapter.getClient().meta.getItem('doc', name);
+        const item = raw?.item ?? raw?.data ?? raw;
+        if (cancelled) return;
+        if (item && typeof item.content === 'string') {
+          setDoc({ name, label: item.label, content: item.content });
+          setState('ready');
+        } else {
+          setState('missing');
+        }
+      } catch (err: any) {
+        if (cancelled) return;
+        // The metadata API answers 404 for unknown names — that is the
+        // ADR-mandated soft-degrade path, not an error.
+        const status = err?.status ?? err?.response?.status;
+        if (status === 404 || /not found/i.test(err?.message ?? '')) {
+          setState('missing');
+        } else {
+          setErrorMessage(err?.message ?? 'Failed to load documentation');
+          setState('error');
+        }
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [name, adapter]);
+
+  // SPA navigation for rewritten doc-to-doc links: anchors render as
+  // plain <a href="/docs/...">; intercept same-app clicks so following a
+  // cross-reference doesn't trigger a full page reload.
+  const onContentClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+      const anchor = (e.target as HTMLElement).closest('a');
+      const href = anchor?.getAttribute('href');
+      if (href && href.startsWith('/docs/')) {
+        e.preventDefault();
+        navigate(href);
+      }
+    },
+    [navigate],
+  );
+
+  if (state === 'loading') {
+    return (
+      <div className="flex h-full items-center justify-center p-10 text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading documentation" />
+      </div>
+    );
+  }
+
+  if (state === 'missing') {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
+        <FileQuestion className="h-10 w-10 text-muted-foreground" />
+        <h1 className="text-lg font-semibold">Documentation not found</h1>
+        <p className="text-sm text-muted-foreground">
+          No document named <code className="rounded bg-muted px-1 py-0.5">{name}</code> is installed.
+          It may belong to a package that is not installed, or it was removed in a newer version.
+        </p>
+      </div>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
+        <AlertCircle className="h-10 w-10 text-destructive" />
+        <h1 className="text-lg font-semibold">Failed to load documentation</h1>
+        <p className="text-sm text-muted-foreground">{errorMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-4 sm:p-6" onClick={onContentClick}>
+      <MarkdownRenderer
+        schema={{ type: 'markdown', content: rewriteDocLinks(doc?.content ?? '') }}
+      />
+    </div>
+  );
+}

--- a/apps/console/src/pages/doc-links.test.ts
+++ b/apps/console/src/pages/doc-links.test.ts
@@ -1,0 +1,49 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { rewriteDocLinks } from './doc-links';
+
+describe('rewriteDocLinks (ADR-0046)', () => {
+  it('rewrites ./name.md links to /docs/name', () => {
+    expect(rewriteDocLinks('See the [guide](./crm_lead_guide.md).'))
+      .toBe('See the [guide](/docs/crm_lead_guide).');
+  });
+
+  it('rewrites bare name.md links and preserves anchors', () => {
+    expect(rewriteDocLinks('Back to [index](crm_index.md#setup).'))
+      .toBe('Back to [index](/docs/crm_index#setup).');
+  });
+
+  it('rewrites multiple links in one document', () => {
+    const input = '[a](./crm_a.md) and [b](./crm_b.md#x)';
+    expect(rewriteDocLinks(input)).toBe('[a](/docs/crm_a) and [b](/docs/crm_b#x)');
+  });
+
+  it('leaves external and non-doc links alone', () => {
+    const input = '[site](https://example.com/x.md) [pdf](./file.pdf) [abs](/docs/already)';
+    expect(rewriteDocLinks(input)).toBe(input);
+  });
+
+  it('does not touch links inside fenced code blocks', () => {
+    const input = 'prose [a](./crm_a.md)\n\n```md\n[b](./crm_b.md)\n```\n\n[c](./crm_c.md)';
+    expect(rewriteDocLinks(input)).toBe(
+      'prose [a](/docs/crm_a)\n\n```md\n[b](./crm_b.md)\n```\n\n[c](/docs/crm_c)',
+    );
+  });
+
+  it('does not touch links inside inline code spans', () => {
+    const input = 'Write `[x](./crm_x.md)` to link; see [y](./crm_y.md).';
+    expect(rewriteDocLinks(input)).toBe('Write `[x](./crm_x.md)` to link; see [y](/docs/crm_y).');
+  });
+
+  it('skips path-shaped targets (subdirectories are banned upstream anyway)', () => {
+    const input = '[deep](./user/crm_a.md)';
+    expect(rewriteDocLinks(input)).toBe(input);
+  });
+});

--- a/apps/console/src/pages/doc-links.ts
+++ b/apps/console/src/pages/doc-links.ts
@@ -1,0 +1,48 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Rewrite ADR-0046 package-doc cross-references for console rendering.
+ *
+ * Docs reference each other with plain relative Markdown links —
+ * `[guide](./crm_lead_guide.md#anchor)` — because the authoring tree is
+ * flat, resolution is a basename lookup: strip `./` and `.md` to get the
+ * target doc name. The console renders a doc at `/docs/<name>`, so this
+ * rewrites those links to `](/docs/crm_lead_guide#anchor)` before the
+ * Markdown renderer sees them.
+ *
+ * Fenced code blocks and inline code spans are left untouched so a doc
+ * can show the link syntax literally.
+ */
+
+const FENCE_RE = /(^```[^\n]*\n[\s\S]*?\n```[ \t]*$|^~~~[^\n]*\n[\s\S]*?\n~~~[ \t]*$)/m;
+const INLINE_CODE_RE = /(`[^`\n]+`)/;
+const DOC_LINK_RE = /\]\((?:\.\/)?([a-z][a-z0-9_]*)\.md(#[^)\s]*)?\)/g;
+
+function rewriteProse(segment: string): string {
+  return segment
+    .split(INLINE_CODE_RE)
+    .map((part, i) => (i % 2 === 1 ? part : part.replace(DOC_LINK_RE, '](/docs/$1$2)')))
+    .join('');
+}
+
+export function rewriteDocLinks(markdown: string): string {
+  const out: string[] = [];
+  let rest = markdown;
+  // FENCE_RE has no /g so each exec finds the next fence in `rest`;
+  // alternating prose/fence segments are rewritten/preserved respectively.
+  for (;;) {
+    const m = FENCE_RE.exec(rest);
+    if (!m || m.index === undefined) {
+      out.push(rewriteProse(rest));
+      return out.join('');
+    }
+    out.push(rewriteProse(rest.slice(0, m.index)), m[0]);
+    rest = rest.slice(m.index + m[0].length);
+  }
+}


### PR DESCRIPTION
## Summary

ADR-0046 P2 (framework side merged as [framework#1789](https://github.com/objectstack-ai/framework/pull/1789)): one authenticated console route renders any installed `doc` metadata item — flat Markdown docs compiled from a package's `src/docs/*.md`.

- **`/docs/:name` route** (App.tsx, inside `ProtectedRoute`): fetches the item via the standard metadata API (`meta.getItem('doc', name)`), renders the sanitized body through `@object-ui/plugin-markdown` (react-markdown + remark-gfm + rehype-sanitize).
- **Cross-reference rewriting** (`doc-links.ts`): `[x](./other_doc.md#anchor)` → `/docs/other_doc#anchor` before rendering; fenced code blocks and inline code spans stay literal; rewritten links navigate via react-router (no full reload).
- **Soft degrade**: unknown names render a "Documentation not found" notice per the ADR — a removed cross-package doc must never become a hard failure.

## Test plan
- [x] `doc-links.test.ts` — 7 cases (rewrite, anchors, external/non-doc links untouched, code blocks/spans untouched, path-shaped targets skipped)
- [x] Workspace `pnpm build` green (console build includes `tsc`)
- [x] E2E against a live backend (framework app-todo example with two cross-referencing docs): doc renders at `/docs/todo_index`, link rewritten to `/docs/todo_user_guide` and SPA-navigates, `/docs/todo_nonexistent` shows the not-found notice, list API stays content-free while item API returns the full body

🤖 Generated with [Claude Code](https://claude.com/claude-code)