### PR TITLE
fix(ADR-0046): enable Tailwind typography so Markdown docs render styled

### DIFF
--- a/.changeset/adr-0046-docs-markdown-typography.md
+++ b/.changeset/adr-0046-docs-markdown-typography.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/console": patch
+---
+
+fix(ADR-0046): enable Tailwind typography so Markdown docs render styled.
+
+`plugin-markdown`'s `MarkdownImpl` renders inside `prose prose-h1:text-3xl …`,
+but the console never registered `@tailwindcss/typography`, so every `prose`
+utility was a no-op — Markdown rendered with no heading sizes, list markers, or
+spacing (the `/docs/<name>` page showed its `# Title` at body size, looking
+unstyled). Register the plugin (`@plugin '@tailwindcss/typography'`) and add the
+dependency. Now doc headings, paragraphs, inline code, and links render with
+proper hierarchy.

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -89,6 +89,7 @@
     "@objectstack/client": "^9.0.0",
     "@objectstack/spec": "^9.1.0",
     "@tailwindcss/postcss": "^4.3.0",
+    "@tailwindcss/typography": "^0.5.20",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/apps/console/src/index.css
+++ b/apps/console/src/index.css
@@ -1,6 +1,13 @@
 @import 'tailwindcss';
 @import '@object-ui/app-shell/styles.css';
 
+/* Typography plugin — generates the `prose` utilities. plugin-markdown's
+   MarkdownImpl renders docs/markdown inside `prose prose-h1:text-3xl …`;
+   without this plugin those classes are no-ops and Markdown renders with
+   NO heading sizes, list markers, or spacing (ADR-0046 docs looked unstyled
+   — headings indistinguishable from body text). */
+@plugin '@tailwindcss/typography';
+
 /* Scan sources for Tailwind classes */
 @source '../src/**/*.{ts,tsx}';
 @source '../../../packages/app-shell/src/**/*.{ts,tsx}';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
+      '@tailwindcss/typography':
+        specifier: ^0.5.20
+        version: 0.5.20(tailwindcss@4.3.0)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -781,7 +784,7 @@ importers:
         version: 9.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -802,7 +805,7 @@ importers:
         version: 4.2.0
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.25
@@ -821,7 +824,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/collaboration:
     dependencies:
@@ -1083,7 +1086,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/data-objectstack:
     dependencies:
@@ -5127,6 +5130,11 @@ packages:
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
+  '@tailwindcss/typography@0.5.20':
+    resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
+
   '@tanstack/history@1.162.0':
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
@@ -8705,6 +8713,10 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -12833,6 +12845,11 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
+  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.0)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.3.0
+
   '@tanstack/history@1.162.0':
     optional: true
 
@@ -13376,11 +13393,6 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       maplibre-gl: 5.24.0
-
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -16908,6 +16920,11 @@ snapshots:
       postcss: 8.5.15
       tsx: 4.22.4
       yaml: 2.9.0
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:


### PR DESCRIPTION
## Problem

The `/docs/<name>` doc viewer rendered **unstyled** — its `# Heading` showed at body-text size with no list markers or spacing, looking broken ("title not displaying").

## Root cause

`plugin-markdown`'s `MarkdownImpl` wraps Markdown in `prose prose-sm prose-h1:text-3xl prose-h2:text-2xl …`. Those `prose-*` utilities only exist if `@tailwindcss/typography` is registered — and the console (Tailwind v4) **never registered it** (it wasn't a dependency anywhere in the repo). So every `prose` class was a no-op and Markdown got zero typography.

## Fix

- `apps/console/src/index.css`: `@plugin '@tailwindcss/typography';`
- add `@tailwindcss/typography` devDependency.

Scoped to `.prose` containers — no effect on non-Markdown UI. Also fixes Markdown widgets embedded in dashboards/pages, which had the same dead-`prose` problem.

## Verification (live, browser)

Logged into the console against a docs-serving backend and opened `/docs/showcase_index`:

| | before | after |
|---|---|---|
| h1 font-size | body (~16px) | **30px / 600** |
| `.prose` active | no | yes |
| paragraphs / inline code / links | flat | styled hierarchy |

Screenshot confirms the doc now renders as proper documentation (large bold title, spaced paragraphs, chip-styled inline code, themed links). No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)