### PR TITLE
feat(studio): calmer remove control + metadata-driven pickers across inspectors

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.test.tsx
@@ -1,52 +1,42 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * DashboardWidgetInspector — dataset binding (ADR-0021). The hand-built widget
- * inspector lets you bind a governed dataset + pick dimensions/values BY NAME,
- * symmetric to the report's dataset binding, so per-widget dataset binding is
- * editable in the form (not only via the raw source tab / API).
+ * DashboardWidgetInspector — dataset binding (ADR-0021). The widget inspector
+ * binds a governed dataset and picks its dimensions/measures from the bound
+ * dataset's semantic layer (the same control the Report inspector uses), and
+ * the inline object query picks object/fields from the live schema — instead
+ * of free-text the author has to recall. These tests stub the catalog hooks so
+ * the pickers render network-free.
  */
 
 import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
+
+// Network-free catalogs.
+vi.mock('../previews/useDatasetCatalog', () => ({
+  useDatasetCatalog: () => ({
+    datasets: [{ name: 'sales_pipeline', label: 'Sales Pipeline', dimensions: [], measures: [] }],
+    loading: false,
+    error: null,
+  }),
+  useDatasetSemantics: () => ({
+    dimensions: [{ name: 'stage', type: 'string' }],
+    measures: [{ name: 'revenue', aggregate: 'sum' }],
+    loading: false,
+    error: null,
+  }),
+}));
+vi.mock('./useDatasetFields', () => ({
+  useObjectOptions: () => ({ options: [{ name: 'crm_opportunity', label: 'Opportunity' }], loading: false }),
+}));
+vi.mock('../previews/useObjectFields', () => ({
+  useObjectFields: () => ({ fields: [{ name: 'amount', label: 'Amount', type: 'currency', hidden: false }], loading: false, error: null }),
+}));
+
 import { DashboardWidgetInspector } from './DashboardWidgetInspector';
 
 afterEach(cleanup);
-
-/**
- * Stateful host that actually applies `onPatch` back into the draft — needed
- * to exercise controlled-input transitions across multiple edits (a bare spy
- * leaves the input value frozen, so a second edit to the same value is a no-op).
- */
-function StatefulInspector({
-  initialWidgets,
-  onPatchSpy,
-  ...rest
-}: {
-  initialWidgets: Record<string, unknown>[];
-  onPatchSpy?: (patch: Record<string, unknown>) => void;
-  [k: string]: unknown;
-}) {
-  const [draft, setDraft] = React.useState<Record<string, unknown>>({ widgets: initialWidgets });
-  return (
-    <DashboardWidgetInspector
-      type="dashboard"
-      name="sales"
-      locale={'en-US'}
-      onClearSelection={vi.fn()}
-      onSelectionChange={vi.fn()}
-      readOnly={false}
-      selection={{ kind: 'widget', id: 'w1' }}
-      {...rest}
-      draft={draft}
-      onPatch={(patch: Record<string, unknown>) => {
-        onPatchSpy?.(patch);
-        setDraft((d) => ({ ...d, ...patch }));
-      }}
-    />
-  );
-}
 
 const baseProps = {
   type: 'dashboard',
@@ -57,32 +47,25 @@ const baseProps = {
   readOnly: false,
 };
 
-function labelledInput(label: string): HTMLInputElement {
-  const lab = screen.getByText(label);
-  const input = lab.parentElement!.querySelector('input, textarea');
-  return input as HTMLInputElement;
+const widget = (extra: Record<string, unknown> = {}) => ({ id: 'w1', type: 'bar', title: 'Revenue', ...extra });
+
+function renderWidget(extra: Record<string, unknown> = {}, props: Record<string, unknown> = {}) {
+  return render(
+    <DashboardWidgetInspector
+      {...baseProps}
+      {...props}
+      draft={{ widgets: [widget(extra)] }}
+      selection={{ kind: 'widget', id: 'w1' }}
+      onPatch={(props.onPatch as any) ?? vi.fn()}
+    />,
+  );
 }
 
-const widget = (extra: Record<string, unknown> = {}) => ({
-  id: 'w1',
-  type: 'bar',
-  title: 'Revenue',
-  ...extra,
-});
-
 describe('DashboardWidgetInspector — dataset binding', () => {
-  it('shows the Dataset field; dimensions/values appear only once a dataset is bound', () => {
-    const { rerender } = render(
-      <DashboardWidgetInspector
-        {...baseProps}
-        draft={{ widgets: [widget()] }}
-        selection={{ kind: 'widget', id: 'w1' }}
-        onPatch={vi.fn()}
-      />,
-    );
-    // Dataset input is always present…
-    expect(labelledInput('Dataset')).toBeInTheDocument();
-    // …but dimensions/values are gated behind a bound dataset.
+  it('shows the Dataset picker; dimensions/values appear only once a dataset is bound', () => {
+    const { rerender } = renderWidget();
+    expect(screen.getByText('Dataset')).toBeInTheDocument();
+    // Dimensions/Values sections are gated behind a bound dataset.
     expect(screen.queryByText('Dimensions')).not.toBeInTheDocument();
     expect(screen.queryByText('Values (measures)')).not.toBeInTheDocument();
 
@@ -94,92 +77,32 @@ describe('DashboardWidgetInspector — dataset binding', () => {
         onPatch={vi.fn()}
       />,
     );
-    expect(labelledInput('Dataset').value).toBe('sales_pipeline');
-    expect(labelledInput('Dimensions').value).toBe('stage');
-    expect(labelledInput('Values (measures)').value).toBe('revenue');
+    // Sections now present, and the bound members render in the lists.
+    expect(screen.getByText('Dimensions')).toBeInTheDocument();
+    expect(screen.getByText('Values (measures)')).toBeInTheDocument();
+    expect(screen.getByText('stage')).toBeInTheDocument();
+    expect(screen.getByText('revenue')).toBeInTheDocument();
   });
 
-  it('commits the dataset name via onPatch (and clears with empty → undefined)', () => {
-    const onPatchSpy = vi.fn();
-    render(<StatefulInspector initialWidgets={[widget()]} onPatchSpy={onPatchSpy} />);
-
-    fireEvent.change(labelledInput('Dataset'), { target: { value: 'sales_pipeline' } });
-    expect(onPatchSpy).toHaveBeenLastCalledWith({
-      widgets: [expect.objectContaining({ id: 'w1', dataset: 'sales_pipeline' })],
-    });
-
-    // The bound value is now reflected (stateful host applied the patch).
-    expect(labelledInput('Dataset').value).toBe('sales_pipeline');
-
-    onPatchSpy.mockClear();
-    fireEvent.change(labelledInput('Dataset'), { target: { value: '' } });
-    expect(onPatchSpy).toHaveBeenLastCalledWith({
-      widgets: [expect.objectContaining({ id: 'w1', dataset: undefined })],
-    });
-  });
-
-  it('parses comma-separated dimensions/values into string arrays', () => {
-    const onPatch = vi.fn();
-    render(
-      <DashboardWidgetInspector
-        {...baseProps}
-        draft={{ widgets: [widget({ dataset: 'sales_pipeline' })] }}
-        selection={{ kind: 'widget', id: 'w1' }}
-        onPatch={onPatch}
-      />,
-    );
-    fireEvent.change(labelledInput('Dimensions'), { target: { value: 'stage, region ,' } });
-    expect(onPatch).toHaveBeenCalledWith({
-      widgets: [expect.objectContaining({ dimensions: ['stage', 'region'] })],
-    });
-
-    onPatch.mockClear();
-    fireEvent.change(labelledInput('Values (measures)'), { target: { value: 'revenue,deal_count' } });
-    expect(onPatch).toHaveBeenCalledWith({
-      widgets: [expect.objectContaining({ values: ['revenue', 'deal_count'] })],
-    });
-  });
-
-  it('keeps the inline object query editable alongside dataset binding (additive dual-form)', () => {
-    render(
-      <DashboardWidgetInspector
-        {...baseProps}
-        draft={{ widgets: [widget({ object: 'crm_opportunity', valueField: 'amount' })] }}
-        selection={{ kind: 'widget', id: 'w1' }}
-        onPatch={vi.fn()}
-      />,
-    );
-    // Both the dataset binding and the legacy inline object field are present.
-    expect(labelledInput('Dataset')).toBeInTheDocument();
-    expect(labelledInput('Data Source (Object)').value).toBe('crm_opportunity');
-    expect(labelledInput('Value Field').value).toBe('amount');
+  it('renders object + field bindings as pickers (inline single-object query)', () => {
+    renderWidget({ object: 'crm_opportunity', valueField: 'amount' });
+    expect(screen.getByText('Data Source (Object)')).toBeInTheDocument();
+    expect(screen.getByText('Value Field')).toBeInTheDocument();
+    // The bound object/field resolve to their catalog labels on the combo triggers.
+    expect(screen.getAllByText('Opportunity').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Amount').length).toBeGreaterThan(0);
   });
 
   it('renders Chinese labels under zh-CN', () => {
-    render(
-      <DashboardWidgetInspector
-        {...baseProps}
-        locale={'zh-CN'}
-        draft={{ widgets: [widget({ dataset: 'sales_pipeline' })] }}
-        selection={{ kind: 'widget', id: 'w1' }}
-        onPatch={vi.fn()}
-      />,
-    );
+    renderWidget({ dataset: 'sales_pipeline' }, { locale: 'zh-CN' });
     expect(screen.getByText('数据集绑定')).toBeInTheDocument();
     expect(screen.getByText('维度')).toBeInTheDocument();
   });
 
-  it('disables the dataset inputs when readOnly', () => {
-    render(
-      <DashboardWidgetInspector
-        {...baseProps}
-        readOnly
-        draft={{ widgets: [widget({ dataset: 'sales_pipeline' })] }}
-        selection={{ kind: 'widget', id: 'w1' }}
-        onPatch={vi.fn()}
-      />,
-    );
-    expect(labelledInput('Dataset')).toBeDisabled();
-    expect(labelledInput('Dimensions')).toBeDisabled();
+  it('disables every picker when readOnly', () => {
+    renderWidget({ dataset: 'sales_pipeline', object: 'crm_opportunity' }, { readOnly: true });
+    const combos = screen.getAllByRole('combobox');
+    expect(combos.length).toBeGreaterThan(0);
+    combos.forEach((c) => expect(c).toBeDisabled());
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
@@ -33,6 +33,11 @@ import type { DashboardWidgetSchema } from '@object-ui/types';
 import type { MetadataInspectorProps } from '../inspector-registry';
 import { t } from '../i18n';
 import { InspectorReorderButtons, moveArray } from './_shared';
+import { InspectorComboField, type InspectorComboOption } from './InspectorComboField';
+import { DatasetNamesEditor } from './ReportDefaultInspector';
+import { useDatasetCatalog, useDatasetSemantics } from '../previews/useDatasetCatalog';
+import { useObjectFields, type ObjectFieldInfo } from '../previews/useObjectFields';
+import { useObjectOptions } from './useDatasetFields';
 
 const WIDGET_TYPES = [
   { value: 'metric', label: 'KPI Metric' },
@@ -77,6 +82,61 @@ export function DashboardWidgetInspector({
   readOnly,
   locale,
 }: MetadataInspectorProps) {
+  const widgetsAll = Array.isArray((draft as any).widgets)
+    ? ((draft as any).widgets as DashboardWidgetSchema[])
+    : [];
+  const selId = selection.kind === 'widget' ? selection.id : undefined;
+  const hit = selId ? findWidget(draft, selId) : null;
+
+  // ── Dataset binding (ADR-0021) ──────────────────────────────────────────
+  // Field access goes through `as any`: the bundled `@object-ui/types`
+  // `DashboardWidgetSchema` only gains `dataset`/`dimensions`/`values` once
+  // objectui bumps `@objectstack/spec`. Same accessor pattern as DatasetWidget.
+  const w = (hit?.widget ?? {}) as any;
+  const datasetName = typeof w.dataset === 'string' ? (w.dataset as string) : '';
+  const objectName = typeof w.object === 'string' ? (w.object as string) : '';
+  const dimensions: string[] = Array.isArray(w.dimensions)
+    ? (w.dimensions as unknown[]).filter((x): x is string => typeof x === 'string')
+    : [];
+  const values: string[] = Array.isArray(w.values)
+    ? (w.values as unknown[]).filter((x): x is string => typeof x === 'string')
+    : [];
+
+  // Catalogs — called unconditionally (stable hook order) BEFORE any early
+  // return, so the dataset/object/field pickers below bind to the live schema
+  // instead of free-text the author has to recall.
+  const catalog = useDatasetCatalog();
+  const semantics = useDatasetSemantics(datasetName || undefined, catalog);
+  const { options: objectOptions, loading: objectsLoading } = useObjectOptions();
+  const { fields: objectFields } = useObjectFields(objectName || undefined);
+
+  const datasetComboOptions: InspectorComboOption[] = React.useMemo(() => {
+    const opts = catalog.datasets.map((d) => ({
+      value: d.name,
+      label: d.label && d.label !== d.name ? `${d.label} (${d.name})` : d.name,
+    }));
+    if (datasetName && !opts.some((o) => o.value === datasetName)) {
+      opts.push({ value: datasetName, label: datasetName });
+    }
+    return opts;
+  }, [catalog.datasets, datasetName]);
+  const objectComboOptions: InspectorComboOption[] = React.useMemo(
+    () => objectOptions.map((o) => ({ value: o.name, label: o.label })),
+    [objectOptions],
+  );
+  const fieldComboOptions: InspectorComboOption[] = React.useMemo(
+    () => objectFields.map((f) => ({ value: f.name, label: f.label, hint: f.type })),
+    [objectFields],
+  );
+  const measureOptions: ObjectFieldInfo[] = React.useMemo(
+    () => semantics.measures.map((m) => ({ name: m.name, label: m.aggregate ? `${m.name} · ${m.aggregate}` : m.name, type: 'number', hidden: false })),
+    [semantics.measures],
+  );
+  const dimensionOptions: ObjectFieldInfo[] = React.useMemo(
+    () => semantics.dimensions.map((d) => ({ name: d.name, label: d.name, type: d.type ?? 'text', hidden: false })),
+    [semantics.dimensions],
+  );
+
   if (selection.kind !== 'widget') {
     return (
       <InspectorEmpty
@@ -86,8 +146,6 @@ export function DashboardWidgetInspector({
       />
     );
   }
-
-  const hit = findWidget(draft, selection.id);
   if (!hit) {
     return (
       <InspectorEmpty
@@ -99,26 +157,12 @@ export function DashboardWidgetInspector({
   }
 
   const { widget, index } = hit;
-  const widgetsAll = Array.isArray((draft as any).widgets)
-    ? ((draft as any).widgets as DashboardWidgetSchema[])
-    : [];
 
   function patchWidget(updates: Partial<DashboardWidgetSchema>) {
     const widgets = [...widgetsAll];
     widgets[index] = { ...widgets[index], ...updates };
     onPatch({ widgets });
   }
-
-  // ── Dataset binding (ADR-0021) ──────────────────────────────────────────
-  // Field access goes through `as any`: the bundled `@object-ui/types`
-  // `DashboardWidgetSchema` only gains `dataset`/`dimensions`/`values` once
-  // objectui bumps `@objectstack/spec`. Same accessor pattern as DatasetWidget.
-  const w = widget as any;
-  const datasetName = typeof w.dataset === 'string' ? (w.dataset as string) : '';
-  const dimensionsCsv = Array.isArray(w.dimensions) ? (w.dimensions as string[]).join(', ') : '';
-  const valuesCsv = Array.isArray(w.values) ? (w.values as string[]).join(', ') : '';
-  const parseList = (s: string): string[] =>
-    s.split(',').map((x) => x.trim()).filter(Boolean);
 
   function moveWidget(to: number) {
     onPatch({ widgets: moveArray(widgetsAll, index, to) });
@@ -200,14 +244,15 @@ export function DashboardWidgetInspector({
           {t('engine.inspector.widget.datasetSection', locale)}
         </div>
         <Field id="widget-dataset" label={t('engine.inspector.widget.dataset', locale)}>
-          <Input
-            id="widget-dataset"
+          <InspectorComboField
             value={datasetName}
+            onCommit={(v) => patchWidget({ dataset: v || undefined } as Partial<DashboardWidgetSchema>)}
+            options={datasetComboOptions}
+            loading={catalog.loading}
             placeholder={t('engine.inspector.widget.datasetPlaceholder', locale)}
-            onChange={(e) =>
-              patchWidget({ dataset: e.target.value || undefined } as Partial<DashboardWidgetSchema>)
-            }
+            searchPlaceholder={t('engine.inspector.widget.datasetPlaceholder', locale)}
             disabled={readOnly}
+            mono
           />
           <p className="text-[10px] leading-snug text-muted-foreground">
             {t('engine.inspector.widget.datasetHint', locale)}
@@ -215,65 +260,67 @@ export function DashboardWidgetInspector({
         </Field>
         {datasetName && (
           <>
-            <Field id="widget-dimensions" label={t('engine.inspector.widget.dimensions', locale)}>
-              <Input
-                id="widget-dimensions"
-                value={dimensionsCsv}
-                placeholder={t('engine.inspector.widget.dimensionsPlaceholder', locale)}
-                onChange={(e) =>
-                  patchWidget({ dimensions: parseList(e.target.value) } as Partial<DashboardWidgetSchema>)
-                }
-                disabled={readOnly}
-              />
-              <p className="text-[10px] leading-snug text-muted-foreground">
-                {t('engine.inspector.widget.dimensionsHint', locale)}
-              </p>
-            </Field>
-            <Field id="widget-values" label={t('engine.inspector.widget.values', locale)}>
-              <Input
-                id="widget-values"
-                value={valuesCsv}
-                placeholder={t('engine.inspector.widget.valuesPlaceholder', locale)}
-                onChange={(e) =>
-                  patchWidget({ values: parseList(e.target.value) } as Partial<DashboardWidgetSchema>)
-                }
-                disabled={readOnly}
-              />
-              <p className="text-[10px] leading-snug text-muted-foreground">
-                {t('engine.inspector.widget.valuesHint', locale)}
-              </p>
-            </Field>
+            {/* Dimensions / measures picked from the bound dataset's semantic
+                layer (reorderable, add-from-catalog) — same control the Report
+                inspector uses — instead of comma-separated free text. */}
+            <DatasetNamesEditor
+              label={t('engine.inspector.widget.dimensions', locale)}
+              emptyText={t('engine.inspector.widget.dimensionsHint', locale)}
+              names={dimensions}
+              options={dimensionOptions}
+              loading={semantics.loading}
+              error={semantics.error}
+              readOnly={readOnly}
+              onCommit={(next) => patchWidget({ dimensions: next } as Partial<DashboardWidgetSchema>)}
+            />
+            <DatasetNamesEditor
+              label={t('engine.inspector.widget.values', locale)}
+              emptyText={t('engine.inspector.widget.valuesHint', locale)}
+              names={values}
+              options={measureOptions}
+              loading={semantics.loading}
+              error={semantics.error}
+              readOnly={readOnly}
+              onCommit={(next) => patchWidget({ values: next } as Partial<DashboardWidgetSchema>)}
+            />
           </>
         )}
       </div>
 
       <Field id="widget-object" label={t('engine.inspector.widget.object', locale)}>
-        <Input
-          id="widget-object"
+        <InspectorComboField
           value={widget.object ?? ''}
-          placeholder="e.g. order"
-          onChange={(e) => patchWidget({ object: e.target.value })}
+          onCommit={(v) => patchWidget({ object: v || undefined })}
+          options={objectComboOptions}
+          loading={objectsLoading}
+          placeholder="Select an object…"
+          searchPlaceholder="Search objects…"
           disabled={readOnly}
+          mono
         />
       </Field>
 
       <Field id="widget-value-field" label={t('engine.inspector.widget.valueField', locale)}>
-        <Input
-          id="widget-value-field"
+        <InspectorComboField
           value={widget.valueField ?? ''}
-          placeholder="e.g. amount"
-          onChange={(e) => patchWidget({ valueField: e.target.value })}
+          onCommit={(v) => patchWidget({ valueField: v || undefined })}
+          options={fieldComboOptions}
+          placeholder={widget.object ? 'Select a field…' : 'e.g. amount'}
+          searchPlaceholder="Search fields…"
           disabled={readOnly}
+          mono
         />
       </Field>
 
       <Field id="widget-category-field" label={t('engine.inspector.widget.categoryField', locale)}>
-        <Input
-          id="widget-category-field"
+        <InspectorComboField
           value={widget.categoryField ?? ''}
-          placeholder="e.g. status"
-          onChange={(e) => patchWidget({ categoryField: e.target.value })}
+          onCommit={(v) => patchWidget({ categoryField: v || undefined })}
+          options={fieldComboOptions}
+          placeholder={widget.object ? 'Select a field…' : 'e.g. status'}
+          searchPlaceholder="Search fields…"
           disabled={readOnly}
+          mono
         />
       </Field>
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
@@ -114,9 +114,11 @@ function readNames(value: unknown): string[] {
 
 /**
  * A reorderable list of dataset member names (the report's `values` or
- * `rows`) with an add-popover fed by the bound dataset's catalog.
+ * `rows`) with an add-popover fed by the bound dataset's catalog. Exported so
+ * the Dashboard widget inspector can bind the same governed dimensions/measures
+ * the same way (single source of truth for dataset-member editing).
  */
-function DatasetNamesEditor({
+export function DatasetNamesEditor({
   label,
   emptyText,
   names,

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.tsx
@@ -32,9 +32,46 @@ import {
   InspectorTextField,
   InspectorSelectField,
 } from './_shared';
+import { InspectorComboField } from './InspectorComboField';
+import { useObjectOptions } from './useDatasetFields';
 import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
 import { SchemaForm } from '../SchemaForm';
 import { useObjectFields, type ObjectFieldInfo } from '../previews/useObjectFields';
+
+/**
+ * Object picker for the view's binding — a searchable dropdown over the live
+ * object catalog (custom value still allowed) instead of recalling the API
+ * name. The catalog hook lives in a child component so the parent inspector's
+ * hook order is unaffected.
+ */
+function ViewObjectPicker({
+  label,
+  value,
+  onCommit,
+  placeholder,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onCommit: (v: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}) {
+  const { options, loading } = useObjectOptions();
+  return (
+    <InspectorComboField
+      label={label}
+      value={value}
+      onCommit={onCommit}
+      options={options.map((o) => ({ value: o.name, label: o.label }))}
+      loading={loading}
+      placeholder={placeholder}
+      searchPlaceholder="Search objects…"
+      disabled={disabled}
+      mono
+    />
+  );
+}
 import { FieldsListEditor } from '../previews/FieldsListEditor';
 import {
   getViewForm,
@@ -278,13 +315,12 @@ export function ViewVariantInspector({
         onCommit={(v) => writeVariant({ type: v })}
         disabled={readOnly}
       />
-      <InspectorTextField
+      <ViewObjectPicker
         label={t('engine.inspector.view.object', locale)}
         value={binding.value}
         onCommit={setObject}
         placeholder={t('engine.inspector.view.objectPlaceholder', locale)}
         disabled={readOnly}
-        mono
       />
 
       {!isFormFamily && (

--- a/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
@@ -18,7 +18,7 @@
  */
 
 import * as React from 'react';
-import { ArrowDown, ArrowUp, X } from 'lucide-react';
+import { ArrowDown, ArrowUp, Trash2, X } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import { Badge, Button, Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@object-ui/components';
 
@@ -261,8 +261,18 @@ export function InspectorCheckboxField({
 }
 
 export function InspectorRemoveButton({ label, onClick, disabled }: { label: string; onClick: () => void; disabled?: boolean }) {
+  // Calm by default (muted outline), escalating to destructive-red only on
+  // hover — a full-width solid-red bar reads as alarming for what is a routine
+  // "remove this element" footer action. The trash icon keeps intent clear.
   return (
-    <Button variant="destructive" size="sm" onClick={onClick} disabled={disabled} className="w-full">
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={onClick}
+      disabled={disabled}
+      className="w-full gap-1.5 text-muted-foreground hover:border-destructive/40 hover:bg-destructive/5 hover:text-destructive"
+    >
+      <Trash2 className="h-3.5 w-3.5" />
       {label}
     </Button>
   );


### PR DESCRIPTION
## Why

A follow-up UX pass over the Studio metadata-admin inspectors, applying the lessons from the dataset designer ([#1865](https://github.com/objectstack-ai/objectui/pull/1865)) to the editors that shared the same two problems: an alarming remove button, and free-text where a metadata-driven picker should be.

## What

**1. Calmer shared remove control (systemic)**
`InspectorRemoveButton` rendered a full-width **solid-red** destructive bar in every curated inspector's footer (object field, view column, app nav, flow node/edge, page block). It's now a muted **outline** button with a trash icon that turns destructive-red only on hover — same footer layout, far less alarming. One change, all six inspectors.

**2. Dashboard widget binding → pickers**
The widget inspector bound dataset / dimensions / measures / object / value+category fields as **free text** (dataset typed by hand; dimensions & measures as comma-separated strings) — the dataset-designer trap, worse for the CSV lists. Rebound to the live schema, reusing the Report inspector's proven controls:
- dataset → searchable combo over the dataset catalog,
- dimensions / measures → the reorderable, add-from-catalog `DatasetNamesEditor` fed by the bound dataset's semantic layer (now exported from the report inspector — one shared implementation),
- object → object-catalog combo; value/category field → field combo over the bound object's fields.

Each combo keeps a custom-value escape hatch (offline / computed paths). Catalog hooks are hoisted above the inspector's early returns to keep hook order stable.

**3. View designer object → picker**
The view's base-object binding was free text; now a searchable object-catalog combo.

## Test plan
- `DashboardWidgetInspector.test.tsx` rewritten for the picker UI (sections gated by a bound dataset, members render, object/field pickers resolve catalog labels, readOnly disables every combo); catalog hooks stubbed for a network-free render.
- Local: app-shell `tsc --noEmit` ✅ · inspectors suite 11 files / 91 tests ✅ · eslint 0 errors.
- Browser-verified against the HotCRM showcase backend:
  - Dashboard `sales_dashboard` → widget inspector: dataset/object/value/category are dropdowns; the value-field combo lists the bound object's 30 real fields (searchable); object resolves to its label (商机).
  - View `crm_account.my_accounts`: base object is a dropdown (客户).
  - View column inspector footer: "删除列" is now a calm outline + trash button, no solid-red bar.
  - No console errors; live previews unaffected.

## Deferred (own follow-up PRs)
- **App-nav icon** → a proper icon picker (needs the Lucide icon widget extracted + virtualized; ~1000 entries).
- **Object-field lookup advanced props** (`displayField` / `sortField` / `filter`) → needs the CEL condition builder wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)