### PR TITLE
feat(forms): declarative successMessage on object-form

### DIFF
--- a/.changeset/form-success-message.md
+++ b/.changeset/form-success-message.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/plugin-form": patch
+"@object-ui/types": patch
+---
+
+feat(forms): declarative `successMessage` on object-form
+
+Metadata-only forms (a wizard/object-form authored as JSON) cannot pass an
+`onSuccess` function, so the post-create/update feedback was a fixed
+"Created"/"Saved" toast. `ObjectFormSchema` now accepts `successMessage`, which
+ObjectForm and WizardForm use for the default success toast when no `onSuccess`
+handler is supplied. Falls back to "Created"/"Saved".

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -618,7 +618,7 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
       if (schema.onSuccess) {
         await schema.onSuccess(result);
       } else if (!schema.submitHandler) {
-        toast.success(schema.mode === 'create' ? 'Created' : 'Saved');
+        toast.success(schema.successMessage || (schema.mode === 'create' ? 'Created' : 'Saved'));
       }
 
       return result;

--- a/packages/plugin-form/src/WizardForm.successMessage.test.tsx
+++ b/packages/plugin-form/src/WizardForm.successMessage.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * A metadata-only wizard cannot pass an `onSuccess` function, so it can now
+ * declare a `successMessage` for the post-create toast. Verify it's honored.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+const { toastSuccess } = vi.hoisted(() => ({ toastSuccess: vi.fn() }));
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, toast: { ...actual.toast, success: toastSuccess, error: vi.fn() } };
+});
+
+import { WizardForm } from './WizardForm';
+import { registerAllFields } from '@object-ui/fields';
+
+registerAllFields();
+
+const objectSchema = { name: 'o', fields: { name: { type: 'text', label: 'Name' } } };
+const makeDS = () => ({
+  getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+  create: vi.fn(async (_o: string, d: any) => ({ id: '1', ...d })),
+  update: vi.fn(),
+  findOne: vi.fn(),
+});
+
+describe('WizardForm — declarative successMessage', () => {
+  it('toasts the configured successMessage on create (no onSuccess function)', async () => {
+    toastSuccess.mockClear();
+    const ds = makeDS();
+    const schema = {
+      type: 'object-form', formType: 'wizard', objectName: 'o', mode: 'create',
+      successMessage: 'Project created',
+      sections: [{ label: 'A', fields: ['name'] }],
+    };
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+    const input = await waitFor(() => {
+      const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+      if (!el) throw new Error('input not ready');
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement); // single step → create
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Project created'));
+  });
+
+  it('falls back to a default message when none configured', async () => {
+    toastSuccess.mockClear();
+    const ds = makeDS();
+    const schema = {
+      type: 'object-form', formType: 'wizard', objectName: 'o', mode: 'create',
+      sections: [{ label: 'A', fields: ['name'] }],
+    };
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+    const input = await waitFor(() => {
+      const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+      if (!el) throw new Error('input not ready');
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'Beta' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Created'));
+  });
+});

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -74,6 +74,12 @@ export interface WizardFormSchema {
    * Submit button text (shown on last step)
    */
   submitText?: string;
+
+  /**
+   * Declarative success toast text shown when no `onSuccess` handler is given
+   * (metadata pages cannot pass a function). Falls back to 'Created'/'Saved'.
+   */
+  successMessage?: string;
   
   /**
    * Show cancel button
@@ -280,7 +286,7 @@ export const WizardForm: React.FC<WizardFormProps> = ({
         } else {
           // Default feedback so a metadata-only wizard (which cannot pass an
           // onSuccess function) still confirms the create/update succeeded.
-          toast.success(schema.mode === 'create' ? 'Created' : 'Saved');
+          toast.success(schema.successMessage || (schema.mode === 'create' ? 'Created' : 'Saved'));
         }
         return result;
       } catch (err) {

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -899,6 +899,13 @@ export interface ObjectFormSchema extends BaseSchema {
    * Submit button text
    */
   submitText?: string;
+
+  /**
+   * Declarative success toast text shown after a successful create/update when
+   * no `onSuccess` function handler is supplied (metadata-only pages cannot
+   * pass a function). Falls back to 'Created' / 'Saved'.
+   */
+  successMessage?: string;
   
   /**
    * Show cancel button

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -172,6 +172,7 @@ export const ObjectFormSchema = BaseSchema.extend({
   columns: z.number().optional().describe('Grid columns'),
   showSubmit: z.boolean().optional().describe('Show submit button'),
   submitText: z.string().optional().describe('Submit button text'),
+  successMessage: z.string().optional().describe('Success toast text after create/update when no onSuccess handler is given'),
   showCancel: z.boolean().optional().describe('Show cancel button'),
   cancelText: z.string().optional().describe('Cancel button text'),
   showReset: z.boolean().optional().describe('Show reset button'),


### PR DESCRIPTION
Follow-up to the default success toast: lets a **metadata-only** form customize its post-create/update feedback. Metadata pages can't pass an `onSuccess` function, so the toast was a fixed "Created"/"Saved".

### Change
- `ObjectFormSchema` gains `successMessage?: string` (interface + zod).
- `ObjectForm` and `WizardForm` use `schema.successMessage` for the default success toast when no `onSuccess` handler is supplied; falls back to "Created"/"Saved".

### Testing
Added `WizardForm.successMessage.test.tsx` (mocked toast): asserts the configured message is toasted on create, and the default fallback otherwise. 2/2 passing.

### Note on navigate/reset
The other declarative success behaviors (navigate-after-create, reset-for-another-entry) need router/reset plumbing not available in the form layer (navigation here is only `window.location`, a full reload that drops the toast) — tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)