### PR TITLE
fix(grid): activate mobile card view at the 768px app breakpoint

### DIFF
--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -319,8 +319,10 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     enabled: !!dataSource && !!schema.objectName,
   });
 
+  // Activate the mobile card view below the 768px app mobile breakpoint so
+  // phones and tablet-portrait never need to side-scroll a wide grid.
   useEffect(() => {
-    const checkWidth = () => setUseCardView(window.innerWidth < 480);
+    const checkWidth = () => setUseCardView(window.innerWidth < 768);
     checkWidth();
     window.addEventListener('resize', checkWidth);
     return () => window.removeEventListener('resize', checkWidth);
@@ -1629,7 +1631,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       ? `${schema.objectName.charAt(0).toUpperCase() + schema.objectName.slice(1)} Detail`
       : 'Record Detail';
 
-  // Mobile card-view fallback for screens below 480px
+  // Mobile card-view: below the 768px app breakpoint (matches useIsMobile /
+  // Tailwind md: / the responsive page+grid layout), render stacked cards
+  // instead of a side-scrolling wide table.
   if (useCardView && data.length > 0 && !isGrouped) {
     const displayColumns = generateColumns().filter((c: any) => c.accessorKey !== '_actions');
 


### PR DESCRIPTION
## Problem

On phones and tablet-portrait, the list **Grid (table) view side-scrolls** — only the first ~3 columns fit; the rest are off-screen. ObjectGrid *already ships* a mobile card view (stacked cards, one field per line, badges with correct colors), but it only activated below **480px**.

That's narrower than the app's mobile breakpoint (**768px**, shared by `useIsMobile`, Tailwind `md:`, and the responsive page + grid layout shipped in #1816). So the **480–768px** band — most phones, tablet-portrait, and even phones whose reported `innerWidth` sits just over 480 (e.g. a 390px viewport reporting 500) — fell through to the cramped scrolling table.

## Fix

Raise the card-view threshold from 480 → **768**, matching every other responsive switch in the shell. One-line change plus clarifying comments. Desktop (≥768) is unchanged.

## Verification (dev console, `showcase_active_projects`)

| width | before | after |
|---|---|---|
| 500px | side-scrolling table | ✅ stacked cards |
| 390px | side-scrolling table | ✅ stacked cards |
| 1280px | table | ✅ table (unchanged) |

- Cards show title + compact currency + status badge + label/value rows, correct badge colors (Planned/On Hold/Green/Red). ✅
- Tapping a card navigates to the record — opens the iOS grouped-inset detail (#1820) in a full-screen overlay. **No horizontal scroll anywhere in the mobile flow.** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)