### PR TITLE
test(forms/related-list): regression coverage for showcase-QA fixes

### DIFF
--- a/packages/plugin-detail/src/__tests__/RelatedList.systemcolumns.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.systemcolumns.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression coverage: auto-derived related-list columns must NOT lead with
+ * system audit fields (created_at / updated_at / …). For a child object with no
+ * name/title field (e.g. invoice lines), those system fields previously filled
+ * the leading columns and pushed business columns (qty, price, amount) past the
+ * column cap. System audit fields are now sorted last.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { RelatedList } from '../RelatedList';
+
+// Declare the system audit fields FIRST to reproduce the pre-fix ordering.
+const fields = {
+  created_at: { type: 'datetime', label: 'Created At' },
+  updated_at: { type: 'datetime', label: 'Last Modified At' },
+  created_by: { type: 'text', label: 'Created By' },
+  updated_by: { type: 'text', label: 'Updated By' },
+  product: { type: 'text', label: 'Product' },
+  description: { type: 'text', label: 'Description' },
+  quantity: { type: 'number', label: 'Qty' },
+};
+
+const makeDS = (rows: any[]) => ({
+  find: vi.fn(async () => rows),
+  getObjectSchema: vi.fn(async () => ({ name: 'line', fields })),
+});
+
+describe('RelatedList — system audit columns are deprioritized', () => {
+  it('orders business columns before created_at / updated_at', async () => {
+    const rows = [{
+      id: 'l1', product: 'Widget', description: 'd', quantity: 2,
+      created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-02T00:00:00Z',
+      created_by: 'u', updated_by: 'u',
+    }];
+    render(
+      <RelatedList
+        title="Lines"
+        type="table"
+        api="line"
+        objectName="line"
+        referenceField="invoice"
+        parentId="INV-1"
+        sortable
+        dataSource={makeDS(rows) as any}
+      />,
+    );
+
+    // `sortable` renders one button per effective column, in column order.
+    const labels = await waitFor(() => {
+      const texts = screen.getAllByRole('button').map((b) => (b.textContent || '').trim());
+      if (!texts.some((t) => t.includes('Product'))) throw new Error('headers not ready');
+      return texts;
+    });
+    const idx = (s: string) => labels.findIndex((t) => t.includes(s));
+
+    expect(idx('Product')).toBeGreaterThanOrEqual(0);
+    // A business field must lead; any shown system audit column comes after it.
+    if (idx('Created At') >= 0) expect(idx('Product')).toBeLessThan(idx('Created At'));
+    if (idx('Last Modified At') >= 0) expect(idx('Product')).toBeLessThan(idx('Last Modified At'));
+  });
+});

--- a/packages/plugin-form/src/WizardForm.regression.test.tsx
+++ b/packages/plugin-form/src/WizardForm.regression.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression coverage: a multi-step `object-form` (`formType: 'wizard'`) must
+ * submit the MERGED payload from every step. Two bugs previously made the
+ * create POST carry an empty/partial body (and the server rejected required
+ * fields):
+ *   1. the footer Next/Create buttons bypassed the inner form and submitted the
+ *      wizard's own (never-collected) `formData`;
+ *   2. the create-mode seeding effect reset `formData` to `{}` on re-render.
+ * The buttons now submit the inner form natively (`type="submit"` + `form={id}`)
+ * and the create seed is idempotent.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { WizardForm } from './WizardForm';
+import { registerAllFields } from '@object-ui/fields';
+
+registerAllFields();
+
+const objectSchema = {
+  name: 'wiz_obj',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    note: { type: 'text', label: 'Note' },
+  },
+};
+
+const makeDS = () => ({
+  getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+  create: vi.fn(async (_o: string, data: any) => ({ id: 'r1', ...data })),
+  update: vi.fn(),
+  findOne: vi.fn(),
+});
+
+const schema = {
+  type: 'object-form',
+  formType: 'wizard',
+  objectName: 'wiz_obj',
+  mode: 'create',
+  sections: [
+    { label: 'Step 1', fields: ['name'] },
+    { label: 'Step 2', fields: ['note'] },
+  ],
+};
+
+describe('WizardForm — multi-step create collects every step', () => {
+  it('submits the merged payload (both steps), not an empty/last-only body', async () => {
+    const ds = makeDS();
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+
+    const nameInput = await waitFor(() => {
+      const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+      if (!el) throw new Error('step-1 name input not rendered');
+      return el;
+    });
+    fireEvent.change(nameInput, { target: { value: 'Alice' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement); // advance to step 2
+
+    const noteInput = await waitFor(() => {
+      const el = container.querySelector('input[name="note"]') as HTMLInputElement | null;
+      if (!el) throw new Error('step-2 note input not rendered');
+      return el;
+    });
+    fireEvent.change(noteInput, { target: { value: 'hello' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement); // final create
+
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+    const [obj, payload] = ds.create.mock.calls[0];
+    expect(obj).toBe('wiz_obj');
+    // The regression was: payload === {} or { note } only. Must carry BOTH steps.
+    expect(payload).toEqual(expect.objectContaining({ name: 'Alice', note: 'hello' }));
+  });
+
+  it('wires the footer Next/Create buttons to the step form (cannot bypass it)', async () => {
+    const ds = makeDS();
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+    await waitFor(() => {
+      if (!container.querySelector('input[name="name"]')) throw new Error('not ready');
+    });
+    const form = container.querySelector('form') as HTMLFormElement;
+    const formId = form.getAttribute('id');
+    expect(formId).toBeTruthy();
+    const nextBtn = screen.getByRole('button', { name: /next/i });
+    expect(nextBtn.getAttribute('type')).toBe('submit');
+    expect(nextBtn.getAttribute('form')).toBe(formId);
+  });
+});


### PR DESCRIPTION
Adds regression tests for the showcase-QA fixes so they can't silently regress (one of them briefly slipped off `main` during a concurrent branch switch before being restored by #1831 — this locks it down).

### Coverage
- **WizardForm** (`WizardForm.regression.test.tsx`)
  - A multi-step `object-form` (`formType: 'wizard'`) create submits the **merged payload from every step**, not an empty/last-only body.
  - The footer **Next/Create buttons are wired to submit the inner step form** (`type="submit"` + `form={id}`) instead of calling the wizard's stale `formData`. This is the assertion that fails if the create-bug fix regresses.
- **RelatedList** (`RelatedList.systemcolumns.test.tsx`)
  - Auto-derived columns **deprioritize system audit fields** (`created_at`/`updated_at`) so business columns lead for child objects without a name/title (e.g. invoice lines).

### Not covered (intentional)
The dashboard chart-height fix isn't unit-tested: the existing `DashboardRenderer` render suite is `describe.skip`'d for a CI hang, and a CSS layout collapse (recharts `width(-1)`) isn't observable in jsdom. It's covered by the showcase smoke instead.

### Testing
`vitest run` on both files: 3 passed. Verified the button-wiring assertion fails against the pre-fix WizardForm (valid guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)