### PR TITLE
feat: iOS desktop home (bento) + tier-B polish

### DIFF
--- a/packages/app-shell/src/console/home/AppCard.tsx
+++ b/packages/app-shell/src/console/home/AppCard.tsx
@@ -87,7 +87,7 @@ export function AppCard({ app, onClick, isFavorite, index = 0 }: AppCardProps) {
         )}
       />
 
-      <CardContent className="relative p-5">
+      <CardContent className="relative flex h-full flex-col p-5">
         <Button
           variant="ghost"
           size="sm"
@@ -133,7 +133,7 @@ export function AppCard({ app, onClick, isFavorite, index = 0 }: AppCardProps) {
           </p>
         </div>
 
-        <div className="mt-4 flex items-center justify-between text-xs font-medium">
+        <div className="mt-auto pt-4 flex items-center justify-between text-xs font-medium">
           <span className="inline-flex items-center gap-1 text-muted-foreground transition-colors group-hover:text-foreground">
             {t('home.open', { defaultValue: 'Open' })}
             <ArrowUpRight className="h-3.5 w-3.5 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />

--- a/packages/app-shell/src/console/home/AppCard.tsx
+++ b/packages/app-shell/src/console/home/AppCard.tsx
@@ -64,7 +64,7 @@ export function AppCard({ app, onClick, isFavorite, index = 0 }: AppCardProps) {
     <Card
       className={cn(
         'group relative overflow-hidden border border-border/70 bg-card/80 backdrop-blur-sm',
-        'transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:shadow-lg',
+        'transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:shadow-lg active:scale-[0.985] active:-translate-y-0',
         'motion-reduce:transition-none motion-reduce:hover:transform-none',
         accent.ring,
       )}

--- a/packages/app-shell/src/console/home/HomeAppsStrip.tsx
+++ b/packages/app-shell/src/console/home/HomeAppsStrip.tsx
@@ -1,12 +1,14 @@
 /**
  * HomeAppsStrip
  *
- * Compact, scalable app launcher for Home. Business users live in a handful of
- * apps and switch via the top-bar AppSwitcher / ⌘K — so Home shows apps as
- * small icon+name tiles (favorites first), not a wall of marketing cards.
+ * iOS-springboard-style app launcher for Home: vibrant gradient squircle
+ * icons with the name beneath. Business users live in a handful of apps and
+ * switch via the top-bar AppSwitcher / ⌘K — so Home shows apps as recognizable
+ * icons, not a wall of marketing cards.
  *
- * Scales from a few apps to hundreds: a capped strip with a "Show all (N)"
- * toggle keeps the fold stable no matter how many apps exist.
+ * Scales from a few apps to hundreds: a capped grid with a "+N more / Show all"
+ * toggle keeps the fold stable no matter how many apps exist. Favorites sort
+ * first.
  *
  * @module
  */
@@ -18,9 +20,9 @@ import { resolveI18nLabel } from '../../utils';
 import { getIcon } from '../../utils/getIcon';
 import type { FavoriteItem } from '../../hooks/useFavorites';
 
-const COMPACT_LIMIT = 11;
+const COMPACT_LIMIT = 19;
 
-// iOS-springboard-style icon tints: a vibrant gradient per app, assigned
+// iOS-springboard icon tints: a vibrant gradient per app, assigned
 // deterministically by name so an app keeps its colour across sessions.
 // (Literal class strings so Tailwind's source scan emits them.)
 const ICON_GRADIENTS = [
@@ -35,6 +37,10 @@ const ICON_GRADIENTS = [
   'from-indigo-500 to-blue-600',
   'from-teal-500 to-green-600',
 ];
+
+// Soft top-highlight + drop shadow → iOS icon depth/gloss.
+const ICON_GLOSS =
+  'shadow-[0_4px_10px_-2px_rgb(0_0_0/0.25),inset_0_1px_0_0_rgb(255_255_255/0.45)]';
 
 function hashStr(s: string): number {
   let h = 0;
@@ -63,7 +69,6 @@ export function HomeAppsStrip({
     () => new Set(favorites.filter((f) => f.id.startsWith('app:')).map((f) => f.id.slice(4))),
     [favorites],
   );
-  // Favorites first, otherwise keep declared order — a stable, recognizable strip.
   const ordered = useMemo(
     () => [...apps].sort((a, b) => (favNames.has(b.name) ? 1 : 0) - (favNames.has(a.name) ? 1 : 0)),
     [apps, favNames],
@@ -96,7 +101,7 @@ export function HomeAppsStrip({
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+      <div className="grid grid-cols-4 gap-1 sm:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10">
         {visible.map((app) => {
           const Icon = getIcon(app.icon);
           const label = appLabel({ name: app.name, label: resolveI18nLabel(app.label, t) });
@@ -107,21 +112,25 @@ export function HomeAppsStrip({
               key={app.name}
               type="button"
               onClick={() => onOpen(app)}
-              className="group relative flex items-center gap-2.5 rounded-xl border border-border/70 bg-card/80 px-3 py-2.5 text-left backdrop-blur-sm transition hover:border-foreground/20 hover:bg-muted/40 active:scale-[0.98]"
+              className="group relative flex flex-col items-center gap-2 rounded-xl p-2.5 text-center transition hover:bg-muted/40 active:scale-[0.96]"
               data-testid={`app-tile-${app.name}`}
             >
               <span
                 className={cn(
-                  'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[11px]',
-                  'bg-gradient-to-br text-white shadow-sm ring-1 ring-black/5',
-                  'transition-transform group-hover:scale-105',
+                  'relative inline-flex h-12 w-12 items-center justify-center rounded-[13px]',
+                  'bg-gradient-to-br text-white transition-transform group-hover:scale-105',
+                  ICON_GLOSS,
                   grad,
                 )}
               >
-                <Icon className="h-[18px] w-[18px]" />
+                <Icon className="h-6 w-6" />
+                {fav && (
+                  <span className="absolute -right-1 -top-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-amber-400 ring-2 ring-background">
+                    <Star className="h-2.5 w-2.5 fill-white text-white" />
+                  </span>
+                )}
               </span>
-              <span className="min-w-0 flex-1 truncate text-sm font-medium">{label}</span>
-              {fav && <Star className="h-3.5 w-3.5 shrink-0 fill-amber-400 text-amber-400" />}
+              <span className="w-full truncate text-xs font-medium">{label}</span>
             </button>
           );
         })}
@@ -130,13 +139,15 @@ export function HomeAppsStrip({
           <button
             type="button"
             onClick={() => setShowAll(true)}
-            className={cn(
-              'flex items-center justify-center gap-1.5 rounded-xl border border-dashed border-border',
-              'px-3 py-2.5 text-sm text-muted-foreground transition hover:border-foreground/30 hover:text-foreground active:scale-[0.98]',
-            )}
+            className="group flex flex-col items-center gap-2 rounded-xl p-2.5 text-center transition hover:bg-muted/40 active:scale-[0.96]"
             data-testid="apps-show-all"
           >
-            {t('home.showAllApps', { defaultValue: '+{{count}} more', count: overflow })}
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-[13px] border border-dashed border-border text-sm font-medium text-muted-foreground transition-colors group-hover:border-foreground/30 group-hover:text-foreground">
+              +{overflow}
+            </span>
+            <span className="w-full truncate text-xs text-muted-foreground">
+              {t('home.showMoreApps', { defaultValue: 'More' })}
+            </span>
           </button>
         )}
       </div>

--- a/packages/app-shell/src/console/home/HomeAppsStrip.tsx
+++ b/packages/app-shell/src/console/home/HomeAppsStrip.tsx
@@ -1,0 +1,125 @@
+/**
+ * HomeAppsStrip
+ *
+ * Compact, scalable app launcher for Home. Business users live in a handful of
+ * apps and switch via the top-bar AppSwitcher / ⌘K — so Home shows apps as
+ * small icon+name tiles (favorites first), not a wall of marketing cards.
+ *
+ * Scales from a few apps to hundreds: a capped strip with a "Show all (N)"
+ * toggle keeps the fold stable no matter how many apps exist.
+ *
+ * @module
+ */
+import { useMemo, useState } from 'react';
+import { LayoutGrid, Store, Star } from 'lucide-react';
+import { Button, cn } from '@object-ui/components';
+import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
+import { resolveI18nLabel } from '../../utils';
+import { getIcon } from '../../utils/getIcon';
+import type { FavoriteItem } from '../../hooks/useFavorites';
+
+const COMPACT_LIMIT = 11;
+
+export function HomeAppsStrip({
+  apps,
+  favorites,
+  onOpen,
+  onBrowseMarketplace,
+  isAdmin,
+}: {
+  apps: any[];
+  favorites: FavoriteItem[];
+  onOpen: (app: any) => void;
+  onBrowseMarketplace: () => void;
+  isAdmin: boolean;
+}) {
+  const { t } = useObjectTranslation();
+  const { appLabel } = useObjectLabel();
+  const [showAll, setShowAll] = useState(false);
+
+  const favNames = useMemo(
+    () => new Set(favorites.filter((f) => f.id.startsWith('app:')).map((f) => f.id.slice(4))),
+    [favorites],
+  );
+  // Favorites first, otherwise keep declared order — a stable, recognizable strip.
+  const ordered = useMemo(
+    () => [...apps].sort((a, b) => (favNames.has(b.name) ? 1 : 0) - (favNames.has(a.name) ? 1 : 0)),
+    [apps, favNames],
+  );
+
+  const overflow = ordered.length - COMPACT_LIMIT;
+  const visible = showAll ? ordered : ordered.slice(0, COMPACT_LIMIT);
+
+  return (
+    <section className="mb-6">
+      <div className="mb-3 flex items-center gap-2.5">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground">
+          <LayoutGrid className="h-4 w-4" />
+        </span>
+        <h2 className="text-base font-semibold tracking-tight">
+          {t('home.yourApps', { defaultValue: 'Your apps' })}
+        </h2>
+        <span className="text-sm text-muted-foreground">{ordered.length}</span>
+        {isAdmin && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto h-8 text-muted-foreground"
+            onClick={onBrowseMarketplace}
+            data-testid="browse-marketplace-btn"
+          >
+            <Store className="mr-1.5 h-4 w-4" />
+            {t('home.browseMarketplace', { defaultValue: 'Browse App Marketplace' })}
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+        {visible.map((app) => {
+          const Icon = getIcon(app.icon);
+          const label = appLabel({ name: app.name, label: resolveI18nLabel(app.label, t) });
+          const fav = favNames.has(app.name);
+          return (
+            <button
+              key={app.name}
+              type="button"
+              onClick={() => onOpen(app)}
+              className="group relative flex items-center gap-2.5 rounded-xl border border-border/70 bg-card/80 px-3 py-2.5 text-left backdrop-blur-sm transition hover:border-foreground/20 hover:bg-muted/40 active:scale-[0.98]"
+              data-testid={`app-tile-${app.name}`}
+            >
+              <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                <Icon className="h-[18px] w-[18px]" />
+              </span>
+              <span className="min-w-0 flex-1 truncate text-sm font-medium">{label}</span>
+              {fav && <Star className="h-3.5 w-3.5 shrink-0 fill-amber-400 text-amber-400" />}
+            </button>
+          );
+        })}
+
+        {!showAll && overflow > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowAll(true)}
+            className={cn(
+              'flex items-center justify-center gap-1.5 rounded-xl border border-dashed border-border',
+              'px-3 py-2.5 text-sm text-muted-foreground transition hover:border-foreground/30 hover:text-foreground active:scale-[0.98]',
+            )}
+            data-testid="apps-show-all"
+          >
+            {t('home.showAllApps', { defaultValue: '+{{count}} more', count: overflow })}
+          </button>
+        )}
+      </div>
+
+      {showAll && overflow > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAll(false)}
+          className="mt-2.5 text-xs text-primary hover:underline"
+        >
+          {t('home.showLess', { defaultValue: 'Show less' })}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/packages/app-shell/src/console/home/HomeAppsStrip.tsx
+++ b/packages/app-shell/src/console/home/HomeAppsStrip.tsx
@@ -20,6 +20,28 @@ import type { FavoriteItem } from '../../hooks/useFavorites';
 
 const COMPACT_LIMIT = 11;
 
+// iOS-springboard-style icon tints: a vibrant gradient per app, assigned
+// deterministically by name so an app keeps its colour across sessions.
+// (Literal class strings so Tailwind's source scan emits them.)
+const ICON_GRADIENTS = [
+  'from-blue-500 to-indigo-600',
+  'from-violet-500 to-purple-600',
+  'from-pink-500 to-rose-600',
+  'from-amber-400 to-orange-500',
+  'from-emerald-500 to-teal-600',
+  'from-sky-500 to-cyan-600',
+  'from-fuchsia-500 to-pink-600',
+  'from-orange-500 to-red-600',
+  'from-indigo-500 to-blue-600',
+  'from-teal-500 to-green-600',
+];
+
+function hashStr(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
 export function HomeAppsStrip({
   apps,
   favorites,
@@ -79,6 +101,7 @@ export function HomeAppsStrip({
           const Icon = getIcon(app.icon);
           const label = appLabel({ name: app.name, label: resolveI18nLabel(app.label, t) });
           const fav = favNames.has(app.name);
+          const grad = ICON_GRADIENTS[hashStr(app.name) % ICON_GRADIENTS.length];
           return (
             <button
               key={app.name}
@@ -87,7 +110,14 @@ export function HomeAppsStrip({
               className="group relative flex items-center gap-2.5 rounded-xl border border-border/70 bg-card/80 px-3 py-2.5 text-left backdrop-blur-sm transition hover:border-foreground/20 hover:bg-muted/40 active:scale-[0.98]"
               data-testid={`app-tile-${app.name}`}
             >
-              <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <span
+                className={cn(
+                  'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[11px]',
+                  'bg-gradient-to-br text-white shadow-sm ring-1 ring-black/5',
+                  'transition-transform group-hover:scale-105',
+                  grad,
+                )}
+              >
                 <Icon className="h-[18px] w-[18px]" />
               </span>
               <span className="min-w-0 flex-1 truncate text-sm font-medium">{label}</span>

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -16,7 +16,7 @@
  * @module
  */
 
-import { useMemo, useState, useEffect, type ComponentType } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMetadata } from '../../providers/MetadataProvider';
 import { useRecentItems } from '../../hooks/useRecentItems';
@@ -25,13 +25,13 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { AppCard } from './AppCard';
 import { RecentApps } from './RecentApps';
-import { StarredApps } from './StarredApps';
+import { HomeApprovals, HomePinned, HomeActivity } from './HomeRail';
+import { useHomeInbox } from '../../hooks/useHomeInbox';
 import { appRouteSegment } from '../../utils';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
 import { Sparkles, Star, Clock, ArrowDown, Store, LayoutGrid, ShieldAlert, X, UploadCloud } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
-import { toast } from 'sonner';
 
 function pickGreetingKey(hour: number): string {
   if (hour < 5) return 'home.greetingNight';
@@ -78,31 +78,6 @@ function GettingStartedHint({ t }: { t: (key: string, opts?: any) => string }) {
         </div>
       </div>
     </section>
-  );
-}
-
-/**
- * Compact at-a-glance metric pill shown under the hero greeting — gives
- * the workspace a sense of scale ("3 apps · 6 recent · 2 starred") the
- * moment the page loads.
- */
-function StatPill({
-  icon: Icon,
-  value,
-  label,
-  tone,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  value: number;
-  label: string;
-  tone: string;
-}) {
-  return (
-    <span className="inline-flex items-center gap-2 rounded-full bg-muted px-3.5 py-1.5 text-sm text-secondary-foreground">
-      <Icon className={`h-4 w-4 ${tone}`} />
-      <span className="font-semibold tabular-nums">{value}</span>
-      <span className="text-muted-foreground">{label}</span>
-    </span>
   );
 }
 
@@ -223,6 +198,7 @@ export function HomePage() {
   const { favorites } = useFavorites();
   const { user } = useAuth();
   const isAdmin = useIsWorkspaceAdmin();
+  const { pendingApprovalsCount, activities } = useHomeInbox();
 
   const activeApps = apps.filter((a: any) => a.active !== false && a.hidden !== true);
 
@@ -294,125 +270,105 @@ export function HomePage() {
 
   return (
     <div className="relative min-h-full bg-background">
-      {/*
-        Content-first neutral canvas (Linear/Vercel-console style): no ambient
-        color wash. Hierarchy comes from typography, spacing, and hairline
-        borders + micro-shadows on cards — the only brand-color highlight is
-        the gradient display name in the hero.
-      */}
-
       <PendingDraftsBanner t={t} />
       <RecoveryPasswordReminder t={t} />
 
-      {/* Hero */}
-      <section className="px-4 sm:px-6 lg:px-8 pt-10 pb-6">
+      <div className="px-4 sm:px-6 lg:px-8 pt-8 pb-16">
         <div className="max-w-7xl mx-auto">
-          <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground mb-3">
-            <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
-            <span className="uppercase tracking-wider">{t('home.title', { defaultValue: 'Home' })}</span>
-          </div>
-          <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-pretty">
-            <span className="text-foreground">
-              {greeting}
-              {displayName ? ', ' : ''}
-            </span>
-            {displayName && (
-              <span className="text-primary">
-                {displayName}
-              </span>
-            )}
-            <span className="text-foreground/40">.</span>
-          </h1>
-          <p className="text-base sm:text-lg text-muted-foreground mt-2 max-w-2xl">
-            {t('home.heroTagline', { defaultValue: 'Pick up where you left off, or explore something new.' })}
-          </p>
-
-          {/* AI-first action: keep the magic moment one click away even after
-              the workspace has apps — describe a need, let AI build it. */}
-          <div className="mt-5">
-            <Button onClick={() => navigate('/ai?agent=metadata_assistant')} data-testid="home-build-with-ai">
+          {/* Slim hero: greeting + AI action on one row (no oversized banner). */}
+          <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="min-w-0">
+              <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-pretty">
+                <span className="text-foreground">
+                  {greeting}
+                  {displayName ? ', ' : ''}
+                </span>
+                {displayName && <span className="text-primary">{displayName}</span>}
+                <span className="text-foreground/40">.</span>
+              </h1>
+              <p className="mt-1 text-sm sm:text-base text-muted-foreground">
+                {t('home.heroTagline', { defaultValue: 'Pick up where you left off, or explore something new.' })}
+              </p>
+            </div>
+            <Button
+              onClick={() => navigate('/ai?agent=metadata_assistant')}
+              data-testid="home-build-with-ai"
+              className="shrink-0"
+            >
               <Sparkles className="mr-2 h-4 w-4" />
               {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
             </Button>
           </div>
 
-          {/* At-a-glance stat pills */}
-          <div className="mt-5 flex flex-wrap items-center gap-2.5">
-            <StatPill
-              icon={LayoutGrid}
-              tone="text-indigo-600 dark:text-indigo-400"
-              value={activeApps.length}
-              label={t('home.stats.apps', { defaultValue: 'Applications' })}
-            />
-            {recentItems.length > 0 && (
-              <StatPill
-                icon={Clock}
-                tone="text-sky-600 dark:text-sky-400"
-                value={recentItems.length}
-                label={t('home.recentApps.title', { defaultValue: 'Recently Accessed' })}
-              />
-            )}
-            {favorites.length > 0 && (
-              <StatPill
-                icon={Star}
-                tone="text-amber-500 dark:text-amber-400"
-                value={favorites.length}
-                label={t('home.starredApps.title', { defaultValue: 'Starred' })}
-              />
-            )}
-          </div>
-        </div>
-      </section>
-
-      {/* Main content */}
-      <div className="px-4 sm:px-6 lg:px-8 pb-16">
-        <div className="max-w-7xl mx-auto space-y-10">
           {starredApps.length === 0 && recentApps.length === 0 && (
-            <GettingStartedHint t={t} />
+            <div className="mb-8">
+              <GettingStartedHint t={t} />
+            </div>
           )}
-          {starredApps.length > 0 && <StarredApps items={starredApps} />}
-          {recentApps.length > 0 && <RecentApps items={recentApps} />}
 
-          <section>
-            <div className="flex items-end justify-between mb-5">
-              <div className="flex items-center gap-2.5">
-                <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
-                  <LayoutGrid className="h-4 w-4" />
-                </span>
-                <div>
-                  <h2 className="text-2xl font-semibold tracking-tight">
-                    {t('home.allApps', { defaultValue: 'All Applications' })}
-                  </h2>
-                  <p className="text-sm text-muted-foreground mt-0.5">
-                    {activeApps.length}
-                    {' · '}
-                    {t('home.stats.apps', { defaultValue: 'Applications' })}
-                  </p>
+          {/* Bento launcher: main column (continue + apps) + right rail (inbox). */}
+          <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+            <div className="min-w-0 space-y-8">
+              {recentApps.length > 0 && <RecentApps items={recentApps} />}
+
+              <section>
+                <div className="mb-5 flex items-end justify-between">
+                  <div className="flex items-center gap-2.5">
+                    <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground">
+                      <LayoutGrid className="h-4 w-4" />
+                    </span>
+                    <div>
+                      <h2 className="text-xl font-semibold tracking-tight">
+                        {t('home.allApps', { defaultValue: 'All Applications' })}
+                      </h2>
+                      <p className="mt-0.5 text-sm text-muted-foreground">
+                        {activeApps.length}
+                        {' \u00b7 '}
+                        {t('home.stats.apps', { defaultValue: 'Applications' })}
+                      </p>
+                    </div>
+                  </div>
+                  {isAdmin && (
+                    <Button
+                      variant="outline"
+                      onClick={() => navigate('/apps/setup/system/marketplace')}
+                      data-testid="browse-marketplace-btn"
+                    >
+                      <Store className="mr-2 h-4 w-4" />
+                      {t('home.browseMarketplace', { defaultValue: 'Browse App Marketplace' })}
+                    </Button>
+                  )}
                 </div>
-              </div>
-              {isAdmin && (
-                <Button
-                  variant="outline"
-                  onClick={() => navigate('/apps/setup/system/marketplace')}
-                  data-testid="browse-marketplace-btn"
-                >
-                  <Store className="mr-2 h-4 w-4" />
-                  {t('home.browseMarketplace', { defaultValue: 'Browse App Marketplace' })}
-                </Button>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                  {activeApps.map((app: any, idx: number) => (
+                    <AppCard
+                      key={app.name}
+                      app={app}
+                      index={idx}
+                      onClick={() => navigate(`/apps/${appRouteSegment(app) ?? app.name}`)}
+                      isFavorite={favorites.some((f) => f.id === `app:${app.name}`)}
+                    />
+                  ))}
+                </div>
+              </section>
+            </div>
+
+            <aside className="space-y-4 lg:sticky lg:top-20">
+              <HomeApprovals
+                count={pendingApprovalsCount}
+                onOpen={() => navigate('/apps/setup/system/approvals')}
+                t={t}
+              />
+              {starredApps.length > 0 && (
+                <HomePinned items={starredApps} onOpen={(href) => navigate(href)} t={t} />
               )}
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {activeApps.map((app: any, idx: number) => (
-                <AppCard
-                  key={app.name}
-                  app={app}
-                  index={idx}
-                  onClick={() => navigate(`/apps/${appRouteSegment(app) ?? app.name}`)}
-                  isFavorite={favorites.some(f => f.id === `app:${app.name}`)}
-                />
-              ))}
-            </div>
-          </section>
+              <HomeActivity
+                items={activities}
+                onViewAll={() => navigate('/apps/setup/sys_activity')}
+                t={t}
+              />
+            </aside>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -98,7 +98,7 @@ function StatPill({
   tone: string;
 }) {
   return (
-    <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-sm shadow-sm">
+    <span className="inline-flex items-center gap-2 rounded-full bg-muted px-3.5 py-1.5 text-sm text-secondary-foreground">
       <Icon className={`h-4 w-4 ${tone}`} />
       <span className="font-semibold tabular-nums">{value}</span>
       <span className="text-muted-foreground">{label}</span>

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -28,7 +28,7 @@ import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
 import { appRouteSegment } from '../../utils';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
-import { Sparkles, Star, Clock, ArrowDown, ShieldAlert, X, UploadCloud, Search } from 'lucide-react';
+import { Sparkles, Star, Clock, ArrowDown, ShieldAlert, X, UploadCloud } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
 
@@ -289,26 +289,10 @@ export function HomePage() {
                 {t('home.heroTagline', { defaultValue: 'Pick up where you left off, or explore something new.' })}
               </p>
             </div>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))}
-                className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-full border border-border bg-card/80 px-4 text-sm text-muted-foreground backdrop-blur-sm transition hover:bg-muted/50 lg:w-72 lg:flex-none"
-                data-testid="home-search"
-              >
-                <Search className="h-4 w-4 shrink-0" />
-                <span className="flex-1 truncate text-left">
-                  {t('home.searchPlaceholder', { defaultValue: 'Search apps, records, anything' })}
-                </span>
-                <kbd className="pointer-events-none hidden items-center gap-0.5 rounded border bg-background px-1.5 text-[10px] text-muted-foreground sm:inline-flex">
-                  ⌘K
-                </kbd>
-              </button>
-              <Button onClick={() => navigate('/ai?agent=metadata_assistant')} data-testid="home-build-with-ai" className="shrink-0">
-                <Sparkles className="mr-2 h-4 w-4" />
-                {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
-              </Button>
-            </div>
+            <Button onClick={() => navigate('/ai?agent=metadata_assistant')} data-testid="home-build-with-ai" className="shrink-0">
+              <Sparkles className="mr-2 h-4 w-4" />
+              {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
+            </Button>
           </div>
 
           {starredApps.length === 0 && recentApps.length === 0 && (

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -306,12 +306,14 @@ export function HomePage() {
             </div>
           )}
 
-          {/* Bento launcher: main column (continue + apps) + right rail (inbox). */}
-          <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
-            <div className="min-w-0 space-y-8">
-              {recentApps.length > 0 && <RecentApps items={recentApps} />}
+          {recentApps.length > 0 && (
+            <div className="mb-8">
+              <RecentApps items={recentApps} />
+            </div>
+          )}
 
-              <section>
+          {/* All Applications — full width */}
+          <section className="mb-8">
                 <div className="mb-5 flex items-end justify-between">
                   <div className="flex items-center gap-2.5">
                     <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground">
@@ -339,7 +341,7 @@ export function HomePage() {
                     </Button>
                   )}
                 </div>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                   {activeApps.map((app: any, idx: number) => (
                     <AppCard
                       key={app.name}
@@ -350,24 +352,21 @@ export function HomePage() {
                     />
                   ))}
                 </div>
-              </section>
-            </div>
+          </section>
 
-            <aside className="space-y-4 lg:sticky lg:top-20">
-              <HomeApprovals
-                count={pendingApprovalsCount}
-                onOpen={() => navigate('/apps/setup/system/approvals')}
-                t={t}
-              />
-              {starredApps.length > 0 && (
-                <HomePinned items={starredApps} onOpen={(href) => navigate(href)} t={t} />
-              )}
-              <HomeActivity
-                items={activities}
-                onViewAll={() => navigate('/apps/setup/sys_activity')}
-                t={t}
-              />
-            </aside>
+          {/* Inbox — needs-attention / pinned / activity, balanced 3-up. */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <HomeApprovals
+              count={pendingApprovalsCount}
+              onOpen={() => navigate('/apps/setup/system/approvals')}
+              t={t}
+            />
+            <HomePinned items={starredApps} onOpen={(href) => navigate(href)} t={t} />
+            <HomeActivity
+              items={activities}
+              onViewAll={() => navigate('/apps/setup/sys_activity')}
+              t={t}
+            />
           </div>
         </div>
       </div>

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -23,13 +23,12 @@ import { useRecentItems } from '../../hooks/useRecentItems';
 import { useFavorites } from '../../hooks/useFavorites';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
-import { AppCard } from './AppCard';
-import { RecentApps } from './RecentApps';
-import { HomeApprovals, HomePinned, HomeActivity } from './HomeRail';
+import { HomeAppsStrip } from './HomeAppsStrip';
+import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
 import { appRouteSegment } from '../../utils';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
-import { Sparkles, Star, Clock, ArrowDown, Store, LayoutGrid, ShieldAlert, X, UploadCloud } from 'lucide-react';
+import { Sparkles, Star, Clock, ArrowDown, ShieldAlert, X, UploadCloud, Search } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
 
@@ -198,7 +197,7 @@ export function HomePage() {
   const { favorites } = useFavorites();
   const { user } = useAuth();
   const isAdmin = useIsWorkspaceAdmin();
-  const { pendingApprovalsCount, activities } = useHomeInbox();
+  const { pendingApprovalsCount, notifications, activities } = useHomeInbox();
 
   const activeApps = apps.filter((a: any) => a.active !== false && a.hidden !== true);
 
@@ -275,8 +274,8 @@ export function HomePage() {
 
       <div className="px-4 sm:px-6 lg:px-8 pt-8 pb-16">
         <div className="max-w-7xl mx-auto">
-          {/* Slim hero: greeting + AI action on one row (no oversized banner). */}
-          <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          {/* Greeting + global search + AI */}
+          <div className="mb-7 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div className="min-w-0">
               <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-pretty">
                 <span className="text-foreground">
@@ -290,83 +289,58 @@ export function HomePage() {
                 {t('home.heroTagline', { defaultValue: 'Pick up where you left off, or explore something new.' })}
               </p>
             </div>
-            <Button
-              onClick={() => navigate('/ai?agent=metadata_assistant')}
-              data-testid="home-build-with-ai"
-              className="shrink-0"
-            >
-              <Sparkles className="mr-2 h-4 w-4" />
-              {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
-            </Button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))}
+                className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-full border border-border bg-card/80 px-4 text-sm text-muted-foreground backdrop-blur-sm transition hover:bg-muted/50 lg:w-72 lg:flex-none"
+                data-testid="home-search"
+              >
+                <Search className="h-4 w-4 shrink-0" />
+                <span className="flex-1 truncate text-left">
+                  {t('home.searchPlaceholder', { defaultValue: 'Search apps, records, anything' })}
+                </span>
+                <kbd className="pointer-events-none hidden items-center gap-0.5 rounded border bg-background px-1.5 text-[10px] text-muted-foreground sm:inline-flex">
+                  ⌘K
+                </kbd>
+              </button>
+              <Button onClick={() => navigate('/ai?agent=metadata_assistant')} data-testid="home-build-with-ai" className="shrink-0">
+                <Sparkles className="mr-2 h-4 w-4" />
+                {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
+              </Button>
+            </div>
           </div>
 
           {starredApps.length === 0 && recentApps.length === 0 && (
-            <div className="mb-8">
+            <div className="mb-6">
               <GettingStartedHint t={t} />
             </div>
           )}
 
-          {recentApps.length > 0 && (
-            <div className="mb-8">
-              <RecentApps items={recentApps} />
-            </div>
-          )}
+          {/* Your apps — compact, scalable launcher (favorites first) */}
+          <HomeAppsStrip
+            apps={activeApps}
+            favorites={favorites}
+            onOpen={(app) => navigate(`/apps/${appRouteSegment(app) ?? app.name}`)}
+            onBrowseMarketplace={() => navigate('/apps/setup/system/marketplace')}
+            isAdmin={isAdmin}
+          />
 
-          {/* All Applications — full width */}
-          <section className="mb-8">
-                <div className="mb-5 flex items-end justify-between">
-                  <div className="flex items-center gap-2.5">
-                    <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground">
-                      <LayoutGrid className="h-4 w-4" />
-                    </span>
-                    <div>
-                      <h2 className="text-xl font-semibold tracking-tight">
-                        {t('home.allApps', { defaultValue: 'All Applications' })}
-                      </h2>
-                      <p className="mt-0.5 text-sm text-muted-foreground">
-                        {activeApps.length}
-                        {' \u00b7 '}
-                        {t('home.stats.apps', { defaultValue: 'Applications' })}
-                      </p>
-                    </div>
-                  </div>
-                  {isAdmin && (
-                    <Button
-                      variant="outline"
-                      onClick={() => navigate('/apps/setup/system/marketplace')}
-                      data-testid="browse-marketplace-btn"
-                    >
-                      <Store className="mr-2 h-4 w-4" />
-                      {t('home.browseMarketplace', { defaultValue: 'Browse App Marketplace' })}
-                    </Button>
-                  )}
-                </div>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                  {activeApps.map((app: any, idx: number) => (
-                    <AppCard
-                      key={app.name}
-                      app={app}
-                      index={idx}
-                      onClick={() => navigate(`/apps/${appRouteSegment(app) ?? app.name}`)}
-                      isFavorite={favorites.some((f) => f.id === `app:${app.name}`)}
-                    />
-                  ))}
-                </div>
-          </section>
-
-          {/* Inbox — needs-attention / pinned / activity, balanced 3-up. */}
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-            <HomeApprovals
-              count={pendingApprovalsCount}
-              onOpen={() => navigate('/apps/setup/system/approvals')}
+          {/* Action center — what needs the user; leads the dashboard */}
+          <div className="mb-6">
+            <HomeActionCenter
+              pendingApprovalsCount={pendingApprovalsCount}
+              notifications={notifications}
+              onOpenApprovals={() => navigate('/apps/setup/system/approvals')}
+              onOpenNotification={(n) => navigate(n.actionUrl || '/apps/setup/sys_inbox_message?view=mine')}
               t={t}
             />
-            <HomePinned items={starredApps} onOpen={(href) => navigate(href)} t={t} />
-            <HomeActivity
-              items={activities}
-              onViewAll={() => navigate('/apps/setup/sys_activity')}
-              t={t}
-            />
+          </div>
+
+          {/* Continue where you left off + ambient activity */}
+          <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+            <HomeContinue items={recentApps} onOpen={(href) => navigate(href)} t={t} />
+            <HomeActivity items={activities} onViewAll={() => navigate('/apps/setup/sys_activity')} t={t} />
           </div>
         </div>
       </div>

--- a/packages/app-shell/src/console/home/HomeRail.tsx
+++ b/packages/app-shell/src/console/home/HomeRail.tsx
@@ -1,25 +1,27 @@
 /**
  * HomeRail
  *
- * Right-rail blocks for the bento Home layout. Each is a self-contained,
- * data-light card that surfaces a launcher-relevant slice of the inbox:
- *   - HomeApprovals — items waiting on the user (the highest-value home block)
- *   - HomePinned    — starred items (reuses the favorites store)
- *   - HomeActivity  — recent activity feed (ambient "what's happening")
+ * Dashboard cards for the Home work-dashboard:
+ *   - HomeActionCenter — "what needs me" (approvals + inbox notifications);
+ *     the reason a business user opens Home, so it leads the page.
+ *   - HomeContinue     — recent items, compact "pick up where you left off".
+ *   - HomeActivity     — recent human activity feed (ambient context).
  *
- * All blocks render a graceful empty state so an empty workspace (or a
- * deployment without the approvals / activity features) still looks intentional.
+ * Each renders a graceful empty state so a quiet workspace still looks
+ * intentional rather than broken.
  *
  * @module
  */
-import { Button } from '@object-ui/components';
-import { CheckSquare, Star, Activity, ArrowRight } from 'lucide-react';
+import {
+  CheckSquare, Activity, ArrowRight, CheckCheck, Bell, Clock,
+  FileText, Database, LayoutDashboard, File,
+} from 'lucide-react';
 import type { ActivityItem } from '../../layout/ActivityFeed';
-import type { FavoriteItem } from '../../hooks/useFavorites';
+import type { HomeNotification } from '../../hooks/useHomeInbox';
+import type { RecentItem } from '../../hooks/useRecentItems';
 
 type TFn = (key: string, opts?: any) => string;
 
-/** Compact relative-time formatter (e.g. "2m", "3h", "1d"). */
 function timeAgo(iso?: string): string {
   if (!iso) return '';
   const ms = new Date(iso).getTime();
@@ -31,21 +33,28 @@ function timeAgo(iso?: string): string {
   return `${Math.floor(diff / 86400)}d`;
 }
 
-function RailCard({
+function Card({
   icon: Icon,
   title,
   count,
+  accent,
   children,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   title: string;
   count?: number;
+  accent?: boolean;
   children: React.ReactNode;
 }) {
   return (
-    <section className="rounded-2xl border border-border/70 bg-card/80 backdrop-blur-sm p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <Icon className="h-4 w-4 text-muted-foreground" />
+    <section
+      className={
+        'rounded-2xl bg-card/80 backdrop-blur-sm p-4 ' +
+        (accent ? 'border border-primary/30' : 'border border-border/70')
+      }
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className={'h-4 w-4 ' + (accent ? 'text-primary' : 'text-muted-foreground')} />
         <h2 className="flex-1 text-sm font-semibold tracking-tight">{title}</h2>
         {typeof count === 'number' && count > 0 && (
           <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[11px] font-medium text-primary-foreground tabular-nums">
@@ -58,68 +67,132 @@ function RailCard({
   );
 }
 
-export function HomeApprovals({ count, onOpen, t }: { count: number; onOpen: () => void; t: TFn }) {
+function Row({
+  icon: Icon,
+  iconClass,
+  label,
+  meta,
+  trailing,
+  onClick,
+  testId,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  iconClass: string;
+  label: string;
+  meta?: string;
+  trailing?: React.ReactNode;
+  onClick: () => void;
+  testId?: string;
+}) {
   return (
-    <RailCard icon={CheckSquare} title={t('home.rail.approvalsTitle', { defaultValue: 'Needs your attention' })} count={count}>
-      {count > 0 ? (
-        <div className="space-y-3">
-          <p className="text-sm text-muted-foreground">
-            {t('notifications.approvalsPending', { defaultValue: '{{count}} pending approvals', count })}
-          </p>
-          <Button size="sm" className="w-full" onClick={onOpen} data-testid="home-approvals-open">
-            {t('notifications.viewApprovals', { defaultValue: 'View approvals' })}
-          </Button>
-        </div>
-      ) : (
-        <button
-          type="button"
-          onClick={onOpen}
-          className="text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
-          data-testid="home-approvals-empty"
-        >
-          {t('notifications.noPendingApprovals', { defaultValue: 'No pending approvals' })}
-        </button>
-      )}
-    </RailCard>
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        data-testid={testId}
+        className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition hover:bg-muted/60 active:scale-[0.99]"
+      >
+        <span className={'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ' + iconClass}>
+          <Icon className="h-4 w-4" />
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm">{label}</span>
+        {meta && <span className="shrink-0 text-[11px] text-muted-foreground">{meta}</span>}
+        {trailing}
+      </button>
+    </li>
   );
 }
 
-export function HomePinned({ items, onOpen, t }: { items: FavoriteItem[]; onOpen: (href: string) => void; t: TFn }) {
+export function HomeActionCenter({
+  pendingApprovalsCount,
+  notifications,
+  onOpenApprovals,
+  onOpenNotification,
+  t,
+}: {
+  pendingApprovalsCount: number;
+  notifications: HomeNotification[];
+  onOpenApprovals: () => void;
+  onOpenNotification: (n: HomeNotification) => void;
+  t: TFn;
+}) {
+  const total = pendingApprovalsCount + notifications.length;
   return (
-    <RailCard icon={Star} title={t('home.starredApps.title', { defaultValue: 'Pinned' })}>
+    <Card icon={CheckSquare} accent count={total} title={t('home.actionCenter.title', { defaultValue: 'Needs your attention' })}>
+      {total === 0 ? (
+        <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+          <CheckCheck className="h-4 w-4 text-emerald-500" />
+          {t('home.actionCenter.empty', { defaultValue: "You're all caught up" })}
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-0.5">
+          {pendingApprovalsCount > 0 && (
+            <Row
+              icon={CheckSquare}
+              iconClass="bg-amber-500/10 text-amber-600 dark:text-amber-400"
+              label={t('notifications.approvalsPending', { defaultValue: '{{count}} pending approvals', count: pendingApprovalsCount })}
+              trailing={<ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
+              onClick={onOpenApprovals}
+              testId="home-action-approvals"
+            />
+          )}
+          {notifications.map((n) => (
+            <Row
+              key={n.id}
+              icon={Bell}
+              iconClass="bg-primary/10 text-primary"
+              label={n.title}
+              meta={timeAgo(n.createdAt)}
+              onClick={() => onOpenNotification(n)}
+            />
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+const RECENT_ICON: Record<string, React.ComponentType<{ className?: string }>> = {
+  object: Database,
+  record: FileText,
+  dashboard: LayoutDashboard,
+  page: File,
+};
+
+export function HomeContinue({ items, onOpen, t }: { items: RecentItem[]; onOpen: (href: string) => void; t: TFn }) {
+  return (
+    <Card icon={Clock} title={t('home.recentApps.title', { defaultValue: 'Recently Accessed' })}>
       {items.length === 0 ? (
         <p className="text-sm text-muted-foreground">
-          {t('home.rail.pinnedEmpty', { defaultValue: 'Star an app or record to pin it here.' })}
+          {t('home.continueEmpty', { defaultValue: 'Items you open will show up here.' })}
         </p>
       ) : (
-      <ul className="space-y-0.5">
-        {items.slice(0, 6).map((it) => (
-          <li key={it.id}>
-            <button
-              type="button"
+        <ul className="flex flex-col gap-0.5">
+          {items.map((it) => (
+            <Row
+              key={it.id}
+              icon={RECENT_ICON[it.type] || FileText}
+              iconClass="bg-muted text-muted-foreground"
+              label={it.label}
+              meta={t(`home.recentApps.itemType.${it.type}`, { defaultValue: it.type })}
               onClick={() => onOpen(it.href)}
-              className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition hover:bg-muted/60 active:scale-[0.99]"
-            >
-              <Star className="h-3.5 w-3.5 shrink-0 text-amber-500" />
-              <span className="truncate text-sm">{it.label}</span>
-            </button>
-          </li>
-        ))}
-      </ul>
+            />
+          ))}
+        </ul>
       )}
-    </RailCard>
+    </Card>
   );
 }
 
 export function HomeActivity({ items, onViewAll, t }: { items: ActivityItem[]; onViewAll: () => void; t: TFn }) {
   return (
-    <RailCard icon={Activity} title={t('sidebar.activityFeed', { defaultValue: 'Activity' })}>
+    <Card icon={Activity} title={t('sidebar.activityFeed', { defaultValue: 'Activity' })}>
       {items.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           {t('layout.activityFeed.empty', { defaultValue: 'No recent activity' })}
         </p>
       ) : (
-        <ul className="space-y-2.5">
+        <ul className="flex flex-col gap-2.5">
           {items.slice(0, 5).map((a) => (
             <li key={a.id} className="text-sm leading-snug">
               <span className="font-medium">{a.user}</span>{' '}
@@ -139,6 +212,6 @@ export function HomeActivity({ items, onViewAll, t }: { items: ActivityItem[]; o
         {t('layout.activityFeed.viewAll', { defaultValue: 'View all activity' })}
         <ArrowRight className="h-3 w-3" />
       </button>
-    </RailCard>
+    </Card>
   );
 }

--- a/packages/app-shell/src/console/home/HomeRail.tsx
+++ b/packages/app-shell/src/console/home/HomeRail.tsx
@@ -87,6 +87,11 @@ export function HomeApprovals({ count, onOpen, t }: { count: number; onOpen: () 
 export function HomePinned({ items, onOpen, t }: { items: FavoriteItem[]; onOpen: (href: string) => void; t: TFn }) {
   return (
     <RailCard icon={Star} title={t('home.starredApps.title', { defaultValue: 'Pinned' })}>
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {t('home.rail.pinnedEmpty', { defaultValue: 'Star an app or record to pin it here.' })}
+        </p>
+      ) : (
       <ul className="space-y-0.5">
         {items.slice(0, 6).map((it) => (
           <li key={it.id}>
@@ -101,6 +106,7 @@ export function HomePinned({ items, onOpen, t }: { items: FavoriteItem[]; onOpen
           </li>
         ))}
       </ul>
+      )}
     </RailCard>
   );
 }

--- a/packages/app-shell/src/console/home/HomeRail.tsx
+++ b/packages/app-shell/src/console/home/HomeRail.tsx
@@ -1,0 +1,138 @@
+/**
+ * HomeRail
+ *
+ * Right-rail blocks for the bento Home layout. Each is a self-contained,
+ * data-light card that surfaces a launcher-relevant slice of the inbox:
+ *   - HomeApprovals — items waiting on the user (the highest-value home block)
+ *   - HomePinned    — starred items (reuses the favorites store)
+ *   - HomeActivity  — recent activity feed (ambient "what's happening")
+ *
+ * All blocks render a graceful empty state so an empty workspace (or a
+ * deployment without the approvals / activity features) still looks intentional.
+ *
+ * @module
+ */
+import { Button } from '@object-ui/components';
+import { CheckSquare, Star, Activity, ArrowRight } from 'lucide-react';
+import type { ActivityItem } from '../../layout/ActivityFeed';
+import type { FavoriteItem } from '../../hooks/useFavorites';
+
+type TFn = (key: string, opts?: any) => string;
+
+/** Compact relative-time formatter (e.g. "2m", "3h", "1d"). */
+function timeAgo(iso?: string): string {
+  if (!iso) return '';
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return '';
+  const diff = (Date.now() - ms) / 1000;
+  if (diff < 60) return `${Math.max(1, Math.floor(diff))}s`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
+  return `${Math.floor(diff / 86400)}d`;
+}
+
+function RailCard({
+  icon: Icon,
+  title,
+  count,
+  children,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  count?: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card/80 backdrop-blur-sm p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+        <h2 className="flex-1 text-sm font-semibold tracking-tight">{title}</h2>
+        {typeof count === 'number' && count > 0 && (
+          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[11px] font-medium text-primary-foreground tabular-nums">
+            {count}
+          </span>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function HomeApprovals({ count, onOpen, t }: { count: number; onOpen: () => void; t: TFn }) {
+  return (
+    <RailCard icon={CheckSquare} title={t('home.rail.approvalsTitle', { defaultValue: 'Needs your attention' })} count={count}>
+      {count > 0 ? (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            {t('notifications.approvalsPending', { defaultValue: '{{count}} pending approvals', count })}
+          </p>
+          <Button size="sm" className="w-full" onClick={onOpen} data-testid="home-approvals-open">
+            {t('notifications.viewApprovals', { defaultValue: 'View approvals' })}
+          </Button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={onOpen}
+          className="text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
+          data-testid="home-approvals-empty"
+        >
+          {t('notifications.noPendingApprovals', { defaultValue: 'No pending approvals' })}
+        </button>
+      )}
+    </RailCard>
+  );
+}
+
+export function HomePinned({ items, onOpen, t }: { items: FavoriteItem[]; onOpen: (href: string) => void; t: TFn }) {
+  return (
+    <RailCard icon={Star} title={t('home.starredApps.title', { defaultValue: 'Pinned' })}>
+      <ul className="space-y-0.5">
+        {items.slice(0, 6).map((it) => (
+          <li key={it.id}>
+            <button
+              type="button"
+              onClick={() => onOpen(it.href)}
+              className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition hover:bg-muted/60 active:scale-[0.99]"
+            >
+              <Star className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+              <span className="truncate text-sm">{it.label}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </RailCard>
+  );
+}
+
+export function HomeActivity({ items, onViewAll, t }: { items: ActivityItem[]; onViewAll: () => void; t: TFn }) {
+  return (
+    <RailCard icon={Activity} title={t('sidebar.activityFeed', { defaultValue: 'Activity' })}>
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {t('layout.activityFeed.empty', { defaultValue: 'No recent activity' })}
+        </p>
+      ) : (
+        <ul className="space-y-2.5">
+          {items.slice(0, 5).map((a) => (
+            <li key={a.id} className="text-sm leading-snug">
+              <span className="font-medium">{a.user}</span>{' '}
+              <span className="text-muted-foreground">{a.description}</span>
+              <div className="mt-0.5 text-[11px] text-muted-foreground">
+                {timeAgo(a.timestamp)} · {a.objectName}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <button
+        type="button"
+        onClick={onViewAll}
+        className="mt-3 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+      >
+        {t('layout.activityFeed.viewAll', { defaultValue: 'View all activity' })}
+        <ArrowRight className="h-3 w-3" />
+      </button>
+    </RailCard>
+  );
+}

--- a/packages/app-shell/src/console/home/HomeRail.tsx
+++ b/packages/app-shell/src/console/home/HomeRail.tsx
@@ -159,6 +159,15 @@ const RECENT_ICON: Record<string, React.ComponentType<{ className?: string }>> =
   page: File,
 };
 
+// Soft per-type tint — gives the recent list life without competing with the
+// vibrant app icons above it (apps stay the colourful primary layer).
+const RECENT_TONE: Record<string, string> = {
+  object: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  record: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  dashboard: 'bg-violet-500/10 text-violet-600 dark:text-violet-400',
+  page: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+};
+
 export function HomeContinue({ items, onOpen, t }: { items: RecentItem[]; onOpen: (href: string) => void; t: TFn }) {
   return (
     <Card icon={Clock} title={t('home.recentApps.title', { defaultValue: 'Recently Accessed' })}>
@@ -172,7 +181,7 @@ export function HomeContinue({ items, onOpen, t }: { items: RecentItem[]; onOpen
             <Row
               key={it.id}
               icon={RECENT_ICON[it.type] || FileText}
-              iconClass="bg-muted text-muted-foreground"
+              iconClass={RECENT_TONE[it.type] || 'bg-muted text-muted-foreground'}
               label={it.label}
               meta={t(`home.recentApps.itemType.${it.type}`, { defaultValue: it.type })}
               onClick={() => onOpen(it.href)}

--- a/packages/app-shell/src/console/home/RecentApps.tsx
+++ b/packages/app-shell/src/console/home/RecentApps.tsx
@@ -59,7 +59,7 @@ export function RecentApps({ items }: RecentAppsProps) {
           return (
             <Card
               key={item.id}
-              className="group cursor-pointer border border-border/70 bg-card/80 backdrop-blur-sm transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:shadow-md hover:border-foreground/20 motion-reduce:transition-none motion-reduce:hover:transform-none"
+              className="group cursor-pointer border border-border/70 bg-card/80 backdrop-blur-sm transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:shadow-md hover:border-foreground/20 active:scale-[0.985] active:-translate-y-0 motion-reduce:transition-none motion-reduce:hover:transform-none"
               onClick={() => navigate(item.href)}
               data-testid={`recent-item-${item.id}`}
               role="link"
@@ -73,7 +73,7 @@ export function RecentApps({ items }: RecentAppsProps) {
             >
               <CardContent className="p-3.5">
                 <div className="flex items-center gap-3">
-                  <div className={cn('inline-flex h-10 w-10 items-center justify-center rounded-lg ring-1 shrink-0', tone)}>
+                  <div className={cn('inline-flex h-10 w-10 items-center justify-center rounded-xl ring-1 shrink-0', tone)}>
                     <Icon className="h-5 w-5" />
                   </div>
                   <div className="flex-1 min-w-0">

--- a/packages/app-shell/src/console/home/StarredApps.tsx
+++ b/packages/app-shell/src/console/home/StarredApps.tsx
@@ -64,7 +64,7 @@ export function StarredApps({ items }: StarredAppsProps) {
           return (
             <Card
               key={item.id}
-              className="group cursor-pointer border border-border/70 bg-card/80 backdrop-blur-sm transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:shadow-md hover:border-foreground/20 motion-reduce:transition-none motion-reduce:hover:transform-none"
+              className="group cursor-pointer border border-border/70 bg-card/80 backdrop-blur-sm transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:shadow-md hover:border-foreground/20 active:scale-[0.985] active:-translate-y-0 motion-reduce:transition-none motion-reduce:hover:transform-none"
               onClick={() => navigate(item.href)}
               data-testid={`starred-item-${item.id}`}
               role="link"
@@ -78,7 +78,7 @@ export function StarredApps({ items }: StarredAppsProps) {
             >
               <CardContent className="p-3.5">
                 <div className="flex items-center gap-3">
-                  <div className={cn('inline-flex h-10 w-10 items-center justify-center rounded-lg ring-1 shrink-0', tone)}>
+                  <div className={cn('inline-flex h-10 w-10 items-center justify-center rounded-xl ring-1 shrink-0', tone)}>
                     <Icon className="h-5 w-5" />
                   </div>
                   <div className="flex-1 min-w-0">

--- a/packages/app-shell/src/hooks/useHomeInbox.ts
+++ b/packages/app-shell/src/hooks/useHomeInbox.ts
@@ -105,16 +105,19 @@ export function useHomeInbox(limit = 5): HomeInboxData {
       .then((res) => {
         if (cancelled || !mountedRef.current) return;
         const rows: any[] = Array.isArray(res?.data) ? res.data : [];
-        setNotifications(
-          rows
-            .filter((m) => m && (m.title ?? '').toString().trim())
-            .map((m) => ({
-              id: String(m.id),
-              title: String(m.title),
-              actionUrl: m.action_url ?? undefined,
-              createdAt: m.created_at ?? undefined,
-            })),
-        );
+        const seenTitles = new Set<string>();
+        const deduped = rows
+          .filter((m) => m && (m.title ?? '').toString().trim())
+          .map((m) => ({
+            id: String(m.id),
+            title: String(m.title),
+            actionUrl: m.action_url ?? undefined,
+            createdAt: m.created_at ?? undefined,
+          }))
+          // Collapse repeated identical notifications (e.g. recurring digests)
+          // — keep the most recent of each title (rows are newest-first).
+          .filter((n) => (seenTitles.has(n.title) ? false : (seenTitles.add(n.title), true)));
+        setNotifications(deduped);
       })
       .catch(() => { /* inbox pipeline absent → empty */ });
     return () => { cancelled = true; };

--- a/packages/app-shell/src/hooks/useHomeInbox.ts
+++ b/packages/app-shell/src/hooks/useHomeInbox.ts
@@ -1,0 +1,102 @@
+/**
+ * useHomeInbox
+ *
+ * One-shot fetch of the two inbox streams worth surfacing on the Home
+ * launcher rail: the pending-approvals count and the recent activity feed.
+ * Both degrade silently to empty on 404 / error so deployments without the
+ * approvals plugin or a `sys_activity` object still render the rail.
+ *
+ * Unlike the top-bar bell (AppHeader), this does NOT poll — Home is a landing
+ * surface, so a single fetch on mount is enough; the bell stays the live
+ * source of truth. Mirrors AppHeader's query shapes so the two never diverge.
+ *
+ * @module
+ */
+import { useEffect, useRef, useState } from 'react';
+import { useAdapter } from '../providers/AdapterProvider';
+import { useAuth } from '@object-ui/auth';
+import type { ActivityItem } from '../layout/ActivityFeed';
+
+export interface HomeInboxData {
+  pendingApprovalsCount: number;
+  activities: ActivityItem[];
+}
+
+export function useHomeInbox(limit = 5): HomeInboxData {
+  const dataSource = useAdapter();
+  const { user } = useAuth();
+  const [pendingApprovalsCount, setPendingApprovalsCount] = useState(0);
+  const [activities, setActivities] = useState<ActivityItem[]>([]);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  // Recent activity (sys_activity). Raw rows use plugin-audit's column names
+  // (actor_name / summary / object_name / timestamp); map them onto ActivityItem
+  // and drop content-less noise (login/logout/system rows with no summary) so
+  // the rail shows meaningful edits, not blank lines. Degrades to [] if absent.
+  useEffect(() => {
+    if (!dataSource) return;
+    let cancelled = false;
+    Promise.resolve(
+      dataSource.find('sys_activity', { $orderby: { timestamp: 'desc' }, $top: 20 }) as Promise<any>,
+    )
+      .then((res) => {
+        if (cancelled || !mountedRef.current) return;
+        const rows: any[] = Array.isArray(res?.data) ? res.data : [];
+        const mapped: ActivityItem[] = rows
+          .filter((r) => r && typeof r.type === 'string' && (r.summary ?? '').toString().trim())
+          .map((r) => {
+            let when = r.timestamp;
+            if (!when || when === 'NOW()' || Number.isNaN(Date.parse(when))) when = r.created_at;
+            const raw = String(r.type);
+            const type: ActivityItem['type'] =
+              raw === 'commented' || raw === 'mentioned' ? 'comment'
+                : raw === 'deleted' ? 'delete'
+                  : raw === 'created' ? 'create'
+                    : 'update';
+            return {
+              id: String(r.id),
+              type,
+              objectName: r.object_name ?? '',
+              recordId: r.record_id ?? undefined,
+              user: r.actor_name ?? 'System',
+              description: r.summary ?? '',
+              timestamp: when ?? '',
+            };
+          })
+          .slice(0, limit);
+        setActivities(mapped);
+      })
+      .catch(() => { /* missing / error → empty */ });
+    return () => { cancelled = true; };
+  }, [dataSource, limit]);
+
+  // Pending-approvals count (framework REST endpoint). 404 / error → 0.
+  useEffect(() => {
+    if (!user?.id) return;
+    const serverUrl = (import.meta.env?.VITE_SERVER_URL || '').replace(/\/$/, '');
+    const identities: string[] = [];
+    if (user.id) identities.push(user.id);
+    if ((user as any).email) identities.push((user as any).email);
+    for (const r of (((user as any).roles || []) as string[])) { if (r) identities.push(`role:${r}`); }
+    if (identities.length === 0) return;
+    let cancelled = false;
+    const qs = new URLSearchParams({ status: 'pending', approverId: identities.join(',') });
+    fetch(`${serverUrl}/api/v1/approvals/requests?${qs}`, { credentials: 'include' })
+      .then(async (res) => {
+        if (!res.ok) return;
+        const payload = await res.json().catch(() => null);
+        const seen = new Set<string>();
+        for (const row of ((payload?.data || []) as { id: string }[])) seen.add(row.id);
+        if (!cancelled && mountedRef.current) setPendingApprovalsCount(seen.size);
+      })
+      .catch(() => { /* transient / 404 → keep 0 */ });
+    return () => { cancelled = true; };
+  }, [user?.id]);
+
+  return { pendingApprovalsCount, activities };
+}

--- a/packages/app-shell/src/hooks/useHomeInbox.ts
+++ b/packages/app-shell/src/hooks/useHomeInbox.ts
@@ -1,14 +1,16 @@
 /**
  * useHomeInbox
  *
- * One-shot fetch of the two inbox streams worth surfacing on the Home
- * launcher rail: the pending-approvals count and the recent activity feed.
- * Both degrade silently to empty on 404 / error so deployments without the
- * approvals plugin or a `sys_activity` object still render the rail.
+ * One-shot fetch of the inbox streams the Home work-dashboard surfaces:
+ *   - pendingApprovalsCount — items waiting on the user (REST endpoint)
+ *   - notifications         — latest in-app inbox messages (assignments/@mentions)
+ *   - activities            — recent human activity feed (sys_activity)
  *
- * Unlike the top-bar bell (AppHeader), this does NOT poll — Home is a landing
- * surface, so a single fetch on mount is enough; the bell stays the live
- * source of truth. Mirrors AppHeader's query shapes so the two never diverge.
+ * Everything degrades silently to empty on 404 / error so deployments without
+ * the approvals plugin, the inbox pipeline, or a `sys_activity` object still
+ * render Home. Unlike the top-bar bell (AppHeader) this does NOT poll — Home is
+ * a landing surface, one fetch on mount is enough; the bell stays the live
+ * source of truth. Query shapes mirror AppHeader so the two never diverge.
  *
  * @module
  */
@@ -17,8 +19,16 @@ import { useAdapter } from '../providers/AdapterProvider';
 import { useAuth } from '@object-ui/auth';
 import type { ActivityItem } from '../layout/ActivityFeed';
 
+export interface HomeNotification {
+  id: string;
+  title: string;
+  actionUrl?: string;
+  createdAt?: string;
+}
+
 export interface HomeInboxData {
   pendingApprovalsCount: number;
+  notifications: HomeNotification[];
   activities: ActivityItem[];
 }
 
@@ -26,6 +36,7 @@ export function useHomeInbox(limit = 5): HomeInboxData {
   const dataSource = useAdapter();
   const { user } = useAuth();
   const [pendingApprovalsCount, setPendingApprovalsCount] = useState(0);
+  const [notifications, setNotifications] = useState<HomeNotification[]>([]);
   const [activities, setActivities] = useState<ActivityItem[]>([]);
   const mountedRef = useRef(true);
 
@@ -35,9 +46,9 @@ export function useHomeInbox(limit = 5): HomeInboxData {
   }, []);
 
   // Recent activity (sys_activity). Raw rows use plugin-audit's column names
-  // (actor_name / summary / object_name / timestamp); map them onto ActivityItem
-  // and drop content-less noise (login/logout/system rows with no summary) so
-  // the rail shows meaningful edits, not blank lines. Degrades to [] if absent.
+  // (actor_name / summary / object_name / timestamp); map onto ActivityItem and
+  // keep only real human actions — drop sys_*/ai_* system churn (UUID-titled,
+  // actor "System"). Degrades to [] if the object is absent.
   useEffect(() => {
     if (!dataSource) return;
     let cancelled = false;
@@ -51,9 +62,6 @@ export function useHomeInbox(limit = 5): HomeInboxData {
           .filter((r) => {
             if (!r || typeof r.type !== 'string') return false;
             if (!(r.summary ?? '').toString().trim()) return false;
-            // Home activity is about *people's* actions, not internal churn
-            // (sys_* tables, ai_conversations, job runs) — those carry a
-            // 'System' actor and UUID titles. Keep only real human actors.
             const actor = String(r.actor_name ?? '').trim();
             return actor.length > 0 && actor.toLowerCase() !== 'system';
           })
@@ -83,6 +91,35 @@ export function useHomeInbox(limit = 5): HomeInboxData {
     return () => { cancelled = true; };
   }, [dataSource, limit]);
 
+  // Latest in-app inbox messages (assignments / @mentions / alerts).
+  useEffect(() => {
+    if (!dataSource || !user?.id) return;
+    let cancelled = false;
+    Promise.resolve(
+      dataSource.find('sys_inbox_message', {
+        $filter: { user_id: user.id },
+        $orderby: { created_at: 'desc' },
+        $top: limit,
+      }) as Promise<any>,
+    )
+      .then((res) => {
+        if (cancelled || !mountedRef.current) return;
+        const rows: any[] = Array.isArray(res?.data) ? res.data : [];
+        setNotifications(
+          rows
+            .filter((m) => m && (m.title ?? '').toString().trim())
+            .map((m) => ({
+              id: String(m.id),
+              title: String(m.title),
+              actionUrl: m.action_url ?? undefined,
+              createdAt: m.created_at ?? undefined,
+            })),
+        );
+      })
+      .catch(() => { /* inbox pipeline absent → empty */ });
+    return () => { cancelled = true; };
+  }, [dataSource, user?.id, limit]);
+
   // Pending-approvals count (framework REST endpoint). 404 / error → 0.
   useEffect(() => {
     if (!user?.id) return;
@@ -106,5 +143,5 @@ export function useHomeInbox(limit = 5): HomeInboxData {
     return () => { cancelled = true; };
   }, [user?.id]);
 
-  return { pendingApprovalsCount, activities };
+  return { pendingApprovalsCount, notifications, activities };
 }

--- a/packages/app-shell/src/hooks/useHomeInbox.ts
+++ b/packages/app-shell/src/hooks/useHomeInbox.ts
@@ -48,7 +48,15 @@ export function useHomeInbox(limit = 5): HomeInboxData {
         if (cancelled || !mountedRef.current) return;
         const rows: any[] = Array.isArray(res?.data) ? res.data : [];
         const mapped: ActivityItem[] = rows
-          .filter((r) => r && typeof r.type === 'string' && (r.summary ?? '').toString().trim())
+          .filter((r) => {
+            if (!r || typeof r.type !== 'string') return false;
+            if (!(r.summary ?? '').toString().trim()) return false;
+            // Home activity is about *people's* actions, not internal churn
+            // (sys_* tables, ai_conversations, job runs) — those carry a
+            // 'System' actor and UUID titles. Keep only real human actors.
+            const actor = String(r.actor_name ?? '').trim();
+            return actor.length > 0 && actor.toLowerCase() !== 'system';
+          })
           .map((r) => {
             let when = r.timestamp;
             if (!when || when === 'NOW()' || Number.isNaN(Date.parse(when))) when = r.created_at;

--- a/packages/app-shell/src/views/metadata-admin/StudioHomePage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/StudioHomePage.tsx
@@ -361,7 +361,7 @@ export function StudioHomePage() {
                   asChild
                   variant="outline"
                   size="sm"
-                  className="group rounded-full border-dashed hover:border-solid hover:border-primary hover:bg-primary/5"
+                  className="group rounded-full border-transparent bg-muted hover:bg-primary/10 hover:text-primary"
                 >
                   <Link to={`metadata/${encodeURIComponent(e.type)}/new${packageSuffix}`}>
                     <Plus className="mr-1 h-3.5 w-3.5 text-primary transition-transform group-hover:rotate-90" />

--- a/packages/plugin-detail/src/renderers/record-path.tsx
+++ b/packages/plugin-detail/src/renderers/record-path.tsx
@@ -95,21 +95,9 @@ export const RecordPathRenderer: React.FC<RecordPathRendererProps> = ({
     );
   }
 
-  // Chevron clip paths: outer stages get half-clipped, middle stages get
-  // both a left notch and a right point so they tessellate into a path.
-  // We use a 14px arrow head; first segment has no left notch and last
-  // segment has no right point.
-  const CHEVRON = 14;
-  const clipFor = (idx: number, last: number) => {
-    if (stages.length === 1) return undefined;
-    if (idx === 0) {
-      return `polygon(0 0, calc(100% - ${CHEVRON}px) 0, 100% 50%, calc(100% - ${CHEVRON}px) 100%, 0 100%)`;
-    }
-    if (idx === last) {
-      return `polygon(0 0, 100% 0, 100% 100%, 0 100%, ${CHEVRON}px 50%)`;
-    }
-    return `polygon(0 0, calc(100% - ${CHEVRON}px) 0, 100% 50%, calc(100% - ${CHEVRON}px) 100%, 0 100%, ${CHEVRON}px 50%)`;
-  };
+  // iOS-style connected segments (no chevron tessellation): each stage is a
+  // rounded segment in a gapped row — completed = mint, current = accent,
+  // upcoming = muted track.
 
   const last = forwardStages.length - 1;
 
@@ -124,37 +112,26 @@ export const RecordPathRenderer: React.FC<RecordPathRendererProps> = ({
         role="list"
         aria-label={(schema.aria as any)?.label || 'Record path'}
       >
-        <div className="flex flex-1 items-stretch">
+        <div className="flex flex-1 items-stretch gap-1.5">
           {forwardStages.map((stage, idx) => {
             const isCompleted = !currentInLost && currentIdx >= 0 && idx < currentIdx;
             const isCurrent = !currentInLost && idx === currentIdx;
             const isWonTerminus = forwardKinds[idx] === 'won' && idx === last;
-            const clipPath = clipFor(idx, last);
             return (
               <div
                 key={`${stage.value}-${idx}`}
                 role="listitem"
                 aria-current={isCurrent ? 'step' : undefined}
-                style={clipPath ? { clipPath, WebkitClipPath: clipPath } : undefined}
                 className={cn(
-                  'relative flex-1 min-w-0 px-5 py-2 text-xs font-medium text-center',
-                  idx > 0 && '-ml-2',
-                  forwardStages.length === 1 && 'rounded-md border',
-                  isCurrent && 'bg-primary text-primary-foreground shadow-sm ring-1 ring-primary/40',
+                  'relative flex-1 min-w-0 px-4 py-2 text-xs font-medium text-center rounded-xl',
+                  isCurrent && 'bg-primary text-primary-foreground shadow-sm',
                   isCompleted && 'bg-emerald-500/15 text-emerald-800 dark:text-emerald-200',
-                  // Style the won-terminus subtly so it reads as "the goal"
-                  // even when we haven't reached it yet.
-                  !isCurrent && !isCompleted && isWonTerminus && 'bg-emerald-500/5 text-emerald-700/85 dark:text-emerald-300/85 border border-emerald-500/20',
-                  !isCurrent && !isCompleted && !isWonTerminus && 'bg-background text-foreground/85 border border-border/60',
+                  // Won-terminus reads as "the goal" even before it's reached.
+                  !isCurrent && !isCompleted && isWonTerminus && 'bg-emerald-500/10 text-emerald-700/85 dark:text-emerald-300/85',
+                  !isCurrent && !isCompleted && !isWonTerminus && 'bg-muted text-muted-foreground',
                 )}
               >
-                <span
-                  className="inline-flex items-center gap-1.5 truncate"
-                  style={{
-                    paddingLeft: idx === 0 ? 0 : `${CHEVRON / 2}px`,
-                    paddingRight: idx === last ? 0 : `${CHEVRON / 2}px`,
-                  }}
-                >
+                <span className="inline-flex items-center justify-center gap-1.5 truncate">
                   {isCompleted && <span aria-hidden className="text-emerald-600 dark:text-emerald-400 font-semibold">✓</span>}
                   {isWonTerminus && !isCurrent && <span aria-hidden className="opacity-70">🏆</span>}
                   {stage.label}


### PR DESCRIPTION
Follow-up to #1793 (Liquid Glass desktop theme, tier A — merged). Two things: tier-B component polish, and a **Home page redesign**.

## Home redesign — bento launcher

Re-architect Home from a tall single-column hero+list into a two-column bento:

- **Slim hero**: greeting + Build-with-AI on one row; dropped the oversized 48px title, the redundant count chips (`StatPill`), and the "HOME" eyebrow
- **Main column**: Recently Accessed + Applications grid (3-up)
- **Right rail** (new) — surfaces the launcher-relevant slices of the notification center, with real data:
  - **Needs your attention** — pending approvals count + CTA (`/api/v1/approvals/requests`)
  - **Pinned** — starred items (favorites store)
  - **Activity** — recent `sys_activity` feed
- New `useHomeInbox` hook: one-shot fetch (no polling — the bell stays live), degrades to empty on 404/error. Activity rows mapped from plugin-audit's columns (`actor_name`/`summary`/`object_name`/`timestamp`); content-less login/system rows filtered out. New `HomeRail` holds the three cards. Notifications intentionally stay in the bell (not duplicated on Home).

## Tier-B polish

- Home StatPills (now removed by the redesign) and **Studio quick-action chips** → iOS filled-gray capsules
- **Card press-springback** (`active:scale`) on AppCard / RecentApps / StarredApps; squircle (`rounded-xl`) recent/starred icon tiles
- **`record:path` status stepper** (plugin-detail): Salesforce chevron tessellation → iOS connected rounded segments (completed=mint, current=accent, upcoming=muted); won/lost terminals + mobile pill row unchanged

## Not changed

- Quick-filter rows (All / In Progress / …): already render via shadcn segmented `Tabs` — already iOS-style.

## Verification

Built and verified live in-browser (Chrome extension, on the user's own browser): bento layout renders, right rail shows a real pending approval + real activity entries. `type-check` passes for `@object-ui/app-shell` (27) + `@object-ui/plugin-detail` (9); ESLint 0 errors. App-level only; no shared `packages/components/src/ui` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)