### PR TITLE
feat(list): iOS/Linear segmented view switcher for 2–4 visualizations

### DIFF
--- a/packages/plugin-list/src/ViewSwitcher.tsx
+++ b/packages/plugin-list/src/ViewSwitcher.tsx
@@ -92,6 +92,49 @@ export const ViewSwitcherDropdown: React.FC<ViewSwitcherProps> = ({
     [animated, currentView, onViewChange],
   );
 
+  // Few visualizations (2–4): render an iOS/Linear-style segmented control
+  // inline — a unified rounded track where the active segment lifts onto a
+  // white thumb. Clearer and more tactile than a dropdown for a short set.
+  // Many (5+) fall through to the compact dropdown below to keep the toolbar
+  // one line.
+  if (availableViews.length >= 2 && availableViews.length <= 4) {
+    return (
+      <div
+        role="tablist"
+        data-testid="view-switcher-segmented"
+        className={cn(
+          'inline-flex items-center gap-0.5 rounded-lg bg-muted p-0.5 oui-view-switcher',
+          className,
+        )}
+      >
+        {availableViews.map((view) => {
+          const active = view === currentView;
+          return (
+            <button
+              key={view}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              aria-label={VIEW_LABELS[view]}
+              title={VIEW_LABELS[view]}
+              data-state={active ? 'on' : 'off'}
+              onClick={() => handleViewChange(view)}
+              className={cn(
+                'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-[7px] text-xs font-medium transition-all duration-150',
+                active
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {VIEW_ICONS[view]}
+              <span className="hidden sm:inline-block">{VIEW_LABELS[view]}</span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>


### PR DESCRIPTION
## What

When a list exposes a small set of visualizations (2–4), the view switcher now renders as a **unified segmented control** — a rounded track where the active segment lifts onto a white thumb — instead of a dropdown. Lists with 5+ visualizations keep the compact dropdown so the toolbar stays one line.

This is part of the "Linear on desktop, iOS-native on mobile" direction for the showcase.

## Details

- New inline segmented variant in `ViewSwitcherDropdown` (the existing API/handlers are reused — same `handleViewChange`, same view-transition animation).
- `role="tablist"` / `role="tab"` / `aria-selected` for accessibility.
- Labels collapse to icons under `sm:` with `aria-label`/`title` preserved, so the mobile toolbar stays compact and one line.

## Verification

Verified on `showcase_active_projects` (grid + kanban = 2 views) via the dev console:
- **Desktop (1440px):** segmented track with `[Grid | Kanban]`, active segment on a white thumb; clicking Kanban switches the view and moves the thumb. ✅
- **Mobile (390px):** collapses to icon-only segments, compact one-line toolbar. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)