### PR TITLE
fix: interface page renders empty grid when source view is hollow

### DIFF
--- a/e2e/live/user-filters.spec.ts
+++ b/e2e/live/user-filters.spec.ts
@@ -70,6 +70,22 @@ test.describe('ADR-0047 interface mode — Task Workbench', () => {
     await expect(page.getByTestId('view-switcher-dropdown')).toHaveCount(0);
   });
 
+  test('grid renders data columns even when the source view is hollow', async ({ page }) => {
+    // Regression: some backends serve the referenced default view without
+    // columns (they live only in named views). The interface page must fall
+    // back to object-derived columns instead of rendering a bare # column.
+    await page.goto('/apps/showcase_app/page/showcase_task_workbench');
+
+    await expect(page.getByTestId('interface-list-page')).toBeVisible();
+    const headers = page.locator('table thead th');
+    // More than just the row-number column.
+    await expect(async () => {
+      expect(await headers.count()).toBeGreaterThan(2);
+    }).toPass({ timeout: 15000 });
+    // The title/assignee business fields are present (not only "#").
+    await expect(page.getByRole('cell', { name: /example\.com/ }).first()).toBeVisible();
+  });
+
   test('dropdown selection filters, keeps counts, persists, and restores', async ({ page }) => {
     await page.goto('/apps/showcase_app/page/showcase_task_workbench');
 

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -35,11 +35,17 @@ interface InterfaceListPageProps {
  * Views merged from ADR-0017 ViewItems are keyed `<object>.<key>`;
  * the page author writes the bare key (`sourceView: 'default'`).
  */
+/** A view "carries columns" only when its column list is actually non-empty. */
+function hasColumns(v: any): boolean {
+  return Array.isArray(v?.columns) && v.columns.length > 0;
+}
+
 function resolveSourceView(objectDef: any, sourceView?: string): any | undefined {
   const views: Record<string, any> = objectDef?.listViews || objectDef?.list_views || {};
   // ADR-0017 expansion can serve a default-view item with an empty config
   // while the full body lives on `objectDef.list` — prefer candidates that
-  // actually carry columns over hollow name matches.
+  // actually carry columns over hollow name matches. An empty `columns: []`
+  // is truthy in JS but renders a column-less grid, so check for non-empty.
   const candidates = sourceView
     ? [
         views[`${objectDef?.name}.${sourceView}`],
@@ -48,7 +54,32 @@ function resolveSourceView(objectDef: any, sourceView?: string): any | undefined
       ]
     : [objectDef?.list, ...Object.values(views)];
   const present = candidates.filter(Boolean);
-  return present.find((v: any) => v?.columns) ?? present[0];
+  return present.find(hasColumns) ?? present[0];
+}
+
+/**
+ * Default column set when the resolved view carries none — mirrors
+ * ObjectView's data-mode fallback so an interface page never renders a
+ * column-less grid. Priority: curated `compactLayout`, else the first
+ * business fields (system/audit columns excluded).
+ */
+const SYSTEM_FIELDS = new Set([
+  'id', 'created_at', 'createdAt', 'updated_at', 'updatedAt',
+  'deleted_at', 'deletedAt', 'created_by', 'createdBy',
+  'updated_by', 'updatedBy', '_version', '_rev',
+]);
+function defaultColumnsFromObject(objectDef: any): string[] {
+  if (Array.isArray(objectDef?.compactLayout) && objectDef.compactLayout.length > 0) {
+    return objectDef.compactLayout.filter((n: string) => objectDef.fields?.[n]);
+  }
+  const fields = objectDef?.fields;
+  if (fields && typeof fields === 'object') {
+    return Object.entries(fields)
+      .filter(([name, f]: [string, any]) => f && !f.hidden && !SYSTEM_FIELDS.has(name))
+      .map(([name]) => name)
+      .slice(0, 6);
+  }
+  return [];
 }
 
 export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
@@ -91,7 +122,9 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
   // (full)` into an infinite render/refetch loop the moment anything (e.g.
   // a `uf_*` URL write) re-renders this component after hydration settled.
   const objectDefName: string | undefined = objectDef?.name;
-  const resolvedViewHollow = !!resolvedView && !resolvedView.columns;
+  // Hollow = no *non-empty* column list. An empty `columns: []` reads as
+  // truthy but renders nothing, so it must still trigger hydration.
+  const resolvedViewHollow = !!resolvedView && !hasColumns(resolvedView);
   const resolvedViewKey = resolvedView?.name
     ?? (cfg.sourceView ? `${cfg.source}.${cfg.sourceView}` : undefined);
   const [hydratedView, setHydratedView] = React.useState<any>(null);
@@ -107,7 +140,7 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
           const all = await ds.listViewOverrides(cfg.source);
           full = all?.[resolvedViewKey] ?? null;
         }
-        if (!full?.columns && typeof ds?.getView === 'function') {
+        if (!hasColumns(full) && typeof ds?.getView === 'function') {
           full = await ds.getView(cfg.source, resolvedViewKey);
         }
         if (!cancelled && full && typeof full === 'object') setHydratedView(full);
@@ -139,11 +172,17 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
       ...(Array.isArray(cfg.filterBy) ? cfg.filterBy : []),
     ];
 
+    // Columns: the referenced view's, else a sensible default derived from
+    // the object (compactLayout / business fields). Some backends serve the
+    // default view hollow (columns live only in named views), so without
+    // this fallback the grid would render just the row-number column.
+    const columns = hasColumns(view) ? view.columns : defaultColumnsFromObject(objectDef);
+
     return {
       type: 'list-view' as const,
       objectName: objectDef.name,
       viewType: (allowed[0] ?? view.type ?? 'grid'),
-      fields: view.columns,
+      fields: columns,
       ...(filters.length ? { filters } : {}),
       ...(view.sort?.length ? { sort: view.sort } : {}),
       grouping: view.grouping,


### PR DESCRIPTION
## The bug

The user opened the backend-served `/_console/` (not the Vite dev server) and found the **Task Workbench interface page rendering an empty grid — only the `#` row-number column**, no data columns. I reproduced it on latest `main`: it is **not** a stale bundle, it is a real bug.

## Root cause

The referenced default view is served **hollow** by some backends — `{ provider, object }`, no columns (columns live only in named views like `tabular`). Two latent bugs, both because an empty `columns: []` reads **truthy** in JS:

1. `resolveSourceView` picked the column-less view (`v?.columns` true for `[]`), and the hydration hollow-check `!resolvedView.columns` computed `false` → the per-view overlay fetch that backfills columns never fired.
2. `InterfaceListPage` had **no default-column fallback** — unlike `ObjectView` (data mode), which derives columns from `compactLayout` / business fields when a view carries none.

So interface mode passed `fields: []` to the grid → bare `#` column.

## Fix

- Shared `hasColumns()` (non-empty array) drives view resolution **and** hollow detection, so a `columns: []` view triggers hydration.
- Schema build falls back to `defaultColumnsFromObject()` (compactLayout, else first business fields, system/audit excluded) — mirrors ObjectView.

Grid now renders full columns + colored badges; filters / URL persistence unaffected.

## Why earlier verification missed it

My ADR-0047 browser checks ran against a backend that *inlined* view columns into the object metadata, so columns rendered by luck. The backend that serves hollow default views exposed the missing fallback. Now locked by a regression e2e (`grid renders data columns even when the source view is hollow`).

## Testing

- `e2e/live/user-filters.spec.ts`: 5 passed (1 lookup case skips when showcase lacks the project filter)
- Browser-verified on the workbench: 7 columns + data render, `?uf_priority=urgent` still filters to 2 rows
- `@object-ui/app-shell` build clean

Note: the framework's `/_console/` is a **pinned prebuilt** SPA vendored from this repo — it picks up this fix when re-vendored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)