### PR TITLE
feat(plugin-chatbot): send a stable per-turn turnId for safe Retry (ADR-0013 D1)

### DIFF
--- a/packages/plugin-chatbot/src/__tests__/withTurnId.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/withTurnId.test.ts
@@ -1,0 +1,74 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit tests for turn idempotency (ADR-0013 D1). `withTurnId` is wired into
+ * the chat transport's `prepareSendMessagesRequest` so every outgoing turn
+ * carries a stable `turnId` derived from the triggering user message — the
+ * key the server uses to dedup the user message and short-circuit a completed
+ * turn on Retry instead of re-planning.
+ */
+import { describe, it, expect } from 'vitest';
+import { withTurnId } from '../useObjectChat';
+
+describe('withTurnId', () => {
+  it('derives turnId from the last user message id', () => {
+    const out = withTurnId({
+      body: { conversationId: 'conv_1' },
+      messages: [
+        { id: 'u1', role: 'user' },
+        { id: 'a1', role: 'assistant' },
+        { id: 'u2', role: 'user' },
+      ],
+    });
+    expect(out.body.turnId).toBe('u2');
+    // Existing body fields are preserved.
+    expect(out.body.conversationId).toBe('conv_1');
+  });
+
+  it('is stable across a Retry — same triggering user message → same turnId', () => {
+    // Initial submit: messages end with the new user turn.
+    const submit = withTurnId({
+      body: {},
+      messages: [
+        { id: 'u1', role: 'user' },
+        { id: 'a1', role: 'assistant' },
+        { id: 'u2', role: 'user' },
+      ],
+    });
+    // Retry/regenerate re-sends the SAME trailing user turn (the assistant
+    // reply being regenerated may be absent or re-appended after it).
+    const retry = withTurnId({
+      body: {},
+      messages: [
+        { id: 'u1', role: 'user' },
+        { id: 'a1', role: 'assistant' },
+        { id: 'u2', role: 'user' },
+        { id: 'a2-failed', role: 'assistant' },
+      ],
+    });
+    expect(submit.body.turnId).toBe('u2');
+    expect(retry.body.turnId).toBe('u2');
+  });
+
+  it('produces a distinct turnId for each new user turn', () => {
+    const first = withTurnId({ body: {}, messages: [{ id: 'u1', role: 'user' }] });
+    const second = withTurnId({
+      body: {},
+      messages: [
+        { id: 'u1', role: 'user' },
+        { id: 'a1', role: 'assistant' },
+        { id: 'u2', role: 'user' },
+      ],
+    });
+    expect(first.body.turnId).toBe('u1');
+    expect(second.body.turnId).toBe('u2');
+    expect(first.body.turnId).not.toBe(second.body.turnId);
+  });
+
+  it('omits turnId when there is no user message (defensive)', () => {
+    const out = withTurnId({ body: { keep: 1 }, messages: [{ id: 'a1', role: 'assistant' }] });
+    expect(out.body.turnId).toBeUndefined();
+    expect(out.body.keep).toBe(1);
+  });
+});

--- a/packages/plugin-chatbot/src/__tests__/withTurnId.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/withTurnId.test.ts
@@ -26,6 +26,26 @@ describe('withTurnId', () => {
     expect(out.body.conversationId).toBe('conv_1');
   });
 
+  it('reconstructs the default body fields (the hook output is sent VERBATIM)', () => {
+    // Regression: returning a body WITHOUT messages makes the server 400 with
+    // "messages array is required". The hook must re-include id/messages/
+    // trigger/messageId, since the SDK does not merge its defaults back in.
+    const messages = [{ id: 'u1', role: 'user' }];
+    const out = withTurnId({
+      id: 'chat_1',
+      body: { conversationId: 'conv_1' },
+      messages,
+      trigger: 'submit-message',
+      messageId: 'u1',
+    });
+    expect(out.body.messages).toBe(messages);
+    expect(out.body.id).toBe('chat_1');
+    expect(out.body.trigger).toBe('submit-message');
+    expect(out.body.messageId).toBe('u1');
+    expect(out.body.turnId).toBe('u1');
+    expect(out.body.conversationId).toBe('conv_1');
+  });
+
   it('is stable across a Retry — same triggering user message → same turnId', () => {
     // Initial submit: messages end with the new user turn.
     const submit = withTurnId({

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -22,17 +22,31 @@ import { uiMessagesToChatMessages } from './mapMessages';
  * dedups the inbound user message by (conversationId, turnId) and
  * short-circuits a completed turn instead of re-running tools / replanning.
  *
- * Exported for unit testing; wired into the transport's
- * `prepareSendMessagesRequest` below.
+ * Used as `DefaultChatTransport.prepareSendMessagesRequest`. IMPORTANT: when
+ * that hook returns a `body`, the SDK sends it VERBATIM — the default body
+ * (`id`/`messages`/`trigger`/`messageId`) is NOT merged in. So we must
+ * reconstruct exactly what the default transport would send and only ADD
+ * `turnId`; otherwise the server receives no `messages` array (400).
+ *
+ * Exported for unit testing.
  */
 export function withTurnId(req: {
-  body: Record<string, unknown> | undefined;
+  id?: string;
+  body?: Record<string, unknown>;
   messages: Array<{ id: string; role: string }>;
+  trigger?: unknown;
+  messageId?: string;
 }): { body: Record<string, unknown> } {
   const lastUser = [...req.messages].reverse().find((m) => m.role === 'user');
   return {
     body: {
+      // Replicate the transport's default body (see HttpChatTransport.sendMessages)…
       ...(req.body ?? {}),
+      id: req.id,
+      messages: req.messages,
+      trigger: req.trigger,
+      messageId: req.messageId,
+      // …then add the per-turn idempotency key.
       ...(lastUser ? { turnId: lastUser.id } : {}),
     },
   };
@@ -256,9 +270,10 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
         ...(systemPrompt ? { systemPrompt } : {}),
         ...(streamingEnabled !== undefined ? { stream: streamingEnabled } : {}),
       },
-      // Stamp a stable per-turn idempotency key (ADR-0013 D1). See withTurnId.
-      prepareSendMessagesRequest: ({ body: reqBody, messages }) =>
-        withTurnId({ body: reqBody, messages }),
+      // Stamp a stable per-turn idempotency key (ADR-0013 D1). See withTurnId —
+      // it reconstructs the full default body (incl. messages) + adds turnId.
+      prepareSendMessagesRequest: ({ id, body: reqBody, messages, trigger, messageId }) =>
+        withTurnId({ id, body: reqBody, messages, trigger, messageId }),
     });
   }, [isApiMode, api, headers, body, model, systemPrompt, streamingEnabled, conversationId]);
 

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -13,6 +13,31 @@ import { DefaultChatTransport } from 'ai';
 import { generateUniqueId } from './utils';
 import { uiMessagesToChatMessages } from './mapMessages';
 
+/**
+ * Stamp a stable per-turn idempotency key (ADR-0013 D1) onto the outgoing
+ * request body, derived from the id of the user message that triggered the
+ * turn. On Retry the AI SDK re-sends the SAME triggering user message
+ * (regenerate-message keeps the trailing user turn), so its id — and thus the
+ * turnId — is identical across the original send and the retry. The server
+ * dedups the inbound user message by (conversationId, turnId) and
+ * short-circuits a completed turn instead of re-running tools / replanning.
+ *
+ * Exported for unit testing; wired into the transport's
+ * `prepareSendMessagesRequest` below.
+ */
+export function withTurnId(req: {
+  body: Record<string, unknown> | undefined;
+  messages: Array<{ id: string; role: string }>;
+}): { body: Record<string, unknown> } {
+  const lastUser = [...req.messages].reverse().find((m) => m.role === 'user');
+  return {
+    body: {
+      ...(req.body ?? {}),
+      ...(lastUser ? { turnId: lastUser.id } : {}),
+    },
+  };
+}
+
 type InitialMessage = OuiChatMessage & {
   parts?: Array<Record<string, unknown>>;
   reasoning?: string;
@@ -231,6 +256,9 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
         ...(systemPrompt ? { systemPrompt } : {}),
         ...(streamingEnabled !== undefined ? { stream: streamingEnabled } : {}),
       },
+      // Stamp a stable per-turn idempotency key (ADR-0013 D1). See withTurnId.
+      prepareSendMessagesRequest: ({ body: reqBody, messages }) =>
+        withTurnId({ body: reqBody, messages }),
     });
   }, [isApiMode, api, headers, body, model, systemPrompt, streamingEnabled, conversationId]);
 


### PR DESCRIPTION
## ADR-0013 D1 — client turnId

Part of the cross-repo durable-turn work for [cloud#334](https://github.com/objectstack-ai/cloud/issues/334). Pairs with framework [#1900](https://github.com/objectstack-ai/framework/pull/1900) (server-side dedup/short-circuit) and a cloud SHA bump, coordinated via the ADR-0012 cross-repo recipe. Builds on D2 ([#1742](https://github.com/objectstack-ai/objectui/pull/1742)) which reconciles a turn that actually succeeded; D1 covers the genuinely-failed retry path.

### Change
The chat transport now stamps a stable `turnId` on every outgoing turn, derived from the id of the user message that triggered it. On Retry the AI SDK re-sends the SAME triggering user message (regenerate-message keeps the trailing user turn), so the id — and thus the `turnId` — is identical across the original send and the retry. The server uses this key to dedup the inbound user message and short-circuit a completed turn instead of re-running tools / re-planning.

- `useObjectChat`: `DefaultChatTransport.prepareSendMessagesRequest` → `withTurnId` (extracted + exported for unit testing). One transport covers both consoles (`AiChatPage` + `ConsoleFloatingChatbot`); it is the only `DefaultChatTransport` in the codebase.

### Tests
`withTurnId`: derivation from last user message, stability across Retry, distinct id per new turn, defensive no-user case. Green alongside `mapMessages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)