### PR TITLE
feat: action progress state + Undo affordance

### DIFF
--- a/.changeset/action-progress-undo.md
+++ b/.changeset/action-progress-undo.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/core": minor
+"@object-ui/app-shell": minor
+"@object-ui/plugin-detail": minor
+---
+
+feat: action progress state + Undo affordance
+
+- **core**: `ActionResult.undo` (an `UndoableOperation`) and `ActionDef.undoable`.
+  On success the `ActionRunner` pushes the operation onto the global UndoManager
+  and the success toast carries an "Undo" affordance (`ToastHandler` gains an
+  `undo` option).
+- **app-shell**: the console action runtime mounts `useGlobalUndo` (Ctrl+Z /
+  Ctrl+Shift+Z) and renders the toast's "Undo" button; its `apiHandler` resolves
+  the row id from the list row record and, for `undoable` actions, captures the
+  changed fields' prior values so the update can be reverted.
+- **plugin-detail**: record-header quick-action buttons show a spinner + disable
+  while the action runs (a visible progress state for slow/flow actions).

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -25,7 +25,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth, createAuthenticatedFetch } from '@object-ui/auth';
 import { useObjectLabel } from '@object-ui/i18n';
-import { ActionProvider } from '@object-ui/react';
+import { ActionProvider, useGlobalUndo } from '@object-ui/react';
 import { toast } from 'sonner';
 import type {
   ActionContext,
@@ -99,6 +99,14 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
 
   const refresh = useCallback(() => { onRefresh?.(); }, [onRefresh]);
 
+  // Global undo/redo (Ctrl+Z / Ctrl+Shift+Z), backed by the dataSource. The
+  // success toast's "Undo" button calls `undoCtl.undo()` for `undoable` actions
+  // (the ActionRunner has already pushed the operation onto the UndoManager).
+  const undoCtl = useGlobalUndo({
+    dataSource,
+    onUndo: () => { refresh(); toast.success('Change undone'); },
+  });
+
   // Promise-based confirm / param / result dialogs.
   const [confirmState, setConfirmState] = useState<ConfirmDialogState>({ open: false, message: '' });
   const [paramState, setParamState] = useState<ParamDialogState>({ open: false, params: [] });
@@ -163,9 +171,16 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     : FALLBACK_USER;
 
   const toastHandler = useCallback<ToastHandler>((message, options) => {
-    if (options?.type === 'error') toast.error(message);
-    else toast.success(message);
-  }, []);
+    if (options?.type === 'error') { toast.error(message); return; }
+    if (options?.undo) {
+      toast.success(message, {
+        duration: options.duration,
+        action: { label: options.undo.label || 'Undo', onClick: () => { void undoCtl.undo(); } },
+      });
+      return;
+    }
+    toast.success(message, { duration: options?.duration });
+  }, [undoCtl]);
 
   const navigateHandler = useCallback<NavigationHandler>((url, options) => {
     if (options?.external || options?.newTab) {
@@ -252,15 +267,43 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       // meaningful when an object context exists (ObjectView); pages without an
       // object resolve their actions through the absolute path above.
       const obj = action.objectName || objApiName;
+      // The row record is stashed under `_rowRecord` for list_item actions —
+      // separate it from the field values, and resolve the record id from it
+      // (the action's static params carry the field changes, not the id).
+      const rowRecord = (params as any)._rowRecord as Record<string, any> | undefined;
+      const fields: Record<string, any> = { ...(params as Record<string, any>) };
+      delete fields._rowRecord;
+      const recId = fields.recordId ?? rowRecord?.[(action as any).recordIdField || 'id'];
+      delete fields.recordId;
+
       if (obj && typeof dataSource?.execute === 'function') {
-        await dataSource.execute(obj, target, params);
-      } else if (obj && (params as any).recordId && Object.keys(params).length > 1 && typeof dataSource?.update === 'function') {
-        await dataSource.update(obj, (params as any).recordId, params);
+        await dataSource.execute(obj, target, fields);
+      } else if (obj && recId && Object.keys(fields).length > 0 && typeof dataSource?.update === 'function') {
+        await dataSource.update(obj, recId, fields);
+      }
+
+      // Undoable single-record update: capture the prior values of the changed
+      // fields from the row record so the success toast can offer "Undo".
+      let undo: ActionResult['undo'];
+      if (action.undoable && obj && recId && rowRecord && Object.keys(fields).length > 0
+          && typeof dataSource?.update === 'function') {
+        const undoData: Record<string, unknown> = {};
+        for (const k of Object.keys(fields)) undoData[k] = rowRecord[k] ?? null;
+        undo = {
+          id: `undo-${obj}-${recId}-${Date.now()}`,
+          type: 'update',
+          objectName: obj,
+          recordId: String(recId),
+          timestamp: Date.now(),
+          description: action.label || `Undo ${obj}`,
+          undoData,
+          redoData: { ...fields },
+        };
       }
 
       const shouldRefresh = action.refreshAfter !== false;
       if (shouldRefresh) refresh();
-      return { success: true, reload: shouldRefresh };
+      return { success: true, reload: shouldRefresh, undo };
     } catch (error) {
       return { success: false, error: (error as Error).message };
     }

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -16,6 +16,7 @@
  */
 
 import { ExpressionEvaluator } from '../evaluator/ExpressionEvaluator';
+import { globalUndoManager, type UndoableOperation } from './UndoManager';
 
 export interface ActionResult {
   success: boolean;
@@ -34,6 +35,12 @@ export interface ActionResult {
    * misleading; the follow-up surface owns its own completion messaging.
    */
   silent?: boolean;
+  /**
+   * An undoable operation captured by the handler (e.g. an `undoable` update
+   * action's prior field values). When present, the runner pushes it onto the
+   * global UndoManager and the success toast offers an "Undo" affordance.
+   */
+  undo?: UndoableOperation;
 }
 
 export interface ActionContext {
@@ -107,6 +114,8 @@ export interface ActionDef {
   errorMessage?: string;
   /** Whether to refresh data after execution (from UIActionSchema) */
   refreshAfter?: boolean;
+  /** Single-record update actions: offer an Undo affordance on success. */
+  undoable?: boolean;
   /** Params object (for custom handlers) */
   params?: Record<string, any>;
   /** ActionParam definitions to collect from user before execution (from spec ActionSchema.params) */
@@ -166,6 +175,9 @@ export type ConfirmationHandler = (message: string, options?: {
 export type ToastHandler = (message: string, options?: {
   type?: 'success' | 'error' | 'info' | 'warning';
   duration?: number;
+  /** When set, the toast offers an "Undo" affordance (the runner has already
+   *  pushed the operation onto the global UndoManager). */
+  undo?: { label?: string };
 }) => void;
 
 /**
@@ -549,7 +561,13 @@ export class ActionRunner {
           ? String((result.data as { message?: unknown }).message).trim()
           : '';
         const message = dyn || action.successMessage || 'Action completed successfully';
-        this.toastHandler(message, { type: 'success', duration });
+        // Undoable action: register the captured operation on the global
+        // UndoManager and surface an "Undo" affordance on the toast (the
+        // consumer's toast handler wires the button to UndoManager).
+        if (result.undo) {
+          try { globalUndoManager.push(result.undo); } catch { /* non-fatal */ }
+        }
+        this.toastHandler(message, { type: 'success', duration, undo: result.undo ? {} : undefined });
       }
 
       if (!result.success && showToast.showOnError !== false && result.error) {

--- a/packages/plugin-detail/src/renderers/record-quick-actions.tsx
+++ b/packages/plugin-detail/src/renderers/record-quick-actions.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { useRecordContext, useActionEngine, useMetadataItem } from '@object-ui/react';
 import { usePermissions } from '@object-ui/permissions';
 import { Button, cn } from '@object-ui/components';
+import { Loader2 } from 'lucide-react';
 import type { ActionDef, ActionLocation } from '@object-ui/core';
 
 const splitDesigner = (props: Record<string, any>) => {
@@ -109,6 +110,11 @@ export const RecordQuickActionsRenderer: React.FC<RecordQuickActionsRendererProp
   // (see packages/react/src/hooks/useActionEngine.ts) so executeAction
   // automatically picks up confirm/param/modal/result-dialog/toast handlers
   // — no need to thread a separate globalExecute.
+  // Tracks the action currently executing so its button shows a spinner and
+  // disables — a visible progress state for record-header actions (e.g. a
+  // `flow` action opening its wizard, or a slow server action).
+  const [runningName, setRunningName] = React.useState<string | null>(null);
+
   const { getActionsForLocation, executeAction } = useActionEngine({
     actions,
     context: {
@@ -158,20 +164,28 @@ export const RecordQuickActionsRenderer: React.FC<RecordQuickActionsRendererProp
         const size = (action as any).size || schema.size || 'sm';
         const disabled =
           typeof action.disabled === 'boolean' ? action.disabled : undefined;
+        const isRunning = runningName === (action.name || `qa-${idx}`);
         return (
           <Button
             key={action.name || `qa-${idx}`}
             variant={variant}
             size={size}
-            disabled={disabled}
-            onClick={() => {
-              if (typeof action.onClick === 'function') {
-                void action.onClick();
-                return;
+            disabled={disabled || isRunning}
+            onClick={async () => {
+              const key = action.name || `qa-${idx}`;
+              setRunningName(key);
+              try {
+                if (typeof action.onClick === 'function') {
+                  await action.onClick();
+                } else if (action.name) {
+                  await executeAction(action.name);
+                }
+              } finally {
+                setRunningName((c) => (c === key ? null : c));
               }
-              if (action.name) void executeAction(action.name);
             }}
           >
+            {isRunning && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {label}
           </Button>
         );


### PR DESCRIPTION
## What

Companion UI for the action progress + Undo work (framework PR `feat/action-conditional-progress-undo`).

### Undo affordance
- **core**: `ActionResult.undo` (an `UndoableOperation`) + `ActionDef.undoable`. On success the `ActionRunner` pushes the op onto the global `UndoManager` and the success toast carries an "Undo" affordance (`ToastHandler` gains an `undo` option).
- **app-shell**: the console action runtime mounts `useGlobalUndo` (Ctrl+Z / Ctrl+Shift+Z) and renders the toast's Undo button. Its `apiHandler` resolves the record id from the list-row record and, for `undoable` actions, captures the changed fields' prior values so the update can be reverted via `dataSource.update`.

### Progress state
- **plugin-detail**: record-header quick-action buttons now show a spinner + disable while the action runs — a visible progress state for slow / flow actions (instant local actions resolve within a frame, so the spinner is brief).

## Verification
Browser E2E (console + app-crm): a list-row **Reassign Lead** (undoable) updates `assigned_to`, the success toast shows **Undo**, and clicking it (or Ctrl+Z) restores the prior owner — confirmed against the DB. Runs clean through the console Vite dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
