### PR TITLE
fix(plugin-form): auto-generated forms must honor field `hidden: true`

### DIFF
--- a/packages/plugin-form/src/__tests__/autoLayout.test.ts
+++ b/packages/plugin-form/src/__tests__/autoLayout.test.ts
@@ -6,6 +6,7 @@ import {
   inferModalSize,
   applyAutoColSpan,
   filterCreateModeFields,
+  filterSystemFields,
   applyAutoLayout,
 } from '../autoLayout';
 import type { FormField } from '@object-ui/types';
@@ -174,7 +175,62 @@ describe('autoLayout', () => {
     });
   });
 
+  describe('filterSystemFields', () => {
+    const objectSchema = {
+      name: 'sys_environment',
+      fields: {
+        display_name: { type: 'text', label: 'Name' },
+        // hidden internal field — must never reach an auto-generated form
+        metadata: { type: 'textarea', label: 'Metadata', hidden: true },
+        database_url: { type: 'url', label: 'DB URL', hidden: true, readonly: true },
+        plan: { type: 'select', label: 'Plan', readonly: true },
+        created_at: { type: 'datetime', label: 'Created' },
+      },
+    };
+
+    it('drops fields marked hidden in the object schema', () => {
+      const fields: FormField[] = [
+        { name: 'display_name', label: 'Name', type: 'field:text' },
+        { name: 'metadata', label: 'Metadata', type: 'field:textarea' },
+        { name: 'database_url', label: 'DB URL', type: 'field:text' },
+        { name: 'plan', label: 'Plan', type: 'field:select' },
+        { name: 'created_at', label: 'Created', type: 'field:datetime' },
+      ];
+
+      const result = filterSystemFields(fields, objectSchema);
+
+      // hidden (metadata, database_url) + readonly (plan) + system name
+      // (created_at) all dropped — only the editable display_name remains.
+      expect(result.map(f => f.name)).toEqual(['display_name']);
+    });
+
+    it('keeps fields when no objectSchema metadata is available', () => {
+      const fields: FormField[] = [
+        { name: 'metadata', label: 'Metadata', type: 'field:textarea' },
+      ];
+      // Without schema metadata we cannot know it is hidden — keep it.
+      expect(filterSystemFields(fields, undefined)).toHaveLength(1);
+    });
+  });
+
   describe('applyAutoLayout', () => {
+    it('drops hidden schema fields in edit mode', () => {
+      const objectSchema = {
+        name: 'sys_environment',
+        fields: {
+          display_name: { type: 'text', label: 'Name' },
+          metadata: { type: 'textarea', label: 'Metadata', hidden: true },
+        },
+      };
+      const fields: FormField[] = [
+        { name: 'display_name', label: 'Name', type: 'field:text' },
+        { name: 'metadata', label: 'Metadata', type: 'field:textarea' },
+      ];
+
+      const result = applyAutoLayout(fields, objectSchema, undefined, 'edit');
+      expect(result.fields.map(f => f.name)).toEqual(['display_name']);
+    });
+
     it('infers 1 column for 3 fields', () => {
       const fields: FormField[] = [
         { name: 'a', label: 'A', type: 'field:text' },

--- a/packages/plugin-form/src/autoLayout.ts
+++ b/packages/plugin-form/src/autoLayout.ts
@@ -158,9 +158,16 @@ export function filterSystemFields(
 ): FormField[] {
   return fields.filter((field) => {
     if (SYSTEM_FIELD_NAMES.has(field.name)) return false;
+    const objField = objectSchema?.fields?.[field.name];
+    // Honor `hidden: true` — internal/system fields (e.g. database_url,
+    // metadata JSON blobs) must never surface as editable inputs in an
+    // auto-generated form. The list grid (ObjectGrid) and detail drawer
+    // already drop hidden fields; the auto-form is the one place that did
+    // not, which leaked e.g. sys_environment.metadata as a raw JSON
+    // textarea into the edit dialog. Applied in create AND edit.
+    if (objField?.hidden === true) return false;
     // Also drop fields the schema explicitly marks readonly — these are
     // platform-managed (e.g. id alias, formula result columns).
-    const objField = objectSchema?.fields?.[field.name];
     if (objField?.readonly === true) return false;
     return true;
   });


### PR DESCRIPTION
## Problem
The auto-generated CRUD form (no explicit form definition) rendered fields marked `hidden: true` in the object schema as editable inputs. Concretely, `sys_environment.metadata` — a `Field.textarea({ hidden: true })` holding internal JSON — showed up as a raw JSON textarea in the environment **edit** dialog. The list grid (`ObjectGrid`) and detail drawer (`RecordDetailDrawer`) already drop hidden fields; the auto-form was the only surface that didn't.

## Root cause
All auto-form variants (`ModalForm`, `DrawerForm`, `ObjectForm`, and `RecordFormPage` via `ObjectForm`) route their generated field list through `applyAutoLayout` → `filterSystemFields`. That filter dropped system-named fields and `readonly` fields, but never checked `hidden`.

## Fix
Add a `hidden` check next to the existing `readonly` check in `filterSystemFields` (one shared chokepoint, runs in **both** create and edit). One line, covers every auto-form variant.

```ts
const objField = objectSchema?.fields?.[field.name];
if (objField?.hidden === true) return false;   // ← added
if (objField?.readonly === true) return false;
```

## Tests
`packages/plugin-form/src/__tests__/autoLayout.test.ts`:
- `filterSystemFields` drops hidden (+ readonly + system-name) fields, keeps editable ones; keeps fields when no schema metadata.
- `applyAutoLayout(..., 'edit')` excludes a hidden field.

`@object-ui/plugin-form` suite: **104 tests pass** (35 in autoLayout incl. the new cases).

## Note
This is the root-cause fix for the JSON-box complaint addressed tactically in cloud#312 (which disabled the generic env edit in favour of a dedicated Rename action). Ships to cloud via `bump-objectui` once merged.