### PR TITLE
fix(fields): show empty-state for optionless select instead of silent dropdown

### DIFF
--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -31,6 +31,22 @@ export function SelectField({ value, onChange, field, readonly, ...props }: Fiel
     return display ? <span className="text-sm">{display}</span> : <EmptyValue />;
   }
 
+  // A select with no options is unfillable — a silently-empty Radix dropdown
+  // reads as "broken widget" and hides the real cause (the field metadata has
+  // no `options`). Surface a legible empty state instead, without needing to
+  // open the popover. Mirrors the inline form renderer's behaviour
+  // (see plugin form `renderFieldComponent`'s `case 'select'`).
+  if (options.length === 0) {
+    return (
+      <div
+        data-testid={fieldName ? `select-empty-${fieldName}` : undefined}
+        className="flex h-9 w-full items-center rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
+      >
+        No options available
+      </div>
+    );
+  }
+
   return (
     <Select 
       {...props}

--- a/packages/plugin-form/src/selectOptions.test.tsx
+++ b/packages/plugin-form/src/selectOptions.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: option propagation for `select` fields in the create/edit form.
+ *
+ * Origin (ObjectOS "create record" form renders no select options): a `select`
+ * field whose object-schema metadata had no `options` rendered a silently-empty
+ * Radix dropdown, which read as a broken widget and was mis-attributed to the
+ * form's option-propagation code. In fact the form propagates options correctly
+ * end-to-end; the real defect was upstream metadata that carried the field
+ * without an `options` array.
+ *
+ * These tests pin BOTH directions of the contract, portal-free (no need to open
+ * the Radix popover, which is flaky under happy-dom):
+ *
+ *   1. options present  → the field renders as a usable dropdown (trigger shown,
+ *      no empty state). If a future change drops options (e.g. `options || []`
+ *      reduced to `[]`), the empty state appears and this test fails — catching
+ *      the regression.
+ *   2. options absent    → a legible "No options available" empty state renders
+ *      instead of a silently-empty dropdown, so the real cause (metadata has no
+ *      options) is visible rather than hidden.
+ *
+ * The grid masks missing options via a humanize+hash fallback in
+ * `SelectCellRenderer`, so a correct-looking list does NOT prove options reach
+ * the client — which is what made the original bug hard to localize.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { registerAllFields } from '@object-ui/fields';
+import { ModalForm } from './ModalForm';
+
+registerAllFields();
+
+const GENRE_OPTIONS = [
+  { value: 'fiction', label: 'Fiction' },
+  { value: 'non_fiction', label: 'Non-Fiction' },
+  { value: 'self_help', label: 'Self-Help' },
+];
+
+const makeDataSource = (genreOptions?: Array<{ value: string; label: string }>): any => ({
+  getObjectSchema: vi.fn().mockResolvedValue({
+    name: 'book',
+    fields: {
+      title: { type: 'text', label: 'Title', required: true },
+      // `options` mirrors the shape the live schema (`GET /meta/object`) returns
+      // for a select field. When omitted, this reproduces the metadata state
+      // that produced the empty dropdown in the field report.
+      genre: { type: 'select', label: 'Genre', required: true, ...(genreOptions ? { options: genreOptions } : {}) },
+    },
+  }),
+  create: vi.fn().mockResolvedValue({ id: '1' }),
+  findOne: vi.fn(),
+});
+
+const renderForm = (ds: any) =>
+  render(
+    <ModalForm
+      schema={{
+        objectName: 'book',
+        mode: 'create',
+        title: 'New Book',
+        open: true,
+        onOpenChange: vi.fn(),
+        fields: ['title', 'genre'],
+      } as any}
+      dataSource={ds}
+    />,
+  );
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('ModalForm select option propagation', () => {
+  it('renders a usable dropdown (no empty state) when the schema field has options', async () => {
+    renderForm(makeDataSource(GENRE_OPTIONS));
+
+    // The select trigger is rendered — options propagated from the object
+    // schema through the form's field-building path to the SelectField widget.
+    await waitFor(() => expect(screen.getByTestId('select-trigger-genre')).toBeTruthy());
+    // And the "no options" empty state is NOT shown. If options were dropped on
+    // the way to the widget, the widget would render the empty state instead —
+    // so this assertion is what fails on a propagation regression.
+    expect(screen.queryByTestId('select-empty-genre')).toBeNull();
+  });
+
+  it('renders a legible empty state (not a silent dropdown) when the field has no options', async () => {
+    renderForm(makeDataSource(undefined));
+
+    // Reproduces the reported scenario: select metadata with no `options`. The
+    // widget surfaces the cause instead of rendering an empty, unusable dropdown.
+    const empty = await waitFor(() => screen.getByTestId('select-empty-genre'));
+    expect(empty.textContent).toContain('No options available');
+    expect(screen.queryByTestId('select-trigger-genre')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

A `select` field whose object-schema metadata carries **no `options`** rendered a silently-empty Radix dropdown in the create/edit form — an unfillable control that read as a broken widget and hid the real cause. This was the failure mode behind the ObjectOS *"create form renders no select options"* report.

`SelectField` now renders a legible **"No options available"** state (matching the inline form renderer's `case 'select'`) when `options` is empty and the field is editable, so the cause is visible without opening the popover. The readonly path is unchanged (it short-circuits before this branch).

## Why this isn't the root cause (and where the root cause lives)

The form's option-propagation path is **correct end-to-end** — every field-building path (`ModalForm`/`ObjectForm`/`DrawerForm` flat + `sectionFields`) reads `objectSchema.fields[name].options` and feeds it to the widget. Verified against the live stack:

- The real defect is **upstream**: the AI app-builder emitted `select` fields with **no `options` at publish time**. Objective proof from `book.genre` history: `options=NULL` at v1–v3 (create/publish), only added at v4. Handed off separately to the cloud repo.
- The list/grid only *looked* correct because `SelectCellRenderer` falls back to `humanizeLabel(value)` + a hashed badge color — so a correct-looking list does **not** prove options reach the client (tell-tale: list showed `"Self Help"` while the real label is `"Self-Help"`).

This PR makes that failure **legible instead of silent**; it does not (and cannot) unblock record creation on its own — that's the builder fix.

## Tests

Adds a **portal-free** `ModalForm` regression test (packages/plugin-form/src/selectOptions.test.tsx) pinning both directions:

- options present -> usable dropdown (no empty-state). Fails if a future change drops options on the way to the widget, catching propagation regressions without opening the flaky Radix popover under happy-dom.
- options absent -> empty-state shown.

No existing tests affected (the change is additive, gated on `options.length === 0 && !readonly`; the one readonly optionless-select test short-circuits earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)