### PR TITLE
fix(marketplace): read install state via dedicated route + restore env install-context (UX#4)

### DIFF
--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -80,6 +80,11 @@ export function MarketplacePackagePage() {
   const [envsLoading, setEnvsLoading] = useState(false);
   const [envsError, setEnvsError] = useState<string | null>(null);
   const [selectedEnv, setSelectedEnv] = useState<string>('');
+  // env id -> installed version, for annotating the picker with each env's
+  // current install state ("Installed v1.0.0" / "Update → v1.0.1"). Lets a
+  // multi-env operator see at a glance where this app already lives and which
+  // copies are out of date before choosing a target.
+  const [envInstallMap, setEnvInstallMap] = useState<Record<string, string>>({});
   const [seedSampleData, setSeedSampleData] = useState(false);
   // PD4: a code-bearing package requires explicit acknowledgement of its
   // requested permissions before the install button is enabled.
@@ -184,6 +189,24 @@ export function MarketplacePackagePage() {
         return orgId ? adminOrgIds.has(String(orgId)) : false;
       });
       setEnvs(installable);
+      // Annotate each installable env with its current install state (best
+      // effort, parallel; a failed lookup just omits the annotation).
+      setEnvInstallMap({});
+      const pkgId = packageId;
+      if (pkgId) void Promise.all(
+        installable.map(async (env) => {
+          try {
+            const info = await getCloudInstallationInfo(pkgId, env.id);
+            return info ? ([env.id, info.version] as const) : null;
+          } catch {
+            return null;
+          }
+        }),
+      ).then((pairs) => {
+        const map: Record<string, string> = {};
+        for (const pair of pairs) if (pair) map[pair[0]] = pair[1];
+        setEnvInstallMap(map);
+      });
       if (list.length > 0 && installable.length === 0) {
         setEnvsError(t('marketplace.install.noPermission'));
       } else if (installable.length === 1) {
@@ -784,12 +807,22 @@ export function MarketplacePackagePage() {
                     <SelectValue placeholder={t('marketplace.install.environmentPlaceholder')} />
                   </SelectTrigger>
                   <SelectContent>
-                    {envs.map((e) => (
-                      <SelectItem key={e.id} value={e.id}>
-                        {e.display_name || e.hostname || e.id}
-                        {e.plan && <span className="text-muted-foreground"> · {e.plan}</span>}
-                      </SelectItem>
-                    ))}
+                    {envs.map((e) => {
+                      const installedHere = envInstallMap[e.id];
+                      const hasUpdate = !!installedHere && !!latestVersion
+                        && installedHere !== 'installed' && installedHere !== latestVersion;
+                      return (
+                        <SelectItem key={e.id} value={e.id}>
+                          {e.display_name || e.hostname || e.id}
+                          {e.plan && <span className="text-muted-foreground"> · {e.plan}</span>}
+                          {installedHere && (
+                            hasUpdate
+                              ? <span className="text-amber-600"> · {t('marketplace.install.updateTo', { defaultValue: 'Update \u2192 v{{version}}', version: latestVersion })}</span>
+                              : <span className="text-muted-foreground"> · {t('marketplace.install.installedVersion', { defaultValue: 'Installed v{{version}}', version: installedHere })}</span>
+                          )}
+                        </SelectItem>
+                      );
+                    })}
                   </SelectContent>
                 </Select>
               </div>

--- a/packages/app-shell/src/console/marketplace/marketplaceApi.ts
+++ b/packages/app-shell/src/console/marketplace/marketplaceApi.ts
@@ -421,34 +421,28 @@ export async function getCloudInstallationInfo(
   }
 
   // ── Cloud control-plane path (runtime IS cloud) ───────────────────────
-  // Same-origin read against the control plane's data API.
+  // Use the dedicated installed-state route, NOT the generic
+  // `/api/v1/data/sys_package_installation`. The control plane does not expose
+  // sys_package_installation rows through the generic data API (the row exists
+  // but the read returns empty), and that row carries `package_version_id`, not
+  // a version string. The dedicated route reads the control DB directly and
+  // resolves the human-readable version — and now enforces org membership for
+  // user-mode callers. Same response shape as the tenant proxy above.
   if (!environmentId) return null;
   const base = SERVER_URL;
-  const filter = JSON.stringify([
-    'and',
-    ['package_id', '=', packageId],
-    ['environment_id', '=', environmentId],
-  ]);
-  const url = `${base}/api/v1/data/sys_package_installation?top=1&filter=${encodeURIComponent(filter)}`;
   try {
-    const res = await fetch(url, {
-      credentials: 'include',
-      headers: { 'Accept': 'application/json' },
-    });
+    const res = await fetch(
+      `${base}/api/v1/cloud/environments/${encodeURIComponent(environmentId)}/installations/${encodeURIComponent(packageId)}`,
+      { credentials: 'include', headers: { 'Accept': 'application/json' } },
+    );
     if (!res.ok) return null;
     const payload: any = await res.json().catch(() => ({}));
-    const rows: any[] = payload?.records ?? payload?.data ?? payload?.items ?? [];
-    if (!Array.isArray(rows) || rows.length === 0) return null;
-    const row = rows[0];
-    const enabled = row?.enabled;
-    if (enabled === false || enabled === 0 || enabled === '0') return null;
+    const data: any = payload?.data ?? payload ?? {};
+    if (!data.installed) return null;
     return {
-      installationId: String(row?.id ?? ''),
-      version: String(row?.version ?? row?.installed_version ?? 'installed'),
-      withSampleData: row?.with_sample_data === true
-        || row?.with_sample_data === 1
-        || row?.with_sample_data === '1'
-        || row?.with_sample_data === 'true',
+      installationId: String(data.installationId ?? ''),
+      version: String(data.version ?? 'installed'),
+      withSampleData: data.withSampleData === true,
     };
   } catch {
     return null;


### PR DESCRIPTION
Completes the install-picker env annotation dropped from #1772.

**Root cause**: `getCloudInstallationInfo`'s cloud-control branch read the generic `/api/v1/data/sys_package_installation`, which returns 0 rows in the control plane (the row exists but isn't exposed there) and carries `package_version_id`, not a version string. So the annotation had no data.

**Fix**: switch to the dedicated `/cloud/environments/:id/installations/:packageId` route — the same one the tenant proxy already uses — which reads the control DB directly and resolves the human-readable version. Pairs with objectstack-ai/cloud#370 (adds a user-mode org guard to that route).

**Restored**: each environment in the "Install to cloud" picker now shows its install state ("Installed v1.0.0" / "Update → v1.0.1").

Verified end-to-end in the browser on the local stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)