### PR TITLE
fix(app-shell): Studio list defaults to current app's package; create form holds back validation noise

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -284,6 +284,11 @@ function MetadataResourceEditPageImpl({
   // in the load catch block, reset at the start of each load.
   const [loadFailed, setLoadFailed] = React.useState(false);
   const [issues, setIssues] = React.useState<SchemaFormIssue[]>([]);
+  // In create mode, hold back validation noise until the author has actually
+  // edited a field. A blank new-item form firing 3 red "required" errors before
+  // the user types anything reads as broken, not helpful (the save path still
+  // validates). Flips true on the first real edit.
+  const [createDirty, setCreateDirty] = React.useState(false);
 
   // Wrap setDraft so that editing a field clears any *server-side*
   // diagnostic issues whose path begins with that field. The user
@@ -301,6 +306,7 @@ function MetadataResourceEditPageImpl({
           if (!Object.is(prev?.[k], resolved?.[k])) changed.add(k);
         }
         if (changed.size > 0) {
+          setCreateDirty(true);
           setIssues((prevIssues) =>
             prevIssues.filter((i) => {
               const head = (i.path ?? '').split('.')[0];
@@ -417,6 +423,12 @@ function MetadataResourceEditPageImpl({
       window.clearTimeout(handle);
     };
   }, [type, draft, entry?.schema]);
+  // Issues to DISPLAY (banner + inline). Suppressed on a pristine create form
+  // so a blank new item doesn't open covered in required-field errors.
+  const displayIssues = React.useMemo(
+    () => (createMode && !createDirty ? [] : issues),
+    [createMode, createDirty, issues],
+  );
   // Per-item draft pending publish (mode=draft saves land here).
   // When non-null, the editor is "viewing the draft" and we surface
   // Publish / Discard-draft actions.
@@ -1854,6 +1866,9 @@ function MetadataResourceEditPageImpl({
               // "failed to load" banner above instead; the empty-default
               // form's required-field issues here would be noise, not a
               // verdict on the item (see shouldRenderDiagnostics).
+              if (createMode && !createDirty) {
+                return null;
+              }
               if (
                 !shouldRenderDiagnostics({
                   loadFailed,
@@ -2140,7 +2155,7 @@ function MetadataResourceEditPageImpl({
                             value={draft}
                             onChange={handleDraftChange}
                             readOnly={formReadOnly}
-                            issues={issues.map((i) => ({
+                            issues={displayIssues.map((i) => ({
                               path: i.path ?? '',
                               message: i.message,
                             }))}
@@ -2184,7 +2199,7 @@ function MetadataResourceEditPageImpl({
                             form={createMode && config.createSchema ? undefined : (entry?.form as any)}
                             value={draft}
                             onChange={handleCreateAwareChange}
-                            issues={issues}
+                            issues={displayIssues}
                             hiddenFields={effectiveHiddenFields}
                             fieldOrder={effectiveFieldOrder}
                             readOnly={formReadOnly}
@@ -2207,7 +2222,7 @@ function MetadataResourceEditPageImpl({
                 form={createMode && config.createSchema ? undefined : (entry?.form as any)}
                 value={draft}
                 onChange={handleCreateAwareChange}
-                issues={issues}
+                issues={displayIssues}
                 hiddenFields={effectiveHiddenFields}
                 fieldOrder={effectiveFieldOrder}
                 readOnly={formReadOnly}

--- a/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
@@ -102,10 +102,10 @@ export function MetadataResourceListPage({ type: typeProp }: MetadataResourceLis
     return <Custom type={type} />;
   }
 
-  return <DefaultMetadataList type={type} />;
+  return <DefaultMetadataList type={type} appName={params.appName} />;
 }
 
-function DefaultMetadataList({ type }: { type: string }) {
+function DefaultMetadataList({ type, appName }: { type: string; appName?: string }) {
   const navigate = useNavigate();
   const client = useMetadataClient();
   const { entries: typesEntries } = useMetadataTypes(client);
@@ -158,14 +158,56 @@ function DefaultMetadataList({ type }: { type: string }) {
     };
   }, [client]);
 
+  // Resolve the CURRENT APP's package so the list defaults to the scope the
+  // admin is actually working in (e.g. opening Pages from the Showcase app
+  // shows that app's pages, not an alphabetically-first empty template). The
+  // route segment may be the app `name` or its package id, so match both.
+  const [appPackage, setAppPackage] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!appName) { setAppPackage(null); return; }
+    (async () => {
+      try {
+        const apps = await client.list<any>('app');
+        if (cancelled) return;
+        const match = (apps ?? [])
+          .map((raw) => (raw && typeof raw === 'object' && 'item' in raw ? (raw as any).item : raw))
+          .find((a: any) => a?.name === appName || a?._packageId === appName);
+        setAppPackage((match as any)?._packageId ?? null);
+      } catch {
+        if (!cancelled) setAppPackage(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [client, appName]);
+
   // Resolve the active package from the URL, validated against the project
   // package set. `null` while packages are still loading (fail closed).
   const urlPackage = searchParams.get('package');
   const activePackage = React.useMemo(() => {
     if (!projectPackages) return null;
     if (urlPackage && projectPackages.some((p) => p.id === urlPackage)) return urlPackage;
-    return projectPackages[0]?.id ?? null;
-  }, [projectPackages, urlPackage]);
+    if (projectPackages.length === 0) return null;
+    // No valid URL package: prefer the CURRENT APP's package (the scope the
+    // admin is working in) when it's a valid project package — this is what
+    // makes "Pages" in the Showcase app default to Showcase's pages.
+    if (appPackage && projectPackages.some((p) => p.id === appPackage)) return appPackage;
+    // Otherwise prefer the project package that actually OWNS rows of this
+    // metadata type, so the list never opens empty on an alphabetically-first
+    // package that happens to own none. Falls back to the first package.
+    const counts = new Map<string, number>();
+    for (const row of items) {
+      const pkg = (row.item as any)?._packageId;
+      if (pkg && pkg !== 'sys_metadata') counts.set(pkg, (counts.get(pkg) ?? 0) + 1);
+    }
+    let best: string | null = null;
+    let bestN = 0;
+    for (const p of projectPackages) {
+      const n = counts.get(p.id) ?? 0;
+      if (n > bestN) { best = p.id; bestN = n; }
+    }
+    return best ?? projectPackages[0]?.id ?? null;
+  }, [projectPackages, urlPackage, items, appPackage]);
 
   // Repair `?package=` so the sidebar selector, deep-links and create/edit
   // navigation all agree on the active scope. Runs once packages resolve
@@ -173,11 +215,18 @@ function DefaultMetadataList({ type }: { type: string }) {
   React.useEffect(() => {
     if (!projectPackages || projectPackages.length === 0) return;
     if (urlPackage && projectPackages.some((p) => p.id === urlPackage)) return;
+    // If the current app's package is known we can repair immediately; otherwise
+    // wait for rows so `activePackage` can resolve to the package that owns this
+    // type (repairing to the alphabetical-first package before then would lock
+    // the list onto an empty scope).
+    const appPkgValid = !!(appPackage && projectPackages.some((p) => p.id === appPackage));
+    if (!appPkgValid && items.length === 0) return;
+    if (!activePackage) return;
     const next = new URLSearchParams(searchParams);
-    next.set('package', projectPackages[0].id);
+    next.set('package', activePackage);
     setSearchParams(next, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectPackages, urlPackage]);
+  }, [projectPackages, urlPackage, items, activePackage, appPackage]);
 
   // Carry the active package into create/edit navigation as `?package=` so
   // the editor binds newly-saved rows to that software package.


### PR DESCRIPTION
## Summary

Two dogfooding follow-ups from building views in Studio — the remaining friction reported in the previous round, now fixed.

### 1. Pages / metadata list opened **empty**
The list is hard-scoped to one project package and defaulted to `projectPackages[0]` (alphabetically first — `app.objectstack.template.project`), which owns none of the current app's rows. So every source read `0` even though the app has pages, and you couldn't find what you'd created.

`DefaultMetadataList` now resolves the **current app's package** (route `appName` → app metadata `_packageId`) and defaults the scope to it; falls back to the package that owns the most rows of the type, then the first package. The Showcase app's Pages list now defaults to `?package=com.example.showcase` and shows its **5 pages** instead of 0.

### 2. Blank create form opened covered in validation errors
A new-page form fired 3 red "required" errors before the user typed anything — reads as broken, not helpful. Added `createDirty` (flips on first edit); the diagnostics banner and inline field errors are suppressed on a **pristine** create form (via `displayIssues`). The save path still validates, and validation reappears the moment the author edits a field.

## Verification (Studio, live showcase)
- Pages list defaults to `com.example.showcase` and lists the 5 showcase pages (was empty).
- New-page form is clean on open; typing one character surfaces validation again.
- 274 metadata-admin tests pass; `@object-ui/app-shell` tsc clean.

Follows objectstack-ai/objectui#1808 (create-list-page dogfooding fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)