### PR TITLE
feat(console/ai): keyboard shortcuts — ⌘⇧O new chat, ⌘⇧S toggle list

### DIFF
--- a/packages/app-shell/src/chrome/KeyboardShortcutsDialog.tsx
+++ b/packages/app-shell/src/chrome/KeyboardShortcutsDialog.tsx
@@ -54,6 +54,13 @@ export function KeyboardShortcutsDialog() {
       ],
     },
     {
+      title: t('console.shortcuts.groups.aiChat', { defaultValue: 'AI assistant' }),
+      shortcuts: [
+        { keys: ['⌘', '⇧', 'O'], description: t('console.shortcuts.newChat', { defaultValue: 'New chat' }) },
+        { keys: ['⌘', '⇧', 'S'], description: t('console.shortcuts.toggleChatsList', { defaultValue: 'Toggle conversations list' }) },
+      ],
+    },
+    {
       title: t('console.shortcuts.groups.preferences'),
       shortcuts: [
         { keys: ['⌘', 'D'], description: t('console.shortcuts.toggleDarkMode') },

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -363,6 +363,35 @@ export function useResizableChatPane(active: boolean): ResizableChatPane {
   return { width, dragging, containerRef, onHandlePointerDown, onHandleKeyDown, reset };
 }
 
+export type AiChatShortcut = 'toggle-list' | 'new-chat';
+
+/**
+ * Match a keydown to an AI-chat shortcut, mirroring ChatGPT/Claude:
+ *  - ⌘/Ctrl+Shift+O → new chat
+ *  - ⌘/Ctrl+Shift+S → toggle the conversations list
+ *
+ * Both use the ⌘/Ctrl+Shift modifier so they're safe to fire even while the
+ * composer is focused (they can't be produced by ordinary typing). Pure +
+ * exported for tests.
+ */
+export function matchAiChatShortcut(e: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}): AiChatShortcut | null {
+  if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey) return null;
+  switch (e.key.toLowerCase()) {
+    case 'o':
+      return 'new-chat';
+    case 's':
+      return 'toggle-list';
+    default:
+      return null;
+  }
+}
+
 export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentProp }: AiChatPageProps = {}) {
   const { user } = useAuth();
   const { t } = useObjectTranslation();
@@ -430,6 +459,18 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     toggle: toggleChatsCollapsed,
     handleCanvasOpenChange,
   } = useCollapsibleChatsList();
+  // Keyboard shortcuts (ChatGPT/Claude parity): ⌘⇧O new chat, ⌘⇧S toggle list.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const action = matchAiChatShortcut(e);
+      if (!action) return;
+      e.preventDefault();
+      if (action === 'toggle-list') toggleChatsCollapsed();
+      else navigate('/ai?new=1');
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [toggleChatsCollapsed, navigate]);
   const restApiBase = useMemo(
     () => apiBase.replace(/\/v1\/ai$/, '').replace(/\/ai$/, '') || '/api',
     [apiBase],

--- a/packages/app-shell/src/console/ai/__tests__/matchAiChatShortcut.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/matchAiChatShortcut.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { matchAiChatShortcut } from '../AiChatPage';
+
+const ev = (over: Partial<{ key: string; metaKey: boolean; ctrlKey: boolean; shiftKey: boolean; altKey: boolean }>) => ({
+  key: 'o',
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  ...over,
+});
+
+describe('matchAiChatShortcut', () => {
+  it('maps ⌘⇧O and Ctrl⇧O to new-chat', () => {
+    expect(matchAiChatShortcut(ev({ key: 'O', metaKey: true, shiftKey: true }))).toBe('new-chat');
+    expect(matchAiChatShortcut(ev({ key: 'o', ctrlKey: true, shiftKey: true }))).toBe('new-chat');
+  });
+
+  it('maps ⌘⇧S to toggle-list', () => {
+    expect(matchAiChatShortcut(ev({ key: 'S', metaKey: true, shiftKey: true }))).toBe('toggle-list');
+  });
+
+  it('requires the shift modifier', () => {
+    expect(matchAiChatShortcut(ev({ key: 'o', metaKey: true }))).toBeNull();
+    expect(matchAiChatShortcut(ev({ key: 's', ctrlKey: true }))).toBeNull();
+  });
+
+  it('requires a ⌘/Ctrl modifier and rejects Alt', () => {
+    expect(matchAiChatShortcut(ev({ key: 'o', shiftKey: true }))).toBeNull();
+    expect(matchAiChatShortcut(ev({ key: 'o', metaKey: true, shiftKey: true, altKey: true }))).toBeNull();
+  });
+
+  it('ignores unrelated keys', () => {
+    expect(matchAiChatShortcut(ev({ key: 'k', metaKey: true, shiftKey: true }))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Power-user parity with ChatGPT / Claude — drive the AI chat from the keyboard.

## What

- **⌘/Ctrl+Shift+O** → new conversation
- **⌘/Ctrl+Shift+S** → toggle the conversations list (drives the same persisted collapse from #1703)

Both use the ⌘/Ctrl+Shift modifier, so they're safe to fire even while the composer is focused (ordinary typing can't produce them). Surfaced in the keyboard-shortcuts cheatsheet (the `?` dialog) under a new **"AI assistant"** group, so they're discoverable.

Match logic is a pure exported `matchAiChatShortcut`.

## Verification

- **487/487** tests (5 new on the matcher: ⌘ and Ctrl variants → new-chat / toggle-list, requires Shift, rejects Alt and a missing ⌘/Ctrl, ignores unrelated keys).
- `tsc` clean; no new lint errors.

Third of the chat-UX pass (after collapsible list #1703 and resizable split #1705).

🤖 Generated with [Claude Code](https://claude.com/claude-code)