### PR TITLE
fix(app-shell): metadata editor — distinguish LOAD failure from field validation

### DIFF
--- a/.changeset/editor-load-vs-validation.md
+++ b/.changeset/editor-load-vs-validation.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Metadata editor: a failed LOAD no longer masquerades as field validation errors.
+
+When the layered/draft fetch fails (network/500/timeout), `ResourceEditPage` previously still rendered the form on empty defaults, so the client Zod validator fired spurious "name/label/regions required" diagnostics — making a transport failure look like a structurally broken item.
+
+- New `loadFailed` state, set in the load catch block and reset at the start of each load.
+- The validation-diagnostics banner is now gated by `shouldRenderDiagnostics()`, which suppresses the diagnostics block entirely on load failure, so the empty-default form's required-field issues never surface.
+- The top error banner is now explicit: "Failed to load &lt;type&gt;/&lt;name&gt;: &lt;message&gt;" (new `engine.edit.loadFailed` i18n key, en + zh-CN).
+
+The happy path is unaffected: a genuinely-invalid item that loaded successfully still shows its validation diagnostics.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -156,6 +156,29 @@ function extractDraftBody(
     : null;
 }
 
+/**
+ * Decide whether the validation-diagnostics banner should render at all.
+ *
+ * The gate has two reasons to stay hidden:
+ *   - `loadFailed` — the layered/draft fetch itself failed, so the form is
+ *     sitting on empty defaults. Any required-field issues the client
+ *     validator produces are an artefact of the empty form, not a verdict on
+ *     the item; the explicit "failed to load" banner already tells the real
+ *     story. Suppress so a transport failure never masquerades as a broken
+ *     item.
+ *   - no diagnostics source — there is neither a server `_diagnostics`
+ *     payload nor a client-side validator for this type, so there is nothing
+ *     to show.
+ */
+export function shouldRenderDiagnostics(opts: {
+  loadFailed: boolean;
+  hasDiag: boolean;
+  hasClientValidator: boolean;
+}): boolean {
+  if (opts.loadFailed) return false;
+  return opts.hasDiag || opts.hasClientValidator;
+}
+
 export interface MetadataResourceEditPageProps {
   type?: string;
   name?: string;
@@ -253,6 +276,13 @@ function MetadataResourceEditPageImpl({
   const [loading, setLoading] = React.useState(!createMode);
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  // Distinguishes "the layered/draft fetch itself failed" (network/500/
+  // timeout) from "we loaded an item that fails validation". Without it a
+  // failed load renders the form with empty defaults and the client
+  // validator fires spurious "name/label/regions required" diagnostics,
+  // making a transport failure look like a structurally broken item. Set
+  // in the load catch block, reset at the start of each load.
+  const [loadFailed, setLoadFailed] = React.useState(false);
   const [issues, setIssues] = React.useState<SchemaFormIssue[]>([]);
 
   // Wrap setDraft so that editing a field clears any *server-side*
@@ -548,6 +578,7 @@ function MetadataResourceEditPageImpl({
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setLoadFailed(false);
     (async () => {
       try {
         const scope = ownerPackageId ? { packageId: ownerPackageId } : {};
@@ -602,7 +633,18 @@ function MetadataResourceEditPageImpl({
         setLoading(false);
       } catch (err: any) {
         if (!cancelled) {
-          setError(err?.message ?? String(err));
+          // A failed fetch is a LOAD error, not a validation error: flag it
+          // so the diagnostics banner suppresses the spurious required-field
+          // issues the empty-default form would otherwise produce, and make
+          // the top error banner explicit about what actually went wrong.
+          setLoadFailed(true);
+          setError(
+            tFormat('engine.edit.loadFailed', locale, {
+              type,
+              name: name ?? '',
+              message: err?.message ?? String(err),
+            }),
+          );
           setLoading(false);
         }
       }
@@ -610,7 +652,7 @@ function MetadataResourceEditPageImpl({
     return () => {
       cancelled = true;
     };
-  }, [client, type, name, ownerPackageId, createMode, reloadKey]);
+  }, [client, type, name, ownerPackageId, createMode, reloadKey, locale]);
 
   // Lazy-load references the first time the References sheet opens.
   const [refsLoading, setRefsLoading] = React.useState(false);
@@ -1799,7 +1841,20 @@ function MetadataResourceEditPageImpl({
               const liveValid = hasClientValidator(type)
                 ? liveErrors.length === 0
                 : diag?.valid !== false;
-              if (!diag && !hasClientValidator(type)) return null;
+              // Gate the whole diagnostics block on a successful load with
+              // a diagnostics source. A failed load shows the explicit
+              // "failed to load" banner above instead; the empty-default
+              // form's required-field issues here would be noise, not a
+              // verdict on the item (see shouldRenderDiagnostics).
+              if (
+                !shouldRenderDiagnostics({
+                  loadFailed,
+                  hasDiag: !!diag,
+                  hasClientValidator: hasClientValidator(type),
+                })
+              ) {
+                return null;
+              }
               const errs = liveErrors;
               const warns = diag?.warnings ?? [];
               const hasErrs = !liveValid && errs.length > 0;

--- a/packages/app-shell/src/views/metadata-admin/diagnostics-gate.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/diagnostics-gate.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Load-failure vs validation-error gate.
+ *
+ * Regression: when the layered/draft fetch fails (network/500/timeout) the
+ * editor renders the form on empty defaults and the client Zod validator
+ * fires "name/label/regions required" — making a transport failure look like
+ * a structurally broken item. `shouldRenderDiagnostics` suppresses the
+ * validation-diagnostics banner whenever the load failed, so only the
+ * explicit "failed to load" error banner shows.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldRenderDiagnostics } from './ResourceEditPage';
+
+describe('shouldRenderDiagnostics — load-failure suppression', () => {
+  it('suppresses the diagnostics banner when the load failed, even with a client validator', () => {
+    // The bug: a failed load + a type that has a client validator would
+    // otherwise surface spurious required-field issues.
+    expect(
+      shouldRenderDiagnostics({
+        loadFailed: true,
+        hasDiag: false,
+        hasClientValidator: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('suppresses the diagnostics banner on load failure even when server diagnostics are present', () => {
+    expect(
+      shouldRenderDiagnostics({
+        loadFailed: true,
+        hasDiag: true,
+        hasClientValidator: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('renders diagnostics for a genuinely-invalid item that DID load (client validator)', () => {
+    // Happy path unaffected: a real validation problem on a loaded item
+    // still shows.
+    expect(
+      shouldRenderDiagnostics({
+        loadFailed: false,
+        hasDiag: false,
+        hasClientValidator: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('renders diagnostics for a loaded item with server-computed diagnostics', () => {
+    expect(
+      shouldRenderDiagnostics({
+        loadFailed: false,
+        hasDiag: true,
+        hasClientValidator: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('renders nothing when there is no diagnostics source at all', () => {
+    expect(
+      shouldRenderDiagnostics({
+        loadFailed: false,
+        hasDiag: false,
+        hasClientValidator: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -469,6 +469,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
     'This metadata does not match the spec — {count} validation error(s).',
   'engine.edit.diagnostics.warnTitle': '{count} warning(s) — review recommended.',
   'engine.edit.diagnostics.more': '+{count} more…',
+  'engine.edit.loadFailed': 'Failed to load {type}/{name}: {message}',
   'engine.edit.unsavedLeaveConfirm':
     'You have unsaved changes. Leave this page anyway?',
   'engine.edit.saving': 'Saving…',
@@ -1110,6 +1111,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.edit.diagnostics.title': '元数据不符合规范 — 共 {count} 个校验错误。',
   'engine.edit.diagnostics.warnTitle': '{count} 个警告 — 建议复查。',
   'engine.edit.diagnostics.more': '还有 {count} 个…',
+  'engine.edit.loadFailed': '加载 {type}/{name} 失败：{message}',
   'engine.edit.unsavedHint': '当前存在未保存的修改。',
   'engine.edit.unsavedLeaveConfirm': '当前存在未保存的修改，确定离开此页面吗？',
   'engine.edit.saving': '保存中…',


### PR DESCRIPTION
## Problem

The metadata editor (`ResourceEditPage`) mis-reported a **load** failure as **field validation** errors. When the draft/record fetch failed (network / 500 / timeout), the form still rendered on empty defaults, so the client Zod validator fired *"name/label/regions required"* — making it look like the item was structurally broken rather than that loading failed.

## Fix

- **`loadFailed` state** — set in the load `catch` block, reset at the start of each load. Distinguishes "the fetch itself failed" from "we loaded an item that fails validation".
- **Suppress validation diagnostics on load failure** — the diagnostics banner is now gated by a new pure helper `shouldRenderDiagnostics({ loadFailed, hasDiag, hasClientValidator })`, which returns `false` whenever the load failed, so the empty-default form's spurious required-field issues never surface.
- **Explicit top error banner** — `"Failed to load <type>/<name>: <message>"` via a new `engine.edit.loadFailed` i18n key (en + zh-CN), rendered in the existing destructive-styled banner (distinct from the validation diagnostics block).

The happy path is unaffected: a genuinely-invalid item that **loaded successfully** still shows its validation diagnostics.

## Tests

- New `diagnostics-gate.test.ts` (5 cases) covering the gate: suppressed on load failure (with/without a client validator and server diagnostics), preserved for a loaded-but-invalid item, and no-op when there's no diagnostics source.
- `pnpm turbo run type-check --filter=@object-ui/app-shell` — clean.
- `vitest run src/views/metadata-admin` — 253 passed (35 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)