### PR TITLE
feat: ADR-0047 UX round 2 — Airtable-parity toolbar polish

### DIFF
--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1627,6 +1627,26 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       return 'other';
     };
 
+    // Resolve a select-like value to its translated option label and
+    // explicit color so card badges match the desktop grid — the raw
+    // stored value (e.g. "in_review") must never reach the user.
+    const resolveOptionMeta = (fieldKey: string, value: any): { label: string; color?: string } => {
+      const rawOptions = objectSchema?.fields?.[fieldKey]?.options;
+      if (Array.isArray(rawOptions) && rawOptions.length > 0) {
+        const translated = schema.objectName
+          ? translateOptions(schema.objectName, fieldKey, rawOptions)
+          : rawOptions;
+        const opt = (translated as any[]).find(o => o && String(o.value) === String(value));
+        if (opt) {
+          return { label: opt.label != null ? String(opt.label) : String(value), color: (opt as any).color };
+        }
+      }
+      // Option-less enum-looking values still get humanized; free text is
+      // passed through untouched so we never rewrite user data.
+      const str = String(value);
+      return { label: /^[a-z0-9]+(_[a-z0-9]+)+$/.test(str) ? humanizeLabel(str) : str };
+    };
+
     return (
       <>
         <div className="space-y-2 p-2">
@@ -1672,14 +1692,25 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
                           : (row[amountCol.accessorKey] != null && typeof row[amountCol.accessorKey] === 'object' ? String(row[amountCol.accessorKey]) : (row[amountCol.accessorKey] ?? '—'))}
                       </span>
                     )}
-                    {stageCol && row[stageCol.accessorKey] && (
-                      <Badge
-                        variant="outline"
-                        className={`text-xs shrink-0 max-w-[140px] truncate ${stageBadgeColor(String(row[stageCol.accessorKey]))}`}
-                      >
-                        {String(row[stageCol.accessorKey])}
-                      </Badge>
-                    )}
+                    {stageCol && row[stageCol.accessorKey] && (() => {
+                      const rawValue = row[stageCol.accessorKey];
+                      const optMeta = resolveOptionMeta(stageCol.accessorKey, rawValue);
+                      // Explicit option color wins (matches desktop grid via
+                      // getBadgeColorClasses); fall back to the pipeline-stage
+                      // heuristics keyed on the raw value, which stays stable
+                      // across locales.
+                      const badgeClasses = optMeta.color
+                        ? getBadgeColorClasses(optMeta.color, rawValue)
+                        : stageBadgeColor(String(rawValue));
+                      return (
+                        <Badge
+                          variant="outline"
+                          className={`text-xs shrink-0 max-w-[140px] truncate ${badgeClasses}`}
+                        >
+                          {optMeta.label}
+                        </Badge>
+                      );
+                    })()}
                   </div>
                 )}
 

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -11,7 +11,7 @@ import { cn, Button, Input, Popover, PopoverContent, PopoverTrigger, FilterBuild
 import type { SortItem } from '@object-ui/components';
 import { Search, SlidersHorizontal, ArrowUpDown, X, EyeOff, Group, Paintbrush, Ruler, Inbox, Download, AlignJustify, Rows4, Rows3, Rows2, Share2, Printer, Plus, Trash2, CheckSquare, icons, type LucideIcon } from 'lucide-react';
 import type { FilterGroup } from '@object-ui/components';
-import { ViewSwitcher, ViewType } from './ViewSwitcher';
+import { ViewSwitcherDropdown, ViewType } from './ViewSwitcher';
 import { TabBar, TabBarSelect } from './components/TabBar';
 import type { ViewTab } from './components/TabBar';
 import { ViewSettingsPopover } from './components/ViewSettingsPopover';
@@ -594,13 +594,18 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // User Filters State (Airtable Interfaces-style)
   const [userFilterConditions, setUserFilterConditions] = React.useState<any[]>([]);
 
-  // Auto-derive userFilters from objectDef when not explicitly configured
+  // User filters render ONLY when explicitly configured (ADR-0047 §data
+  // mode): saved list views already act as the preset switcher, so an
+  // unconfigured view keeps a clean toolbar instead of growing auto-derived
+  // dropdowns. When a config asks for dropdown/toggle elements without
+  // naming fields, fill the field list from objectDef select-like fields so
+  // authors can write `userFilters: { element: 'dropdown' }` as shorthand.
   const resolvedUserFilters = React.useMemo<ListViewSchema['userFilters'] | undefined>(() => {
-    // If explicitly configured, use as-is
-    if (schema.userFilters) return schema.userFilters;
-
-    // Auto-derive from objectDef for select/multi-select/boolean fields
-    if (!objectDef?.fields) return undefined;
+    const configured = schema.userFilters;
+    if (!configured) return undefined;
+    if (configured.element === 'tabs') return configured;
+    if (configured.fields && configured.fields.length > 0) return configured;
+    if (!objectDef?.fields) return configured;
 
     const FILTERABLE_FIELD_TYPES = new Set(['select', 'multi-select', 'boolean']);
     const derivedFields: NonNullable<NonNullable<ListViewSchema['userFilters']>['fields']> = [];
@@ -620,10 +625,16 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       }
     }
 
-    if (derivedFields.length === 0) return undefined;
+    if (derivedFields.length === 0) return configured;
 
-    return { element: 'dropdown', fields: derivedFields };
-  }, [schema.userFilters, objectDef]);
+    return { ...configured, fields: derivedFields };
+  }, [schema.userFilters, objectDef, tFieldLabel]);
+
+  // Tabs and filter elements are mutually exclusive on the toolbar
+  // (Airtable parity: the Elements choice is tabs OR dropdowns, never
+  // both). Metadata tabs win — they are author-curated named presets; a
+  // userFilters config on the same view only renders when no tabs exist.
+  const filterElements = schema.tabs && schema.tabs.length > 0 ? undefined : resolvedUserFilters;
 
   // Hidden Fields State (initialized from schema)
   const [hiddenFields, setHiddenFields] = React.useState<Set<string>>(
@@ -1525,17 +1536,6 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           {isRefreshing ? t('list.refreshing') : t('list.pullToRefresh')}
         </div>
       )}
-      {/* Unified toolbar — Row 1: View tabs (when present) */}
-      {showViewSwitcher && (
-        <div className="px-4 py-1 flex items-center bg-background">
-          <ViewSwitcher
-            currentView={currentView}
-            availableViews={availableViews}
-            onViewChange={handleViewChange}
-          />
-        </div>
-      )}
-
       {/* View Description (single line, no border duplication) */}
       {schema.description && (schema.appearance?.showDescription !== false) && (
         <div className="px-4 pt-1.5 text-xs text-muted-foreground bg-background" data-testid="view-description">
@@ -1572,17 +1572,15 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
               </div>
             </>
           )}
-          {/* Vertical divider between tabs and user filters */}
-          {schema.tabs && schema.tabs.length > 0 && resolvedUserFilters && (
-            <div className="hidden sm:block h-4 w-px bg-border/60 mx-1 shrink-0" />
-          )}
-          {/* User Filters — predefined filter presets shown as a horizontal
-              chip row. On mobile we keep them visible (single line, scrollable)
-              to match the Airtable Interface pattern. */}
-          {resolvedUserFilters && (
+          {/* User Filters — filter elements (dropdown chips / preset tabs /
+              toggles). Mutually exclusive with view tabs above, so at most
+              one filter element group ever renders here. On mobile we keep
+              them visible (single line, scrollable) to match the Airtable
+              Interface pattern. */}
+          {filterElements && (
               <div className="shrink-0 min-w-0 overflow-x-auto" data-testid="user-filters">
                 <UserFilters
-                  config={resolvedUserFilters}
+                  config={filterElements}
                   objectDef={objectDef}
                   data={data}
                   onFilterChange={setUserFilterConditions}
@@ -1593,6 +1591,19 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         </div>
 
         <div className="flex items-center gap-0 shrink-0 rounded-lg border border-border bg-muted/40 p-0.5 shadow-sm">
+          {/* Visualization switcher — compact dropdown (Airtable-style
+              "List ▾"), first slot of the right tool cluster so the whole
+              toolbar stays a single row. */}
+          {showViewSwitcher && (
+            <>
+              <ViewSwitcherDropdown
+                currentView={currentView}
+                availableViews={availableViews}
+                onViewChange={handleViewChange}
+              />
+              <div className="h-4 w-px bg-border/60 mx-0.5" />
+            </>
+          )}
           {/* Hide Fields — hidden on mobile (collapsed into ViewSettingsPopover) */}
           {toolbarFlags.showHideFields && !toolbarFlags.compactToolbar && (
           <Popover open={showHideFields} onOpenChange={setShowHideFields}>
@@ -1657,7 +1668,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
 
           {/* Filter — universal advanced filter builder.
               Always shown when enabled. The left-side quick-filter chips
-              (resolvedUserFilters) are predefined named filters; the
+              (filterElements) are predefined named filters; the
               right-side Popover is a free-form field-by-field builder that
               can express filters the chips cannot. They serve different
               purposes and must coexist. */}

--- a/packages/plugin-list/src/UserFilters.tsx
+++ b/packages/plugin-list/src/UserFilters.tsx
@@ -263,10 +263,31 @@ function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, 
     return init;
   });
 
-  const resolvedFields = React.useMemo(
-    () => resolveFields(fields, objectDef, data, { objectName, fieldLabel, translateOptions }),
-    [fields, objectDef, data, objectName, fieldLabel, translateOptions],
-  );
+  // Option counts must reflect the result set BEFORE the field's own
+  // selection narrows it — the server returns already-filtered rows, so
+  // counting those would zero out every unselected option the moment one
+  // value is picked. Snapshot each field's counts while it has no active
+  // selection and replay the snapshot while one is active.
+  const countsSnapshotRef = React.useRef<Record<string, Map<string, number>>>({});
+  const resolvedFields = React.useMemo(() => {
+    const resolved = resolveFields(fields, objectDef, data, { objectName, fieldLabel, translateOptions });
+    return resolved.map(f => {
+      if (!f.showCount) return f;
+      const selected = selectedValues[f.field] || [];
+      if (selected.length === 0) {
+        countsSnapshotRef.current[f.field] = new Map(
+          f.options.map(o => [String(o.value), o.count ?? 0]),
+        );
+        return f;
+      }
+      const snapshot = countsSnapshotRef.current[f.field];
+      if (!snapshot) return f;
+      return {
+        ...f,
+        options: f.options.map(o => ({ ...o, count: snapshot.get(String(o.value)) ?? o.count })),
+      };
+    });
+  }, [fields, objectDef, data, objectName, fieldLabel, translateOptions, selectedValues]);
 
   const emitFilters = React.useCallback(
     (next: Record<string, (string | number | boolean)[]>) => {

--- a/packages/plugin-list/src/ViewSwitcher.tsx
+++ b/packages/plugin-list/src/ViewSwitcher.tsx
@@ -7,16 +7,18 @@
  */
 
 import * as React from 'react';
-import { cn } from '@object-ui/components';
-import { 
-  Grid, 
-  LayoutGrid, 
-  Calendar, 
+import { cn, Popover, PopoverContent, PopoverTrigger } from '@object-ui/components';
+import {
+  Grid,
+  LayoutGrid,
+  Calendar,
   Images,    // gallery
   Activity,  // timeline
   GanttChartSquare, // gantt
   Map,        // map
   BarChart3,  // chart
+  Check,
+  ChevronDown,
 } from 'lucide-react';
 
 export type ViewType =
@@ -58,6 +60,76 @@ const VIEW_LABELS: Record<ViewType, string> = {
   gantt: 'Gantt',
   map: 'Map',
   chart: 'Chart',
+};
+
+/**
+ * Compact dropdown form of the visualization switcher (Airtable-style):
+ * a single "List ▾" button in the toolbar's right cluster that opens a
+ * menu of the available visualizations. Replaces the full button row so
+ * the toolbar stays one line tall.
+ */
+export const ViewSwitcherDropdown: React.FC<ViewSwitcherProps> = ({
+  currentView,
+  availableViews = ['grid', 'kanban'],
+  onViewChange,
+  className,
+  animated = true,
+}) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleViewChange = React.useCallback(
+    (view: ViewType) => {
+      setOpen(false);
+      if (view === currentView) return;
+      if (animated && typeof document !== 'undefined' && 'startViewTransition' in document) {
+        (document as Document & {
+          startViewTransition: (cb: () => void) => { finished: Promise<void> };
+        }).startViewTransition(() => onViewChange(view));
+      } else {
+        onViewChange(view);
+      }
+    },
+    [animated, currentView, onViewChange],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="view-switcher-dropdown"
+          aria-label={VIEW_LABELS[currentView]}
+          className={cn(
+            'inline-flex items-center gap-1.5 h-7 px-2 rounded-md text-xs font-medium transition-colors oui-view-switcher',
+            open ? 'text-foreground bg-muted' : 'text-muted-foreground hover:text-foreground',
+            className,
+          )}
+        >
+          {VIEW_ICONS[currentView]}
+          <span className="hidden sm:inline-block">{VIEW_LABELS[currentView]}</span>
+          <ChevronDown className="h-3 w-3 opacity-60" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-44 p-1">
+        {availableViews.map((view) => (
+          <button
+            key={view}
+            type="button"
+            onClick={() => handleViewChange(view)}
+            data-state={view === currentView ? 'on' : 'off'}
+            className={cn(
+              'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs transition-colors hover:bg-muted',
+              view === currentView ? 'text-foreground font-medium' : 'text-muted-foreground',
+            )}
+          >
+            {VIEW_ICONS[view]}
+            <span className="flex-1 text-left">{VIEW_LABELS[view]}</span>
+            {view === currentView && <Check className="h-3.5 w-3.5" />}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
 };
 
 export const ViewSwitcher: React.FC<ViewSwitcherProps> = ({

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -113,13 +113,11 @@ describe('ListView', () => {
     };
 
     renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-    
-    // Find kanban view button and click it
-    // ViewSwitcher uses buttons with aria-label
-    const kanbanButton = screen.getByLabelText('Kanban');
 
-    fireEvent.click(kanbanButton);
-    
+    // Open the visualization dropdown, then pick Kanban from the menu
+    fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
+    fireEvent.click(screen.getByRole('button', { name: 'Kanban' }));
+
     // localStorage should be set with new view
     const storageKey = 'listview-contacts-view';
     expect(localStorageMock.getItem(storageKey)).toBe('kanban');
@@ -498,7 +496,52 @@ describe('ListView', () => {
       expect(screen.getByTestId('user-filters-dropdown')).toBeInTheDocument();
     });
 
-    it('should auto-derive userFilters from objectDef select/boolean fields', async () => {
+    it('should NOT render filter elements without explicit userFilters config (ADR-0047 data mode)', async () => {
+      const mockDs = {
+        find: vi.fn().mockResolvedValue([]),
+        findOne: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        getObjectSchema: vi.fn().mockResolvedValue({
+          name: 'tasks',
+          fields: {
+            name: { type: 'text', label: 'Name' },
+            status: {
+              type: 'select',
+              label: 'Status',
+              options: [
+                { label: 'Open', value: 'open' },
+                { label: 'Closed', value: 'closed' },
+              ],
+            },
+            is_active: { type: 'boolean', label: 'Active' },
+          },
+        }),
+      };
+
+      const schema: ListViewSchema = {
+        type: 'list-view',
+        objectName: 'tasks',
+        viewType: 'grid',
+        fields: ['name', 'status', 'is_active'],
+      };
+
+      render(
+        <SchemaRendererProvider dataSource={mockDs}>
+          <ListView schema={schema} dataSource={mockDs} />
+        </SchemaRendererProvider>
+      );
+
+      // Wait for the objectDef fetch to settle, then confirm no filter
+      // elements appeared: select fields alone must not grow dropdowns.
+      await vi.waitFor(() => {
+        expect(mockDs.getObjectSchema).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('user-filters')).not.toBeInTheDocument();
+    });
+
+    it('should fill fields from objectDef for a `{ element: "dropdown" }` shorthand config', async () => {
       const mockDs = {
         find: vi.fn().mockResolvedValue([]),
         findOne: vi.fn(),
@@ -528,6 +571,7 @@ describe('ListView', () => {
         objectName: 'tasks',
         viewType: 'grid',
         fields: ['name', 'status', 'is_active'],
+        userFilters: { element: 'dropdown' },
       };
 
       render(
@@ -536,13 +580,12 @@ describe('ListView', () => {
         </SchemaRendererProvider>
       );
 
-      // Wait for objectDef to load and userFilters to render
+      // Wait for objectDef to load — the badges appear once the shorthand
+      // config fills its field list from the fetched schema.
       await vi.waitFor(() => {
-        expect(screen.getByTestId('user-filters')).toBeInTheDocument();
+        expect(screen.getByTestId('filter-badge-status')).toBeInTheDocument();
       });
       expect(screen.getByTestId('user-filters-dropdown')).toBeInTheDocument();
-      // Should have badges for status and is_active (select + boolean)
-      expect(screen.getByTestId('filter-badge-status')).toBeInTheDocument();
       expect(screen.getByTestId('filter-badge-is_active')).toBeInTheDocument();
     });
 
@@ -1409,10 +1452,11 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      // Should only show grid and kanban, not calendar
-      expect(screen.getByLabelText('Grid')).toBeInTheDocument();
-      expect(screen.getByLabelText('Kanban')).toBeInTheDocument();
-      expect(screen.queryByLabelText('Calendar')).not.toBeInTheDocument();
+      // Should only offer grid and kanban in the dropdown, not calendar
+      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
+      expect(screen.getAllByRole('button', { name: 'Grid' }).length).toBeGreaterThan(0);
+      expect(screen.getByRole('button', { name: 'Kanban' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Calendar' })).not.toBeInTheDocument();
     });
   });
 
@@ -1431,7 +1475,8 @@ describe('ListView', () => {
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
       // Should enable kanban view since kanban.groupField is set
-      expect(screen.getByLabelText('Kanban')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
+      expect(screen.getByRole('button', { name: 'Kanban' })).toBeInTheDocument();
     });
 
     it('should use spec gallery config over legacy options', () => {
@@ -1444,7 +1489,8 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      expect(screen.getByLabelText('Gallery')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
+      expect(screen.getByRole('button', { name: 'Gallery' })).toBeInTheDocument();
     });
 
     it('should use spec timeline config over legacy options', () => {
@@ -1457,7 +1503,8 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      expect(screen.getByLabelText('Timeline')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
+      expect(screen.getByRole('button', { name: 'Timeline' })).toBeInTheDocument();
     });
 
     it('should use spec calendar config over legacy options', () => {
@@ -1470,7 +1517,8 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      expect(screen.getByLabelText('Calendar')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
+      expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument();
     });
 
     it('should use spec gantt config over legacy options', () => {
@@ -1483,7 +1531,8 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      expect(screen.getByLabelText('Gantt')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
+      expect(screen.getByRole('button', { name: 'Gantt' })).toBeInTheDocument();
     });
   });
 

--- a/packages/plugin-list/src/index.tsx
+++ b/packages/plugin-list/src/index.tsx
@@ -12,6 +12,7 @@ import { ViewSwitcher } from './ViewSwitcher';
 import { ObjectGallery } from './ObjectGallery';
 
 export { ListView, ViewSwitcher, ObjectGallery };
+export { ViewSwitcherDropdown } from './ViewSwitcher';
 export { TabBar, TabBarSelect } from './components/TabBar';
 export type { TabBarProps, ViewTab } from './components/TabBar';
 export { UserFilters } from './UserFilters';


### PR DESCRIPTION
## Summary

Second UX pass on the ADR-0047 surfaces, aligning the toolbar with Airtable's actual interaction patterns (per design review against Airtable Interfaces):

1. **Visualization switcher → right-side dropdown.** The standalone button row is gone; a compact `Grid ▾` dropdown (icon menu, checkmark on current) sits as the first slot of the right tool cluster. The toolbar is now a single row on desktop and mobile.
2. **Tabs and dropdown filters are mutually exclusive** on the toolbar (Airtable's Elements choice is tabs OR dropdowns, never both). Metadata tabs win when a view configures both.
3. **Data mode keeps a clean toolbar**: filter elements render only when `userFilters` is explicitly configured — no more auto-derived dropdowns on every object with select fields. The `{ element: 'dropdown' }` shorthand still fills fields from the object definition.
4. **Option counts survive selection**: counts snapshot while a field has an active selection, so picking "Urgent" no longer zeroes Low/Medium/High (the server returns pre-filtered rows).
5. **Mobile card badges localize**: select values resolve to translated option labels + explicit metadata colors instead of leaking raw enums (`in_review` → `In Review`).

## Testing

- `plugin-list`: 130/130 pass (tests updated to dropdown interaction + new explicit-config contract)
- `plugin-grid`: 53/53 pass; both packages build clean
- Browser-verified against app-showcase (desktop 1600px + mobile 375px): single-row toolbar, dropdown switching, counts retention with filter applied on Task Workbench, localized mobile chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)