### PR TITLE
fix(plugin-grid): row Edit/Delete honor object userActions.{edit,delete}

### DIFF
--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -38,6 +38,7 @@ import { useRowColor } from './useRowColor';
 import { useGroupedData } from './useGroupedData';
 import { GroupRow } from './GroupRow';
 import { useColumnSummary } from './useColumnSummary';
+import { resolveRowCrudAffordances } from './rowCrudAffordances';
 import { RowActionMenu, formatActionLabel } from './components/RowActionMenu';
 import { BulkActionBar } from './components/BulkActionBar';
 import { BulkActionDialog } from './components/BulkActionDialog';
@@ -1291,8 +1292,20 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const wantEditAction = rowActionsList.includes('edit');
   const wantDeleteAction = rowActionsList.includes('delete');
   const customRowActions = rowActionsList.filter(a => a !== 'edit' && a !== 'delete');
-  const canEdit = !!((operations?.update || wantEditAction) && onEdit);
-  const canDelete = !!((operations?.delete || wantDeleteAction) && onDelete);
+  // Honor the object's CRUD affordance flags: when `userActions.edit`/`delete`
+  // is explicitly false the object opted out of the generic row Edit/Delete
+  // (e.g. sys_environment ships a dedicated Rename + cascade-Delete instead).
+  // This stops a generic "Delete" from duplicating the object's own Delete
+  // action, and a generic "Edit" the object turned off from leaking back in.
+  const { canEdit, canDelete } = resolveRowCrudAffordances({
+    operationsUpdate: operations?.update,
+    operationsDelete: operations?.delete,
+    wantEditAction,
+    wantDeleteAction,
+    hasOnEdit: !!onEdit,
+    hasOnDelete: !!onDelete,
+    userActions: (objectSchema as any)?.userActions,
+  });
   const hasActions = !!(operations && (operations.update || operations.delete));
   const hasRowActions = customRowActions.length > 0 || rowActionDefsList.length > 0 || wantEditAction || wantDeleteAction;
 

--- a/packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts
+++ b/packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 ObjectStack Inc. MIT.
+import { describe, it, expect } from 'vitest';
+import { resolveRowCrudAffordances } from '../rowCrudAffordances';
+
+describe('resolveRowCrudAffordances', () => {
+  const wired = { operationsUpdate: true, operationsDelete: true, hasOnEdit: true, hasOnDelete: true };
+
+  it('surfaces generic edit/delete by default (userActions undefined)', () => {
+    expect(resolveRowCrudAffordances({ ...wired })).toEqual({ canEdit: true, canDelete: true });
+  });
+
+  it('keeps both when userActions explicitly true', () => {
+    expect(resolveRowCrudAffordances({ ...wired, userActions: { edit: true, delete: true } }))
+      .toEqual({ canEdit: true, canDelete: true });
+  });
+
+  it('suppresses generic edit/delete when the object opts out (userActions false)', () => {
+    // sys_environment case: edit:false + delete:false → no generic kebab entries,
+    // leaving only the object's dedicated Rename / Delete actions (no duplicate).
+    expect(resolveRowCrudAffordances({ ...wired, userActions: { edit: false, delete: false } }))
+      .toEqual({ canEdit: false, canDelete: false });
+  });
+
+  it('gates edit and delete independently', () => {
+    expect(resolveRowCrudAffordances({ ...wired, userActions: { edit: false } }))
+      .toEqual({ canEdit: false, canDelete: true });
+    expect(resolveRowCrudAffordances({ ...wired, userActions: { delete: false } }))
+      .toEqual({ canEdit: true, canDelete: false });
+  });
+
+  it('still requires the callback + operation to be wired (opt-out is not opt-in)', () => {
+    expect(resolveRowCrudAffordances({ hasOnEdit: false, hasOnDelete: false, operationsUpdate: true, operationsDelete: true }))
+      .toEqual({ canEdit: false, canDelete: false });
+  });
+
+  it('honors explicit rowActions (edit/delete strings) when callbacks exist', () => {
+    expect(resolveRowCrudAffordances({ wantEditAction: true, wantDeleteAction: true, hasOnEdit: true, hasOnDelete: true }))
+      .toEqual({ canEdit: true, canDelete: true });
+  });
+});

--- a/packages/plugin-grid/src/rowCrudAffordances.ts
+++ b/packages/plugin-grid/src/rowCrudAffordances.ts
@@ -1,0 +1,48 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Resolve whether a list row's kebab should surface the GENERIC Edit / Delete
+ * entries.
+ *
+ * Two inputs decide this:
+ *
+ *  1. Whether the consumer wired the affordance at all — i.e. the view's
+ *     `operations.update` / `operations.delete` (or an explicit `'edit'` /
+ *     `'delete'` in `rowActions`) AND an `onEdit` / `onDelete` callback exists.
+ *
+ *  2. The OBJECT's CRUD affordance flags (`userActions.edit` / `userActions.delete`).
+ *     When an object sets these to **`false`** it has deliberately opted out of
+ *     the generic row CRUD — typically because it ships dedicated actions
+ *     instead (e.g. `sys_environment` replaces generic edit with a `Rename`
+ *     action and generic delete with a cascade-teardown `Delete` action). Before
+ *     this gate, the generic entries rendered anyway, producing a confusing
+ *     duplicate (a generic "Delete" next to the object's own "Delete" action)
+ *     and leaking a generic "Edit" the object had turned off.
+ *
+ * `userActions.edit` / `delete` left `undefined` (or `true`) preserves the
+ * out-of-the-box behaviour — every main list keeps its Edit/Delete kebab.
+ */
+export function resolveRowCrudAffordances(opts: {
+  operationsUpdate?: boolean;
+  operationsDelete?: boolean;
+  wantEditAction?: boolean;
+  wantDeleteAction?: boolean;
+  hasOnEdit?: boolean;
+  hasOnDelete?: boolean;
+  /** The object's `userActions` block ({ create, edit, delete, import }). */
+  userActions?: { edit?: boolean; delete?: boolean } | null;
+}): { canEdit: boolean; canDelete: boolean } {
+  const editOptedOut = opts.userActions?.edit === false;
+  const deleteOptedOut = opts.userActions?.delete === false;
+  const canEdit =
+    !!((opts.operationsUpdate || opts.wantEditAction) && opts.hasOnEdit) && !editOptedOut;
+  const canDelete =
+    !!((opts.operationsDelete || opts.wantDeleteAction) && opts.hasOnDelete) && !deleteOptedOut;
+  return { canEdit, canDelete };
+}


### PR DESCRIPTION
## Problem
The list row kebab rendered the **generic Edit/Delete** entries whenever the consumer wired `onEdit`/`onDelete` callbacks — independent of the object's CRUD affordance flags (`userActions.edit` / `userActions.delete`).

So an object that opts out of generic CRUD by setting `userActions.edit:false` / `delete:false` (e.g. `sys_environment`, which ships a dedicated **Rename** action + a cascade-teardown **Delete** action) still got:
- a generic **Edit** it had explicitly turned off, and
- a generic **Delete** that **duplicated** its own Delete action in the same kebab.

(Found in the cloud customer-journey audit: the environment row kebab showed `编辑 · 删除 · … · Rename · … · Delete` — a confusing duplicate.)

## Fix
Gate `canEdit` / `canDelete` on `objectSchema.userActions.{edit,delete}`:
- explicit `false` → suppress the generic entry,
- `undefined` / `true` → unchanged (every main list keeps its out-of-box kebab).

Extracted the decision into a pure `resolveRowCrudAffordances()` helper with unit tests (6 cases incl. the sys_environment opt-out and independent edit/delete gating).

## Tests
`packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts` — 6 pass. Full `@object-ui/plugin-grid` suite: **59 pass**. Build clean.

Pairs with cloud#312 (which set `userActions.edit/delete:false` + added the Rename/Delete actions) and objectui#1732 (auto-form honoring `hidden`). Ships to cloud via `bump-objectui`.