### PR TITLE
feat(ai-chat): absolute-date tooltip on conversation-list timestamps

### DIFF
--- a/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
+++ b/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
@@ -49,6 +49,18 @@ function formatTimestamp(
   return d.toLocaleDateString();
 }
 
+/**
+ * Full, locale-aware date+time for the row's `title` tooltip. The visible
+ * label is relative ("2 minutes ago") which is scannable but vague — hovering
+ * reveals the exact moment, matching ChatGPT/Claude. Returns '' for a missing
+ * or invalid timestamp so no empty tooltip appears.
+ */
+function absoluteTimestamp(iso: string | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString();
+}
+
 export type ConversationGroupKey = 'today' | 'yesterday' | 'previous7Days' | 'previous30Days' | 'older';
 
 export interface ConversationGroup {
@@ -394,7 +406,10 @@ function ConversationRow({
               {highlightQuery(conversation.preview, query)}
             </span>
           ) : null}
-          <span className="mt-0.5 block text-[10px] text-muted-foreground">
+          <span
+            className="mt-0.5 block text-[10px] text-muted-foreground"
+            title={absoluteTimestamp(conversation.updatedAt ?? conversation.createdAt)}
+          >
             {formatTimestamp(conversation.updatedAt ?? conversation.createdAt, t)}
           </span>
         </button>

--- a/packages/app-shell/src/console/ai/__tests__/ConversationsSidebar.test.tsx
+++ b/packages/app-shell/src/console/ai/__tests__/ConversationsSidebar.test.tsx
@@ -83,6 +83,14 @@ describe('ConversationsSidebar', () => {
     expect(screen.getByText('How many users are in the system?')).toBeInTheDocument();
   });
 
+  it('exposes the absolute date as a title tooltip on the relative timestamp', () => {
+    renderSidebar();
+    const stamp = screen.getAllByText('console.ai.justNow')[0];
+    const title = stamp.getAttribute('title') ?? '';
+    expect(title.length).toBeGreaterThan(0);
+    expect(/\d/.test(title)).toBe(true);
+  });
+
   it('filters by query and highlights the matched substring', () => {
     renderSidebar();
     fireEvent.change(screen.getByPlaceholderText('Search chats...'), {


### PR DESCRIPTION
## What

The conversation list shows a **relative** timestamp ("2 minutes ago") — scannable but vague (2pm vs 2am? which day last week?). This adds a native `title` tooltip carrying the full locale **date + time**, revealed on hover, matching ChatGPT/Claude. Empty/invalid timestamps produce no tooltip.

Native `title` (not a Radix Tooltip) keeps it zero-dependency and layout-safe inside the scroll-area + row button.

## Test

`ConversationsSidebar.test.tsx`: the relative-timestamp span exposes a non-empty, date-bearing `title`. Suite green (3).

Small readability win in the AI chat conversation-list (③) polish track, on top of date-groups + search highlighting (#1726).

🤖 Generated with [Claude Code](https://claude.com/claude-code)