### PR TITLE
feat(detail): timeline drill-to-source link (ADR-0052 ActivityPointer)

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -991,6 +991,10 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
             actorAvatarUrl: row.actor_avatar_url ?? undefined,
             body: row.summary ?? '',
             createdAt: when,
+            // ADR-0052 ActivityPointer: drill from the summary to the source
+            // rich entity (sys_email row, call/meeting task, …) when present.
+            sourceObject: row.source_object ?? undefined,
+            sourceId: row.source_id ?? undefined,
           } as FeedItem);
         }
         if (!mapped.length) return;

--- a/packages/plugin-detail/src/RecordActivityTimeline.tsx
+++ b/packages/plugin-detail/src/RecordActivityTimeline.tsx
@@ -414,6 +414,18 @@ export const RecordActivityTimeline: React.FC<RecordActivityTimelineProps> = ({
                           </p>
                         )}
 
+                        {/* Drill to source rich entity (ADR-0052 ActivityPointer) */}
+                        {item.sourceObject && item.sourceId != null && (
+                          <a
+                            href={`/objects/${item.sourceObject}/${item.sourceId}`}
+                            className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                            data-testid="activity-source-link"
+                          >
+                            {t('detail.viewSource')}
+                            <span aria-hidden>→</span>
+                          </a>
+                        )}
+
                         {/* Field changes */}
                         {item.type === 'field_change' && item.fieldChanges && (
                           <div className="space-y-1 mt-1">

--- a/packages/plugin-detail/src/__tests__/RecordActivityTimeline.source.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordActivityTimeline.source.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * ADR-0052 ActivityPointer: a timeline row carrying a `sourceObject`/`sourceId`
+ * pointer (e.g. an email derived from a `sys_email` row) renders a "view source"
+ * link so the user can drill from the one-line summary to the full record.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RecordActivityTimeline } from '../RecordActivityTimeline';
+import type { FeedItem } from '@object-ui/types';
+
+describe('RecordActivityTimeline — source drill link (ADR-0052 ActivityPointer)', () => {
+  it('renders a "view source" link to the source entity when sourceObject/sourceId are present', () => {
+    const items: FeedItem[] = [
+      {
+        id: 'act-1',
+        type: 'comment',
+        actor: 'System',
+        body: 'Email: Q3 proposal',
+        createdAt: new Date().toISOString(),
+        sourceObject: 'sys_email',
+        sourceId: 'email-123',
+      },
+    ];
+    render(<RecordActivityTimeline items={items} />);
+    const link = screen.getByTestId('activity-source-link') as HTMLAnchorElement;
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('/objects/sys_email/email-123');
+  });
+
+  it('renders no source link when the activity has no source pointer', () => {
+    const items: FeedItem[] = [
+      {
+        id: 'act-2',
+        type: 'comment',
+        actor: 'System',
+        body: 'Status: To Do → Done',
+        createdAt: new Date().toISOString(),
+      },
+    ];
+    render(<RecordActivityTimeline items={items} />);
+    expect(screen.queryByTestId('activity-source-link')).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/useDetailTranslation.ts
+++ b/packages/plugin-detail/src/useDetailTranslation.ts
@@ -173,6 +173,7 @@ export const DETAIL_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'detail.loadMore': 'Load more',
   'detail.edited': '(edited)',
   'detail.via': 'via {{source}}',
+  'detail.viewSource': 'View source',
   // Replies
   'detail.replyCount': '{{count}} reply',
   'detail.replyCountPlural': '{{count}} replies',

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -360,6 +360,14 @@ export interface FeedItem {
   pinned?: boolean;
   /** Whether this item has been edited */
   edited?: boolean;
+  /**
+   * Source rich-entity pointer (ADR-0052 ActivityPointer). When the activity
+   * was derived from a separate record — an email in `sys_email`, a call/meeting
+   * task — these identify it so the timeline can drill from the one-line summary
+   * to the full record. Distinct from `source` (the origin channel).
+   */
+  sourceObject?: string;
+  sourceId?: string | number;
 }
 
 /**


### PR DESCRIPTION
## What

Pairs with framework's `sys_activity.source_object/source_id` (ADR-0052 §5, ActivityPointer model). When an activity row carries a **source pointer** — an email derived from a `sys_email` row, a call/meeting task — the record timeline now renders a **"View source →"** link so the user drills from the one-line summary to the full record. Reuses the URL pattern `InboxPopover` already uses for notification source pointers.

- `@object-ui/types`: `FeedItem` gains `sourceObject`/`sourceId` (distinct from `source` = origin channel).
- `app-shell` `RecordDetailView`: map `sys_activity.source_object/source_id` → `FeedItem` in the existing sys_activity→feed mapper.
- `plugin-detail` `RecordActivityTimeline`: render the drill link when present.
- i18n `detail.viewSource`; unit test (2/2): link renders with the right href when source present, absent otherwise.

**Reactions + threading were already wired** (`sys_comment.reactions`/`parent_id` parsed in `RecordDetailView`) — this PR adds the missing ActivityPointer drill-through, the genuinely-new piece.

## Verification

`pnpm --filter @object-ui/plugin-detail exec vitest run … RecordActivityTimeline.source.test.tsx` → **2/2 pass**. `@object-ui/types` + `plugin-detail` typecheck clean.

> Note: `app-shell` has a **pre-existing** typecheck error on `actionDescription` (`RecordDetailView:122`, `useConsoleActionRuntime:90`) on `main`, unrelated to this change (my edit is the source pointer in the sys_activity mapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
