### PR TITLE
fix(app-shell): merge draft overlay over effective baseline (preserve inherited fields)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -542,10 +542,16 @@ function MetadataResourceEditPageImpl({
         // Prefer the pending draft as the editing baseline — the
         // operator is mid-flight on this item and should see their
         // own in-progress state, not the last published version.
-        const rawInitial = (draftReal
-          ?? lay.effective
-          ?? lay.code
-          ?? {}) as Record<string, unknown>;
+        // A pending draft overlay can carry only the edited fields, so using
+        // it wholesale would drop inherited fields that were never touched —
+        // notably `type`, which section-level `visibleOn` predicates depend on
+        // (ADR-0047 hides Data Context / Layout when `data.type == 'list'`).
+        // Merge the draft over the effective baseline so those fields survive;
+        // the draft still wins for anything it does carry.
+        const baseline = (lay.effective ?? lay.code ?? {}) as Record<string, unknown>;
+        const rawInitial: Record<string, unknown> = draftReal
+          ? { ...baseline, ...(draftReal as Record<string, unknown>) }
+          : baseline;
         // Normalise the wire shape into the editor's draft shape (e.g.
         // `view` unwraps an expanded ViewItem's `config` into a
         // `{ list | form }` family key). No-op for types without a hook.
@@ -893,7 +899,12 @@ function MetadataResourceEditPageImpl({
       setLayered(lay);
       const draftReal = extractDraftBody(draftResp);
       setHasDraft(!!draftReal);
-      const rawFresh = (draftReal ?? lay.effective ?? itemToSave) as Record<string, unknown>;
+      // Merge the draft over the effective baseline (see the load effect):
+      // a partial draft overlay must not drop inherited fields like `type`.
+      const freshBaseline = (lay.effective ?? itemToSave) as Record<string, unknown>;
+      const rawFresh: Record<string, unknown> = draftReal
+        ? { ...freshBaseline, ...(draftReal as Record<string, unknown>) }
+        : freshBaseline;
       // Re-normalise the refreshed wire shape so the editor keeps showing
       // the canonical draft shape after a save (e.g. the backend re-expands
       // a view into the ViewItem `config` wrapper).
@@ -1010,7 +1021,13 @@ function MetadataResourceEditPageImpl({
       setLayered(lay);
       const draftReal = extractDraftBody(draftResp);
       setHasDraft(!!draftReal);
-      const fresh = (draftReal ?? lay.effective ?? draft) as Record<string, unknown>;
+      // Merge the draft over the effective baseline so a partial draft overlay
+      // doesn't drop inherited fields like `type` (section visibleOn depends
+      // on it — ADR-0047).
+      const freshBaseline = (lay.effective ?? draft) as Record<string, unknown>;
+      const fresh: Record<string, unknown> = draftReal
+        ? { ...freshBaseline, ...(draftReal as Record<string, unknown>) }
+        : freshBaseline;
       setDraft(fresh);
       draftSnapshotRef.current = fresh;
     } catch (err: any) {


### PR DESCRIPTION
## Why
When editing a metadata item, a pending **draft overlay** can carry only the *edited* fields. `ResourceEditPage` was using that draft **wholesale** (`draftReal ?? lay.effective`), so any field the user never touched — notably `type` — was dropped from the editing baseline.

That bites section-level `visibleOn` predicates: ADR-0047 hides the **Data Context** / **Layout** sections on a list page via `data.type == 'list'`. If `type` is missing from the draft value, the predicate misfires. (The companion ADR-0047 work — [#1704](https://github.com/objectstack-ai/objectui/pull/1704) / framework [#1817](https://github.com/objectstack-ai/framework/pull/1817) — is verified working in a clean environment; this PR hardens the partial-draft path so it can't regress.)

## Change
Merge the draft **over** the effective baseline at all three draft-init sites (initial load + two post-save reloads):

```
const baseline = lay.effective ?? lay.code ?? {};
const initial = draftReal ? { ...baseline, ...draftReal } : baseline;
```

Standard overlay semantics — the draft still wins for anything it carries; inherited fields survive. No-op when the draft is already a full snapshot.

## Risk
Low. If a draft intentionally *omitted* a field to mean "removed", the baseline value would resurface — but metadata drafts are full/additive snapshots, not deletion diffs, so this is not a concern in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)