### PR TITLE
feat(docs): mermaid diagrams + long-doc table of contents (ADR-0046)

### DIFF
--- a/.changeset/docs-mermaid-toc.md
+++ b/.changeset/docs-mermaid-toc.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/plugin-markdown": minor
+"@object-ui/console": minor
+"@object-ui/i18n": patch
+---
+
+Docs: mermaid diagrams + long-doc table of contents (ADR-0046).
+
+- **plugin-markdown** renders ```mermaid fenced blocks as diagrams (`<Mermaid>`: lazy-loaded mermaid, `securityLevel: 'strict'`, rendered post-`rehype-sanitize` by a trusted component, degrades to the raw source on error). Mermaid is text → SVG, so it stays within the v1 image/binary ban. Adds `extractToc(markdown)` — a TOC builder whose slugs are generated with the same `github-slugger` `rehype-slug` uses, so `#id` links resolve to the rendered heading anchors.
+- **console** `DocPage` shows a sticky right-rail table of contents (h2–h3) for docs with ≥3 headings, plus an app-independent `/apps/:packageId/docs` index already added earlier.
+- **i18n** adds `help.onThisPage` (en/zh; other locales fall back).

--- a/apps/console/src/pages/DocPage.tsx
+++ b/apps/console/src/pages/DocPage.tsx
@@ -6,11 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AlertCircle, FileQuestion, Loader2 } from 'lucide-react';
 import { useAdapter } from '@object-ui/app-shell';
-import { MarkdownRenderer } from '@object-ui/plugin-markdown';
+import { MarkdownRenderer, extractToc } from '@object-ui/plugin-markdown';
+import { useObjectTranslation } from '@object-ui/i18n';
 import { rewriteDocLinks } from './doc-links';
 import { DocShell } from './DocShell';
 
@@ -39,6 +40,7 @@ export default function DocPage() {
   const { name, appName } = useParams<{ name: string; appName?: string }>();
   const navigate = useNavigate();
   const adapter = useAdapter();
+  const { t } = useObjectTranslation();
   const [doc, setDoc] = useState<DocItem | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'missing' | 'error'>('loading');
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -96,6 +98,12 @@ export default function DocPage() {
     [navigate],
   );
 
+  // Long-doc table of contents (h2–h3). Slugs match rehype-slug so a #id
+  // link resolves to the rendered heading's anchor. Shown only past a few
+  // headings so short docs stay clean.
+  const toc = useMemo(() => extractToc(doc?.content ?? ''), [doc?.content]);
+  const tocLabel = t('help.onThisPage', { defaultValue: 'On this page' });
+
   if (state === 'loading') {
     return (
       <div className="flex h-full items-center justify-center p-10 text-muted-foreground">
@@ -133,10 +141,36 @@ export default function DocPage() {
 
   return (
     <DocShell breadcrumb={doc?.label ?? name}>
-      <div className="mx-auto max-w-3xl p-4 sm:p-6" onClick={onContentClick}>
-        <MarkdownRenderer
-          schema={{ type: 'markdown', content: rewriteDocLinks(doc?.content ?? '') }}
-        />
+      <div className="mx-auto flex max-w-5xl gap-8 p-4 sm:p-6">
+        <article
+          className="min-w-0 max-w-3xl flex-1 [&_h1]:scroll-mt-24 [&_h2]:scroll-mt-24 [&_h3]:scroll-mt-24"
+          onClick={onContentClick}
+        >
+          <MarkdownRenderer
+            schema={{ type: 'markdown', content: rewriteDocLinks(doc?.content ?? '') }}
+          />
+        </article>
+        {toc.length >= 3 ? (
+          <aside className="hidden xl:block w-56 shrink-0">
+            <nav aria-label={tocLabel} className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-auto">
+              <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {tocLabel}
+              </div>
+              <ul className="border-l border-border text-sm">
+                {toc.map((item) => (
+                  <li key={item.id} style={{ paddingLeft: (item.depth - 2) * 12 }}>
+                    <a
+                      href={`#${item.id}`}
+                      className="-ml-px block border-l border-transparent py-0.5 pl-3 text-muted-foreground hover:border-primary hover:text-foreground"
+                    >
+                      {item.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </aside>
+        ) : null}
       </div>
     </DocShell>
   );

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1471,6 +1471,7 @@ const en = {
     settings: 'Workspace settings',
   },
   help: {
+    onThisPage: 'On this page',
     appDocs: "This app's docs",
     allDocs: 'All documentation',
     onlineDocs: 'Online documentation',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1484,6 +1484,7 @@ const zh = {
     settings: '工作区设置',
   },
   help: {
+    onThisPage: '本页目录',
     appDocs: '本应用文档',
     allDocs: '全部文档',
     onlineDocs: '在线文档',

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -35,6 +35,8 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
+    "github-slugger": "^2.0.0",
+    "mermaid": "^11.4.0",
     "react-markdown": "^10.1.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-highlight": "^7.0.0",

--- a/packages/plugin-markdown/src/MarkdownImpl.tsx
+++ b/packages/plugin-markdown/src/MarkdownImpl.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from "react"
-import ReactMarkdown from "react-markdown"
+import ReactMarkdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { remarkAlert } from "remark-github-blockquote-alert"
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize"
@@ -15,6 +15,7 @@ import rehypeSlug from "rehype-slug"
 import rehypeHighlight from "rehype-highlight"
 import rehypeAutolinkHeadings from "rehype-autolink-headings"
 import { ensureMarkdownStyles } from "./markdown-theme"
+import { Mermaid } from "./Mermaid"
 
 /**
  * Props for the Markdown component implementation.
@@ -99,10 +100,38 @@ const rehypePlugins = [
   rehypeNormalizeClassName,
   // Skip code blocks tagged with an unknown language instead of throwing;
   // highlight only what it recognises.
-  [rehypeHighlight, { detect: true, ignoreMissing: true }],
+  [rehypeHighlight, { detect: true, ignoreMissing: true, plainText: ["mermaid"] }],
   [rehypeAutolinkHeadings, { behavior: "append", properties: { className: ["md-anchor"], ariaHidden: true, tabIndex: -1 }, content: { type: "text", value: "#" } }],
   [rehypeSanitize, sanitizeSchema],
 ] as React.ComponentProps<typeof ReactMarkdown>["rehypePlugins"]
+
+// Flatten a react-markdown code child down to its raw text. mermaid blocks are
+// emitted as a plain text node (rehype-highlight is told to skip "mermaid"), so
+// this yields the diagram source verbatim.
+function nodeText(node: React.ReactNode): string {
+  if (typeof node === "string") return node
+  if (typeof node === "number") return String(node)
+  if (Array.isArray(node)) return node.map(nodeText).join("")
+  if (React.isValidElement(node)) return nodeText((node.props as { children?: React.ReactNode }).children)
+  return ""
+}
+
+// Intercept fenced ```mermaid blocks at the <pre> level (so no <pre> wrapper is
+// emitted) and render them as diagrams; every other block renders normally.
+const mdComponents: Components = {
+  pre({ node: _node, children, ...rest }) {
+    const child = React.Children.toArray(children)[0]
+    const className =
+      React.isValidElement(child) && typeof (child.props as { className?: unknown }).className === "string"
+        ? ((child.props as { className?: string }).className as string)
+        : ""
+    if (/\blanguage-mermaid\b/.test(className)) {
+      const source = nodeText((child as React.ReactElement<{ children?: React.ReactNode }>).props.children)
+      return <Mermaid chart={source} />
+    }
+    return <pre {...rest}>{children}</pre>
+  },
+}
 
 /**
  * Internal Markdown implementation component.
@@ -139,6 +168,7 @@ export default function MarkdownImpl({ content, className }: MarkdownImplProps) 
       <ReactMarkdown
         remarkPlugins={remarkPlugins}
         rehypePlugins={rehypePlugins}
+        components={mdComponents}
         // Defense-in-depth beyond rehype-sanitize: these never reach the DOM.
         disallowedElements={['script', 'style', 'iframe', 'object', 'embed']}
         unwrapDisallowed={true}

--- a/packages/plugin-markdown/src/Mermaid.tsx
+++ b/packages/plugin-markdown/src/Mermaid.tsx
@@ -1,0 +1,110 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from "react"
+
+/**
+ * Mermaid diagram renderer for ```mermaid fenced code blocks (ADR-0046).
+ *
+ * Mermaid is text → SVG, so it sidesteps the v1 image/binary ban while still
+ * giving docs flow / state-machine / sequence diagrams. The library is heavy,
+ * so it is dynamically imported the first time a diagram actually mounts —
+ * docs with no diagrams pay nothing.
+ *
+ * Security: rendered with `securityLevel: 'strict'` (labels sanitized, no raw
+ * HTML, no click handlers). The SVG is injected by this trusted component
+ * AFTER react-markdown's `rehype-sanitize` gate (which only sees the source
+ * text, never this output), so the two sanitizers do not fight. A render
+ * failure degrades to the raw source in a <pre>, never a thrown error.
+ */
+
+let mermaidPromise: Promise<typeof import("mermaid").default> | null = null
+function loadMermaid() {
+  if (!mermaidPromise) mermaidPromise = import("mermaid").then((m) => m.default)
+  return mermaidPromise
+}
+
+// Module-scoped monotonic id — mermaid.render needs a unique DOM id per call.
+let renderSeq = 0
+
+function isDark(): boolean {
+  return typeof document !== "undefined" && document.documentElement.classList.contains("dark")
+}
+
+export function Mermaid({ chart }: { chart: string }) {
+  const [svg, setSvg] = React.useState<string>("")
+  const [error, setError] = React.useState<string | null>(null)
+  // Re-render when the app theme toggles so the diagram matches light/dark.
+  const [dark, setDark] = React.useState<boolean>(isDark)
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") return
+    const target = document.documentElement
+    const obs = new MutationObserver(() => setDark(isDark()))
+    obs.observe(target, { attributes: true, attributeFilter: ["class"] })
+    return () => obs.disconnect()
+  }, [])
+
+  React.useEffect(() => {
+    let cancelled = false
+    const source = chart.trim()
+    if (!source) {
+      setSvg("")
+      setError(null)
+      return
+    }
+    loadMermaid()
+      .then(async (mermaid) => {
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: "strict",
+          theme: dark ? "dark" : "default",
+        })
+        const id = `os-mermaid-${(renderSeq += 1)}`
+        const { svg } = await mermaid.render(id, source)
+        if (!cancelled) {
+          setSvg(svg)
+          setError(null)
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [chart, dark])
+
+  if (error) {
+    return (
+      <pre data-mermaid data-mermaid-error className="my-4 overflow-auto rounded border border-destructive/40 bg-muted p-3 text-xs">
+        <code>{chart}</code>
+      </pre>
+    )
+  }
+
+  if (!svg) {
+    // Pre-render placeholder: keep the source reachable to assistive tech
+    // and to tests while the (async) diagram is still being drawn.
+    return (
+      <div data-mermaid data-mermaid-pending className="my-4 text-sm text-muted-foreground">
+        <pre className="sr-only">{chart}</pre>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-mermaid
+      role="img"
+      className="my-4 flex justify-center overflow-auto [&_svg]:h-auto [&_svg]:max-w-full"
+      // eslint-disable-next-line react/no-danger -- mermaid strict-mode SVG, rendered post-sanitize by our own trusted component
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  )
+}

--- a/packages/plugin-markdown/src/index.tsx
+++ b/packages/plugin-markdown/src/index.tsx
@@ -12,6 +12,8 @@ import { Skeleton } from '@object-ui/components';
 
 // Export types for external use
 export type { MarkdownSchema } from './types';
+export { extractToc, type TocItem } from './toc';
+export { Mermaid } from './Mermaid';
 
 // 🚀 Lazy load the implementation file
 // This ensures react-markdown is only loaded when the component is actually rendered

--- a/packages/plugin-markdown/src/markdown-render.test.tsx
+++ b/packages/plugin-markdown/src/markdown-render.test.tsx
@@ -79,3 +79,20 @@ describe('markdown enrichments (ADR-0046)', () => {
     expect(html).not.toContain('<svg');
   });
 });
+
+describe('mermaid diagrams (ADR-0046)', () => {
+  it('routes ```mermaid blocks to a diagram container, not a code block', () => {
+    const html = render('```mermaid\ngraph TD; A-->B;\n```\n');
+    // rendered by the trusted <Mermaid> component, not the highlight pipeline
+    expect(html).toContain('data-mermaid');
+    expect(html).not.toMatch(/hljs[^"]*language-mermaid|language-mermaid[^"]*hljs/);
+    // source preserved (a11y / fallback) while the async render runs
+    expect(html).toContain('graph TD');
+  });
+
+  it('still renders ordinary fenced code as a highlighted block', () => {
+    const html = render('```js\nconst x = 1;\n```\n');
+    expect(html).not.toContain('data-mermaid');
+    expect(html).toContain('hljs');
+  });
+});

--- a/packages/plugin-markdown/src/toc.test.ts
+++ b/packages/plugin-markdown/src/toc.test.ts
@@ -1,0 +1,47 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractToc } from './toc';
+
+describe('extractToc (ADR-0046 long-doc TOC)', () => {
+  it('extracts h2/h3 with rehype-slug-compatible ids', () => {
+    const toc = extractToc('# Title\n\n## First Section\n\n### Sub A\n\n## Second\n');
+    expect(toc).toEqual([
+      { depth: 2, text: 'First Section', id: 'first-section' },
+      { depth: 3, text: 'Sub A', id: 'sub-a' },
+      { depth: 2, text: 'Second', id: 'second' },
+    ]);
+  });
+
+  it('excludes h1 and h4+ by default', () => {
+    const toc = extractToc('# H1\n\n## H2\n\n#### H4\n');
+    expect(toc.map((t) => t.depth)).toEqual([2]);
+  });
+
+  it('skips headings inside fenced code blocks', () => {
+    const toc = extractToc('## Real\n\n```\n## Not A Heading\n```\n\n~~~\n### Also Not\n~~~\n');
+    expect(toc.map((t) => t.text)).toEqual(['Real']);
+  });
+
+  it('strips inline markdown from heading text', () => {
+    const toc = extractToc('## The **overlay** `rule` and a [link](/x)\n');
+    expect(toc[0]).toEqual({ depth: 2, text: 'The overlay rule and a link', id: 'the-overlay-rule-and-a-link' });
+  });
+
+  it('matches duplicate-heading suffixes like rehype-slug (shared slugger over all headings)', () => {
+    // the h1 also advances the slugger, exactly as rehype-slug does
+    const toc = extractToc('# Setup\n\n## Setup\n\n## Setup\n');
+    expect(toc.map((t) => t.id)).toEqual(['setup-1', 'setup-2']);
+  });
+
+  it('returns [] for empty / heading-free content', () => {
+    expect(extractToc('')).toEqual([]);
+    expect(extractToc('just a paragraph\n')).toEqual([]);
+  });
+});

--- a/packages/plugin-markdown/src/toc.ts
+++ b/packages/plugin-markdown/src/toc.ts
@@ -1,0 +1,71 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import GithubSlugger from "github-slugger"
+
+export interface TocItem {
+  /** Heading level (1–6). */
+  depth: number
+  /** Visible heading text, inline markdown stripped. */
+  text: string
+  /** Slug id, identical to what `rehype-slug` puts on the rendered heading. */
+  id: string
+}
+
+/** Strip the inline-markdown wrappers so the text matches `rehype-slug`'s. */
+function stripInline(s: string): string {
+  return s
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "") // images
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links → text
+    .replace(/`([^`]+)`/g, "$1") // inline code
+    .replace(/(\*\*|__)(.*?)\1/g, "$2") // bold
+    .replace(/(\*|_)(.*?)\1/g, "$2") // italic
+    .replace(/<[^>]+>/g, "") // raw html
+    .trim()
+}
+
+/**
+ * Build a table of contents from Markdown source.
+ *
+ * Slugs are generated with the SAME `github-slugger` that `rehype-slug` uses,
+ * walking every heading in document order so duplicate-heading `-1/-2` suffixes
+ * line up — that is what makes a `#id` TOC link resolve to the rendered
+ * heading's anchor. Headings inside fenced code blocks are ignored. Only
+ * `minDepth..maxDepth` (default h2–h3) are returned, but all headings still
+ * advance the slugger so ids stay in sync.
+ */
+export function extractToc(
+  markdown: string,
+  opts?: { minDepth?: number; maxDepth?: number },
+): TocItem[] {
+  const minDepth = opts?.minDepth ?? 2
+  const maxDepth = opts?.maxDepth ?? 3
+  const slugger = new GithubSlugger()
+  const items: TocItem[] = []
+  let fence: string | null = null
+
+  for (const line of (markdown ?? "").split(/\r?\n/)) {
+    const fenceMatch = line.match(/^\s{0,3}(`{3,}|~{3,})/)
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0]
+      if (fence === null) fence = marker
+      else if (marker === fence) fence = null
+      continue
+    }
+    if (fence !== null) continue
+
+    const m = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/)
+    if (!m) continue
+    const depth = m[1].length
+    const text = stripInline(m[2])
+    if (!text) continue
+    const id = slugger.slug(text) // advance the slugger for EVERY heading
+    if (depth >= minDepth && depth <= maxDepth) items.push({ depth, text, id })
+  }
+  return items
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,7 +784,7 @@ importers:
         version: 9.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -805,7 +805,7 @@ importers:
         version: 4.2.0
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.25
@@ -824,7 +824,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/collaboration:
     dependencies:
@@ -1086,7 +1086,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/data-objectstack:
     dependencies:
@@ -2118,6 +2118,12 @@ importers:
       '@object-ui/types':
         specifier: workspace:*
         version: link:../types
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
+      mermaid:
+        specifier: ^11.4.0
+        version: 11.15.0
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -13393,6 +13399,11 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       maplibre-gl: 5.24.0
+
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
## Why

Follow-up to the docs hub work — the two genuinely-needed rendering features for ADR-0046 docs, grounded in the existing renderer (which already does GFM tables, admonitions, code highlighting, heading anchors):

- **Mermaid** — flows / state-machines / sequences are the platform's core domain and are inherently visual; mermaid is **text → SVG**, so it gives diagrams while staying inside the v1 image/binary ban.
- **Long-doc TOC** — `rehype-slug` already emits heading anchors but there was no table of contents; longer docs need one.

## What

**`@object-ui/plugin-markdown`**
- `<Mermaid>` renders ```mermaid fenced blocks: mermaid is **lazy-loaded** (docs with no diagrams pay nothing), `securityLevel: 'strict'`, and the SVG is injected by this trusted component **after** `rehype-sanitize` runs (the two sanitizers never fight). A render error soft-degrades to the raw source in a `<pre>`. `rehype-highlight` is told `plainText: ['mermaid']` and the block is intercepted at the `<pre>` level so no code wrapper is emitted.
- `extractToc(markdown)` builds a TOC whose slugs come from the **same `github-slugger`** `rehype-slug` uses (every heading advances the slugger, so duplicate `-1/-2` suffixes line up) — that's what makes a `#id` link resolve to the rendered anchor. Skips fenced code, strips inline markdown, returns h2–h3 by default.

**`@object-ui/console`** — `DocPage` shows a sticky right-rail TOC (`本页目录` / "On this page") for docs with ≥3 headings, with `scroll-mt` so the sticky header doesn't overlap anchored jumps.

**`@object-ui/i18n`** — `help.onThisPage` (en/zh; other locales fall back to the default).

## Verification

- Unit tests: `toc.test.ts` (6 cases incl. slug parity with rehype-slug & fenced-code skipping) + 2 mermaid routing tests; full file run green (18/18).
- i18n parity test green (40/40); console `tsc --noEmit` clean.
- **Browser** (showcase backend + console): a demo doc with two mermaid blocks + multiple headings — both diagrams render to SVG, ordinary ```ts still highlights, and the TOC rail lists all 5 sections with the h3 nested. Screenshot captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)