### PR TITLE
feat(form): modal forms can host a tabbed layout — modal+tabbed (framework#1890)

### DIFF
--- a/.changeset/modal-tabbed-layout-1890.md
+++ b/.changeset/modal-tabbed-layout-1890.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/plugin-form": patch
+---
+
+feat(form): modal forms can host a tabbed layout (modal + tabbed composes)
+
+`ModalForm` rendered sections as a flat vertical stack — a modal create/edit
+form could never be tabbed, because `formType` (one field) couldn't be both
+`modal` (container) and `tabbed` (layout). Per ADR-0050 (additive first), the
+modal container now accepts a `contentLayout` ('simple' | 'tabbed'): when
+`tabbed`, sections render as tabs inside the dialog. The console record
+New/Edit modal (`AppContent`) forwards the default form view's layout, so a
+`type:'tabbed'` form view now renders tabbed in the modal too — not just on the
+full-page route (#1762). Non-breaking; `FormView.type` enum unchanged.
+
+Refs objectstack-ai/framework#1890, ADR-0050

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -601,6 +601,15 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
                 // them as an atomic master-detail form (no bespoke page).
                 subforms: (currentObjectDef as any).form?.subforms
                   ?? (currentObjectDef as any).formViews?.default?.subforms,
+                // ADR-0050 (#1890): forward the default form view's layout so the
+                // New/Edit modal can be tabbed (not just a flat stack). `formType`
+                // stays 'modal' (the container); `contentLayout` carries the layout.
+                ...(() => {
+                  const fd: any = (currentObjectDef as any).form ?? (currentObjectDef as any).formViews?.default;
+                  return fd?.type === 'tabbed' && Array.isArray(fd?.sections)
+                    ? { contentLayout: 'tabbed' as const, sections: fd.sections }
+                    : {};
+                })(),
                 title: editingRecord
                   ? t('form.editTitle', { object: objectLabel(currentObjectDef as any) })
                   : t('form.createTitle', { object: objectLabel(currentObjectDef as any) }),

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -24,6 +24,10 @@ import {
   Skeleton,
   Button,
   cn,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
 } from '@object-ui/components';
 import { Loader2 } from 'lucide-react';
 import { FormSection } from './FormSection';
@@ -51,6 +55,9 @@ export interface ModalFormSchema {
   title?: string;
   description?: string;
   sections?: ModalFormSectionConfig[];
+  /** Internal content layout (ADR-0050, #1890): 'tabbed' renders sections as
+   *  tabs inside the modal, so "modal + tabbed" composes. Default stacks them. */
+  contentLayout?: 'simple' | 'tabbed';
   fields?: string[];
   customFields?: FormField[];
 
@@ -449,28 +456,59 @@ export const ModalForm: React.FC<ModalFormProps> = ({
 
     // Sections layout
     if (schema.sections?.length) {
+      const sections = schema.sections;
+      const sectionKey = (sec: ModalFormSectionConfig, i: number) => sec.name || sec.label || String(i);
+      const renderBody = (section: ModalFormSectionConfig) => (
+        <SchemaRenderer
+          schema={{
+            ...baseFormSchema,
+            fields: applyFieldPerms(buildSectionFields(section)),
+            // Actions are in the sticky footer, not inside sections
+          }}
+        />
+      );
+
+      // ADR-0050 (#1890): a modal can host a tabbed layout — sections render as
+      // tabs (label on the trigger) instead of a vertical stack, so a modal
+      // create/edit form composes with `tabbed`.
+      if (schema.contentLayout === 'tabbed' && sections.length > 1) {
+        return (
+          <Tabs defaultValue={sectionKey(sections[0], 0)} className="w-full">
+            <TabsList className="mb-4">
+              {sections.map((section, index) => (
+                <TabsTrigger key={sectionKey(section, index)} value={sectionKey(section, index)}>
+                  {section.label || `Section ${index + 1}`}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {sections.map((section, index) => (
+              <TabsContent key={sectionKey(section, index)} value={sectionKey(section, index)}>
+                <FormSection
+                  description={section.description}
+                  columns={section.columns || 1}
+                  gridClassName={CONTAINER_GRID_COLS[section.columns || 1]}
+                >
+                  {renderBody(section)}
+                </FormSection>
+              </TabsContent>
+            ))}
+          </Tabs>
+        );
+      }
+
       return (
         <div className="space-y-6">
-          {schema.sections.map((section, index) => {
-            const sectionCols = section.columns || 1;
-            return (
-              <FormSection
-                key={section.name || section.label || index}
-                label={section.label}
-                description={section.description}
-                columns={sectionCols}
-                gridClassName={CONTAINER_GRID_COLS[sectionCols]}
-              >
-                <SchemaRenderer
-                  schema={{
-                    ...baseFormSchema,
-                    fields: applyFieldPerms(buildSectionFields(section)),
-                    // Actions are in the sticky footer, not inside sections
-                  }}
-                />
-              </FormSection>
-            );
-          })}
+          {sections.map((section, index) => (
+            <FormSection
+              key={sectionKey(section, index)}
+              label={section.label}
+              description={section.description}
+              columns={section.columns || 1}
+              gridClassName={CONTAINER_GRID_COLS[section.columns || 1]}
+            >
+              {renderBody(section)}
+            </FormSection>
+          ))}
         </div>
       );
     }


### PR DESCRIPTION
## What

Unlocks **"modal + tabbed"** — the capability the form-variant work in #1890 / #1762 / ADR-0050 identified as blocked.

`ModalForm` rendered sections as a flat vertical stack, so a modal create/edit form could **never** be tabbed: `formType` is one field and can't be both `modal` (the container) and `tabbed` (the layout). Per **ADR-0050** (additive-first), this adds the missing composition **without** touching the `FormView.type` enum (non-breaking).

## Change

- **`ModalForm`** — new `contentLayout?: 'simple' | 'tabbed'`. When `tabbed`, sections render as **Tabs inside the dialog** (reusing `@object-ui/components` Tabs); otherwise the existing vertical stack.
- **`AppContent`** (console record New/Edit modal) — forwards the default form view's layout as `contentLayout` + `sections`, so a `type:'tabbed'` form view renders tabbed in the modal too — matching the full-page route fixed in #1762.

## Verification

**Browser-verified**: showcase Task → **New** (modal) now renders **Overview / Schedule / Details tabs** with working tab switching (Schedule tab shows Start/End/Due Date + Progress), instead of one flat stack.

## Follow-ups (ADR-0050)

- `DrawerForm` + the remaining modal entry points (`useActionModal`, `DashboardView`) should forward layout the same way (consistency).
- `FormView.type` enum narrowing — drop `drawer`/`modal`/`split` (breaking, M2, needs sign-off per ADR-0050).

Refs objectstack-ai/framework#1890

🤖 Generated with [Claude Code](https://claude.com/claude-code)
