### PR TITLE
feat(studio): harden designer preview against page-locking overlay forms

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/PageBlockCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PageBlockCanvas.tsx
@@ -35,17 +35,9 @@ import {
   type BlockTypeId,
 } from './block-types';
 import { parsePath, hopsToPath, getByPath, setByPath } from '../inspectors/PageBlockInspector';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, PreviewModeProvider } from '@object-ui/react';
 import { PreviewErrorBoundary } from './PreviewShell';
-
-/** Overlay form types (`drawer` / `modal`) render their body through a portal
- *  as a modal Sheet/Dialog. On the canvas that portal escapes the
- *  `pointer-events-none` click-trap below and — because Radix sets
- *  `pointer-events:none` on <body> and traps focus while open — locks the whole
- *  designer, which reads as "frozen". We coerce them to an inline `simple` form
- *  so the field layout shows in place, mirroring ViewPreview. The saved metadata
- *  keeps its real formType. */
-const OVERLAY_FORM_TYPES = new Set(['drawer', 'modal']);
+import { isOverlayFormType } from './form-preview';
 
 /** Build the schema handed to SchemaRenderer, neutralising overlay form types so
  *  a live form block never mounts a modal over the design canvas. SchemaRenderer
@@ -61,7 +53,7 @@ export function toCanvasSchema(block: Block): Record<string, unknown> {
     ? (schema.properties as Record<string, unknown>)
     : undefined;
   const formType = (props?.formType ?? schema.formType) as unknown;
-  if (typeof formType === 'string' && OVERLAY_FORM_TYPES.has(formType)) {
+  if (isOverlayFormType(formType)) {
     if (props) schema.properties = { ...props, formType: 'simple' };
     if ('formType' in schema) schema.formType = 'simple';
   }
@@ -76,7 +68,9 @@ function BlockLivePreview({ block, maxHeightClass = 'max-h-72' }: { block: Block
   return (
     <div className={cn('pointer-events-none select-none overflow-hidden p-3', maxHeightClass)}>
       <PreviewErrorBoundary fallbackHint={`"${typeStr}" can't render with its current configuration — check its Properties.`}>
-        <SchemaRenderer schema={toCanvasSchema(block) as never} />
+        <PreviewModeProvider>
+          <SchemaRenderer schema={toCanvasSchema(block) as never} />
+        </PreviewModeProvider>
       </PreviewErrorBoundary>
     </div>
   );

--- a/packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx
@@ -23,7 +23,8 @@
  */
 
 import * as React from 'react';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, PreviewModeProvider } from '@object-ui/react';
+import { toInlineFormType } from './form-preview';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewErrorBoundary, PreviewMessage } from './PreviewShell';
 import { primaryVariantBinding } from '../view-variant-model';
@@ -46,10 +47,6 @@ function resolveObjectName(
   return undefined;
 }
 
-// Form layouts that render inline. `drawer` / `modal` render as overlays that
-// need a trigger to open, so the preview coerces them to `simple` — the point
-// of the preview pane is to show the section/field layout, not the chrome.
-const INLINE_FORM_TYPES = new Set(['simple', 'tabbed', 'wizard', 'split']);
 
 // A ViewItem form section uses the spec's `{ field, readonly, … }` shape, but
 // `object-form` selects fields by `name` and reads `readOnly`. Normalize so the
@@ -70,7 +67,7 @@ function buildFormPreviewSchema(
   body: Record<string, unknown>,
 ): Record<string, unknown> {
   const rawType = typeof body.type === 'string' ? body.type : 'simple';
-  const formType = INLINE_FORM_TYPES.has(rawType) ? rawType : 'simple';
+  const formType = toInlineFormType(rawType);
   const sections = Array.isArray(body.sections)
     ? (body.sections as any[]).map((s) => ({
         ...s,
@@ -132,7 +129,7 @@ export function ViewPreview({ name, draft, editing }: MetadataPreviewProps) {
       <PreviewShell hint={`view · ${(schema as any).type}${designMode ? ' · design' : ''}`}>
         <PreviewErrorBoundary fallbackHint="The view's `type` may not be registered, or required fields are missing.">
           <div className="min-h-[300px] max-h-[75vh] overflow-auto">
-            <SchemaRenderer schema={schema as any} />
+            <PreviewModeProvider><SchemaRenderer schema={schema as any} /></PreviewModeProvider>
           </div>
         </PreviewErrorBoundary>
       </PreviewShell>
@@ -162,7 +159,7 @@ export function ViewPreview({ name, draft, editing }: MetadataPreviewProps) {
       <PreviewShell hint={`view · ${rawType} · form${designMode ? ' · design' : ''}`}>
         <PreviewErrorBoundary fallbackHint="The form view references an object or field that doesn't resolve.">
           <div className="min-h-[300px] max-h-[75vh] overflow-auto">
-            <SchemaRenderer schema={formSchema as any} />
+            <PreviewModeProvider><SchemaRenderer schema={formSchema as any} /></PreviewModeProvider>
           </div>
         </PreviewErrorBoundary>
       </PreviewShell>
@@ -193,7 +190,7 @@ export function ViewPreview({ name, draft, editing }: MetadataPreviewProps) {
     <PreviewShell hint={`view · ${defaultViewType}${designMode ? ' · design' : ''}`}>
       <PreviewErrorBoundary fallbackHint="The view references an object or field that doesn't resolve.">
         <div className="min-h-[300px] max-h-[75vh] overflow-auto">
-          <SchemaRenderer schema={schema as any} />
+          <PreviewModeProvider><SchemaRenderer schema={schema as any} /></PreviewModeProvider>
         </div>
       </PreviewErrorBoundary>
     </PreviewShell>

--- a/packages/app-shell/src/views/metadata-admin/previews/form-preview.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/form-preview.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import {
+  INLINE_FORM_TYPES,
+  OVERLAY_FORM_TYPES,
+  isOverlayFormType,
+  toInlineFormType,
+} from './form-preview';
+import { BLOCK_CONFIG } from './block-config';
+
+describe('form-preview — overlay/inline classifier', () => {
+  it('isOverlayFormType flags only drawer/modal', () => {
+    expect(isOverlayFormType('drawer')).toBe(true);
+    expect(isOverlayFormType('modal')).toBe(true);
+    for (const t of ['simple', 'tabbed', 'wizard', 'split']) {
+      expect(isOverlayFormType(t)).toBe(false);
+    }
+    expect(isOverlayFormType(undefined)).toBe(false);
+    expect(isOverlayFormType(42)).toBe(false);
+  });
+
+  it('toInlineFormType collapses overlay types to simple, passes inline through', () => {
+    expect(toInlineFormType('drawer')).toBe('simple');
+    expect(toInlineFormType('modal')).toBe('simple');
+    expect(toInlineFormType('wizard')).toBe('wizard');
+    expect(toInlineFormType('tabbed')).toBe('tabbed');
+    expect(toInlineFormType('split')).toBe('split');
+    expect(toInlineFormType('simple')).toBe('simple');
+    expect(toInlineFormType(undefined)).toBe('simple');
+    expect(toInlineFormType('nonsense')).toBe('simple');
+  });
+
+  it('inline and overlay sets never overlap', () => {
+    for (const t of OVERLAY_FORM_TYPES) expect(INLINE_FORM_TYPES.has(t)).toBe(false);
+  });
+
+  // Drift guard: every form type offered by the page inspector must be
+  // classified as exactly one of inline/overlay. Adding a new formType option
+  // to block-config without classifying it here turns this test red.
+  it('every inspector form-type option is classified exactly once', () => {
+    const field = (BLOCK_CONFIG['object-form'] || []).find((f) => f.name === 'formType') as
+      | { options?: Array<{ value: string }> }
+      | undefined;
+    const values = (field?.options ?? []).map((o) => o.value);
+    expect(values.length).toBeGreaterThan(0);
+    for (const v of values) {
+      const inline = INLINE_FORM_TYPES.has(v);
+      const overlay = OVERLAY_FORM_TYPES.has(v);
+      expect(inline !== overlay).toBe(true); // exactly one, never both/neither
+    }
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/form-preview.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/form-preview.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * form-preview — shared classifier for rendering form blocks/views on a design
+ * or preview surface (ViewPreview, the page-designer canvas).
+ *
+ * Overlay form types (`drawer` / `modal`) render their body through a portal as
+ * a modal Sheet/Dialog. On a preview canvas that overlay escapes the layout and
+ * locks the whole editor — Radix sets body `pointer-events:none` and traps focus
+ * while open — which reads as a frozen UI. Preview surfaces neutralise overlay
+ * types to an inline form before handing the schema to SchemaRenderer.
+ *
+ * This is the schema-level layer; `DrawerForm`/`ModalForm` also self-guard via
+ * `PreviewModeProvider` (rendering inline under preview), so a form rendered live
+ * can never lock the page even if a surface forgets to coerce. Keep the single
+ * source of truth here so the two preview surfaces never drift apart.
+ */
+
+/** Form types that render inline (no portalled overlay). */
+export const INLINE_FORM_TYPES = new Set(['simple', 'tabbed', 'wizard', 'split']);
+
+/** Form types that render as a portalled, page-locking overlay. */
+export const OVERLAY_FORM_TYPES = new Set(['drawer', 'modal']);
+
+/** True when `t` is a form type that would mount a page-locking overlay. */
+export function isOverlayFormType(t: unknown): boolean {
+  return typeof t === 'string' && OVERLAY_FORM_TYPES.has(t);
+}
+
+/** Map any form type to an inline one: overlay types collapse to `simple`,
+ *  inline types pass through, unknown/missing falls back to `simple`. */
+export function toInlineFormType(t: unknown): string {
+  return typeof t === 'string' && INLINE_FORM_TYPES.has(t) ? t : 'simple';
+}

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -24,7 +24,7 @@ import {
   cn,
 } from '@object-ui/components';
 
-import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
+import { SchemaRenderer, useSafeFieldLabel, usePreviewMode } from '@object-ui/react';
 import { MasterDetailForm } from './MasterDetailForm';
 import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
@@ -130,6 +130,7 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
   className,
 }) => {
   const { fieldLabel } = useSafeFieldLabel();
+  const previewMode = usePreviewMode();
   const [objectSchema, setObjectSchema] = useState<any>(null);
   const [formFields, setFormFields] = useState<FormField[]>([]);
   const [formData, setFormData] = useState<Record<string, any>>({});
@@ -425,6 +426,24 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
   ) : (
     renderContent()
   );
+
+  // Design/preview surfaces render this live on a canvas; a portalled modal Sheet
+  // would lock the whole editor (Radix sets body pointer-events:none + a focus trap
+  // while open). Render the body inline instead — a hard backstop complementing the
+  // schema-level coercion the preview surfaces apply.
+  if (previewMode) {
+    return (
+      <div className="@container rounded-md border bg-card p-4">
+        {(schema.title || schema.description) && (
+          <div className="mb-3 space-y-0.5">
+            {schema.title && <div className="text-sm font-semibold">{schema.title}</div>}
+            {schema.description && <p className="text-xs text-muted-foreground">{schema.description}</p>}
+          </div>
+        )}
+        {drawerBody}
+      </div>
+    );
+  }
 
   return (
     <Sheet open={isOpen} onOpenChange={schema.onOpenChange}>

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -32,7 +32,7 @@ import {
 import { Loader2 } from 'lucide-react';
 import { FormSection } from './FormSection';
 import { MasterDetailForm } from './MasterDetailForm';
-import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
+import { SchemaRenderer, useSafeFieldLabel, usePreviewMode } from '@object-ui/react';
 import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
 import { applyAutoLayout, inferModalSize } from './autoLayout';
@@ -154,6 +154,7 @@ export const ModalForm: React.FC<ModalFormProps> = ({
   className,
 }) => {
   const { fieldLabel } = useSafeFieldLabel();
+  const previewMode = usePreviewMode();
   const perms = usePermissions();
   // FLS gate: drop non-readable fields, disable non-editable ones.
   // Fail-open when no PermissionProvider mounted (perms.isLoaded false).
@@ -501,6 +502,25 @@ export const ModalForm: React.FC<ModalFormProps> = ({
   // render the master-detail form inside the dialog (it owns its own Save/Cancel
   // action bar, so the modal footer is suppressed). Persisted atomically.
   const subforms = (schema as any).subforms as any[] | undefined;
+  // Design/preview surfaces render this live on a canvas; a portalled modal Dialog
+  // would lock the whole editor (Radix sets body pointer-events:none + a focus trap
+  // while open). Render the form body inline instead — a hard backstop complementing
+  // the schema-level coercion the preview surfaces apply. (The master-detail line
+  // items are omitted in preview; the base field layout is what the canvas shows.)
+  if (previewMode) {
+    return (
+      <div className="@container rounded-md border bg-card p-4">
+        {(schema.title || schema.description) && (
+          <div className="mb-3 space-y-0.5">
+            {schema.title && <div className="text-sm font-semibold">{schema.title}</div>}
+            {schema.description && <p className="text-xs text-muted-foreground">{schema.description}</p>}
+          </div>
+        )}
+        {renderContent()}
+      </div>
+    );
+  }
+
   if (subforms?.length && schema.mode !== 'view') {
     return (
       <Dialog open={isOpen} onOpenChange={schema.onOpenChange}>

--- a/packages/plugin-form/src/PreviewMode.test.tsx
+++ b/packages/plugin-form/src/PreviewMode.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import { ObjectForm } from './ObjectForm';
+import { registerAllFields } from '@object-ui/fields';
+import { PreviewModeProvider } from '@object-ui/react';
+
+registerAllFields();
+afterEach(cleanup);
+
+const objectSchema = { name: 'proj', fields: { name: { type: 'text', label: 'Name' } } };
+const ds: any = {
+  getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+  findOne: vi.fn().mockResolvedValue({}),
+  create: vi.fn(),
+  update: vi.fn(),
+};
+
+// Regression guard for the designer freeze: an overlay form (drawer/modal)
+// rendered live on a preview surface must NOT mount a portalled, page-locking
+// modal. At runtime (no provider) it mounts a real dialog; under
+// PreviewModeProvider it renders inline.
+describe('Preview mode — overlay forms render inline', () => {
+  for (const formType of ['drawer', 'modal'] as const) {
+    it(`${formType}: mounts a real overlay dialog at runtime (control)`, async () => {
+      render(
+        <ObjectForm
+          schema={{ type: 'object-form', objectName: 'proj', mode: 'create', formType }}
+          dataSource={ds}
+        />,
+      );
+      await waitFor(() => expect(document.querySelector('[role="dialog"]')).toBeTruthy());
+    });
+
+    it(`${formType}: renders inline with no dialog under PreviewModeProvider`, async () => {
+      render(
+        <PreviewModeProvider>
+          <ObjectForm
+            schema={{ type: 'object-form', objectName: 'proj', mode: 'create', formType }}
+            dataSource={ds}
+          />
+        </PreviewModeProvider>,
+      );
+      // give effects a tick to resolve the object schema
+      await waitFor(() => expect(document.body.textContent).toBeDefined());
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  }
+});

--- a/packages/react/src/context/PreviewModeContext.tsx
+++ b/packages/react/src/context/PreviewModeContext.tsx
@@ -1,0 +1,41 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { createContext, useContext } from 'react';
+
+/**
+ * PreviewModeContext — signals that the subtree is rendered inside a design /
+ * metadata preview surface (the Studio canvas, a view/page preview pane) rather
+ * than a live runtime route.
+ *
+ * Overlay form components (DrawerForm, ModalForm) consume this to render their
+ * body inline instead of mounting a portalled modal Sheet/Dialog. A modal in a
+ * preview escapes the canvas and locks the whole editor — Radix sets body
+ * `pointer-events:none` and traps focus while open — which reads as a frozen UI.
+ *
+ * Defaults to `false`, so live runtime usage (record pages, action modals,
+ * the field/object designers) is completely unaffected.
+ */
+const PreviewModeContext = createContext<boolean>(false);
+
+export const PreviewModeProvider = ({
+  value = true,
+  children,
+}: {
+  value?: boolean;
+  children: React.ReactNode;
+}) => (
+  <PreviewModeContext.Provider value={value}>
+    {children}
+  </PreviewModeContext.Provider>
+);
+
+/** True when rendering inside a design / preview surface. Safe outside a provider. */
+export const usePreviewMode = (): boolean => useContext(PreviewModeContext);
+
+export { PreviewModeContext };

--- a/packages/react/src/context/index.ts
+++ b/packages/react/src/context/index.ts
@@ -1,4 +1,5 @@
 export * from './SchemaRendererContext';
+export * from './PreviewModeContext';
 export * from './ActionContext';
 export * from './ThemeContext';
 export * from './NotificationContext';


### PR DESCRIPTION
Follow-up hardening to #1840. Two layers so a form rendered live on any preview surface can't mount a page-locking modal: (1) a shared inline/overlay form-type classifier (previews/form-preview.ts) used by both ViewPreview and PageBlockCanvas; (2) a PreviewModeContext so DrawerForm/ModalForm render inline under a PreviewModeProvider (hard backstop; runtime unaffected, defaults false). Tests: form-preview.test.ts (classifier + drift guard) and PreviewMode.test.tsx (drawer/modal mount a dialog at runtime, render inline with no dialog under the provider). plugin-form (134) and app-shell/previews (121) suites green; @object-ui/react type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)