### PR TITLE
fix(console): localize action confirm dialog + surface inner action failure

### DIFF
--- a/packages/app-shell/src/views/ActionConfirmDialog.tsx
+++ b/packages/app-shell/src/views/ActionConfirmDialog.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@object-ui/components';
+import { useObjectTranslation } from '@object-ui/i18n';
 
 export interface ConfirmDialogState {
   open: boolean;
@@ -29,6 +30,7 @@ interface ActionConfirmDialogProps {
 }
 
 export function ActionConfirmDialog({ state, onOpenChange }: ActionConfirmDialogProps) {
+  const { t } = useObjectTranslation();
   const handleConfirm = () => {
     state.resolve?.(true);
     onOpenChange(false);
@@ -45,15 +47,15 @@ export function ActionConfirmDialog({ state, onOpenChange }: ActionConfirmDialog
     }}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>{state.options?.title || 'Confirm Action'}</AlertDialogTitle>
+          <AlertDialogTitle>{state.options?.title || t('actionConfirm.title')}</AlertDialogTitle>
           <AlertDialogDescription>{state.message}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={handleCancel}>
-            {state.options?.cancelText || 'Cancel'}
+            {state.options?.cancelText || t('actionConfirm.cancel')}
           </AlertDialogCancel>
           <AlertDialogAction onClick={handleConfirm}>
-            {state.options?.confirmText || 'Continue'}
+            {state.options?.confirmText || t('actionConfirm.confirm')}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -544,8 +544,16 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         },
       );
       const json = await res.json().catch(() => null);
-      if (!res.ok || (json && json.success === false)) {
-        const errMsg = json?.error || `Action "${targetName}" failed (HTTP ${res.status})`;
+      // The action route wraps the handler's return value in a {success, data}
+      // envelope. A script action that THROWS is reported as
+      // `data: { success: false, error }` while the OUTER success stays true,
+      // so we must inspect the inner envelope too — otherwise a failed action
+      // is mistaken for success and fires the green "completed" toast while the
+      // real error is swallowed.
+      const inner = json?.data;
+      const innerFailed = inner && typeof inner === 'object' && inner.success === false;
+      if (!res.ok || (json && json.success === false) || innerFailed) {
+        const errMsg = (innerFailed && inner.error) || json?.error || `Action "${targetName}" failed (HTTP ${res.status})`;
         if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
         // Surface the failure — this custom new-tab path bypasses
         // ActionRunner's toast-on-error, so otherwise the user gets no feedback.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1372,6 +1372,11 @@ const ar = {
     lookupPlaceholder: "لصق معرف السجل (UUID) لـ {{label}}",
     lookupHelpText: "أدخل معرف سجل الكائن المرجع. سيتم إضافة أداة اختيار قريباً.",
   },
+  actionConfirm: {
+    title: "تأكيد الإجراء",
+    confirm: "متابعة",
+    cancel: "إلغاء",
+  },
   rowAction: {
     openMenu: "فتح القائمة",
     edit: "تعديل",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1372,6 +1372,11 @@ const de = {
     lookupPlaceholder: "Datensatz-ID (UUID) für {{label}} einfügen",
     lookupHelpText: "Geben Sie die Datensatz-ID des referenzierten Objekts ein. Eine Auswahlhilfe kommt bald.",
   },
+  actionConfirm: {
+    title: "Aktion bestätigen",
+    confirm: "Weiter",
+    cancel: "Abbrechen",
+  },
   rowAction: {
     openMenu: "Menü öffnen",
     edit: "Bearbeiten",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1718,6 +1718,11 @@ const en = {
     defaultActionTitle: 'Action',
     ok: 'OK',
   },
+  actionConfirm: {
+    title: 'Confirm Action',
+    confirm: 'Continue',
+    cancel: 'Cancel',
+  },
   rowAction: {
     openMenu: 'Open menu',
     edit: 'Edit',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1372,6 +1372,11 @@ const es = {
     lookupPlaceholder: "Pegar ID de registro (UUID) para {{label}}",
     lookupHelpText: "Ingrese el ID del registro del objeto referenciado. Pronto se añadirá un selector.",
   },
+  actionConfirm: {
+    title: "Confirmar acción",
+    confirm: "Continuar",
+    cancel: "Cancelar",
+  },
   rowAction: {
     openMenu: "Abrir menú",
     edit: "Editar",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1372,6 +1372,11 @@ const fr = {
     lookupPlaceholder: "Coller l'ID d'enregistrement (UUID) pour {{label}}",
     lookupHelpText: "Entrez l'ID de l'enregistrement de l'objet référencé. Un sélecteur sera bientôt ajouté.",
   },
+  actionConfirm: {
+    title: "Confirmer l’action",
+    confirm: "Continuer",
+    cancel: "Annuler",
+  },
   rowAction: {
     openMenu: "Ouvrir le menu",
     edit: "Modifier",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1372,6 +1372,11 @@ const ja = {
     lookupPlaceholder: "{{label}} のレコードID（UUID）を貼り付け",
     lookupHelpText: "参照オブジェクトのレコードIDを入力してください。ピッカーは近日公開予定です。",
   },
+  actionConfirm: {
+    title: "操作の確認",
+    confirm: "続行",
+    cancel: "キャンセル",
+  },
   rowAction: {
     openMenu: "メニューを開く",
     edit: "編集",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1372,6 +1372,11 @@ const ko = {
     lookupPlaceholder: "{{label}}의 레코드 ID(UUID) 붙여넣기",
     lookupHelpText: "참조된 개체의 레코드 ID를 입력하세요. 선택기가 곧 추가됩니다.",
   },
+  actionConfirm: {
+    title: "작업 확인",
+    confirm: "계속",
+    cancel: "취소",
+  },
   rowAction: {
     openMenu: "메뉴 열기",
     edit: "편집",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1372,6 +1372,11 @@ const pt = {
     lookupPlaceholder: "Colar ID do registro (UUID) para {{label}}",
     lookupHelpText: "Insira o ID do registro do objeto referenciado. Um seletor será adicionado em breve.",
   },
+  actionConfirm: {
+    title: "Confirmar ação",
+    confirm: "Continuar",
+    cancel: "Cancelar",
+  },
   rowAction: {
     openMenu: "Abrir menu",
     edit: "Editar",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1372,6 +1372,11 @@ const ru = {
     lookupPlaceholder: "Вставить ID записи (UUID) для {{label}}",
     lookupHelpText: "Введите ID записи связанного объекта. Выбор записи будет добавлен позже.",
   },
+  actionConfirm: {
+    title: "Подтвердите действие",
+    confirm: "Продолжить",
+    cancel: "Отмена",
+  },
   rowAction: {
     openMenu: "Открыть меню",
     edit: "Редактировать",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1730,6 +1730,11 @@ const zh = {
     defaultActionTitle: '操作',
     ok: '确定',
   },
+  actionConfirm: {
+    title: '确认操作',
+    confirm: '继续',
+    cancel: '取消',
+  },
   rowAction: {
     openMenu: '更多操作',
     edit: '编辑',


### PR DESCRIPTION
## Summary

Two related fixes to the record-header **action** UX, both surfaced by a real project (a Chinese-locale deployment running an `申请转商机` script action):

### 1. Localize the action confirm dialog
`ActionConfirmDialog` hardcoded English defaults — `Confirm Action` / `Cancel` / `Continue`. An action that only sets `confirmText` (the message) still rendered an **English title and buttons** even under a `zh` locale, because the spec's `ActionSchema` has no structured `confirm: { title, cancelText }` field to override them.

Fix: route the defaults through i18n with new `actionConfirm.*` keys.
- `packages/app-shell/src/views/ActionConfirmDialog.tsx` — use `t('actionConfirm.title|confirm|cancel')`
- `packages/i18n/src/locales/{en,zh}.ts` — add the `actionConfirm` namespace (other locales fall back to `en`, so no regression)

### 2. Surface inner action failure instead of a false success toast
The action route wraps the handler return value as `{ success: true, data: <result> }`. When a script action **throws**, the runtime turns it into `data: { success: false, error: "...threw: ..." }` — so the response is:

```json
{ "success": true, "data": { "success": false, "error": "..." } }
```

The outer `success` stays `true`. The client's `handleServerAction` only checked the **outer** success, so a failed action was treated as a success: it fired the green *"Action completed successfully"* toast and **swallowed the real error**.

Fix: `packages/app-shell/src/views/RecordDetailView.tsx` — also inspect `json.data?.success === false` and surface `json.data.error`.

## Before / After
- **Before:** clicking an action whose script throws → green success toast, error hidden.
- **After:** red error toast with the real message (e.g. `线索信息不完整，提交转商机申请前请补全：营销人员`); confirm dialog renders title/buttons in the active locale.

## Notes
- No structured-`confirm` spec change needed; fix is purely in the console layer.
- Verified the live `@objectstack/console@9.7.0` bundle behavior matches the patched source.