### PR TITLE
fix(i18n): localize record activity feed timestamps and actor fallbacks

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -961,7 +961,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         const mapped: FeedItem[] = res.data.map((c: any) => ({
           id: c.id,
           type: 'comment' as const,
-          actor: c.author_name ?? 'Unknown',
+          actor: c.author_name ?? t('detail.unknownUser', { defaultValue: 'Unknown' }),
           actorAvatarUrl: c.author_avatar_url ?? undefined,
           body: c.body ?? '',
           createdAt: c.created_at,
@@ -1021,8 +1021,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         if (!res?.data?.length) return;
         const mapped: FeedItem[] = [];
         for (const row of res.data) {
-          const t = activityTypeToFeed[row.type];
-          if (!t) continue;
+          const feedType = activityTypeToFeed[row.type];
+          if (!feedType) continue;
           // Prefer the explicit `timestamp` column, but tolerate older
           // rows where the driver leaked the literal "NOW()" — fall
           // back to created_at (always a real ISO date).
@@ -1032,8 +1032,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           }
           mapped.push({
             id: row.id,
-            type: t,
-            actor: row.actor_name ?? 'System',
+            type: feedType,
+            actor: row.actor_name ?? t('detail.systemActor', { defaultValue: 'System' }),
             actorAvatarUrl: row.actor_avatar_url ?? undefined,
             body: row.summary ?? '',
             createdAt: when,

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -448,6 +448,9 @@ const en = {
     minutesAgo: '{{count}}m ago',
     hoursAgo: '{{count}}h ago',
     daysAgo: '{{count}}d ago',
+    // Activity feed actors
+    systemActor: 'System',
+    unknownUser: 'Unknown',
     // Record meta footer (audit provenance)
     createdBy: 'Created by',
     updatedBy: 'Updated by',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -452,6 +452,9 @@ const zh = {
     minutesAgo: '{{count}}分钟前',
     hoursAgo: '{{count}}小时前',
     daysAgo: '{{count}}天前',
+    // Activity feed actors
+    systemActor: '系统',
+    unknownUser: '未知用户',
     // Record meta footer (audit provenance)
     createdBy: '创建于',
     updatedBy: '更新于',

--- a/packages/plugin-detail/src/RecordActivityTimeline.tsx
+++ b/packages/plugin-detail/src/RecordActivityTimeline.tsx
@@ -102,19 +102,22 @@ function getFilterOptions(t: (key: string) => string): { value: FeedFilterMode; 
   ];
 }
 
-function formatTimestamp(timestamp: string): string {
+function formatTimestamp(
+  timestamp: string,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
   try {
     const date = new Date(timestamp);
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(diffMs / 60000);
 
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffMins < 1) return t('detail.justNow');
+    if (diffMins < 60) return t('detail.minutesAgo', { count: diffMins });
     const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffHours < 24) return t('detail.hoursAgo', { count: diffHours });
     const diffDays = Math.floor(diffHours / 24);
-    if (diffDays < 7) return `${diffDays}d ago`;
+    if (diffDays < 7) return t('detail.daysAgo', { count: diffDays });
     return date.toLocaleDateString();
   } catch {
     return timestamp;
@@ -397,7 +400,7 @@ export const RecordActivityTimeline: React.FC<RecordActivityTimelineProps> = ({
                             </span>
                           )}
                           <span className="text-xs text-muted-foreground">
-                            {formatTimestamp(item.createdAt)}
+                            {formatTimestamp(item.createdAt, t)}
                           </span>
                           {item.edited && (
                             <span className="text-xs text-muted-foreground italic">{t('detail.edited')}</span>

--- a/packages/plugin-detail/src/ThreadedReplies.tsx
+++ b/packages/plugin-detail/src/ThreadedReplies.tsx
@@ -24,19 +24,22 @@ export interface ThreadedRepliesProps {
   className?: string;
 }
 
-function formatTimestamp(timestamp: string): string {
+function formatTimestamp(
+  timestamp: string,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
   try {
     const date = new Date(timestamp);
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(diffMs / 60000);
 
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffMins < 1) return t('detail.justNow');
+    if (diffMins < 60) return t('detail.minutesAgo', { count: diffMins });
     const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffHours < 24) return t('detail.hoursAgo', { count: diffHours });
     const diffDays = Math.floor(diffHours / 24);
-    if (diffDays < 7) return `${diffDays}d ago`;
+    if (diffDays < 7) return t('detail.daysAgo', { count: diffDays });
     return date.toLocaleDateString();
   } catch {
     return timestamp;
@@ -125,7 +128,7 @@ export const ThreadedReplies: React.FC<ThreadedRepliesProps> = ({
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs font-medium">{reply.actor}</span>
                   <span className="text-[10px] text-muted-foreground">
-                    {formatTimestamp(reply.createdAt)}
+                    {formatTimestamp(reply.createdAt, t)}
                   </span>
                 </div>
                 <p className="text-xs whitespace-pre-wrap break-words">{reply.body}</p>


### PR DESCRIPTION
## 背景
派工单详情页「讨论 / 活动」在 zh-CN 下仍显示英文（见用户截图）：相对时间 `2d ago`、动态发起人 `System`。

## 排查结论
- 相对时间：`RecordActivityTimeline` 与 `ThreadedReplies` 的 `formatTimestamp()` 硬编码英文，而 zh-CN 翻译 key（`detail.justNow/minutesAgo/hoursAgo/daysAgo`）其实早已存在，只是从未被调用。
- 发起人名：`RecordDetailView` 用硬编码的 `'System'` / `'Unknown'` 作为 fallback。

## 改动
- `formatTimestamp` 接收并使用 `t()`（两个组件）。
- 新增翻译 key `detail.systemActor`（系统）、`detail.unknownUser`（未知用户），en + zh 双语补齐；feed 发起人 fallback 改走 `t()`。
- 重命名遮蔽外层 `t` 的循环变量 `t` → `feedType`，否则翻译函数在该作用域不可达。

## 不在本 PR 范围
- 动态正文 `Created <object> "DO-00030"` 来自服务端 `sys_activity.summary`，需后端处理。
- 「编辑视图」表单的英文标签来自上游 `@objectstack/spec` 的 JSON Schema（`SchemaForm` 对 schema 派生标签无翻译层），属上游 / 服务端 `/meta/types` 翻译机制范畴。

## 验证
- `tsc --noEmit`（plugin-detail）在装好依赖的主 checkout 下通过。
- 浏览器端因需后端数据 + 登录态 + zh-CN 环境,未在本环境复现。