### PR TITLE
fix(layout): responsive page regions + grid columns on mobile

### DIFF
--- a/packages/components/src/renderers/layout/grid.tsx
+++ b/packages/components/src/renderers/layout/grid.tsx
@@ -72,6 +72,19 @@ ComponentRegistry.register('grid',
     if (schema.lgColumns) lgCols = schema.lgColumns;
     if (schema.xlColumns) xlCols = schema.xlColumns;
 
+    // Mobile-first ramp: a bare numeric `columns` (no explicit responsive
+    // overrides) collapses on small screens so an N-across row doesn't render
+    // as unreadable slivers on a phone. Authors who pass a responsive object
+    // or sm/md/lg/xlColumns keep full control.
+    if (
+      typeof schema.columns === 'number' && baseCols > 1 &&
+      smCols === undefined && mdCols === undefined && lgCols === undefined && xlCols === undefined
+    ) {
+      mdCols = baseCols;
+      smCols = Math.min(2, baseCols);
+      baseCols = 1;
+    }
+
     const gap = schema.gap ?? 4;
     
     // Generate Tailwind grid classes

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -38,6 +38,22 @@ function getRegionWidthClass(width?: string): string {
   }
 }
 
+/** Sidebar/aside width — full-width on mobile, fixed at md+ so the rail stacks
+ *  above/below the main column on phones instead of squeezing it. LITERAL
+ *  responsive strings so Tailwind's JIT scanner emits them. */
+function getSidebarWidthClass(width?: string): string {
+  switch (width) {
+    case 'small':
+      return 'w-full md:w-64';
+    case 'medium':
+      return 'w-full md:w-80';
+    case 'large':
+      return 'w-full md:w-96';
+    default:
+      return 'w-full';
+  }
+}
+
 /** Max-width constraint by page type */
 function getPageMaxWidth(pageType?: string): string {
   switch (pageType) {
@@ -129,9 +145,9 @@ const RegionLayout: React.FC<{
       )}
 
       {/* Body: sidebar + main + aside */}
-      <div className="flex flex-1 gap-6">
+      <div className="flex flex-col md:flex-row flex-1 gap-6">
         {sidebar && (
-          <aside className={cn('shrink-0', getRegionWidthClass(sidebar.width as string || 'small'))}>
+          <aside className={cn('md:shrink-0', getSidebarWidthClass(sidebar.width as string || 'small'))}>
             <RegionContent region={sidebar} />
           </aside>
         )}
@@ -144,7 +160,7 @@ const RegionLayout: React.FC<{
         </div>
 
         {aside && (
-          <aside className={cn('shrink-0', getRegionWidthClass(aside.width as string || 'small'), aside.className)}>
+          <aside className={cn('md:shrink-0', getSidebarWidthClass(aside.width as string || 'small'), aside.className)}>
             <RegionContent region={aside} />
           </aside>
         )}
@@ -209,9 +225,9 @@ const HeaderSidebarMainTemplate: React.FC<{ schema: PageSchema }> = ({ schema })
   return (
     <div className="flex flex-col gap-6" data-template="header-sidebar-main">
       {header && <RegionContent region={header} />}
-      <div className="flex flex-1 gap-6">
+      <div className="flex flex-col md:flex-row flex-1 gap-6">
         {sidebar && (
-          <aside className={cn('shrink-0', getRegionWidthClass(sidebar.width as string || 'medium'))}>
+          <aside className={cn('md:shrink-0', getSidebarWidthClass(sidebar.width as string || 'medium'))}>
             <RegionContent region={sidebar} />
           </aside>
         )}
@@ -241,9 +257,9 @@ const ThreeColumnTemplate: React.FC<{ schema: PageSchema }> = ({ schema }) => {
   return (
     <div className="flex flex-col gap-6" data-template="three-column">
       {header && <RegionContent region={header} />}
-      <div className="flex flex-1 gap-6">
+      <div className="flex flex-col md:flex-row flex-1 gap-6">
         {sidebar && (
-          <aside className={cn('shrink-0', getRegionWidthClass(sidebar.width as string || 'small'))}>
+          <aside className={cn('md:shrink-0', getSidebarWidthClass(sidebar.width as string || 'small'))}>
             <RegionContent region={sidebar} />
           </aside>
         )}
@@ -254,7 +270,7 @@ const ThreeColumnTemplate: React.FC<{ schema: PageSchema }> = ({ schema }) => {
           ))}
         </div>
         {aside && (
-          <aside className={cn('shrink-0', getRegionWidthClass(aside.width as string || 'small'), aside.className)}>
+          <aside className={cn('md:shrink-0', getSidebarWidthClass(aside.width as string || 'small'), aside.className)}>
             <RegionContent region={aside} />
           </aside>
         )}


### PR DESCRIPTION
Mobile-mode QA (390×844) found two foundational responsiveness gaps that made every composed page render poorly on phones.

## 1 — Region layouts didn't stack
Sidebar + main stayed **side-by-side at all widths** — on a phone the sidebar squeezed main to an unreadable sliver. `RegionLayout`, `header-sidebar-main`, and three-column templates now use `flex flex-col md:flex-row`, and sidebars are `w-full` on mobile (fixed width only at `md+`, via a new `getSidebarWidthClass` that returns **literal** responsive strings so Tailwind's JIT emits them). Rails stack above/below main on phones, restore side-by-side on desktop.

## 2 — Layout grid didn't collapse
A bare numeric `columns: N` rendered `grid-cols-N` at **all** widths — a 4-up KPI row became 4 slivers on mobile. A bare numeric columns (no explicit responsive object / `sm/md/lg/xlColumns`) now ramps mobile-first: `grid-cols-1 sm:grid-cols-2 md:grid-cols-N`. Explicit responsive configs keep full control.

## Verified
Browser-tested at **390×844** and **1440×900**: showcase home, My Work, dashboard, list/table, and record pages all read well on mobile and are unchanged on desktop. `components` layout tests pass (1203).

🤖 Generated with [Claude Code](https://claude.com/claude-code)