### PR TITLE
feat(components): wire element:button onClick to an action (navigate / invoke / redirect)

### DIFF
--- a/packages/components/src/__tests__/element-button-action.test.tsx
+++ b/packages/components/src/__tests__/element-button-action.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * element:button — action onClick.
+ *
+ * A standalone-page button was inert: the renderer ignored its action/events,
+ * so a metadata-defined "Upgrade" CTA could not navigate or invoke a route.
+ * These tests cover the new `properties.action` wiring (executed via the shared
+ * ActionRunner) plus the back-compat path (no action → inert, no crash).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider } from '@object-ui/react';
+import '../renderers/basic/elements';
+
+function ElementButton({ schema }: { schema: any }) {
+  const C = ComponentRegistry.get('element:button');
+  if (!C) throw new Error('element:button not registered');
+  return <C schema={schema} />;
+}
+
+describe('element:button — action onClick', () => {
+  it('executes a navigation action on click (drives the navigation handler)', async () => {
+    const onNavigate = vi.fn();
+    render(
+      <ActionProvider onNavigate={onNavigate}>
+        <ElementButton
+          schema={{
+            type: 'element:button',
+            properties: {
+              label: 'Upgrade',
+              action: { type: 'navigation', to: '/apps/cloud_control/sys_environment' },
+            },
+          }}
+        />
+      </ActionProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Upgrade/i }));
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith(
+        '/apps/cloud_control/sys_environment',
+        expect.anything(),
+      ),
+    );
+  });
+
+  it('renders inert without an action — no onClick, no crash (back-compat)', () => {
+    render(
+      <ElementButton schema={{ type: 'element:button', properties: { label: 'Static' } }} />,
+    );
+    const btn = screen.getByRole('button', { name: /Static/i });
+    expect(btn).toBeTruthy();
+    // Must not throw even with no ActionProvider mounted.
+    fireEvent.click(btn);
+  });
+
+  it('renders as type=button so it never submits a surrounding form', () => {
+    render(
+      <ElementButton schema={{ type: 'element:button', properties: { label: 'Safe' } }} />,
+    );
+    expect(screen.getByRole('button', { name: /Safe/i }).getAttribute('type')).toBe('button');
+  });
+});

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -26,7 +26,7 @@
 
 import * as React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
-import { useAdapter } from '@object-ui/react';
+import { useAdapter, useAction } from '@object-ui/react';
 import { cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { Button, Separator } from '../../ui';
@@ -199,18 +199,66 @@ function ElementButtonRenderer({ schema }: { schema: any }) {
     iconPosition?: 'left' | 'right';
     disabled?: boolean;
     aria?: Record<string, any>;
+    /**
+     * Optional action executed on click. Any ActionDef the ActionRunner
+     * understands — `url`/`navigation` (link to another page), `api`/`script`
+     * (POST a cloud route, with optional param collection + redirect), `modal`,
+     * `flow`. This is what makes a standalone-page button interactive: without
+     * it the button renders inert (back-compat). Executed via `useAction`,
+     * which falls back to a local runner when no ActionProvider is mounted, so
+     * adding the hook never throws in non-page contexts.
+     */
+    action?: Record<string, any>;
   }>(schema);
   const variant = (SHADCN_BUTTON_VARIANT[props.variant ?? 'primary'] ?? 'default') as any;
   const size = (SHADCN_BUTTON_SIZE[props.size ?? 'medium'] ?? 'default') as any;
   const label = resolveI18nLabel(props.label);
   const iconPosition = props.iconPosition ?? 'left';
   const icon = props.icon ? <LazyIcon name={props.icon} className="h-4 w-4" /> : null;
+
+  const { execute } = useAction();
+  const [running, setRunning] = React.useState(false);
+  const action = props.action;
+
+  const handleClick = React.useCallback(async () => {
+    if (!action || running) return;
+    setRunning(true);
+    try {
+      // Mirror action:button's param routing: an array of {name,type,…} defs is
+      // forwarded for in-dialog collection; a plain object is passed as values.
+      const paramsPayload = Array.isArray(action.params)
+        ? { actionParams: action.params }
+        : { params: action.params };
+      await execute({
+        type: action.actionType || action.type,
+        name: action.name,
+        label: action.label,
+        description: action.description,
+        target: action.target,
+        endpoint: action.endpoint,
+        method: action.method,
+        navigate: action.navigate,
+        to: action.to,
+        opensInNewTab: action.opensInNewTab,
+        confirmText: action.confirmText,
+        successMessage: action.successMessage,
+        errorMessage: action.errorMessage,
+        refreshAfter: action.refreshAfter,
+        ...paramsPayload,
+      } as any);
+    } finally {
+      setRunning(false);
+    }
+  }, [action, execute, running]);
+
   return (
     <Button
+      type="button"
       variant={variant}
       size={size}
-      disabled={props.disabled}
+      disabled={props.disabled || running}
       className={cn(schema?.className)}
+      onClick={action ? handleClick : undefined}
       {...ariaAttrs(props.aria)}
     >
       {iconPosition === 'left' && icon}


### PR DESCRIPTION
## Why
`element:button` rendered **inert** — the renderer read only `label`/`variant`/`icon` and ignored any action/events. A metadata-defined button on a standalone Page (a pricing CTA, "Upgrade", "Manage billing") couldn't navigate or call a route. The page spec declared an `events` field but the renderer never honoured it. This blocks building interactive server-driven pages from built-in blocks.

## What
- `element:button` gains an optional `properties.action` — **any** `ActionDef` the `ActionRunner` understands: `navigation`/`url` (link to another page), `api`/`script` (POST a route, with param collection + redirect), `modal`, `flow`.
- Executed via the shared `useAction()` (mirrors `action:button`'s param routing). `useAction()` falls back to a local runner when no `ActionProvider` is mounted, so adding the hook **never throws** in existing non-page contexts.
- Buttons now render as `type="button"` so they can't accidentally submit a surrounding form.
- No `action` → unchanged inert render (**back-compat**).

## Impact
Unblocks pages composed entirely from built-in blocks (`page:card` + `element:text` + `element:button`) driving real actions — e.g. a cloud-defined pricing page whose CTA opens the existing self-serve upgrade checkout — **with no per-page React**.

## Tests
`packages/components/src/__tests__/element-button-action.test.tsx`: navigation action fires the navigation handler on click; no-action button is inert + crash-free; renders `type=button`. 35 existing renderer tests pass; dependency-ordered turbo build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)