### PR TITLE
feat(studio): searchable icon picker for every icon field

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -279,6 +279,22 @@ function detectFieldRefWidget(
   return undefined;
 }
 
+/**
+ * Detect the icon picker by NAME CONVENTION: a string prop named `icon` (or
+ * `*Icon`) with no enum. Mirrors {@link detectFieldRefWidget} so every metadata
+ * type's icon field renders the searchable Lucide picker instead of a free-text
+ * input, without each spec `*.form.ts` having to pin `widget: 'icon'`.
+ */
+function detectIconWidget(name: string, schema: JsonSchema | undefined): string | undefined {
+  if (Array.isArray(schema?.enum)) return undefined;
+  const isString =
+    schema?.type === 'string' ||
+    (Array.isArray(schema?.anyOf) && (schema!.anyOf as JsonSchema[]).some((b) => b?.type === 'string'));
+  if (!isString) return undefined;
+  if (name === 'icon' || /Icon$/.test(name)) return 'icon';
+  return undefined;
+}
+
 /* -------------------------------------------------------------------------- */
 /* FormView spec (subset)                                                     */
 /* -------------------------------------------------------------------------- */
@@ -739,6 +755,10 @@ function FieldRow({
   if (!fieldSpec?.widget) {
     const refWidget = detectFieldRefWidget(name, schema, widgetContext);
     if (refWidget) widget = refWidget;
+    else {
+      const iconWidget = detectIconWidget(name, schema);
+      if (iconWidget) widget = iconWidget;
+    }
   }
 
   // Booleans with a schema default are never *missing* — don't show the

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
@@ -48,6 +48,7 @@ import {
 import { useObjectOptions } from '../previews/useObjectOptions';
 import { useObjectFields } from '../previews/useObjectFields';
 import { ConditionBuilder } from './ConditionBuilder';
+import { IconPickerWidget } from '../widgets';
 
 /* ─────────────── constants ─────────────── */
 
@@ -253,7 +254,10 @@ export function ActionDefaultInspector({
         hint={objectName ? 'Bound action — surfaces in this object’s views per the placement below.' : 'Empty = global action — must be referenced by a page’s quick actions, global nav, a flow, or AI to appear.'}
       />
       <div className="grid grid-cols-2 gap-2">
-        <InspectorTextField label="Icon" value={str('icon')} onCommit={(v) => onPatch({ icon: v })} placeholder="lucide name" disabled={readOnly} />
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Icon</Label>
+          <IconPickerWidget schema={{ type: 'string' }} value={str('icon')} onChange={(v) => onPatch({ icon: (v as string) || undefined })} readOnly={readOnly} />
+        </div>
         <InspectorSelectField label="Variant" value={str('variant') || undefined} options={VARIANT_OPTS} onCommit={(v) => onPatch({ variant: v })} disabled={readOnly} />
       </div>
 

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -1036,7 +1036,7 @@ const ICON_RESULT_LIMIT = 60;
  * Built inline (no Radix portal) so the search + grid render eagerly — the same
  * jsdom-friendly choice the other pickers' tests rely on.
  */
-function IconPickerWidget({ id, value, onChange, readOnly }: WidgetProps) {
+export function IconPickerWidget({ id, value, onChange, readOnly }: WidgetProps) {
   const locale = detectLocale();
   const current = value == null ? '' : String(value);
   const [open, setOpen] = React.useState(false);


### PR DESCRIPTION
## Summary

From an admin's perspective, picking an icon shouldn't require memorising Lucide names. The studio already ships a searchable `IconPickerWidget`, but it only activated when a spec form explicitly pinned `widget: 'icon'`, so most icon fields rendered as a free-text input.

- **SchemaForm**: auto-detect icon fields by name convention — a string prop named `icon` or `*Icon` (no enum) now resolves to the `icon` widget, mirroring the existing field-reference convention. Every metadata type's icon field gets the searchable picker in the generic form, with zero per-form wiring.
- **widgets**: export `IconPickerWidget` so curated inspectors can reuse it.
- **ActionDefaultInspector**: render the Action icon with the picker instead of a text input.

## Verification
Verified live against the showcase app: the **App** icon (generic SchemaForm) and the **Action** icon (curated inspector) both now render the searchable picker; confirmed via DOM inspection that the dropdown opens with the full icon grid and is not clipped by the inspector's scroll container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)