### PR TITLE
polish(record): cap detail content at a comfortable reading width

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1893,6 +1893,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
 
       <div className="flex-1 overflow-hidden flex flex-row">
         <div className="flex-1 overflow-auto p-3 sm:p-4 lg:p-6 scroll-pb-48">
+          {/* Cap the detail content at a comfortable reading width — record
+              pages are scan surfaces; full-bleed field rows on wide monitors
+              push values far from labels. Data surfaces (lists/dashboards)
+              stay full-width; this only affects the record detail column. */}
+          <div className="mx-auto w-full max-w-[1400px]">
           <ActionProvider
             context={{ record: {}, objectName, user: currentUser }}
             onConfirm={confirmHandler}
@@ -1943,6 +1948,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
             />
             {modalElement}
           </ActionProvider>
+          </div>
         </div>
         <MetadataPanel
           open={showDebug}


### PR DESCRIPTION
Record pages are scan/read surfaces. On wide monitors the full-bleed detail column stretched field rows so values sat far from their labels, hurting scannability. Cap the `RecordDetailView` content column at `max-w-[1400px]` (centered).

- Data surfaces (lists / dashboards / visualizations) are **untouched** — they stay full-width.
- Only affects viewports where the content region exceeds 1400px (~1665px+), so common **1440/1280 layouts are unchanged**.

Verified at **1920** (content centers, field rows tighten) and **1440** (no change). Matches the record-page convention in Salesforce Lightning / Linear / Notion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)