### PR TITLE
fix(ADR-0046): docs portal shows summaries, not machine ids

### DIFF
--- a/.changeset/adr-0046-docs-portal-description.md
+++ b/.changeset/adr-0046-docs-portal-description.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/console": patch
+---
+
+fix(ADR-0046): docs portal shows summaries, not machine ids.
+
+The portal listed each doc as title + its raw machine name (`showcase_index`)
+— noise for the business readers docs are written for. Drop the machine id from
+the reader-facing list and render the doc's `description` (ADR-0046) as a
+one-line summary under the title instead. Falls back cleanly when a doc has no
+description.

--- a/apps/console/src/pages/DocsIndex.tsx
+++ b/apps/console/src/pages/DocsIndex.tsx
@@ -52,7 +52,7 @@ export default function DocsIndex() {
         if (cancelled) return;
         setGroups(
           groupDocsByPackage(
-            items.map((it) => ({ name: it?.name, label: it?.label })),
+            items.map((it) => ({ name: it?.name, label: it?.label, description: it?.description })),
           ),
         );
         setState('ready');
@@ -110,11 +110,17 @@ export default function DocsIndex() {
                   <li key={doc.name}>
                     <Link
                       to={`/docs/${doc.name}`}
-                      className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/50"
+                      className="flex items-start gap-3 px-3 py-3 hover:bg-muted/50"
                     >
-                      <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                      <span className="font-medium">{doc.label ?? doc.name}</span>
-                      <code className="ml-auto text-xs text-muted-foreground">{doc.name}</code>
+                      <BookOpen className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium">{doc.label ?? doc.name}</div>
+                        {doc.description ? (
+                          <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                            {doc.description}
+                          </div>
+                        ) : null}
+                      </div>
                     </Link>
                   </li>
                 ))}

--- a/apps/console/src/pages/doc-groups.ts
+++ b/apps/console/src/pages/doc-groups.ts
@@ -9,6 +9,7 @@
 export interface DocListItem {
   name: string;
   label?: string;
+  description?: string;
 }
 
 export interface DocGroup {


### PR DESCRIPTION
## Why

The docs portal listed each doc as **title + its raw machine name** (`showcase_index`) on the right. That id is a URL/link key for authors — noise for the business readers docs are written for.

## Change

- **Drop the machine id** from the reader-facing list.
- **Render the doc `description`** (ADR-0046, new field) as a one-line summary under the title. Graceful fallback when a doc has no description.
- `DocListItem` carries `description`; the portal fetch maps it through.

## Verification (live, browser)

Portal against a description-serving backend (companion framework PR objectstack-ai/framework#1811):

- `SHOWCASE` group → **Documentation Guide** + "The authoring rules every package doc must follow — …" and **Showcase** + "Overview of the showcase package and the docs-as-metadata feature it demonstrates."
- No machine ids in the list. Bold title + gray summary, two-line clamp.

Screenshot captured.

## Stack

Pairs with framework#1811 (`description` field + `/meta/doc` list carries it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)