### PR TITLE
fix(markdown): docs table first column flush against border (padding)

### DIFF
--- a/packages/plugin-markdown/src/markdown-theme.ts
+++ b/packages/plugin-markdown/src/markdown-theme.ts
@@ -128,6 +128,18 @@ const CSS = `
 .dark .os-markdown .markdown-alert-important .markdown-alert-title { color: #ab7df8; }
 .dark .os-markdown .markdown-alert-warning { border-left-color: #d29922; }
 .dark .os-markdown .markdown-alert-warning .markdown-alert-title { color: #d29922; }
+
+/* Bordered tables: @tailwindcss/typography zeroes padding on each row's
+   first (inline-start) and last (inline-end) cell because it assumes
+   borderless tables. We add cell borders (prose-th/td:border), so restore
+   symmetric horizontal padding — otherwise the first column's text sits
+   flush against the left border, misaligned with every other column. The
+   0.6666667em matches prose-sm's inner-cell padding. The `.os-markdown`
+   class selector outranks typography's zero-specificity :where() rules. */
+.os-markdown table th:first-child,
+.os-markdown table td:first-child { padding-inline-start: 0.6666667em; }
+.os-markdown table th:last-child,
+.os-markdown table td:last-child { padding-inline-end: 0.6666667em; }
 `
 
 /**

--- a/packages/plugin-markdown/src/markdown-theme.ts
+++ b/packages/plugin-markdown/src/markdown-theme.ts
@@ -134,7 +134,7 @@ const CSS = `
    borderless tables. We add cell borders (prose-th/td:border), so restore
    symmetric horizontal padding — otherwise the first column's text sits
    flush against the left border, misaligned with every other column. The
-   0.6666667em matches prose-sm's inner-cell padding. The `.os-markdown`
+   0.6666667em matches prose-sm's inner-cell padding. The .os-markdown
    class selector outranks typography's zero-specificity :where() rules. */
 .os-markdown table th:first-child,
 .os-markdown table td:first-child { padding-inline-start: 0.6666667em; }


### PR DESCRIPTION
## Problem

In rendered metadata-docs tables, the **first column** (e.g. the 对象 column) sits flush against the left border, misaligned with the other columns. Same for the last column against the right border.

![first column padding issue](first column 对象 text jammed against the left cell border)

## Root cause

`MarkdownImpl` renders tables with bordered cells:

```
"prose-table:border prose-th:border prose-th:bg-muted prose-td:border"
```

But `@tailwindcss/typography` zeroes the edge padding on table cells — `padding-inline-start: 0` on each row's **first** cell and `padding-inline-end: 0` on the **last** cell — because it assumes borderless tables where flush edges align with the surrounding text column. With cell borders added, that zeroed padding makes the first column's text touch the left border.

## Fix

Restore symmetric horizontal padding on the first/last cell in `markdown-theme.ts`:

```css
.os-markdown table th:first-child,
.os-markdown table td:first-child { padding-inline-start: 0.6666667em; }
.os-markdown table th:last-child,
.os-markdown table td:last-child { padding-inline-end: 0.6666667em; }
```

`0.6666667em` matches prose-sm's inner-cell padding (MarkdownImpl uses `prose prose-sm`), so all columns get equal horizontal padding. The `.os-markdown` class selector outranks typography's zero-specificity `:where()` rules, so no `!important` is needed.

## Test

- [ ] Render a GFM table in a doc → first/last column text has the same horizontal padding as inner columns; no text flush against the border.