### PR TITLE
feat(ADR-0046): lightweight chrome (DocShell) for the docs routes

### DIFF
--- a/.changeset/adr-0046-docs-shell.md
+++ b/.changeset/adr-0046-docs-shell.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/console": patch
+---
+
+feat(ADR-0046): lightweight chrome for the docs routes.
+
+The `/docs` portal and `/docs/:name` viewer are app-independent top-level
+routes, so they rendered as bare full-bleed pages with no header and no way
+back. Add a minimal sticky `DocShell` header — a "Documentation" home link
+(→ `/docs`) plus a breadcrumb of the current doc — shared by the portal and the
+viewer. Keeps ADR-0046's "no nav taxonomy in v1" intent (no app sidebar) while
+giving readers orientation and a way out. The portal's redundant in-body title
+is dropped in favour of the header.

--- a/apps/console/src/pages/DocPage.tsx
+++ b/apps/console/src/pages/DocPage.tsx
@@ -12,6 +12,7 @@ import { AlertCircle, FileQuestion, Loader2 } from 'lucide-react';
 import { useAdapter } from '@object-ui/app-shell';
 import { MarkdownRenderer } from '@object-ui/plugin-markdown';
 import { rewriteDocLinks } from './doc-links';
+import { DocShell } from './DocShell';
 
 interface DocItem {
   name: string;
@@ -100,32 +101,38 @@ export default function DocPage() {
 
   if (state === 'missing') {
     return (
-      <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
-        <FileQuestion className="h-10 w-10 text-muted-foreground" />
-        <h1 className="text-lg font-semibold">Documentation not found</h1>
-        <p className="text-sm text-muted-foreground">
-          No document named <code className="rounded bg-muted px-1 py-0.5">{name}</code> is installed.
-          It may belong to a package that is not installed, or it was removed in a newer version.
-        </p>
-      </div>
+      <DocShell breadcrumb={name}>
+        <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
+          <FileQuestion className="h-10 w-10 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Documentation not found</h1>
+          <p className="text-sm text-muted-foreground">
+            No document named <code className="rounded bg-muted px-1 py-0.5">{name}</code> is installed.
+            It may belong to a package that is not installed, or it was removed in a newer version.
+          </p>
+        </div>
+      </DocShell>
     );
   }
 
   if (state === 'error') {
     return (
-      <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
-        <AlertCircle className="h-10 w-10 text-destructive" />
-        <h1 className="text-lg font-semibold">Failed to load documentation</h1>
-        <p className="text-sm text-muted-foreground">{errorMessage}</p>
-      </div>
+      <DocShell breadcrumb={name}>
+        <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
+          <AlertCircle className="h-10 w-10 text-destructive" />
+          <h1 className="text-lg font-semibold">Failed to load documentation</h1>
+          <p className="text-sm text-muted-foreground">{errorMessage}</p>
+        </div>
+      </DocShell>
     );
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-4 sm:p-6" onClick={onContentClick}>
-      <MarkdownRenderer
-        schema={{ type: 'markdown', content: rewriteDocLinks(doc?.content ?? '') }}
-      />
-    </div>
+    <DocShell breadcrumb={doc?.label ?? name}>
+      <div className="mx-auto max-w-3xl p-4 sm:p-6" onClick={onContentClick}>
+        <MarkdownRenderer
+          schema={{ type: 'markdown', content: rewriteDocLinks(doc?.content ?? '') }}
+        />
+      </div>
+    </DocShell>
   );
 }

--- a/apps/console/src/pages/DocShell.tsx
+++ b/apps/console/src/pages/DocShell.tsx
@@ -1,0 +1,47 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { BookOpen } from 'lucide-react';
+
+/**
+ * Lightweight chrome for the package-documentation routes (ADR-0046).
+ *
+ * The doc viewer/portal are app-independent top-level routes, so they don't
+ * get the console's app sidebar. This adds a minimal sticky header — a
+ * "Documentation" home link (→ `/docs`) plus an optional breadcrumb — so a
+ * reader always knows where they are and has a way back, without pulling in
+ * the full app shell (which ADR-0046 deliberately keeps out of v1).
+ */
+export function DocShell({ breadcrumb, children }: { breadcrumb?: string; children: ReactNode }) {
+  return (
+    <div className="min-h-full">
+      <header className="sticky top-0 z-10 border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="mx-auto flex max-w-3xl items-center gap-2 px-4 py-3 sm:px-6">
+          <Link
+            to="/docs"
+            className="flex items-center gap-2 text-sm font-semibold hover:opacity-80"
+          >
+            <BookOpen className="h-4 w-4 text-muted-foreground" />
+            <span>Documentation</span>
+          </Link>
+          {breadcrumb ? (
+            <>
+              <span className="text-muted-foreground/60" aria-hidden>
+                /
+              </span>
+              <span className="truncate text-sm text-muted-foreground">{breadcrumb}</span>
+            </>
+          ) : null}
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/apps/console/src/pages/DocsIndex.tsx
+++ b/apps/console/src/pages/DocsIndex.tsx
@@ -11,6 +11,7 @@ import { Link } from 'react-router-dom';
 import { AlertCircle, BookOpen, Loader2 } from 'lucide-react';
 import { useAdapter } from '@object-ui/app-shell';
 import { type DocGroup, groupDocsByPackage } from './doc-groups';
+import { DocShell } from './DocShell';
 
 /**
  * `/docs` — the platform-level documentation portal (ADR-0046).
@@ -86,12 +87,8 @@ export default function DocsIndex() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl p-4 sm:p-6">
-      <div className="mb-6 flex items-center gap-2">
-        <BookOpen className="h-6 w-6 text-muted-foreground" />
-        <h1 className="text-2xl font-semibold">Documentation</h1>
-      </div>
-
+    <DocShell>
+      <div className="mx-auto max-w-3xl p-4 sm:p-6">
       {groups.length === 0 ? (
         <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
           <BookOpen className="h-10 w-10" />
@@ -126,6 +123,7 @@ export default function DocsIndex() {
           ))}
         </div>
       )}
-    </div>
+      </div>
+    </DocShell>
   );
 }


### PR DESCRIPTION
## Why

The `/docs` portal and `/docs/<name>` viewer are app-independent top-level routes, so they rendered as **bare full-bleed pages** — no header, no breadcrumb, no way back. After the typography fix (#1687) the *content* looks right, but the page still felt unfinished/floating.

## Change

A minimal, shared **`DocShell`** sticky header used by both pages:
- a "📖 Documentation" home link → `/docs`
- a breadcrumb of the current doc (label) on the viewer

No app sidebar — that keeps ADR-0046's stated "no navigation taxonomy in v1" intent. This is just orientation + a way out. The portal's redundant in-body `Documentation` title is dropped in favour of the header.

## Verification (live, browser)

Ran the console against a docs-serving backend and exercised both routes:

- **Portal `/docs`**: sticky header + `SHOWCASE` group listing `Documentation Guide` / `Showcase` with machine names.
- **Doc `/docs/showcase_index`**: header breadcrumb `Documentation / Showcase`, then the typography-styled body (h1 30px, spaced paragraphs, chip inline-code, themed links).
- **Back-link**: clicking "Documentation" in a doc header returns to the portal (which shows the groups).
- No console errors.

Screenshots of both states captured during verification.

## Stack

Builds on #1687 (typography). Together: docs now render styled **and** have basic chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)