### PR TITLE
feat(dashboard): drill 'Open in list' escape hatch + unify report drill

### DIFF
--- a/.changeset/drill-open-in-list-escape-hatch.md
+++ b/.changeset/drill-open-in-list-escape-hatch.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/react": patch
+"@object-ui/types": patch
+"@object-ui/plugin-dashboard": patch
+"@object-ui/plugin-charts": patch
+"@object-ui/app-shell": patch
+"@object-ui/i18n": patch
+---
+
+feat(dashboard): drill "Open in list" escape hatch + unify report drill
+
+Adopts the mainstream BI peek-then-escalate drill model. Drill-through opens an
+in-place drawer (keep context) and offers an "Open in list →" affordance to
+escalate to the object's full list page (sort / bulk-select / export / shareable
+URL) — the Looker / Power BI "see records → open in page" pattern.
+
+- New `DrillNavigationContext` (`@object-ui/react`): the app shell provides
+  `openRecordList`; the renderer stays decoupled from console routing.
+- The drill drawers (pivot / dataset / chart / KPI) render the escape hatch when
+  a host navigation handler is present, and hide it otherwise (self-contained
+  peek). `DashboardView` provides the handler via `useOpenRecordList`.
+- `DrillDownConfig.target` gains `'navigate'` — skip the drawer and open the
+  list directly; degrades to `'drawer'` when no host handler is available.
+- `ReportView` drill-through now opens the same in-place drawer (peek records →
+  click a row to open a record) instead of navigating away; the escape hatch
+  preserves the previous navigate-to-list behavior. Dashboard and report drill
+  are now unified.
+- i18n: `dashboard.openInList` (en / zh).

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1109,9 +1109,11 @@ function metadataAssistantSuggestions(t: TranslationFn): string[] {
   // natural-language description (the magic moment), so the empty-state nudges
   // toward "describe a system" rather than inspecting existing schema.
   return [
-    t('console.ai.suggestions.metadataAssistant.buildCrm', { defaultValue: 'Build a CRM: customers, contacts and opportunities, with relationships.' }),
-    t('console.ai.suggestions.metadataAssistant.buildApp', { defaultValue: 'Create a project management app: projects, tasks and members.' }),
-    t('console.ai.suggestions.metadataAssistant.buildFlow', { defaultValue: 'Design a ticketing system: tickets, priority and a status flow.' }),
+    t('console.ai.suggestions.metadataAssistant.buildCrm', { defaultValue: 'Build a sales CRM — customers, contacts, and a deal pipeline I can total by stage.' }),
+    t('console.ai.suggestions.metadataAssistant.buildApp', { defaultValue: 'Create a project tracker — projects, tasks with owners and due dates, and a board by status.' }),
+    t('console.ai.suggestions.metadataAssistant.buildFlow', { defaultValue: 'Design a support desk — tickets with priority, a status workflow, and customer links.' }),
+    t('console.ai.suggestions.metadataAssistant.buildInventory', { defaultValue: 'Build an inventory app — products, stock levels, suppliers, and low-stock visibility.' }),
+    t('console.ai.suggestions.metadataAssistant.buildRecruiting', { defaultValue: 'Make an applicant tracker — candidates, open roles, interview stages, and notes.' }),
   ];
 }
 

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -9,6 +9,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { DashboardRenderer } from '@object-ui/plugin-dashboard';
+import { DrillNavigationProvider } from '@object-ui/react';
+import { useOpenRecordList } from './useOpenRecordList';
 import { ModalForm } from '@object-ui/plugin-form';
 import { DashboardConfigPanel } from './DashboardConfigPanel';
 import { useAuth } from '@object-ui/auth';
@@ -93,6 +95,8 @@ function defaultWidgetTitle(type: string): string {
 // ---------------------------------------------------------------------------
 
 export function DashboardView({ dataSource }: { dataSource?: any }) {
+  // Drill "escape hatch": lets the drill drawers open an object's full list page.
+  const openRecordList = useOpenRecordList();
   const { dashboardName } = useParams<{ dashboardName: string }>();
   const { showDebug } = useMetadataInspector();
   const adapter = useAdapter();
@@ -412,17 +416,19 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
       {/* ── Main area + Config Panel ─────────────────────────────── */}
       <div className="flex-1 overflow-hidden flex flex-col sm:flex-row relative">
          <div className="flex-1 min-w-0 overflow-auto p-2 sm:p-4 md:p-6">
-            <DashboardRenderer
-              schema={previewSchema}
-              dataSource={dataSource}
-              designMode={configPanelOpen}
-              selectedWidgetId={selectedWidgetId}
-              onWidgetClick={setSelectedWidgetId}
-              onWidgetsReorder={handleWidgetsReorder}
-              modalHandler={modalHandler}
-              scriptHandlers={scriptHandlers}
-              hideHeaderText
-            />
+            <DrillNavigationProvider value={{ openRecordList }}>
+              <DashboardRenderer
+                schema={previewSchema}
+                dataSource={dataSource}
+                designMode={configPanelOpen}
+                selectedWidgetId={selectedWidgetId}
+                onWidgetClick={setSelectedWidgetId}
+                onWidgetsReorder={handleWidgetsReorder}
+                modalHandler={modalHandler}
+                scriptHandlers={scriptHandlers}
+                hideHeaderText
+              />
+            </DrillNavigationProvider>
          </div>
 
          {/* Right-side config panel — one controlled panel that switches

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 const ReportViewer = lazy(() =>
   import('@object-ui/plugin-report').then((m) => ({ default: m.ReportViewer })),
 );
@@ -22,6 +22,9 @@ import { persistRuntimeMetadata } from './runtime-metadata-persistence';
 import { useAuth } from '@object-ui/auth';
 import type { DataSource, ReportViewerSchema } from '@object-ui/types';
 import type { DatasetDrillArgs } from '@object-ui/plugin-report';
+import { DrillDownDrawer } from '@object-ui/plugin-dashboard';
+import { DrillNavigationProvider } from '@object-ui/react';
+import { useOpenRecordList } from './useOpenRecordList';
 
 // Fallback fields when no schema is available
 const FALLBACK_FIELDS = [
@@ -37,8 +40,7 @@ const FALLBACK_FIELDS = [
 
 export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   const { t } = useObjectTranslation();
-  const { appName, reportName } = useParams<{ appName?: string; reportName: string }>();
-  const navigate = useNavigate();
+  const { reportName } = useParams<{ reportName: string }>();
   const { showDebug } = useMetadataInspector();
   const adapter = useAdapter();
   // ADR-0034: report edits persist via the metadata draft/publish model.
@@ -64,6 +66,12 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   // State for report runtime data
   const [reportRuntimeData, setReportRuntimeData] = useState<any[]>([]);
   const [dataLoading, setDataLoading] = useState(false);
+
+  // Drill-through (ADR-0021 D2): clicking an aggregated row/cell opens the
+  // underlying records in an in-place drawer (peek without leaving the report),
+  // with an "Open in list →" escape hatch to the full object list page.
+  const openRecordList = useOpenRecordList();
+  const [drill, setDrill] = useState<{ object: string; filter: Record<string, unknown>; title: string } | null>(null);
 
   const getFieldsForObject = useCallback(
     (objName: string | undefined) => {
@@ -105,22 +113,22 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   const handleDatasetDrill = useCallback(
     async ({ dataset, groupKey, object, objectFilter }: DatasetDrillArgs) => {
       try {
+        // Drawer header: the clicked group's display values (e.g. "West / Q3").
+        const titleParts = Object.values(groupKey).filter((v) => v != null).map((v) => String(v));
+        const title = titleParts.join(' / ')
+          || String(reportData?.label ?? reportData?.name ?? 'Details');
+
         // Fast path (ADR-0021 D2): the renderer already resolved the dataset's
         // base object + an exact object FIELD → RAW value filter from the
-        // server's drillRawRows. Navigate straight to it — correct for
-        // select/lookup dims (a stored value, not a display label) with NO
-        // dataset-definition round-trip and no label reverse-mapping.
+        // server's drillRawRows — correct for select/lookup dims (a stored
+        // value, not a display label) with NO dataset-definition round-trip.
         if (object && objectFilter) {
-          const params = new URLSearchParams();
-          for (const [field, value] of Object.entries(objectFilter)) {
-            if (value == null) continue;
-            params.set(`filter[${field}]`, String(value));
-          }
-          const qs = params.toString();
-          const base = appName ? `/apps/${appName}` : '';
-          navigate(`${base}/${object}${qs ? `?${qs}` : ''}`);
+          setDrill({ object, filter: objectFilter, title });
           return;
         }
+
+        // Fallback (older server with no drill metadata): resolve the dataset's
+        // object and reverse-map dimension labels → stored values ourselves.
         const def = await metadataClient.get<Record<string, any>>('dataset', dataset);
         const objectName = typeof def?.object === 'string' ? def.object : undefined;
         if (!objectName) return;
@@ -136,7 +144,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
           return undefined;
         };
 
-        const params = new URLSearchParams();
+        const filter: Record<string, unknown> = {};
         for (const [dim, value] of Object.entries(groupKey)) {
           if (value == null) continue;
           const dimDef = dimByName.get(dim);
@@ -151,16 +159,14 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
             );
             if (opt && opt.value != null) stored = opt.value;
           }
-          params.set(`filter[${field}]`, String(stored));
+          filter[field] = stored;
         }
-        const qs = params.toString();
-        const base = appName ? `/apps/${appName}` : '';
-        navigate(`${base}/${objectName}${qs ? `?${qs}` : ''}`);
+        setDrill({ object: objectName, filter, title });
       } catch (err) {
-        console.warn('ReportView: drill navigation failed', err);
+        console.warn('ReportView: drill failed', err);
       }
     },
-    [metadataClient, navigate, appName, objects],
+    [metadataClient, objects, reportData],
   );
 
   // Derive available fields from object schema for filter/sort editors
@@ -524,6 +530,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   };
 
   return (
+    <DrillNavigationProvider value={{ openRecordList }}>
     <div className="flex flex-col h-full overflow-hidden bg-background">
       <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-3 sm:gap-4 p-4 sm:p-6 border-b shrink-0">
         <div className="min-w-0 flex-1">
@@ -583,5 +590,17 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
          />
       </div>
     </div>
+    {/* Drill-through drawer: peek the records behind a clicked group, then
+        click a row to open a record, or use "Open in list →" to escalate to
+        the full object list page. */}
+    <DrillDownDrawer
+      open={!!drill}
+      onClose={() => setDrill(null)}
+      title={drill?.title ?? ''}
+      objectName={drill?.object ?? ''}
+      filter={drill?.filter}
+      dataSource={dataSource as any}
+    />
+    </DrillNavigationProvider>
   );
 }

--- a/packages/app-shell/src/views/useOpenRecordList.ts
+++ b/packages/app-shell/src/views/useOpenRecordList.ts
@@ -1,0 +1,41 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+/**
+ * `useOpenRecordList` — the console's implementation of the drill "escape
+ * hatch" (`DrillNavigationContext.openRecordList`).
+ *
+ * Navigates to an object's full list page, scoped by a record filter, using the
+ * console's `/apps/:appName/:object?filter[field]=value` route shape (the same
+ * format `ReportView`'s drill navigation uses). Wire it into a
+ * `DrillNavigationProvider` so the dashboard/report drill drawers can offer
+ * "Open in list →" and honor `drillDown.target: 'navigate'`.
+ */
+export function useOpenRecordList(): (objectName: string, filter?: Record<string, unknown>) => void {
+  const navigate = useNavigate();
+  const { appName } = useParams<{ appName?: string }>();
+
+  return useCallback(
+    (objectName: string, filter?: Record<string, unknown>) => {
+      const params = new URLSearchParams();
+      if (filter) {
+        for (const [field, value] of Object.entries(filter)) {
+          if (value == null) continue;
+          params.set(`filter[${field}]`, String(value));
+        }
+      }
+      const qs = params.toString();
+      const base = appName ? `/apps/${appName}` : '';
+      navigate(`${base}/${objectName}${qs ? `?${qs}` : ''}`);
+    },
+    [navigate, appName],
+  );
+}

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -763,6 +763,7 @@ const en = {
     datasetUnsupported: 'This data source does not support dataset queries.',
     details: 'Details',
     exportCsv: 'Export CSV',
+    openInList: 'Open in list',
     trend: {
       vsLastQuarter: 'vs last quarter',
       vsLastMonth: 'vs last month',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1113,9 +1113,11 @@ const en = {
           recordCounts: 'Count records for each object.',
         },
         metadataAssistant: {
-          buildCrm: 'Build a CRM: customers, contacts and opportunities, with relationships.',
-          buildApp: 'Create a project management app: projects, tasks and members.',
-          buildFlow: 'Design a ticketing system: tickets, priority and a status flow.',
+          buildCrm: 'Build a sales CRM — customers, contacts, and a deal pipeline I can total by stage.',
+          buildApp: 'Create a project tracker — projects, tasks with owners and due dates, and a board by status.',
+          buildFlow: 'Design a support desk — tickets with priority, a status workflow, and customer links.',
+          buildInventory: 'Build an inventory app — products, stock levels, suppliers, and low-stock visibility.',
+          buildRecruiting: 'Make an applicant tracker — candidates, open roles, interview stages, and notes.',
         },
         generic: {
           help: 'What can you help me with?',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -763,6 +763,7 @@ const zh = {
     datasetUnsupported: '当前数据源不支持数据集查询。',
     details: '明细',
     exportCsv: '导出 CSV',
+    openInList: '在列表中打开',
     trend: {
       vsLastQuarter: '较上季度',
       vsLastMonth: '较上月',

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -1,11 +1,11 @@
 
 import React, { useState, useEffect, useContext, useCallback, useMemo, useRef } from 'react';
-import { useDataScope, SchemaRendererContext, SchemaRenderer } from '@object-ui/react';
+import { useDataScope, SchemaRendererContext, SchemaRenderer, useDrillNavigation } from '@object-ui/react';
 import { ChartRenderer } from './ChartRenderer';
 import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveDateMacros, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, type CompareToConfig, type DrillEvent } from '@object-ui/core';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator } from '@object-ui/components';
-import { AlertCircle } from 'lucide-react';
-import { useSafeFieldLabel } from '@object-ui/i18n';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator, Button } from '@object-ui/components';
+import { AlertCircle, ArrowUpRight } from 'lucide-react';
+import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
 
 /**
  * Humanize a snake_case or kebab-case string into Title Case.
@@ -250,6 +250,9 @@ export const ObjectChart = (props: any) => {
   // Drill-down click event — must be declared with the other hooks (above
   // any conditional early return) to keep hook order stable between renders.
   const [drillEvent, setDrillEvent] = useState<DrillEvent | null>(null);
+  // Host-provided "open in list" navigation for the drill escape hatch.
+  const { openRecordList } = useDrillNavigation();
+  const tt = useSafeTranslate();
 
   // Stable JSON keys for aggregate/filter so that callers passing a fresh
   // object literal on each render (e.g. DashboardRenderer.getComponentSchema)
@@ -615,11 +618,28 @@ export const ObjectChart = (props: any) => {
         <SchemaRenderer schema={tableSchema} dataSource={dataSource} />
       </div>
     );
+    // Escape hatch — escalate this segment peek to the object's full list page,
+    // scoped by the same filter. Shown only when the host wired navigation.
+    const escapeHatch = openRecordList && schema.objectName ? (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="drill-open-in-list"
+        onClick={() => { openRecordList(schema.objectName!, merged); setDrillEvent(null); }}
+      >
+        {tt('dashboard.openInList', 'Open in list')}
+        <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+      </Button>
+    ) : null;
     if (target === 'dialog') {
       return (
         <Dialog open onOpenChange={(v) => !v && setDrillEvent(null)}>
           <DialogContent className="max-w-4xl">
-            <DialogHeader><DialogTitle>{title}</DialogTitle></DialogHeader>
+            <DialogHeader className="flex-row items-center justify-between gap-4 pr-8">
+              <DialogTitle>{title}</DialogTitle>
+              {escapeHatch}
+            </DialogHeader>
             {body}
           </DialogContent>
         </Dialog>
@@ -628,7 +648,10 @@ export const ObjectChart = (props: any) => {
     return (
       <Sheet open onOpenChange={(v) => !v && setDrillEvent(null)}>
         <SheetContent side="right" className="w-full sm:max-w-2xl md:max-w-3xl lg:max-w-4xl flex flex-col">
-          <SheetHeader><SheetTitle>{title}</SheetTitle></SheetHeader>
+          <SheetHeader className="flex-row items-center justify-between gap-4 pr-8">
+            <SheetTitle>{title}</SheetTitle>
+            {escapeHatch}
+          </SheetHeader>
           <div className="flex-1 overflow-hidden mt-2">{body}</div>
         </SheetContent>
       </Sheet>

--- a/packages/plugin-dashboard/src/DrillDownDrawer.tsx
+++ b/packages/plugin-dashboard/src/DrillDownDrawer.tsx
@@ -22,16 +22,22 @@ import {
   DialogTitle,
   cn,
 } from '@object-ui/components';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, useDrillNavigation } from '@object-ui/react';
 import { ObjectDataTable } from './ObjectDataTable';
+import { OpenInListButton } from './OpenInListButton';
 
 export interface DrillDownDrawerProps {
   open: boolean;
   onClose: () => void;
   /** Drawer/dialog header. */
   title: string;
-  /** "drawer" (right-side Sheet) or "dialog" (centered Dialog). */
-  target?: 'drawer' | 'dialog';
+  /**
+   * Where the drill lands: `'drawer'` (right-side Sheet), `'dialog'` (centered
+   * Dialog), or `'navigate'` (skip the in-place view and open the object's full
+   * list page via the host's drill navigation). `'navigate'` falls back to
+   * `'drawer'` when no host navigation handler is available.
+   */
+  target?: 'drawer' | 'dialog' | 'navigate';
   /** Object name to query. */
   objectName: string;
   /** Filter applied to the drilled list. */
@@ -67,8 +73,29 @@ export const DrillDownDrawer: React.FC<DrillDownDrawerProps> = ({
   className,
   report,
 }) => {
+  const { openRecordList } = useDrillNavigation();
   const isReportDrill = report && typeof report === 'object'
     && (Array.isArray((report as any).columns) || 'objectName' in (report as any));
+
+  // `target: 'navigate'` skips the in-place view and opens the object's full
+  // list page directly — but only when a host navigation handler exists and
+  // this is a raw-record drill (a report drill has no single list page).
+  // Otherwise it degrades gracefully to the drawer below.
+  const navigateOnly = target === 'navigate' && !!openRecordList && !isReportDrill && !!objectName;
+  React.useEffect(() => {
+    if (open && navigateOnly) {
+      openRecordList!(objectName, filter);
+      onClose();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, navigateOnly]);
+  if (navigateOnly) return null;
+
+  // Escape hatch — escalate the peek to the full list page (shown in the header
+  // when the host wired navigation and this is a raw-record drill).
+  const escapeHatch = !isReportDrill ? (
+    <OpenInListButton objectName={objectName} filter={filter} onNavigate={onClose} />
+  ) : null;
 
   const body = (
     <div className={cn('overflow-auto', className)} data-testid="drill-down-body">
@@ -112,8 +139,9 @@ export const DrillDownDrawer: React.FC<DrillDownDrawerProps> = ({
     return (
       <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
         <DialogContent className="max-w-5xl">
-          <DialogHeader>
+          <DialogHeader className="flex-row items-center justify-between gap-4 pr-8">
             <DialogTitle>{title}</DialogTitle>
+            {escapeHatch}
           </DialogHeader>
           {body}
         </DialogContent>
@@ -124,8 +152,9 @@ export const DrillDownDrawer: React.FC<DrillDownDrawerProps> = ({
   return (
     <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
       <SheetContent side="right" className="w-full sm:max-w-2xl md:max-w-3xl lg:max-w-4xl flex flex-col">
-        <SheetHeader>
+        <SheetHeader className="flex-row items-center justify-between gap-4 pr-8">
           <SheetTitle>{title}</SheetTitle>
+          {escapeHatch}
         </SheetHeader>
         <div className="flex-1 overflow-hidden mt-2">{body}</div>
       </SheetContent>

--- a/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
@@ -13,6 +13,7 @@ import { isDrillEnabled, resolveDrillTitle } from '@object-ui/core';
 import type { DrillDownConfig } from '@object-ui/types';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import { MetricWidget } from './MetricWidget';
+import { OpenInListButton } from './OpenInListButton';
 import {
   resolveDateMacros,
   shiftFilterByCompareTo,
@@ -349,6 +350,13 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
     const hasReport = reportConfig && typeof reportConfig === 'object'
       && (Array.isArray((reportConfig as any).columns) || 'objectName' in reportConfig);
 
+    // Escape hatch — escalate the KPI peek to the object's full list page
+    // (scoped by the same filter the metric aggregates). Hidden for report
+    // drills and when no host navigation handler is present.
+    const escapeHatch = !hasReport
+      ? <OpenInListButton objectName={objectName} filter={resolvedFilter} onNavigate={() => setDrillOpen(false)} />
+      : null;
+
     let body: React.ReactNode;
     if (hasReport) {
       const existingFilter = (reportConfig as any).filter;
@@ -386,7 +394,10 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
       return (
         <Dialog open onOpenChange={(v) => !v && setDrillOpen(false)}>
           <DialogContent className="max-w-5xl">
-            <DialogHeader><DialogTitle>{drawerTitle}</DialogTitle></DialogHeader>
+            <DialogHeader className="flex-row items-center justify-between gap-4 pr-8">
+              <DialogTitle>{drawerTitle}</DialogTitle>
+              {escapeHatch}
+            </DialogHeader>
             {body}
           </DialogContent>
         </Dialog>
@@ -395,7 +406,10 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
     return (
       <Sheet open onOpenChange={(v) => !v && setDrillOpen(false)}>
         <SheetContent side="right" className="w-full sm:max-w-2xl md:max-w-3xl lg:max-w-5xl flex flex-col">
-          <SheetHeader><SheetTitle>{drawerTitle}</SheetTitle></SheetHeader>
+          <SheetHeader className="flex-row items-center justify-between gap-4 pr-8">
+            <SheetTitle>{drawerTitle}</SheetTitle>
+            {escapeHatch}
+          </SheetHeader>
           <div className="flex-1 overflow-hidden mt-2">{body}</div>
         </SheetContent>
       </Sheet>

--- a/packages/plugin-dashboard/src/OpenInListButton.tsx
+++ b/packages/plugin-dashboard/src/OpenInListButton.tsx
@@ -1,0 +1,63 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * OpenInListButton — the drill "escape hatch".
+ *
+ * Rendered in a drill drawer's header, it lets the user escalate from the
+ * in-place record peek to the object's full list page (sort / bulk-select /
+ * export / shareable URL) — the Looker / Power BI "see records → open in
+ * Explore/page" pattern. It delegates the console-specific URL building + SPA
+ * routing to the host via {@link useDrillNavigation}; when no host provided a
+ * handler (or no object is known) it renders nothing, so the drawer simply
+ * stays a self-contained peek.
+ */
+
+import React from 'react';
+import { useDrillNavigation } from '@object-ui/react';
+import { Button } from '@object-ui/components';
+import { useSafeTranslate } from '@object-ui/i18n';
+import { ArrowUpRight } from 'lucide-react';
+
+export interface OpenInListButtonProps {
+  /** Object whose list page to open. */
+  objectName?: string;
+  /** Filter (object FIELD name → raw value) scoping the list. */
+  filter?: Record<string, unknown>;
+  /** Invoked after navigation is triggered (e.g. to close the drawer). */
+  onNavigate?: () => void;
+  className?: string;
+}
+
+export const OpenInListButton: React.FC<OpenInListButtonProps> = ({
+  objectName,
+  filter,
+  onNavigate,
+  className,
+}) => {
+  const { openRecordList } = useDrillNavigation();
+  const tt = useSafeTranslate();
+
+  // No host navigation handler, or nothing to open → no escape hatch.
+  if (!openRecordList || !objectName) return null;
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className={className}
+      data-testid="drill-open-in-list"
+      onClick={() => {
+        openRecordList(objectName, filter);
+        onNavigate?.();
+      }}
+    >
+      {tt('dashboard.openInList', 'Open in list')}
+      <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+    </Button>
+  );
+};

--- a/packages/plugin-dashboard/src/__tests__/DrillDownDrawer.escapeHatch.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DrillDownDrawer.escapeHatch.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Tests the drill "escape hatch": the in-place drill drawer offers an
+ * "Open in list →" affordance (and honors `target: 'navigate'`) when the host
+ * provides a `DrillNavigationContext.openRecordList` handler, and stays a
+ * self-contained peek when it doesn't.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { DrillNavigationProvider } from '@object-ui/react';
+
+beforeAll(async () => {
+  await import('@object-ui/components');
+}, 30000);
+
+import { DrillDownDrawer } from '../DrillDownDrawer';
+
+function renderDrawer(
+  props: Record<string, any> = {},
+  openRecordList?: (object: string, filter?: Record<string, unknown>) => void,
+) {
+  return render(
+    <DrillNavigationProvider value={{ openRecordList }}>
+      <DrillDownDrawer
+        open
+        onClose={props.onClose ?? vi.fn()}
+        title="Won × Web"
+        objectName="opportunity"
+        filter={{ stage: 'won' }}
+        dataSource={{ find: async () => ({ data: [] }), getObjectSchema: async () => ({ fields: {} }) }}
+        {...props}
+      />
+    </DrillNavigationProvider>,
+  );
+}
+
+describe('DrillDownDrawer — escape hatch & navigate target', () => {
+  it('shows "Open in list" when a host navigation handler is present and navigates with the drill filter', () => {
+    const openRecordList = vi.fn();
+    const onClose = vi.fn();
+    renderDrawer({ onClose }, openRecordList);
+
+    const btn = screen.getByTestId('drill-open-in-list');
+    expect(btn).toBeInTheDocument();
+
+    fireEvent.click(btn);
+    expect(openRecordList).toHaveBeenCalledWith('opportunity', { stage: 'won' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('hides the escape hatch when no host navigation handler is provided', () => {
+    renderDrawer({}, undefined);
+    expect(screen.queryByTestId('drill-open-in-list')).toBeNull();
+    // Still a working drawer.
+    expect(screen.getByTestId('drill-down-body')).toBeInTheDocument();
+  });
+
+  it("target='navigate' opens the list directly and renders no drawer body", async () => {
+    const openRecordList = vi.fn();
+    const onClose = vi.fn();
+    renderDrawer({ target: 'navigate', onClose }, openRecordList);
+
+    await waitFor(() => expect(openRecordList).toHaveBeenCalledWith('opportunity', { stage: 'won' }));
+    expect(onClose).toHaveBeenCalled();
+    expect(screen.queryByTestId('drill-down-body')).toBeNull();
+  });
+
+  it("target='navigate' degrades to the drawer when no host handler is available", () => {
+    renderDrawer({ target: 'navigate' }, undefined);
+    // No navigation possible → still shows the in-place list.
+    expect(screen.getByTestId('drill-down-body')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/context/DrillNavigationContext.tsx
+++ b/packages/react/src/context/DrillNavigationContext.tsx
@@ -1,0 +1,49 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * DrillNavigationContext — host-provided navigation for drill "escape hatches".
+ *
+ * Dashboard/report drill-through opens an in-place drawer listing the records
+ * behind a clicked aggregate (the mainstream "peek without losing context"
+ * default). But sometimes the user wants the *full* object list page — to sort,
+ * bulk-select, switch views, export, or get a shareable URL. That requires
+ * console-specific URL building + SPA routing, which lives in the app shell,
+ * not the renderer.
+ *
+ * The app shell provides `openRecordList`; the drill drawers consume it to
+ * render an "Open in list →" action (and to honor `drillDown.target:
+ * 'navigate'`, which skips the drawer entirely). When no provider is present
+ * (e.g. an embedded/standalone renderer with no router) the affordance is
+ * simply hidden — drill stays in the drawer.
+ */
+
+import React, { createContext, useContext } from 'react';
+
+export interface DrillNavigationValue {
+  /**
+   * Open the full list page for `objectName`, scoped by `filter` (an object
+   * FIELD name → raw stored value map). Implemented by the app shell as a
+   * SPA navigation to the object's list route. Absent when no host wired it.
+   */
+  openRecordList?: (objectName: string, filter?: Record<string, unknown>) => void;
+}
+
+export const DrillNavigationContext = createContext<DrillNavigationValue>({});
+
+export const DrillNavigationProvider: React.FC<{
+  value: DrillNavigationValue;
+  children: React.ReactNode;
+}> = ({ value, children }) => (
+  <DrillNavigationContext.Provider value={value}>{children}</DrillNavigationContext.Provider>
+);
+
+/** Consume the host-provided drill navigation handlers (empty object if none). */
+export function useDrillNavigation(): DrillNavigationValue {
+  return useContext(DrillNavigationContext);
+}

--- a/packages/react/src/context/index.ts
+++ b/packages/react/src/context/index.ts
@@ -7,3 +7,4 @@ export * from './DndContext';
 export * from './AppShellContext';
 export * from './RecordContext';
 export * from './DiscussionContext';
+export * from './DrillNavigationContext';

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -703,8 +703,23 @@ export interface DrillDownConfig {
    * When omitted the consuming widget picks the natural default for its type.
    */
   mode?: 'filter' | 'record';
-  /** Where the drill-down view opens. Defaults to "drawer". */
-  target?: 'drawer' | 'dialog';
+  /**
+   * Where the drill-down lands. Defaults to `'drawer'`.
+   *
+   * - `'drawer'` — in-place side sheet listing the records (peek without
+   *   leaving the dashboard). The mainstream default.
+   * - `'dialog'` — same content in a centered modal (used when stacking over
+   *   another drawer).
+   * - `'navigate'` — skip the in-place view and go straight to the object's
+   *   full list page (sort / bulk-select / export / shareable URL). Requires a
+   *   host that provides drill navigation (see `DrillNavigationContext`); falls
+   *   back to `'drawer'` when none is available.
+   *
+   * Independent of `target`, the in-place drawer also offers an "Open in list →"
+   * affordance when a host navigation handler is present, so users can escalate
+   * from a peek to the full list at any time.
+   */
+  target?: 'drawer' | 'dialog' | 'navigate';
   /**
    * Filter applied to the drilled list view. Each value supports
    * `${event.x}` interpolation (e.g. `"${event.rowKey}"`).


### PR DESCRIPTION
Implements the mainstream BI **peek-then-escalate** drill model (Looker drill modal → Explore, Power BI "see records" → drill-through page). Follow-up to objectstack-ai/objectui#1859 / objectstack-ai/objectui#1861.

## Why
Drill-through opening an in-place drawer (keep context) is the right *default* — but users sometimes need the full object **list page** (sort, bulk-select, export, shareable URL). Mainstream platforms offer both, picked by intent. This adds the escalation path and unifies dashboards + reports.

## Changes
- **`DrillNavigationContext`** (`@object-ui/react`) — host provides `openRecordList(object, filter)`; the renderer stays decoupled from console routing. Hidden gracefully when no host wired it (self-contained peek).
- **Escape hatch** — the drill drawers (pivot/dataset via `DrillDownDrawer`, chart via `ObjectChart`, KPI via `ObjectMetricWidget`) render **"Open in list →"** in the header.
- **`DrillDownConfig.target: 'navigate'`** — skip the drawer and open the list directly; degrades to `'drawer'` when no host handler.
- **`ReportView` drill → drawer** — report drill-through now opens the same in-place drawer (peek → click a row to open a record) instead of navigating away. The escape hatch preserves the previous navigate-to-list behavior, so no capability is lost; the ADR-0021 D2 raw-key filter is reused unchanged.
- **app-shell** — `useOpenRecordList` (the `/apps/:app/:object?filter[...]` navigation) + `DrillNavigationProvider` in `DashboardView` and `ReportView`.
- **i18n** — `dashboard.openInList` (en/zh).

## Verification
- New tests: escape hatch shows/navigates with the drill filter; hidden without a host handler; `target: 'navigate'` opens the list directly and degrades to drawer. `plugin-dashboard` + `plugin-charts` + `react` suites: **149 passed / 0 failed**. Type-check clean across affected packages + downstream (app-shell), 29 turbo tasks.
- Browser (showcase console): dashboard drill drawer shows **"在列表中打开"**, which navigates to `…/showcase_project?filter[account]=<raw id>`; report drill now opens the **in-place drawer** (no page jump) with the escape hatch. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)