### PR TITLE
feat(forms): declarative navigateOnSuccess + resetOnSuccess on object-form

### DIFF
--- a/.changeset/form-navigate-reset.md
+++ b/.changeset/form-navigate-reset.md
@@ -1,0 +1,19 @@
+---
+"@object-ui/plugin-form": patch
+"@object-ui/types": patch
+---
+
+feat(forms): declarative `navigateOnSuccess` + `resetOnSuccess` on object-form
+
+Rounds out declarative success behavior for metadata-only forms (which can't
+pass an `onSuccess` function), complementing `successMessage`:
+
+- **`navigateOnSuccess`** — after a successful create/update, navigate here.
+  Supports `{id}`/`{recordId}` interpolation from the saved record and is
+  same-origin-guarded; takes precedence over the toast (landing on the record
+  is the confirmation).
+- **`resetOnSuccess`** — after a successful create, reset the form for another
+  entry (the wizard returns to a cleared step 1). Ignored when navigating.
+
+Wired in both ObjectForm and WizardForm via a small shared `successBehavior`
+helper (kept dependency-free to avoid an EmbeddableForm import cycle).

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -18,6 +18,7 @@ import type { ObjectFormSchema, FormField, FormSchema, DataSource } from '@objec
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { mapFieldTypeToFormType, buildValidationRules, evaluateCondition, formatFileSize } from '@object-ui/fields';
 import { useIsMobile, toast } from '@object-ui/components';
+import { resolveSuccessNavigate } from './successBehavior';
 import { usePermissions } from '@object-ui/permissions';
 import { TabbedForm } from './TabbedForm';
 import { WizardForm } from './WizardForm';
@@ -618,6 +619,11 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
       if (schema.onSuccess) {
         await schema.onSuccess(result);
       } else if (!schema.submitHandler) {
+        const nav = resolveSuccessNavigate(schema.navigateOnSuccess, result);
+        if (nav) {
+          window.location.assign(nav);
+          return result;
+        }
         toast.success(schema.successMessage || (schema.mode === 'create' ? 'Created' : 'Saved'));
       }
 
@@ -844,7 +850,7 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     cancelLabel: schema.cancelText,
     showSubmit: schema.showSubmit !== false && schema.mode !== 'view',
     showCancel: schema.showCancel !== false,
-    resetOnSubmit: schema.showReset,
+    resetOnSubmit: schema.showReset || (schema.resetOnSuccess && schema.mode === 'create'),
     defaultValues: finalDefaultValues,
     onSubmit: handleSubmit,
     onCancel: handleCancel,

--- a/packages/plugin-form/src/WizardForm.successBehavior.test.tsx
+++ b/packages/plugin-form/src/WizardForm.successBehavior.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Declarative post-success behaviors for metadata-only wizards:
+ *   - navigateOnSuccess (interpolate {id}, same-origin, skip toast)
+ *   - resetOnSuccess (back to a cleared step 1, toast)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+const { toastSuccess } = vi.hoisted(() => ({ toastSuccess: vi.fn() }));
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, toast: { ...actual.toast, success: toastSuccess, error: vi.fn() } };
+});
+
+import { WizardForm } from './WizardForm';
+import { registerAllFields } from '@object-ui/fields';
+
+registerAllFields();
+
+const objectSchema = {
+  name: 'o',
+  fields: { name: { type: 'text', label: 'Name' }, note: { type: 'text', label: 'Note' } },
+};
+const makeDS = () => ({
+  getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+  create: vi.fn(async (_o: string, d: any) => ({ id: 'r1', ...d })),
+  update: vi.fn(),
+  findOne: vi.fn(),
+});
+const waitInput = (c: HTMLElement, name: string) =>
+  waitFor(() => {
+    const el = c.querySelector(`input[name="${name}"]`) as HTMLInputElement | null;
+    if (!el) throw new Error(`${name} not ready`);
+    return el;
+  });
+
+describe('WizardForm — navigateOnSuccess', () => {
+  beforeEach(() => toastSuccess.mockClear());
+  it('navigates to the saved record (interpolated) and skips the toast', async () => {
+    const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+    const ds = makeDS();
+    const schema = {
+      type: 'object-form', formType: 'wizard', objectName: 'o', mode: 'create',
+      navigateOnSuccess: '/apps/x/o/record/{id}', sections: [{ label: 'A', fields: ['name'] }],
+    };
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+    fireEvent.change(await waitInput(container, 'name'), { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/apps/x/o/record/r1'));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    assign.mockRestore();
+  });
+});
+
+describe('WizardForm — resetOnSuccess', () => {
+  beforeEach(() => toastSuccess.mockClear());
+  it('returns to a cleared step 1 after create and toasts', async () => {
+    const ds = makeDS();
+    const schema = {
+      type: 'object-form', formType: 'wizard', objectName: 'o', mode: 'create',
+      resetOnSuccess: true,
+      sections: [{ label: 'A', fields: ['name'] }, { label: 'B', fields: ['note'] }],
+    };
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+    fireEvent.change(await waitInput(container, 'name'), { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement); // → step 2
+    fireEvent.change(await waitInput(container, 'note'), { target: { value: 'hi' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement); // → create
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+    // Reset: step 1 field is back and cleared.
+    await waitFor(() => {
+      const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+      if (!el) throw new Error('not back to step 1');
+      expect(el.value).toBe('');
+    });
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -20,6 +20,7 @@ import { Check, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import { FormSection } from './FormSection';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
+import { resolveSuccessNavigate } from './successBehavior';
 import type { FormSectionConfig } from './TabbedForm';
 
 export interface WizardFormSchema {
@@ -80,6 +81,15 @@ export interface WizardFormSchema {
    * (metadata pages cannot pass a function). Falls back to 'Created'/'Saved'.
    */
   successMessage?: string;
+
+  /** Navigate here after a successful create/update (declarative; metadata
+   * pages can't pass onSuccess). Supports `{id}`/`{recordId}` interpolation
+   * from the saved record. Same-origin-guarded. Takes precedence over the toast. */
+  navigateOnSuccess?: string;
+
+  /** Reset the wizard (back to step 1, cleared) after a successful create so the
+   * user can enter another. Ignored when `navigateOnSuccess` is set. */
+  resetOnSuccess?: boolean;
   
   /**
    * Show cancel button
@@ -177,6 +187,9 @@ export const WizardForm: React.FC<WizardFormProps> = ({
   // accumulated record actually reaches the server. Without this the create
   // POST body was `{}` and the server rejected all required fields.
   const stepFormId = React.useId();
+  // Bumped on resetOnSuccess to force the inner step form to remount fresh
+  // (it's otherwise reused across steps so back/forward retains values).
+  const [resetNonce, setResetNonce] = useState(0);
   // Seed `formData` only once. The data-loading effect below depends on
   // `dataSource`/`objectSchema`, whose identity can churn across renders;
   // re-running its create-mode branch would `setFormData({})` mid-wizard and
@@ -284,9 +297,21 @@ export const WizardForm: React.FC<WizardFormProps> = ({
         if (schema.onSuccess) {
           await schema.onSuccess(result);
         } else {
-          // Default feedback so a metadata-only wizard (which cannot pass an
-          // onSuccess function) still confirms the create/update succeeded.
+          // Declarative success behaviors for metadata-only wizards.
+          const nav = resolveSuccessNavigate(schema.navigateOnSuccess, result);
+          if (nav) {
+            // Landing on the saved record is the confirmation — no toast needed.
+            window.location.assign(nav);
+            return result;
+          }
           toast.success(schema.successMessage || (schema.mode === 'create' ? 'Created' : 'Saved'));
+          if (schema.resetOnSuccess && schema.mode === 'create') {
+            // Back to a fresh step 1 for the next entry.
+            setFormData({});
+            setCompletedSteps(new Set());
+            setCurrentStep(0);
+            setResetNonce((n) => n + 1);
+          }
         }
         return result;
       } catch (err) {
@@ -436,6 +461,7 @@ export const WizardForm: React.FC<WizardFormProps> = ({
           >
             {currentSectionFields.length > 0 ? (
               <SchemaRenderer
+                key={resetNonce}
                 schema={{
                   type: 'form' as const,
                   id: stepFormId,

--- a/packages/plugin-form/src/successBehavior.ts
+++ b/packages/plugin-form/src/successBehavior.ts
@@ -1,0 +1,42 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Declarative post-success behaviors shared by ObjectForm + WizardForm. A
+ * metadata-only form (authored as JSON) cannot pass an `onSuccess` function, so
+ * these let it declare what happens after a create/update: a custom toast
+ * (`successMessage`), navigate to the new record (`navigateOnSuccess`), or reset
+ * for another entry (`resetOnSuccess`).
+ *
+ * Kept dependency-free on purpose: importing the redirect guard from
+ * EmbeddableForm would create a cycle (EmbeddableForm → ObjectForm → WizardForm
+ * → here), so the same-origin check is inlined.
+ */
+
+/** Same-origin guard for declarative navigation (relative or absolute URLs). */
+function isSameOriginUrl(rawUrl: string): boolean {
+  try {
+    if (typeof window === 'undefined') return false;
+    const url = new URL(rawUrl, window.location.href);
+    return url.origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a `navigateOnSuccess` template into a safe URL: interpolate
+ * `{id}` / `{recordId}` from the created/updated record and same-origin-guard it.
+ * Returns null when there's no template, no usable id, or the URL fails the
+ * guard — callers then fall back to a toast.
+ */
+export function resolveSuccessNavigate(
+  template: string | undefined,
+  record: any,
+): string | null {
+  if (!template) return null;
+  const id = record?.id ?? record?.recordId ?? record?._id;
+  if (id == null || id === '') return null;
+  const url = template.replace(/\{(?:id|recordId)\}/g, String(id));
+  return isSameOriginUrl(url) ? url : null;
+}

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -906,6 +906,19 @@ export interface ObjectFormSchema extends BaseSchema {
    * pass a function). Falls back to 'Created' / 'Saved'.
    */
   successMessage?: string;
+
+  /**
+   * Navigate here after a successful create/update (declarative; falls back to
+   * a toast). Supports `{id}`/`{recordId}` interpolation from the saved record;
+   * same-origin-guarded. Takes precedence over `successMessage`.
+   */
+  navigateOnSuccess?: string;
+
+  /**
+   * Reset the form after a successful create so the user can enter another.
+   * Ignored when `navigateOnSuccess` is set.
+   */
+  resetOnSuccess?: boolean;
   
   /**
    * Show cancel button

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -173,6 +173,8 @@ export const ObjectFormSchema = BaseSchema.extend({
   showSubmit: z.boolean().optional().describe('Show submit button'),
   submitText: z.string().optional().describe('Submit button text'),
   successMessage: z.string().optional().describe('Success toast text after create/update when no onSuccess handler is given'),
+  navigateOnSuccess: z.string().optional().describe('Navigate here after success ({id}/{recordId} interpolated, same-origin-guarded); precedes the toast'),
+  resetOnSuccess: z.boolean().optional().describe('Reset the form after a successful create for another entry'),
   showCancel: z.boolean().optional().describe('Show cancel button'),
   cancelText: z.string().optional().describe('Cancel button text'),
   showReset: z.boolean().optional().describe('Show reset button'),


### PR DESCRIPTION
Completes the declarative success behaviors for **metadata-only** forms (which can't pass an `onSuccess` function), alongside `successMessage` (#1848). Closes the form half of #1849.

### Added (on `ObjectFormSchema`)
- **`navigateOnSuccess?: string`** — after a successful create/update, navigate here. `{id}`/`{recordId}` are interpolated from the saved record; the URL is same-origin-guarded. Takes precedence over the toast (landing on the new record *is* the confirmation).
- **`resetOnSuccess?: boolean`** — after a successful create, reset the form for another entry. The wizard returns to a **cleared step 1** (via a remount nonce, since the step form is otherwise reused across steps to retain back/forward values). Ignored when `navigateOnSuccess` is set.

### Implementation
Both wired in `ObjectForm` and `WizardForm` via a small shared `successBehavior.ts` helper, kept **dependency-free** on purpose (importing the redirect guard from `EmbeddableForm` would create a cycle `EmbeddableForm → ObjectForm → WizardForm → here`).

### Testing
`WizardForm.successBehavior.test.tsx`: navigate (interpolates `{id}`, skips toast) + reset (returns to cleared step 1, toasts). Full plugin-form form suite green on a clean base (ObjectForm.test.tsx + regression + successMessage + new): **12/12**.

### Not included
`onSuccess` as a function stays the runtime/host path; this only adds the declarative metadata fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)