### PR TITLE
fix(console): syntax-color chat code blocks (Streamdown Tailwind classes were purged)

### DIFF
--- a/apps/console/src/index.css
+++ b/apps/console/src/index.css
@@ -36,6 +36,16 @@
 @source inline("{,group-hover:}list-{inside,outside,decimal,disc,none}");
 @source inline("whitespace-{normal,nowrap,pre,pre-wrap,pre-line}");
 @source inline("[li_&]:pl-{2,3,4,5,6,8}");
+/* Streamdown ALSO emits syntax-highlight color + background utilities as runtime
+   arbitrary-value classes. Without these the per-token color (carried in an
+   inline `--sdm-c` var) has no `color: var(--sdm-c)` rule to apply it, so chat
+   code blocks render MONOCHROME. The previous safelist (above) missed these. */
+@source inline("text-[var(--sdm-c,inherit)]");
+@source inline("dark:text-[var(--shiki-dark,var(--sdm-c,inherit))]");
+@source inline("bg-[var(--sdm-tbg)]");
+@source inline("dark:bg-[var(--shiki-dark-bg,var(--sdm-tbg))]");
+@source inline("bg-[var(--sdm-bg,inherit)]");
+@source inline("dark:bg-[var(--shiki-dark-bg,var(--sdm-bg,inherit))]");
 @source '../../../packages/plugin-editor/src/**/*.{ts,tsx}';
 @source '../../../packages/plugin-view/src/**/*.{ts,tsx}';
 @source '../../../packages/plugin-detail/src/**/*.{ts,tsx}';


### PR DESCRIPTION
## Symptom

Code blocks in the AI chat render **monochrome** — no syntax highlighting (every token near-black), unlike ChatGPT/Claude.

## Root cause

Streamdown colors each token via an inline `--sdm-c` CSS variable **plus** a Tailwind arbitrary-value utility it emits at runtime: `text-[var(--sdm-c,inherit)]` (+ a `dark:` variant reading `--shiki-dark`, and matching `bg-[var(--sdm-tbg)]` / `bg-[var(--shiki-*-bg,...)]`). Those class strings live in `node_modules/streamdown/dist`, and **Tailwind v4 doesn't scan node_modules**, so the utilities are purged. Result: the inline `--sdm-c` colors are present but there's no `color: var(--sdm-c)` rule to apply them → inherited near-black.

The console already safelists *some* Streamdown classes via `@source inline(...)` (list markers, whitespace) — but it **missed the color/background ones**.

## Fix

Add the missing color + background utilities to the existing safelist (same `@source inline(...)` pattern):

```
text-[var(--sdm-c,inherit)]
dark:text-[var(--shiki-dark,var(--sdm-c,inherit))]
bg-[var(--sdm-tbg)]   dark:bg-[var(--shiki-dark-bg,var(--sdm-tbg))]
bg-[var(--sdm-bg,inherit)]   dark:bg-[var(--shiki-dark-bg,var(--sdm-bg,inherit))]
```

## Verification

Inspected the compiled stylesheet in the running console:
- **Before:** 0 generated rules reference `--sdm-c` (purged).
- **After:** Tailwind emits `.text-[var(--sdm-c,inherit)] { color: var(--sdm-c,inherit) }` + the bg/dark variants, and Streamdown's exact token markup renders in 5 distinct colors (keyword/string/function/param), confirming the inline per-token `--sdm-c` colors now apply.

CSS-only safelist change; no behavior/runtime risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)