### PR TITLE
feat(dashboard): expand drill-in — table/list row→record + scatter/treemap/sankey drill-through

### DIFF
--- a/.changeset/dashboard-drill-expansion.md
+++ b/.changeset/dashboard-drill-expansion.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/types": patch
+"@object-ui/plugin-dashboard": patch
+"@object-ui/plugin-charts": patch
+---
+
+feat(dashboard): expand drill-in — table/list row→record + scatter/treemap/sankey drill-through
+
+Drill-in now covers the widgets that were missing it, and formalizes the two
+interaction semantics mainstream BI/low-code platforms separate. `DrillDownConfig`
+gains a `mode` discriminator: `'filter'` (drill-through: aggregate bucket → filtered
+record list) and `'record'` (drill-to-record: a table/list row → that record's detail).
+
+- Scatter, treemap and sankey charts now wire click → the existing filtered-record
+  drill drawer (radar excluded — no single clickable category point). The
+  Recharts-payload → drill-event mapping is extracted to pure, tested functions.
+- Object-backed table/list widgets drill to the clicked record in a read-only detail
+  drawer (Sheet/Dialog), on by default (`drillDown:{enabled:false}` opts out). Field
+  labels and value formatting (incl. tenant-default currency) are shared with the
+  table cells so a value reads identically in both. An author-supplied `onRowClick`
+  still wins.
+- The chart/KPI drill-through record lists now drill into a record too, completing the
+  segment → list → record chain.

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -148,6 +148,56 @@ export default function AdvancedChartImpl({
   const cartesianClickProps = onChartClick ? { onClick: handleCartesianClick, style: { cursor: 'pointer' as const } } : {};
   const pieClickProps = onChartClick ? { onClick: handlePieClick, style: { cursor: 'pointer' as const } } : {};
 
+  // Scatter: each <Scatter> point fires with the point node. The node's
+  // `payload` is the original data row, so we read the category (xAxisKey)
+  // and the y-value from it — same { category, series, value } contract the
+  // pie/cartesian handlers use, so ObjectChart's drill drawer works unchanged.
+  const handleScatterClick = React.useCallback((node: any) => {
+    if (!onChartClick || !node) return;
+    const row = node.payload ?? node;
+    const cat = row?.[xAxisKey];
+    const dk = series[0]?.dataKey || 'value';
+    onChartClick({
+      category: cat != null ? String(cat) : undefined,
+      series: dk,
+      value: typeof row?.[dk] === 'number' ? row[dk] : undefined,
+    });
+  }, [onChartClick, xAxisKey, series]);
+
+  // Treemap: clicking a tile drills into the category it represents. Recharts
+  // passes the clicked node; its `name` is the category label and `value`/
+  // `size` the aggregated measure.
+  const handleTreemapClick = React.useCallback((node: any) => {
+    if (!onChartClick || !node) return;
+    const name = node.name ?? node.payload?.name ?? node.root?.name;
+    if (name == null) return;
+    const val = node.value ?? node.size ?? node.payload?.size;
+    onChartClick({
+      category: String(name),
+      series: series[0]?.dataKey || 'value',
+      value: typeof val === 'number' ? val : undefined,
+    });
+  }, [onChartClick, series]);
+
+  // Sankey: drill on a flow *node* (a category). Links carry source/target
+  // indices but no `name`, and the synthetic root node (depth 0) aggregates
+  // everything — both are ignored so only category nodes drill.
+  const handleSankeyClick = React.useCallback((payload: any) => {
+    if (!onChartClick || !payload) return;
+    const node = payload.payload ?? payload;
+    const name = node?.name;
+    if (name == null || node?.depth === 0) return;
+    onChartClick({
+      category: String(name),
+      series: series[0]?.dataKey || 'value',
+      value: typeof node?.value === 'number' ? node.value : undefined,
+    });
+  }, [onChartClick, series]);
+
+  const scatterClickProps = onChartClick ? { onClick: handleScatterClick, cursor: 'pointer' } : {};
+  const treemapClickProps = onChartClick ? { onClick: handleTreemapClick, style: { cursor: 'pointer' as const } } : {};
+  const sankeyClickProps = onChartClick ? { onClick: handleSankeyClick, style: { cursor: 'pointer' as const } } : {};
+
   React.useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth < 640);
     checkMobile();
@@ -371,7 +421,7 @@ export default function AdvancedChartImpl({
     };
     return (
       <ChartContainer config={config} className={className}>
-        <Treemap data={tmData} dataKey="size" nameKey="name" isAnimationActive content={<TreemapCell />}>
+        <Treemap data={tmData} dataKey="size" nameKey="name" isAnimationActive content={<TreemapCell />} {...treemapClickProps}>
           <Tooltip />
         </Treemap>
       </ChartContainer>
@@ -397,6 +447,7 @@ export default function AdvancedChartImpl({
           nodePadding={24}
           link={{ stroke: 'hsl(var(--muted-foreground))', strokeOpacity: 0.25 }}
           node={{ fill: 'hsl(var(--chart-1))' } as any}
+          {...sankeyClickProps}
         >
           <Tooltip />
         </Sankey>
@@ -474,6 +525,7 @@ export default function AdvancedChartImpl({
                 data={data}
                 fill={color}
                 fillOpacity={cmp?.fillOpacity}
+                {...scatterClickProps}
               />
             );
           })}

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -43,6 +43,7 @@ import {
   ChartLegendContent,
   ChartConfig
 } from './ChartContainerImpl';
+import { mapScatterClick, mapTreemapClick, mapSankeyClick } from './chartDrillEvents';
 
 // Default color fallback for chart series
 const DEFAULT_CHART_COLOR = 'hsl(var(--primary))';
@@ -148,50 +149,26 @@ export default function AdvancedChartImpl({
   const cartesianClickProps = onChartClick ? { onClick: handleCartesianClick, style: { cursor: 'pointer' as const } } : {};
   const pieClickProps = onChartClick ? { onClick: handlePieClick, style: { cursor: 'pointer' as const } } : {};
 
-  // Scatter: each <Scatter> point fires with the point node. The node's
-  // `payload` is the original data row, so we read the category (xAxisKey)
-  // and the y-value from it — same { category, series, value } contract the
-  // pie/cartesian handlers use, so ObjectChart's drill drawer works unchanged.
+  // Scatter / treemap / sankey element clicks map to the same
+  // { category, series, value } drill event via pure mappers (see
+  // chartDrillEvents). Each returns null for non-drillable targets (e.g. a
+  // sankey link or root node), in which case we don't fire.
   const handleScatterClick = React.useCallback((node: any) => {
-    if (!onChartClick || !node) return;
-    const row = node.payload ?? node;
-    const cat = row?.[xAxisKey];
-    const dk = series[0]?.dataKey || 'value';
-    onChartClick({
-      category: cat != null ? String(cat) : undefined,
-      series: dk,
-      value: typeof row?.[dk] === 'number' ? row[dk] : undefined,
-    });
+    if (!onChartClick) return;
+    const ev = mapScatterClick(node, xAxisKey, series);
+    if (ev) onChartClick(ev);
   }, [onChartClick, xAxisKey, series]);
 
-  // Treemap: clicking a tile drills into the category it represents. Recharts
-  // passes the clicked node; its `name` is the category label and `value`/
-  // `size` the aggregated measure.
   const handleTreemapClick = React.useCallback((node: any) => {
-    if (!onChartClick || !node) return;
-    const name = node.name ?? node.payload?.name ?? node.root?.name;
-    if (name == null) return;
-    const val = node.value ?? node.size ?? node.payload?.size;
-    onChartClick({
-      category: String(name),
-      series: series[0]?.dataKey || 'value',
-      value: typeof val === 'number' ? val : undefined,
-    });
+    if (!onChartClick) return;
+    const ev = mapTreemapClick(node, series);
+    if (ev) onChartClick(ev);
   }, [onChartClick, series]);
 
-  // Sankey: drill on a flow *node* (a category). Links carry source/target
-  // indices but no `name`, and the synthetic root node (depth 0) aggregates
-  // everything — both are ignored so only category nodes drill.
   const handleSankeyClick = React.useCallback((payload: any) => {
-    if (!onChartClick || !payload) return;
-    const node = payload.payload ?? payload;
-    const name = node?.name;
-    if (name == null || node?.depth === 0) return;
-    onChartClick({
-      category: String(name),
-      series: series[0]?.dataKey || 'value',
-      value: typeof node?.value === 'number' ? node.value : undefined,
-    });
+    if (!onChartClick) return;
+    const ev = mapSankeyClick(payload, series);
+    if (ev) onChartClick(ev);
   }, [onChartClick, series]);
 
   const scatterClickProps = onChartClick ? { onClick: handleScatterClick, cursor: 'pointer' } : {};

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -606,6 +606,9 @@ export const ObjectChart = (props: any) => {
       pagination: true,
       pageSize: drillDown?.maxRows,
       columns: drillDown?.columns?.map((c: string) => ({ accessorKey: c, header: c })),
+      // Complete the drill chain: a row in the filtered list opens that record.
+      // Rendered as a dialog so it stacks cleanly over this drill drawer.
+      drillDown: { enabled: true, mode: 'record' as const, target: 'dialog' as const },
     };
     const body = (
       <div className="overflow-auto" data-testid="chart-drill-body">

--- a/packages/plugin-charts/src/__tests__/chartDrillEvents.test.ts
+++ b/packages/plugin-charts/src/__tests__/chartDrillEvents.test.ts
@@ -1,0 +1,89 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit tests for the scatter / treemap / sankey drill-event mappers. These lock
+ * the Recharts-payload → { category, series, value } contract that ObjectChart's
+ * drill drawer depends on.
+ */
+import { describe, it, expect } from 'vitest';
+import { mapScatterClick, mapTreemapClick, mapSankeyClick } from '../chartDrillEvents';
+
+const series = [{ dataKey: 'sales' }];
+
+describe('mapScatterClick', () => {
+  it('reads category (xAxisKey) and value from node.payload', () => {
+    const node = { payload: { region: 'West', sales: 4200 } };
+    expect(mapScatterClick(node, 'region', series)).toEqual({
+      category: 'West',
+      series: 'sales',
+      value: 4200,
+    });
+  });
+
+  it('falls back to top-level node fields when no payload', () => {
+    const node = { region: 'East', sales: 9 };
+    expect(mapScatterClick(node, 'region', series)).toEqual({
+      category: 'East',
+      series: 'sales',
+      value: 9,
+    });
+  });
+
+  it('coerces a non-string category and omits a non-numeric value', () => {
+    const node = { payload: { region: 2025, sales: 'n/a' } };
+    expect(mapScatterClick(node, 'region', series)).toEqual({
+      category: '2025',
+      series: 'sales',
+      value: undefined,
+    });
+  });
+
+  it('returns null when there is no category', () => {
+    expect(mapScatterClick({ payload: { sales: 1 } }, 'region', series)).toBeNull();
+    expect(mapScatterClick(null, 'region', series)).toBeNull();
+  });
+
+  it('defaults the series key to "value"', () => {
+    expect(mapScatterClick({ x: 'A', value: 3 }, 'x', undefined)?.series).toBe('value');
+  });
+});
+
+describe('mapTreemapClick', () => {
+  it('maps tile name + value', () => {
+    expect(mapTreemapClick({ name: 'Tech', value: 1200 }, series)).toEqual({
+      category: 'Tech',
+      series: 'sales',
+      value: 1200,
+    });
+  });
+
+  it('falls back to size, then payload.name', () => {
+    expect(mapTreemapClick({ name: 'A', size: 7 }, series)?.value).toBe(7);
+    expect(mapTreemapClick({ payload: { name: 'B' } }, series)?.category).toBe('B');
+  });
+
+  it('returns null without a name', () => {
+    expect(mapTreemapClick({ value: 1 }, series)).toBeNull();
+    expect(mapTreemapClick(null, series)).toBeNull();
+  });
+});
+
+describe('mapSankeyClick', () => {
+  it('drills on a category node', () => {
+    expect(mapSankeyClick({ payload: { name: 'Web', depth: 1, value: 500 } }, series)).toEqual({
+      category: 'Web',
+      series: 'sales',
+      value: 500,
+    });
+  });
+
+  it('ignores the synthetic root node (depth 0)', () => {
+    expect(mapSankeyClick({ payload: { name: 'Total', depth: 0 } }, series)).toBeNull();
+  });
+
+  it('ignores links (no name)', () => {
+    expect(mapSankeyClick({ payload: { source: 0, target: 1, value: 5 } }, series)).toBeNull();
+    expect(mapSankeyClick(null, series)).toBeNull();
+  });
+});

--- a/packages/plugin-charts/src/chartDrillEvents.ts
+++ b/packages/plugin-charts/src/chartDrillEvents.ts
@@ -1,0 +1,87 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Pure mappers from a Recharts element-click payload to the shared
+ * `{ category, series, value }` drill event consumed by ObjectChart's drill
+ * drawer. Kept separate from AdvancedChartImpl so the (Recharts-shape-sensitive)
+ * payload extraction can be unit-tested without rendering a chart.
+ */
+
+export interface ChartDrillEvent {
+  category?: string;
+  series?: string;
+  value?: number;
+}
+
+interface SeriesLike {
+  dataKey?: string;
+}
+
+function seriesKey(series: SeriesLike[] | undefined): string {
+  return series?.[0]?.dataKey || 'value';
+}
+
+/**
+ * Scatter point click. Recharts spreads the data row onto the node and also
+ * exposes it under `.payload`; we read the category (xAxisKey) and the
+ * y-measure from whichever is present. Returns `null` when there's no category.
+ */
+export function mapScatterClick(
+  node: any,
+  xAxisKey: string,
+  series: SeriesLike[] | undefined,
+): ChartDrillEvent | null {
+  if (!node) return null;
+  const row = node.payload ?? node;
+  const cat = row?.[xAxisKey];
+  if (cat == null) return null;
+  const dk = seriesKey(series);
+  return {
+    category: String(cat),
+    series: dk,
+    value: typeof row?.[dk] === 'number' ? row[dk] : undefined,
+  };
+}
+
+/**
+ * Treemap tile click. The node carries the category label as `name` and the
+ * measure as `value`/`size`. Returns `null` when there's no name.
+ */
+export function mapTreemapClick(
+  node: any,
+  series: SeriesLike[] | undefined,
+): ChartDrillEvent | null {
+  if (!node) return null;
+  const name = node.name ?? node.payload?.name ?? node.root?.name;
+  if (name == null) return null;
+  const val = node.value ?? node.size ?? node.payload?.size;
+  return {
+    category: String(name),
+    series: seriesKey(series),
+    value: typeof val === 'number' ? val : undefined,
+  };
+}
+
+/**
+ * Sankey click. Drill only on flow *nodes* (categories): links carry
+ * source/target indices but no `name`, and the synthetic root node (depth 0)
+ * aggregates everything. Returns `null` for those so they don't drill.
+ */
+export function mapSankeyClick(
+  payload: any,
+  series: SeriesLike[] | undefined,
+): ChartDrillEvent | null {
+  if (!payload) return null;
+  const node = payload.payload ?? payload;
+  const name = node?.name;
+  if (name == null || node?.depth === 0) return null;
+  return {
+    category: String(name),
+    series: seriesKey(series),
+    value: typeof node?.value === 'number' ? node.value : undefined,
+  };
+}

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -586,6 +586,14 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                 // Support data at widget level or nested inside options
                 const widgetData = (widget as any).data || options.data;
 
+                // Default-on drill-to-record for object-backed tables: clicking a
+                // row opens that record in a detail drawer. Static (data-array)
+                // tables stay opt-in (no object to fetch the record's schema from).
+                const isObjectTable = isObjectProvider(widgetData) || (!widgetData && !!widget.object);
+                const tableDrill = isObjectTable
+                    ? (options.drillDown ?? { enabled: true, mode: 'record' as const })
+                    : undefined;
+
                 // provider: 'object' — use ObjectDataTable for async data loading
                 if (isObjectProvider(widgetData)) {
                     const { data: _data, ...restOptions } = options;
@@ -597,6 +605,7 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                         filter: widgetData.filter || widget.filter,
                         searchable: widget.searchable ?? false,
                         pagination: widget.pagination ?? false,
+                        drillDown: tableDrill,
                         className: "border-0"
                     };
                 }
@@ -610,6 +619,7 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                         filter: widget.filter,
                         searchable: widget.searchable ?? false,
                         pagination: widget.pagination ?? false,
+                        drillDown: tableDrill,
                         className: "border-0"
                     };
                 }
@@ -688,6 +698,13 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
             if (widgetType === 'list') {
                 const widgetData = (widget as any).data || options.data;
 
+                // Default-on drill-to-record for object-backed lists (same policy
+                // as the table widget — a list row is a record).
+                const isObjectList = isObjectProvider(widgetData) || (!widgetData && !!widget.object);
+                const listDrill = isObjectList
+                    ? (options.drillDown ?? { enabled: true, mode: 'record' as const })
+                    : undefined;
+
                 if (isObjectProvider(widgetData)) {
                     const { data: _data, ...restOptions } = options;
                     return {
@@ -698,6 +715,7 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                         filter: widgetData.filter || widget.filter,
                         searchable: false,
                         pagination: false,
+                        drillDown: listDrill,
                         className: "border-0",
                     };
                 }
@@ -710,6 +728,7 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                         filter: widget.filter,
                         searchable: false,
                         pagination: false,
+                        drillDown: listDrill,
                         className: "border-0",
                     };
                 }

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -150,11 +150,13 @@ const UNSUPPORTED_CHART_TYPES = new Set([
 /**
  * Chart sub-types that have a meaningful drill-down interaction.
  * Mirrors WidgetConfigPanel.DRILL_DOWN_TYPES and the click-handler wiring
- * in plugin-charts/AdvancedChartImpl. Scatter and funnel are excluded
- * because no onChartClick is wired for them today.
+ * in plugin-charts/AdvancedChartImpl. Radar is excluded because a polar
+ * polygon has no single clickable category point (the interaction would be
+ * ambiguous); every cartesian / part-to-whole / flow family is covered.
  */
 const DRILLABLE_CHART_TYPES = new Set([
   'bar', 'horizontal-bar', 'line', 'area', 'pie', 'donut', 'funnel',
+  'scatter', 'treemap', 'sankey',
 ]);
 
 /**

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -6,13 +6,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useEffect, useContext, useMemo } from 'react';
+import React, { useState, useEffect, useContext, useMemo, useCallback } from 'react';
 import { useDataScope, SchemaRendererContext, SchemaRenderer } from '@object-ui/react';
-import { extractRecords } from '@object-ui/core';
+import { extractRecords, isDrillEnabled } from '@object-ui/core';
+import type { DrillDownConfig } from '@object-ui/types';
 import { Skeleton, RefreshIndicator, cn } from '@object-ui/components';
 import { useSafeFieldLabel, useObjectTranslation, useLocalization } from '@object-ui/i18n';
-import { getCellRenderer, resolveCellRendererType, formatCurrency, formatPercent, formatDate } from '@object-ui/fields';
 import { resolveDateMacros } from './utils';
+import {
+  buildFieldMeta,
+  renderFieldValue,
+  isNumericFieldMeta,
+  isSystemField,
+} from './recordFields';
+import { RecordDetailDrawer } from './RecordDetailDrawer';
 
 export interface ObjectDataTableProps {
   schema: {
@@ -153,6 +160,18 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
   });
   const [error, setError] = useState<string | null>(null);
 
+  // --- Drill-to-record ---------------------------------------------------
+  // Table / list widgets drill *to record*: clicking a row opens that single
+  // record in a detail drawer (the row already IS a record, so there is no
+  // filter to derive). Opt-in via `schema.drillDown` — DashboardRenderer
+  // defaults object-backed table/list widgets to `{ enabled: true }`.
+  const drillDown = schema.drillDown as DrillDownConfig | undefined;
+  const recordDrillEnabled = isDrillEnabled(drillDown) && (drillDown?.mode ?? 'record') === 'record';
+  const [drillRecord, setDrillRecord] = useState<Record<string, any> | null>(null);
+  const handleRowClick = useCallback((row: Record<string, any>) => {
+    setDrillRecord(row ?? null);
+  }, []);
+
   useEffect(() => {
     let isMounted = true;
 
@@ -255,84 +274,36 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
     };
 
     const enrich = (col: NormalizedColumn): NormalizedColumn => {
-      const meta = fieldsByName[col.accessorKey];
-      const referenceTo =
-        col.referenceTo ??
-        meta?.referenceTo ??
-        (typeof meta?.reference === 'string' ? meta.reference : meta?.reference?.to) ??
-        meta?.target;
-
-      // For select fields, build options with translated labels so that
-      // the badge shows e.g. "提案" instead of the English/raw "proposal".
-      let options: Array<{ value: any; label: string; color?: string }> | undefined =
-        col.options ?? meta?.options;
-      if (
-        objectName &&
-        options &&
-        (meta?.type === 'select' || meta?.type === 'picklist' || meta?.type === 'dropdown' || meta?.type === 'status')
-      ) {
-        options = options.map((opt: any) => {
-          if (opt == null) return opt;
-          const value = typeof opt === 'object' ? opt.value : opt;
-          const fallback = typeof opt === 'object' ? (opt.label || String(value)) : String(value);
-          return {
-            value,
-            label: fieldOptionLabel(objectName, col.accessorKey, String(value), fallback),
-            color: typeof opt === 'object' ? opt.color : undefined,
-          };
-        });
-      }
-
-      // For lookup-like fields just pass through `referenceTo`. The server
-      // expands these via `$expand` in the fetch above so the cell value will
-      // be `{ id, name }`, which LookupCellRenderer/UserCellRenderer handle
-      // natively without needing an `options` map.
-
-      const fieldMeta: any = {
-        name: col.accessorKey,
+      // Build the shared FieldMeta (translated select options, resolved
+      // referenceTo / currency / decimals). Column-level props override the
+      // schema-derived values. Lookup fields just pass `referenceTo` through —
+      // the server expands them via `$expand` so the cell value is `{ id, name }`,
+      // which the lookup/user cell renderers handle natively.
+      const fieldMeta = buildFieldMeta({
+        accessorKey: col.accessorKey,
         label: col.header,
-        type: col.type ?? meta?.type,
-        options,
-        referenceTo,
-        format: col.format ?? meta?.format,
-        currency: (col as any).currency ?? meta?.currency ?? meta?.defaultCurrency,
-        decimals: (col as any).decimals ?? meta?.decimals ?? meta?.precision ?? meta?.scale,
-      };
+        def: fieldsByName[col.accessorKey],
+        objectName,
+        fieldOptionLabel,
+        overrides: {
+          type: col.type,
+          format: col.format,
+          options: col.options,
+          referenceTo: (col as any).referenceTo,
+          currency: (col as any).currency,
+          decimals: (col as any).decimals,
+        },
+      });
 
       // Numeric-flavoured columns look better right-aligned (tabular-nums
       // already on the cell). Honor an explicit `align` if the author set one.
-      const NUMERIC_TYPES = new Set([
-        'currency', 'money', 'number', 'integer', 'decimal', 'float', 'percent', 'percentage',
-      ]);
       const inferredAlign = (col as any).align
-        ?? ((NUMERIC_TYPES.has(fieldMeta.type as string) ||
-            (typeof fieldMeta.format === 'string' && /^[\$¥€£]|%$|0/.test(fieldMeta.format)))
-          ? 'right'
-          : undefined);
+        ?? (isNumericFieldMeta(fieldMeta) ? 'right' : undefined);
 
       if (typeof col.cell === 'function') return { ...col, ...fieldMeta, align: inferredAlign };
 
-      const cell = (value: any): React.ReactNode => {
-        if (value == null || value === '') return '';
-        const fmt = fieldMeta.format;
-        if (typeof fmt === 'string' && /^\$|¥|€|£/.test(fmt) && typeof value === 'number') {
-          // Honor explicit `currency`; else infer from the leading symbol so
-          // we never silently fall back to USD when the author wrote `¥`/`€`.
-          const symbolMap: Record<string, string> = { '$': 'USD', '¥': 'JPY', '€': 'EUR', '£': 'GBP' };
-          const inferred = symbolMap[fmt[0]];
-          return formatCurrency(value, fieldMeta.currency || inferred || tenantCurrency);
-        }
-        if (typeof fmt === 'string' && /%/.test(fmt) && typeof value === 'number') {
-          const decimals = (fmt.match(/0\.(0+)%/) || [, ''])[1].length;
-          const normalized = value > 1 ? value / 100 : value;
-          return formatPercent(normalized * 100, decimals);
-        }
-        if (typeof fmt === 'string' && /[YMDHms]/.test(fmt)) {
-          return formatDate(value, fmt);
-        }
-        const Renderer = getCellRenderer(resolveCellRendererType(fieldMeta as any));
-        return <Renderer value={value} field={fieldMeta as any} />;
-      };
+      // Tenant-default currency backstops a currency column with no explicit code.
+      const cell = (value: any): React.ReactNode => renderFieldValue(value, fieldMeta, tenantCurrency);
       return { ...col, ...fieldMeta, align: inferredAlign, cell };
     };
 
@@ -345,27 +316,9 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
     }
     if (finalData.length === 0) return [];
 
-    // Auto-derived columns should hide framework/system audit fields by
-    // default. Users wanting them can pass an explicit `columns` whitelist.
-    const SYSTEM_FIELDS = new Set([
-      'id',
-      'organization_id',
-      'tenant_id',
-      'created_at',
-      'updated_at',
-      'created_by',
-      'updated_by',
-      'deleted_at',
-      'deleted_by',
-      'version',
-      '_id',
-      '__typename',
-    ]);
-    const isSystemField = (name: string, def?: any): boolean => {
-      if (def && (def.isSystem === true || def.system === true)) return true;
-      return SYSTEM_FIELDS.has(name);
-    };
-
+    // Auto-derived columns hide framework/system audit fields by default
+    // (shared `isSystemField` denylist). Users wanting them can pass an
+    // explicit `columns` whitelist.
     // Prefer the objectSchema field order (declaration order = author intent)
     // and drop system fields. Fall back to the row's keys when no schema
     // is loaded, applying the same denylist.
@@ -374,7 +327,7 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
       : Object.keys(finalData[0]).filter((k) => !k.startsWith('_') && !isSystemField(k));
 
     return orderedKeys.map((k) => enrich({ header: buildHeader(k), accessorKey: k }));
-  }, [schema.columns, schema.objectName, finalData, objectSchema, fieldLabel, fieldOptionLabel]);
+  }, [schema.columns, schema.objectName, finalData, objectSchema, fieldLabel, fieldOptionLabel, tenantCurrency]);
 
   // Note: per-cell select-label translation that used to happen here is now
   // handled by SelectCellRenderer in the shared field registry, which also
@@ -451,17 +404,37 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
   // Delegate to data-table via SchemaRenderer. Wrap in a positioned container
   // so the re-fetch indicator can anchor to the top of the table when a
   // refresh is in flight while existing rows remain visible.
+  // Honor an author-supplied onRowClick; otherwise wire the drill-to-record
+  // handler when drill-down is enabled. The base data-table guards against
+  // firing on interactive cells (buttons / menus / dialogs).
   const tableSchema = {
     ...schema,
     type: 'data-table',
     data: finalData,
     columns: derivedColumns,
+    onRowClick: (schema as any).onRowClick ?? (recordDrillEnabled ? handleRowClick : undefined),
   };
+
+  // A `${event.*}` template (filter-mode title) is meaningless for a single
+  // record — fall back to the record's display name in that case.
+  const recordTitle =
+    drillDown?.title && !drillDown.title.includes('${') ? drillDown.title : undefined;
 
   return (
     <div className={cn('relative', className)}>
       <RefreshIndicator active={loading && finalData.length > 0} />
       <SchemaRenderer schema={tableSchema} className={className} />
+      {recordDrillEnabled && (
+        <RecordDetailDrawer
+          record={drillRecord}
+          objectName={schema.objectName}
+          objectSchema={objectSchema}
+          fields={drillDown?.columns}
+          title={recordTitle}
+          target={drillDown?.target === 'dialog' ? 'dialog' : 'drawer'}
+          onClose={() => setDrillRecord(null)}
+        />
+      )}
     </div>
   );
 };

--- a/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
@@ -371,7 +371,9 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
         objectName,
         filter: resolvedFilter,
         pageSize: 25,
-        drillDown: { enabled: false },
+        // Complete the drill chain: a row in the KPI's record list opens that
+        // record. Dialog target so it stacks cleanly over this drill drawer.
+        drillDown: { enabled: true, mode: 'record', target: 'dialog' },
       } as any;
       body = (
         <div className="h-full overflow-auto">

--- a/packages/plugin-dashboard/src/RecordDetailDrawer.tsx
+++ b/packages/plugin-dashboard/src/RecordDetailDrawer.tsx
@@ -1,0 +1,152 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * RecordDetailDrawer — the drill-to-record surface for dashboard table / list
+ * widgets.
+ *
+ * When a row in a table / list widget is clicked (and drill-down is enabled),
+ * this opens a side drawer (or dialog) showing that single record's fields,
+ * read-only. It mirrors Salesforce's list-view row → record preview and Power
+ * BI's "see records" row drill: the row already *is* a record, so there is no
+ * filter to derive — we just present the record we already fetched.
+ *
+ * The record object is supplied directly by the table (it was fetched with all
+ * columns), so the drawer renders without an additional round-trip. Field
+ * labels and value formatting come from the shared {@link recordFields} helpers
+ * so a value reads identically in the table cell and in this drawer.
+ */
+
+import React, { useMemo } from 'react';
+import {
+  Sheet, SheetContent, SheetHeader, SheetTitle,
+  Dialog, DialogContent, DialogHeader, DialogTitle,
+} from '@object-ui/components';
+import { useSafeFieldLabel, useLocalization } from '@object-ui/i18n';
+import {
+  indexObjectFields,
+  buildFieldMeta,
+  renderFieldValue,
+  isSystemField,
+  isNumericFieldMeta,
+} from './recordFields';
+
+export interface RecordDetailDrawerProps {
+  /** The record to display, or `null` when nothing is selected. */
+  record: Record<string, any> | null;
+  /** Object the record belongs to (drives label translation + field meta). */
+  objectName?: string;
+  /** Object schema (field metadata) for labels / formatting. Optional. */
+  objectSchema?: any;
+  /**
+   * Optional whitelist of field accessors to show (e.g. `drillDown.columns`).
+   * When omitted, all non-system fields are shown in schema declaration order
+   * (falling back to the record's own keys when no schema is available).
+   */
+  fields?: string[];
+  /** Explicit drawer/dialog title; defaults to the record's display name. */
+  title?: string;
+  /** Where to open. Defaults to `'drawer'` (right-side Sheet). */
+  target?: 'drawer' | 'dialog';
+  /** Called when the drawer requests to close. */
+  onClose: () => void;
+}
+
+/** Candidate fields, in priority order, used to title the drawer. */
+const NAME_FIELDS = ['name', 'title', 'label', 'subject', 'display_name', 'full_name'];
+
+function resolveRecordTitle(record: Record<string, any>, explicit?: string): string {
+  if (explicit && explicit.trim()) return explicit;
+  for (const f of NAME_FIELDS) {
+    const v = record[f];
+    if (typeof v === 'string' && v.trim()) return v;
+  }
+  // Last resort: a record id keeps the drawer from being titled "Record".
+  const id = record.id ?? record._id;
+  return id != null ? String(id) : 'Record';
+}
+
+export const RecordDetailDrawer: React.FC<RecordDetailDrawerProps> = ({
+  record,
+  objectName,
+  objectSchema,
+  fields,
+  title,
+  target = 'drawer',
+  onClose,
+}) => {
+  const { fieldLabel, fieldOptionLabel } = useSafeFieldLabel();
+  const { currency: tenantCurrency } = useLocalization();
+
+  const rows = useMemo(() => {
+    if (!record) return [];
+    const fieldsByName = indexObjectFields(objectSchema);
+
+    // Which fields, in which order: explicit whitelist → schema declaration
+    // order → record's own keys. System / audit fields are hidden unless the
+    // author explicitly listed them.
+    let keys: string[];
+    if (fields && fields.length > 0) {
+      keys = fields;
+    } else if (Object.keys(fieldsByName).length > 0) {
+      keys = Object.keys(fieldsByName).filter((k) => !isSystemField(k, fieldsByName[k]));
+    } else {
+      keys = Object.keys(record).filter((k) => !k.startsWith('_') && !isSystemField(k));
+    }
+
+    return keys.map((key) => {
+      const def = fieldsByName[key];
+      const humanized = key.charAt(0).toUpperCase() + key.slice(1).replace(/([A-Z])/g, ' $1').replace(/_/g, ' ');
+      const label = objectName ? fieldLabel(objectName, key, humanized) : humanized;
+      const fieldMeta = buildFieldMeta({ accessorKey: key, label, def, objectName, fieldOptionLabel });
+      return {
+        key,
+        label,
+        node: renderFieldValue(record[key], fieldMeta, tenantCurrency),
+        numeric: isNumericFieldMeta(fieldMeta),
+      };
+    });
+  }, [record, objectSchema, objectName, fields, fieldLabel, fieldOptionLabel, tenantCurrency]);
+
+  if (!record) return null;
+
+  const heading = resolveRecordTitle(record, title);
+
+  const body = (
+    <dl className="divide-y divide-border/60" data-testid="record-detail-body">
+      {rows.map((row) => (
+        <div key={row.key} className="grid grid-cols-3 gap-3 py-2.5">
+          <dt className="text-xs font-medium text-muted-foreground self-center">{row.label}</dt>
+          <dd className={`col-span-2 text-sm break-words ${row.numeric ? 'tabular-nums' : ''}`}>
+            {row.node === '' || row.node == null
+              ? <span className="text-muted-foreground/60">—</span>
+              : row.node}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+
+  if (target === 'dialog') {
+    return (
+      <Dialog open onOpenChange={(v) => !v && onClose()}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader><DialogTitle>{heading}</DialogTitle></DialogHeader>
+          <div className="max-h-[70vh] overflow-auto">{body}</div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Sheet open onOpenChange={(v) => !v && onClose()}>
+      <SheetContent side="right" className="w-full sm:max-w-md md:max-w-lg flex flex-col">
+        <SheetHeader><SheetTitle>{heading}</SheetTitle></SheetHeader>
+        <div className="flex-1 overflow-auto mt-2 pr-1">{body}</div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/packages/plugin-dashboard/src/WidgetConfigPanel.tsx
+++ b/packages/plugin-dashboard/src/WidgetConfigPanel.tsx
@@ -72,10 +72,15 @@ const AGGREGATING_TYPES = ['metric', ...CHART_TYPES];
 // re-runs the query grouped by that field, producing multiple results).
 const CATEGORY_GROUPED_TYPES = [...CHART_TYPES];
 
-// Widget types that support drill-down (clicking a cell/segment opens a
-// filtered list of underlying records). Pairs with the @object-ui/core
-// `drill-down` helpers.
-const DRILL_DOWN_TYPES = ['pivot', 'metric', 'bar', 'horizontal-bar', 'line', 'area', 'pie', 'donut', 'funnel'];
+// Widget types that support drill-down. Aggregating widgets (chart / pivot /
+// metric) drill *through* — clicking a cell/segment opens a filtered list of
+// underlying records. Record widgets (table / list) drill *to record* —
+// clicking a row opens that record's detail. Pairs with the @object-ui/core
+// `drill-down` helpers and the `DrillDownConfig.mode` discriminator.
+const DRILL_DOWN_TYPES = [
+  'pivot', 'metric', 'bar', 'horizontal-bar', 'line', 'area', 'pie', 'donut', 'funnel',
+  'scatter', 'treemap', 'sankey', 'table', 'list',
+];
 
 function isChartType(t: string | undefined): boolean {
   return !!t && CHART_TYPES.includes(t);
@@ -509,7 +514,7 @@ function buildWidgetSchema(
             label: 'Enable drill-down',
             type: 'switch',
             defaultValue: false,
-            helpText: 'When enabled, clicking a cell / segment opens a filtered list of underlying records.',
+            helpText: 'When enabled, clicking a chart segment / pivot cell opens a filtered list of underlying records; clicking a table or list row opens that record.',
           },
           {
             key: 'drillDownTarget',

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.drill.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.drill.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Behavior tests for ObjectDataTable drill-to-record: with `drillDown` enabled
+ * (record mode), clicking a row opens that record in a RecordDetailDrawer. With
+ * drill absent / disabled / in filter-mode, no drawer opens. An author-supplied
+ * onRowClick is never hijacked by the drill handler.
+ *
+ * These render the real `data-table` renderer (registered transitively via
+ * `@object-ui/components`) so they exercise the actual row-click path, not a
+ * mock.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+// Ensure the base data-table renderer is registered before any test renders.
+beforeAll(async () => {
+  await import('@object-ui/components');
+}, 30000);
+
+import { ObjectDataTable } from '../ObjectDataTable';
+
+const records = [
+  { id: '1', name: 'Acme Renewal', amount: 1500 },
+  { id: '2', name: 'Globex Expansion', amount: 9000 },
+];
+
+function renderTable(extra: Record<string, any> = {}) {
+  return render(
+    <ObjectDataTable
+      schema={{ type: 'object-data-table', objectName: 'opportunity', data: records, ...extra }}
+    />,
+  );
+}
+
+/** Click the table cell carrying the given record name. */
+function clickRow(name: string) {
+  fireEvent.click(screen.getByText(name));
+}
+
+describe('ObjectDataTable — drill-to-record', () => {
+  it('opens the record drawer when a row is clicked (drill enabled)', () => {
+    renderTable({ drillDown: { enabled: true } });
+
+    expect(screen.queryByTestId('record-detail-body')).toBeNull();
+    clickRow('Acme Renewal');
+
+    const body = screen.getByTestId('record-detail-body');
+    expect(body).toBeInTheDocument();
+    // The drawer shows the clicked record's fields. (No object schema is bound
+    // in this test, so `amount` renders as its raw value — currency formatting
+    // from a bound schema is covered by RecordDetailDrawer.test.tsx.)
+    expect(within(body).getByText('Amount')).toBeInTheDocument();
+    expect(within(body).getByText('1500')).toBeInTheDocument();
+  });
+
+  it('does not open a drawer when drill-down is absent', () => {
+    renderTable();
+    clickRow('Acme Renewal');
+    expect(screen.queryByTestId('record-detail-body')).toBeNull();
+  });
+
+  it('does not open a drawer when drill-down is explicitly disabled', () => {
+    renderTable({ drillDown: { enabled: false } });
+    clickRow('Acme Renewal');
+    expect(screen.queryByTestId('record-detail-body')).toBeNull();
+  });
+
+  it('ignores filter-mode drill on a record table (no row→record)', () => {
+    renderTable({ drillDown: { enabled: true, mode: 'filter' } });
+    clickRow('Acme Renewal');
+    expect(screen.queryByTestId('record-detail-body')).toBeNull();
+  });
+
+  it('preserves an author-supplied onRowClick over the drill handler', () => {
+    const authorClick = vi.fn();
+    renderTable({ drillDown: { enabled: true }, onRowClick: authorClick });
+
+    clickRow('Globex Expansion');
+    expect(authorClick).toHaveBeenCalledTimes(1);
+    // The author handler wins — the drill drawer must not open.
+    expect(screen.queryByTestId('record-detail-body')).toBeNull();
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/RecordDetailDrawer.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/RecordDetailDrawer.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit tests for RecordDetailDrawer — the drill-to-record surface for table /
+ * list widgets. Verifies field selection (system fields hidden, whitelist
+ * honored), label + value formatting (shared with the table cells), title
+ * resolution, and the drawer/dialog target switch.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { RecordDetailDrawer } from '../RecordDetailDrawer';
+
+const opportunitySchema = {
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    amount: { type: 'currency', label: 'Amount', defaultCurrency: 'USD' },
+    stage: {
+      type: 'select',
+      label: 'Stage',
+      options: [
+        { value: 'won', label: 'Won', color: 'green' },
+        { value: 'lost', label: 'Lost', color: 'red' },
+      ],
+    },
+    created_at: { type: 'datetime', label: 'Created' },
+  },
+};
+
+describe('RecordDetailDrawer', () => {
+  it('renders nothing when no record is selected', () => {
+    const { container } = render(
+      <RecordDetailDrawer record={null} objectName="opportunity" onClose={vi.fn()} />,
+    );
+    expect(container.querySelector('[data-testid="record-detail-body"]')).toBeNull();
+  });
+
+  it('shows business fields with labels and formatted values, hiding system fields', () => {
+    render(
+      <RecordDetailDrawer
+        record={{ id: 'opp-1', name: 'Acme Renewal', amount: 1500, stage: 'won' }}
+        objectName="opportunity"
+        objectSchema={opportunitySchema}
+        onClose={vi.fn()}
+      />,
+    );
+
+    // Field labels rendered
+    expect(screen.getByText('Amount')).toBeInTheDocument();
+    expect(screen.getByText('Stage')).toBeInTheDocument();
+
+    // Currency formatting via the shared renderer (USD inferred from schema)
+    expect(screen.getByText(/1,500/)).toBeInTheDocument();
+
+    // Select option label resolved ("won" → "Won")
+    expect(screen.getByText('Won')).toBeInTheDocument();
+
+    // System field `id` is not shown as its own row
+    expect(screen.queryByText('Id')).toBeNull();
+  });
+
+  it('titles the drawer with the record display name', () => {
+    render(
+      <RecordDetailDrawer
+        record={{ id: 'opp-1', name: 'Acme Renewal', amount: 1500 }}
+        objectName="opportunity"
+        objectSchema={opportunitySchema}
+        onClose={vi.fn()}
+      />,
+    );
+    // Title (SheetTitle) + the name field value both read "Acme Renewal"
+    expect(screen.getAllByText('Acme Renewal').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('honors an explicit field whitelist (and order)', () => {
+    render(
+      <RecordDetailDrawer
+        record={{ id: 'opp-1', name: 'Acme', amount: 1500, stage: 'won' }}
+        objectName="opportunity"
+        objectSchema={opportunitySchema}
+        fields={['stage']}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Stage')).toBeInTheDocument();
+    // amount was not whitelisted
+    expect(screen.queryByText('Amount')).toBeNull();
+  });
+
+  it('falls back to record keys when no object schema is available', () => {
+    render(
+      <RecordDetailDrawer
+        record={{ id: 'r1', title: 'Untitled task', priority: 'high' }}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('record-detail-body')).toBeInTheDocument();
+    expect(screen.getByText('high')).toBeInTheDocument();
+    // _-prefixed / system keys stay hidden
+    expect(screen.queryByText('Id')).toBeNull();
+  });
+
+  it('renders as a dialog when target="dialog"', () => {
+    render(
+      <RecordDetailDrawer
+        record={{ id: '1', name: 'Acme' }}
+        objectName="opportunity"
+        target="dialog"
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/drillDownTypes.test.ts
+++ b/packages/plugin-dashboard/src/__tests__/drillDownTypes.test.ts
@@ -1,0 +1,29 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Guards the drill-down widget-type registry exposed by the config panel:
+ * the chart families (incl. scatter / treemap / sankey), pivot and metric
+ * drill *through*; table / list drill *to record*. Radar is intentionally
+ * excluded (no single clickable category point).
+ */
+import { describe, it, expect } from 'vitest';
+import { supportsDrillDown } from '../WidgetConfigPanel';
+
+describe('supportsDrillDown', () => {
+  it.each([
+    'pivot', 'metric',
+    'bar', 'horizontal-bar', 'line', 'area', 'pie', 'donut', 'funnel',
+    'scatter', 'treemap', 'sankey',
+    'table', 'list',
+  ])('enables drill-down for %s', (t) => {
+    expect(supportsDrillDown(t)).toBe(true);
+  });
+
+  it.each(['radar', 'custom', 'gauge', undefined])(
+    'does not enable drill-down for %s',
+    (t) => {
+      expect(supportsDrillDown(t as any)).toBe(false);
+    },
+  );
+});

--- a/packages/plugin-dashboard/src/recordFields.tsx
+++ b/packages/plugin-dashboard/src/recordFields.tsx
@@ -1,0 +1,197 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Shared field-rendering helpers for the dashboard data widgets.
+ *
+ * Both the table widget cells (`ObjectDataTable`) and the drill-to-record
+ * detail drawer (`RecordDetailDrawer`) must format a field value identically —
+ * a currency in the table must read as a currency in the record drawer. These
+ * helpers centralize that logic so the two surfaces never drift:
+ *
+ * - {@link indexObjectFields} normalizes an object schema's `fields` (array or
+ *   map form) into a `name → def` lookup.
+ * - {@link buildFieldMeta} derives the `FieldMeta` consumed by the shared
+ *   `@object-ui/fields` cell renderers from an object-schema field definition
+ *   (with optional per-column overrides + translated select options).
+ * - {@link renderFieldValue} turns a raw value + `FieldMeta` into a React node
+ *   using the same currency / percent / date / cell-renderer rules as the grid.
+ */
+
+import React from 'react';
+import {
+  getCellRenderer,
+  resolveCellRendererType,
+  formatCurrency,
+  formatPercent,
+  formatDate,
+} from '@object-ui/fields';
+
+/** Field types treated as relations (rendered as links to the related record). */
+const LOOKUP_TYPES = new Set(['lookup', 'reference', 'master_detail', 'user', 'owner']);
+
+/**
+ * Framework / system audit fields hidden from auto-derived columns and the
+ * record-detail drawer. Authors wanting them can pass an explicit whitelist.
+ */
+export const SYSTEM_FIELDS = new Set([
+  'id', 'organization_id', 'tenant_id', 'created_at', 'updated_at',
+  'created_by', 'updated_by', 'deleted_at', 'deleted_by', 'version',
+  '_id', '__typename',
+]);
+
+/** Whether a field name/def is a framework/system field that should be hidden. */
+export function isSystemField(name: string, def?: any): boolean {
+  if (def && (def.isSystem === true || def.system === true)) return true;
+  return SYSTEM_FIELDS.has(name);
+}
+
+/** Field types whose `options` carry per-value labels worth translating. */
+const OPTION_TYPES = new Set(['select', 'picklist', 'dropdown', 'status']);
+
+/** Numeric-flavoured field types (right-aligned in tables). */
+export const NUMERIC_FIELD_TYPES = new Set([
+  'currency', 'money', 'number', 'integer', 'decimal', 'float', 'percent', 'percentage',
+]);
+
+export interface FieldMeta {
+  name: string;
+  label: string;
+  type?: string;
+  options?: Array<{ value: any; label: string; color?: string }>;
+  referenceTo?: unknown;
+  format?: string;
+  currency?: string;
+  decimals?: number;
+}
+
+/**
+ * Normalize an object schema's `fields` into a `{ name → def }` map. Accepts
+ * both the array form (`[{ name, type, ... }]`) and the keyed map form
+ * (`{ name: { type, ... } }`). Returns an empty object when no schema.
+ */
+export function indexObjectFields(objectSchema: any): Record<string, any> {
+  const out: Record<string, any> = {};
+  const fields = objectSchema?.fields;
+  if (!fields) return out;
+  if (Array.isArray(fields)) {
+    for (const def of fields) if (def?.name) out[def.name] = def;
+  } else {
+    for (const [name, def] of Object.entries(fields)) out[name] = { name, ...(def as any) };
+  }
+  return out;
+}
+
+export interface BuildFieldMetaParams {
+  accessorKey: string;
+  label: string;
+  /** Field definition from the object schema (if known). */
+  def?: any;
+  /** Object name, used to translate select-option labels. */
+  objectName?: string;
+  /** Translator for per-option labels (from `useSafeFieldLabel`). */
+  fieldOptionLabel?: (objectName: string, field: string, value: string, fallback: string) => string;
+  /** Per-column overrides (table columns may pin type/format/options). */
+  overrides?: {
+    type?: string;
+    format?: string;
+    options?: any;
+    referenceTo?: unknown;
+    currency?: string;
+    decimals?: number;
+  };
+}
+
+/**
+ * Build the `FieldMeta` for a single field, resolving `referenceTo`, currency
+ * and decimals from the schema field def and translating select options.
+ * Column-level overrides win over schema-derived values.
+ */
+export function buildFieldMeta(params: BuildFieldMetaParams): FieldMeta {
+  const { accessorKey, label, def: meta, objectName, fieldOptionLabel, overrides = {} } = params;
+
+  const referenceTo =
+    overrides.referenceTo ??
+    meta?.referenceTo ??
+    (typeof meta?.reference === 'string' ? meta.reference : meta?.reference?.to) ??
+    meta?.target;
+
+  let options: Array<{ value: any; label: string; color?: string }> | undefined =
+    overrides.options ?? meta?.options;
+
+  if (objectName && options && fieldOptionLabel && OPTION_TYPES.has(meta?.type)) {
+    options = options.map((opt: any) => {
+      if (opt == null) return opt;
+      const value = typeof opt === 'object' ? opt.value : opt;
+      const fallback = typeof opt === 'object' ? (opt.label || String(value)) : String(value);
+      return {
+        value,
+        label: fieldOptionLabel(objectName, accessorKey, String(value), fallback),
+        color: typeof opt === 'object' ? opt.color : undefined,
+      };
+    });
+  }
+
+  return {
+    name: accessorKey,
+    label,
+    type: overrides.type ?? meta?.type,
+    options,
+    referenceTo,
+    format: overrides.format ?? meta?.format,
+    currency: overrides.currency ?? meta?.currency ?? meta?.defaultCurrency,
+    decimals: overrides.decimals ?? meta?.decimals ?? meta?.precision ?? meta?.scale,
+  };
+}
+
+/** Whether a `FieldMeta` should be right-aligned (numeric / currency / percent). */
+export function isNumericFieldMeta(fieldMeta: Pick<FieldMeta, 'type' | 'format'>): boolean {
+  return (
+    NUMERIC_FIELD_TYPES.has(fieldMeta.type as string) ||
+    (typeof fieldMeta.format === 'string' && /^[\$¥€£]|%$|0/.test(fieldMeta.format))
+  );
+}
+
+/**
+ * Render a raw field value to a React node using the same currency / percent /
+ * date / cell-renderer rules as the dashboard table. Returns `''` for nullish /
+ * empty values.
+ *
+ * `tenantCurrency` (localization.currency, ADR-0053) backstops a currency
+ * field/format that declares no explicit code of its own, so both the table
+ * cell and the record-detail drawer honor the tenant default.
+ */
+export function renderFieldValue(
+  value: any,
+  fieldMeta: FieldMeta,
+  tenantCurrency?: string,
+): React.ReactNode {
+  if (value == null || value === '') return '';
+  const fmt = fieldMeta.format;
+  if (typeof fmt === 'string' && /^\$|¥|€|£/.test(fmt) && typeof value === 'number') {
+    // Honor explicit `currency`; else infer from the leading symbol so we never
+    // silently fall back to USD when the author wrote `¥`/`€`; finally fall back
+    // to the tenant default currency.
+    const symbolMap: Record<string, string> = { '$': 'USD', '¥': 'JPY', '€': 'EUR', '£': 'GBP' };
+    const inferred = symbolMap[fmt[0]];
+    return formatCurrency(value, fieldMeta.currency || inferred || tenantCurrency);
+  }
+  if (typeof fmt === 'string' && /%/.test(fmt) && typeof value === 'number') {
+    const decimals = (fmt.match(/0\.(0+)%/) || [, ''] as any)[1].length;
+    const normalized = value > 1 ? value / 100 : value;
+    return formatPercent(normalized * 100, decimals);
+  }
+  if (typeof fmt === 'string' && /[YMDHms]/.test(fmt)) {
+    return formatDate(value, fmt);
+  }
+  const Renderer = getCellRenderer(resolveCellRendererType(fieldMeta as any));
+  return <Renderer value={value} field={fieldMeta as any} />;
+}
+
+/** Whether a field is a relation/lookup (used to drive `$expand`). */
+export function isLookupType(t: unknown): boolean {
+  return LOOKUP_TYPES.has(t as string);
+}

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -687,6 +687,22 @@ export type PivotAggregation = 'sum' | 'count' | 'avg' | 'min' | 'max';
 export interface DrillDownConfig {
   /** Master switch. Set to true (or supply any other field) to enable. */
   enabled?: boolean;
+  /**
+   * Which drill interaction the widget performs:
+   *
+   * - `'filter'` (default) — **drill-through**: the click point is an
+   *   aggregated bucket (pivot cell, chart segment, KPI). The drawer lists
+   *   the underlying records filtered by the click context. Used by charts,
+   *   pivot tables and metric cards.
+   * - `'record'` — **drill-to-record**: the click point already *is* a single
+   *   record (a row in a table / list widget). The drawer shows that record's
+   *   detail instead of a filtered list. This is the default for table / list
+   *   widgets, mirroring Salesforce list-view row → record and Power BI's
+   *   "see records" row interaction.
+   *
+   * When omitted the consuming widget picks the natural default for its type.
+   */
+  mode?: 'filter' | 'record';
   /** Where the drill-down view opens. Defaults to "drawer". */
   target?: 'drawer' | 'dialog';
   /**

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -18,6 +18,11 @@ export default defineConfig({
       '**/e2e/**',
       '**/.{idea,git,cache,output,temp}/**',
       '**/.claude/**',
+      // In-repo git worktrees (`.wt-*`, per AGENTS.md / the worktree workflow)
+      // are full checkouts of other branches. Without this their *.test.tsx
+      // copies get globbed in and run against this tree's source — producing
+      // phantom failures from another branch's code.
+      '**/.wt-*/**',
       // Apps have their own '@/' alias pointing at their own src/, so they
       // can't share the root '@' alias (→ packages/components). They are
       // brought back in via the `projects` array below with their own


### PR DESCRIPTION
## What & why

Drill-in was only fully realized on a couple of widgets. This expands it to the gaps, and formalizes the two interaction semantics mainstream BI/low-code platforms separate (Power BI *drill-through* vs Salesforce list-row → record).

`DrillDownConfig` gains a `mode` discriminator:
- `'filter'` (default) — **drill-through**: aggregate bucket (pivot cell / chart segment / KPI) → filtered record list.
- `'record'` — **drill-to-record**: a table/list row → that record's detail. Default for table/list.

## Changes

**1. Chart drill-through completion** — scatter / treemap / sankey now wire `onClick` and reuse ObjectChart's existing drill drawer. Radar is intentionally excluded (a polar polygon has no single clickable category point). The Recharts-payload → drill-event mapping is extracted to pure, unit-tested functions (`chartDrillEvents.ts`). Fixes a stale comment that claimed scatter/funnel had no click wiring.

**2. Table/list drill-to-record** — clicking a row in an object-backed table/list opens that record read-only in a `RecordDetailDrawer` (Sheet, or Dialog). Field labels + cell formatting are shared with the table via a new `recordFields` module so a value reads identically in the cell and the drawer. Object-backed table/list widgets get this on by default; authors opt out with `drillDown:{enabled:false}`. An author-supplied `onRowClick` always wins.

**3. Completes the drill chain** — the chart/KPI drill-through record lists now drill into a record too (rendered as a dialog so it stacks over the outer drawer), matching Power BI's segment → list → record path.

**4. Config panel** — `scatter/treemap/sankey/table/list` added to `DRILL_DOWN_TYPES` so the drill toggle is offered for them.

**5. vitest** — exclude in-repo `.wt-*` git worktrees so sibling-branch test copies aren't globbed into runs.

## Verification

- 40 new tests; `plugin-dashboard` + `plugin-charts` full suites **107 passed / 0 failed**. Integration test renders the real `data-table` and asserts the record drawer opens on row click; author `onRowClick` preserved; disabled / filter-mode tables don't drill.
- `type-check` clean across affected packages + downstream consumers (app-shell / components / react), 29 turbo tasks.
- Browser smoke on the showcase console (code live via src alias + HMR): dashboards render with **zero console errors**, drill-through still works, table rows correctly become drill-enabled. Live record-drawer click wasn't exercisable because the showcase backend only seeds dataset-bound tables — covered by the integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)