### PR TITLE
fix(build): cache composite tsc .tsbuildinfo as a turbo output

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "build/**"],
+      "outputs": ["dist/**", ".next/**", "build/**", "**/*.tsbuildinfo"],
       "env": ["NODE_ENV", "VITE_BASE_PATH"]
     },
     "test": {


### PR DESCRIPTION
## Problem

Follow-up to #1760 / #1766. Composite-`tsc` packages (`composite: true` — e.g. `packages/app-shell`, `react`, `core`, `types`, `tenant`, `mobile`) write incremental build state to `<package>/tsconfig.tsbuildinfo` at the **package root**. The `build` task in `turbo.json` only declared `dist/**`, `.next/**`, `build/**` as `outputs`, so the incremental build-info was:

- not part of the cache hash, and
- not cached/restored in sync with `dist/`.

A turbo cache hit restored `dist/` but left whatever stale `tsconfig.tsbuildinfo` happened to be on disk; a build run against a desynced tsbuildinfo can **under-emit** (tsc believing the project is up-to-date), producing a **partial `dist/`** that turbo then caches and replays — surfacing as `TS2307: Cannot find module '@object-ui/app-shell'` in consumers. (Observed while diagnosing #1760, when manually clearing `dist/` but not the package-root tsbuildinfo.)

## Fix

Add `**/*.tsbuildinfo` to the `build` task `outputs` so the incremental state is cached and restored **atomically with `dist/`**.

```diff
-      "outputs": ["dist/**", ".next/**", "build/**"],
+      "outputs": ["dist/**", ".next/**", "build/**", "**/*.tsbuildinfo"],
```

## Scope / safety

- CI fresh checkouts were already safe — `*.tsbuildinfo` is gitignored, so it's always absent on checkout → tsc always does a full emit. This change closes the **local / warm-cache** desync where a cache hit could pair a restored `dist/` with a stale tsbuildinfo.
- Outputs-only change; it cannot break the build itself — it only adds an additional cached artifact glob.

## Verification

This is a one-line `turbo.json` `outputs` addition (valid JSON, valid output glob). The authoritative check is **CI's Bundle Analysis job** (`pnpm turbo run build --filter='./packages/*'`), which runs the real `turbo run build` and must stay green. (Local turbo was unavailable in my worktree due to an unrelated install/platform-binary flake; CI is the source of truth for turbo behavior here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)