### PR TITLE
fix(build): deterministic flat plugin .d.ts to stop flaky app-shell build (#1760)

### DIFF
--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -20,7 +20,7 @@ import { useAdapter } from '../providers/AdapterProvider';
 import { useMetadataClient } from './metadata-admin/useMetadata';
 import { persistRuntimeMetadata } from './runtime-metadata-persistence';
 import { useAuth } from '@object-ui/auth';
-import type { DataSource } from '@object-ui/types';
+import type { DataSource, ReportViewerSchema } from '@object-ui/types';
 import type { DatasetDrillArgs } from '@object-ui/plugin-report';
 
 // Fallback fields when no schema is available
@@ -496,7 +496,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
         Array.isArray(previewReport.columns)),
   );
   const reportForViewer = mapReportForViewer(previewReport);
-  const viewerSchema = {
+  const viewerSchema: ReportViewerSchema = {
       type: 'report-viewer',
       report: reportForViewer, // The report definition
       data: reportRuntimeData, // Runtime data fetched from the data source

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),
   ],

--- a/packages/fields/vite.config.ts
+++ b/packages/fields/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: path.resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: path.resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
     }),
   ],
   resolve: {

--- a/packages/layout/vite.config.ts
+++ b/packages/layout/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),
   ],

--- a/packages/plugin-ai/vite.config.ts
+++ b/packages/plugin-ai/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-calendar/vite.config.ts
+++ b/packages/plugin-calendar/vite.config.ts
@@ -22,7 +22,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-charts/vite.config.ts
+++ b/packages/plugin-charts/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-chatbot/vite.config.ts
+++ b/packages/plugin-chatbot/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-dashboard/vite.config.ts
+++ b/packages/plugin-dashboard/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-designer/vite.config.ts
+++ b/packages/plugin-designer/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-detail/vite.config.ts
+++ b/packages/plugin-detail/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       outDir: 'dist',
       tsconfigPath: './tsconfig.json',
     }),

--- a/packages/plugin-editor/vite.config.ts
+++ b/packages/plugin-editor/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),
   ],

--- a/packages/plugin-form/vite.config.ts
+++ b/packages/plugin-form/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),
   ],

--- a/packages/plugin-gantt/vite.config.ts
+++ b/packages/plugin-gantt/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-grid/vite.config.ts
+++ b/packages/plugin-grid/vite.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
       include: ['src'],
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
     }),
   ],
   resolve: {

--- a/packages/plugin-kanban/vite.config.ts
+++ b/packages/plugin-kanban/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-list/vite.config.ts
+++ b/packages/plugin-list/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       outDir: 'dist',
       tsconfigPath: './tsconfig.json',
     }),

--- a/packages/plugin-map/vite.config.ts
+++ b/packages/plugin-map/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-markdown/vite.config.ts
+++ b/packages/plugin-markdown/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),
   ],

--- a/packages/plugin-report/vite.config.ts
+++ b/packages/plugin-report/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-timeline/vite.config.ts
+++ b/packages/plugin-timeline/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
       skipDiagnostics: true,

--- a/packages/plugin-view/vite.config.ts
+++ b/packages/plugin-view/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, '../..') },
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx'],
     }),


### PR DESCRIPTION
## Problem

Closes #1760. Under a full parallel `turbo run build`, `@object-ui/app-shell`'s composite `tsc` intermittently failed with `error TS2307: Cannot find module '@object-ui/plugin-*'`, flipping the **Bundle Analysis / Build** job red or flaky. Long-masked by the turbo cache, so any PR touching an app-shell dependency could trip it — eroding CI trust.

## Root cause

Every dts-emitting package configured `vite-plugin-dts` with `compilerOptions.rootDir` at the **monorepo root** plus `@object-ui/*` `resolve.alias` entries pointing into sibling **`src`**. Consequences:

1. **Deeply nested dist** — `dist/packages/<pkg>/src/*.d.ts`, with `dist/index.d.ts` re-exporting the deep `./packages/<pkg>/src/index.js` path.
2. **Cross-package type imports rewritten to relative sibling-src paths** (e.g. `../../types/src`). Under the nested layout these pointed nowhere valid → consumers silently degraded those types to `any` (masking real type errors); flattened naively they resolve to raw `src` → consumers re-walk/recompile cross-package source.

Generating this nested, cross-`src`-walking `.d.ts` for ~15 plugins concurrently is unstable, so app-shell's composite `tsc` intermittently couldn't resolve a plugin's `.d.ts`. Building app-shell in isolation always succeeded — consistent with a concurrency race.

## Fix

Applied consistently to all dts-emitting packages (`vite.config.ts`):

- `compilerOptions.rootDir` → each package's **own `src`** ⇒ flat emit (`dist/index.d.ts` + `dist/*.d.ts`, no nested `packages/<pkg>/src` tree).
- `aliasesExclude: [/^@object-ui\//]` ⇒ cross-package type imports stay **bare** (`@object-ui/types`) and resolve to each dependency's **own built `dist/*.d.ts`**, instead of being rewritten to relative sibling-`src` paths.

Plus `packages/app-shell/src/views/ReportView.tsx`: annotate `viewerSchema` as `ReportViewerSchema` — a real type error that was previously masked because the broken relative-path resolution degraded `ReportViewer`'s prop type to `any`.

**JS bundles are byte-identical** — rollup already externalizes bare imports via `rollupOptions.external`; the aliases only fed the bundler/tests, not the published JS.

## Verification

This is a flaky build-system fix, so it needs repeated proof:

- **Repro (before):** clean turbo cache + full `pnpm build` reproduced `app-shell` failing with `Cannot find module '@object-ui/plugin-report'`.
- **After:** the exact Bundle Analysis command `pnpm turbo run build --filter='./packages/*'` is **green across 5 clean runs** (turbo cache + `*.tsbuildinfo` + `dist` cleared each pass): `37/37` tasks, `cannot-find=0`, `TSerr=0`.
- Spot-checked emitted `.d.ts`: flat layout, **zero** relative `../../*/src` refs, all cross-package imports bare `@object-ui/*`. app-shell (a downstream consumer) type-checks against the plugin `.d.ts` and builds green.

> Not declaring success on a single green — confirmed stability across repeated clean builds. Will wait for CI to be green and stable before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)