### PR TITLE
feat(plugin-gantt): locate icon + flash highlight + group node type (4-level tree)

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -320,6 +320,7 @@ const en = {
     row: {
       expand: 'Expand',
       collapse: 'Collapse',
+      locate: 'Locate on timeline',
     },
     aria: {
       taskList: 'Task list',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -320,6 +320,7 @@ const zh = {
     row: {
       expand: '展开',
       collapse: '收起',
+      locate: '在甘特图上定位',
     },
     aria: {
       taskList: '任务列表',

--- a/packages/plugin-gantt/demo/main.tsx
+++ b/packages/plugin-gantt/demo/main.tsx
@@ -116,6 +116,39 @@ function edgeFixture(): GanttTask[] {
   ];
 }
 
+/**
+ * 制造排班 4 层树 (?mfg=1) — mirrors 3.4.1 树状结构 (左侧任务列表区):
+ *   一级 项目      → type:'group'  无条 (pure header, expand/collapse)
+ *   二级 产品      → type:'group'  无条
+ *   三级 排产计划   → summary (has children) 有时间条 · 全部甘特图操作
+ *   四级 派工单     → task leaf     子任务条 (查看/跳转)
+ * The two `group` levels render NO timeline bar; only 排产计划 + 派工单 carry bars.
+ */
+function manufacturingFixture(): GanttTask[] {
+  const PLAN = '#0d9488'; // 排产计划 bar color
+  const WORK = '#5eead4'; // 派工单 child color
+  return [
+    // 一级: 项目 (无条)
+    { id: 'prj-A', title: '项目A（导管架制造）', start: d('2026-06-01'), end: d('2026-06-30'), progress: 0, parent: null, type: 'group' },
+
+    // 二级: 产品 (无条)
+    { id: 'prod-A1', title: '产品A-1（XX项目导管架）', start: d('2026-06-01'), end: d('2026-06-30'), progress: 0, parent: 'prj-A', type: 'group' },
+
+    // 三级: 排产计划 (有时间条) — children drive its rollup range
+    { id: 'plan-1', title: '将军柱组焊（排产计划）', start: d('2026-06-03'), end: d('2026-06-10'), progress: 0, parent: 'prod-A1', color: PLAN },
+    { id: 'wo-001', title: 'WO001 张三（派工单）', start: d('2026-06-03'), end: d('2026-06-06'), progress: 100, parent: 'plan-1', color: WORK },
+    { id: 'wo-002', title: 'WO002 李四（派工单）', start: d('2026-06-06'), end: d('2026-06-10'), progress: 40, parent: 'plan-1', color: WORK, dependencies: [{ id: 'wo-001', type: 'fs' }] },
+
+    { id: 'plan-2', title: '主腿管接长（排产计划）', start: d('2026-06-08'), end: d('2026-06-14'), progress: 0, parent: 'prod-A1', color: PLAN },
+    { id: 'wo-003', title: 'WO003 王五（派工单）', start: d('2026-06-08'), end: d('2026-06-14'), progress: 20, parent: 'plan-2', color: WORK },
+
+    // 二级: 第二个产品 (无条)
+    { id: 'prod-A2', title: '产品A-2（YY项目导管架）', start: d('2026-06-12'), end: d('2026-06-30'), progress: 0, parent: 'prj-A', type: 'group' },
+    { id: 'plan-3', title: '分段预制（排产计划）', start: d('2026-06-12'), end: d('2026-06-20'), progress: 0, parent: 'prod-A2', color: PLAN },
+    { id: 'wo-004', title: 'WO004 赵六（派工单）', start: d('2026-06-12'), end: d('2026-06-20'), progress: 10, parent: 'plan-3', color: WORK },
+  ];
+}
+
 function perfFixture(n: number): GanttTask[] {
   const tasks: GanttTask[] = [];
   const groupSize = 10;
@@ -279,6 +312,7 @@ function App() {
   if (params.get('quickfilter') === '1') return <QuickFilterDemo />;
   const perf = Number(params.get('perf') || 0);
   const edge = params.has('edge');
+  const mfg = params.has('mfg');
   const workingCalendar: WorkingCalendar | undefined =
     params.get('cal') === '1' ? { skipWeekends: true } : undefined;
   const showBaselines = params.get('baselines') !== '0';
@@ -310,7 +344,7 @@ function App() {
   }, [resourceMode, resourceField]);
   const t0 = React.useMemo(() => performance.now(), []);
   const [tasks, setTasks] = React.useState<GanttTask[]>(() => {
-    const base = perf > 0 ? perfFixture(perf) : edge ? edgeFixture() : projectFixture();
+    const base = perf > 0 ? perfFixture(perf) : edge ? edgeFixture() : mfg ? manufacturingFixture() : projectFixture();
     return groupField || resourceMode ? decorateForGrouping(base) : base;
   });
   const [renderMs, setRenderMs] = React.useState<number | null>(null);
@@ -341,6 +375,7 @@ function App() {
         <span>{tasks.length} tasks</span>
         {renderMs != null && <span data-testid="demo-render-ms">initial render: {renderMs.toFixed(1)}ms</span>}
         <a href="?">project fixture</a>
+        <a href="?mfg=1&lang=zh&mode=day">制造排班 (4层树)</a>
         <a href="?cal=1">working calendar</a>
         <a href="?baselines=0">no baselines</a>
         <a href="?readonly=1">read-only</a>

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -29,6 +29,7 @@ import {
   FileDown,
   Save,
   Lock,
+  Crosshair,
 } from "lucide-react"
 import {
   cn,
@@ -88,7 +89,7 @@ export type GanttDependency = string | number | GanttDependencyObject;
  * Task rendering variant. `summary` is implied for any task that has
  * children; `milestone` is implied when end <= start (zero duration).
  */
-export type GanttTaskType = 'task' | 'summary' | 'milestone';
+export type GanttTaskType = 'task' | 'summary' | 'milestone' | 'group';
 
 export interface GanttTask {
   id: string | number
@@ -101,6 +102,12 @@ export interface GanttTask {
   dependencies?: GanttDependency[]
   /** Parent task id — builds the hierarchy. Unknown ids render as roots. */
   parent?: string | number | null
+  /**
+   * Node kind. Defaults to a leaf `task` (or `summary` automatically when it has
+   * children). Set `'group'` to render a pure tree header — expandable/collapsible
+   * like a summary but with NO timeline bar (用于 项目/产品 这类纯分组层级，左侧成树、右侧无条).
+   * Its children still render their own bars normally.
+   */
   type?: GanttTaskType
   /**
    * Baseline (planned) start/end. When both are present a thin reference bar is
@@ -1516,6 +1523,11 @@ export function GanttView({
   // and the "Today" button can target a stable node.
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
 
+  // 定位闪烁: id of the bar currently pulsing after a "locate" click, plus the
+  // pending timers that toggle it on/off (cleared on re-trigger and unmount).
+  const [flashTaskId, setFlashTaskId] = React.useState<string | number | null>(null);
+  const flashTimerRef = React.useRef<number[]>([]);
+
   // --- Virtualization ------------------------------------------------------
   // Rows and timeline columns render only what's in (or near) the viewport,
   // so the chart stays responsive with thousands of tasks / multi-year day
@@ -1628,6 +1640,41 @@ export function GanttView({
       return true;
     },
     [timelineRange, dateToX],
+  );
+  // 定位到记录: scroll the timeline so a row's bar is centered horizontally,
+  // triggered by the locate icon in the task list's End column. Centers on the
+  // bar's midpoint and clamps so an out-of-range edge still lands on-screen.
+  const scrollToTask = React.useCallback(
+    (start: Date, end: Date, taskId?: string | number) => {
+      const el = scrollAreaRef.current;
+      if (!el) return;
+      const startX = dateToX(start);
+      const endX = dateToX(end);
+      const mid = (startX + endX) / 2;
+      el.scrollTo({ left: Math.max(0, mid - el.clientWidth / 2), behavior: 'smooth' });
+      // 闪烁高亮: pulse the located bar so the eye can catch it after the scroll.
+      // Toggle off → on (rAF) restarts the CSS animation when the same row is
+      // clicked repeatedly; auto-clear once the animation has run its course.
+      if (taskId != null) {
+        flashTimerRef.current.forEach((id) => window.clearTimeout(id));
+        flashTimerRef.current = [];
+        setFlashTaskId(null);
+        flashTimerRef.current.push(
+          window.setTimeout(() => setFlashTaskId(taskId), 40),
+        );
+        flashTimerRef.current.push(
+          window.setTimeout(
+            () => setFlashTaskId((cur) => (cur === taskId ? null : cur)),
+            40 + 1400,
+          ),
+        );
+      }
+    },
+    [dateToX],
+  );
+  React.useEffect(
+    () => () => flashTimerRef.current.forEach((id) => window.clearTimeout(id)),
+    [],
   );
   const jumpToWeek = React.useCallback(
     () => scrollToDate(startOfUnit(new Date(), 'week')),
@@ -2050,6 +2097,22 @@ export function GanttView({
       <style>{`
         .gantt-resize-handle:hover { background-color: rgba(255, 255, 255, 0.4); }
         .gantt-bar-hover:hover { filter: brightness(1.1); }
+        .gantt-locate-btn { opacity: 0; transition: opacity 0.15s ease; }
+        .group\\/task-row:hover .gantt-locate-btn { opacity: 0.6; }
+        .gantt-locate-btn:hover, .gantt-locate-btn:focus-visible { opacity: 1; }
+        /* 定位闪烁: pulse the located bar with a ring. Outline (not box-shadow)
+           so it never clashes with the critical-path bar's inline box-shadow. */
+        @keyframes gantt-flash {
+          0%, 100% { outline-color: rgba(59, 130, 246, 0); }
+          20% { outline-color: rgba(59, 130, 246, 0.95); }
+          45% { outline-color: rgba(59, 130, 246, 0.25); }
+          70% { outline-color: rgba(59, 130, 246, 0.95); }
+        }
+        .gantt-flash {
+          outline: 2px solid transparent;
+          outline-offset: 2px;
+          animation: gantt-flash 1.4s ease-in-out;
+        }
         @media (min-width: 640px) {
           .gantt-sm-h50 { height: 50px; }
           .gantt-sm-w20 { width: 80px; }
@@ -2497,7 +2560,22 @@ export function GanttView({
                       onClick={(e) => e.stopPropagation()}
                     />
                   ) : (
-                    row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })
+                    <span className="inline-flex items-center justify-end gap-1">
+                      {row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })}
+                      {/* 定位到甘特图: scroll the timeline to center this row's bar. */}
+                      <button
+                        type="button"
+                        title={t('gantt.row.locate')}
+                        aria-label={t('gantt.row.locate')}
+                        className="gantt-locate-btn shrink-0"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          scrollToTask(row.start, row.end, row.task.id);
+                        }}
+                      >
+                        <Crosshair className="w-3 h-3" />
+                      </button>
+                    </span>
                   )}
                 </div>
                 {/* Row actions removed: View / Edit / Delete are reachable
@@ -2664,6 +2742,21 @@ export function GanttView({
                      </div>
                    ) : null;
 
+                   if (task.type === 'group') {
+                     // 分组层级 (项目/产品): a pure tree header — the left list still
+                     // shows the caret + label, but the timeline row carries NO bar.
+                     return (
+                       <div
+                         key={task.id}
+                         className="relative border-b hover:bg-accent/50"
+                         style={{ height: rowHeight }}
+                         onPointerMove={clearLinkTarget}
+                       >
+                         {tooltip}
+                       </div>
+                     );
+                   }
+
                    if (row.isSummary) {
                      // Summary bar: a solid row-centered bar (slightly slimmer
                      // than task bars) with the title and a darker progress
@@ -2682,7 +2775,8 @@ export function GanttView({
                           className={cn(
                             'gantt-bar-hover absolute rounded-sm border shadow-sm flex items-center px-2 select-none',
                             onTaskUpdate ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
-                            isDragging && 'ring-2 ring-primary z-10'
+                            isDragging && 'ring-2 ring-primary z-10',
+                            flashTaskId === task.id && 'gantt-flash z-10'
                           )}
                           /* Explicit colors: alpha utilities aren't emitted in
                              the prebuilt components CSS. */
@@ -2751,7 +2845,8 @@ export function GanttView({
                             "gantt-bar-hover absolute rotate-45 rounded-[2px] border shadow-sm select-none",
                             canDrag ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
                             isDragging && "ring-2 ring-primary z-10",
-                            isLinkTarget && "ring-2 ring-primary"
+                            isLinkTarget && "ring-2 ring-primary",
+                            flashTaskId === task.id && "gantt-flash z-10"
                           )}
                           style={{
                             left: liveStyle.left - size / 2,
@@ -2811,7 +2906,8 @@ export function GanttView({
                           "gantt-bar-hover absolute rounded-sm bg-primary border shadow-sm flex items-center px-2 group select-none",
                           canDrag ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
                           isDragging && "ring-2 ring-primary z-10",
-                          isLinkTarget && "ring-2 ring-primary"
+                          isLinkTarget && "ring-2 ring-primary",
+                          flashTaskId === task.id && "gantt-flash z-10"
                         )}
                         style={{
                           left: liveStyle.left,

--- a/packages/plugin-gantt/src/ObjectGantt.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import { ObjectGantt, normalizeDependencies } from './ObjectGantt';
+import { ObjectGantt, normalizeDependencies, normalizeTaskType } from './ObjectGantt';
 import { DataSource } from '@object-ui/types';
 
 // Mock GanttView so we can drive create/update/delete directly via the
@@ -444,5 +444,26 @@ describe('normalizeDependencies', () => {
 
   it('drops unknown link types but keeps the id', () => {
     expect(normalizeDependencies([{ id: 't1', type: 'banana' }])).toEqual([{ id: 't1' }]);
+  });
+});
+
+describe('normalizeTaskType', () => {
+  it('maps group/folder to the no-bar group header (case/space-insensitive)', () => {
+    expect(normalizeTaskType('group')).toBe('group');
+    expect(normalizeTaskType('Folder')).toBe('group');
+    expect(normalizeTaskType('  GROUP ')).toBe('group');
+  });
+
+  it('keeps summary/project/phase as bar-carrying summaries', () => {
+    expect(normalizeTaskType('summary')).toBe('summary');
+    expect(normalizeTaskType('project')).toBe('summary');
+    expect(normalizeTaskType('phase')).toBe('summary');
+  });
+
+  it('maps milestone and task, and infers (undefined) for unknown/empty', () => {
+    expect(normalizeTaskType('milestone')).toBe('milestone');
+    expect(normalizeTaskType('task')).toBe('task');
+    expect(normalizeTaskType('banana')).toBeUndefined();
+    expect(normalizeTaskType(null)).toBeUndefined();
   });
 });

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -78,6 +78,12 @@ export interface QuickFilterDef {
  */
 type GanttConfigEx = GanttConfig & {
   parentField?: string;
+  /**
+   * Record field whose value maps onto a node kind (see {@link normalizeTaskType}):
+   * `task` / `summary` (project/phase) / `milestone` / `group`. `group` (or
+   * `folder`) renders a pure tree header with NO bar — for 项目/产品 style levels
+   * that only group, never schedule.
+   */
   typeField?: string;
   /** Baseline (planned) start/end fields → planned-vs-actual reference bars. */
   baselineStartField?: string;
@@ -121,7 +127,10 @@ export function normalizeTaskType(raw: unknown): GanttTaskType | undefined {
   if (raw == null) return undefined;
   const key = String(raw).toLowerCase().trim();
   if (key === 'milestone') return 'milestone';
-  if (key === 'summary' || key === 'project' || key === 'group' || key === 'phase') return 'summary';
+  // Pure grouping header (无条): a tree node with no timeline bar. Use for
+  // 项目/产品 style levels that只分组、不排期.
+  if (key === 'group' || key === 'folder') return 'group';
+  if (key === 'summary' || key === 'project' || key === 'phase') return 'summary';
   if (key === 'task') return 'task';
   return undefined;
 }

--- a/packages/plugin-gantt/src/useGanttTranslation.ts
+++ b/packages/plugin-gantt/src/useGanttTranslation.ts
@@ -45,6 +45,7 @@ export const GANTT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'gantt.viewMode.year': 'Year',
   'gantt.row.expand': 'Expand',
   'gantt.row.collapse': 'Collapse',
+  'gantt.row.locate': 'Locate on timeline',
   'gantt.aria.taskList': 'Task list',
   'gantt.tooltip.days': 'd',
   'gantt.menu.view': 'View details',


### PR DESCRIPTION
## What

Three Gantt enhancements, driven by a manufacturing-scheduling spec (项目 → 产品 → 排产计划 → 派工单):

1. **Locate-on-timeline icon** — each task-list **End** cell gets a 🞋 (Crosshair) button. Clicking it smooth-scrolls the timeline to center that row's bar **and** pulses the bar with a ring (`gantt-flash`) so it's easy to spot after the scroll. The button reveals on row hover; `stopPropagation` keeps it from opening the detail drawer.

2. **`type:'group'` node kind** — a pure tree header that is expandable/collapsible like a summary row but renders **no timeline bar**. This makes pure grouping levels (项目/产品: 左侧成树、右侧无条) possible — previously any node with children always drew a summary bar. Children still render their own bars normally.

3. **4-level demo fixture** (`?mfg=1`) — 项目A → 产品A-1/A-2 → 排产计划 → 派工单(WO001 张三…), exercising group headers + summary bars + task bars together.

## Spec coverage

| 层级 | 节点 | 要求 | 状态 |
|---|---|---|---|
| 一级 项目 | `type:'group'` | 无条 · 展开/折叠 | ✅ |
| 二级 产品 | `type:'group'` | 无条 · 展开/折叠 | ✅ |
| 三级 排产计划 | summary | 有时间条 · 全部甘特操作 | ✅ |
| 四级 派工单 | task | 子任务条 | ✅ (有条) |

Not in this PR (follow-ups, noted with the requester): seed-able "三级默认折叠" prop, and per-node read-only lock so 派工单 is view-only while 排产计划 stays draggable.

## i18n

Adds `gantt.row.locate` (zh `在甘特图上定位` / en `Locate on timeline`) plus the standalone fallback in `GANTT_DEFAULT_TRANSLATIONS`.

## Verification

- `pnpm --filter @object-ui/plugin-gantt vitest run` → **188 passed (16 files)**.
- Manual (demo `?mfg=1`): only 排产计划 rows carry summary bars and only 派工单 rows carry task bars; the 项目/产品 group rows render no bar; collapsing 项目A hides its whole subtree and expands back; locate click centers + flashes the target bar.

## Config-driven (not hardcoded)

No business terms live in the component — `GanttView` only knows the generic primitives `parent` (builds the tree) and `type` (node kind). The 4-level manufacturing data lives **only in the demo fixture** (`demo/main.tsx`), never in the runtime.

The structure is configured through **view metadata**, not code:
- `parentField` → which record field builds the hierarchy
- `typeField` → which record field maps to the node kind. A value of `group` (or `folder`) now yields the no-bar header; `summary`/`project`/`phase` keep a bar; `milestone`/`task` as before.

So an app models 项目/产品 as records whose `typeField` = `group`, and 排产计划/派工单 fall out of the `parent` chain + start/end fields — no plugin changes needed.
