### PR TITLE
fix(plugin-form): resolve spec `field` key in section forms (fixes form render crash)

### DIFF
--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -27,6 +27,7 @@ import {
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { MasterDetailForm } from './MasterDetailForm';
 import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
+import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
 import { applyAutoLayout } from './autoLayout';
 import { sanitizeFormData } from './sanitize';
 
@@ -196,40 +197,17 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
   }, [objectSchema, schema.mode, schema.recordId, schema.initialData, schema.initialValues, dataSource, schema.objectName]);
 
   // Build form fields from section config
-  const buildSectionFields = useCallback((section: DrawerFormSectionConfig): FormField[] => {
-    const fields: FormField[] = [];
-
-    for (const fieldDef of section.fields) {
-      const fieldName = typeof fieldDef === 'string' ? fieldDef : fieldDef.name;
-
-      if (typeof fieldDef === 'object') {
-        fields.push(fieldDef);
-      } else if (objectSchema?.fields?.[fieldName]) {
-        const field = objectSchema.fields[fieldName];
-        fields.push({
-          name: fieldName,
-          label: fieldLabel(schema.objectName, fieldName, field.label || fieldName),
-          type: mapFieldTypeToFormType(field.type),
-          required: field.required || false,
-          disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
-          placeholder: field.placeholder,
-          description: field.help || field.description,
-          validation: buildValidationRules(field),
-          field: field,
-          options: field.options,
-          multiple: field.multiple,
-        });
-      } else {
-        fields.push({
-          name: fieldName,
-          label: fieldName,
-          type: 'input',
-        });
-      }
-    }
-
-    return fields;
-  }, [objectSchema, schema.readOnly, schema.mode]);
+  const buildSectionFields = useCallback(
+    (section: DrawerFormSectionConfig): FormField[] =>
+      buildSectionFieldsShared(section as any, {
+        objectSchema,
+        objectName: schema.objectName,
+        readOnly: schema.readOnly,
+        mode: schema.mode,
+        fieldLabel,
+      }),
+    [objectSchema, schema.readOnly, schema.mode, schema.objectName, fieldLabel],
+  );
 
   // Build fields from flat field list (when no sections provided)
   useEffect(() => {

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -33,7 +33,8 @@ import { Loader2 } from 'lucide-react';
 import { FormSection } from './FormSection';
 import { MasterDetailForm } from './MasterDetailForm';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
-import { mapFieldTypeToFormType, buildValidationRules, evaluateCondition } from '@object-ui/fields';
+import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
+import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
 import { applyAutoLayout, inferModalSize } from './autoLayout';
 import { sanitizeFormData } from './sanitize';
 import { usePermissions } from '@object-ui/permissions';
@@ -258,53 +259,17 @@ export const ModalForm: React.FC<ModalFormProps> = ({
   }, [objectSchema, schema.mode, schema.recordId, schema.initialData, schema.initialValues, dataSource, schema.objectName]);
 
   // Build form fields from section config
-  const buildSectionFields = useCallback((section: ModalFormSectionConfig): FormField[] => {
-    const fields: FormField[] = [];
-
-    // Convert spec-level `visibleOn` CEL string (or object-field `visible_on`
-    // hyphen-cased mirror) into a reactive `visible(formData)` predicate so
-    // FormSection's children honor live field-level visibility.
-    const attachVisibility = (formField: FormField, expr: any): FormField => {
-      if (typeof expr === 'string' && expr.trim()) {
-        return {
-          ...formField,
-          visible: (formData: any) => evaluateCondition(expr, formData),
-        };
-      }
-      return formField;
-    };
-
-    for (const fieldDef of section.fields) {
-      const fieldName = typeof fieldDef === 'string' ? fieldDef : fieldDef.name;
-
-      if (typeof fieldDef === 'object') {
-        fields.push(attachVisibility(fieldDef as FormField, (fieldDef as any).visibleOn));
-      } else if (objectSchema?.fields?.[fieldName]) {
-        const field = objectSchema.fields[fieldName];
-        fields.push(attachVisibility({
-          name: fieldName,
-          label: fieldLabel(schema.objectName, fieldName, field.label || fieldName),
-          type: mapFieldTypeToFormType(field.type),
-          required: field.required || false,
-          disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
-          placeholder: field.placeholder,
-          description: field.help || field.description,
-          validation: buildValidationRules(field),
-          field: field,
-          options: field.options,
-          multiple: field.multiple,
-        }, (field as any).visible_on ?? (field as any).visibleOn));
-      } else {
-        fields.push({
-          name: fieldName,
-          label: fieldName,
-          type: 'input',
-        });
-      }
-    }
-
-    return fields;
-  }, [objectSchema, schema.readOnly, schema.mode, schema.objectName]);
+  const buildSectionFields = useCallback(
+    (section: ModalFormSectionConfig): FormField[] =>
+      buildSectionFieldsShared(section as any, {
+        objectSchema,
+        objectName: schema.objectName,
+        readOnly: schema.readOnly,
+        mode: schema.mode,
+        fieldLabel,
+      }),
+    [objectSchema, schema.readOnly, schema.mode, schema.objectName, fieldLabel],
+  );
 
   // Build fields from flat field list (when no sections)
   useEffect(() => {

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -716,7 +716,7 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
   if (effectiveSections?.length && (!schema.formType || schema.formType === 'simple')) {
     const groupedFields: FormField[] = [];
     effectiveSections.forEach((section, index) => {
-      const sectionFieldNames = section.fields.map(f => typeof f === 'string' ? f : f.name);
+      const sectionFieldNames = section.fields.map(f => typeof f === 'string' ? f : ((f as any).field ?? f.name));
       const sectionFields = applyFieldPerms(formFields.filter(f => sectionFieldNames.includes(f.name)));
       if (sectionFields.length === 0) return;
 

--- a/packages/plugin-form/src/SplitForm.tsx
+++ b/packages/plugin-form/src/SplitForm.tsx
@@ -24,7 +24,7 @@ import {
 } from '@object-ui/components';
 import { FormSection } from './FormSection';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
-import { mapFieldTypeToFormType, buildValidationRules, evaluateCondition } from '@object-ui/fields';
+import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
 
 export interface SplitFormSectionConfig {
   name?: string;
@@ -140,50 +140,17 @@ export const SplitForm: React.FC<SplitFormProps> = ({
   }, [objectSchema, schema.mode, schema.recordId, schema.initialData, schema.initialValues, dataSource, schema.objectName]);
 
   // Build form fields from section config
-  const buildSectionFields = useCallback((section: SplitFormSectionConfig): FormField[] => {
-    const fields: FormField[] = [];
-
-    const attachVisibility = (formField: FormField, expr: any): FormField => {
-      if (typeof expr === 'string' && expr.trim()) {
-        return {
-          ...formField,
-          visible: (formData: any) => evaluateCondition(expr, formData),
-        };
-      }
-      return formField;
-    };
-
-    for (const fieldDef of section.fields) {
-      const fieldName = typeof fieldDef === 'string' ? fieldDef : fieldDef.name;
-
-      if (typeof fieldDef === 'object') {
-        fields.push(attachVisibility(fieldDef as FormField, (fieldDef as any).visibleOn));
-      } else if (objectSchema?.fields?.[fieldName]) {
-        const field = objectSchema.fields[fieldName];
-        fields.push(attachVisibility({
-          name: fieldName,
-          label: fieldLabel(schema.objectName, fieldName, field.label || fieldName),
-          type: mapFieldTypeToFormType(field.type),
-          required: field.required || false,
-          disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
-          placeholder: field.placeholder,
-          description: field.help || field.description,
-          validation: buildValidationRules(field),
-          field: field,
-          options: field.options,
-          multiple: field.multiple,
-        }, (field as any).visible_on ?? (field as any).visibleOn));
-      } else {
-        fields.push({
-          name: fieldName,
-          label: fieldName,
-          type: 'input',
-        });
-      }
-    }
-
-    return fields;
-  }, [objectSchema, schema.readOnly, schema.mode, schema.objectName]);
+  const buildSectionFields = useCallback(
+    (section: SplitFormSectionConfig): FormField[] =>
+      buildSectionFieldsShared(section as any, {
+        objectSchema,
+        objectName: schema.objectName,
+        readOnly: schema.readOnly,
+        mode: schema.mode,
+        fieldLabel,
+      }),
+    [objectSchema, schema.readOnly, schema.mode, schema.objectName, fieldLabel],
+  );
 
   // Handle form submission
   const handleSubmit = useCallback(async (data: Record<string, any>) => {

--- a/packages/plugin-form/src/TabbedForm.tsx
+++ b/packages/plugin-form/src/TabbedForm.tsx
@@ -18,7 +18,7 @@ import type { FormField, DataSource } from '@object-ui/types';
 import { Tabs, TabsContent, TabsList, TabsTrigger, cn } from '@object-ui/components';
 import { FormSection } from './FormSection';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
-import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
+import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
 
 export interface FormSectionConfig {
   /**
@@ -219,43 +219,17 @@ export const TabbedForm: React.FC<TabbedFormProps> = ({
   }, [objectSchema, schema.mode, schema.recordId, schema.initialData, schema.initialValues, dataSource, schema.objectName]);
 
   // Build form fields from section config
-  const buildSectionFields = useCallback((section: FormSectionConfig): FormField[] => {
-    const fields: FormField[] = [];
-    
-    for (const fieldDef of section.fields) {
-      const fieldName = typeof fieldDef === 'string' ? fieldDef : fieldDef.name;
-      
-      if (typeof fieldDef === 'object') {
-        // Use the field definition directly
-        fields.push(fieldDef);
-      } else if (objectSchema?.fields?.[fieldName]) {
-        // Build from object schema
-        const field = objectSchema.fields[fieldName];
-        fields.push({
-          name: fieldName,
-          label: fieldLabel(schema.objectName, fieldName, field.label || fieldName),
-          type: mapFieldTypeToFormType(field.type),
-          required: field.required || false,
-          disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
-          placeholder: field.placeholder,
-          description: field.help || field.description,
-          validation: buildValidationRules(field),
-          field: field,
-          options: field.options,
-          multiple: field.multiple,
-        });
-      } else {
-        // Fallback for unknown fields
-        fields.push({
-          name: fieldName,
-          label: fieldName,
-          type: 'input',
-        });
-      }
-    }
-    
-    return fields;
-  }, [objectSchema, schema.readOnly, schema.mode]);
+  const buildSectionFields = useCallback(
+    (section: FormSectionConfig): FormField[] =>
+      buildSectionFieldsShared(section as any, {
+        objectSchema,
+        objectName: schema.objectName,
+        readOnly: schema.readOnly,
+        mode: schema.mode,
+        fieldLabel,
+      }),
+    [objectSchema, schema.readOnly, schema.mode, schema.objectName, fieldLabel],
+  );
 
   // Handle form submission
   const handleSubmit = useCallback(async (data: Record<string, any>) => {

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -19,7 +19,7 @@ import { Button, cn } from '@object-ui/components';
 import { Check, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import { FormSection } from './FormSection';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
-import { mapFieldTypeToFormType, buildValidationRules, evaluateCondition } from '@object-ui/fields';
+import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
 import type { FormSectionConfig } from './TabbedForm';
 
 export interface WizardFormSchema {
@@ -210,50 +210,17 @@ export const WizardForm: React.FC<WizardFormProps> = ({
   }, [objectSchema, schema.mode, schema.recordId, schema.initialData, schema.initialValues, dataSource, schema.objectName]);
 
   // Build section fields from object schema
-  const buildSectionFields = useCallback((section: FormSectionConfig): FormField[] => {
-    const fields: FormField[] = [];
-
-    const attachVisibility = (formField: FormField, expr: any): FormField => {
-      if (typeof expr === 'string' && expr.trim()) {
-        return {
-          ...formField,
-          visible: (formData: any) => evaluateCondition(expr, formData),
-        };
-      }
-      return formField;
-    };
-
-    for (const fieldDef of section.fields) {
-      const fieldName = typeof fieldDef === 'string' ? fieldDef : fieldDef.name;
-
-      if (typeof fieldDef === 'object') {
-        fields.push(attachVisibility(fieldDef as FormField, (fieldDef as any).visibleOn));
-      } else if (objectSchema?.fields?.[fieldName]) {
-        const field = objectSchema.fields[fieldName];
-        fields.push(attachVisibility({
-          name: fieldName,
-          label: fieldLabel(schema.objectName, fieldName, field.label || fieldName),
-          type: mapFieldTypeToFormType(field.type),
-          required: field.required || false,
-          disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
-          placeholder: field.placeholder,
-          description: field.help || field.description,
-          validation: buildValidationRules(field),
-          field: field,
-          options: field.options,
-          multiple: field.multiple,
-        }, (field as any).visible_on ?? (field as any).visibleOn));
-      } else {
-        fields.push({
-          name: fieldName,
-          label: fieldName,
-          type: 'input',
-        });
-      }
-    }
-    
-    return fields;
-  }, [objectSchema, schema.readOnly, schema.mode, schema.objectName]);
+  const buildSectionFields = useCallback(
+    (section: FormSectionConfig): FormField[] =>
+      buildSectionFieldsShared(section as any, {
+        objectSchema,
+        objectName: schema.objectName,
+        readOnly: schema.readOnly,
+        mode: schema.mode,
+        fieldLabel,
+      }),
+    [objectSchema, schema.readOnly, schema.mode, schema.objectName, fieldLabel],
+  );
 
   // Current section fields
   const currentSectionFields = useMemo(() => {

--- a/packages/plugin-form/src/sectionFields.test.ts
+++ b/packages/plugin-form/src/sectionFields.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeSectionField, buildSectionFields } from './sectionFields';
+import { mapFieldTypeToFormType } from '@object-ui/fields';
+
+const objectSchema = {
+  name: 'crm_account',
+  fields: {
+    name: { type: 'text', label: 'Account Name', required: true, description: 'Legal name' },
+    industry: {
+      type: 'select',
+      label: 'Industry',
+      options: [{ label: 'Tech', value: 'tech' }],
+    },
+    billing_address: { type: 'address', label: 'Billing Address' },
+  },
+};
+
+const ctx = {
+  objectSchema,
+  objectName: 'crm_account',
+  fieldLabel: (_obj: string, _name: string, fallback?: string) => fallback || _name,
+};
+
+describe('normalizeSectionField', () => {
+  it('resolves a spec FormFieldSchema object (key `field`, not `name`)', () => {
+    // This is the exact shape that crashed the form: react-hook-form received
+    // `name === undefined` and threw on `name.split('.')`.
+    const f = normalizeSectionField({ field: 'name', required: true, colSpan: 2 }, ctx);
+    expect(f.name).toBe('name');           // ← was undefined before the fix
+    expect(f.type).toBe(mapFieldTypeToFormType('text')); // merged from object schema
+    expect(f.required).toBe(true);         // spec override
+    expect((f as any).colSpan).toBe(2);    // spec override
+    expect((f as any).field).toMatchObject({ type: 'text' }); // metadata object, not the string
+  });
+
+  it('merges select options + label from the object schema', () => {
+    const f = normalizeSectionField({ field: 'industry' }, ctx);
+    expect(f.name).toBe('industry');
+    expect(f.type).toBe(mapFieldTypeToFormType('select'));
+    expect((f as any).options).toEqual([{ label: 'Tech', value: 'tech' }]);
+  });
+
+  it('maps spec override keys (helpText→description, readonly→disabled)', () => {
+    const f = normalizeSectionField(
+      { field: 'name', helpText: 'Custom hint', readonly: true },
+      ctx,
+    );
+    expect(f.description).toBe('Custom hint');
+    expect((f as any).disabled).toBe(true);
+  });
+
+  it('builds from the object schema for a string shorthand', () => {
+    const f = normalizeSectionField('industry', ctx);
+    expect(f.name).toBe('industry');
+    expect(f.type).toBe(mapFieldTypeToFormType('select'));
+  });
+
+  it('passes a runtime FormField object through unchanged (field = metadata object)', () => {
+    const runtime = { name: 'custom', type: 'text', label: 'Custom' };
+    const f = normalizeSectionField(runtime as any, ctx);
+    expect(f.name).toBe('custom');
+    expect(f.type).toBe('text');
+  });
+
+  it('still yields a name when the spec field is not in the object schema', () => {
+    const f = normalizeSectionField({ field: 'ghost', required: true }, ctx);
+    expect(f.name).toBe('ghost'); // never undefined → no `.split` crash
+  });
+});
+
+describe('buildSectionFields', () => {
+  it('normalizes a mixed section (string + spec object) with no undefined names', () => {
+    const fields = buildSectionFields(
+      { fields: ['industry', { field: 'name', required: true, colSpan: 2 }] },
+      ctx,
+    );
+    expect(fields.map((f) => f.name)).toEqual(['industry', 'name']);
+    expect(fields.every((f) => typeof f.name === 'string')).toBe(true);
+  });
+});

--- a/packages/plugin-form/src/sectionFields.ts
+++ b/packages/plugin-form/src/sectionFields.ts
@@ -1,0 +1,135 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Shared section-field normalizer for the sectioned form variants
+ * (Tabbed / Wizard / Split / Drawer / Modal).
+ *
+ * A form-view section lists its fields in one of three shapes:
+ *
+ *   1. a plain string — the field name:                 `'account_number'`
+ *   2. a spec FormFieldSchema object (canonical) —      `{ field: 'name', required: true, colSpan: 2 }`
+ *   3. an already-built runtime FormField object —       `{ name: 'x', type: 'text', ... }`
+ *
+ * Shape (2) is what `@objectstack/spec` emits — see FormFieldSchema, where the
+ * key is `field`, NOT `name`. The variants used to read `fieldDef.name` and push
+ * the raw object straight through, so a spec entry reached react-hook-form with
+ * `name === undefined` and crashed the whole form on `name.split('.')`. This
+ * helper normalizes all three shapes into a runtime FormField with a real
+ * `name`, merging object-schema metadata (type/options/validation) with the
+ * spec-level overrides.
+ */
+
+import type { FormField } from '@object-ui/types';
+import { mapFieldTypeToFormType, buildValidationRules, evaluateCondition } from '@object-ui/fields';
+
+export interface SectionFieldsContext {
+  /** Resolved object schema (`{ fields: { [name]: fieldDef } }`) or null. */
+  objectSchema: any;
+  /** Object name, for label translation. */
+  objectName: string;
+  /** Whole-form read-only flag. */
+  readOnly?: boolean;
+  /** Form mode — `view` forces every field disabled. */
+  mode?: 'create' | 'edit' | 'view';
+  /** Translation-aware label resolver (from `useSafeFieldLabel`). */
+  fieldLabel: (objectName: string, fieldName: string, fallback?: string) => string;
+}
+
+/** Attach a reactive `visible(formData)` predicate from a CEL `visibleOn` string. */
+function attachVisibility(formField: FormField, expr: any): FormField {
+  if (typeof expr === 'string' && expr.trim()) {
+    return {
+      ...formField,
+      visible: (formData: any) => evaluateCondition(expr, formData),
+    } as FormField;
+  }
+  return formField;
+}
+
+/** Build a runtime FormField from object-schema metadata for `fieldName`. */
+function fromObjectSchema(fieldName: string, ctx: SectionFieldsContext): FormField {
+  const field = ctx.objectSchema?.fields?.[fieldName];
+  if (!field) {
+    return { name: fieldName, label: fieldName, type: 'input' } as FormField;
+  }
+  return {
+    name: fieldName,
+    label: ctx.fieldLabel(ctx.objectName, fieldName, field.label || fieldName),
+    type: mapFieldTypeToFormType(field.type),
+    required: field.required || false,
+    disabled: ctx.readOnly || ctx.mode === 'view' || field.readonly,
+    placeholder: field.placeholder,
+    description: field.help || field.description,
+    validation: buildValidationRules(field),
+    field,
+    options: field.options,
+    multiple: field.multiple,
+  } as FormField;
+}
+
+/**
+ * Normalize one section field definition (string | spec object | runtime
+ * FormField) into a runtime FormField with a guaranteed `name`.
+ */
+export function normalizeSectionField(
+  fieldDef: string | Record<string, any>,
+  ctx: SectionFieldsContext,
+): FormField {
+  // (1) string shorthand → build entirely from the object schema.
+  if (typeof fieldDef === 'string') {
+    const meta = ctx.objectSchema?.fields?.[fieldDef] as any;
+    return attachVisibility(fromObjectSchema(fieldDef, ctx), meta?.visible_on ?? meta?.visibleOn);
+  }
+
+  const fd = fieldDef as Record<string, any>;
+
+  // (3) already a runtime FormField (inline customFields): it carries its own
+  // `name` (and usually `type`). NOTE: in the spec shape `field` is a *string*
+  // (the field name); in a runtime FormField `field` is the *metadata object*.
+  // So a string `field` is the disambiguator for the spec shape below.
+  if (typeof fd.field !== 'string') {
+    return attachVisibility(fd as FormField, fd.visibleOn);
+  }
+
+  // (2) spec FormFieldSchema object — merge object-schema base + spec overrides.
+  const fieldName = fd.field;
+  const base = fromObjectSchema(fieldName, ctx) as any;
+
+  if (fd.type != null) base.type = mapFieldTypeToFormType(fd.type);
+  if (fd.widget != null) base.widget = fd.widget;
+  if (fd.label != null) base.label = fd.label;
+  if (fd.placeholder != null) base.placeholder = fd.placeholder;
+  if (fd.helpText != null) base.description = fd.helpText;
+  if (fd.required != null) base.required = fd.required;
+  if (fd.readonly != null) base.disabled = fd.readonly || base.disabled;
+  if (fd.immutable != null) base.immutable = fd.immutable;
+  if (fd.hidden != null) base.hidden = fd.hidden;
+  if (fd.colSpan != null) base.colSpan = fd.colSpan;
+  if (fd.options != null) base.options = fd.options;
+  if (fd.multiple != null) base.multiple = fd.multiple;
+  if (fd.reference != null) base.reference = fd.reference;
+  if (fd.maxLength != null) base.maxLength = fd.maxLength;
+  if (fd.minLength != null) base.minLength = fd.minLength;
+  if (fd.min != null) base.min = fd.min;
+  if (fd.max != null) base.max = fd.max;
+  if (fd.precision != null) base.precision = fd.precision;
+  if (fd.scale != null) base.scale = fd.scale;
+  if (fd.language != null) base.language = fd.language;
+  if (Array.isArray(fd.fields)) base.fields = fd.fields;
+
+  return attachVisibility(base as FormField, fd.visibleOn);
+}
+
+/** Normalize every field def in a section. */
+export function buildSectionFields(
+  section: { fields: Array<string | Record<string, any>> },
+  ctx: SectionFieldsContext,
+): FormField[] {
+  return (section.fields ?? []).map((fieldDef) => normalizeSectionField(fieldDef, ctx));
+}


### PR DESCRIPTION
## Problem

Opening a **Create/Edit** form for an object whose form view declares sections crashed the entire form:

> Component "form" failed to render: Cannot read properties of undefined (reading 'split')

Repro: HotCRM → Account → **New** (any object with a tabbed/sectioned form view).

## Root cause

Form-view sections declare fields with the spec key **`field`** (`FormFieldSchema`), e.g.:

```ts
{ field: 'name', required: true, colSpan: 2 }
```

The sectioned form variants' `buildSectionFields` read `fieldDef.name` (undefined) and pushed the raw spec object straight through. That field reached react-hook-form's `<Controller name={undefined}>`, which crashes on `name.split('.')`.

It surfaces through the New/Edit modal (`AppContent` forwards raw spec `sections` via `contentLayout: 'tabbed'`), which bypasses the `form-view` spec-bridge that *does* map `field`→`name`.

## Fix

- New shared **`packages/plugin-form/src/sectionFields.ts`** normalizer handling all three section-field shapes — string shorthand, spec `{ field }` object, and runtime `FormField` — always producing a real `name`, merging object-schema metadata (type/options/validation) with spec overrides (`helpText`→description, `readonly`→disabled, required, colSpan, …). Disambiguates spec-vs-runtime by whether `field` is a string or a metadata object.
- Wired all five variants (`Tabbed`/`Wizard`/`Split`/`Drawer`/`Modal`) + the `ObjectForm` section filter to it (dedups ~210 lines of near-identical code).

## Tests / verification

- **+7 unit tests** (`sectionFields.test.ts`), incl. the exact crash case.
- **111 existing plugin-form tests** still pass; package build + DTS compile clean.
- **Verified live in the browser** against real HotCRM data: the Create Account modal renders fully across all tabs (Profile, Financials, Locations w/ composite address + geo, Description) with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)