### PR TITLE
feat(app-shell): carry isPlatformAdmin into the CEL action context

### DIFF
--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -44,7 +44,7 @@ import { ActionResultDialog, type ResultDialogState } from '../views/ActionResul
 import { FlowRunner, type ScreenFlowState } from '../views/FlowRunner';
 import { resolveActionParams } from '../utils/resolveActionParams';
 
-const FALLBACK_USER = { id: 'current-user', name: 'Demo User' };
+const FALLBACK_USER = { id: 'current-user', name: 'Demo User', isPlatformAdmin: false };
 
 export interface ConsoleActionRuntimeOptions {
   /** Adapter for generic CRUD / execute calls. */
@@ -156,7 +156,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel, actionParamText]);
 
   const currentUser = user
-    ? { id: user.id, name: user.name, avatar: user.image }
+    ? { id: user.id, name: user.name, avatar: user.image, isPlatformAdmin: (user as any)?.isPlatformAdmin ?? false }
     : FALLBACK_USER;
 
   const toastHandler = useCallback<ToastHandler>((message, options) => {


### PR DESCRIPTION
## What
Forward the `isPlatformAdmin` flag from the session user into the Console action-runtime `currentUser`, defaulting to `false`, and add it to `FALLBACK_USER`.

## Why
Console action `visible` predicates evaluate against `ctx.user`, but the runtime user object only carried `id/name/avatar` — so a platform-admin gate like `ctx.user.isPlatformAdmin == true` could never be satisfied. This enables hiding platform-admin-only object actions (e.g. `sys_environment.change_plan`) from non-admins in the Console UI.

## Change
`packages/app-shell/src/hooks/useConsoleActionRuntime.tsx`:
- `currentUser` now includes `isPlatformAdmin: (user as any)?.isPlatformAdmin ?? false` (`AuthUser` has an index signature, so TS is fine).
- `FALLBACK_USER` gains `isPlatformAdmin: false` for consistency.

Server-side authz is unchanged; this is purely a UX visibility signal. Pairs with the framework change that emits the flag and the cloud change that consumes it in the `change_plan` predicate.

## Validation
- `turbo type-check --filter=@object-ui/app-shell` green (deps built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)