### PR TITLE
fix(plugin-chatbot): expand the ADR-0038 verification chip into its findings

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -222,6 +222,12 @@ export interface ChatToolInvocation {
      * separate statements they are. Absent on older tool output.
      */
     verification?: { errors: number; warnings: number };
+    /**
+     * ADR-0038 L1 — the individual findings behind the `verification` counts,
+     * surfaced under the chip so "N issues" expands into WHAT is wrong instead
+     * of being a dead-end badge.
+     */
+    issues?: Array<{ severity: 'error' | 'warning'; code: string; message: string; fix?: string }>;
   };
 }
 
@@ -1285,6 +1291,39 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     </span>
                   ) : null}
                 </div>
+                {/* ADR-0038 L1 — the findings behind the issues chip, so the
+                    user sees WHAT is broken (and the fix hint) instead of a
+                    bare "N issues" count with no way to learn more. Mirrors the
+                    L3 health line below. */}
+                {tool.draftReview.issues && tool.draftReview.issues.length > 0 ? (
+                  <div
+                    className="flex flex-col gap-1 border-t bg-muted/20 px-3 py-2"
+                    data-testid="draft-issues"
+                  >
+                    {tool.draftReview.issues
+                      .filter((i) => i.severity === 'error')
+                      .map((iss, idx) => (
+                        <div
+                          key={`e${idx}`}
+                          className="flex items-start gap-1.5 text-xs text-red-600"
+                        >
+                          <XCircle className="mt-0.5 size-3.5 shrink-0" />
+                          <span>{iss.fix ? `${iss.message} — ${iss.fix}` : iss.message}</span>
+                        </div>
+                      ))}
+                    {tool.draftReview.issues
+                      .filter((i) => i.severity !== 'error')
+                      .map((iss, idx) => (
+                        <div
+                          key={`w${idx}`}
+                          className="flex items-start gap-1.5 text-xs text-amber-600"
+                        >
+                          <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+                          <span>{iss.message}</span>
+                        </div>
+                      ))}
+                  </div>
+                ) : null}
                 {/* ADR-0038 L3 — build-health line: what the publish actually
                     did at runtime. Renders only when the host supplied health
                     data; "Published" alone never implies "verified". */}

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -209,6 +209,43 @@ describe('ChatbotEnhanced (AI Elements composition)', () => {
     expect(screen.getByText('Parameters')).toBeInTheDocument();
   });
 
+  it('expands the verification chip into the actual lint findings (ADR-0038 L1)', () => {
+    const issueTool: ChatMessage = {
+      id: 'a2',
+      role: 'assistant',
+      content: 'Drafted your app.',
+      toolInvocations: [
+        {
+          toolCallId: 'tc2',
+          toolName: 'create_metadata',
+          state: 'output-available',
+          args: {},
+          result: { status: 'drafted', type: 'object', name: 'book' },
+          draftReview: {
+            items: [{ type: 'object', name: 'book' }],
+            summary: 'Drafted new object "book"',
+            verification: { errors: 1, warnings: 0 },
+            issues: [
+              {
+                severity: 'error',
+                code: 'select_without_options',
+                message: 'genre is a required select with no options',
+                fix: 'Add an options array.',
+              },
+            ],
+          },
+        },
+      ],
+    };
+    render(<ChatbotEnhanced messages={[issueTool]} onReviewDraft={vi.fn()} />);
+    // The chip still shows the COUNT, and the new detail block expands it into
+    // the actual finding + fix hint \u2014 no more dead-end "1 issue" badge.
+    expect(screen.getByTestId('draft-verification-chip')).toHaveTextContent('1 issue');
+    const detail = screen.getByTestId('draft-issues');
+    expect(detail).toHaveTextContent('genre is a required select with no options');
+    expect(detail).toHaveTextContent('Add an options array.');
+  });
+
   it('renders a model picker and forwards changes', () => {
     const onModelChange = vi.fn();
     render(

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -290,6 +290,43 @@ describe('draftReview detection (ADR-0033)', () => {
     expect(draftReviewOf({ users: [] })).toBeUndefined();
     expect(draftReviewOf({ status: 'drafted' })).toBeUndefined(); // no type/name → no target
   });
+
+  it('lifts ADR-0038 lint issues (message + fix) alongside the verification counts', () => {
+    const dr = draftReviewOf({
+      status: 'drafted',
+      type: 'object',
+      name: 'book',
+      summary: 'Drafted new object "book"',
+      verification: { errors: 1, warnings: 1 },
+      issues: [
+        {
+          layer: 'graph',
+          severity: 'error',
+          artifact: { type: 'object', name: 'book' },
+          code: 'select_without_options',
+          message: 'genre is a required select with no options',
+          fix: 'Add an options array.',
+        },
+        { severity: 'warning', code: 'unknown_column', message: 'author renders empty' },
+        { code: 'no_message_dropped' }, // malformed → must be dropped
+      ],
+    });
+    expect(dr?.verification).toEqual({ errors: 1, warnings: 1 });
+    expect(dr?.issues).toEqual([
+      {
+        severity: 'error',
+        code: 'select_without_options',
+        message: 'genre is a required select with no options',
+        fix: 'Add an options array.',
+      },
+      { severity: 'warning', code: 'unknown_column', message: 'author renders empty' },
+    ]);
+  });
+
+  it('omits the issues key entirely when there are none (no envelope churn)', () => {
+    const dr = draftReviewOf({ status: 'drafted', type: 'view', name: 'grid_v' });
+    expect(dr).toEqual({ items: [{ type: 'view', name: 'grid_v' }] });
+  });
 });
 
 describe('uiMessagesToChatMessages', () => {

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -136,6 +136,12 @@ export interface DraftReview {
   failedCount?: number;
   materialized?: boolean;
   verification?: { errors: number; warnings: number };
+  /**
+   * ADR-0038 L1 — the individual lint findings behind the `verification`
+   * counts, so the chat can show WHAT is wrong (not just "N issues"). Each
+   * carries an agent-actionable `message`; `fix` is the mechanical hint.
+   */
+  issues?: Array<{ severity: 'error' | 'warning'; code: string; message: string; fix?: string }>;
 }
 
 export function detectDraftResult(result: unknown): DraftReview | undefined {
@@ -176,6 +182,25 @@ export function detectDraftResult(result: unknown): DraftReview | undefined {
           warnings: (rawVerification as { warnings: number }).warnings,
         }
       : undefined;
+  // The lint findings themselves (`issues: BuildIssue[]`) ride alongside the
+  // counts on the same envelope. Lift the user-facing fields so the chip can
+  // expand into "WHAT is wrong" instead of a bare "N issues". Defensive: only
+  // well-formed entries with a string message survive.
+  const rawIssues = (obj as { issues?: unknown }).issues;
+  const issues = Array.isArray(rawIssues)
+    ? rawIssues.flatMap((i) => {
+        const r = i as { severity?: unknown; code?: unknown; message?: unknown; fix?: unknown };
+        if (typeof r?.message !== 'string' || !r.message) return [];
+        return [
+          {
+            severity: r.severity === 'error' ? ('error' as const) : ('warning' as const),
+            code: typeof r.code === 'string' ? r.code : 'issue',
+            message: r.message,
+            ...(typeof r.fix === 'string' && r.fix ? { fix: r.fix } : {}),
+          },
+        ];
+      })
+    : [];
   return {
     items,
     summary: typeof obj.summary === 'string' ? obj.summary : undefined,
@@ -186,6 +211,7 @@ export function detectDraftResult(result: unknown): DraftReview | undefined {
     // hidden). The canvas then previews the REAL app URL, not the draft overlay.
     ...(obj.materialized === true ? { materialized: true } : {}),
     ...(verification ? { verification } : {}),
+    ...(issues.length ? { issues } : {}),
   };
 }
 


### PR DESCRIPTION
## Problem

When the graph lint flags a staged AI build, the build-health card shows an amber **\"N issues\"** chip — but it's a **dead end**. Clicking or hovering it reveals nothing, so the user learns *that* something is wrong but never *what*. They have to click through the generated app to discover the broken artifact.

Observed 2026-06-18 during a magic-build E2E: a Book Library build's **\"1 issue\"** badge gave no hint that it was a nav entry pointing at a non-existent dashboard — the user only found out by opening the Overview page and hitting \"Dashboard Not Found\".

## Root cause

The findings were already in the tool-result envelope. `detectDraftResult` lifted only the `verification: { errors, warnings }` **counts** and dropped the `issues[]` array that carries each finding's `message` and `fix`.

## Fix

- **mapMessages**: lift `issues[]` (defensively — `message` + `fix`, malformed entries dropped) onto `DraftReview` alongside the counts; the key is omitted entirely when empty so existing envelopes don't churn.
- **ChatbotEnhanced**: render the findings under the chip as a compact list, **mirroring the existing L3 `PublishHealthLine` markup** (errors red / warnings amber, fix hint appended) — no new state, no new imports.

## Verification

Deterministic component + unit tests (no live stack needed for a pure-UI change):

- `detectDraftResult` lifts issues (and drops malformed ones) and omits the key when empty.
- `ChatbotEnhanced` renders **both** the chip count (`1 issue`) **and** the expanded detail block (`data-testid="draft-issues"`) with the finding message *and* fix hint.

**66/66 pass** across `mapMessages.test.ts` + `ChatbotEnhanced.test.tsx`.

Complements the cloud-side BVL work (the lint that now flags `select_without_options`): the lint produces the findings; this makes them legible in the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)