### PR TITLE
fix(i18n): add missing console login keys (signingIn, ssoHandoff)

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1356,6 +1356,8 @@ const en = {
       submittingButton: 'Signing in...',
       noAccountText: "Don't have an account?",
       signUpText: 'Sign up',
+      signingIn: 'Signing you in…',
+      ssoHandoff: 'Continue to {{target}}',
       errors: {
         invalidCredentials: 'Invalid email or password. Please try again.',
         emailNotVerified: 'Please verify your email address before signing in.',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1356,6 +1356,8 @@ const zh = {
       submittingButton: '登录中...',
       noAccountText: '还没有账户？',
       signUpText: '注册',
+      signingIn: '正在登录…',
+      ssoHandoff: '继续前往 {{target}}',
       errors: {
         invalidCredentials: '邮箱或密码错误，请重试。',
         emailNotVerified: '请先验证您的邮箱后再登录。',


### PR DESCRIPTION
The console LoginPage references `auth.login.signingIn` and `auth.login.ssoHandoff`, but the i18n bundles only carried `defaultValue` fallbacks — so each render logged a `[object-ui i18n] Missing translation` dev warning (surfaced during the designer option-sweep QA).

Adds both keys to `en` and `zh`, matching the in-code defaults. `ssoHandoff` keeps the `{{target}}` interpolation.

i18n suite green (150 tests, incl. key parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)