### PR TITLE
feat(app-shell): Studio can create list/interface pages directly (dogfooding fixes)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -499,6 +499,10 @@ export function SchemaForm({
           issues={issuesByPath[key]}
           readOnly={readOnly}
           widgetContext={widgetContext}
+          // Honor an explicit `widget` declared on a raw JSON-schema property
+          // (e.g. createSchema's `object: { widget: 'ref:object' }`) so the
+          // flat auto-form can use rich pickers, not just type inference.
+          fieldSpec={(props[key] as any)?.widget ? { field: key, widget: (props[key] as any).widget } : undefined}
           formData={v as Record<string, unknown>}
           onChange={(val) => setField(key, val)}
         />

--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -137,14 +137,18 @@ export function registerBuiltinAnchors(): void {
         type: {
           type: 'string',
           title: 'Page type',
-          enum: ['record', 'app', 'home', 'dashboard', 'utility'],
-          default: 'record',
-          description: 'A `record` page renders for an object’s records; pick the object below.',
+          // 'list' (interface page) is the primary, most-built page type — offer
+          // it first and as the default. 'dashboard' is roadmap (no distinct
+          // renderer yet), so it's omitted here, matching the edit form.
+          enum: ['list', 'record', 'home', 'app', 'utility'],
+          default: 'list',
+          description: 'List / Interface page = a data view (Airtable-style: columns, filters, visualizations). Record page renders one object record.',
         },
         object: {
           type: 'string',
           title: 'Object',
-          description: 'For a record page — the object whose records this page renders.',
+          widget: 'ref:object',
+          description: 'The object this page reads from — the data source for a list page, or the record object for a record page.',
         },
         kind: {
           type: 'string',
@@ -155,11 +159,17 @@ export function registerBuiltinAnchors(): void {
         },
       },
     },
-    createDefaults: { type: 'record', kind: 'full', regions: [] },
+    createDefaults: { type: 'list', kind: 'full', regions: [] },
     // Seed a record page's regions from the bound object's synthesized default
     // detail page, so authoring starts from the auto-generated layout (the same
     // one the runtime renders by default) instead of a blank canvas.
     createSeed: async (draft, { client }) => {
+      // List/interface page: pre-bind the chosen object as the data source so
+      // the new page renders immediately (the author then curates columns,
+      // filters, visualizations in the editor).
+      if (draft?.type === 'list') {
+        return draft?.object ? { interfaceConfig: { source: String(draft.object) } } : {};
+      }
       if (draft?.type !== 'record' || !draft?.object) return {};
       try {
         const objectDef = await client.get('object', String(draft.object));


### PR DESCRIPTION
## Summary

Dogfooding the Studio **create-page** flow as an admin building business views surfaced that you couldn't create the platform's *primary* page type — a **list / interface page** — and the create form was clumsier than the editor. Three fixes, all browser-verified:

### `anchors.ts` (page create config)
- **Page type now offers `list` (first + default).** The create enum was `['record','app','home','dashboard','utility']` — no `list` at all, so an admin building views was stuck on `record`. (Also dropped roadmap `dashboard`, matching the edit form.)
- **`createSeed` pre-binds the chosen object** as `interfaceConfig.source` for list pages → a freshly created page renders its data immediately.
- **`Object` field is now a `ref:object` picker** (was free text — type the name and hope), with a type-agnostic description.

### `SchemaForm.tsx`
- The flat auto-form (no FormView layout — e.g. create mode) now honors an explicit **`widget`** on a raw JSON-schema property, which is what lets `createSchema`'s `object: { widget: 'ref:object' }` render the picker. General + back-compat (only when a property declares `widget`).

## Verified end-to-end (Studio, live showcase)
Created **"My Open Tasks"** from scratch: type defaulted to `list`, source pre-bound, object chosen via the picker → preview rendered immediately. Configured user-filter **Tabs** (In Progress / Done) + a **Mark Done** object-action button, **published**, and the live page filters correctly (In Progress → 2 rows). 274 metadata-admin tests pass; `tsc` clean.

## Also found (reported, not in this PR)
- **Pages list lands empty**: it's hard-scoped to `projectPackages[0]` (`app.objectstack.template.project`), but the app's pages live in another package, so the list shows `0` across all sources even after creating a page. Root cause: `ResourceListPage` mandatory package scope + a default package that owns no rows of the type. Recommend defaulting to a package that actually has items (or an "all packages" view). Deliberately not fixed here — it touches the package-scope model and wants its own change.
- **Create form shows 3 validation errors on a blank form** (known artefact per the ResourceEditPage comment) — consider deferring validation until first edit/blur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)