### PR TITLE
fix(app-shell): edit-in-studio pencil no longer overlaps interface-page toolbar

### DIFF
--- a/.changeset/edit-pencil-overlap.md
+++ b/.changeset/edit-pencil-overlap.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(app-shell): edit-in-studio pencil no longer overlaps interface-page toolbar buttons
+
+The PageView "Edit in studio" pencil is an absolute overlay at the page's
+top-right. On an interface (list) page whose header surfaces toolbar buttons
+(e.g. an Approvals page's "Mark Done"), the pencil sat on top of the rightmost
+button, clipping its label. PageView now tells InterfaceListPage to reserve
+right padding on its header (`reserveEditAffordance`, only when the pencil is
+shown) so the toolbar clears the affordance. Non-admin / non-editable pages are
+unchanged.

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -33,6 +33,10 @@ interface InterfaceListPageProps {
    * page's interfaceConfig metadata (Airtable parity — the toolbar IS the
    * authoring surface). Receives a partial interfaceConfig patch. */
   onConfigChange?: (patch: Record<string, unknown>) => void;
+  /** When the host overlays an edit-in-studio affordance at the page's
+   * top-right (PageView's pencil), reserve right padding on the header so the
+   * toolbar buttons don't sit under it. */
+  reserveEditAffordance?: boolean;
 }
 
 /**
@@ -167,7 +171,7 @@ export function defaultMapFromObject(objectDef: any): { locationField: string } 
   return field ? { locationField: field } : undefined;
 }
 
-export function InterfaceListPage({ page, className, onConfigChange }: InterfaceListPageProps) {
+export function InterfaceListPage({ page, className, onConfigChange, reserveEditAffordance }: InterfaceListPageProps) {
   const { t } = useObjectTranslation();
   const { objects } = useMetadata();
   const dataSource = useAdapter();
@@ -418,7 +422,7 @@ export function InterfaceListPage({ page, className, onConfigChange }: Interface
 
   return (
     <div className={className ?? 'h-full flex flex-col'} data-testid="interface-list-page">
-      <div className="px-4 pt-4 pb-2 shrink-0 flex items-start justify-between gap-3">
+      <div className={`pl-4 pt-4 pb-2 shrink-0 flex items-start justify-between gap-3 ${reserveEditAffordance ? 'pr-12' : 'pr-4'}`}>
         <div className="min-w-0">
           <h1 className="text-lg font-semibold leading-tight">
             {typeof page.label === 'string' ? page.label : page.name}

--- a/packages/app-shell/src/views/PageView.tsx
+++ b/packages/app-shell/src/views/PageView.tsx
@@ -101,7 +101,7 @@ export function PageView() {
           {(page as any).interfaceConfig?.source ? (
             // ADR-0047 interface mode: the page binds a source view into a
             // curated list surface — rendered directly, not via regions.
-            <InterfaceListPage key={refreshKey} page={page} />
+            <InterfaceListPage key={refreshKey} page={page} reserveEditAffordance={canEditInStudio} />
           ) : (
             <SchemaRenderer
               key={refreshKey}


### PR DESCRIPTION
On an interface (list) page whose header surfaces toolbar buttons (e.g. an Approvals page with a "Mark Done" object action), PageView's absolute top-right **"Edit in studio" pencil sat on top of the rightmost button**, clipping its label ("Mark Don●").

### Fix
PageView passes `reserveEditAffordance={canEditInStudio}` to `InterfaceListPage`, which reserves right padding on its header row **only when the pencil is shown**. Non-admin / non-editable pages are unchanged (no extra gutter).

### Testing
Verified in the browser on the showcase Approvals page: "Mark Done" now renders in full with the pencil cleanly separated to its right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)