### PR TITLE
fix(i18n): home welcome/noApps keys missing → English leak on zh home

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1529,6 +1529,9 @@ const en = {
     starred: 'Starred',
     welcome: 'Build your business system with AI',
     welcomeDescription: 'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or start from scratch.',
+    welcomeAdminDescription: 'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or set things up yourself from the menu on the left.',
+    noAppsTitle: 'No applications yet',
+    noAppsDescription: 'There are no applications available to you yet. Please contact your workspace administrator.',
     buildWithAI: 'Build with AI',
     recoveryReminder: {
       message: 'Set a recovery password so you can still sign in if single sign-on is ever unavailable.',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1542,6 +1542,9 @@ const zh = {
     starred: '收藏',
     welcome: '用 AI 搭建你的业务系统',
     welcomeDescription: '用一句话描述你的业务，AI 帮你生成对象、界面、API 和 agent 工具。也可以手动从零开始。',
+    welcomeAdminDescription: '用一句话描述你的业务，AI 会为你生成对象、界面、API 和智能体工具；也可以从左侧菜单自行搭建。',
+    noAppsTitle: '还没有应用',
+    noAppsDescription: '当前还没有可用的应用。请联系你的工作区管理员。',
     buildWithAI: '用 AI 搭建',
     recoveryReminder: {
       message: '建议设置一个备用密码，这样即使单点登录不可用，你仍能直接登录此环境。',


### PR DESCRIPTION
## Problem
`HomePage` renders `t('home.welcomeAdminDescription')` (the admin empty-state "build with AI" body) and `t('home.noAppsTitle')` / `t('home.noAppsDescription')` (non-admin state) — but **none of those keys existed in any locale**, so they fell back to the English `defaultValue`. On the Chinese product surface the env-home magic-moment rendered an **English body under a Chinese title** (the mixed-language issue from the customer-journey audit).

## Fix
Add the three keys to `en` (source) + `zh` (translated). The remaining 8 locales keep falling back to the English `defaultValue` exactly as before — no regression; full coverage for those is a separate i18n pass (the parity test only enforces top-level sections).

## Tests
`@object-ui/i18n` build clean; suite **113 pass**.

Ships to cloud via `bump-objectui`.

> Note: the form-field **helpText** leaks (create/change-plan action params) are a separate, deeper fix — the spec `TranslationData` type doesn't model action params yet (objectui `resolveActionParams` never i18n's helpText), so that needs a `@objectstack/spec` type + resolver change across repos. Flagged as a follow-up.