### PR TITLE
feat(types): formalize $searchFields in QueryParams (ADR-0061 P3)

### DIFF
--- a/packages/types/src/data.ts
+++ b/packages/types/src/data.ts
@@ -63,6 +63,15 @@ export interface QueryParams {
   $search?: string;
 
   /**
+   * Optional override of which fields `$search` matches (ADR-0061).
+   * The server intersects this with the object's allowed searchable set and
+   * ignores anything outside it — it can only *narrow*, never widen, the
+   * server-resolved default (`object.searchableFields`). Omit to let the server
+   * resolve fields from metadata (the normal case).
+   */
+  $searchFields?: string[];
+
+  /**
    * Total count of records (for pagination)
    */
   $count?: boolean;


### PR DESCRIPTION
Closes the client↔server drift flagged in the record-search liveness audit: `ListView` already sends `$searchFields` (derived from a view's `searchableFields`), but it was an **undocumented extension** missing from the `QueryParams` contract.

Adds `$searchFields?: string[]` to `QueryParams` as a documented, optional **override**: per ADR-0061, the server intersects it with the object's allowed searchable set and it can only *narrow*, never widen, the metadata-resolved default (`object.searchableFields`). Omit it to let the server resolve fields from metadata (the normal case).

Pairs with framework **#2134** (the server-side `$search` executor). Type-only change.