### PR TITLE
feat(dashboard): row/column/grand totals for dataset pivot cross-tab

### DIFF
--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1829,6 +1829,10 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       limit?: number;
       offset?: number;
       timezone?: string;
+      /** Marginal-aggregate groupings (e.g. `[rows, [colDim], []]`) — server
+       *  computes each subtotal with the measure's TRUE aggregate (never client
+       *  re-derived). `[]` is the grand total. */
+      totals?: { groupings: string[][] };
     },
   ): Promise<{
     rows: Array<Record<string, unknown>>;
@@ -1839,6 +1843,8 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     dimensionFields?: Record<string, string>;
     /** Raw grouped values per row (aligned to `rows` by index) for drill filters. */
     drillRawRows?: Array<Record<string, unknown>>;
+    /** Server-computed marginal aggregates, one entry per requested grouping. */
+    totals?: Array<{ dimensions: string[]; rows: Array<Record<string, unknown>> }>;
   }> {
     await this.connect();
     const base = (this.baseUrl || '').replace(/\/$/, '');
@@ -1893,7 +1899,8 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         ? ((data as any).dimensionFields as Record<string, string>)
         : undefined;
     const drillRawRows = Array.isArray((data as any)?.drillRawRows) ? (data as any).drillRawRows : undefined;
-    return { rows, fields, object, dimensionFields, drillRawRows };
+    const totals = Array.isArray((data as any)?.totals) ? (data as any).totals : undefined;
+    return { rows, fields, object, dimensionFields, drillRawRows, totals };
   }
 
   /** Client-side aggregation fallback */

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -38,7 +38,8 @@ import { DrillDownDrawer } from './DrillDownDrawer';
 type Row = Record<string, unknown>;
 /** Measure column metadata from the analytics result (ADR-0021). */
 interface ResultField { name: string; type?: string; label?: string; format?: string; currency?: string }
-interface DatasetResult { rows: Row[]; fields?: ResultField[]; object?: string; dimensionFields?: Record<string, string> }
+interface DatasetTotals { dimensions: string[]; rows: Row[] }
+interface DatasetResult { rows: Row[]; fields?: ResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Row[]; totals?: DatasetTotals[] }
 interface DatasetCapableSource {
   queryDataset?: (dataset: string, selection: unknown) => Promise<DatasetResult>;
 }
@@ -207,6 +208,15 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   const widgetType = String(widget?.type ?? '');
   const isMetric = METRIC_TYPES.has(widgetType) || dimensions.length === 0;
   const isTable = widgetType === 'table' || widgetType === 'pivot';
+  // pivot with ≥2 dims → a true cross-tab: last dim spreads across as columns,
+  // the rest go down as rows. Computed up-front so the fetch can also request
+  // the matching subtotal groupings.
+  const isMatrix = widgetType === 'pivot' && dimensions.length >= 2;
+  const rowDims = isMatrix ? dimensions.slice(0, -1) : [];
+  const colDim = isMatrix ? dimensions[dimensions.length - 1] : '';
+  // Row subtotals, column subtotals, and the grand total ([]) — the server
+  // computes each with the measure's TRUE aggregate (never re-derived here).
+  const totalsGroupings = isMatrix ? [rowDims, [colDim], []] : undefined;
 
   const tt = useTranslate();
   const { fieldLabel } = useSafeFieldLabel();
@@ -225,13 +235,13 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     [rawFilter],
   );
 
-  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: ResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; error?: string }>({ status: 'idle', rows: [] });
+  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: ResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; totals?: DatasetTotals[]; error?: string }>({ status: 'idle', rows: [] });
   // Drill-through (ADR-0021 D2): the clicked bucket's record-list filter + title.
   const [drill, setDrill] = useState<{ filter: Record<string, unknown>; title: string } | null>(null);
 
   // Signature uses the RAW filter (stable) — the resolved one carries a
   // render-time `now` and would otherwise force a refetch loop.
-  const signature = `${datasetName}|${dimensions.join(',')}|${values.join(',')}|${JSON.stringify(rawFilter ?? null)}|${JSON.stringify(compareTo ?? null)}`;
+  const signature = `${widgetType}|${datasetName}|${dimensions.join(',')}|${values.join(',')}|${JSON.stringify(rawFilter ?? null)}|${JSON.stringify(compareTo ?? null)}`;
   useEffect(() => {
     const src = dataSource as DatasetCapableSource | undefined;
     if (!src || typeof src.queryDataset !== 'function') {
@@ -246,8 +256,9 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       measures: values,
       ...(runtimeFilter ? { runtimeFilter } : {}),
       ...(compareTo ? { compareTo } : {}),
+      ...(totalsGroupings ? { totals: { groupings: totalsGroupings } } : {}),
     })
-      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [], fields: Array.isArray(res?.fields) ? res.fields : [], object: res?.object, dimensionFields: res?.dimensionFields, drillRawRows: Array.isArray(res?.drillRawRows) ? res.drillRawRows : undefined }); })
+      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [], fields: Array.isArray(res?.fields) ? res.fields : [], object: res?.object, dimensionFields: res?.dimensionFields, drillRawRows: Array.isArray(res?.drillRawRows) ? res.drillRawRows : undefined, totals: Array.isArray(res?.totals) ? res.totals : undefined }); })
       .catch((e) => { if (!cancelled) setState({ status: 'error', rows: [], error: String((e as Error)?.message ?? e) }); });
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -331,15 +342,26 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     // cells just place those pre-aggregated values — no client re-aggregation
     // (an avg/min/max can't be recombined). With <2 dimensions a cross-tab is
     // meaningless, so it degrades to the flat grouped table.
-    const isMatrix = widgetType === 'pivot' && dimensions.length >= 2;
     if (isMatrix) {
-      const rowDims = dimensions.slice(0, -1);
-      const colDim = dimensions[dimensions.length - 1];
       const pivot = buildPivot(state.rows, rowDims, colDim);
       // Single measure → one column per across-bucket; multiple → bucket × measure.
       const cellCols = pivot.colHeaders.flatMap((col) =>
         values.map((m) => ({ col, measure: m, header: values.length === 1 ? col.label : `${col.label} · ${headerLabel(m)}` })),
       );
+      const fmtMeasure = (v: unknown, m: string) => formatMeasure(v, measureField(m)?.format, measureField(m)?.currency);
+      // Server-supplied marginal totals (ADR-0021): match each grouping by its
+      // dimension array, then its rows to the pivot headers via the same bucket
+      // ids. Absent (older server) → maps stay empty and no totals UI renders.
+      const findTotals = (dims: string[]) =>
+        state.totals?.find((t) => Array.isArray(t.dimensions) && t.dimensions.join(',') === dims.join(','))?.rows;
+      const rowTotalById = new Map<string, Row>();
+      for (const r of findTotals(rowDims) ?? []) rowTotalById.set(rowDims.map((d) => String(r[d] ?? '∅')).join(''), r);
+      const colTotalById = new Map<string, Row>();
+      for (const r of findTotals([colDim]) ?? []) colTotalById.set(String(r[colDim] ?? '∅'), r);
+      const grandTotal = findTotals([])?.[0];
+      const showTotalCol = rowTotalById.size > 0;
+      const showTotalRow = colTotalById.size > 0;
+      const totalLabel = tt('dashboard.total', 'Total');
       return (
         <div className="h-full w-full overflow-auto p-1" data-testid="dataset-matrix">
           <table className="w-full text-xs">
@@ -350,6 +372,11 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
                 ))}
                 {cellCols.map((cc) => (
                   <th key={`${cc.col.id}-${cc.measure}`} className="px-2 py-1.5 text-right font-medium whitespace-nowrap">{cc.header}</th>
+                ))}
+                {showTotalCol && values.map((m) => (
+                  <th key={`total-${m}`} className="px-2 py-1.5 text-right font-medium whitespace-nowrap" data-testid="matrix-total-col-header">
+                    {values.length === 1 ? totalLabel : `${totalLabel} · ${headerLabel(m)}`}
+                  </th>
                 ))}
               </tr>
             </thead>
@@ -371,12 +398,34 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
                         data-testid={clickable ? 'dataset-drill-cell' : undefined}
                         onClick={clickable ? () => openDrill(index as number, title) : undefined}
                       >
-                        {fr ? formatMeasure(fr[cc.measure], measureField(cc.measure)?.format, measureField(cc.measure)?.currency) : '—'}
+                        {fr ? fmtMeasure(fr[cc.measure], cc.measure) : '—'}
                       </td>
                     );
                   })}
+                  {showTotalCol && values.map((m) => (
+                    <td key={`total-${m}`} className="px-2 py-1 text-right tabular-nums whitespace-nowrap font-medium" data-testid="matrix-row-total">
+                      {fmtMeasure(rowTotalById.get(rh.id)?.[m], m)}
+                    </td>
+                  ))}
                 </tr>
               ))}
+              {showTotalRow && (
+                <tr className="border-t bg-muted/30 font-medium" data-testid="matrix-total-row">
+                  {rowDims.length > 0 && (
+                    <td colSpan={rowDims.length} className="px-2 py-1 whitespace-nowrap">{totalLabel}</td>
+                  )}
+                  {cellCols.map((cc) => (
+                    <td key={`${cc.col.id}-${cc.measure}`} className="px-2 py-1 text-right tabular-nums whitespace-nowrap">
+                      {fmtMeasure(colTotalById.get(cc.col.id)?.[cc.measure], cc.measure)}
+                    </td>
+                  ))}
+                  {showTotalCol && values.map((m) => (
+                    <td key={`grand-${m}`} className="px-2 py-1 text-right tabular-nums whitespace-nowrap" data-testid="matrix-grand-total">
+                      {fmtMeasure(grandTotal?.[m], m)}
+                    </td>
+                  ))}
+                </tr>
+              )}
             </tbody>
           </table>
           {drawer}

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -245,4 +245,58 @@ describe('DatasetWidget', () => {
     render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status', 'priority'], values: ['task_count'] }} dataSource={src} />);
     expect(await screen.findByTestId('dataset-drill-cell')).toBeInTheDocument();
   });
+
+  // ── pivot totals ─────────────────────────────────────────────────────────
+  it('requests subtotal groupings (rows, [col], grand) for a pivot matrix', async () => {
+    const src = makeSource(async () => ({ rows: [{ status: 'Open', priority: 'High', task_count: 1 }] }));
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status', 'priority'], values: ['task_count'] }} dataSource={src} />);
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    expect((src.queryDataset.mock.calls[0][1] as any).totals).toEqual({ groupings: [['status'], ['priority'], []] });
+  });
+
+  it('does NOT request totals for a flat table', async () => {
+    const src = makeSource(async () => ({ rows: [{ status: 'Open', task_count: 1 }] }));
+    render(<DatasetWidget widget={{ type: 'table', dataset: 'tasks', dimensions: ['status'], values: ['task_count'] }} dataSource={src} />);
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    expect((src.queryDataset.mock.calls[0][1] as any).totals).toBeUndefined();
+  });
+
+  it('renders server-supplied row / column / grand totals in the cross-tab', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [
+        { status: 'Open', priority: 'High', task_count: 2 },
+        { status: 'Open', priority: 'Low', task_count: 1 },
+        { status: 'Done', priority: 'High', task_count: 3 },
+      ],
+      fields: [
+        { name: 'status', type: 'string', label: 'Status' },
+        { name: 'priority', type: 'string', label: 'Priority' },
+        { name: 'task_count', type: 'number', label: 'Tasks' },
+      ],
+      totals: [
+        { dimensions: ['status'], rows: [{ status: 'Open', task_count: 3 }, { status: 'Done', task_count: 3 }] },
+        { dimensions: ['priority'], rows: [{ priority: 'High', task_count: 5 }, { priority: 'Low', task_count: 1 }] },
+        { dimensions: [], rows: [{ task_count: 6 }] },
+      ],
+    })) };
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status', 'priority'], values: ['task_count'] }} dataSource={src} />);
+    const m = await screen.findByTestId('dataset-matrix');
+    expect(within(m).getByTestId('matrix-total-col-header')).toBeInTheDocument();
+    expect(within(m).getByTestId('matrix-total-row')).toBeInTheDocument();
+    // Per-row totals (Open=3, Done=3) — server's true aggregate, not re-derived.
+    expect(within(m).getAllByTestId('matrix-row-total').map((e) => e.textContent)).toEqual(['3', '3']);
+    // Grand total.
+    expect(within(m).getByTestId('matrix-grand-total').textContent).toBe('6');
+  });
+
+  it('renders no totals UI when the server omits totals (older server)', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ status: 'Open', priority: 'High', task_count: 2 }],
+      fields: [{ name: 'status', type: 'string', label: 'Status' }, { name: 'priority', type: 'string', label: 'Priority' }, { name: 'task_count', type: 'number', label: 'Tasks' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['status', 'priority'], values: ['task_count'] }} dataSource={src} />);
+    await screen.findByTestId('dataset-matrix');
+    expect(screen.queryByTestId('matrix-total-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('matrix-total-col-header')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Why
Following #1825 (which turned dataset `pivot` widgets into a true cross-tab), the matrix had **no totals**. A pivot without subtotals is half a pivot.

## What
A pivot matrix now requests the marginal subtotal groupings `[rowDims, [colDim], []]` and renders:
- a **row-totals** column (per measure),
- a **column-totals** row (per measure),
- the **grand total**.

Totals are **server-computed** with each measure's true aggregate (ADR-0021) — no client re-aggregation, so an `avg`/`min`/`max` total is correct rather than a recombined approximation. An older server that returns no `totals` just renders the plain cross-tab (no totals UI). The "Total" label is i18n (`dashboard.total` → "总计" in zh).

`data-objectstack.queryDataset` forwards the `totals` selection and passes the `totals` result through (the server already computes them — same path plugin-report's matrix uses).

## Tests
`DatasetWidget.test.tsx` (29 total): requests the right groupings for a matrix, does NOT request totals for a flat table, renders server row/column/grand totals, and degrades gracefully when totals are absent. Type-check green.

## Verified live
Chart Gallery "Tasks by Status × Priority": headers `状态 | Low | Medium | High | Urgent | 总计`, per-row totals, a `总计` row with column totals `1·4·3·2`, grand total `10` (1+4+3+2 = 2×5 = 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)