### PR TITLE
fix(metadata-admin): currency-aware, labelled headers in the dataset preview

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
@@ -39,6 +39,38 @@ describe('DatasetPreview', () => {
     expect(screen.getByText('EU')).toBeInTheDocument();
   });
 
+  it('renders display labels for headers and currency-formatted measures', async () => {
+    queryDataset.mockResolvedValue({
+      rows: [{ region: 'NA', revenue: 1000 }],
+      object: 'opportunity',
+      fields: [
+        { name: 'region', type: 'string', label: 'Region' },
+        { name: 'revenue', type: 'number', label: 'Revenue', format: '0,0', currency: 'USD' },
+      ],
+    });
+    render(<DatasetPreview {...baseProps} draft={draft} />);
+    // Headers use the server field label, not the raw dimension/measure name.
+    expect(await screen.findByRole('columnheader', { name: 'Region' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Revenue' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'revenue' })).not.toBeInTheDocument();
+    // Amount carries the declared currency symbol (never a bare number).
+    expect(screen.getByText('$1,000')).toBeInTheDocument();
+  });
+
+  it('formats an amount with no declared currency as a plain number (no $)', async () => {
+    queryDataset.mockResolvedValue({
+      rows: [{ region: 'NA', revenue: 1234 }],
+      object: 'opportunity',
+      fields: [
+        { name: 'region', type: 'string', label: 'Region' },
+        { name: 'revenue', type: 'number', label: 'Revenue', format: '0,0' },
+      ],
+    });
+    render(<DatasetPreview {...baseProps} draft={draft} />);
+    expect(await screen.findByText('1,234')).toBeInTheDocument();
+    expect(screen.queryByText('$1,234')).not.toBeInTheDocument();
+  });
+
   it('surfaces a server/compile error as an alert (no silent fallback)', async () => {
     queryDataset.mockRejectedValue(new Error('relationship "account" is not declared in the dataset\'s `include`'));
     render(<DatasetPreview {...baseProps} draft={draft} />);

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx
@@ -21,6 +21,13 @@ import { Loader2, BarChart3, AlertTriangle } from 'lucide-react';
 import { useAdapter } from '../../../providers/AdapterProvider';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewEmptyState, PreviewErrorBoundary } from './PreviewShell';
+import {
+  formatMeasure,
+  formatDimensionValue,
+  buildDatasetFieldHelpers,
+  type DatasetResultField,
+} from '@object-ui/core';
+import { useSafeFieldLabel } from '@object-ui/i18n';
 
 // Lazy-loaded so the (recharts-backed) chart bundle only loads when a dataset
 // preview actually renders a chart — keeps the metadata-admin bundle small.
@@ -31,20 +38,12 @@ const ChartRenderer = React.lazy(() =>
 type Row = Record<string, unknown>;
 type PreviewState =
   | { status: 'idle' | 'loading'; rows: Row[]; error?: undefined }
-  | { status: 'ok'; rows: Row[]; error?: undefined }
+  | { status: 'ok'; rows: Row[]; fields?: DatasetResultField[]; object?: string; error?: undefined }
   | { status: 'error'; rows: Row[]; error: string };
-
-function formatCell(v: unknown): string {
-  if (v == null) return '—';
-  if (typeof v === 'number') {
-    return Number.isInteger(v) ? String(v) : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
-  }
-  if (typeof v === 'boolean') return v ? 'true' : 'false';
-  return String(v);
-}
 
 export function DatasetPreview({ draft }: MetadataPreviewProps) {
   const adapter = useAdapter();
+  const { fieldLabel } = useSafeFieldLabel();
 
   const objectName = (draft as Record<string, unknown>).object as string | undefined;
 
@@ -67,9 +66,14 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
     setState({ status: 'loading', rows: [] });
     try {
       const result = await (adapter as unknown as {
-        queryDataset: (d: unknown, s: unknown) => Promise<{ rows: Row[] }>;
+        queryDataset: (d: unknown, s: unknown) => Promise<{ rows: Row[]; fields?: DatasetResultField[]; object?: string }>;
       }).queryDataset(draft, { dimensions: dimensionNames, measures: measureNames });
-      setState({ status: 'ok', rows: Array.isArray(result?.rows) ? result.rows : [] });
+      setState({
+        status: 'ok',
+        rows: Array.isArray(result?.rows) ? result.rows : [],
+        fields: Array.isArray(result?.fields) ? result.fields : [],
+        object: result?.object,
+      });
     } catch (e) {
       setState({ status: 'error', rows: [], error: String((e as Error)?.message ?? e) });
     }
@@ -108,6 +112,12 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
     );
   }
 
+  // Display labels + currency-aware formatting, shared with the dashboard widget
+  // and the report renderer (@object-ui/core). Falls back to the raw name / plain
+  // number when the server result carries no field metadata.
+  const resultFields = state.status === 'ok' ? state.fields : undefined;
+  const resultObject = state.status === 'ok' ? state.object : undefined;
+  const { measureField, headerLabel } = buildDatasetFieldHelpers(resultFields, resultObject, fieldLabel);
   const columns = [...dimensionNames, ...measureNames];
 
   return (
@@ -153,7 +163,7 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
                   schema={{
                     data: state.rows as Array<Record<string, unknown>>,
                     xAxisKey: dimensionNames[0],
-                    series: measureNames.map((m) => ({ dataKey: m, label: m, chartType: 'bar' as const })),
+                    series: measureNames.map((m) => ({ dataKey: m, label: headerLabel(m), chartType: 'bar' as const })),
                   } as any}
                 />
               </div>
@@ -167,7 +177,7 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
               <thead className="bg-muted/40">
                 <tr>
                   {columns.map((c) => (
-                    <th key={c} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">{c}</th>
+                    <th key={c} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">{headerLabel(c)}</th>
                   ))}
                 </tr>
               </thead>
@@ -175,7 +185,11 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
                 {state.rows.map((row, i) => (
                   <tr key={i} className="border-t">
                     {columns.map((c) => (
-                      <td key={c} className="px-2 py-1 tabular-nums whitespace-nowrap">{formatCell(row[c])}</td>
+                      <td key={c} className="px-2 py-1 tabular-nums whitespace-nowrap">
+                        {measureNames.includes(c)
+                          ? formatMeasure(row[c], measureField(c)?.format, measureField(c)?.currency)
+                          : formatDimensionValue(row[c])}
+                      </td>
                     ))}
                   </tr>
                 ))}


### PR DESCRIPTION
## What

Found during an audit of sibling dataset-render surfaces (after [#1830](https://github.com/objectstack-ai/objectui/pull/1830) / [#1841](https://github.com/objectstack-ai/objectui/pull/1841) / [#1842](https://github.com/objectstack-ai/objectui/pull/1842)). The live dataset-authoring preview (`DatasetPreview`) had the **same three bugs** the dashboard widget and report renderer were already fixed for:

1. Raw dimension/measure **names** in table headers (`<th>{c}`).
2. A local **currency-blind** `formatCell` (plain `toLocaleString`).
3. No i18n.

It renders the *same* `queryDataset` result a dashboard/report does, so authors saw a different rendering of the exact numbers their published surfaces show.

## Fix

Reuse the shared helpers instead of a bespoke formatter:
- `buildDatasetFieldHelpers` + `useSafeFieldLabel` → headers resolve **field label → i18n fieldLabel → raw name**.
- `formatMeasure` → measure cells use the field's declared **currency** (`Intl` symbol) + numeral format, never a misleading `$`; `formatDimensionValue` for dimensions.
- The preview chart's series **label** now uses the display label too (was the raw measure name).

Graceful: when the result carries no field metadata (older server), headers fall back to the raw name and amounts to plain numbers — no regression (the existing `fields: []` test still passes).

## Tests
- `DatasetPreview` → **6 passed** (+2: labelled headers, and currency / no-currency formatting).
- `type-check` green for `app-shell`.

## Audit note
Swept all dataset-consuming surfaces: `ReportPreview` already delegates to the (fixed) `DatasetReportRenderer`; `ObjectChart` uses the label-aware `buildChartSeries`. `DatasetPreview` was the one remaining instance. Separately, `plugin-grid/useColumnSummary.ts` has a currency-blind aggregation footer, but it's a different data source (grid field metadata, not dataset results) — left as a potential follow-up, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)