### PR TITLE
refactor(fields): migrate CurrencyField to the shared currency resolver

### DIFF
--- a/packages/fields/src/currency.ts
+++ b/packages/fields/src/currency.ts
@@ -1,0 +1,30 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Licensed under the MIT license found in the LICENSE file.
+ */
+
+/**
+ * Resolve the display currency code for a currency field, in precedence order:
+ * the field's explicit `currency` → its `currencyConfig.defaultCurrency` (fixed
+ * mode) → a legacy top-level `defaultCurrency` → the tenant default
+ * (`localization.currency`, ADR-0053). Returns `undefined` when none is known,
+ * so the renderer shows a plain number rather than guessing a symbol.
+ *
+ * This is the single resolution the field renderers share — ending the
+ * per-renderer inconsistency where some read only `currency`, others only
+ * `defaultCurrency`, and others `currencyConfig`.
+ */
+export function resolveFieldCurrency(
+  field: { currency?: string; defaultCurrency?: string; currencyConfig?: { defaultCurrency?: string } } | null | undefined,
+  tenantDefault?: string,
+): string | undefined {
+  return (
+    field?.currency ||
+    field?.currencyConfig?.defaultCurrency ||
+    field?.defaultCurrency ||
+    tenantDefault ||
+    undefined
+  );
+}

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -267,29 +267,8 @@ export function coerceToSafeValue(value: unknown): string | number | boolean | n
  * Trailing `.00` is dropped when the value is a whole number — Salesforce
  * convention: `$1,234.50` keeps cents; `$1,234` does not.
  */
-/**
- * Resolve the display currency code for a currency field, in precedence order:
- * the field's explicit `currency` → its `currencyConfig.defaultCurrency` (fixed
- * mode) → a legacy top-level `defaultCurrency` → the tenant default
- * (`localization.currency`, ADR-0053). Returns `undefined` when none is known,
- * so the renderer shows a plain number rather than guessing a symbol.
- *
- * This is the single resolution the field renderers share — ending the
- * per-renderer inconsistency where some read only `currency`, others only
- * `defaultCurrency`, and others `currencyConfig`.
- */
-export function resolveFieldCurrency(
-  field: { currency?: string; defaultCurrency?: string; currencyConfig?: { defaultCurrency?: string } } | null | undefined,
-  tenantDefault?: string,
-): string | undefined {
-  return (
-    field?.currency ||
-    field?.currencyConfig?.defaultCurrency ||
-    field?.defaultCurrency ||
-    tenantDefault ||
-    undefined
-  );
-}
+import { resolveFieldCurrency } from './currency';
+export { resolveFieldCurrency };
 
 export function formatCurrency(value: number, currency?: string): string {
   const isWhole = Number.isFinite(value) && value === Math.trunc(value);

--- a/packages/fields/src/widgets/CurrencyField.tsx
+++ b/packages/fields/src/widgets/CurrencyField.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
 import { FieldWidgetProps } from './types';
+import { useLocalization } from '@object-ui/i18n';
+import { resolveFieldCurrency } from '../currency';
 
 /**
  * Format currency value for display. When `currency` is undefined the value
@@ -36,7 +38,9 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
 
 export function CurrencyField({ value, onChange, field, readonly, errorMessage, className, ...props }: FieldWidgetProps<number>) {
   const currencyField = (field || (props as any).schema) as any;
-  const currency: string | undefined = currencyField?.currency;
+  // Shared precedence: field currency → currencyConfig → tenant default (ADR-0053).
+  const { currency: tenantCurrency } = useLocalization();
+  const currency: string | undefined = resolveFieldCurrency(currencyField, tenantCurrency);
   const precision = currencyField?.precision ?? 2;
 
   if (readonly) {


### PR DESCRIPTION
## Phase 2b migration — batch 1

Follows the foundation #1856. `CurrencyField` (currency form input + readonly display) read **only** `field.currency`, so a field declaring its currency via `currencyConfig.defaultCurrency` — or relying on the tenant default — rendered symbol-less.

- **Extract** `resolveFieldCurrency` from the ~2k-line `index.tsx` into a leaf `fields/src/currency.ts` (re-exported from index, no API change), so widget components can import it without an `index ↔ widget` circular import.
- **`CurrencyField`** now resolves via `resolveFieldCurrency(field, useLocalization().currency)` — field currency → `currencyConfig` → tenant default → plain number.

## Remaining (staged, each a small mechanical swap onto the helper)
- Same-package-deps clean: dashboard `MetricWidget`/`ObjectDataTable` (has i18n+fields).
- Need a dep added: `DetailView` (plugin-detail), `useColumnSummary` (plugin-grid, + its stale "defaults to USD" comment), `ObjectGantt`, `ObjectGrid`, `FieldFactory` (react), `elements:number` (components), `formatValue`/`PivotTable`.
- Then collapse the two divergent `formatCurrency` (i18n `en` vs fields `en-US`) into one with a single locale.

## Tests
- `resolveFieldCurrency` (4) + `standard-widgets` (18) pass; `type-check` green. No behavior change with no provider or an explicit field currency (the common case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)