### PR TITLE
feat(app-shell): type customDomain/sso runtime features (cloud ADR-0011/0012)

### DIFF
--- a/packages/app-shell/src/runtime-config.test.ts
+++ b/packages/app-shell/src/runtime-config.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * runtime-config commercial-feature parsing (cloud ADR-0011/0012).
+ *
+ * `customDomain` / `sso` are paid flags: they must default OFF and only turn on
+ * when the server explicitly grants them, so an older/vanilla runtime that
+ * omits them never surfaces a paid affordance.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { initRuntimeConfig, getRuntimeConfig, resetRuntimeConfigForTesting } from './runtime-config.js';
+
+function mockConfig(features: Record<string, unknown>) {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ features }),
+    })) as any);
+}
+
+afterEach(() => {
+    resetRuntimeConfigForTesting();
+    vi.unstubAllGlobals();
+});
+
+describe('runtime-config commercial features', () => {
+    it('defaults customDomain/sso OFF before init', () => {
+        resetRuntimeConfigForTesting();
+        expect(getRuntimeConfig().features.customDomain).toBe(false);
+        expect(getRuntimeConfig().features.sso).toBe(false);
+    });
+
+    it('grants customDomain/sso only when the server says true', async () => {
+        mockConfig({ customDomain: true, sso: false });
+        await initRuntimeConfig();
+        expect(getRuntimeConfig().features.customDomain).toBe(true);
+        expect(getRuntimeConfig().features.sso).toBe(false);
+    });
+
+    it('business-tier grants both', async () => {
+        mockConfig({ customDomain: true, sso: true });
+        await initRuntimeConfig();
+        expect(getRuntimeConfig().features.customDomain).toBe(true);
+        expect(getRuntimeConfig().features.sso).toBe(true);
+    });
+
+    it('older runtime omitting the flags keeps them OFF (no paid surface leak)', async () => {
+        mockConfig({ aiStudio: true }); // no customDomain/sso keys at all
+        await initRuntimeConfig();
+        expect(getRuntimeConfig().features.customDomain).toBe(false);
+        expect(getRuntimeConfig().features.sso).toBe(false);
+        // sanity: existing flags still parse
+        expect(getRuntimeConfig().features.aiStudio).toBe(true);
+    });
+});

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -40,6 +40,20 @@ export interface RuntimeFeatures {
    * (env-revertible via `OS_AI_AUTOPUBLISH_DISABLED`). Default true.
    */
   autoPublishAiBuilds: boolean;
+  /**
+   * Branded subdomains + custom (BYO-DNS) domains are available on this
+   * environment's plan. Optional commercial flag — absent on self-hosted /
+   * vanilla runtimes (treated as off). When false the SPA hides custom-domain
+   * settings (or shows them as an upgrade affordance). Server-derived from the
+   * plan entitlements (cloud ADR-0011/0012).
+   */
+  customDomain?: boolean;
+  /**
+   * SSO / SAML enterprise login is available on this environment's plan.
+   * Optional commercial flag — absent on self-hosted / vanilla runtimes
+   * (treated as off). Server-derived from the plan entitlements.
+   */
+  sso?: boolean;
 }
 
 export interface RuntimeBranding {
@@ -69,7 +83,7 @@ const defaults: RuntimeConfig = {
   singleEnvironment: false,
   defaultOrgId: null,
   defaultEnvironmentId: null,
-  features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true },
+  features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true, customDomain: false, sso: false },
   branding: { productName: 'ObjectOS', productShortName: 'ObjectOS' },
 };
 
@@ -123,6 +137,10 @@ export async function initRuntimeConfig(baseUrl: string = ''): Promise<void> {
           marketplace: body.features.marketplace !== false,
           aiStudio: body.features.aiStudio !== false,
           autoPublishAiBuilds: body.features.autoPublishAiBuilds !== false,
+          // Commercial flags default OFF unless the server explicitly grants
+          // them — never show a paid surface on an unknown/older runtime.
+          customDomain: body.features.customDomain === true,
+          sso: body.features.sso === true,
         }
         : current.features,
       branding: body.branding


### PR DESCRIPTION
## What

Completes the wire contract for the billing entitlements work: the cloud control plane now ships `features.customDomain` / `features.sso` on `/api/v1/runtime/config` (derived from the env's plan entitlements via the open-core feature seam — framework #1847 / cloud #306). This types them on `RuntimeFeatures` so the SPA can consume them.

**Safety**: commercial flags default **OFF** and turn on **only** when the server explicitly grants them — an older/vanilla runtime that omits the keys never leaks a paid affordance.

## Verification

New `runtime-config.test.ts`: default-off before init, server-grant on `true`, business grants both, and the omitted-keys case stays off. 4/4 pass.

Gating an actual custom-domain / SSO **settings UI** on these flags is a follow-up once those product surfaces exist (none today). This lands the typed contract end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)