### PR TITLE
refactor(plugin-view): suppress duplicate named-view tabs in app-shell (ADR-0053)

### DIFF
--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1703,6 +1703,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                                             }}
                                             renderListView={renderListView}
                                             onCreateView={handleCreateView}
+                                            hideNamedViewTabs
                                             onViewAction={handleViewAction}
                                         />
                                     </div>
@@ -1745,6 +1746,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                                 }}
                                 renderListView={renderListView}
                                 onCreateView={handleCreateView}
+                                hideNamedViewTabs
                                 onViewAction={handleViewAction}
                             />
                         </div>

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -122,6 +122,13 @@ export interface ObjectViewProps {
    * Render a custom ListView implementation for multi-view support.
    * When provided, this replaces the default view rendering for the content area.
    */
+  /**
+   * ADR-0053: when the host (app-shell ObjectView) already renders the view
+   * switcher (ViewTabBar), set this so the inner view doesn't render its own
+   * duplicate named-view tab row. Standalone consumers leave it unset.
+   */
+  hideNamedViewTabs?: boolean;
+
   renderListView?: (props: {
     schema: any;
     dataSource: DataSource;
@@ -209,6 +216,7 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
   onRowClick,
   onEdit: onEditProp,
   renderListView,
+  hideNamedViewTabs,
   toolbarAddon,
   onCreateView,
   onViewAction,
@@ -1034,6 +1042,8 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
 
   // --- Named list views tabs ---
   const renderNamedViewTabs = () => {
+    // ADR-0053: host owns the switcher (ViewTabBar) — don't duplicate it.
+    if (hideNamedViewTabs) return null;
     if (!hasNamedViews) return null;
     const entries = Object.entries(namedListViews!);
     if (entries.length <= 1) return null;


### PR DESCRIPTION
Part of **ADR-0053**. Removes the latent duplicate of mechanism #2 (`renderNamedViewTabs`).

## What
The app-shell `ObjectView` already renders the canonical `ViewTabBar` switcher, but it also mounts the plugin-view `ObjectView` which can render its **own** `renderNamedViewTabs` row from `schema.listViews` — a duplicate.

- plugin-view `ObjectView`: new `hideNamedViewTabs?: boolean` prop; `renderNamedViewTabs` returns null when set.
- app-shell `ObjectView`: passes `hideNamedViewTabs` to both `PluginObjectView` mount points (it owns the `ViewTabBar`).
- **Standalone consumers** (`byo-backend-console`, `SystemObjectViewPage`) leave it unset → they keep `renderNamedViewTabs` as their only switcher. So the renderer is *suppressed in context*, not removed.

## Verification
Browser: object list shows **one** switcher row (ViewTabBar), no duplicate `view-tabs` row, 10 records render, no console/vite errors. `type-check` passes (27/27 affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)