### PR TITLE
chore(agents): enforce worktree-first discipline with a PreToolUse guard

### DIFF
--- a/.claude/hooks/guard-main-checkout.sh
+++ b/.claude/hooks/guard-main-checkout.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# guard-main-checkout.sh — PreToolUse guard enforcing worktree-first discipline.
+# Blocks Edit / Write / NotebookEdit while the session's checkout is on the repo's
+# default branch (main).
+#
+# Why: this repo is worked on by multiple agents in parallel. The shared default
+# checkout has its HEAD switched and the tree reset *under you* by other agents,
+# silently clobbering uncommitted edits. Dedicated per-task worktrees are
+# physically isolated, so edits there are safe. This guard turns the documented
+# discipline into a hard stop for the one place it actually fails — editing on the
+# shared default branch.
+#
+# Deliberate exception (a human quick-fix that still lands via PR, never task work
+# committed straight to the default branch): export OS_ALLOW_MAIN_EDITS=1.
+
+set -uo pipefail
+
+# Escape hatch.
+[ "${OS_ALLOW_MAIN_EDITS:-}" = "1" ] && exit 0
+
+dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Not a git repo (or git unavailable) → nothing to guard, allow.
+branch="$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
+
+# Repo default branch (origin/HEAD), e.g. "main"; fall back to "main".
+default="$(git -C "$dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)"
+default="${default#origin/}"
+[ -n "$default" ] || default="main"
+
+if [ "$branch" = "$default" ]; then
+  root="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$dir")"
+  name="$(basename "$root")"
+  cat >&2 <<EOF
+⛔ Blocked: editing files while on the shared '$default' checkout (root=$root).
+
+This repo is worked on by multiple agents in parallel — the shared '$default' tree
+gets its HEAD switched and reset under you, silently clobbering uncommitted edits.
+
+Per AGENTS.md (worktree-first), create a dedicated worktree and edit from there:
+
+  git worktree add ../$name-<task> -b <branch> $default
+  cd ../$name-<task> && pnpm install
+
+Deliberate exception (not task work): re-run with OS_ALLOW_MAIN_EDITS=1.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,5 +12,18 @@
       "mcp__Claude_Preview__preview_console_logs",
       "mcp__Claude_Preview__preview_network"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-main-checkout.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ export const SchemaRenderer = ({ schema }: { schema: UIComponent }) => {
 本仓库有**多个 agent 并行**修改 —— 分支会被切换、共享文件会在你工作时被改动(正常现象,不是 bug):
 
 - **只改你任务需要的文件**;别去"修"无关的 diff、回退或别人的在途编辑,也别管整棵工作树。
-- **首选一个任务一个 git worktree**(`git worktree add ../objectui-<task> -b <branch>`)做物理隔离;下面这些防御性条款适用于必须共用同一工作树的情况。
+- **必须一个任务一个 git worktree**(`git worktree add ../objectui-<task> -b <branch> main`,新树里跑 `pnpm install`)做物理隔离 —— 这是强制而非「首选」。共享的 `main` checkout **不是**可用退路:HEAD 会被别的 agent 切换、你刚写的文件会在操作中途被 reset 掉。一个 **PreToolUse 钩子**(`.claude/hooks/guard-main-checkout.sh`)**强制**此规则:HEAD 在 `main` 上时拦截 `Edit`/`Write`/`NotebookEdit`(确属非任务的临时改动用 `OS_ALLOW_MAIN_EDITS=1` 放行)。即便在自己的 worktree 里,下面这些防御性条款仍然适用。
 - **一个任务一个 feature 分支 + 一个 PR**;**绝不**把任务改动直接提交到 `main`。
 - **绝不 `git push --force`/`--force-with-lease`,绝不推 `main`**(会覆盖并行 agent 的工作;`main` 共享,一律走 PR)。
 - **每次 commit/push 前先确认当前分支**(`git rev-parse --abbrev-ref HEAD`);HEAD 可能被别的 agent 切走 —— 不是你的分支就停下重新 checkout。


### PR DESCRIPTION
## Why
This repo is worked on by multiple agents in parallel. The shared `main` checkout gets its HEAD switched and the tree reset *under* an agent mid-task, silently clobbering uncommitted edits — observed in `../framework`, where a full session's work was reverted **twice**. AGENTS.md already recommended one-worktree-per-task, but it was a soft "prefer" and **nothing enforced it**. The gap was adherence, not clarity — so this adds a guardrail (matching the one just landed in `../framework`).

## What
- **`.claude/hooks/guard-main-checkout.sh`** (new) — a PreToolUse hook wired in `.claude/settings.json` that blocks `Edit`/`Write`/`NotebookEdit` whenever the session's checkout HEAD is on the repo's default branch (auto-detected via `origin/HEAD`, falls back to `main`), with an actionable message. Allows on any feature branch / non-git dir. `OS_ALLOW_MAIN_EDITS=1` overrides for a deliberate non-task fix.
- **AGENTS.md** — multi-agent section hardened: worktree-first is now mandatory (not "prefer"), the shared `main` checkout is explicitly not a supported fallback, and the hook is referenced.

## Verification
Hook tested across all paths: on `main` → exit 2 (block) with guidance; on a feature branch → exit 0 (allow); with `OS_ALLOW_MAIN_EDITS=1` → exit 0 (allow); repo name auto-detected in the message.

Tooling/docs only — no package version impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)