### PR TITLE
feat(plugin-chatbot): elapsed-time liveness counter on running AI turns

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -1626,7 +1626,10 @@ function AssistantThinkingMessage({
           />
         ) : null}
         <MessageContent className="rounded-lg border bg-muted/30 px-3 py-2 text-muted-foreground">
-          <ThinkingDots />
+          <span className="inline-flex items-center gap-2">
+            <ThinkingDots />
+            <ElapsedTime active />
+          </span>
         </MessageContent>
       </div>
     </Message>
@@ -1643,6 +1646,52 @@ function ThinkingDots() {
         <span className="size-1.5 rounded-full bg-current animate-pulse" />
       </span>
     </>
+  );
+}
+
+/**
+ * Seconds elapsed since this hook first mounted, ticking once a second while
+ * `active`. AI builds run 1–3 min with long quiet gaps; a live counter reassures
+ * the user the stream is still alive (the tick only advances while React is
+ * responsive) and sets the expectation that the wait is normal — the same cue
+ * Claude Code shows next to a running step. Freezes at its last value once
+ * `active` turns false so the final duration stays visible.
+ */
+function useElapsedSeconds(active: boolean): number {
+  const startRef = React.useRef<number>(Date.now());
+  const [elapsed, setElapsed] = React.useState(0);
+  React.useEffect(() => {
+    if (!active) return;
+    const tick = () => setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  return elapsed;
+}
+
+/** Format an elapsed-seconds count as `m:ss` (e.g. 42 → "0:42", 95 → "1:35"). */
+function formatElapsed(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+/**
+ * Small monospace `m:ss` chip with a clock glyph, shown beside a running
+ * spinner so a slow, quiet AI turn reads as "still connected, still working"
+ * rather than "stalled". Language-neutral by design (no i18n string needed).
+ */
+function ElapsedTime({ active }: { active: boolean }) {
+  const seconds = useElapsedSeconds(active);
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-xs font-normal tabular-nums text-muted-foreground"
+      aria-label={`Elapsed ${seconds} seconds`}
+    >
+      <Clock3 className="size-3 shrink-0" aria-hidden />
+      {formatElapsed(seconds)}
+    </span>
   );
 }
 
@@ -1701,6 +1750,9 @@ function BuildProgressPanel({
         {!isDone && phase === 'data' ? (
           <span className="text-xs font-normal text-muted-foreground">adding sample data</span>
         ) : null}
+        <span className="ml-auto">
+          <ElapsedTime active={!isDone} />
+        </span>
       </div>
       <div className="mb-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
         <div

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -7,8 +7,8 @@
  * e2e suite — these only validate the public surface stays stable.
  */
 import '@testing-library/jest-dom/vitest';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ChatbotEnhanced, type ChatMessage } from '../ChatbotEnhanced';
 
 describe('ChatbotEnhanced (AI Elements composition)', () => {
@@ -573,5 +573,58 @@ describe('publishHealthFromResponse', () => {
   it('returns undefined when the server reported neither (older runtimes)', async () => {
     const { publishHealthFromResponse } = await import('../ChatbotEnhanced');
     expect(publishHealthFromResponse({ success: true, data: { publishedCount: 3 } })).toBeUndefined();
+  });
+});
+
+describe('ChatbotEnhanced — elapsed-time liveness counter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('ticks a m:ss counter on the thinking spinner so a slow turn reads as alive', () => {
+    render(<ChatbotEnhanced isLoading messages={[]} />);
+    // Mount renders 0:00 immediately…
+    expect(screen.getByText('0:00')).toBeInTheDocument();
+    // …then advances once a second while the turn is in flight.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByText('0:03')).toBeInTheDocument();
+  });
+
+  it('shows a running counter on an in-flight build panel and freezes it when done', () => {
+    const building: ChatMessage[] = [
+      {
+        id: 'b1',
+        role: 'assistant',
+        content: '',
+        buildProgress: {
+          phase: 'structure',
+          appLabel: '进销存',
+          items: [{ type: 'object', name: 'product' }],
+          done: 1,
+          total: 4,
+        },
+      },
+    ];
+    const { rerender } = render(<ChatbotEnhanced messages={building} />);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.getByText('0:02')).toBeInTheDocument();
+
+    // Build finishes → counter freezes at its last value (no further ticks).
+    const done: ChatMessage[] = [
+      { ...building[0], buildProgress: { ...building[0].buildProgress!, phase: 'done', done: 4 } },
+    ];
+    rerender(<ChatbotEnhanced messages={done} />);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText('0:02')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Why

AI app builds run **1–3 minutes** with long quiet gaps (LLM thinking, sample-data generation). During those gaps the only on-screen signal was a static spinner, so a slow turn looked identical to a dropped connection — users worried the network had died ("ai 执行会很卡很慢… 让用户知道服务器还连接着，网络没断").

## What

A Claude-Code-style `m:ss` elapsed counter beside both running spinners:

- the generic **thinking** message (`AssistantThinkingMessage`)
- the in-flight **build panel** header (`BuildProgressPanel`)

The tick only advances while React is responsive, so the live counter is itself a "still connected, still working" cue and sets the expectation that the wait is normal. It **freezes** at its final value when the turn ends, leaving the total build duration visible. Language-neutral (a bare `m:ss` + clock glyph — no new i18n string).

Self-contained: a small `useElapsedSeconds` hook + presentational `ElapsedTime`; no new deps (`Clock3` already imported), no API/route change, untouched routing.

## Verification

- `tsc --noEmit` clean, `vite build` clean
- **69/69** unit tests pass, incl. 2 new ones that render the real component under fake timers and assert the counter ticks `0:00 → 0:03` on the thinking spinner and `0:02`-then-frozen on the build panel after `phase: 'done'`.

## Follow-up (out of scope)

For true stall-vs-connected discrimination (server holds the SSE open but sends nothing), a server-side keep-alive heartbeat + "last activity Xs ago" indicator would be the next step. The elapsed counter covers the dropped-connection / "is it alive" reassurance, which is the reported pain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)