### PR TITLE
feat: render `element:metadata_viewer` + ```metadata doc fence (ADR-0051 P1)

### DIFF
--- a/packages/components/src/__tests__/metadata-viewer.test.tsx
+++ b/packages/components/src/__tests__/metadata-viewer.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * element:metadata_viewer (ADR-0051) — read-only live metadata views.
+ *
+ * Renders the component through ComponentRegistry (the same path a
+ * ```metadata doc fence and a page node both use) with a mocked metadata
+ * context, and asserts each of the three view kinds plus graceful
+ * degradation.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { MetadataCtx } from '@object-ui/react';
+import '../renderers/basic/metadata-viewer';
+
+function metaCtx(getItem: (type: string, name: string) => Promise<any>) {
+  return {
+    apps: [], objects: [], dashboards: [], reports: [], pages: [],
+    loading: false, error: null,
+    refresh: async () => {}, invalidate: () => {}, ensureType: async () => [],
+    getItem, getItemsByType: () => [], getTypeStatus: () => 'ready' as const,
+  };
+}
+
+function Viewer({ properties, getItem }: { properties: any; getItem: (t: string, n: string) => Promise<any> }) {
+  const C = ComponentRegistry.get('element:metadata_viewer');
+  if (!C) throw new Error('element:metadata_viewer not registered');
+  return (
+    <MetadataCtx.Provider value={metaCtx(getItem) as any}>
+      <C schema={{ type: 'element:metadata_viewer', properties }} />
+    </MetadataCtx.Provider>
+  );
+}
+
+const TASK_OBJECT = {
+  name: 'showcase_task',
+  fields: {
+    status: {
+      type: 'select',
+      options: [
+        { value: 'backlog', label: 'Backlog', color: '#94A3B8', default: true },
+        { value: 'todo', label: 'To Do', color: '#3B82F6' },
+        { value: 'in_progress', label: 'In Progress', color: '#F59E0B' },
+        { value: 'done', label: 'Done', color: '#10B981' },
+      ],
+    },
+  },
+  validations: [
+    {
+      type: 'state_machine',
+      name: 'task_status_flow',
+      label: 'Task Status Flow',
+      field: 'status',
+      transitions: {
+        backlog: ['todo'],
+        todo: ['in_progress', 'backlog'],
+        in_progress: ['done'],
+        done: [],
+      },
+    },
+  ],
+};
+
+describe('element:metadata_viewer', () => {
+  it('registers as a component', () => {
+    expect(ComponentRegistry.get('element:metadata_viewer')).toBeTruthy();
+  });
+
+  describe('state_machine', () => {
+    it('renders the transition graph with option labels, initial + final badges', async () => {
+      const getItem = vi.fn(async (type: string) => (type === 'object' ? TASK_OBJECT : null));
+      render(<Viewer getItem={getItem} properties={{ type: 'state_machine', object: 'showcase_task', name: 'task_status_flow' }} />);
+
+      await waitFor(() => expect(screen.getByText('Task Status Flow')).toBeTruthy());
+      // option label, not the raw value
+      expect(screen.getAllByText('Backlog').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
+      // backlog is the default option → initial; done has no outgoing → final
+      expect(screen.getByText(/initial/i)).toBeTruthy();
+      expect(screen.getByText(/final/i)).toBeTruthy();
+      expect(getItem).toHaveBeenCalledWith('object', 'showcase_task');
+    });
+
+    it('warns when the named rule is absent', async () => {
+      const getItem = vi.fn(async () => ({ name: 'x', validations: [] }));
+      render(<Viewer getItem={getItem} properties={{ type: 'state_machine', object: 'x', name: 'nope' }} />);
+      await waitFor(() => expect(screen.getByText(/No state machine/i)).toBeTruthy());
+    });
+  });
+
+  describe('flow', () => {
+    const FLOW = {
+      name: 'reassign',
+      label: 'Reassign Task',
+      nodes: [
+        { id: 'start', type: 'start', label: 'Start' },
+        { id: 's1', type: 'script', label: 'Do Plumbing' },
+        { id: 'end', type: 'end', label: 'End' },
+      ],
+    };
+
+    it('folds technical nodes at business altitude (default)', async () => {
+      const getItem = vi.fn(async () => FLOW);
+      render(<Viewer getItem={getItem} properties={{ type: 'flow', name: 'reassign' }} />);
+      await waitFor(() => expect(screen.getByText('Reassign Task')).toBeTruthy());
+      expect(screen.getByText('Start')).toBeTruthy();
+      expect(screen.getByText('End')).toBeTruthy();
+      expect(screen.queryByText('Do Plumbing')).toBeNull(); // script folded
+      expect(screen.getByText(/technical step.*hidden/i)).toBeTruthy();
+    });
+
+    it('shows technical nodes when detail=technical', async () => {
+      const getItem = vi.fn(async () => FLOW);
+      render(<Viewer getItem={getItem} properties={{ type: 'flow', name: 'reassign', detail: 'technical' }} />);
+      await waitFor(() => expect(screen.getByText('Do Plumbing')).toBeTruthy());
+    });
+  });
+
+  describe('permission', () => {
+    it('renders an object CRUD matrix', async () => {
+      const getItem = vi.fn(async () => ({
+        name: 'contributor',
+        label: 'Contributor',
+        objects: { showcase_task: { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: false } },
+      }));
+      render(<Viewer getItem={getItem} properties={{ type: 'permission', name: 'contributor' }} />);
+      await waitFor(() => expect(screen.getByText('Contributor')).toBeTruthy());
+      expect(screen.getByText('showcase_task')).toBeTruthy();
+    });
+  });
+
+  it('degrades on an unknown view type', () => {
+    render(<Viewer getItem={async () => null} properties={{ type: 'nonsense' }} />);
+    expect(screen.getByText(/Unknown metadata view type/i)).toBeTruthy();
+  });
+});

--- a/packages/components/src/renderers/basic/index.ts
+++ b/packages/components/src/renderers/basic/index.ts
@@ -17,4 +17,5 @@ import './button-group';
 import './pagination';
 import './navigation-menu';
 import './elements';
+import './metadata-viewer';
 import './data-list';

--- a/packages/components/src/renderers/basic/metadata-viewer.tsx
+++ b/packages/components/src/renderers/basic/metadata-viewer.tsx
@@ -1,0 +1,386 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `element:metadata_viewer` — a read-only, live-resolved view of a metadata
+ * item, embedded inline in content (ADR-0051). This is the SDUI component a
+ * ```` ```metadata ```` doc fence compiles to: the inline form of ADR-0046 §3.5
+ * ("derived content is rendered, never written"). It resolves the target
+ * metadata by name at render time (so it never goes stale) and renders a
+ * read-only projection — it carries no expressions or actions, staying on the
+ * data side of the §3.4 trust boundary.
+ *
+ * Spec: `framework/packages/spec/src/ui/component.zod.ts`
+ *   ElementMetadataViewerPropsSchema → { type, name, object?, mode?, detail? }
+ *   type ∈ state_machine | flow | permission   (`object` embeds deferred)
+ */
+
+import * as React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { useMetadataItem } from '@object-ui/react';
+import {
+  ArrowRight,
+  CircleDot,
+  Flag,
+  Workflow,
+  GitBranch,
+  ShieldCheck,
+  Check,
+  Minus,
+  AlertTriangle,
+} from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+interface ViewerProps {
+  type?: 'state_machine' | 'flow' | 'permission';
+  name?: string;
+  object?: string;
+  mode?: 'diagram' | 'matrix' | 'summary';
+  detail?: 'business' | 'technical';
+}
+
+function readProps(schema: any): ViewerProps {
+  const fromProperties = (schema?.properties ?? {}) as ViewerProps;
+  const fromProps = (schema?.props ?? {}) as ViewerProps;
+  return { ...fromProps, ...fromProperties };
+}
+
+/** Tolerate `fields` as either an object map or an array of `{name,...}`. */
+function getField(obj: any, name?: string): any {
+  if (!obj || !name) return undefined;
+  const f = obj.fields;
+  if (!f) return undefined;
+  if (Array.isArray(f)) return f.find((x: any) => x?.name === name);
+  return f[name];
+}
+
+function Shell({
+  hint,
+  icon: Icon,
+  title,
+  subtitle,
+  children,
+}: {
+  hint: string;
+  icon: React.ComponentType<{ className?: string }>;
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border bg-card text-card-foreground shadow-sm overflow-hidden">
+      <div className="flex items-start gap-2.5 border-b bg-muted/40 px-3.5 py-2.5">
+        <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-2">
+            <span className="text-sm font-semibold leading-tight">{title}</span>
+            <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">{hint}</span>
+          </div>
+          {subtitle && <div className="mt-0.5 text-xs text-muted-foreground">{subtitle}</div>}
+        </div>
+      </div>
+      <div className="p-3.5">{children}</div>
+    </div>
+  );
+}
+
+function Placeholder({ tone = 'muted', children }: { tone?: 'muted' | 'warn'; children: React.ReactNode }) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 rounded-md border border-dashed px-3 py-2.5 text-xs',
+        tone === 'warn'
+          ? 'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300'
+          : 'bg-muted/30 text-muted-foreground',
+      )}
+    >
+      {tone === 'warn' && <AlertTriangle className="h-3.5 w-3.5 shrink-0" />}
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// state_machine — live transition graph from a `state_machine` validation rule
+// ---------------------------------------------------------------------------
+
+interface SelectOption {
+  label?: string;
+  value: string;
+  color?: string;
+  default?: boolean;
+}
+
+function StateMachineView({ object, name }: ViewerProps) {
+  const { item: obj, loading, error } = useMetadataItem('object', object ?? null);
+
+  const rule = React.useMemo(() => {
+    const rules: any[] = obj?.validations ?? obj?.validationRules ?? [];
+    if (!Array.isArray(rules)) return undefined;
+    return rules.find(
+      (r) => r?.type === 'state_machine' && (!name || r?.name === name),
+    );
+  }, [obj, name]);
+
+  if (!object) return <Placeholder tone="warn">Missing <code className="font-mono">object</code> for the state machine.</Placeholder>;
+  if (loading) return <Placeholder>Loading <code className="font-mono">{object}</code>…</Placeholder>;
+  if (error) return <Placeholder tone="warn">Failed to load object <code className="font-mono">{object}</code>: {error.message}</Placeholder>;
+  if (!obj) return <Placeholder tone="warn">Object <code className="font-mono">{object}</code> not found.</Placeholder>;
+  if (!rule) {
+    return (
+      <Placeholder tone="warn">
+        No state machine{name ? ` named “${name}”` : ''} on <code className="font-mono">{object}</code>.
+      </Placeholder>
+    );
+  }
+
+  const transitions: Record<string, string[]> =
+    rule.transitions && typeof rule.transitions === 'object' && !Array.isArray(rule.transitions)
+      ? rule.transitions
+      : {};
+  const field = getField(obj, rule.field);
+  const options: SelectOption[] = Array.isArray(field?.options) ? field.options : [];
+  const optByValue = new Map(options.map((o) => [o.value, o]));
+  const labelOf = (v: string) => optByValue.get(v)?.label ?? v;
+  const colorOf = (v: string) => optByValue.get(v)?.color;
+  const initial = options.find((o) => o.default)?.value;
+
+  // All states = union of declared options, transition sources, and targets —
+  // ordered: initial first, then option order, then any extras.
+  const ordered = new Set<string>();
+  if (initial) ordered.add(initial);
+  for (const o of options) ordered.add(o.value);
+  for (const [from, tos] of Object.entries(transitions)) {
+    ordered.add(from);
+    for (const t of tos) ordered.add(t);
+  }
+  const states = [...ordered];
+
+  const Chip = ({ value }: { value: string }) => {
+    const color = colorOf(value);
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-xs font-medium">
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: color ?? 'var(--muted-foreground)' }} />
+        {labelOf(value)}
+      </span>
+    );
+  };
+
+  return (
+    <Shell
+      hint="state machine"
+      icon={Workflow}
+      title={rule.label ?? rule.name ?? 'State machine'}
+      subtitle={
+        <>
+          Lifecycle of <code className="font-mono">{object}</code>
+          {rule.field ? <> · field <code className="font-mono">{rule.field}</code></> : null}
+        </>
+      }
+    >
+      <ol className="space-y-1.5">
+        {states.map((s) => {
+          const tos = transitions[s] ?? [];
+          const isInitial = s === initial;
+          const isFinal = tos.length === 0;
+          return (
+            <li
+              key={s}
+              className="flex flex-wrap items-center gap-x-2 gap-y-1.5 rounded-md border bg-muted/20 px-2.5 py-2"
+            >
+              <Chip value={s} />
+              {isInitial && (
+                <span className="inline-flex items-center gap-1 rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400">
+                  <CircleDot className="h-3 w-3" /> initial
+                </span>
+              )}
+              {isFinal ? (
+                <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <Flag className="h-3 w-3" /> final
+                </span>
+              ) : (
+                <>
+                  <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="flex flex-wrap gap-1.5">
+                    {tos.map((t) => (
+                      <Chip key={t} value={t} />
+                    ))}
+                  </span>
+                </>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </Shell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// flow — ordered step summary of a flow's nodes (read-only)
+// ---------------------------------------------------------------------------
+
+// Node-action families that are infrastructure, not business steps. With
+// `detail: business` (the default), these are folded away so a non-technical
+// reader sees the process, not the plumbing (ADR-0051 §3.4 altitude projection).
+const TECHNICAL_NODE_TYPES = new Set([
+  'script',
+  'http_request',
+  'connector_action',
+  'assignment',
+  'get_record',
+  'create_record',
+  'update_record',
+  'delete_record',
+  'boundary_event',
+]);
+
+function FlowView({ name, detail }: ViewerProps) {
+  const { item: flow, loading, error } = useMetadataItem('flow', name ?? null);
+
+  if (!name) return <Placeholder tone="warn">Missing <code className="font-mono">name</code> for the flow.</Placeholder>;
+  if (loading) return <Placeholder>Loading flow <code className="font-mono">{name}</code>…</Placeholder>;
+  if (error) return <Placeholder tone="warn">Failed to load flow <code className="font-mono">{name}</code>: {error.message}</Placeholder>;
+  if (!flow) return <Placeholder tone="warn">Flow <code className="font-mono">{name}</code> not found.</Placeholder>;
+
+  const allNodes: any[] = Array.isArray(flow.nodes) ? flow.nodes : [];
+  const business = (detail ?? 'business') === 'business';
+  const nodes = business ? allNodes.filter((n) => !TECHNICAL_NODE_TYPES.has(n?.type)) : allNodes;
+  const hiddenCount = allNodes.length - nodes.length;
+
+  return (
+    <Shell
+      hint="flow"
+      icon={GitBranch}
+      title={flow.label ?? flow.name ?? name}
+      subtitle={flow.description ?? <>Process with {allNodes.length} step{allNodes.length === 1 ? '' : 's'}</>}
+    >
+      {nodes.length === 0 ? (
+        <Placeholder>No steps to show.</Placeholder>
+      ) : (
+        <ol className="space-y-1.5">
+          {nodes.map((n, i) => (
+            <li key={n?.id ?? i} className="flex items-center gap-2.5 rounded-md border bg-muted/20 px-2.5 py-2">
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[11px] font-semibold text-primary">
+                {i + 1}
+              </span>
+              <span className="text-sm">{n?.label ?? n?.id ?? '(step)'}</span>
+              {n?.type && (
+                <span className="ml-auto rounded border bg-background px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                  {n.type}
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+      {business && hiddenCount > 0 && (
+        <div className="mt-2 text-[11px] text-muted-foreground">
+          {hiddenCount} technical step{hiddenCount === 1 ? '' : 's'} hidden · set <code className="font-mono">detail: technical</code> to show all
+        </div>
+      )}
+    </Shell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// permission — compact object-level CRUD matrix (read-only)
+// ---------------------------------------------------------------------------
+
+const CRUD: Array<{ key: string; label: string }> = [
+  { key: 'allowCreate', label: 'C' },
+  { key: 'allowRead', label: 'R' },
+  { key: 'allowEdit', label: 'U' },
+  { key: 'allowDelete', label: 'D' },
+];
+
+function PermissionView({ name }: ViewerProps) {
+  const { item: perm, loading, error } = useMetadataItem('permission', name ?? null);
+
+  if (!name) return <Placeholder tone="warn">Missing <code className="font-mono">name</code> for the permission set.</Placeholder>;
+  if (loading) return <Placeholder>Loading permission set <code className="font-mono">{name}</code>…</Placeholder>;
+  if (error) return <Placeholder tone="warn">Failed to load permission <code className="font-mono">{name}</code>: {error.message}</Placeholder>;
+  if (!perm) return <Placeholder tone="warn">Permission set <code className="font-mono">{name}</code> not found.</Placeholder>;
+
+  const objects: Record<string, any> = perm.objects && typeof perm.objects === 'object' ? perm.objects : {};
+  const entries = Object.entries(objects);
+
+  return (
+    <Shell
+      hint="permission"
+      icon={ShieldCheck}
+      title={perm.label ?? perm.name ?? name}
+      subtitle={<>Object access · {entries.length} object{entries.length === 1 ? '' : 's'}{perm.isProfile ? ' · profile' : ''}</>}
+    >
+      {entries.length === 0 ? (
+        <Placeholder>No object permissions declared.</Placeholder>
+      ) : (
+        <table className="w-full border-separate border-spacing-0 text-xs">
+          <thead>
+            <tr className="text-muted-foreground">
+              <th className="border-b px-2 py-1.5 text-left font-medium">Object</th>
+              {CRUD.map((c) => (
+                <th key={c.key} className="border-b px-2 py-1.5 text-center font-mono font-medium" title={c.key}>
+                  {c.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(([objName, perms]) => (
+              <tr key={objName}>
+                <td className="border-b px-2 py-1.5 font-mono">{objName}</td>
+                {CRUD.map((c) => (
+                  <td key={c.key} className="border-b px-2 py-1.5 text-center">
+                    {perms?.[c.key] ? (
+                      <Check className="mx-auto h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+                    ) : (
+                      <Minus className="mx-auto h-3.5 w-3.5 text-muted-foreground/40" />
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Shell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher + registration
+// ---------------------------------------------------------------------------
+
+export function ElementMetadataViewerRenderer({ schema }: { schema: any }) {
+  const props = readProps(schema);
+  switch (props.type) {
+    case 'state_machine':
+      return <StateMachineView {...props} />;
+    case 'flow':
+      return <FlowView {...props} />;
+    case 'permission':
+      return <PermissionView {...props} />;
+    default:
+      return (
+        <Placeholder tone="warn">
+          Unknown metadata view type{props.type ? ` “${props.type}”` : ''}. Expected{' '}
+          <code className="font-mono">state_machine</code>, <code className="font-mono">flow</code>, or{' '}
+          <code className="font-mono">permission</code>.
+        </Placeholder>
+      );
+  }
+}
+
+ComponentRegistry.register('element:metadata_viewer', ElementMetadataViewerRenderer, {
+  namespace: 'element',
+  label: 'Metadata Viewer',
+  category: 'content',
+});

--- a/packages/plugin-markdown/src/MarkdownImpl.tsx
+++ b/packages/plugin-markdown/src/MarkdownImpl.tsx
@@ -14,6 +14,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize"
 import rehypeSlug from "rehype-slug"
 import rehypeHighlight from "rehype-highlight"
 import rehypeAutolinkHeadings from "rehype-autolink-headings"
+import { ComponentRegistry } from "@object-ui/core"
 import { ensureMarkdownStyles } from "./markdown-theme"
 import { Mermaid } from "./Mermaid"
 
@@ -100,7 +101,7 @@ const rehypePlugins = [
   rehypeNormalizeClassName,
   // Skip code blocks tagged with an unknown language instead of throwing;
   // highlight only what it recognises.
-  [rehypeHighlight, { detect: true, ignoreMissing: true, plainText: ["mermaid"] }],
+  [rehypeHighlight, { detect: true, ignoreMissing: true, plainText: ["mermaid", "metadata"] }],
   [rehypeAutolinkHeadings, { behavior: "append", properties: { className: ["md-anchor"], ariaHidden: true, tabIndex: -1 }, content: { type: "text", value: "#" } }],
   [rehypeSanitize, sanitizeSchema],
 ] as React.ComponentProps<typeof ReactMarkdown>["rehypePlugins"]
@@ -116,8 +117,59 @@ function nodeText(node: React.ReactNode): string {
   return ""
 }
 
-// Intercept fenced ```mermaid blocks at the <pre> level (so no <pre> wrapper is
-// emitted) and render them as diagrams; every other block renders normally.
+// ── ```metadata fence (ADR-0051) ─────────────────────────────────────────
+// A ```metadata block is a declarative reference to a metadata item that is
+// lifted into the live, read-only `element:metadata_viewer` SDUI component —
+// the same component an `element:metadata_viewer` node renders on a page, so
+// docs and pages share one runtime. The body is a flat `key: value` block
+// (data, not code: type / name / object / mode / detail), parsed here. Like
+// mermaid, the language is excluded from rehype-highlight (plainText above) so
+// nodeText yields the body verbatim.
+function parseMetadataFence(src: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const raw of src.split("\n")) {
+    const line = raw.trim()
+    if (!line || line.startsWith("#")) continue
+    const i = line.indexOf(":")
+    if (i < 1) continue
+    const key = line.slice(0, i).trim()
+    let value = line.slice(i + 1).trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    if (key) out[key] = value
+  }
+  return out
+}
+
+function MetadataFence({ source }: { source: string }) {
+  const properties = React.useMemo(() => parseMetadataFence(source), [source])
+  const Comp = ComponentRegistry.get("element:metadata_viewer") as
+    | React.ComponentType<{ schema: unknown }>
+    | undefined
+  // Degrade gracefully when the SDUI component isn't registered (e.g. a
+  // consumer that renders Markdown without @object-ui/components loaded):
+  // show the raw reference rather than throwing.
+  if (!Comp) {
+    return (
+      <pre>
+        <code>{source}</code>
+      </pre>
+    )
+  }
+  return (
+    <div className="not-prose my-4">
+      <Comp schema={{ type: "element:metadata_viewer", properties }} />
+    </div>
+  )
+}
+
+// Intercept fenced ```mermaid / ```metadata blocks at the <pre> level (so no
+// <pre> wrapper is emitted) and render them as live views; every other block
+// renders normally.
 const mdComponents: Components = {
   pre({ node: _node, children, ...rest }) {
     const child = React.Children.toArray(children)[0]
@@ -128,6 +180,10 @@ const mdComponents: Components = {
     if (/\blanguage-mermaid\b/.test(className)) {
       const source = nodeText((child as React.ReactElement<{ children?: React.ReactNode }>).props.children)
       return <Mermaid chart={source} />
+    }
+    if (/\blanguage-metadata\b/.test(className)) {
+      const source = nodeText((child as React.ReactElement<{ children?: React.ReactNode }>).props.children)
+      return <MetadataFence source={source} />
     }
     return <pre {...rest}>{children}</pre>
   },

--- a/packages/plugin-markdown/src/MarkdownImpl.tsx
+++ b/packages/plugin-markdown/src/MarkdownImpl.tsx
@@ -125,7 +125,7 @@ function nodeText(node: React.ReactNode): string {
 // (data, not code: type / name / object / mode / detail), parsed here. Like
 // mermaid, the language is excluded from rehype-highlight (plainText above) so
 // nodeText yields the body verbatim.
-function parseMetadataFence(src: string): Record<string, string> {
+export function parseMetadataFence(src: string): Record<string, string> {
   const out: Record<string, string> = {}
   for (const raw of src.split("\n")) {
     const line = raw.trim()

--- a/packages/plugin-markdown/src/metadata-fence.test.ts
+++ b/packages/plugin-markdown/src/metadata-fence.test.ts
@@ -1,0 +1,37 @@
+/**
+ * parseMetadataFence (ADR-0051) — the ```metadata fence body is DATA, not
+ * code: a flat `key: value` block. These tests pin that contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseMetadataFence } from './MarkdownImpl';
+
+describe('parseMetadataFence', () => {
+  it('parses a flat key: value block', () => {
+    expect(
+      parseMetadataFence('type: state_machine\nobject: showcase_task\nname: task_status_flow'),
+    ).toEqual({ type: 'state_machine', object: 'showcase_task', name: 'task_status_flow' });
+  });
+
+  it('trims whitespace and strips surrounding quotes', () => {
+    expect(parseMetadataFence('  type :  flow \n name: "my_flow" \n mode: \'diagram\''))
+      .toEqual({ type: 'flow', name: 'my_flow', mode: 'diagram' });
+  });
+
+  it('ignores blank lines and # comments', () => {
+    expect(parseMetadataFence('# a comment\n\ntype: permission\n\n# another\nname: contrib'))
+      .toEqual({ type: 'permission', name: 'contrib' });
+  });
+
+  it('keeps values containing colons (only splits on the first)', () => {
+    expect(parseMetadataFence('note: a:b:c')).toEqual({ note: 'a:b:c' });
+  });
+
+  it('skips malformed lines without a key', () => {
+    expect(parseMetadataFence('justtext\n: noval\ntype: flow')).toEqual({ type: 'flow' });
+  });
+
+  it('returns an empty object for empty input', () => {
+    expect(parseMetadataFence('')).toEqual({});
+  });
+});


### PR DESCRIPTION
The **objectui half** of [ADR-0051](https://github.com/objectstack-ai/framework/pull/1940) — "inline metadata views in docs". Pairs with framework spec PR [#1942](https://github.com/objectstack-ai/framework/pull/1942) (`element:metadata_viewer` schema) and a framework showcase example.

A ` ```metadata ` fenced block in a `doc` is lifted into a live, read-only `element:metadata_viewer` SDUI component — **the same component a page node renders, so docs and pages share one runtime** (no parallel renderer).

## Changes

- **`components`** — new `element:metadata_viewer` renderer (a read-only *Content* element, deliberately not Interactive). Resolves the target metadata live via `useMetadataItem` and renders:
  - `state_machine` — transition graph from a `state_machine` validation rule (initial/final badges, field-option colors)
  - `flow` — ordered step list; `detail: business` folds technical nodes (scripts, record I/O…)
  - `permission` — object-level C/R/U/D matrix

  Registered in `ComponentRegistry`; degrades to a clear placeholder on a missing/forbidden reference.
- **`plugin-markdown`** — dispatch ` ```metadata ` at the `<pre>` level (beside ` ```mermaid `) into the SDUI component through the shared `ComponentRegistry`. Flat `key: value` body parser (data, not code). `metadata` added to `rehype-highlight` `plainText` so the body is read verbatim.

## Verification (browser)

Ran the framework `app-showcase` backend (`:3000`) + this console dev (Vite, `/api` proxied) and opened the showcase doc. **All four embeds resolve live with no console errors:**

- `task_status_flow` / `project_status_flow` state machines — colored chips, INITIAL badge, real transitions
- `showcase_reassign_wizard` flow — business steps, "1 technical step hidden" note
- `showcase_contributor` permission — C/R/U/D matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)