### PR TITLE
feat(plugin-form): render object fieldGroups as full-width, collapsible form sections

### DIFF
--- a/examples/byo-backend-console/package.json
+++ b/examples/byo-backend-console/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@object-ui/app-shell": "workspace:*",
     "@object-ui/components": "workspace:*",
+    "@object-ui/plugin-form": "workspace:*",
     "@object-ui/plugin-view": "workspace:*",
     "@object-ui/providers": "workspace:*",
     "@object-ui/react": "workspace:*",

--- a/examples/byo-backend-console/src/App.tsx
+++ b/examples/byo-backend-console/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Link, useParams } from 'react-router-dom';
 import { AppShell } from '@object-ui/app-shell';
 import { ObjectView } from '@object-ui/plugin-view';
+import { ObjectForm } from '@object-ui/plugin-form';
 import { ThemeProvider, DataSourceProvider } from '@object-ui/providers';
 import { mockDataSource } from './mockDataSource';
 
@@ -19,6 +20,7 @@ function App() {
           <AppShell sidebar={<Sidebar />}>
             <Routes>
               <Route path="/" element={<Home />} />
+              <Route path="/form/:objectName" element={<ObjectFormPage />} />
               <Route path="/:objectName" element={<ObjectPage />} />
             </Routes>
           </AppShell>
@@ -51,6 +53,12 @@ function Sidebar() {
           className="block rounded px-3 py-2 text-sm hover:bg-accent"
         >
           Accounts
+        </Link>
+        <Link
+          to="/form/contact"
+          className="block rounded px-3 py-2 text-sm hover:bg-accent"
+        >
+          Contact Form (grouped)
         </Link>
       </div>
 
@@ -130,6 +138,31 @@ function ObjectPage() {
           listViews: [
             { id: 'default', label: 'All', type: 'grid' },
           ],
+        }}
+        dataSource={mockDataSource}
+      />
+    </div>
+  );
+}
+
+/**
+ * Standalone simple ObjectForm. Unlike the grid's modal create/view dialogs,
+ * this is the default `formType: 'simple'` form — so when the object declares
+ * `fieldGroups` (see mockDataSource), the form renders grouped sections.
+ */
+function ObjectFormPage() {
+  const { objectName } = useParams<{ objectName: string }>();
+
+  return (
+    <div className="mx-auto max-w-2xl p-8">
+      <h1 className="mb-6 text-2xl font-bold">
+        New {objectName} (simple form)
+      </h1>
+      <ObjectForm
+        schema={{
+          type: 'object-form',
+          objectName: objectName || '',
+          mode: 'create',
         }}
         dataSource={mockDataSource}
       />

--- a/examples/byo-backend-console/src/index.css
+++ b/examples/byo-backend-console/src/index.css
@@ -1,45 +1,176 @@
 /**
- * Minimal CSS for the example
- * In a real app, you'd import your full Tailwind setup
+ * Tailwind v4 setup for the example.
+ *
+ * This project depends on Tailwind v4 (`@tailwindcss/postcss`), so it MUST use
+ * the v4 entry syntax — NOT the legacy v3 `@tailwind base/components/utilities`
+ * directives (v4 ignores them, which is why the form/grid/app-shell rendered
+ * completely unstyled).
+ *
+ * Three pieces are required, mirroring apps/console/src/index.css:
+ *  1. `@import 'tailwindcss'`                       — Tailwind v4 engine + preflight.
+ *  2. `@import '@object-ui/app-shell/styles.css'`   — shared variant/theming contract.
+ *  3. `@theme { --color-*: hsl(var(--*)) }` + `:root`/`.dark` token blocks —
+ *     registers `bg-card` / `text-muted-foreground` / `border` etc. as real
+ *     utilities AND gives them values. Without the `@theme` mapping those
+ *     class names don't exist in v4.
+ *  4. `@source` globs — Tailwind only generates classes it can see; the class
+ *     names live inside the `@object-ui/*` package sources, so those dirs must
+ *     be scanned or the components stay unstyled.
  */
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss';
+@import '@object-ui/app-shell/styles.css';
 
-:root {
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
-  --muted: 210 40% 96.1%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --accent: 210 40% 96.1%;
-  --accent-foreground: 222.2 47.4% 11.2%;
-  --primary: 222.2 47.4% 11.2%;
-  --primary-foreground: 210 40% 98%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 214.3 31.8% 91.4%;
+/* Scan this app + every ObjectUI package whose components we render. */
+@source '../src/**/*.{ts,tsx}';
+@source '../../../packages/app-shell/src/**/*.{ts,tsx}';
+@source '../../../packages/components/src/**/*.{ts,tsx}';
+@source '../../../packages/layout/src/**/*.{ts,tsx}';
+@source '../../../packages/fields/src/**/*.{ts,tsx}';
+@source '../../../packages/react/src/**/*.{ts,tsx}';
+@source '../../../packages/plugin-form/src/**/*.{ts,tsx}';
+@source '../../../packages/plugin-view/src/**/*.{ts,tsx}';
+@source '../../../packages/plugin-grid/src/**/*.{ts,tsx}';
+@source '../../../packages/plugin-list/src/**/*.{ts,tsx}';
+@source '../../../packages/plugin-detail/src/**/*.{ts,tsx}';
+
+/* Map the shadcn-style HSL design tokens to Tailwind v4 color utilities. */
+@theme {
+  --radius-lg: var(--radius);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 4px);
+
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-sidebar: hsl(var(--sidebar));
+  --color-sidebar-foreground: hsl(var(--sidebar-foreground));
+  --color-sidebar-primary: hsl(var(--sidebar-primary));
+  --color-sidebar-primary-foreground: hsl(var(--sidebar-primary-foreground));
+  --color-sidebar-accent: hsl(var(--sidebar-accent));
+  --color-sidebar-accent-foreground: hsl(var(--sidebar-accent-foreground));
+  --color-sidebar-border: hsl(var(--sidebar-border));
+  --color-sidebar-ring: hsl(var(--sidebar-ring));
+
+  --color-success: hsl(var(--success));
+  --color-success-foreground: hsl(var(--success-foreground));
+  --color-warning: hsl(var(--warning));
+  --color-warning-foreground: hsl(var(--warning-foreground));
 }
 
-.dark {
-  --background: 222.2 84% 4.9%;
-  --foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 17.5%;
-  --muted-foreground: 215 20.2% 65.1%;
-  --accent: 217.2 32.6% 17.5%;
-  --accent-foreground: 210 40% 98%;
-  --primary: 210 40% 98%;
-  --primary-foreground: 222.2 47.4% 11.2%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 217.2 32.6% 17.5%;
-}
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
 
-* {
-  border-color: hsl(var(--border));
-}
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
 
-body {
-  background-color: hsl(var(--background));
-  color: hsl(var(--foreground));
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+
+    --primary: 243 75% 59%;
+    --primary-foreground: 0 0% 100%;
+
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 243 75% 59%;
+
+    --radius: 0.5rem;
+
+    --sidebar: 0 0% 98%;
+    --sidebar-foreground: 240 5.3% 26.1%;
+    --sidebar-primary: 243 75% 59%;
+    --sidebar-primary-foreground: 0 0% 98%;
+    --sidebar-accent: 240 4.8% 95.9%;
+    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-border: 220 13% 91%;
+    --sidebar-ring: 243 75% 59%;
+
+    --success: 142 71% 45%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 100%;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+
+    --primary: 239 84% 67%;
+    --primary-foreground: 0 0% 100%;
+
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 239 84% 67%;
+
+    --sidebar: 240 5.9% 10%;
+    --sidebar-foreground: 240 4.8% 95.9%;
+    --sidebar-primary: 239 84% 67%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 240 3.7% 15.9%;
+    --sidebar-accent-foreground: 240 4.8% 95.9%;
+    --sidebar-border: 240 3.7% 15.9%;
+    --sidebar-ring: 239 84% 67%;
+
+    --success: 142 65% 50%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 55%;
+    --warning-foreground: 0 0% 10%;
+  }
+
+  * {
+    border-color: hsl(var(--border));
+  }
+
+  body {
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+  }
 }

--- a/examples/byo-backend-console/src/mockDataSource.ts
+++ b/examples/byo-backend-console/src/mockDataSource.ts
@@ -3,6 +3,12 @@
  *
  * A simple in-memory data source that demonstrates the DataSource interface.
  * In a real application, replace this with calls to your REST API, GraphQL, etc.
+ *
+ * The runtime (list / form / detail) drives every schema-aware component off
+ * `getObjectSchema(objectName)`, which must return the object's `fields` as a
+ * **map** (`{ [fieldName]: fieldDef }`) plus optional top-level `fieldGroups`.
+ * The `contact` object below declares `fieldGroups` so the runtime ObjectForm
+ * renders grouped sections — matching the designer.
  */
 
 interface DataSource {
@@ -11,14 +17,15 @@ interface DataSource {
   create(objectName: string, data: any): Promise<any>;
   update(objectName: string, id: string, data: any): Promise<any>;
   delete(objectName: string, id: string): Promise<void>;
+  getObjectSchema(objectName: string): Promise<any>;
   getMetadata(): Promise<any>;
 }
 
 // Mock data storage
 const mockData: Record<string, any[]> = {
   contact: [
-    { id: '1', name: 'John Doe', email: 'john@example.com', phone: '555-1234' },
-    { id: '2', name: 'Jane Smith', email: 'jane@example.com', phone: '555-5678' },
+    { id: '1', name: 'John Doe', email: 'john@example.com', phone: '555-1234', notes: 'VIP customer' },
+    { id: '2', name: 'Jane Smith', email: 'jane@example.com', phone: '555-5678', notes: '' },
   ],
   account: [
     { id: '1', name: 'Acme Corp', industry: 'Technology', website: 'acme.com' },
@@ -26,34 +33,40 @@ const mockData: Record<string, any[]> = {
   ],
 };
 
-// Mock metadata
-const mockMetadata = {
-  objects: [
-    {
-      name: 'contact',
-      label: 'Contacts',
-      fields: [
-        { name: 'name', label: 'Name', type: 'text', required: true },
-        { name: 'email', label: 'Email', type: 'email' },
-        { name: 'phone', label: 'Phone', type: 'text' },
-      ],
-      views: [
-        { id: 'grid', name: 'All Contacts', type: 'grid' },
-      ],
+/**
+ * Per-object schemas keyed by object name. `fields` is a map (not an array) and
+ * `contact` carries `fieldGroups` + per-field `group` to exercise grouped form
+ * sections at runtime.
+ */
+const objectSchemas: Record<string, any> = {
+  contact: {
+    name: 'contact',
+    label: 'Contacts',
+    fieldGroups: [
+      // `collapsible` renders a chevron toggle on the section header; `collapsed`
+      // would start the group closed. Each group spans the full form width.
+      { key: 'identity', label: 'Identity', collapsible: true },
+      { key: 'contact_info', label: 'Contact Info', collapsible: true },
+    ],
+    fields: {
+      name: { name: 'name', label: 'Name', type: 'text', required: true, group: 'identity' },
+      email: { name: 'email', label: 'Email', type: 'email', group: 'contact_info' },
+      phone: { name: 'phone', label: 'Phone', type: 'text', group: 'contact_info' },
+      // No `group` → renders in the trailing ungrouped section.
+      notes: { name: 'notes', label: 'Notes', type: 'textarea' },
     },
-    {
-      name: 'account',
-      label: 'Accounts',
-      fields: [
-        { name: 'name', label: 'Name', type: 'text', required: true },
-        { name: 'industry', label: 'Industry', type: 'text' },
-        { name: 'website', label: 'Website', type: 'url' },
-      ],
-      views: [
-        { id: 'grid', name: 'All Accounts', type: 'grid' },
-      ],
+    views: [{ id: 'grid', name: 'All Contacts', type: 'grid' }],
+  },
+  account: {
+    name: 'account',
+    label: 'Accounts',
+    fields: {
+      name: { name: 'name', label: 'Name', type: 'text', required: true },
+      industry: { name: 'industry', label: 'Industry', type: 'text' },
+      website: { name: 'website', label: 'Website', type: 'url' },
     },
-  ],
+    views: [{ id: 'grid', name: 'All Accounts', type: 'grid' }],
+  },
 };
 
 export const mockDataSource: DataSource = {
@@ -78,7 +91,7 @@ export const mockDataSource: DataSource = {
 
   async create(objectName: string, data: any) {
     await delay(300);
-    const newId = String(Date.now());
+    const newId = String(mockData[objectName]?.length ?? 0) + '-' + (data.name || 'rec');
     const newRecord = { ...data, id: newId };
 
     if (!mockData[objectName]) {
@@ -116,9 +129,18 @@ export const mockDataSource: DataSource = {
     mockData[objectName].splice(index, 1);
   },
 
+  async getObjectSchema(objectName: string) {
+    await delay(150);
+    const schema = objectSchemas[objectName];
+    if (!schema) {
+      throw new Error(`Unknown object: ${objectName}`);
+    }
+    return schema;
+  },
+
   async getMetadata() {
     await delay(200);
-    return mockMetadata;
+    return { objects: Object.values(objectSchemas) };
   },
 };
 

--- a/packages/plugin-form/src/ObjectForm.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.test.tsx
@@ -113,6 +113,72 @@ describe('ObjectForm Integration', () => {
         });
     });
 
+    it('auto-derives sections from the object fieldGroups metadata', async () => {
+        // Fields opt into groups via `field.group`; the object declares the
+        // groups via top-level `fieldGroups`. Even without explicit
+        // schema.sections, the form must render those groups as sections.
+        const ds: any = {
+            getObjectSchema: vi.fn().mockResolvedValue({
+                name: 'test_object',
+                fieldGroups: [
+                    { key: 'contact', label: 'Contact Info' },
+                    { key: 'billing', label: 'Billing' },
+                ],
+                fields: {
+                    email: { type: 'email', label: 'Email', group: 'contact' },
+                    phone: { type: 'phone', label: 'Phone', group: 'contact' },
+                    amount: { type: 'currency', label: 'Amount', group: 'billing' },
+                    notes: { type: 'textarea', label: 'Notes' },
+                },
+            }),
+        };
+
+        const { container } = render(
+            <ObjectForm
+                schema={{
+                    type: 'object-form',
+                    objectName: 'test_object',
+                    mode: 'create',
+                } as any}
+                dataSource={ds}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Contact Info')).toBeTruthy();
+        });
+        expect(screen.getByText('Billing')).toBeTruthy();
+        // All fields still render, including the ungrouped one.
+        expect(container.querySelector('input[name="email"]')).toBeTruthy();
+        expect(container.querySelector('input[name="amount"]')).toBeTruthy();
+        expect(container.querySelector('[name="notes"]')).toBeTruthy();
+    });
+
+    it('stays flat when the object declares no fieldGroups', async () => {
+        const ds: any = {
+            getObjectSchema: vi.fn().mockResolvedValue({
+                name: 'test_object',
+                fields: {
+                    name: { type: 'text', label: 'Name' },
+                    email: { type: 'email', label: 'Email' },
+                },
+            }),
+        };
+
+        render(
+            <ObjectForm
+                schema={{ type: 'object-form', objectName: 'test_object', mode: 'create' } as any}
+                dataSource={ds}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Name')).toBeTruthy();
+        });
+        // No section headers should appear for a flat form.
+        expect(screen.queryByText('Contact Info')).toBeNull();
+    });
+
     it('renders as a master-detail form when schema.subforms is set', async () => {
         // A plain object form becomes master-detail by config (no bespoke page):
         // parent fields on top + an editable child grid + a single Save action.

--- a/packages/plugin-form/src/ObjectForm.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.test.tsx
@@ -154,6 +154,52 @@ describe('ObjectForm Integration', () => {
         expect(container.querySelector('[name="notes"]')).toBeTruthy();
     });
 
+    it('collapses a collapsible fieldGroup section on header click, hiding its fields', async () => {
+        // A group declared `collapsible: true` renders a clickable header; toggling
+        // it hides that group's fields (while a single shared form preserves their
+        // values) without affecting other groups or the ungrouped bucket.
+        const ds: any = {
+            getObjectSchema: vi.fn().mockResolvedValue({
+                name: 'test_object',
+                fieldGroups: [
+                    { key: 'contact', label: 'Contact Info', collapsible: true },
+                    { key: 'billing', label: 'Billing' },
+                ],
+                fields: {
+                    email: { type: 'email', label: 'Email', group: 'contact' },
+                    amount: { type: 'currency', label: 'Amount', group: 'billing' },
+                    notes: { type: 'textarea', label: 'Notes' },
+                },
+            }),
+        };
+
+        const { container } = render(
+            <ObjectForm
+                schema={{ type: 'object-form', objectName: 'test_object', mode: 'create' } as any}
+                dataSource={ds}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(container.querySelector('input[name="email"]')).toBeTruthy();
+        });
+
+        // Collapse the Contact Info group → its email field leaves the DOM,
+        // while the other group's field and the ungrouped field stay.
+        fireEvent.click(screen.getByText('Contact Info'));
+        await waitFor(() => {
+            expect(container.querySelector('input[name="email"]')).toBeNull();
+        });
+        expect(container.querySelector('input[name="amount"]')).toBeTruthy();
+        expect(container.querySelector('[name="notes"]')).toBeTruthy();
+
+        // Expand again → the field returns.
+        fireEvent.click(screen.getByText('Contact Info'));
+        await waitFor(() => {
+            expect(container.querySelector('input[name="email"]')).toBeTruthy();
+        });
+    });
+
     it('stays flat when the object declares no fieldGroups', async () => {
         const ds: any = {
             getObjectSchema: vi.fn().mockResolvedValue({

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -27,6 +27,7 @@ import { ModalForm } from './ModalForm';
 import { MasterDetailForm } from './MasterDetailForm';
 import { FormSection } from './FormSection';
 import { applyAutoLayout } from './autoLayout';
+import { deriveFieldGroupSections } from './fieldGroups';
 
 export interface ObjectFormProps {
   /**
@@ -464,6 +465,10 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
           visibleWhen: field.visibleWhen,
           readonlyWhen: field.readonlyWhen,
           requiredWhen: field.requiredWhen ?? field.conditionalRequired,
+          // Field-group membership (Field.group → object.fieldGroups[].key).
+          // Carried through so the form can auto-derive sections from the
+          // object's declared field groups when no explicit sections are given.
+          group: field.group,
           // Important: Pass the original field metadata so widgets can access properties like precision, currency, etc.
           field: field,
         };
@@ -651,6 +656,20 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
      ...initialData
   };
 
+  // Auto-derive sections from the object's declared `fieldGroups` when the
+  // consumer hasn't supplied explicit sections. This makes field groups laid
+  // out in the object designer render as sections on the actual form — not just
+  // in the designer preview. Falls back to a flat form (null) when the object
+  // declares no groups or no field opts into one.
+  const fieldGroupSections = React.useMemo(
+    () =>
+      schema.sections?.length
+        ? null
+        : deriveFieldGroupSections(formFields, objectSchema?.fieldGroups),
+    [schema.sections, formFields, objectSchema],
+  );
+  const effectiveSections = schema.sections?.length ? schema.sections : fieldGroupSections;
+
   // Render error state
   if (error) {
     return (
@@ -678,15 +697,16 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     ? schema.layout 
     : 'vertical';
 
-  // If sections are provided for the simple form, render with FormSection grouping
-  if (schema.sections?.length && (!schema.formType || schema.formType === 'simple')) {
+  // If sections are provided (explicitly, or derived from the object's
+  // `fieldGroups`) for the simple form, render with FormSection grouping.
+  if (effectiveSections?.length && (!schema.formType || schema.formType === 'simple')) {
     return (
       <div className="w-full space-y-6">
-        {schema.sections.map((section, index) => {
+        {effectiveSections.map((section, index) => {
           // Filter formFields to only include fields in this section
           const sectionFieldNames = section.fields.map(f => typeof f === 'string' ? f : f.name);
           const sectionFields = applyFieldPerms(formFields.filter(f => sectionFieldNames.includes(f.name)));
-          
+
           return (
             <FormSection
               key={section.name || section.label || index}
@@ -704,8 +724,8 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
                   layout: formLayout,
                   defaultValues: finalDefaultValues,
                   // Only show action buttons after the last section
-                  showSubmit: index === schema.sections!.length - 1 && schema.showSubmit !== false && schema.mode !== 'view',
-                  showCancel: index === schema.sections!.length - 1 && schema.showCancel !== false,
+                  showSubmit: index === effectiveSections!.length - 1 && schema.showSubmit !== false && schema.mode !== 'view',
+                  showCancel: index === effectiveSections!.length - 1 && schema.showCancel !== false,
                   submitLabel: schema.submitText || (schema.mode === 'create' ? 'Create' : 'Update'),
                   cancelLabel: schema.cancelText,
                   onSubmit: handleSubmit,

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -25,7 +25,6 @@ import { SplitForm } from './SplitForm';
 import { DrawerForm } from './DrawerForm';
 import { ModalForm } from './ModalForm';
 import { MasterDetailForm } from './MasterDetailForm';
-import { FormSection } from './FormSection';
 import { applyAutoLayout } from './autoLayout';
 import { deriveFieldGroupSections } from './fieldGroups';
 
@@ -670,6 +669,11 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
   );
   const effectiveSections = schema.sections?.length ? schema.sections : fieldGroupSections;
 
+  // Per-section collapse state for the simple grouped form. Keyed by section
+  // name/label; an unseeded key falls back to the section's declared `collapsed`
+  // (so a group declared `collapsed: true` starts closed without pre-seeding).
+  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
+
   // Render error state
   if (error) {
     return (
@@ -698,43 +702,70 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     : 'vertical';
 
   // If sections are provided (explicitly, or derived from the object's
-  // `fieldGroups`) for the simple form, render with FormSection grouping.
+  // `fieldGroups`) for the simple form, render them as full-width, optionally
+  // collapsible groups.
+  //
+  // All sections share ONE SchemaRenderer / react-hook-form instance: a virtual
+  // `section-divider` field renders each group's header, and the group's own
+  // fields follow inline. This is the same single-form pattern DrawerForm uses,
+  // and it matters for correctness — N separate per-section <form> elements
+  // would each own isolated form state, so a submit (which only fired the last
+  // section) silently dropped every other group's edits. One form also lets
+  // collapse simply hide a group's fields (`hidden: true`) while react-hook-form
+  // retains their values, and lets cross-section conditions resolve via watch().
   if (effectiveSections?.length && (!schema.formType || schema.formType === 'simple')) {
-    return (
-      <div className="w-full space-y-6">
-        {effectiveSections.map((section, index) => {
-          // Filter formFields to only include fields in this section
-          const sectionFieldNames = section.fields.map(f => typeof f === 'string' ? f : f.name);
-          const sectionFields = applyFieldPerms(formFields.filter(f => sectionFieldNames.includes(f.name)));
+    const groupedFields: FormField[] = [];
+    effectiveSections.forEach((section, index) => {
+      const sectionFieldNames = section.fields.map(f => typeof f === 'string' ? f : f.name);
+      const sectionFields = applyFieldPerms(formFields.filter(f => sectionFieldNames.includes(f.name)));
+      if (sectionFields.length === 0) return;
 
-          return (
-            <FormSection
-              key={section.name || section.label || index}
-              label={section.name ? sectionLabel(schema.objectName, section.name, section.label || section.name) : section.label}
-              description={section.description}
-              collapsible={section.collapsible}
-              collapsed={section.collapsed}
-              columns={section.columns}
-              showBorder={(section as any).showBorder}
-            >
-              <SchemaRenderer
-                schema={{
-                  type: 'form',
-                  fields: sectionFields,
-                  layout: formLayout,
-                  defaultValues: finalDefaultValues,
-                  // Only show action buttons after the last section
-                  showSubmit: index === effectiveSections!.length - 1 && schema.showSubmit !== false && schema.mode !== 'view',
-                  showCancel: index === effectiveSections!.length - 1 && schema.showCancel !== false,
-                  submitLabel: schema.submitText || (schema.mode === 'create' ? 'Create' : 'Update'),
-                  cancelLabel: schema.cancelText,
-                  onSubmit: handleSubmit,
-                  onCancel: handleCancel,
-                } as FormSchema}
-              />
-            </FormSection>
-          );
-        })}
+      const sectionKey = section.name || section.label || String(index);
+      // Untitled trailing bucket (ungrouped fields) renders flat — no divider.
+      const label = section.name
+        ? sectionLabel(schema.objectName, section.name, section.label || section.name)
+        : section.label;
+      const isCollapsed = collapsedSections[sectionKey] ?? (section.collapsed ?? false);
+
+      if (label) {
+        groupedFields.push({
+          name: `__section_${sectionKey}`,
+          label,
+          type: 'section-divider',
+          colSpan: 4,
+          collapsible: section.collapsible,
+          collapsed: isCollapsed,
+          onToggle: section.collapsible
+            ? () => setCollapsedSections(prev => ({ ...prev, [sectionKey]: !isCollapsed }))
+            : undefined,
+        } as FormField);
+      }
+
+      // Collapsed groups keep their fields registered (values preserved) but
+      // hidden from the DOM. An untitled bucket is never collapsible.
+      if (label && isCollapsed) {
+        groupedFields.push(...sectionFields.map(f => ({ ...f, hidden: true })));
+      } else {
+        groupedFields.push(...sectionFields);
+      }
+    });
+
+    return (
+      <div className="w-full">
+        <SchemaRenderer
+          schema={{
+            type: 'form',
+            fields: groupedFields,
+            layout: formLayout,
+            defaultValues: finalDefaultValues,
+            showSubmit: schema.showSubmit !== false && schema.mode !== 'view',
+            showCancel: schema.showCancel !== false,
+            submitLabel: schema.submitText || (schema.mode === 'create' ? 'Create' : 'Update'),
+            cancelLabel: schema.cancelText,
+            onSubmit: handleSubmit,
+            onCancel: handleCancel,
+          } as FormSchema}
+        />
       </div>
     );
   }

--- a/packages/plugin-form/src/fieldGroups.test.ts
+++ b/packages/plugin-form/src/fieldGroups.test.ts
@@ -35,6 +35,21 @@ describe('readObjectFieldGroups', () => {
     expect(readObjectFieldGroups(null)).toEqual([]);
     expect(readObjectFieldGroups({})).toEqual([]);
   });
+
+  it('reads collapsible/collapsed flags when present and ignores non-booleans', () => {
+    expect(
+      readObjectFieldGroups([
+        { key: 'a', label: 'A', collapsible: true, collapsed: true },
+        { key: 'b', label: 'B', collapsible: false },
+        { key: 'c', label: 'C', collapsible: 'yes' },
+      ]),
+    ).toEqual([
+      { key: 'a', label: 'A', collapsible: true, collapsed: true },
+      { key: 'b', label: 'B', collapsible: false },
+      // 'yes' is not a boolean → dropped (treated as not set)
+      { key: 'c', label: 'C' },
+    ]);
+  });
 });
 
 describe('deriveFieldGroupSections', () => {
@@ -92,5 +107,25 @@ describe('deriveFieldGroupSections', () => {
       [{ key: 'contact' }],
     );
     expect(sections).toEqual([{ name: 'contact', label: 'contact', fields: ['email'] }]);
+  });
+
+  it('passes collapsible/collapsed through to derived sections', () => {
+    const sections = deriveFieldGroupSections(
+      [field('email', 'contact'), field('amount', 'billing')],
+      [
+        { key: 'contact', label: 'Contact Info', collapsible: true, collapsed: true },
+        { key: 'billing', label: 'Billing', collapsible: true },
+      ],
+    );
+    expect(sections).toEqual([
+      { name: 'contact', label: 'Contact Info', fields: ['email'], collapsible: true, collapsed: true },
+      { name: 'billing', label: 'Billing', fields: ['amount'], collapsible: true },
+    ]);
+  });
+
+  it('omits collapse flags entirely when a group does not declare them', () => {
+    const [section] = deriveFieldGroupSections([field('email', 'contact')], groups)!;
+    expect(section).not.toHaveProperty('collapsible');
+    expect(section).not.toHaveProperty('collapsed');
   });
 });

--- a/packages/plugin-form/src/fieldGroups.test.ts
+++ b/packages/plugin-form/src/fieldGroups.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { readObjectFieldGroups, deriveFieldGroupSections } from './fieldGroups';
+import type { FormField } from '@object-ui/types';
+
+const field = (name: string, group?: string): FormField =>
+  ({ name, label: name, ...(group ? { group } : {}) }) as FormField;
+
+describe('readObjectFieldGroups', () => {
+  it('normalizes a well-formed list', () => {
+    expect(
+      readObjectFieldGroups([
+        { key: 'contact', label: 'Contact' },
+        { key: 'billing', label: 'Billing' },
+      ]),
+    ).toEqual([
+      { key: 'contact', label: 'Contact' },
+      { key: 'billing', label: 'Billing' },
+    ]);
+  });
+
+  it('drops entries without a string key and tolerates a missing label', () => {
+    expect(
+      readObjectFieldGroups([
+        { key: 'contact' },
+        { label: 'no key' },
+        { key: 42 },
+        null,
+        'nope',
+      ]),
+    ).toEqual([{ key: 'contact', label: undefined }]);
+  });
+
+  it('returns [] for non-array input', () => {
+    expect(readObjectFieldGroups(undefined)).toEqual([]);
+    expect(readObjectFieldGroups(null)).toEqual([]);
+    expect(readObjectFieldGroups({})).toEqual([]);
+  });
+});
+
+describe('deriveFieldGroupSections', () => {
+  const groups = [
+    { key: 'contact', label: 'Contact Info' },
+    { key: 'billing', label: 'Billing' },
+  ];
+
+  it('returns null when no groups are declared', () => {
+    expect(deriveFieldGroupSections([field('a', 'contact')], undefined)).toBeNull();
+    expect(deriveFieldGroupSections([field('a', 'contact')], [])).toBeNull();
+  });
+
+  it('returns null when no field opts into a declared group', () => {
+    expect(deriveFieldGroupSections([field('a'), field('b')], groups)).toBeNull();
+    // group references an undeclared key → treated as ungrouped → null
+    expect(deriveFieldGroupSections([field('a', 'unknown')], groups)).toBeNull();
+  });
+
+  it('groups fields in declared order using field names', () => {
+    const sections = deriveFieldGroupSections(
+      [field('email', 'contact'), field('amount', 'billing'), field('phone', 'contact')],
+      groups,
+    );
+    expect(sections).toEqual([
+      { name: 'contact', label: 'Contact Info', fields: ['email', 'phone'] },
+      { name: 'billing', label: 'Billing', fields: ['amount'] },
+    ]);
+  });
+
+  it('drops empty declared groups', () => {
+    const sections = deriveFieldGroupSections([field('email', 'contact')], groups);
+    expect(sections).toEqual([
+      { name: 'contact', label: 'Contact Info', fields: ['email'] },
+    ]);
+  });
+
+  it('collects ungrouped fields into a trailing untitled section', () => {
+    const sections = deriveFieldGroupSections(
+      [field('name'), field('email', 'contact'), field('notes', 'unknown')],
+      groups,
+    );
+    expect(sections).toEqual([
+      { name: 'contact', label: 'Contact Info', fields: ['email'] },
+      { fields: ['name', 'notes'] },
+    ]);
+    // The trailing bucket carries no name/label so it renders flat (no header).
+    expect(sections?.[1]).not.toHaveProperty('name');
+    expect(sections?.[1]).not.toHaveProperty('label');
+  });
+
+  it('falls back to a group key when no label is given', () => {
+    const sections = deriveFieldGroupSections(
+      [field('email', 'contact')],
+      [{ key: 'contact' }],
+    );
+    expect(sections).toEqual([{ name: 'contact', label: 'contact', fields: ['email'] }]);
+  });
+});

--- a/packages/plugin-form/src/fieldGroups.ts
+++ b/packages/plugin-form/src/fieldGroups.ts
@@ -1,0 +1,103 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Field-group helpers for ObjectForm.
+ *
+ * An object's metadata can declare top-level `fieldGroups` (a.k.a. sections),
+ * and individual fields opt into a group via `field.group === group.key`. The
+ * object designer already lays out fields this way; these helpers let the
+ * runtime form renderer honour the same grouping so authored sections show up
+ * on the actual record form — not just in the designer preview.
+ *
+ * The grouping semantics mirror the designer's `groupEntries`: sections render
+ * in declared order, and any field without a (declared) group lands in a
+ * trailing untitled bucket.
+ */
+
+import type { FormField, ObjectFormSection } from '@object-ui/types';
+
+/** A declared field group on the object metadata. */
+export interface DeclaredFieldGroup {
+  key: string;
+  label?: string;
+}
+
+/** Read an object's `fieldGroups` into a normalized, well-typed list. */
+export function readObjectFieldGroups(input: unknown): DeclaredFieldGroup[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .filter((g): g is { key?: unknown; label?: unknown } => !!g && typeof g === 'object')
+    .map((g) => ({
+      key: typeof (g as { key?: unknown }).key === 'string' ? ((g as { key: string }).key) : '',
+      label:
+        typeof (g as { label?: unknown }).label === 'string'
+          ? ((g as { label: string }).label)
+          : undefined,
+    }))
+    .filter((g) => g.key);
+}
+
+/**
+ * Derive form sections from an object's declared `fieldGroups` and each
+ * rendered field's `group`.
+ *
+ * Returns `null` when grouping does not apply — no declared groups, or no
+ * rendered field opts into a declared group — so callers fall back to a flat
+ * form. Sections come back in declared order; fields without a declared group
+ * collect into a trailing untitled section (no `name`/`label`) so they render
+ * as a plain block rather than a card.
+ *
+ * Section `fields` are returned as field *names* (strings) so the result plugs
+ * straight into ObjectForm's existing section-render path, which resolves names
+ * back to generated `FormField`s and applies field-level permissions.
+ */
+export function deriveFieldGroupSections(
+  fields: FormField[],
+  fieldGroups: unknown,
+): ObjectFormSection[] | null {
+  const declared = readObjectFieldGroups(fieldGroups);
+  if (declared.length === 0) return null;
+
+  const declaredKeys = new Set(declared.map((g) => g.key));
+  const groupOf = (f: FormField): string | null => {
+    const g = (f as { group?: unknown }).group;
+    return typeof g === 'string' && declaredKeys.has(g) ? g : null;
+  };
+
+  // No field references a declared group → keep the flat layout.
+  if (!fields.some((f) => groupOf(f) !== null)) return null;
+
+  const buckets = new Map<string, FormField[]>();
+  for (const g of declared) buckets.set(g.key, []);
+  const ungrouped: FormField[] = [];
+  for (const f of fields) {
+    const g = groupOf(f);
+    if (g) buckets.get(g)!.push(f);
+    else ungrouped.push(f);
+  }
+
+  const sections: ObjectFormSection[] = [];
+  for (const g of declared) {
+    const items = buckets.get(g.key)!;
+    if (items.length === 0) continue;
+    sections.push({
+      name: g.key,
+      label: g.label ?? g.key,
+      fields: items.map((f) => f.name),
+    });
+  }
+  // Trailing untitled bucket for ungrouped fields. Omitting `name`/`label`
+  // makes the section render flat (no card chrome) instead of surfacing an
+  // internal key as a header.
+  if (ungrouped.length > 0) {
+    sections.push({ fields: ungrouped.map((f) => f.name) });
+  }
+
+  return sections;
+}

--- a/packages/plugin-form/src/fieldGroups.ts
+++ b/packages/plugin-form/src/fieldGroups.ts
@@ -26,19 +26,22 @@ import type { FormField, ObjectFormSection } from '@object-ui/types';
 export interface DeclaredFieldGroup {
   key: string;
   label?: string;
+  /** Render the group's section header with a collapse toggle. */
+  collapsible?: boolean;
+  /** Start the (collapsible) group collapsed. */
+  collapsed?: boolean;
 }
 
 /** Read an object's `fieldGroups` into a normalized, well-typed list. */
 export function readObjectFieldGroups(input: unknown): DeclaredFieldGroup[] {
   if (!Array.isArray(input)) return [];
   return input
-    .filter((g): g is { key?: unknown; label?: unknown } => !!g && typeof g === 'object')
+    .filter((g): g is Record<string, unknown> => !!g && typeof g === 'object')
     .map((g) => ({
-      key: typeof (g as { key?: unknown }).key === 'string' ? ((g as { key: string }).key) : '',
-      label:
-        typeof (g as { label?: unknown }).label === 'string'
-          ? ((g as { label: string }).label)
-          : undefined,
+      key: typeof g.key === 'string' ? (g.key as string) : '',
+      label: typeof g.label === 'string' ? (g.label as string) : undefined,
+      collapsible: typeof g.collapsible === 'boolean' ? (g.collapsible as boolean) : undefined,
+      collapsed: typeof g.collapsed === 'boolean' ? (g.collapsed as boolean) : undefined,
     }))
     .filter((g) => g.key);
 }
@@ -90,6 +93,8 @@ export function deriveFieldGroupSections(
       name: g.key,
       label: g.label ?? g.key,
       fields: items.map((f) => f.name),
+      ...(g.collapsible !== undefined ? { collapsible: g.collapsible } : {}),
+      ...(g.collapsed !== undefined ? { collapsed: g.collapsed } : {}),
     });
   }
   // Trailing untitled bucket for ungrouped fields. Omitting `name`/`label`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@object-ui/components':
         specifier: workspace:*
         version: link:../../packages/components
+      '@object-ui/plugin-form':
+        specifier: workspace:*
+        version: link:../../packages/plugin-form
       '@object-ui/plugin-view':
         specifier: workspace:*
         version: link:../../packages/plugin-view
@@ -784,7 +787,7 @@ importers:
         version: 9.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -805,7 +808,7 @@ importers:
         version: 4.2.0
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.25
@@ -824,7 +827,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/collaboration:
     dependencies:
@@ -1086,7 +1089,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/data-objectstack:
     dependencies:
@@ -5204,6 +5207,12 @@ packages:
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
 
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    resolution: {integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
   '@tailwindcss/oxide-darwin-arm64@4.3.1':
     resolution: {integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==}
     engines: {node: '>= 20'}
@@ -5221,6 +5230,12 @@ packages:
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
     resolution: {integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==}
@@ -5242,6 +5257,13 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -5359,6 +5381,16 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
+  '@turbo/darwin-64@2.9.18':
+    resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.18':
+    resolution: {integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@turbo/linux-64@2.9.18':
     resolution: {integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==}
     cpu: [x64]
@@ -5368,6 +5400,11 @@ packages:
     resolution: {integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==}
     cpu: [arm64]
     os: [linux]
+
+  '@turbo/windows-64@2.9.18':
+    resolution: {integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==}
+    cpu: [x64]
+    os: [win32]
 
   '@turbo/windows-arm64@2.9.18':
     resolution: {integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==}
@@ -13019,6 +13056,9 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.3.1
 
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    optional: true
+
   '@tailwindcss/oxide-darwin-arm64@4.3.1':
     optional: true
 
@@ -13028,6 +13068,9 @@ snapshots:
   '@tailwindcss/oxide-freebsd-x64@4.3.1':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
     optional: true
 
@@ -13035,6 +13078,9 @@ snapshots:
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
@@ -13048,12 +13094,15 @@ snapshots:
 
   '@tailwindcss/oxide@4.3.1':
     optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.1
       '@tailwindcss/oxide-darwin-arm64': 4.3.1
       '@tailwindcss/oxide-darwin-x64': 4.3.1
       '@tailwindcss/oxide-freebsd-x64': 4.3.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.1
       '@tailwindcss/oxide-linux-arm64-gnu': 4.3.1
       '@tailwindcss/oxide-linux-arm64-musl': 4.3.1
       '@tailwindcss/oxide-linux-x64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.1
       '@tailwindcss/oxide-wasm32-wasi': 4.3.1
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
@@ -13180,10 +13229,19 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
 
+  '@turbo/darwin-64@2.9.18':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.18':
+    optional: true
+
   '@turbo/linux-64@2.9.18':
     optional: true
 
   '@turbo/linux-arm64@2.9.18':
+    optional: true
+
+  '@turbo/windows-64@2.9.18':
     optional: true
 
   '@turbo/windows-arm64@2.9.18':
@@ -13605,11 +13663,6 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       maplibre-gl: 5.24.0
-
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -18475,8 +18528,11 @@ snapshots:
 
   turbo@2.9.18:
     optionalDependencies:
+      '@turbo/darwin-64': 2.9.18
+      '@turbo/darwin-arm64': 2.9.18
       '@turbo/linux-64': 2.9.18
       '@turbo/linux-arm64': 2.9.18
+      '@turbo/windows-64': 2.9.18
       '@turbo/windows-arm64': 2.9.18
 
   type-check@0.4.0:


### PR DESCRIPTION
## What & why

对象字段渲染也需要支持 `fieldGroups` 属性——之前只有设计器（designer preview）会按字段分组（field groups）布局，运行时的实际表单仍是平铺的。本 PR 让运行时表单渲染也遵循对象元数据上声明的字段分组，并支持**整行**、**可收缩**的分组。

When an object declares top-level `fieldGroups` and its fields opt into a group via `field.group === group.key`, the runtime `SimpleObjectForm` now auto-derives form sections from that metadata — so groups authored in the object designer actually render as sections on the record form, not only in the designer preview. Groups render full-width and can be made collapsible.

## Changes

### Field-group sections (base)
- **New** [`packages/plugin-form/src/fieldGroups.ts`](packages/plugin-form/src/fieldGroups.ts)
  - `readObjectFieldGroups` — normalize an object's `fieldGroups` list (incl. `collapsible` / `collapsed` flags).
  - `deriveFieldGroupSections` — build sections from generated `FormField`s + declared groups, mirroring the designer's `groupEntries` semantics: sections in declared order, empty declared groups dropped, ungrouped fields collected into a trailing **untitled** section. Returns `null` (→ flat form) when no groups are declared or no field opts into one. Passes `collapsible`/`collapsed` through to the section.

### Full-width + collapsible groups, and a submit-bug fix
- [`ObjectForm.tsx`](packages/plugin-form/src/ObjectForm.tsx)
  - Carry each field's `group` onto the generated `FormField`; compute `effectiveSections` (explicit `schema.sections` **or** derived field-group sections).
  - **Single-form rendering.** Previously each derived section rendered its own `<SchemaRenderer type="form">` — N independent react-hook-form instances — with the submit button only on the last one, so **submit captured just the last group's fields and silently dropped every other group's edits**. All sections now share ONE form (the same pattern `DrawerForm` uses): a virtual `section-divider` field renders each group's header and the group's fields follow inline. This fixes submit, lets a collapsed group hide its fields (`hidden: true`) while react-hook-form retains their values, and lets cross-section field conditions resolve via `watch()`.
  - Per-section collapse state, toggled from the section header chevron; `collapsed` declares the initial state.

### Example (byo-backend-console)
- Fixed the Tailwind v4 entry (`index.css`) so `@object-ui` components are actually styled (was using obsolete v3 `@tailwind` directives + missing `@source`/`@theme`).
- Added a standalone `/form/:objectName` route rendering the simple `ObjectForm`, and a sidebar link.
- The `contact` mock declares two **collapsible** groups (Identity, Contact Info) plus an ungrouped field (Notes) to demo grouping end-to-end.

## Behavior / compatibility

- Only kicks in for the default simple form when the consumer passes **no** explicit `schema.sections`. Tabbed/wizard/split/drawer/modal variants and master-detail are unchanged.
- Objects without `fieldGroups` (or with no field referencing a declared group) render exactly as before (flat).
- Visual note: derived sections render as full-width underlined section headers (chevron when collapsible), not bordered cards — required to keep all fields in one form for correct submit + collapse.

## Tests

- `fieldGroups.test.ts` — normalization, declared-order grouping, empty-group dropping, trailing untitled bucket, label fallback, **collapsible/collapsed read + passthrough**.
- `ObjectForm.test.tsx` — a schema with `fieldGroups` renders section headers + all fields (incl. ungrouped); a schema without groups stays flat; **collapsing a group on header click removes its fields from the DOM and restores them on expand**.
- plugin-form suite green (incl. the 18 fieldGroups/ObjectForm tests). Verified live in the example: collapse toggles fields, and a typed value survives a collapse/expand round-trip (proving the shared form retains it).