### PR TITLE
feat(app-shell): render full object forms (incl. master-detail) in screen-flow wizard steps

### DIFF
--- a/.changeset/flow-object-form-screen.md
+++ b/.changeset/flow-object-form-screen.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/app-shell": minor
+"@object-ui/plugin-form": minor
+"@object-ui/fields": minor
+"@object-ui/data-objectstack": minor
+---
+
+feat(app-shell): render full object forms (incl. master-detail) in screen-flow wizard steps
+
+`FlowRunner` now renders an `object-form` screen step: when the paused screen
+carries `kind: 'object-form'`, it mounts the real `<ObjectForm>` for the named
+object (auto-routing to `MasterDetailForm` for inline child collections),
+prefilled from the step's `defaults`. The form persists itself (atomic
+master-detail batch), then resumes the run with the saved record id bound to the
+step's `idVariable`. `dataSource`/`objects` are threaded through all three
+`FlowRunner` mount points.
+
+Also fixes three pre-existing bugs this surfaced (each affects normal forms too):
+
+- **plugin-form**: `ObjectForm` now forwards `initialValues`/`initialData` when
+  routing to `MasterDetailForm`, so prefilled header values are no longer
+  dropped on master-detail create forms.
+- **fields**: `PercentField` treated values as `0–1` fractions (`value × 100`),
+  so a `0–100` field (e.g. `probability` default `50`) rendered as `5000%` —
+  exceeding `max=100`, which makes HTML5 constraint validation mark the field
+  `:invalid` and silently block the whole form's submit. It now treats a field
+  declaring `max > 1` as the `0–100` whole-number convention, matching the
+  read-side formatter.
+- **data-objectstack**: `ObjectStackAdapter.batchTransaction` now sends
+  `credentials: 'include'`, so master-detail batch saves authenticate under the
+  console's cookie session (previously every batch save 401'd).

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -507,6 +507,8 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
         state={screenFlow}
         authFetch={authFetch}
         baseUrl={import.meta.env.VITE_SERVER_URL || ''}
+        dataSource={dataSource}
+        objects={objects}
         onClose={() => setScreenFlow(null)}
         onComplete={() => { setScreenFlow(null); refresh(); }}
       />

--- a/packages/app-shell/src/views/FlowRunner.tsx
+++ b/packages/app-shell/src/views/FlowRunner.tsx
@@ -29,6 +29,7 @@ import {
   SelectContent,
   SelectItem,
 } from '@object-ui/components';
+import { ObjectForm } from '@object-ui/plugin-form';
 import { toast } from 'sonner';
 
 export interface ScreenFieldSpec {
@@ -45,6 +46,18 @@ export interface ScreenSpec {
   title?: string;
   description?: string;
   fields: ScreenFieldSpec[];
+  /**
+   * `'object-form'` renders the named object's FULL create/edit form — incl.
+   * inline master-detail child grids — as a wizard step (vs. the flat `fields`
+   * list). The form persists the record (and its children, atomically) itself,
+   * then resumes the run with the saved id bound to `idVariable`.
+   */
+  kind?: 'fields' | 'object-form';
+  objectName?: string;
+  mode?: 'create' | 'edit';
+  recordId?: string;
+  defaults?: Record<string, unknown>;
+  idVariable?: string;
 }
 export interface ScreenFlowState {
   flowName: string;
@@ -63,6 +76,17 @@ export interface FlowRunnerProps {
   onClose: () => void;
   /** The flow ran to completion — host should refresh. */
   onComplete: () => void;
+  /**
+   * Data source — required to render `object-form` wizard steps. ObjectForm
+   * fetches the object schema and persists (incl. atomic master-detail batch)
+   * through this adapter.
+   */
+  dataSource?: any;
+  /**
+   * Object definitions — used to derive an `object-form` step's inline
+   * master-detail `subforms` (mirrors RecordFormPage's create form).
+   */
+  objects?: any[];
 }
 
 function initialValues(screen: ScreenSpec): Record<string, unknown> {
@@ -71,7 +95,7 @@ function initialValues(screen: ScreenSpec): Record<string, unknown> {
   return v;
 }
 
-export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete }: FlowRunnerProps) {
+export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dataSource, objects }: FlowRunnerProps) {
   const [screen, setScreen] = useState<ScreenSpec | null>(null);
   const [runId, setRunId] = useState('');
   const [flowName, setFlowName] = useState('');
@@ -91,6 +115,44 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete }: F
 
   const setVal = (name: string, v: unknown) => setValues((p) => ({ ...p, [name]: v }));
 
+  // Resume the paused run with `inputs` (applied as bare flow variables) and
+  // advance: render the next screen (multi-step wizard) or finish + refresh.
+  // Shared by the flat-field submit and the object-form save callback.
+  const resumeWith = async (inputs: Record<string, unknown>): Promise<void> => {
+    const res = await authFetch(
+      `${baseUrl}/api/v1/automation/${encodeURIComponent(flowName)}/runs/${encodeURIComponent(runId)}/resume`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ inputs }) },
+    );
+    const json = await res.json().catch(() => null);
+    if (!res.ok || json?.success === false) {
+      // Transport / envelope failure — possibly transient (network, 5xx), so
+      // keep the dialog open and let the user retry the same run.
+      toast.error(json?.error || `Resume failed (HTTP ${res.status})`);
+      return;
+    }
+    const data = json?.data ?? {};
+    // The HTTP envelope is `{ success:true, data: AutomationResult }`; a flow
+    // that errored downstream surfaces as `data.success === false`. That is
+    // TERMINAL: the engine consumes the suspension before running downstream
+    // nodes (resume-once), so this run can never be resumed again — a retry
+    // would only hit "No suspended run". Close the runner instead of leaving
+    // a dead form open.
+    if (data.success === false || data.status === 'failed') {
+      toast.error(data.error || 'The flow failed to complete.');
+      onClose();
+      return;
+    }
+    if (data.status === 'paused' && data.screen) {
+      setScreen(data.screen);
+      setRunId(data.runId || runId);
+      setValues(initialValues(data.screen));
+      toast.success('Saved — next step');
+    } else {
+      toast.success('Done');
+      onComplete();
+    }
+  };
+
   const submit = async () => {
     const missing = screen.fields.filter(
       (f) => f.required && (values[f.name] === undefined || values[f.name] === '' || values[f.name] === null),
@@ -101,38 +163,7 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete }: F
     }
     setSubmitting(true);
     try {
-      const res = await authFetch(
-        `${baseUrl}/api/v1/automation/${encodeURIComponent(flowName)}/runs/${encodeURIComponent(runId)}/resume`,
-        { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ inputs: values }) },
-      );
-      const json = await res.json().catch(() => null);
-      if (!res.ok || json?.success === false) {
-        // Transport / envelope failure — possibly transient (network, 5xx), so
-        // keep the dialog open and let the user retry the same run.
-        toast.error(json?.error || `Resume failed (HTTP ${res.status})`);
-        return;
-      }
-      const data = json?.data ?? {};
-      // The HTTP envelope is `{ success:true, data: AutomationResult }`; a flow
-      // that errored downstream surfaces as `data.success === false`. That is
-      // TERMINAL: the engine consumes the suspension before running downstream
-      // nodes (resume-once), so this run can never be resumed again — a retry
-      // would only hit "No suspended run". Close the runner instead of leaving
-      // a dead form open.
-      if (data.success === false || data.status === 'failed') {
-        toast.error(data.error || 'The flow failed to complete.');
-        onClose();
-        return;
-      }
-      if (data.status === 'paused' && data.screen) {
-        setScreen(data.screen);
-        setRunId(data.runId || runId);
-        setValues(initialValues(data.screen));
-        toast.success('Saved — next step');
-      } else {
-        toast.success('Done');
-        onComplete();
-      }
+      await resumeWith(values);
     } catch (err) {
       toast.error((err as Error).message);
     } finally {
@@ -140,30 +171,91 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete }: F
     }
   };
 
+  // Object-form step: ObjectForm has already persisted the record (and its
+  // children, atomically). Resume the run with the new record's id bound to the
+  // step's `idVariable` so later steps can reference it (e.g. the Opportunity
+  // form's `account` FK = the Customer step's new id).
+  const onObjectFormSaved = async (saved: any) => {
+    const id = saved?.id ?? saved?.data?.id ?? saved?.record?.id;
+    const inputs = screen.idVariable && id != null ? { [screen.idVariable]: id } : {};
+    setSubmitting(true);
+    try {
+      await resumeWith(inputs);
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isObjectForm = screen.kind === 'object-form' && !!screen.objectName;
+  const objectDef = isObjectForm && Array.isArray(objects)
+    ? objects.find((o: any) => o?.name === screen.objectName)
+    : undefined;
+  const subforms = objectDef
+    ? ((objectDef as any).form?.subforms ?? (objectDef as any).formViews?.default?.subforms)
+    : undefined;
+
   return (
     <Dialog open onOpenChange={(o) => { if (!o && !submitting) onClose(); }}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className={isObjectForm ? 'sm:max-w-3xl max-h-[90vh] overflow-y-auto' : 'sm:max-w-md'}>
         <DialogHeader>
           <DialogTitle>{screen.title || 'Input'}</DialogTitle>
           {screen.description && <DialogDescription>{screen.description}</DialogDescription>}
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
-          {screen.fields.map((f) => (
-            <div key={f.name} className="space-y-1.5">
-              <Label htmlFor={`ff-${f.name}`} className="text-sm">
-                {f.label || f.name}
-                {f.required && <span className="text-destructive"> *</span>}
-              </Label>
-              <FieldInput field={f} value={values[f.name]} onChange={(v) => setVal(f.name, v)} />
+        {isObjectForm ? (
+          // Full object create/edit form (with inline master-detail grids). The
+          // form owns its own Save/Cancel bar; on save it persists and calls
+          // onObjectFormSaved, which resumes the run to the next step.
+          <div className="py-2">
+            {dataSource ? (
+              <ObjectForm
+                key={screen.nodeId}
+                schema={{
+                  type: 'object-form',
+                  formType: 'simple',
+                  objectName: screen.objectName!,
+                  mode: screen.mode === 'edit' ? 'edit' : 'create',
+                  recordId: screen.mode === 'edit' ? screen.recordId : undefined,
+                  ...(screen.defaults ? { initialValues: screen.defaults } : {}),
+                  layout: 'vertical',
+                  subforms,
+                  onSuccess: onObjectFormSaved,
+                  onCancel: onClose,
+                  showSubmit: true,
+                  showCancel: true,
+                  submitText: 'Save & Continue',
+                  cancelText: 'Cancel',
+                } as any}
+                dataSource={dataSource}
+              />
+            ) : (
+              <div className="text-sm text-destructive py-4">
+                This step renders an object form but no data source is available.
+              </div>
+            )}
+          </div>
+        ) : (
+          <>
+            <div className="space-y-4 py-2">
+              {screen.fields.map((f) => (
+                <div key={f.name} className="space-y-1.5">
+                  <Label htmlFor={`ff-${f.name}`} className="text-sm">
+                    {f.label || f.name}
+                    {f.required && <span className="text-destructive"> *</span>}
+                  </Label>
+                  <FieldInput field={f} value={values[f.name]} onChange={(v) => setVal(f.name, v)} />
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
-          <Button onClick={submit} disabled={submitting}>{submitting ? 'Submitting…' : 'Submit'}</Button>
-        </DialogFooter>
+            <DialogFooter>
+              <Button variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
+              <Button onClick={submit} disabled={submitting}>{submitting ? 'Submitting…' : 'Submit'}</Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1810,6 +1810,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           state={screenFlow}
           authFetch={authFetch}
           baseUrl={import.meta.env.VITE_SERVER_URL || ''}
+          dataSource={dataSource}
+          objects={objects}
           onClose={() => setScreenFlow(null)}
           onComplete={() => { setScreenFlow(null); setActionRefreshKey(k => k + 1); }}
         />
@@ -1919,6 +1921,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         state={screenFlow}
         authFetch={authFetch}
         baseUrl={import.meta.env.VITE_SERVER_URL || ''}
+        dataSource={dataSource}
+        objects={objects}
         onClose={() => setScreenFlow(null)}
         onComplete={() => { setScreenFlow(null); setActionRefreshKey(k => k + 1); }}
       />

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -870,6 +870,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },
+      // Send the session cookie too: in the browser console auth is cookie-based
+      // (no bearer `token`), so without `credentials: 'include'` this raw fetch
+      // is unauthenticated — every master-detail batch save would 401. Bearer
+      // (server-to-server) and cookie (console) auth now both work.
+      credentials: 'include',
       body: JSON.stringify({ operations }),
     });
     if (!response.ok) {

--- a/packages/fields/src/widgets/PercentField.tsx
+++ b/packages/fields/src/widgets/PercentField.tsx
@@ -11,18 +11,30 @@ export function PercentField({ value, onChange, field, readonly, errorMessage, c
   const percentField = (field || (props as any).schema) as any;
   const precision = percentField?.precision ?? 2;
 
+  // Convention detection. A field declaring `max > 1` (e.g. `max: 100`) stores
+  // WHOLE-NUMBER percents (0–100); otherwise values are FRACTIONS (0–1) shown
+  // as 0–100%. This matches the read-side formatter so the edit widget agrees
+  // with display — and, crucially, keeps the rendered <input> within its `max`
+  // (a whole-number 50 must show "50", not "5000", or HTML5 constraint
+  // validation marks the field `:invalid` and blocks the whole form's submit).
+  const maxAttr = typeof percentField?.max === 'number' ? (percentField.max as number) : undefined;
+  const whole = maxAttr != null && maxAttr > 1;
+  const toDisplay = (v: number) => (whole ? v : v * 100);
+  const fromDisplay = (n: number) => (whole ? n : n / 100);
+  const sliderMax = whole ? maxAttr! : 100;
+
   if (readonly) {
     if (value == null) return <EmptyValue />;
     return (
       <span className="text-sm font-medium tabular-nums">
-        {(value * 100).toFixed(precision)}%
+        {toDisplay(value).toFixed(precision)}%
       </span>
     );
   }
 
-  // Convert between stored value (0-1) and display value (0-100)
-  const displayValue = value != null ? (value * 100) : '';
-  const sliderValue = value != null ? value * 100 : 0;
+  // Convert between stored value and 0–100 display value
+  const displayValue = value != null ? toDisplay(value) : '';
+  const sliderValue = value != null ? toDisplay(value) : 0;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value === '') {
@@ -30,7 +42,7 @@ export function PercentField({ value, onChange, field, readonly, errorMessage, c
       return;
     }
     const parsed = parseFloat(e.target.value);
-    const val = isNaN(parsed) ? null : parsed / 100;
+    const val = isNaN(parsed) ? null : fromDisplay(parsed);
     onChange(val as any);
   };
 
@@ -41,7 +53,7 @@ export function PercentField({ value, onChange, field, readonly, errorMessage, c
       return;
     }
     const raw = values[0];
-    const nextValue = typeof raw === 'number' ? raw / 100 : null;
+    const nextValue = typeof raw === 'number' ? fromDisplay(raw) : null;
     onChange(nextValue as any);
   };
 
@@ -70,7 +82,7 @@ export function PercentField({ value, onChange, field, readonly, errorMessage, c
         value={[sliderValue]}
         onValueChange={handleSliderChange}
         min={0}
-        max={100}
+        max={sliderMax}
         step={sliderStep}
         disabled={readonly || props.disabled}
         className="w-full"

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -69,6 +69,10 @@ export interface MasterDetailFormSchema {
   objectName: string;
   mode?: 'create' | 'edit';
   recordId?: string;
+  /** Prefilled parent header values (create mode) — seeds the parent form's
+   *  initial values, e.g. a conversion wizard carrying the lead/account over. */
+  initialValues?: Record<string, any>;
+  initialData?: Record<string, any>;
   /** Parent form sections/fields — passed straight through to ObjectForm. */
   sections?: any[];
   fields?: any[];
@@ -573,6 +577,10 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
       objectName: schema.objectName,
       mode: schema.mode ?? 'create',
       recordId: schema.recordId,
+      // Carry prefilled header values into the parent form (create-mode
+      // wizards, e.g. lead conversion prefilling name/account).
+      initialValues: schema.initialValues,
+      initialData: schema.initialData,
       formType: schema.formType,
       sections: schema.sections,
       fields: schema.fields,

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -115,6 +115,10 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
           objectName: schema.objectName,
           mode: schema.mode === 'edit' ? 'edit' : 'create',
           recordId: schema.recordId,
+          // Forward prefilled header values so create-mode wizards (e.g. lead
+          // conversion) seed the parent fields, not just plain forms.
+          initialValues: (schema as any).initialValues,
+          initialData: (schema as any).initialData,
           formType: schema.formType === 'tabbed' ? 'tabbed' : 'simple',
           sections: schema.sections as any,
           fields: schema.fields as any,


### PR DESCRIPTION
## What

`FlowRunner` can now render an **`object-form` screen-flow step**: when a paused screen carries `kind: 'object-form'`, it mounts the real `<ObjectForm>` for the named object (auto-routing to `MasterDetailForm` when the object declares inline child collections), prefilled from the step's `defaults`. The form persists itself (atomic master-detail batch), then resumes the run with the saved record id bound to the step's `idVariable`.

This is the renderer half of the master-detail **lead → customer + opportunity conversion wizard** (framework companion PR `feat/master-detail-convert-wizard`). `dataSource` / `objects` are now threaded through all three `FlowRunner` mount points (`RecordDetailView` ×2, `useConsoleActionRuntime`).

## Pre-existing bugs fixed (each breaks normal forms too, not just the wizard)

1. **Master-detail prefill dropped** — `ObjectForm` didn't forward `initialValues` / `initialData` when routing to `MasterDetailForm`, so prefilled header values were lost on any master-detail create form. Now forwarded through `ObjectForm` → `MasterDetailForm` → parent form.

2. **PercentField blocked form submit** — the widget assumed values are `0–1` fractions (`value × 100`), so a `0–100` field (e.g. `probability` default `50`) rendered as **5000%**. That exceeds the input's `max=100`, so HTML5 constraint validation marks the field `:invalid` and **silently blocks the entire form's submit** (button click / `requestSubmit` become no-ops). Now treats a field declaring `max > 1` as the `0–100` whole-number convention, matching the read-side formatter. Fixes submit for *any* form containing a 0–100 percent field.

3. **batchTransaction unauthenticated under cookie sessions** — `ObjectStackAdapter.batchTransaction` did a raw `fetch` without `credentials: 'include'`. The browser console authenticates by cookie (no bearer `token`), so every master-detail batch save `401`'d. Now sends the session cookie; bearer (server-to-server) and cookie (console) auth both work.

## Verification

End-to-end in the console against `app-crm`: the conversion wizard renders both full forms with prefill carryover and the live product line-item grid, and the final Save persists the opportunity + line item atomically and completes the flow. Changes run clean through the console's Vite dev build (workspace `@object-ui/*` aliased to `src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
