### PR TITLE
feat(app-shell): interface pages read page-owned columns/sort (revise ADR-0047)

### DIFF
--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -232,18 +232,25 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
     const gallery =
       view.gallery ?? (allowedSet.has('gallery') ? defaultGalleryFromObject(objectDef) : undefined);
 
-    // Inherited data semantics (the iron rule: all from the view) + the
-    // page's own always-on criteria (`filterBy`).
+    // Data semantics — ADR-0047 (revised): the PAGE owns its view metadata.
+    // Precedence everywhere: the page's own config → legacy sourceView view
+    // (back-compat) → a sensible default derived from the object.
     const filters = [
       ...(Array.isArray(view.filter) ? view.filter : []),
       ...(Array.isArray(cfg.filterBy) ? cfg.filterBy : []),
     ];
 
-    // Columns: the referenced view's, else a sensible default derived from
-    // the object (compactLayout / business fields). Some backends serve the
-    // default view hollow (columns live only in named views), so without
-    // this fallback the grid would render just the row-number column.
-    const columns = hasColumns(view) ? view.columns : defaultColumnsFromObject(objectDef);
+    // Columns: the page's own `columns` win; else the legacy referenced view's;
+    // else a default from the object so the grid never renders just the
+    // row-number column.
+    const columns = hasColumns(cfg)
+      ? (cfg.columns as any)
+      : hasColumns(view)
+        ? view.columns
+        : defaultColumnsFromObject(objectDef);
+
+    // Sort: the page's own first, then the legacy view's.
+    const sort = Array.isArray(cfg.sort) && cfg.sort.length ? cfg.sort : view.sort;
 
     return {
       type: 'list-view' as const,
@@ -251,7 +258,7 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
       viewType: (allowed[0] ?? view.type ?? 'grid'),
       fields: columns,
       ...(filters.length ? { filters } : {}),
-      ...(view.sort?.length ? { sort: view.sort } : {}),
+      ...(sort?.length ? { sort } : {}),
       grouping: view.grouping,
       rowColor: view.rowColor,
       pagination: view.pagination,


### PR DESCRIPTION
## Summary

Runtime half of the "interface pages own their view metadata" change (Airtable parity — no more "inherit from a separate view").

`InterfaceListPage` now resolves data semantics with this precedence:

```
page's own config  →  legacy sourceView view (back-compat)  →  object default
```

- **columns**: `cfg.columns ?? resolvedView.columns ?? defaultColumnsFromObject(objectDef)`
- **sort**: `cfg.sort ?? view.sort`
- **filterBy** remains the page's always-on base filter on top.

Existing pages that still carry a `sourceView` keep working unchanged via the fallback; new/edited pages define `columns`/`sort` directly.

Pairs with the framework spec PR (objectstack-ai/framework#2050): `InterfacePageConfig` gains `columns`/`sort`, `sourceView` deprecated, and the page editor replaces the **Source View** picker with a **Columns** picker.

## Verification
- `tsc --noEmit` clean for `@object-ui/app-shell`.
- Browser (live showcase, :5181): the page editor shows **Source / Columns / Filter By** (no Source View); picking columns re-renders the preview live; **task-triage** and **task-workbench** render their own column sets — workbench shows **Estimate (h)**, which the object's default view omits, proving the page defines columns independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)