### PR TITLE
feat: action/flow completion messaging (silent handoff + flow success/error toast)

### DIFF
--- a/.changeset/flow-action-messages.md
+++ b/.changeset/flow-action-messages.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/core": minor
+"@object-ui/app-shell": minor
+---
+
+feat: action/flow completion messaging
+
+- **core**: `ActionResult.silent` — a handler sets it when the action only
+  HANDED OFF to a follow-up UI (rather than completing), so `ActionRunner`
+  skips the automatic success toast. Fixes the misleading "Action completed
+  successfully" toast that fired the moment a `flow` action opened its wizard.
+- **app-shell**: both flow handlers now return `silent: true` when the flow
+  pauses at a screen (the wizard only opened — it hasn't completed). `FlowRunner`
+  renders the flow's declared `successMessage` / `errorMessage` (from the
+  terminal `AutomationResult`) instead of a generic "Done" / the raw error.

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -316,7 +316,9 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       const data = json?.data ?? {};
       if (data.status === 'paused' && data.screen) {
         setScreenFlow({ flowName, runId: data.runId, screen: data.screen });
-        return { success: true };
+        // The action only OPENED the wizard — it hasn't completed. Suppress the
+        // action-level success toast; the flow-runner owns completion messaging.
+        return { success: true, silent: true };
       }
       const shouldRefresh = action.refreshAfter !== false;
       if (shouldRefresh) refresh();

--- a/packages/app-shell/src/views/FlowRunner.tsx
+++ b/packages/app-shell/src/views/FlowRunner.tsx
@@ -138,7 +138,8 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
     // would only hit "No suspended run". Close the runner instead of leaving
     // a dead form open.
     if (data.success === false || data.status === 'failed') {
-      toast.error(data.error || 'The flow failed to complete.');
+      // Prefer the flow's friendly `errorMessage`; fall back to the raw error.
+      toast.error(data.errorMessage || data.error || 'The flow failed to complete.');
       onClose();
       return;
     }
@@ -148,7 +149,8 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
       setValues(initialValues(data.screen));
       toast.success('Saved — next step');
     } else {
-      toast.success('Done');
+      // Terminal success — show the flow's declared completion message.
+      toast.success(data.successMessage || 'Done');
       onComplete();
     }
   };

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -435,7 +435,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       const data = json?.data ?? {};
       if (data.status === 'paused' && data.screen) {
         setScreenFlow({ flowName, runId: data.runId, screen: data.screen });
-        return { success: true };
+        // The action only OPENED the wizard — it hasn't completed. Suppress the
+        // action-level success toast; the flow-runner owns completion messaging.
+        return { success: true, silent: true };
       }
       const shouldRefresh = action.refreshAfter !== false;
       if (shouldRefresh) {

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -26,6 +26,14 @@ export interface ActionResult {
   redirect?: string;
   /** Modal schema to render (for type: 'modal') */
   modal?: any;
+  /**
+   * Suppress the automatic success toast for this result. A handler sets this
+   * when the action only HANDED OFF to a follow-up UI rather than completing —
+   * e.g. a `flow` action that paused at a screen and opened the flow-runner. The
+   * action hasn't "completed yet", so a "success" toast on open would be
+   * misleading; the follow-up surface owns its own completion messaging.
+   */
+  silent?: boolean;
 }
 
 export interface ActionContext {
@@ -529,7 +537,7 @@ export class ActionRunner {
       const showToast = action.toast ?? { showOnSuccess: true, showOnError: true };
       const duration = action.toast?.duration;
 
-      if (result.success && !hasResultDialog && showToast.showOnSuccess !== false) {
+      if (result.success && !hasResultDialog && !result.silent && showToast.showOnSuccess !== false) {
         // Prefer a DYNAMIC message the server returned (result.data.message)
         // over the static action.successMessage. Server-driven actions like
         // check_app_updates / publish / install compute a real outcome


### PR DESCRIPTION
## What

The companion UI half of the action/flow completion-messaging improvements (framework PR `feat/action-flow-messages`).

### 1. Stop the misleading "Action completed successfully" toast
A `flow` action that pauses at a screen only OPENS its wizard — it hasn't completed — yet the action runner fired a success toast immediately on open. Added `ActionResult.silent`; `ActionRunner` skips the auto success toast when set, and both flow handlers now return `silent: true` on flow pause. The wizard's own completion drives the messaging.

### 2. Render the flow's declared completion / error message
`FlowRunner` now shows the flow's `successMessage` / `errorMessage` (carried on the terminal `AutomationResult`) instead of a generic "Done" / the raw error.

## Changes
- **core**: `ActionResult.silent`; `ActionRunner` honours it (skips success toast).
- **app-shell**: `RecordDetailView` + `useConsoleActionRuntime` flow handlers return `silent: true` on pause; `FlowRunner` renders `data.successMessage` / `data.errorMessage`.

## Verification
Browser E2E (console + app-crm): triggering Convert Lead no longer shows "Action completed successfully" on open; completing the wizard shows the flow's custom "🎉 Lead converted…" toast. Runs clean through the console Vite dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
