### PR TITLE
fix(grid): paginate grouped view + share one horizontal scrollbar

### DIFF
--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -183,6 +183,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     showRowNumbers = false,
     showAddRow = false,
     borderless = false,
+    disableInnerScroll = false,
   } = schema;
 
   // i18n support for pagination labels
@@ -756,7 +757,13 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
           the table sits flush against its container without a floating
           right-edge gradient that looked odd without a surrounding border. */}
       <div className={cn(
-        "flex-1 min-h-0 overflow-auto relative bg-background [-webkit-overflow-scrolling:touch]",
+        "relative bg-background",
+        // When embedded in a shared scroll container (grouped grid), let the
+        // table overflow outward instead of creating its own scrollbar so all
+        // sub-tables share one horizontal scrollbar with aligned columns.
+        disableInnerScroll
+          ? "overflow-visible"
+          : "flex-1 min-h-0 overflow-auto [-webkit-overflow-scrolling:touch]",
         !borderless && "rounded-md border shadow-[inset_-8px_0_8px_-8px_rgba(0,0,0,0.08)]",
       )}>
         <Table>

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -33,7 +33,7 @@ import {
 } from '@object-ui/components';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { evaluatePlainCondition, buildExpandFields } from '@object-ui/core';
-import { ChevronRight, ChevronDown, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock } from 'lucide-react';
+import { ChevronRight, ChevronDown, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock } from 'lucide-react';
 import { useRowColor } from './useRowColor';
 import { useGroupedData } from './useGroupedData';
 import { GroupRow } from './GroupRow';
@@ -92,6 +92,9 @@ const GRID_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'grid.yes': 'Yes',
   'grid.no': 'No',
   'grid.systemFields': 'System',
+  // Reused by the grouped-view pager (falls back here when no I18nProvider).
+  'table.rowsPerPage': 'Rows per page',
+  'table.pageInfo': 'Page {{current}} of {{total}}',
 };
 
 /**
@@ -240,6 +243,12 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const [activeBulkDef, setActiveBulkDef] = useState<BulkActionDef | null>(null);
   const [activeBulkRows, setActiveBulkRows] = useState<any[]>([]);
   const lastFindParamsRef = React.useRef<Record<string, unknown> | null>(null);
+  // Grouped view paginates whole groups (groups stay intact, never split across
+  // pages). Defaults to the schema page size, falling back to 10 groups/page.
+  const [groupedPage, setGroupedPage] = useState(1);
+  const [groupedPageSize, setGroupedPageSize] = useState<number>(
+    (schema.pagination as any)?.pageSize ?? schema.pageSize ?? 10,
+  );
 
   // Sync internal rowHeightMode when schema.rowHeight prop changes (e.g., parent ListView density toggle)
   React.useEffect(() => {
@@ -651,6 +660,16 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     schema.aggregations,
     groupValueFormatter,
   );
+
+  // Reset grouped pagination to page 1 whenever the grouping config, page size
+  // or the underlying data changes (e.g. switching grouping field, reload).
+  const groupingKey = React.useMemo(
+    () => JSON.stringify(schema.grouping ?? null),
+    [schema.grouping],
+  );
+  React.useEffect(() => {
+    setGroupedPage(1);
+  }, [groupingKey, groupedPageSize, refreshKey]);
 
   // --- Column summary support ---
   const summaryColumns = React.useMemo(() => {
@@ -1556,6 +1575,28 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     },
   };
 
+  // Shared column widths for the grouped view. Each per-group sub-table would
+  // otherwise auto-size its columns from its own (often 1–2) rows, so columns
+  // never line up between groups and each group gets its own horizontal
+  // scrollbar. Pre-computing explicit widths from the FULL dataset (same
+  // heuristic as DataTable's autosize) keeps every group's columns aligned and
+  // lets them share ONE horizontal scrollbar provided by the wrapper below.
+  const groupedColumnWidths: Record<string, number | string> = {};
+  for (const col of orderedColumns as any[]) {
+    const key = col.accessorKey;
+    if (!key) continue;
+    const saved = columnState.widths?.[key];
+    if (saved) { groupedColumnWidths[key] = saved; continue; }
+    if (col.width) { groupedColumnWidths[key] = col.width; continue; }
+    let maxLen = String(col.header ?? '').length;
+    for (const row of data.slice(0, 50)) {
+      const v = row?.[key];
+      const len = v != null ? String(v).length : 0;
+      if (len > maxLen) maxLen = len;
+    }
+    groupedColumnWidths[key] = Math.min(400, Math.max(80, maxLen * 8 + 48));
+  }
+
   /** Build a per-group data-table schema (inherits everything except data & pagination). */
   const buildGroupTableSchema = (groupRows: any[]) => ({
     ...dataTableSchema,
@@ -1567,6 +1608,18 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     // Drop the table's outer rounded border so groups look like Airtable's
     // flat sub-tables rather than nested cards.
     borderless: true,
+    // Let every group's table overflow into the single shared horizontal
+    // scroll container (see grouped gridContent) instead of scrolling on its
+    // own — this restores a working x-axis scrollbar and aligned columns.
+    disableInnerScroll: true,
+    // Frozen columns rely on per-table sticky offsets that don't compose with
+    // the shared scroll container; disable them in grouped mode.
+    frozenColumns: 0,
+    // Pin explicit, shared widths so columns align across all groups.
+    columns: (dataTableSchema.columns as any[]).map((c: any) => ({
+      ...c,
+      width: groupedColumnWidths[c.accessorKey] ?? c.width,
+    })),
   });
 
   // Build record detail title
@@ -2015,8 +2068,63 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     );
   };
 
+  // Grouped pagination — paginate whole top-level groups so a group is never
+  // split across pages. Clamp the current page in case the group count shrank.
+  const totalGroupPages = Math.max(1, Math.ceil(groups.length / groupedPageSize));
+  const safeGroupedPage = Math.min(groupedPage, totalGroupPages);
+  const pagedGroups = groups.slice(
+    (safeGroupedPage - 1) * groupedPageSize,
+    safeGroupedPage * groupedPageSize,
+  );
+
+  const groupedPager = groups.length > 0 && totalGroupPages > 1 ? (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-2 px-3 sm:px-4 py-2 border-t">
+      <div className="flex items-center gap-2">
+        <span className="text-xs sm:text-sm text-muted-foreground">{t('table.rowsPerPage')}:</span>
+        <select
+          className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+          value={groupedPageSize}
+          onChange={(e) => { setGroupedPageSize(Number(e.target.value)); setGroupedPage(1); }}
+        >
+          {[5, 10, 20, 50, 100].map((n) => (
+            <option key={n} value={n}>{n}</option>
+          ))}
+        </select>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-xs sm:text-sm text-muted-foreground">
+          {t('table.pageInfo', { current: safeGroupedPage, total: totalGroupPages })}
+        </span>
+        <div className="flex items-center gap-1">
+          <Button variant="outline" size="icon" onClick={() => setGroupedPage(1)} disabled={safeGroupedPage === 1}>
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" onClick={() => setGroupedPage(Math.max(1, safeGroupedPage - 1))} disabled={safeGroupedPage === 1}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" onClick={() => setGroupedPage(Math.min(totalGroupPages, safeGroupedPage + 1))} disabled={safeGroupedPage === totalGroupPages}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" onClick={() => setGroupedPage(totalGroupPages)} disabled={safeGroupedPage === totalGroupPages}>
+            <ChevronsRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  ) : null;
+
   const gridContent = isGrouped ? (
-    <div className="space-y-4 px-3 sm:px-4 pt-2 pb-4">{groups.map(renderGroup)}</div>
+    <div className="flex flex-col h-full min-h-0">
+      {/* Single shared horizontal scroll container: every group's sub-table
+          overflows into this one scroller (disableInnerScroll), so columns
+          stay aligned and there is exactly one x-axis scrollbar. */}
+      <div className="flex-1 min-h-0 overflow-auto [-webkit-overflow-scrolling:touch]">
+        <div className="min-w-max space-y-4 px-3 sm:px-4 pt-2 pb-4">
+          {pagedGroups.map(renderGroup)}
+        </div>
+      </div>
+      {groupedPager}
+    </div>
   ) : (
     <>
       <SchemaRenderer schema={dataTableSchema} />

--- a/packages/plugin-grid/src/__tests__/groupedPagination.test.tsx
+++ b/packages/plugin-grid/src/__tests__/groupedPagination.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Grouped view pagination + shared horizontal scroll
+ *
+ * Regression coverage for the grouped list view bugs:
+ *   1. data shown incompletely (every group rendered at once, squeezed)
+ *   2. no pagination (groups never paginated)
+ *   3. no x-axis scrollbar (each group scrolled independently / not at all)
+ *
+ * The fix paginates whole top-level groups (a group never splits across a
+ * page) and wraps every per-group sub-table in ONE shared horizontal scroll
+ * container so columns stay aligned with a single x-axis scrollbar.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+// 25 rows, each with a unique `category` → 25 distinct top-level groups.
+const manyGroups = Array.from({ length: 25 }, (_, i) => ({
+  id: String(i + 1),
+  name: `Row ${i + 1}`,
+  category: `Cat ${String(i + 1).padStart(2, '0')}`,
+  amount: (i + 1) * 10,
+}));
+
+function renderGroupedGrid(opts?: Record<string, any>) {
+  const schema: any = {
+    type: 'object-grid' as const,
+    objectName: 'test_object',
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'amount', label: 'Amount', type: 'number' },
+    ],
+    data: { provider: 'value', items: manyGroups },
+    grouping: { fields: [{ field: 'category' }] },
+    ...opts,
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} />
+    </ActionProvider>
+  );
+}
+
+const groupRows = () =>
+  document.querySelectorAll('[data-testid^="group-row-"]');
+
+describe('Grouped view pagination', () => {
+  it('paginates top-level groups instead of rendering all at once', async () => {
+    renderGroupedGrid();
+    // Default page size falls back to 10 → first page shows 10 of 25 groups.
+    await waitFor(() => expect(groupRows().length).toBe(10));
+    expect(screen.getByText('Cat 01')).toBeInTheDocument();
+    expect(screen.queryByText('Cat 11')).not.toBeInTheDocument();
+  });
+
+  it('renders a pager with page info when there is more than one page', async () => {
+    renderGroupedGrid();
+    await waitFor(() => expect(groupRows().length).toBe(10));
+    // 25 groups / 10 per page = 3 pages.
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+    expect(screen.getByText('Rows per page:')).toBeInTheDocument();
+  });
+
+  it('advances to the next page of groups when clicking next', async () => {
+    renderGroupedGrid();
+    await waitFor(() => expect(screen.getByText('Page 1 of 3')).toBeInTheDocument());
+
+    // The "next" chevron is the 3rd of the 4 nav buttons (first, prev, next, last).
+    const navButtons = screen
+      .getByText('Page 1 of 3')
+      .parentElement!.querySelectorAll('button');
+    expect(navButtons.length).toBe(4);
+    fireEvent.click(navButtons[2]); // next
+
+    await waitFor(() => expect(screen.getByText('Page 2 of 3')).toBeInTheDocument());
+    expect(screen.getByText('Cat 11')).toBeInTheDocument();
+    expect(screen.queryByText('Cat 01')).not.toBeInTheDocument();
+    expect(groupRows().length).toBe(10);
+  });
+
+  it('shows the last (partial) page of groups', async () => {
+    renderGroupedGrid();
+    await waitFor(() => expect(screen.getByText('Page 1 of 3')).toBeInTheDocument());
+
+    const navButtons = screen
+      .getByText('Page 1 of 3')
+      .parentElement!.querySelectorAll('button');
+    fireEvent.click(navButtons[3]); // last
+
+    await waitFor(() => expect(screen.getByText('Page 3 of 3')).toBeInTheDocument());
+    // 25 = 10 + 10 + 5 → last page has the remaining 5 groups.
+    expect(groupRows().length).toBe(5);
+    expect(screen.getByText('Cat 25')).toBeInTheDocument();
+  });
+
+  it('changing page size repaginates and resets to page 1', async () => {
+    renderGroupedGrid();
+    await waitFor(() => expect(screen.getByText('Page 1 of 3')).toBeInTheDocument());
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    fireEvent.change(select, { target: { value: '20' } });
+
+    // 25 / 20 = 2 pages, page reset to 1, first page shows 20 groups.
+    await waitFor(() => expect(screen.getByText('Page 1 of 2')).toBeInTheDocument());
+    expect(groupRows().length).toBe(20);
+  });
+
+  it('does not render a pager when groups fit on a single page', async () => {
+    renderGroupedGrid({ pagination: { pageSize: 100 } });
+    await waitFor(() => expect(groupRows().length).toBe(25));
+    expect(screen.queryByText(/^Page \d+ of \d+$/)).not.toBeInTheDocument();
+  });
+
+  it('wraps grouped tables in a single shared horizontal scroll container', async () => {
+    const { container } = renderGroupedGrid();
+    await waitFor(() => expect(groupRows().length).toBe(10));
+    // One shared overflow scroller whose inner track is min-w-max so every
+    // sub-table overflows into the SAME x-axis scrollbar.
+    const innerTrack = container.querySelector('.min-w-max');
+    expect(innerTrack).toBeTruthy();
+    const scroller = innerTrack!.parentElement!;
+    expect(scroller.className).toContain('overflow-auto');
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -310,6 +310,15 @@ export interface DataTableSchema extends BaseSchema {
    */
   borderless?: boolean;
   /**
+   * Drop the table's own horizontal/vertical scroll container so the table
+   * overflows into a shared parent scroll container instead. Used by the
+   * grouped grid so every per-group sub-table participates in ONE shared
+   * horizontal scrollbar (and keeps columns aligned) rather than each group
+   * scrolling independently.
+   * @default false
+   */
+  disableInnerScroll?: boolean;
+  /**
    * Table caption
    */
   caption?: string;


### PR DESCRIPTION
## Problem

When grouping is enabled in the list view, three bugs appear:

1. **Data shown incompletely** — every group rendered as its own table at once, columns squeezed.
2. **No pagination** — groups were never paginated.
3. **No x-axis scrollbar** — each group sized/scrolled independently (or not at all), columns never aligned.

Reported on the MTC `mtc_lead` list (75+ groups), but the bug is generic to any grouped `ObjectGrid`.

## Fix

- **Paginate whole top-level groups** — a group is never split across a page. Reuses the schema page size (fallback 10) with a chevron pager (first / prev / next / last) + a page-size selector. Resets to page 1 when grouping config, page size, or data changes.
- **One shared horizontal scrollbar** — pre-compute shared column widths from the full dataset (same heuristic as DataTable autosize) and wrap every per-group sub-table in a single `overflow-auto` + `min-w-max` container, so columns align and there's exactly one x-axis scrollbar.
- **New `DataTableSchema.disableInnerScroll`** — lets a sub-table overflow into the shared scroller instead of creating its own. Frozen columns are disabled in grouped mode (their sticky offsets don't compose with the shared scroller). Flat (non-grouped) view behavior is unchanged — all changes are gated behind this flag.
- **i18n** — reuses existing `table.rowsPerPage` / `table.pageInfo` keys (also added to the grid's no-provider fallback map). No new locale keys.

## Tests

`packages/plugin-grid/src/__tests__/groupedPagination.test.tsx` — 7 cases rendering the real `ObjectGrid`:
- first page shows N of M groups (rest not in DOM)
- pager + page info render when >1 page
- next / last navigation swaps the rendered groups
- last page shows the partial remainder
- changing page size repaginates and resets to page 1
- no pager when all groups fit one page
- grouped tables are wrapped in one shared `overflow-auto` + `min-w-max` scroll container

Full `@object-ui/plugin-grid` suite: 66 passing. `types`, `components`, `plugin-grid` all build clean.