### PR TITLE
feat(console-ai): split AI surfaces — agent-scoped /ai/:agent routing + launcher

### DIFF
--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -255,12 +255,26 @@ export function App() {
               <Route path="settings" element={<DefaultSettingsPage />} />
             </Route>
             <Route path="/system/*" element={<SystemRedirect />} />
+            {/*
+              AI surfaces are agent-scoped: the active assistant is baked into
+              the route (`/ai/:agent`) rather than a `?agent=` query snapshot,
+              so each assistant ("build" authoring vs "ask" data Q&A, plus any
+              custom `*.agent.ts`) is its own page. AiChatPage handles the
+              back-compat redirects: bare `/ai` → the default agent surface, and
+              a single-segment `/ai/:agent` that is actually a legacy bare
+              conversation id → `/ai/:agent/:conversationId`.
+            */}
             <Route path="/ai" element={
               <ProtectedRoute>
                 <DefaultAiChatPage />
               </ProtectedRoute>
             } />
-            <Route path="/ai/:conversationId" element={
+            <Route path="/ai/:agent" element={
+              <ProtectedRoute>
+                <DefaultAiChatPage />
+              </ProtectedRoute>
+            } />
+            <Route path="/ai/:agent/:conversationId" element={
               <ProtectedRoute>
                 <DefaultAiChatPage />
               </ProtectedRoute>

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -470,7 +470,6 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     useParams<{ agent?: string; conversationId?: string }>();
   const [searchParams] = useSearchParams();
   const searchString = searchParams.toString();
-  const queryString = searchString ? `?${searchString}` : '';
   // Explicit new-conversation intent (`?new=1`, the sidebar's New button).
   // Read LIVE (not snapshotted): the button can be clicked again later from an
   // existing conversation, and the flag is stripped once the fresh id is
@@ -500,11 +499,17 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     return resolveAgentParam(agentSegment, catalogNames) !== undefined;
   }, [agentSegment, agents.length, catalogNames]);
 
-  // App/platform default — used for a bare `/ai`, and as the endpoint while a
-  // legacy bare-id link is being redirected to its real agent surface.
+  // Back-compat: the legacy deep-link `/ai?agent=metadata_assistant` (only
+  // meaningful on a bare `/ai`, before the agent moved into the path). Honored
+  // here, then stripped as the route is canonicalized to `/ai/:agent`.
+  const legacyAgentParam = !agentSegment ? searchParams.get('agent') ?? undefined : undefined;
+
+  // App/platform default — used for a bare `/ai` (respecting the legacy
+  // `?agent=`), and as the endpoint while a legacy bare-id link is being
+  // redirected to its real agent surface.
   const fallbackAgent = useMemo(
-    () => resolveDefaultAgentName(agents, defaultAgentProp ?? envDefaultAgent),
-    [agents, defaultAgentProp, envDefaultAgent],
+    () => resolveDefaultAgentName(agents, legacyAgentParam ?? defaultAgentProp ?? envDefaultAgent),
+    [agents, legacyAgentParam, defaultAgentProp, envDefaultAgent],
   );
 
   // Resolved backend agent name for this surface (route agent wins; else default).
@@ -525,8 +530,13 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`
     : undefined;
 
-  const { conversationId, initialMessages } = useChatConversation({
-    userId,
+  const { conversationId, conversationScope, initialMessages } = useChatConversation({
+    // Gate resolution on the agent being known: resolving while `activeAgent`
+    // is still undefined (catalog loading) would bind a SCOPELESS conversation
+    // that the per-(user,scope) guard then sticks with — so the agent surface
+    // would resume some other agent's last chat. Waiting one tick keys the
+    // conversation to the right agent from the first resolve.
+    userId: activeAgent ? userId : undefined,
     scope: activeAgent,
     apiBase,
     activeId: urlConversationId ?? legacyConversationId,
@@ -535,22 +545,26 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
 
   // ── Route canonicalization ──────────────────────────────────────────────
   // Back-compat redirects (the agent is now in the path): bare `/ai` → the
-  // default agent surface; a legacy built-in id in the agent slot
-  // (`/ai/metadata_assistant`) → its friendly form (`/ai/build`). Custom agents
-  // already route by their own name and no-op here. Query (e.g. `?new=1`) is
-  // preserved so the New-chat intent survives the redirect.
+  // default agent surface (or the `?agent=` deep-link target); a legacy built-in
+  // id in the agent slot (`/ai/metadata_assistant`) → its friendly form
+  // (`/ai/build`). Custom agents already route by their own name and no-op here.
+  // The `?new=1` intent is preserved; the consumed legacy `agent` param is
+  // stripped so it doesn't linger in the canonical URL.
   useEffect(() => {
     if (agents.length === 0 || !activeAgent) return;
     const friendly = agentRouteName(activeAgent);
+    const preserved = new URLSearchParams(searchString);
+    preserved.delete('agent');
+    const preservedQuery = preserved.toString() ? `?${preserved.toString()}` : '';
     if (!agentSegment) {
-      navigate(`/ai/${friendly}${queryString}`, { replace: true });
+      navigate(`/ai/${friendly}${preservedQuery}`, { replace: true });
       return;
     }
     if (segmentIsAgent && agentSegment !== friendly) {
       const tail = urlConversationId ? `/${encodeURIComponent(urlConversationId)}` : '';
-      navigate(`/ai/${friendly}${tail}${queryString}`, { replace: true });
+      navigate(`/ai/${friendly}${tail}${preservedQuery}`, { replace: true });
     }
-  }, [agents.length, activeAgent, agentSegment, segmentIsAgent, urlConversationId, queryString, navigate]);
+  }, [agents.length, activeAgent, agentSegment, segmentIsAgent, urlConversationId, searchString, navigate]);
 
   // ── Legacy `/ai/:conversationId` (bare id) ──────────────────────────────
   // Resolve the conversation's own agent and 301 to `/ai/:agent/:conversationId`
@@ -644,8 +658,13 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   useEffect(() => {
     if (!segmentIsAgent || urlConversationId || !conversationId || !activeAgentRoute) return;
     if (staleNewTargetRef.current && staleNewTargetRef.current.id === conversationId) return;
+    // Don't mirror a conversation that belongs to the PREVIOUS agent: right
+    // after a launcher switch, `conversationId` still holds the old agent's id
+    // until the hook re-resolves under the new scope. Mirroring it would write
+    // it onto the new agent's URL and resume the wrong chat.
+    if (conversationScope !== activeAgent) return;
     navigate(`/ai/${activeAgentRoute}/${conversationId}`, { replace: true });
-  }, [segmentIsAgent, urlConversationId, conversationId, activeAgentRoute, navigate]);
+  }, [segmentIsAgent, urlConversationId, conversationId, conversationScope, activeAgent, activeAgentRoute, navigate]);
 
   const titledRef = useRef<Set<string>>(new Set());
 

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -40,6 +40,11 @@ import {
   useObjectChat,
   useHitlInChat,
   resolveDefaultAgentName,
+  PLATFORM_DEFAULT_AGENT,
+  agentRouteName,
+  resolveAgentParam,
+  isBuildAgent,
+  isAskAgent,
   publishHealthFromResponse,
   detectDraftResult,
   buildProgressFromDraftReview,
@@ -55,6 +60,7 @@ import { getRuntimeConfig } from '../../runtime-config';
 import { cloudPricingDeepLink } from '../marketplace/marketplaceApi';
 import { useNavigationContext } from '../../context/NavigationContext';
 import {
+  fetchConversation,
   sanitizeChatMessagesForCache,
   useChatConversation,
   writeConversationMessagesCache,
@@ -159,9 +165,11 @@ function firstUserMessageText(messages: HydratedUIMessage[]): string | undefined
   return text || undefined;
 }
 
+// Keyed by the FRIENDLY agent name (alias-group head) so the new id, the legacy
+// id, and the route segment all localize to the same label.
 const PLATFORM_AGENT_LABEL_KEYS: Record<string, { key: string; defaultValue: string }> = {
-  data_chat: { key: 'console.ai.agentLabels.dataChat', defaultValue: 'Assistant' },
-  metadata_assistant: { key: 'console.ai.agentLabels.metadataAssistant', defaultValue: 'Metadata Assistant' },
+  ask: { key: 'console.ai.agentLabels.ask', defaultValue: 'Ask' },
+  build: { key: 'console.ai.agentLabels.build', defaultValue: 'Build' },
 };
 
 function localizeAgentLabel(
@@ -169,9 +177,45 @@ function localizeAgentLabel(
   agentName: string | undefined,
   fallback: string,
 ): string {
-  const known = agentName ? PLATFORM_AGENT_LABEL_KEYS[agentName] : undefined;
+  const known = agentName ? PLATFORM_AGENT_LABEL_KEYS[agentRouteName(agentName)] : undefined;
   if (!known) return fallback;
   return t(known.key, { defaultValue: known.defaultValue });
+}
+
+/**
+ * Per-surface empty-state branding. The split gives each assistant its own
+ * identity: the Build surface reads as authoring ("describe an app"), the Ask
+ * surface as data Q&A ("ask about your records"). Keyed by friendly name; falls
+ * back to the generic empty state for custom agents.
+ */
+function agentEmptyState(
+  t: (key: string, options?: Record<string, unknown>) => string,
+  agentName: string | undefined,
+): { title: string; description: string } {
+  if (isBuildAgent(agentName)) {
+    return {
+      title: t('console.ai.empty.build.title', { defaultValue: 'Build with AI' }),
+      description: t('console.ai.empty.build.description', {
+        defaultValue:
+          'Describe an app or workflow in plain language — I draft the objects, screens and automations, then you review and publish.',
+      }),
+    };
+  }
+  if (isAskAgent(agentName)) {
+    return {
+      title: t('console.ai.empty.ask.title', { defaultValue: 'Ask your data' }),
+      description: t('console.ai.empty.ask.description', {
+        defaultValue:
+          'Ask questions about your records — counts, lists, and summaries across the data you can access.',
+      }),
+    };
+  }
+  return {
+    title: t('console.ai.emptyTitle', { defaultValue: 'Start a conversation' }),
+    description: t('console.ai.emptyDescription', {
+      defaultValue: 'Ask anything — the assistant has access to your current app context.',
+    }),
+  };
 }
 
 function resolveApiBase(explicit?: string): string {
@@ -417,19 +461,17 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   const { user } = useAuth();
   const { t } = useObjectTranslation();
   const userId = user?.id;
-  const { conversationId: urlConversationId } = useParams<{ conversationId?: string }>();
+  // The agent is BAKED INTO THE ROUTE now: `/ai/:agent[/:conversationId]`.
+  // Deriving it from the path param (resolved against the live catalog) removes
+  // the old `?agent=` query snapshot, which StrictMode's double-mount + the
+  // `/ai`→`/ai/:id` URL rewrite used to drop (the metadata_assistant deep-link
+  // bug). The dropdown is now a launcher that navigates between these routes.
+  const { agent: agentSegment, conversationId: urlConversationId } =
+    useParams<{ agent?: string; conversationId?: string }>();
   const [searchParams] = useSearchParams();
-  // Deep-link entry point: `/ai?agent=metadata_assistant` opens the workspace
-  // directly on a specific agent. Used by the AI-first home hero to land a new
-  // user straight on the authoring assistant (the magic moment) instead of the
-  // data-query default. Falls back gracefully when the agent isn't available.
-  //
-  // Captured ONCE at mount: this page immediately replaces `/ai` with
-  // `/ai/:conversationId` (see the redirect effect below), which strips the
-  // query string — so reading it lazily would lose the agent before the
-  // selection effect runs. The initializer snapshots it before that race.
-  const [agentParam] = useState<string | undefined>(() => searchParams.get('agent') ?? undefined);
-  // Explicit new-conversation intent (`/ai?new=1`, the sidebar's New button).
+  const searchString = searchParams.toString();
+  const queryString = searchString ? `?${searchString}` : '';
+  // Explicit new-conversation intent (`?new=1`, the sidebar's New button).
   // Read LIVE (not snapshotted): the button can be clicked again later from an
   // existing conversation, and the flag is stripped once the fresh id is
   // mirrored into the URL.
@@ -446,18 +488,38 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   const envDefaultAgent = env.VITE_AI_DEFAULT_AGENT as string | undefined;
 
   const { agents, isLoading: agentsLoading, error: agentsError } = useAgents({ apiBase });
+  const catalogNames = useMemo(() => agents.map((a) => a.name), [agents]);
 
-  const [activeAgent, setActiveAgent] = useState<string | undefined>(undefined);
-  useEffect(() => {
-    if (!activeAgent && agents.length > 0) {
-      // Prefer the data-query agent over "first in catalog" so the
-      // dedicated AI workspace opens on the same default the rest of the
-      // platform binds to.
-      const preferred = agentParam ?? defaultAgentProp ?? envDefaultAgent;
-      const resolved = resolveDefaultAgentName(agents, preferred);
-      if (resolved) setActiveAgent(resolved);
+  // Is the first path segment an agent? It is when it resolves to one (friendly
+  // alias / new id / legacy id). When it doesn't, it's a legacy bare
+  // `/ai/:conversationId` link (redirected below). `undefined` = catalog still
+  // loading, so we can't tell yet and redirects must wait.
+  const segmentIsAgent = useMemo<boolean | undefined>(() => {
+    if (!agentSegment) return false;
+    if (agents.length === 0) return undefined;
+    return resolveAgentParam(agentSegment, catalogNames) !== undefined;
+  }, [agentSegment, agents.length, catalogNames]);
+
+  // App/platform default — used for a bare `/ai`, and as the endpoint while a
+  // legacy bare-id link is being redirected to its real agent surface.
+  const fallbackAgent = useMemo(
+    () => resolveDefaultAgentName(agents, defaultAgentProp ?? envDefaultAgent),
+    [agents, defaultAgentProp, envDefaultAgent],
+  );
+
+  // Resolved backend agent name for this surface (route agent wins; else default).
+  const activeAgent = useMemo(() => {
+    if (agents.length === 0) return undefined;
+    if (agentSegment && segmentIsAgent) {
+      return resolveAgentParam(agentSegment, catalogNames);
     }
-  }, [agents, activeAgent, agentParam, defaultAgentProp, envDefaultAgent]);
+    return fallbackAgent;
+  }, [agents.length, agentSegment, segmentIsAgent, catalogNames, fallbackAgent]);
+  const activeAgentRoute = activeAgent ? agentRouteName(activeAgent) : undefined;
+
+  // A first segment that ISN'T an agent is a legacy bare conversation id.
+  const legacyConversationId =
+    agentSegment && segmentIsAgent === false ? agentSegment : undefined;
 
   const chatApi = activeAgent
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`
@@ -467,9 +529,52 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     userId,
     scope: activeAgent,
     apiBase,
-    activeId: urlConversationId,
+    activeId: urlConversationId ?? legacyConversationId,
     forceNew: forceNewConversation,
   });
+
+  // ── Route canonicalization ──────────────────────────────────────────────
+  // Back-compat redirects (the agent is now in the path): bare `/ai` → the
+  // default agent surface; a legacy built-in id in the agent slot
+  // (`/ai/metadata_assistant`) → its friendly form (`/ai/build`). Custom agents
+  // already route by their own name and no-op here. Query (e.g. `?new=1`) is
+  // preserved so the New-chat intent survives the redirect.
+  useEffect(() => {
+    if (agents.length === 0 || !activeAgent) return;
+    const friendly = agentRouteName(activeAgent);
+    if (!agentSegment) {
+      navigate(`/ai/${friendly}${queryString}`, { replace: true });
+      return;
+    }
+    if (segmentIsAgent && agentSegment !== friendly) {
+      const tail = urlConversationId ? `/${encodeURIComponent(urlConversationId)}` : '';
+      navigate(`/ai/${friendly}${tail}${queryString}`, { replace: true });
+    }
+  }, [agents.length, activeAgent, agentSegment, segmentIsAgent, urlConversationId, queryString, navigate]);
+
+  // ── Legacy `/ai/:conversationId` (bare id) ──────────────────────────────
+  // Resolve the conversation's own agent and 301 to `/ai/:agent/:conversationId`
+  // so old bookmarks keep working under the agent-scoped routes.
+  useEffect(() => {
+    if (legacyConversationId === undefined) return;
+    let cancelled = false;
+    (async () => {
+      let convAgent: string | undefined;
+      try {
+        const conv = await fetchConversation(apiBase, legacyConversationId);
+        convAgent = (conv as { agentId?: string } | null)?.agentId ?? undefined;
+      } catch {
+        /* gone / inaccessible — fall back to the default surface below */
+      }
+      if (cancelled) return;
+      const resolved = resolveAgentParam(convAgent ?? '', catalogNames);
+      const friendly = agentRouteName(resolved ?? activeAgent ?? PLATFORM_DEFAULT_AGENT);
+      navigate(`/ai/${friendly}/${encodeURIComponent(legacyConversationId)}`, { replace: true });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [legacyConversationId, apiBase, catalogNames, activeAgent, navigate]);
 
   const [refreshKey, setRefreshKey] = useState(0);
   const [titleHints, setTitleHints] = useState<Record<string, string>>({});
@@ -487,11 +592,11 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
       if (!action) return;
       e.preventDefault();
       if (action === 'toggle-list') toggleChatsCollapsed();
-      else navigate('/ai?new=1');
+      else navigate(activeAgentRoute ? `/ai/${activeAgentRoute}?new=1` : '/ai?new=1');
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, [toggleChatsCollapsed, navigate]);
+  }, [toggleChatsCollapsed, navigate, activeAgentRoute]);
   const restApiBase = useMemo(
     () => apiBase.replace(/\/v1\/ai$/, '').replace(/\/ai$/, '') || '/api',
     [apiBase],
@@ -532,14 +637,15 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     staleNewTargetRef.current = null;
   }
 
-  // After the hook resolves a real id for a fresh `/ai` visit, mirror it into
-  // the URL so the sidebar's active-row + share/refresh both work.
+  // After the hook resolves a real id for a fresh agent-surface visit, mirror
+  // it into the URL (`/ai/:agent/:id`) so the sidebar's active-row + share +
+  // refresh all work. Only fires on a real agent surface that has no id yet —
+  // not while a bare `/ai` or a legacy bare id is still being redirected.
   useEffect(() => {
-    if (!urlConversationId && conversationId) {
-      if (staleNewTargetRef.current && staleNewTargetRef.current.id === conversationId) return;
-      navigate(`/ai/${conversationId}`, { replace: true });
-    }
-  }, [urlConversationId, conversationId, navigate]);
+    if (!segmentIsAgent || urlConversationId || !conversationId || !activeAgentRoute) return;
+    if (staleNewTargetRef.current && staleNewTargetRef.current.id === conversationId) return;
+    navigate(`/ai/${activeAgentRoute}/${conversationId}`, { replace: true });
+  }, [segmentIsAgent, urlConversationId, conversationId, activeAgentRoute, navigate]);
 
   const titledRef = useRef<Set<string>>(new Set());
 
@@ -634,6 +740,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
           <ConversationsSidebar
             userId={userId}
             apiBase={apiBase}
+            activeAgent={activeAgent}
             refreshKey={refreshKey}
             titleHints={titleHints}
             className="h-full border-r-0"
@@ -657,6 +764,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
           <ConversationsSidebar
             userId={userId}
             apiBase={apiBase}
+            activeAgent={activeAgent}
             refreshKey={refreshKey}
             titleHints={titleHints}
             className="hidden w-72 shrink-0 border-r md:flex"
@@ -669,10 +777,6 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
             agentsLoading={agentsLoading}
             agentsError={agentsError}
             activeAgent={activeAgent}
-            onAgentChange={setActiveAgent}
-            // ADR-0040: end users never pick an agent — the roster shows only
-            // on explicit ?agent= pins (developer surfaces like Studio).
-            showAgentPicker={Boolean(agentParam)}
             chatApi={chatApi}
             apiBase={apiBase}
             conversationId={conversationId}
@@ -692,13 +796,6 @@ interface ChatPaneProps {
   agentsLoading: boolean;
   agentsError: Error | undefined;
   activeAgent: string | undefined;
-  onAgentChange: (name: string) => void;
-  /**
-   * ADR-0040: the agent roster is NOT consumer UX. The picker renders only
-   * when an explicit `?agent=` pin is present (builder/developer deep links,
-   * e.g. Studio); end users see the resolved assistant's label.
-   */
-  showAgentPicker: boolean;
   chatApi: string | undefined;
   apiBase: string;
   conversationId: string | undefined;
@@ -712,10 +809,8 @@ interface ChatPaneProps {
 function ChatPane({
   agents,
   agentsLoading,
-  showAgentPicker,
   agentsError,
   activeAgent,
-  onAgentChange,
   chatApi,
   apiBase,
   conversationId,
@@ -726,6 +821,10 @@ function ChatPane({
 }: ChatPaneProps) {
   const { t } = useObjectTranslation();
   const navigate = useNavigate();
+  // The agent dropdown is a LAUNCHER now (not an in-surface mode toggle): it
+  // navigates to `/ai/:agent`, so it naturally lists custom agents and can stay
+  // always-available. Shown only when there's more than one agent to switch to.
+  const showAgentLauncher = agents.length > 1;
 
   // ── ADR-0037 Live Canvas ────────────────────────────────────────────────
   // When a build session drafts an `app`, open the split-view canvas: the
@@ -780,6 +879,9 @@ function ChatPane({
     if (hydrated.length > 0) return undefined;
     return buildAgentSuggestions(activeAgent, activeAgentLabel, t);
   }, [hydrated.length, activeAgent, activeAgentLabel, t]);
+
+  // Per-surface empty-state branding (Build = authoring, Ask = data Q&A).
+  const emptyState = useMemo(() => agentEmptyState(t, activeAgent), [t, activeAgent]);
 
   // ADR-0013 D2: reconcile a stream-transport failure instead of blindly
   // retrying. Shared across chat surfaces — see useReconcileOnError.
@@ -859,13 +961,18 @@ function ChatPane({
   const headerSlot = (
     <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/50 px-4 pb-2 pt-3 sm:px-6">
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        {showAgentPicker && agents.length > 0 ? (
-          <Select value={activeAgent} onValueChange={onAgentChange} disabled={agentsLoading}>
+        {showAgentLauncher ? (
+          <Select
+            value={activeAgent}
+            onValueChange={(name) => navigate(`/ai/${agentRouteName(name)}`)}
+            disabled={agentsLoading}
+          >
             <SelectTrigger
               className="h-7 w-auto min-w-0 border-0 bg-transparent px-1.5 text-xs shadow-none hover:bg-accent focus:ring-0 focus:ring-offset-0 focus-visible:ring-1 focus-visible:ring-border/80 focus-visible:ring-offset-0 sm:min-w-[160px]"
               data-testid="ai-chat-agent-picker"
+              aria-label={t('console.ai.switchAssistant', { defaultValue: 'Switch assistant' })}
             >
-              <SelectValue placeholder="Choose agent..." />
+              <SelectValue placeholder={t('console.ai.chooseAgent', { defaultValue: 'Choose assistant…' })} />
             </SelectTrigger>
             <SelectContent align="start">
               {agents.map((agent) => (
@@ -939,8 +1046,8 @@ function ChatPane({
               : t('console.ai.askAnything')
         }
         labels={{
-          emptyTitle: t('console.ai.emptyTitle'),
-          emptyDescription: t('console.ai.emptyDescription'),
+          emptyTitle: emptyState.title,
+          emptyDescription: emptyState.description,
           clear: t('console.ai.clearConversation'),
           sendHint: t('console.ai.sendHint'),
           agentActivity: t('console.ai.agentActivity'),
@@ -1130,12 +1237,10 @@ function buildAgentSuggestions(
   agentLabel: string,
   t: TranslationFn,
 ): string[] {
-  if (agentName === 'data_chat') {
-    return dataChatSuggestions(t);
-  }
-  if (agentName === 'metadata_assistant') {
-    return metadataAssistantSuggestions(t);
-  }
+  // Alias-aware: `ask`/`data_chat` → data starters, `build`/`metadata_assistant`
+  // → authoring starters. Custom agents fall back to a name/label heuristic.
+  if (isAskAgent(agentName)) return dataChatSuggestions(t);
+  if (isBuildAgent(agentName)) return metadataAssistantSuggestions(t);
   const lower = (agentName ?? agentLabel).toLowerCase();
   if (lower.includes('data')) return dataChatSuggestions(t);
   if (lower.includes('metadata')) return metadataAssistantSuggestions(t);

--- a/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
+++ b/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
@@ -19,11 +19,19 @@ import {
   EmptyDescription,
   cn,
 } from '@object-ui/components';
+import { agentAliasGroup, agentRouteName } from '@object-ui/plugin-chatbot';
 import { useConversationList, type ConversationSummary } from '../../hooks/useConversationList';
 
 export interface ConversationsSidebarProps {
   userId: string | undefined;
   apiBase: string;
+  /**
+   * Backend name of the surface's active agent. When set, the list is scoped to
+   * this agent's conversations (each `/ai/:agent` surface shows its own history)
+   * and New/delete navigation stays on the surface. Alias-aware, so legacy and
+   * new ids match. Omit for an unscoped, all-agents list.
+   */
+  activeAgent?: string;
   className?: string;
   refreshKey?: number | string;
   titleHints?: Record<string, string>;
@@ -119,6 +127,7 @@ export function groupConversationsByDate(
 export function ConversationsSidebar({
   userId,
   apiBase,
+  activeAgent,
   className,
   refreshKey,
   titleHints,
@@ -136,6 +145,14 @@ export function ConversationsSidebar({
   const [filter, setFilter] = useState('');
   const [renamingId, setRenamingId] = useState<string | undefined>(undefined);
 
+  // Friendly route segment for New/delete navigation (stays on this surface).
+  const agentRoute = activeAgent ? agentRouteName(activeAgent) : undefined;
+  // Names equivalent to the active agent, for scoping the list (alias-aware).
+  const agentGroup = useMemo(
+    () => (activeAgent ? new Set(agentAliasGroup(activeAgent)) : undefined),
+    [activeAgent],
+  );
+
   const decoratedConversations = useMemo(() => {
     return conversations.map((conversation) => {
       const hint = titleHints?.[conversation.id]?.trim();
@@ -146,33 +163,54 @@ export function ConversationsSidebar({
     });
   }, [conversations, titleHints]);
 
+  // Scope to this surface's agent. Lenient: a conversation with no agent yet
+  // (freshly created, pre-first-message) and the currently-open one are always
+  // kept so nothing the user is looking at can vanish from the list.
+  const scoped = useMemo(() => {
+    if (!agentGroup) return decoratedConversations;
+    return decoratedConversations.filter(
+      (c) => !c.agentId || agentGroup.has(c.agentId) || c.id === activeId,
+    );
+  }, [decoratedConversations, agentGroup, activeId]);
+
   const visible = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    if (!q) return decoratedConversations;
-    return decoratedConversations.filter((c) => {
+    if (!q) return scoped;
+    return scoped.filter((c) => {
       const hay = `${c.title ?? ''} ${c.preview ?? ''}`.toLowerCase();
       return hay.includes(q);
     });
-  }, [decoratedConversations, filter]);
+  }, [scoped, filter]);
+
+  // Navigate to a conversation on its OWN agent surface (so a lenient
+  // cross-agent row still opens correctly); fall back to this surface.
+  const conversationHref = useCallback(
+    (c: ConversationSummary) => {
+      const seg = c.agentId ? agentRouteName(c.agentId) : agentRoute;
+      return seg ? `/ai/${seg}/${c.id}` : `/ai/${c.id}`;
+    },
+    [agentRoute],
+  );
 
   const handleNew = useCallback(() => {
-    // `?new=1` is the explicit new-conversation intent. A bare `/ai` resumes
-    // the last cached conversation (by design), so without the flag this
-    // button silently landed back on the current chat.
-    navigate('/ai?new=1');
+    // `?new=1` is the explicit new-conversation intent — a bare surface visit
+    // resumes the last cached conversation (by design), so without the flag
+    // this button silently landed back on the current chat. Stays on the
+    // active agent's surface.
+    navigate(agentRoute ? `/ai/${agentRoute}?new=1` : '/ai?new=1');
     onNavigate?.();
-  }, [navigate, onNavigate]);
+  }, [navigate, agentRoute, onNavigate]);
 
   const handleDelete = useCallback(
     async (e: React.MouseEvent, id: string) => {
       e.stopPropagation();
       await remove(id);
       if (id === activeId) {
-        navigate('/ai', { replace: true });
+        navigate(agentRoute ? `/ai/${agentRoute}` : '/ai', { replace: true });
         onNavigate?.();
       }
     },
-    [remove, activeId, navigate, onNavigate],
+    [remove, activeId, navigate, agentRoute, onNavigate],
   );
 
   const handleRenameSubmit = useCallback(
@@ -223,7 +261,7 @@ export function ConversationsSidebar({
           <div className="px-3 py-4 text-xs text-destructive">
             {error.message}
           </div>
-        ) : conversations.length === 0 ? (
+        ) : scoped.length === 0 ? (
           <Empty className="px-3 py-8">
             <MessageSquare className="h-8 w-8 text-muted-foreground" />
             <EmptyTitle>{t('console.ai.noChatsYet')}</EmptyTitle>
@@ -247,7 +285,7 @@ export function ConversationsSidebar({
                       active={c.id === activeId}
                       renaming={c.id === renamingId}
                       onSelect={() => {
-                        navigate(`/ai/${c.id}`);
+                        navigate(conversationHref(c));
                         onNavigate?.();
                       }}
                       onDelete={(e) => handleDelete(e, c.id)}

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -28,7 +28,7 @@ import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
 import { appRouteSegment } from '../../utils';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
-import { Sparkles, Star, Clock, ArrowDown, ShieldAlert, X, UploadCloud } from 'lucide-react';
+import { Sparkles, Star, Clock, ArrowDown, ShieldAlert, X, UploadCloud, MessageSquareText } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
 
@@ -245,9 +245,13 @@ export function HomePage() {
               })}
             </EmptyDescription>
             <div className="mt-6 flex flex-col sm:flex-row items-center gap-3">
-              <Button onClick={() => navigate('/ai?agent=metadata_assistant')} data-testid="build-with-ai-btn">
+              <Button onClick={() => navigate('/ai/build')} data-testid="build-with-ai-btn">
                 <Sparkles className="mr-2 h-4 w-4" />
                 {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
+              </Button>
+              <Button variant="outline" onClick={() => navigate('/ai/ask')} data-testid="ask-ai-btn">
+                <MessageSquareText className="mr-2 h-4 w-4" />
+                {t('home.askAI', { defaultValue: 'Ask AI' })}
               </Button>
             </div>
           </Empty>
@@ -289,10 +293,16 @@ export function HomePage() {
                 {t('home.heroTagline', { defaultValue: 'Pick up where you left off, or explore something new.' })}
               </p>
             </div>
-            <Button onClick={() => navigate('/ai?agent=metadata_assistant')} data-testid="home-build-with-ai" className="shrink-0">
-              <Sparkles className="mr-2 h-4 w-4" />
-              {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
-            </Button>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button variant="outline" onClick={() => navigate('/ai/ask')} data-testid="home-ask-ai">
+                <MessageSquareText className="mr-2 h-4 w-4" />
+                {t('home.askAI', { defaultValue: 'Ask AI' })}
+              </Button>
+              <Button onClick={() => navigate('/ai/build')} data-testid="home-build-with-ai">
+                <Sparkles className="mr-2 h-4 w-4" />
+                {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
+              </Button>
+            </div>
           </div>
 
           {starredApps.length === 0 && recentApps.length === 0 && (

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -58,6 +58,13 @@ export interface UseChatConversationOptions {
 
 export interface UseChatConversationReturn {
   conversationId: string | undefined;
+  /**
+   * The `scope` (agent) the current `conversationId` was resolved under. Lets a
+   * host distinguish "this id belongs to the active agent" from "this id is the
+   * PREVIOUS agent's, pending re-resolution after a switch" — so it doesn't
+   * mirror a stale id onto the new agent's URL.
+   */
+  conversationScope: string | undefined;
   initialMessages: HydratedUIMessage[];
   isLoading: boolean;
   /** Delete the current conversation + start a fresh one. */
@@ -325,10 +332,13 @@ export function useChatConversation(
   const [initialMessages, setInitialMessages] = useState<HydratedUIMessage[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(Boolean(userId));
   const mountedRef = useRef(true);
-  // Tracks "we have already resolved a no-activeId conversation for this user".
-  // Prevents creating duplicate conversations when sibling state (e.g. the
-  // page's selected agent / `scope`) transitions during the same /ai visit.
+  // Tracks the (user, scope) we have already resolved a no-activeId
+  // conversation for. Keyed by SCOPE as well as user so a deliberate agent
+  // switch (the `/ai/:agent` launcher changes `scope`) re-resolves under the
+  // new agent's cache instead of clinging to the previous agent's conversation,
+  // while a no-op re-render under the same scope still short-circuits.
   const resolvedForUserRef = useRef<string | undefined>(undefined);
+  const resolvedScopeRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -343,22 +353,30 @@ export function useChatConversation(
       setInitialMessages([]);
       setIsLoading(false);
       resolvedForUserRef.current = undefined;
+      resolvedScopeRef.current = undefined;
       return;
     }
-    // Already resolved a conversation for this user during the no-activeId
-    // window — don't re-create just because `scope` or another dep changed.
-    // An explicit new-conversation intent (`forceNew`) overrides the guard.
-    if (!activeId && !forceNew && resolvedForUserRef.current === userId && conversationId) {
+    // Already resolved a conversation for this (user, scope) during the
+    // no-activeId window — don't re-create just because an unrelated dep
+    // changed. A `forceNew` intent or a scope (agent) change overrides it.
+    const scopeChanged = resolvedScopeRef.current !== scope;
+    if (
+      !activeId &&
+      !forceNew &&
+      !scopeChanged &&
+      resolvedForUserRef.current === userId &&
+      conversationId
+    ) {
       return;
     }
     let cancelled = false;
     const key = cacheKey(userId, scope);
-    // Explicit new-conversation intent: drop the previous id NOW, before the
-    // async create. The host page mirrors `conversationId` into the URL the
-    // moment `activeId` is empty — with the stale id still in state it would
-    // bounce straight back to `/ai/:oldId` and strip the `?new=1` flag before
-    // the fresh conversation ever existed.
-    if (!activeId && forceNew) {
+    // Drop the previous id NOW, before the async resolve, for both an explicit
+    // new-conversation intent AND an agent switch: the host page mirrors
+    // `conversationId` into the URL the moment `activeId` is empty, so a stale
+    // id left in state would be written onto the new agent's URL (`/ai/:agent`)
+    // and then resumed as that agent's conversation.
+    if (!activeId && (forceNew || (scopeChanged && resolvedForUserRef.current === userId))) {
       setConversationId(undefined);
       setInitialMessages([]);
     }
@@ -375,6 +393,7 @@ export function useChatConversation(
             const messages = toUIMessages(existing.messages);
             setInitialMessages(messages.length > 0 ? messages : readMessageCache(existing.id));
             resolvedForUserRef.current = userId;
+            resolvedScopeRef.current = scope;
             return;
           }
           // Requested id is gone — fall through to create a fresh one.
@@ -390,6 +409,7 @@ export function useChatConversation(
               const messages = toUIMessages(existing.messages);
               setInitialMessages(messages.length > 0 ? messages : readMessageCache(existing.id));
               resolvedForUserRef.current = userId;
+              resolvedScopeRef.current = scope;
               return;
             }
             writeCache(key, undefined);
@@ -402,6 +422,7 @@ export function useChatConversation(
         setConversationId(fresh.id);
         setInitialMessages(toUIMessages(fresh.messages));
         resolvedForUserRef.current = userId;
+        resolvedScopeRef.current = scope;
       } catch {
         if (!cancelled) {
           setConversationId(undefined);
@@ -445,5 +466,8 @@ export function useChatConversation(
     }
   }, [conversationId, userId, scope, apiBase]);
 
-  return { conversationId, initialMessages, isLoading, reset };
+  // `resolvedScopeRef` is updated in lockstep with every `setConversationId`
+  // (same async tick), so at render time it always describes the scope the
+  // current `conversationId` was resolved under.
+  return { conversationId, conversationScope: resolvedScopeRef.current, initialMessages, isLoading, reset };
 }

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -723,9 +723,11 @@ export default function ConsoleFloatingChatbot({
 
   // Server-backed conversation. Scoped by agent so each agent gets its own
   // persistent history. Hook is inert until `userId` is provided; without it
-  // the FAB continues to work in local-only mode (no persistence).
+  // the FAB continues to work in local-only mode (no persistence). Gate `userId`
+  // on the agent being resolved so the conversation binds to the right scope
+  // from the first resolve (not a scopeless one during the catalog load).
   const { conversationId, initialMessages } = useChatConversation({
-    userId,
+    userId: activeAgent ? userId : undefined,
     scope: activeAgent,
     apiBase,
   });

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -20,6 +20,7 @@ import {
   resolveDefaultAgentName,
   uiMessagesToChatMessages,
   publishHealthFromResponse,
+  agentRouteName,
   type ChatMessage,
   type AgentDescriptor,
 } from '@object-ui/plugin-chatbot';
@@ -52,10 +53,13 @@ import { cloudPricingDeepLink } from '../console/marketplace/marketplaceApi';
  * labels ("Data Assistant" / "Metadata Assistant"); we localize the known
  * ones here so the whole surface reads natively. Custom app agents fall back
  * to whatever label the backend provides.
+ *
+ * Keyed by the FRIENDLY name (alias-group head) so the new id (`build`/`ask`)
+ * and the legacy id (`metadata_assistant`/`data_chat`) both resolve.
  */
 const PLATFORM_AGENT_LABELS: Record<string, { zh: string; en: string }> = {
-  data_chat: { zh: '智能助手', en: 'Assistant' },
-  metadata_assistant: { zh: '元数据开发助手', en: 'Metadata Assistant' },
+  ask: { zh: '智能助手', en: 'Assistant' },
+  build: { zh: '构建助手', en: 'Build assistant' },
 };
 
 function localizeAgentLabel(
@@ -63,7 +67,7 @@ function localizeAgentLabel(
   agentName: string | undefined,
   fallbackLabel: string,
 ): string {
-  const known = agentName ? PLATFORM_AGENT_LABELS[agentName] : undefined;
+  const known = agentName ? PLATFORM_AGENT_LABELS[agentRouteName(agentName)] : undefined;
   if (known) return isZh ? known.zh : known.en;
   return fallbackLabel;
 }

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -11,6 +11,7 @@
 import React, { useEffect } from 'react';
 import { AppShell } from '@object-ui/layout';
 import { useDiscovery } from '@object-ui/react';
+import { isBuildAgent } from '@object-ui/plugin-chatbot';
 
 // Lightweight FAB stub — the heavy chat chunk graph (plugin-chatbot,
 // shiki, streamdown, mermaid, @ai-sdk, ~20MB) only downloads on first
@@ -76,8 +77,11 @@ export function ConsoleLayout({
   // assistant so the chatbot falls back to the generic data assistant — the
   // generic data-chat experience stays available.
   const aiStudioEnabled = getRuntimeConfig().features.aiStudio !== false;
+  // Alias-aware: the build/authoring agent is `build` (new) or
+  // `metadata_assistant` (legacy). When AI Studio is off, drop it so the FAB
+  // falls back to the generic data assistant.
   const effectiveDefaultAgent =
-    !aiStudioEnabled && activeApp?.defaultAgent === 'metadata_assistant'
+    !aiStudioEnabled && isBuildAgent(activeApp?.defaultAgent)
       ? undefined
       : activeApp?.defaultAgent;
   const { setContext, setCurrentAppName } = useNavigationContext();

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1108,6 +1108,20 @@ const en = {
       askAnything: 'Ask anything...',
       emptyTitle: 'Start a conversation',
       emptyDescription: 'Ask anything — the assistant has access to your current app context.',
+      switchAssistant: 'Switch assistant',
+      chooseAgent: 'Choose assistant…',
+      empty: {
+        build: {
+          title: 'Build with AI',
+          description:
+            'Describe an app or workflow in plain language — I draft the objects, screens and automations, then you review and publish.',
+        },
+        ask: {
+          title: 'Ask your data',
+          description:
+            'Ask questions about your records — counts, lists, and summaries across the data you can access.',
+        },
+      },
       clearConversation: 'Clear',
       sendHint: 'to send',
       agentActivity: 'Agent activity',
@@ -1130,6 +1144,9 @@ const en = {
       hoursAgo: '{{count}}h ago',
       daysAgo: '{{count}}d ago',
       agentLabels: {
+        ask: 'Ask',
+        build: 'Build',
+        // Legacy keys kept for back-compat with any external overrides.
         dataChat: 'Assistant',
         metadataAssistant: 'Metadata Assistant',
       },
@@ -1603,6 +1620,7 @@ const en = {
     noAppsTitle: 'No applications yet',
     noAppsDescription: 'There are no applications available to you yet. Please contact your workspace administrator.',
     buildWithAI: 'Build with AI',
+    askAI: 'Ask AI',
     recoveryReminder: {
       message: 'Set a recovery password so you can still sign in if single sign-on is ever unavailable.',
       cta: 'Set password',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1108,6 +1108,18 @@ const zh = {
       askAnything: '输入你的问题...',
       emptyTitle: '开始对话',
       emptyDescription: '可以直接提问，助手会结合当前应用上下文提供帮助。',
+      switchAssistant: '切换助手',
+      chooseAgent: '选择助手…',
+      empty: {
+        build: {
+          title: '用 AI 搭建',
+          description: '用自然语言描述一个应用或流程 —— 我会起草对象、界面和自动化，随后你审阅并发布。',
+        },
+        ask: {
+          title: '向你的数据提问',
+          description: '针对你的记录提问 —— 在你有权访问的数据范围内进行计数、列举和汇总。',
+        },
+      },
       clearConversation: '清空',
       sendHint: '发送',
       agentActivity: '执行过程',
@@ -1130,6 +1142,9 @@ const zh = {
       hoursAgo: '{{count}} 小时前',
       daysAgo: '{{count}} 天前',
       agentLabels: {
+        ask: '提问',
+        build: '构建',
+        // 旧键保留，兼容外部覆盖。
         dataChat: '智能助手',
         metadataAssistant: '元数据开发助手',
       },
@@ -1614,6 +1629,7 @@ const zh = {
     noAppsTitle: '还没有应用',
     noAppsDescription: '当前还没有可用的应用。请联系你的工作区管理员。',
     buildWithAI: '用 AI 搭建',
+    askAI: '问 AI',
     recoveryReminder: {
       message: '建议设置一个备用密码，这样即使单点登录不可用，你仍能直接登录此环境。',
       cta: '设置密码',

--- a/packages/plugin-chatbot/src/__tests__/agentAliases.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/agentAliases.test.ts
@@ -1,0 +1,107 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit tests for agent alias resolution — the bridge between friendly console
+ * routes (`/ai/build`, `/ai/ask`) and the built-in agent identifiers, robust
+ * across the Path A rename (`metadata_assistant`→`build`, `data_chat`→`ask`)
+ * and the legacy ids. Also covers `resolveDefaultAgentName`'s alias-awareness.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  agentAliasGroup,
+  agentRouteName,
+  resolveAgentParam,
+  isBuildAgent,
+  isAskAgent,
+} from '../agentAliases';
+import { resolveDefaultAgentName, type AgentDescriptor } from '../useAgents';
+
+const LEGACY: readonly string[] = ['data_chat', 'metadata_assistant'];
+const RENAMED: readonly string[] = ['ask', 'build'];
+
+function agents(...names: string[]): AgentDescriptor[] {
+  return names.map((name) => ({ name, label: name }));
+}
+
+describe('agentRouteName', () => {
+  it('maps built-in ids (new and legacy) to their friendly route name', () => {
+    expect(agentRouteName('metadata_assistant')).toBe('build');
+    expect(agentRouteName('build')).toBe('build');
+    expect(agentRouteName('data_chat')).toBe('ask');
+    expect(agentRouteName('ask')).toBe('ask');
+  });
+  it('leaves custom agents as their own name', () => {
+    expect(agentRouteName('sales_assistant')).toBe('sales_assistant');
+  });
+});
+
+describe('agentAliasGroup', () => {
+  it('returns the friendly-first equivalence group for built-ins', () => {
+    expect(agentAliasGroup('metadata_assistant')).toEqual(['build', 'metadata_assistant']);
+    expect(agentAliasGroup('ask')).toEqual(['ask', 'data_chat']);
+  });
+  it('returns a singleton for custom agents', () => {
+    expect(agentAliasGroup('custom_x')).toEqual(['custom_x']);
+  });
+});
+
+describe('resolveAgentParam', () => {
+  it('resolves a friendly route param against a legacy (pre-rename) catalog', () => {
+    expect(resolveAgentParam('build', LEGACY)).toBe('metadata_assistant');
+    expect(resolveAgentParam('ask', LEGACY)).toBe('data_chat');
+  });
+  it('resolves a friendly route param against a renamed (post-rename) catalog', () => {
+    expect(resolveAgentParam('build', RENAMED)).toBe('build');
+    expect(resolveAgentParam('ask', RENAMED)).toBe('ask');
+  });
+  it('resolves a legacy id param against either catalog', () => {
+    expect(resolveAgentParam('metadata_assistant', LEGACY)).toBe('metadata_assistant');
+    expect(resolveAgentParam('metadata_assistant', RENAMED)).toBe('build');
+    expect(resolveAgentParam('data_chat', RENAMED)).toBe('ask');
+  });
+  it('resolves a custom agent by its own name when present (criterion c)', () => {
+    expect(resolveAgentParam('sales_assistant', ['data_chat', 'sales_assistant'])).toBe('sales_assistant');
+  });
+  it('returns undefined for a non-agent segment (e.g. a legacy conversation id)', () => {
+    expect(resolveAgentParam('conv_abc-123', LEGACY)).toBeUndefined();
+    expect(resolveAgentParam(undefined, LEGACY)).toBeUndefined();
+    // A friendly name whose target isn't served (empty catalog) is unresolvable.
+    expect(resolveAgentParam('build', [])).toBeUndefined();
+  });
+});
+
+describe('isBuildAgent / isAskAgent', () => {
+  it('classify built-ins regardless of new vs legacy id', () => {
+    expect(isBuildAgent('build')).toBe(true);
+    expect(isBuildAgent('metadata_assistant')).toBe(true);
+    expect(isAskAgent('ask')).toBe(true);
+    expect(isAskAgent('data_chat')).toBe(true);
+  });
+  it('do not misclassify the other built-in or custom agents', () => {
+    expect(isBuildAgent('data_chat')).toBe(false);
+    expect(isAskAgent('metadata_assistant')).toBe(false);
+    expect(isBuildAgent('sales_assistant')).toBe(false);
+    expect(isAskAgent(undefined)).toBe(false);
+  });
+});
+
+describe('resolveDefaultAgentName (alias-aware)', () => {
+  it('prefers the platform data agent across the rename', () => {
+    // legacy catalog → resolves the platform default (ask) to data_chat
+    expect(resolveDefaultAgentName(agents('data_chat', 'metadata_assistant'))).toBe('data_chat');
+    // renamed catalog → resolves to ask
+    expect(resolveDefaultAgentName(agents('ask', 'build'))).toBe('ask');
+  });
+  it('honors a preferred agent given as a friendly name, new id, or legacy id', () => {
+    const legacy = agents('data_chat', 'metadata_assistant');
+    expect(resolveDefaultAgentName(legacy, 'build')).toBe('metadata_assistant');
+    expect(resolveDefaultAgentName(legacy, 'metadata_assistant')).toBe('metadata_assistant');
+    const renamed = agents('ask', 'build');
+    expect(resolveDefaultAgentName(renamed, 'metadata_assistant')).toBe('build');
+  });
+  it('falls back to the first agent when neither preferred nor platform default is present', () => {
+    expect(resolveDefaultAgentName(agents('sales_assistant'))).toBe('sales_assistant');
+    expect(resolveDefaultAgentName([])).toBeUndefined();
+  });
+});

--- a/packages/plugin-chatbot/src/agentAliases.ts
+++ b/packages/plugin-chatbot/src/agentAliases.ts
@@ -1,0 +1,76 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Agent alias resolution — the bridge between human-friendly console routes
+ * (`/ai/build`, `/ai/ask`) and the platform's built-in agent identifiers.
+ *
+ * The built-in agents are being renamed (Path A): `metadata_assistant`→`build`
+ * (the authoring "magic moment" agent) and `data_chat`→`ask` (the data-query
+ * agent). That rename spans three repos and rolls out gradually, so at any
+ * moment the live agent catalog (`GET /api/v1/ai/agents`) may expose EITHER the
+ * new id or the legacy one, and existing bookmarks/links may carry the legacy
+ * id directly.
+ *
+ * Every alias group lists equivalent names with the FRIENDLY (canonical URL)
+ * name first. Resolution always picks whichever member the live catalog
+ * actually serves, so one route works before, during, and after the rename —
+ * no hard cutover, no dead links. Custom user agents (`*.agent.ts`) are not in
+ * any group and route by their own name, unchanged.
+ */
+
+/** Equivalent names per built-in agent, friendly (URL) name first. */
+export const AGENT_ALIAS_GROUPS: readonly (readonly string[])[] = [
+  ['build', 'metadata_assistant'],
+  ['ask', 'data_chat'],
+];
+
+/**
+ * All names equivalent to `name` (including itself), friendly-first. Returns a
+ * singleton `[name]` for custom agents that belong to no group.
+ */
+export function agentAliasGroup(name: string): readonly string[] {
+  const group = AGENT_ALIAS_GROUPS.find((g) => g.includes(name));
+  return group ?? [name];
+}
+
+/**
+ * The preferred URL segment for an agent — the friendly alias for a built-in,
+ * otherwise the agent's own name. Use this to BUILD `/ai/:agent` links so they
+ * read nicely and stay stable across the rename.
+ */
+export function agentRouteName(name: string): string {
+  return agentAliasGroup(name)[0];
+}
+
+/**
+ * Resolve a `/ai/:agent` route param to a concrete agent name that the catalog
+ * actually serves. Tries, in order: an exact catalog match → any alias-group
+ * sibling present in the catalog. Returns `undefined` when the param is not an
+ * agent at all (e.g. a legacy bare `/ai/:conversationId` link), letting callers
+ * distinguish an agent segment from a conversation id.
+ *
+ * @param param   the first path segment after `/ai/`
+ * @param catalog agent names the backend currently exposes
+ */
+export function resolveAgentParam(
+  param: string | undefined,
+  catalog: readonly string[],
+): string | undefined {
+  if (!param) return undefined;
+  if (catalog.includes(param)) return param;
+  for (const sibling of agentAliasGroup(param)) {
+    if (catalog.includes(sibling)) return sibling;
+  }
+  return undefined;
+}
+
+/** True when `name` is the authoring/build agent (either `build` or `metadata_assistant`). */
+export function isBuildAgent(name: string | undefined): boolean {
+  return name != null && agentRouteName(name) === 'build';
+}
+
+/** True when `name` is the data-query/ask agent (either `ask` or `data_chat`). */
+export function isAskAgent(name: string | undefined): boolean {
+  return name != null && agentRouteName(name) === 'ask';
+}

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -256,6 +256,17 @@ export type {
   AgentDescriptor,
 } from './useAgents';
 
+// Agent alias resolution — friendly console routes (`/ai/build`, `/ai/ask`) ↔
+// built-in agent ids, robust across the Path A rename.
+export {
+  AGENT_ALIAS_GROUPS,
+  agentAliasGroup,
+  agentRouteName,
+  resolveAgentParam,
+  isBuildAgent,
+  isAskAgent,
+} from './agentAliases';
+
 // Export floating chatbot components
 export { FloatingChatbot } from './FloatingChatbot';
 export type { FloatingChatbotProps } from './FloatingChatbot';

--- a/packages/plugin-chatbot/src/useAgents.ts
+++ b/packages/plugin-chatbot/src/useAgents.ts
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { resolveAgentParam } from './agentAliases';
 
 export interface AgentDescriptor {
   /** Stable identifier used in the chat URL (e.g. "sales_assistant"). */
@@ -59,12 +60,15 @@ interface RawAgent {
  * Canonical name of the platform's data-query agent.
  *
  * Mirrors `DEFAULT_DATA_AGENT_NAME` in `@objectstack/service-ai`. This is
- * the implicit copilot bound to every application that does not pin its
- * own `app.defaultAgent` (Studio is the only built-in that overrides it,
- * → `metadata_assistant`). The UI prefers it so end users land on the
- * data assistant without having to choose from a list.
+ * the implicit copilot bound to every application that does not pin its own
+ * `app.defaultAgent` (Studio is the only built-in that overrides it, → the
+ * `build` authoring agent). The UI prefers it so end users land on the data
+ * assistant without having to choose from a list.
+ *
+ * Path A renamed `data_chat`→`ask`; resolution below is alias-aware, so a
+ * catalog still serving the legacy `data_chat` id resolves correctly too.
  */
-export const PLATFORM_DEFAULT_AGENT = 'data_chat';
+export const PLATFORM_DEFAULT_AGENT = 'ask';
 
 /**
  * Resolve which agent the chat surface should open with, mirroring the
@@ -72,10 +76,12 @@ export const PLATFORM_DEFAULT_AGENT = 'data_chat';
  * on the default even before the first request:
  *
  * 1. `preferred` — the app's `defaultAgent` (or a `VITE_AI_DEFAULT_AGENT`
- *    override), when it exists in the fetched catalog.
- * 2. The platform data-query agent (`data_chat`).
+ *    override), when it (or an alias of it) exists in the fetched catalog.
+ * 2. The platform data-query agent (`ask`, alias `data_chat`).
  * 3. The first agent in the catalog (last-resort fallback).
  *
+ * Resolution is alias-aware ({@link resolveAgentParam}) so the friendly name,
+ * the new id, and the legacy id all map to whichever the catalog serves.
  * Returns `undefined` only when the catalog is empty.
  */
 export function resolveDefaultAgentName(
@@ -83,12 +89,13 @@ export function resolveDefaultAgentName(
   preferred?: string,
 ): string | undefined {
   if (agents.length === 0) return undefined;
+  const catalog = agents.map((a) => a.name);
   if (preferred) {
-    const match = agents.find((a) => a.name === preferred);
-    if (match) return match.name;
+    const match = resolveAgentParam(preferred, catalog);
+    if (match) return match;
   }
-  const platform = agents.find((a) => a.name === PLATFORM_DEFAULT_AGENT);
-  if (platform) return platform.name;
+  const platform = resolveAgentParam(PLATFORM_DEFAULT_AGENT, catalog);
+  if (platform) return platform;
   return agents[0].name;
 }
 


### PR DESCRIPTION
## Why

The two built-in assistants were mixed in one full-page surface behind a hidden, `?agent=`-gated dropdown. The product owner found the combined chat/build surface confusing (Claude Code separates "chat" vs "code"; Airtable Omni keeps them distinct). This splits them into their own pages and fixes the known StrictMode deep-link bug where `?agent=metadata_assistant` didn't activate on the dev server.

This is the **objectui** half of a Path A rename (`metadata_assistant`→`build`, `data_chat`→`ask`). It is written to work **before, during, and after** the cross-repo rename via an alias layer, so it can land independently. Framework + cloud rename + the `agent_id` data migration follow in separate PRs.

## What

- **Canonical route is generic & agent-scoped:** `/ai/:agent` and `/ai/:agent/:conversationId`. The active agent is derived from the path param (resolved against the live `GET /ai/agents` catalog) — the `?agent=` query snapshot is gone (that's what StrictMode's double-mount + the `/ai`→`/ai/:id` rewrite used to drop).
- **New alias module** (`@object-ui/plugin-chatbot/agentAliases`): friendly route names (`build`/`ask`) ↔ built-in ids, resolving to whichever the catalog actually serves. `resolveDefaultAgentName` is now alias-aware. Custom `*.agent.ts` agents route by their own name, unchanged.
- **Dropdown → launcher:** navigates to `/ai/:agent` instead of toggling an in-surface mode; always available when >1 agent, lists custom agents naturally.
- **Back-compat redirects:** bare `/ai` → default agent surface; `/ai?agent=X` → `/ai/X`; legacy built-in id (`/ai/metadata_assistant`) → friendly form (`/ai/build`); legacy bare `/ai/:conversationId` → `/ai/:agent/:conversationId` (resolved via the conversation's `agentId`).
- **Per-surface branding + starters:** Build = authoring empty-state + build starters; Ask = data-query empty-state + data starters (alias-aware).
- **Conversations sidebar scoped to the active agent** (lenient: never hides a null-agent or the currently-open conversation).
- **Per-agent conversation resolution fix:** landing on `/ai/:agent` (or switching via the launcher) used to resume a *scopeless / previous-agent* conversation because `useChatConversation` resolved once per user. Now keyed per `(user, scope)`, gated on the agent being known, with the URL-mirror guarded against the switch-transition race.
- **Home:** "Build with AI" → `/ai/build`; added "Ask AI" → `/ai/ask`.
- **ConsoleLayout / FAB** build-agent checks + labels made alias-aware (FAB binding per app is unchanged).
- i18n (en/zh): `ask`/`build` labels, per-surface empty states, `home.askAI`.

## Verification (live, against the local EE rig on :3100 — `data_chat` + `metadata_assistant`)

| Acceptance | Result |
|---|---|
| (a) `/ai/build` opens Build directly, build starters, build→draft→Publish | ✅ drafted `bug` object + Publish affordance |
| (b) `/ai/ask` opens the data assistant + data starters | ✅ |
| (c) `/ai/<custom>` generic routing | ✅ via resolver (unit-tested; no custom agent on the rig) |
| (d) legacy `/ai`, `/ai?agent=…`, `/ai/:conversationId` redirect | ✅ all canonicalize correctly |
| (e) FAB binds per app | ✅ Studio→Build, simple_crm→Ask |
| (f) old names still resolve (alias) + conversations still appear | ✅ + Ask/Build now resolve **distinct** convs; switch doesn't leak |

Added 14 unit tests for the alias resolver (legacy + renamed catalogs, custom-agent, non-agent segments). Note: component test files can't run via direct vitest locally (`@tailwindcss/postcss` missing from node_modules — reproduces on `main` too); they run in CI.

## Follow-ups (Path A, separate PRs)
- framework `service-ai`: rename `data_chat`→`ask` (+ back-compat alias in the agent resolver / `/agents/:name/chat`); **expose `agentId` on the conversation list+detail API** (this rig's build omits it, so sidebar scoping + legacy-id agent resolution currently degrade gracefully to the default).
- cloud `service-ai-studio`: rename `metadata_assistant`→`build`; update the Studio app `defaultAgent`.
- one-time migration of `ai_conversations.agent_id` (+ `ai_messages`) old→new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)