### PR TITLE
feat(dashboard): label headers, currency-correct amounts, i18n & drill-through for dataset widgets

### DIFF
--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1830,7 +1830,16 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       offset?: number;
       timezone?: string;
     },
-  ): Promise<{ rows: Array<Record<string, unknown>>; fields: Array<{ name: string; type: string }> }> {
+  ): Promise<{
+    rows: Array<Record<string, unknown>>;
+    fields: Array<{ name: string; type: string }>;
+    /** ADR-0021 D2 drill-through: the dataset's base object (records to drill into). */
+    object?: string;
+    /** Drillable dimension NAME → underlying object FIELD name. */
+    dimensionFields?: Record<string, string>;
+    /** Raw grouped values per row (aligned to `rows` by index) for drill filters. */
+    drillRawRows?: Array<Record<string, unknown>>;
+  }> {
     await this.connect();
     const base = (this.baseUrl || '').replace(/\/$/, '');
     const url = `${base}/api/v1/analytics/dataset/query`;
@@ -1874,7 +1883,17 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       ? (data as any).rows
       : (Array.isArray(data) ? (data as any) : []);
     const fields = Array.isArray((data as any)?.fields) ? (data as any).fields : [];
-    return { rows, fields };
+    // Drill-through metadata (ADR-0021 D2): the server exposes the dataset's
+    // base object + drillable dimension→field mapping, plus a parallel array of
+    // RAW grouped values (the rows themselves carry display labels), so a host
+    // can build an exact-match filter from a clicked bucket.
+    const object = typeof (data as any)?.object === 'string' ? (data as any).object : undefined;
+    const dimensionFields =
+      (data as any)?.dimensionFields && typeof (data as any).dimensionFields === 'object'
+        ? ((data as any).dimensionFields as Record<string, string>)
+        : undefined;
+    const drillRawRows = Array.isArray((data as any)?.drillRawRows) ? (data as any).drillRawRows : undefined;
+    return { rows, fields, object, dimensionFields, drillRawRows };
   }
 
   /** Client-side aggregation fallback */

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -757,6 +757,10 @@ const en = {
     total: 'Total',
     noDataAvailable: 'No data available',
     noDataSourceFor: 'No data source available for',
+    noRows: 'No rows',
+    pickMeasures: 'Pick measures (values) for this dataset widget.',
+    datasetUnsupported: 'This data source does not support dataset queries.',
+    details: 'Details',
     trend: {
       vsLastQuarter: 'vs last quarter',
       vsLastMonth: 'vs last month',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -757,6 +757,10 @@ const zh = {
     total: '总计',
     noDataAvailable: '暂无数据',
     noDataSourceFor: '没有可用的数据源：',
+    noRows: '暂无数据行',
+    pickMeasures: '请为该数据集组件选择度量（值）。',
+    datasetUnsupported: '当前数据源不支持数据集查询。',
+    details: '明细',
     trend: {
       vsLastQuarter: '较上季度',
       vsLastMonth: '较上月',

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -66,6 +66,38 @@ export function buildDrillFilter(
 }
 
 /**
+ * Pivot flat dataset rows into a cross-tab: `rowDims` go DOWN, `colDim` spreads
+ * ACROSS. Returns ordered row/column headers (display labels from the rows) and
+ * a map from a `${rowId} ${colId}` cell key to the FLAT row index holding
+ * that combination's measure values. No re-aggregation — the dataset already
+ * grouped by every dimension, so each cell maps to exactly one row (the index
+ * is also what drill-through uses to read `drillRawRows`).
+ */
+export function buildPivot(
+  rows: Array<Record<string, unknown>>,
+  rowDims: string[],
+  colDim: string,
+): {
+  rowHeaders: Array<{ id: string; labels: string[] }>;
+  colHeaders: Array<{ id: string; label: string }>;
+  cellIndex: Map<string, number>;
+} {
+  const rowHeaders: Array<{ id: string; labels: string[] }> = [];
+  const colHeaders: Array<{ id: string; label: string }> = [];
+  const rowSeen = new Set<string>();
+  const colSeen = new Set<string>();
+  const cellIndex = new Map<string, number>();
+  rows.forEach((row, index) => {
+    const rid = rowDims.map((d) => String(row[d] ?? '∅')).join('');
+    const cid = String(row[colDim] ?? '∅');
+    if (!rowSeen.has(rid)) { rowSeen.add(rid); rowHeaders.push({ id: rid, labels: rowDims.map((d) => formatValue(row[d])) }); }
+    if (!colSeen.has(cid)) { colSeen.add(cid); colHeaders.push({ id: cid, label: formatValue(row[colDim]) }); }
+    cellIndex.set(`${rid} ${cid}`, index);
+  });
+  return { rowHeaders, colHeaders, cellIndex };
+}
+
+/**
  * Translate with a graceful fallback. Mirrors the PivotTable pattern: when no
  * i18n provider is mounted (or the key is missing), return the English default
  * so the widget never renders a raw translation key.
@@ -265,22 +297,95 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     );
   }
 
-  // Table / pivot — a grouped table of the selected dimensions + measures.
+  // Table / pivot — a grouped table or, for a pivot with ≥2 dimensions, a true
+  // cross-tab.
   if (isTable) {
-    const columns = [...dimensions, ...values];
     // Drill-through is available when the server returned the dataset's object +
     // at least one drillable dimension that this widget actually groups by.
     const { object, dimensionFields, drillRawRows } = state;
     const drillDims = dimensionFields ? dimensions.filter((d) => d in dimensionFields) : [];
     const canDrill = !!object && drillDims.length > 0;
 
-    const openDrill = (row: Row, index: number) => {
+    // Drill by FLAT row index — both the flat table and the matrix cells map a
+    // clicked element to a single dataset row (and its `drillRawRows` entry).
+    const openDrill = (index: number, title: string) => {
       if (!object || !dimensionFields) return;
       const merged = buildDrillFilter(drillRawRows?.[index], drillDims, dimensionFields, runtimeFilter);
-      const title = drillDims.map((d) => formatValue(row[d])).filter(Boolean).join(' / ') || String(widget?.title ?? '');
-      setDrill({ filter: merged, title });
+      setDrill({ filter: merged, title: title || String(widget?.title ?? '') });
     };
 
+    const drawer = drill && object ? (
+      <DrillDownDrawer
+        open
+        onClose={() => setDrill(null)}
+        title={drill.title || String(widget?.title ?? tt('dashboard.details', 'Details'))}
+        objectName={object}
+        filter={drill.filter}
+        dataSource={dataSource}
+      />
+    ) : null;
+
+    // pivot → a true cross-tab when there are ≥2 dimensions: the LAST dimension
+    // spreads ACROSS as columns, the rest go DOWN as rows, measures fill the
+    // cells. The dataset already returns one row per dimension combination, so
+    // cells just place those pre-aggregated values — no client re-aggregation
+    // (an avg/min/max can't be recombined). With <2 dimensions a cross-tab is
+    // meaningless, so it degrades to the flat grouped table.
+    const isMatrix = widgetType === 'pivot' && dimensions.length >= 2;
+    if (isMatrix) {
+      const rowDims = dimensions.slice(0, -1);
+      const colDim = dimensions[dimensions.length - 1];
+      const pivot = buildPivot(state.rows, rowDims, colDim);
+      // Single measure → one column per across-bucket; multiple → bucket × measure.
+      const cellCols = pivot.colHeaders.flatMap((col) =>
+        values.map((m) => ({ col, measure: m, header: values.length === 1 ? col.label : `${col.label} · ${headerLabel(m)}` })),
+      );
+      return (
+        <div className="h-full w-full overflow-auto p-1" data-testid="dataset-matrix">
+          <table className="w-full text-xs">
+            <thead className="bg-muted/40">
+              <tr>
+                {rowDims.map((d) => (
+                  <th key={d} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">{headerLabel(d)}</th>
+                ))}
+                {cellCols.map((cc) => (
+                  <th key={`${cc.col.id}-${cc.measure}`} className="px-2 py-1.5 text-right font-medium whitespace-nowrap">{cc.header}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {pivot.rowHeaders.map((rh) => (
+                <tr key={rh.id} className="border-t">
+                  {rh.labels.map((lbl, di) => (
+                    <td key={di} className="px-2 py-1 whitespace-nowrap font-medium">{lbl}</td>
+                  ))}
+                  {cellCols.map((cc) => {
+                    const index = pivot.cellIndex.get(`${rh.id} ${cc.col.id}`);
+                    const fr = index != null ? state.rows[index] : undefined;
+                    const clickable = canDrill && index != null;
+                    const title = [...rh.labels, cc.col.label].filter(Boolean).join(' / ');
+                    return (
+                      <td
+                        key={`${cc.col.id}-${cc.measure}`}
+                        className={cn('px-2 py-1 text-right tabular-nums whitespace-nowrap', clickable && 'cursor-pointer hover:bg-accent/40')}
+                        data-testid={clickable ? 'dataset-drill-cell' : undefined}
+                        onClick={clickable ? () => openDrill(index as number, title) : undefined}
+                      >
+                        {fr ? formatMeasure(fr[cc.measure], measureField(cc.measure)?.format, measureField(cc.measure)?.currency) : '—'}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {drawer}
+        </div>
+      );
+    }
+
+    // table (and a 1-dimension pivot) → a flat grouped table.
+    const columns = [...dimensions, ...values];
     return (
       <div className="h-full w-full overflow-auto p-1">
         <table className="w-full text-xs">
@@ -297,7 +402,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
                 key={i}
                 className={cn('border-t', canDrill && 'cursor-pointer hover:bg-accent/40')}
                 data-testid={canDrill ? 'dataset-drill-row' : undefined}
-                onClick={canDrill ? () => openDrill(row, i) : undefined}
+                onClick={canDrill ? () => openDrill(i, drillDims.map((d) => formatValue(row[d])).filter(Boolean).join(' / ')) : undefined}
               >
                 {columns.map((c) => (
                   <td key={c} className="px-2 py-1 whitespace-nowrap tabular-nums">
@@ -308,16 +413,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
             ))}
           </tbody>
         </table>
-        {drill && object && (
-          <DrillDownDrawer
-            open
-            onClose={() => setDrill(null)}
-            title={drill.title || String(widget?.title ?? tt('dashboard.details', 'Details'))}
-            objectName={object}
-            filter={drill.filter}
-            dataSource={dataSource}
-          />
-        )}
+        {drawer}
       </div>
     );
   }

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -11,7 +11,9 @@
  * Rendering dispatch (by `widget.type`):
  *  - metric / kpi / gauge / solid-gauge / bullet (or no dimensions) → KPI value
  *    with the measure's display label + format.
- *  - table / pivot → a grouped table of `dimensions` + `values`.
+ *  - table / pivot → a grouped table of `dimensions` + `values`. Rows drill
+ *    through to the underlying records (ADR-0021 D2) when the server returns the
+ *    dataset's `object` + dimension→field mapping.
  *  - bar / column / horizontal-bar / line / area / pie / donut / funnel /
  *    scatter / radar / treemap / sankey → the shared advanced `chart` renderer
  *    with its TRUE chart type and one series per measure. A type the renderer
@@ -28,34 +30,97 @@ import { useEffect, useMemo, useState } from 'react';
 import { SchemaRenderer } from '@object-ui/react';
 import { buildChartSeries } from '@object-ui/core';
 import { cn } from '@object-ui/components';
+import { useObjectTranslation, useSafeFieldLabel } from '@object-ui/i18n';
 import { Loader2, BarChart3, AlertTriangle } from 'lucide-react';
 import { resolveDateMacros } from './utils';
+import { DrillDownDrawer } from './DrillDownDrawer';
 
 type Row = Record<string, unknown>;
 /** Measure column metadata from the analytics result (ADR-0021). */
-interface ResultField { name: string; type?: string; label?: string; format?: string }
+interface ResultField { name: string; type?: string; label?: string; format?: string; currency?: string }
+interface DatasetResult { rows: Row[]; fields?: ResultField[]; object?: string; dimensionFields?: Record<string, string> }
 interface DatasetCapableSource {
-  queryDataset?: (dataset: string, selection: unknown) => Promise<{ rows: Row[]; fields?: ResultField[] }>;
+  queryDataset?: (dataset: string, selection: unknown) => Promise<DatasetResult>;
 }
 
 /**
- * Format a measure value using its dataset `format` hint (numeral-style, e.g.
- * "$0,0", "0.0", "0.0%"). Falls back to a thousand-separated number. The format
- * can't be baked into the numeric row value server-side (charts need the raw
- * number), so it is applied here at render time.
+ * Build the record-list filter for a drilled row. Each drillable dimension maps
+ * to its underlying object field, filtered by the dimension's RAW grouped value
+ * (taken from the server's parallel `drillRawRows` array — the visible `row`
+ * carries the display label, which would mis-filter a select/lookup field). The
+ * widget's render-time scope (`runtimeFilter`) is ANDed in so the drilled list
+ * stays within the same slice the aggregate was computed over.
  */
-function formatMeasure(v: unknown, format?: string): string {
+export function buildDrillFilter(
+  rawRow: Record<string, unknown> | undefined,
+  drillDims: string[],
+  dimensionFields: Record<string, string>,
+  runtimeFilter?: Record<string, unknown>,
+): Record<string, unknown> {
+  const drillFilter: Record<string, unknown> = {};
+  for (const d of drillDims) {
+    const raw = rawRow?.[d];
+    drillFilter[dimensionFields[d]] = raw === '' || raw === undefined ? null : raw;
+  }
+  return runtimeFilter ? { ...runtimeFilter, ...drillFilter } : drillFilter;
+}
+
+/**
+ * Translate with a graceful fallback. Mirrors the PivotTable pattern: when no
+ * i18n provider is mounted (or the key is missing), return the English default
+ * so the widget never renders a raw translation key.
+ */
+function useTranslate(): (key: string, fallback: string) => string {
+  let t: ((k: string) => string) | undefined;
+  try {
+    t = useObjectTranslation().t;
+  } catch {
+    t = undefined;
+  }
+  return (key, fallback) => {
+    if (!t) return fallback;
+    const v = t(key);
+    return !v || v === key ? fallback : v;
+  };
+}
+
+/**
+ * Format a measure value. Currency comes from the field's declared `currency`
+ * (locale-correct symbol via `Intl`), NOT from a "$" baked into the format
+ * string — an amount with no declared currency must render as a plain number,
+ * never a misleading "$". The numeral-style `format` hint (e.g. "0,0", "0.0%")
+ * controls grouping / decimals / percent; it can't be baked into the row value
+ * server-side (charts need the raw number), so it is applied here.
+ */
+function formatMeasure(v: unknown, format?: string, currency?: string): string {
   if (v == null) return '—';
   if (typeof v !== 'number') return String(v);
+
+  const decimals = format ? (format.split('.')[1]?.match(/0/g)?.length ?? 0) : undefined;
+
+  if (currency) {
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: decimals ?? 0,
+        maximumFractionDigits: decimals ?? 2,
+      }).format(v);
+    } catch {
+      // Unknown currency code → fall through to plain number formatting.
+    }
+  }
+
   if (!format) {
     // No format hint → preserve the plain rendering (integers verbatim).
     return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
   }
   const isPercent = format.includes('%');
-  const isCurrency = format.includes('$');
-  const decimals = format.split('.')[1]?.match(/0/g)?.length ?? 0;
-  const body = v.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
-  return `${isCurrency ? '$' : ''}${body}${isPercent ? '%' : ''}`;
+  // A legacy "$" literal in the format string is still honored (explicit author
+  // choice) — but it is NOT how a real currency field gets its symbol.
+  const legacyDollar = format.includes('$') ? '$' : '';
+  const body = v.toLocaleString(undefined, { minimumFractionDigits: decimals ?? 0, maximumFractionDigits: decimals ?? 0 });
+  return `${legacyDollar}${body}${isPercent ? '%' : ''}`;
 }
 
 function formatValue(v: unknown): string {
@@ -111,6 +176,9 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   const isMetric = METRIC_TYPES.has(widgetType) || dimensions.length === 0;
   const isTable = widgetType === 'table' || widgetType === 'pivot';
 
+  const tt = useTranslate();
+  const { fieldLabel } = useSafeFieldLabel();
+
   // ADR-0021 dual-form: the widget's presentation-scope `filter` must flow into
   // the dataset query as `runtimeFilter`, or a dataset-bound widget renders the
   // UNFILTERED total (e.g. "open pipeline" showing the grand total). Resolve
@@ -125,7 +193,9 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     [rawFilter],
   );
 
-  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: ResultField[]; error?: string }>({ status: 'idle', rows: [] });
+  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: ResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; error?: string }>({ status: 'idle', rows: [] });
+  // Drill-through (ADR-0021 D2): the clicked bucket's record-list filter + title.
+  const [drill, setDrill] = useState<{ filter: Record<string, unknown>; title: string } | null>(null);
 
   // Signature uses the RAW filter (stable) — the resolved one carries a
   // render-time `now` and would otherwise force a refetch loop.
@@ -133,7 +203,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   useEffect(() => {
     const src = dataSource as DatasetCapableSource | undefined;
     if (!src || typeof src.queryDataset !== 'function') {
-      setState({ status: 'error', rows: [], error: 'This data source does not support dataset queries.' });
+      setState({ status: 'error', rows: [], error: tt('dashboard.datasetUnsupported', 'This data source does not support dataset queries.') });
       return;
     }
     if (values.length === 0) { setState({ status: 'idle', rows: [] }); return; }
@@ -145,14 +215,14 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       ...(runtimeFilter ? { runtimeFilter } : {}),
       ...(compareTo ? { compareTo } : {}),
     })
-      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [], fields: Array.isArray(res?.fields) ? res.fields : [] }); })
+      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [], fields: Array.isArray(res?.fields) ? res.fields : [], object: res?.object, dimensionFields: res?.dimensionFields, drillRawRows: Array.isArray(res?.drillRawRows) ? res.drillRawRows : undefined }); })
       .catch((e) => { if (!cancelled) setState({ status: 'error', rows: [], error: String((e as Error)?.message ?? e) }); });
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [signature]);
 
   if (values.length === 0) {
-    return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground">Pick measures (values) for this dataset widget.</div>;
+    return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground">{tt('dashboard.pickMeasures', 'Pick measures (values) for this dataset widget.')}</div>;
   }
   if (state.status === 'loading' || state.status === 'idle') {
     return <div className="flex h-full w-full items-center justify-center p-4 text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /></div>;
@@ -168,12 +238,19 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // latter reads as broken for KPIs like "Total Books" on a fresh app. Charts
   // and tables keep the empty state (there is genuinely nothing to plot).
   if (state.rows.length === 0 && !isMetric) {
-    return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground"><BarChart3 className="mr-2 h-4 w-4" />No rows</div>;
+    return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground"><BarChart3 className="mr-2 h-4 w-4" />{tt('dashboard.noRows', 'No rows')}</div>;
   }
 
-  // Measure metadata (label + format) carried on the result fields, keyed by name.
+  // Measure metadata (label + format + currency) carried on the result fields, keyed by name.
   const fieldByName = new Map((state.fields ?? []).map((f) => [f.name, f]));
   const measureField = (name: string) => fieldByName.get(name);
+  // Resolve a column header: the dataset's display label (server-enriched onto
+  // the field, for dimensions and measures alike), then through the i18n
+  // field-label convention so a translated label wins, then the raw name.
+  const headerLabel = (name: string) => {
+    const fallback = measureField(name)?.label ?? name;
+    return state.object ? fieldLabel(state.object, name, fallback) : fallback;
+  };
 
   // Metric / KPI — show the single measure value of the first row, using the
   // measure's display label (not the raw name) and its format (e.g. "$616,000").
@@ -182,8 +259,8 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     const value = state.rows[0]?.[values[0]] ?? 0;
     return (
       <div className="flex h-full w-full flex-col items-start justify-center gap-1 p-2">
-        <span className="text-2xl font-semibold tabular-nums">{formatMeasure(value, f?.format)}</span>
-        <span className="text-xs text-muted-foreground">{f?.label ?? values[0]}</span>
+        <span className="text-2xl font-semibold tabular-nums">{formatMeasure(value, f?.format, f?.currency)}</span>
+        <span className="text-xs text-muted-foreground">{headerLabel(values[0])}</span>
       </div>
     );
   }
@@ -191,28 +268,56 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // Table / pivot — a grouped table of the selected dimensions + measures.
   if (isTable) {
     const columns = [...dimensions, ...values];
+    // Drill-through is available when the server returned the dataset's object +
+    // at least one drillable dimension that this widget actually groups by.
+    const { object, dimensionFields, drillRawRows } = state;
+    const drillDims = dimensionFields ? dimensions.filter((d) => d in dimensionFields) : [];
+    const canDrill = !!object && drillDims.length > 0;
+
+    const openDrill = (row: Row, index: number) => {
+      if (!object || !dimensionFields) return;
+      const merged = buildDrillFilter(drillRawRows?.[index], drillDims, dimensionFields, runtimeFilter);
+      const title = drillDims.map((d) => formatValue(row[d])).filter(Boolean).join(' / ') || String(widget?.title ?? '');
+      setDrill({ filter: merged, title });
+    };
+
     return (
       <div className="h-full w-full overflow-auto p-1">
         <table className="w-full text-xs">
           <thead className="bg-muted/40">
             <tr>
               {columns.map((c) => (
-                <th key={c} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">{measureField(c)?.label ?? c}</th>
+                <th key={c} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">{headerLabel(c)}</th>
               ))}
             </tr>
           </thead>
           <tbody>
             {state.rows.map((row, i) => (
-              <tr key={i} className="border-t">
+              <tr
+                key={i}
+                className={cn('border-t', canDrill && 'cursor-pointer hover:bg-accent/40')}
+                data-testid={canDrill ? 'dataset-drill-row' : undefined}
+                onClick={canDrill ? () => openDrill(row, i) : undefined}
+              >
                 {columns.map((c) => (
                   <td key={c} className="px-2 py-1 whitespace-nowrap tabular-nums">
-                    {values.includes(c) ? formatMeasure(row[c], measureField(c)?.format) : formatValue(row[c])}
+                    {values.includes(c) ? formatMeasure(row[c], measureField(c)?.format, measureField(c)?.currency) : formatValue(row[c])}
                   </td>
                 ))}
               </tr>
             ))}
           </tbody>
         </table>
+        {drill && object && (
+          <DrillDownDrawer
+            open
+            onClose={() => setDrill(null)}
+            title={drill.title || String(widget?.title ?? tt('dashboard.details', 'Details'))}
+            objectName={object}
+            filter={drill.filter}
+            dataSource={dataSource}
+          />
+        )}
       </div>
     );
   }

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
-import { DatasetWidget } from '../DatasetWidget';
+import { DatasetWidget, buildDrillFilter } from '../DatasetWidget';
 
 afterEach(cleanup);
 
@@ -99,5 +99,88 @@ describe('DatasetWidget', () => {
     const src = makeSource(async () => ({ rows: [] }));
     render(<DatasetWidget widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
     expect(await screen.findByText('No rows')).toBeInTheDocument();
+  });
+
+  // ── #2 header labels ────────────────────────────────────────────────────
+  it('renders the dataset display label for a dimension header, not the raw field name', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ status: 'Open', task_count: 5 }],
+      fields: [
+        { name: 'status', type: 'string', label: 'Status' },
+        { name: 'task_count', type: 'number', label: 'Tasks' },
+      ],
+    })) };
+    render(<DatasetWidget widget={{ type: 'table', dataset: 'tasks', dimensions: ['status'], values: ['task_count'] }} dataSource={src} />);
+    expect(await screen.findByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Tasks')).toBeInTheDocument();
+    // The raw field name must not leak into a header (cell value is "Open").
+    expect(screen.queryByText('status')).not.toBeInTheDocument();
+  });
+
+  // ── #3 currency ─────────────────────────────────────────────────────────
+  it('formats an amount with NO declared currency as a plain number (no $)', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ budget_sum: 616000 }],
+      fields: [{ name: 'budget_sum', type: 'number', label: 'Total Budget', format: '0,0' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'proj', values: ['budget_sum'] }} dataSource={src} />);
+    expect(await screen.findByText('616,000')).toBeInTheDocument();
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
+  });
+
+  it('uses the declared currency (Intl symbol) when the field carries a currency', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ budget_sum: 616000 }],
+      fields: [{ name: 'budget_sum', type: 'number', label: 'Total Budget', format: '0,0', currency: 'CNY' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'proj', values: ['budget_sum'] }} dataSource={src} />);
+    // CNY → "¥"/"CN¥"/"CNY" depending on ICU; never "$".
+    const el = await screen.findByText(/(¥|CNY)\s?616,000/);
+    expect(el).toBeInTheDocument();
+    expect(el.textContent).not.toContain('$');
+  });
+
+  // ── #1 drill-through ────────────────────────────────────────────────────
+  it('is NOT drillable without server object + dimensionFields metadata', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ status: 'Open', task_count: 5 }],
+      fields: [{ name: 'status', type: 'string', label: 'Status' }, { name: 'task_count', type: 'number', label: 'Tasks' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status'], values: ['task_count'] }} dataSource={src} />);
+    await screen.findByText('Status');
+    expect(screen.queryByTestId('dataset-drill-row')).not.toBeInTheDocument();
+  });
+
+  it('marks rows drillable once the server returns object + dimensionFields', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ status: 'Open', task_count: 5 }],
+      fields: [{ name: 'status', type: 'string', label: 'Status' }, { name: 'task_count', type: 'number', label: 'Tasks' }],
+      object: 'showcase_task',
+      dimensionFields: { status: 'status' },
+      drillRawRows: [{ status: 'open' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status'], values: ['task_count'] }} dataSource={src} />);
+    expect(await screen.findByTestId('dataset-drill-row')).toBeInTheDocument();
+  });
+
+  it('buildDrillFilter filters by the RAW stored value, not the display label', () => {
+    // The raw-values row carries the stored value "open"; the display label
+    // "Open" never reaches the filter.
+    expect(buildDrillFilter({ status: 'open' }, ['status'], { status: 'status' })).toEqual({ status: 'open' });
+  });
+
+  it('buildDrillFilter maps a dimension to its underlying object field', () => {
+    expect(buildDrillFilter({ account: 'acc_123' }, ['account'], { account: 'account_id' })).toEqual({ account_id: 'acc_123' });
+  });
+
+  it('buildDrillFilter ANDs the widget runtime filter in', () => {
+    expect(
+      buildDrillFilter({ status: 'open', priority: 'high' }, ['status', 'priority'], { status: 'status', priority: 'priority' }, { archived: false }),
+    ).toEqual({ archived: false, status: 'open', priority: 'high' });
+  });
+
+  it('buildDrillFilter normalizes a missing/empty raw value to null', () => {
+    expect(buildDrillFilter({ status: '' }, ['status'], { status: 'status' })).toEqual({ status: null });
+    expect(buildDrillFilter(undefined, ['status'], { status: 'status' })).toEqual({ status: null });
   });
 });

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup, waitFor } from '@testing-library/react';
-import { DatasetWidget, buildDrillFilter } from '../DatasetWidget';
+import { render, screen, cleanup, waitFor, within } from '@testing-library/react';
+import { DatasetWidget, buildDrillFilter, buildPivot } from '../DatasetWidget';
 
 afterEach(cleanup);
 
@@ -182,5 +182,67 @@ describe('DatasetWidget', () => {
   it('buildDrillFilter normalizes a missing/empty raw value to null', () => {
     expect(buildDrillFilter({ status: '' }, ['status'], { status: 'status' })).toEqual({ status: null });
     expect(buildDrillFilter(undefined, ['status'], { status: 'status' })).toEqual({ status: null });
+  });
+
+  // ── pivot cross-tab ──────────────────────────────────────────────────────
+  it('buildPivot turns flat rows into a cross-tab keyed to flat row indices', () => {
+    const rows = [
+      { status: 'Open', priority: 'High', task_count: 2 },
+      { status: 'Open', priority: 'Low', task_count: 1 },
+      { status: 'Done', priority: 'High', task_count: 3 },
+    ];
+    const p = buildPivot(rows, ['status'], 'priority');
+    expect(p.rowHeaders.map((r) => r.labels[0])).toEqual(['Open', 'Done']);
+    expect(p.colHeaders.map((c) => c.label)).toEqual(['High', 'Low']);
+    expect(p.cellIndex.get('Open High')).toBe(0);
+    expect(p.cellIndex.get('Open Low')).toBe(1);
+    expect(p.cellIndex.get('Done High')).toBe(2);
+    expect(p.cellIndex.get('Done Low')).toBeUndefined(); // sparse combo absent
+  });
+
+  it('renders a pivot (≥2 dims) as a true cross-tab, not a flat table', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [
+        { status: 'Open', priority: 'High', task_count: 2 },
+        { status: 'Open', priority: 'Low', task_count: 1 },
+        { status: 'Done', priority: 'High', task_count: 3 },
+      ],
+      fields: [
+        { name: 'status', type: 'string', label: 'Status' },
+        { name: 'priority', type: 'string', label: 'Priority' },
+        { name: 'task_count', type: 'number', label: 'Tasks' },
+      ],
+    })) };
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status', 'priority'], values: ['task_count'] }} dataSource={src} />);
+    const matrix = await screen.findByTestId('dataset-matrix');
+    // Last dim (priority) spreads across as column headers…
+    expect(within(matrix).getByText('High')).toBeInTheDocument();
+    expect(within(matrix).getByText('Low')).toBeInTheDocument();
+    // …first dim (status) is the row header (rendered once per row, not per combo).
+    expect(within(matrix).getByText('Status')).toBeInTheDocument();
+    expect(within(matrix).getByText('Done')).toBeInTheDocument();
+    expect(within(matrix).getAllByText('Open')).toHaveLength(1);
+  });
+
+  it('falls back to a flat table for a single-dimension pivot', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ status: 'Open', task_count: 5 }],
+      fields: [{ name: 'status', type: 'string', label: 'Status' }, { name: 'task_count', type: 'number', label: 'Tasks' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status'], values: ['task_count'] }} dataSource={src} />);
+    await screen.findByText('Status');
+    expect(screen.queryByTestId('dataset-matrix')).not.toBeInTheDocument();
+  });
+
+  it('makes matrix cells drillable when the server returns drill metadata', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ status: 'Open', priority: 'High', task_count: 2 }],
+      fields: [{ name: 'status', type: 'string', label: 'Status' }, { name: 'priority', type: 'string', label: 'Priority' }, { name: 'task_count', type: 'number', label: 'Tasks' }],
+      object: 'showcase_task',
+      dimensionFields: { status: 'status', priority: 'priority' },
+      drillRawRows: [{ status: 'open', priority: 'high' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status', 'priority'], values: ['task_count'] }} dataSource={src} />);
+    expect(await screen.findByTestId('dataset-drill-cell')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Why
From a user-perspective review of the report page (`dashboard/showcase_chart_gallery`), the "二维表"/table widgets — rendered by `DatasetWidget` — had four gaps:

1. **Headers showed raw field names** (`status`) instead of labels (`Status`).
2. **Amounts showed a `$`** even when the field has no declared currency.
3. **Hardcoded English** strings ("No rows", "Pick measures…", errors); no i18n.
4. **No data drill-through** — rows were inert.

## What
- **Headers**: resolve via the server-enriched field label → i18n field-label convention → raw name.
- **Currency**: `formatMeasure` derives the symbol from the field's `currency` via `Intl` (locale-correct) and renders a **plain number when no currency is declared**. A legacy `$` literal in a format string is still honored.
- **i18n**: strings go through `useObjectTranslation` (+ `en`/`zh` entries); graceful English fallback when no provider.
- **Drill-through**: table/pivot rows open the `DrillDownDrawer` filtered by the clicked bucket, using the server's **raw** grouped values (`drillRawRows`) + dimension→field map — so select/lookup dims filter by the *stored value*, not the display label. Pure `buildDrillFilter` helper is unit-tested.
- `data-objectstack.queryDataset` passes the new `object`/`dimensionFields`/`drillRawRows` metadata through.

## Tests
`DatasetWidget.test.tsx`: header labels, currency (plain vs Intl symbol), drill enablement, and `buildDrillFilter` (raw value, field mapping, runtime-filter AND, null normalization). 21/21 green; package type-check green.

## Requires
Server metadata from framework PR #2080 for the dimension labels (#1/#2) and drill-through (#4) to light up end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)