### PR TITLE
feat(fields): recently-used, quick-create, preview & combobox a11y for lookups

### DIFF
--- a/packages/fields/src/complex-widgets.test.tsx
+++ b/packages/fields/src/complex-widgets.test.tsx
@@ -84,6 +84,7 @@ describe('Complex & Relationship Widgets', () => {
 
         beforeEach(() => {
             vi.clearAllMocks();
+            try { localStorage.clear(); } catch { /* jsdom */ }
         });
 
         it('fetches data from DataSource when dialog opens', async () => {
@@ -310,6 +311,53 @@ describe('Complex & Relationship Widgets', () => {
             });
 
             expect(onCreateNew).toHaveBeenCalledWith('');
+        });
+
+        it('quick-creates via dataSource.create when allow_create is set', async () => {
+            mockDataSource.find.mockResolvedValue({ data: [], total: 0 });
+            mockDataSource.create.mockResolvedValue({ id: 'new-1', name: 'Acme' });
+            const onChange = vi.fn();
+            const field = { ...dynamicField, allow_create: true } as any;
+
+            render(<LookupField {...dynamicProps} field={field} onChange={onChange} />);
+
+            await act(async () => {
+                fireEvent.click(screen.getByRole('button', { name: /Select/i }));
+            });
+
+            const input = await screen.findByRole('combobox');
+            await act(async () => {
+                fireEvent.change(input, { target: { value: 'Acme' } });
+            });
+
+            const createBtn = await screen.findByText('Create new "Acme"');
+            await act(async () => {
+                fireEvent.click(createBtn);
+            });
+
+            await waitFor(() => {
+                expect(mockDataSource.create).toHaveBeenCalledWith('customers', { name: 'Acme' });
+            });
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalledWith('new-1');
+            });
+        });
+
+        it('shows a recently-used section on empty focus', async () => {
+            localStorage.setItem('objectui:lookup:recent:customers', JSON.stringify(['r1']));
+            mockDataSource.find.mockResolvedValue({ data: [{ id: 'a', name: 'Acme Corp' }], total: 1 });
+            mockDataSource.findOne.mockResolvedValue({ id: 'r1', name: 'Recent Co' });
+
+            render(<LookupField {...dynamicProps} />);
+
+            await act(async () => {
+                fireEvent.click(screen.getByRole('button', { name: /Select/i }));
+            });
+
+            await waitFor(() => {
+                expect(screen.getByText('Recently used')).toBeInTheDocument();
+                expect(screen.getByText('Recent Co')).toBeInTheDocument();
+            });
         });
 
         it('navigates options with arrow keys and selects with Enter', async () => {

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -12,6 +12,7 @@ import type { DataSource, QueryParams, LookupColumnDef } from '@object-ui/types'
 import { RecordPickerDialog, lookupFiltersToRecord } from './RecordPickerDialog';
 import type { RecordPickerFilterColumn } from './RecordPickerDialog';
 import { deriveLookupColumns } from './deriveLookupColumns';
+import { getRecentLookupIds, pushRecentLookupId } from './recentLookups';
 import { getCellRendererResolver } from './_cell-renderer-bridge';
 import { SchemaRendererContext as ImportedSchemaRendererContext } from '@object-ui/react';
 import { useFieldTranslation } from './useFieldTranslation';
@@ -129,6 +130,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const { t } = useFieldTranslation();
+  const listboxId = React.useId();
 
   // Dynamic data loading state
   const [fetchedOptions, setFetchedOptions] = useState<LookupOption[]>([]);
@@ -165,6 +167,9 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   const idField = fieldMeta?.id_field || 'id';
   // ObjectStack convention uses `reference`; types define `reference_to` — support both
   const referenceTo: string | undefined = fieldMeta?.reference_to || fieldMeta?.reference;
+  // Opt-in inline quick-create: when set, an empty/zero-result picker offers to
+  // create a record from the typed text via dataSource.create.
+  const allowCreate: boolean = !!(fieldMeta?.allow_create ?? fieldMeta?.allowCreate);
 
   // Enterprise Record Picker configuration
   const lookupColumns: Array<string | LookupColumnDef> | undefined = fieldMeta?.lookup_columns ?? fieldMeta?.lookupColumns;
@@ -508,15 +513,17 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
         if (isSelected) {
           onChange(currentValues.filter((v: any) => v !== option.value));
         } else {
+          if (referenceTo) pushRecentLookupId(referenceTo, option.value);
           onChange([...currentValues, option.value]);
         }
       } else {
+        if (referenceTo) pushRecentLookupId(referenceTo, option.value);
         if (onSelectRecord) onSelectRecord(option);
         else onChange(option.value);
         setIsOpen(false);
       }
     },
-    [multiple, value, onChange, onSelectRecord],
+    [multiple, value, onChange, onSelectRecord, referenceTo],
   );
 
   const handleRemove = (optionValue: any) => {
@@ -533,9 +540,88 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   const handlePickerSelectRecords = useCallback(
     (records: any[]) => {
       const mapped = records.map(r => recordToOption(r, displayField, idField, effectiveDescriptionField, refTitleFormat));
+      if (referenceTo) mapped.forEach((o) => pushRecentLookupId(referenceTo, o.value));
       setPickerResolvedRecords(mapped);
     },
-    [displayField, idField, effectiveDescriptionField, refTitleFormat],
+    [displayField, idField, effectiveDescriptionField, refTitleFormat, referenceTo],
+  );
+
+  // ── Recently-used, quick-create, combined option list ────────────────────
+  const [recentOptions, setRecentOptions] = useState<LookupOption[]>([]);
+  useEffect(() => {
+    if (!isOpen || !hasDataSource || !dataSource || !referenceTo || searchQuery) return;
+    const ids = getRecentLookupIds(referenceTo);
+    if (!ids.length) { setRecentOptions([]); return; }
+    let cancelled = false;
+    (async () => {
+      try {
+        const recs: LookupOption[] = [];
+        for (const id of ids) {
+          const cached = findOption(id);
+          if (cached) { recs.push(cached); continue; }
+          if (typeof (dataSource as any).findOne === 'function') {
+            const r = await (dataSource as any).findOne(referenceTo, id);
+            if (r) recs.push(recordToOption(r, displayField, idField, effectiveDescriptionField, refTitleFormat));
+          }
+        }
+        if (!cancelled) setRecentOptions(recs);
+      } catch { if (!cancelled) setRecentOptions([]); }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, hasDataSource, referenceTo, searchQuery]);
+
+  // Recently-used first (only before the user types), then live results — one
+  // de-duped list that drives BOTH rendering and arrow-key navigation.
+  const recentCount = (!searchQuery && hasDataSource) ? recentOptions.length : 0;
+  const visibleOptions = useMemo(() => {
+    if (searchQuery || !hasDataSource || recentOptions.length === 0) return filteredOptions;
+    const recentIds = new Set(recentOptions.map((o) => o.value));
+    return [...recentOptions, ...filteredOptions.filter((o) => !recentIds.has(o.value))];
+  }, [searchQuery, hasDataSource, recentOptions, filteredOptions]);
+  useEffect(() => { setActiveIndex(-1); }, [visibleOptions.length]);
+
+  const [creating, setCreating] = useState(false);
+  const canCreate = !!onCreateNew || (allowCreate && hasDataSource);
+  const handleCreateNew = useCallback(
+    async (q: string) => {
+      const label = (q || '').trim();
+      if (onCreateNew) { onCreateNew(label); setIsOpen(false); return; }
+      if (!allowCreate || !dataSource || !referenceTo || !label) return;
+      setCreating(true);
+      setError(null);
+      try {
+        const created = await (dataSource as any).create(referenceTo, { [displayField]: label });
+        const opt = recordToOption(created, displayField, idField, effectiveDescriptionField, refTitleFormat);
+        setPickerResolvedRecords((prev) => [opt, ...prev.filter((o) => o.value !== opt.value)]);
+        handleSelect(opt);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setCreating(false);
+      }
+    },
+    [onCreateNew, allowCreate, dataSource, referenceTo, displayField, idField, effectiveDescriptionField, refTitleFormat, handleSelect],
+  );
+
+  // Compact one-line preview of an option's extra (non-display) columns —
+  // shown as a native tooltip so users can disambiguate without opening it.
+  const previewOf = useCallback(
+    (option: LookupOption): string | undefined => {
+      if (!pickerColumns || pickerColumns.length === 0) return undefined;
+      const parts: string[] = [];
+      for (const c of pickerColumns) {
+        const f = typeof c === 'string' ? c : c.field;
+        if (f === displayField) continue;
+        const v = (option as any)[f];
+        if (v === null || v === undefined || v === '') continue;
+        const lbl = typeof c === 'string' ? f : (c.label || f);
+        const text = typeof v === 'object' ? (v.name ?? v.label ?? JSON.stringify(v)) : v;
+        parts.push(`${lbl}: ${text}`);
+      }
+      return parts.length ? parts.join(' · ') : undefined;
+    },
+    [pickerColumns, displayField],
   );
 
   // Keyboard handler for the search input — arrow keys + Enter
@@ -544,19 +630,19 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setActiveIndex(prev =>
-          prev < filteredOptions.length - 1 ? prev + 1 : prev,
+          prev < visibleOptions.length - 1 ? prev + 1 : prev,
         );
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         setActiveIndex(prev => (prev > 0 ? prev - 1 : 0));
       } else if (e.key === 'Enter') {
         e.preventDefault();
-        if (activeIndex >= 0 && activeIndex < filteredOptions.length) {
-          handleSelect(filteredOptions[activeIndex]);
+        if (activeIndex >= 0 && activeIndex < visibleOptions.length) {
+          handleSelect(visibleOptions[activeIndex]);
         }
       }
     },
-    [filteredOptions, activeIndex, handleSelect],
+    [visibleOptions, activeIndex, handleSelect],
   );
 
   // Scroll active item into view
@@ -633,6 +719,9 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
               compact && 'h-8 rounded-none border-0 bg-transparent px-2 shadow-none focus-visible:ring-1 focus-visible:ring-ring/60',
             )}
             type="button"
+            aria-haspopup="listbox"
+            aria-expanded={isOpen}
+            aria-controls={listboxId}
             disabled={dependenciesMissing || (props as any).disabled}
             data-testid={dependenciesMissing ? 'lookup-trigger-gated' : (((props as any).name || lookupField?.name) ? `lookup-trigger-${(props as any).name || lookupField.name}` : 'lookup-trigger')}
             title={dependenciesMissing
@@ -663,6 +752,11 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
                 onChange={(e) => handleSearchChange(e.target.value)}
                 onKeyDown={handleSearchKeyDown}
                 className="w-full pl-9 h-8 text-sm"
+                role="combobox"
+                aria-autocomplete="list"
+                aria-controls={listboxId}
+                aria-expanded={isOpen}
+                aria-activedescendant={activeIndex >= 0 ? `${listboxId}-opt-${activeIndex}` : undefined}
               />
               {loading && (
                 <Loader2
@@ -699,65 +793,78 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
 
           {/* Options list */}
           {!error && !(loading && filteredOptions.length === 0) && (
-            <div ref={listRef} className="max-h-64 overflow-y-auto px-1 pb-1" role="listbox">
-              {filteredOptions.length === 0 ? (
+            <div ref={listRef} className="max-h-64 overflow-y-auto px-1 pb-1" role="listbox" id={listboxId}>
+              {visibleOptions.length === 0 ? (
                 <div className="py-4 text-center">
                   <p className="text-sm text-muted-foreground">
                     {t('lookup.noOptions')}
                   </p>
                   {/* Quick-create entry */}
-                  {onCreateNew && (
+                  {canCreate && (
                     <Button
                       variant="ghost"
                       size="sm"
                       className="mt-2 gap-1"
                       type="button"
-                      onClick={() => {
-                        onCreateNew(searchQuery);
-                        setIsOpen(false);
-                      }}
+                      disabled={creating}
+                      onClick={() => handleCreateNew(searchQuery)}
                     >
-                      <Plus className="size-4" />
-                      {t('lookup.createNew')}
+                      {creating ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+                      {searchQuery ? t('lookup.createNamed', { name: searchQuery }) : t('lookup.createNew')}
                     </Button>
                   )}
                 </div>
               ) : (
                 <>
-                  {filteredOptions.map((option, idx) => {
+                  {visibleOptions.map((option, idx) => {
                     const isSelected = multiple
                       ? (Array.isArray(value) ? value : []).includes(option.value)
                       : value === option.value;
                     const isActive = idx === activeIndex;
+                    const showRecentHeader = recentCount > 0 && idx === 0;
+                    const showResultsHeader = recentCount > 0 && idx === recentCount;
 
                     return (
-                      <button
-                        key={option.value}
-                        data-lookup-index={idx}
-                        role="option"
-                        aria-selected={isSelected}
-                        onClick={() => handleSelect(option)}
-                        className={`w-full text-left px-3 py-2 rounded-md text-sm hover:bg-accent flex items-center justify-between ${
-                          isActive
-                            ? 'bg-accent text-accent-foreground'
-                            : isSelected
-                              ? 'bg-accent/50 text-accent-foreground'
-                              : ''
-                        }`}
-                        type="button"
-                      >
-                        <div className="min-w-0 flex-1">
-                          <span className="block truncate">{option.label}</span>
-                          {option.description && (
-                            <span className="block truncate text-xs text-muted-foreground">
-                              {option.description}
-                            </span>
-                          )}
-                        </div>
-                        {isSelected && (
-                          <Badge variant="default" className="ml-2 shrink-0">{t('lookup.selectedBadge')}</Badge>
+                      <React.Fragment key={option.value}>
+                        {showRecentHeader && (
+                          <div className="px-3 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                            {t('lookup.recentlyUsed')}
+                          </div>
                         )}
-                      </button>
+                        {showResultsHeader && (
+                          <div className="mt-1 border-t px-3 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                            {t('lookup.allResults')}
+                          </div>
+                        )}
+                        <button
+                          id={`${listboxId}-opt-${idx}`}
+                          data-lookup-index={idx}
+                          role="option"
+                          aria-selected={isSelected}
+                          title={previewOf(option)}
+                          onClick={() => handleSelect(option)}
+                          className={`w-full text-left px-3 py-2 rounded-md text-sm hover:bg-accent flex items-center justify-between ${
+                            isActive
+                              ? 'bg-accent text-accent-foreground'
+                              : isSelected
+                                ? 'bg-accent/50 text-accent-foreground'
+                                : ''
+                          }`}
+                          type="button"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <span className="block truncate">{option.label}</span>
+                            {option.description && (
+                              <span className="block truncate text-xs text-muted-foreground">
+                                {option.description}
+                              </span>
+                            )}
+                          </div>
+                          {isSelected && (
+                            <Badge variant="default" className="ml-2 shrink-0">{t('lookup.selectedBadge')}</Badge>
+                          )}
+                        </button>
+                      </React.Fragment>
                     );
                   })}
                   {/* Show total count when fetched from DataSource */}
@@ -782,16 +889,14 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
                     </button>
                   )}
                   {/* Quick-create entry (below results) */}
-                  {onCreateNew && (
+                  {canCreate && (
                     <button
                       type="button"
                       className="w-full text-left px-3 py-2 rounded-md text-sm hover:bg-accent flex items-center gap-1.5 text-muted-foreground"
-                      onClick={() => {
-                        onCreateNew(searchQuery);
-                        setIsOpen(false);
-                      }}
+                      disabled={creating}
+                      onClick={() => handleCreateNew(searchQuery)}
                     >
-                      <Plus className="size-3.5" />
+                      {creating ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
                       {searchQuery ? t('lookup.createNamed', { name: searchQuery }) : t('lookup.createNew')}
                     </button>
                   )}

--- a/packages/fields/src/widgets/recentLookups.test.ts
+++ b/packages/fields/src/widgets/recentLookups.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getRecentLookupIds, pushRecentLookupId } from './recentLookups';
+
+describe('recentLookups', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('returns [] when nothing stored', () => {
+    expect(getRecentLookupIds('acc')).toEqual([]);
+  });
+
+  it('stores and returns ids most-recent-first', () => {
+    pushRecentLookupId('acc', 'a');
+    pushRecentLookupId('acc', 'b');
+    expect(getRecentLookupIds('acc')).toEqual(['b', 'a']);
+  });
+
+  it('de-dupes and moves a re-picked id to the front', () => {
+    pushRecentLookupId('acc', 'a');
+    pushRecentLookupId('acc', 'b');
+    pushRecentLookupId('acc', 'a');
+    expect(getRecentLookupIds('acc')).toEqual(['a', 'b']);
+  });
+
+  it('caps at 5 entries', () => {
+    for (const id of ['a', 'b', 'c', 'd', 'e', 'f', 'g']) pushRecentLookupId('acc', id);
+    const ids = getRecentLookupIds('acc');
+    expect(ids).toHaveLength(5);
+    expect(ids[0]).toBe('g');
+    expect(ids).not.toContain('a');
+  });
+
+  it('scopes per object name', () => {
+    pushRecentLookupId('acc', 'a');
+    pushRecentLookupId('prod', 'x');
+    expect(getRecentLookupIds('acc')).toEqual(['a']);
+    expect(getRecentLookupIds('prod')).toEqual(['x']);
+  });
+
+  it('ignores empty/nullish ids and object names', () => {
+    pushRecentLookupId('acc', '');
+    pushRecentLookupId('acc', null);
+    pushRecentLookupId('', 'a');
+    expect(getRecentLookupIds('acc')).toEqual([]);
+  });
+});

--- a/packages/fields/src/widgets/recentLookups.ts
+++ b/packages/fields/src/widgets/recentLookups.ts
@@ -1,0 +1,47 @@
+/**
+ * Recently-used lookup memory.
+ *
+ * Mainstream record pickers (Salesforce, Dataverse, SAP, ServiceNow) surface
+ * the user's recently-picked records the moment a lookup is focused — before
+ * any typing. We approximate that with a small per-object ring of the last few
+ * selected record ids, kept in localStorage (no backend dependency). When a
+ * recent-items API later exists, this module is the single seam to swap.
+ */
+
+const KEY_PREFIX = 'objectui:lookup:recent:';
+const MAX_RECENT = 5;
+
+function storage(): Storage | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch {
+    // Accessing localStorage can throw in sandboxed iframes / SSR.
+    return null;
+  }
+}
+
+/** Most-recent-first list of record ids previously chosen for `objectName`. */
+export function getRecentLookupIds(objectName: string): Array<string | number> {
+  const s = storage();
+  if (!objectName || !s) return [];
+  try {
+    const raw = s.getItem(KEY_PREFIX + objectName);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr.slice(0, MAX_RECENT) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Record that `id` was just chosen for `objectName` (moves it to the front). */
+export function pushRecentLookupId(objectName: string, id: string | number | null | undefined): void {
+  const s = storage();
+  if (!objectName || id === null || id === undefined || id === '' || !s) return;
+  try {
+    const next = [id, ...getRecentLookupIds(objectName).filter((x) => x !== id)].slice(0, MAX_RECENT);
+    s.setItem(KEY_PREFIX + objectName, JSON.stringify(next));
+  } catch {
+    // Ignore quota / serialization failures — recents are best-effort.
+  }
+}

--- a/packages/fields/src/widgets/useFieldTranslation.ts
+++ b/packages/fields/src/widgets/useFieldTranslation.ts
@@ -17,6 +17,8 @@ const FIELD_DEFAULTS: Record<string, string> = {
   'lookup.loading': 'Loading…',
   'lookup.noOptions': 'No options found',
   'lookup.noRecords': 'No records found',
+  'lookup.recentlyUsed': 'Recently used',
+  'lookup.allResults': 'All results',
   'lookup.createNew': 'Create new',
   'lookup.createNamed': 'Create new "{{name}}"',
   'lookup.showingResults': 'Showing {{shown}} of {{total}} results',

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1,5 +1,7 @@
 const ar = {
   lookup: {
+    recentlyUsed: 'المستخدمة مؤخرًا',
+    allResults: 'كل النتائج',
     createNew: 'إنشاء جديد',
     createNamed: 'إنشاء «{{name}}»',
     showingResults: 'عرض {{shown}} من {{total}} نتيجة',

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1,5 +1,7 @@
 const de = {
   lookup: {
+    recentlyUsed: 'Zuletzt verwendet',
+    allResults: 'Alle Ergebnisse',
     createNew: 'Neu erstellen',
     createNamed: '„{{name}}" erstellen',
     showingResults: '{{shown}} von {{total}} Ergebnissen',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -3,6 +3,8 @@
  */
 const en = {
   lookup: {
+    recentlyUsed: 'Recently used',
+    allResults: 'All results',
     loading: 'Loading…',
     noOptions: 'No options found',
     noRecords: 'No records found',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1,5 +1,7 @@
 const es = {
   lookup: {
+    recentlyUsed: 'Usados recientemente',
+    allResults: 'Todos los resultados',
     createNew: 'Crear nuevo',
     createNamed: 'Crear «{{name}}»',
     showingResults: 'Mostrando {{shown}} de {{total}} resultados',

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1,5 +1,7 @@
 const fr = {
   lookup: {
+    recentlyUsed: 'Récemment utilisés',
+    allResults: 'Tous les résultats',
     createNew: 'Créer',
     createNamed: 'Créer « {{name}} »',
     showingResults: 'Affichage de {{shown}} sur {{total}} résultats',

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1,5 +1,7 @@
 const ja = {
   lookup: {
+    recentlyUsed: '最近使用したもの',
+    allResults: 'すべての結果',
     createNew: '新規作成',
     createNamed: '「{{name}}」を新規作成',
     showingResults: '{{total}} 件中 {{shown}} 件を表示',

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1,5 +1,7 @@
 const ko = {
   lookup: {
+    recentlyUsed: '최근 사용',
+    allResults: '모든 결과',
     createNew: '새로 만들기',
     createNamed: '“{{name}}” 새로 만들기',
     showingResults: '{{total}}개 중 {{shown}}개 표시',

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1,5 +1,7 @@
 const pt = {
   lookup: {
+    recentlyUsed: 'Usados recentemente',
+    allResults: 'Todos os resultados',
     createNew: 'Criar novo',
     createNamed: 'Criar “{{name}}”',
     showingResults: 'Mostrando {{shown}} de {{total}} resultados',

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1,5 +1,7 @@
 const ru = {
   lookup: {
+    recentlyUsed: 'Недавние',
+    allResults: 'Все результаты',
     createNew: 'Создать',
     createNamed: 'Создать «{{name}}»',
     showingResults: 'Показано {{shown}} из {{total}} результатов',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -3,6 +3,8 @@
  */
 const zh = {
   lookup: {
+    recentlyUsed: '最近使用',
+    allResults: '全部结果',
     loading: '加载中…',
     noOptions: '未找到选项',
     noRecords: '未找到记录',


### PR DESCRIPTION
Follow-up to #1860 — closes the remaining record-picker table-stakes vs. Salesforce / Power Apps-Dataverse / SAP Fiori / ServiceNow. All renderer-contained; browser-verified live against app-showcase (zh-CN).

## Changes
- **Recently used** (`recentLookups.ts`) — a per-object `localStorage` ring records the last few picked records. The quick-select popover shows a **最近使用 / Recently used** section on empty focus, then **全部结果 / All results**, as one de-duped list that also drives arrow-key navigation. No backend dependency (single swap-in seam for a future recent-items API).
- **Inline quick-create** — host `onCreateNew` still wins; otherwise an opt-in `allowCreate` field flag enables optimistic create via `dataSource.create({ [displayField]: typedText })` → auto-select, with validation errors surfaced inline. Inert unless opted in (companion spec flag lands in framework).
- **Preview tooltip** — each option carries a native-tooltip summary of its other derived columns (e.g. `Industry: Retail · Revenue: 8,000,000`) to disambiguate without opening the record.
- **Combobox a11y** — the search input is a real `role=combobox` with `aria-controls` / `aria-expanded` / `aria-autocomplete=list` and `aria-activedescendant` tracking the active option (each option now has a stable id). The trigger advertises `aria-haspopup=listbox` + `aria-expanded` but stays a **native button** (no role override) so existing behaviour/queries are unchanged.
- Mobile: the full picker already adapts (95vw + horizontal column scroll) — verified at 375px.

## Verification
- Unit: `recentLookups.test.ts` (6) + existing `complex-widgets` (27) + i18n parity (40) all green.
- **Live** (zh-CN): picked Contoso → reopened the Account lookup → "最近使用: Contoso (已选)" then "全部结果: Northwind / Fabrikam", each with an industry secondary line and a derived-columns tooltip; confirmed input `role=combobox` + `aria-controls`==listbox id, `aria-activedescendant`, trigger `aria-haspopup=listbox`.

New `lookup.recentlyUsed` / `lookup.allResults` keys added to all 10 locale bundles.