### PR TITLE
fix(action): consume spec `disabled` (boolean|CEL) in action button (framework#1885)

### DIFF
--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -51,8 +51,15 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
     // Record data may be passed from SchemaRenderer (e.g. DetailView passes record data)
     const recordData = data != null && typeof data === 'object' ? data as Record<string, any> : {};
 
-    // Evaluate visibility and enabled conditions with record data context
+    // Evaluate visibility and disabled conditions with record data context.
     const isVisible = useCondition(toPredicateInput(schema.visible), recordData);
+    // Spec field is `disabled` (boolean | CEL predicate — disabled when TRUE).
+    // It previously had zero consumers (the renderer only read a non-spec
+    // `enabled`), so a spec-authored `disabled` guard did nothing (#1885,
+    // ADR-0049). We now consume `disabled` as the primary control and keep the
+    // legacy non-spec `enabled` as a deprecated fallback so existing metadata
+    // keeps working.
+    const isDisabled = useCondition(toPredicateInput((schema as any).disabled), recordData);
     const isEnabled = useCondition(toPredicateInput(schema.enabled), recordData);
 
     // Resolve icon
@@ -113,7 +120,13 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
         variant={variant as any}
         size={size as any}
         className={cn(schema.className, className)}
-        disabled={(schema.enabled ? !isEnabled : false) || loading}
+        disabled={(
+          (schema as any).disabled != null
+            ? isDisabled
+            : schema.enabled != null
+              ? !isEnabled
+              : false
+        ) || loading}
         onClick={handleClick}
         {...rest}
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}


### PR DESCRIPTION
## What

The action button renderer only read a **non-spec `enabled`** prop. The spec field is **`disabled`** (boolean | CEL predicate — disabled when TRUE), which had **zero consumers** — so a spec-authored `disabled` guard silently did nothing.

Surfaced by the metadata property liveness audit (objectstack-ai/framework#1878, item #1885; ADR-0049 "enforce-or-remove").

## Change
`action-button.tsx` now consumes `disabled` as the primary control (via the existing `toPredicateInput`/`useCondition`, which already handle boolean + CEL `{source}` forms). The legacy non-spec `enabled` is retained as a **deprecated fallback** so existing metadata keeps working.

## Verification
`tsc --noEmit` clean for `@object-ui/components`.

Refs objectstack-ai/framework#1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)
