### PR TITLE
feat(app-shell): interface-page editor polish — popover disclosure, buttons=actions, toolbar persistence

### DIFF
--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -18,7 +18,7 @@
 import * as React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { ListView } from '@object-ui/plugin-list';
-import { useAdapter } from '@object-ui/react';
+import { useAdapter, SchemaRenderer } from '@object-ui/react';
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
 import { Database } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
@@ -28,6 +28,10 @@ import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlSta
 interface InterfaceListPageProps {
   page: any;
   className?: string;
+  /** Design-mode only: persist toolbar edits (sort, column order) back to the
+   * page's interfaceConfig metadata (Airtable parity — the toolbar IS the
+   * authoring surface). Receives a partial interfaceConfig patch. */
+  onConfigChange?: (patch: Record<string, unknown>) => void;
 }
 
 /**
@@ -135,7 +139,7 @@ export function defaultGalleryFromObject(objectDef: any): { coverField: string }
   return field ? { coverField: field } : undefined;
 }
 
-export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
+export function InterfaceListPage({ page, className, onConfigChange }: InterfaceListPageProps) {
   const { t } = useObjectTranslation();
   const { objects } = useMetadata();
   const dataSource = useAdapter();
@@ -315,14 +319,34 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
     );
   }
 
+  // Toolbar buttons ARE object actions (ADR-0047): resolve the configured
+  // action names against the source object's ActionSchema and render them via
+  // the shared action:bar (which handles execution).
+  const buttonActions = Array.isArray(cfg.buttons) && cfg.buttons.length
+    ? (cfg.buttons as string[])
+        .map((name) => (objectDef.actions || []).find((a: any) => a?.name === name))
+        .filter(Boolean)
+        // The author explicitly chose these as page buttons, so surface them in
+        // the toolbar regardless of the action's own `locations` (the action:bar
+        // filters by location).
+        .map((a: any) => ({ ...a, locations: ['list_toolbar'] }))
+    : [];
+
   return (
     <div className={className ?? 'h-full flex flex-col'} data-testid="interface-list-page">
-      <div className="px-4 pt-4 pb-2 shrink-0">
-        <h1 className="text-lg font-semibold leading-tight">
-          {typeof page.label === 'string' ? page.label : page.name}
-        </h1>
-        {typeof page.description === 'string' && page.description && (
-          <p className="text-sm text-muted-foreground mt-0.5">{page.description}</p>
+      <div className="px-4 pt-4 pb-2 shrink-0 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="text-lg font-semibold leading-tight">
+            {typeof page.label === 'string' ? page.label : page.name}
+          </h1>
+          {typeof page.description === 'string' && page.description && (
+            <p className="text-sm text-muted-foreground mt-0.5">{page.description}</p>
+          )}
+        </div>
+        {buttonActions.length > 0 && (
+          <div className="shrink-0" data-testid="interface-page-buttons">
+            <SchemaRenderer schema={{ type: 'action:bar', location: 'list_toolbar', actions: buttonActions, size: 'sm', variant: 'outline' }} />
+          </div>
         )}
       </div>
       <div className="flex-1 min-h-0 overflow-auto">
@@ -331,6 +355,8 @@ export function InterfaceListPage({ page, className }: InterfaceListPageProps) {
           dataSource={dataSource}
           userFilterSelections={initialUfSelections}
           onUserFilterSelectionsChange={handleUserFilterSelectionsChange}
+          onSortChange={onConfigChange ? (sort: any) => onConfigChange({ sort }) : undefined}
+          onColumnStateChange={onConfigChange ? (st: { order?: string[] }) => { if (st?.order?.length) onConfigChange({ columns: st.order }); } : undefined}
         />
       </div>
     </div>

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -507,9 +507,12 @@ function MetadataResourceEditPageImpl({
     ((draft as any)?.objectName as string | undefined);
   const [objectFields, setObjectFields] = React.useState<Array<{ name: string; label?: string; type?: string }>>([]);
   const [objectFieldsLoading, setObjectFieldsLoading] = React.useState(false);
+  // Action catalog of the source object — fuels the `action-multi` picker so
+  // interface-page `buttons` reference the object's real actions.
+  const [objectActions, setObjectActions] = React.useState<Array<{ name: string; label?: string; locations?: string[] }>>([]);
   React.useEffect(() => {
     let cancelled = false;
-    if (!sourceObjectName) { setObjectFields([]); return; }
+    if (!sourceObjectName) { setObjectFields([]); setObjectActions([]); return; }
     setObjectFieldsLoading(true);
     (async () => {
       try {
@@ -522,8 +525,13 @@ function MetadataResourceEditPageImpl({
             ? Object.entries(raw).map(([name, f]: [string, any]) => ({ name, label: f?.label, type: f?.type }))
             : [];
         setObjectFields(list.filter((f) => !!f.name));
+        const rawActions = (obj as any)?.actions;
+        const acts = Array.isArray(rawActions)
+          ? rawActions.map((a: any) => ({ name: a?.name, label: a?.label, locations: a?.locations })).filter((a: any) => !!a.name)
+          : [];
+        if (!cancelled) setObjectActions(acts);
       } catch {
-        if (!cancelled) setObjectFields([]);
+        if (!cancelled) { setObjectFields([]); setObjectActions([]); }
       } finally {
         if (!cancelled) setObjectFieldsLoading(false);
       }
@@ -565,8 +573,8 @@ function MetadataResourceEditPageImpl({
   }, [client, sourceObjectName]);
 
   const widgetContext = React.useMemo(
-    () => ({ objectNames, objectsLoading, objectFields, objectFieldsLoading, objectViews, objectViewsLoading }),
-    [objectNames, objectsLoading, objectFields, objectFieldsLoading, objectViews, objectViewsLoading],
+    () => ({ objectNames, objectsLoading, objectFields, objectFieldsLoading, objectViews, objectViewsLoading, objectActions }),
+    [objectNames, objectsLoading, objectFields, objectFieldsLoading, objectViews, objectViewsLoading, objectActions],
   );
 
   // Load layered view + initial draft.

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -42,7 +42,8 @@ import {
   SelectValue,
 } from '@object-ui/components';
 import { Button } from '@object-ui/components';
-import { Plus, Trash2, ChevronDown, ChevronRight, GripVertical } from 'lucide-react';
+import { Plus, Trash2, ChevronDown, ChevronRight, GripVertical, Settings2 } from 'lucide-react';
+import { Popover, PopoverTrigger, PopoverContent } from '@object-ui/components';
 import {
   Tabs,
   TabsList,
@@ -334,6 +335,10 @@ export interface FormFieldSpec {
   hidden?: boolean;
   colSpan?: 1 | 2 | 3 | 4;
   widget?: string;
+  /** Composite rendering: 'inline' (default, bordered box) or 'popover'
+   * (summary line + gear that opens the sub-fields in a popover — Airtable
+   * progressive disclosure, keeps the panel lean). */
+  disclosure?: 'inline' | 'popover';
   /** For `type: 'code'` — syntax highlighting language (e.g. 'javascript', 'sql', 'json'). */
   language?: string;
   visibleOn?: string | { dialect?: string; source: string };
@@ -854,6 +859,7 @@ function FieldControl({
         schema={schema}
         readOnly={readOnly}
         widgetContext={widgetContext}
+        fieldSpec={fieldSpec}
         onChange={onChange}
       />
     );
@@ -1238,12 +1244,30 @@ function pickSubSchema(parent: JsonSchema | undefined, kind: 'composite' | 'repe
   return (props?.[subName] as JsonSchema) ?? {};
 }
 
+// Compact, human-readable summary of a composite value for the popover
+// disclosure trigger — booleans show their field label when true, arrays show
+// their entries, scalars show the value. Keeps the collapsed row informative.
+function summariseComposite(obj: Record<string, unknown>, specs: FormFieldSpec[]): string {
+  const parts: string[] = [];
+  for (const spec of specs) {
+    const v = obj[spec.field];
+    if (v == null || v === '' || v === false) continue;
+    const label = spec.label || spec.field;
+    if (v === true) parts.push(label);
+    else if (Array.isArray(v)) { if (v.length) parts.push(v.map((x) => (typeof x === 'object' && x ? ((x as any).field ?? (x as any).name ?? '') : String(x))).filter(Boolean).join(', ')); }
+    else if (typeof v === 'object') parts.push(label);
+    else parts.push(String(v));
+  }
+  return parts.join(' · ');
+}
+
 function CompositeField({
   value,
   fields,
   schema,
   readOnly,
   widgetContext,
+  fieldSpec,
   onChange,
 }: {
   value: unknown;
@@ -1251,31 +1275,57 @@ function CompositeField({
   schema: JsonSchema;
   readOnly?: boolean;
   widgetContext?: WidgetContext;
+  fieldSpec?: FormFieldSpec;
   onChange: (v: unknown) => void;
 }) {
   const obj = (value && typeof value === 'object' && !Array.isArray(value))
     ? (value as Record<string, unknown>)
     : {};
   const specs = fields.map(normaliseField);
+
+  const rows = specs.map((spec) => {
+    const subSchema = pickSubSchema(schema, 'composite', spec.field);
+    return (
+      <FieldRow
+        key={spec.field}
+        name={spec.field}
+        schema={subSchema}
+        value={obj[spec.field]}
+        required={Boolean(spec.required)}
+        readOnly={readOnly || spec.readonly}
+        fieldSpec={spec}
+        widgetContext={widgetContext}
+        formData={obj}
+        onChange={(v) => onChange({ ...obj, [spec.field]: v })}
+      />
+    );
+  });
+
+  // Progressive disclosure (Airtable parity): summary line + gear → popover.
+  if (fieldSpec?.disclosure === 'popover') {
+    const summary = summariseComposite(obj, specs);
+    return (
+      <div className="flex items-center justify-between gap-2 rounded-md border border-border/50 bg-muted/20 px-3 py-1.5">
+        <span className="text-sm text-muted-foreground truncate" title={summary}>
+          {summary || <span className="italic opacity-70">Not configured</span>}
+        </span>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-7 w-7 p-0 shrink-0" aria-label="Configure" data-testid={`composite-popover-${fieldSpec.field}`}>
+              <Settings2 className="h-4 w-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-80 space-y-3">
+            {rows}
+          </PopoverContent>
+        </Popover>
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-md border border-border/50 bg-muted/20 p-3 space-y-3">
-      {specs.map((spec) => {
-        const subSchema = pickSubSchema(schema, 'composite', spec.field);
-        return (
-          <FieldRow
-            key={spec.field}
-            name={spec.field}
-            schema={subSchema}
-            value={obj[spec.field]}
-            required={Boolean(spec.required)}
-            readOnly={readOnly || spec.readonly}
-            fieldSpec={spec}
-            widgetContext={widgetContext}
-            formData={obj}
-            onChange={(v) => onChange({ ...obj, [spec.field]: v })}
-          />
-        );
-      })}
+      {rows}
     </div>
   );
 }

--- a/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx
@@ -106,7 +106,10 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
     return (
       <PreviewShell hint="page · interface">
         <PreviewErrorBoundary fallbackHint="The interface page references a source object/view that isn't available.">
-          <InterfaceListPage page={draft as Record<string, unknown>} />
+          <InterfaceListPage
+            page={draft as Record<string, unknown>}
+            onConfigChange={canEdit ? (patch) => onPatch!({ interfaceConfig: { ...(((draft as any).interfaceConfig) || {}), ...patch } }) : undefined}
+          />
         </PreviewErrorBoundary>
       </PreviewShell>
     );

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -60,6 +60,14 @@ export interface WidgetContext {
   objectViews?: Array<{ name: string; label?: string }>;
   /** Loading flag for the view catalog. */
   objectViewsLoading?: boolean;
+  /**
+   * Action catalog of the bound/source object. Drives the `action-multi`
+   * picker so interface-page toolbar `buttons` reference the object's real
+   * actions (ActionSchema) instead of free-text — correct-by-construction.
+   */
+  objectActions?: Array<{ name: string; label?: string; locations?: string[] }>;
+  /** Loading flag for the action catalog. */
+  objectActionsLoading?: boolean;
 }
 
 export interface WidgetProps {
@@ -1473,6 +1481,75 @@ function FilterModeWidget({ value, onChange, readOnly, context }: WidgetProps) {
   );
 }
 
+/* -------------------------------------------------------------------------- */
+/* action-multi — pick toolbar buttons from the source object's actions       */
+/*                                                                            */
+/* Interface-page `buttons` are object Actions (ActionSchema), not free text. */
+/* This makes "buttons = object actions" correct-by-construction (the picker  */
+/* only offers actions the object actually defines).                          */
+/* -------------------------------------------------------------------------- */
+function ActionMultiWidget({ id, value, onChange, readOnly, context }: WidgetProps) {
+  const actions = context?.objectActions ?? [];
+  const selected: string[] = Array.isArray(value)
+    ? value.map(String)
+    : typeof value === 'string' && value
+      ? value.split(',').map((s) => s.trim()).filter(Boolean)
+      : [];
+  const labelFor = (name: string) => actions.find((a) => a.name === name)?.label || name;
+  const remaining = actions.filter((a) => !selected.includes(a.name));
+
+  const add = (name: string) => { if (!selected.includes(name)) onChange([...selected, name]); };
+  const removeAt = (i: number) => { const next = selected.slice(); next.splice(i, 1); onChange(next); };
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= selected.length) return;
+    const next = selected.slice();
+    [next[i], next[j]] = [next[j], next[i]];
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-2" data-testid="action-multi">
+      {selected.length > 0 && (
+        <div className="space-y-1">
+          {selected.map((name, i) => (
+            <div key={name} className="flex items-center gap-1 rounded border border-input bg-background px-2 py-1 text-sm">
+              <span className="flex-1 truncate">
+                {labelFor(name)}
+                <code className="ml-2 text-xs text-muted-foreground">{name}</code>
+              </span>
+              {!readOnly && (
+                <>
+                  <button type="button" aria-label="Move up" disabled={i === 0} onClick={() => move(i, -1)} className="px-1 text-muted-foreground hover:text-foreground disabled:opacity-30">↑</button>
+                  <button type="button" aria-label="Move down" disabled={i === selected.length - 1} onClick={() => move(i, 1)} className="px-1 text-muted-foreground hover:text-foreground disabled:opacity-30">↓</button>
+                  <button type="button" aria-label={`Remove ${name}`} onClick={() => removeAt(i)} className="px-1 text-muted-foreground hover:text-destructive">×</button>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {!readOnly && (
+        <Select value="" onValueChange={add} disabled={remaining.length === 0}>
+          <SelectTrigger id={id} data-testid="action-multi-add">
+            <SelectValue placeholder={actions.length ? (remaining.length ? '+ Add action button…' : 'All actions added') : 'Bind a source object to pick actions'} />
+          </SelectTrigger>
+          <SelectContent>
+            {remaining.map((a) => (
+              <SelectItem key={a.name} value={a.name}>
+                <span className="flex items-center gap-2">
+                  <span>{a.label || a.name}</span>
+                  <code className="text-xs text-muted-foreground">{a.name}</code>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </div>
+  );
+}
+
 export const WIDGETS: Record<string, WidgetRenderer> = {
   'ref:object': RefObjectWidget,
   'filter-mode': FilterModeWidget,
@@ -1480,6 +1557,7 @@ export const WIDGETS: Record<string, WidgetRenderer> = {
   'field-selector': FieldSelectorWidget,
   'field-ref': FieldRefWidget,
   'field-multi': FieldRefMultiWidget,
+  'action-multi': ActionMultiWidget,
   'view-ref': ViewRefWidget,
   'icon': IconPickerWidget,
   'master-detail': MasterDetailWidget,


### PR DESCRIPTION
## Summary

Three Airtable-parity polish items for the interface-page editor (objectui runtime side; pairs with the framework spec PR):

### 1. Progressive-disclosure popovers
`SchemaForm`'s `CompositeField` honors `fieldSpec.disclosure === 'popover'`: a composite renders as a one-line **summary + ⚙ gear** that opens its sub-fields in a Popover, instead of an always-expanded inline box. Applied to `appearance` / `userActions` / `addRecord` — the panel reads clean like Airtable's.

### 2. Buttons ARE object actions
- New **`action-multi`** widget + `WidgetContext.objectActions`; `ResourceEditPage` prefetches the source object's actions so the **Buttons** picker only offers actions the object actually defines (no free-text IDs) — correct-by-construction.
- `InterfaceListPage` resolves `interfaceConfig.buttons` against the object's ActionSchema and renders them via the shared **`action:bar`** in the page header (execution included).

### 3. Toolbar edits persist to page metadata (design mode)
- `InterfaceListPage` gains `onConfigChange`; ListView's `onSortChange` / `onColumnStateChange` forward as `{ sort }` / `{ columns: order }`.
- `PagePreview` wires it to `onPatch({ interfaceConfig })` **only when editing**, so sorting / reordering columns in the Studio designer writes straight to the page draft. Runtime is untouched.

## Verification (Studio, live showcase)
- Composites collapse to **summary + ⚙**; the popover shows their controls (Show Description, Allowed Visualizations, toolbar toggles).
- **Buttons** field lists the task object's real actions (Mark Done / Reassign… / Quick View / …); **task-workbench** renders **Reassign… / Mark Done** in its header.
- Sorting via the preview toolbar **creates a draft**; a clean editor open creates **none** (no spurious on-load drafts).
- `tsc --noEmit` clean for `@object-ui/app-shell`.

Pairs with objectstack-ai/framework (spec: `disclosure` on FormFieldSchema, `buttons` on InterfacePageConfig + action-multi in the page form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)