### PR TITLE
fix(sdui): page:card shadowing, matrix header, image cell URLs, gantt initial scroll

### DIFF
--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1054,31 +1054,44 @@ export function FileCellRenderer({ value, field }: CellRendererProps): React.Rea
  */
 export function ImageCellRenderer({ value }: CellRendererProps): React.ReactElement {
   if (!value) return <EmptyValue />;
-  
+
+  // An image value may be a plain URL string, an object ({ url | src | href }),
+  // or an array of either. Normalize so a string-URL field (common — e.g. a
+  // `cover` seeded with a CDN link) renders a thumbnail instead of a broken
+  // <img src=""> placeholder.
+  const urlOf = (v: any): string =>
+    typeof v === 'string' ? v : (v?.url || v?.src || v?.href || v?.thumbnailUrl || '');
+  const nameOf = (v: any, fallback: string): string =>
+    (v && typeof v === 'object' && (v.name || v.original_name)) || fallback;
+
   if (Array.isArray(value)) {
+    const imgs = value.map((v) => ({ url: urlOf(v), name: nameOf(v, 'Image') })).filter((i) => i.url);
+    if (imgs.length === 0) return <EmptyValue />;
     return (
       <div className="flex -space-x-2">
-        {value.slice(0, 3).map((img, idx) => (
+        {imgs.slice(0, 3).map((img, idx) => (
           <img
             key={idx}
-            src={img.url || ''}
+            src={img.url}
             alt={img.name || `Image ${idx + 1}`}
             className="size-8 rounded-md border-2 border-white object-cover"
           />
         ))}
-        {value.length > 3 && (
+        {imgs.length > 3 && (
           <div className="size-8 rounded-md border-2 border-white bg-gray-100 flex items-center justify-center text-xs font-medium text-gray-600">
-            +{value.length - 3}
+            +{imgs.length - 3}
           </div>
         )}
       </div>
     );
   }
-  
+
+  const url = urlOf(value);
+  if (!url) return <EmptyValue />;
   return (
     <img
-      src={value.url || ''}
-      alt={value.name || 'Image'}
+      src={url}
+      alt={nameOf(value, 'Image')}
       className="size-10 rounded-md object-cover"
     />
   );

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -39,9 +39,14 @@ export function registerLayout() {
       ]
   });
 
-  // Page Card
+  // Page Card — register ONLY as `layout:page:card`. `skipFallback` keeps this
+  // thin div from clobbering the bare `page:card` key, which belongs to the
+  // record-aware PageCardRenderer in @object-ui/components (it renders
+  // title/body/children; this one only renders React children and would
+  // otherwise leak schema props onto the DOM). Same rationale as `page-header`.
   ComponentRegistry.register('page:card', PageCard, {
     namespace: 'layout',
+    skipFallback: true,
     label: 'Page Card',
     category: 'Layout',
     isContainer: true

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -1628,6 +1628,28 @@ export function GanttView({
     scrollAreaRef.current.scrollTo({ left: target, behavior: 'smooth' });
   }, [todayLeftPx]);
 
+  // One-shot initial scroll: open the timeline where the work is, not at the
+  // padded left edge. Prefer today (when in range); otherwise the earliest
+  // task's start. Runs once after layout is measurable — without this, a board
+  // whose tasks sit weeks into the range opens on empty columns (issue: Gantt
+  // landed on a blank window).
+  const didInitialScrollRef = React.useRef(false);
+  React.useEffect(() => {
+    if (didInitialScrollRef.current || tasks.length === 0) return;
+    const raf = window.requestAnimationFrame(() => {
+      const el = scrollAreaRef.current;
+      if (!el || el.clientWidth === 0) return; // layout not ready yet — retry next render
+      let targetX = todayLeftPx;
+      if (targetX == null) {
+        const earliest = new Date(Math.min(...tasks.map((t) => t.start.getTime())));
+        targetX = Math.round(dateToX(earliest));
+      }
+      el.scrollLeft = Math.max(0, targetX - el.clientWidth / 2);
+      didInitialScrollRef.current = true;
+    });
+    return () => window.cancelAnimationFrame(raf);
+  }, [tasks, todayLeftPx, dateToX]);
+
   // 导航: scroll the timeline so a given date sits near the left edge. Returns
   // false (no-op) when the date is outside the rendered range.
   const scrollToDate = React.useCallback(

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -40,6 +40,17 @@ import { mergeFilters } from './mergeFilters';
 
 type Row = Record<string, unknown>;
 
+/** Humanize a dimension NAME for a header label (the renderer only knows
+ *  dimension names, not the dataset's display labels): snake/camel → Title
+ *  Case. e.g. 'status' → 'Status', 'created_at' → 'Created At'. */
+function humanizeDimension(name: string): string {
+  return String(name)
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
 /** One server-computed totals grouping: `dimensions: []` is the grand total. */
 interface DatasetTotals {
   dimensions: string[];
@@ -390,7 +401,7 @@ function DatasetMatrixTable({
           <tr>
             {rows.map((d) => (
               <th key={d} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">
-                {d}
+                {humanizeDimension(d)}
               </th>
             ))}
             {cellCols.map((cc) => (


### PR DESCRIPTION
Four remaining renderer polish bugs found in the showcase QA pass. All browser-verified on `:5181`.

## 1 — `page:card` rendered empty in page regions
Title/body missing, schema props leaked onto the DOM. Root cause: `@object-ui/layout`'s thin `PageCard` (a bare `<div {...props}>`) registered the **bare `page:card`** key **without `skipFallback`**, shadowing the record-aware `PageCardRenderer` in `@object-ui/components` (load-order dependent). Added `skipFallback: true` — the same fix the file already applies to `page-header`. Now renders title + body/children, no prop leak.

## 2 — Matrix report row-header showed raw dimension name
Showed `status` (the dimension name). The renderer only knows dimension names, not the dataset's display labels, so humanize for display: `status` → **Status**, `created_at` → **Created At**.

## 3 — Image grid cell broke on string-URL fields
`ImageCellRenderer` only read `value.url`/arrays, so a plain string URL (e.g. a `cover` CDN link) rendered `<img src="">`. Normalized to accept `string | {url|src|href} | array`, with an `EmptyValue` fallback. Cover thumbnails load in grids again.

## 4 — Gantt opened on an empty window
No initial scroll — it opened at the padded left edge with tasks weeks off-screen. Added a one-shot post-layout scroll to **today** (when in range), else the earliest task's start.

## Verified
Report header reads "Status"; All Views cover column loads 10/10 thumbnails; Team Schedule opens centered on today with bars in view; My Work `page:card`s render title+children.

## Tests
Changed-package suites pass (fields 4000, plugin-report 32, plugin-gantt 179). The standalone `layout` (32) and `GanttView.layout.test` (12) failures are a **pre-existing jsdom `localStorage.clear` gap** — identical with these changes stashed, so unaffected.

Companion framework PR re-instates the showcase `page:card`s on My Work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)