### PR TITLE
feat(console): dynamic action result toast + list error state + per-version release notes

### DIFF
--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -711,17 +711,22 @@ export function MarketplacePackagePage() {
               {data.versions.length === 0 ? (
                 <p className="text-sm text-muted-foreground">{t('marketplace.detail.noApprovedVersions')}</p>
               ) : (
-                <ul className="space-y-2">
+                <ul className="space-y-3">
                   {data.versions.map((v) => (
-                    <li key={v.id} className="flex items-center justify-between gap-2 text-sm">
-                      <span className="flex items-center gap-1.5">
-                        <Package className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-                        <code className="font-mono">v{v.version}</code>
-                        {v.is_prerelease && <Badge variant="outline" className="text-xs">{t('marketplace.detail.prerelease')}</Badge>}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {v.published_at ? new Date(v.published_at).toLocaleDateString() : '—'}
-                      </span>
+                    <li key={v.id} className="space-y-1 text-sm">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="flex items-center gap-1.5">
+                          <Package className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+                          <code className="font-mono">v{v.version}</code>
+                          {v.is_prerelease && <Badge variant="outline" className="text-xs">{t('marketplace.detail.prerelease')}</Badge>}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {v.published_at ? new Date(v.published_at).toLocaleDateString() : '\u2014'}
+                        </span>
+                      </div>
+                      {v.release_notes && v.release_notes.trim() && (
+                        <p className="whitespace-pre-line pl-5 text-xs text-muted-foreground">{v.release_notes.trim()}</p>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/packages/app-shell/src/console/marketplace/marketplaceApi.ts
+++ b/packages/app-shell/src/console/marketplace/marketplaceApi.ts
@@ -95,6 +95,10 @@ export interface MarketplacePackageVersion {
   status?: string;
   is_prerelease?: boolean;
   published_at?: string | null;
+  // Human-authored "what changed in this version" notes (ADR-0010 version
+  // lifecycle / UX#6). Distinct from the package-level description; shown per
+  // version in the detail page's version history.
+  release_notes?: string | null;
   listing_status?: string;
   reviewed_at?: string | null;
 

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -530,7 +530,17 @@ export class ActionRunner {
       const duration = action.toast?.duration;
 
       if (result.success && !hasResultDialog && showToast.showOnSuccess !== false) {
-        const message = action.successMessage || 'Action completed successfully';
+        // Prefer a DYNAMIC message the server returned (result.data.message)
+        // over the static action.successMessage. Server-driven actions like
+        // check_app_updates / publish / install compute a real outcome
+        // ("2 app updates available: CRM 1.0.0→1.0.1", "Published v1.2.0")
+        // that the static label can't express; without this the user only ever
+        // sees a generic "Done". Falls back to the static label, then a default.
+        const dyn = (result.data && typeof result.data === 'object'
+          && typeof (result.data as { message?: unknown }).message === 'string')
+          ? String((result.data as { message?: unknown }).message).trim()
+          : '';
+        const message = dyn || action.successMessage || 'Action completed successfully';
         this.toastHandler(message, { type: 'success', duration });
       }
 

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -511,6 +511,34 @@ describe('ActionRunner', () => {
       expect(toastHandler).toHaveBeenCalledWith('Saved!', { type: 'success', duration: undefined });
     });
 
+    it('should prefer a dynamic server message (result.data.message) over successMessage', async () => {
+      const toastHandler = vi.fn();
+      runner.setToastHandler(toastHandler);
+      // Server-driven actions (check_app_updates / publish / install) return a
+      // computed outcome the static label cannot express.
+      runner.registerHandler('check-updates', vi.fn().mockResolvedValue({
+        success: true,
+        data: { message: '2 app update(s) available: CRM 1.0.0\u21921.0.1', update_count: 2 },
+      }));
+
+      await runner.execute({ type: 'check-updates', successMessage: 'Checked.' });
+
+      expect(toastHandler).toHaveBeenCalledWith(
+        '2 app update(s) available: CRM 1.0.0\u21921.0.1',
+        { type: 'success', duration: undefined },
+      );
+    });
+
+    it('should fall back to successMessage when result.data has no message', async () => {
+      const toastHandler = vi.fn();
+      runner.setToastHandler(toastHandler);
+      runner.registerHandler('noop', vi.fn().mockResolvedValue({ success: true, data: { update_count: 0 } }));
+
+      await runner.execute({ type: 'noop', successMessage: 'Done.' });
+
+      expect(toastHandler).toHaveBeenCalledWith('Done.', { type: 'success', duration: undefined });
+    });
+
     it('should emit error toast on failure', async () => {
       const toastHandler = vi.fn();
       runner.setToastHandler(toastHandler);

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -228,6 +228,9 @@ const en = {
     firstRunMessage: 'Create your first record to get started.',
     noMatches: 'No matching records',
     noMatchesMessage: 'No records match your current filters or search. Try adjusting or clearing them.',
+    loadErrorTitle: 'Couldn\u2019t load records',
+    loadErrorMessage: 'Something went wrong while loading this data. Check your connection and try again.',
+    retry: 'Retry',
     managedBy: {
       system: {
         title: 'Nothing here yet',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -228,6 +228,9 @@ const zh = {
     firstRunMessage: '创建第一条记录即可开始。',
     noMatches: '没有匹配的记录',
     noMatchesMessage: '没有符合当前筛选或搜索条件的记录，试试调整或清除它们。',
+    loadErrorTitle: '无法加载记录',
+    loadErrorMessage: '加载数据时出错。请检查网络连接后重试。',
+    retry: '重试',
     managedBy: {
       system: {
         title: '这里还没有数据',

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react';
 import { cn, Button, Input, Popover, PopoverContent, PopoverTrigger, FilterBuilder, SortBuilder, NavigationOverlay, GroupingEditor, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, RefreshIndicator, DataEmptyState } from '@object-ui/components';
 import type { SortItem } from '@object-ui/components';
-import { Search, SlidersHorizontal, ArrowUpDown, X, EyeOff, Group, Paintbrush, Ruler, Inbox, Download, AlignJustify, Rows4, Rows3, Rows2, Share2, Printer, Plus, Trash2, CheckSquare, icons, type LucideIcon } from 'lucide-react';
+import { Search, SlidersHorizontal, ArrowUpDown, X, EyeOff, Group, Paintbrush, Ruler, Inbox, Download, AlignJustify, Rows4, Rows3, Rows2, Share2, Printer, Plus, Trash2, CheckSquare, AlertTriangle, RotateCw, icons, type LucideIcon } from 'lucide-react';
 import type { FilterGroup } from '@object-ui/components';
 import { ViewSwitcherDropdown, ViewType } from './ViewSwitcher';
 import { TabBar, TabBarSelect } from './components/TabBar';
@@ -213,6 +213,10 @@ const LIST_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'list.noMatches': 'No matching records',
   'list.noMatchesMessage': 'No records match your current filters or search. Try adjusting or clearing them.',
   'list.loading': 'Loading records…',
+  // Load FAILED (network / server error) — distinct from empty. Offer retry.
+  'list.loadErrorTitle': 'Couldn\u2019t load records',
+  'list.loadErrorMessage': 'Something went wrong while loading this data. Check your connection and try again.',
+  'list.retry': 'Retry',
   'list.search': 'Search',
   'list.filter': 'Filter',
   'list.filterRecords': 'Filter Records',
@@ -519,6 +523,10 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // Data State
   const dataSource = props.dataSource;
   const [data, setData] = React.useState<any[]>([]);
+  // Load failure (network / server error) is distinct from "empty": we must
+  // not tell a user to "create your first record" when the fetch actually
+  // failed. Captured here so the render can show a retryable error panel.
+  const [loadError, setLoadError] = React.useState<string | null>(null);
   // Start in loading state when we will fetch from a dataSource so the empty
   // state doesn't flash before the first effect runs. Inline data (schema.data
   // as an array or a `value` provider) starts as not-loading.
@@ -915,6 +923,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       }
       
       setLoading(true);
+      setLoadError(null);
       try {
         // Construct filter
         let finalFilter: any = [];
@@ -1101,9 +1110,13 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         setData(items);
         setDataLimitReached(items.length >= effectivePageSize);
       } catch (err) {
-        // Only log errors from the latest request
+        // Only log + surface errors from the latest request. A failed fetch is
+        // NOT an empty result — record it so the render shows an error panel
+        // (with retry) rather than "Create your first record".
         if (requestId === fetchRequestIdRef.current) {
           console.error("ListView data fetch error:", err);
+          setData([]);
+          setLoadError((err as any)?.message ? String((err as any).message) : String(err ?? 'Unknown error'));
         }
       } finally {
         if (isMounted && requestId === fetchRequestIdRef.current) {
@@ -2204,7 +2217,27 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
             the ListView level so every inner view (grid/kanban/calendar/...)
             gets a consistent indicator instead of momentarily showing an
             empty state on slow networks. */}
-        {loading && data.length === 0 ? (
+        {loadError && data.length === 0 ? (
+          <DataEmptyState
+            data-testid="list-error-state"
+            className="h-full min-h-[200px] p-8 gap-1 [&>h3]:text-lg [&>h3]:font-medium [&>h3]:text-foreground [&>p]:max-w-md"
+            icon={<AlertTriangle className="h-12 w-12 text-destructive/60" />}
+            iconWrapperClassName="mb-3"
+            title={t('list.loadErrorTitle')}
+            description={t('list.loadErrorMessage')}
+            action={(
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="list-error-retry"
+                onClick={() => setRefreshKey((k) => k + 1)}
+              >
+                <RotateCw className="h-4 w-4 mr-1.5" />
+                {t('list.retry')}
+              </Button>
+            )}
+          />
+        ) : loading && data.length === 0 ? (
           <div
             className="flex flex-col h-full min-h-[200px] p-4 gap-2"
             data-testid="list-loading"


### PR DESCRIPTION
Three console UX improvements **surfaced and browser-verified** while testing the ADR-0010 version lifecycle. All framework-level and independent. Pairs with objectstack-ai/cloud#368 (backend).

## 1. Dynamic action result toast (keystone)
`ActionRunner` now prefers a **dynamic** server message (`result.data.message`) over the static `action.successMessage`. Server-driven actions compute a real outcome the static label can't express. Verified live:
- `check_app_updates` → "No apps installed." / "All installed apps are up to date."
- install → "Installed Local Sample App v1.0.0." / "Reinstalled …" / "Updated … v1.0.0 → v1.0.1."

Falls back to the static label, then a default. **+2 regression tests.**

## 2. List error state (≠ empty) — verified
`ListView` previously logged fetch failures then rendered "Create your first record" — telling a user to create data when the load actually *failed*. A failed fetch now renders a dedicated **error panel with Retry**. loading / error / first-run / filtered-empty are four distinct states. New i18n keys added to the central **en/zh** locales (the console uses central i18n, not the plugin-local fallback). Verified live: injected a fetch failure → error panel rendered → Retry recovered the list.

## 3. Per-version release notes — verified
Package detail version history shows per-version `release_notes` (distinct from the package-level description). Backed by cloud#368 exposing the field. Verified live: a version's release note rendered under v1.0.0.

## Dropped from scope
An env-install-context annotation for the cloud-control install picker was prototyped and **dropped**: the multi-env picker only renders in cloud-control, where `sys_package_installation` is not currently readable via `/api/v1/data` (returns 200 + 0 rows despite the row existing). Tracked separately.

## Test
- `core` + `plugin-list` + `app-shell` + `i18n` build clean (tsc); i18n locale-parity tests green.
- Core suite: **3906 passed** (incl. 2 new ActionRunner cases). i18n: 120 passed.
- Browser E2E on the full local stack (cloud control plane + console overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)