### PR TITLE
feat(studio): metadata-driven pickers for the dataset designer

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
@@ -70,9 +70,7 @@ describe('DatasetDefaultInspector', () => {
   it('removes the measure row', () => {
     const onPatch = vi.fn();
     render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={onPatch} readOnly={false} />);
-    // The measure block's remove button is the last "Remove" (dimension is first).
-    const removes = screen.getAllByText('Remove');
-    fireEvent.click(removes[removes.length - 1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove measure' }));
     expect(onPatch).toHaveBeenCalledWith({ measures: [] });
   });
 
@@ -88,6 +86,6 @@ describe('DatasetDefaultInspector', () => {
   it('hides add/remove affordances when readOnly', () => {
     render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={vi.fn()} readOnly={true} />);
     expect(screen.queryByText('Add measure')).not.toBeInTheDocument();
-    expect(screen.queryByText('Remove')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Remove/ })).not.toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
@@ -2,6 +2,17 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+// Stub the catalog hooks so the inspector renders without a MetadataClient /
+// network. The pickers fall back to showing the raw committed value, which is
+// all these structural assertions need.
+vi.mock('./useDatasetFields', () => ({
+  useObjectOptions: () => ({ options: [], loading: false }),
+  useDatasetFieldCatalog: () => ({ relationships: [], fieldOptions: [], loading: false }),
+  useDatasetUsage: () => ({ reports: 0, dashboards: 0, loading: false }),
+  fieldTypeToDimensionType: (t: string) => (t === 'date' ? 'date' : 'string'),
+}));
+
 import { DatasetDefaultInspector } from './DatasetDefaultInspector';
 
 afterEach(cleanup);
@@ -20,12 +31,16 @@ const draft = {
 describe('DatasetDefaultInspector', () => {
   it('renders the structured designer (object / dimension / measure rows)', () => {
     render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={vi.fn()} readOnly={false} />);
-    expect(screen.getByDisplayValue('opportunity')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('account')).toBeInTheDocument(); // include relationship row
+    // Base object + included relationship now render as combo triggers showing
+    // the committed value (catalog is empty in this test); the value also
+    // surfaces in the join-path hint, so assert presence rather than uniqueness.
+    expect(screen.getAllByText('opportunity').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('account').length).toBeGreaterThan(0);
+    expect(screen.getByText('Base object')).toBeInTheDocument();
     expect(screen.getByText('Dimension 1')).toBeInTheDocument();
     expect(screen.getByText('Measure 1')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('region')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('revenue')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('region')).toBeInTheDocument(); // dimension name input
+    expect(screen.getByDisplayValue('revenue')).toBeInTheDocument(); // measure name input
   });
 
   it('adds a measure via onPatch', () => {
@@ -55,10 +70,19 @@ describe('DatasetDefaultInspector', () => {
   it('removes the measure row', () => {
     const onPatch = vi.fn();
     render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={onPatch} readOnly={false} />);
-    // The measure block's remove button is the second "Remove" (dimension is first).
+    // The measure block's remove button is the last "Remove" (dimension is first).
     const removes = screen.getAllByText('Remove');
     fireEvent.click(removes[removes.length - 1]);
     expect(onPatch).toHaveBeenCalledWith({ measures: [] });
+  });
+
+  it('toggles a derived measure on via the advanced disclosure', () => {
+    const onPatch = vi.fn();
+    render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={onPatch} readOnly={false} />);
+    fireEvent.click(screen.getByText('Derived — computed from other measures'));
+    expect(onPatch).toHaveBeenCalledWith({
+      measures: [expect.objectContaining({ name: 'revenue', derived: { op: 'ratio', of: [] } })],
+    });
   });
 
   it('hides add/remove affordances when readOnly', () => {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
@@ -20,14 +20,13 @@
  */
 
 import * as React from 'react';
-import { ArrowRight, Plus, X } from 'lucide-react';
+import { ArrowRight, Plus, Trash2, X } from 'lucide-react';
 import { Badge, Button, Label } from '@object-ui/components';
 import {
   InspectorShell,
   InspectorTextField,
   InspectorSelectField,
   InspectorCheckboxField,
-  InspectorRemoveButton,
   appendArray,
   spliceArray,
 } from './_shared';
@@ -250,7 +249,19 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
           <div key={i} className="rounded-md border p-2 space-y-1.5">
             <div className="flex items-center justify-between">
               <span className="text-[11px] font-medium text-muted-foreground">Dimension {i + 1}</span>
-              {!readOnly && <InspectorRemoveButton label="Remove" onClick={() => onPatch({ dimensions: spliceArray(dimensions, i, null) })} />}
+              {!readOnly && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label="Remove dimension"
+                  title="Remove dimension"
+                  className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+                  onClick={() => onPatch({ dimensions: spliceArray(dimensions, i, null) })}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              )}
             </div>
             <InspectorTextField label="Name" value={d.name ?? ''} onCommit={(v) => patchDimension(i, { name: v })} placeholder="e.g. region" disabled={readOnly} mono />
             <InspectorComboField
@@ -290,7 +301,19 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
             <div key={i} className="rounded-md border p-2 space-y-1.5">
               <div className="flex items-center justify-between">
                 <span className="text-[11px] font-medium text-muted-foreground">Measure {i + 1}</span>
-                {!readOnly && <InspectorRemoveButton label="Remove" onClick={() => onPatch({ measures: spliceArray(measures, i, null) })} />}
+                {!readOnly && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label="Remove measure"
+                    title="Remove measure"
+                    className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+                    onClick={() => onPatch({ measures: spliceArray(measures, i, null) })}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                )}
               </div>
               <InspectorTextField label="Name" value={m.name ?? ''} onCommit={(v) => patchMeasure(i, { name: v })} placeholder="e.g. revenue" disabled={readOnly} mono />
               <InspectorSelectField label="Aggregate" value={m.aggregate} options={AGGREGATE_OPTIONS} onCommit={(v) => patchMeasure(i, { aggregate: v })} disabled={readOnly} />

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
@@ -7,19 +7,21 @@
  *
  *   - base `object`,
  *   - `include` relationships (the join allowlist — D-C),
- *   - `dimensions` (name + field/`relationship.field` + type), and
- *   - `measures` (name + aggregate + field + certified).
+ *   - `dimensions` (name + field/`relationship.field` + type + granularity), and
+ *   - `measures` (name + aggregate + field + certified + format/currency/derived).
  *
- * The aggregate is a closed dropdown (count/sum/avg/min/max/count_distinct) so
- * an author can't type an unsupported function — the dataset compiler rejects
- * `array_agg`/`string_agg` in v1, and surfacing only the valid set avoids that
- * round-trip. Edits flow through `onPatch`; the DatasetPreview on the canvas
- * re-runs live as the draft changes.
+ * The base object, the included relationships, and every `field` are picked
+ * from the live object graph (a searchable combo over {@link useDatasetFieldCatalog})
+ * — not recalled by hand — so authoring matches mainstream low-code dataset
+ * builders. The aggregate / type / granularity are closed dropdowns so an
+ * author can't type an unsupported value. Each combo still allows a custom
+ * value as an escape hatch (offline catalog, computed path). Edits flow through
+ * `onPatch`; the DatasetPreview on the canvas re-runs live as the draft changes.
  */
 
 import * as React from 'react';
-import { Plus, X } from 'lucide-react';
-import { Badge, Button, Input, Label } from '@object-ui/components';
+import { ArrowRight, Plus, X } from 'lucide-react';
+import { Badge, Button, Label } from '@object-ui/components';
 import {
   InspectorShell,
   InspectorTextField,
@@ -29,6 +31,13 @@ import {
   appendArray,
   spliceArray,
 } from './_shared';
+import { InspectorComboField, type InspectorComboOption } from './InspectorComboField';
+import {
+  useObjectOptions,
+  useDatasetFieldCatalog,
+  useDatasetUsage,
+  fieldTypeToDimensionType,
+} from './useDatasetFields';
 import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
 
 // Closed to what the dataset compiler supports (no array_agg/string_agg in v1).
@@ -49,8 +58,34 @@ const DIMENSION_TYPE_OPTIONS = [
   { value: 'lookup', label: 'lookup' },
 ];
 
-type Dimension = { name?: string; field?: string; type?: string };
-type Measure = { name?: string; aggregate?: string; field?: string; certified?: boolean };
+const DATE_GRANULARITY_OPTIONS = [
+  { value: '', label: '— none —' },
+  { value: 'day', label: 'day' },
+  { value: 'week', label: 'week' },
+  { value: 'month', label: 'month' },
+  { value: 'quarter', label: 'quarter' },
+  { value: 'year', label: 'year' },
+];
+
+const DERIVED_OP_OPTIONS = [
+  { value: 'ratio', label: 'ratio (a ÷ b)' },
+  { value: 'sum', label: 'sum (a + b)' },
+  { value: 'difference', label: 'difference (a − b)' },
+  { value: 'product', label: 'product (a × b)' },
+];
+
+type Dimension = { name?: string; label?: string; field?: string; type?: string; dateGranularity?: string };
+type DerivedSpec = { op?: string; of?: string[] };
+type Measure = {
+  name?: string;
+  label?: string;
+  aggregate?: string;
+  field?: string;
+  certified?: boolean;
+  format?: string;
+  currency?: string;
+  derived?: DerivedSpec;
+};
 
 function SectionHeader({ title, count, onAdd, addLabel }: { title: string; count: number; onAdd?: () => void; addLabel: string }) {
   return (
@@ -68,6 +103,21 @@ function SectionHeader({ title, count, onAdd, addLabel }: { title: string; count
   );
 }
 
+/** Native disclosure for a row's optional / advanced fields. */
+function Advanced({ children }: { children: React.ReactNode }) {
+  return (
+    <details className="group">
+      <summary className="cursor-pointer select-none list-none text-[11px] text-muted-foreground hover:text-foreground">
+        <span className="inline-flex items-center gap-1">
+          <ArrowRight className="h-3 w-3 transition-transform group-open:rotate-90" />
+          Advanced
+        </span>
+      </summary>
+      <div className="mt-1.5 space-y-1.5 border-l pl-2.5">{children}</div>
+    </details>
+  );
+}
+
 export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDefaultInspectorProps) {
   const label = typeof draft.label === 'string' ? draft.label : '';
   const description = typeof draft.description === 'string' ? draft.description : '';
@@ -75,17 +125,69 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
   const include: string[] = Array.isArray(draft.include) ? (draft.include as string[]) : [];
   const dimensions: Dimension[] = Array.isArray(draft.dimensions) ? (draft.dimensions as Dimension[]) : [];
   const measures: Measure[] = Array.isArray(draft.measures) ? (draft.measures as Measure[]) : [];
+  const datasetName = typeof draft.name === 'string' ? draft.name : undefined;
+
+  const { options: objectOptions, loading: objectsLoading } = useObjectOptions();
+  const { relationships, fieldOptions, loading: catalogLoading } = useDatasetFieldCatalog(object, include);
+  const usage = useDatasetUsage(datasetName);
+
+  const objectComboOptions: InspectorComboOption[] = React.useMemo(
+    () => objectOptions.map((o) => ({ value: o.name, label: o.label })),
+    [objectOptions],
+  );
+  const relationshipComboOptions: InspectorComboOption[] = React.useMemo(
+    () => relationships.map((r) => ({ value: r.name, label: r.label, hint: r.referenceTo ? `→ ${r.referenceTo}` : undefined })),
+    [relationships],
+  );
+  const fieldComboOptions: InspectorComboOption[] = React.useMemo(
+    () => fieldOptions.map((f) => ({ value: f.value, label: f.label, hint: f.type, group: f.group })),
+    [fieldOptions],
+  );
+
+  const baseLabel = objectComboOptions.find((o) => o.value === object)?.label ?? object;
 
   const patchDimension = (i: number, patch: Partial<Dimension>) =>
     onPatch({ dimensions: dimensions.map((d, idx) => (idx === i ? { ...d, ...patch } : d)) });
   const patchMeasure = (i: number, patch: Partial<Measure>) =>
     onPatch({ measures: measures.map((m, idx) => (idx === i ? { ...m, ...patch } : m)) });
 
+  // Picking a field auto-infers the dimension type from the field's framework
+  // type (region:string, close_date:date, …) — the BI "pick field, type follows"
+  // convention — while leaving the Type select free to override.
+  const pickDimensionField = (i: number, v: string) => {
+    const opt = fieldOptions.find((o) => o.value === v);
+    patchDimension(i, opt?.type ? { field: v, type: fieldTypeToDimensionType(opt.type) } : { field: v });
+  };
+
   return (
     <InspectorShell kindLabel="Dataset" title={String(label || draft.name || 'Dataset')} onClose={() => {}} hideClose>
+      {datasetName && !usage.loading && (
+        <p
+          className={
+            usage.reports + usage.dashboards > 0
+              ? 'rounded-md border border-amber-500/30 bg-amber-500/5 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300'
+              : 'text-[11px] text-muted-foreground'
+          }
+        >
+          {usage.reports + usage.dashboards > 0
+            ? `Bound by ${usage.reports} report${usage.reports === 1 ? '' : 's'} · ${usage.dashboards} dashboard${usage.dashboards === 1 ? '' : 's'} — changes affect them.`
+            : 'Not yet bound by any report or dashboard.'}
+        </p>
+      )}
+
       <InspectorTextField label="Label" value={label} onCommit={(v) => onPatch({ label: v })} disabled={readOnly} />
       <InspectorTextField label="Description" value={description} onCommit={(v) => onPatch({ description: v })} disabled={readOnly} />
-      <InspectorTextField label="Base object" value={object} onCommit={(v) => onPatch({ object: v })} placeholder="e.g. opportunity" disabled={readOnly} mono />
+      <InspectorComboField
+        label="Base object"
+        value={object}
+        onCommit={(v) => onPatch({ object: v })}
+        options={objectComboOptions}
+        loading={objectsLoading}
+        placeholder="Select an object…"
+        searchPlaceholder="Search objects…"
+        disabled={readOnly}
+        mono
+      />
 
       {/* Included relationships (the join allowlist) */}
       <div className="border-t pt-3 space-y-1.5">
@@ -97,17 +199,20 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
         />
         {include.length === 0 ? (
           <p className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-center text-[11px] text-muted-foreground">
-            No joins. Add a relationship name (e.g. <code>account</code>) to use <code>account.field</code> dimensions/measures.
+            No joins. Add a relationship (a lookup field on <code>{baseLabel || 'the base object'}</code>) to use <code>relationship.field</code> dimensions/measures.
           </p>
         ) : (
           include.map((rel, i) => (
             <div key={i} className="flex items-center gap-1.5">
-              <Input
+              <InspectorComboField
                 value={rel}
-                onChange={(e) => onPatch({ include: include.map((r, idx) => (idx === i ? e.target.value : r)) })}
-                placeholder="relationship name (lookup field)"
+                onCommit={(v) => onPatch({ include: include.map((r, idx) => (idx === i ? v : r)) })}
+                options={relationshipComboOptions}
+                loading={catalogLoading}
+                placeholder="Select a relationship…"
+                searchPlaceholder="Search relationships…"
                 disabled={readOnly}
-                className="h-8 text-sm font-mono"
+                mono
               />
               {!readOnly && (
                 <Button type="button" variant="ghost" size="sm" className="h-7 w-7 shrink-0 p-0" onClick={() => onPatch({ include: spliceArray(include, i, null) })} aria-label="Remove relationship">
@@ -116,6 +221,20 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
               )}
             </div>
           ))
+        )}
+        {object && include.length > 0 && (
+          <div className="flex flex-wrap items-center gap-x-1 gap-y-0.5 pt-0.5 text-[10px] text-muted-foreground">
+            <span className="font-mono font-medium">{baseLabel}</span>
+            {include.map((rel, i) => {
+              const r = relationships.find((x) => x.name === rel);
+              return (
+                <span key={i} className="inline-flex items-center gap-1">
+                  <ArrowRight className="h-3 w-3 opacity-60" />
+                  <span className="font-mono">{rel}{r?.referenceTo ? ` (${r.referenceTo})` : ''}</span>
+                </span>
+              );
+            })}
+          </div>
         )}
       </div>
 
@@ -134,8 +253,24 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
               {!readOnly && <InspectorRemoveButton label="Remove" onClick={() => onPatch({ dimensions: spliceArray(dimensions, i, null) })} />}
             </div>
             <InspectorTextField label="Name" value={d.name ?? ''} onCommit={(v) => patchDimension(i, { name: v })} placeholder="e.g. region" disabled={readOnly} mono />
-            <InspectorTextField label="Field" value={d.field ?? ''} onCommit={(v) => patchDimension(i, { field: v })} placeholder="field or relationship.field" disabled={readOnly} mono />
+            <InspectorComboField
+              label="Field"
+              value={d.field ?? ''}
+              onCommit={(v) => pickDimensionField(i, v)}
+              options={fieldComboOptions}
+              loading={catalogLoading}
+              placeholder="field or relationship.field"
+              searchPlaceholder="Search fields…"
+              disabled={readOnly}
+              mono
+            />
             <InspectorSelectField label="Type" value={d.type} options={DIMENSION_TYPE_OPTIONS} onCommit={(v) => patchDimension(i, { type: v })} disabled={readOnly} />
+            <Advanced>
+              <InspectorTextField label="Label (optional)" value={d.label ?? ''} onCommit={(v) => patchDimension(i, { label: v || undefined })} placeholder={d.name || 'Display label'} disabled={readOnly} />
+              {d.type === 'date' && (
+                <InspectorSelectField label="Date bucket" value={d.dateGranularity ?? ''} options={DATE_GRANULARITY_OPTIONS} onCommit={(v) => patchDimension(i, { dateGranularity: v || undefined })} disabled={readOnly} />
+              )}
+            </Advanced>
           </div>
         ))}
       </div>
@@ -148,18 +283,73 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
           addLabel="Add measure"
           onAdd={readOnly ? undefined : () => onPatch({ measures: appendArray(measures, { name: '', aggregate: 'sum', field: '', certified: false }) })}
         />
-        {measures.map((m, i) => (
-          <div key={i} className="rounded-md border p-2 space-y-1.5">
-            <div className="flex items-center justify-between">
-              <span className="text-[11px] font-medium text-muted-foreground">Measure {i + 1}</span>
-              {!readOnly && <InspectorRemoveButton label="Remove" onClick={() => onPatch({ measures: spliceArray(measures, i, null) })} />}
+        {measures.map((m, i) => {
+          const otherMeasures = measures.filter((_, idx) => idx !== i).map((x) => x.name).filter((n): n is string => !!n);
+          const derived = m.derived;
+          return (
+            <div key={i} className="rounded-md border p-2 space-y-1.5">
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-medium text-muted-foreground">Measure {i + 1}</span>
+                {!readOnly && <InspectorRemoveButton label="Remove" onClick={() => onPatch({ measures: spliceArray(measures, i, null) })} />}
+              </div>
+              <InspectorTextField label="Name" value={m.name ?? ''} onCommit={(v) => patchMeasure(i, { name: v })} placeholder="e.g. revenue" disabled={readOnly} mono />
+              <InspectorSelectField label="Aggregate" value={m.aggregate} options={AGGREGATE_OPTIONS} onCommit={(v) => patchMeasure(i, { aggregate: v })} disabled={readOnly} />
+              <InspectorComboField
+                label="Field"
+                value={m.field ?? ''}
+                onCommit={(v) => patchMeasure(i, { field: v })}
+                options={fieldComboOptions}
+                loading={catalogLoading}
+                placeholder="field (optional for count)"
+                searchPlaceholder="Search fields…"
+                disabled={readOnly}
+                mono
+              />
+              <InspectorCheckboxField label="Certified" value={!!m.certified} onCommit={(v) => patchMeasure(i, { certified: v })} disabled={readOnly} />
+              <Advanced>
+                <InspectorTextField label="Label (optional)" value={m.label ?? ''} onCommit={(v) => patchMeasure(i, { label: v || undefined })} placeholder={m.name || 'Display label'} disabled={readOnly} />
+                <div className="grid grid-cols-2 gap-1.5">
+                  <InspectorTextField label="Format" value={m.format ?? ''} onCommit={(v) => patchMeasure(i, { format: v || undefined })} placeholder="$0,0.00" disabled={readOnly} mono />
+                  <InspectorTextField label="Currency" value={m.currency ?? ''} onCommit={(v) => patchMeasure(i, { currency: v ? v.toUpperCase().slice(0, 3) : undefined })} placeholder="USD" disabled={readOnly} mono />
+                </div>
+                <InspectorCheckboxField
+                  label="Derived — computed from other measures"
+                  value={!!derived}
+                  onCommit={(v) => patchMeasure(i, { derived: v ? { op: 'ratio', of: [] } : undefined })}
+                  disabled={readOnly}
+                />
+                {derived && (
+                  <div className="space-y-1.5 rounded-md border border-dashed p-2">
+                    <InspectorSelectField label="Operation" value={derived.op} options={DERIVED_OP_OPTIONS} onCommit={(v) => patchMeasure(i, { derived: { ...derived, op: v } })} disabled={readOnly} />
+                    <Label className="text-xs text-muted-foreground">Operands (other measures)</Label>
+                    {otherMeasures.length === 0 ? (
+                      <p className="text-[11px] italic text-muted-foreground">Add other measures first.</p>
+                    ) : (
+                      <div className="space-y-1">
+                        {otherMeasures.map((nm) => {
+                          const checked = Array.isArray(derived.of) && derived.of.includes(nm);
+                          return (
+                            <InspectorCheckboxField
+                              key={nm}
+                              label={nm}
+                              value={checked}
+                              disabled={readOnly}
+                              onCommit={(v) => {
+                                const current = Array.isArray(derived.of) ? derived.of : [];
+                                const next = v ? [...current, nm] : current.filter((x) => x !== nm);
+                                patchMeasure(i, { derived: { ...derived, of: next } });
+                              }}
+                            />
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </Advanced>
             </div>
-            <InspectorTextField label="Name" value={m.name ?? ''} onCommit={(v) => patchMeasure(i, { name: v })} placeholder="e.g. revenue" disabled={readOnly} mono />
-            <InspectorSelectField label="Aggregate" value={m.aggregate} options={AGGREGATE_OPTIONS} onCommit={(v) => patchMeasure(i, { aggregate: v })} disabled={readOnly} />
-            <InspectorTextField label="Field" value={m.field ?? ''} onCommit={(v) => patchMeasure(i, { field: v })} placeholder="field (optional for count)" disabled={readOnly} mono />
-            <InspectorCheckboxField label="Certified" value={!!m.certified} onCommit={(v) => patchMeasure(i, { certified: v })} disabled={readOnly} />
-          </div>
-        ))}
+          );
+        })}
       </div>
     </InspectorShell>
   );

--- a/packages/app-shell/src/views/metadata-admin/inspectors/InspectorComboField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/InspectorComboField.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * InspectorComboField — a searchable single-select for scoped inspectors that
+ * still lets the author type a value not in the list.
+ *
+ * Mainstream low-code dataset designers let you *pick* an object / relationship
+ * / field from the live schema instead of recalling its API name. This combo
+ * renders that picker (grouped, searchable) over a catalog the caller supplies,
+ * while keeping the power-user escape hatch: when the typed text matches no
+ * option, a "Use «text»" row commits the raw value verbatim (so an offline
+ * catalog, a computed path, or a server-only field is never a dead end).
+ *
+ * Self-filters (`shouldFilter={false}`) for predictable label+value matching.
+ */
+
+import * as React from 'react';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import {
+  cn,
+  Button,
+  Label,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@object-ui/components';
+
+export interface InspectorComboOption {
+  value: string;
+  label: string;
+  /** Small muted suffix, e.g. a field type. */
+  hint?: string;
+  /** Optional group heading; options sharing a group render together. */
+  group?: string;
+}
+
+export interface InspectorComboFieldProps {
+  label?: string;
+  value: string;
+  onCommit: (v: string) => void;
+  options: InspectorComboOption[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  /** Allow committing a typed value that matches no option (default true). */
+  allowCustom?: boolean;
+  /** Render the trigger value in a monospace font. */
+  mono?: boolean;
+  /** Override the trigger label for the currently-selected custom value. */
+  className?: string;
+}
+
+function matches(option: InspectorComboOption, q: string): boolean {
+  if (!q) return true;
+  const needle = q.toLowerCase();
+  return (
+    option.value.toLowerCase().includes(needle) ||
+    option.label.toLowerCase().includes(needle) ||
+    (option.group?.toLowerCase().includes(needle) ?? false)
+  );
+}
+
+export function InspectorComboField({
+  label,
+  value,
+  onCommit,
+  options,
+  placeholder = 'Select…',
+  searchPlaceholder = 'Search or type…',
+  emptyText = 'No match — keep typing to use a custom value.',
+  disabled,
+  loading,
+  allowCustom = true,
+  mono,
+  className,
+}: InspectorComboFieldProps) {
+  const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+
+  const selected = options.find((o) => o.value === value);
+  const triggerText = selected ? selected.label : value || (loading ? 'Loading…' : placeholder);
+
+  const filtered = React.useMemo(() => options.filter((o) => matches(o, search)), [options, search]);
+  const groups = React.useMemo(() => {
+    const order: string[] = [];
+    const byGroup = new Map<string, InspectorComboOption[]>();
+    for (const o of filtered) {
+      const g = o.group ?? '';
+      if (!byGroup.has(g)) {
+        byGroup.set(g, []);
+        order.push(g);
+      }
+      byGroup.get(g)!.push(o);
+    }
+    return order.map((g) => ({ heading: g, items: byGroup.get(g)! }));
+  }, [filtered]);
+
+  const trimmed = search.trim();
+  const showCustom =
+    allowCustom && !!trimmed && !options.some((o) => o.value === trimmed);
+
+  const commit = (v: string) => {
+    onCommit(v);
+    setOpen(false);
+    setSearch('');
+  };
+
+  const field = (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setSearch('');
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn('h-8 w-full justify-between px-2 text-sm font-normal', className)}
+        >
+          <span className={cn('truncate', mono && 'font-mono', !selected && !value && 'text-muted-foreground')}>
+            {triggerText}
+          </span>
+          <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] min-w-[14rem] p-0"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput value={search} onValueChange={setSearch} placeholder={searchPlaceholder} />
+          <CommandList>
+            {!showCustom && filtered.length === 0 && <CommandEmpty>{emptyText}</CommandEmpty>}
+            {showCustom && (
+              <CommandGroup>
+                <CommandItem value={`__custom__${trimmed}`} onSelect={() => commit(trimmed)}>
+                  <span className="truncate">
+                    Use <span className="font-mono">“{trimmed}”</span>
+                  </span>
+                </CommandItem>
+              </CommandGroup>
+            )}
+            {groups.map((g, gi) => (
+              <CommandGroup key={g.heading || `g${gi}`} heading={g.heading || undefined}>
+                {g.items.map((o) => (
+                  <CommandItem key={o.value} value={o.value} onSelect={() => commit(o.value)}>
+                    <Check className={cn('h-3.5 w-3.5', o.value === value ? 'opacity-100' : 'opacity-0')} />
+                    <span className="truncate font-mono">{o.value}</span>
+                    {o.label && o.label !== o.value && (
+                      <span className="ml-1 truncate text-muted-foreground">{o.label}</span>
+                    )}
+                    {o.hint && <span className="ml-auto pl-2 text-[10px] text-muted-foreground">{o.hint}</span>}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+
+  if (!label) return field;
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      {field}
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveLabel,
+  resolveReferenceTo,
+  fieldTypeToDimensionType,
+  normalizeObject,
+  buildFieldOptions,
+  referencesDataset,
+  type NormalizedObject,
+} from './useDatasetFields';
+
+describe('resolveLabel', () => {
+  it('reads a plain string', () => expect(resolveLabel('Region', 'x')).toBe('Region'));
+  it('reads an i18n object default', () => expect(resolveLabel({ default: 'Région' }, 'x')).toBe('Région'));
+  it('falls back when empty / missing', () => {
+    expect(resolveLabel('', 'fallback')).toBe('fallback');
+    expect(resolveLabel(undefined, 'fallback')).toBe('fallback');
+    expect(resolveLabel({}, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('resolveReferenceTo', () => {
+  it('reads string / camel / snake variants', () => {
+    expect(resolveReferenceTo({ reference: 'account' })).toBe('account'); // framework lookup shape
+    expect(resolveReferenceTo({ reference_to: 'account' })).toBe('account');
+    expect(resolveReferenceTo({ referenceTo: 'account' })).toBe('account');
+    expect(resolveReferenceTo({ reference_to_object: 'account' })).toBe('account');
+  });
+  it('reads array + object shapes', () => {
+    expect(resolveReferenceTo({ reference_to: ['account', 'lead'] })).toBe('account');
+    expect(resolveReferenceTo({ reference_to: { object: 'account' } })).toBe('account');
+  });
+  it('returns undefined when absent', () => expect(resolveReferenceTo({ type: 'text' })).toBeUndefined());
+});
+
+describe('fieldTypeToDimensionType', () => {
+  it('maps relationships → lookup', () => {
+    expect(fieldTypeToDimensionType('lookup')).toBe('lookup');
+    expect(fieldTypeToDimensionType('master_detail')).toBe('lookup');
+  });
+  it('maps temporal → date and numeric → number', () => {
+    expect(fieldTypeToDimensionType('datetime')).toBe('date');
+    expect(fieldTypeToDimensionType('currency')).toBe('number');
+    expect(fieldTypeToDimensionType('percent')).toBe('number');
+  });
+  it('maps boolean and defaults to string', () => {
+    expect(fieldTypeToDimensionType('boolean')).toBe('boolean');
+    expect(fieldTypeToDimensionType('text')).toBe('string');
+    expect(fieldTypeToDimensionType(undefined)).toBe('string');
+  });
+});
+
+describe('normalizeObject', () => {
+  it('reads record-shaped fields and extracts relationships', () => {
+    const norm = normalizeObject(
+      {
+        label: 'Opportunity',
+        fields: {
+          amount: { type: 'currency', label: 'Amount' },
+          account: { type: 'lookup', label: 'Account', reference_to: 'account' },
+          stage: { type: 'text' },
+        },
+      },
+      'opportunity',
+    );
+    expect(norm.label).toBe('Opportunity');
+    expect(norm.fields.map((f) => f.name)).toEqual(['amount', 'account', 'stage']);
+    expect(norm.relationships).toEqual([{ name: 'account', label: 'Account', referenceTo: 'account' }]);
+  });
+
+  it('reads array-shaped fields too', () => {
+    const norm = normalizeObject(
+      { fields: [{ name: 'owner', type: 'master_detail', reference_to: 'user' }] },
+      'task',
+    );
+    expect(norm.relationships).toEqual([{ name: 'owner', label: 'owner', referenceTo: 'user' }]);
+  });
+
+  it('is defensive about a missing doc', () => {
+    expect(normalizeObject(null, 'x')).toEqual({ label: 'x', fields: [], relationships: [] });
+  });
+});
+
+describe('buildFieldOptions', () => {
+  const base: NormalizedObject = {
+    label: 'Opportunity',
+    fields: [
+      { name: 'amount', label: 'Amount', type: 'currency', def: {} },
+      { name: 'account', label: 'Account', type: 'lookup', def: {} },
+    ],
+    relationships: [{ name: 'account', label: 'Account', referenceTo: 'account' }],
+  };
+  const accountObj: NormalizedObject = {
+    label: 'Account',
+    fields: [{ name: 'region', label: 'Region', type: 'text', def: {} }],
+    relationships: [],
+  };
+
+  it('lists base fields under the base group', () => {
+    const opts = buildFieldOptions(base, [], {});
+    expect(opts).toEqual([
+      { value: 'amount', label: 'Amount', type: 'currency', group: 'Opportunity' },
+      { value: 'account', label: 'Account', type: 'lookup', group: 'Opportunity' },
+    ]);
+  });
+
+  it('appends relationship.field paths for included relationships', () => {
+    const opts = buildFieldOptions(base, ['account'], { account: accountObj });
+    expect(opts).toContainEqual({ value: 'account.region', label: 'Region', type: 'text', group: 'Account → Account' });
+  });
+
+  it('skips included relationships whose target is not loaded', () => {
+    const opts = buildFieldOptions(base, ['account'], {});
+    expect(opts.some((o) => o.value.startsWith('account.'))).toBe(false);
+  });
+});
+
+describe('referencesDataset', () => {
+  it('matches a top-level dataset binding', () => {
+    expect(referencesDataset({ dataset: 'sales' }, 'sales')).toBe(true);
+    expect(referencesDataset({ dataset: 'other' }, 'sales')).toBe(false);
+  });
+  it('matches a nested widget binding', () => {
+    const dashboard = { widgets: [{ type: 'kpi' }, { type: 'chart', dataset: 'sales' }] };
+    expect(referencesDataset(dashboard, 'sales')).toBe(true);
+  });
+  it('is false for unrelated docs', () => {
+    expect(referencesDataset({ widgets: [{ object: 'sales' }] }, 'sales')).toBe(false);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * useDatasetFields — metadata-driven catalogs for the DatasetDefaultInspector
+ * pickers (ADR-0021). Turns the dataset designer's three free-text inputs
+ * (base object, included relationships, dimension/measure `field`) into
+ * dropdowns of the real object graph, so an author picks instead of recalling
+ * exact API names.
+ *
+ *   • {@link useObjectOptions}        — every object (Base object picker).
+ *   • {@link useDatasetFieldCatalog}  — the base object's relationships
+ *     (join allowlist) + a flat `field` / `relationship.field` option list,
+ *     fetching each included relationship's target object on demand.
+ *   • {@link useDatasetUsage}         — reverse lineage: how many reports /
+ *     dashboards bind this dataset (shown before a breaking edit).
+ *
+ * The hooks are defensive (a 404 / transport error resolves to an empty
+ * catalog so the inspector falls back to free-text entry) and the heavy
+ * normalization is factored into exported pure helpers for unit testing.
+ */
+
+import * as React from 'react';
+import { useMetadataClient } from '../useMetadata';
+import { readFields } from '../previews/object-fields-io';
+
+/* ─────────────── Types ─────────────── */
+
+export interface DatasetObjectOption {
+  /** Object API name (snake_case) — what `dataset.object` stores. */
+  name: string;
+  /** Human label (falls back to the name). */
+  label: string;
+}
+
+export interface DatasetRelationship {
+  /** Relationship field name — what goes in `dataset.include`. */
+  name: string;
+  /** Human label (falls back to the name). */
+  label: string;
+  /** Target object the relationship points at (for `rel.field` paths). */
+  referenceTo?: string;
+}
+
+export interface DatasetFieldOption {
+  /** Field path: a base field name or `relationship.field`. */
+  value: string;
+  /** Human label (falls back to the value). */
+  label: string;
+  /** Raw framework field type (e.g. 'text', 'currency', 'lookup'). */
+  type?: string;
+  /** Group heading: the base object label, or `rel → target`. */
+  group: string;
+}
+
+export interface DatasetFieldCatalog {
+  relationships: DatasetRelationship[];
+  fieldOptions: DatasetFieldOption[];
+  loading: boolean;
+}
+
+/* ─────────────── Pure helpers (unit-tested) ─────────────── */
+
+/** Field types that join to another object (so they're valid `include` entries). */
+const RELATIONSHIP_TYPES = new Set(['lookup', 'master_detail', 'masterdetail', 'master-detail']);
+
+/** Resolve a string | i18n-object label down to a display string. */
+export function resolveLabel(label: unknown, fallback: string): string {
+  if (typeof label === 'string' && label) return label;
+  if (label && typeof label === 'object') {
+    const def = (label as { default?: unknown }).default;
+    if (typeof def === 'string' && def) return def;
+  }
+  return fallback;
+}
+
+/** Read a lookup/master_detail field's target object from its raw def. */
+export function resolveReferenceTo(def: Record<string, unknown>): string | undefined {
+  // Framework lookup/master_detail fields carry the target object in `reference`;
+  // older / spec shapes use `reference_to` / `referenceTo` / `reference_to_object`.
+  const raw =
+    def.reference ?? def.reference_to ?? (def as any).referenceTo ?? (def as any).reference_to_object;
+  if (typeof raw === 'string' && raw) return raw;
+  if (Array.isArray(raw) && typeof raw[0] === 'string') return raw[0];
+  if (raw && typeof raw === 'object') {
+    const obj = (raw as { object?: unknown }).object;
+    if (typeof obj === 'string' && obj) return obj;
+  }
+  return undefined;
+}
+
+/** Map a framework field type onto a dataset dimension type. */
+export function fieldTypeToDimensionType(type: string | undefined): string {
+  switch (type) {
+    case 'lookup':
+    case 'master_detail':
+    case 'masterDetail':
+    case 'master-detail':
+      return 'lookup';
+    case 'date':
+    case 'datetime':
+    case 'time':
+      return 'date';
+    case 'number':
+    case 'currency':
+    case 'percent':
+    case 'int':
+    case 'integer':
+    case 'float':
+    case 'double':
+    case 'autonumber':
+      return 'number';
+    case 'boolean':
+    case 'toggle':
+      return 'boolean';
+    default:
+      return 'string';
+  }
+}
+
+export interface NormalizedObject {
+  label: string;
+  fields: Array<{ name: string; label: string; type?: string; def: Record<string, unknown> }>;
+  relationships: DatasetRelationship[];
+}
+
+/** Normalize a raw object metadata doc into label + fields + relationships. */
+export function normalizeObject(doc: Record<string, unknown> | null | undefined, name: string): NormalizedObject {
+  if (!doc) return { label: name, fields: [], relationships: [] };
+  const label = resolveLabel(doc.label, name);
+  const fields = readFields((doc as any).fields).entries.map((e) => ({
+    name: e.name,
+    label: resolveLabel(e.def.label, e.name),
+    type: typeof e.def.type === 'string' ? (e.def.type as string) : undefined,
+    def: e.def,
+  }));
+  const relationships: DatasetRelationship[] = fields
+    .filter((f) => f.type && RELATIONSHIP_TYPES.has(f.type.toLowerCase()))
+    .map((f) => ({ name: f.name, label: f.label, referenceTo: resolveReferenceTo(f.def) }));
+  return { label, fields, relationships };
+}
+
+/**
+ * Build the flat `field` / `relationship.field` option list from the base
+ * object and the included relationships' (already-fetched) target objects.
+ */
+export function buildFieldOptions(
+  base: NormalizedObject,
+  include: string[],
+  targets: Record<string, NormalizedObject>,
+): DatasetFieldOption[] {
+  const options: DatasetFieldOption[] = base.fields.map((f) => ({
+    value: f.name,
+    label: f.label,
+    type: f.type,
+    group: base.label,
+  }));
+  for (const rel of include) {
+    const relationship = base.relationships.find((r) => r.name === rel);
+    const target = relationship?.referenceTo ? targets[relationship.referenceTo] : undefined;
+    if (!target) continue;
+    const heading = `${relationship!.label} → ${target.label}`;
+    for (const f of target.fields) {
+      options.push({ value: `${rel}.${f.name}`, label: f.label, type: f.type, group: heading });
+    }
+  }
+  return options;
+}
+
+/** Recursively test whether a metadata doc references `datasetName` via a `dataset` key. */
+export function referencesDataset(doc: unknown, datasetName: string): boolean {
+  if (!doc || typeof doc !== 'object') return false;
+  if (Array.isArray(doc)) return doc.some((d) => referencesDataset(d, datasetName));
+  const rec = doc as Record<string, unknown>;
+  if (typeof rec.dataset === 'string' && rec.dataset === datasetName) return true;
+  return Object.values(rec).some((v) => v && typeof v === 'object' && referencesDataset(v, datasetName));
+}
+
+/* ─────────────── Hooks ─────────────── */
+
+/** Every object as `{ name, label }`, sorted by label. Fetched once. */
+export function useObjectOptions(): { options: DatasetObjectOption[]; loading: boolean } {
+  const client = useMetadataClient();
+  const [state, setState] = React.useState<{ options: DatasetObjectOption[]; loading: boolean }>({
+    options: [],
+    loading: true,
+  });
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true }));
+    client
+      .list<Record<string, unknown>>('object')
+      .then((docs) => {
+        if (cancelled) return;
+        const options = (Array.isArray(docs) ? docs : [])
+          .map((d) => ({ name: typeof d.name === 'string' ? d.name : '', label: resolveLabel(d.label, typeof d.name === 'string' ? d.name : '') }))
+          .filter((o) => !!o.name)
+          .sort((a, b) => a.label.localeCompare(b.label));
+        setState({ options, loading: false });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ options: [], loading: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  return state;
+}
+
+/**
+ * The base object's relationships (join allowlist) + a flat `field` /
+ * `relationship.field` option list. Refetches when `object` or the set of
+ * included relationships changes.
+ */
+export function useDatasetFieldCatalog(
+  object: string | undefined,
+  include: string[],
+): DatasetFieldCatalog {
+  const client = useMetadataClient();
+  const includeKey = include.join(' ');
+  const [state, setState] = React.useState<DatasetFieldCatalog>({
+    relationships: [],
+    fieldOptions: [],
+    loading: !!object,
+  });
+
+  React.useEffect(() => {
+    if (!object) {
+      setState({ relationships: [], fieldOptions: [], loading: false });
+      return;
+    }
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true }));
+    (async () => {
+      try {
+        const baseDoc = await client.get<Record<string, unknown>>('object', object);
+        if (cancelled) return;
+        const base = normalizeObject(baseDoc, object);
+        // Resolve which target objects the included relationships point at,
+        // then fetch each unique target's fields for `rel.field` options.
+        const wantedTargets = new Set<string>();
+        for (const rel of includeKey ? includeKey.split(' ') : []) {
+          const r = base.relationships.find((x) => x.name === rel);
+          if (r?.referenceTo) wantedTargets.add(r.referenceTo);
+        }
+        const targetEntries = await Promise.all(
+          [...wantedTargets].map(async (t) => {
+            try {
+              const doc = await client.get<Record<string, unknown>>('object', t);
+              return [t, normalizeObject(doc, t)] as const;
+            } catch {
+              return [t, normalizeObject(null, t)] as const;
+            }
+          }),
+        );
+        if (cancelled) return;
+        const targets: Record<string, NormalizedObject> = Object.fromEntries(targetEntries);
+        const includeList = includeKey ? includeKey.split(' ') : [];
+        setState({
+          relationships: base.relationships,
+          fieldOptions: buildFieldOptions(base, includeList, targets),
+          loading: false,
+        });
+      } catch {
+        if (!cancelled) setState({ relationships: [], fieldOptions: [], loading: false });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // includeKey captures the include array by value; eslint-disable the
+    // exhaustive-deps array-identity warning since we key on the joined string.
+  }, [client, object, includeKey]);
+
+  return state;
+}
+
+export interface DatasetUsage {
+  reports: number;
+  dashboards: number;
+  loading: boolean;
+}
+
+/** Reverse lineage: how many reports / dashboards bind this dataset by name. */
+export function useDatasetUsage(name: string | undefined): DatasetUsage {
+  const client = useMetadataClient();
+  const [state, setState] = React.useState<DatasetUsage>({ reports: 0, dashboards: 0, loading: !!name });
+
+  React.useEffect(() => {
+    if (!name) {
+      setState({ reports: 0, dashboards: 0, loading: false });
+      return;
+    }
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true }));
+    (async () => {
+      const [reports, dashboards] = await Promise.all([
+        client.list<Record<string, unknown>>('report').catch(() => []),
+        client.list<Record<string, unknown>>('dashboard').catch(() => []),
+      ]);
+      if (cancelled) return;
+      setState({
+        reports: (Array.isArray(reports) ? reports : []).filter((d) => referencesDataset(d, name)).length,
+        dashboards: (Array.isArray(dashboards) ? dashboards : []).filter((d) => referencesDataset(d, name)).length,
+        loading: false,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, name]);
+
+  return state;
+}


### PR DESCRIPTION
## Why

The dataset DefaultInspector's three free-text inputs — **base object**, **included relationships**, and dimension/measure **`field`** — forced authors to recall exact API names. That gap (vs. mainstream low-code dataset builders, which let you *pick* from the live schema) is the most-felt difference for the dataset designer.

## What

Replace the free-text inputs with searchable dropdowns over the live object graph, and surface previously JSON-only fields.

**P0 — metadata-driven pickers**
- **Base object** → object dropdown (shows the object's label).
- **Included relationships** → dropdown of the base object's `lookup` / `master_detail` fields (the join allowlist), with the target object as a hint.
- **Dimension / measure `field`** → grouped, searchable dropdown of base fields **+ `relationship.field`** paths for each included relationship (fetches each relationship's target object on demand). Picking a dimension field auto-infers its `type`.
- Every combo keeps a **"Use «typed»" custom-value** escape hatch (offline catalog, computed path, server-only field).

**P1 — surface JSON-only fields in an Advanced disclosure**
- Dimension: `label`, `dateGranularity` (when type = date).
- Measure: `label`, `format`, `currency`, and a **derived-measure** editor (`op` + operands, excluding self).

**P2 — context**
- Join-path hint (`base → rel (target)`).
- Reverse-lineage banner ("Bound by N reports · M dashboards — changes affect them.").

## Files
- `useDatasetFields.ts` (new) — `useObjectOptions` / `useDatasetFieldCatalog` / `useDatasetUsage` + exported pure normalizers. Resolves a lookup's target from `reference` (framework) and `reference_to`/`referenceTo` (spec) shapes.
- `InspectorComboField.tsx` (new) — searchable, grouped single-select (cmdk) with custom-value support.
- `DatasetDefaultInspector.tsx` — rewired to the pickers + advanced fields + hints.

## Test plan
- `useDatasetFields.test.ts` (new) — unit tests for the pure normalizers (`resolveLabel`, `resolveReferenceTo`, `fieldTypeToDimensionType`, `normalizeObject`, `buildFieldOptions`, `referencesDataset`).
- `DatasetDefaultInspector.test.tsx` (updated) — structural + behavioral (add/remove/edit, derived toggle, readOnly).
- Local: app-shell `tsc --noEmit` ✅ · inspectors suite 11 files / 93 tests ✅ · eslint 0 errors.
- Browser-verified against the showcase backend: object/relationship/field pickers resolve real schema, `account.*` cross-object paths appear, join-path + lineage render, no console errors, live preview unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)