### PR TITLE
fix(app-shell): merge action bodyExtra into RecordDetailView update payload

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -381,6 +381,17 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       const params: Record<string, any> = { ...(action.params || {}) };
       delete params._rowRecord;
 
+      // Merge `bodyExtra` constant fields into the update payload. Per the
+      // ActionSchema contract these are "applied last; overrides user params",
+      // and the PageView/list executeAPI path already honors them. Without this
+      // merge, a pure-confirm action (confirmText, no `params` array — the
+      // trigger carried entirely in `bodyExtra`) collects empty `params`, so the
+      // generic `default` branch below skips the update and the action silently
+      // no-ops on the record-detail page while working from a list row.
+      if (action.bodyExtra && typeof action.bodyExtra === 'object') {
+        Object.assign(params, action.bodyExtra);
+      }
+
       let undo: any;
       switch (target) {
         case 'opportunity_change_stage':


### PR DESCRIPTION
## Problem

`type: 'api'` actions invoked from a **record-detail page** silently fail to
persist when their mutation payload is carried in `bodyExtra` rather than in a
visible `params` array. The success toast fires, but nothing is written.

The **exact same action works from a list row**, which is the confusing part
users hit first.

### Root cause

`RecordDetailView`'s `apiHandler` builds its `dataSource.update` payload from
`action.params` only:

```ts
const params = { ...(action.params || {}) };
delete params._rowRecord;
// ...
default:
  if (Object.keys(params).length > 0) {          // <-- empty → skipped
    await dataSource.update(objectName!, pureRecordId!, params);
  }
```

A **pure-confirm action** — `confirmText` + a hidden trigger field, with the
trigger carried entirely in `bodyExtra` and **no `params` array** — therefore
collects empty `params`, fails the `Object.keys(params).length > 0` guard, and
no-ops.

The list-row path does not have this bug because the shared console runtime
already merges `bodyExtra`:

```ts
// packages/app-shell/src/hooks/useConsoleActionRuntime.tsx:239
if (action.bodyExtra && typeof action.bodyExtra === 'object') {
  Object.assign(body, action.bodyExtra);
}
```

This is also what the `ActionSchema` contract documents — `bodyExtra` is
"applied last; overrides user params" (`@objectstack/spec`,
`object.zod` → `bodyExtra?: Record<string, unknown>`).

So `RecordDetailView`'s handler was simply missing the merge that the
list/PageView path already had.

## Fix

Merge `action.bodyExtra` into `params` right after stripping `_rowRecord`,
mirroring the shared runtime exactly. The merge runs before the `switch`, so
the named `opportunity_*` cases are unaffected (they build explicit payloads)
and the generic `default` update now includes the constant fields.

```ts
if (action.bodyExtra && typeof action.bodyExtra === 'object') {
  Object.assign(params, action.bodyExtra);
}
```

One file, +11 lines (8 of them an explanatory comment).

## Testing

- `pnpm --filter @object-ui/app-shell type-check`: **no new errors** — the diff
  produces the identical pre-existing error count (26 → 26, all in unrelated
  files: i18n exports, `ActionResult` typing, `plugin-report`), none in the
  edited region.
- `pnpm --filter @object-ui/app-shell exec vitest run src/hooks/__tests__/useConsoleActionRuntime.test.tsx`:
  **12/12 pass** — confirms the `bodyExtra` contract this change brings the
  detail-page path in line with.
- `bodyExtra` is a typed optional on the spec `ActionSchema`
  (`Record<string, unknown> | undefined`); the guard + `Object.assign` is
  type-safe and matches the existing sibling usage.

## Note for reviewers

`RecordDetailView` keeps its own `apiHandler` (dataSource-based, for the
already-loaded record) distinct from `useConsoleActionRuntime`'s HTTP-fetch
`apiHandler`. Both transports are legitimate, but the `bodyExtra` handling had
drifted between them. This PR restores parity with a minimal change;
consolidating the two handlers is a larger refactor and intentionally left out
of scope.
