### PR TITLE
feat(console): iOS "Liquid Glass" desktop theme

### DIFF
--- a/apps/console/src/index.css
+++ b/apps/console/src/index.css
@@ -277,3 +277,149 @@
 .dark [data-sidebar="menu-button"][data-active="true"]:hover {
   background-color: hsl(var(--primary) / 0.24);
 }
+
+/* ============================================================
+ * iOS desktop experience — "Liquid Glass" theme layer (iteration 1)
+ *
+ * App-level theming only (console/index.css); no shared component
+ * library (packages/components/src/ui) is touched. Delete this whole
+ * block to revert to the stock look.
+ *
+ * What it changes: iOS-scale concentric corners, a grouped system-gray
+ * canvas so white cards read as floating layers, SF Pro typography with
+ * iOS tracking, a frosted-glass top bar, soft elevation on overlays, and
+ * an iOS press-springback on buttons.
+ * ============================================================ */
+@layer base {
+  :root {
+    /* iOS uses larger, concentric corner radii */
+    --radius: 0.875rem;
+
+    /* iOS "grouped" canvas: soft system gray (≈ #F2F2F7) instead of pure
+       white, so white cards/popovers float above it with real depth. */
+    --background: 240 24% 97%;
+    --secondary: 240 18% 94%;
+    --muted: 240 18% 94%;
+    --accent: 240 18% 94%;
+    --border: 240 16% 90%;
+  }
+
+  .dark {
+    /* iOS dark uses near-black, not blue-black; cards sit slightly above. */
+    --background: 240 6% 6%;
+    --card: 240 6% 10%;
+    --popover: 240 6% 11%;
+    --secondary: 240 5% 16%;
+    --muted: 240 5% 16%;
+    --accent: 240 5% 16%;
+    --border: 240 5% 18%;
+  }
+
+  body {
+    /* SF Pro / system font with iOS rendering + tighter tracking */
+    font-family: -apple-system, "SF Pro Text", "SF Pro Display",
+      BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif,
+      "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    letter-spacing: -0.011em;
+  }
+}
+
+/* Frosted-glass top bar (the signature iOS "material") */
+header.sticky {
+  background-color: hsl(var(--background) / 0.72) !important;
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  backdrop-filter: saturate(180%) blur(20px);
+  border-bottom-color: hsl(var(--border) / 0.7);
+}
+.dark header.sticky {
+  background-color: hsl(var(--background) / 0.6) !important;
+}
+
+/* Soft, diffuse iOS elevation on floating surfaces (dialogs, menus, popovers). */
+[role="dialog"],
+[role="menu"],
+[data-radix-popper-content-wrapper] > * {
+  box-shadow:
+    0 12px 32px -8px hsl(240 40% 20% / 0.18),
+    0 4px 12px -4px hsl(240 40% 20% / 0.12) !important;
+}
+
+/* iOS-style press springback on interactive controls. */
+@media (hover: hover) {
+  button:not([disabled]) {
+    transition: transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1),
+      filter 0.18s ease;
+  }
+  button:not([disabled]):active {
+    transform: scale(0.96);
+  }
+}
+
+/* ------------------------------------------------------------
+ * iOS theme — iteration 2: system-blue accent + deeper controls
+ * ------------------------------------------------------------ */
+@layer base {
+  :root {
+    /* iOS system blue (#007AFF) replaces the indigo brand accent.
+       Drives buttons, links, progress bars, focus rings, active nav. */
+    --primary: 211 100% 50%;
+    --ring: 211 100% 50%;
+    --sidebar-primary: 211 100% 50%;
+    --sidebar-ring: 211 100% 50%;
+    /* iOS sidebar is a translucent vibrancy material → near-white base. */
+    --sidebar: 240 24% 98%;
+  }
+  .dark {
+    /* iOS dark blue (#0A84FF) is a touch brighter for contrast. */
+    --primary: 211 100% 60%;
+    --ring: 211 100% 60%;
+    --sidebar-primary: 211 100% 60%;
+    --sidebar-ring: 211 100% 60%;
+    --sidebar: 240 6% 8%;
+  }
+}
+
+/* Frosted-glass sidebar (iPad-style translucent vibrancy). */
+[data-sidebar="sidebar"] {
+  background-color: hsl(var(--sidebar) / 0.7) !important;
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  backdrop-filter: saturate(180%) blur(20px);
+}
+
+/* iOS toggle: switches turn system-green (#34C759) when on, not blue. */
+[role="switch"][data-state="checked"] {
+  background-color: hsl(135 59% 49%) !important;
+}
+
+/* iOS sheet/dialog: extra-rounded corners. */
+[role="dialog"] {
+  border-radius: 1.25rem !important;
+}
+
+/* iOS-blue tinted text selection. */
+::selection {
+  background-color: hsl(211 100% 50% / 0.22);
+}
+
+/* Thin, overlay-style iOS scrollbars. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(240 6% 70% / 0.6) transparent;
+}
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-thumb {
+  background-color: hsl(240 6% 70% / 0.55);
+  border-radius: 9999px;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(240 6% 60% / 0.75);
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}

--- a/apps/console/src/index.css
+++ b/apps/console/src/index.css
@@ -423,3 +423,28 @@ header.sticky {
 *::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* ------------------------------------------------------------
+ * iOS theme — iteration 3: high-confidence control polish
+ * (CSS-only overrides; shadcn ui components not edited)
+ * ------------------------------------------------------------ */
+
+/* iOS "spotlight"-style backdrop: blur + lighten the dim behind any
+   dialog / sheet / command palette overlay instead of a flat 80% black. */
+.fixed.inset-0.z-50.bg-black\/80 {
+  background-color: rgb(0 0 0 / 0.35) !important;
+  -webkit-backdrop-filter: blur(8px) saturate(140%);
+  backdrop-filter: blur(8px) saturate(140%);
+}
+
+/* iOS slider thumb: solid white knob with a soft drop shadow instead of a
+   hollow accent-ring. (Radix SliderThumb carries role="slider".) */
+[role="slider"] {
+  height: 1.5rem !important;
+  width: 1.5rem !important;
+  background-color: #fff !important;
+  border-color: transparent !important;
+  box-shadow:
+    0 1px 4px rgb(0 0 0 / 0.25),
+    0 0 0 0.5px rgb(0 0 0 / 0.06) !important;
+}

--- a/packages/app-shell/src/console/home/AppCard.tsx
+++ b/packages/app-shell/src/console/home/AppCard.tsx
@@ -80,11 +80,6 @@ export function AppCard({ app, onClick, isFavorite, index = 0 }: AppCardProps) {
 
       <div
         aria-hidden
-        className={cn('absolute inset-x-0 top-0 h-1', accent.solid)}
-      />
-
-      <div
-        aria-hidden
         className={cn(
           'absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity duration-300 group-hover:opacity-100',
           accent.from,
@@ -113,7 +108,7 @@ export function AppCard({ app, onClick, isFavorite, index = 0 }: AppCardProps) {
 
         <div
           className={cn(
-            'inline-flex h-14 w-14 items-center justify-center rounded-xl mb-4 ring-1 ring-inset',
+            'inline-flex h-14 w-14 items-center justify-center rounded-2xl mb-4 ring-1 ring-inset',
             'bg-gradient-to-br ring-border/40',
             accent.from,
             accent.to,
@@ -133,10 +128,7 @@ export function AppCard({ app, onClick, isFavorite, index = 0 }: AppCardProps) {
               </Badge>
             )}
           </div>
-          <p className={cn(
-            'text-sm text-muted-foreground mt-1.5 line-clamp-2 min-h-[2.5rem]',
-            !description && 'italic',
-          )}>
+          <p className="text-sm text-muted-foreground mt-1.5 line-clamp-2 min-h-[2.5rem]">
             {description || t('home.appCard.noDescription', { defaultValue: 'No description' })}
           </p>
         </div>

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -317,7 +317,7 @@ export function HomePage() {
               {displayName ? ', ' : ''}
             </span>
             {displayName && (
-              <span className="bg-gradient-to-r from-indigo-600 via-violet-600 to-fuchsia-600 bg-clip-text text-transparent dark:from-indigo-400 dark:via-violet-400 dark:to-fuchsia-400">
+              <span className="text-primary">
                 {displayName}
               </span>
             )}


### PR DESCRIPTION
## What

Gives the **desktop** console an iOS (latest "Liquid Glass") look & feel. App-level theming, delivered in clearly-delimited, deletable blocks. The shared shadcn UI library (`packages/components/src/ui`, the no-touch zone) is **not** edited — restyling is done via CSS tokens + role/attribute-scoped overrides in `apps/console/src/index.css`, plus two small home-page component tweaks in `packages/app-shell`.

## Scope (tier A — "desktop is iOS now")

**Global theme tokens & materials** — `apps/console/src/index.css`
- iOS concentric corners (`--radius` 0.5 → 0.875rem; dialogs extra-rounded)
- "grouped" system-gray canvas so white cards/popovers float as layers
- SF Pro / `-apple-system` typography, antialiasing, iOS tracking
- frosted-glass (backdrop-blur) **top bar** and **sidebar**
- iOS **system-blue** accent (`#007AFF` / dark `#0A84FF`) for console chrome — per-app brand colors (injected as inline `<html>` vars) intentionally still win, so the branding system is preserved
- iOS-green toggles, blue selection, thin scrollbars, button press-springback
- dark mode retuned to iOS near-black (#0e0e10)
- **overlay**: dialog / sheet / ⌘K backdrop → iOS spotlight-style blur+lighten (not flat 80% black)
- **slider**: solid white knob with soft shadow instead of a hollow accent ring

**Home page** — `packages/app-shell/src/console/home/`
- hero display name uses the iOS-blue accent (solid) instead of the indigo→fuchsia gradient that clashed with the new accent
- AppCard: dropped the hard color top stripe — accent now lives only in the rounded-2xl (squircle) icon tile, iOS springboard style
- AppCard: "No description" no longer italic

## Verification

Ran the console locally and verified in-browser (Chrome DevTools), light + dark, across **8 surfaces**: home, login, list/grid, kanban board, record-detail sheet, ⌘K command palette, create-record form dialog, Studio admin. Token-level theme carries ~80% of surfaces; remaining gaps are isolated component details (tracked as tier B/C below).

`type-check` passes for `@object-ui/app-shell` + `@object-ui/console`. (The one pre-existing `react-hooks/static-components` lint error at `AppCard.tsx:46` is outside this diff.)

## Not in this PR (follow-ups)

- **Tier B** (low-risk polish): iOS filled-gray capsule chips; card `:active` press-scale; detail-page status-stepper chevrons → simpler segments
- **Tier C** (iOS signature, higher cost): Large-Title collapse-into-navbar on scroll; "Recently visited" as an iOS inset-grouped list

## Revert

Delete the `iOS theme` blocks at the end of `apps/console/src/index.css` and revert the two `packages/app-shell/src/console/home/` tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)