### PR TITLE
fix(registry): silence bare-name collision warnings; keep display owners

### DIFF
--- a/packages/core/src/registry/__tests__/Registry.test.ts
+++ b/packages/core/src/registry/__tests__/Registry.test.ts
@@ -320,4 +320,69 @@ describe('Registry', () => {
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
   });
+
+  // Regression guard for the dev-console collision warnings. The real packages
+  // register a form-input/display/view/plugin component under a bare name AND a
+  // `field:`/`view:`/`plugin-markdown:` namespaced renderer that shares the same
+  // short name. The bare key must stay with the DISPLAY/UI/view owner (forms
+  // reach the field widget via the explicit `field:<type>` lookup), and no
+  // collision warning must fire. Each case below mirrors the registration order
+  // and skipFallback flags used by the shipping code.
+  describe('bare-name ownership for field vs display/view/plugin collisions', () => {
+    // [bareName, sequence in registration order]. The LAST entry whose
+    // skipFallback is falsy owns the bare key; `owner` asserts the intended one.
+    const CASES: Array<{
+      name: string;
+      owner: string; // namespace expected to own the bare key
+      seq: Array<{ ns: string; skipFallback?: boolean }>;
+    }> = [
+      // @object-ui/components registers `ui:*` first (owns bare), then
+      // @object-ui/fields registers `field:*` with skipFallback.
+      { name: 'textarea', owner: 'ui', seq: [{ ns: 'ui' }, { ns: 'field', skipFallback: true }] },
+      { name: 'select', owner: 'ui', seq: [{ ns: 'ui' }, { ns: 'field', skipFallback: true }] },
+      { name: 'email', owner: 'ui', seq: [{ ns: 'ui' }, { ns: 'field', skipFallback: true }] },
+      { name: 'password', owner: 'ui', seq: [{ ns: 'ui' }, { ns: 'field', skipFallback: true }] },
+      { name: 'slider', owner: 'ui', seq: [{ ns: 'ui' }, { ns: 'field', skipFallback: true }] },
+      // The bullet-list display primitive owns bare `list`; the data ListView is
+      // a namespaced-only `view:list` alias.
+      { name: 'list', owner: 'ui', seq: [{ ns: 'ui' }, { ns: 'view', skipFallback: true }] },
+      // The markdown editor field registers first (skipFallback), then the
+      // markdown DISPLAY plugin claims the bare key.
+      { name: 'markdown', owner: 'plugin-markdown', seq: [{ ns: 'field', skipFallback: true }, { ns: 'plugin-markdown' }] },
+    ];
+
+    for (const { name, owner, seq } of CASES) {
+      it(`bare "${name}" resolves to the "${owner}" owner with no collision warning`, () => {
+        const components: Record<string, () => string> = {};
+        for (const { ns, skipFallback } of seq) {
+          const component = () => `${ns}:${name}`;
+          components[ns] = component;
+          registry.register(name, component, { namespace: ns, skipFallback });
+        }
+
+        // Bare key resolves to the intended display/view/plugin owner.
+        expect(registry.get(name)).toBe(components[owner]);
+        // Every namespaced renderer remains reachable via its explicit key —
+        // this is the lookup forms use (`field:<type>`), so they are unaffected.
+        for (const { ns } of seq) {
+          expect(registry.get(name, ns)).toBe(components[ns]);
+        }
+        // No "bare-name fallback is being overwritten" warning.
+        const collisionWarned = consoleWarnSpy.mock.calls.some((args: unknown[]) =>
+          typeof args[0] === 'string' && args[0].includes('bare-name fallback is being overwritten'),
+        );
+        expect(collisionWarned).toBe(false);
+      });
+    }
+
+    it('still warns if a field renderer drops skipFallback and clobbers the bare display key', () => {
+      const display = () => 'ui:textarea';
+      const field = () => 'field:textarea';
+      registry.register('textarea', display, { namespace: 'ui' });
+      // Simulate the bug this fix prevents: field:* without skipFallback.
+      registry.register('textarea', field, { namespace: 'field' });
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      expect(registry.get('textarea')).toBe(field); // bare clobbered (the regression)
+    });
+  });
 });

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1980,16 +1980,31 @@ const fieldWidgetMap: Record<string, () => Promise<{ default: React.ComponentTyp
  * // Register only the text field
  * registerField('text');
  */
-// Field types whose short name collides with a display widget in
-// @object-ui/components. These remain accessible via the namespaced
-// `field:<type>` key, but should not overwrite the bare `<type>` fallback
-// (which the display widget owns and which most schemas expect).
+// Field types whose short name collides with a display/ui/view/plugin component
+// registered elsewhere (e.g. the display widgets and form-input primitives in
+// @object-ui/components, or the markdown display plugin). These remain
+// accessible via the namespaced `field:<type>` key — which is how forms resolve
+// them (see form.tsx renderFieldComponent + mapFieldTypeToFormType) — but must
+// not overwrite the bare `<type>` fallback, which the display/ui primitive owns
+// and which page schemas expect (e.g. `{ type: 'markdown', content }` → the
+// markdown renderer, not the RichText editor). Without skipFallback each of
+// these logged a "bare-name fallback is being overwritten" warning at boot.
 const FIELD_TYPES_SKIP_FALLBACK = new Set([
+  // Display widgets (text/html/image/avatar/grid live in @object-ui/components
+  // or @object-ui/layout as the bare-name owners).
   'text',
   'html',
   'image',
   'avatar',
   'grid',
+  // Form-input primitives owned by `ui:*` in @object-ui/components.
+  'textarea',
+  'select',
+  'email',
+  'password',
+  'slider',
+  // Display renderer owned by `plugin-markdown:markdown`.
+  'markdown',
 ]);
 
 export function registerField(fieldType: string): void {
@@ -2037,24 +2052,33 @@ export function registerFields() {
   // only via the namespaced `field:text` key and let the display widget win
   // the bare `text` lookup.
   ComponentRegistry.register('text', createFieldRenderer(TextField), { namespace: 'field', skipFallback: true });
-  ComponentRegistry.register('textarea', createFieldRenderer(TextAreaField), { namespace: 'field' });
+  // `textarea`/`select` collide with the `ui:*` form-input primitives that own
+  // the bare keys; namespaced-only (forms use `field:<type>`). See the shared
+  // FIELD_TYPES_SKIP_FALLBACK note above registerField().
+  ComponentRegistry.register('textarea', createFieldRenderer(TextAreaField), { namespace: 'field', skipFallback: true });
   ComponentRegistry.register('number', createFieldRenderer(NumberField), { namespace: 'field' });
   ComponentRegistry.register('boolean', createFieldRenderer(BooleanField), { namespace: 'field' });
-  ComponentRegistry.register('select', createFieldRenderer(SelectField), { namespace: 'field' });
+  ComponentRegistry.register('select', createFieldRenderer(SelectField), { namespace: 'field', skipFallback: true });
   ComponentRegistry.register('date', createFieldRenderer(DateField), { namespace: 'field' });
   ComponentRegistry.register('datetime', createFieldRenderer(DateTimeField), { namespace: 'field' });
   ComponentRegistry.register('time', createFieldRenderer(TimeField), { namespace: 'field' });
   
   // Contact fields - wrapped for documentation compatibility
-  ComponentRegistry.register('email', createFieldRenderer(EmailField), { namespace: 'field' });
+  // `email` collides with the `ui:email` input variant; namespaced-only so the
+  // display/input primitive keeps the bare key (forms use `field:email`).
+  ComponentRegistry.register('email', createFieldRenderer(EmailField), { namespace: 'field', skipFallback: true });
   ComponentRegistry.register('phone', createFieldRenderer(PhoneField), { namespace: 'field' });
   ComponentRegistry.register('url', createFieldRenderer(UrlField), { namespace: 'field' });
   
   // Specialized fields - wrapped for documentation compatibility
   ComponentRegistry.register('currency', createFieldRenderer(CurrencyField), { namespace: 'field' });
   ComponentRegistry.register('percent', createFieldRenderer(PercentField), { namespace: 'field' });
-  ComponentRegistry.register('password', createFieldRenderer(PasswordField), { namespace: 'field' });
-  ComponentRegistry.register('markdown', createFieldRenderer(RichTextField), { namespace: 'field' });
+  // `password` collides with the `ui:password` input variant; namespaced-only.
+  ComponentRegistry.register('password', createFieldRenderer(PasswordField), { namespace: 'field', skipFallback: true });
+  // `markdown` collides with the markdown DISPLAY renderer (plugin-markdown:markdown),
+  // which owns bare `{ type: 'markdown', content }`; the field renderer here is the
+  // RichText editor, reached by forms via `field:markdown`. Namespaced-only.
+  ComponentRegistry.register('markdown', createFieldRenderer(RichTextField), { namespace: 'field', skipFallback: true });
   // `html` collides with the HTML-rendering display widget. Keep the
   // markdown field, but expose the HTML field only via `field:html` so the
   // display widget remains the default for { type: 'html', content }.
@@ -2089,7 +2113,8 @@ export function registerFields() {
   
   // NEW: Additional field types from @objectstack/spec
   ComponentRegistry.register('color', createFieldRenderer(ColorField), { namespace: 'field' });
-  ComponentRegistry.register('slider', createFieldRenderer(SliderField), { namespace: 'field' });
+  // `slider` collides with the `ui:slider` display control; namespaced-only.
+  ComponentRegistry.register('slider', createFieldRenderer(SliderField), { namespace: 'field', skipFallback: true });
   ComponentRegistry.register('rating', createFieldRenderer(RatingField), { namespace: 'field' });
   ComponentRegistry.register('code', createFieldRenderer(CodeField), { namespace: 'field' });
   // `avatar` collides with the display avatar widget; namespaced-only.

--- a/packages/plugin-list/src/index.tsx
+++ b/packages/plugin-list/src/index.tsx
@@ -54,9 +54,18 @@ ComponentRegistry.register('list-view', ListView, {
   }
 });
 
-// Alias for generic view
+// Alias for generic view, exposed only as `view:list`.
+//
+// `skipFallback` is required: the bare `list` key belongs to the bullet/numbered
+// list DISPLAY primitive (`ui:list` in @object-ui/components), used by page
+// schemas like `{ type: 'list', items: [...] }`. Without skipFallback this alias
+// clobbered the bare key, so a hand-authored bullet list resolved to the
+// data-bound ListView (which requires `objectName`) instead. Object list VIEWS
+// are rendered via `type: 'list-view'`, never the bare `list` lookup, so the
+// data view loses nothing by yielding the bare key.
 ComponentRegistry.register('list', ListView, {
   namespace: 'view',
+  skipFallback: true,
   category: 'view',
   label: 'List',
   icon: 'LayoutList',


### PR DESCRIPTION
## Problem

The dev console logged a batch of `bare-name fallback is being overwritten` warnings on every boot, for `textarea`, `select`, `email`, `password`, `slider` (overwritten by `field:*`), `list` (by `view:list`), and `markdown` (by `plugin-markdown:markdown`).

The warning fires (`packages/core/src/registry/Registry.ts:145`) when a namespaced registration claims a bare-name fallback already owned by a *different* component. Several form-field renderers in `@object-ui/fields` and the `view:list` alias in `@object-ui/plugin-list` were clobbering bare keys owned by the display/ui primitives.

## Decision

Object **forms** resolve field widgets via an explicit `field:<type>` lookup (`form.tsx` `renderFieldComponent` + `mapFieldTypeToFormType`), so the field renderers never need the bare fallback. List **views** render via `type: 'list-view'`, never the bare `list`. So the bare keys belong to the display/ui/view/plugin primitives — exactly the convention already applied to `text`/`html`/`image`/`grid`/`avatar`.

| bare name | now resolves to |
|---|---|
| textarea, select, email, password, slider | `ui:*` (form-input primitives) |
| markdown | `plugin-markdown:markdown` (display renderer) |
| list | `ui:list` (bullet/numbered list) |

## Changes

- **`packages/fields/src/index.tsx`** — add the six names to `FIELD_TYPES_SKIP_FALLBACK` (the real registration path via `registerField()`); the deprecated `registerFields()` is kept consistent.
- **`packages/plugin-list/src/index.tsx`** — `skipFallback: true` on the `view:list` alias.
- **`packages/core/src/registry/__tests__/Registry.test.ts`** — table-driven test asserting each bare name resolves to its intended owner with no collision warning, plus a regression guard.

Also fixes a **latent bug**: a page schema `{ type: 'list', items: [...] }` (e.g. schema-catalog `basic-list.json`) previously resolved to the data-bound `ListView` (which needs `objectName`) instead of a bullet list.

## Verification

- Registry unit tests: 89/89 pass.
- Browser (managed preview against live backend): dev console logs **zero** collision warnings after the fix (previously all 7 at boot).
- Live registry singleton (full app booted, 518 types) confirms each bare name resolves to its intended owner and every `field:*` key forms depend on is intact.
- Confirmed no impact on the framework `app-showcase`: `type: 'list'` pages there are ADR-0047 interface pages (`interfaceConfig.source` set → `InterfaceListPage` → `list-view`), and `type: 'select'` is a form field — both bypass the bare-name lookup. Docs (`data-display/list`, `plugin-markdown`) and skills already describe the now-correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)