### PR TITLE
feat(console): ADR-0048 — package-scoped doc route /apps/:packageId/docs/:name

### DIFF
--- a/apps/console/src/AppContent.tsx
+++ b/apps/console/src/AppContent.tsx
@@ -30,6 +30,9 @@ const ApiConsolePage = lazy(() => import('./pages/developer/ApiConsolePage').the
 const FlowRunsPage = lazy(() => import('./pages/developer/FlowRunsPage').then(m => ({ default: m.FlowRunsPage })));
 const PublicFormsPage = lazy(() => import('./pages/developer/PublicFormsPage').then(m => ({ default: m.PublicFormsPage })));
 const IntegrationsPage = lazy(() => import('./pages/developer/IntegrationsPage').then(m => ({ default: m.IntegrationsPage })));
+// ADR-0048 — package docs are viewed inside their package container:
+// /apps/:packageId/docs/:name (DocPage is a default export).
+const DocPage = lazy(() => import('./pages/DocPage'));
 
 // Note: marketplace routes (`system/marketplace`, `system/marketplace/:packageId`)
 // are registered by DefaultAppContent in @object-ui/app-shell so they're
@@ -84,6 +87,8 @@ const systemRoutes = (
     <Route path="developer/flow-runs" element={<Suspense fallback={<LoadingScreen />}><FlowRunsPage /></Suspense>} />
     <Route path="developer/public-forms" element={<Suspense fallback={<LoadingScreen />}><PublicFormsPage /></Suspense>} />
     <Route path="developer/integrations" element={<Suspense fallback={<LoadingScreen />}><IntegrationsPage /></Suspense>} />
+    {/* ADR-0048 — package docs under the package container: /apps/:packageId/docs/:name */}
+    <Route path="docs/:name" element={<Suspense fallback={<LoadingScreen />}><DocPage /></Suspense>} />
     {/* Legacy URL redirects → metadata-admin engine (zero-cost compatibility). */}
     <Route path="system/objects" element={<ObjectRedirect />} />
     <Route path="system/objects/:objectName" element={<ObjectRedirect />} />

--- a/apps/console/src/pages/DocsIndex.tsx
+++ b/apps/console/src/pages/DocsIndex.tsx
@@ -52,7 +52,7 @@ export default function DocsIndex() {
         if (cancelled) return;
         setGroups(
           groupDocsByPackage(
-            items.map((it) => ({ name: it?.name, label: it?.label, description: it?.description })),
+            items.map((it) => ({ name: it?.name, label: it?.label, description: it?.description, packageId: it?._packageId })),
           ),
         );
         setState('ready');
@@ -109,7 +109,7 @@ export default function DocsIndex() {
                 {group.docs.map((doc) => (
                   <li key={doc.name}>
                     <Link
-                      to={`/docs/${doc.name}`}
+                      to={doc.packageId ? `/apps/${doc.packageId}/docs/${doc.name}` : `/docs/${doc.name}`}
                       className="flex items-start gap-3 px-3 py-3 hover:bg-muted/50"
                     >
                       <BookOpen className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />

--- a/apps/console/src/pages/doc-groups.ts
+++ b/apps/console/src/pages/doc-groups.ts
@@ -10,6 +10,8 @@ export interface DocListItem {
   name: string;
   label?: string;
   description?: string;
+  /** Owning package id (`_packageId`), used to build `/apps/:packageId/docs/:name`. */
+  packageId?: string;
 }
 
 export interface DocGroup {


### PR DESCRIPTION
Completes ADR-0048 routing for docs: the doc viewer now lives under the package container, matching apps/pages/dashboards.

## What
- Mount the doc viewer at **`/apps/:packageId/docs/:name`** via the console's `extraRoutes` (DocPage renders inside the app shell). Legacy top-level `/docs/:name` kept as a fallback.
- `DocsIndex` carries each doc's `_packageId` and links to `/apps/<packageId>/docs/<name>` (falls back to `/docs/<name>` when a doc has no package provenance).
- `DocPage` resolution unchanged — doc names are namespace-prefixed by ADR-0046 build convention, so `getItem('doc', name)` is unambiguous.

## Browser-verified (live app-showcase backend)
- `/apps/com.example.showcase/docs/showcase_index` → renders the doc (markdown heading "Showcase") inside the showcase app container; no "not found".
- `/docs` index → all doc links package-scoped (`/apps/com.example.showcase/docs/…`).
- Console typecheck clean.

## Follow-ups (separate)
- **Framework**: enforce the doc-name namespace prefix at the spec layer (`doc.zod` is snake_case-only today; prefix is the load-bearing uniqueness convention).
- Optionally have DocPage scope `getItem` by the route's package id (defense-in-depth) — needs client/REST package-param threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)