### PR TITLE
polish(dashboard): tabular-nums + tighter tracking on metric value

### DIFF
--- a/packages/plugin-dashboard/src/MetricWidget.tsx
+++ b/packages/plugin-dashboard/src/MetricWidget.tsx
@@ -257,7 +257,7 @@ export const MetricWidget = ({
           </div>
         ) : (
           <>
-            <div className="text-2xl font-bold truncate">{displayValue}</div>
+            <div className="text-2xl font-bold tabular-nums tracking-tight truncate">{displayValue}</div>
             {(trend || description) && (
               <div className="text-xs text-muted-foreground mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 min-w-0">
                 {trend && (


### PR DESCRIPTION
KPI/metric values are numbers — render them with `tabular-nums` so digits align across a row of tiles, plus `tracking-tight` for a more deliberate, "designed" look. Pure styling on `MetricWidget`; no behavior change.

Verified on the showcase home + My Work (with the companion framework PR that opts the showcase KPIs into `colorVariant`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)