### PR TITLE
feat(studio): scope editor post-save refresh by package (ADR-0048 #1824)

### DIFF
--- a/.changeset/adr-0048-editor-refresh-scope.md
+++ b/.changeset/adr-0048-editor-refresh-scope.md
@@ -1,0 +1,9 @@
+---
+"@object-ui/app-shell": patch
+---
+
+ADR-0048 (#1824): the Studio metadata editor's post-save refresh now scopes its
+layered + draft re-read to the same package as the initial load (`?package=`), so
+when two installed packages ship the same `type`/`name` the editor re-reads
+this package's own row after saving — not another package's. The save itself
+already binds the package; this aligns the refresh with it.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -892,10 +892,13 @@ function MetadataResourceEditPageImpl({
         mode: 'draft',
         ...(activePackage ? { packageId: activePackage } : {}),
       });
-      // Refresh layered + draft state after save.
+      // Refresh layered + draft state after save — scope to the same package
+      // as the initial load (ADR-0048) so a same-name collision re-reads this
+      // package's own row, not another's.
+      const refreshScope = ownerPackageId ? { packageId: ownerPackageId } : {};
       const [lay, draftResp] = await Promise.all([
-        client.layered<any>(type, savedName),
-        client.getDraft<any>(type, savedName).catch(() => null),
+        client.layered<any>(type, savedName, refreshScope),
+        client.getDraft<any>(type, savedName, refreshScope).catch(() => null),
       ]);
       setLayered(lay);
       const draftReal = extractDraftBody(draftResp);


### PR DESCRIPTION
Frontend counterpart to [framework#1827](https://github.com/objectstack-ai/framework/pull/1827) (package-scoped customization overlays, closes framework #1824).

The Studio metadata editor's **post-save refresh** re-read its layered + draft state context-free. The initial load (and the save) already pass `?package=` (since #1711); this aligns the refresh so that — when two installed packages ship the same `type`/`name` and each has its own overlay — the editor re-reads **this** package's own row after saving, not another's.

One-line change: `client.layered/getDraft(type, name, { packageId: ownerPackageId })` on the refresh path.

Depends on framework #1827 for the server to actually persist/resolve per-package overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)