### PR TITLE
fix(plugin-list): gate speculative $select fields by the object's real schema

### DIFF
--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -983,12 +983,42 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           for (const c of cols) required.add(c);
           for (const e of expandFields) required.add(e);
 
+          // Real fields of the object, used to gate the SPECULATIVE
+          // view-binding fields below. The comment above is the tell: "some
+          // backends reject unknown select keys with an empty result set
+          // rather than ignoring them" — the cloud multi-tenant runtime does
+          // exactly that, so a single unknown column in $select silently
+          // zeroes the whole list (an AI-built `product` view auto-requesting
+          // `status`/`due_date`/`image` then looks like "no data exists").
+          // The user-declared `cols` and `expandFields` are already
+          // known-valid (perms.checkField / buildExpandFields derived them
+          // from the schema); only the auto-included view-binding fields are
+          // unsafe. When the object schema isn't loaded yet we can't
+          // validate, so we keep the prior permissive behavior (the data
+          // fetch waits for objectDefLoaded, so this is virtually never hit).
+          const knownObjectFields = (() => {
+            const f = objectDef?.fields;
+            if (!f) return null;
+            const names = Array.isArray(f)
+              ? (f as any[]).map(x => x?.name).filter((n): n is string => typeof n === 'string')
+              : Object.keys(f);
+            const s = new Set<string>(names);
+            s.add('id'); s.add('created_at'); s.add('updated_at');
+            return s;
+          })();
+          const addSpeculative = (f: unknown) => {
+            if (typeof f !== 'string' || !f) return;
+            if (!knownObjectFields || knownObjectFields.has(f)) required.add(f);
+          };
+
           // View-specific runtime fields. Each non-grid view binds to one
           // or more record fields (groupBy for kanban, dates for calendar/
           // timeline/gantt, image/title for gallery). Without these in the
           // projection the view renders correctly-shaped records but with
           // blank values — e.g. a kanban grouped by `industry` puts every
-          // card into the implicit "no value" column.
+          // card into the implicit "no value" column. Added via
+          // addSpeculative so a binding naming a field this object lacks is
+          // dropped instead of poisoning the query.
           const collectViewFields = (v: any) => {
             if (!v) return;
             const candidates = [
@@ -1002,9 +1032,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
               ...(Array.isArray(v.visibleFields) ? v.visibleFields : []),
               ...(Array.isArray(v.metaFields) ? v.metaFields : []),
             ];
-            for (const f of candidates) {
-              if (typeof f === 'string' && f) required.add(f);
-            }
+            for (const f of candidates) addSpeculative(f);
           };
           collectViewFields(schema.kanban);
           collectViewFields(schema.options?.kanban);
@@ -1017,13 +1045,14 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           // Timeline plugin shows status / priority chips inline. Auto-include
           // them when no explicit metaFields was configured so views like
           // `task_timeline` ({ columns: ['subject', 'status'] }) still get
-          // priority badges out of the box. Inclusion is harmless when the
-          // object lacks these fields — the projection ignores unknown names.
+          // priority badges out of the box. Gated through addSpeculative: only
+          // added when the object actually has these fields (a `product` with
+          // no status/priority must not get them, or the list goes empty).
           {
             const tCfg: any = schema.timeline ?? schema.options?.timeline;
             if (tCfg && !Array.isArray(tCfg.metaFields)) {
-              required.add('status');
-              required.add('priority');
+              addSpeculative('status');
+              addSpeculative('priority');
             }
           }
           collectViewFields(schema.gantt);

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -645,6 +645,89 @@ describe('ListView', () => {
     });
   });
 
+  describe('$select projection — speculative view-binding fields', () => {
+    const lastSelect = (find: ReturnType<typeof vi.fn>): string[] | undefined => {
+      const call = find.mock.calls.at(-1);
+      return call?.[1]?.$select as string[] | undefined;
+    };
+
+    it('drops speculative fields the object does not have (so they cannot zero the list)', async () => {
+      // Reproduces the "published app shows no data" bug: a timeline config
+      // auto-adds status/priority, but `product` has neither. Backends that
+      // reject unknown $select keys with an empty result then return 0 rows.
+      const mockDs = {
+        find: vi.fn().mockResolvedValue([]),
+        findOne: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(),
+        getObjectSchema: vi.fn().mockResolvedValue({
+          name: 'product',
+          fields: {
+            product_name: { type: 'text' },
+            sku: { type: 'text' },
+            is_active: { type: 'boolean' },
+          },
+        }),
+      };
+
+      const schema = {
+        type: 'list-view',
+        objectName: 'product',
+        viewType: 'grid',
+        fields: ['product_name', 'sku', 'is_active'],
+        // Present so the status/priority + date auto-include paths fire.
+        timeline: {},
+        calendar: {},
+      } as unknown as ListViewSchema;
+
+      render(
+        <SchemaRendererProvider dataSource={mockDs}>
+          <ListView schema={schema} dataSource={mockDs} />
+        </SchemaRendererProvider>
+      );
+
+      await vi.waitFor(() => expect(mockDs.find).toHaveBeenCalled());
+      const select = lastSelect(mockDs.find)!;
+      // Real fields survive…
+      expect(select).toEqual(expect.arrayContaining(['product_name', 'sku', 'is_active']));
+      // …phantom view-binding fields are gone.
+      for (const phantom of ['status', 'priority', 'start_date', 'end_date', 'due_date']) {
+        expect(select).not.toContain(phantom);
+      }
+    });
+
+    it('keeps a speculative field when the object actually has it', async () => {
+      const mockDs = {
+        find: vi.fn().mockResolvedValue([]),
+        findOne: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(),
+        getObjectSchema: vi.fn().mockResolvedValue({
+          name: 'task',
+          fields: {
+            subject: { type: 'text' },
+            status: { type: 'select' },
+            priority: { type: 'select' },
+          },
+        }),
+      };
+
+      const schema = {
+        type: 'list-view',
+        objectName: 'task',
+        viewType: 'grid',
+        fields: ['subject'],
+        timeline: {},
+      } as unknown as ListViewSchema;
+
+      render(
+        <SchemaRendererProvider dataSource={mockDs}>
+          <ListView schema={schema} dataSource={mockDs} />
+        </SchemaRendererProvider>
+      );
+
+      await vi.waitFor(() => expect(mockDs.find).toHaveBeenCalled());
+      const select = lastSelect(mockDs.find)!;
+      expect(select).toEqual(expect.arrayContaining(['subject', 'status', 'priority']));
+    });
+  });
+
   // ============================================
   // Merged Toolbar Layout
   // ============================================


### PR DESCRIPTION
## Problem

A list view auto-includes view-binding fields in `$select` so alternate view modes (kanban groupBy, calendar/gantt/timeline dates, gallery image, timeline `status`/`priority`) render populated. These were added **unconditionally**, on the assumption — stated in a code comment — that *"the projection ignores unknown names."*

That assumption is false against the cloud multi-tenant runtime: an unknown `$select` column returns an **empty result set**, so a single phantom field zeroes the whole list. An AI-built `product` view auto-requesting `status,name,due_date,image,priority,start_date,end_date` (none of which exist on `product`) then renders "Nothing here yet" even though the rows are in the DB.

This was diagnosed against a live env: `select=id,product_name,sku` → 6 rows, but the renderer's actual `select=...,status,name,due_date,image,priority,start_date,end_date` → 0 rows.

## Fix

Gate the speculative additions through `addSpeculative()`, which only keeps a field that exists in `objectDef.fields` (already loaded before the data fetch). User-declared columns and expand roots are untouched — they're already known-valid.

## Tests

- New: a `product`-shaped object with timeline/calendar config drops the phantom `status/priority/*_date` from `$select` (fails without the fix).
- New: a `task` object that *has* `status`/`priority` keeps them.
- Full plugin-list suite: 125 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)