### PR TITLE
feat(i18n): locale-aware element:text / element:button / action params

### DIFF
--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -29,7 +29,7 @@ import {
   SelectValue,
   Checkbox,
 } from '@object-ui/components';
-import { useObjectTranslation } from '@object-ui/i18n';
+import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionParamDef } from '@object-ui/core';
 import { LookupField } from '@object-ui/fields';
 
@@ -50,7 +50,7 @@ interface ActionParamDialogProps {
 }
 
 export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProps) {
-  const { t } = useObjectTranslation();
+  const { t, language } = useObjectTranslation();
   const [values, setValues] = useState<Record<string, any>>({});
   const [errors, setErrors] = useState<Record<string, boolean>>({});
 
@@ -116,7 +116,13 @@ export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProp
         </DialogHeader>
 
         <div className="grid gap-4 py-4">
-          {state.params.map((param) => {
+          {state.params.map((rawParam) => {
+            const param = {
+              ...rawParam,
+              label: pickLocalized(rawParam.label, language),
+              helpText: rawParam.helpText != null ? pickLocalized(rawParam.helpText, language) : rawParam.helpText,
+              options: rawParam.options?.map((o) => ({ ...o, label: pickLocalized(o.label, language) })),
+            };
             const isBooleanParam =
               param.type === 'boolean' || param.type === 'checkbox';
             // Boolean → render as inline checkbox row (label sits beside the

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -27,6 +27,7 @@
 import * as React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { useAdapter, useAction } from '@object-ui/react';
+import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import { cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { Button, Separator } from '../../ui';
@@ -72,11 +73,12 @@ const VARIANT_CLASS: Record<string, string> = {
 
 function ElementTextRenderer({ schema }: { schema: any }) {
   const props = readProps<{
-    content?: string;
+    content?: unknown;
     variant?: 'heading' | 'subheading' | 'body' | 'caption';
     align?: 'left' | 'center' | 'right';
     aria?: Record<string, any>;
   }>(schema);
+  const { language } = useObjectTranslation();
   const variant = props.variant ?? 'body';
   const align = props.align ?? 'left';
   const Tag = variant === 'heading' ? 'h2' : variant === 'subheading' ? 'h3' : 'p';
@@ -85,7 +87,7 @@ function ElementTextRenderer({ schema }: { schema: any }) {
       className={cn(VARIANT_CLASS[variant] ?? VARIANT_CLASS.body, ALIGN_CLASS[align], schema?.className)}
       {...ariaAttrs(props.aria)}
     >
-      {props.content ?? ''}
+      {pickLocalized(props.content, language)}
     </Tag>
   );
 }
@@ -178,17 +180,6 @@ const SHADCN_BUTTON_SIZE: Record<string, string> = {
   large: 'lg',
 };
 
-function resolveI18nLabel(label: unknown): string {
-  if (label == null) return '';
-  if (typeof label === 'string') return label;
-  if (typeof label === 'object') {
-    // I18nLabel: { en: 'Save', zh: '保存', default?: '...' } — pick a
-    // reasonable default without coupling to a locale helper here.
-    const o = label as Record<string, string>;
-    return o.default ?? o.en ?? Object.values(o)[0] ?? '';
-  }
-  return String(label);
-}
 
 function ElementButtonRenderer({ schema }: { schema: any }) {
   const props = readProps<{
@@ -212,7 +203,8 @@ function ElementButtonRenderer({ schema }: { schema: any }) {
   }>(schema);
   const variant = (SHADCN_BUTTON_VARIANT[props.variant ?? 'primary'] ?? 'default') as any;
   const size = (SHADCN_BUTTON_SIZE[props.size ?? 'medium'] ?? 'default') as any;
-  const label = resolveI18nLabel(props.label);
+  const { language } = useObjectTranslation();
+  const label = pickLocalized(props.label, language);
   const iconPosition = props.iconPosition ?? 'left';
   const icon = props.icon ? <LazyIcon name={props.icon} className="h-4 w-4" /> : null;
 

--- a/packages/i18n/src/__tests__/pickLocalized.test.ts
+++ b/packages/i18n/src/__tests__/pickLocalized.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { pickLocalized } from '../pickLocalized';
+
+describe('pickLocalized', () => {
+  it('passes plain strings through', () => {
+    expect(pickLocalized('Pricing', 'zh-CN')).toBe('Pricing');
+  });
+  it('picks the exact language key', () => {
+    expect(pickLocalized({ en: 'Pricing', 'zh-CN': '定价' }, 'zh-CN')).toBe('定价');
+  });
+  it('falls back from region to base language (zh-CN -> zh)', () => {
+    expect(pickLocalized({ en: 'Pricing', zh: '定价' }, 'zh-CN')).toBe('定价');
+  });
+  it('falls back to default then en then first', () => {
+    expect(pickLocalized({ default: 'D', en: 'E' }, 'fr')).toBe('D');
+    expect(pickLocalized({ en: 'E', ja: 'J' }, 'fr')).toBe('E');
+    expect(pickLocalized({ ja: 'J' }, 'fr')).toBe('J');
+  });
+  it('handles null/undefined and missing language', () => {
+    expect(pickLocalized(null, 'zh')).toBe('');
+    expect(pickLocalized(undefined, 'zh')).toBe('');
+    expect(pickLocalized({ en: 'E' }, undefined)).toBe('E');
+  });
+});

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -88,3 +88,5 @@ export {
   transformSpecTranslations,
   type SpecTranslationData,
 } from './utils/index';
+
+export { pickLocalized } from './pickLocalized';

--- a/packages/i18n/src/pickLocalized.ts
+++ b/packages/i18n/src/pickLocalized.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolve a possibly-localized value to the best string for a language.
+ *
+ * Accepts a plain string (passed through) or an i18n object keyed by language
+ * code — e.g. `{ en: 'Pricing', 'zh-CN': '定价', zh: '定价', default: 'Pricing' }`.
+ * Resolution order: exact language -> base language (`zh-CN` -> `zh`) -> `default`
+ * -> `en` -> first value. Unlike a `default`/`en`-only resolver this is genuinely
+ * locale-aware, so server-driven metadata (page text, action param labels) can
+ * carry inline translations instead of rendering "[object Object]" or English.
+ *
+ * Pure — pair it with `useObjectTranslation().language` (or any current-locale
+ * source) at the call site.
+ */
+export function pickLocalized(value: unknown, language: string | undefined | null): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'object') {
+    const o = value as Record<string, unknown>;
+    const lang = (language || 'en').trim();
+    const base = lang.split('-')[0];
+    const pick =
+      o[lang] ??
+      o[base] ??
+      o.default ??
+      o.en ??
+      Object.values(o).find((v) => typeof v === 'string');
+    return pick == null ? '' : String(pick);
+  }
+  return String(value);
+}


### PR DESCRIPTION
Locale-aware text so server-driven metadata carries inline translations. pickLocalized(value,language) in @object-ui/i18n resolves string or {en,zh-CN,zh,default} to active language. element:text content + element:button label + ActionParamDialog params now localize. Degrades safely (no provider -> en). Unblocks localizing cloud Pricing page + Upgrade dialog. Tests: pickLocalized unit + 25 existing renderer tests pass.