### PR TITLE
fix(app-shell): refresh metadata after a live-registry change (chat publish + marketplace install)

### DIFF
--- a/packages/app-shell/src/assistant/assistantBus.test.ts
+++ b/packages/app-shell/src/assistant/assistantBus.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { assistantBus, emitPublished, subscribePublished } from './assistantBus';
+import { assistantBus, emitMetadataRefresh, subscribeMetadataRefresh } from './assistantBus';
 
 // The bus is a module singleton, so tests share state — assertions are
 // relative (before/after) rather than absolute where openSeq is involved.
@@ -66,16 +66,16 @@ describe('assistantBus — snapshot stability', () => {
 });
 
 
-describe('assistantBus — publish channel', () => {
-  it('emitPublished notifies every subscriber', () => {
+describe('assistantBus — metadata-refresh channel', () => {
+  it('emitMetadataRefresh notifies every subscriber', () => {
     let a = 0;
     let b = 0;
-    const offA = subscribePublished(() => { a += 1; });
-    const offB = subscribePublished(() => { b += 1; });
-    emitPublished();
+    const offA = subscribeMetadataRefresh(() => { a += 1; });
+    const offB = subscribeMetadataRefresh(() => { b += 1; });
+    emitMetadataRefresh();
     expect(a).toBe(1);
     expect(b).toBe(1);
-    emitPublished();
+    emitMetadataRefresh();
     expect(a).toBe(2);
     expect(b).toBe(2);
     offA();
@@ -84,11 +84,11 @@ describe('assistantBus — publish channel', () => {
 
   it('unsubscribed listeners stop receiving publish events', () => {
     let n = 0;
-    const off = subscribePublished(() => { n += 1; });
-    emitPublished();
+    const off = subscribeMetadataRefresh(() => { n += 1; });
+    emitMetadataRefresh();
     expect(n).toBe(1);
     off();
-    emitPublished();
+    emitMetadataRefresh();
     expect(n).toBe(1);
   });
 });

--- a/packages/app-shell/src/assistant/assistantBus.test.ts
+++ b/packages/app-shell/src/assistant/assistantBus.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { assistantBus } from './assistantBus';
+import { assistantBus, emitPublished, subscribePublished } from './assistantBus';
 
 // The bus is a module singleton, so tests share state — assertions are
 // relative (before/after) rather than absolute where openSeq is involved.
@@ -61,6 +61,34 @@ describe('assistantBus — snapshot stability', () => {
     expect(n).toBe(1);
     unsub();
     assistantBus.requestOpen();
+    expect(n).toBe(1);
+  });
+});
+
+
+describe('assistantBus — publish channel', () => {
+  it('emitPublished notifies every subscriber', () => {
+    let a = 0;
+    let b = 0;
+    const offA = subscribePublished(() => { a += 1; });
+    const offB = subscribePublished(() => { b += 1; });
+    emitPublished();
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+    emitPublished();
+    expect(a).toBe(2);
+    expect(b).toBe(2);
+    offA();
+    offB();
+  });
+
+  it('unsubscribed listeners stop receiving publish events', () => {
+    let n = 0;
+    const off = subscribePublished(() => { n += 1; });
+    emitPublished();
+    expect(n).toBe(1);
+    off();
+    emitPublished();
     expect(n).toBe(1);
   });
 });

--- a/packages/app-shell/src/assistant/assistantBus.ts
+++ b/packages/app-shell/src/assistant/assistantBus.ts
@@ -142,6 +142,29 @@ export function subscribeCanvasInvalidate(
   };
 }
 
+// ── Publish signal ───────────────────────────────────────────
+// A publish just promoted staged drafts to the live registry. Unlike the
+// per-artifact, draft-only canvas invalidations above, this is a coarse "the
+// published world changed" pulse: every mounted MetadataProvider refetches its
+// loaded types so already-open forms/views pick up the new schema WITHOUT a
+// full page reload. Fire-and-forget, off the snapshot bus (same reasoning as
+// canvas invalidations — an event, not state).
+
+const publishedListeners = new Set<() => void>();
+
+/** Announce that staged drafts were just published (publish hosts call this). */
+export function emitPublished(): void {
+  for (const l of publishedListeners) l();
+}
+
+/** Subscribe to publish events; returns an unsubscriber. */
+export function subscribePublished(listener: () => void): () => void {
+  publishedListeners.add(listener);
+  return () => {
+    publishedListeners.delete(listener);
+  };
+}
+
 /** Subscribe a component to the assistant bus snapshot. */
 export function useAssistant(): AssistantSnapshot {
   return useSyncExternalStore(

--- a/packages/app-shell/src/assistant/assistantBus.ts
+++ b/packages/app-shell/src/assistant/assistantBus.ts
@@ -142,26 +142,28 @@ export function subscribeCanvasInvalidate(
   };
 }
 
-// ── Publish signal ───────────────────────────────────────────
-// A publish just promoted staged drafts to the live registry. Unlike the
-// per-artifact, draft-only canvas invalidations above, this is a coarse "the
-// published world changed" pulse: every mounted MetadataProvider refetches its
-// loaded types so already-open forms/views pick up the new schema WITHOUT a
-// full page reload. Fire-and-forget, off the snapshot bus (same reasoning as
-// canvas invalidations — an event, not state).
+// ── Live-metadata-changed signal ─────────────────────────────
+// The live registry just changed out-of-band from the metadata trees — a
+// publish promoted staged drafts, or a marketplace install merged a package.
+// Unlike the per-artifact, draft-only canvas invalidations above, this is a
+// coarse "the live world changed, refetch" pulse: EVERY mounted
+// MetadataProvider (nav sidebar included, not just the surface that triggered
+// it) refetches its loaded types so already-open forms/views/nav pick up the
+// change WITHOUT a full page reload. Fire-and-forget, off the snapshot bus
+// (same reasoning as canvas invalidations — an event, not state).
 
-const publishedListeners = new Set<() => void>();
+const metadataRefreshListeners = new Set<() => void>();
 
-/** Announce that staged drafts were just published (publish hosts call this). */
-export function emitPublished(): void {
-  for (const l of publishedListeners) l();
+/** Announce that the live metadata registry changed (publish / install hosts call this). */
+export function emitMetadataRefresh(): void {
+  for (const l of metadataRefreshListeners) l();
 }
 
-/** Subscribe to publish events; returns an unsubscriber. */
-export function subscribePublished(listener: () => void): () => void {
-  publishedListeners.add(listener);
+/** Subscribe to live-metadata-changed events; returns an unsubscriber. */
+export function subscribeMetadataRefresh(listener: () => void): () => void {
+  metadataRefreshListeners.add(listener);
   return () => {
-    publishedListeners.delete(listener);
+    metadataRefreshListeners.delete(listener);
   };
 }
 

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -50,6 +50,7 @@ import {
 
 import { AppHeader } from '../../layout/AppHeader';
 import { fetchPendingDraftCount } from '../../preview/draftStatus';
+import { emitPublished } from '../../assistant/assistantBus';
 import { getRuntimeConfig } from '../../runtime-config';
 import { cloudPricingDeepLink } from '../marketplace/marketplaceApi';
 import { useNavigationContext } from '../../context/NavigationContext';
@@ -1014,6 +1015,12 @@ function ChatPane({
             } else {
               toast.success(t('console.ai.publishOk', { defaultValue: 'Published — objects are now live.' }));
             }
+            // The live registry just changed but the chat-card publish path
+            // does not reload the page (unlike DraftPreviewBar). Pulse every
+            // mounted MetadataProvider so open forms/views (incl. the canvas
+            // preview) refetch the new schema instead of showing stale, empty
+            // dropdowns until a manual reload.
+            emitPublished();
             // ADR-0038 L3 — hand the runtime verification (seedApplied +
             // probes) back to the chat so the Published card grows a
             // build-health line instead of claiming bare success.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -50,7 +50,7 @@ import {
 
 import { AppHeader } from '../../layout/AppHeader';
 import { fetchPendingDraftCount } from '../../preview/draftStatus';
-import { emitPublished } from '../../assistant/assistantBus';
+import { emitMetadataRefresh } from '../../assistant/assistantBus';
 import { getRuntimeConfig } from '../../runtime-config';
 import { cloudPricingDeepLink } from '../marketplace/marketplaceApi';
 import { useNavigationContext } from '../../context/NavigationContext';
@@ -1020,7 +1020,7 @@ function ChatPane({
             // mounted MetadataProvider so open forms/views (incl. the canvas
             // preview) refetch the new schema instead of showing stale, empty
             // dropdowns until a manual reload.
-            emitPublished();
+            emitMetadataRefresh();
             // ADR-0038 L3 — hand the runtime verification (seedApplied +
             // probes) back to the chat so the Published card grows a
             // build-health line instead of claiming bare success.

--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -61,6 +61,7 @@ import {
   type CloudInstallationInfo,
 } from './marketplaceApi';
 import { getRuntimeConfig } from '../../runtime-config';
+import { emitMetadataRefresh } from '../../assistant/assistantBus';
 import { useMetadata } from '../../providers/MetadataProvider';
 
 export function MarketplacePackagePage() {
@@ -278,6 +279,7 @@ export function MarketplacePackagePage() {
         }
       }
       setInstallResult({ ok: true, message: t('marketplace.install.success') });
+      emitMetadataRefresh();
     } catch (e: any) {
       setInstallResult({ ok: false, message: e?.message ?? String(e) });
     } finally {
@@ -309,6 +311,7 @@ export function MarketplacePackagePage() {
           name: data?.package ? localizePackage(data.package as any, language).displayName : result.manifestId,
         }),
       });
+      emitMetadataRefresh();
     } catch (e: any) {
       const code = e?.code;
       let msg = e?.message ?? String(e);

--- a/packages/app-shell/src/console/marketplace/MarketplacePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePage.tsx
@@ -37,6 +37,7 @@ import {
   type OrgPackageSummary,
 } from './marketplaceApi';
 import { getRuntimeConfig } from '../../runtime-config';
+import { emitMetadataRefresh } from '../../assistant/assistantBus';
 
 /**
  * Format a published-at timestamp as a localized relative string.
@@ -141,6 +142,10 @@ export function MarketplacePage() {
       }
       setOrgMsg({ ok: true, text: t('marketplace.org.installed', { defaultValue: `Installed ${pkg.display_name}`, name: pkg.display_name }) });
       await load();
+      // The install merged a package into the live registry. Pulse every
+      // mounted MetadataProvider so the new app appears in the nav (and its
+      // objects/views resolve) without a manual browser refresh.
+      emitMetadataRefresh();
     } catch (e: any) {
       setOrgMsg({ ok: false, text: e?.message ?? String(e) });
     } finally {

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -10,7 +10,7 @@ import { MetadataClient, type ObjectStackAdapter } from '@object-ui/data-objects
 import { resolveInlineMode } from '@object-ui/plugin-form';
 import { MetadataCtx, useMetadata, type MetadataContextValue, type MetadataState } from '@object-ui/react';
 import { usePreviewDrafts } from '../preview/PreviewModeContext';
-import { subscribeCanvasInvalidate, subscribePublished } from '../assistant/assistantBus';
+import { subscribeCanvasInvalidate, subscribeMetadataRefresh } from '../assistant/assistantBus';
 
 export type { MetadataState, MetadataContextValue };
 export { useMetadataItem } from '@object-ui/react';
@@ -535,14 +535,14 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
     });
   }, [previewDrafts, invalidate]);
 
-  // Post-publish refresh: a publish promoted staged drafts to the live
-  // registry, so the schema this tree cached is stale. Refetch every loaded
-  // type — open forms/views then reflect the new live world without a manual
-  // page reload (the chat-card "Publish" path does not reload, unlike the
-  // DraftPreviewBar). NOT gated to preview-drafts mode: a publish changes the
-  // live world every tree reads, draft-overlay or published.
+  // Live-metadata-changed refresh: a publish (drafts → live) or a marketplace
+  // install changed the registry out-of-band, so the schema this tree cached
+  // is stale. Refetch every loaded type — open forms/views/nav then reflect
+  // the new live world without a manual page reload (the chat-card "Publish"
+  // and Browse-page install paths do not reload, unlike the DraftPreviewBar).
+  // NOT gated to preview-drafts mode: the live world every tree reads changed.
   useEffect(() => {
-    return subscribePublished(() => {
+    return subscribeMetadataRefresh(() => {
       void refresh();
     });
   }, [refresh]);

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -10,7 +10,7 @@ import { MetadataClient, type ObjectStackAdapter } from '@object-ui/data-objects
 import { resolveInlineMode } from '@object-ui/plugin-form';
 import { MetadataCtx, useMetadata, type MetadataContextValue, type MetadataState } from '@object-ui/react';
 import { usePreviewDrafts } from '../preview/PreviewModeContext';
-import { subscribeCanvasInvalidate } from '../assistant/assistantBus';
+import { subscribeCanvasInvalidate, subscribePublished } from '../assistant/assistantBus';
 
 export type { MetadataState, MetadataContextValue };
 export { useMetadataItem } from '@object-ui/react';
@@ -534,6 +534,18 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
       invalidate(type);
     });
   }, [previewDrafts, invalidate]);
+
+  // Post-publish refresh: a publish promoted staged drafts to the live
+  // registry, so the schema this tree cached is stale. Refetch every loaded
+  // type — open forms/views then reflect the new live world without a manual
+  // page reload (the chat-card "Publish" path does not reload, unlike the
+  // DraftPreviewBar). NOT gated to preview-drafts mode: a publish changes the
+  // live world every tree reads, draft-overlay or published.
+  useEffect(() => {
+    return subscribePublished(() => {
+      void refresh();
+    });
+  }, [refresh]);
 
   const [initialLoading, setInitialLoading] = useState(true);
   const [initialError, setInitialError] = useState<Error | null>(null);


### PR DESCRIPTION
## Problem

A live-registry change made **out-of-band** from the metadata trees left the nav/forms **stale until a manual browser refresh**. Two reported instances, same root cause:

1. **Chat-card "Publish"** (`AiChatPage.onPublishDrafts`) promotes drafts to live but — unlike `DraftPreviewBar`, which does a full `window.location.reload()` — refetched nothing.
2. **App Marketplace install** — the user reported the installed app only shows up after a browser refresh. `MarketplacePackagePage` called the **local** `refreshMetadata()` (its own MetadataProvider context only — not the nav sidebar's tree); the Browse-grid `doOrgInstall` refetched nothing.

The nav sidebar / app switcher is rendered by a *different* MetadataProvider than the surface that triggered the change, so a local refresh never reached it.

## Fix

One coarse **"live world changed, refetch"** pulse on the existing assistant bus, consumed by **every** mounted MetadataProvider:

- **assistantBus**: `emitMetadataRefresh()` / `subscribeMetadataRefresh()` — fire-and-forget, off the snapshot bus (mirrors the existing canvas-invalidate channel).
- **MetadataProvider**: on the pulse, `refresh()` every loaded type — in every tree (nav included), not gated to preview-drafts mode.
- Emitters on success: `AiChatPage` publish, `MarketplacePage.doOrgInstall` (Browse grid), `MarketplacePackagePage.doInstall` (env) + `doInstallLocal` (local).

Reuses the proven `invalidate → bump → re-render` path the canvas channel already drives. **Additive**: with nothing emitting/subscribing it's a no-op.

## Verification — browser E2E on an isolated local stack

Installed "Local Sample App" from the marketplace and captured the network. Immediately after the install POST, **with no page navigation/reload**, the client refetched every loaded metadata type:

```
POST /api/v1/cloud-connection/install            200
GET  /api/v1/cloud-connection/installation?...   200
GET  /api/v1/meta/app                             200   ← refresh() fired
GET  /api/v1/meta/object                          200
GET  /api/v1/meta/view                            200
GET  /api/v1/meta/dashboard                       200
GET  /api/v1/meta/report                          200
GET  /api/v1/meta/page                            200
```

That refetch cascade is exactly `emitMetadataRefresh() → subscribeMetadataRefresh → refresh()`. Before this change the install POST fired alone and the user had to reload. The publish path shares the same bus + subscriber, so it's covered by the same mechanism.

(Note: the seeded sample package registers no nav-visible app of its own, so there was no new launcher entry to screenshot — the decisive evidence is the live refetch cascade above.)

- Bus unit tests **7/7**; app-shell `tsc` clean.

Supersedes the publish-only scope this PR originally shipped with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)