### PR TITLE
test(plugin-list): fix ViewSwitcher tests for inline segmented control

### DIFF
--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -40,6 +40,33 @@ const renderWithProvider = (component: React.ReactNode) => {
   );
 };
 
+/**
+ * Reveal the visualization options regardless of which form the switcher
+ * takes. With 2–4 visualizations the switcher renders an inline segmented
+ * control whose option buttons are always visible, so there is nothing to
+ * open. With 5+ it collapses into a "List ▾" dropdown that must be clicked
+ * first. Click the dropdown trigger only when it exists.
+ */
+const openViewSwitcher = () => {
+  const trigger = screen.queryByTestId('view-switcher-dropdown');
+  if (trigger) fireEvent.click(trigger);
+};
+
+/**
+ * Find a visualization option by its accessible name, regardless of switcher
+ * form. The inline segmented control exposes each option as role="tab"; the
+ * collapsed dropdown menu exposes them as plain buttons. Returns null when the
+ * option is not offered.
+ */
+const queryViewOption = (name: string) =>
+  screen.queryByRole('tab', { name }) ?? screen.queryByRole('button', { name });
+
+const getViewOption = (name: string) => {
+  const option = queryViewOption(name);
+  if (!option) throw new Error(`View option "${name}" not found`);
+  return option;
+};
+
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 
 describe('ListView', () => {
@@ -114,9 +141,9 @@ describe('ListView', () => {
 
     renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
 
-    // Open the visualization dropdown, then pick Kanban from the menu
-    fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
-    fireEvent.click(screen.getByRole('button', { name: 'Kanban' }));
+    // Reveal the visualization options, then pick Kanban
+    openViewSwitcher();
+    fireEvent.click(getViewOption('Kanban'));
 
     // localStorage should be set with new view
     const storageKey = 'listview-contacts-view';
@@ -1460,11 +1487,11 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      // Should only offer grid and kanban in the dropdown, not calendar
-      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
-      expect(screen.getAllByRole('button', { name: 'Grid' }).length).toBeGreaterThan(0);
-      expect(screen.getByRole('button', { name: 'Kanban' })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Calendar' })).not.toBeInTheDocument();
+      // Should only offer grid and kanban, not calendar
+      openViewSwitcher();
+      expect(queryViewOption('Grid')).toBeInTheDocument();
+      expect(queryViewOption('Kanban')).toBeInTheDocument();
+      expect(queryViewOption('Calendar')).not.toBeInTheDocument();
     });
   });
 
@@ -1483,8 +1510,8 @@ describe('ListView', () => {
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
       // Should enable kanban view since kanban.groupField is set
-      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
-      expect(screen.getByRole('button', { name: 'Kanban' })).toBeInTheDocument();
+      openViewSwitcher();
+      expect(queryViewOption('Kanban')).toBeInTheDocument();
     });
 
     it('should use spec gallery config over legacy options', () => {
@@ -1497,8 +1524,8 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
-      expect(screen.getByRole('button', { name: 'Gallery' })).toBeInTheDocument();
+      openViewSwitcher();
+      expect(queryViewOption('Gallery')).toBeInTheDocument();
     });
 
     it('should use spec timeline config over legacy options', () => {
@@ -1511,8 +1538,8 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
-      expect(screen.getByRole('button', { name: 'Timeline' })).toBeInTheDocument();
+      openViewSwitcher();
+      expect(queryViewOption('Timeline')).toBeInTheDocument();
     });
 
     it('should use spec calendar config over legacy options', () => {
@@ -1525,8 +1552,8 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
-      expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument();
+      openViewSwitcher();
+      expect(queryViewOption('Calendar')).toBeInTheDocument();
     });
 
     it('should use spec gantt config over legacy options', () => {
@@ -1539,8 +1566,8 @@ describe('ListView', () => {
       };
 
       renderWithProvider(<ListView schema={schema} showViewSwitcher={true} />);
-      fireEvent.click(screen.getByTestId('view-switcher-dropdown'));
-      expect(screen.getByRole('button', { name: 'Gantt' })).toBeInTheDocument();
+      openViewSwitcher();
+      expect(queryViewOption('Gantt')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Problem

`packages/plugin-list/src/__tests__/ListView.test.tsx` had **7 consistently failing tests** that held CI red across recent commits on `main` (c2596476, e1f5d646, 4cc3fd16):

- should persist view preference to localStorage
- should restrict ViewSwitcher to allowedVisualizations
- should use spec {kanban,gallery,timeline,calendar,gantt} config over legacy options

## Diagnosis

The tests — not the implementation — regressed. The list/grid view-switcher work ([#1821](https://github.com/objectstack-ai/objectui/pull/1821), [#1822](https://github.com/objectstack-ai/objectui/pull/1822)) changed `ViewSwitcherDropdown` so that the **2–4 visualization** case renders an inline iOS/Linear-style **segmented control** (options as `role="tab"`, always visible, no trigger) instead of a click-to-open dropdown. The dropdown form is now reached only at 5+ visualizations.

All 7 tests configure exactly 2 visualizations, so they now render the segmented control. They still:
1. Clicked a `view-switcher-dropdown` testid to "open" the menu — that element no longer exists for 2 views (`TestingLibraryElementError: Unable to find ... [data-testid="view-switcher-dropdown"]`).
2. Queried options by `role="button"` — the segmented options expose `role="tab"`.

The segmented control is the intended UX, so the fix is in the tests.

## Fix

Make the tests agnostic to which switcher form renders:

- `openViewSwitcher()` — clicks the dropdown trigger only when present (no-op for the inline segmented control; still opens the dropdown at 5+ views).
- `queryViewOption()` / `getViewOption()` — match an option by accessible name across both `tab` and `button` roles.

No production code changed.

## Verification

```
pnpm --filter @object-ui/plugin-list exec vitest run src/__tests__/ListView.test.tsx
# Tests  115 passed (115)

pnpm --filter @object-ui/plugin-list exec vitest run
# Test Files  4 passed (4) — Tests  127 passed (127)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)