### PR TITLE
test(app-shell): page inspector hides data-view sections for list pages (ADR-0047)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.pageVisibility.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.pageVisibility.test.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SchemaForm } from './SchemaForm';
+
+afterEach(cleanup);
+
+/**
+ * ADR-0047 follow-up — page inspector section visibility for `list` pages.
+ *
+ * Framework PR #1817 marks the page form's "Data Context" (object/variables)
+ * and "Layout" (regions) sections with `visibleOn: "data.type != 'list'"`,
+ * and the "Interface (list pages)" section with `data.type == 'list'`. For a
+ * `type: 'list'` page the data-view sections must hide and the Interface
+ * section must show.
+ *
+ * This test pins the renderer side of that contract: given the PR-#1817 form
+ * shape and a draft carrying `type: 'list'`, `SectionedSchemaForm` evaluates
+ * each `visibleOn` against `value` and renders the right sections. (The bug
+ * report's "still shows Data Context + Layout" symptom turned out to be a
+ * stale backend serving the pre-#1817 form — see the section labels below for
+ * the exact predicates the backend must serve.)
+ */
+
+// Minimal JSONSchema mirroring the page item fields the form references.
+const pageSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string', title: 'Name' },
+    type: { type: 'string', title: 'Type' },
+    object: { type: 'string', title: 'Object' },
+    variables: { type: 'array', title: 'Variables', items: { type: 'object' } },
+    regions: { type: 'array', title: 'Regions', items: { type: 'object' } },
+    interfaceConfig: { type: 'object', title: 'Interface Config' },
+  },
+};
+
+// FormView mirroring framework PR #1817 (packages/spec/src/ui/page.form.ts).
+const pageForm = {
+  type: 'simple' as const,
+  sections: [
+    { label: 'Basics', fields: [{ field: 'name' }, { field: 'type' }] },
+    {
+      label: 'Data Context',
+      visibleOn: "data.type != 'list'",
+      fields: [{ field: 'object' }, { field: 'variables' }],
+    },
+    {
+      label: 'Layout',
+      visibleOn: "data.type != 'list'",
+      fields: [{ field: 'regions' }],
+    },
+    {
+      label: 'Interface (list pages)',
+      // Mirror the framework's collapsed-by-default + CEL dialect shape so we
+      // exercise the same predicate path the backend serves.
+      collapsible: true,
+      collapsed: false,
+      visibleOn: { dialect: 'cel', source: "data.type == 'list'" },
+      fields: [{ field: 'interfaceConfig' }],
+    },
+  ],
+};
+
+describe('SchemaForm — page inspector section visibility (ADR-0047 / #1817)', () => {
+  it('a list page hides Data Context + Layout and shows the Interface section', () => {
+    render(
+      <SchemaForm
+        schema={pageSchema}
+        form={pageForm}
+        value={{ name: 'showcase_task_workbench', type: 'list' }}
+        onChange={() => {}}
+      />,
+    );
+    // Always-visible identity section.
+    expect(screen.getByText('Basics')).toBeInTheDocument();
+    // `data.type != 'list'` → false for a list page → hidden.
+    expect(screen.queryByText('Data Context')).not.toBeInTheDocument();
+    expect(screen.queryByText('Layout')).not.toBeInTheDocument();
+    // `data.type == 'list'` → true → shown.
+    expect(screen.getByText('Interface (list pages)')).toBeInTheDocument();
+  });
+
+  it('a non-list (record) page shows Data Context + Layout and hides the Interface section', () => {
+    render(
+      <SchemaForm
+        schema={pageSchema}
+        form={pageForm}
+        value={{ name: 'some_record_page', type: 'record' }}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Data Context')).toBeInTheDocument();
+    expect(screen.getByText('Layout')).toBeInTheDocument();
+    expect(screen.queryByText('Interface (list pages)')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Adds a regression test for the metadata-admin **page inspector** section visibility (ADR-0047): given the framework PR #1817 page-form shape, a `type: 'list'` page must hide **Data Context** + **Layout** (`visibleOn: "data.type != 'list'"`) and show the **Interface** section (`data.type == 'list'`); a `record` page does the inverse.

`packages/app-shell/src/views/metadata-admin/SchemaForm.pageVisibility.test.tsx` — 2 cases (list page, record page).

## Why

ADR-0047 follow-up. Investigation showed **objectui was already correct** — `SchemaForm`/`SectionedSchemaForm` honor section `visibleOn`, and the page draft carries `type`. The original "Data Context still shows" symptom was a **stale backend** serving the pre-#1817 form, not a renderer bug. This test pins the renderer side of the contract so a future regression is caught.

Renderer-only verification — **no source change**. Complements the existing `SchemaForm.collapsible.test.tsx`.

## Verification

- Ran locally: `vitest run SchemaForm.pageVisibility.test.tsx SchemaForm.collapsible.test.tsx` → **5/5 pass**.
- Browser-verified end-to-end against a backend containing framework #1817 (`showcase_task_workbench` list page hides Data Context + Layout, shows Interface; `showcase_project_detail` record page shows them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)