### PR TITLE
fix(plugin-report): drill by RAW stored value (correct for select/lookup dims)

### DIFF
--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -87,22 +87,40 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
     [objects],
   );
 
-  // ADR-0021 D2 drill-down: a click on an aggregated row/cell emits dimension
-  // NAMES + bucket values; resolve them through the dataset definition
-  // (object + dimension→field) and open the object's list scoped by
+  // ADR-0021 D2 drill-down: open the dataset's object list scoped by
   // `?filter[<field>]=<value>` (the same equality-filter contract the
   // related-list "View All" buttons use).
   //
-  // The analytics service resolves dimension buckets to DISPLAY labels in
-  // place (select option label, lookup record name) — so the clicked value
-  // must be mapped back to the stored value before it can filter:
+  // Preferred: the renderer hands us the base `object` + an exact field→RAW
+  // `objectFilter` (built from the server's drillRawRows), so we navigate
+  // straight away — correct for select/lookup dims, no metadata round-trip.
+  //
+  // Fallback (older server with no drill metadata): only dimension NAMES +
+  // DISPLAY-label bucket values arrive, so resolve them through the dataset
+  // definition and reverse-map labels to stored values before filtering:
   //   - select fields  → reverse-map label → option value
   //   - lookup fields  → the label is a record name, not the FK id; skip the
   //     dim (the drill lands on a superset rather than filtering wrongly)
   //   - granularity-bucketed dates → need a range, not equality; skip too
   const handleDatasetDrill = useCallback(
-    async ({ dataset, groupKey }: DatasetDrillArgs) => {
+    async ({ dataset, groupKey, object, objectFilter }: DatasetDrillArgs) => {
       try {
+        // Fast path (ADR-0021 D2): the renderer already resolved the dataset's
+        // base object + an exact object FIELD → RAW value filter from the
+        // server's drillRawRows. Navigate straight to it — correct for
+        // select/lookup dims (a stored value, not a display label) with NO
+        // dataset-definition round-trip and no label reverse-mapping.
+        if (object && objectFilter) {
+          const params = new URLSearchParams();
+          for (const [field, value] of Object.entries(objectFilter)) {
+            if (value == null) continue;
+            params.set(`filter[${field}]`, String(value));
+          }
+          const qs = params.toString();
+          const base = appName ? `/apps/${appName}` : '';
+          navigate(`${base}/${object}${qs ? `?${qs}` : ''}`);
+          return;
+        }
         const def = await metadataClient.get<Record<string, any>>('dataset', dataset);
         const objectName = typeof def?.object === 'string' ? def.object : undefined;
         if (!objectName) return;

--- a/packages/core/src/utils/dataset-format.ts
+++ b/packages/core/src/utils/dataset-format.ts
@@ -108,3 +108,30 @@ export function buildDatasetFieldHelpers(
   };
   return { measureField, headerLabel };
 }
+
+/**
+ * Build the record-list filter for a drilled dataset bucket (ADR-0021 D2).
+ *
+ * Each drillable dimension maps to its underlying object field, filtered by the
+ * dimension's RAW grouped value (from the server's parallel `drillRawRows`, NOT
+ * the visible row which carries the display LABEL — a select/lookup label would
+ * mis-filter). An empty/undefined raw value normalizes to `null` (an explicit
+ * "is empty" filter). The render-time `runtimeFilter` is ANDed in so the drilled
+ * list stays within the same slice the aggregate was computed over.
+ *
+ * Shared by the dashboard `DatasetWidget` and the report renderer so a drill
+ * filters identically (and correctly, including lookups) on both surfaces.
+ */
+export function buildDatasetDrillFilter(
+  rawRow: Record<string, unknown> | undefined,
+  drillDims: string[],
+  dimensionFields: Record<string, string>,
+  runtimeFilter?: Record<string, unknown>,
+): Record<string, unknown> {
+  const drillFilter: Record<string, unknown> = {};
+  for (const d of drillDims) {
+    const raw = rawRow?.[d];
+    drillFilter[dimensionFields[d]] = raw === '' || raw === undefined ? null : raw;
+  }
+  return runtimeFilter ? { ...runtimeFilter, ...drillFilter } : drillFilter;
+}

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -33,6 +33,7 @@ import {
   formatMeasure,
   formatDimensionValue,
   buildDatasetFieldHelpers,
+  buildDatasetDrillFilter,
   type DatasetResultField,
 } from '@object-ui/core';
 import { cn } from '@object-ui/components';
@@ -49,26 +50,11 @@ interface DatasetCapableSource {
 }
 
 /**
- * Build the record-list filter for a drilled row. Each drillable dimension maps
- * to its underlying object field, filtered by the dimension's RAW grouped value
- * (taken from the server's parallel `drillRawRows` array — the visible `row`
- * carries the display label, which would mis-filter a select/lookup field). The
- * widget's render-time scope (`runtimeFilter`) is ANDed in so the drilled list
- * stays within the same slice the aggregate was computed over.
+ * Build the record-list filter for a drilled row. Re-exported for back-compat;
+ * the implementation now lives in `@object-ui/core` (`buildDatasetDrillFilter`)
+ * so the dashboard and the report renderer drill identically.
  */
-export function buildDrillFilter(
-  rawRow: Record<string, unknown> | undefined,
-  drillDims: string[],
-  dimensionFields: Record<string, string>,
-  runtimeFilter?: Record<string, unknown>,
-): Record<string, unknown> {
-  const drillFilter: Record<string, unknown> = {};
-  for (const d of drillDims) {
-    const raw = rawRow?.[d];
-    drillFilter[dimensionFields[d]] = raw === '' || raw === undefined ? null : raw;
-  }
-  return runtimeFilter ? { ...runtimeFilter, ...drillFilter } : drillFilter;
-}
+export const buildDrillFilter = buildDatasetDrillFilter;
 
 /**
  * Pivot flat dataset rows into a cross-tab: `rowDims` go DOWN, `colDim` spreads

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -46,6 +46,7 @@ import {
   formatMeasure,
   formatDimensionValue,
   buildDatasetFieldHelpers,
+  buildDatasetDrillFilter,
   type DatasetResultField,
 } from '@object-ui/core';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
@@ -63,7 +64,14 @@ interface DatasetCapableSource {
   queryDataset?: (
     dataset: string,
     selection: unknown,
-  ) => Promise<{ rows: Row[]; fields?: DatasetResultField[]; object?: string; totals?: DatasetTotals[] }>;
+  ) => Promise<{
+    rows: Row[];
+    fields?: DatasetResultField[];
+    object?: string;
+    dimensionFields?: Record<string, string>;
+    drillRawRows?: Row[];
+    totals?: DatasetTotals[];
+  }>;
 }
 
 /** What a drill click means — the host resolves names to a navigation target. */
@@ -74,6 +82,16 @@ export interface DatasetDrillArgs {
   groupKey: Record<string, unknown>;
   /** The effective render-time scope filter, if any. */
   runtimeFilter?: Record<string, unknown>;
+  /** The dataset's base object (records to drill into), when the server supplied it. */
+  object?: string;
+  /**
+   * Exact record-list filter (object FIELD name → RAW stored value) for the
+   * clicked bucket, ANDed with `runtimeFilter`. Present only when the server
+   * returned the dimension→field mapping + raw grouped values, so the host can
+   * filter precisely — including select/lookup dims a display-label `groupKey`
+   * would mis-filter — without re-fetching the dataset definition.
+   */
+  objectFilter?: Record<string, unknown>;
 }
 
 /** A report (or joined block) bound to a dataset. Field access is permissive — */
@@ -144,6 +162,8 @@ function useDatasetRows(
     rows: Row[];
     fields?: DatasetResultField[];
     object?: string;
+    dimensionFields?: Record<string, string>;
+    drillRawRows?: Row[];
     totals?: DatasetTotals[];
     error?: string;
   }>({
@@ -180,6 +200,8 @@ function useDatasetRows(
             rows: Array.isArray(res?.rows) ? res.rows : [],
             fields: Array.isArray(res?.fields) ? res.fields : [],
             object: res?.object,
+            dimensionFields: res?.dimensionFields,
+            drillRawRows: Array.isArray(res?.drillRawRows) ? res.drillRawRows : undefined,
             totals: Array.isArray(res?.totals) ? res.totals : undefined,
           });
         }
@@ -256,10 +278,20 @@ function DatasetReportTable({
 
   // Drilling needs at least one dimension to scope by.
   const canDrill = !!onDrill && rows.length > 0;
-  const drill = (row: Row) => {
+  // Dims the server can map to object fields → raw-value (drill-correct) filter.
+  const drillDims = state.dimensionFields ? rows.filter((d) => d in state.dimensionFields!) : [];
+  const drill = (row: Row, index: number) => {
     const groupKey: Record<string, unknown> = {};
     for (const dim of rows) groupKey[dim] = row[dim];
-    onDrill!({ dataset, groupKey, runtimeFilter });
+    // ADR-0021 D2: when the server returned the object + raw grouped values,
+    // emit an exact field→raw filter (correct for select/lookup dims, which a
+    // display-label groupKey would mis-filter); the host then filters with no
+    // extra metadata round-trip. Older server → groupKey-only fallback.
+    const objectFilter =
+      state.object && state.dimensionFields && drillDims.length > 0
+        ? buildDatasetDrillFilter(state.drillRawRows?.[index], drillDims, state.dimensionFields, runtimeFilter)
+        : undefined;
+    onDrill!({ dataset, groupKey, runtimeFilter, object: state.object, objectFilter });
   };
 
   const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
@@ -282,7 +314,7 @@ function DatasetReportTable({
               key={i}
               className={`border-t${canDrill ? ` ${DRILL_CLASS}` : ''}`}
               data-testid={canDrill ? 'dataset-drill-row' : undefined}
-              onClick={canDrill ? () => drill(row) : undefined}
+              onClick={canDrill ? () => drill(row, i) : undefined}
             >
               {columns.map((c) => (
                 <td key={c} className="px-2 py-1 tabular-nums whitespace-nowrap">
@@ -348,8 +380,8 @@ function DatasetMatrixTable({
     const colHeaders: Array<{ id: string; label: string; key: Row }> = [];
     const seenRow = new Set<string>();
     const seenCol = new Set<string>();
-    const cells = new Map<string, Row>();
-    for (const r of state.rows) {
+    const cells = new Map<string, { row: Row; index: number }>();
+    state.rows.forEach((r, index) => {
       const rid = bucketId(rows, r);
       const cid = bucketId(columnsAcross, r);
       if (!seenRow.has(rid)) {
@@ -364,8 +396,8 @@ function DatasetMatrixTable({
         for (const d of columnsAcross) key[d] = r[d];
         colHeaders.push({ id: cid, label: bucketLabel(columnsAcross, r), key });
       }
-      cells.set(`${rid} ${cid}`, r);
-    }
+      cells.set(`${rid} ${cid}`, { row: r, index });
+    });
     return { rowHeaders, colHeaders, cells };
   }, [state, rows, columnsAcross]);
 
@@ -377,8 +409,16 @@ function DatasetMatrixTable({
   const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
   const totalText = tt('report.total', 'Total');
   const canDrill = !!onDrill;
-  const drillCell = (rowKey: Row, colKey: Row) => {
-    onDrill!({ dataset, groupKey: { ...rowKey, ...colKey }, runtimeFilter });
+  // Down + across dims the server can map to object fields → raw-value filter.
+  const drillDims = state.dimensionFields
+    ? [...rows, ...columnsAcross].filter((d) => d in state.dimensionFields!)
+    : [];
+  const drillCell = (rowKey: Row, colKey: Row, index: number) => {
+    const objectFilter =
+      state.object && state.dimensionFields && drillDims.length > 0
+        ? buildDatasetDrillFilter(state.drillRawRows?.[index], drillDims, state.dimensionFields, runtimeFilter)
+        : undefined;
+    onDrill!({ dataset, groupKey: { ...rowKey, ...colKey }, runtimeFilter, object: state.object, objectFilter });
   };
 
   // Single measure → one column per across-bucket; multiple → bucket × measure.
@@ -439,15 +479,15 @@ function DatasetMatrixTable({
                 </td>
               ))}
               {cellCols.map((cc) => {
-                const cell = pivot.cells.get(`${rh.id} ${cc.col.id}`);
-                const value = cell?.[cc.measure];
-                const clickable = canDrill && cell != null;
+                const entry = pivot.cells.get(`${rh.id} ${cc.col.id}`);
+                const value = entry?.row[cc.measure];
+                const clickable = canDrill && entry != null;
                 return (
                   <td
                     key={`${cc.col.id}-${cc.measure}`}
                     className={`px-2 py-1 text-right tabular-nums whitespace-nowrap${clickable ? ` ${DRILL_CLASS}` : ''}`}
                     data-testid={clickable ? 'dataset-drill-cell' : undefined}
-                    onClick={clickable ? () => drillCell(rh.key, cc.col.key) : undefined}
+                    onClick={clickable ? () => drillCell(rh.key, cc.col.key, entry!.index) : undefined}
                   >
                     {formatMeasure(value, measureField(cc.measure)?.format, measureField(cc.measure)?.currency)}
                   </td>

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -25,6 +25,8 @@ type MockResult = {
   rows: MockRows;
   fields?: MockField[];
   object?: string;
+  dimensionFields?: Record<string, string>;
+  drillRawRows?: MockRows;
   totals?: Array<{ dimensions: string[]; rows: MockRows }>;
 };
 
@@ -40,6 +42,8 @@ function makeSource(byDataset: Record<string, MockRows | MockResult>) {
         rows: entry?.rows ?? [],
         ...(entry?.fields ? { fields: entry.fields } : {}),
         ...(entry?.object ? { object: entry.object } : {}),
+        ...(entry?.dimensionFields ? { dimensionFields: entry.dimensionFields } : {}),
+        ...(entry?.drillRawRows ? { drillRawRows: entry.drillRawRows } : {}),
         ...(entry?.totals ? { totals: entry.totals } : {}),
       };
     }),
@@ -465,6 +469,105 @@ describe('DatasetReportRenderer', () => {
     expect(screen.getByTestId('matrix-total-col-header')).toHaveTextContent('总计');
     expect(screen.getByTestId('matrix-total-row')).toHaveTextContent('总计');
     expect(screen.queryByText('report.total')).not.toBeInTheDocument();
+  });
+
+  // ── raw-value drill (ADR-0021 D2) ──────────────────────────────────────────
+  it('drill: emits object + raw objectFilter (stored value, not display label)', async () => {
+    const src = makeSource({
+      task_metrics: {
+        rows: [{ status: 'In Progress', est_hours: 30 }],
+        object: 'task',
+        dimensionFields: { status: 'status' },
+        // the visible row carries the DISPLAY label; the raw row carries the stored value
+        drillRawRows: [{ status: 'in_progress' }],
+      },
+    });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+        runtimeFilter={{ owner: 'me' }}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-drill-row')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('dataset-drill-row'));
+    expect(onDrill).toHaveBeenCalledWith(expect.objectContaining({
+      dataset: 'task_metrics',
+      object: 'task',
+      groupKey: { status: 'In Progress' },
+      // raw stored value, mapped to the underlying object field, ANDed with scope
+      objectFilter: { owner: 'me', status: 'in_progress' },
+    }));
+  });
+
+  it('drill: raw objectFilter filters a lookup dim by its FK id, not the record name', async () => {
+    const src = makeSource({
+      deal_metrics: {
+        rows: [{ account: 'Acme Corp', amount: 1000 }],
+        object: 'deal',
+        dimensionFields: { account: 'account_id' },
+        drillRawRows: [{ account: 'acc_123' }],
+      },
+    });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'deal_metrics', rows: ['account'], values: ['amount'] }}
+        dataSource={src}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-drill-row')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('dataset-drill-row'));
+    expect(onDrill).toHaveBeenCalledWith(expect.objectContaining({
+      object: 'deal',
+      objectFilter: { account_id: 'acc_123' },
+    }));
+  });
+
+  it('matrix drill: cell emits raw objectFilter over both row + across dims', async () => {
+    const src = makeSource({
+      task_metrics: {
+        rows: [{ status: 'In Progress', priority: 'High', est_hours: 10 }],
+        object: 'task',
+        dimensionFields: { status: 'status', priority: 'priority' },
+        drillRawRows: [{ status: 'in_progress', priority: 'p1' }],
+      },
+    });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'task_metrics', rows: ['status'], columns: ['priority'], values: ['est_hours'] }}
+        dataSource={src}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    fireEvent.click(screen.getAllByTestId('dataset-drill-cell')[0]);
+    expect(onDrill).toHaveBeenCalledWith(expect.objectContaining({
+      object: 'task',
+      groupKey: { status: 'In Progress', priority: 'High' },
+      objectFilter: { status: 'in_progress', priority: 'p1' },
+    }));
+  });
+
+  it('drill: omits objectFilter when the server returns no drill metadata (older server)', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-drill-row')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('dataset-drill-row'));
+    const args = onDrill.mock.calls[0][0];
+    expect(args.groupKey).toEqual({ status: 'Backlog' });
+    expect(args.objectFilter).toBeUndefined();
   });
 
   it('shows an error when the data source cannot run dataset queries', async () => {


### PR DESCRIPTION
## The bug

The report renderer's drill emitted a `groupKey` of **display labels** (the analytics server resolves dimension buckets to labels in `rows`). The host (`ReportView.handleDatasetDrill`) then had to compensate: re-fetch the dataset definition, reverse-map select labels → option values, and **skip lookup dims entirely** (a lookup label is a record *name*, not the FK id) — so a lookup dimension drilled to a **superset** instead of filtering. This is the same class of bug the dashboard already fixed via `drillRawRows`.

## The fix

The renderer already had `dimensionFields` + `drillRawRows` available from `queryDataset` but wasn't capturing them. Now it does, and alongside `groupKey` it emits:
- `object` — the dataset's base object, and
- `objectFilter` — an exact **object FIELD → RAW stored value** filter (ANDed with the render scope), built with the shared `buildDatasetDrillFilter` (`@object-ui/core`, which also now backs the dashboard's `buildDrillFilter` — single source of truth).

`ReportView` gains a **fast path**: when `object` + `objectFilter` are present it navigates straight to the scoped list — correct for select/lookup dims, with **no dataset-definition round-trip** and no label reverse-mapping. Older servers that don't return drill metadata fall back to the existing label-resolution path unchanged.

Stacked on #1841 (now merged) for the shared `@object-ui/core` helpers.

## Behavior

| dim type | before | after |
|---|---|---|
| select | host reverse-maps label→value (extra metadata fetch) | exact raw value, no fetch |
| **lookup** | **skipped — drills to a superset** | **filters by FK id** |
| plain | OK | OK (no fetch) |

## Tests
- `plugin-report` → **44 passed**: raw stored value (not display label), lookup FK id, matrix-cell over row+across dims, and the older-server fallback (no `objectFilter`).
- `plugin-dashboard` `DatasetWidget` → **33 passed** (`buildDrillFilter` re-export).
- `type-check` green across core / plugin-report / plugin-dashboard / app-shell.

> The `ReportView` host fast path is a thin `URLSearchParams` builder over `objectFilter`; its correctness-critical input is covered by the renderer + core `buildDatasetDrillFilter` tests. There is no existing `ReportView` unit harness, so I did not add a bespoke router-mock test for the 6-line nav loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)