### PR TITLE
feat(console): book-driven documentation portal (ADR-0046 §6)

### DIFF
--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -44,6 +44,7 @@ import { MetadataHmrReloader } from './components/MetadataHmrReloader';
 import SharedRecordPage from './pages/SharedRecordPage';
 import DocPage from './pages/DocPage';
 import DocsIndex from './pages/DocsIndex';
+import DocsSlug from './pages/DocsSlug';
 import { LoginPage } from './pages/auth/LoginPage';
 import { RegisterPage } from './pages/auth/RegisterPage';
 import { ForgotPasswordPage } from './pages/auth/ForgotPasswordPage';
@@ -189,7 +190,16 @@ export function App() {
                 <DocsIndex />
               </ProtectedRoute>
             } />
-            <Route path="/docs/:name" element={
+            {/* One portal segment: a book landing (slug) or a flat-doc permalink
+              * that redirects to its canonical /docs/<book>/<name> (ADR-0046 §6). */}
+            <Route path="/docs/:slug" element={
+              <ProtectedRoute>
+                <DocsSlug />
+              </ProtectedRoute>
+            } />
+            {/* In-book reader: <slug> = book, <name> = doc (doc identity stays
+              * single-coordinate; the book segment is derived navigation). */}
+            <Route path="/docs/:slug/:name" element={
               <ProtectedRoute>
                 <DocPage />
               </ProtectedRoute>

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -45,6 +45,7 @@ import SharedRecordPage from './pages/SharedRecordPage';
 import DocPage from './pages/DocPage';
 import DocsIndex from './pages/DocsIndex';
 import DocsSlug from './pages/DocsSlug';
+import DocsLayout from './pages/DocsLayout';
 import { LoginPage } from './pages/auth/LoginPage';
 import { RegisterPage } from './pages/auth/RegisterPage';
 import { ForgotPasswordPage } from './pages/auth/ForgotPasswordPage';
@@ -185,25 +186,22 @@ export function App() {
               * lists every installed `doc` (grouped by package), and one
               * viewer route renders any item; cross-references between docs
               * resolve to that same viewer route. Both are app-independent. */}
+            {/* Docs portal (ADR-0046 §6). The layout fetches book + doc once
+              * and shares it with every child route via context. Children:
+              *   index        → book index
+              *   :slug        → a book landing, or a flat-doc permalink that
+              *                  redirects to its canonical /docs/<book>/<name>
+              *   :slug/:name  → in-book reader (doc identity stays single-
+              *                  coordinate; the book segment is derived nav). */}
             <Route path="/docs" element={
               <ProtectedRoute>
-                <DocsIndex />
+                <DocsLayout />
               </ProtectedRoute>
-            } />
-            {/* One portal segment: a book landing (slug) or a flat-doc permalink
-              * that redirects to its canonical /docs/<book>/<name> (ADR-0046 §6). */}
-            <Route path="/docs/:slug" element={
-              <ProtectedRoute>
-                <DocsSlug />
-              </ProtectedRoute>
-            } />
-            {/* In-book reader: <slug> = book, <name> = doc (doc identity stays
-              * single-coordinate; the book segment is derived navigation). */}
-            <Route path="/docs/:slug/:name" element={
-              <ProtectedRoute>
-                <DocPage />
-              </ProtectedRoute>
-            } />
+            }>
+              <Route index element={<DocsIndex />} />
+              <Route path=":slug" element={<DocsSlug />} />
+              <Route path=":slug/:name" element={<DocPage />} />
+            </Route>
             <Route path="/home" element={
               <ProtectedRoute>
                 <HomeRoute />

--- a/apps/console/src/AppContent.tsx
+++ b/apps/console/src/AppContent.tsx
@@ -36,6 +36,7 @@ const IntegrationsPage = lazy(() => import('./pages/developer/IntegrationsPage')
 const DocPage = lazy(() => import('./pages/DocPage'));
 const AppDocsIndex = lazy(() => import('./pages/AppDocsIndex'));
 const DocsSlug = lazy(() => import('./pages/DocsSlug'));
+const DocsLayout = lazy(() => import('./pages/DocsLayout'));
 
 // Note: marketplace routes (`system/marketplace`, `system/marketplace/:packageId`)
 // are registered by DefaultAppContent in @object-ui/app-shell so they're
@@ -92,11 +93,14 @@ const systemRoutes = (
     <Route path="developer/integrations" element={<Suspense fallback={<LoadingScreen />}><IntegrationsPage /></Suspense>} />
     {/* ADR-0048 — package docs under the package container: app-scoped index
         (/apps/:packageId/docs) + single-doc viewer (/apps/:packageId/docs/:name) */}
-    <Route path="docs" element={<Suspense fallback={<LoadingScreen />}><AppDocsIndex /></Suspense>} />
-    {/* ADR-0046 §6 — one segment resolves to a book landing or redirects a flat
-        doc to its canonical /docs/<book>/<name>; then the in-book reader. */}
-    <Route path="docs/:slug" element={<Suspense fallback={<LoadingScreen />}><DocsSlug /></Suspense>} />
-    <Route path="docs/:slug/:name" element={<Suspense fallback={<LoadingScreen />}><DocPage /></Suspense>} />
+    {/* ADR-0046 §6 — the docs layout fetches book + doc once and shares it with
+        the app-scoped index, book landings, and reader (one segment resolves to
+        a book landing or redirects a flat doc to /docs/<book>/<name>). */}
+    <Route path="docs" element={<Suspense fallback={<LoadingScreen />}><DocsLayout /></Suspense>}>
+      <Route index element={<Suspense fallback={<LoadingScreen />}><AppDocsIndex /></Suspense>} />
+      <Route path=":slug" element={<Suspense fallback={<LoadingScreen />}><DocsSlug /></Suspense>} />
+      <Route path=":slug/:name" element={<Suspense fallback={<LoadingScreen />}><DocPage /></Suspense>} />
+    </Route>
     {/* Legacy URL redirects → metadata-admin engine (zero-cost compatibility). */}
     <Route path="system/objects" element={<ObjectRedirect />} />
     <Route path="system/objects/:objectName" element={<ObjectRedirect />} />

--- a/apps/console/src/AppContent.tsx
+++ b/apps/console/src/AppContent.tsx
@@ -35,6 +35,7 @@ const IntegrationsPage = lazy(() => import('./pages/developer/IntegrationsPage')
 // app-scoped index at /apps/:packageId/docs (AppDocsIndex).
 const DocPage = lazy(() => import('./pages/DocPage'));
 const AppDocsIndex = lazy(() => import('./pages/AppDocsIndex'));
+const DocsSlug = lazy(() => import('./pages/DocsSlug'));
 
 // Note: marketplace routes (`system/marketplace`, `system/marketplace/:packageId`)
 // are registered by DefaultAppContent in @object-ui/app-shell so they're
@@ -92,7 +93,10 @@ const systemRoutes = (
     {/* ADR-0048 — package docs under the package container: app-scoped index
         (/apps/:packageId/docs) + single-doc viewer (/apps/:packageId/docs/:name) */}
     <Route path="docs" element={<Suspense fallback={<LoadingScreen />}><AppDocsIndex /></Suspense>} />
-    <Route path="docs/:name" element={<Suspense fallback={<LoadingScreen />}><DocPage /></Suspense>} />
+    {/* ADR-0046 §6 — one segment resolves to a book landing or redirects a flat
+        doc to its canonical /docs/<book>/<name>; then the in-book reader. */}
+    <Route path="docs/:slug" element={<Suspense fallback={<LoadingScreen />}><DocsSlug /></Suspense>} />
+    <Route path="docs/:slug/:name" element={<Suspense fallback={<LoadingScreen />}><DocPage /></Suspense>} />
     {/* Legacy URL redirects → metadata-admin engine (zero-cost compatibility). */}
     <Route path="system/objects" element={<ObjectRedirect />} />
     <Route path="system/objects/:objectName" element={<ObjectRedirect />} />

--- a/apps/console/src/pages/AppDocsIndex.tsx
+++ b/apps/console/src/pages/AppDocsIndex.tsx
@@ -6,77 +6,33 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import { AlertCircle, BookOpen, Loader2 } from 'lucide-react';
-import { useAdapter } from '@object-ui/app-shell';
+import { useMemo } from 'react';
+import { Link, Navigate, useParams } from 'react-router-dom';
+import { BookOpen, Loader2 } from 'lucide-react';
 import { DocShell } from './DocShell';
-
-interface AppDocItem {
-  name: string;
-  label?: string;
-  description?: string;
-}
+import { useBookData } from './use-book-data';
+import { buildBookCards, pkgOfBook, type Book } from './book-nav';
 
 /**
- * `/apps/:appName/docs` — the app-scoped documentation index (ADR-0046/0048).
+ * `/apps/:appName/docs` — the app-scoped documentation index (ADR-0046 §6 /
+ * ADR-0048). The package-scoped sibling of the platform `/docs` portal: it
+ * shows the books owned by the app whose container this route renders inside
+ * (`:appName` is the package-id segment).
  *
- * The platform `/docs` portal lists *every* installed doc grouped by package;
- * this is its package-scoped sibling: the docs owned by the app whose
- * container this route renders inside (`:appName` is the package-id segment,
- * matched against each doc's `_packageId`). It is the landing target for the
- * header Help menu's "This app's docs" entry when an app ships more than one
- * doc — a single-doc app deep-links straight to the viewer instead.
- *
- * Like the rest of the doc routes it degrades softly: an app with no docs
- * shows an empty-state notice, never a hard error.
+ * Book-driven like the portal: a package always has at least its implicit book
+ * (§6.4). The common single-book case lands straight on that book's grouped
+ * reader; a package with several books lists them. Reads the shared book/doc
+ * data provided by the `/docs` layout — no separate fetch.
  */
 export default function AppDocsIndex() {
-  // `appName` is the parent route's package-id segment (/apps/:appName/docs).
   const { appName } = useParams<{ appName?: string }>();
-  const adapter = useAdapter();
-  const [docs, setDocs] = useState<AppDocItem[]>([]);
-  const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading');
-  const [errorMessage, setErrorMessage] = useState<string>('');
+  const { books, docs, state } = useBookData();
 
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      if (!adapter) return;
-      const client: any = adapter.getClient();
-      if (!client?.meta?.getItems) {
-        setErrorMessage('meta.getItems is not available on this client');
-        setState('error');
-        return;
-      }
-      setState('loading');
-      try {
-        const result: any = await client.meta.getItems('doc');
-        const items: any[] = Array.isArray(result)
-          ? result
-          : Array.isArray(result?.items)
-            ? result.items
-            : Array.isArray(result?.value)
-              ? result.value
-              : [];
-        if (cancelled) return;
-        const mine = items
-          .filter((it) => it && it.name && it._packageId === appName)
-          .map((it) => ({ name: it.name, label: it.label, description: it.description }))
-          .sort((a, b) => (a.label ?? a.name).localeCompare(b.label ?? b.name));
-        setDocs(mine);
-        setState('ready');
-      } catch (err: any) {
-        if (cancelled) return;
-        setErrorMessage(err?.message ?? 'Failed to load documentation');
-        setState('error');
-      }
-    }
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, [adapter, appName]);
+  const myBooks = useMemo<Book[]>(
+    () => books.filter((b) => pkgOfBook(b) === appName),
+    [books, appName],
+  );
+  const cards = useMemo(() => buildBookCards(myBooks, docs), [myBooks, docs]);
 
   if (state === 'loading') {
     return (
@@ -86,45 +42,41 @@ export default function AppDocsIndex() {
     );
   }
 
-  if (state === 'error') {
-    return (
-      <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
-        <AlertCircle className="h-10 w-10 text-destructive" />
-        <h1 className="text-lg font-semibold">Failed to load documentation</h1>
-        <p className="text-sm text-muted-foreground">{errorMessage}</p>
-      </div>
-    );
+  // One book (the usual case) → land directly on its grouped reader.
+  if (cards.length === 1) {
+    return <Navigate to={`/apps/${appName}/docs/${cards[0].slug}`} replace />;
   }
 
   return (
     <DocShell>
       <div className="mx-auto max-w-3xl p-4 sm:p-6">
-        {docs.length === 0 ? (
+        {cards.length === 0 ? (
           <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
             <BookOpen className="h-10 w-10" />
-            <p className="text-sm">
-              This app does not ship any documentation yet.
-            </p>
+            <p className="text-sm">This app does not ship any documentation yet.</p>
             <Link to="/docs" className="text-sm font-medium text-primary hover:underline">
               Browse all documentation
             </Link>
           </div>
         ) : (
-          <ul className="divide-y divide-border rounded-md border border-border">
-            {docs.map((doc) => (
-              <li key={doc.name}>
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {cards.map((card) => (
+              <li key={card.name}>
                 <Link
-                  to={`/apps/${appName}/docs/${doc.name}`}
-                  className="flex items-start gap-3 px-3 py-3 hover:bg-muted/50"
+                  to={`/apps/${appName}/docs/${card.slug}`}
+                  className="flex h-full items-start gap-3 rounded-md border border-border p-3 hover:bg-muted/50"
                 >
-                  <BookOpen className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                  <BookOpen className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
                   <div className="min-w-0">
-                    <div className="text-sm font-medium">{doc.label ?? doc.name}</div>
-                    {doc.description ? (
+                    <div className="text-sm font-semibold">{card.label}</div>
+                    {card.description ? (
                       <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-                        {doc.description}
+                        {card.description}
                       </div>
                     ) : null}
+                    <div className="mt-1 text-xs text-muted-foreground/80">
+                      {card.docCount} {card.docCount === 1 ? 'article' : 'articles'}
+                    </div>
                   </div>
                 </Link>
               </li>

--- a/apps/console/src/pages/AppDocsIndex.tsx
+++ b/apps/console/src/pages/AppDocsIndex.tsx
@@ -73,6 +73,10 @@ export default function AppDocsIndex() {
                       <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
                         {card.description}
                       </div>
+                    ) : card.subtitle ? (
+                      <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground/70">
+                        {card.subtitle}
+                      </div>
                     ) : null}
                     <div className="mt-1 text-xs text-muted-foreground/80">
                       {card.docCount} {card.docCount === 1 ? 'article' : 'articles'}

--- a/apps/console/src/pages/BookPage.tsx
+++ b/apps/console/src/pages/BookPage.tsx
@@ -1,0 +1,130 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useMemo } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { FileText, FileQuestion, Loader2 } from 'lucide-react';
+import { DocShell } from './DocShell';
+import { BookSidebar } from './BookSidebar';
+import { useBookData } from './use-book-data';
+import { resolveBookTree, scopeDocsToBook, bookSlug } from './book-nav';
+
+/**
+ * `/docs/:slug` — a book landing page (ADR-0046 §6). Resolves the book's spine
+ * against the current docs and shows the grouped table of contents: the
+ * persistent nav sidebar plus an overview that lists every section's docs. Each
+ * doc links to the in-book reader (`/docs/:slug/:name`), which keeps this
+ * sidebar in view. `:slug` is the book's `slug` (an implicit per-package book
+ * uses its packageId).
+ */
+export default function BookPage() {
+  const { slug, appName } = useParams<{ slug: string; appName?: string }>();
+  const { books, docs, state, error } = useBookData();
+
+  const found = useMemo(() => books.find((b) => bookSlug(b) === slug), [books, slug]);
+  const resolved = useMemo(
+    () => (found ? resolveBookTree(found, scopeDocsToBook(found, docs)) : null),
+    [found, docs],
+  );
+
+  const base = appName ? `/apps/${appName}/docs` : '/docs';
+  const docHref = (name: string) => `${base}/${slug}/${name}`;
+
+  if (state === 'loading') {
+    return (
+      <div className="flex h-full items-center justify-center p-10 text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading documentation" />
+      </div>
+    );
+  }
+
+  if (state === 'error' || !found || !resolved) {
+    return (
+      <DocShell breadcrumb={slug}>
+        <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
+          <FileQuestion className="h-10 w-10 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">
+            {state === 'error' ? 'Failed to load documentation' : 'Book not found'}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {error ?? (
+              <>
+                No book named <code className="rounded bg-muted px-1 py-0.5">{slug}</code> is installed.
+              </>
+            )}
+          </p>
+        </div>
+      </DocShell>
+    );
+  }
+
+  return (
+    <DocShell breadcrumb={resolved.label ?? slug}>
+      <div className="mx-auto flex max-w-5xl gap-8 p-4 sm:p-6">
+        <aside className="hidden w-60 shrink-0 lg:block">
+          <div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-auto pr-1">
+            <BookSidebar book={resolved} docHref={docHref} />
+          </div>
+        </aside>
+
+        <div className="min-w-0 max-w-3xl flex-1">
+          <h1 className="text-2xl font-bold">{resolved.label ?? slug}</h1>
+          {resolved.description ? (
+            <p className="mt-2 text-sm text-muted-foreground">{resolved.description}</p>
+          ) : null}
+
+          <div className="mt-6 space-y-8">
+            {resolved.groups.map((group) => (
+              <section key={group.key}>
+                <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {group.label}
+                </h2>
+                <ul className="divide-y divide-border rounded-md border border-border">
+                  {group.entries
+                    .filter((e) => !e.separator)
+                    .map((entry, i) =>
+                      entry.href ? (
+                        <li key={`ext-${i}`}>
+                          <a
+                            href={entry.href}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="flex items-start gap-3 px-3 py-3 hover:bg-muted/50"
+                          >
+                            <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                            <span className="text-sm font-medium">{entry.label ?? entry.href}</span>
+                          </a>
+                        </li>
+                      ) : entry.doc ? (
+                        <li key={entry.doc}>
+                          <Link
+                            to={docHref(entry.doc)}
+                            className="flex items-start gap-3 px-3 py-3 hover:bg-muted/50"
+                          >
+                            <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0">
+                              <div className="text-sm font-medium">{entry.label ?? entry.doc}</div>
+                              {entry.description ? (
+                                <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                                  {entry.description}
+                                </div>
+                              ) : null}
+                            </div>
+                          </Link>
+                        </li>
+                      ) : null,
+                    )}
+                </ul>
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+    </DocShell>
+  );
+}

--- a/apps/console/src/pages/BookPage.tsx
+++ b/apps/console/src/pages/BookPage.tsx
@@ -7,33 +7,28 @@
  */
 
 import { useMemo } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import { FileText, FileQuestion, Loader2 } from 'lucide-react';
+import { Navigate, useParams } from 'react-router-dom';
+import { BookOpen, FileQuestion, Loader2 } from 'lucide-react';
 import { DocShell } from './DocShell';
-import { BookSidebar } from './BookSidebar';
 import { useBookData } from './use-book-data';
-import { resolveBookTree, scopeDocsToBook, bookSlug } from './book-nav';
+import { resolveBookTree, scopeDocsToBook, bookSlug, firstDoc } from './book-nav';
 
 /**
- * `/docs/:slug` — a book landing page (ADR-0046 §6). Resolves the book's spine
- * against the current docs and shows the grouped table of contents: the
- * persistent nav sidebar plus an overview that lists every section's docs. Each
- * doc links to the in-book reader (`/docs/:slug/:name`), which keeps this
- * sidebar in view. `:slug` is the book's `slug` (an implicit per-package book
- * uses its packageId).
+ * `/docs/:slug` — a book landing (ADR-0046 §6). Opening a book means starting
+ * to read it, so this resolves the book's spine and redirects to its overview
+ * doc (`*_index`, else the first doc in order); the reader then shows that doc
+ * with the book sidebar. This avoids duplicating the table of contents (the
+ * sidebar already is it). A book with no readable docs shows an empty state.
  */
 export default function BookPage() {
   const { slug, appName } = useParams<{ slug: string; appName?: string }>();
-  const { books, docs, state, error } = useBookData();
+  const { books, docs, state } = useBookData();
 
   const found = useMemo(() => books.find((b) => bookSlug(b) === slug), [books, slug]);
-  const resolved = useMemo(
-    () => (found ? resolveBookTree(found, scopeDocsToBook(found, docs)) : null),
+  const opensTo = useMemo(
+    () => (found ? firstDoc(resolveBookTree(found, scopeDocsToBook(found, docs))) : undefined),
     [found, docs],
   );
-
-  const base = appName ? `/apps/${appName}/docs` : '/docs';
-  const docHref = (name: string) => `${base}/${slug}/${name}`;
 
   if (state === 'loading') {
     return (
@@ -43,87 +38,30 @@ export default function BookPage() {
     );
   }
 
-  if (state === 'error' || !found || !resolved) {
-    return (
-      <DocShell breadcrumb={slug}>
-        <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
-          <FileQuestion className="h-10 w-10 text-muted-foreground" />
-          <h1 className="text-lg font-semibold">
-            {state === 'error' ? 'Failed to load documentation' : 'Book not found'}
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            {error ?? (
-              <>
-                No book named <code className="rounded bg-muted px-1 py-0.5">{slug}</code> is installed.
-              </>
-            )}
-          </p>
-        </div>
-      </DocShell>
-    );
+  if (found && opensTo) {
+    const base = appName ? `/apps/${appName}/docs` : '/docs';
+    return <Navigate to={`${base}/${slug}/${opensTo}`} replace />;
   }
 
+  // Unknown book, or a book with no readable docs yet.
   return (
-    <DocShell breadcrumb={resolved.label ?? slug}>
-      <div className="mx-auto flex max-w-5xl gap-8 p-4 sm:p-6">
-        <aside className="hidden w-60 shrink-0 lg:block">
-          <div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-auto pr-1">
-            <BookSidebar book={resolved} docHref={docHref} />
-          </div>
-        </aside>
-
-        <div className="min-w-0 max-w-3xl flex-1">
-          <h1 className="text-2xl font-bold">{resolved.label ?? slug}</h1>
-          {resolved.description ? (
-            <p className="mt-2 text-sm text-muted-foreground">{resolved.description}</p>
-          ) : null}
-
-          <div className="mt-6 space-y-8">
-            {resolved.groups.map((group) => (
-              <section key={group.key}>
-                <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  {group.label}
-                </h2>
-                <ul className="divide-y divide-border rounded-md border border-border">
-                  {group.entries
-                    .filter((e) => !e.separator)
-                    .map((entry, i) =>
-                      entry.href ? (
-                        <li key={`ext-${i}`}>
-                          <a
-                            href={entry.href}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="flex items-start gap-3 px-3 py-3 hover:bg-muted/50"
-                          >
-                            <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                            <span className="text-sm font-medium">{entry.label ?? entry.href}</span>
-                          </a>
-                        </li>
-                      ) : entry.doc ? (
-                        <li key={entry.doc}>
-                          <Link
-                            to={docHref(entry.doc)}
-                            className="flex items-start gap-3 px-3 py-3 hover:bg-muted/50"
-                          >
-                            <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                            <div className="min-w-0">
-                              <div className="text-sm font-medium">{entry.label ?? entry.doc}</div>
-                              {entry.description ? (
-                                <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-                                  {entry.description}
-                                </div>
-                              ) : null}
-                            </div>
-                          </Link>
-                        </li>
-                      ) : null,
-                    )}
-                </ul>
-              </section>
-            ))}
-          </div>
-        </div>
+    <DocShell breadcrumb={found ? (found.label ?? slug) : slug}>
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
+        {found ? (
+          <>
+            <BookOpen className="h-10 w-10 text-muted-foreground" />
+            <h1 className="text-lg font-semibold">{found.label ?? slug}</h1>
+            <p className="text-sm text-muted-foreground">This book has no documents yet.</p>
+          </>
+        ) : (
+          <>
+            <FileQuestion className="h-10 w-10 text-muted-foreground" />
+            <h1 className="text-lg font-semibold">Book not found</h1>
+            <p className="text-sm text-muted-foreground">
+              No book named <code className="rounded bg-muted px-1 py-0.5">{slug}</code> is installed.
+            </p>
+          </>
+        )}
       </div>
     </DocShell>
   );

--- a/apps/console/src/pages/BookSidebar.test.tsx
+++ b/apps/console/src/pages/BookSidebar.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BookSidebar } from './BookSidebar';
+import type { ResolvedBook } from './book-nav';
+
+afterEach(cleanup);
+
+const book: ResolvedBook = {
+  name: 'crm_manual',
+  label: 'CRM Manual',
+  groups: [
+    {
+      key: 'start',
+      label: 'Getting started',
+      entries: [
+        { doc: 'crm_intro', label: 'Intro' },
+        { separator: true },
+        { href: 'https://example.com', label: 'External' },
+      ],
+    },
+    { key: 'extra', label: 'Extra', synthetic: true, entries: [{ doc: 'misc_note', label: 'Note' }] },
+  ],
+};
+
+function renderSidebar(activeDoc?: string) {
+  return render(
+    <MemoryRouter>
+      <BookSidebar book={book} activeDoc={activeDoc} docHref={(n) => `/docs/${n}`} />
+    </MemoryRouter>,
+  );
+}
+
+describe('BookSidebar', () => {
+  it('renders the book label and group headings', () => {
+    renderSidebar();
+    expect(screen.getByText('CRM Manual')).toBeInTheDocument();
+    expect(screen.getByText('Getting started')).toBeInTheDocument();
+    expect(screen.getByText('Extra')).toBeInTheDocument();
+  });
+
+  it('renders doc links to the resolved href', () => {
+    renderSidebar();
+    const link = screen.getByRole('link', { name: 'Intro' });
+    expect(link).toHaveAttribute('href', '/docs/crm_intro');
+  });
+
+  it('marks the active doc with aria-current', () => {
+    renderSidebar('crm_intro');
+    expect(screen.getByRole('link', { name: 'Intro' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Note' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('renders external links with target=_blank', () => {
+    renderSidebar();
+    const ext = screen.getByRole('link', { name: /External/ });
+    expect(ext).toHaveAttribute('href', 'https://example.com');
+    expect(ext).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders a separator as a non-interactive divider', () => {
+    renderSidebar();
+    // The "Getting started" group has 2 links (Intro + External) and 1 separator.
+    const startNav = screen.getByLabelText('CRM Manual');
+    expect(within(startNav).getAllByRole('link').length).toBe(3); // Intro, External, Note
+  });
+});

--- a/apps/console/src/pages/BookSidebar.tsx
+++ b/apps/console/src/pages/BookSidebar.tsx
@@ -1,0 +1,87 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Link } from 'react-router-dom';
+import { ExternalLink } from 'lucide-react';
+import type { ResolvedBook } from './book-nav';
+
+/**
+ * The persistent left navigation for a book (ADR-0046 §6) — the resolved
+ * spine rendered as grouped links. Used by the book landing page and shown
+ * alongside the single-doc reader so a reader can move within the book
+ * without losing their place.
+ *
+ * Routing is delegated: the parent supplies `docHref` so the same sidebar
+ * works under the top-level `/docs/:name` route and the package-scoped
+ * `/apps/:appName/docs/:name` route.
+ */
+export function BookSidebar({
+  book,
+  activeDoc,
+  docHref,
+}: {
+  book: ResolvedBook;
+  activeDoc?: string;
+  docHref: (docName: string) => string;
+}) {
+  return (
+    <nav aria-label={book.label ?? book.name} className="text-sm">
+      {book.label ? (
+        <div className="mb-3 px-2 text-sm font-semibold text-foreground">{book.label}</div>
+      ) : null}
+      <div className="space-y-5">
+        {book.groups.map((group) => (
+          <div key={group.key}>
+            <div className="mb-1 px-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {group.label}
+            </div>
+            <ul className="space-y-0.5">
+              {group.entries.map((entry, i) => {
+                if (entry.separator) {
+                  return <li key={`sep-${i}`} className="my-1.5 border-t border-border/60" aria-hidden />;
+                }
+                if (entry.href) {
+                  return (
+                    <li key={`ext-${i}`}>
+                      <a
+                        href={entry.href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-center gap-1.5 rounded px-2 py-1 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                      >
+                        <span className="truncate">{entry.label ?? entry.href}</span>
+                        <ExternalLink className="h-3 w-3 shrink-0 opacity-60" />
+                      </a>
+                    </li>
+                  );
+                }
+                if (!entry.doc) return null;
+                const active = entry.doc === activeDoc;
+                return (
+                  <li key={entry.doc}>
+                    <Link
+                      to={docHref(entry.doc)}
+                      aria-current={active ? 'page' : undefined}
+                      className={`block truncate rounded px-2 py-1 transition ${
+                        active
+                          ? 'bg-primary/10 font-medium text-foreground'
+                          : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+                      }`}
+                    >
+                      {entry.label ?? entry.doc}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/apps/console/src/pages/DocPage.tsx
+++ b/apps/console/src/pages/DocPage.tsx
@@ -8,7 +8,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { AlertCircle, FileQuestion, Loader2 } from 'lucide-react';
+import { AlertCircle, ChevronDown, FileQuestion, Loader2, Menu } from 'lucide-react';
 import { useAdapter } from '@object-ui/app-shell';
 import { MarkdownRenderer, extractToc } from '@object-ui/plugin-markdown';
 import { useObjectTranslation } from '@object-ui/i18n';
@@ -156,6 +156,20 @@ export default function DocPage() {
 
   return (
     <DocShell breadcrumb={doc?.label ?? name}>
+      {/* Narrow screens: the persistent left sidebar is hidden, so the book
+        * nav collapses into a disclosure above the content instead of vanishing. */}
+      {resolvedBook ? (
+        <details className="group mx-auto max-w-6xl px-4 pt-4 sm:px-6 lg:hidden">
+          <summary className="flex cursor-pointer list-none items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm font-medium [&::-webkit-details-marker]:hidden">
+            <Menu className="h-4 w-4 text-muted-foreground" />
+            <span className="truncate">{resolvedBook.label ?? 'Contents'}</span>
+            <ChevronDown className="ml-auto h-4 w-4 text-muted-foreground transition-transform group-open:rotate-180" />
+          </summary>
+          <div className="mt-2 rounded-md border p-3">
+            <BookSidebar book={resolvedBook} activeDoc={name} docHref={docHref} />
+          </div>
+        </details>
+      ) : null}
       <div className={`mx-auto flex gap-8 p-4 sm:p-6 ${resolvedBook ? 'max-w-6xl' : 'max-w-5xl'}`}>
         {resolvedBook ? (
           <aside className="hidden w-56 shrink-0 lg:block">

--- a/apps/console/src/pages/DocPage.tsx
+++ b/apps/console/src/pages/DocPage.tsx
@@ -14,6 +14,9 @@ import { MarkdownRenderer, extractToc } from '@object-ui/plugin-markdown';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { rewriteDocLinks } from './doc-links';
 import { DocShell } from './DocShell';
+import { BookSidebar } from './BookSidebar';
+import { useBookData } from './use-book-data';
+import { resolveBookTree, scopeDocsToBook, bookSlug, type ResolvedBook } from './book-nav';
 
 interface DocItem {
   name: string;
@@ -35,9 +38,9 @@ interface DocItem {
  * "not found" notice — never an install-time or hard failure.
  */
 export default function DocPage() {
-  // `appName` is the parent route's package-id segment
-  // (/apps/:appName/docs/:name); undefined on the legacy top-level /docs/:name.
-  const { name, appName } = useParams<{ name: string; appName?: string }>();
+  // Route is `/docs/:slug/:name` (`:slug` = book, `:name` = doc). `appName` is
+  // the parent route's package-id segment under `/apps/:appName/docs/:slug/:name`.
+  const { slug, name, appName } = useParams<{ slug?: string; name: string; appName?: string }>();
   const navigate = useNavigate();
   const adapter = useAdapter();
   const { t } = useObjectTranslation();
@@ -104,6 +107,18 @@ export default function DocPage() {
   const toc = useMemo(() => extractToc(doc?.content ?? ''), [doc?.content]);
   const tocLabel = t('help.onThisPage', { defaultValue: 'On this page' });
 
+  // Book context (ADR-0046 §6): the `:slug` segment names the book we're
+  // reading in, so its spine renders as a persistent left nav. Resolved from
+  // the portal book set; degrades to no sidebar if the slug is unknown (e.g.
+  // the backend serves no books yet).
+  const { books, docs: allDocs } = useBookData();
+  const base = appName ? `/apps/${appName}/docs` : '/docs';
+  const resolvedBook = useMemo<ResolvedBook | null>(() => {
+    const book = books.find((b) => bookSlug(b) === slug);
+    return book ? resolveBookTree(book, scopeDocsToBook(book, allDocs)) : null;
+  }, [books, allDocs, slug]);
+  const docHref = useCallback((docName: string) => `${base}/${slug}/${docName}`, [base, slug]);
+
   if (state === 'loading') {
     return (
       <div className="flex h-full items-center justify-center p-10 text-muted-foreground">
@@ -141,7 +156,14 @@ export default function DocPage() {
 
   return (
     <DocShell breadcrumb={doc?.label ?? name}>
-      <div className="mx-auto flex max-w-5xl gap-8 p-4 sm:p-6">
+      <div className={`mx-auto flex gap-8 p-4 sm:p-6 ${resolvedBook ? 'max-w-6xl' : 'max-w-5xl'}`}>
+        {resolvedBook ? (
+          <aside className="hidden w-56 shrink-0 lg:block">
+            <nav className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-auto pr-1">
+              <BookSidebar book={resolvedBook} activeDoc={name} docHref={docHref} />
+            </nav>
+          </aside>
+        ) : null}
         <article
           className="min-w-0 max-w-3xl flex-1 [&_h1]:scroll-mt-24 [&_h2]:scroll-mt-24 [&_h3]:scroll-mt-24"
           onClick={onContentClick}

--- a/apps/console/src/pages/DocsIndex.tsx
+++ b/apps/console/src/pages/DocsIndex.tsx
@@ -6,67 +6,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { AlertCircle, BookOpen, Loader2 } from 'lucide-react';
-import { useAdapter } from '@object-ui/app-shell';
-import { type DocGroup, groupDocsByPackage } from './doc-groups';
 import { DocShell } from './DocShell';
+import { useBookData } from './use-book-data';
+import { buildBookCards } from './book-nav';
 
 /**
- * `/docs` — the platform-level documentation portal (ADR-0046).
+ * `/docs` — the platform-level documentation portal (ADR-0046 §6).
  *
- * Lists every installed `doc` metadata item, grouped by package
- * namespace, each linking to the single-doc viewer at `/docs/<name>`.
- * The viewer route is app-independent, so this portal is the canonical
- * place to discover docs regardless of which app (if any) is active.
- * An app may additionally surface a contextual link into a specific
- * `/docs/<name>`, but discovery lives here.
+ * The portal is organised entirely by `book`: authored books plus an implicit
+ * per-package book for every package that has docs but no authored one (§6.4 —
+ * there is no "flat vs book" fork; a flat package is just its implicit book).
+ * Each card opens that book's grouped reader at `/docs/<slug>`; the single-doc
+ * reader lives at `/docs/<slug>/<name>`.
  */
 export default function DocsIndex() {
-  const adapter = useAdapter();
-  const [groups, setGroups] = useState<DocGroup[]>([]);
-  const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading');
-  const [errorMessage, setErrorMessage] = useState<string>('');
+  const { books, docs, state, error } = useBookData();
 
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      if (!adapter) return;
-      const client: any = adapter.getClient();
-      if (!client?.meta?.getItems) {
-        setErrorMessage('meta.getItems is not available on this client');
-        setState('error');
-        return;
-      }
-      setState('loading');
-      try {
-        const result: any = await client.meta.getItems('doc');
-        const items: any[] = Array.isArray(result)
-          ? result
-          : Array.isArray(result?.items)
-            ? result.items
-            : Array.isArray(result?.value)
-              ? result.value
-              : [];
-        if (cancelled) return;
-        setGroups(
-          groupDocsByPackage(
-            items.map((it) => ({ name: it?.name, label: it?.label, description: it?.description, packageId: it?._packageId })),
-          ),
-        );
-        setState('ready');
-      } catch (err: any) {
-        if (cancelled) return;
-        setErrorMessage(err?.message ?? 'Failed to load documentation');
-        setState('error');
-      }
-    }
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, [adapter]);
+  // Cards carry the book's url slug so links match the `/docs/:slug` route.
+  const cards = useMemo(() => buildBookCards(books, docs), [books, docs]);
 
   if (state === 'loading') {
     return (
@@ -81,7 +41,7 @@ export default function DocsIndex() {
       <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
         <AlertCircle className="h-10 w-10 text-destructive" />
         <h1 className="text-lg font-semibold">Failed to load documentation</h1>
-        <p className="text-sm text-muted-foreground">{errorMessage}</p>
+        <p className="text-sm text-muted-foreground">{error}</p>
       </div>
     );
   }
@@ -89,46 +49,40 @@ export default function DocsIndex() {
   return (
     <DocShell>
       <div className="mx-auto max-w-3xl p-4 sm:p-6">
-      {groups.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
-          <BookOpen className="h-10 w-10" />
-          <p className="text-sm">
-            No documentation is installed. Packages ship docs as flat
-            <code className="mx-1 rounded bg-muted px-1 py-0.5">src/docs/*.md</code>
-            files (ADR-0046).
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-8">
-          {groups.map((group) => (
-            <section key={group.pkg}>
-              <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                {group.pkg}
-              </h2>
-              <ul className="divide-y divide-border rounded-md border border-border">
-                {group.docs.map((doc) => (
-                  <li key={doc.name}>
-                    <Link
-                      to={doc.packageId ? `/apps/${doc.packageId}/docs/${doc.name}` : `/docs/${doc.name}`}
-                      className="flex items-start gap-3 px-3 py-3 hover:bg-muted/50"
-                    >
-                      <BookOpen className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                      <div className="min-w-0">
-                        <div className="text-sm font-medium">{doc.label ?? doc.name}</div>
-                        {doc.description ? (
-                          <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-                            {doc.description}
-                          </div>
-                        ) : null}
+        {cards.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
+            <BookOpen className="h-10 w-10" />
+            <p className="text-sm">
+              No documentation is installed. Packages ship docs as flat
+              <code className="mx-1 rounded bg-muted px-1 py-0.5">src/docs/*.md</code>
+              files, organised by a <code className="rounded bg-muted px-1 py-0.5">book</code> (ADR-0046).
+            </p>
+          </div>
+        ) : (
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {cards.map((card) => (
+              <li key={card.name}>
+                <Link
+                  to={`/docs/${card.slug}`}
+                  className="flex h-full items-start gap-3 rounded-md border border-border p-3 hover:bg-muted/50"
+                >
+                  <BookOpen className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold">{card.label}</div>
+                    {card.description ? (
+                      <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                        {card.description}
                       </div>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
-        </div>
-      )}
+                    ) : null}
+                    <div className="mt-1 text-xs text-muted-foreground/80">
+                      {card.docCount} {card.docCount === 1 ? 'article' : 'articles'}
+                    </div>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </DocShell>
   );

--- a/apps/console/src/pages/DocsIndex.tsx
+++ b/apps/console/src/pages/DocsIndex.tsx
@@ -48,7 +48,13 @@ export default function DocsIndex() {
 
   return (
     <DocShell>
-      <div className="mx-auto max-w-3xl p-4 sm:p-6">
+      <div className="mx-auto max-w-4xl p-4 sm:p-6">
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold tracking-tight">Documentation</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Books and guides from your installed packages.
+          </p>
+        </header>
         {cards.length === 0 ? (
           <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
             <BookOpen className="h-10 w-10" />
@@ -59,9 +65,9 @@ export default function DocsIndex() {
             </p>
           </div>
         ) : (
-          <ul className="grid gap-3 sm:grid-cols-2">
+          <ul className="grid items-stretch gap-3 sm:grid-cols-2">
             {cards.map((card) => (
-              <li key={card.name}>
+              <li key={card.name} className="h-full">
                 <Link
                   to={`/docs/${card.slug}`}
                   className="flex h-full items-start gap-3 rounded-md border border-border p-3 hover:bg-muted/50"
@@ -72,6 +78,10 @@ export default function DocsIndex() {
                     {card.description ? (
                       <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
                         {card.description}
+                      </div>
+                    ) : card.subtitle ? (
+                      <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground/70">
+                        {card.subtitle}
                       </div>
                     ) : null}
                     <div className="mt-1 text-xs text-muted-foreground/80">

--- a/apps/console/src/pages/DocsLayout.tsx
+++ b/apps/console/src/pages/DocsLayout.tsx
@@ -1,0 +1,25 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Outlet } from 'react-router-dom';
+import { BookDataContext, useBookDataFetch } from './use-book-data';
+
+/**
+ * Layout route for the docs portal (`/docs/*`). Fetches the book + doc
+ * metadata ONCE and shares it with every child route (index, book landing,
+ * reader) via context, so navigating within the section doesn't re-fetch and a
+ * single page never issues the same request from several components.
+ */
+export default function DocsLayout() {
+  const data = useBookDataFetch();
+  return (
+    <BookDataContext.Provider value={data}>
+      <Outlet />
+    </BookDataContext.Provider>
+  );
+}

--- a/apps/console/src/pages/DocsSlug.tsx
+++ b/apps/console/src/pages/DocsSlug.tsx
@@ -1,0 +1,63 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Navigate, useParams } from 'react-router-dom';
+import { FileQuestion, Loader2 } from 'lucide-react';
+import { DocShell } from './DocShell';
+import BookPage from './BookPage';
+import { useBookData } from './use-book-data';
+import { bookSlug, homeBook } from './book-nav';
+
+/**
+ * `/docs/:slug` — resolves a single segment under the portal to either a book
+ * landing or a legacy doc permalink (ADR-0046).
+ *
+ * Books and docs share the `/docs/<segment>` space deliberately: a doc's
+ * identity stays single-coordinate (`<name>`, ADR §4) while a book occupies a
+ * `slug` portal segment (ADR §6). When the segment is a book slug we render its
+ * landing; otherwise we treat it as a flat doc name and redirect to its
+ * canonical in-book URL `/docs/<homeBook>/<name>` — every doc has a home book
+ * (its package's authored or implicit book, §6.4), so this resolves for any
+ * installed doc. An unknown segment degrades to a "not found" notice.
+ */
+export default function DocsSlug() {
+  const { slug, appName } = useParams<{ slug: string; appName?: string }>();
+  const { books, docs, state } = useBookData();
+
+  if (state === 'loading') {
+    return (
+      <div className="flex h-full items-center justify-center p-10 text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading documentation" />
+      </div>
+    );
+  }
+
+  // A book slug → render its landing (BookPage reads the same `:slug` param).
+  if (slug && books.some((b) => bookSlug(b) === slug)) {
+    return <BookPage />;
+  }
+
+  // Otherwise a flat doc permalink → redirect to its canonical in-book URL.
+  const base = appName ? `/apps/${appName}/docs` : '/docs';
+  const hb = slug ? homeBook(slug, books, docs) : null;
+  if (hb && slug) {
+    return <Navigate to={`${base}/${bookSlug(hb)}/${slug}`} replace />;
+  }
+
+  return (
+    <DocShell breadcrumb={slug}>
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-3 p-10 text-center">
+        <FileQuestion className="h-10 w-10 text-muted-foreground" />
+        <h1 className="text-lg font-semibold">Documentation not found</h1>
+        <p className="text-sm text-muted-foreground">
+          No book or document named <code className="rounded bg-muted px-1 py-0.5">{slug}</code> is installed.
+        </p>
+      </div>
+    </DocShell>
+  );
+}

--- a/apps/console/src/pages/book-nav.test.ts
+++ b/apps/console/src/pages/book-nav.test.ts
@@ -138,6 +138,11 @@ describe('buildPortalBooks (ADR-0046 §6.4 — no flat/book fork)', () => {
     expect(portal.map((b) => b.name)).toContain('misc'); // implicit book keyed by packageId
     // no duplicate implicit 'crm' book, since crm_manual already owns 'crm'
     expect(portal.filter((b) => b.name === 'crm').length).toBe(0);
+    // authored books lead, implicit ones follow
+    expect(portal[0].name).toBe('crm_manual');
+    expect(portal[portal.length - 1].name).toBe('misc');
+    // implicit label is humanized, not the raw package id
+    expect(portal.find((b) => b.name === 'misc')?.label).toBe('Misc');
   });
 
   it('with no authored books, every package becomes its own implicit book', () => {

--- a/apps/console/src/pages/book-nav.test.ts
+++ b/apps/console/src/pages/book-nav.test.ts
@@ -1,0 +1,217 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveBookTree,
+  deriveImplicitPackageBook,
+  buildBookCards,
+  buildPortalBooks,
+  homeBook,
+  bookSlug,
+  pkgOf,
+  findBookContainingDoc,
+  sortBooks,
+  countEntries,
+  type Book,
+  type ResolverDoc,
+} from './book-nav';
+
+const docs: ResolverDoc[] = [
+  { name: 'crm_intro', label: 'Intro', order: 1 },
+  { name: 'crm_guide_lead', label: 'Leads', order: 2 },
+  { name: 'crm_guide_deal', label: 'Deals', order: 1 },
+  { name: 'crm_ref_api', label: 'API' },
+  { name: 'misc_note' }, // matched by no rule → Uncategorized
+];
+
+describe('resolveBookTree (ADR-0046 §6)', () => {
+  it('derives membership from glob include and sorts by order then label', () => {
+    const book: Book = {
+      name: 'crm_manual',
+      label: 'CRM Manual',
+      groups: [
+        { key: 'start', label: 'Getting started', order: 1, include: 'crm_intro' },
+        { key: 'guides', label: 'Guides', order: 2, include: 'crm_guide_*' },
+      ],
+    };
+    const r = resolveBookTree(book, docs);
+    expect(r.groups.map((g) => g.key)).toEqual(['start', 'guides', 'uncategorized']);
+    // guides sorted by order: deal(1) before lead(2)
+    expect(r.groups[1].entries.map((e) => e.doc)).toEqual(['crm_guide_deal', 'crm_guide_lead']);
+  });
+
+  it('drops nothing — unmatched docs fall into Uncategorized last', () => {
+    const book: Book = { name: 'b', groups: [{ key: 'g', label: 'G', include: 'crm_guide_*' }] };
+    const r = resolveBookTree(book, docs);
+    const uncategorized = r.groups.find((g) => g.key === 'uncategorized');
+    expect(uncategorized?.entries.map((e) => e.doc)).toContain('misc_note');
+    expect(uncategorized?.entries.map((e) => e.doc)).toContain('crm_intro');
+  });
+
+  it('first matching group wins — a doc is never duplicated across groups', () => {
+    const book: Book = {
+      name: 'b',
+      groups: [
+        { key: 'all', label: 'All', order: 1, include: 'crm_*' },
+        { key: 'guides', label: 'Guides', order: 2, include: 'crm_guide_*' },
+      ],
+    };
+    const r = resolveBookTree(book, docs);
+    expect(r.groups[1].entries).toHaveLength(0); // everything already claimed by 'all'
+  });
+
+  it('honours a tag include rule', () => {
+    const tagged: ResolverDoc[] = [{ name: 'd1', tags: ['start'] }, { name: 'd2' }];
+    const book: Book = { name: 'b', groups: [{ key: 'g', label: 'G', include: { tag: 'start' } }] };
+    const r = resolveBookTree(book, tagged);
+    expect(r.groups[0].entries.map((e) => e.doc)).toEqual(['d1']);
+  });
+
+  it('explicit pages override: verbatim order, --- separator, badge, external link, ... rest', () => {
+    const book: Book = {
+      name: 'b',
+      groups: [
+        {
+          key: 'curated',
+          label: 'Curated',
+          include: 'crm_guide_*',
+          pages: [
+            'crm_intro',
+            '---',
+            { doc: 'crm_guide_lead', label: 'Lead mgmt', badge: 'new' },
+            { href: 'https://example.com', label: 'External' },
+            '...', // expands to the remaining crm_guide_* (i.e. crm_guide_deal)
+          ],
+        },
+      ],
+    };
+    const r = resolveBookTree(book, docs);
+    const e = r.groups[0].entries;
+    expect(e[0].doc).toBe('crm_intro');
+    expect(e[1].separator).toBe(true);
+    expect(e[2]).toMatchObject({ doc: 'crm_guide_lead', label: 'Lead mgmt', badge: 'new' });
+    expect(e[3]).toMatchObject({ href: 'https://example.com', label: 'External' });
+    expect(e[4].doc).toBe('crm_guide_deal'); // the rest
+  });
+
+  it('scopes include to a package when group.package / bookPackage is set', () => {
+    const mixed: ResolverDoc[] = [
+      { name: 'a_x', packageId: 'a' },
+      { name: 'b_x', packageId: 'b' },
+    ];
+    const book: Book = { name: 'bk', groups: [{ key: 'g', label: 'G', include: '*', package: 'a' }] };
+    const r = resolveBookTree(book, mixed);
+    expect(r.groups[0].entries.map((e) => e.doc)).toEqual(['a_x']);
+    // b_x is orphaned, not in group g
+    expect(r.groups.find((g) => g.key === 'uncategorized')?.entries.map((e) => e.doc)).toEqual(['b_x']);
+  });
+});
+
+describe('deriveImplicitPackageBook', () => {
+  it("includes only the package's own docs (scoped by name prefix when unstamped)", () => {
+    const book = deriveImplicitPackageBook('crm', 'CRM');
+    const r = resolveBookTree(book, docs);
+    expect(r.groups[0].key).toBe('all');
+    const inAll = r.groups[0].entries.map((e) => e.doc);
+    // The four crm_* docs land in the implicit crm book...
+    expect(inAll).toHaveLength(4);
+    expect(inAll).toEqual(expect.arrayContaining(['crm_intro', 'crm_guide_lead', 'crm_guide_deal', 'crm_ref_api']));
+    // ...and misc_note (package 'misc') does not.
+    expect(inAll).not.toContain('misc_note');
+  });
+});
+
+describe('buildPortalBooks (ADR-0046 §6.4 — no flat/book fork)', () => {
+  it('synthesizes an implicit per-package book for packages without an authored one', () => {
+    const authored: Book[] = [
+      { name: 'crm_manual', label: 'CRM Manual', groups: [{ key: 'g', label: 'G', include: 'crm_guide_*' }] },
+    ];
+    const portal = buildPortalBooks(authored, docs);
+    // crm has an authored book (pkg 'crm'); misc only has the implicit one.
+    expect(portal.map((b) => b.name)).toContain('crm_manual');
+    expect(portal.map((b) => b.name)).toContain('misc'); // implicit book keyed by packageId
+    // no duplicate implicit 'crm' book, since crm_manual already owns 'crm'
+    expect(portal.filter((b) => b.name === 'crm').length).toBe(0);
+  });
+
+  it('with no authored books, every package becomes its own implicit book', () => {
+    const portal = buildPortalBooks([], docs);
+    expect(portal.map((b) => b.name).sort()).toEqual(['crm', 'misc']);
+  });
+});
+
+describe('homeBook + bookSlug', () => {
+  it('resolves a doc to its package book and exposes its url slug', () => {
+    const portal = buildPortalBooks([], docs);
+    const hb = homeBook('crm_intro', portal, docs);
+    expect(hb?.name).toBe('crm');
+    expect(bookSlug(hb!)).toBe('crm');
+  });
+
+  it('prefers an authored book over the implicit one as a doc\'s home', () => {
+    const authored: Book[] = [
+      { name: 'crm_manual', slug: 'manual', label: 'CRM Manual', groups: [{ key: 'g', label: 'G', include: 'crm_*' }] },
+    ];
+    const portal = buildPortalBooks(authored, docs);
+    const hb = homeBook('crm_intro', portal, docs);
+    expect(hb?.name).toBe('crm_manual');
+    expect(bookSlug(hb!)).toBe('manual'); // explicit slug wins over name
+  });
+
+  it('pkgOf falls back to the name prefix when unstamped', () => {
+    expect(pkgOf({ name: 'crm_intro' })).toBe('crm');
+    expect(pkgOf({ name: 'crm_intro', packageId: 'override' })).toBe('override');
+  });
+});
+
+describe('portal helpers', () => {
+  it('sortBooks orders by order then label then index', () => {
+    const books: Book[] = [
+      { name: 'z', label: 'Z', order: 2 },
+      { name: 'a', label: 'A', order: 1 },
+      { name: 'b', label: 'B', order: 1 },
+    ];
+    expect(sortBooks(books).map((b) => b.name)).toEqual(['a', 'b', 'z']);
+  });
+
+  it('buildBookCards reports a deduped doc count', () => {
+    const books: Book[] = [
+      { name: 'm', label: 'Manual', groups: [{ key: 'g', label: 'G', include: 'crm_*' }] },
+    ];
+    const [card] = buildBookCards(books, docs);
+    expect(card.label).toBe('Manual');
+    expect(card.slug).toBe('m'); // no explicit slug → falls back to the book name
+    expect(card.docCount).toBe(4); // the four crm_* docs
+  });
+
+  it('findBookContainingDoc returns the first book whose tree holds the doc', () => {
+    const books: Book[] = [
+      { name: 'guides', label: 'Guides', order: 1, groups: [{ key: 'g', label: 'G', include: 'crm_guide_*' }] },
+      { name: 'all', label: 'All', order: 2, groups: [{ key: 'a', label: 'A', include: 'crm_*' }] },
+    ];
+    const hit = findBookContainingDoc(books, docs, 'crm_guide_lead');
+    expect(hit?.book.name).toBe('guides');
+    expect(findBookContainingDoc(books, docs, 'nonexistent')).toBeNull();
+  });
+
+  it('a doc that only lands in a book\'s synthetic Uncategorized is NOT owned by it', () => {
+    // 'misc_note' matches neither book's rule → only ever in Uncategorized.
+    const books: Book[] = [
+      { name: 'guides', label: 'Guides', groups: [{ key: 'g', label: 'G', include: 'crm_guide_*' }] },
+    ];
+    expect(findBookContainingDoc(books, docs, 'misc_note')).toBeNull();
+  });
+
+  it('countEntries ignores separators', () => {
+    const groups = [
+      { key: 'g', label: 'G', entries: [{ doc: 'a' }, { separator: true }, { href: 'x' }] },
+    ];
+    expect(countEntries(groups)).toBe(2);
+  });
+});

--- a/apps/console/src/pages/book-nav.test.ts
+++ b/apps/console/src/pages/book-nav.test.ts
@@ -12,6 +12,7 @@ import {
   deriveImplicitPackageBook,
   buildBookCards,
   buildPortalBooks,
+  firstDoc,
   homeBook,
   bookSlug,
   pkgOf,
@@ -142,7 +143,18 @@ describe('buildPortalBooks (ADR-0046 §6.4 — no flat/book fork)', () => {
     expect(portal[0].name).toBe('crm_manual');
     expect(portal[portal.length - 1].name).toBe('misc');
     // implicit label is humanized, not the raw package id
-    expect(portal.find((b) => b.name === 'misc')?.label).toBe('Misc');
+    const misc = portal.find((b) => b.name === 'misc');
+    expect(misc?.label).toBe('Misc');
+    expect(misc?.implicit).toBe(true); // synthetic books are flagged
+  });
+
+  it('cards surface the package id as a subtitle for implicit books only', () => {
+    const authored: Book[] = [
+      { name: 'crm_manual', label: 'CRM Manual', description: 'd', groups: [{ key: 'g', label: 'G', include: 'crm_*' }] },
+    ];
+    const cards = buildBookCards(buildPortalBooks(authored, docs), docs);
+    expect(cards.find((c) => c.name === 'crm_manual')?.subtitle).toBeUndefined(); // authored: has a description
+    expect(cards.find((c) => c.name === 'misc')?.subtitle).toBe('misc'); // implicit: package id
   });
 
   it('with no authored books, every package becomes its own implicit book', () => {
@@ -211,6 +223,26 @@ describe('portal helpers', () => {
       { name: 'guides', label: 'Guides', groups: [{ key: 'g', label: 'G', include: 'crm_guide_*' }] },
     ];
     expect(findBookContainingDoc(books, docs, 'misc_note')).toBeNull();
+  });
+
+  it('firstDoc prefers an *_index doc, else the first in reading order', () => {
+    const withIndex = resolveBookTree(
+      { name: 'b', groups: [{ key: 'g', label: 'G', include: 'crm_*' }] },
+      [
+        { name: 'crm_guide_lead', order: 1 },
+        { name: 'crm_index', order: 9 }, // later in order, but the index wins
+      ],
+    );
+    expect(firstDoc(withIndex)).toBe('crm_index');
+
+    const noIndex = resolveBookTree(
+      { name: 'b', groups: [{ key: 'g', label: 'G', include: 'crm_*' }] },
+      [{ name: 'crm_b', order: 2 }, { name: 'crm_a', order: 1 }],
+    );
+    expect(firstDoc(noIndex)).toBe('crm_a'); // first by order
+
+    // A book with no readable docs → undefined.
+    expect(firstDoc({ name: 'b', label: 'B', groups: [] })).toBeUndefined();
   });
 
   it('countEntries ignores separators', () => {

--- a/apps/console/src/pages/book-nav.ts
+++ b/apps/console/src/pages/book-nav.ts
@@ -53,6 +53,8 @@ export interface Book {
   groups?: BookGroup[];
   /** Owning package id (`_packageId`), stamped by the metadata API. */
   packageId?: string;
+  /** True for a synthetic implicit per-package book (ADR-0046 §6.4). */
+  implicit?: boolean;
 }
 
 /** Minimal doc header the resolver needs. */
@@ -267,6 +269,8 @@ export interface BookCard {
   slug: string;
   label: string;
   description?: string;
+  /** Context line for cards without a description — the owning package id. */
+  subtitle?: string;
   icon?: string;
   packageId?: string;
   /** Number of docs the book currently resolves to (excludes separators/links). */
@@ -335,6 +339,9 @@ export function buildBookCards(books: Book[], docs: ResolverDoc[]): BookCard[] {
     slug: bookSlug(b),
     label: b.label ?? b.name,
     description: b.description,
+    // Implicit per-package books have no authored description; surface the
+    // package id so the card still says where the docs come from.
+    subtitle: b.implicit && !b.description ? b.packageId : undefined,
     icon: b.icon,
     packageId: b.packageId,
     docCount: countBookDocs(b, docs),
@@ -356,7 +363,7 @@ export function buildPortalBooks(authored: Book[], docs: ResolverDoc[]): Book[] 
     // Humanize the package id for the visible label (the slug/name stays the
     // full id so it remains unique and reversible); keep the group as the
     // generic "Documentation".
-    .map((p) => ({ ...deriveImplicitPackageBook(p), label: humanizePackageId(p), packageId: p }));
+    .map((p) => ({ ...deriveImplicitPackageBook(p), label: humanizePackageId(p), packageId: p, implicit: true }));
   // Authored books lead (curated, primary) in their own order; the synthetic
   // per-package books follow, alphabetically — so an authored book with an
   // explicit `order` is never pushed below a fallback.
@@ -402,6 +409,19 @@ export function findBookContainingDoc(
     if (has) return { book, resolved };
   }
   return null;
+}
+
+/**
+ * The doc a book opens to — its overview. Prefers an `*_index` doc, else the
+ * first doc in reading order. Returns undefined for a book with no readable
+ * docs (only external links / separators).
+ */
+export function firstDoc(resolved: ResolvedBook): string | undefined {
+  const names: string[] = [];
+  for (const g of resolved.groups) {
+    for (const e of g.entries) if (e.doc && !e.separator) names.push(e.doc);
+  }
+  return names.find((n) => /(^|_)index$/.test(n)) ?? names[0];
 }
 
 /** Total docs an entry list covers — handy for "N articles" labels. */

--- a/apps/console/src/pages/book-nav.ts
+++ b/apps/console/src/pages/book-nav.ts
@@ -1,0 +1,395 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Book-driven documentation navigation (ADR-0046 §6).
+ *
+ * A `book` is the *spine* of a table of contents: an ordered set of groups
+ * (sections) plus identity and access. It deliberately does NOT store its
+ * members — membership is **derived** at render time from a rule on each
+ * group (`include` glob/tag) plus an optional per-doc `order`/`group`.
+ *
+ * The portal resolves that spine against the docs that exist *now*. This is
+ * a faithful local port of the framework's `resolveBookTree` (book.zod.ts)
+ * so the portal works the moment the backend serves `book` + `doc` through
+ * the ordinary metadata API — without depending on a particular published
+ * `@objectstack/spec` version or the `/meta/book/:name/tree` endpoint.
+ */
+
+// ── Authored spine (a subset of the framework `Book` shape) ────────────────
+
+export type BookInclude = string | { tag: string };
+
+export type BookNode =
+  | string // a doc name, or the literals '---' (separator) / '...' (rest)
+  | { doc?: string; href?: string; label?: string; badge?: string; icon?: string };
+
+export interface BookGroup {
+  key: string;
+  label: string;
+  order?: number;
+  include?: BookInclude;
+  /** Scope the rule to a package id (default: the book's package). */
+  package?: string;
+  /** Explicit override — a hand-pinned curated order; wins over `include`. */
+  pages?: BookNode[];
+}
+
+export type BookAudience = 'org' | 'public' | { profile: string };
+
+export interface Book {
+  name: string;
+  label?: string;
+  description?: string;
+  slug?: string;
+  icon?: string;
+  order?: number;
+  audience?: BookAudience;
+  groups?: BookGroup[];
+  /** Owning package id (`_packageId`), stamped by the metadata API. */
+  packageId?: string;
+}
+
+/** Minimal doc header the resolver needs. */
+export interface ResolverDoc {
+  name: string;
+  label?: string;
+  description?: string;
+  order?: number;
+  /** Explicit placement: the `key` of the group this doc belongs to. */
+  group?: string;
+  /** Tags for `include: { tag }` matching. */
+  tags?: string[];
+  /** Owning package id (`_packageId`); used to scope `include`. */
+  packageId?: string;
+}
+
+// ── Resolved tree (what the UI renders) ────────────────────────────────────
+
+export interface ResolvedEntry {
+  /** Doc name, or undefined for an external link / separator. */
+  doc?: string;
+  href?: string;
+  label?: string;
+  description?: string;
+  badge?: string;
+  icon?: string;
+  /** True for a `---` separator node. */
+  separator?: boolean;
+}
+
+export interface ResolvedGroup {
+  key: string;
+  label: string;
+  entries: ResolvedEntry[];
+  /**
+   * True for the synthetic "Uncategorized" catch-all. It appears in EVERY
+   * book's resolution (it absorbs whatever the book's own groups didn't
+   * claim), so it must be excluded from authored-membership questions like
+   * "how many docs does this book organize?" or "which book owns this doc?".
+   */
+  synthetic?: boolean;
+}
+
+export interface ResolvedBook {
+  name: string;
+  label?: string;
+  description?: string;
+  groups: ResolvedGroup[];
+}
+
+const UNCATEGORIZED_KEY = 'uncategorized';
+
+/** The namespace prefix of a metadata name (everything before the first `_`). */
+export function namePrefix(name: string): string {
+  const i = name.indexOf('_');
+  return i > 0 ? name.slice(0, i) : name;
+}
+
+/**
+ * The package a doc belongs to. Prefer the server-stamped `_packageId`; fall
+ * back to the name's namespace prefix (ADR-0046 names are prefix-scoped by
+ * build convention), so package scoping still works before the backend stamps
+ * provenance.
+ */
+export function pkgOf(doc: ResolverDoc): string {
+  return doc.packageId ?? namePrefix(doc.name);
+}
+
+/** The package a book belongs to — same precedence as {@link pkgOf}. */
+export function pkgOfBook(book: Book): string {
+  return book.packageId ?? namePrefix(book.name);
+}
+
+/** The portal URL segment for a book (ADR-0046 §6: `slug`, default the name). */
+export function bookSlug(book: Book): string {
+  return book.slug ?? book.name;
+}
+
+/** Compile a `*`-glob over doc names to a RegExp anchored on the whole name. */
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function matchesInclude(doc: ResolverDoc, include: BookInclude, scopePackage?: string): boolean {
+  if (scopePackage && pkgOf(doc) !== scopePackage) return false;
+  if (typeof include === 'string') return globToRegExp(include).test(doc.name);
+  return Array.isArray(doc.tags) && doc.tags.includes(include.tag);
+}
+
+function byOrderThenLabel(a: ResolverDoc, b: ResolverDoc): number {
+  return (a.order ?? 0) - (b.order ?? 0) || (a.label ?? a.name).localeCompare(b.label ?? b.name);
+}
+
+function entryFromDoc(doc: ResolverDoc): ResolvedEntry {
+  return { doc: doc.name, label: doc.label, description: doc.description };
+}
+
+/**
+ * Resolve a book spine against the current doc set into a rendered tree.
+ * Faithful port of ADR-0046 §6.2.1 — see book-nav.ts header.
+ */
+export function resolveBookTree(book: Book, docs: ResolverDoc[], bookPackage?: string): ResolvedBook {
+  const scopeDefault = bookPackage ?? book.packageId;
+  const groupsSorted = [...(book.groups ?? [])]
+    .map((g, i) => ({ g, i }))
+    .sort((a, b) => (a.g.order ?? 0) - (b.g.order ?? 0) || a.i - b.i)
+    .map((x) => x.g);
+
+  const claimed = new Set<string>();
+  const byName = new Map(docs.map((d) => [d.name, d] as const));
+
+  // First pass: rule/explicit membership for groups WITHOUT an explicit
+  // `pages` override, so a `...` in an override group can later draw from rest.
+  const derivedMembers = new Map<string, ResolverDoc[]>();
+  for (const group of groupsSorted) {
+    if (group.pages) continue;
+    const scope = group.package ?? scopeDefault;
+    const members = docs.filter((d) => {
+      if (claimed.has(d.name)) return false;
+      return (
+        (group.include != null && matchesInclude(d, group.include, scope)) ||
+        (d.group != null && d.group === group.key)
+      );
+    });
+    members.sort(byOrderThenLabel);
+    members.forEach((d) => claimed.add(d.name));
+    derivedMembers.set(group.key, members);
+  }
+
+  const resolvedGroups: ResolvedGroup[] = [];
+  for (const group of groupsSorted) {
+    let entries: ResolvedEntry[];
+    if (group.pages) {
+      const scope = group.package ?? scopeDefault;
+      entries = [];
+      const pinned = new Set(
+        group.pages.filter((n): n is string => typeof n === 'string' && n !== '...' && n !== '---'),
+      );
+      for (const node of group.pages) {
+        if (node === '---') {
+          entries.push({ separator: true });
+        } else if (node === '...') {
+          const rest = docs.filter(
+            (d) =>
+              !claimed.has(d.name) &&
+              !pinned.has(d.name) &&
+              ((group.include != null && matchesInclude(d, group.include, scope)) ||
+                (d.group != null && d.group === group.key)),
+          );
+          rest.sort(byOrderThenLabel);
+          rest.forEach((d) => {
+            claimed.add(d.name);
+            entries.push(entryFromDoc(d));
+          });
+        } else if (typeof node === 'string') {
+          const d = byName.get(node);
+          claimed.add(node);
+          entries.push(d ? entryFromDoc(d) : { doc: node }); // missing doc → renderer shows "not found"
+        } else if (node.doc) {
+          const d = byName.get(node.doc);
+          claimed.add(node.doc);
+          entries.push({
+            ...(d ? entryFromDoc(d) : { doc: node.doc }),
+            label: node.label ?? d?.label,
+            badge: node.badge,
+            icon: node.icon,
+          });
+        } else if (node.href) {
+          entries.push({ href: node.href, label: node.label, badge: node.badge, icon: node.icon });
+        }
+      }
+    } else {
+      entries = (derivedMembers.get(group.key) ?? []).map(entryFromDoc);
+    }
+    resolvedGroups.push({ key: group.key, label: group.label, entries });
+  }
+
+  // Orphans: docs claimed by no group fall into a synthetic Uncategorized
+  // group appended last — nothing is ever dropped.
+  const orphans = docs.filter((d) => !claimed.has(d.name)).sort(byOrderThenLabel);
+  if (orphans.length) {
+    resolvedGroups.push({
+      key: UNCATEGORIZED_KEY,
+      label: 'Uncategorized',
+      entries: orphans.map(entryFromDoc),
+      synthetic: true,
+    });
+  }
+
+  return { name: book.name, label: book.label, description: book.description, groups: resolvedGroups };
+}
+
+/**
+ * Synthesize the implicit per-package book (ADR-0046 §6.4): no authored book ⇒
+ * one book keyed by the package id, a single group including every doc.
+ */
+export function deriveImplicitPackageBook(packageId: string, label?: string): Book {
+  return {
+    name: packageId,
+    label: label ?? packageId,
+    audience: 'org',
+    groups: [{ key: 'all', label: label ?? 'Documentation', include: '*', package: packageId }],
+  };
+}
+
+// ── Portal helpers (multi-book) ────────────────────────────────────────────
+
+export interface BookCard {
+  name: string;
+  /** Portal URL segment (`/docs/<slug>`). */
+  slug: string;
+  label: string;
+  description?: string;
+  icon?: string;
+  packageId?: string;
+  /** Number of docs the book currently resolves to (excludes separators/links). */
+  docCount: number;
+}
+
+/** The set of packages a book draws from: its own plus any group overrides. */
+function bookPackages(book: Book): Set<string> {
+  const pkgs = new Set<string>();
+  if (book.packageId) pkgs.add(book.packageId);
+  for (const g of book.groups ?? []) if (g.package) pkgs.add(g.package);
+  return pkgs;
+}
+
+/**
+ * Narrow the doc set to the packages a book draws from before resolving, so the
+ * synthetic Uncategorized group stays scoped to the book instead of vacuuming
+ * up every other package's docs. When a book declares no package (its own or a
+ * group override) we can't scope safely, so all docs are kept and membership
+ * falls to each group's `include` glob.
+ */
+export function scopeDocsToBook(book: Book, docs: ResolverDoc[]): ResolverDoc[] {
+  const pkgs = bookPackages(book);
+  if (pkgs.size === 0) return docs;
+  return docs.filter((d) => pkgs.has(pkgOf(d)));
+}
+
+/** Sort books for the index: by `order`, then label, then name (stable). */
+export function sortBooks(books: Book[]): Book[] {
+  return [...books]
+    .map((b, i) => ({ b, i }))
+    .sort(
+      (a, b) =>
+        (a.b.order ?? 0) - (b.b.order ?? 0) ||
+        (a.b.label ?? a.b.name).localeCompare(b.b.label ?? b.b.name) ||
+        a.i - b.i,
+    )
+    .map((x) => x.b);
+}
+
+/**
+ * Count the docs a book *organizes* — i.e. those landing in an authored group,
+ * excluding the synthetic Uncategorized catch-all (see {@link ResolvedGroup}).
+ */
+export function countBookDocs(book: Book, docs: ResolverDoc[]): number {
+  const resolved = resolveBookTree(book, scopeDocsToBook(book, docs));
+  const seen = new Set<string>();
+  for (const g of resolved.groups) {
+    if (g.synthetic) continue;
+    for (const e of g.entries) {
+      if (e.doc && !e.separator) seen.add(e.doc);
+    }
+  }
+  return seen.size;
+}
+
+/** Build the index cards for the portal landing, in display order. */
+export function buildBookCards(books: Book[], docs: ResolverDoc[]): BookCard[] {
+  return sortBooks(books).map((b) => ({
+    name: b.name,
+    slug: bookSlug(b),
+    label: b.label ?? b.name,
+    description: b.description,
+    icon: b.icon,
+    packageId: b.packageId,
+    docCount: countBookDocs(b, docs),
+  }));
+}
+
+/**
+ * The portal's full book set (ADR-0046 §6.4): every authored book, plus a
+ * synthetic implicit book for any package that has docs but no authored book
+ * of its own. There is no "flat vs book" fork — a package without an authored
+ * book is still browsed as its implicit per-package book (keyed by packageId,
+ * one group including every doc). Returned in display order.
+ */
+export function buildPortalBooks(authored: Book[], docs: ResolverDoc[]): Book[] {
+  const ownPkgs = new Set(authored.map(pkgOfBook));
+  const docPkgs = new Set(docs.map(pkgOf));
+  const implicit: Book[] = [...docPkgs]
+    .filter((p) => !ownPkgs.has(p))
+    .map((p) => ({ ...deriveImplicitPackageBook(p), packageId: p }));
+  return sortBooks([...authored, ...implicit]);
+}
+
+/**
+ * The canonical ("home") book for a doc — the authored or implicit book of the
+ * doc's own package. Used for the legacy `/docs/:name` permalink redirect and
+ * as the default reading context. A doc curated into a cross-package authored
+ * book is still reachable there, but its canonical URL is its home book.
+ */
+export function homeBook(docName: string, portalBooks: Book[], docs: ResolverDoc[]): Book | null {
+  const doc = docs.find((d) => d.name === docName);
+  const pkg = doc ? pkgOf(doc) : namePrefix(docName);
+  return sortBooks(portalBooks).find((b) => pkgOfBook(b) === pkg) ?? null;
+}
+
+/**
+ * Find the first book (in display order) whose resolved tree contains `docName`
+ * — used by the single-doc reader to show the surrounding book's nav. Returns
+ * the resolved book and the matching book record, or null when the doc belongs
+ * to no authored book.
+ */
+export function findBookContainingDoc(
+  books: Book[],
+  docs: ResolverDoc[],
+  docName: string,
+): { book: Book; resolved: ResolvedBook } | null {
+  for (const book of sortBooks(books)) {
+    const resolved = resolveBookTree(book, scopeDocsToBook(book, docs));
+    // Authored membership only — a doc that merely lands in this book's
+    // synthetic Uncategorized group is not "owned" by it (every book has one).
+    const has = resolved.groups.some(
+      (g) => !g.synthetic && g.entries.some((e) => e.doc === docName && !e.separator),
+    );
+    if (has) return { book, resolved };
+  }
+  return null;
+}
+
+/** Total docs an entry list covers — handy for "N articles" labels. */
+export function countEntries(groups: ResolvedGroup[]): number {
+  let n = 0;
+  for (const g of groups) for (const e of g.entries) if ((e.doc || e.href) && !e.separator) n += 1;
+  return n;
+}

--- a/apps/console/src/pages/book-nav.ts
+++ b/apps/console/src/pages/book-nav.ts
@@ -323,9 +323,14 @@ export function countBookDocs(book: Book, docs: ResolverDoc[]): number {
   return seen.size;
 }
 
-/** Build the index cards for the portal landing, in display order. */
+/**
+ * Build the index cards for the portal landing. Input order is preserved —
+ * callers pass {@link buildPortalBooks} output, which already orders authored
+ * books (by `order`) ahead of the synthetic per-package ones; re-sorting here
+ * would undo that.
+ */
 export function buildBookCards(books: Book[], docs: ResolverDoc[]): BookCard[] {
-  return sortBooks(books).map((b) => ({
+  return books.map((b) => ({
     name: b.name,
     slug: bookSlug(b),
     label: b.label ?? b.name,
@@ -348,8 +353,20 @@ export function buildPortalBooks(authored: Book[], docs: ResolverDoc[]): Book[] 
   const docPkgs = new Set(docs.map(pkgOf));
   const implicit: Book[] = [...docPkgs]
     .filter((p) => !ownPkgs.has(p))
-    .map((p) => ({ ...deriveImplicitPackageBook(p), packageId: p }));
-  return sortBooks([...authored, ...implicit]);
+    // Humanize the package id for the visible label (the slug/name stays the
+    // full id so it remains unique and reversible); keep the group as the
+    // generic "Documentation".
+    .map((p) => ({ ...deriveImplicitPackageBook(p), label: humanizePackageId(p), packageId: p }));
+  // Authored books lead (curated, primary) in their own order; the synthetic
+  // per-package books follow, alphabetically — so an authored book with an
+  // explicit `order` is never pushed below a fallback.
+  return [...sortBooks(authored), ...sortBooks(implicit)];
+}
+
+/** "com.objectstack.setup" → "Setup" — a readable label for an implicit book. */
+function humanizePackageId(pkg: string): string {
+  const seg = pkg.split('.').pop() || pkg;
+  return seg.charAt(0).toUpperCase() + seg.slice(1);
 }
 
 /**

--- a/apps/console/src/pages/docs-portal.test.tsx
+++ b/apps/console/src/pages/docs-portal.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Integration test for the book-driven docs portal (ADR-0046 §6): mounts the
+ * REAL DocsIndex / DocsSlug / BookPage / DocPage under the REAL route table,
+ * backed by a mocked metadata adapter (no authored books — so the implicit
+ * per-package books are exercised, §6.4). Verifies the full reader flow that
+ * the unit tests can't: routing, the /docs/:slug dispatcher, the book landing,
+ * the in-book reader + sidebar, and the legacy /docs/:name redirect.
+ *
+ * This is a jsdom integration test, not a real browser — it needs no backend.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+// ── Sample metadata the mocked adapter serves (two packages, no books) ──────
+// Defined via vi.hoisted so the hoisted vi.mock factory can close over them,
+// and so the adapter is a STABLE singleton — the real useAdapter() returns a
+// memoized instance, so a fresh object per render would loop the fetch effects.
+const { ADAPTER } = vi.hoisted(() => {
+  const DOCS = [
+    { name: 'crm_intro', label: 'CRM Intro', _packageId: 'crm', order: 1 },
+    { name: 'crm_guide_lead', label: 'Leads', _packageId: 'crm', order: 2 },
+    { name: 'ops_setup', label: 'Setup', _packageId: 'ops' },
+  ];
+  const CONTENT: Record<string, string> = {
+    crm_intro: 'Welcome to the CRM',
+    crm_guide_lead: 'Managing leads',
+    ops_setup: 'Operations setup',
+  };
+  const ADAPTER = {
+    getClient: () => ({
+      meta: {
+        getItems: async (type: string) => (type === 'doc' ? DOCS : []), // no authored books
+        getItem: async (_type: string, name: string) => ({ item: { name, content: CONTENT[name] } }),
+      },
+    }),
+  };
+  return { ADAPTER };
+});
+
+vi.mock('@object-ui/app-shell', () => ({ useAdapter: () => ADAPTER }));
+
+vi.mock('@object-ui/plugin-markdown', () => ({
+  MarkdownRenderer: ({ schema }: { schema: { content?: string } }) => (
+    <div data-testid="doc-content">{schema.content}</div>
+  ),
+  extractToc: () => [],
+}));
+
+vi.mock('@object-ui/i18n', () => ({
+  useObjectTranslation: () => ({ t: (_k: string, o?: { defaultValue?: string }) => o?.defaultValue ?? _k }),
+}));
+
+// Imported AFTER the mocks so the pages pick up the mocked modules.
+import DocsIndex from './DocsIndex';
+import DocsSlug from './DocsSlug';
+import DocPage from './DocPage';
+
+function Harness({ entry }: { entry: string }) {
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/docs" element={<DocsIndex />} />
+        <Route path="/docs/:slug" element={<DocsSlug />} />
+        <Route path="/docs/:slug/:name" element={<DocPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(cleanup);
+
+describe('book-driven docs portal (integration)', () => {
+  it('/docs lists an implicit per-package book for every package with docs', async () => {
+    render(<Harness entry="/docs" />);
+    // Implicit books keyed by packageId: crm (2 docs) + ops (1 doc).
+    const crm = await screen.findByRole('link', { name: /crm/i });
+    expect(crm).toHaveAttribute('href', '/docs/crm');
+    expect(screen.getByRole('link', { name: /ops/i })).toHaveAttribute('href', '/docs/ops');
+    expect(screen.getByText('2 articles')).toBeInTheDocument();
+    expect(screen.getByText('1 article')).toBeInTheDocument();
+  });
+
+  it('/docs/:slug renders the book landing with its docs (resolved spine)', async () => {
+    render(<Harness entry="/docs/crm" />);
+    // Both the sidebar and the overview list the book's docs.
+    expect(await screen.findAllByText('CRM Intro')).not.toHaveLength(0);
+    expect(screen.getAllByText('Leads').length).toBeGreaterThan(0);
+    // The overview links a doc to the in-book reader URL.
+    const links = screen.getAllByRole('link', { name: 'CRM Intro' });
+    expect(links.some((a) => a.getAttribute('href') === '/docs/crm/crm_intro')).toBe(true);
+  });
+
+  it('/docs/:slug/:name renders the doc content with the book sidebar (active)', async () => {
+    render(<Harness entry="/docs/crm/crm_intro" />);
+    expect(await screen.findByTestId('doc-content')).toHaveTextContent('Welcome to the CRM');
+    // Sidebar marks the current doc as active.
+    const active = screen.getByRole('link', { name: 'CRM Intro' });
+    expect(active).toHaveAttribute('aria-current', 'page');
+    // A sibling doc is reachable from the sidebar.
+    expect(screen.getByRole('link', { name: 'Leads' })).toHaveAttribute('href', '/docs/crm/crm_guide_lead');
+  });
+
+  it('legacy /docs/:name redirects to the doc\'s canonical in-book URL', async () => {
+    render(<Harness entry="/docs/crm_intro" />);
+    // 'crm_intro' is not a book slug → dispatcher redirects to /docs/crm/crm_intro,
+    // which renders the reader.
+    expect(await screen.findByTestId('doc-content')).toHaveTextContent('Welcome to the CRM');
+    expect(screen.getByRole('link', { name: 'CRM Intro' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('an unknown segment degrades to a not-found notice', async () => {
+    render(<Harness entry="/docs/does_not_exist" />);
+    expect(await screen.findByText('Documentation not found')).toBeInTheDocument();
+  });
+
+  it('clicking a book card navigates to its landing (real router flow)', async () => {
+    render(<Harness entry="/docs" />);
+    fireEvent.click(await screen.findByRole('link', { name: /ops/i }));
+    // Now on /docs/ops — the ops book landing renders, headed by the book, with
+    // its doc reachable (in both the sidebar and the overview list).
+    expect(await screen.findByRole('heading', { name: 'ops' })).toBeInTheDocument();
+    const setupLinks = screen.getAllByRole('link', { name: 'Setup' });
+    expect(setupLinks.some((a) => a.getAttribute('href') === '/docs/ops/ops_setup')).toBe(true);
+  });
+});

--- a/apps/console/src/pages/docs-portal.test.tsx
+++ b/apps/console/src/pages/docs-portal.test.tsx
@@ -126,9 +126,9 @@ describe('book-driven docs portal (integration)', () => {
   it('clicking a book card navigates to its landing (real router flow)', async () => {
     render(<Harness entry="/docs" />);
     fireEvent.click(await screen.findByRole('link', { name: /ops/i }));
-    // Now on /docs/ops — the ops book landing renders, headed by the book, with
-    // its doc reachable (in both the sidebar and the overview list).
-    expect(await screen.findByRole('heading', { name: 'ops' })).toBeInTheDocument();
+    // Now on /docs/ops — the ops book landing renders, headed by the book
+    // (its label is the humanized package id, "Ops"), with its doc reachable.
+    expect(await screen.findByRole('heading', { name: /ops/i })).toBeInTheDocument();
     const setupLinks = screen.getAllByRole('link', { name: 'Setup' });
     expect(setupLinks.some((a) => a.getAttribute('href') === '/docs/ops/ops_setup')).toBe(true);
   });

--- a/apps/console/src/pages/docs-portal.test.tsx
+++ b/apps/console/src/pages/docs-portal.test.tsx
@@ -94,32 +94,33 @@ describe('book-driven docs portal (integration)', () => {
     expect(screen.getByText('1 article')).toBeInTheDocument();
   });
 
-  it('/docs/:slug renders the book landing with its docs (resolved spine)', async () => {
+  it('/docs/:slug opens the book to its overview doc (no duplicated TOC)', async () => {
     render(<Harness entry="/docs/crm" />);
-    // Both the sidebar and the overview list the book's docs.
-    expect(await screen.findAllByText('CRM Intro')).not.toHaveLength(0);
-    expect(screen.getAllByText('Leads').length).toBeGreaterThan(0);
-    // The overview links a doc to the in-book reader URL.
-    const links = screen.getAllByRole('link', { name: 'CRM Intro' });
-    expect(links.some((a) => a.getAttribute('href') === '/docs/crm/crm_intro')).toBe(true);
+    // The landing redirects into the reader of the first doc; content + sidebar.
+    expect(await screen.findByTestId('doc-content')).toHaveTextContent('Welcome to the CRM');
+    const intro = screen.getAllByRole('link', { name: 'CRM Intro' });
+    expect(intro.every((l) => l.getAttribute('aria-current') === 'page')).toBe(true);
   });
 
   it('/docs/:slug/:name renders the doc content with the book sidebar (active)', async () => {
     render(<Harness entry="/docs/crm/crm_intro" />);
     expect(await screen.findByTestId('doc-content')).toHaveTextContent('Welcome to the CRM');
-    // Sidebar marks the current doc as active.
-    const active = screen.getByRole('link', { name: 'CRM Intro' });
-    expect(active).toHaveAttribute('aria-current', 'page');
+    // The sidebar is rendered twice (persistent on wide, a disclosure on narrow);
+    // both mark the current doc active.
+    const active = screen.getAllByRole('link', { name: 'CRM Intro' });
+    expect(active.length).toBeGreaterThanOrEqual(1);
+    expect(active.every((l) => l.getAttribute('aria-current') === 'page')).toBe(true);
     // A sibling doc is reachable from the sidebar.
-    expect(screen.getByRole('link', { name: 'Leads' })).toHaveAttribute('href', '/docs/crm/crm_guide_lead');
+    const leads = screen.getAllByRole('link', { name: 'Leads' });
+    expect(leads.some((l) => l.getAttribute('href') === '/docs/crm/crm_guide_lead')).toBe(true);
   });
 
   it('legacy /docs/:name redirects to the doc\'s canonical in-book URL', async () => {
     render(<Harness entry="/docs/crm_intro" />);
-    // 'crm_intro' is not a book slug → dispatcher redirects to /docs/crm/crm_intro,
-    // which renders the reader.
+    // 'crm_intro' is not a book slug → dispatcher redirects to /docs/crm/crm_intro.
     expect(await screen.findByTestId('doc-content')).toHaveTextContent('Welcome to the CRM');
-    expect(screen.getByRole('link', { name: 'CRM Intro' })).toHaveAttribute('aria-current', 'page');
+    const active = screen.getAllByRole('link', { name: 'CRM Intro' });
+    expect(active.every((l) => l.getAttribute('aria-current') === 'page')).toBe(true);
   });
 
   it('an unknown segment degrades to a not-found notice', async () => {
@@ -127,13 +128,10 @@ describe('book-driven docs portal (integration)', () => {
     expect(await screen.findByText('Documentation not found')).toBeInTheDocument();
   });
 
-  it('clicking a book card navigates to its landing (real router flow)', async () => {
+  it('clicking a book card opens it (real router flow)', async () => {
     render(<Harness entry="/docs" />);
     fireEvent.click(await screen.findByRole('link', { name: /ops/i }));
-    // Now on /docs/ops — the ops book landing renders, headed by the book
-    // (its label is the humanized package id, "Ops"), with its doc reachable.
-    expect(await screen.findByRole('heading', { name: /ops/i })).toBeInTheDocument();
-    const setupLinks = screen.getAllByRole('link', { name: 'Setup' });
-    expect(setupLinks.some((a) => a.getAttribute('href') === '/docs/ops/ops_setup')).toBe(true);
+    // /docs/ops opens the ops book → reader of its single doc.
+    expect(await screen.findByTestId('doc-content')).toHaveTextContent('Operations setup');
   });
 });

--- a/apps/console/src/pages/docs-portal.test.tsx
+++ b/apps/console/src/pages/docs-portal.test.tsx
@@ -61,17 +61,21 @@ vi.mock('@object-ui/i18n', () => ({
 }));
 
 // Imported AFTER the mocks so the pages pick up the mocked modules.
+import DocsLayout from './DocsLayout';
 import DocsIndex from './DocsIndex';
 import DocsSlug from './DocsSlug';
 import DocPage from './DocPage';
 
+// Mirrors the real route table: the layout fetches once and shares the data.
 function Harness({ entry }: { entry: string }) {
   return (
     <MemoryRouter initialEntries={[entry]}>
       <Routes>
-        <Route path="/docs" element={<DocsIndex />} />
-        <Route path="/docs/:slug" element={<DocsSlug />} />
-        <Route path="/docs/:slug/:name" element={<DocPage />} />
+        <Route path="/docs" element={<DocsLayout />}>
+          <Route index element={<DocsIndex />} />
+          <Route path=":slug" element={<DocsSlug />} />
+          <Route path=":slug/:name" element={<DocPage />} />
+        </Route>
       </Routes>
     </MemoryRouter>
   );

--- a/apps/console/src/pages/use-book-data.ts
+++ b/apps/console/src/pages/use-book-data.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useAdapter } from '@object-ui/app-shell';
 import { buildPortalBooks, type Book, type ResolverDoc } from './book-nav';
 
@@ -77,7 +77,12 @@ interface RawState {
   error?: string;
 }
 
-export function useBookData(): BookData {
+/**
+ * Fetch the book + doc metadata once. Used by {@link BookDataProvider} at the
+ * `/docs` layout route so the whole docs section shares a single fetch, rather
+ * than each page (index, book landing, reader) re-fetching independently.
+ */
+function useBookDataFetch(): BookData {
   const adapter = useAdapter();
   const [data, setData] = useState<RawState>({ authoredBooks: [], docs: [], state: 'loading' });
 
@@ -124,4 +129,21 @@ export function useBookData(): BookData {
   );
 
   return { ...data, books };
+}
+
+const LOADING: BookData = { authoredBooks: [], books: [], docs: [], state: 'loading' };
+
+/**
+ * Shared book/doc data, provided once at the `/docs` layout route (see
+ * DocsLayout) and consumed by {@link useBookData}. Exported so the layout's
+ * provider — which lives in a `.tsx` file — can supply it.
+ */
+export const BookDataContext = createContext<BookData | null>(null);
+
+/** The one-time fetcher the layout drives. Internal to the docs section. */
+export { useBookDataFetch };
+
+/** Read the shared book/doc data. Returns a loading state outside the provider. */
+export function useBookData(): BookData {
+  return useContext(BookDataContext) ?? LOADING;
 }

--- a/apps/console/src/pages/use-book-data.ts
+++ b/apps/console/src/pages/use-book-data.ts
@@ -1,0 +1,127 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useAdapter } from '@object-ui/app-shell';
+import { buildPortalBooks, type Book, type ResolverDoc } from './book-nav';
+
+/**
+ * Fetch the `book` + `doc` metadata that drives the portal navigation
+ * (ADR-0046 §6). Both are loaded through the ordinary metadata API the doc
+ * pages already use (`meta.getItems`), so this works the moment the backend
+ * serves these types — no new endpoint required.
+ *
+ * Degrades softly: a backend that doesn't serve `book` yet (or returns an
+ * error for it) yields `books: []`, letting callers fall back to the legacy
+ * package-grouped view rather than failing the whole page.
+ */
+export interface BookData {
+  /** Authored books exactly as published. */
+  authoredBooks: Book[];
+  /**
+   * The portal's full book set: authored books plus a synthetic implicit book
+   * for any package that has docs but no authored book (ADR-0046 §6.4). This
+   * is what the portal navigates — there is no "flat vs book" fork.
+   */
+  books: Book[];
+  docs: ResolverDoc[];
+  state: 'loading' | 'ready' | 'error';
+  error?: string;
+}
+
+function unwrapList(result: unknown): any[] {
+  if (Array.isArray(result)) return result;
+  const r = result as any;
+  if (Array.isArray(r?.items)) return r.items;
+  if (Array.isArray(r?.value)) return r.value;
+  return [];
+}
+
+function toBook(it: any): Book | null {
+  if (!it || typeof it.name !== 'string' || !it.name) return null;
+  return {
+    name: it.name,
+    label: it.label,
+    description: it.description,
+    slug: it.slug,
+    icon: it.icon,
+    order: typeof it.order === 'number' ? it.order : undefined,
+    audience: it.audience,
+    groups: Array.isArray(it.groups) ? it.groups : [],
+    packageId: it._packageId ?? it.packageId,
+  };
+}
+
+function toDoc(it: any): ResolverDoc | null {
+  if (!it || typeof it.name !== 'string' || !it.name) return null;
+  return {
+    name: it.name,
+    label: it.label,
+    description: it.description,
+    order: typeof it.order === 'number' ? it.order : undefined,
+    group: typeof it.group === 'string' ? it.group : undefined,
+    tags: Array.isArray(it.tags) ? it.tags : undefined,
+    packageId: it._packageId ?? it.packageId,
+  };
+}
+
+interface RawState {
+  authoredBooks: Book[];
+  docs: ResolverDoc[];
+  state: 'loading' | 'ready' | 'error';
+  error?: string;
+}
+
+export function useBookData(): BookData {
+  const adapter = useAdapter();
+  const [data, setData] = useState<RawState>({ authoredBooks: [], docs: [], state: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!adapter) return;
+      const client: any = adapter.getClient();
+      if (!client?.meta?.getItems) {
+        setData({ authoredBooks: [], docs: [], state: 'error', error: 'meta.getItems is not available' });
+        return;
+      }
+      setData((d) => ({ ...d, state: 'loading' }));
+      try {
+        // Docs are required; books are optional (the type may not be served
+        // yet) — so tolerate a book fetch failure without failing the page.
+        const docsRaw = await client.meta.getItems('doc');
+        let booksRaw: unknown = [];
+        try {
+          booksRaw = await client.meta.getItems('book');
+        } catch {
+          booksRaw = [];
+        }
+        if (cancelled) return;
+        const docs = unwrapList(docsRaw).map(toDoc).filter((d): d is ResolverDoc => d !== null);
+        const authoredBooks = unwrapList(booksRaw).map(toBook).filter((b): b is Book => b !== null);
+        setData({ authoredBooks, docs, state: 'ready' });
+      } catch (err: any) {
+        if (cancelled) return;
+        setData({ authoredBooks: [], docs: [], state: 'error', error: err?.message ?? 'Failed to load documentation' });
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [adapter]);
+
+  // Synthesize the portal's implicit per-package books on top of the authored
+  // ones, so every package with docs is browsable as a book (ADR-0046 §6.4).
+  const books = useMemo(
+    () => buildPortalBooks(data.authoredBooks, data.docs),
+    [data.authoredBooks, data.docs],
+  );
+
+  return { ...data, books };
+}


### PR DESCRIPTION
## What

Makes the documentation portal **book-driven** (ADR-0046 §6). A `book` is the *authored navigation spine* — ordered groups whose membership over docs is **derived** from each group's `include` rule (glob / `{ tag }`), with an optional explicit `pages` override. Per §6.4 there is **no "flat vs book" fork**: a package with no authored book is browsed as its *implicit per-package book*, so every doc always has a book.

## URL scheme

Doc **identity** stays single-coordinate (`<name>`, ADR §4 rejects `/docs/<book>/<name>` as identity); the portal **reading** URL carries a *derived* book segment:

```
/docs               book index (authored + implicit per-package)
/docs/:slug         book landing — or a flat-doc permalink that 302s to
                    its canonical /docs/<homeBook>/<name>
/docs/:slug/:name   in-book reader (persistent book sidebar + breadcrumb)
```

`:slug` = book.slug (ADR §6 "portal URL segment"); an implicit book uses its packageId. A single `/docs/:slug` dispatcher resolves a segment to a book landing or redirects a flat doc to its canonical in-book URL. App-scoped mirrors this under `/apps/:appName/docs/...`.

## Changes (all in `apps/console/src`)

- **`pages/book-nav.ts`** — local port of `resolveBookTree` + portal helpers: `buildPortalBooks` (authored ahead of implicit per-package), `homeBook`, `bookSlug`, `pkgOf`/`pkgOfBook` (use `_packageId`, falling back to the name prefix when unstamped), `scopeDocsToBook`, `buildBookCards`. Synthetic *Uncategorized* is flagged and excluded from authored membership. No dependency on a published spec version or a `/tree` endpoint.
- **`pages/DocsLayout.tsx` + `use-book-data.ts`** — the `/docs` layout route fetches book + doc **once** and shares it via context; pages read it with `useBookData`. Navigating within the section issues no further book/doc requests.
- **`pages/DocsSlug.tsx`** — the `/docs/:slug` dispatcher. **`BookSidebar.tsx` / `BookPage.tsx`** — the resolved spine as nav + a book landing.
- **`pages/DocsIndex.tsx`** — book index (authored books lead). **`pages/DocPage.tsx`** — in-book reader with the `:slug` book's sidebar. **`pages/AppDocsIndex.tsx`** — app-scoped, book-driven (single book → redirect to its reader).
- Implicit book labels are humanized (`com.objectstack.setup` → `Setup`); slug/name keep the full id.
- Routes nested under the layout (top-level `App.tsx` + app-scoped `AppContent.tsx`).

## Verification

- **Browser-verified end-to-end** against the framework showcase backend (which serves `book`): the `/docs` index (authored *Showcase Manual* + implicit *Setup*/*Studio*), the `/docs/manual` landing (Getting Started / Guides resolved from `pages` + `include`), the in-book reader (markdown + sidebar), the flat-doc → canonical redirect, and the app-scoped `/apps/:pkg/docs` redirect inside the app container. The shared-layout fetch was confirmed in the network panel (one book/doc fetch per section, not per page).
- `book-nav` (17) + `BookSidebar` (5) + a `docs-portal` integration test (6, mounts the real pages under the real route table); existing doc tests unchanged — 47 in `pages`. `tsc --noEmit` exit 0; `eslint` 0 errors.

## Deployment note & follow-up

`book` + `doc` must be served by the backend for real data — published `@objectstack/spec@9.5.1` serves neither yet, so every surface degrades gracefully and lights up when a framework build with `book` is deployed.

**Open decision (not in this PR):** anonymous `audience: public` reading (ADR §6.7). `/docs` stays behind `ProtectedRoute`; opening it to unauthenticated visitors is a security-gate change to make deliberately.

## Relationship to the other book PRs

- **#1775** — ADR-0046 `book` **admin/authoring** UI. **#1774** (merged) — ADR-0051 inline `metadata_viewer` doc fence. **This** — the **reader** portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
