### PR TITLE
feat(app-shell): unify D2 reconcile-on-error across chat surfaces (ADR-0013)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -56,10 +56,8 @@ import {
   writeConversationMessagesCache,
   type HydratedUIMessage,
   type HydratedUIMessagePart,
-  fetchConversation,
-  toUIMessages,
 } from '../../hooks/useChatConversation';
-import { isReconcilableCompletedTurn } from './reconcileTurn';
+import { useReconcileOnError } from '../../hooks/useReconcileOnError';
 import { ConversationsSidebar } from './ConversationsSidebar';
 import { LiveCanvas } from './LiveCanvas';
 
@@ -745,34 +743,10 @@ function ChatPane({
     return buildAgentSuggestions(activeAgent, activeAgentLabel, t);
   }, [hydrated.length, activeAgent, activeAgentLabel, t]);
 
-  // ADR-0013 D2: a stream-transport drop may happen AFTER the server already
-  // persisted the final reply (it persists before streaming). Before surfacing a
-  // scary "Response failed", reconcile from the server — if the turn completed,
-  // render the persisted reply instead of offering a re-run.
-  const [errorSuppressed, setErrorSuppressed] = useState(false);
-  const setMessagesRef = useRef<((m: unknown[]) => void) | undefined>(undefined);
-  const handleChatError = useCallback(
-    async (_err: Error) => {
-      const aiBase = chatApi?.replace(/\/agents\/[^/]+\/chat$/, '');
-      if (!conversationId || !aiBase) {
-        setErrorSuppressed(false);
-        return;
-      }
-      try {
-        const conv = await fetchConversation(aiBase, conversationId);
-        const ui = toUIMessages(conv?.messages);
-        if (isReconcilableCompletedTurn(ui) && setMessagesRef.current) {
-          setMessagesRef.current(ui as unknown[]);
-          setErrorSuppressed(true);
-          return;
-        }
-      } catch {
-        /* fall through to the normal error banner */
-      }
-      setErrorSuppressed(false);
-    },
-    [conversationId, chatApi],
-  );
+  // ADR-0013 D2: reconcile a stream-transport failure instead of blindly
+  // retrying. Shared across chat surfaces — see useReconcileOnError.
+  const { errorSuppressed, handleChatError, setMessagesRef, resetSuppression } =
+    useReconcileOnError({ chatApi, conversationId });
 
   const {
     messages,
@@ -823,7 +797,7 @@ function ChatPane({
 
   const handleSend = useCallback(
     (content: string, files?: File[]) => {
-      setErrorSuppressed(false);
+      resetSuppression();
       sendMessage(content, files);
       onSent(content);
     },

--- a/packages/app-shell/src/hooks/__tests__/useReconcileOnError.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/useReconcileOnError.test.ts
@@ -1,0 +1,89 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit tests for the shared ADR-0013 D2 reconcile-on-error wiring used by every
+ * chat surface (AiChatPage + console floating chatbot). The pure decision is
+ * tested in console/ai/__tests__/reconcileTurn.test.ts; here we test the hook's
+ * branching: completed turn → re-hydrate + suppress; incomplete → surface.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../useChatConversation', () => ({
+  fetchConversation: vi.fn(async () => ({ id: 'c1', messages: [] })),
+  toUIMessages: vi.fn((m: unknown) => m ?? []),
+}));
+vi.mock('../../console/ai/reconcileTurn', () => ({
+  isReconcilableCompletedTurn: vi.fn(),
+}));
+
+import { useReconcileOnError } from '../useReconcileOnError';
+import { fetchConversation } from '../useChatConversation';
+import { isReconcilableCompletedTurn } from '../../console/ai/reconcileTurn';
+
+const API = 'https://x/api/v1/ai/agents/metadata_assistant/chat';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useReconcileOnError', () => {
+  it('completed turn → re-hydrates via setMessages and suppresses the error', async () => {
+    (isReconcilableCompletedTurn as any).mockReturnValue(true);
+    const setMessages = vi.fn();
+    const { result } = renderHook(() =>
+      useReconcileOnError({ chatApi: API, conversationId: 'c1' }),
+    );
+    result.current.setMessagesRef.current = setMessages;
+
+    await act(async () => {
+      await result.current.handleChatError(new Error('stream dropped'));
+    });
+
+    expect(fetchConversation).toHaveBeenCalledWith('https://x/api/v1/ai', 'c1');
+    expect(setMessages).toHaveBeenCalledTimes(1);
+    expect(result.current.errorSuppressed).toBe(true);
+  });
+
+  it('incomplete turn → does NOT suppress and does NOT re-hydrate', async () => {
+    (isReconcilableCompletedTurn as any).mockReturnValue(false);
+    const setMessages = vi.fn();
+    const { result } = renderHook(() =>
+      useReconcileOnError({ chatApi: API, conversationId: 'c1' }),
+    );
+    result.current.setMessagesRef.current = setMessages;
+
+    await act(async () => {
+      await result.current.handleChatError(new Error('boom'));
+    });
+
+    expect(setMessages).not.toHaveBeenCalled();
+    expect(result.current.errorSuppressed).toBe(false);
+  });
+
+  it('no conversationId → no fetch, never suppresses', async () => {
+    const { result } = renderHook(() =>
+      useReconcileOnError({ chatApi: API, conversationId: undefined }),
+    );
+    await act(async () => {
+      await result.current.handleChatError(new Error('boom'));
+    });
+    expect(fetchConversation).not.toHaveBeenCalled();
+    expect(result.current.errorSuppressed).toBe(false);
+  });
+
+  it('resetSuppression clears a prior suppression', async () => {
+    (isReconcilableCompletedTurn as any).mockReturnValue(true);
+    const { result } = renderHook(() =>
+      useReconcileOnError({ chatApi: API, conversationId: 'c1' }),
+    );
+    result.current.setMessagesRef.current = vi.fn();
+    await act(async () => {
+      await result.current.handleChatError(new Error('x'));
+    });
+    expect(result.current.errorSuppressed).toBe(true);
+    act(() => result.current.resetSuppression());
+    expect(result.current.errorSuppressed).toBe(false);
+  });
+});

--- a/packages/app-shell/src/hooks/useReconcileOnError.ts
+++ b/packages/app-shell/src/hooks/useReconcileOnError.ts
@@ -1,0 +1,77 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { fetchConversation, toUIMessages } from './useChatConversation';
+import { isReconcilableCompletedTurn } from '../console/ai/reconcileTurn';
+
+/**
+ * ADR-0013 D2 — shared "reconcile a stream-transport failure instead of
+ * blindly retrying" wiring, used by every chat surface (AiChatPage and the
+ * console floating chatbot) so the behaviour is identical.
+ *
+ * The agent runtime persists the final assistant reply BEFORE it streams it
+ * (framework `service-ai`), so a network drop AFTER the turn completed leaves a
+ * complete reply server-side while the client only sees a stream error. On
+ * error we GET the conversation and, if the turn actually finished
+ * (`isReconcilableCompletedTurn`), re-hydrate the thread with the persisted
+ * messages and suppress the scary "Response failed / Retry" banner — the
+ * failure becomes a non-event. A genuinely-incomplete turn still surfaces
+ * Retry, whose re-send is idempotent under D1 (same `turnId`).
+ */
+export interface ReconcileOnError {
+  /** True when the last stream error was reconciled away (turn had completed). */
+  errorSuppressed: boolean;
+  /** Wire as `useObjectChat({ onError })`. */
+  handleChatError: (err: Error) => Promise<void>;
+  /**
+   * Assign `ref.current = setMessages` from `useObjectChat` (API mode) so the
+   * thread can be re-hydrated from the server on a reconcilable failure.
+   */
+  setMessagesRef: React.MutableRefObject<((m: unknown[]) => void) | undefined>;
+  /** Call when a fresh turn is sent, to clear any prior suppression. */
+  resetSuppression: () => void;
+}
+
+export function useReconcileOnError(opts: {
+  /** The agent chat endpoint, e.g. `${apiBase}/agents/:name/chat`. */
+  chatApi?: string;
+  /** Active conversation id (no reconciliation possible without one). */
+  conversationId?: string;
+}): ReconcileOnError {
+  const { chatApi, conversationId } = opts;
+  const [errorSuppressed, setErrorSuppressed] = useState(false);
+  const setMessagesRef = useRef<((m: unknown[]) => void) | undefined>(undefined);
+
+  const handleChatError = useCallback(
+    async (_err: Error) => {
+      const aiBase = chatApi?.replace(/\/agents\/[^/]+\/chat$/, '');
+      if (!conversationId || !aiBase) {
+        setErrorSuppressed(false);
+        return;
+      }
+      try {
+        const conv = await fetchConversation(aiBase, conversationId);
+        const ui = toUIMessages(conv?.messages);
+        if (isReconcilableCompletedTurn(ui) && setMessagesRef.current) {
+          setMessagesRef.current(ui as unknown[]);
+          setErrorSuppressed(true);
+          return;
+        }
+      } catch {
+        /* fall through to the normal error banner */
+      }
+      setErrorSuppressed(false);
+    },
+    [conversationId, chatApi],
+  );
+
+  const resetSuppression = useCallback(() => setErrorSuppressed(false), []);
+
+  return { errorSuppressed, handleChatError, setMessagesRef, resetSuppression };
+}

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -11,6 +11,7 @@
  * @module
  */
 import React from 'react';
+import { useReconcileOnError } from '../hooks/useReconcileOnError';
 import {
   FloatingChatbot,
   useObjectChat,
@@ -385,6 +386,11 @@ function ChatbotInner({
     [editor, language],
   );
 
+  // ADR-0013 D2: reconcile a stream-transport failure instead of blindly
+  // retrying. Shared across chat surfaces — see useReconcileOnError.
+  const { errorSuppressed, handleChatError, setMessagesRef, resetSuppression } =
+    useReconcileOnError({ chatApi, conversationId });
+
   const {
     messages,
     isLoading,
@@ -393,9 +399,11 @@ function ChatbotInner({
     stop,
     reload,
     clear,
+    setMessages,
   } = useObjectChat({
     api: chatApi,
     conversationId,
+    onError: handleChatError,
     body: {
       context: {
         activeApp: appLabel,
@@ -431,6 +439,10 @@ function ChatbotInner({
   });
 
   React.useEffect(() => {
+    setMessagesRef.current = setMessages;
+  }, [setMessages]);
+
+  React.useEffect(() => {
     writeConversationMessagesCache(
       conversationId,
       sanitizeChatMessagesForCache(messages as ChatMessage[]),
@@ -446,6 +458,7 @@ function ChatbotInner({
     messages: messages as ChatMessage[],
     apiBase,
     continueConversation: (prompt) => {
+      resetSuppression();
       sendMessage(prompt);
     },
   });
@@ -547,12 +560,12 @@ function ChatbotInner({
               ? locale.loadingPlaceholder
               : locale.placeholder
         }
-        onSendMessage={(content: string) => sendMessage(content)}
+        onSendMessage={(content: string) => { resetSuppression(); sendMessage(content); }}
         onClear={clear}
         onStop={isLoading ? stop : undefined}
         onReload={reload}
         isLoading={isLoading}
-        error={error}
+        error={errorSuppressed ? undefined : error}
         enableMarkdown
         onToolApprove={hitl.decide}
         toolDecisions={hitl.decisions}


### PR DESCRIPTION
## Why
ADR-0013 **D2** ([#1742](https://github.com/objectstack-ai/objectui/pull/1742)) added "reconcile a stream-transport failure instead of blindly retrying" to **AiChatPage only**. The console **floating chatbot** still showed a scary "Response failed / Retry" even when the turn had actually completed server-side (the runtime persists the final reply *before* streaming). This unifies the behaviour so both surfaces reconcile.

## Change
Extract the D2 wiring into a shared hook **`useReconcileOnError`** (GET conversation → `isReconcilableCompletedTurn` → re-hydrate via `setMessages` + suppress the banner), used by both surfaces:
- **AiChatPage**: refactored onto the hook (behaviour unchanged, −26 lines of inline code).
- **ConsoleFloatingChatbot**: now reconciles too — wires `onError` + `setMessages`, gates the error banner behind suppression, resets suppression on a fresh send.

## D1 + D2 end-to-end
Retry on a genuinely-incomplete turn re-sends with the **same `turnId`** (the banner's Retry → `reload`/regenerate), so it's idempotent under D1 (no duplicate user row, no tool re-run). Completed-but-stream-dropped turn → reconciled to a non-event.

## Tests
- 4 new `renderHook` cases for `useReconcileOnError` (completed → re-hydrate+suppress; incomplete → surface; no conversationId → no-op; resetSuppression).
- Existing `reconcileTurn` (6) intact; `pnpm --filter "@object-ui/app-shell..." build` clean.

Refs #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)