### PR TITLE
fix(currency): resolve tenant default currency across long-tail renderers

### DIFF
--- a/.changeset/phase2b-currency-renderers.md
+++ b/.changeset/phase2b-currency-renderers.md
@@ -1,0 +1,33 @@
+---
+"@object-ui/i18n": patch
+"@object-ui/fields": patch
+"@object-ui/plugin-grid": patch
+"@object-ui/plugin-dashboard": patch
+"@object-ui/plugin-detail": patch
+"@object-ui/plugin-gantt": patch
+"@object-ui/components": patch
+---
+
+fix(currency): resolve the tenant default currency across the long-tail renderers
+
+Phase 2b of the currency-resolution work (ADR-0053). The cell/field renderers
+already funnelled through `resolveFieldCurrency` + `useLocalization` (#1856),
+but the rest of the renderers still hard-coded `USD` or read only one of
+`currency`/`defaultCurrency`. They now share the same resolution chain — explicit
+field currency -> `currencyConfig.defaultCurrency` -> legacy `defaultCurrency` ->
+tenant `localization.currency` -> plain number:
+
+- `plugin-dashboard` `ObjectMetricWidget` (inferred currency), `ObjectDataTable`
+  (symbol-format fallback).
+- `plugin-grid` `useColumnSummary` (footer agrees with the cells) and
+  `ObjectGrid` (compact amount + name-inferred currency cells).
+- `plugin-detail` `DetailView` summary metrics.
+- `plugin-gantt` `ObjectGantt` currency tooltips.
+- `components` `element:number` (`format: 'currency'`) — tenant default instead
+  of a baked-in `USD`, and renders with the tenant locale.
+
+`resolveFieldCurrency` now lives in `@object-ui/i18n` (co-located with
+`useLocalization`, which supplies the tenant default); `@object-ui/fields`
+re-exports it, so the existing import path is unchanged. No behavior change when
+no tenant currency is configured — a field that declares its own currency, or a
+deployment with no `localization.currency`, renders exactly as before.

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -27,7 +27,7 @@
 import * as React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { useAdapter, useAction } from '@object-ui/react';
-import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
+import { useObjectTranslation, pickLocalized, useLocalization } from '@object-ui/i18n';
 import { cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { Button, Separator } from '../../ui';
@@ -276,10 +276,23 @@ const FORMAT_OPTS: Record<string, Intl.NumberFormatOptions> = {
   percent: { style: 'percent', maximumFractionDigits: 1 },
 };
 
-function formatValue(value: number | null | undefined, format?: string, prefix?: string, suffix?: string): string {
+function formatValue(
+  value: number | null | undefined,
+  format?: string,
+  prefix?: string,
+  suffix?: string,
+  currency?: string,
+  locale?: string,
+): string {
   if (value == null || Number.isNaN(value)) return '—';
-  const opts = FORMAT_OPTS[format ?? 'number'] ?? FORMAT_OPTS.number;
-  const body = new Intl.NumberFormat(undefined, opts).format(value);
+  let opts = FORMAT_OPTS[format ?? 'number'] ?? FORMAT_OPTS.number;
+  // A `currency`-format metric resolves its ISO code from the tenant default
+  // (localization.currency, ADR-0053) instead of a baked-in USD; falls back to
+  // USD only when no tenant currency is configured.
+  if (format === 'currency') {
+    opts = { ...FORMAT_OPTS.currency, currency: currency || 'USD' };
+  }
+  const body = new Intl.NumberFormat(locale, opts).format(value);
   return `${prefix ?? ''}${body}${suffix ?? ''}`;
 }
 
@@ -295,6 +308,8 @@ function ElementNumberRenderer({ schema }: { schema: any }) {
     aria?: Record<string, any>;
   }>(schema);
   const adapter = useAdapter() as any;
+  // Tenant default currency + locale (ADR-0053) for a `currency`-format metric.
+  const { currency: tenantCurrency, locale } = useLocalization();
   const [value, setValue] = React.useState<number | null>(null);
   const [loading, setLoading] = React.useState<boolean>(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -358,7 +373,7 @@ function ElementNumberRenderer({ schema }: { schema: any }) {
   return (
     <div className={cn('flex flex-col gap-1', schema?.className)} {...ariaAttrs(props.aria)}>
       <div className="text-3xl font-semibold tracking-tight tabular-nums">
-        {loading ? '…' : formatValue(value, props.format, props.prefix, props.suffix)}
+        {loading ? '…' : formatValue(value, props.format, props.prefix, props.suffix, tenantCurrency, locale)}
       </div>
       {error && <div className="text-xs text-destructive">{error}</div>}
     </div>

--- a/packages/fields/src/currency.ts
+++ b/packages/fields/src/currency.ts
@@ -6,25 +6,9 @@
  */
 
 /**
- * Resolve the display currency code for a currency field, in precedence order:
- * the field's explicit `currency` → its `currencyConfig.defaultCurrency` (fixed
- * mode) → a legacy top-level `defaultCurrency` → the tenant default
- * (`localization.currency`, ADR-0053). Returns `undefined` when none is known,
- * so the renderer shows a plain number rather than guessing a symbol.
- *
- * This is the single resolution the field renderers share — ending the
- * per-renderer inconsistency where some read only `currency`, others only
- * `defaultCurrency`, and others `currencyConfig`.
+ * `resolveFieldCurrency` now lives in `@object-ui/i18n` (co-located with
+ * `useLocalization`, which supplies the tenant default). This module re-exports
+ * it so the long-standing `@object-ui/fields` import path keeps working for
+ * every field/cell renderer that already depends on it.
  */
-export function resolveFieldCurrency(
-  field: { currency?: string; defaultCurrency?: string; currencyConfig?: { defaultCurrency?: string } } | null | undefined,
-  tenantDefault?: string,
-): string | undefined {
-  return (
-    field?.currency ||
-    field?.currencyConfig?.defaultCurrency ||
-    field?.defaultCurrency ||
-    tenantDefault ||
-    undefined
-  );
-}
+export { resolveFieldCurrency } from '@object-ui/i18n';

--- a/packages/i18n/src/__tests__/resolveFieldCurrency.test.ts
+++ b/packages/i18n/src/__tests__/resolveFieldCurrency.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFieldCurrency } from '../index';
+
+/**
+ * `resolveFieldCurrency` now lives in `@object-ui/i18n` (co-located with
+ * `useLocalization`, which supplies the tenant default). `@object-ui/fields`
+ * re-exports it; this proves the canonical home resolves the precedence chain.
+ */
+describe('resolveFieldCurrency (i18n canonical home)', () => {
+  it('prefers the field explicit currency over everything', () => {
+    expect(
+      resolveFieldCurrency({ currency: 'JPY', currencyConfig: { defaultCurrency: 'EUR' } }, 'USD'),
+    ).toBe('JPY');
+  });
+
+  it('falls back to currencyConfig.defaultCurrency, then legacy defaultCurrency', () => {
+    expect(resolveFieldCurrency({ currencyConfig: { defaultCurrency: 'EUR' } }, 'USD')).toBe('EUR');
+    expect(resolveFieldCurrency({ defaultCurrency: 'GBP' } as any, 'USD')).toBe('GBP');
+  });
+
+  it('falls back to the tenant default when the field omits its own (ADR-0053)', () => {
+    expect(resolveFieldCurrency({}, 'CNY')).toBe('CNY');
+    expect(resolveFieldCurrency(null, 'CNY')).toBe('CNY');
+    expect(resolveFieldCurrency(undefined, 'CNY')).toBe('CNY');
+  });
+
+  it('returns undefined when nothing is known (renderer shows a plain number)', () => {
+    expect(resolveFieldCurrency({})).toBeUndefined();
+    expect(resolveFieldCurrency(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/packages/i18n/src/currency.ts
+++ b/packages/i18n/src/currency.ts
@@ -1,0 +1,37 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Resolve the display currency code for a currency-typed field, in precedence
+ * order: the field's explicit `currency` -> its `currencyConfig.defaultCurrency`
+ * (fixed mode) -> a legacy top-level `defaultCurrency` -> the tenant default
+ * (`localization.currency`, ADR-0053, surfaced via {@link useLocalization}).
+ * Returns `undefined` when none is known, so the renderer shows a plain number
+ * rather than guessing a symbol.
+ *
+ * This is the single resolution every field / measure / cell renderer shares -
+ * ending the per-renderer drift where some read only `currency`, others only
+ * `defaultCurrency`, and others `currencyConfig`. It lives in `@object-ui/i18n`
+ * (alongside `useLocalization`) because the tenant default is a localization
+ * concern; `@object-ui/fields` re-exports it for backward compatibility.
+ */
+export function resolveFieldCurrency(
+  field:
+    | { currency?: string; defaultCurrency?: string; currencyConfig?: { defaultCurrency?: string } }
+    | null
+    | undefined,
+  tenantDefault?: string,
+): string | undefined {
+  return (
+    field?.currency ||
+    field?.currencyConfig?.defaultCurrency ||
+    field?.defaultCurrency ||
+    tenantDefault ||
+    undefined
+  );
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -91,3 +91,4 @@ export {
 
 export { pickLocalized } from './pickLocalized';
 export { LocalizationProvider, useLocalization, type LocalizationValue } from './LocalizationContext';
+export { resolveFieldCurrency } from './currency';

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -10,7 +10,7 @@ import React, { useState, useEffect, useContext, useMemo } from 'react';
 import { useDataScope, SchemaRendererContext, SchemaRenderer } from '@object-ui/react';
 import { extractRecords } from '@object-ui/core';
 import { Skeleton, RefreshIndicator, cn } from '@object-ui/components';
-import { useSafeFieldLabel, useObjectTranslation } from '@object-ui/i18n';
+import { useSafeFieldLabel, useObjectTranslation, useLocalization } from '@object-ui/i18n';
 import { getCellRenderer, resolveCellRendererType, formatCurrency, formatPercent, formatDate } from '@object-ui/fields';
 import { resolveDateMacros } from './utils';
 
@@ -126,6 +126,8 @@ export function computeLookupExpand(
 }
 
 export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSource: propDataSource, className }) => {
+  // Tenant default currency backstops columns that omit an explicit code.
+  const { currency: tenantCurrency } = useLocalization();
   const context = useContext(SchemaRendererContext);
   const dataSource = propDataSource || context?.dataSource;
   const boundData = useDataScope(schema.bind);
@@ -318,7 +320,7 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
           // we never silently fall back to USD when the author wrote `¥`/`€`.
           const symbolMap: Record<string, string> = { '$': 'USD', '¥': 'JPY', '€': 'EUR', '£': 'GBP' };
           const inferred = symbolMap[fmt[0]];
-          return formatCurrency(value, fieldMeta.currency || inferred);
+          return formatCurrency(value, fieldMeta.currency || inferred || tenantCurrency);
         }
         if (typeof fmt === 'string' && /%/.test(fmt) && typeof value === 'number') {
           const decimals = (fmt.match(/0\.(0+)%/) || [, ''])[1].length;

--- a/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
@@ -11,6 +11,7 @@ import { SchemaRendererContext, SchemaRenderer } from '@object-ui/react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle } from '@object-ui/components';
 import { isDrillEnabled, resolveDrillTitle } from '@object-ui/core';
 import type { DrillDownConfig } from '@object-ui/types';
+import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import { MetricWidget } from './MetricWidget';
 import {
   resolveDateMacros,
@@ -169,11 +170,14 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
     return undefined;
   }, [format, valueFieldDef]);
 
+  // Tenant default currency (localization.currency, ADR-0053) backstops a
+  // currency field that declares no explicit code of its own.
+  const { currency: tenantCurrency } = useLocalization();
   const inferredCurrency = useMemo(() => {
     if (currency) return currency;
     if (valueFieldDef?.type !== 'currency') return undefined;
-    return valueFieldDef.defaultCurrency || valueFieldDef.currency || undefined;
-  }, [currency, valueFieldDef]);
+    return resolveFieldCurrency(valueFieldDef, tenantCurrency);
+  }, [currency, valueFieldDef, tenantCurrency]);
 
   // Stable JSON keys to prevent infinite refetch loops when callers
   // pass fresh `aggregate` / `filter` object references each render

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.cells.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.cells.test.tsx
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { LocalizationProvider } from '@object-ui/i18n';
 
 let lastTableSchema: any = null;
 
@@ -123,6 +124,30 @@ describe('ObjectDataTable type-aware cells', () => {
     await waitFor(() => expect(screen.getByText(/150,000/)).toBeInTheDocument(), { timeout: 2000 });
     expect(screen.getByText(/\$150,000/)).toBeInTheDocument();
     expect(screen.getByText(/60%/)).toBeInTheDocument();
+  });
+
+  it('renders a currency-type column with the tenant default currency (ADR-0053)', async () => {
+    const ds = makeDataSource(
+      [{ amount: 1000 }],
+      { fields: { amount: { type: 'currency', label: 'Amount' } } },
+    );
+    const schema: any = {
+      type: 'object-data-table',
+      objectName: 'opportunity',
+      columns: [{ header: 'Amount', accessorKey: 'amount' }],
+    };
+
+    // The field declares no currency of its own; the tenant default (CNY)
+    // flows through CurrencyCellRenderer via useLocalization.
+    render(
+      <LocalizationProvider value={{ currency: 'CNY' }}>
+        <ObjectDataTable schema={schema} dataSource={ds} />
+      </LocalizationProvider>,
+    );
+    await waitFor(() => expect(screen.getByText(/1,000/)).toBeInTheDocument(), { timeout: 2000 });
+    // A yuan/yen glyph appears — never a bare number or a wrong-currency $.
+    expect(screen.getByText(/[¥]/)).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/\$1,000/);
   });
 });
 

--- a/packages/plugin-detail/package.json
+++ b/packages/plugin-detail/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@object-ui/i18n": "workspace:*",
     "lucide-react": "^1.18.0"
   },
   "peerDependencies": {

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -45,6 +45,7 @@ import { RecordMetaFooter } from './RecordMetaFooter';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildExpandFields } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
+import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import type { DetailViewSchema, DataSource, ActionSchema, SchemaNode } from '@object-ui/types';
 import { useDetailTranslation } from './useDetailTranslation';
 
@@ -215,6 +216,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
   const [reloadTick, setReloadTick] = React.useState(0);
   const [isCancellingApproval, setIsCancellingApproval] = React.useState(false);
   const { t } = useDetailTranslation();
+  // Tenant default currency (ADR-0053) for summary metrics whose field omits one.
+  const { currency: tenantCurrency } = useLocalization();
   const { fieldOptionLabel } = useSafeFieldLabel();
   const isMobile = useIsMobile();
 
@@ -848,7 +851,7 @@ export const DetailView: React.FC<DetailViewProps> = ({
                     if (ftype === 'currency') {
                       const num = Number(val);
                       if (!Number.isNaN(num)) {
-                        const cur = (sectionField as any)?.currency || objField?.currency;
+                        const cur = resolveFieldCurrency({ ...(objField as any), ...(sectionField as any) }, tenantCurrency);
                         display = cur
                           ? new Intl.NumberFormat(undefined, {
                               style: 'currency',

--- a/packages/plugin-gantt/package.json
+++ b/packages/plugin-gantt/package.json
@@ -34,6 +34,7 @@
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
     "@object-ui/fields": "workspace:*",
+    "@object-ui/i18n": "workspace:*",
     "@object-ui/plugin-detail": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -26,6 +26,7 @@ import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import type { ObjectGridSchema, DataSource, ViewData, GanttConfig } from '@object-ui/types';
 import { GanttConfigSchema } from '@objectstack/spec/ui';
 import { useNavigationOverlay } from '@object-ui/react';
+import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import { RecordDetailDrawer, deriveRecordPageHref } from '@object-ui/plugin-detail';
 import {
   AlertDialog,
@@ -294,6 +295,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [objectSchema, setObjectSchema] = useState<any>(null);
+  // Tenant default currency (ADR-0053) for currency tooltips lacking a code.
+  const { currency: tenantCurrency } = useLocalization();
 
   const rawDataConfig = getDataConfig(schema);
   // Memoize dataConfig using deep comparison to prevent infinite loops
@@ -457,7 +460,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         case 'decimal':
           return formatNumber(Number(value));
         case 'currency':
-          return formatCurrency(Number(value));
+          return formatCurrency(Number(value), resolveFieldCurrency(def as any, tenantCurrency));
         case 'percent':
           return formatPercent(Number(value));
         case 'boolean':

--- a/packages/plugin-grid/package.json
+++ b/packages/plugin-grid/package.json
@@ -23,6 +23,7 @@
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
     "@object-ui/fields": "workspace:*",
+    "@object-ui/i18n": "workspace:*",
     "@object-ui/mobile": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -26,6 +26,7 @@ import type { ObjectGridSchema, DataSource, ListColumn, ViewData } from '@object
 import type { I18nLabel } from '@objectstack/spec/ui';
 import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useObjectTranslation, useSafeFieldLabel } from '@object-ui/react';
 import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses } from '@object-ui/fields';
+import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import {
   Badge, Button, NavigationOverlay, EmptyValue,
   Popover, PopoverContent, PopoverTrigger,
@@ -228,6 +229,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const [data, setData] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  // Tenant default currency (ADR-0053) backstops amount cells that lack a code.
+  const { currency: tenantCurrency } = useLocalization();
   const { t } = useGridTranslation();
   const { fieldLabel: resolveFieldLabel, translateOptions } = useSafeFieldLabel();
   const [objectSchema, setObjectSchema] = useState<any>(null);
@@ -1758,7 +1761,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
                     {amountCol && (
                       <span className="text-sm tabular-nums font-medium">
                         {typeof row[amountCol.accessorKey] === 'number'
-                          ? formatCompactCurrency(row[amountCol.accessorKey])
+                          ? formatCompactCurrency(row[amountCol.accessorKey], resolveFieldCurrency(amountCol as any, tenantCurrency))
                           : (row[amountCol.accessorKey] != null && typeof row[amountCol.accessorKey] === 'object' ? String(row[amountCol.accessorKey]) : (row[amountCol.accessorKey] ?? '—'))}
                       </span>
                     )}
@@ -1957,7 +1960,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       // Detect currency-like fields by name
       const currencyFields = ['amount', 'price', 'total', 'revenue', 'cost', 'value', 'budget', 'salary'];
       if (typeof value === 'number' && currencyFields.some(f => key.toLowerCase().includes(f))) {
-        return <span className="text-sm tabular-nums font-medium">{formatCurrency(value)}</span>;
+        return <span className="text-sm tabular-nums font-medium">{formatCurrency(value, tenantCurrency)}</span>;
       }
       return <span className="text-sm break-words">{String(value)}</span>;
     };

--- a/packages/plugin-grid/src/useColumnSummary.test.tsx
+++ b/packages/plugin-grid/src/useColumnSummary.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { LocalizationProvider } from '@object-ui/i18n';
+import { useColumnSummary } from './useColumnSummary';
+
+/**
+ * Grid footer summaries (useColumnSummary) must agree with the cells above
+ * them: a `currency` column that declares no explicit code now resolves the
+ * tenant default (localization.currency, ADR-0053) through the shared
+ * resolveFieldCurrency, instead of degrading to a bare number.
+ */
+const COLUMNS: any[] = [{ field: 'amount', summary: 'sum', type: 'currency' }];
+const DATA = [{ amount: 1000 }, { amount: 234 }];
+
+function wrapper(currency?: string) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <LocalizationProvider value={{ currency }}>{children}</LocalizationProvider>
+  );
+}
+
+describe('useColumnSummary tenant-default currency', () => {
+  it('formats a currency column with the tenant default when the column omits a code', () => {
+    const { result } = renderHook(() => useColumnSummary(COLUMNS, DATA), {
+      wrapper: wrapper('CNY'),
+    });
+    const label = result.current.summaries.get('amount')?.label ?? '';
+    // 1234 in CNY → a yen/yuan symbol, never a bare number.
+    expect(label).toMatch(/Sum:/);
+    expect(label).toMatch(/[¥]|CN¥|CNY/);
+    expect(label).toMatch(/1,234/);
+  });
+
+  it('falls back to a plain number when no tenant currency is configured', () => {
+    const { result } = renderHook(() => useColumnSummary(COLUMNS, DATA), {
+      wrapper: wrapper(undefined),
+    });
+    const label = result.current.summaries.get('amount')?.label ?? '';
+    expect(label).toMatch(/Sum: /);
+    expect(label).not.toMatch(/[¥$€£]/);
+    expect(label).toMatch(/1,234/);
+  });
+
+  it('still prefers an explicit column currency over the tenant default', () => {
+    const cols: any[] = [{ field: 'amount', summary: 'sum', type: 'currency', currency: 'USD' }];
+    const { result } = renderHook(() => useColumnSummary(cols, DATA), {
+      wrapper: wrapper('CNY'),
+    });
+    const label = result.current.summaries.get('amount')?.label ?? '';
+    expect(label).toMatch(/\$|US\$/);
+  });
+});

--- a/packages/plugin-grid/src/useColumnSummary.ts
+++ b/packages/plugin-grid/src/useColumnSummary.ts
@@ -8,6 +8,7 @@
 
 import { useMemo } from 'react';
 import type { ListColumn } from '@object-ui/types';
+import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 
 /**
  * Summary configuration for a column.
@@ -67,7 +68,8 @@ function computeAggregation(type: string, values: number[]): number | null {
 function formatSummaryLabel(
   type: string,
   value: number | null,
-  column?: { type?: string; currency?: string; defaultCurrency?: string; precision?: number | null; scale?: number | null }
+  column?: { type?: string; currency?: string; defaultCurrency?: string; currencyConfig?: { defaultCurrency?: string }; precision?: number | null; scale?: number | null },
+  tenantDefault?: string,
 ): string {
   if (value === null) return '';
   const typeLabels: Record<string, string> = {
@@ -82,7 +84,7 @@ function formatSummaryLabel(
   const colType = column?.type;
   let formatted: string;
   if (type !== 'count' && colType === 'currency') {
-    const currency = column?.currency || column?.defaultCurrency;
+    const currency = resolveFieldCurrency(column, tenantDefault);
     const decimals = column?.precision ?? column?.scale ?? 0;
     try {
       formatted = currency
@@ -126,6 +128,9 @@ export function useColumnSummary(
   data: any[],
   fieldMetadata?: Record<string, { type?: string; currency?: string; defaultCurrency?: string; precision?: number | null; scale?: number | null }>
 ): { summaries: Map<string, ColumnSummaryResult>; hasSummary: boolean } {
+  // Tenant default currency (ADR-0053) backstops a currency column that
+  // declares no explicit code, so the footer agrees with the cells above it.
+  const { currency: tenantCurrency } = useLocalization();
   return useMemo(() => {
     const summaries = new Map<string, ColumnSummaryResult>();
 
@@ -175,10 +180,10 @@ export function useColumnSummary(
       summaries.set(col.field, {
         field: col.field,
         value: result,
-        label: formatSummaryLabel(config.type, result, columnHints),
+        label: formatSummaryLabel(config.type, result, columnHints, tenantCurrency),
       });
     }
 
     return { summaries, hasSummary: summaries.size > 0 };
-  }, [columns, data, fieldMetadata]);
+  }, [columns, data, fieldMetadata, tenantCurrency]);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,7 +787,7 @@ importers:
         version: 9.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -808,7 +808,7 @@ importers:
         version: 4.2.0
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.25
@@ -827,7 +827,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/collaboration:
     dependencies:
@@ -1089,7 +1089,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/data-objectstack:
     dependencies:
@@ -1681,6 +1681,9 @@ importers:
 
   packages/plugin-detail:
     dependencies:
+      '@object-ui/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@object-ui/permissions':
         specifier: workspace:^
         version: link:../permissions
@@ -1834,6 +1837,9 @@ importers:
       '@object-ui/fields':
         specifier: workspace:*
         version: link:../fields
+      '@object-ui/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@object-ui/plugin-detail':
         specifier: workspace:*
         version: link:../plugin-detail
@@ -1886,6 +1892,9 @@ importers:
       '@object-ui/fields':
         specifier: workspace:*
         version: link:../fields
+      '@object-ui/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@object-ui/mobile':
         specifier: workspace:*
         version: link:../mobile
@@ -13663,6 +13672,11 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       maplibre-gl: 5.24.0
+
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
## What

Phase 2b (final) of the currency-resolution work (ADR-0053). The low-level field/cell renderers already funnel through `resolveFieldCurrency` + `useLocalization` ([#1856](https://github.com/objectstack-ai/objectui/pull/1856)/[#1857](https://github.com/objectstack-ai/objectui/pull/1857)). This unifies the **remaining ("long-tail") renderers** onto the same resolution chain so a tenant's `localization.currency` flows everywhere instead of being hard-coded to `USD` or read from only one of `currency`/`defaultCurrency`.

**Resolution chain** (shared `resolveFieldCurrency`): explicit field `currency` → `currencyConfig.defaultCurrency` → legacy `defaultCurrency` → tenant `localization.currency` → plain number.

## Renderers migrated

| Package | Site | Before |
|---|---|---|
| `plugin-dashboard` | `ObjectMetricWidget` inferred currency | read only `defaultCurrency`/`currency` |
| `plugin-dashboard` | `ObjectDataTable` symbol-format cell | no tenant fallback |
| `plugin-grid` | `useColumnSummary` footer | read only `currency`/`defaultCurrency` |
| `plugin-grid` | `ObjectGrid` compact amount + name-inferred cells | bare number |
| `plugin-detail` | `DetailView` summary metrics | read only `currency` |
| `plugin-gantt` | `ObjectGantt` currency tooltips | no currency at all |
| `components` | `element:number` (`format: 'currency'`) | **baked-in `USD`** |

## Architecture

`resolveFieldCurrency` moves into `@object-ui/i18n` (co-located with `useLocalization`, which supplies the tenant default); `@object-ui/fields` re-exports it, so the existing `@object-ui/fields` import path is unchanged. `@object-ui/i18n` added as a dep to `plugin-grid` / `plugin-gantt` / `plugin-detail`.

## Compatibility

No behavior change when no tenant currency is configured: a field that declares its own currency, or a deployment with no `localization.currency`, renders exactly as before. `element:number` keeps `USD` as the last-resort fallback.

## Tests

- `@object-ui/i18n` — `resolveFieldCurrency` precedence (canonical home).
- `@object-ui/plugin-grid` — `useColumnSummary` tenant-default footer (renderHook + `LocalizationProvider`); explicit column currency still wins; plain number with no tenant.
- `@object-ui/plugin-dashboard` — `ObjectDataTable` renders a currency-type column with the tenant default through `CurrencyCellRenderer`.

All touched-package suites green; type-check clean across all 7 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)