### PR TITLE
feat: ADR-0047 — persist user-filter selections in the URL

### DIFF
--- a/e2e/live/user-filters.spec.ts
+++ b/e2e/live/user-filters.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * ADR-0047 — end-user filter surfaces, locked end-to-end.
+ *
+ * Covers the behaviors hand-verified during the ADR-0047 rounds so they
+ * cannot silently regress:
+ *
+ *  1. Data mode (showcase_task "All Tasks"): metadata filter TABS render and
+ *     dropdowns are suppressed (tabs XOR dropdowns); picking a tab filters
+ *     the grid and persists as `uf__tab` in the URL; reload restores it.
+ *  2. Data mode visualization switcher: a compact dropdown in the toolbar's
+ *     right cluster (single row), offering only the whitelist.
+ *  3. Interface mode (Task Workbench page): author-enabled dropdown filters
+ *     only — no view tabs, no visualization switcher (single-entry
+ *     whitelist = locked); selecting a value filters rows, persists as
+ *     `uf_<field>`, survives reload; per-option counts do NOT zero out
+ *     while the selection is active (counts snapshot).
+ */
+
+test.describe('ADR-0047 data mode — filter tabs + viz dropdown', () => {
+  test('filter tabs render exclusively, persist to URL, and restore on reload', async ({ page }) => {
+    await page.goto('/apps/showcase_app/showcase_task');
+
+    // The default "All Tasks" view configures metadata tabs — they render…
+    // (TabBar renders role="tab" with stable view-tab-<name> testids)
+    const urgentTab = page.getByTestId('view-tab-urgent');
+    await expect(urgentTab).toBeVisible();
+    // …and dropdown filter badges do not (tabs XOR dropdowns).
+    await expect(page.getByTestId('filter-badge-status')).toHaveCount(0);
+
+    // Picking a tab filters the grid and mirrors into the URL.
+    await urgentTab.click();
+    await expect(page).toHaveURL(/uf__tab=urgent/);
+    await expect(page.getByTestId('record-count-bar')).toContainText(/^2 /, { timeout: 15000 });
+
+    // Reload: the tab selection and its filter survive.
+    await page.reload();
+    await expect(page).toHaveURL(/uf__tab=urgent/);
+    await expect(page.getByTestId('record-count-bar')).toContainText(/^2 /, { timeout: 15000 });
+  });
+
+  test('visualization switcher is a single dropdown offering the whitelist', async ({ page }) => {
+    await page.goto('/apps/showcase_app/showcase_task');
+
+    const trigger = page.getByTestId('view-switcher-dropdown');
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    // Whitelist: grid, kanban, gallery, calendar — and nothing else.
+    await expect(page.getByRole('button', { name: 'Kanban' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Gallery' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Calendar' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Timeline' })).toHaveCount(0);
+
+    // Switching actually swaps the renderer (kanban board appears).
+    await page.getByRole('button', { name: 'Kanban' }).click();
+    await expect(trigger).toContainText('Kanban');
+  });
+});
+
+test.describe('ADR-0047 interface mode — Task Workbench', () => {
+  test('locked surface: dropdowns only, no view tabs, no switcher', async ({ page }) => {
+    await page.goto('/apps/showcase_app/page/showcase_task_workbench');
+
+    await expect(page.getByTestId('interface-list-page')).toBeVisible();
+    await expect(page.getByTestId('filter-badge-status')).toBeVisible();
+    await expect(page.getByTestId('filter-badge-priority')).toBeVisible();
+    // Single-entry visualization whitelist renders no switcher.
+    await expect(page.getByTestId('view-switcher-dropdown')).toHaveCount(0);
+  });
+
+  test('dropdown selection filters, keeps counts, persists, and restores', async ({ page }) => {
+    await page.goto('/apps/showcase_app/page/showcase_task_workbench');
+
+    // Open the priority dropdown (showCount: true) and capture pre-selection state.
+    await page.getByTestId('filter-badge-priority').click();
+    const options = page.getByTestId('filter-options-priority');
+    await expect(options).toBeVisible();
+    await expect(options.getByText('Urgent')).toBeVisible();
+
+    // Select Urgent: the grid narrows and the URL picks up the selection.
+    await options.getByText('Urgent').click();
+    await expect(page).toHaveURL(/uf_priority=urgent/);
+    await expect(page.getByTestId('record-count-bar')).toContainText(/^2 /, { timeout: 15000 });
+
+    // Counts snapshot: with Urgent active the OTHER options keep their
+    // pre-selection counts instead of collapsing to 0 (the server already
+    // filtered the rows; the popover replays the snapshot).
+    const optionRows = options.locator('label');
+    const texts = await optionRows.allTextContents();
+    const nonUrgent = texts.filter(t => !/Urgent/.test(t));
+    expect(nonUrgent.length).toBeGreaterThan(0);
+    // Every non-selected option still shows a non-zero count.
+    for (const t of nonUrgent) {
+      expect(t).not.toMatch(/\b0\b/);
+    }
+
+    // Reload: badge selection state and the filtered result set survive.
+    await page.reload();
+    await expect(page).toHaveURL(/uf_priority=urgent/);
+    await expect(page.getByTestId('filter-badge-priority')).toContainText('1');
+    await expect(page.getByTestId('record-count-bar')).toContainText(/^2 /, { timeout: 15000 });
+  });
+});

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -83,36 +83,48 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
   // the full body lives behind the per-view overlay API — the same
   // hydration ObjectView performs. Only fetch when the resolution came up
   // hollow.
+  //
+  // IMPORTANT: the deps are SCALARS, not the objectDef/resolvedView object
+  // identities. `useMetadata().objects` is rebuilt per render, so identity
+  // deps re-fire this effect on every render — and the unconditional
+  // `setHydratedView(null)` then ping-pongs with the async `setHydratedView
+  // (full)` into an infinite render/refetch loop the moment anything (e.g.
+  // a `uf_*` URL write) re-renders this component after hydration settled.
+  const objectDefName: string | undefined = objectDef?.name;
+  const resolvedViewHollow = !!resolvedView && !resolvedView.columns;
+  const resolvedViewKey = resolvedView?.name
+    ?? (cfg.sourceView ? `${cfg.source}.${cfg.sourceView}` : undefined);
   const [hydratedView, setHydratedView] = React.useState<any>(null);
   React.useEffect(() => {
     let cancelled = false;
     setHydratedView(null);
-    if (!objectDef || !cfg.source || resolvedView?.columns) return;
-    const viewKey = resolvedView?.name
-      ?? (cfg.sourceView ? `${cfg.source}.${cfg.sourceView}` : undefined);
-    if (!viewKey) return;
+    if (!objectDefName || !cfg.source || !resolvedViewHollow || !resolvedViewKey) return;
     (async () => {
       try {
         const ds: any = dataSource;
         let full: any = null;
         if (typeof ds?.listViewOverrides === 'function') {
           const all = await ds.listViewOverrides(cfg.source);
-          full = all?.[viewKey] ?? null;
+          full = all?.[resolvedViewKey] ?? null;
         }
         if (!full?.columns && typeof ds?.getView === 'function') {
-          full = await ds.getView(cfg.source, viewKey);
+          full = await ds.getView(cfg.source, resolvedViewKey);
         }
         if (!cancelled && full && typeof full === 'object') setHydratedView(full);
       } catch { /* hollow view stays hollow — renderer falls back to defaults */ }
     })();
     return () => { cancelled = true; };
-  }, [objectDef, cfg.source, cfg.sourceView, resolvedView, dataSource]);
+  }, [objectDefName, cfg.source, cfg.sourceView, resolvedViewHollow, resolvedViewKey, dataSource]);
 
   const viewDef = React.useMemo(
     () => (hydratedView ? { ...resolvedView, ...hydratedView } : resolvedView),
     [resolvedView, hydratedView],
   );
 
+  // Key the schema on CONTENT, not object identity — `objects` (and thus
+  // objectDef/resolvedView) are rebuilt per render, and a new schema
+  // identity makes ListView refetch. The serialized view config is small.
+  const viewDefJson = JSON.stringify(viewDef ?? null);
   const schema = React.useMemo(() => {
     if (!objectDef) return undefined;
     const view = viewDef || {};
@@ -164,7 +176,8 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
       allowExport: false,
       inlineEdit: false,
     };
-  }, [objectDef, viewDef, cfg]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [objectDefName, viewDefJson, cfg]);
 
   if (!objectDef || !schema) {
     return (

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -16,12 +16,14 @@
  */
 
 import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { ListView } from '@object-ui/plugin-list';
 import { useAdapter } from '@object-ui/react';
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
 import { Database } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useMetadata } from '../providers/MetadataProvider';
+import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState';
 
 interface InterfaceListPageProps {
   page: any;
@@ -53,6 +55,19 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
   const { t } = useObjectTranslation();
   const { objects } = useMetadata();
   const dataSource = useAdapter();
+  const [, setSearchParams] = useSearchParams();
+
+  // ADR-0047 filter persistence: restore `uf_*` URL params once at mount,
+  // mirror every selection change back (replace — no history spam).
+  const [initialUfSelections] = React.useState<Record<string, string[]> | undefined>(
+    () => parseUserFilterParams(new URLSearchParams(window.location.search)),
+  );
+  const handleUserFilterSelectionsChange = React.useCallback(
+    (selections: Record<string, Array<string | number | boolean>>) => {
+      setSearchParams(prev => applyUserFilterParams(prev, selections), { replace: true });
+    },
+    [setSearchParams],
+  );
 
   const cfg = page?.interfaceConfig || {};
   const objectDef = React.useMemo(
@@ -181,7 +196,12 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
         )}
       </div>
       <div className="flex-1 min-h-0 overflow-auto">
-        <ListView schema={schema} dataSource={dataSource} />
+        <ListView
+          schema={schema}
+          dataSource={dataSource}
+          userFilterSelections={initialUfSelections}
+          onUserFilterSelectionsChange={handleUserFilterSelectionsChange}
+        />
       </div>
     </div>
   );

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -11,6 +11,7 @@
 
 import { useMemo, useState, useCallback, useEffect, useRef, lazy, Suspense, type ComponentType } from 'react';
 import { useParams, useSearchParams, useNavigate, useLocation } from 'react-router-dom';
+import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState';
 const ObjectChart = lazy(() =>
   import('@object-ui/plugin-charts').then((m) => ({ default: m.ObjectChart })),
 );
@@ -919,17 +920,39 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
      * which matches the shape consumed by the list view's data fetcher when
      * merging base filters.
      */
+    // Dep on the serialized `filter[...]` entries only — `uf_*` user-filter
+    // params also live in the URL and must not invalidate this memo (a new
+    // array identity here rebuilds the whole list schema and refetches).
+    const filterParamsKey = Array.from(searchParams.entries())
+        .filter(([k]) => k.startsWith('filter['))
+        .map(([k, v]) => `${k}=${v}`)
+        .join('&');
     const urlFilters = useMemo(() => {
         const out: Array<[string, string, any]> = [];
-        searchParams.forEach((value, key) => {
+        new URLSearchParams(filterParamsKey).forEach((value, key) => {
             const m = /^filter\[(.+)\]$/.exec(key);
             if (m && m[1] && value !== '') {
                 out.push([m[1], '=', value]);
             }
         });
         return out;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [searchParams.toString()]);
+    }, [filterParamsKey]);
+
+    /**
+     * End-user filter selections restored from `uf_*` URL params (ADR-0047
+     * persistence). Captured once per ObjectView mount — UserFilters only
+     * reads them at its own mount, and later URL writes must not churn the
+     * schema memo.
+     */
+    const [initialUfSelections] = useState<Record<string, string[]> | undefined>(
+        () => parseUserFilterParams(new URLSearchParams(window.location.search)),
+    );
+    const handleUserFilterSelectionsChange = useCallback(
+        (selections: Record<string, Array<string | number | boolean>>) => {
+            setSearchParams(prev => applyUserFilterParams(prev, selections), { replace: true });
+        },
+        [setSearchParams],
+    );
     // Memoize onNavigate to prevent stale closure in useNavigationOverlay's handleClick
     const handleNavOverlayNavigate = useCallback(
         (recordId: string | number, action?: string) => {
@@ -1331,10 +1354,12 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 onColumnStateChange={(state: { order?: string[]; widths?: Record<string, number> }) => {
                     persistViewPatch(viewDef.id, viewDef, { columnState: state });
                 }}
+                userFilterSelections={initialUfSelections}
+                onUserFilterSelectionsChange={handleUserFilterSelectionsChange}
                 dataSource={ds}
             />
         );
-    }, [activeView, objectDef, objectName, refreshKey, navOverlay, actions, persistViewPatch, urlFilters]);
+    }, [activeView, objectDef, objectName, refreshKey, navOverlay, actions, persistViewPatch, urlFilters, initialUfSelections, handleUserFilterSelectionsChange]);
 
     // Memoize the merged views array so PluginObjectView doesn't get a new
     // reference on every render (which would trigger unnecessary data refetches).

--- a/packages/app-shell/src/views/userFilterUrlState.ts
+++ b/packages/app-shell/src/views/userFilterUrlState.ts
@@ -1,0 +1,56 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * URL persistence for end-user filter selections (ADR-0047).
+ *
+ * Selections live in `uf_<field>` search params (comma-joined values,
+ * each URI-encoded so literal commas survive); the active tab preset is
+ * carried as `uf__tab=<tabId>` via the reserved `_tab` key. Mirroring the
+ * state into the URL makes filter selections survive a reload and makes
+ * filtered lists shareable as links — Airtable Interfaces parity.
+ */
+
+const PREFIX = 'uf_';
+
+/** Read `uf_*` params into the UserFilters `initialSelections` shape. */
+export function parseUserFilterParams(
+  searchParams: URLSearchParams,
+): Record<string, string[]> | undefined {
+  const out: Record<string, string[]> = {};
+  searchParams.forEach((value, key) => {
+    if (key.startsWith(PREFIX) && value !== '') {
+      const field = key.slice(PREFIX.length);
+      out[field] = value.split(',').map(v => {
+        try { return decodeURIComponent(v); } catch { return v; }
+      });
+    }
+  });
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Mirror a selections payload into a copy of the given params. Only the
+ * fields present in `selections` are touched — empty value lists delete
+ * their param. Returns the next URLSearchParams (caller decides replace).
+ */
+export function applyUserFilterParams(
+  prev: URLSearchParams,
+  selections: Record<string, Array<string | number | boolean>>,
+): URLSearchParams {
+  const next = new URLSearchParams(prev);
+  for (const [field, values] of Object.entries(selections)) {
+    const key = PREFIX + field;
+    if (values && values.length > 0) {
+      next.set(key, values.map(v => encodeURIComponent(String(v))).join(','));
+    } else {
+      next.delete(key);
+    }
+  }
+  return next;
+}

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -39,6 +39,10 @@ export interface ListViewProps {
   onRowClick?: (record: Record<string, unknown>) => void;
   /** Show view type switcher (Grid/Kanban/etc). Default: false (view type is fixed) */
   showViewSwitcher?: boolean;
+  /** Initial user-filter selections to restore (field → values; `_tab` for the active preset). */
+  userFilterSelections?: Record<string, Array<string | number | boolean>>;
+  /** Fires with the raw user-filter selections whenever the user changes them. */
+  onUserFilterSelectionsChange?: (selections: Record<string, Array<string | number | boolean>>) => void;
   [key: string]: any;
 }
 
@@ -319,6 +323,8 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   onColumnStateChange,
   onRowClick,
   showViewSwitcher: showViewSwitcherProp,
+  userFilterSelections,
+  onUserFilterSelectionsChange,
   ...props
 }, ref) => {
   // The switcher can be enabled either by the host component (prop) or by
@@ -455,16 +461,35 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     conditions: []
   });
 
-  // Tab State
+  // Tab State. A URL-restored tab (`userFilterSelections._tab`) wins over
+  // the author's `isDefault` (ADR-0047 filter persistence).
   const [activeTab, setActiveTab] = React.useState<string | undefined>(() => {
     if (!schema.tabs || schema.tabs.length === 0) return undefined;
+    const restored = userFilterSelections?._tab?.[0];
+    if (typeof restored === 'string' && schema.tabs.some((t: any) => t.name === restored)) {
+      return restored;
+    }
     const defaultTab = schema.tabs.find((t: any) => t.isDefault);
     return defaultTab?.name ?? schema.tabs[0]?.name;
   });
 
+  // Apply the initially-active tab's filter on mount so a restored tab
+  // scopes the first fetch the same way a user click would.
+  React.useEffect(() => {
+    const tab = schema.tabs?.find((t: any) => t.name === activeTab);
+    if (tab && Array.isArray(tab.filter) && tab.filter.length > 0) {
+      const conditions = tab.filter
+        .filter((r: any) => r && typeof r.field === 'string')
+        .map((r: any) => ({ field: r.field, operator: r.operator ?? 'equals', value: r.value }));
+      setCurrentFilters({ id: `tab-filter-${tab.name}`, logic: 'and', conditions });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleTabChange = React.useCallback(
     (tab: ViewTab) => {
       setActiveTab(tab.name);
+      onUserFilterSelectionsChange?.({ _tab: [tab.name] });
       // Apply tab filter if defined. Two shapes are accepted:
       // - @objectstack/spec ViewTab.filter: ViewFilterRule[] — an array of
       //   `{ field, operator, value }` rules (the canonical metadata shape)
@@ -488,7 +513,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         onFilterChange?.(emptyFilters);
       }
     },
-    [onFilterChange],
+    [onFilterChange, onUserFilterSelectionsChange],
   );
 
   // Data State
@@ -1585,6 +1610,8 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
                   data={data}
                   onFilterChange={setUserFilterConditions}
                   maxVisible={3}
+                  initialSelections={userFilterSelections}
+                  onSelectionsChange={onUserFilterSelectionsChange}
                 />
               </div>
           )}

--- a/packages/plugin-list/src/UserFilters.tsx
+++ b/packages/plugin-list/src/UserFilters.tsx
@@ -59,6 +59,18 @@ export interface UserFiltersProps {
   /** Maximum visible filter badges before collapsing into "More" dropdown (dropdown mode only) */
   maxVisible?: number;
   className?: string;
+  /**
+   * Initial selections to restore (e.g. from URL params). Keyed by field
+   * name → selected values; the active tab preset is carried under the
+   * reserved `_tab` key as a single-entry array.
+   */
+  initialSelections?: Record<string, Array<string | number | boolean>>;
+  /**
+   * Fires with the raw selection state on every user change (same shape as
+   * `initialSelections`). Hosts use this to persist selections — e.g.
+   * ObjectView/InterfaceListPage mirror them into `uf_*` URL params.
+   */
+  onSelectionsChange?: (selections: Record<string, Array<string | number | boolean>>) => void;
 }
 
 /** Map @objectstack/spec ViewFilterRule operators to ObjectQL AST operators. */
@@ -110,6 +122,8 @@ export function UserFilters({
   onFilterChange,
   maxVisible,
   className,
+  initialSelections,
+  onSelectionsChange,
 }: UserFiltersProps) {
   switch (config.element) {
     case 'dropdown':
@@ -121,6 +135,8 @@ export function UserFilters({
           onFilterChange={onFilterChange}
           maxVisible={maxVisible}
           className={className}
+          initialSelections={initialSelections}
+          onSelectionsChange={onSelectionsChange}
         />
       );
     case 'tabs':
@@ -131,6 +147,8 @@ export function UserFilters({
           allowAddTab={config.allowAddTab}
           onFilterChange={onFilterChange}
           className={className}
+          initialTab={typeof initialSelections?._tab?.[0] === 'string' ? (initialSelections._tab[0] as string) : undefined}
+          onSelectionsChange={onSelectionsChange}
         />
       );
     case 'toggle':
@@ -245,9 +263,11 @@ interface DropdownFiltersProps {
   onFilterChange: (filters: any[]) => void;
   maxVisible?: number;
   className?: string;
+  initialSelections?: Record<string, Array<string | number | boolean>>;
+  onSelectionsChange?: (selections: Record<string, Array<string | number | boolean>>) => void;
 }
 
-function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, className }: DropdownFiltersProps) {
+function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, className, initialSelections, onSelectionsChange }: DropdownFiltersProps) {
   const { fieldLabel, translateOptions } = useSafeFieldLabel();
   const moreLabel = useMoreLabel();
   const objectName: string | undefined = objectDef?.name;
@@ -258,6 +278,11 @@ function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, 
     fields.forEach(f => {
       if (f.defaultValues && f.defaultValues.length > 0) {
         init[f.field] = f.defaultValues;
+      }
+      // Restored selections (e.g. from URL params) override author defaults.
+      const restored = initialSelections?.[f.field];
+      if (restored && restored.length > 0) {
+        init[f.field] = restored;
       }
     });
     return init;
@@ -303,12 +328,35 @@ function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, 
     const next = { ...selectedValues, [field]: values };
     setSelectedValues(next);
     emitFilters(next);
+    onSelectionsChange?.(next);
   };
 
-  // Emit default filters on mount
+  // Emit default/restored filters on mount. URL-restored values arrive as
+  // strings; coerce them against the resolved option value types so the
+  // checkbox state (`selected.includes(opt.value)`) matches typed options
+  // (numbers, booleans) — the query condition uses the same coerced value.
   React.useEffect(() => {
-    const hasDefaults = Object.values(selectedValues).some(v => v.length > 0);
-    if (hasDefaults) emitFilters(selectedValues);
+    let current = selectedValues;
+    const coerced: Record<string, (string | number | boolean)[]> = {};
+    let changed = false;
+    for (const [field, values] of Object.entries(current)) {
+      const rf = resolvedFields.find(f => f.field === field);
+      const next = values.map(v => {
+        if (!rf || typeof v !== 'string') return v;
+        const opt = rf.options.find(o => String(o.value) === v);
+        if (opt && opt.value !== v) return opt.value;
+        if (rf.type === 'boolean' && (v === 'true' || v === 'false')) return v === 'true';
+        return v;
+      });
+      coerced[field] = next;
+      if (next.some((v, i) => v !== values[i])) changed = true;
+    }
+    if (changed) {
+      setSelectedValues(coerced);
+      current = coerced;
+    }
+    const hasSelections = Object.values(current).some(v => v.length > 0);
+    if (hasSelections) emitFilters(current);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -476,10 +524,18 @@ interface TabFiltersProps {
   allowAddTab?: boolean;
   onFilterChange: (filters: any[]) => void;
   className?: string;
+  /** Tab id to activate on mount (e.g. restored from URL); wins over `default`. */
+  initialTab?: string;
+  /** Fires with `{ _tab: [tabId] }` when the user switches tabs. */
+  onSelectionsChange?: (selections: Record<string, Array<string | number | boolean>>) => void;
 }
 
-function TabFilters({ tabs, showAllRecords, allowAddTab, onFilterChange, className }: TabFiltersProps) {
+function TabFilters({ tabs, showAllRecords, allowAddTab, onFilterChange, className, initialTab, onSelectionsChange }: TabFiltersProps) {
   const [activeTab, setActiveTab] = React.useState<string>(() => {
+    // URL-restored tab wins over the author's default.
+    if (initialTab && (initialTab === '__all__' || tabs.some(t => t.id === initialTab))) {
+      return initialTab;
+    }
     const defaultTab = tabs.find(t => t.default);
     return defaultTab?.id || (showAllRecords ? '__all__' : tabs[0]?.id || '');
   });
@@ -493,8 +549,9 @@ function TabFilters({ tabs, showAllRecords, allowAddTab, onFilterChange, classNa
         const tab = tabs.find(t => t.id === tabId);
         onFilterChange(tab?.filters || []);
       }
+      onSelectionsChange?.({ _tab: [tabId] });
     },
-    [tabs, onFilterChange],
+    [tabs, onFilterChange, onSelectionsChange],
   );
 
   const allTabs = React.useMemo(() => {
@@ -505,11 +562,12 @@ function TabFilters({ tabs, showAllRecords, allowAddTab, onFilterChange, classNa
     return result;
   }, [tabs, showAllRecords]);
 
-  // Emit default tab filters on mount
+  // Emit the initially-active tab's filters on mount (restored tab or
+  // author default — `activeTab` already resolved the precedence).
   React.useEffect(() => {
-    const defaultTab = tabs.find(t => t.default);
-    if (defaultTab) {
-      onFilterChange(defaultTab.filters || []);
+    if (activeTab && activeTab !== '__all__') {
+      const tab = tabs.find(t => t.id === activeTab);
+      if (tab) onFilterChange(tab.filters || []);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/plugin-list/src/__tests__/UserFilters.test.tsx
+++ b/packages/plugin-list/src/__tests__/UserFilters.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UserFilters } from '../UserFilters';
+
+const objectDef = {
+  name: 'tasks',
+  fields: {
+    status: {
+      type: 'select',
+      label: 'Status',
+      options: [
+        { label: 'To Do', value: 'todo' },
+        { label: 'Done', value: 'done' },
+      ],
+    },
+    points: {
+      type: 'select',
+      label: 'Points',
+      options: [
+        { label: 'One', value: 1 },
+        { label: 'Two', value: 2 },
+      ],
+    },
+    is_active: { type: 'boolean', label: 'Active' },
+  },
+};
+
+describe('UserFilters — selection persistence (ADR-0047)', () => {
+  it('restores dropdown selections from initialSelections and emits conditions on mount', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'status' }] }}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={onFilterChange}
+        initialSelections={{ status: ['todo'] }}
+      />,
+    );
+
+    // Badge shows the restored selection count
+    expect(screen.getByTestId('filter-badge-status').textContent).toContain('1');
+    // The restored selection was emitted as a query condition
+    expect(onFilterChange).toHaveBeenCalledWith([['status', 'in', ['todo']]]);
+  });
+
+  it('coerces URL-restored string values to typed option values', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'points' }, { field: 'is_active' }] }}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={onFilterChange}
+        initialSelections={{ points: ['2'], is_active: ['true'] }}
+      />,
+    );
+
+    const emitted = onFilterChange.mock.calls.at(-1)?.[0];
+    expect(emitted).toEqual(
+      expect.arrayContaining([
+        ['points', 'in', [2]],
+        ['is_active', 'in', [true]],
+      ]),
+    );
+  });
+
+  it('fires onSelectionsChange with raw selections when the user changes a dropdown', () => {
+    const onSelectionsChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'status' }] }}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={() => {}}
+        onSelectionsChange={onSelectionsChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-badge-status'));
+    fireEvent.click(screen.getByText('To Do'));
+    expect(onSelectionsChange).toHaveBeenCalledWith({ status: ['todo'] });
+
+    // Clearing via the badge × empties the selection
+    fireEvent.click(screen.getByTestId('filter-clear-status'));
+    expect(onSelectionsChange).toHaveBeenLastCalledWith({ status: [] });
+  });
+
+  it('restores the active tab from initialSelections._tab and emits its filters', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{
+          element: 'tabs',
+          tabs: [
+            { name: 'all', label: 'All', isDefault: true },
+            { name: 'urgent', label: 'Urgent', filter: [{ field: 'priority', operator: 'equals', value: 'urgent' }] },
+          ],
+        }}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={onFilterChange}
+        initialSelections={{ _tab: ['urgent'] }}
+      />,
+    );
+
+    // Restored tab wins over the isDefault tab and emits its preset filter
+    expect(onFilterChange).toHaveBeenCalledWith([['priority', '=', 'urgent']]);
+  });
+
+  it('reports tab switches through onSelectionsChange', () => {
+    const onSelectionsChange = vi.fn();
+    render(
+      <UserFilters
+        config={{
+          element: 'tabs',
+          tabs: [
+            { name: 'all', label: 'All', isDefault: true },
+            { name: 'urgent', label: 'Urgent', filter: [{ field: 'priority', operator: 'equals', value: 'urgent' }] },
+          ],
+        }}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={() => {}}
+        onSelectionsChange={onSelectionsChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-tab-urgent'));
+    expect(onSelectionsChange).toHaveBeenCalledWith({ _tab: ['urgent'] });
+  });
+});


### PR DESCRIPTION
## Summary

Filter selections were session-memory only — a reload dropped them. They now mirror into `uf_<field>` search params (active tab preset as `uf__tab`) and restore on load, making filtered lists reload-safe and shareable (Airtable Interfaces parity).

- `UserFilters`: `initialSelections` restores dropdown values with typed coercion (URL strings → number/boolean option values) and the active tab; `onSelectionsChange` reports raw selections.
- `ListView`: forwards both; the metadata view-tab path (TabBar) restores the active tab and scopes the first fetch with its filter.
- `ObjectView` / `InterfaceListPage`: parse `uf_*` once at mount, write back with `replace` (no history spam). The `filter[...]` URL memo no longer invalidates on `uf_*` writes (avoids schema rebuild + refetch per click).

## Testing

- plugin-list 135/135 (5 new UserFilters persistence tests: restore, typed coercion, selections callback, tab restore, tab switch report)
- Browser-verified on app-showcase: `?uf_priority=urgent` (workbench dropdown) and `?uf__tab=urgent` (data-mode tab) both survive reload with correct badge/tab state and filtered rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)