### PR TITLE
fix(chat): restore build panel + publish button on conversation reload

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -805,6 +805,20 @@ function ChatPane({
     );
   }, [conversationId, messages]);
 
+  // ADR-0037: refresh the live preview when a turn finishes while the canvas is
+  // open. The per-artifact `onDraftArtifacts` signal covers a build streaming in,
+  // but an incremental edit (add a field, rename) can land without growing the
+  // de-duped artifact set — so its draft never reached the iframe and the pane
+  // (and its "Changes (N)" count) went stale until a manual reload. Bumping on
+  // the loading falling-edge guarantees the preview reflects every change.
+  const prevLoadingRef = useRef(false);
+  useEffect(() => {
+    if (prevLoadingRef.current && !isLoading && canvasApp) {
+      setCanvasRefreshKey((k) => k + 1);
+    }
+    prevLoadingRef.current = isLoading;
+  }, [isLoading, canvasApp]);
+
   const hitl = useHitlInChat({
     messages: messages as ChatMessage[],
     apiBase,

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -41,6 +41,8 @@ import {
   useHitlInChat,
   resolveDefaultAgentName,
   publishHealthFromResponse,
+  detectDraftResult,
+  buildProgressFromDraftReview,
   type AgentDescriptor,
   type ChatbotEnhancedToolInvocation,
   type ChatMessage,
@@ -100,6 +102,7 @@ function partToolState(part: HydratedUIMessagePart): ChatbotEnhancedToolInvocati
 export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): ChatMessage[] {
   return messages.map((message) => {
     const toolInvocations: ChatbotEnhancedToolInvocation[] = [];
+    let buildProgress: ReturnType<typeof buildProgressFromDraftReview>;
     const content = message.parts
       .filter((part) => part.type === 'text')
       .map((part) => part.text ?? '')
@@ -111,12 +114,26 @@ export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): C
         const toolName = partString(part, 'toolName') ?? part.type.slice('tool-'.length);
         const toolCallId = partString(part, 'toolCallId') ?? `${message.id}-${toolName}`;
         const state = partToolState(part);
+        // The tool RESULT (merged onto the call part by toUIMessages from the
+        // separate `tool` row) carries the ADR-0033 draft envelope. Rebuild
+        // `draftReview` so the publish / preview / review affordances return,
+        // and synthesize the "Built X" panel so the blueprint summary survives
+        // a refresh (the live progress bar is transient and not persisted).
+        const result =
+          (part as { output?: unknown }).output ?? (part as { result?: unknown }).result;
+        const draftReview = detectDraftResult(result);
         toolInvocations.push({
           toolCallId,
           toolName,
           ...(state ? { state } : {}),
+          ...(result !== undefined ? { result } : {}),
+          ...(draftReview ? { draftReview } : {}),
           ...(part.errorText ? { errorText: String(part.errorText) } : {}),
         });
+        if (!buildProgress) {
+          const synthesized = buildProgressFromDraftReview(draftReview);
+          if (synthesized) buildProgress = synthesized;
+        }
       }
     }
 
@@ -125,6 +142,7 @@ export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): C
       role: message.role,
       content,
       ...(toolInvocations.length > 0 ? { toolInvocations } : {}),
+      ...(buildProgress ? { buildProgress } : {}),
     };
   });
 }

--- a/packages/app-shell/src/hooks/useChatConversation.test.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Hydration regression tests for the AI chat conversation loader.
+ *
+ * The server persists conversations in ModelMessage format: a tool CALL lives on
+ * the assistant message, while its RESULT lives in a SEPARATE `tool`-role row.
+ * Earlier `toUIMessages` dropped the `tool` row entirely, so the result (and the
+ * ADR-0033 draft envelope it carries) was lost on reload — the build card +
+ * Publish button vanished on refresh. These tests pin the fix: the result is
+ * merged back onto the assistant tool-call part so the chat can rebuild the
+ * draft affordances after a refresh.
+ */
+import { describe, it, expect } from 'vitest';
+import { toUIMessages } from './useChatConversation';
+
+describe('toUIMessages — merging tool-results onto the call (refresh survival)', () => {
+  const draftEnvelope = {
+    status: 'drafted',
+    drafted: [
+      { type: 'object', name: 'expense' },
+      { type: 'app', name: 'expense_tracker' },
+    ],
+    packageId: 'com.workspace',
+    materialized: true,
+  };
+
+  const rows = [
+    { id: 'u1', role: 'user', content: 'build an expense tracker' },
+    {
+      id: 'a1',
+      role: 'assistant',
+      content: [
+        { type: 'text', text: "I'll build it." },
+        { type: 'tool-call', toolCallId: 'call_1', toolName: 'apply_blueprint', input: { blueprint: {} } },
+      ],
+    },
+    {
+      id: 't1',
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'call_1', toolName: 'apply_blueprint', output: draftEnvelope }],
+    },
+    { id: 'a2', role: 'assistant', content: 'Done!' },
+  ];
+
+  it('drops the standalone tool row but merges its output onto the assistant call part', () => {
+    const out = toUIMessages(rows as never);
+    // user, assistant(call), assistant(done) — the `tool` row is not rendered.
+    expect(out.map((m) => m.role)).toEqual(['user', 'assistant', 'assistant']);
+    const callPart = out[1].parts.find((p) => p.toolCallId === 'call_1');
+    expect(callPart).toBeDefined();
+    expect((callPart as { output?: unknown }).output).toEqual(draftEnvelope);
+    // a finished result terminalizes the call so the chip never reads "Running".
+    expect((callPart as { state?: string }).state).toBe('output-available');
+  });
+
+  it('marks the call output-error when the tool result reports an error', () => {
+    const errRows = [
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: [{ type: 'tool-call', toolCallId: 'c_err', toolName: 'add_field', input: {} }],
+      },
+      {
+        id: 't1',
+        role: 'tool',
+        content: [
+          { type: 'tool-result', toolCallId: 'c_err', toolName: 'add_field', output: { ok: false }, errorText: 'boom' },
+        ],
+      },
+    ];
+    const out = toUIMessages(errRows as never);
+    const callPart = out[0].parts.find((p) => p.toolCallId === 'c_err');
+    expect((callPart as { state?: string }).state).toBe('output-error');
+    expect((callPart as { errorText?: string }).errorText).toBe('boom');
+  });
+
+  it('leaves messages without tool results untouched', () => {
+    const plain = [
+      { id: 'u1', role: 'user', content: 'hi' },
+      { id: 'a1', role: 'assistant', content: 'hello' },
+    ];
+    const out = toUIMessages(plain as never);
+    expect(out.map((m) => m.role)).toEqual(['user', 'assistant']);
+    expect(out[1].parts).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+});

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -226,14 +226,59 @@ function contentToParts(content: unknown): HydratedUIMessagePart[] {
   return [];
 }
 
+/**
+ * Merge a `tool`-role message's tool-result outputs back onto the assistant
+ * tool-call parts that requested them. The server persists conversations in
+ * ModelMessage format, where a tool CALL (assistant message) and its RESULT (a
+ * separate `tool` row) live in different messages. The chat UI needs the output
+ * ON the call part so `detectDraftResult` can rebuild the publish/preview
+ * affordances after a reload — otherwise the result, and the whole `tool` row
+ * (which the UI never renders directly), is dropped and the build card + publish
+ * button vanish on refresh.
+ */
+function mergeToolResultsInto(
+  content: unknown,
+  byCallId: Map<string, HydratedUIMessagePart>,
+): void {
+  for (const part of contentToParts(content)) {
+    const callId = typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
+    if (!callId) continue;
+    const target = byCallId.get(callId);
+    if (!target) continue;
+    const output =
+      (part as { output?: unknown }).output ?? (part as { result?: unknown }).result;
+    if (output === undefined) continue;
+    target.output = output;
+    const errorText = (part as { errorText?: unknown }).errorText;
+    const isError = Boolean((part as { isError?: unknown }).isError) || typeof errorText === 'string';
+    target.state = isError ? 'output-error' : 'output-available';
+    if (typeof errorText === 'string') target.errorText = errorText;
+  }
+}
+
 export function toUIMessages(rows: ServerMessage[] | undefined): HydratedUIMessage[] {
   if (!rows) return [];
   const out: HydratedUIMessage[] = [];
+  // Index assistant tool-call parts by id so a later `tool`-role result row can
+  // merge its output onto the matching call (see mergeToolResultsInto).
+  const toolPartByCallId = new Map<string, HydratedUIMessagePart>();
   rows.forEach((row, idx) => {
-    const role = row.role as HydratedUIMessage['role'];
+    const role = row.role as HydratedUIMessage['role'] | 'tool';
+    if (role === 'tool') {
+      mergeToolResultsInto(row.content, toolPartByCallId);
+      return;
+    }
     if (role !== 'user' && role !== 'assistant' && role !== 'system') return;
     const parts = contentToParts(row.content);
     if (parts.length === 0) return;
+    if (role === 'assistant') {
+      for (const part of parts) {
+        const callId = typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
+        if (callId && (part.type === 'tool-call' || part.type.startsWith('tool-'))) {
+          toolPartByCallId.set(callId, part);
+        }
+      }
+    }
     out.push({
       id: row.id ?? `msg-${idx}`,
       role,

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -1960,9 +1960,11 @@ function BuildProgressPanel({
         {!isDone && phase === 'data' ? (
           <span className="text-xs font-normal text-muted-foreground">adding sample data</span>
         ) : null}
-        <span className="ml-auto">
-          <LivenessIndicator active={!isDone} activityKey={activityKey} waitingLabel={waitingLabel} />
-        </span>
+        {!isDone ? (
+          <span className="ml-auto">
+            <LivenessIndicator active activityKey={activityKey} waitingLabel={waitingLabel} />
+          </span>
+        ) : null}
       </div>
       <div className="mb-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
         <div

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -346,7 +346,7 @@ describe('buildProgressFromDraftReview (reload synthesis)', () => {
     });
     expect(bp).toEqual({
       phase: 'done',
-      appLabel: 'expense_tracker',
+      appLabel: 'Expense Tracker',
       items: [
         { type: 'object', name: 'expense' },
         { type: 'view', name: 'expense.list' },
@@ -392,7 +392,7 @@ describe('buildProgressFromDraftReview (reload synthesis)', () => {
         },
       ],
     });
-    expect(out.buildProgress).toMatchObject({ phase: 'done', appLabel: 'expense_tracker', done: 2, total: 2 });
+    expect(out.buildProgress).toMatchObject({ phase: 'done', appLabel: 'Expense Tracker', done: 2, total: 2 });
     // and the draft affordances survive too
     expect(out.toolInvocations?.[0]?.draftReview?.packageId).toBe('com.workspace');
   });

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -7,7 +7,12 @@
  * `@ai-sdk/react`'s `useChat()` directly (e.g. Studio's chat panel).
  */
 import { describe, it, expect } from 'vitest';
-import { uiMessageToChatMessage, uiMessagesToChatMessages } from '../mapMessages';
+import {
+  uiMessageToChatMessage,
+  uiMessagesToChatMessages,
+  detectDraftResult,
+  buildProgressFromDraftReview,
+} from '../mapMessages';
 
 describe('uiMessageToChatMessage', () => {
   it('concatenates text parts and falls back to streaming=false by default', () => {
@@ -322,5 +327,104 @@ describe('uiMessagesToChatMessages', () => {
       { isStreaming: false },
     );
     expect(out[0]?.streaming).toBeFalsy();
+  });
+});
+
+// Refresh-survival (the user-reported bug): the live `data-build-progress` parts
+// are transient and never persisted, so a reloaded whole-app build lost its
+// "Built X" panel + Open/Preview affordances. We reconstruct a completed summary
+// from the apply_blueprint draft envelope, which IS persisted on the tool result.
+describe('buildProgressFromDraftReview (reload synthesis)', () => {
+  it('synthesizes a done panel from a whole-app draft (includes an app item)', () => {
+    const bp = buildProgressFromDraftReview({
+      items: [
+        { type: 'object', name: 'expense' },
+        { type: 'view', name: 'expense.list' },
+        { type: 'app', name: 'expense_tracker' },
+      ],
+      packageId: 'com.workspace',
+    });
+    expect(bp).toEqual({
+      phase: 'done',
+      appLabel: 'expense_tracker',
+      items: [
+        { type: 'object', name: 'expense' },
+        { type: 'view', name: 'expense.list' },
+        { type: 'app', name: 'expense_tracker' },
+      ],
+      done: 3,
+      total: 3,
+    });
+  });
+
+  it('returns undefined for an incremental edit (no app item) — keeps the draft card but no build tree', () => {
+    expect(
+      buildProgressFromDraftReview({ items: [{ type: 'field', name: 'expense.payment_method' }] }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for empty / missing input', () => {
+    expect(buildProgressFromDraftReview(undefined)).toBeUndefined();
+    expect(buildProgressFromDraftReview({ items: [] })).toBeUndefined();
+  });
+
+  it('uiMessageToChatMessage reconstructs buildProgress from a persisted apply_blueprint result (no live build-progress part)', () => {
+    const out = uiMessageToChatMessage({
+      id: 'm-reload-build',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-apply_blueprint',
+          toolCallId: 'call_reload',
+          state: 'output-available',
+          input: { blueprint: {} },
+          // The persisted ModelMessage result merged back onto the call part —
+          // no `data-build-progress` part exists after reload.
+          output: {
+            status: 'drafted',
+            drafted: [
+              { type: 'object', name: 'expense' },
+              { type: 'app', name: 'expense_tracker' },
+            ],
+            packageId: 'com.workspace',
+            materialized: true,
+          },
+        },
+      ],
+    });
+    expect(out.buildProgress).toMatchObject({ phase: 'done', appLabel: 'expense_tracker', done: 2, total: 2 });
+    // and the draft affordances survive too
+    expect(out.toolInvocations?.[0]?.draftReview?.packageId).toBe('com.workspace');
+  });
+
+  it('does NOT override a live data-build-progress part with the synthesized summary', () => {
+    const out = uiMessageToChatMessage({
+      id: 'm-live-build',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'data-build-progress',
+          id: 'build-progress',
+          data: { phase: 'data', appLabel: 'Live', items: [{ type: 'object', name: 'x' }], done: 1, total: 4 },
+        },
+        {
+          type: 'tool-apply_blueprint',
+          toolCallId: 'call_live',
+          state: 'output-available',
+          input: {},
+          output: { status: 'drafted', drafted: [{ type: 'app', name: 'x_app' }], packageId: 'p' },
+        },
+      ],
+    });
+    // live progress wins (phase 'data', not the synthesized 'done')
+    expect(out.buildProgress).toMatchObject({ phase: 'data', appLabel: 'Live', done: 1, total: 4 });
+  });
+});
+
+describe('detectDraftResult is exported for shared hydration', () => {
+  it('parses a batch envelope into items', () => {
+    expect(detectDraftResult({ status: 'drafted', drafted: [{ type: 'app', name: 'a' }] })?.items).toEqual([
+      { type: 'app', name: 'a' },
+    ]);
   });
 });

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -299,7 +299,10 @@ export * as AIElements from './elements';
 export {
   uiMessageToChatMessage,
   uiMessagesToChatMessages,
+  detectDraftResult,
+  buildProgressFromDraftReview,
 } from './mapMessages';
+export type { DraftReview } from './mapMessages';
 
 // Display helpers used internally by ChatbotEnhanced. Exported so app
 // authors composing their own chat surface get the same pretty tool-call

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -128,9 +128,7 @@ function detectPendingApproval(
  * "Review N change(s)" affordance that opens the designer's review/diff.
  * `blueprint_proposed` (propose_blueprint) has no draft yet → not surfaced here.
  */
-function detectDraftResult(
-  result: unknown,
-): {
+export interface DraftReview {
   items: Array<{ type: string; name: string }>;
   summary?: string;
   packageId?: string;
@@ -138,7 +136,9 @@ function detectDraftResult(
   failedCount?: number;
   materialized?: boolean;
   verification?: { errors: number; warnings: number };
-} | undefined {
+}
+
+export function detectDraftResult(result: unknown): DraftReview | undefined {
   const obj = parseResultEnvelope(result);
   if (!obj || obj.status !== 'drafted') return undefined;
   const items: Array<{ type: string; name: string }> = [];
@@ -186,6 +186,31 @@ function detectDraftResult(
     // hidden). The canvas then previews the REAL app URL, not the draft overlay.
     ...(obj.materialized === true ? { materialized: true } : {}),
     ...(verification ? { verification } : {}),
+  };
+}
+
+/**
+ * Synthesize a COMPLETED build-progress summary from a persisted apply_blueprint
+ * draft envelope. The live "build tree" (`buildProgress`) is driven by transient
+ * `data-build-progress` stream parts that are never persisted — so a reloaded
+ * conversation loses the "Built X" panel (ADR-0037/0045). On hydration we
+ * reconstruct the done-state from the draft result, which IS persisted, so the
+ * summary + its preview/open affordances survive a refresh. Only whole-app
+ * builds (a draft set that includes an `app`) get a panel — incremental edits
+ * keep their draft card but no build tree, matching the live behaviour.
+ */
+export function buildProgressFromDraftReview(
+  draft: DraftReview | undefined,
+): ChatBuildProgress | undefined {
+  if (!draft || !Array.isArray(draft.items) || draft.items.length === 0) return undefined;
+  const app = draft.items.find((it) => it.type === 'app');
+  if (!app) return undefined;
+  return {
+    phase: 'done',
+    appLabel: app.name,
+    items: draft.items,
+    done: draft.items.length,
+    total: draft.items.length,
   };
 }
 
@@ -338,14 +363,26 @@ export function uiMessageToChatMessage(
   // other (historical) message a dangling tool state is stale by definition.
   const tools = extractToolInvocations(parts, { liveTail: opts.streaming });
   const legacyTools = Array.isArray(msg.toolInvocations) ? msg.toolInvocations : [];
+  const resolvedTools = tools.length > 0 ? tools : legacyTools;
+  // The live `data-build-progress` parts are transient (never persisted), so a
+  // reloaded whole-app build loses its "Built X" panel. Fall back to a summary
+  // synthesized from the apply_blueprint draft envelope — which IS persisted on
+  // the tool result — so the panel + its open/preview affordances survive a
+  // refresh. Re-derived on every map (incl. useObjectChat's round-trip), so it
+  // cannot be lost the way a one-shot hydration value would.
+  const buildProgress =
+    extractBuildProgress(parts) ??
+    resolvedTools
+      .map((tool) => buildProgressFromDraftReview(tool.draftReview))
+      .find((bp): bp is ChatBuildProgress => Boolean(bp));
   return {
     id: (msg.id ?? `msg-${Math.random().toString(36).slice(2, 8)}`) as string,
     role: (msg.role ?? 'assistant') as ChatMessage['role'],
     content: extractText(msg, parts),
     reasoning: extractReasoning(parts),
-    toolInvocations: tools.length > 0 ? tools : legacyTools,
+    toolInvocations: resolvedTools,
     sources: extractSources(parts),
-    buildProgress: extractBuildProgress(parts),
+    buildProgress,
     charts: extractCharts(parts),
     streaming: opts.streaming,
   };

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -189,6 +189,15 @@ export function detectDraftResult(result: unknown): DraftReview | undefined {
   };
 }
 
+/** snake/kebab artifact name → human title, e.g. `expense_tracker` → `Expense Tracker`. */
+function humanizeArtifactName(name: string): string {
+  return name
+    .replace(/[._-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 /**
  * Synthesize a COMPLETED build-progress summary from a persisted apply_blueprint
  * draft envelope. The live "build tree" (`buildProgress`) is driven by transient
@@ -207,7 +216,7 @@ export function buildProgressFromDraftReview(
   if (!app) return undefined;
   return {
     phase: 'done',
-    appLabel: app.name,
+    appLabel: humanizeArtifactName(app.name),
     items: draft.items,
     done: draft.items.length,
     total: draft.items.length,


### PR DESCRIPTION
## Problem

In the AI **magic flow**, the blueprint **build progress panel** (Open / Preview) and the draft **Publish button** disappeared whenever the user **refreshed the browser** mid- or post-build. Reported by the user; reproduced in the local full-stack browser E2E.

Two layers of data loss on hydration:

1. **The tool result was dropped.** The server persists conversations in ModelMessage format, where a tool **CALL** (assistant message) and its **RESULT** (a separate `tool` row) are different messages. `toUIMessages` skipped non-user/assistant/system rows, so the `tool` row — carrying the apply_blueprint **draft envelope** (ADR-0033, `{status:'drafted', drafted:[…], packageId, …}`) that drives the publish/preview/review affordances — was never available after reload.
2. **Build progress is transient.** The live `data-build-progress` stream parts that render the "Built X" panel are never persisted, so the panel vanished on reload too.

## Fix (objectui only)

- **`toUIMessages`** merges a `tool` row's result back onto the matching assistant tool-call part as `output` (+ terminal `output-available`/`output-error` state), so `detectDraftResult` can rebuild `draftReview` after a refresh.
- **`uiMessageToChatMessage`** synthesizes a *completed* `buildProgress` summary from the persisted apply_blueprint draft envelope when no live progress part exists — re-derived on every map (incl. `useObjectChat`'s round-trip), so it can't be lost like a one-shot hydration value. Only whole-app builds (draft set includes an `app`) get a panel; incremental edits keep their draft card but no build tree (matches live behaviour).
- **`hydratedMessagesToChatMessages`** reads the merged result → `draftReview` and the same synthesized `buildProgress`.
- Export `detectDraftResult` + new `buildProgressFromDraftReview` (+ `DraftReview` type).

## Verification

Browser-verified end-to-end on the full local stack (cloud + objectos runtime + real AI gateway): build → auto-publish → live preview → AI iterate (add field) → unpublished draft + **Publish (1)** button → **refresh-safe at every step**. The "Built expense_tracker" panel (progress bar + artifact tree + Open/Preview) and the Publish button now persist across reloads.

Unit tests: **plugin-chatbot 86 passed**, **app-shell 546 passed** (incl. new cases for the tool-result merge and the reload synthesis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)