### PR TITLE
fix(chart): render ADR-0021 dataset-bound chart views (framework#1890)

### DIFF
--- a/.changeset/fix-chart-dataset-1890.md
+++ b/.changeset/fix-chart-dataset-1890.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+fix(chart): consume ADR-0021 `dataset` binding in list/object chart views
+
+Chart views authored to the current spec (ADR-0021: `dataset` + `dimensions` +
+`values`) previously rendered nothing — the renderers only read the **removed**
+legacy inline `xAxisField` / `yAxisFields` / `aggregation` shape, so a
+spec-compliant chart view showed an empty canvas. `ObjectChart` now runs the
+governed `queryDataset` path when a chart binds to a dataset (the same path the
+dashboard `DatasetWidget` uses, so numbers stay consistent), and `ListView` /
+`ObjectView` emit the dataset shape. The legacy inline aggregate is kept as a
+deprecated fallback so pre-ADR-0021 metadata keeps rendering.
+
+Refs objectstack-ai/framework#1890

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1074,6 +1074,31 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
 
         if (viewDef.type === 'chart') {
             const chartConfig = viewDef.chart || {};
+            // ADR-0021 (#1890): dataset-bound chart — the single author-facing
+            // shape. Selects dimensions/measures BY NAME and runs through the
+            // governed queryDataset path (numbers consistent across surfaces).
+            if (chartConfig.dataset) {
+                const dims: string[] = Array.isArray(chartConfig.dimensions) ? chartConfig.dimensions : [];
+                const vals: string[] = Array.isArray(chartConfig.values) ? chartConfig.values : [];
+                return (
+                    <Suspense key={key} fallback={<div className="p-4 text-sm text-muted-foreground">Loading chart…</div>}>
+                        <ObjectChart
+                            dataSource={ds}
+                            schema={{
+                                type: 'object-chart',
+                                dataset: chartConfig.dataset,
+                                dimensions: dims,
+                                values: vals,
+                                chartType: chartConfig.chartType || 'bar',
+                                xAxisKey: dims[0],
+                                series: vals.map((v: string) => ({ dataKey: v, label: v })),
+                                config: chartConfig.config,
+                                className: 'h-[400px] w-full',
+                            } as any}
+                        />
+                    </Suspense>
+                );
+            }
             // ObjectChart consumes a structured `aggregate` ({ field, function,
             // groupBy }) + `xAxisKey` + `series`, NOT the flat spec-level
             // `xAxisField`/`yAxisFields`/`aggregation` keys. Translate here so the

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -244,7 +244,7 @@ export const ObjectChart = (props: any) => {
   // doesn't flash before the fetch effect runs and flips loading to true.
   const [loading, setLoading] = useState<boolean>(() => {
     const hasInline = Array.isArray(schema.data) && schema.data.length > 0;
-    return !hasInline && !!schema.objectName;
+    return !hasInline && (!!schema.objectName || !!schema.dataset);
   });
   const [error, setError] = useState<string | null>(null);
   // Drill-down click event — must be declared with the other hooks (above
@@ -265,6 +265,15 @@ export const ObjectChart = (props: any) => {
   const compareToKey = useMemo(
     () => ((schema as any).compareTo ? JSON.stringify((schema as any).compareTo) : ''),
     [(schema as any).compareTo],
+  );
+  // ADR-0021 (#1890): a chart can bind to a semantic-layer `dataset` instead of
+  // the legacy inline `objectName` + `aggregate` query. Stable key over the
+  // dataset selection so a fresh object literal each render doesn't refetch-loop.
+  const datasetKey = useMemo(
+    () => (schema.dataset
+      ? JSON.stringify({ d: schema.dataset, dim: schema.dimensions ?? [], val: schema.values ?? [] })
+      : ''),
+    [schema.dataset, schema.dimensions, schema.values],
   );
 
   // Pie / donut / funnel are single-distribution charts where a comparison
@@ -323,7 +332,7 @@ export const ObjectChart = (props: any) => {
   }, [schema.objectName, aggregateKey]);
 
   const fetchData = useCallback(async (ds: any, mounted: { current: boolean }) => {
-      if (!ds || !schema.objectName) {
+      if (!ds || (!schema.objectName && !schema.dataset)) {
         // No way to fetch — clear loading so the no-datasource / empty state
         // can render instead of an indefinite "Loading chart data…".
         if (mounted.current) setLoading(false);
@@ -334,6 +343,25 @@ export const ObjectChart = (props: any) => {
         setError(null);
       }
       try {
+          // ── Dataset-bound path (ADR-0021, #1890) ──────────────
+          // When the chart binds to a semantic-layer `dataset`, run the same
+          // governed `queryDataset` path the dashboard DatasetWidget and
+          // dataset-bound reports use, so the numbers match everywhere. The
+          // server resolves dimension labels + measure formats, so the legacy
+          // client-side aggregate / groupBy-label resolution below is skipped.
+          if (schema.dataset && typeof ds.queryDataset === 'function') {
+              const runtimeFilter = resolveDateMacros(schema.filter);
+              const res = await ds.queryDataset(schema.dataset, {
+                  dimensions: Array.isArray(schema.dimensions) ? schema.dimensions : [],
+                  measures: Array.isArray(schema.values) ? schema.values : [],
+                  ...(runtimeFilter ? { runtimeFilter } : {}),
+              });
+              if (mounted.current) {
+                  setFetchedData(Array.isArray(res?.rows) ? res.rows : []);
+              }
+              return;
+          }
+
           // Resolve relative-date macros (e.g. "{current_quarter_start}")
           // so both aggregate and find see real ISO dates and any drill-down
           // filter further down the line stays consistent.
@@ -440,12 +468,12 @@ export const ObjectChart = (props: any) => {
           if (mounted.current) setLoading(false);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [schema.objectName, aggregateKey, filterKey, compareToKey, schema.xAxisKey, schema.chartType, runAggregate]);
+  }, [schema.objectName, datasetKey, aggregateKey, filterKey, compareToKey, schema.xAxisKey, schema.chartType, runAggregate]);
 
   useEffect(() => {
     const mounted = { current: true };
 
-    if (schema.objectName && !boundData && !schema.data) {
+    if ((schema.objectName || schema.dataset) && !boundData && !schema.data) {
         fetchData(dataSource, mounted);
     } else if (mounted.current) {
         // Have inline / bound data — won't fetch; clear loading.
@@ -453,7 +481,7 @@ export const ObjectChart = (props: any) => {
     }
     return () => { mounted.current = false; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [schema.objectName, dataSource, boundData, schema.data, filterKey, aggregateKey, compareToKey, fetchData]);
+  }, [schema.objectName, datasetKey, dataSource, boundData, schema.data, filterKey, aggregateKey, compareToKey, fetchData]);
 
   const rawData = boundData || schema.data || fetchedData;
   const finalData = Array.isArray(rawData) ? rawData : [];

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1411,6 +1411,25 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         // records (e.g. sum of estimate_hours grouped by status), delegating
         // to the same object-chart component the dashboard uses.
         const chartCfg = (schema as any).chart || schema.options?.chart || {};
+        // ADR-0021 (#1890): the single author-facing shape binds to a semantic
+        // `dataset` and selects dimensions/measures BY NAME, so the chart runs
+        // through the governed queryDataset path (numbers consistent everywhere).
+        if (chartCfg.dataset) {
+          const dims: string[] = Array.isArray(chartCfg.dimensions) ? chartCfg.dimensions : [];
+          const vals: string[] = Array.isArray(chartCfg.values) ? chartCfg.values : [];
+          return {
+            type: 'object-chart',
+            dataset: chartCfg.dataset,
+            dimensions: dims,
+            values: vals,
+            chartType: chartCfg.chartType || 'bar',
+            xAxisKey: dims[0],
+            series: vals.map((v: string) => ({ dataKey: v, label: v })),
+            className: 'h-[400px] w-full',
+          };
+        }
+        // Legacy inline aggregate (deprecated — pre-ADR-0021 metadata). Kept as a
+        // fallback so existing authored chart views keep rendering.
         const valueField = (Array.isArray(chartCfg.yAxisFields) && chartCfg.yAxisFields[0])
           || chartCfg.valueField || 'value';
         const categoryField = chartCfg.xAxisField || chartCfg.categoryField || 'name';

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -752,6 +752,22 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
         // Aggregated chart of the object's records, delegating to the same
         // object-chart component the dashboard uses.
         const chartCfg = viewOptions.chart || {};
+        // ADR-0021 (#1890): dataset-bound chart — the single author-facing shape.
+        if (chartCfg.dataset) {
+          const dims: string[] = Array.isArray(chartCfg.dimensions) ? chartCfg.dimensions : [];
+          const vals: string[] = Array.isArray(chartCfg.values) ? chartCfg.values : [];
+          return {
+            type: 'object-chart',
+            dataset: chartCfg.dataset,
+            dimensions: dims,
+            values: vals,
+            chartType: chartCfg.chartType || 'bar',
+            xAxisKey: dims[0],
+            series: vals.map((v: string) => ({ dataKey: v, label: v })),
+            className: 'h-[400px] w-full',
+          };
+        }
+        // Legacy inline aggregate (deprecated — pre-ADR-0021 metadata).
         const valueField = (Array.isArray(chartCfg.yAxisFields) && chartCfg.yAxisFields[0])
           || chartCfg.valueField || 'value';
         const categoryField = chartCfg.xAxisField || chartCfg.categoryField || 'name';

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -2092,16 +2092,22 @@ export interface KanbanConditionalFormattingRule {
  */
 export interface ObjectChartSchema extends BaseSchema {
   type: 'object-chart';
-  /** ObjectQL object name */
-  objectName: string;
+  /** ObjectQL object name (legacy inline path; optional under ADR-0021 dataset binding) */
+  objectName?: string;
   /** Chart type */
   chartType: 'bar' | 'line' | 'pie' | 'area' | 'scatter';
-  /** Field for X axis (categories) */
-  xAxisField: string;
-  /** Fields for Y axis (values) */
+  /** Field for X axis (categories) — legacy inline path */
+  xAxisField?: string;
+  /** Fields for Y axis (values) — legacy */
   yAxisFields?: string[];
-  /** Aggregation function */
+  /** Aggregation function — legacy */
   aggregation?: 'cardinality' | 'sum' | 'avg' | 'min' | 'max';
+  /** Semantic-layer dataset name (ADR-0021, #1890) */
+  dataset?: string;
+  /** Dataset dimension names */
+  dimensions?: string[];
+  /** Dataset measure names */
+  values?: string[];
 }
 
 /**

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -421,11 +421,18 @@ export const ObjectKanbanSchema = BaseSchema.extend({
  */
 export const ObjectChartSchema = BaseSchema.extend({
   type: z.literal('object-chart'),
-  objectName: z.string().describe('ObjectQL object name'),
+  // Legacy inline path (objectName + aggregate). Optional now that a chart may
+  // instead bind to a semantic-layer dataset (ADR-0021, #1890).
+  objectName: z.string().optional().describe('ObjectQL object name (legacy inline path)'),
   chartType: z.enum(['bar', 'line', 'pie', 'area', 'scatter']).describe('Chart type'),
-  xAxisField: z.string().describe('X axis field'),
-  yAxisFields: z.array(z.string()).optional().describe('Y axis fields'),
-  aggregation: z.enum(['cardinality', 'sum', 'avg', 'min', 'max']).optional().describe('Aggregation'),
+  xAxisField: z.string().optional().describe('X axis field (legacy inline path)'),
+  yAxisFields: z.array(z.string()).optional().describe('Y axis fields (legacy)'),
+  aggregation: z.enum(['cardinality', 'sum', 'avg', 'min', 'max']).optional().describe('Aggregation (legacy)'),
+  // ADR-0021 semantic-layer binding: dimensions/measures selected BY NAME from a
+  // dataset, queried via the governed queryDataset path.
+  dataset: z.string().optional().describe('Semantic-layer dataset name (ADR-0021)'),
+  dimensions: z.array(z.string()).optional().describe('Dataset dimension names'),
+  values: z.array(z.string()).optional().describe('Dataset measure names'),
 });
 
 /**


### PR DESCRIPTION
## What

Chart views authored to the **current** spec rendered **nothing**. Post-ADR-0021 the spec exposes only `dataset` / `dimensions` / `values` (the legacy inline `xAxisField` / `yAxisFields` / `aggregation` shape was removed in `@objectstack/spec` 9.0.0), but the chart renderers were never migrated — they still read the removed legacy keys. A spec-compliant chart view showed an empty canvas.

Surfaced by the view-schema liveness audit (objectstack-ai/framework#1890).

## Change
- **`ObjectChart`** — when a chart binds to a `dataset`, fetch via the governed `dataSource.queryDataset` path (the same path the dashboard `DatasetWidget` and dataset-bound reports use, so numbers/labels/formats stay consistent). Legacy single-object `aggregate` kept as a deprecated fallback.
- **object-chart schema** (`@object-ui/types`) — `objectName`/`xAxisField` now optional; added optional `dataset`/`dimensions`/`values`.
- **`ListView`** (`type:'chart'`) + **`ObjectView`** (plugin-view & app-shell) — chart case emits the dataset shape when `chart.dataset` is set; legacy aggregate retained as a deprecated fallback so pre-ADR-0021 metadata keeps rendering.

## Verification
- Core packages build green (`@object-ui/types`, `plugin-charts`, `plugin-list`, `plugin-view`).
- **In-browser**: showcase Task → "Hours by Status (Chart)" view (binds `showcase_task_metrics`) now renders a bar chart with live data (was blank before the change).

Refs objectstack-ai/framework#1890

🤖 Generated with [Claude Code](https://claude.com/claude-code)
