### PR TITLE
feat(i18n): translate action description (last gap of action i18n, cloud#73)

### DIFF
--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@object-ui/i18n', () => ({
     fieldOptionLabel: (_o: any, _f: any, _v: any, l: any) => l,
     actionParamText: (_o: any, _a: any, _p: any, _attr: any, fallback: any) => fallback,
     actionParamOptionLabel: (_o: any, _a: any, _p: any, _v: any, fallback: any) => fallback,
+    actionDescription: (_o: any, _a: any, fallback: any) => fallback,
   }),
 }));
 

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -87,7 +87,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   const { dataSource, objects, objectName, onRefresh } = opts;
   const navigate = useNavigate();
   const { user, activeOrganization } = useAuth();
-  const { fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel } = useObjectLabel();
+  const { fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel, actionDescription } = useObjectLabel();
 
   const objectDef = useMemo(
     () => (objectName ? objects?.find((o: any) => o.name === objectName) : undefined),
@@ -152,7 +152,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
         open: true,
         params: localized,
         title: action?.label || action?.title,
-        description: action?.description,
+        description: actionDescription(objForI18n, action?.name, action?.description),
         resolve,
       });
     });

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -119,7 +119,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   const location = useLocation();
   const originFrom = (location.state as any)?.from as { pathname?: string; label?: string } | undefined;
   const { t } = useObjectTranslation();
-  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, actionParamOptionLabel, fieldLabel, fieldOptionLabel } = useObjectLabel();
+  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, actionParamOptionLabel, actionDescription, fieldLabel, fieldOptionLabel } = useObjectLabel();
   const { isFavorite, toggleFavorite, refreshLabel: refreshFavoriteLabel } = useFavorites();
   const { addRecentItem } = useRecentItems();
   const [isLoading, setIsLoading] = useState(true);
@@ -341,7 +341,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         params: localized,
         // Title the dialog as the action rather than the generic "Action parameters".
         title: action?.label || action?.title,
-        description: action?.description,
+        description: actionDescription(objForI18n, action?.name, action?.description),
         resolve,
       });
     });

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -386,6 +386,23 @@ export function useObjectLabel() {
     },
 
     /**
+     * Resolve translated action description (the explanatory line shown in the
+     * action's param dialog / sheet / drawer header).
+     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.description`.
+     * Falls back to `{ns}.globalActions.{actionName}.description`, then the
+     * metadata's literal string; undefined when nothing resolves.
+     */
+    actionDescription: (objectName: string | undefined, actionName: string | undefined, fallback?: string) => {
+      const fb = fallback ?? '';
+      if (!actionName) return fb || undefined;
+      const suffixes = objectName
+        ? objectSuffixes(objectName, `_actions.${actionName}.description`)
+        : `globalActions.${actionName}.description`;
+      const resolved = resolve(suffixes, fb);
+      return resolved || undefined;
+    },
+
+    /**
      * Resolve translated action-PARAMETER text (label / placeholder / helpText).
      * Convention: `{ns}.objects.{objectName}._actions.{actionName}.params.{paramName}.{attr}`.
      * Falls back to the provided value (the metadata's literal string) when no


### PR DESCRIPTION
Closes the **description** half of objectstack-ai/cloud#73 ("动作的 description 与参数 label/helpText/placeholder 无法翻译").

## Re-verification of #73
Re-checked the current state — most of #73 is **already done & wired**:
- action **label** → `actionLabel`; **confirmText** → `actionConfirm`; **successMessage** → `actionSuccess`
- param **label/placeholder/helpText** → `actionParamText`; option **label** → `actionParamOptionLabel`
  (resolved in `useConsoleActionRuntime` / `RecordDetailView` before the dialog opens)

The **one** missing piece: the action's own `description` — there was no `actionDescription` resolver, so it flowed to `useActionModal` raw (untranslated).

## This PR
- Adds `actionDescription` to `useObjectLabel` (mirrors `actionSuccess`; convention `objects.{object}._actions.{action}.description`).
- Wires it at the two descriptor-build sites so the dialog gets a localized description (same mechanism as the already-live `actionParamText`).
- Updates the runtime test mock so existing tests stay green.

## Note on verification
No shipped action currently sets a top-level `description`, so this is a forward-looking capability with **no visible change today** — a browser demo would show nothing different without manufacturing a description+translation fixture. Verified by build + full **app-shell (546)** and **i18n (120)** suites; the wiring is byte-identical to the param-text path that already translates live.

Out of scope (separate, minor): `MetadataTypeActions` (admin tooling) renders `action.label` raw, bypassing i18n. `QuickActions` is already `t()`-based (not a gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)