### PR TITLE
feat(i18n): localize action-param select option labels

### DIFF
--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@object-ui/i18n', () => ({
     fieldLabel: (_o: any, _n: any, l: any) => l,
     fieldOptionLabel: (_o: any, _f: any, _v: any, l: any) => l,
     actionParamText: (_o: any, _a: any, _p: any, _attr: any, fallback: any) => fallback,
+    actionParamOptionLabel: (_o: any, _a: any, _p: any, _v: any, fallback: any) => fallback,
   }),
 }));
 

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -87,7 +87,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   const { dataSource, objects, objectName, onRefresh } = opts;
   const navigate = useNavigate();
   const { user, activeOrganization } = useAuth();
-  const { fieldLabel, fieldOptionLabel, actionParamText } = useObjectLabel();
+  const { fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel } = useObjectLabel();
 
   const objectDef = useMemo(
     () => (objectName ? objects?.find((o: any) => o.name === objectName) : undefined),
@@ -144,6 +144,9 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
         label: actionParamText(objForI18n, action?.name, p.name, 'label', p.label) ?? p.label,
         placeholder: actionParamText(objForI18n, action?.name, p.name, 'placeholder', p.placeholder) ?? p.placeholder,
         helpText: actionParamText(objForI18n, action?.name, p.name, 'helpText', p.helpText) ?? p.helpText,
+        options: Array.isArray(p.options)
+          ? p.options.map((o: any) => ({ ...o, label: actionParamOptionLabel(objForI18n, action?.name, p.name, o.value, o.label) }))
+          : p.options,
       }));
       setParamState({
         open: true,
@@ -153,7 +156,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
         resolve,
       });
     });
-  }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel, actionParamText]);
+  }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel]);
 
   const currentUser = user
     ? { id: user.id, name: user.name, avatar: user.image, isPlatformAdmin: (user as any)?.isPlatformAdmin ?? false }

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -119,7 +119,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   const location = useLocation();
   const originFrom = (location.state as any)?.from as { pathname?: string; label?: string } | undefined;
   const { t } = useObjectTranslation();
-  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, fieldLabel, fieldOptionLabel } = useObjectLabel();
+  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, actionParamOptionLabel, fieldLabel, fieldOptionLabel } = useObjectLabel();
   const { isFavorite, toggleFavorite, refreshLabel: refreshFavoriteLabel } = useFavorites();
   const { addRecentItem } = useRecentItems();
   const [isLoading, setIsLoading] = useState(true);
@@ -332,6 +332,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         label: actionParamText(objForI18n, action?.name, p.name, 'label', p.label) ?? p.label,
         placeholder: actionParamText(objForI18n, action?.name, p.name, 'placeholder', p.placeholder) ?? p.placeholder,
         helpText: actionParamText(objForI18n, action?.name, p.name, 'helpText', p.helpText) ?? p.helpText,
+        options: Array.isArray(p.options)
+          ? p.options.map((o: any) => ({ ...o, label: actionParamOptionLabel(objForI18n, action?.name, p.name, o.value, o.label) }))
+          : p.options,
       }));
       setParamState({
         open: true,
@@ -342,7 +345,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         resolve,
       });
     });
-  }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel, actionParamText]);
+  }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel]);
 
   const toastHandler = useCallback((message: string, options?: { type?: string }) => {
     if (options?.type === 'error') toast.error(message);

--- a/packages/i18n/src/__tests__/useObjectLabel-actionParamOption.test.tsx
+++ b/packages/i18n/src/__tests__/useObjectLabel-actionParamOption.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider } from '../provider';
+import { useObjectLabel } from '../useObjectLabel';
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    I18nProvider,
+    { config: { defaultLanguage: 'en', detectBrowserLanguage: false } },
+    children,
+  );
+
+describe('useObjectLabel().actionParamOptionLabel', () => {
+  it('is exposed and falls back to the provided label when untranslated', () => {
+    const { result } = renderHook(() => useObjectLabel(), { wrapper });
+    expect(result.current.actionParamOptionLabel).toBeTypeOf('function');
+    // No translation registered for this option key → fallback (English literal).
+    expect(
+      result.current.actionParamOptionLabel('sys_environment', 'upgrade', 'plan', 'team', 'Team — $99/mo'),
+    ).toBe('Team — $99/mo');
+  });
+
+  it('returns the fallback when action or param name is missing', () => {
+    const { result } = renderHook(() => useObjectLabel(), { wrapper });
+    expect(result.current.actionParamOptionLabel(undefined, undefined, 'plan', 'team', 'Team')).toBe('Team');
+    expect(result.current.actionParamOptionLabel('sys_environment', 'upgrade', '', 'team', 'Team')).toBe('Team');
+  });
+});

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -407,6 +407,25 @@ export function useObjectLabel() {
       const resolved = resolve(suffixes, fb);
       return resolved || undefined;
     },
+    /**
+     * Resolve a translated action-parameter SELECT OPTION label.
+     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.params.{paramName}.options.{optionValue}`.
+     * Falls back to the provided (English metadata) label when untranslated.
+     */
+    actionParamOptionLabel: (
+      objectName: string | undefined,
+      actionName: string | undefined,
+      paramName: string,
+      optionValue: string,
+      fallback: string,
+    ) => {
+      if (!actionName || !paramName) return fallback;
+      const suffix = `_actions.${actionName}.params.${paramName}.options.${optionValue}`;
+      const suffixes = objectName
+        ? objectSuffixes(objectName, suffix)
+        : `globalActions.${actionName}.params.${paramName}.options.${optionValue}`;
+      return resolve(suffixes, fallback);
+    },
   };
   }, [t, i18n]);
 }


### PR DESCRIPTION
Adds useObjectLabel().actionParamOptionLabel() (objects.<o>._actions.<a>.params.<p>.options.<value>), mapped over each param's options[].label in useConsoleActionRuntime + RecordDetailView; falls back to metadata literal. Spec models it (framework#1860). New unit test + existing suite passes.