### PR TITLE
fix(plugin-chatbot): make AI-turn liveness real, not a fake clock

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -230,6 +230,12 @@ export interface ChatbotLabels {
   trace?: string;
   /** Trace link tooltip in debug mode. */
   viewTrace?: string;
+  /**
+   * Shown beside a running turn once the server stream goes quiet (no bytes for
+   * a few seconds) — e.g. "Waiting for server…". Honest stall cue, not a claim
+   * of progress.
+   */
+  connectionWaiting?: string;
 }
 
 export type ChatbotProcessVisibility = 'hidden' | 'summary' | 'debug';
@@ -775,6 +781,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         stopResponse: labels?.stopResponse ?? 'Stop response',
         trace: labels?.trace ?? 'trace',
         viewTrace: labels?.viewTrace ?? 'View trace',
+        connectionWaiting: labels?.connectionWaiting ?? 'Waiting for server…',
       }),
       [labels],
     );
@@ -1373,6 +1380,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                           openBuiltAppLabel={openBuiltAppLabel}
                           onPreviewDraftApp={onPreviewDraftApp}
                           previewDraftLabel={previewDraftLabel}
+                          waitingLabel={L.connectionWaiting}
                         />
                       ) : null}
                       {!isUser && processVisibility === 'debug' && reasoning ? (
@@ -1473,6 +1481,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                 showAvatar={showAvatars}
                 assistantAvatarUrl={assistantAvatarUrl}
                 assistantAvatarFallback={assistantAvatarFallback}
+                waitingLabel={L.connectionWaiting}
               />
             ) : null}
           </ConversationContent>
@@ -1610,10 +1619,12 @@ function AssistantThinkingMessage({
   showAvatar,
   assistantAvatarUrl,
   assistantAvatarFallback,
+  waitingLabel,
 }: {
   showAvatar: boolean;
   assistantAvatarUrl?: string;
   assistantAvatarFallback?: string;
+  waitingLabel: string;
 }) {
   return (
     <Message from="assistant" aria-live="polite">
@@ -1628,7 +1639,10 @@ function AssistantThinkingMessage({
         <MessageContent className="rounded-lg border bg-muted/30 px-3 py-2 text-muted-foreground">
           <span className="inline-flex items-center gap-2">
             <ThinkingDots />
-            <ElapsedTime active />
+            {/* No server bytes yet for this turn → `pending`: shows a neutral
+                "waiting" that escalates to amber if the first token never comes,
+                never a false "receiving". */}
+            <LivenessIndicator active pending activityKey={0} waitingLabel={waitingLabel} />
           </span>
         </MessageContent>
       </div>
@@ -1649,27 +1663,6 @@ function ThinkingDots() {
   );
 }
 
-/**
- * Seconds elapsed since this hook first mounted, ticking once a second while
- * `active`. AI builds run 1–3 min with long quiet gaps; a live counter reassures
- * the user the stream is still alive (the tick only advances while React is
- * responsive) and sets the expectation that the wait is normal — the same cue
- * Claude Code shows next to a running step. Freezes at its last value once
- * `active` turns false so the final duration stays visible.
- */
-function useElapsedSeconds(active: boolean): number {
-  const startRef = React.useRef<number>(Date.now());
-  const [elapsed, setElapsed] = React.useState(0);
-  React.useEffect(() => {
-    if (!active) return;
-    const tick = () => setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
-    tick();
-    const id = setInterval(tick, 1000);
-    return () => clearInterval(id);
-  }, [active]);
-  return elapsed;
-}
-
 /** Format an elapsed-seconds count as `m:ss` (e.g. 42 → "0:42", 95 → "1:35"). */
 function formatElapsed(totalSeconds: number): string {
   const m = Math.floor(totalSeconds / 60);
@@ -1678,19 +1671,150 @@ function formatElapsed(totalSeconds: number): string {
 }
 
 /**
- * Small monospace `m:ss` chip with a clock glyph, shown beside a running
- * spinner so a slow, quiet AI turn reads as "still connected, still working"
- * rather than "stalled". Language-neutral by design (no i18n string needed).
+ * After this many seconds with no new bytes from the server, a running turn is
+ * treated as "quiet" — we genuinely have not heard back, so the indicator says
+ * so instead of implying progress. During an app build the server streams
+ * `data-build-progress` parts every few seconds, so a healthy build stays under
+ * this threshold; only real silence (pre-first-token wait, a stalled/dropped
+ * stream) crosses it.
  */
-function ElapsedTime({ active }: { active: boolean }) {
-  const seconds = useElapsedSeconds(active);
+const LIVENESS_QUIET_AFTER_SECONDS = 6;
+
+export interface TurnLiveness {
+  /** Whole-turn duration in seconds (since the indicator mounted). */
+  elapsedSeconds: number;
+  /** Seconds since the last real byte arrived from the server. */
+  quietSeconds: number;
+  /** True while bytes have arrived recently — an *observed* live stream. */
+  live: boolean;
+}
+
+/**
+ * Liveness derived from REAL stream activity, not a free-running clock.
+ *
+ * `activityKey` must change whenever actual data arrives from the server (a
+ * streamed token, a tool delta, a `data-build-progress` update). We stamp the
+ * arrival time when it changes; `live` is then a genuine "the server sent us
+ * something in the last few seconds" signal — it goes false during true silence
+ * (a stalled or dropped stream), so the UI can stop pretending the turn is
+ * progressing. A 1s ticker keeps `quietSeconds` current between arrivals.
+ * Everything freezes once `active` turns false, leaving the final duration.
+ */
+function useTurnLiveness(active: boolean, activityKey: string | number): TurnLiveness {
+  const startRef = React.useRef<number>(0);
+  const lastActivityRef = React.useRef<number>(0);
+  const [seconds, setSeconds] = React.useState({ elapsed: 0, quiet: 0 });
+
+  // Establish the time origin once, in an effect — keeps Date.now() out of
+  // render so the derived seconds stay pure for the renderer. Runs before the
+  // activity/tick effects below (effects fire in declaration order).
+  React.useEffect(() => {
+    const now = Date.now();
+    startRef.current = now;
+    lastActivityRef.current = now;
+  }, []);
+
+  // Real data arrived (activityKey changed) → stamp the arrival and zero the
+  // quiet timer. Refs/Date.now() are touched only inside this effect, never
+  // during render.
+  React.useEffect(() => {
+    const now = Date.now();
+    lastActivityRef.current = now;
+    setSeconds({ elapsed: Math.floor((now - startRef.current) / 1000), quiet: 0 });
+  }, [activityKey]);
+
+  React.useEffect(() => {
+    if (!active) return;
+    const tick = () => {
+      const now = Date.now();
+      setSeconds({
+        elapsed: Math.floor((now - startRef.current) / 1000),
+        quiet: Math.floor((now - lastActivityRef.current) / 1000),
+      });
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [active]);
+
+  return {
+    elapsedSeconds: seconds.elapsed,
+    quietSeconds: seconds.quiet,
+    live: seconds.quiet < LIVENESS_QUIET_AFTER_SECONDS,
+  };
+}
+
+/**
+ * Honest connection cue beside a running spinner, with three states that each
+ * reflect a real fact about the stream:
+ *
+ *  - **receiving** (emerald pulse + `m:ss`) — bytes arrived from the server in
+ *    the last few seconds. Only shown when real data has actually been seen.
+ *  - **waiting** (muted) — the request is in flight but nothing has come back
+ *    yet (`pending`, e.g. before the first token). Neutral, not alarming; never
+ *    claims "receiving" when nothing has been received.
+ *  - **stalled** (amber + "no response for Ns") — the stream has gone genuinely
+ *    quiet past the threshold. The honest "we have not heard back" signal.
+ *
+ * A hard disconnect surfaces separately via the chat error banner. `pending`
+ * selects the waiting-vs-receiving wording for the live window: pass it when no
+ * server bytes have been observed for this turn yet (the bare thinking state).
+ */
+function LivenessIndicator({
+  active,
+  activityKey,
+  pending = false,
+  waitingLabel,
+}: {
+  active: boolean;
+  activityKey: string | number;
+  pending?: boolean;
+  waitingLabel: string;
+}) {
+  const { elapsedSeconds, quietSeconds, live } = useTurnLiveness(active, activityKey);
+  const tier: 'receiving' | 'waiting' | 'stalled' = !live
+    ? 'stalled'
+    : pending
+      ? 'waiting'
+      : 'receiving';
   return (
     <span
-      className="inline-flex items-center gap-1 text-xs font-normal tabular-nums text-muted-foreground"
-      aria-label={`Elapsed ${seconds} seconds`}
+      className={cn(
+        'inline-flex items-center gap-1.5 text-xs font-normal tabular-nums',
+        tier === 'stalled' ? 'text-amber-600' : 'text-muted-foreground',
+      )}
+      aria-live="polite"
+      title={
+        tier === 'receiving'
+          ? `Receiving from server · ${formatElapsed(elapsedSeconds)} elapsed`
+          : tier === 'waiting'
+            ? `${waitingLabel} · ${formatElapsed(elapsedSeconds)} elapsed`
+            : `${waitingLabel} (${quietSeconds}s with no response)`
+      }
     >
-      <Clock3 className="size-3 shrink-0" aria-hidden />
-      {formatElapsed(seconds)}
+      <span
+        aria-hidden
+        className={cn(
+          'size-1.5 shrink-0 rounded-full',
+          tier === 'receiving'
+            ? 'bg-emerald-500 animate-pulse'
+            : tier === 'waiting'
+              ? 'bg-muted-foreground/50 animate-pulse'
+              : 'bg-amber-500',
+        )}
+      />
+      {tier === 'receiving' ? (
+        <>
+          <Clock3 className="size-3 shrink-0" aria-hidden />
+          {formatElapsed(elapsedSeconds)}
+        </>
+      ) : tier === 'waiting' ? (
+        <span>{waitingLabel}</span>
+      ) : (
+        <span>
+          {waitingLabel} {quietSeconds}s
+        </span>
+      )}
     </span>
   );
 }
@@ -1716,15 +1840,21 @@ function BuildProgressPanel({
   openBuiltAppLabel = 'Open app',
   onPreviewDraftApp,
   previewDraftLabel = 'Preview',
+  waitingLabel = 'Waiting for server…',
 }: {
   progress: ChatBuildProgress;
   onOpenBuiltApp?: (appName: string) => void;
   openBuiltAppLabel?: string;
   onPreviewDraftApp?: (appName: string) => void;
   previewDraftLabel?: string;
+  waitingLabel?: string;
 }) {
   const { phase, appLabel, items, done, total } = progress;
   const isDone = phase === 'done';
+  // Real activity key: bumps whenever the server streams another build-progress
+  // part (a new artifact / phase). Drives the liveness indicator off observed
+  // bytes, so a healthy build reads as "receiving" and a genuine stall as amber.
+  const activityKey = `${phase}:${done}:${items.length}`;
   // The created `app` artifact (navigation shell) — the natural "open it" target.
   const builtApp = items.find((it) => it.type === 'app');
   const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : isDone ? 100 : 6;
@@ -1751,7 +1881,7 @@ function BuildProgressPanel({
           <span className="text-xs font-normal text-muted-foreground">adding sample data</span>
         ) : null}
         <span className="ml-auto">
-          <ElapsedTime active={!isDone} />
+          <LivenessIndicator active={!isDone} activityKey={activityKey} waitingLabel={waitingLabel} />
         </span>
       </div>
       <div className="mb-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -576,7 +576,7 @@ describe('publishHealthFromResponse', () => {
   });
 });
 
-describe('ChatbotEnhanced — elapsed-time liveness counter', () => {
+describe('ChatbotEnhanced — activity-driven liveness (not a fake clock)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -585,46 +585,80 @@ describe('ChatbotEnhanced — elapsed-time liveness counter', () => {
     vi.useRealTimers();
   });
 
-  it('ticks a m:ss counter on the thinking spinner so a slow turn reads as alive', () => {
+  const buildMsg = (done: number, items: Array<{ type: string; name: string }>, phase = 'structure'): ChatMessage[] => [
+    {
+      id: 'b1',
+      role: 'assistant',
+      content: '',
+      buildProgress: { phase: phase as 'structure' | 'data' | 'done', appLabel: '进销存', items, done, total: 4 },
+    },
+  ];
+
+  it('pre-first-token turn shows a neutral "waiting", never a fake "receiving"', () => {
     render(<ChatbotEnhanced isLoading messages={[]} />);
-    // Mount renders 0:00 immediately…
-    expect(screen.getByText('0:00')).toBeInTheDocument();
-    // …then advances once a second while the turn is in flight.
-    act(() => {
-      vi.advanceTimersByTime(3000);
-    });
-    expect(screen.getByText('0:03')).toBeInTheDocument();
+    // No server bytes yet → honest waiting cue, and crucially NOT an m:ss
+    // "receiving" timer that would imply data is flowing.
+    expect(screen.getByText(/Waiting for server/i)).toBeInTheDocument();
+    expect(screen.queryByText('0:00')).not.toBeInTheDocument();
   });
 
-  it('shows a running counter on an in-flight build panel and freezes it when done', () => {
-    const building: ChatMessage[] = [
-      {
-        id: 'b1',
-        role: 'assistant',
-        content: '',
-        buildProgress: {
-          phase: 'structure',
-          appLabel: '进销存',
-          items: [{ type: 'object', name: 'product' }],
-          done: 1,
-          total: 4,
-        },
-      },
-    ];
-    const { rerender } = render(<ChatbotEnhanced messages={building} />);
+  it('escalates to an amber "no response for Ns" once the stream is genuinely quiet', () => {
+    render(<ChatbotEnhanced isLoading messages={[]} />);
+    act(() => {
+      vi.advanceTimersByTime(7000);
+    });
+    // Honest stall: the seconds-since-last-byte are surfaced.
+    expect(
+      screen.getByText((t) => /Waiting for server/i.test(t) && /7s/.test(t)),
+    ).toBeInTheDocument();
+  });
+
+  it('build panel reads as "receiving" (m:ss) while progress bytes keep arriving', () => {
+    const { rerender } = render(<ChatbotEnhanced messages={buildMsg(1, [{ type: 'object', name: 'product' }])} />);
     act(() => {
       vi.advanceTimersByTime(2000);
     });
     expect(screen.getByText('0:02')).toBeInTheDocument();
 
-    // Build finishes → counter freezes at its last value (no further ticks).
-    const done: ChatMessage[] = [
-      { ...building[0], buildProgress: { ...building[0].buildProgress!, phase: 'done', done: 4 } },
-    ];
-    rerender(<ChatbotEnhanced messages={done} />);
+    // A new build-progress part arrives (done 1→2) → activity re-stamped,
+    // stays "receiving"; it is real stream activity, not a free clock.
+    rerender(
+      <ChatbotEnhanced
+        messages={buildMsg(2, [
+          { type: 'object', name: 'product' },
+          { type: 'object', name: 'order' },
+        ])}
+      />,
+    );
     act(() => {
-      vi.advanceTimersByTime(5000);
+      vi.advanceTimersByTime(2000);
     });
-    expect(screen.getByText('0:02')).toBeInTheDocument();
+    expect(screen.getByText('0:04')).toBeInTheDocument();
+    expect(screen.queryByText(/Waiting for server/i)).not.toBeInTheDocument();
+  });
+
+  it('build panel flips to amber when progress genuinely stalls, then recovers on the next byte', () => {
+    const { rerender } = render(<ChatbotEnhanced messages={buildMsg(1, [{ type: 'object', name: 'product' }])} />);
+    // No new progress for >6s → honest stall, not a reassuring tick.
+    act(() => {
+      vi.advanceTimersByTime(7000);
+    });
+    expect(screen.getByText((t) => /Waiting for server/i.test(t) && /7s/.test(t))).toBeInTheDocument();
+
+    // The server sends the next artifact → back to "receiving".
+    rerender(
+      <ChatbotEnhanced
+        messages={buildMsg(2, [
+          { type: 'object', name: 'product' },
+          { type: 'view', name: 'product_list' },
+        ])}
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByText(/Waiting for server/i)).not.toBeInTheDocument();
+    // Back to "receiving" — the m:ss is the whole-turn duration (7s stall + 1s).
+    expect(screen.getByText('0:08')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Why

The elapsed counter shipped in #1699 ticked off a **client-side `setInterval`** — it kept counting up regardless of what the server was doing. If the connection dropped, it would happily keep showing "still working." That's reassurance-theater: it *looks* like liveness but proves nothing. (用户: "不能假装，要真的工作才对" — don't fake it, it has to actually work.)

## What

Drive the indicator off **real observed stream activity** instead of a clock.

`useChat` (AI SDK v6) surfaces server bytes by mutating its message parts — a streamed token, a tool delta, or a `data-build-progress` update. We turn that into an honest signal:

- **`useTurnLiveness(active, activityKey)`** — stamps the instant real data arrives (the `activityKey` changes) and measures *seconds since the last byte*. `live` means "the server genuinely sent us something in the last few seconds."
- **`LivenessIndicator`** renders three states, each a real fact:
  - 🟢 **receiving** (emerald pulse + `m:ss`) — bytes arrived recently
  - ⚪ **waiting** (muted) — request in flight, nothing back yet (pre-first-token). Never claims "receiving" when nothing has been received.
  - 🟠 **stalled** (amber + "no response for *N*s") — genuinely silent past 6s — the honest "we haven't heard back" cue.
- The **build panel** feeds its live progress (`phase:done:items`) as the activity key. A healthy build streams progress every few seconds → reads as *receiving*; a true stall flips to amber. A hard disconnect still surfaces via the existing error banner.

## Honest limitation (follow-up)

During a genuinely **silent-but-alive** server stretch (e.g. an LLM call inside a tool that emits nothing for >6s), the client can only truthfully say "no response for *N*s" — it cannot prove the socket is alive from the client alone. Proving "still connected" there requires a **server-side SSE keep-alive heartbeat** (`encodeVercelDataStream` in framework `service-ai`). This PR stops the lying; the heartbeat (separate, cross-repo) would let those quiet windows read green *truthfully*. Happy to do that next.

## Verification

- **71/71** unit tests. 4 new ones render the real component under fake timers and assert the honest behavior: pre-first-token shows a neutral wait (not a fake `m:ss`), a quiet stream escalates to amber "…*N*s", a streaming build reads as *receiving*, and a stalled build flips amber then **recovers on the next byte**.
- `tsc --noEmit` clean, `vite build` clean. New code is lint-clean (no `Date.now()`/ref reads during render).

Supersedes the clock-only behavior from #1699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)