### PR TITLE
fix(home): link into apps by package-id route segment (ADR-0048)

### DIFF
--- a/.changeset/adr-0048-home-app-link-packageid.md
+++ b/.changeset/adr-0048-home-app-link-packageid.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/app-shell": patch
+---
+
+ADR-0048: the console **home** page now links into apps by their canonical
+package-id route segment, matching the nav. The app grid (`HomePage`) and the
+"add to favorites" href (`AppCard`) were still building `/apps/<app.name>` while
+the sidebar/switcher/command-palette emit `/apps/<packageId>` (via
+`appRouteSegment`). So opening an app from the home page produced a name-form URL
+(e.g. `/apps/studio`) instead of `/apps/com.objectstack.studio`. Both now use
+`appRouteSegment(app)`.

--- a/packages/app-shell/src/console/home/AppCard.tsx
+++ b/packages/app-shell/src/console/home/AppCard.tsx
@@ -9,7 +9,7 @@
 import { Star, StarOff, ArrowUpRight } from 'lucide-react';
 import { Card, CardContent, Button, Badge } from '@object-ui/components';
 import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
-import { resolveI18nLabel } from '../../utils';
+import { resolveI18nLabel, appRouteSegment } from '../../utils';
 import { useFavorites } from '../../hooks/useFavorites';
 import { getIcon } from '../../utils/getIcon';
 import { cn } from '@object-ui/components';
@@ -53,7 +53,9 @@ export function AppCard({ app, onClick, isFavorite, index = 0 }: AppCardProps) {
     toggleFavorite({
       id: `app:${app.name}`,
       label,
-      href: `/apps/${app.name}`,
+      // ADR-0048 — link to the canonical package-id route segment, not the
+      // app name, so the favorite opens `/apps/<packageId>` like the nav does.
+      href: `/apps/${appRouteSegment(app) ?? app.name}`,
       type: 'object',
     });
   };

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -26,6 +26,7 @@ import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { AppCard } from './AppCard';
 import { RecentApps } from './RecentApps';
 import { StarredApps } from './StarredApps';
+import { appRouteSegment } from '../../utils';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
 import { Sparkles, Star, Clock, ArrowDown, Store, LayoutGrid, ShieldAlert, X, UploadCloud } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
@@ -406,7 +407,7 @@ export function HomePage() {
                   key={app.name}
                   app={app}
                   index={idx}
-                  onClick={() => navigate(`/apps/${app.name}`)}
+                  onClick={() => navigate(`/apps/${appRouteSegment(app) ?? app.name}`)}
                   isFavorite={favorites.some(f => f.id === `app:${app.name}`)}
                 />
               ))}


### PR DESCRIPTION
## Bug

Opening an app from the console **home** page produced a **name-form** URL (e.g. `/apps/studio`) instead of the canonical package-id form (`/apps/com.objectstack.studio`) that the rest of the nav uses.

The ADR-0048 emission fix (#1696) updated the sidebar / app-switcher / command-palette to link via `appRouteSegment(app)` (= `_packageId ?? name`), but **missed the home surface**:
- `HomePage.tsx` app grid: `navigate(\`/apps/${app.name}\`)`
- `AppCard.tsx` favorite href: `href: \`/apps/${app.name}\``

## Fix

Both now use `appRouteSegment(app)`.

## Verification

Browser-tested against a live backend (dev console with live source; the `/_console/` bundle on a deployed backend is pinned and picks this up on its next `@objectstack/console` bump):

- Click **Studio** card → `/apps/com.objectstack.studio` ✅ (was `/apps/studio`)
- Click **HotCRM** card → `/apps/app.objectstack.hotcrm/dashboard/executive_dashboard` ✅, app renders (Executive dashboard, full nav). No console errors.

(App names ≠ package ids, confirmed via `/meta/app`: `studio`→`com.objectstack.studio`, `crm_enterprise`→`app.objectstack.hotcrm`, `showcase_app`→`com.example.showcase`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)