### PR TITLE
feat(studio): visual Tabs preset editor + canonical tab schema (ADR-0053)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/FilterModeWidget.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/FilterModeWidget.test.tsx
@@ -70,9 +70,60 @@ describe('filter-mode widget', () => {
     expect(screen.getByTestId('filter-mode-add-field')).toBeInTheDocument();
   });
 
-  it('tabs mode shows the source-view hint, not a field picker', () => {
+  it('tabs mode renders the visual tab-preset editor, not the field picker', () => {
     render(<FilterMode value={{ element: 'tabs' }} onChange={() => {}} context={ctx} schema={{}} />);
-    expect(screen.getByTestId('filter-mode-tabs-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-mode-tabs-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-mode-add-tab')).toBeInTheDocument();
     expect(screen.queryByTestId('filter-mode-fields')).not.toBeInTheDocument();
+  });
+
+  it('Add tab appends a canonical { name, label, filter } preset', () => {
+    const onChange = vi.fn();
+    render(<FilterMode value={{ element: 'tabs' }} onChange={onChange} context={ctx} schema={{}} />);
+    fireEvent.click(screen.getByTestId('filter-mode-add-tab'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        element: 'tabs',
+        tabs: [expect.objectContaining({ name: expect.any(String), label: expect.any(String), filter: [] })],
+      }),
+    );
+  });
+
+  it('renders existing tab presets (canonical { name, label, filter })', () => {
+    render(
+      <FilterMode
+        value={{
+          element: 'tabs',
+          tabs: [{ name: 'urgent', label: 'Urgent', filter: [{ field: 'priority', operator: 'equals', value: 'urgent' }] }],
+        }}
+        onChange={() => {}}
+        context={ctx}
+        schema={{}}
+      />,
+    );
+    expect(screen.getByTestId('tab-preset-0')).toBeInTheDocument();
+    expect((screen.getByTestId('tab-label-0') as HTMLInputElement).value).toBe('Urgent');
+    expect(screen.getByTestId('tab-0-rule-0')).toBeInTheDocument();
+  });
+
+  it('normalizes a legacy { id, filters } tab into the canonical shape on edit', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterMode
+        value={{ element: 'tabs', tabs: [{ id: 'done', label: 'Done', filters: [['status', 'equals', 'done']] }] }}
+        onChange={onChange}
+        context={ctx}
+        schema={{}}
+      />,
+    );
+    // editing the label triggers a canonical write: name re-derived from the
+    // new label, legacy `filters` AST normalized to `filter` predicate objects.
+    fireEvent.change(screen.getByTestId('tab-label-0'), { target: { value: 'Resolved' } });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        element: 'tabs',
+        tabs: [expect.objectContaining({ name: 'resolved', label: 'Resolved', filter: [{ field: 'status', operator: 'equals', value: 'done' }] })],
+      }),
+    );
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -33,7 +33,7 @@ import {
   LazyIcon,
   toKebabIconName,
 } from '@object-ui/components';
-import { ChevronsUpDown, Plus, Search, Trash2 } from 'lucide-react';
+import { ChevronDown, ChevronsUpDown, ChevronUp, Plus, Search, Trash2 } from 'lucide-react';
 // @ts-ignore - lucide-react has no `exports` field; subpath types live alongside dynamic.mjs
 import { iconNames } from 'lucide-react/dynamic.mjs';
 import { detectLocale, t } from './i18n';
@@ -1177,6 +1177,8 @@ function IconPickerWidget({ id, value, onChange, readOnly }: WidgetProps) {
 type UFElement = 'dropdown' | 'tabs' | 'toggle';
 type UFMode = 'dropdown' | 'tabs';
 interface UFField { field: string; showCount?: boolean; label?: string; [k: string]: unknown }
+interface UFRule { field: string; operator: string; value?: unknown }
+interface UFTab { name: string; label: string; icon?: string; filter?: UFRule[]; isDefault?: boolean; [k: string]: unknown }
 interface UFValue { element?: UFElement; fields?: UFField[]; tabs?: unknown[]; showAllRecords?: boolean; [k: string]: unknown }
 
 const FILTER_MODES: Array<{ key: 'none' | UFMode; label: string }> = [
@@ -1184,6 +1186,23 @@ const FILTER_MODES: Array<{ key: 'none' | UFMode; label: string }> = [
   { key: 'tabs', label: 'Tabs' },
   { key: 'dropdown', label: 'Dropdown' },
 ];
+
+// Common predicate operators offered in the tab rule builder. Free-form
+// operators authored elsewhere still round-trip; this is the curated set that
+// keeps AI/Studio authoring consistent (ADR-0053).
+const TAB_OPERATORS = [
+  'equals',
+  'not_equals',
+  'contains',
+  'in',
+  'greater_than',
+  'less_than',
+  'is_empty',
+  'is_not_empty',
+];
+
+const slugifyTabName = (s: string): string =>
+  (s || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'tab';
 
 function FilterModeWidget({ value, onChange, readOnly, context }: WidgetProps) {
   const uf = (value && typeof value === 'object' ? value : undefined) as UFValue | undefined;
@@ -1208,6 +1227,64 @@ function FilterModeWidget({ value, onChange, readOnly, context }: WidgetProps) {
   // field picker too so it stays editable, even though Toggle isn't offered
   // as a new authoring choice.
   const isFieldMode = mode === 'dropdown' || mode === 'toggle';
+
+  // ── Tabs preset editing (ADR-0053) ──────────────────────────────────────
+  // Read any shape (canonical {name,filter} or legacy {id,filters}) into the
+  // canonical editing model; writes always emit the canonical form so authoring
+  // converges on one schema.
+  const readTabs = (): UFTab[] => {
+    const raw = Array.isArray(uf?.tabs) ? (uf!.tabs as any[]) : [];
+    return raw.map((t) => ({
+      ...t,
+      name: t?.name ?? t?.id ?? '',
+      label: typeof t?.label === 'string' ? t.label : (t?.name ?? t?.id ?? ''),
+      filter: Array.isArray(t?.filter)
+        ? t.filter
+        : Array.isArray(t?.filters)
+          ? t.filters
+              .filter((r: any) => Array.isArray(r) && r.length >= 2)
+              .map((r: any) => ({ field: String(r[0]), operator: String(r[1]), value: r[2] }))
+          : [],
+      isDefault: t?.isDefault ?? t?.default,
+    }));
+  };
+  const tabs = readTabs();
+
+  const canonicalTab = (t: UFTab): UFTab => {
+    const out: UFTab = { name: slugifyTabName(t.label || t.name), label: t.label || t.name || 'Tab' };
+    if (t.icon) out.icon = t.icon;
+    out.filter = Array.isArray(t.filter) ? t.filter : [];
+    if (t.isDefault) out.isDefault = true;
+    return out;
+  };
+  const writeTabs = (next: UFTab[]) => {
+    const seen: Record<string, true> = {};
+    const canon = next.map(canonicalTab).map((o) => {
+      let n = o.name;
+      if (seen[n]) { let k = 2; while (seen[`${o.name}_${k}`]) k++; n = `${o.name}_${k}`; }
+      seen[n] = true;
+      return { ...o, name: n };
+    });
+    onChange({ ...(uf ?? {}), element: 'tabs', tabs: canon });
+  };
+  const addTab = () => writeTabs([...tabs, { name: '', label: `Tab ${tabs.length + 1}`, filter: [] }]);
+  const removeTab = (ti: number) => writeTabs(tabs.filter((_, i) => i !== ti));
+  const moveTab = (ti: number, dir: -1 | 1) => {
+    const next = [...tabs];
+    const j = ti + dir;
+    if (j < 0 || j >= next.length) return;
+    [next[ti], next[j]] = [next[j], next[ti]];
+    writeTabs(next);
+  };
+  const patchTab = (ti: number, patch: Partial<UFTab>) =>
+    writeTabs(tabs.map((t, i) => (i === ti ? { ...t, ...patch } : t)));
+  const addRule = (ti: number) =>
+    patchTab(ti, { filter: [...(tabs[ti].filter ?? []), { field: objectFields[0]?.name ?? '', operator: 'equals', value: '' }] });
+  const patchRule = (ti: number, ri: number, patch: Partial<UFRule>) =>
+    patchTab(ti, { filter: (tabs[ti].filter ?? []).map((r, j) => (j === ri ? { ...r, ...patch } : r)) });
+  const removeRule = (ti: number, ri: number) =>
+    patchTab(ti, { filter: (tabs[ti].filter ?? []).filter((_, j) => j !== ri) });
+  const setShowAllRecords = (c: boolean) => onChange({ ...(uf ?? {}), element: 'tabs', showAllRecords: c });
 
   return (
     <div className="space-y-3">
@@ -1290,10 +1367,107 @@ function FilterModeWidget({ value, onChange, readOnly, context }: WidgetProps) {
         </div>
       )}
 
+      {/* Visual tab-preset editor for tabs mode (ADR-0053). Each tab is a pure
+          filter preset { name, label, icon?, filter:[{field,operator,value}] };
+          it never switches the view form (that is the Visualizations axis). */}
       {mode === 'tabs' && (
-        <p className="text-xs text-muted-foreground" data-testid="filter-mode-tabs-hint">
-          Tab presets (name + filter rules) are edited in the source / JSON view.
-        </p>
+        <div className="space-y-2" data-testid="filter-mode-tabs-editor">
+          {tabs.map((tab, ti) => (
+            <div key={ti} className="rounded-md border border-input bg-background p-2 space-y-2" data-testid={`tab-preset-${ti}`}>
+              <div className="flex items-center gap-1.5">
+                <Input
+                  value={tab.label}
+                  placeholder="Tab label"
+                  disabled={readOnly}
+                  className="h-8 text-sm flex-1"
+                  data-testid={`tab-label-${ti}`}
+                  onChange={(e) => patchTab(ti, { label: e.target.value })}
+                />
+                <code className="text-[10px] text-muted-foreground shrink-0 max-w-[6rem] truncate" title={tab.name}>{tab.name}</code>
+                {!readOnly && (
+                  <>
+                    <button type="button" aria-label="Move tab up" disabled={ti === 0}
+                      onClick={() => moveTab(ti, -1)}
+                      className="px-1 text-muted-foreground hover:text-foreground disabled:opacity-30">
+                      <ChevronUp className="h-3.5 w-3.5" />
+                    </button>
+                    <button type="button" aria-label="Move tab down" disabled={ti === tabs.length - 1}
+                      onClick={() => moveTab(ti, 1)}
+                      className="px-1 text-muted-foreground hover:text-foreground disabled:opacity-30">
+                      <ChevronDown className="h-3.5 w-3.5" />
+                    </button>
+                    <button type="button" aria-label="Remove tab"
+                      onClick={() => removeTab(ti)}
+                      className="px-1 text-muted-foreground hover:text-destructive">
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                )}
+              </div>
+
+              {/* Per-tab filter rules ({ field, operator, value }) */}
+              <div className="space-y-1 pl-1">
+                {(tab.filter ?? []).map((rule, ri) => (
+                  <div key={ri} className="flex items-center gap-1" data-testid={`tab-${ti}-rule-${ri}`}>
+                    <Select value={rule.field || undefined} disabled={readOnly} onValueChange={(v) => patchRule(ti, ri, { field: v })}>
+                      <SelectTrigger className="h-7 text-xs flex-1 min-w-0"><SelectValue placeholder="Field" /></SelectTrigger>
+                      <SelectContent>
+                        {objectFields.map((f) => (<SelectItem key={f.name} value={f.name}>{f.label || f.name}</SelectItem>))}
+                      </SelectContent>
+                    </Select>
+                    <Select value={rule.operator || 'equals'} disabled={readOnly} onValueChange={(v) => patchRule(ti, ri, { operator: v })}>
+                      <SelectTrigger className="h-7 text-xs w-[7.5rem] shrink-0"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        {TAB_OPERATORS.map((op) => (<SelectItem key={op} value={op}>{op}</SelectItem>))}
+                      </SelectContent>
+                    </Select>
+                    <Input
+                      value={rule.value == null ? '' : String(rule.value)}
+                      placeholder="value"
+                      disabled={readOnly}
+                      className="h-7 text-xs w-[6rem] shrink-0"
+                      onChange={(e) => patchRule(ti, ri, { value: e.target.value })}
+                    />
+                    {!readOnly && (
+                      <button type="button" aria-label="Remove rule" onClick={() => removeRule(ti, ri)}
+                        className="px-1 text-muted-foreground hover:text-destructive shrink-0">
+                        <Trash2 className="h-3 w-3" />
+                      </button>
+                    )}
+                  </div>
+                ))}
+                {!readOnly && (
+                  <button type="button" data-testid={`tab-${ti}-add-rule`} onClick={() => addRule(ti)}
+                    disabled={objectFields.length === 0}
+                    className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground disabled:opacity-40">
+                    <Plus className="h-3 w-3 mr-1" /> Add rule
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+
+          {!readOnly && (
+            <button type="button" data-testid="filter-mode-add-tab" onClick={addTab}
+              className="inline-flex items-center text-xs font-medium text-primary hover:underline">
+              <Plus className="h-3.5 w-3.5 mr-1" /> Add tab
+            </button>
+          )}
+
+          <label className="flex items-center gap-2 text-xs text-muted-foreground pt-1">
+            <Switch
+              checked={uf?.showAllRecords !== false}
+              disabled={readOnly}
+              data-testid="filter-mode-show-all"
+              onCheckedChange={setShowAllRecords}
+            />
+            Show “All records” tab
+          </label>
+
+          {objectFields.length === 0 && (
+            <p className="text-xs text-muted-foreground">Bind a source object to build tab filter rules.</p>
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/types/src/__tests__/phase2-schemas.test.ts
+++ b/packages/types/src/__tests__/phase2-schemas.test.ts
@@ -678,7 +678,34 @@ describe('ListViewSchema userFilters Zod Validation', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should validate toggle mode userFilters', () => {
+  it('should validate canonical tabs ({ name, label, filter:[{field,operator,value}] })', () => {
+    const schema = {
+      type: 'list-view',
+      objectName: 'accounts',
+      userFilters: {
+        element: 'tabs',
+        showAllRecords: true,
+        tabs: [
+          { name: 'active', label: 'Active', filter: [{ field: 'status', operator: 'equals', value: 'active' }], isDefault: true },
+          { name: 'mine', label: 'My Items', filter: [{ field: 'owner', operator: 'equals', value: '$currentUser' }] },
+        ],
+      },
+    };
+    const result = ListViewSchema.safeParse(schema);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject a tab missing both name and id', () => {
+    const schema = {
+      type: 'list-view',
+      objectName: 'accounts',
+      userFilters: { element: 'tabs', tabs: [{ label: 'No identifier', filter: [] }] },
+    };
+    const result = ListViewSchema.safeParse(schema);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject the deprecated toggle element (ADR-0053 — only dropdown | tabs)', () => {
     const schema = {
       type: 'list-view',
       objectName: 'accounts',
@@ -691,7 +718,7 @@ describe('ListViewSchema userFilters Zod Validation', () => {
       },
     };
     const result = ListViewSchema.safeParse(schema);
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 
   it('should reject invalid element type', () => {

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1814,17 +1814,30 @@ export interface ListViewSchema extends BaseSchema {
     /**
      * Named filter presets (used by 'tabs' mode).
      * Each tab represents a pre-configured filter combination.
+     *
+     * Canonical shape is `{ name, label, icon?, filter, isDefault? }` — aligned
+     * with the `{ field, operator, value }` rules used by every other filter in
+     * the protocol, so AI authoring and the Studio tabs editor emit one
+     * consistent form. The legacy `{ id, filters, default }` fields remain
+     * accepted (normalized at runtime by `normalizeTabPresets`) for back-compat.
      */
     tabs?: Array<{
-      /** Unique tab identifier */
-      id: string;
-      /** Tab display label */
+      /** Unique tab identifier (snake_case). Falls back to `id` if omitted. */
+      name?: string;
+      /** Tab display label. */
       label: string;
-      /** Filter conditions to apply when this tab is active */
-      filters: Array<any[] | string>;
-      /** Icon name (Lucide icon identifier) */
+      /** Filter rules applied when this tab is active. */
+      filter?: Array<{ field: string; operator: string; value?: unknown }>;
+      /** Icon name (Lucide icon identifier). */
       icon?: string;
-      /** Whether this is the default active tab */
+      /** Whether this tab is active by default. */
+      isDefault?: boolean;
+
+      /** @deprecated use `name`. */
+      id?: string;
+      /** @deprecated use `filter` ({ field, operator, value }). */
+      filters?: Array<any[] | string>;
+      /** @deprecated use `isDefault`. */
       default?: boolean;
     }>;
 

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -225,15 +225,39 @@ const UserFilterFieldSchema = z.object({
 });
 
 /**
- * User Filters — tab preset definition (tabs mode)
+ * User Filters — tab preset rule: `{ field, operator, value }`, the same
+ * predicate shape used by every other filter in the protocol.
  */
-const UserFilterTabSchema = z.object({
-  id: z.string().describe('Unique tab identifier'),
-  label: z.string().describe('Tab display label'),
-  filters: z.array(z.union([z.array(z.any()), z.string()])).describe('Filter conditions'),
-  icon: z.string().optional().describe('Icon name'),
-  default: z.boolean().optional().describe('Default active tab'),
+const UserFilterTabRuleSchema = z.object({
+  field: z.string().describe('Field name to filter on'),
+  operator: z.string().describe('Filter operator (equals, not_equals, contains, in, greater_than, less_than, …)'),
+  value: z.any().optional().describe('Filter value'),
 });
+
+/**
+ * User Filters — tab preset definition (tabs mode).
+ *
+ * Canonical shape: `{ name, label, icon?, filter, isDefault? }`. The legacy
+ * `{ id, filters, default }` fields stay optional (normalized at runtime by
+ * `normalizeTabPresets`) so older metadata keeps validating, but new authoring
+ * — by AI or the Studio tabs editor — emits the canonical form.
+ */
+const UserFilterTabSchema = z
+  .object({
+    name: z.string().optional().describe('Unique tab identifier (snake_case)'),
+    label: z.string().describe('Tab display label'),
+    filter: z.array(UserFilterTabRuleSchema).optional().describe('Filter rules applied when this tab is active'),
+    icon: z.string().optional().describe('Lucide icon name'),
+    isDefault: z.boolean().optional().describe('Whether this tab is active by default'),
+
+    /** @deprecated use `name` */
+    id: z.string().optional().describe('@deprecated use name'),
+    /** @deprecated use `filter` */
+    filters: z.array(z.union([z.array(z.any()), z.string()])).optional().describe('@deprecated use filter'),
+    /** @deprecated use `isDefault` */
+    default: z.boolean().optional().describe('@deprecated use isDefault'),
+  })
+  .refine((t) => Boolean(t.name || t.id), { message: 'tab requires a name' });
 
 /**
  * User Filters Configuration Schema (Airtable Interfaces-style)


### PR DESCRIPTION
## Summary

Closes the last **Airtable-parity gap** in the Studio page designer and removes a three-way schema drift behind it.

When verifying the Studio page-design tool against Airtable's Interface Designer, every `interfaceConfig` control had a visual editor **except** the end-user **Tabs** filter element — selecting `userFilters.element: 'tabs'` showed only a hint to *"edit tab presets in the source / JSON view"*, while Dropdown got a visual field picker and the base **Filter By** got a visual `{field, operator, value}` rule builder.

### What changed

**1. Visual Tabs preset editor** (`FilterModeWidget`)
Tabs mode now renders a full editor:
- add / remove / reorder (↑↓) tabs, inline-editable **label**
- per-tab **filter rules** with a `{ field, operator, value }` builder (field select + operator select + value input, add/remove) — same UX as "Filter By"
- **Show "All records"** toggle
- derived `snake_case` **name** shown read-only; de-duped on write
- reads either shape (canonical or legacy) and always **writes canonical**

**2. Single canonical tab schema** (correct-by-construction AI authoring)
The tab-preset shape had drifted: the Zod/TS type said `{ id, filters, default }`, but every example *and* the runtime consumer used `{ name, filter, isDefault }` — reconciled only by `normalizeTabPresets`. An AI following the schema and a human following the examples would emit different metadata.

Both the TS type (`ListViewSchema.userFilters.tabs`) and the Zod `UserFilterTabSchema` are now the canonical:
```ts
{ name, label, icon?, filter: [{ field, operator, value }], isDefault? }
```
Legacy `{ id, filters, default }` stay **deprecated-optional** (`refine: name || id`) so older metadata keeps validating; the editor/AI now emit one consistent form.

**3. Fixed a stale test**
`should validate toggle mode userFilters` expected success, but ADR-0053 already removed `'toggle'` from the element enum (this test was already red on `main`). It now correctly asserts rejection.

## Verification

- ✅ Unit tests: types **69** + FilterModeWidget **10** + PagePreview/SchemaForm **5** pass
- ✅ `tsc --noEmit` clean for both `@object-ui/types` and `@object-ui/app-shell`
- ✅ Browser-tested in Studio against the live showcase backend: the editor reads the 4 existing presets (In Progress / Urgent / In Review / Done), each with its `field=equals=value` rule; **Add tab** + **Add rule** drive the live page preview in real time; draft discarded afterward so the showcase metadata is unchanged.

| Airtable "User filters → Tabs" | Studio (before) | Studio (after) |
|---|---|---|
| Add/name/reorder filter tabs | JSON-only | ✅ visual |
| Per-tab filter conditions | JSON-only | ✅ visual `{field, operator, value}` |
| Show "All records" | JSON-only | ✅ toggle |

🤖 Generated with [Claude Code](https://claude.com/claude-code)