### PR TITLE
feat(app-shell): interface Add-Record config takes effect; honest view picker (ADR-0047)

### DIFF
--- a/.changeset/interface-panel-polish-round2.md
+++ b/.changeset/interface-panel-polish-round2.md
@@ -1,0 +1,8 @@
+---
+"@object-ui/app-shell": minor
+---
+
+interface page: Add-Record config now takes effect; view picker mirrors runtime resolution
+
+- **Fix: `interfaceConfig.addRecord` did nothing.** `InterfaceListPage` never forwarded `addRecord` into the schema it hands to `ListView`, so the panel's Add-Record toggle/position/mode were silently dropped — the button could never appear on an interface page. Now `addRecord` is passed through (ListView already gates the button on `addRecord.enabled` across all visualizations).
+- **`view-ref` picker no longer mislabels resolvable values.** A stored `sourceView` like the bare `default` was tagged "(not in object)" even though the runtime resolves it. The widget now mirrors `InterfaceListPage.resolveSourceView` (exact name / `<object>.<name>` suffix / `default`-`list` special-case) via an extracted, unit-tested `resolveStoredViewRef`, showing the matched view's label (e.g. "All Tasks → showcase_task.default") instead of a false warning.

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -268,6 +268,10 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
       appearance,
       showViewSwitcher: allowed.length > 1,
       showRecordCount: cfg.showRecordCount,
+      // Add-record entry point (ListView gates the button on addRecord.enabled,
+      // independent of the active visualization). Without forwarding this, the
+      // panel's "Add Record" config silently did nothing at runtime.
+      addRecord: cfg.addRecord,
 
       // userActions toggles → toolbar flags. Interface mode is closed by
       // default: the advanced filter builder and view-management tools are

--- a/packages/app-shell/src/views/metadata-admin/ViewRefWidget.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ViewRefWidget.test.tsx
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
-import { WIDGETS } from './widgets';
+import { WIDGETS, resolveStoredViewRef } from './widgets';
 
 afterEach(cleanup);
 
@@ -57,5 +57,50 @@ describe('view-ref widget', () => {
       />,
     );
     expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+});
+
+
+/**
+ * resolveStoredViewRef mirrors the runtime InterfaceListPage.resolveSourceView so
+ * the editor doesn't mislabel a working stored value (e.g. bare `default`) as
+ * "(not in object)". View metadata names are object-prefixed FQNs.
+ */
+describe('resolveStoredViewRef', () => {
+  const views = [
+    { name: 'showcase_task.default', label: 'All Tasks' },
+    { name: 'showcase_task.board', label: 'Board (Kanban)' },
+  ];
+
+  it('resolves a bare name via the `<object>.<name>` suffix and exposes the matched view', () => {
+    const r = resolveStoredViewRef(views, 'board');
+    expect(r.resolves).toBe(true);
+    expect(r.suffixMatch?.name).toBe('showcase_task.board');
+    expect(r.showStored).toBe(true); // not an exact catalog entry → synthesize an item
+  });
+
+  it('resolves an exact FQN without needing a synthesized item', () => {
+    const r = resolveStoredViewRef(views, 'showcase_task.default');
+    expect(r.exact?.name).toBe('showcase_task.default');
+    expect(r.resolves).toBe(true);
+    expect(r.showStored).toBe(false);
+  });
+
+  it('treats `default`/`list` as special-case resolvable even without a suffix match', () => {
+    expect(resolveStoredViewRef([], 'default').resolves).toBe(true);
+    expect(resolveStoredViewRef([], 'list').resolves).toBe(true);
+  });
+
+  it('flags a truly unknown value as unresolved (gets the not-in-object tag)', () => {
+    const r = resolveStoredViewRef(views, 'typo_view');
+    expect(r.resolves).toBe(false);
+    expect(r.suffixMatch).toBeUndefined();
+    expect(r.showStored).toBe(true);
+  });
+
+  it('an empty value resolves to nothing and needs no synthesized item', () => {
+    const r = resolveStoredViewRef(views, '');
+    expect(r.resolves).toBe(false);
+    expect(r.showStored).toBe(false);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -812,6 +812,24 @@ function FieldRefWidget({ id, value, onChange, readOnly, context }: WidgetProps)
 }
 
 /**
+ * Resolve a stored `sourceView` value against a source object's view catalog,
+ * mirroring the runtime resolver (InterfaceListPage.resolveSourceView): a value
+ * resolves if it's an exact view name, a bare name matching a view's
+ * `<object>.<name>` suffix, or the special `default`/`list` (→ object default
+ * view). `showStored` is true when the stored value needs a synthesized option
+ * (i.e. it isn't already an exact catalog entry). Exported for unit tests.
+ */
+export function resolveStoredViewRef(
+  views: Array<{ name: string; label?: string }>,
+  current: string,
+): { exact?: { name: string; label?: string }; suffixMatch?: { name: string; label?: string }; isSpecial: boolean; resolves: boolean; showStored: boolean } {
+  const exact = current ? views.find((v) => v.name === current) : undefined;
+  const suffixMatch = current && !exact ? views.find((v) => v.name.endsWith(`.${current}`)) : undefined;
+  const isSpecial = current === 'default' || current === 'list';
+  return { exact, suffixMatch, isSpecial, resolves: !!exact || !!suffixMatch || isSpecial, showStored: !!current && !exact };
+}
+
+/**
  * Single view picker for `interfaceConfig.sourceView`. Views come from
  * `context.objectViews` (the source object's views, loaded from the object
  * named by the sibling `source` field). A value not present in the catalog is
@@ -823,7 +841,12 @@ function ViewRefWidget({ id, value, onChange, readOnly, context }: WidgetProps) 
   const locale = detectLocale();
   const views = context?.objectViews ?? [];
   const current = value == null ? '' : String(value);
-  const inCatalog = !current || views.some((v) => v.name === current);
+  // Mirror the runtime resolver (InterfaceListPage.resolveSourceView): a stored
+  // value resolves if it's an exact view name, OR a bare name matching a view's
+  // `<object>.<name>` suffix, OR the special `default`/`list` (→ object default
+  // view). Only a value that resolves to NOTHING gets the "(not in object)" tag —
+  // so a working bare value like `default` is no longer mislabelled.
+  const { suffixMatch, resolves, showStored } = resolveStoredViewRef(views, current);
   return (
     <Select
       value={current || NO_FIELD}
@@ -837,10 +860,15 @@ function ViewRefWidget({ id, value, onChange, readOnly, context }: WidgetProps) 
         <SelectItem value={NO_FIELD}>
           <span className="text-muted-foreground">{t('engine.form.none', locale)}</span>
         </SelectItem>
-        {!inCatalog && current && (
+        {showStored && (
           <SelectItem value={current}>
-            <span className="font-mono">{current}</span>
-            <span className="ml-2 text-xs text-muted-foreground">{t('engine.form.notInObject', locale)}</span>
+            <span className="flex items-center gap-2">
+              <span>{suffixMatch?.label || current}</span>
+              <code className="text-xs text-muted-foreground">{suffixMatch ? `\u2192 ${suffixMatch.name}` : current}</code>
+              {!resolves && (
+                <span className="ml-1 text-xs text-muted-foreground">{t('engine.form.notInObject', locale)}</span>
+              )}
+            </span>
           </SelectItem>
         )}
         {views.map((v) => (


### PR DESCRIPTION
Round-2 polish of the ADR-0047 interface-page config panel, found while browser-verifying the previous round.

## 1. Fix: the Add-Record config did nothing (functional bug)
`InterfaceListPage` built the schema it hands to `ListView` but **never forwarded `interfaceConfig.addRecord`**. `ListView` gates the Add button on `schema.addRecord?.enabled` (ListView.tsx:380, tested), so on an interface page the button **could never appear** regardless of the panel's Add-Record toggle/position/mode — exactly the "配置点了没反应" (configs that do nothing) complaint.

Fix: one-line passthrough `addRecord: cfg.addRecord`. The consumer side is already covered by ListView tests (enabled true/false, `userActions.addRecordForm` gate, position top/bottom).

## 2. View picker no longer mislabels resolvable values
The new `view-ref` picker tagged a stored `sourceView` like the bare `default` as **"(not in object)"** even though the runtime resolves it. The widget now mirrors `InterfaceListPage.resolveSourceView` — exact name, `<object>.<name>` suffix match, or the `default`/`list` special-case — via an extracted, unit-tested `resolveStoredViewRef`. A bare `default` now shows the matched view's label (e.g. **"All Tasks → showcase_task.default"**) instead of a false warning.

## Verification
- **Browser (live, showcase backend on :3000, worktree console):** the picker now renders "All Tasks → showcase_task.default" for the stored bare `default` (screenshot-confirmed) — item 2.
- **Unit:** `resolveStoredViewRef` 5 cases (suffix match, exact FQN, default/list special-case, unknown→unresolved, empty); existing ViewRef/MultiSelect/InterfaceListPage suites green (21 tests).
- `tsc --noEmit` on `@object-ui/app-shell` → 0 errors.
- Item 1 is a passthrough into a gate the ListView test-suite already locks; the previously-missing key meant the button never rendered on interface pages.

## Follow-ups (spun off, not in this PR)
- Icon field has no picker (plain text input) — a lucide icon-picker widget.
- Metadata-editor load failures can surface as "required" validation errors instead of a clear "failed to load" state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)