### PR TITLE
fix(sdui): grid alias collision, expression user-context, record:history self-fetch

### DIFF
--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -484,7 +484,10 @@ const PageCardRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { designer } = splitDesignerProps(props);
   const title = labelText(schema?.title);
   const bordered = schema?.bordered !== false;
-  const body = schema?.body;
+  // Accept `children` as well as `body` — every other container (grid/flex/
+  // section/tabs) renders `children`, so authors expect it to work here too.
+  // `body` kept first for back-compat with existing card schemas.
+  const body = schema?.body ?? schema?.children;
   const footer = schema?.footer;
 
   return (

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -135,6 +135,19 @@ export class Registry<T = any> {
     // the last registration wins for non-namespaced lookups
     // Skip this if skipFallback is true to avoid overwriting other components
     if (meta?.namespace && !meta?.skipFallback) {
+      // Collision guard: a bare-name fallback that overwrites a DIFFERENT
+      // component is almost always an accident (e.g. plugin 'view:grid' silently
+      // clobbering the layout 'grid'). Warn so it surfaces instead of 404-ing at
+      // render time. Pass `skipFallback: true` when a namespaced-only alias is
+      // intended.
+      const existing = this.components.get(type);
+      if (existing && existing.component !== component && existing.type !== fullType) {
+        console.warn(
+          `Component "${type}" bare-name fallback is being overwritten by "${fullType}". ` +
+          `If this is intentional keep going; otherwise register "${fullType}" with ` +
+          `{ skipFallback: true } so it doesn't claim the bare "${type}" key.`,
+        );
+      }
       this.components.set(type, {
         type: fullType, // Keep reference to namespaced type
         component,

--- a/packages/core/src/registry/__tests__/Registry.test.ts
+++ b/packages/core/src/registry/__tests__/Registry.test.ts
@@ -287,4 +287,37 @@ describe('Registry', () => {
       expect(registry.get('button')).toBe(component);
     });
   });
+
+  describe('skipFallback / bare-name collisions', () => {
+    it('skipFallback prevents a namespaced registration from claiming the bare name', () => {
+      const layout = () => 'layout-grid';
+      const objectGrid = () => 'object-grid';
+      // Layout component owns the bare `grid` key.
+      registry.register('grid', layout, { namespace: 'layout' });
+      // A view-namespaced alias registered WITHOUT skipFallback would clobber it;
+      // WITH skipFallback it only registers `view:grid` and leaves bare `grid`.
+      registry.register('grid', objectGrid, { namespace: 'view', skipFallback: true });
+
+      expect(registry.get('grid')).toBe(layout);          // bare unchanged
+      expect(registry.get('grid', 'view')).toBe(objectGrid); // namespaced still available
+    });
+
+    it('warns when a namespaced registration overwrites a DIFFERENT bare component', () => {
+      const layout = () => 'layout-grid';
+      const objectGrid = () => 'object-grid';
+      registry.register('grid', layout, { namespace: 'layout' });
+      registry.register('grid', objectGrid, { namespace: 'view' }); // no skipFallback → clobbers + warns
+
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      expect(registry.get('grid')).toBe(objectGrid); // last-wins (documented behaviour)
+    });
+
+    it('does not warn when re-registering the same component under its namespace', () => {
+      const same = () => 'same';
+      registry.register('thing', same, { namespace: 'a' });
+      consoleWarnSpy.mockClear();
+      registry.register('thing', same, { namespace: 'a' });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/plugin-detail/src/renderers/record-history.tsx
+++ b/packages/plugin-detail/src/renderers/record-history.tsx
@@ -5,17 +5,21 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * `record:history` — renders an audit-log timeline for the current
- * record. Thin wrapper around `<HistoryTimeline>`.
+ * `record:history` — renders an audit-log timeline for the current record.
+ * Thin wrapper around `<HistoryTimeline>`.
  *
- * Data model: the schema carries `entries` (array of history rows)
- * and `loading` (boolean) directly. The owning page (typically
- * RecordDetailView's synthesizer path) is responsible for fetching
- * entries and passing them through. This keeps the renderer pure /
- * stateless and lets the host plug in different audit data sources.
+ * Data model: a host MAY pass `entries` (array of history rows) + `loading`
+ * directly (RecordDetailView's synthesizer path does this). When no host
+ * entries are supplied — e.g. the block is hand-authored inside a `page:tabs`
+ * on a custom record page — the renderer SELF-FETCHES from `sys_activity`
+ * (the same source the discussion/activity feed reads), scoped to the current
+ * record via `useRecordContext`. This makes `record:history` drop-anywhere,
+ * matching `record:related_list`'s self-fetch behaviour, instead of silently
+ * showing "No history yet".
  */
 
 import React from 'react';
+import { useRecordContext } from '@object-ui/react';
 import { HistoryTimeline, type HistoryEntry } from '../HistoryTimeline';
 
 const splitDesigner = (props: Record<string, any>) => {
@@ -28,6 +32,7 @@ export interface RecordHistoryRendererProps {
     entries?: HistoryEntry[];
     loading?: boolean;
     emptyText?: string;
+    limit?: number;
     properties?: Record<string, any>;
     [k: string]: any;
   };
@@ -35,21 +40,75 @@ export interface RecordHistoryRendererProps {
   [k: string]: any;
 }
 
+/** sys_activity row → HistoryEntry. Only field-mutating activity types map to
+ *  history (comments/mentions/logins are not record-history). */
+const HISTORY_TYPES = new Set(['created', 'updated', 'assigned', 'shared', 'deleted']);
+
 export const RecordHistoryRenderer: React.FC<RecordHistoryRendererProps> = ({
   schema = {} as any,
   className,
   ...props
 }) => {
   const { designer } = splitDesigner(props);
-  // Spec bridge inlines `properties.*` onto the node but also preserves
-  // the raw bag. Read from either location for compatibility.
-  const entries: HistoryEntry[] = Array.isArray(schema.entries)
+  const ctx = useRecordContext() as any;
+
+  // Spec bridge inlines `properties.*` onto the node but also preserves the raw
+  // bag. Read from either location for compatibility.
+  const hostEntries: HistoryEntry[] | undefined = Array.isArray(schema.entries)
     ? schema.entries
     : Array.isArray(schema.properties?.entries)
       ? (schema.properties!.entries as HistoryEntry[])
-      : [];
-  const loading = schema.loading ?? schema.properties?.loading ?? false;
+      : undefined;
+  const hostLoading = schema.loading ?? schema.properties?.loading;
   const emptyText = schema.emptyText ?? schema.properties?.emptyText;
+  const limit: number = Number(schema.limit ?? schema.properties?.limit ?? 50) || 50;
+
+  // Self-fetch only when the host did not supply entries.
+  const objectName: string | undefined = ctx?.objectName;
+  const recordId = ctx?.data?.id ?? ctx?.data?._id ?? ctx?.recordId;
+  const dataSource = ctx?.dataSource;
+  const canSelfFetch = hostEntries === undefined && !!dataSource?.find && !!objectName && recordId != null;
+
+  const [fetched, setFetched] = React.useState<HistoryEntry[] | null>(null);
+  const [selfLoading, setSelfLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!canSelfFetch) return;
+    let cancelled = false;
+    setSelfLoading(true);
+    Promise.resolve(
+      dataSource.find('sys_activity', {
+        $filter: { object_name: objectName, record_id: recordId },
+        $orderby: { timestamp: 'desc' },
+        $top: Math.max(1, limit),
+      }),
+    )
+      .then((res: any) => {
+        if (cancelled) return;
+        const rows: any[] = res?.data ?? res?.records ?? [];
+        const mapped: HistoryEntry[] = rows
+          .filter((r) => HISTORY_TYPES.has(r?.type))
+          .map((r) => {
+            let when = r.timestamp;
+            if (!when || when === 'NOW()' || Number.isNaN(Date.parse(when))) when = r.created_at;
+            return {
+              id: r.id,
+              created_at: when,
+              action: r.type,
+              user_name: r.actor_name ?? null,
+              user_avatar: r.actor_avatar_url ?? null,
+              summary: r.summary ?? null,
+            } as HistoryEntry;
+          });
+        setFetched(mapped);
+      })
+      .catch(() => { if (!cancelled) setFetched([]); })
+      .finally(() => { if (!cancelled) setSelfLoading(false); });
+    return () => { cancelled = true; };
+  }, [canSelfFetch, dataSource, objectName, recordId, limit]);
+
+  const entries: HistoryEntry[] = hostEntries ?? fetched ?? [];
+  const loading = hostLoading ?? (canSelfFetch && fetched === null ? selfLoading || true : false);
 
   return (
     <div className={className} {...designer}>

--- a/packages/plugin-grid/src/index.tsx
+++ b/packages/plugin-grid/src/index.tsx
@@ -59,9 +59,13 @@ ComponentRegistry.register('object-grid', ObjectGridRenderer, {
 });
 
 // Alias for view namespace - this allows using { type: 'view:grid' } in schemas
-// which is semantically meaningful for data display components
+// which is semantically meaningful for data display components.
+// `skipFallback` keeps this from also claiming the bare `grid` key, which
+// belongs to the @object-ui/components layout grid (issue: object-grid was
+// shadowing the layout container, so `{type:'grid'}` 404'd needing objectName).
 ComponentRegistry.register('grid', ObjectGridRenderer, {
   namespace: 'view',
+  skipFallback: true,
   label: 'Data Grid',
   category: 'view',
   inputs: [

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -21,6 +21,7 @@ import {
   validateSchema,
 } from '@object-ui/core';
 import { SchemaRendererContext } from './context/SchemaRendererContext';
+import { usePredicateScope } from './hooks/useExpression';
 import { resolveI18nLabel } from './utils/i18n';
 
 /**
@@ -187,6 +188,10 @@ export class SchemaErrorBoundary extends Component<
 export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<string, any>>(({ schema, ...props }, _ref) => {
   const context = useContext(SchemaRendererContext);
   const dataSource = context?.dataSource || {};
+  // Ambient host scope (user / app / features), fed by app-shell's
+  // ExpressionProvider. Threaded into `visible`/expression evaluation so
+  // component predicates can gate on the signed-in user & deployment flags.
+  const predicateScope = usePredicateScope();
 
   // Re-render trigger when the global ComponentRegistry mutates (e.g. a
   // lazy-loaded plugin finishes registering its components).
@@ -207,7 +212,14 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
   const evaluatedSchema = useMemo(() => {
     if (!schema || typeof schema === 'string') return schema;
 
-    const evaluator = new ExpressionEvaluator({ data: dataSource });
+    // `data` (record/datasource) plus the ambient host scope. `current_user`
+    // is aliased to `user` so both `user.email` and `current_user.email`
+    // resolve in component `visible`/`visibleOn` expressions.
+    const evaluator = new ExpressionEvaluator({
+      ...predicateScope,
+      current_user: (predicateScope as any)?.user,
+      data: dataSource,
+    });
     // Shallow copy
     const newSchema = { ...schema };
 
@@ -283,7 +295,7 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
     }
 
     return newSchema;
-  }, [schema, dataSource]);
+  }, [schema, dataSource, predicateScope]);
 
   if (!evaluatedSchema) return null;
   // Handle visibility: if evaluated schema is hidden, render nothing


### PR DESCRIPTION
Four non-obvious renderer/registry gaps found while building composed SDUI pages (the framework `app-showcase` enterprise surfaces). All browser-verified on `:5181`.

## 1 — `grid` shadowed by ObjectGrid
`plugin-grid` registered `register('grid', ObjectGridRenderer, { namespace: 'view' })` **without `skipFallback`**, so `Registry.register`'s bare-name fallback clobbered the `@object-ui/components` **layout grid**. Result: `{ type: 'grid' }` 404'd with *"object name required for data fetching"*. Added `skipFallback: true` → the alias only claims `view:grid`, leaving bare `grid` as the layout container. **Verified:** My Work KPI row now renders in a `grid-cols-3` layout.

## 2 — Registry collision guard
`Registry.register` now `console.warn`s when a namespaced registration's bare-name fallback would overwrite a **different** component (the clobber in #1 was silent). +3 regression tests.

## 3 — `visible` expressions had no user context
`SchemaRenderer` built `new ExpressionEvaluator({ data })`, ignoring the ambient scope app-shell's `ExpressionProvider` already feeds (`user`, `app`, `features`). Now evaluates against `{ ...scope, current_user: scope.user, data }`, so component `visible`/`visibleOn` can gate on the signed-in user. `current_user` aliased to `user`. **Verified:** an `element` gated `visible: "user.email == 'admin@objectos.ai'"` shows for the admin; one gated to a different email stays hidden.

## 4 — `record:history` always empty unless host-fed
It was stateless by design ("the host fetches entries"), so a hand-authored history tab showed *"No history yet"*. Added a **self-fetch fallback** from `sys_activity` field_change events via the record context (mirrors `record:related_list`). **Verified:** Account 360 History tab now lists *"UPDATED · Industry: Finance → Technology"* after edits.

## Also
`page:card` now accepts `children` (not just `body`) for consistency with grid/flex/section/tabs.

> A separate `page:card`-in-region prop-leak (props serialized onto the DOM, title/body not rendering) remains and is **not** addressed here — flagged for follow-up.

## Tests
Full workspace suite (4021) + plugin-detail (120) + plugin-grid (66) pass. Registry tests: 27 (incl. 3 new for skipFallback/collision).

A companion framework PR re-instates the showcase features these fixes unlock (grid KPIs, role-gated note, History tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)