### PR TITLE
fix(dashboard): complete drill chain in shared DrillDownDrawer (pivot + dataset)

### DIFF
--- a/.changeset/drill-chain-drilldowndrawer.md
+++ b/.changeset/drill-chain-drilldowndrawer.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/plugin-dashboard": patch
+---
+
+fix(dashboard): complete the drill chain in the shared DrillDownDrawer
+
+The chart and KPI drill-through record lists already let you click a row to open
+that record, but the shared `DrillDownDrawer` (used by **pivot** and **dataset**
+widget drill-through) did not — so the segment → list → record chain was
+inconsistent across widget types. `DrillDownDrawer` now enables record drill on
+its filtered list (dialog target, stacking over the drawer), so every
+drill-through list lands on a clickable record.

--- a/packages/plugin-dashboard/src/DrillDownDrawer.tsx
+++ b/packages/plugin-dashboard/src/DrillDownDrawer.tsx
@@ -96,6 +96,11 @@ export const DrillDownDrawer: React.FC<DrillDownDrawerProps> = ({
               pagination: true,
               searchable: false,
               pageSize: maxRows,
+              // Complete the drill chain: a row in this filtered record list
+              // opens that record. Dialog target so it stacks over this drawer.
+              // Mirrors the chart / KPI drill tables — every drill-through list
+              // (pivot, dataset, chart, metric) lands on a clickable record.
+              drillDown: { enabled: true, mode: 'record', target: 'dialog' },
             }}
             dataSource={dataSource}
           />

--- a/packages/plugin-dashboard/src/__tests__/DrillDownDrawer.chain.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DrillDownDrawer.chain.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Verifies the drill chain completes through DrillDownDrawer: the filtered
+ * record list it renders (for pivot / dataset / chart drill-through) is itself
+ * drill-to-record, so clicking a row opens that record.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+// Register the base data-table renderer (transitively via @object-ui/components).
+beforeAll(async () => {
+  await import('@object-ui/components');
+}, 30000);
+
+import { DrillDownDrawer } from '../DrillDownDrawer';
+
+const records = [
+  { id: '1', name: 'Acme Renewal', amount: 1500 },
+  { id: '2', name: 'Globex Expansion', amount: 9000 },
+];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: records })),
+    getObjectSchema: vi.fn(async () => ({
+      fields: { name: { type: 'text', label: 'Name' }, amount: { type: 'number', label: 'Amount' } },
+    })),
+  };
+}
+
+describe('DrillDownDrawer — completes the drill chain to a record', () => {
+  it('wires record drill on the filtered drill list (chain completion)', async () => {
+    render(
+      <DrillDownDrawer
+        open
+        onClose={vi.fn()}
+        title="Won × Web"
+        objectName="opportunity"
+        filter={{ stage: 'won' }}
+        dataSource={makeDataSource()}
+      />,
+    );
+
+    // The drill-through list renders the underlying records.
+    await waitFor(() => expect(screen.getByText('Acme Renewal')).toBeInTheDocument());
+
+    // Its rows are drill-to-record: the data-table marks clickable rows with
+    // `cursor-pointer` only when an onRowClick is wired, which ObjectDataTable
+    // does only when record drill is enabled. (The record drawer opening on
+    // click is covered by ObjectDataTable.drill.test.)
+    const row = screen.getByText('Acme Renewal').closest('tr') as HTMLElement;
+    expect(row.className).toContain('cursor-pointer');
+  });
+});


### PR DESCRIPTION
Follow-up to #1859. That PR completed the segment → list → record drill chain for **object-backed chart and KPI** drill-through lists, but the shared `DrillDownDrawer` — used by **pivot** and **dataset** widget drill-through — still rendered a non-clickable record list. So the chain was inconsistent across widget types.

`DrillDownDrawer` now enables record drill on its filtered list (`mode: 'record'`, dialog target so it stacks over the drawer), matching the chart/KPI path. Every drill-through list now lands on a clickable record.

## Verification
- New test asserts `DrillDownDrawer`'s list wires record drill (rows become clickable). The record drawer opening on click is already covered by `ObjectDataTable.drill.test`.
- `plugin-dashboard` full suite: **87 passed / 0 failed**; type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)