### PR TITLE
feat(studio): generic secret + dynamic-config widgets for metadata-admin SchemaForm

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/DynamicConfigWidget.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/DynamicConfigWidget.test.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { WIDGETS } from './widgets';
+
+afterEach(cleanup);
+
+const Dyn = WIDGETS['dynamic-config'];
+
+const ctx = {
+  dynamicSchemas: {
+    sqlite: { properties: { filename: { type: 'string', title: 'Filename' } }, required: ['filename'] },
+    postgres: { properties: { host: { type: 'string', title: 'Host' }, port: { type: 'number', title: 'Port' } } },
+  },
+};
+
+/**
+ * `dynamic-config` widget — renders an object field whose shape depends on a
+ * sibling field's value (`fieldSpec.dependsOn` → `context.dynamicSchemas[value]`).
+ */
+describe('dynamic-config widget', () => {
+  it('is registered in the WIDGETS map', () => {
+    expect(Dyn).toBeTypeOf('function');
+  });
+
+  it('prompts to select the parent when the dependency is unset', () => {
+    render(<Dyn value={{}} onChange={() => {}} schema={{ type: 'object' }} fieldSpec={{ field: 'config', dependsOn: 'driver' }} formData={{}} context={ctx} />);
+    expect(screen.getByText(/Select driver to configure/i)).toBeInTheDocument();
+  });
+
+  it('renders the sub-schema fields for the chosen parent value and merges edits', () => {
+    const onChange = vi.fn();
+    render(<Dyn value={{}} onChange={onChange} schema={{ type: 'object' }} fieldSpec={{ field: 'config', dependsOn: 'driver' }} formData={{ driver: 'sqlite' }} context={ctx} />);
+    const input = screen.getByLabelText('Filename') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '/tmp/x.db' } });
+    expect(onChange).toHaveBeenLastCalledWith({ filename: '/tmp/x.db' });
+  });
+
+  it('renders different fields when the parent value changes', () => {
+    render(<Dyn value={{}} onChange={() => {}} schema={{ type: 'object' }} fieldSpec={{ field: 'config', dependsOn: 'driver' }} formData={{ driver: 'postgres' }} context={ctx} />);
+    expect(screen.getByLabelText('Host')).toBeInTheDocument();
+    expect(screen.getByLabelText('Port')).toBeInTheDocument();
+  });
+
+  it('shows a no-config message for an unknown parent value', () => {
+    render(<Dyn value={{}} onChange={() => {}} schema={{ type: 'object' }} fieldSpec={{ field: 'config', dependsOn: 'driver' }} formData={{ driver: 'memory' }} context={ctx} />);
+    expect(screen.getByText(/No configuration needed/i)).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/DynamicConfigWidget.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/DynamicConfigWidget.test.tsx
@@ -43,6 +43,14 @@ describe('dynamic-config widget', () => {
     expect(screen.getByLabelText('Port')).toBeInTheDocument();
   });
 
+  it('renders a credential sub-field (format:password) via the masked secret input', () => {
+    const ctxPw = { dynamicSchemas: { mysql: { properties: { password: { type: 'string', title: 'Password', format: 'password' } } } } };
+    render(<Dyn value={{}} onChange={() => {}} schema={{ type: 'object' }} fieldSpec={{ field: 'config', dependsOn: 'driver' }} formData={{ driver: 'mysql' }} context={ctxPw} />);
+    // SecretWidget exposes a reveal toggle + the masked input.
+    expect(screen.getByLabelText('Secret value')).toHaveAttribute('type', 'password');
+    expect(screen.getByLabelText('Reveal value')).toBeInTheDocument();
+  });
+
   it('shows a no-config message for an unknown parent value', () => {
     render(<Dyn value={{}} onChange={() => {}} schema={{ type: 'object' }} fieldSpec={{ field: 'config', dependsOn: 'driver' }} formData={{ driver: 'memory' }} context={ctx} />);
     expect(screen.getByText(/No configuration needed/i)).toBeInTheDocument();

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -327,6 +327,27 @@ function detectConditionWidget(name: string, schema: JsonSchema | undefined): st
   return undefined;
 }
 
+const SECRET_FIELD_NAME_RE = /(^|_)(secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|credential|private[_-]?key|passphrase)$/i;
+/**
+ * Detect a write-only credential field → the masked `secret` widget. The
+ * reliable signals are `format: 'password'` (driver configSchemas use this) and
+ * JSON-Schema `writeOnly: true`; a conservative NAME CONVENTION (secret / token
+ * / apiKey / accessKey / clientSecret / credential / privateKey / passphrase)
+ * is the secondary cue. So credential fields render masked + write-only on every
+ * metadata type, without each spec pinning `widget: 'secret'`. Bare `password`
+ * is intentionally NOT matched here (auth owns that field, one-way hashed).
+ */
+function detectSecretWidget(name: string, schema: JsonSchema | undefined): string | undefined {
+  if (schema?.format === 'password' || (schema as { writeOnly?: boolean } | undefined)?.writeOnly === true) return 'secret';
+  if (Array.isArray(schema?.enum)) return undefined;
+  const isString =
+    schema?.type === 'string' ||
+    (Array.isArray(schema?.anyOf) && (schema!.anyOf as JsonSchema[]).some((b) => b?.type === 'string'));
+  if (!isString) return undefined;
+  if (SECRET_FIELD_NAME_RE.test(name)) return 'secret';
+  return undefined;
+}
+
 /* -------------------------------------------------------------------------- */
 /* FormView spec (subset)                                                     */
 /* -------------------------------------------------------------------------- */
@@ -788,14 +809,18 @@ function FieldRow({
     const refWidget = detectFieldRefWidget(name, schema, widgetContext);
     if (refWidget) widget = refWidget;
     else {
-      const iconWidget = detectIconWidget(name, schema);
-      if (iconWidget) widget = iconWidget;
+      const secretWidget = detectSecretWidget(name, schema);
+      if (secretWidget) widget = secretWidget;
       else {
-        const colorWidget = detectColorWidget(name, schema);
-        if (colorWidget) widget = colorWidget;
+        const iconWidget = detectIconWidget(name, schema);
+        if (iconWidget) widget = iconWidget;
         else {
-          const condWidget = detectConditionWidget(name, schema);
-          if (condWidget) widget = condWidget;
+          const colorWidget = detectColorWidget(name, schema);
+          if (colorWidget) widget = colorWidget;
+          else {
+            const condWidget = detectConditionWidget(name, schema);
+            if (condWidget) widget = condWidget;
+          }
         }
       }
     }

--- a/packages/app-shell/src/views/metadata-admin/SecretWidget.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SecretWidget.test.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { WIDGETS, SECRET_MASK } from './widgets';
+
+afterEach(cleanup);
+
+const Secret = WIDGETS['secret'];
+
+/**
+ * `secret` widget — write-only/masked credential input for `secret` field types
+ * and `format: 'password'` props. A stored secret reads back as SECRET_MASK, so
+ * the box starts empty (keep-on-blank); typing replaces; Clear removes.
+ */
+describe('secret widget', () => {
+  it('is registered in the WIDGETS map', () => {
+    expect(Secret).toBeTypeOf('function');
+  });
+
+  it('renders an empty password input for a new (unset) secret and emits typed value', () => {
+    const onChange = vi.fn();
+    render(<Secret value={undefined} onChange={onChange} schema={{ type: 'string', format: 'password' }} />);
+    const input = screen.getByLabelText('Secret value') as HTMLInputElement;
+    expect(input).toHaveAttribute('type', 'password');
+    expect(input.value).toBe('');
+    fireEvent.change(input, { target: { value: 'hunter2' } });
+    expect(onChange).toHaveBeenLastCalledWith('hunter2');
+  });
+
+  it('starts blank for a stored secret and keeps it (emits SECRET_MASK) when left blank', () => {
+    const onChange = vi.fn();
+    render(<Secret value={SECRET_MASK} onChange={onChange} schema={{ type: 'string', format: 'password' }} />);
+    const input = screen.getByLabelText('Secret value') as HTMLInputElement;
+    expect(input.value).toBe('');
+    // type then clear back to blank → keep (no-op write)
+    fireEvent.change(input, { target: { value: 'x' } });
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange).toHaveBeenLastCalledWith(SECRET_MASK);
+  });
+
+  it('exposes a Clear action for a stored secret that emits null', () => {
+    const onChange = vi.fn();
+    render(<Secret value={SECRET_MASK} onChange={onChange} schema={{ type: 'string' }} />);
+    fireEvent.click(screen.getByText('Clear'));
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('toggles reveal between password and text', () => {
+    render(<Secret value={undefined} onChange={() => {}} schema={{ type: 'string' }} />);
+    const input = screen.getByLabelText('Secret value');
+    expect(input).toHaveAttribute('type', 'password');
+    fireEvent.click(screen.getByLabelText('Reveal value'));
+    expect(input).toHaveAttribute('type', 'text');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -1782,15 +1782,20 @@ function DynamicConfigWidget({ value, onChange, readOnly, fieldSpec, formData, c
         return (
           <div key={key} className="space-y-1">
             <Label className="text-xs">{label}{isReq ? ' *' : ''}</Label>
-            <Input
-              type={isSecret ? 'password' : isNum ? 'number' : 'text'}
-              value={cur != null ? String(cur) : ''}
-              disabled={readOnly}
-              autoComplete={isSecret ? 'off' : undefined}
-              aria-label={label}
-              onChange={(e) => setKey(key, isNum ? (e.target.value === '' ? undefined : Number(e.target.value)) : e.target.value)}
-              className="h-8 text-sm"
-            />
+            {isSecret ? (
+              // Credential sub-field → reuse the masked/keep/reveal secret input
+              // so a config password (e.g. postgres) behaves like any secret field.
+              <SecretWidget value={cur} onChange={(v) => setKey(key, v)} readOnly={readOnly} schema={p as Record<string, any>} />
+            ) : (
+              <Input
+                type={isNum ? 'number' : 'text'}
+                value={cur != null ? String(cur) : ''}
+                disabled={readOnly}
+                aria-label={label}
+                onChange={(e) => setKey(key, isNum ? (e.target.value === '' ? undefined : Number(e.target.value)) : e.target.value)}
+                className="h-8 text-sm"
+              />
+            )}
             {(p as any)?.description && <p className="text-[11px] text-muted-foreground">{(p as any).description}</p>}
           </div>
         );

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -41,7 +41,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@object-ui/components';
-import { ChevronDown, ChevronsUpDown, ChevronUp, Plus, Search, Trash2 } from 'lucide-react';
+import { ChevronDown, ChevronsUpDown, ChevronUp, Eye, EyeOff, Plus, Search, Trash2 } from 'lucide-react';
 // @ts-ignore - lucide-react has no `exports` field; subpath types live alongside dynamic.mjs
 import { iconNames } from 'lucide-react/dynamic.mjs';
 import { detectLocale, t, tFormat } from './i18n';
@@ -78,6 +78,13 @@ export interface WidgetContext {
   objectActions?: Array<{ name: string; label?: string; locations?: string[] }>;
   /** Loading flag for the action catalog. */
   objectActionsLoading?: boolean;
+  /**
+   * Per-value sub-schemas for the `dynamic-config` widget: a map from a parent
+   * field's value (e.g. the chosen driver id) to the JSON-Schema describing the
+   * config object for that value. Lets a single `config` field render different
+   * fields depending on a sibling selection (driver → connection settings).
+   */
+  dynamicSchemas?: Record<string, { properties?: Record<string, any>; required?: string[] }>;
 }
 
 export interface WidgetProps {
@@ -1662,6 +1669,136 @@ function ConditionWidget({ value, onChange, readOnly, context }: WidgetProps) {
   );
 }
 
+/* -------------------------------------------------------------------------- */
+/* secret — write-only / masked credential input (encrypt-on-write fields)     */
+/* -------------------------------------------------------------------------- */
+
+/** Mirrors objectql\'s SECRET_MASK: a stored secret reads back as this, never plaintext. */
+export const SECRET_MASK = '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022';
+
+/**
+ * `secret` widget — a write-only credential input for `secret` field types (and
+ * `format: 'password'` / `writeOnly` props). A stored secret reads back masked,
+ * so the box starts empty with a "leave blank to keep" hint; typing replaces it,
+ * a reveal toggle shows what you type, and Clear removes it. Emits the typed
+ * value (new secret), `SECRET_MASK` (blank + existing = keep, a no-op on write),
+ * `null` (Clear), or `undefined` (blank + none).
+ */
+function SecretWidget({ value, onChange, readOnly, schema, id }: WidgetProps) {
+  const stored = value === SECRET_MASK;
+  const [reveal, setReveal] = React.useState(false);
+  const [draft, setDraft] = React.useState<string>(stored || value == null ? '' : String(value));
+  const update = (v: string) => {
+    setDraft(v);
+    if (v === '') onChange(stored ? SECRET_MASK : undefined); // blank: keep if stored, else unset
+    else onChange(v);
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        id={id}
+        type={reveal ? 'text' : 'password'}
+        value={draft}
+        disabled={readOnly}
+        autoComplete="off"
+        placeholder={stored ? (schema?.description ? '•••••••• set — type to replace' : '•••••••• set — leave blank to keep') : (typeof schema?.description === 'string' ? '' : 'Enter a value')}
+        onChange={(e) => update(e.target.value)}
+        className="h-8 text-sm font-mono"
+        aria-label="Secret value"
+      />
+      <Button type="button" variant="ghost" size="icon" className="h-8 w-8 shrink-0" disabled={readOnly} aria-label={reveal ? 'Hide value' : 'Reveal value'} onClick={() => setReveal((r) => !r)}>
+        {reveal ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+      </Button>
+      {stored && (
+        <Button type="button" variant="ghost" size="sm" className="h-8 shrink-0 text-destructive hover:text-destructive" disabled={readOnly} onClick={() => { setDraft(''); onChange(null); }}>
+          Clear
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* dynamic-config — sub-form whose schema is chosen by a sibling field value   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `dynamic-config` widget — renders an object field whose shape depends on a
+ * SIBLING field\'s value. `fieldSpec.dependsOn` names the parent field (e.g.
+ * `driver`); `context.dynamicSchemas[<parentValue>]` supplies the JSON-Schema
+ * for the config object. The canonical case is a datasource\'s `config` field
+ * that changes fields per driver, but it is generic: any "pick X → these
+ * settings" pattern can reuse it by populating `dynamicSchemas`.
+ */
+function DynamicConfigWidget({ value, onChange, readOnly, fieldSpec, formData, context }: WidgetProps) {
+  const dep = Array.isArray(fieldSpec?.dependsOn) ? fieldSpec!.dependsOn![0] : fieldSpec?.dependsOn;
+  const depVal = dep ? (formData?.[dep] as string | undefined) : undefined;
+  const sub = depVal != null ? context?.dynamicSchemas?.[String(depVal)] : undefined;
+  const props = (sub?.properties ?? {}) as Record<string, any>;
+  const required = new Set<string>(sub?.required ?? []);
+  const cfg = (value && typeof value === 'object' ? (value as Record<string, unknown>) : {}) as Record<string, unknown>;
+  const setKey = (k: string, v: unknown) => {
+    const next = { ...cfg };
+    if (v === undefined || v === '') delete next[k]; else next[k] = v;
+    onChange(next);
+  };
+
+  if (!depVal) {
+    return <p className="text-xs text-muted-foreground">Select {dep ?? 'an option'} to configure.</p>;
+  }
+  if (!sub || Object.keys(props).length === 0) {
+    return <p className="text-xs text-muted-foreground">No configuration needed for "{String(depVal)}".</p>;
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-border/60 p-3">
+      {Object.entries(props).map(([key, p]) => {
+        const label = (p as any)?.title || key;
+        const cur = cfg[key];
+        const isReq = required.has(key);
+        if ((p as any)?.type === 'boolean') {
+          return (
+            <div key={key} className="flex items-center justify-between gap-2">
+              <Label className="text-xs">{label}</Label>
+              <Switch checked={Boolean(cur)} disabled={readOnly} onCheckedChange={(c) => setKey(key, c)} />
+            </div>
+          );
+        }
+        if (Array.isArray((p as any)?.enum)) {
+          return (
+            <div key={key} className="space-y-1">
+              <Label className="text-xs">{label}{isReq ? ' *' : ''}</Label>
+              <Select value={cur != null ? String(cur) : ''} onValueChange={(v) => setKey(key, v)} disabled={readOnly}>
+                <SelectTrigger className="h-8" aria-label={label}><SelectValue placeholder="Select…" /></SelectTrigger>
+                <SelectContent>
+                  {((p as any).enum as unknown[]).map((o) => <SelectItem key={String(o)} value={String(o)}>{String(o)}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+          );
+        }
+        const isSecret = (p as any)?.format === 'password' || (p as any)?.writeOnly === true;
+        const isNum = (p as any)?.type === 'number' || (p as any)?.type === 'integer';
+        return (
+          <div key={key} className="space-y-1">
+            <Label className="text-xs">{label}{isReq ? ' *' : ''}</Label>
+            <Input
+              type={isSecret ? 'password' : isNum ? 'number' : 'text'}
+              value={cur != null ? String(cur) : ''}
+              disabled={readOnly}
+              autoComplete={isSecret ? 'off' : undefined}
+              aria-label={label}
+              onChange={(e) => setKey(key, isNum ? (e.target.value === '' ? undefined : Number(e.target.value)) : e.target.value)}
+              className="h-8 text-sm"
+            />
+            {(p as any)?.description && <p className="text-[11px] text-muted-foreground">{(p as any).description}</p>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export const WIDGETS: Record<string, WidgetRenderer> = {
   'ref:object': RefObjectWidget,
   'filter-mode': FilterModeWidget,
@@ -1679,6 +1816,8 @@ export const WIDGETS: Record<string, WidgetRenderer> = {
   'string-tags': StringTagsWidget,
   'multiselect': MultiSelectWidget,
   'code': CodeWidget,
+  'secret': SecretWidget,
+  'dynamic-config': DynamicConfigWidget,
 };
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## What
Two reusable widgets for the metadata-admin `SchemaForm`, so **any** metadata type gets them — finishing the secret-field GAP and generalizing the datasource driver→config form logic.

### `secret` (write-only / masked)
Credential input with reveal toggle + Clear. A stored secret reads back as `SECRET_MASK`, so the box starts empty and **blank = keep** (emits the mask, a no-op write); typing replaces; Clear emits `null`. Auto-detected by `format: 'password'` / `writeOnly`, or a conservative name convention (secret/token/apiKey/accessKey/clientSecret/credential/privateKey/passphrase). Bare `password` is intentionally **excluded** (auth owns that, one-way hashed).

### `dynamic-config` (dependency-driven sub-form)
An object field whose sub-schema is chosen by a **sibling field's value**: `fieldSpec.dependsOn` → `context.dynamicSchemas[value]`. Canonical case: a datasource `config` that changes fields per driver — but it's generic ("pick X → these settings").

Both registered in `WIDGETS`; `secret` wired into the SchemaForm detection chain (priority right after field-ref). `WidgetContext` gains `dynamicSchemas`.

## Why
These were the two backlog items from the datasource-in-the-engine work: the engine couldn't render secret/credential fields or driver-dependent config generically, so datasource shipped a bespoke form. These widgets make the capability generic and reusable; datasource (and other side-effectful types) can adopt them.

## Tests
`SecretWidget` (5) + `DynamicConfigWidget` (5) green; app-shell typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)