### PR TITLE
feat(plugin-chatbot): drive build liveness off the server keep-alive seq

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -116,6 +116,14 @@ export interface ChatBuildProgress {
   /** Count of artifacts done and the rough total (for the progress bar). */
   done: number;
   total: number;
+  /**
+   * Monotonic emit counter from the server. Bumps on every progress update —
+   * including the keep-alive heartbeats sent during long, quiet seed-generation
+   * awaits — so it's the reliable "a fresh byte just arrived" signal the build
+   * panel keys its liveness off (content fields stay identical across a
+   * heartbeat). Absent from older runtimes.
+   */
+  seq?: number;
 }
 
 export interface ChatToolInvocation {
@@ -1849,12 +1857,15 @@ function BuildProgressPanel({
   previewDraftLabel?: string;
   waitingLabel?: string;
 }) {
-  const { phase, appLabel, items, done, total } = progress;
+  const { phase, appLabel, items, done, total, seq } = progress;
   const isDone = phase === 'done';
   // Real activity key: bumps whenever the server streams another build-progress
-  // part (a new artifact / phase). Drives the liveness indicator off observed
-  // bytes, so a healthy build reads as "receiving" and a genuine stall as amber.
-  const activityKey = `${phase}:${done}:${items.length}`;
+  // part. Prefer the server's monotonic `seq` (it also advances on the keep-alive
+  // heartbeats during long, quiet seed-generation awaits, where the content
+  // fields don't change); fall back to the content signature for older runtimes
+  // that don't send `seq`. Drives the liveness indicator off observed bytes, so a
+  // healthy build reads as "receiving" and a genuine stall as amber.
+  const activityKey = seq ?? `${phase}:${done}:${items.length}`;
   // The created `app` artifact (navigation shell) — the natural "open it" target.
   const builtApp = items.find((it) => it.type === 'app');
   const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : isDone ? 100 : 6;

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -661,4 +661,43 @@ describe('ChatbotEnhanced — activity-driven liveness (not a fake clock)', () =
     // Back to "receiving" — the m:ss is the whole-turn duration (7s stall + 1s).
     expect(screen.getByText('0:08')).toBeInTheDocument();
   });
+
+  it('server keep-alive heartbeats (bumped seq, identical content) keep the build panel "receiving" through a quiet stretch', () => {
+    // A seeding level can run >6s with no new artifact — content stays identical.
+    // The server re-emits a heartbeat that only advances `seq`; that must keep
+    // the panel green (receiving), proving liveness rides REAL server bytes and
+    // not a free clock (without the heartbeat, this same gap goes amber — see the
+    // test above).
+    const seedingMsg = (seq: number): ChatMessage[] => [
+      {
+        id: 'b1',
+        role: 'assistant',
+        content: '',
+        buildProgress: {
+          phase: 'data',
+          appLabel: '进销存',
+          items: [{ type: 'object', name: 'product' }],
+          done: 1,
+          total: 4,
+          seq,
+        },
+      },
+    ];
+    const { rerender } = render(<ChatbotEnhanced messages={seedingMsg(1)} />);
+    // Heartbeats arrive every ~3s; advance 9s but re-stamp via seq at 3s and 6s.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    rerender(<ChatbotEnhanced messages={seedingMsg(2)} />);
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    rerender(<ChatbotEnhanced messages={seedingMsg(3)} />);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    // Never went amber — the heartbeats kept it honestly "receiving".
+    expect(screen.queryByText(/Waiting for server/i)).not.toBeInTheDocument();
+    expect(screen.getByText('0:08')).toBeInTheDocument();
+  });
 });

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -277,6 +277,10 @@ function extractBuildProgress(parts: AnyPart[]): ChatBuildProgress | undefined {
     items,
     done: typeof d.done === 'number' ? d.done : items.length,
     total: typeof d.total === 'number' ? d.total : items.length,
+    // Monotonic emit counter — advances even on keep-alive heartbeats (identical
+    // content), so the build panel can keep its liveness "live" during long
+    // quiet seed-generation awaits. Absent on older runtimes.
+    ...(typeof d.seq === 'number' ? { seq: d.seq } : {}),
   };
 }
 


### PR DESCRIPTION
## Why

The build panel's liveness (from #1700) keys off a content signature (`phase:done:items`). The server now sends **keep-alive heartbeats** during long, quiet seed-generation windows (cloud #287) — but those re-emits are **content-identical** (the reconciled `data-build-progress` part has a stable id), so the content key wouldn't change and the panel would still flip to amber mid-build *despite real bytes arriving*.

## What

Read the server's monotonic **`seq`** through `extractBuildProgress` into `ChatBuildProgress`, and prefer it as the build panel's activity key — falling back to the content signature when it's absent (older runtimes). `seq` advances on every emit including heartbeats, so a long quiet seed-generation window now reads as honestly **"receiving"** — driven by real server bytes, not a clock.

## Verification

- **72/72** tests. New one re-renders the panel with a **bumped `seq` + identical content** across a 9s span and asserts it **never goes amber** — directly contrasting the existing test where an *unchanged* snapshot correctly goes amber after 6s.
- `tsc` + `vite build` clean; new code lint-clean.

Pairs with cloud #287. Completes the honest-liveness arc: #1700 stopped the client from lying; #287 + this let the genuinely-busy quiet build windows read green **truthfully**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)