### PR TITLE
fix(form): honour form view layout (tabbed/wizard/split) in full-page record form (framework#1890)

### DIFF
--- a/.changeset/form-variant-entry-1890.md
+++ b/.changeset/form-variant-entry-1890.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(form): honour the form view layout in the full-page record form
+
+`RecordFormPage` hard-coded `formType: 'simple'`, so a record's declared form
+view layout (`tabbed` / `wizard` / `split`) was ignored on the full-page
+create/edit route — `ObjectForm` already renders every variant, the entry point
+just never passed it through. It now reads the object's `form` / `formViews.default`
+`type` + `sections` and forwards them (plus variant props: defaultTab, tabPosition,
+allowSkip, showStepIndicator, split*). Page-level layouts only — `drawer`/`modal`
+are presentation/open-modes, not record-page layouts, so they fall back to `simple`.
+
+Refs objectstack-ai/framework#1890

--- a/packages/app-shell/src/views/RecordFormPage.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.tsx
@@ -225,6 +225,28 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
     );
   }
 
+  // Honour the object's form view layout (#1890): wire the declared `type`
+  // (simple/tabbed/wizard/split) + `sections` through to ObjectForm, which
+  // already renders each variant. Page-level layouts only — `drawer`/`modal`
+  // are presentation/open-modes, not record-page layouts, so they fall back to
+  // `simple` here (see the form-layout-vs-presentation modelling note in #1890).
+  const formDef: any = (objectDef as any).form ?? (objectDef as any).formViews?.default ?? {};
+  const pageFormType: 'simple' | 'tabbed' | 'wizard' | 'split' =
+    ['tabbed', 'wizard', 'split'].includes(formDef.type) ? formDef.type : 'simple';
+  const formLayoutProps =
+    pageFormType !== 'simple' && Array.isArray(formDef.sections)
+      ? {
+          sections: formDef.sections,
+          defaultTab: formDef.defaultTab,
+          tabPosition: formDef.tabPosition,
+          allowSkip: formDef.allowSkip,
+          showStepIndicator: formDef.showStepIndicator,
+          splitDirection: formDef.splitDirection,
+          splitSize: formDef.splitSize,
+          splitResizable: formDef.splitResizable,
+        }
+      : {};
+
   return (
     <ExpressionProvider user={expressionUser} app={{ name: appName }} data={{}} features={features}>
       <div
@@ -270,7 +292,8 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
               key={`${mode}:${objectName}:${recordId ?? 'new'}`}
               schema={{
                 type: 'object-form',
-                formType: 'simple',
+                formType: pageFormType,
+                ...formLayoutProps,
                 objectName: objectDef.name,
                 mode,
                 recordId: mode === 'edit' ? recordId : undefined,


### PR DESCRIPTION
## What

The full-page record form (`RecordFormPage`, used by `:objectName/new` and `:objectName/record/:recordId/edit`) hard-coded `formType: 'simple'`, so a record's declared form view layout (`tabbed` / `wizard` / `split`) was ignored — every full-page create/edit rendered a flat stack regardless of the spec. `ObjectForm` already implements `TabbedForm` / `WizardForm` / `SplitForm`; the entry point just never passed the layout through.

Surfaced by the viewschema liveness audit (objectstack-ai/framework#1890, recommendation #2).

## Change

`RecordFormPage` now reads the object's `form` / `formViews.default` `type` + `sections` and forwards them (plus variant props: `defaultTab`, `tabPosition`, `allowSkip`, `showStepIndicator`, `split*`) to `ObjectForm`. **Page-level layouts only** — `drawer` / `modal` are presentation/open-modes, not record-page layouts, so they fall back to `simple` here.

## Verification

**Browser-verified**: `/apps/showcase_app/showcase_task/new` now renders a **tabbed** form (Overview / Schedule / Details tabs, switching shows each section's fields) instead of one flat stack. (`RecordFormPage` had no type errors in the build; the worktree's app-shell `tsc` failure is the pre-existing #1760 turbo-cache debt, unrelated.)

## Known limitation — modelling debt (M2)

`formType` conflates **two orthogonal dimensions**: *layout* (`simple`/`tabbed`/`wizard`/`split`) and *presentation container* (`drawer`/`modal`). The real modal create/edit entry points (`AppContent`, `useActionModal`) set `formType:'modal'`, so a modal form **cannot also be tabbed** — the field can only hold one value. Fully fixing form variants across modal/drawer surfaces needs `formType` split into `layout` ⊥ `presentation`. Tracked in objectstack-ai/framework#1890 for a small ADR + M2 work; this PR fixes the full-page route, which is the clean case.

Refs objectstack-ai/framework#1890

🤖 Generated with [Claude Code](https://claude.com/claude-code)
