### PR TITLE
fix(plugin-dashboard): show 0 (not "No rows") for an empty-dataset metric

### DIFF
--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -164,7 +164,10 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       </div>
     );
   }
-  if (state.rows.length === 0) {
+  // A metric (single value) over an empty dataset is 0, not "No rows" — the
+  // latter reads as broken for KPIs like "Total Books" on a fresh app. Charts
+  // and tables keep the empty state (there is genuinely nothing to plot).
+  if (state.rows.length === 0 && !isMetric) {
     return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground"><BarChart3 className="mr-2 h-4 w-4" />No rows</div>;
   }
 
@@ -176,7 +179,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // measure's display label (not the raw name) and its format (e.g. "$616,000").
   if (isMetric) {
     const f = measureField(values[0]);
-    const value = state.rows[0]?.[values[0]];
+    const value = state.rows[0]?.[values[0]] ?? 0;
     return (
       <div className="flex h-full w-full flex-col items-start justify-center gap-1 p-2">
         <span className="text-2xl font-semibold tabular-nums">{formatMeasure(value, f?.format)}</span>

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -78,4 +78,26 @@ describe('DatasetWidget', () => {
     expect(screen.getByText(/Pick measures/)).toBeInTheDocument();
     expect(src.queryDataset).not.toHaveBeenCalled();
   });
+
+  it('shows 0 (not "No rows") for a metric over an empty dataset', async () => {
+    const src = makeSource(async () => ({ rows: [] }));
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'books', values: ['count'] }} dataSource={src} />);
+    expect(await screen.findByText('0')).toBeInTheDocument();
+    expect(screen.queryByText('No rows')).not.toBeInTheDocument();
+  });
+
+  it('formats the empty-metric zero (e.g. $0) using the measure format', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [],
+      fields: [{ name: 'revenue', type: 'number', label: 'Revenue', format: '$0,0' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'sales', values: ['revenue'] }} dataSource={src} />);
+    expect(await screen.findByText('$0')).toBeInTheDocument();
+  });
+
+  it('still shows "No rows" for a dimensioned chart over an empty dataset', async () => {
+    const src = makeSource(async () => ({ rows: [] }));
+    render(<DatasetWidget widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
+    expect(await screen.findByText('No rows')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Problem

A metric / KPI widget (single value, or any dimensionless dataset widget) rendered the dashed **"No rows"** empty state when its query returned no rows. But a count/sum over an empty dataset is **0**, not "no rows". On a freshly built app every KPI — "Total Books", "Active Loans", … — read as *broken* until data existed (observed during the 2026-06-18 magic-flow review).

## Fix

The empty-rows guard now skips metric widgets and falls through to the metric branch, which defaults the absent value to `0` → `formatMeasure` renders **"0"** (or "$0", per the measure format). Charts and tables keep the "No rows" state — there is genuinely nothing to plot.

## Tests

+3 (12/12 pass): empty metric → `0`; empty metric with `$` format → `$0`; empty dimensioned chart → still `No rows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)