### PR TITLE
fix(studio): readable dashboard KPI titles + package-scoped metadata list

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
@@ -221,47 +221,61 @@ function DefaultMetadataList({ type }: { type: string }) {
   }, [client, type, refreshKey]);
 
   const searchableFields = config.searchableFields ?? ['name', 'label', 'description'];
-  const filtered = items.filter((row) => {
-    // Per-type hide hook (e.g. `view` drops the bare aggregated container
-    // that the framework keeps for runtime dual-read).
-    if (config.listFilter && !config.listFilter(row.item)) return false;
+  // Structural scope — every row this package could ever show for this
+  // type, before the user's search box / source dropdown narrow it. Header
+  // counts, the source filter, and the empty-state copy all key off this so
+  // a package with zero items of a type reads as "暂无…条目", not "no match
+  // for an (empty) query" just because *other* packages own rows of the
+  // same type (server list() is not package-scoped; we scope client-side).
+  const scopedItems = React.useMemo(
+    () =>
+      items.filter((row) => {
+        // Per-type hide hook (e.g. `view` drops the bare aggregated
+        // container the framework keeps for runtime dual-read).
+        if (config.listFilter && !config.listFilter(row.item)) return false;
+        // Mandatory project-package scope: show nothing until a concrete
+        // project package is active, then only rows tagged with it. The
+        // 'sys_metadata' sentinel and untagged rows never match.
+        if (!activePackage) return false;
+        const pkg = (row.item as any)?._packageId;
+        const effectivePkg = !pkg || pkg === 'sys_metadata' ? null : pkg;
+        return effectivePkg === activePackage;
+      }),
+    [items, activePackage, config],
+  );
+
+  // User-driven filters (search query + source provenance) on top of scope.
+  const filtered = scopedItems.filter((row) => {
     if (!matchesQuery(row.item, query, searchableFields)) return false;
     if (sourceFilter !== 'all' && row.source !== sourceFilter) return false;
-    // Mandatory project-package scope: show nothing until a concrete project
-    // package is active, then only rows tagged with it. The 'sys_metadata'
-    // sentinel and untagged rows never match a concrete package.
-    if (!activePackage) return false;
-    const pkg = (row.item as any)?._packageId;
-    const effectivePkg = !pkg || pkg === 'sys_metadata' ? null : pkg;
-    if (effectivePkg !== activePackage) return false;
     return true;
   });
 
   // Compute source + invalid counts for filter / header stats.
   const sourceCounts = React.useMemo(() => {
-    const c = { all: items.length, artifact: 0, runtime: 0 };
-    for (const r of items) {
+    const c = { all: scopedItems.length, artifact: 0, runtime: 0 };
+    for (const r of scopedItems) {
       c[r.source]++;
     }
     return c;
-  }, [items]);
+  }, [scopedItems]);
 
   const invalidCount = React.useMemo(
-    () => items.filter((r) => r.diagnostics && r.diagnostics.valid === false).length,
-    [items],
+    () => scopedItems.filter((r) => r.diagnostics && r.diagnostics.valid === false).length,
+    [scopedItems],
   );
 
   // Items with warnings but no errors — softer, advisory tier. We
   // count rows (not warning instances) for consistency with `invalid`.
   const warnOnlyCount = React.useMemo(
     () =>
-      items.filter(
+      scopedItems.filter(
         (r) =>
           r.diagnostics &&
           r.diagnostics.valid !== false &&
           (r.diagnostics.warnings?.length ?? 0) > 0,
       ).length,
-    [items],
+    [scopedItems],
   );
 
   const columns = config.listColumns ?? defaultColumns(config.primaryKey ?? 'name');
@@ -280,7 +294,7 @@ function DefaultMetadataList({ type }: { type: string }) {
     <PageShell
       entry={entry ?? { type, label: type }}
       stats={[
-        { label: t('engine.list.items', locale), value: items.length },
+        { label: t('engine.list.items', locale), value: scopedItems.length },
         { label: t('engine.list.filtered', locale), value: filtered.length },
         ...(invalidCount > 0
           ? [
@@ -390,7 +404,7 @@ function DefaultMetadataList({ type }: { type: string }) {
         {!loading && !error && projectPackages !== null && projectPackages.length > 0 && filtered.length === 0 && (
           <Empty>
             <EmptyTitle>
-              {items.length === 0
+              {scopedItems.length === 0
                 ? tFormat('engine.list.emptyType', locale, { type: typeLabel })
                 : tFormat('engine.list.emptyQuery', locale, { query })}
             </EmptyTitle>
@@ -400,7 +414,7 @@ function DefaultMetadataList({ type }: { type: string }) {
                   ? tFormat('engine.list.createHint', locale, { type: typeLabel })
                   : t('engine.list.readOnlyHint', locale))}
             </EmptyDescription>
-            {items.length === 0 && (entry?.allowOrgOverride || entry?.allowRuntimeCreate) && (
+            {scopedItems.length === 0 && (entry?.allowOrgOverride || entry?.allowRuntimeCreate) && (
               <div className="mt-4">
                 <Button onClick={() => navigate(`./new${pkgSuffix}`)}>
                   <Plus className="h-4 w-4 mr-1" />

--- a/packages/app-shell/src/views/metadata-admin/previews/DashboardPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DashboardPreview.tsx
@@ -143,15 +143,27 @@ export function DashboardPreview({
           }
         >
           <div className="p-3 max-h-[70vh] overflow-auto">
-            <DashboardRenderer
-              schema={draft as any}
-              dataSource={adapter as any}
-              designMode={designMode}
-              selectedWidgetId={selectedWidgetId}
-              onWidgetClick={designMode ? handleWidgetClick : undefined}
-              onWidgetsReorder={designMode && onPatch ? handleReorder : undefined}
-              hideHeaderText
-            />
+            {/*
+             * The runtime dashboard grid is 12 columns wide. Inside the
+             * Studio canvas — especially with the inspector open — the
+             * available width collapses to ~500px, squeezing metric cards
+             * down to ~120px so their titles truncate to a couple of
+             * characters ("管道…"). Pin a desktop-like minimum width so
+             * the grid lays out as end users see it; the parent's
+             * overflow-auto adds a horizontal scrollbar when the canvas is
+             * narrower.
+             */}
+            <div className="min-w-[768px]">
+              <DashboardRenderer
+                schema={draft as any}
+                dataSource={adapter as any}
+                designMode={designMode}
+                selectedWidgetId={selectedWidgetId}
+                onWidgetClick={designMode ? handleWidgetClick : undefined}
+                onWidgetsReorder={designMode && onPatch ? handleReorder : undefined}
+                hideHeaderText
+              />
+            </div>
           </div>
         </React.Suspense>
       </PreviewErrorBoundary>


### PR DESCRIPTION
Two Studio metadata-admin designer UX fixes, both found during a browser sweep of the designers against the HotCRM showcase package and verified live (vite dev → showcase backend).

## 1. Dashboard KPI titles unreadable in the design canvas
The runtime dashboard grid is 12 columns wide. Inside the Studio canvas with the inspector open, the available width collapses to ~500px, squeezing metric cards to ~120px so their titles truncate to a couple of characters ("管道…"). `DashboardPreview` now pins a desktop-like minimum width so the grid lays out as end users see it; the parent's `overflow-auto` adds a horizontal scrollbar when the canvas is narrower.

**Verified:** all four KPI titles on `sales_dashboard` ("管道总额 / 本季度已成交 / 进行中商机 / 平均订单金额") render in full (measured 0 truncation vs. the previous 42px clamp).

## 2. Metadata list counts & empty-state ignored the active package
The list header counts (条目 / 全部来源 N), source filter, diagnostics badges, and empty-state copy all keyed off the unscoped `items` array, which holds rows from every package (server `list()` is not package-scoped — the page scopes client-side). For a type the package owns none of but others do (dataset: HotCRM has 0, 7 exist elsewhere), the list showed a contradictory **条目 7 / 已筛选 0** and the wrong empty message *没有匹配 "" 的结果* (emptyQuery with a blank query) instead of *暂无 … 条目*.

Introduced a memoized `scopedItems` (project-package + per-type `listFilter` scope) and keyed every count, the source dropdown, and the empty-state discriminator off it. The table still renders the query/source-filtered subset.

**Verified:** dataset → `0 / 0 / 全部来源 (0)` + *暂无 Dataset 条目* + 新建 CTA; view → `80 / 80 / 全部来源 (80)` (was 134/80) with all rows intact; read-only empty type (email_template) → clean *暂无 邮件模板 条目* + read-only hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)