### PR TITLE
feat(nav): iOS-native polish for the mobile sidebar drawer

### DIFF
--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -355,9 +355,9 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
         <SidebarHeader className="border-b p-1.5">
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton asChild className="h-9 text-sm font-medium">
+              <SidebarMenuButton asChild className="min-h-[44px] text-[15px] font-medium rounded-xl">
                 <Link to="/home" onClick={() => setOpenMobile(false)} data-testid="mobile-sidebar-home">
-                  <Home className="h-4 w-4" />
+                  <Home className="h-5 w-5" />
                   <span>{t('home.nav', { defaultValue: 'Home' })}</span>
                 </Link>
               </SidebarMenuButton>

--- a/packages/components/src/ui/sidebar.tsx
+++ b/packages/components/src/ui/sidebar.tsx
@@ -212,7 +212,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden data-[state=open]:duration-300 data-[state=open]:ease-out"
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,

--- a/packages/layout/src/NavigationRenderer.tsx
+++ b/packages/layout/src/NavigationRenderer.tsx
@@ -62,6 +62,8 @@ import {
   CollapsibleContent,
   Badge,
   Separator,
+  cn,
+  useIsMobile,
 } from '@object-ui/components';
 import type { NavigationItem } from '@object-ui/types';
 
@@ -712,6 +714,11 @@ function NavigationItemRenderer({
   templateContext?: NavTemplateContext;
 }) {
   const location = useLocation();
+  // iOS-native mobile drawer polish: >=44px tap targets, larger text and
+  // icons, rounder rows. Desktop (>=768px) keeps the compact rail untouched.
+  const isMobile = useIsMobile();
+  const mobileBtnClass = isMobile ? 'min-h-[44px] text-[15px] gap-3 rounded-xl' : undefined;
+  const navIconClass = cn('shrink-0', isMobile ? 'h-5 w-5' : 'h-4 w-4');
   // Resolve the initial open state with platform-aware defaults:
   //
   // 1. `expanded` is the spec field name; `defaultOpen` is the legacy
@@ -787,10 +794,10 @@ function NavigationItemRenderer({
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <SidebarGroup>
           <SidebarGroupLabel asChild>
-            <CollapsibleTrigger className="flex w-full items-center justify-between">
+            <CollapsibleTrigger className={cn('flex w-full items-center justify-between', isMobile && 'min-h-[44px] text-[15px] rounded-xl')}>
               {groupLabel}
               <ChevronRight
-                className={`ml-auto h-4 w-4 transition-transform ${isOpen ? 'rotate-90' : ''}`}
+                className={cn('ml-auto transition-transform', isMobile ? 'h-5 w-5' : 'h-4 w-4', isOpen && 'rotate-90')}
               />
             </CollapsibleTrigger>
           </SidebarGroupLabel>
@@ -843,8 +850,9 @@ function NavigationItemRenderer({
         <SidebarMenuButton
           tooltip={actionLabel}
           onClick={() => onAction?.(item)}
+          className={mobileBtnClass}
         >
-          <Icon className="h-4 w-4" />
+          <Icon className={navIconClass} />
           <span>{actionLabel}</span>
           {item.badge != null && (
             <Badge variant={item.badgeVariant ?? 'default'} className="ml-auto text-[10px] px-1.5 py-0">
@@ -884,7 +892,7 @@ function NavigationItemRenderer({
 
   const content = (
     <>
-      <Icon className="h-4 w-4" />
+      <Icon className={navIconClass} />
       <span>{itemLabel}</span>
       {item.badge != null && (
         <Badge variant={item.badgeVariant ?? 'default'} className="ml-auto text-[10px] px-1.5 py-0">
@@ -905,7 +913,7 @@ function NavigationItemRenderer({
           <GripVertical className="h-3.5 w-3.5" />
         </span>
       )}
-      <SidebarMenuButton asChild isActive={isActive} tooltip={itemLabel}>
+      <SidebarMenuButton asChild isActive={isActive} tooltip={itemLabel} className={mobileBtnClass}>
         {external ? (
           <a href={href} target="_blank" rel="noopener noreferrer">
             {content}


### PR DESCRIPTION
## What

You deliberately removed the mobile bottom-tab nav on 2026-05-20 ([`00363fd2e`](https://github.com/objectstack-ai/objectui/commit/00363fd2e)) in favor of drawer-only (Notion/Linear pattern). This PR **keeps that decision** and instead makes the **drawer itself** feel iOS-native on phones.

## Changes (all gated behind `useIsMobile()` — desktop rail untouched)

1. **Tap targets** — nav rows go from 32–36px to **≥44px** (iOS HIG minimum), with 15px text, 20px icons, and `rounded-xl` rows. Applied in the shared `NavigationRenderer` only when mobile.
2. **Snappier open** — the mobile sidebar `Sheet` opens in **300ms ease-out** instead of the shared 500ms default. Scoped to the drawer's `SheetContent` className only, so other Sheets/dialogs keep their timing.
3. **Mobile Home row** — `UnifiedSidebar`'s phone-only "Home" affordance matches: 44px, 15px text, 20px icon, `rounded-xl`.

## Verification

- **Mobile (390px):** drawer nav rows measure **44px** (was 32–36px); rounded-xl + larger text/icons render; no console errors. ✅
- **Desktop (1280px):** sidebar rows stay **32px**; class-list inspection confirms **no** `min-h-[44px]` / `rounded-xl` leak — desktop is unchanged. ✅
- `turbo run type-check` passes for `@object-ui/components`, `@object-ui/layout`, `@object-ui/app-shell` (28/28 tasks). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)