### PR TITLE
fix(routing): sweep remaining app-entry links onto package-id segment (ADR-0048)

### DIFF
--- a/.changeset/adr-0048-app-entry-links-sweep.md
+++ b/.changeset/adr-0048-app-entry-links-sweep.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/console": patch
+---
+
+ADR-0048: finish sweeping app-entry links onto the canonical package-id route
+segment (follow-up to the home-page fix).
+
+- `AppManagementPage` (System → Apps) "Open app" button now opens
+  `/apps/<packageId>` (`app._packageId ?? app.name`) instead of `/apps/<name>`.
+- `AppContent` current-app sub-routes/redirects (the `metadata/package` →
+  `component/developer/packages` redirect, and the record-form `baseUrl`) now
+  build against the URL's own `appName` segment instead of `activeApp.name`, so a
+  `/apps/<packageId>/…` URL keeps its package-id segment instead of flipping to
+  the name form. `requestedAppMissing` (preview-drafts) now resolves the segment
+  via `matchAppBySegment` so a package-id URL isn't treated as a missing app.

--- a/apps/console/src/pages/system/AppManagementPage.tsx
+++ b/apps/console/src/pages/system/AppManagementPage.tsx
@@ -226,7 +226,9 @@ export function AppManagementPage() {
                       size="icon"
                       title="Open app"
                       aria-label={`Open ${app.label || app.name}`}
-                      onClick={() => navigate(`/apps/${app.name}`)}
+                      // ADR-0048 — open via the canonical package-id route segment
+                      // (falls back to name for runtime apps without a package id).
+                      onClick={() => navigate(`/apps/${app._packageId ?? app.name}`)}
                     >
                       <ExternalLink className="h-4 w-4" />
                     </Button>

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -184,18 +184,22 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
   // silently preview the WRONG app; treat the request as "not ready" instead
   // and let the preview-specific empty state below say so.
   const requestedAppMissing =
-    previewDrafts && !!appName && !apps.some((a: any) => a.name === appName);
+    previewDrafts && !!appName && !matchAppBySegment(apps, appName);
 
   useEffect(() => {
     if (!activeApp?.name) return;
-    const packageMetadataPath = `/apps/${activeApp.name}/metadata/package`;
+    // ADR-0048 — build against the URL's own segment (`appName`, which may be the
+    // package id) so the match works and the redirect keeps the same segment;
+    // `activeApp.name` would flip a `/apps/<packageId>/…` URL to the name form.
+    const seg = appName ?? activeApp.name;
+    const packageMetadataPath = `/apps/${seg}/metadata/package`;
     if (
       location.pathname === packageMetadataPath ||
       location.pathname.startsWith(`${packageMetadataPath}/`)
     ) {
-      navigate(`/apps/${activeApp.name}/component/developer/packages`, { replace: true });
+      navigate(`/apps/${seg}/component/developer/packages`, { replace: true });
     }
-  }, [activeApp?.name, location.pathname, navigate]);
+  }, [activeApp?.name, appName, location.pathname, navigate]);
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingRecord, setEditingRecord] = useState<any>(null);
@@ -331,7 +335,7 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
     // preserved for any object without the flag.
     const target = resolveRecordFormTarget({
       objectDef: currentObjectDef as any,
-      baseUrl: activeApp?.name ? `/apps/${activeApp.name}` : '',
+      baseUrl: appName ? `/apps/${appName}` : (activeApp?.name ? `/apps/${activeApp.name}` : ''),
       record,
     });
     if (target.kind === 'page') {
@@ -470,7 +474,7 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
                     score 16; declaration order breaks the tie). */}
                 <Route
                   path="metadata/package/*"
-                  element={<Navigate to={`/apps/${activeApp.name}/component/developer/packages`} replace />}
+                  element={<Navigate to={`/apps/${appName ?? activeApp.name}/component/developer/packages`} replace />}
                 />
                 <Route path="metadata">
                   <Route index element={<MetadataDirectoryPage />} />


### PR DESCRIPTION
Follow-up to #1717 (home-page app links). Swept the console for app-entry links still building `/apps/<app.name>` instead of the canonical package-id segment.

## Fixed
- **AppManagementPage** (System → Apps) "Open app" button: `/apps/${app.name}` → `/apps/${app._packageId ?? app.name}`.
- **AppContent** current-app sub-routes/redirects that used `activeApp.name` (which flipped a `/apps/<packageId>/…` URL to the name form):
  - the `metadata/package` → `component/developer/packages` redirect (path matcher + target),
  - the record-form `baseUrl`,
  - now build against the URL's own `appName` route param.
  - `requestedAppMissing` (preview-drafts) now resolves via `matchAppBySegment`, so a package-id URL isn't mistaken for a missing app.

## Left deliberately
- `ConsoleFloatingChatbot` "open just-published app" — its `published` payload is `{type, name}` with no `_packageId`, so name-form is the only option (and `matchAppBySegment` falls back to name).
- All the `appName`-from-`useParams()` sub-route builders (RecordFormPage, ObjectView, marketplace pages, …) — they correctly reuse the current segment.

## Verification
Browser (dev console against a live backend): System → Apps → **Open Showcase** → `/apps/com.example.showcase/showcase_project`, app renders. Typecheck clean for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
