### PR TITLE
feat(chart): grouped series for multi-dimension dataset charts (#1759)

### DIFF
--- a/.changeset/fix-chart-dataset-1890.md
+++ b/.changeset/fix-chart-dataset-1890.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+fix(chart): consume ADR-0021 `dataset` binding in list/object chart views
+
+Chart views authored to the current spec (ADR-0021: `dataset` + `dimensions` +
+`values`) previously rendered nothing — the renderers only read the **removed**
+legacy inline `xAxisField` / `yAxisFields` / `aggregation` shape, so a
+spec-compliant chart view showed an empty canvas. `ObjectChart` now runs the
+governed `queryDataset` path when a chart binds to a dataset (the same path the
+dashboard `DatasetWidget` uses, so numbers stay consistent), and `ListView` /
+`ObjectView` emit the dataset shape. The legacy inline aggregate is kept as a
+deprecated fallback so pre-ADR-0021 metadata keeps rendering.
+
+Refs objectstack-ai/framework#1890

--- a/.changeset/multidim-chart-1759.md
+++ b/.changeset/multidim-chart-1759.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/core": patch
+---
+
+feat(chart): visualise the second dataset dimension as grouped series
+
+A dataset chart with two dimensions (e.g. `['status','priority']`) previously
+only rendered the first dimension — the second was invisible (repeated x-axis
+labels, no grouping). New shared `buildChartSeries` helper (`@object-ui/core`)
+pivots the second dimension into one series per value; `ObjectChart`
+(plugin-charts) and `DatasetWidget` (plugin-dashboard) both use it, so
+multi-dimension charts render consistently as grouped/coloured bars.
+
+Refs objectstack-ai/objectui#1759, objectstack-ai/framework#1890

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1074,6 +1074,31 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
 
         if (viewDef.type === 'chart') {
             const chartConfig = viewDef.chart || {};
+            // ADR-0021 (#1890): dataset-bound chart — the single author-facing
+            // shape. Selects dimensions/measures BY NAME and runs through the
+            // governed queryDataset path (numbers consistent across surfaces).
+            if (chartConfig.dataset) {
+                const dims: string[] = Array.isArray(chartConfig.dimensions) ? chartConfig.dimensions : [];
+                const vals: string[] = Array.isArray(chartConfig.values) ? chartConfig.values : [];
+                return (
+                    <Suspense key={key} fallback={<div className="p-4 text-sm text-muted-foreground">Loading chart…</div>}>
+                        <ObjectChart
+                            dataSource={ds}
+                            schema={{
+                                type: 'object-chart',
+                                dataset: chartConfig.dataset,
+                                dimensions: dims,
+                                values: vals,
+                                chartType: chartConfig.chartType || 'bar',
+                                xAxisKey: dims[0],
+                                series: vals.map((v: string) => ({ dataKey: v, label: v })),
+                                config: chartConfig.config,
+                                className: 'h-[400px] w-full',
+                            } as any}
+                        />
+                    </Suspense>
+                );
+            }
             // ObjectChart consumes a structured `aggregate` ({ field, function,
             // groupBy }) + `xAxisKey` + `series`, NOT the flat spec-level
             // `xAxisField`/`yAxisFields`/`aggregation` keys. Translate here so the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,3 +40,4 @@ export { composeStacks } from '@objectstack/spec';
 export * from './utils/drill-down.js';
 export * from './utils/date-macros.js';
 export * from './utils/compare-to.js';
+export * from './utils/chart-series.js';

--- a/packages/core/src/utils/chart-series.test.ts
+++ b/packages/core/src/utils/chart-series.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { buildChartSeries } from './chart-series';
+
+describe('buildChartSeries (#1759)', () => {
+  it('single dimension + single measure → x-axis = dim, one series = measure', () => {
+    const rows = [
+      { status: 'Backlog', est_hours: 5 },
+      { status: 'Done', est_hours: 24 },
+    ];
+    const r = buildChartSeries(rows, ['status'], ['est_hours']);
+    expect(r.xAxisKey).toBe('status');
+    expect(r.series).toEqual([{ dataKey: 'est_hours', label: 'est_hours' }]);
+    expect(r.data).toEqual(rows);
+  });
+
+  it('uses field label for measure series when provided', () => {
+    const r = buildChartSeries([], ['status'], ['est_hours'], [{ name: 'est_hours', label: 'Estimated Hours' }]);
+    expect(r.series).toEqual([{ dataKey: 'est_hours', label: 'Estimated Hours' }]);
+  });
+
+  it('single dimension + multiple measures → series per measure (no pivot)', () => {
+    const rows = [{ status: 'Done', a: 1, b: 2 }];
+    const r = buildChartSeries(rows, ['status'], ['a', 'b']);
+    expect(r.xAxisKey).toBe('status');
+    expect(r.series.map((s) => s.dataKey)).toEqual(['a', 'b']);
+    expect(r.data).toEqual(rows);
+  });
+
+  it('two dimensions + single measure → pivots second dim into series', () => {
+    const rows = [
+      { status: 'Backlog', priority: 'High', est_hours: 5 },
+      { status: 'Backlog', priority: 'Low', est_hours: 3 },
+      { status: 'Done', priority: 'High', est_hours: 24 },
+    ];
+    const r = buildChartSeries(rows, ['status', 'priority'], ['est_hours']);
+    expect(r.xAxisKey).toBe('status');
+    // one series per distinct priority, in first-seen order
+    expect(r.series).toEqual([
+      { dataKey: 'High', label: 'High' },
+      { dataKey: 'Low', label: 'Low' },
+    ]);
+    // wide-format: one row per status, a column per priority holding the measure
+    expect(r.data).toEqual([
+      { status: 'Backlog', High: 5, Low: 3 },
+      { status: 'Done', High: 24 },
+    ]);
+  });
+
+  it('tolerates empty / nullish input', () => {
+    const r = buildChartSeries(null, null, null);
+    expect(r.data).toEqual([]);
+    expect(r.xAxisKey).toBeUndefined();
+    expect(r.series).toEqual([]);
+  });
+});

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -1,0 +1,87 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * chart-series — shape a semantic-layer `queryDataset` result into the
+ * `{ data, xAxisKey, series }` triple a chart renderer consumes (ADR-0021, #1759).
+ *
+ * Shared by `ObjectChart` (plugin-charts) and `DatasetWidget` (plugin-dashboard)
+ * so multi-dimension charts visualise identically across surfaces.
+ *
+ * Rules:
+ *  - **2+ dimensions, single measure** → pivot the SECOND dimension into one
+ *    series per distinct value (grouped/coloured bars). `xAxisKey` = first
+ *    dimension; each output row is one first-dimension bucket with a column per
+ *    second-dimension value holding the measure. This makes the second dimension
+ *    visible instead of just repeating the x-axis label.
+ *  - **otherwise** (single dimension, or multiple measures) → first dimension is
+ *    the x-axis and each measure is its own series (long format passes through).
+ */
+
+export interface ChartResultField {
+  name: string;
+  label?: string;
+  format?: string;
+}
+
+export interface ChartSeries {
+  dataKey: string;
+  label: string;
+}
+
+export interface ChartSeriesResult {
+  data: Array<Record<string, unknown>>;
+  xAxisKey: string | undefined;
+  series: ChartSeries[];
+}
+
+export function buildChartSeries(
+  rows: Array<Record<string, unknown>> | null | undefined,
+  dimensions: string[] | null | undefined,
+  values: string[] | null | undefined,
+  fields?: ChartResultField[] | null,
+): ChartSeriesResult {
+  const dims = (dimensions ?? []).filter(Boolean);
+  const vals = (values ?? []).filter(Boolean);
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const labelOf = (name: string): string =>
+    (fields ?? []).find((f) => f.name === name)?.label ?? name;
+
+  // Multi-dimension, single-measure → pivot the second dimension into series.
+  if (dims.length >= 2 && vals.length === 1) {
+    const xKey = dims[0];
+    const groupKey = dims[1];
+    const measure = vals[0];
+    const seriesKeys: string[] = [];
+    const byX = new Map<string, Record<string, unknown>>();
+
+    for (const row of safeRows) {
+      const xRaw = row[xKey];
+      const xId = String(xRaw ?? '');
+      if (!byX.has(xId)) byX.set(xId, { [xKey]: xRaw });
+      const gId = String(row[groupKey] ?? '');
+      if (gId !== '' && !seriesKeys.includes(gId)) seriesKeys.push(gId);
+      byX.get(xId)![gId] = row[measure];
+    }
+
+    return {
+      data: Array.from(byX.values()),
+      xAxisKey: xKey,
+      // Series labels are the second-dimension values themselves (already
+      // server-resolved to display labels by queryDataset).
+      series: seriesKeys.map((k) => ({ dataKey: k, label: k })),
+    };
+  }
+
+  // Default: first dimension on the x-axis, one series per measure.
+  return {
+    data: safeRows,
+    xAxisKey: dims[0],
+    series: vals.map((v) => ({ dataKey: v, label: labelOf(v) })),
+  };
+}

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useContext, useCallback, useMemo, useRef } from 'react';
 import { useDataScope, SchemaRendererContext, SchemaRenderer } from '@object-ui/react';
 import { ChartRenderer } from './ChartRenderer';
-import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveDateMacros, shiftFilterByCompareTo, compareToTrendLabelKey, type CompareToConfig, type DrillEvent } from '@object-ui/core';
+import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveDateMacros, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, type CompareToConfig, type DrillEvent } from '@object-ui/core';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator } from '@object-ui/components';
 import { AlertCircle } from 'lucide-react';
 import { useSafeFieldLabel } from '@object-ui/i18n';
@@ -548,11 +548,16 @@ export const ObjectChart = (props: any) => {
     ];
   }, [enableComparisonSeries, (schema as any).series, schema.aggregate, schema.filter, compareToConfig]);
 
-  const finalSchema = {
-    ...schema,
-    data: finalData,
-    ...(augmentedSeries ? { series: augmentedSeries } : {}),
-  };
+  // ADR-0021 (#1759): when the chart binds to a dataset, derive data/xAxisKey/
+  // series from its dimensions/measures via the shared buildChartSeries helper —
+  // this pivots a second dimension into grouped series, matching DatasetWidget.
+  const datasetChart = schema.dataset
+    ? buildChartSeries(finalData, schema.dimensions, schema.values)
+    : null;
+
+  const finalSchema = datasetChart
+    ? { ...schema, data: datasetChart.data, xAxisKey: datasetChart.xAxisKey, series: datasetChart.series }
+    : { ...schema, data: finalData, ...(augmentedSeries ? { series: augmentedSeries } : {}) };
   
   if (loading && finalData.length === 0) {
       return <div className={"flex items-center justify-center text-muted-foreground text-sm p-4 " + (schema.className || '')} data-testid="chart-loading">Loading chart data…</div>;

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -244,7 +244,7 @@ export const ObjectChart = (props: any) => {
   // doesn't flash before the fetch effect runs and flips loading to true.
   const [loading, setLoading] = useState<boolean>(() => {
     const hasInline = Array.isArray(schema.data) && schema.data.length > 0;
-    return !hasInline && !!schema.objectName;
+    return !hasInline && (!!schema.objectName || !!schema.dataset);
   });
   const [error, setError] = useState<string | null>(null);
   // Drill-down click event — must be declared with the other hooks (above
@@ -265,6 +265,15 @@ export const ObjectChart = (props: any) => {
   const compareToKey = useMemo(
     () => ((schema as any).compareTo ? JSON.stringify((schema as any).compareTo) : ''),
     [(schema as any).compareTo],
+  );
+  // ADR-0021 (#1890): a chart can bind to a semantic-layer `dataset` instead of
+  // the legacy inline `objectName` + `aggregate` query. Stable key over the
+  // dataset selection so a fresh object literal each render doesn't refetch-loop.
+  const datasetKey = useMemo(
+    () => (schema.dataset
+      ? JSON.stringify({ d: schema.dataset, dim: schema.dimensions ?? [], val: schema.values ?? [] })
+      : ''),
+    [schema.dataset, schema.dimensions, schema.values],
   );
 
   // Pie / donut / funnel are single-distribution charts where a comparison
@@ -323,7 +332,7 @@ export const ObjectChart = (props: any) => {
   }, [schema.objectName, aggregateKey]);
 
   const fetchData = useCallback(async (ds: any, mounted: { current: boolean }) => {
-      if (!ds || !schema.objectName) {
+      if (!ds || (!schema.objectName && !schema.dataset)) {
         // No way to fetch — clear loading so the no-datasource / empty state
         // can render instead of an indefinite "Loading chart data…".
         if (mounted.current) setLoading(false);
@@ -334,6 +343,25 @@ export const ObjectChart = (props: any) => {
         setError(null);
       }
       try {
+          // ── Dataset-bound path (ADR-0021, #1890) ──────────────
+          // When the chart binds to a semantic-layer `dataset`, run the same
+          // governed `queryDataset` path the dashboard DatasetWidget and
+          // dataset-bound reports use, so the numbers match everywhere. The
+          // server resolves dimension labels + measure formats, so the legacy
+          // client-side aggregate / groupBy-label resolution below is skipped.
+          if (schema.dataset && typeof ds.queryDataset === 'function') {
+              const runtimeFilter = resolveDateMacros(schema.filter);
+              const res = await ds.queryDataset(schema.dataset, {
+                  dimensions: Array.isArray(schema.dimensions) ? schema.dimensions : [],
+                  measures: Array.isArray(schema.values) ? schema.values : [],
+                  ...(runtimeFilter ? { runtimeFilter } : {}),
+              });
+              if (mounted.current) {
+                  setFetchedData(Array.isArray(res?.rows) ? res.rows : []);
+              }
+              return;
+          }
+
           // Resolve relative-date macros (e.g. "{current_quarter_start}")
           // so both aggregate and find see real ISO dates and any drill-down
           // filter further down the line stays consistent.
@@ -440,12 +468,12 @@ export const ObjectChart = (props: any) => {
           if (mounted.current) setLoading(false);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [schema.objectName, aggregateKey, filterKey, compareToKey, schema.xAxisKey, schema.chartType, runAggregate]);
+  }, [schema.objectName, datasetKey, aggregateKey, filterKey, compareToKey, schema.xAxisKey, schema.chartType, runAggregate]);
 
   useEffect(() => {
     const mounted = { current: true };
 
-    if (schema.objectName && !boundData && !schema.data) {
+    if ((schema.objectName || schema.dataset) && !boundData && !schema.data) {
         fetchData(dataSource, mounted);
     } else if (mounted.current) {
         // Have inline / bound data — won't fetch; clear loading.
@@ -453,7 +481,7 @@ export const ObjectChart = (props: any) => {
     }
     return () => { mounted.current = false; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [schema.objectName, dataSource, boundData, schema.data, filterKey, aggregateKey, compareToKey, fetchData]);
+  }, [schema.objectName, datasetKey, dataSource, boundData, schema.data, filterKey, aggregateKey, compareToKey, fetchData]);
 
   const rawData = boundData || schema.data || fetchedData;
   const finalData = Array.isArray(rawData) ? rawData : [];

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -26,6 +26,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { SchemaRenderer } from '@object-ui/react';
+import { buildChartSeries } from '@object-ui/core';
 import { cn } from '@object-ui/components';
 import { Loader2, BarChart3, AlertTriangle } from 'lucide-react';
 import { resolveDateMacros } from './utils';
@@ -217,11 +218,13 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // and one series per measure. Series carry the measure display label so the
   // legend reads "Tasks" rather than "task_count".
   const chartType = CHART_TYPE_MAP[widgetType] ?? 'bar';
-  const series = values.map((v) => ({ dataKey: v, label: measureField(v)?.label ?? v }));
+  // ADR-0021 (#1759): shared helper — pivots a second dimension into grouped
+  // series so multi-dimension dataset widgets match the chart-view renderer.
+  const { data: chartData, xAxisKey, series } = buildChartSeries(state.rows, dimensions, values, state.fields);
   return (
     <div className={cn('h-full w-full min-h-[220px]')}>
       <SchemaRenderer
-        schema={{ type: 'chart', chartType, data: state.rows, xAxisKey: dimensions[0], series } as any}
+        schema={{ type: 'chart', chartType, data: chartData, xAxisKey, series } as any}
       />
     </div>
   );

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1411,6 +1411,25 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         // records (e.g. sum of estimate_hours grouped by status), delegating
         // to the same object-chart component the dashboard uses.
         const chartCfg = (schema as any).chart || schema.options?.chart || {};
+        // ADR-0021 (#1890): the single author-facing shape binds to a semantic
+        // `dataset` and selects dimensions/measures BY NAME, so the chart runs
+        // through the governed queryDataset path (numbers consistent everywhere).
+        if (chartCfg.dataset) {
+          const dims: string[] = Array.isArray(chartCfg.dimensions) ? chartCfg.dimensions : [];
+          const vals: string[] = Array.isArray(chartCfg.values) ? chartCfg.values : [];
+          return {
+            type: 'object-chart',
+            dataset: chartCfg.dataset,
+            dimensions: dims,
+            values: vals,
+            chartType: chartCfg.chartType || 'bar',
+            xAxisKey: dims[0],
+            series: vals.map((v: string) => ({ dataKey: v, label: v })),
+            className: 'h-[400px] w-full',
+          };
+        }
+        // Legacy inline aggregate (deprecated — pre-ADR-0021 metadata). Kept as a
+        // fallback so existing authored chart views keep rendering.
         const valueField = (Array.isArray(chartCfg.yAxisFields) && chartCfg.yAxisFields[0])
           || chartCfg.valueField || 'value';
         const categoryField = chartCfg.xAxisField || chartCfg.categoryField || 'name';

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -752,6 +752,22 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
         // Aggregated chart of the object's records, delegating to the same
         // object-chart component the dashboard uses.
         const chartCfg = viewOptions.chart || {};
+        // ADR-0021 (#1890): dataset-bound chart — the single author-facing shape.
+        if (chartCfg.dataset) {
+          const dims: string[] = Array.isArray(chartCfg.dimensions) ? chartCfg.dimensions : [];
+          const vals: string[] = Array.isArray(chartCfg.values) ? chartCfg.values : [];
+          return {
+            type: 'object-chart',
+            dataset: chartCfg.dataset,
+            dimensions: dims,
+            values: vals,
+            chartType: chartCfg.chartType || 'bar',
+            xAxisKey: dims[0],
+            series: vals.map((v: string) => ({ dataKey: v, label: v })),
+            className: 'h-[400px] w-full',
+          };
+        }
+        // Legacy inline aggregate (deprecated — pre-ADR-0021 metadata).
         const valueField = (Array.isArray(chartCfg.yAxisFields) && chartCfg.yAxisFields[0])
           || chartCfg.valueField || 'value';
         const categoryField = chartCfg.xAxisField || chartCfg.categoryField || 'name';

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -2092,16 +2092,22 @@ export interface KanbanConditionalFormattingRule {
  */
 export interface ObjectChartSchema extends BaseSchema {
   type: 'object-chart';
-  /** ObjectQL object name */
-  objectName: string;
+  /** ObjectQL object name (legacy inline path; optional under ADR-0021 dataset binding) */
+  objectName?: string;
   /** Chart type */
   chartType: 'bar' | 'line' | 'pie' | 'area' | 'scatter';
-  /** Field for X axis (categories) */
-  xAxisField: string;
-  /** Fields for Y axis (values) */
+  /** Field for X axis (categories) — legacy inline path */
+  xAxisField?: string;
+  /** Fields for Y axis (values) — legacy */
   yAxisFields?: string[];
-  /** Aggregation function */
+  /** Aggregation function — legacy */
   aggregation?: 'cardinality' | 'sum' | 'avg' | 'min' | 'max';
+  /** Semantic-layer dataset name (ADR-0021, #1890) */
+  dataset?: string;
+  /** Dataset dimension names */
+  dimensions?: string[];
+  /** Dataset measure names */
+  values?: string[];
 }
 
 /**

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -421,11 +421,18 @@ export const ObjectKanbanSchema = BaseSchema.extend({
  */
 export const ObjectChartSchema = BaseSchema.extend({
   type: z.literal('object-chart'),
-  objectName: z.string().describe('ObjectQL object name'),
+  // Legacy inline path (objectName + aggregate). Optional now that a chart may
+  // instead bind to a semantic-layer dataset (ADR-0021, #1890).
+  objectName: z.string().optional().describe('ObjectQL object name (legacy inline path)'),
   chartType: z.enum(['bar', 'line', 'pie', 'area', 'scatter']).describe('Chart type'),
-  xAxisField: z.string().describe('X axis field'),
-  yAxisFields: z.array(z.string()).optional().describe('Y axis fields'),
-  aggregation: z.enum(['cardinality', 'sum', 'avg', 'min', 'max']).optional().describe('Aggregation'),
+  xAxisField: z.string().optional().describe('X axis field (legacy inline path)'),
+  yAxisFields: z.array(z.string()).optional().describe('Y axis fields (legacy)'),
+  aggregation: z.enum(['cardinality', 'sum', 'avg', 'min', 'max']).optional().describe('Aggregation (legacy)'),
+  // ADR-0021 semantic-layer binding: dimensions/measures selected BY NAME from a
+  // dataset, queried via the governed queryDataset path.
+  dataset: z.string().optional().describe('Semantic-layer dataset name (ADR-0021)'),
+  dimensions: z.array(z.string()).optional().describe('Dataset dimension names'),
+  values: z.array(z.string()).optional().describe('Dataset measure names'),
 });
 
 /**


### PR DESCRIPTION
## What

Follow-up to #1757 (closes #1759). A dataset-bound chart with **two dimensions** (e.g. `dimensions: ['status','priority']`) previously only honoured the first dimension: `xAxisKey = dimensions[0]`, `series = values`. The second dimension was **invisible** — the x-axis just repeated the first-dimension label once per second-dimension bucket, with no grouping/colour/legend. Data was correct; the second dimension wasn't visualised.

## Change

- **`@object-ui/core`** — new shared `buildChartSeries(rows, dimensions, values, fields)`:
  - 2+ dimensions + single measure → **pivot** the second dimension into one series per distinct value (long→wide), `xAxisKey` = first dimension.
  - otherwise → first dimension on x-axis, one series per measure (unchanged).
- **`ObjectChart`** (plugin-charts) — dataset mode now derives `data`/`xAxisKey`/`series` via the helper.
- **`DatasetWidget`** (plugin-dashboard) — chart branch uses the same helper, so dashboard widgets and chart views render multi-dimension charts **identically** (grouped/coloured bars + legend).

## Verification

- `buildChartSeries` unit tests (5) cover single-dim, multi-measure, two-dim pivot, field labels, nullish input — all green.
- `@object-ui/core`, `plugin-charts`, `plugin-dashboard` build green.
- (Base dataset-chart rendering was browser-verified in #1757; this PR changes only series derivation, consumed by the chart renderer's existing multi-series path.)

> Note: the **Bundle Analysis** check may fail on the pre-existing app-shell build debt tracked in #1760 (turbo-cache-masked; unrelated to this PR's code).

Refs objectstack-ai/framework#1890
