### PR TITLE
refactor(dataset-render): share measure formatting + header labels; fix binary-file NUL; register report.total

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,3 +40,4 @@ export * from './utils/drill-down.js';
 export * from './utils/date-macros.js';
 export * from './utils/compare-to.js';
 export * from './utils/chart-series.js';
+export * from './utils/dataset-format.js';

--- a/packages/core/src/utils/__tests__/dataset-format.test.ts
+++ b/packages/core/src/utils/__tests__/dataset-format.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatMeasure,
+  formatDimensionValue,
+  buildDatasetFieldHelpers,
+  type DatasetResultField,
+} from '../dataset-format';
+
+describe('formatMeasure', () => {
+  it('renders null as an em dash and passes non-numbers through', () => {
+    expect(formatMeasure(null)).toBe('—');
+    expect(formatMeasure(undefined)).toBe('—');
+    expect(formatMeasure('n/a')).toBe('n/a');
+  });
+
+  it('formats a plain number with no currency and no misleading $', () => {
+    expect(formatMeasure(1234, '0,0')).toBe('1,234');
+    // No format hint → integers render verbatim (the documented plain path).
+    expect(formatMeasure(1234)).toBe('1234');
+    expect(formatMeasure(1234, '0,0')).not.toContain('$');
+  });
+
+  it('uses the declared currency via Intl (CNY → ¥ family, never bare/wrong)', () => {
+    const out = formatMeasure(1234, '0,0', 'CNY');
+    expect(out).toMatch(/[¥￥]|CN¥/);
+    expect(out).toContain('1,234');
+  });
+
+  it('honors a legacy $ literal in the format string when there is no currency', () => {
+    expect(formatMeasure(1000, '$0,0')).toBe('$1,000');
+  });
+
+  it('applies percent and decimal hints', () => {
+    expect(formatMeasure(50, '0%')).toBe('50%');
+    expect(formatMeasure(12.5, '0.0')).toBe('12.5');
+  });
+
+  it('falls back to plain formatting for an unknown currency code', () => {
+    expect(formatMeasure(1234, '0,0', 'NOTACODE')).toBe('1,234');
+  });
+});
+
+describe('formatDimensionValue', () => {
+  it('tidies nulls and integers, leaves strings intact', () => {
+    expect(formatDimensionValue(null)).toBe('—');
+    expect(formatDimensionValue(42)).toBe('42');
+    expect(formatDimensionValue('Backlog')).toBe('Backlog');
+  });
+});
+
+describe('buildDatasetFieldHelpers', () => {
+  const fields: DatasetResultField[] = [
+    { name: 'status', type: 'string', label: 'Stage' },
+    { name: 'amount', type: 'number', label: 'Amount', format: '0,0', currency: 'USD' },
+  ];
+
+  it('headerLabel: field label → i18n fieldLabel → raw name', () => {
+    const fieldLabel = (_o: string, _f: string, fb: string) => `i18n:${fb}`;
+    const { headerLabel } = buildDatasetFieldHelpers(fields, 'deal', fieldLabel);
+    // i18n hook wraps the field label fallback.
+    expect(headerLabel('status')).toBe('i18n:Stage');
+    // unknown field → raw name flows through the i18n layer.
+    expect(headerLabel('missing')).toBe('i18n:missing');
+  });
+
+  it('headerLabel falls back to field label when no object/fieldLabel given', () => {
+    const { headerLabel } = buildDatasetFieldHelpers(fields, undefined);
+    expect(headerLabel('amount')).toBe('Amount');
+    expect(headerLabel('missing')).toBe('missing');
+  });
+
+  it('measureField exposes format/currency', () => {
+    const { measureField } = buildDatasetFieldHelpers(fields, 'deal');
+    expect(measureField('amount')?.format).toBe('0,0');
+    expect(measureField('amount')?.currency).toBe('USD');
+    expect(measureField('nope')).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/dataset-format.ts
+++ b/packages/core/src/utils/dataset-format.ts
@@ -1,0 +1,110 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * dataset-format — shared value formatting for semantic-layer `queryDataset`
+ * results (ADR-0021). Used by every dataset-bound surface (dashboard widgets,
+ * reports, the dataset preview) so a measure renders identically everywhere:
+ * a currency amount carries its declared currency symbol, a plain number stays
+ * a plain number, and a dimension label passes through untouched.
+ *
+ * Pure (no React / i18n) so it can live in `@object-ui/core` and be imported
+ * by both `@object-ui/plugin-dashboard` and `@object-ui/plugin-report`.
+ */
+
+/**
+ * Column metadata the analytics server returns alongside the rows: a display
+ * `label` for both dimensions and measures, plus a measure's numeral `format`
+ * and declared `currency`. A superset of {@link ChartResultField} (which only
+ * needs name/label/format).
+ */
+export interface DatasetResultField {
+  name: string;
+  type?: string;
+  label?: string;
+  format?: string;
+  currency?: string;
+}
+
+/**
+ * Format a MEASURE value. Currency comes from the field's declared `currency`
+ * (locale-correct symbol via `Intl`), NOT from a "$" baked into the format
+ * string — an amount with no declared currency must render as a plain number,
+ * never a misleading "$". The numeral `format` hint (e.g. "0,0", "0.0%")
+ * controls grouping / decimals / percent; it can't be baked into the row value
+ * server-side (the same number feeds charts), so it is applied here.
+ */
+export function formatMeasure(v: unknown, format?: string, currency?: string): string {
+  if (v == null) return '—';
+  if (typeof v !== 'number') return String(v);
+
+  const decimals = format ? (format.split('.')[1]?.match(/0/g)?.length ?? 0) : undefined;
+
+  if (currency) {
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: decimals ?? 0,
+        maximumFractionDigits: decimals ?? 2,
+      }).format(v);
+    } catch {
+      // Unknown currency code → fall through to plain number formatting.
+    }
+  }
+
+  if (!format) {
+    // No format hint → preserve the plain rendering (integers verbatim).
+    return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  const isPercent = format.includes('%');
+  // A legacy "$" literal in the format string is still honored (explicit author
+  // choice) — but it is NOT how a real currency field gets its symbol.
+  const legacyDollar = format.includes('$') ? '$' : '';
+  const body = v.toLocaleString(undefined, { minimumFractionDigits: decimals ?? 0, maximumFractionDigits: decimals ?? 0 });
+  return `${legacyDollar}${body}${isPercent ? '%' : ''}`;
+}
+
+/**
+ * Format a non-measure (dimension / label) value — the server already resolves
+ * dimension display labels, so this only tidies numbers and nulls.
+ */
+export function formatDimensionValue(v: unknown): string {
+  if (v == null) return '—';
+  if (typeof v === 'number') {
+    return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  return String(v);
+}
+
+/**
+ * Resolve a column header / measure helper pair for one result set.
+ * `headerLabel` maps a dimension/measure NAME to its display label — the
+ * server-enriched field `label`, then (when `fieldLabel` is supplied) through
+ * the i18n field-label convention so a translated label wins, then the raw name
+ * as a last resort. `measureField` exposes a field's `format`/`currency`.
+ *
+ * `fieldLabel` is injected (rather than imported) so this stays React/i18n-free;
+ * callers pass `useSafeFieldLabel().fieldLabel`.
+ */
+export function buildDatasetFieldHelpers(
+  fields: DatasetResultField[] | undefined,
+  object: string | undefined,
+  fieldLabel?: (objectName: string, fieldName: string, fallback: string) => string,
+): {
+  measureField: (name: string) => DatasetResultField | undefined;
+  headerLabel: (name: string) => string;
+} {
+  const fieldByName = new Map((fields ?? []).map((f) => [f.name, f] as const));
+  const measureField = (name: string) => fieldByName.get(name);
+  const headerLabel = (name: string) => {
+    const fallback = measureField(name)?.label ?? name;
+    return object && fieldLabel ? fieldLabel(object, name, fallback) : fallback;
+  };
+  return { measureField, headerLabel };
+}

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1836,7 +1836,9 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     },
   ): Promise<{
     rows: Array<Record<string, unknown>>;
-    fields: Array<{ name: string; type: string }>;
+    /** Column metadata: a display `label` (dimensions and measures), and a
+     *  measure's numeral `format` + declared `currency` for value formatting. */
+    fields: Array<{ name: string; type: string; label?: string; format?: string; currency?: string }>;
     /** ADR-0021 D2 drill-through: the dataset's base object (records to drill into). */
     object?: string;
     /** Drillable dimension NAME → underlying object FIELD name. */

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -38,7 +38,7 @@ export { createI18n, getDirection, getAvailableLanguages, type I18nConfig, type 
 export { I18nProvider, useObjectTranslation, useI18nContext, type I18nProviderProps } from './provider';
 
 // Safe translation hook factory
-export { createSafeTranslation } from './useSafeTranslation';
+export { createSafeTranslation, useSafeTranslate } from './useSafeTranslation';
 
 // Convention-based object/field label i18n
 export { useObjectLabel, useSafeFieldLabel } from './useObjectLabel';

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1432,6 +1432,7 @@ const ar = {
     language: "اللغة",
   },
   report: {
+    total: "الإجمالي",
     rowTotal: "إجمالي الصف",
     columnTotal: "إجمالي العمود",
     grandTotal: "الإجمالي الكلي",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1432,6 +1432,7 @@ const de = {
     language: "Sprache",
   },
   report: {
+    total: "Gesamt",
     rowTotal: "Zeilensumme",
     columnTotal: "Spaltensumme",
     grandTotal: "Gesamtsumme",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -549,6 +549,7 @@ const en = {
     loading: 'Loading chart...',
   },
   report: {
+    total: 'Total',
     rowTotal: 'Row Total',
     columnTotal: 'Column Total',
     grandTotal: 'Grand Total',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1432,6 +1432,7 @@ const es = {
     language: "Idioma",
   },
   report: {
+    total: "Total",
     rowTotal: "Total fila",
     columnTotal: "Total columna",
     grandTotal: "Gran total",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1432,6 +1432,7 @@ const fr = {
     language: "Langue",
   },
   report: {
+    total: "Total",
     rowTotal: "Total ligne",
     columnTotal: "Total colonne",
     grandTotal: "Total général",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1432,6 +1432,7 @@ const ja = {
     language: "言語",
   },
   report: {
+    total: "合計",
     rowTotal: "行合計",
     columnTotal: "列合計",
     grandTotal: "総合計",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1432,6 +1432,7 @@ const ko = {
     language: "언어",
   },
   report: {
+    total: "합계",
     rowTotal: "행 합계",
     columnTotal: "열 합계",
     grandTotal: "총합계",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1432,6 +1432,7 @@ const pt = {
     language: "Idioma",
   },
   report: {
+    total: "Total",
     rowTotal: "Total da linha",
     columnTotal: "Total da coluna",
     grandTotal: "Total geral",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1432,6 +1432,7 @@ const ru = {
     language: "Язык",
   },
   report: {
+    total: "Итого",
     rowTotal: "Итог строки",
     columnTotal: "Итог столбца",
     grandTotal: "Общий итог",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -553,6 +553,7 @@ const zh = {
     loading: '图表加载中...',
   },
   report: {
+    total: '总计',
     rowTotal: '行合计',
     columnTotal: '列合计',
     grandTotal: '总计',

--- a/packages/i18n/src/useSafeTranslation.ts
+++ b/packages/i18n/src/useSafeTranslation.ts
@@ -47,3 +47,33 @@ export function createSafeTranslation(
     }
   };
 }
+
+/**
+ * Per-call graceful translate hook for plugin renderers.
+ *
+ * Returns `t(keyOrKeys, fallback)`: tries each i18n key in order and returns the
+ * first real translation; when no `I18nProvider` is mounted (tests / standalone)
+ * or every key is missing, returns the English `fallback` — never a raw key.
+ *
+ * Unlike {@link createSafeTranslation} (a factory keyed by a defaults map), this
+ * takes the English default at each call site, which suits one-off labels like
+ * "Total". The key-array form supports a migration fallback chain, e.g.
+ * `tt(['common.total', 'dashboard.total'], 'Total')`.
+ */
+export function useSafeTranslate(): (keyOrKeys: string | string[], fallback: string) => string {
+  let t: ((key: string) => string) | undefined;
+  try {
+    t = useObjectTranslation().t;
+  } catch {
+    t = undefined;
+  }
+  return (keyOrKeys, fallback) => {
+    if (!t) return fallback;
+    const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+    for (const key of keys) {
+      const v = t(key);
+      if (v && v !== key) return v;
+    }
+    return fallback;
+  };
+}

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -28,18 +28,22 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { SchemaRenderer } from '@object-ui/react';
-import { buildChartSeries } from '@object-ui/core';
+import {
+  buildChartSeries,
+  formatMeasure,
+  formatDimensionValue,
+  buildDatasetFieldHelpers,
+  type DatasetResultField,
+} from '@object-ui/core';
 import { cn } from '@object-ui/components';
-import { useObjectTranslation, useSafeFieldLabel } from '@object-ui/i18n';
+import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
 import { Loader2, BarChart3, AlertTriangle, Download } from 'lucide-react';
 import { resolveDateMacros } from './utils';
 import { DrillDownDrawer } from './DrillDownDrawer';
 
 type Row = Record<string, unknown>;
-/** Measure column metadata from the analytics result (ADR-0021). */
-interface ResultField { name: string; type?: string; label?: string; format?: string; currency?: string }
 interface DatasetTotals { dimensions: string[]; rows: Row[] }
-interface DatasetResult { rows: Row[]; fields?: ResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Row[]; totals?: DatasetTotals[] }
+interface DatasetResult { rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Row[]; totals?: DatasetTotals[] }
 interface DatasetCapableSource {
   queryDataset?: (dataset: string, selection: unknown) => Promise<DatasetResult>;
 }
@@ -91,75 +95,11 @@ export function buildPivot(
   rows.forEach((row, index) => {
     const rid = rowDims.map((d) => String(row[d] ?? '∅')).join('');
     const cid = String(row[colDim] ?? '∅');
-    if (!rowSeen.has(rid)) { rowSeen.add(rid); rowHeaders.push({ id: rid, labels: rowDims.map((d) => formatValue(row[d])) }); }
-    if (!colSeen.has(cid)) { colSeen.add(cid); colHeaders.push({ id: cid, label: formatValue(row[colDim]) }); }
+    if (!rowSeen.has(rid)) { rowSeen.add(rid); rowHeaders.push({ id: rid, labels: rowDims.map((d) => formatDimensionValue(row[d])) }); }
+    if (!colSeen.has(cid)) { colSeen.add(cid); colHeaders.push({ id: cid, label: formatDimensionValue(row[colDim]) }); }
     cellIndex.set(`${rid} ${cid}`, index);
   });
   return { rowHeaders, colHeaders, cellIndex };
-}
-
-/**
- * Translate with a graceful fallback. Mirrors the PivotTable pattern: when no
- * i18n provider is mounted (or the key is missing), return the English default
- * so the widget never renders a raw translation key.
- */
-function useTranslate(): (key: string, fallback: string) => string {
-  let t: ((k: string) => string) | undefined;
-  try {
-    t = useObjectTranslation().t;
-  } catch {
-    t = undefined;
-  }
-  return (key, fallback) => {
-    if (!t) return fallback;
-    const v = t(key);
-    return !v || v === key ? fallback : v;
-  };
-}
-
-/**
- * Format a measure value. Currency comes from the field's declared `currency`
- * (locale-correct symbol via `Intl`), NOT from a "$" baked into the format
- * string — an amount with no declared currency must render as a plain number,
- * never a misleading "$". The numeral-style `format` hint (e.g. "0,0", "0.0%")
- * controls grouping / decimals / percent; it can't be baked into the row value
- * server-side (charts need the raw number), so it is applied here.
- */
-function formatMeasure(v: unknown, format?: string, currency?: string): string {
-  if (v == null) return '—';
-  if (typeof v !== 'number') return String(v);
-
-  const decimals = format ? (format.split('.')[1]?.match(/0/g)?.length ?? 0) : undefined;
-
-  if (currency) {
-    try {
-      return new Intl.NumberFormat(undefined, {
-        style: 'currency',
-        currency,
-        minimumFractionDigits: decimals ?? 0,
-        maximumFractionDigits: decimals ?? 2,
-      }).format(v);
-    } catch {
-      // Unknown currency code → fall through to plain number formatting.
-    }
-  }
-
-  if (!format) {
-    // No format hint → preserve the plain rendering (integers verbatim).
-    return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
-  }
-  const isPercent = format.includes('%');
-  // A legacy "$" literal in the format string is still honored (explicit author
-  // choice) — but it is NOT how a real currency field gets its symbol.
-  const legacyDollar = format.includes('$') ? '$' : '';
-  const body = v.toLocaleString(undefined, { minimumFractionDigits: decimals ?? 0, maximumFractionDigits: decimals ?? 0 });
-  return `${legacyDollar}${body}${isPercent ? '%' : ''}`;
-}
-
-function formatValue(v: unknown): string {
-  if (v == null) return '—';
-  if (typeof v === 'number') return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
-  return String(v);
 }
 
 /** RFC4180-ish CSV cell: quote when it contains a comma, quote, or newline. */
@@ -246,7 +186,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // computes each with the measure's TRUE aggregate (never re-derived here).
   const totalsGroupings = isMatrix ? [rowDims, [colDim], []] : undefined;
 
-  const tt = useTranslate();
+  const tt = useSafeTranslate();
   const { fieldLabel } = useSafeFieldLabel();
 
   // ADR-0021 dual-form: the widget's presentation-scope `filter` must flow into
@@ -263,7 +203,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     [rawFilter],
   );
 
-  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: ResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; totals?: DatasetTotals[]; error?: string }>({ status: 'idle', rows: [] });
+  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; totals?: DatasetTotals[]; error?: string }>({ status: 'idle', rows: [] });
   // Drill-through (ADR-0021 D2): the clicked bucket's record-list filter + title.
   const [drill, setDrill] = useState<{ filter: Record<string, unknown>; title: string } | null>(null);
 
@@ -312,16 +252,9 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground"><BarChart3 className="mr-2 h-4 w-4" />{tt('dashboard.noRows', 'No rows')}</div>;
   }
 
-  // Measure metadata (label + format + currency) carried on the result fields, keyed by name.
-  const fieldByName = new Map((state.fields ?? []).map((f) => [f.name, f]));
-  const measureField = (name: string) => fieldByName.get(name);
-  // Resolve a column header: the dataset's display label (server-enriched onto
-  // the field, for dimensions and measures alike), then through the i18n
-  // field-label convention so a translated label wins, then the raw name.
-  const headerLabel = (name: string) => {
-    const fallback = measureField(name)?.label ?? name;
-    return state.object ? fieldLabel(state.object, name, fallback) : fallback;
-  };
+  // Measure metadata (label + format + currency) + header-label resolution,
+  // shared with the report renderer via @object-ui/core.
+  const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
 
   // Metric / KPI — show the single measure value of the first row, using the
   // measure's display label (not the raw name) and its format (e.g. "$616,000").
@@ -503,11 +436,11 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
                 key={i}
                 className={cn('border-t', canDrill && 'cursor-pointer hover:bg-accent/40')}
                 data-testid={canDrill ? 'dataset-drill-row' : undefined}
-                onClick={canDrill ? () => openDrill(i, drillDims.map((d) => formatValue(row[d])).filter(Boolean).join(' / ')) : undefined}
+                onClick={canDrill ? () => openDrill(i, drillDims.map((d) => formatDimensionValue(row[d])).filter(Boolean).join(' / ')) : undefined}
               >
                 {columns.map((c) => (
                   <td key={c} className="px-2 py-1 whitespace-nowrap tabular-nums">
-                    {values.includes(c) ? formatMeasure(row[c], measureField(c)?.format, measureField(c)?.currency) : formatValue(row[c])}
+                    {values.includes(c) ? formatMeasure(row[c], measureField(c)?.format, measureField(c)?.currency) : formatDimensionValue(row[c])}
                   </td>
                 ))}
               </tr>

--- a/packages/plugin-dashboard/src/PivotTable.tsx
+++ b/packages/plugin-dashboard/src/PivotTable.tsx
@@ -10,26 +10,14 @@ import React, { useMemo } from 'react';
 import type { PivotTableSchema, PivotAggregation } from '@object-ui/types';
 import { cn, DataEmptyState } from '@object-ui/components';
 import { isDrillEnabled, type DrillEvent } from '@object-ui/core';
-import { useObjectTranslation } from '@object-ui/i18n';
+import { useSafeTranslate } from '@object-ui/i18n';
 
 function useTotalLabel(): string {
-  try {
-    const { t } = useObjectTranslation();
-    const v = t('dashboard.total');
-    return !v || v === 'dashboard.total' ? 'Total' : v;
-  } catch {
-    return 'Total';
-  }
+  return useSafeTranslate()('dashboard.total', 'Total');
 }
 
 function useNoDataLabel(): string {
-  try {
-    const { t } = useObjectTranslation();
-    const v = t('dashboard.noDataAvailable');
-    return !v || v === 'dashboard.noDataAvailable' ? 'No data available' : v;
-  } catch {
-    return 'No data available';
-  }
+  return useSafeTranslate()('dashboard.noDataAvailable', 'No data available');
 }
 
 export interface PivotTableProps {

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -42,25 +42,16 @@
 
 import * as React from 'react';
 import { Loader2, AlertTriangle, Table2 } from 'lucide-react';
-import { useObjectTranslation, useSafeFieldLabel } from '@object-ui/i18n';
+import {
+  formatMeasure,
+  formatDimensionValue,
+  buildDatasetFieldHelpers,
+  type DatasetResultField,
+} from '@object-ui/core';
+import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
 import { mergeFilters } from './mergeFilters';
 
 type Row = Record<string, unknown>;
-
-/**
- * Column metadata the analytics server returns alongside the rows (ADR-0021):
- * a display `label` for both dimensions and measures, plus the measure's
- * numeral `format` and declared `currency`. The renderer uses these to show
- * human labels in headers and currency-correct values in cells — never the
- * raw field name or a misleading "$".
- */
-interface ResultField {
-  name: string;
-  type?: string;
-  label?: string;
-  format?: string;
-  currency?: string;
-}
 
 /** One server-computed totals grouping: `dimensions: []` is the grand total. */
 interface DatasetTotals {
@@ -72,47 +63,7 @@ interface DatasetCapableSource {
   queryDataset?: (
     dataset: string,
     selection: unknown,
-  ) => Promise<{ rows: Row[]; fields?: ResultField[]; object?: string; totals?: DatasetTotals[] }>;
-}
-
-/**
- * Translate with a graceful fallback. Mirrors the DatasetWidget pattern: when
- * no i18n provider is mounted (or the key is missing), return the English
- * default so the report never renders a raw translation key.
- */
-function useTranslate(): (key: string, fallback: string) => string {
-  let t: ((k: string) => string) | undefined;
-  try {
-    t = useObjectTranslation().t;
-  } catch {
-    t = undefined;
-  }
-  return (key, fallback) => {
-    if (!t) return fallback;
-    const v = t(key);
-    return !v || v === key ? fallback : v;
-  };
-}
-
-/**
- * Resolve column helpers for a result set: `headerLabel` maps a dimension/
- * measure NAME to its display label — the server-enriched field `label`, then
- * through the i18n field-label convention so a translated label wins, then the
- * raw name as a last resort. `measureField` exposes a field's `format`/
- * `currency` for currency-aware value formatting.
- */
-function buildFieldHelpers(
-  fields: ResultField[] | undefined,
-  object: string | undefined,
-  fieldLabel: (objectName: string, fieldName: string, fallback: string) => string,
-) {
-  const fieldByName = new Map((fields ?? []).map((f) => [f.name, f] as const));
-  const measureField = (name: string) => fieldByName.get(name);
-  const headerLabel = (name: string) => {
-    const fallback = measureField(name)?.label ?? name;
-    return object ? fieldLabel(object, name, fallback) : fallback;
-  };
-  return { measureField, headerLabel };
+  ) => Promise<{ rows: Row[]; fields?: DatasetResultField[]; object?: string; totals?: DatasetTotals[] }>;
 }
 
 /** What a drill click means — the host resolves names to a navigation target. */
@@ -175,55 +126,6 @@ function resolveText(label: unknown, fallback: string): string {
   return fallback;
 }
 
-/** Format a non-measure (dimension / label) value — the server already
- *  resolves dimension display labels, so this only tidies numbers and nulls. */
-function formatCell(v: unknown): string {
-  if (v == null) return '—';
-  if (typeof v === 'number') {
-    return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
-  }
-  return String(v);
-}
-
-/**
- * Format a MEASURE value. Currency comes from the field's declared `currency`
- * (locale-correct symbol via `Intl`), NOT from a "$" baked into the format
- * string — an amount with no declared currency must render as a plain number,
- * never a misleading "$". The numeral `format` hint (e.g. "0,0", "0.0%")
- * controls grouping / decimals / percent; it can't be baked into the row value
- * server-side (the same number feeds charts), so it is applied here. Mirrors
- * the dashboard DatasetWidget so reports and dashboards format identically.
- */
-function formatMeasure(v: unknown, format?: string, currency?: string): string {
-  if (v == null) return '—';
-  if (typeof v !== 'number') return String(v);
-
-  const decimals = format ? (format.split('.')[1]?.match(/0/g)?.length ?? 0) : undefined;
-
-  if (currency) {
-    try {
-      return new Intl.NumberFormat(undefined, {
-        style: 'currency',
-        currency,
-        minimumFractionDigits: decimals ?? 0,
-        maximumFractionDigits: decimals ?? 2,
-      }).format(v);
-    } catch {
-      // Unknown currency code → fall through to plain number formatting.
-    }
-  }
-
-  if (!format) {
-    return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
-  }
-  const isPercent = format.includes('%');
-  // A legacy "$" literal in the format string is still honored (explicit author
-  // choice) — but it is NOT how a real currency field gets its symbol.
-  const legacyDollar = format.includes('$') ? '$' : '';
-  const body = v.toLocaleString(undefined, { minimumFractionDigits: decimals ?? 0, maximumFractionDigits: decimals ?? 0 });
-  return `${legacyDollar}${body}${isPercent ? '%' : ''}`;
-}
-
 function readNames(value: unknown): string[] {
   return Array.isArray(value) ? (value as unknown[]).filter((v): v is string => typeof v === 'string' && !!v) : [];
 }
@@ -240,7 +142,7 @@ function useDatasetRows(
   const [state, setState] = React.useState<{
     status: 'idle' | 'loading' | 'ok' | 'error';
     rows: Row[];
-    fields?: ResultField[];
+    fields?: DatasetResultField[];
     object?: string;
     totals?: DatasetTotals[];
     error?: string;
@@ -360,7 +262,7 @@ function DatasetReportTable({
     onDrill!({ dataset, groupKey, runtimeFilter });
   };
 
-  const { measureField, headerLabel } = buildFieldHelpers(state.fields, state.object, fieldLabel);
+  const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
   const columns = [...rows, ...values];
   return (
     <div className="overflow-auto max-h-[70vh] rounded-md border">
@@ -386,7 +288,7 @@ function DatasetReportTable({
                 <td key={c} className="px-2 py-1 tabular-nums whitespace-nowrap">
                   {values.includes(c)
                     ? formatMeasure(row[c], measureField(c)?.format, measureField(c)?.currency)
-                    : formatCell(row[c])}
+                    : formatDimensionValue(row[c])}
                 </td>
               ))}
             </tr>
@@ -403,7 +305,7 @@ function bucketId(dims: string[], row: Row): string {
 }
 
 function bucketLabel(dims: string[], row: Row): string {
-  return dims.map((d) => formatCell(row[d])).join(' / ');
+  return dims.map((d) => formatDimensionValue(row[d])).join(' / ');
 }
 
 /**
@@ -437,7 +339,7 @@ function DatasetMatrixTable({
     columnsAcross,
     [],
   ]);
-  const tt = useTranslate();
+  const tt = useSafeTranslate();
   const { fieldLabel } = useSafeFieldLabel();
 
   const pivot = React.useMemo(() => {
@@ -462,7 +364,7 @@ function DatasetMatrixTable({
         for (const d of columnsAcross) key[d] = r[d];
         colHeaders.push({ id: cid, label: bucketLabel(columnsAcross, r), key });
       }
-      cells.set(`${rid} ${cid}`, r);
+      cells.set(`${rid} ${cid}`, r);
     }
     return { rowHeaders, colHeaders, cells };
   }, [state, rows, columnsAcross]);
@@ -472,7 +374,7 @@ function DatasetMatrixTable({
   if (state.status === 'error') return <FetchStates status="error" error={state.error} />;
   if (!pivot || pivot.rowHeaders.length === 0) return <NoRows />;
 
-  const { measureField, headerLabel } = buildFieldHelpers(state.fields, state.object, fieldLabel);
+  const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
   const totalText = tt('report.total', 'Total');
   const canDrill = !!onDrill;
   const drillCell = (rowKey: Row, colKey: Row) => {
@@ -533,11 +435,11 @@ function DatasetMatrixTable({
             <tr key={rh.id} className="border-t">
               {rows.map((d) => (
                 <td key={d} className="px-2 py-1 whitespace-nowrap font-medium">
-                  {formatCell(rh.key[d])}
+                  {formatDimensionValue(rh.key[d])}
                 </td>
               ))}
               {cellCols.map((cc) => {
-                const cell = pivot.cells.get(`${rh.id} ${cc.col.id}`);
+                const cell = pivot.cells.get(`${rh.id} ${cc.col.id}`);
                 const value = cell?.[cc.measure];
                 const clickable = canDrill && cell != null;
                 return (

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
 import { DatasetReportRenderer, isDatasetReport } from '../DatasetReportRenderer';
 
 type MockRows = Array<Record<string, unknown>>;
@@ -436,6 +437,33 @@ describe('DatasetReportRenderer', () => {
     // graceful fallback → the English default, never a raw "report.total" key.
     expect(screen.getByTestId('matrix-total-col-header')).toHaveTextContent('Total');
     expect(screen.getByTestId('matrix-total-row')).toHaveTextContent('Total');
+    expect(screen.queryByText('report.total')).not.toBeInTheDocument();
+  });
+
+  it('uses the mounted i18n translation for the totals label (zh → 总计)', async () => {
+    const src = makeSource({
+      task_metrics: {
+        rows: [{ status: 'Backlog', priority: 'High', est_hours: 10 }],
+        totals: [
+          { dimensions: ['status'], rows: [{ status: 'Backlog', est_hours: 10 }] },
+          { dimensions: ['priority'], rows: [{ priority: 'High', est_hours: 10 }] },
+          { dimensions: [], rows: [{ est_hours: 10 }] },
+        ],
+      },
+    });
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <DatasetReportRenderer
+          report={{ name: 'm', type: 'matrix', dataset: 'task_metrics', rows: ['status'], columns: ['priority'], values: ['est_hours'] }}
+          dataSource={src}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    // report.total resolves to its zh bundle value — the provider wins over the
+    // English fallback, and never leaks the raw key.
+    expect(screen.getByTestId('matrix-total-col-header')).toHaveTextContent('总计');
+    expect(screen.getByTestId('matrix-total-row')).toHaveTextContent('总计');
     expect(screen.queryByText('report.total')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## What & why

Follow-up cleanup to [#1830](https://github.com/objectstack-ai/objectui/pull/1830). The dashboard `DatasetWidget` and the report `DatasetReportRenderer` had drifted into **two copies** of the same dataset-result formatting logic — which is precisely why the currency/label/i18n bug had to be fixed in both. This hoists the shared logic, removes a latent tooling hazard, and makes the report's "Total" genuinely translatable.

## Changes

**`@object-ui/core`** — new `utils/dataset-format.ts`:
- `formatMeasure(v, format?, currency?)` — currency via the field's declared `currency` (`Intl` symbol), never a misleading `$`.
- `formatDimensionValue(v)`, `buildDatasetFieldHelpers(fields, object, fieldLabel?)` (field label → i18n `fieldLabel` → raw name), and the `DatasetResultField` type.
- Pure (no React/i18n — `fieldLabel` is injected). Unit-tested (10 cases).

**`@object-ui/i18n`**:
- New `useSafeTranslate()` — per-call graceful `t(keyOrKeys, fallback)` with an ordered key-fallback chain. This is the inline pattern both renderers (and `PivotTable`) duplicated.
- Register `report.total` in **all 10 locale bundles** (reusing each locale's existing `dashboard.total` value), so the report's "Total" is a real translation, not just an English fallback.

**Renderers**:
- `DatasetReportRenderer` and `DatasetWidget` now import the shared core/i18n helpers (**net −235 lines** of duplication). `PivotTable`'s two local graceful-translate helpers fold into `useSafeTranslate`.
- **Fix 2 literal NUL bytes** in `DatasetReportRenderer` (the matrix bucket-key separator) that made the `.tsx` register as a **binary file** to grep/ripgrep/editors — now a normal space, matching the dashboard's pivot separator.

**`@object-ui/data-objectstack`**:
- Widen `queryDataset`'s declared `fields` type to include `label`/`format`/`currency` (already shipped at runtime) so consumers stop re-declaring + casting.

## Behavior

No user-facing behavior change intended — this is a refactor. The one observable improvement: the report's "Total" now picks up the mounted locale (e.g. zh → 总计) instead of only the English fallback.

## Tests
- `plugin-report` → **40 passed** (incl. a new positive i18n test: zh provider → 总计)
- `plugin-dashboard` → **4031 passed**
- `i18n` → **150 passed**; `core` dataset-format → **10 passed**
- `type-check` green across core / i18n / data-objectstack / plugin-report / plugin-dashboard

> `main` CI may still show 7 unrelated plugin-list/ListView failures (separate task); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)