### PR TITLE
feat(ai-chat): reconcile stream-transport failure instead of blind retry (ADR-0013 D2)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -56,7 +56,10 @@ import {
   writeConversationMessagesCache,
   type HydratedUIMessage,
   type HydratedUIMessagePart,
+  fetchConversation,
+  toUIMessages,
 } from '../../hooks/useChatConversation';
+import { isReconcilableCompletedTurn } from './reconcileTurn';
 import { ConversationsSidebar } from './ConversationsSidebar';
 import { LiveCanvas } from './LiveCanvas';
 
@@ -742,6 +745,35 @@ function ChatPane({
     return buildAgentSuggestions(activeAgent, activeAgentLabel, t);
   }, [hydrated.length, activeAgent, activeAgentLabel, t]);
 
+  // ADR-0013 D2: a stream-transport drop may happen AFTER the server already
+  // persisted the final reply (it persists before streaming). Before surfacing a
+  // scary "Response failed", reconcile from the server — if the turn completed,
+  // render the persisted reply instead of offering a re-run.
+  const [errorSuppressed, setErrorSuppressed] = useState(false);
+  const setMessagesRef = useRef<((m: unknown[]) => void) | undefined>(undefined);
+  const handleChatError = useCallback(
+    async (_err: Error) => {
+      const aiBase = chatApi?.replace(/\/agents\/[^/]+\/chat$/, '');
+      if (!conversationId || !aiBase) {
+        setErrorSuppressed(false);
+        return;
+      }
+      try {
+        const conv = await fetchConversation(aiBase, conversationId);
+        const ui = toUIMessages(conv?.messages);
+        if (isReconcilableCompletedTurn(ui) && setMessagesRef.current) {
+          setMessagesRef.current(ui as unknown[]);
+          setErrorSuppressed(true);
+          return;
+        }
+      } catch {
+        /* fall through to the normal error banner */
+      }
+      setErrorSuppressed(false);
+    },
+    [conversationId, chatApi],
+  );
+
   const {
     messages,
     isLoading,
@@ -750,9 +782,11 @@ function ChatPane({
     stop,
     reload,
     clear,
+    setMessages,
   } = useObjectChat({
     api: chatApi,
     conversationId,
+    onError: handleChatError,
     body: {
       context: {
         activeApp: 'AI',
@@ -767,6 +801,10 @@ function ChatPane({
     autoResponseText: "Thanks for your message! I'm here to help.",
     autoResponseDelay: 600,
   });
+
+  useEffect(() => {
+    setMessagesRef.current = setMessages;
+  }, [setMessages]);
 
   useEffect(() => {
     writeConversationMessagesCache(
@@ -785,6 +823,7 @@ function ChatPane({
 
   const handleSend = useCallback(
     (content: string, files?: File[]) => {
+      setErrorSuppressed(false);
       sendMessage(content, files);
       onSent(content);
     },
@@ -900,7 +939,7 @@ function ChatPane({
         onStop={isLoading ? stop : undefined}
         onReload={reload}
         isLoading={isLoading}
-        error={error}
+        error={errorSuppressed ? undefined : error}
         enableMarkdown
         onToolApprove={hitl.decide}
         toolDecisions={hitl.decisions}

--- a/packages/app-shell/src/console/ai/__tests__/reconcileTurn.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/reconcileTurn.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { isReconcilableCompletedTurn } from '../reconcileTurn';
+
+const text = (t: string) => ({ type: 'text', text: t });
+const toolCall = { type: 'tool-create_object', toolCallId: 'x' };
+
+describe('isReconcilableCompletedTurn (ADR-0013 D2)', () => {
+  it('true when the thread ends on an assistant text reply', () => {
+    expect(isReconcilableCompletedTurn([
+      { role: 'user', parts: [text('build a CRM')] },
+      { role: 'assistant', parts: [toolCall, text('Done — your CRM is ready.')] },
+    ])).toBe(true);
+  });
+
+  it('false when the last assistant turn only emitted tool calls (no final text)', () => {
+    expect(isReconcilableCompletedTurn([
+      { role: 'user', parts: [text('build a CRM')] },
+      { role: 'assistant', parts: [toolCall] },
+    ])).toBe(false);
+  });
+
+  it('false when the thread ends on a tool result (turn still mid-flight)', () => {
+    expect(isReconcilableCompletedTurn([
+      { role: 'user', parts: [text('build a CRM')] },
+      { role: 'assistant', parts: [toolCall] },
+      { role: 'tool', parts: [{ type: 'tool-result' }] },
+    ])).toBe(false);
+  });
+
+  it('false for an assistant reply that is only whitespace', () => {
+    expect(isReconcilableCompletedTurn([
+      { role: 'user', parts: [text('hi')] },
+      { role: 'assistant', parts: [text('   ')] },
+    ])).toBe(false);
+  });
+
+  it('false for empty / missing history', () => {
+    expect(isReconcilableCompletedTurn([])).toBe(false);
+    expect(isReconcilableCompletedTurn(undefined)).toBe(false);
+  });
+
+  it('false when the last message is the user (no reply yet)', () => {
+    expect(isReconcilableCompletedTurn([
+      { role: 'user', parts: [text('hi')] },
+    ])).toBe(false);
+  });
+});

--- a/packages/app-shell/src/console/ai/reconcileTurn.ts
+++ b/packages/app-shell/src/console/ai/reconcileTurn.ts
@@ -1,0 +1,28 @@
+// ADR-0013 D2: pure decision helper for "reconcile on stream-transport failure".
+//
+// The agent runtime persists the FINAL assistant reply BEFORE it streams it, so a
+// transport drop after completion leaves a complete reply in the conversation. On
+// a chat stream error the client re-fetches the conversation and asks: did this
+// turn actually finish? If so it renders the persisted reply instead of a scary
+// "Response failed / Retry" (which would blindly re-run and risk re-planning).
+//
+// "Finished" = the last message is an assistant message that carries non-empty
+// TEXT (not merely tool calls). A thread that ends on a tool result, or on an
+// assistant turn that only emitted tool calls, did NOT produce a final reply →
+// genuine failure → show the banner.
+
+export interface ReconcileMessageLike {
+  role: string;
+  parts: Array<{ type: string; text?: unknown }>;
+}
+
+export function isReconcilableCompletedTurn(
+  messages: ReconcileMessageLike[] | undefined,
+): boolean {
+  if (!messages || messages.length === 0) return false;
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'assistant') return false;
+  return last.parts.some(
+    (part) => part.type === 'text' && String(part.text ?? '').trim().length > 0,
+  );
+}

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -226,7 +226,7 @@ function contentToParts(content: unknown): HydratedUIMessagePart[] {
   return [];
 }
 
-function toUIMessages(rows: ServerMessage[] | undefined): HydratedUIMessage[] {
+export function toUIMessages(rows: ServerMessage[] | undefined): HydratedUIMessage[] {
   if (!rows) return [];
   const out: HydratedUIMessage[] = [];
   rows.forEach((row, idx) => {
@@ -243,7 +243,7 @@ function toUIMessages(rows: ServerMessage[] | undefined): HydratedUIMessage[] {
   return out;
 }
 
-async function fetchConversation(apiBase: string, id: string): Promise<ServerConversation | null> {
+export async function fetchConversation(apiBase: string, id: string): Promise<ServerConversation | null> {
   const res = await fetch(`${apiBase}/conversations/${encodeURIComponent(id)}`, {
     credentials: 'include',
   });

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -109,6 +109,8 @@ export interface UseObjectChatReturn {
   reload: () => void;
   /** Clear all messages */
   clear: () => void;
+  /** ADR-0013 D2: re-hydrate the thread (API mode only); undefined in local mode. */
+  setMessages?: (messages: unknown[]) => void;
   /** Whether the hook is operating in API (streaming) mode */
   isApiMode: boolean;
   /** Input value (controlled by the hook for API mode) */
@@ -322,6 +324,10 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
       stop,
       reload: regenerate,
       clear,
+      // ADR-0013 D2: expose the underlying useChat setMessages so the host can
+      // re-hydrate the thread from the server after a stream-transport failure
+      // (the reply may already be persisted server-side — reconcile, don't re-run).
+      setMessages,
       isApiMode: true,
       input: apiInput,
       setInput: setApiInput,


### PR DESCRIPTION
ADR-0013 **D2** (objectui-only). The agent runtime persists the final assistant reply **before** it streams it (framework `service-ai` `ai-service.ts:779/895` persist → `789/905` yield). So a transport drop **after** the turn completed leaves a complete reply in the DB — but the chat UI shows "Response failed" and Retry **re-runs the whole turn** (re-plans, risks orphan drafts).

**Change**: on a chat stream error, GET the conversation and check if the turn actually finished; if so, re-hydrate the thread from the server and **suppress the error banner**. Only a genuinely-incomplete turn still shows Retry. **Turns the most common "it actually succeeded" failure into a non-event.**

### Files
- `useChatConversation.ts` — export `fetchConversation` + `toUIMessages`
- `useObjectChat.ts` — expose `setMessages` (API mode)
- `reconcileTurn.ts` — pure `isReconcilableCompletedTurn()` + **6 unit tests (pass)**
- `AiChatPage.tsx` — onError reconcile + suppress, reset on send, gate banner

### Verification
- `reconcileTurn.test.ts`: 6/6 pass (ends-on-assistant-text → reconcile; ends-on-tool-call/tool-result/whitespace/empty/user → fall through to banner).
- No framework/schema change (server already persists-before-yield); objectui-only.
- Full build/typecheck in CI.

Pairs with the (heavier, cross-repo) ADR-0013 **D1** turnId idempotency, which handles the *genuinely-failed* retry path; D2 here handles *"it actually succeeded."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)