### PR TITLE
feat(console-ai): richer, outcome-framed metadata-assistant starters

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1109,9 +1109,11 @@ function metadataAssistantSuggestions(t: TranslationFn): string[] {
   // natural-language description (the magic moment), so the empty-state nudges
   // toward "describe a system" rather than inspecting existing schema.
   return [
-    t('console.ai.suggestions.metadataAssistant.buildCrm', { defaultValue: 'Build a CRM: customers, contacts and opportunities, with relationships.' }),
-    t('console.ai.suggestions.metadataAssistant.buildApp', { defaultValue: 'Create a project management app: projects, tasks and members.' }),
-    t('console.ai.suggestions.metadataAssistant.buildFlow', { defaultValue: 'Design a ticketing system: tickets, priority and a status flow.' }),
+    t('console.ai.suggestions.metadataAssistant.buildCrm', { defaultValue: 'Build a sales CRM — customers, contacts, and a deal pipeline I can total by stage.' }),
+    t('console.ai.suggestions.metadataAssistant.buildApp', { defaultValue: 'Create a project tracker — projects, tasks with owners and due dates, and a board by status.' }),
+    t('console.ai.suggestions.metadataAssistant.buildFlow', { defaultValue: 'Design a support desk — tickets with priority, a status workflow, and customer links.' }),
+    t('console.ai.suggestions.metadataAssistant.buildInventory', { defaultValue: 'Build an inventory app — products, stock levels, suppliers, and low-stock visibility.' }),
+    t('console.ai.suggestions.metadataAssistant.buildRecruiting', { defaultValue: 'Make an applicant tracker — candidates, open roles, interview stages, and notes.' }),
   ];
 }
 

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1113,9 +1113,11 @@ const en = {
           recordCounts: 'Count records for each object.',
         },
         metadataAssistant: {
-          buildCrm: 'Build a CRM: customers, contacts and opportunities, with relationships.',
-          buildApp: 'Create a project management app: projects, tasks and members.',
-          buildFlow: 'Design a ticketing system: tickets, priority and a status flow.',
+          buildCrm: 'Build a sales CRM — customers, contacts, and a deal pipeline I can total by stage.',
+          buildApp: 'Create a project tracker — projects, tasks with owners and due dates, and a board by status.',
+          buildFlow: 'Design a support desk — tickets with priority, a status workflow, and customer links.',
+          buildInventory: 'Build an inventory app — products, stock levels, suppliers, and low-stock visibility.',
+          buildRecruiting: 'Make an applicant tracker — candidates, open roles, interview stages, and notes.',
         },
         generic: {
           help: 'What can you help me with?',


### PR DESCRIPTION
## Why

Competitive review of Airtable's Omni AI builder: its empty-state offers many inspiring, **outcome-framed** idea prompts across domains. Our build-assistant empty-state had three terse starters.

## Change

- Reword the existing 3 metadata-assistant starters to lead with the **business outcome** (e.g. "Build a sales CRM — customers, contacts, and a deal pipeline I can total by stage.").
- Add two more domains: **inventory** and **recruiting**.
- Strings only; the `Suggestions` row already scrolls horizontally so no layout change. en bundle (`packages/i18n`) and the inline `defaultValue`s are kept in sync; `t()` accepts the two new keys (loosely typed).

## Verification

Ran objectui's console dev server (`DEV_PROXY_TARGET=<rig>`) and confirmed the edited module is served with the new starters. (Rendering of metadata-assistant chips uses the `?agent=metadata_assistant` deep-link, which resolves on the bundled console.)

Part of the post-Omni-review improvement series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)