### PR TITLE
feat(plugin-gantt): drag-to-link endpoints, resizable name column, handle ergonomics & view-switch anchoring

### DIFF
--- a/packages/plugin-gantt/demo/main.tsx
+++ b/packages/plugin-gantt/demo/main.tsx
@@ -117,36 +117,116 @@ function edgeFixture(): GanttTask[] {
 }
 
 /**
- * 制造排班 4 层树 (?mfg=1) — mirrors 3.4.1 树状结构 (左侧任务列表区):
+ * 制造排班 4 层树 (?mfg=1) — mirrors 3.4 制造排班甘特图 as closely as the demo
+ * fixture can express it.
+ *
+ * 3.4.1 树状结构 (左侧任务列表区):
  *   一级 项目      → type:'group'  无条 (pure header, expand/collapse)
  *   二级 产品      → type:'group'  无条
- *   三级 排产计划   → summary (has children) 有时间条 · 全部甘特图操作
- *   四级 派工单     → task leaf     子任务条 (查看/跳转)
- * The two `group` levels render NO timeline bar; only 排产计划 + 派工单 carry bars.
+ *   三级 排产计划   → summary (has children) 有时间条 · 全部甘特图操作 · 默认折叠
+ *   四级 派工单     → task leaf     子任务条 (仅查看/跳转, locked) · 不可展开
+ *
+ * 3.4.3 任务展示 — 按状态着色:
+ *   排产计划: 00待开始=深灰 · 01已下推=蓝 · 02进行中=绿(带进度) · 03已完成=深绿
+ *   里程碑 (是否里程碑=是): 仍是普通排产计划条, 仅在条上文字前加 ◆ 前缀, 不画菱形
+ *   派工单:   00待开始=浅灰 · 01进行中=浅蓝 · 02已报工=浅橙 · 03已完成=浅绿
+ *
+ * 3.4.4 悬浮详情 — `fields` 驱动 tooltip:
+ *   排产计划: 编号/作业对象/计划起止/定额工时/管理责任人/执行责任人/状态/进度
+ *   派工单:   派工单编号/执行责任人/作业对象/计划起止/实际起止/状态
+ *
+ * 3.4.6 依赖校验 — FS 依赖连线仅在三级 (排产计划) 之间; 四级不参与。
+ * 计划 vs 实际 — 派工单用 baseline 条展示 计划起止 (实际 = 主条)。
  */
+// 三级 排产计划 状态色
+const PLAN_COLOR = {
+  todo: '#6b7280', // 00 待开始 深灰
+  pushed: '#3b82f6', // 01 已下推 蓝
+  doing: '#22c55e', // 02 进行中 绿
+  done: '#15803d', // 03 已完成 深绿
+} as const;
+// 四级 派工单 状态色 (浅色系, 紧贴所属排产计划下方)
+const WORK_COLOR = {
+  todo: '#d1d5db', // 00 待开始 浅灰
+  doing: '#93c5fd', // 01 进行中 浅蓝
+  reported: '#fdba74', // 02 已报工 浅橙
+  done: '#86efac', // 03 已完成 浅绿
+} as const;
+
 function manufacturingFixture(): GanttTask[] {
-  const PLAN = '#0d9488'; // 排产计划 bar color
-  const WORK = '#5eead4'; // 派工单 child color
+  // 三级 悬浮详情: 编号/作业对象/计划起止/定额工时/管理责任人/执行责任人/状态/进度
+  const plan3 = (
+    f: { code: string; obj: string; span: string; quota: string; mgr: string; doers: string; status: string; progress: string },
+  ) => [
+    { label: '编号', value: f.code },
+    { label: '作业对象', value: f.obj },
+    { label: '计划起止', value: f.span },
+    { label: '定额工时', value: f.quota },
+    { label: '管理责任人', value: f.mgr },
+    { label: '执行责任人', value: f.doers },
+    { label: '状态', value: f.status },
+    { label: '进度', value: f.progress },
+  ];
+  // 四级 悬浮详情: 派工单编号/执行责任人/作业对象/计划起止/实际起止/状态
+  const wo4 = (
+    f: { code: string; doer: string; obj: string; plan: string; actual: string; status: string },
+  ) => [
+    { label: '派工单编号', value: f.code },
+    { label: '执行责任人', value: f.doer },
+    { label: '作业对象', value: f.obj },
+    { label: '计划起止', value: f.plan },
+    { label: '实际起止', value: f.actual },
+    { label: '状态', value: f.status },
+  ];
   return [
-    // 一级: 项目 (无条)
+    // ── 一级: 项目 (无条) ───────────────────────────────────────────────
     { id: 'prj-A', title: '项目A（导管架制造）', start: d('2026-06-01'), end: d('2026-06-30'), progress: 0, parent: null, type: 'group' },
 
-    // 二级: 产品 (无条)
+    // ── 二级: 产品A-1 (无条) ────────────────────────────────────────────
     { id: 'prod-A1', title: '产品A-1（XX项目导管架）', start: d('2026-06-01'), end: d('2026-06-30'), progress: 0, parent: 'prj-A', type: 'group' },
 
-    // 三级: 排产计划 (有时间条) — children drive its rollup range
-    // 四级 派工单 are `locked` (仅查看/跳转): no drag/resize/progress/link/edit.
-    { id: 'plan-1', title: '将军柱组焊（排产计划）', start: d('2026-06-03'), end: d('2026-06-10'), progress: 0, parent: 'prod-A1', color: PLAN },
-    { id: 'wo-001', title: 'WO001 张三（派工单）', start: d('2026-06-03'), end: d('2026-06-06'), progress: 100, parent: 'plan-1', color: WORK, locked: true },
-    { id: 'wo-002', title: 'WO002 李四（派工单）', start: d('2026-06-06'), end: d('2026-06-10'), progress: 40, parent: 'plan-1', color: WORK, locked: true, dependencies: [{ id: 'wo-001', type: 'fs' }] },
+    // 三级 plan-1 — 03 已完成 (深绿, 100%)
+    { id: 'plan-1', title: '将军柱组焊（排产计划）', start: d('2026-06-03'), end: d('2026-06-10'), progress: 100, parent: 'prod-A1', color: PLAN_COLOR.done,
+      fields: plan3({ code: 'PP-2026-001', obj: '将军柱·KK节点', span: '06-03 ~ 06-10', quota: '120h', mgr: '李工', doers: '张三、李四', status: '已完成', progress: '100%' }) },
+    { id: 'wo-001', title: 'WO001 张三（派工单）', start: d('2026-06-03'), end: d('2026-06-06'), progress: 100, parent: 'plan-1', color: WORK_COLOR.done, locked: true,
+      baselineStart: d('2026-06-03'), baselineEnd: d('2026-06-07'),
+      fields: wo4({ code: 'WO-2026-001', doer: '张三', obj: '将军柱·KK节点', plan: '06-03 ~ 06-07', actual: '06-03 ~ 06-06', status: '已完成' }) },
+    { id: 'wo-002', title: 'WO002 李四（派工单）', start: d('2026-06-06'), end: d('2026-06-10'), progress: 60, parent: 'plan-1', color: WORK_COLOR.reported, locked: true,
+      baselineStart: d('2026-06-06'), baselineEnd: d('2026-06-09'),
+      fields: wo4({ code: 'WO-2026-002', doer: '李四', obj: '将军柱·KK节点', plan: '06-06 ~ 06-09', actual: '06-06 ~ 06-10', status: '已报工' }) },
 
-    { id: 'plan-2', title: '主腿管接长（排产计划）', start: d('2026-06-08'), end: d('2026-06-14'), progress: 0, parent: 'prod-A1', color: PLAN },
-    { id: 'wo-003', title: 'WO003 王五（派工单）', start: d('2026-06-08'), end: d('2026-06-14'), progress: 20, parent: 'plan-2', color: WORK, locked: true },
+    // 三级 plan-2 — 02 进行中 (绿, 45%) · 依赖 plan-1 (FS)
+    { id: 'plan-2', title: '主腿管接长（排产计划）', start: d('2026-06-10'), end: d('2026-06-16'), progress: 45, parent: 'prod-A1', color: PLAN_COLOR.doing,
+      dependencies: [{ id: 'plan-1', type: 'fs' }],
+      fields: plan3({ code: 'PP-2026-002', obj: '主腿管·D1800', span: '06-10 ~ 06-16', quota: '96h', mgr: '李工', doers: '王五、赵六', status: '进行中', progress: '45%' }) },
+    { id: 'wo-003', title: 'WO003 王五（派工单）', start: d('2026-06-10'), end: d('2026-06-13'), progress: 70, parent: 'plan-2', color: WORK_COLOR.doing, locked: true,
+      baselineStart: d('2026-06-10'), baselineEnd: d('2026-06-12'),
+      fields: wo4({ code: 'WO-2026-003', doer: '王五', obj: '主腿管·D1800', plan: '06-10 ~ 06-12', actual: '06-10 ~ —（超期中）', status: '进行中' }) },
+    { id: 'wo-004', title: 'WO004 赵六（派工单）', start: d('2026-06-13'), end: d('2026-06-16'), progress: 0, parent: 'plan-2', color: WORK_COLOR.todo, locked: true,
+      fields: wo4({ code: 'WO-2026-004', doer: '赵六', obj: '主腿管·D1800', plan: '06-13 ~ 06-16', actual: '— ~ —', status: '待开始' }) },
 
-    // 二级: 第二个产品 (无条)
+    // 三级 里程碑 — 仍是一条普通排产计划 (有计划起止/时间条), 只是 `是否里程碑=是`,
+    // 显示时在条上文字最前面加 ◆ 前缀标记 (不画菱形)。依赖 plan-2 (FS)。
+    { id: 'ms-A1', title: '◆ 段建完成（排产计划·里程碑）', start: d('2026-06-16'), end: d('2026-06-17'), progress: 0, parent: 'prod-A1', color: PLAN_COLOR.todo,
+      dependencies: [{ id: 'plan-2', type: 'fs' }],
+      fields: plan3({ code: 'PP-2026-005', obj: '段建·阶段验收', span: '06-16 ~ 06-17', quota: '8h', mgr: '李工', doers: '李工', status: '待开始', progress: '0%' }).concat({ label: '是否里程碑', value: '是' }) },
+
+    // ── 二级: 产品A-2 (无条) ────────────────────────────────────────────
     { id: 'prod-A2', title: '产品A-2（YY项目导管架）', start: d('2026-06-12'), end: d('2026-06-30'), progress: 0, parent: 'prj-A', type: 'group' },
-    { id: 'plan-3', title: '分段预制（排产计划）', start: d('2026-06-12'), end: d('2026-06-20'), progress: 0, parent: 'prod-A2', color: PLAN },
-    { id: 'wo-004', title: 'WO004 赵六（派工单）', start: d('2026-06-12'), end: d('2026-06-20'), progress: 10, parent: 'plan-3', color: WORK, locked: true },
+
+    // 三级 plan-3 — 01 已下推 (蓝, 0%) · 依赖 plan-2 (FS)
+    { id: 'plan-3', title: '分段预制（排产计划）', start: d('2026-06-17'), end: d('2026-06-23'), progress: 0, parent: 'prod-A2', color: PLAN_COLOR.pushed,
+      dependencies: [{ id: 'plan-2', type: 'fs' }],
+      fields: plan3({ code: 'PP-2026-003', obj: '分段·S2', span: '06-17 ~ 06-23', quota: '80h', mgr: '陈工', doers: '钱七', status: '已下推', progress: '0%' }) },
+    { id: 'wo-005', title: 'WO005 钱七（派工单）', start: d('2026-06-17'), end: d('2026-06-23'), progress: 0, parent: 'plan-3', color: WORK_COLOR.todo, locked: true,
+      fields: wo4({ code: 'WO-2026-005', doer: '钱七', obj: '分段·S2', plan: '06-17 ~ 06-23', actual: '— ~ —', status: '待开始' }) },
+
+    // 三级 plan-4 — 00 待开始 (深灰) · 依赖 plan-3 (FS)
+    { id: 'plan-4', title: '总装合拢（排产计划）', start: d('2026-06-24'), end: d('2026-06-30'), progress: 0, parent: 'prod-A2', color: PLAN_COLOR.todo,
+      dependencies: [{ id: 'plan-3', type: 'fs' }],
+      fields: plan3({ code: 'PP-2026-004', obj: '导管架·总装', span: '06-24 ~ 06-30', quota: '140h', mgr: '陈工', doers: '孙八', status: '待开始', progress: '0%' }) },
+    { id: 'wo-006', title: 'WO006 孙八（派工单）', start: d('2026-06-24'), end: d('2026-06-30'), progress: 0, parent: 'plan-4', color: WORK_COLOR.todo, locked: true,
+      fields: wo4({ code: 'WO-2026-006', doer: '孙八', obj: '导管架·总装', plan: '06-24 ~ 06-30', actual: '— ~ —', status: '待开始' }) },
   ];
 }
 
@@ -308,6 +388,44 @@ function QuickFilterDemo() {
   );
 }
 
+/** 状态色图例 (3.4.3) — decodes the 排产计划 / 派工单 bar colors for the mfg demo. */
+function ManufacturingLegend() {
+  const Swatch = ({ color, label, hollow }: { color: string; label: string; hollow?: boolean }) => (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <span style={{ width: 12, height: 12, borderRadius: 3, background: hollow ? 'transparent' : color, border: hollow ? `1px solid ${color}` : 'none', display: 'inline-block' }} />
+      {label}
+    </span>
+  );
+  return (
+    <div
+      data-testid="mfg-legend"
+      style={{ padding: '4px 12px', fontSize: 11, borderBottom: '1px solid hsl(var(--border))', display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center', color: 'hsl(var(--muted-foreground))' }}
+    >
+      <strong style={{ color: 'hsl(var(--foreground))' }}>排产计划</strong>
+      <Swatch color={PLAN_COLOR.todo} label="待开始" />
+      <Swatch color={PLAN_COLOR.pushed} label="已下推" />
+      <Swatch color={PLAN_COLOR.doing} label="进行中" />
+      <Swatch color={PLAN_COLOR.done} label="已完成" />
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        <span style={{ fontWeight: 700 }}>◆</span>前缀 = 里程碑标记
+      </span>
+      <span style={{ opacity: 0.4 }}>|</span>
+      <strong style={{ color: 'hsl(var(--foreground))' }}>派工单</strong>
+      <Swatch color={WORK_COLOR.todo} label="待开始" />
+      <Swatch color={WORK_COLOR.doing} label="进行中" />
+      <Swatch color={WORK_COLOR.reported} label="已报工" />
+      <Swatch color={WORK_COLOR.done} label="已完成" />
+      <span style={{ opacity: 0.4 }}>|</span>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        <span style={{ width: 14, height: 4, borderRadius: 1, background: 'rgba(100,116,139,0.35)', border: '1px solid rgba(100,116,139,0.6)', display: 'inline-block' }} />
+        细灰条 = 计划基线
+      </span>
+      <span style={{ opacity: 0.4 }}>|</span>
+      <span>依赖连线仅在三级之间 (FS) · 派工单 locked 仅查看 · 悬浮看详情</span>
+    </div>
+  );
+}
+
 function App() {
   const params = new URLSearchParams(window.location.search);
   if (params.get('quickfilter') === '1') return <QuickFilterDemo />;
@@ -393,6 +511,7 @@ function App() {
           <a href={withParam('lang', 'zh')}>中文</a>
         </span>
       </div>
+      {mfg && <ManufacturingLegend />}
       <div style={{ flex: 1, minHeight: 0 }}>
         {resourceMode ? (
           <ResourceWorkload

--- a/packages/plugin-gantt/demo/main.tsx
+++ b/packages/plugin-gantt/demo/main.tsx
@@ -135,17 +135,18 @@ function manufacturingFixture(): GanttTask[] {
     { id: 'prod-A1', title: '产品A-1（XX项目导管架）', start: d('2026-06-01'), end: d('2026-06-30'), progress: 0, parent: 'prj-A', type: 'group' },
 
     // 三级: 排产计划 (有时间条) — children drive its rollup range
+    // 四级 派工单 are `locked` (仅查看/跳转): no drag/resize/progress/link/edit.
     { id: 'plan-1', title: '将军柱组焊（排产计划）', start: d('2026-06-03'), end: d('2026-06-10'), progress: 0, parent: 'prod-A1', color: PLAN },
-    { id: 'wo-001', title: 'WO001 张三（派工单）', start: d('2026-06-03'), end: d('2026-06-06'), progress: 100, parent: 'plan-1', color: WORK },
-    { id: 'wo-002', title: 'WO002 李四（派工单）', start: d('2026-06-06'), end: d('2026-06-10'), progress: 40, parent: 'plan-1', color: WORK, dependencies: [{ id: 'wo-001', type: 'fs' }] },
+    { id: 'wo-001', title: 'WO001 张三（派工单）', start: d('2026-06-03'), end: d('2026-06-06'), progress: 100, parent: 'plan-1', color: WORK, locked: true },
+    { id: 'wo-002', title: 'WO002 李四（派工单）', start: d('2026-06-06'), end: d('2026-06-10'), progress: 40, parent: 'plan-1', color: WORK, locked: true, dependencies: [{ id: 'wo-001', type: 'fs' }] },
 
     { id: 'plan-2', title: '主腿管接长（排产计划）', start: d('2026-06-08'), end: d('2026-06-14'), progress: 0, parent: 'prod-A1', color: PLAN },
-    { id: 'wo-003', title: 'WO003 王五（派工单）', start: d('2026-06-08'), end: d('2026-06-14'), progress: 20, parent: 'plan-2', color: WORK },
+    { id: 'wo-003', title: 'WO003 王五（派工单）', start: d('2026-06-08'), end: d('2026-06-14'), progress: 20, parent: 'plan-2', color: WORK, locked: true },
 
     // 二级: 第二个产品 (无条)
     { id: 'prod-A2', title: '产品A-2（YY项目导管架）', start: d('2026-06-12'), end: d('2026-06-30'), progress: 0, parent: 'prj-A', type: 'group' },
     { id: 'plan-3', title: '分段预制（排产计划）', start: d('2026-06-12'), end: d('2026-06-20'), progress: 0, parent: 'prod-A2', color: PLAN },
-    { id: 'wo-004', title: 'WO004 赵六（派工单）', start: d('2026-06-12'), end: d('2026-06-20'), progress: 10, parent: 'plan-3', color: WORK },
+    { id: 'wo-004', title: 'WO004 赵六（派工单）', start: d('2026-06-12'), end: d('2026-06-20'), progress: 10, parent: 'plan-3', color: WORK, locked: true },
   ];
 }
 
@@ -416,7 +417,9 @@ function App() {
           mobileReadOnly={mobileReadOnly}
           groupBy={groupBy}
           ungroupedLabel="未分组"
-          persistLayoutKey="demo-project"
+          // 制造排班示例: 三级排产计划 (depth 2) 默认折叠。
+          defaultCollapsedDepth={mfg ? 2 : undefined}
+          persistLayoutKey={mfg ? undefined : "demo-project"}
           onLayoutChange={(l) => console.log('[gantt-demo] layout saved', l)}
           inlineEdit
           onTaskClick={(t) => console.log('[gantt-demo] click', t.id)}

--- a/packages/plugin-gantt/src/GanttView.dnd.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.dnd.test.tsx
@@ -13,7 +13,7 @@ import { render, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GanttView, type GanttTask } from './GanttView';
 
-// Force the container width to >=1024 so columnWidth=80 (deterministic).
+// Force the container width to >=1024 so columnWidth=110 (deterministic).
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 });
@@ -68,15 +68,15 @@ describe('GanttView drag-and-drop', () => {
     const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
     expect(bar).toBeTruthy();
 
-    // columnWidth at width>=1024 = 80. Drag +240px → +3 days.
+    // columnWidth at width>=1024 = 110. Drag +330px → +3 days.
     act(() => {
       bar.dispatchEvent(pointer('pointerdown', 500));
     });
     act(() => {
-      window.dispatchEvent(pointer('pointermove', 740));
+      window.dispatchEvent(pointer('pointermove', 830));
     });
     act(() => {
-      window.dispatchEvent(pointer('pointerup', 740));
+      window.dispatchEvent(pointer('pointerup', 830));
     });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
@@ -93,14 +93,14 @@ describe('GanttView drag-and-drop', () => {
     expect(handle).toBeTruthy();
 
     act(() => { handle.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 620)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 620)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 720)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 720)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [, changes] = onTaskUpdate.mock.calls[0];
     // start unchanged
     expect(changes.start.toISOString()).toBe('2024-06-10T00:00:00.000Z');
-    // end shifted +120px / 60 = +2 days
+    // end shifted +220px / 110 = +2 days
     expect(changes.end.toISOString()).toBe('2024-06-17T00:00:00.000Z');
   });
 
@@ -111,12 +111,12 @@ describe('GanttView drag-and-drop', () => {
     expect(handle).toBeTruthy();
 
     act(() => { handle.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 340)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 340)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 280)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 280)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [, changes] = onTaskUpdate.mock.calls[0];
-    // start shifted -160px / 80 = -2 days
+    // start shifted -220px / 110 = -2 days
     expect(changes.start.toISOString()).toBe('2024-06-08T00:00:00.000Z');
     // end unchanged
     expect(changes.end.toISOString()).toBe('2024-06-15T00:00:00.000Z');
@@ -126,10 +126,10 @@ describe('GanttView drag-and-drop', () => {
     const onTaskUpdate = vi.fn();
     const { container } = renderView(onTaskUpdate);
     const handle = container.querySelector('[data-testid="gantt-task-resize-left-t1"]') as HTMLElement;
-    // Try to drag start +600px (10 days) — would put it 5 days past end.
+    // Try to drag start +1100px (10 days) — would put it 5 days past end.
     act(() => { handle.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 1100)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 1100)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 1600)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 1600)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [, changes] = onTaskUpdate.mock.calls[0];
@@ -143,7 +143,7 @@ describe('GanttView drag-and-drop', () => {
     const { container } = renderView(onTaskUpdate);
     const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
-    // Move <30px — rounds to 0 days at columnWidth=80.
+    // Move <30px — rounds to 0 days at columnWidth=110.
     act(() => { window.dispatchEvent(pointer('pointermove', 510)); });
     act(() => { window.dispatchEvent(pointer('pointerup', 510)); });
     expect(onTaskUpdate).not.toHaveBeenCalled();
@@ -249,10 +249,10 @@ describe('GanttView summary group drag', () => {
     const bracket = container.querySelector('[data-testid="gantt-summary-bar-p"]') as HTMLElement;
     expect(bracket).toBeTruthy();
 
-    // +160px → +2 days at columnWidth 80.
+    // +220px → +2 days at columnWidth 110.
     act(() => { bracket.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 660)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 660)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 720)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 720)); });
 
     // Summary + c1 + c2 + grandchild — one update each, all shifted +2 days
     // with durations preserved.
@@ -307,11 +307,11 @@ describe('GanttView summary group drag', () => {
       width: parseFloat(bracket().style.width),
     };
 
-    // Drag c2 (the latest child) +240px → +3 days past the parent's end.
+    // Drag c2 (the latest child) +330px → +3 days past the parent's end.
     const bar = container.querySelector('[data-testid="gantt-task-bar-c2"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 740)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 740)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 830)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 830)); });
 
     const after = {
       left: parseFloat(bracket().style.left),
@@ -319,6 +319,6 @@ describe('GanttView summary group drag', () => {
     };
     // Parent start is still c1's start; parent end follows c2 → +3 days wider.
     expect(after.left).toBeCloseTo(before.left, 0);
-    expect(after.width).toBeCloseTo(before.width + 3 * 80, 0);
+    expect(after.width).toBeCloseTo(before.width + 3 * 110, 0);
   });
 });

--- a/packages/plugin-gantt/src/GanttView.dnd.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.dnd.test.tsx
@@ -13,7 +13,7 @@ import { render, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GanttView, type GanttTask } from './GanttView';
 
-// Force the container width to >=1024 so columnWidth=60 (deterministic).
+// Force the container width to >=1024 so columnWidth=80 (deterministic).
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 });
@@ -68,15 +68,15 @@ describe('GanttView drag-and-drop', () => {
     const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
     expect(bar).toBeTruthy();
 
-    // columnWidth at width>=1024 = 60. Drag +180px → +3 days.
+    // columnWidth at width>=1024 = 80. Drag +240px → +3 days.
     act(() => {
       bar.dispatchEvent(pointer('pointerdown', 500));
     });
     act(() => {
-      window.dispatchEvent(pointer('pointermove', 680));
+      window.dispatchEvent(pointer('pointermove', 740));
     });
     act(() => {
-      window.dispatchEvent(pointer('pointerup', 680));
+      window.dispatchEvent(pointer('pointerup', 740));
     });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
@@ -111,12 +111,12 @@ describe('GanttView drag-and-drop', () => {
     expect(handle).toBeTruthy();
 
     act(() => { handle.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 380)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 380)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 340)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 340)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [, changes] = onTaskUpdate.mock.calls[0];
-    // start shifted -120px / 60 = -2 days
+    // start shifted -160px / 80 = -2 days
     expect(changes.start.toISOString()).toBe('2024-06-08T00:00:00.000Z');
     // end unchanged
     expect(changes.end.toISOString()).toBe('2024-06-15T00:00:00.000Z');
@@ -143,7 +143,7 @@ describe('GanttView drag-and-drop', () => {
     const { container } = renderView(onTaskUpdate);
     const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
-    // Move <30px — rounds to 0 days at columnWidth=60.
+    // Move <30px — rounds to 0 days at columnWidth=80.
     act(() => { window.dispatchEvent(pointer('pointermove', 510)); });
     act(() => { window.dispatchEvent(pointer('pointerup', 510)); });
     expect(onTaskUpdate).not.toHaveBeenCalled();
@@ -249,10 +249,10 @@ describe('GanttView summary group drag', () => {
     const bracket = container.querySelector('[data-testid="gantt-summary-bar-p"]') as HTMLElement;
     expect(bracket).toBeTruthy();
 
-    // +120px → +2 days at columnWidth 60.
+    // +160px → +2 days at columnWidth 80.
     act(() => { bracket.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 620)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 620)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 660)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 660)); });
 
     // Summary + c1 + c2 + grandchild — one update each, all shifted +2 days
     // with durations preserved.
@@ -307,11 +307,11 @@ describe('GanttView summary group drag', () => {
       width: parseFloat(bracket().style.width),
     };
 
-    // Drag c2 (the latest child) +180px → +3 days past the parent's end.
+    // Drag c2 (the latest child) +240px → +3 days past the parent's end.
     const bar = container.querySelector('[data-testid="gantt-task-bar-c2"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 680)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 680)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 740)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 740)); });
 
     const after = {
       left: parseFloat(bracket().style.left),
@@ -319,6 +319,6 @@ describe('GanttView summary group drag', () => {
     };
     // Parent start is still c1's start; parent end follows c2 → +3 days wider.
     expect(after.left).toBeCloseTo(before.left, 0);
-    expect(after.width).toBeCloseTo(before.width + 3 * 60, 0);
+    expect(after.width).toBeCloseTo(before.width + 3 * 80, 0);
   });
 });

--- a/packages/plugin-gantt/src/GanttView.interactions.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.interactions.test.tsx
@@ -185,7 +185,7 @@ describe('GanttView drag-to-create dependency', () => {
     const onDependencyCreate = vi.fn();
     const { container } = renderView([A(), B()], { onDependencyCreate });
 
-    const dot = container.querySelector('[data-testid="gantt-link-dot-a"]') as HTMLElement;
+    const dot = container.querySelector('[data-testid="gantt-link-dot-end-a"]') as HTMLElement;
     expect(dot).toBeTruthy();
     fireEvent.pointerDown(dot, { button: 0, clientX: 600, clientY: 20 });
 
@@ -206,10 +206,31 @@ describe('GanttView drag-to-create dependency', () => {
     expect(container.querySelector('[data-testid="gantt-link-draft"]')).toBeFalsy();
   });
 
+  it('dragging from the start dot derives a Start-anchored link type', () => {
+    const onDependencyCreate = vi.fn();
+    const { container } = renderView([A(), B()], { onDependencyCreate });
+
+    const dot = container.querySelector('[data-testid="gantt-link-dot-start-a"]') as HTMLElement;
+    expect(dot).toBeTruthy();
+    fireEvent.pointerDown(dot, { button: 0, clientX: 600, clientY: 20 });
+    act(() => { window.dispatchEvent(pointer('pointermove', 700, 60)); });
+
+    const barB = container.querySelector('[data-testid="gantt-task-bar-b"]') as HTMLElement;
+    fireEvent.pointerMove(barB, { clientX: 980, clientY: 60 });
+    act(() => { window.dispatchEvent(pointer('pointerup', 980, 60)); });
+
+    expect(onDependencyCreate).toHaveBeenCalledTimes(1);
+    const [source, target, type] = onDependencyCreate.mock.calls[0];
+    expect(source.id).toBe('a');
+    expect(target.id).toBe('b');
+    // start source + start target (jsdom rects collapse to zero-width → left half) = ss
+    expect(type).toBe('ss');
+  });
+
   it('releasing over empty space creates nothing', () => {
     const onDependencyCreate = vi.fn();
     const { container } = renderView([A(), B()], { onDependencyCreate });
-    const dot = container.querySelector('[data-testid="gantt-link-dot-a"]') as HTMLElement;
+    const dot = container.querySelector('[data-testid="gantt-link-dot-end-a"]') as HTMLElement;
 
     fireEvent.pointerDown(dot, { button: 0, clientX: 600, clientY: 20 });
     act(() => { window.dispatchEvent(pointer('pointermove', 1100, 30)); });

--- a/packages/plugin-gantt/src/GanttView.interactions.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.interactions.test.tsx
@@ -2,7 +2,7 @@
  * Phase 4 interaction tests: progress drag handle, hover tooltip, context
  * menu, keyboard navigation, drag-to-create dependency, row reorder.
  *
- * Conventions match the links/tree tests: innerWidth=1280 → columnWidth 80,
+ * Conventions match the links/tree tests: innerWidth=1280 → columnWidth 110,
  * rowHeight 40; geometry asserted via inline styles (timezone-safe); window
  * pointer events dispatched inside act().
  */
@@ -61,10 +61,10 @@ describe('GanttView progress drag handle', () => {
     const handle = container.querySelector('[data-testid="gantt-progress-handle-a"]') as HTMLElement;
     expect(handle).toBeTruthy();
 
-    // Bar is 10 days * 80px = 800px wide; +160px = +20% → 70.
+    // Bar is 10 days * 110px = 1100px wide; +220px = +20% → 70.
     fireEvent.pointerDown(handle, { button: 0, clientX: 300, clientY: 100 });
-    act(() => { window.dispatchEvent(pointer('pointermove', 460)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 460)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 520)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 520)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [task, changes] = onTaskUpdate.mock.calls[0];
@@ -399,14 +399,14 @@ describe('GanttView drag conflict reschedule (拖拽冲突校验 + 顺延确认)
     }),
   ];
 
-  // Drag a task bar horizontally by whole day-columns (columnWidth=80 at
+  // Drag a task bar horizontally by whole day-columns (columnWidth=110 at
   // innerWidth=1280). Positive = later, negative = earlier.
   function dragBar(container: HTMLElement, id: string, deltaCols: number) {
     const bar = container.querySelector(`[data-testid="gantt-task-bar-${id}"]`) as HTMLElement;
     const originX = 800;
     fireEvent.pointerDown(bar, { button: 0, clientX: originX, clientY: 100 });
-    act(() => { window.dispatchEvent(pointer('pointermove', originX + deltaCols * 80, 100)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', originX + deltaCols * 80, 100)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', originX + deltaCols * 110, 100)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', originX + deltaCols * 110, 100)); });
   }
 
   it('dragging a successor before its predecessor finishes prompts 顺延 confirmation', () => {

--- a/packages/plugin-gantt/src/GanttView.interactions.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.interactions.test.tsx
@@ -2,7 +2,7 @@
  * Phase 4 interaction tests: progress drag handle, hover tooltip, context
  * menu, keyboard navigation, drag-to-create dependency, row reorder.
  *
- * Conventions match the links/tree tests: innerWidth=1280 → columnWidth 60,
+ * Conventions match the links/tree tests: innerWidth=1280 → columnWidth 80,
  * rowHeight 40; geometry asserted via inline styles (timezone-safe); window
  * pointer events dispatched inside act().
  */
@@ -61,10 +61,10 @@ describe('GanttView progress drag handle', () => {
     const handle = container.querySelector('[data-testid="gantt-progress-handle-a"]') as HTMLElement;
     expect(handle).toBeTruthy();
 
-    // Bar is 10 days * 60px = 600px wide; +120px = +20% → 70.
+    // Bar is 10 days * 80px = 800px wide; +160px = +20% → 70.
     fireEvent.pointerDown(handle, { button: 0, clientX: 300, clientY: 100 });
-    act(() => { window.dispatchEvent(pointer('pointermove', 420)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 420)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 460)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 460)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [task, changes] = onTaskUpdate.mock.calls[0];
@@ -399,14 +399,14 @@ describe('GanttView drag conflict reschedule (拖拽冲突校验 + 顺延确认)
     }),
   ];
 
-  // Drag a task bar horizontally by whole day-columns (columnWidth=60 at
+  // Drag a task bar horizontally by whole day-columns (columnWidth=80 at
   // innerWidth=1280). Positive = later, negative = earlier.
   function dragBar(container: HTMLElement, id: string, deltaCols: number) {
     const bar = container.querySelector(`[data-testid="gantt-task-bar-${id}"]`) as HTMLElement;
     const originX = 800;
     fireEvent.pointerDown(bar, { button: 0, clientX: originX, clientY: 100 });
-    act(() => { window.dispatchEvent(pointer('pointermove', originX + deltaCols * 60, 100)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', originX + deltaCols * 60, 100)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', originX + deltaCols * 80, 100)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', originX + deltaCols * 80, 100)); });
   }
 
   it('dragging a successor before its predecessor finishes prompts 顺延 confirmation', () => {

--- a/packages/plugin-gantt/src/GanttView.layout.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.layout.test.tsx
@@ -3,7 +3,7 @@
  * (保存布局), and the PNG / PDF export toolbar buttons.
  *
  * Conventions match the other interaction tests: innerWidth=1280 →
- * columnWidth 80, rowHeight 40.
+ * columnWidth 110, rowHeight 40.
  */
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';

--- a/packages/plugin-gantt/src/GanttView.layout.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.layout.test.tsx
@@ -3,7 +3,7 @@
  * (保存布局), and the PNG / PDF export toolbar buttons.
  *
  * Conventions match the other interaction tests: innerWidth=1280 →
- * columnWidth 60, rowHeight 40.
+ * columnWidth 80, rowHeight 40.
  */
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';

--- a/packages/plugin-gantt/src/GanttView.links.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.links.test.tsx
@@ -12,7 +12,7 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GanttView, type GanttTask, type GanttDependency } from './GanttView';
 
-// Force the container width to >=1024 so columnWidth=60 (deterministic).
+// Force the container width to >=1024 so columnWidth=80 (deterministic).
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 });
@@ -180,19 +180,19 @@ describe('GanttView dependency links', () => {
     const path = container.querySelector('[data-testid="gantt-link-a-b"]') as SVGPathElement;
     const before = pathEndpoints(path);
 
-    // Drag bar b +120px = +2 days at columnWidth 60 (don't release yet).
+    // Drag bar b +160px = +2 days at columnWidth 80 (don't release yet).
     const barB = container.querySelector('[data-testid="gantt-task-bar-b"]') as HTMLElement;
     act(() => { barB.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 620)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 660)); });
 
     const during = pathEndpoints(
       container.querySelector('[data-testid="gantt-link-a-b"]') as SVGPathElement,
     );
     // Source bar untouched, target anchor follows the drag preview.
     expect(during.start.x).toBeCloseTo(before.start.x, 0);
-    expect(during.end.x).toBeCloseTo(before.end.x + 120, 0);
+    expect(during.end.x).toBeCloseTo(before.end.x + 160, 0);
 
-    act(() => { window.dispatchEvent(pointer('pointerup', 620)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 660)); });
   });
 
   it('renders a backward fs link (dependent starts before predecessor ends) without crashing', () => {

--- a/packages/plugin-gantt/src/GanttView.links.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.links.test.tsx
@@ -12,7 +12,7 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GanttView, type GanttTask, type GanttDependency } from './GanttView';
 
-// Force the container width to >=1024 so columnWidth=80 (deterministic).
+// Force the container width to >=1024 so columnWidth=110 (deterministic).
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 });
@@ -180,19 +180,19 @@ describe('GanttView dependency links', () => {
     const path = container.querySelector('[data-testid="gantt-link-a-b"]') as SVGPathElement;
     const before = pathEndpoints(path);
 
-    // Drag bar b +160px = +2 days at columnWidth 80 (don't release yet).
+    // Drag bar b +220px = +2 days at columnWidth 110 (don't release yet).
     const barB = container.querySelector('[data-testid="gantt-task-bar-b"]') as HTMLElement;
     act(() => { barB.dispatchEvent(pointer('pointerdown', 500)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 660)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 720)); });
 
     const during = pathEndpoints(
       container.querySelector('[data-testid="gantt-link-a-b"]') as SVGPathElement,
     );
     // Source bar untouched, target anchor follows the drag preview.
     expect(during.start.x).toBeCloseTo(before.start.x, 0);
-    expect(during.end.x).toBeCloseTo(before.end.x + 160, 0);
+    expect(during.end.x).toBeCloseTo(before.end.x + 220, 0);
 
-    act(() => { window.dispatchEvent(pointer('pointerup', 660)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 720)); });
   });
 
   it('renders a backward fs link (dependent starts before predecessor ends) without crashing', () => {

--- a/packages/plugin-gantt/src/GanttView.scales.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.scales.test.tsx
@@ -12,12 +12,12 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { GanttView, type GanttTask, type GanttViewMode } from './GanttView';
 
-// Force the container width to >=1024 so columnWidth=80 (deterministic).
+// Force the container width to >=1024 so columnWidth=110 (deterministic).
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 });
 
-const COLUMN_WIDTH = 80;
+const COLUMN_WIDTH = 110;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const NOMINAL_DAYS: Record<GanttViewMode, number> = { day: 1, week: 7, month: 30.44, quarter: 91.31 };
 
@@ -116,7 +116,7 @@ describe('GanttView time scales', () => {
     const units = unitCells(container);
     expect(units.length).toBeGreaterThanOrEqual(3);
     expect(units.length).toBeLessThanOrEqual(4);
-    // June (30 days) column width = 30 * 80/30.44.
+    // June (30 days) column width = 30 * 110/30.44.
     const pxPerDay = COLUMN_WIDTH / NOMINAL_DAYS.month;
     const first = units[0];
     const days = Math.round(parseFloat(first.style.width) / pxPerDay);
@@ -180,9 +180,9 @@ describe('GanttView time scales', () => {
 
     const bar = container.querySelector('[data-testid="gantt-task-bar-a"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 300)); });
-    // +80px = one column = one week.
-    act(() => { window.dispatchEvent(pointer('pointermove', 380)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 380)); });
+    // +110px = one column = one week.
+    act(() => { window.dispatchEvent(pointer('pointermove', 410)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 410)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [, changes] = onTaskUpdate.mock.calls[0];
@@ -202,8 +202,8 @@ describe('GanttView time scales', () => {
 
     const bar = container.querySelector('[data-testid="gantt-task-bar-a"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 300)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 380)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 380)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 410)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 410)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [, changes] = onTaskUpdate.mock.calls[0];

--- a/packages/plugin-gantt/src/GanttView.scales.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.scales.test.tsx
@@ -12,12 +12,12 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { GanttView, type GanttTask, type GanttViewMode } from './GanttView';
 
-// Force the container width to >=1024 so columnWidth=60 (deterministic).
+// Force the container width to >=1024 so columnWidth=80 (deterministic).
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 });
 
-const COLUMN_WIDTH = 60;
+const COLUMN_WIDTH = 80;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const NOMINAL_DAYS: Record<GanttViewMode, number> = { day: 1, week: 7, month: 30.44, quarter: 91.31 };
 
@@ -116,7 +116,7 @@ describe('GanttView time scales', () => {
     const units = unitCells(container);
     expect(units.length).toBeGreaterThanOrEqual(3);
     expect(units.length).toBeLessThanOrEqual(4);
-    // June (30 days) column width = 30 * 60/30.44.
+    // June (30 days) column width = 30 * 80/30.44.
     const pxPerDay = COLUMN_WIDTH / NOMINAL_DAYS.month;
     const first = units[0];
     const days = Math.round(parseFloat(first.style.width) / pxPerDay);
@@ -180,9 +180,9 @@ describe('GanttView time scales', () => {
 
     const bar = container.querySelector('[data-testid="gantt-task-bar-a"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 300)); });
-    // +60px = one column = one week.
-    act(() => { window.dispatchEvent(pointer('pointermove', 360)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 360)); });
+    // +80px = one column = one week.
+    act(() => { window.dispatchEvent(pointer('pointermove', 380)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 380)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [, changes] = onTaskUpdate.mock.calls[0];
@@ -202,8 +202,8 @@ describe('GanttView time scales', () => {
 
     const bar = container.querySelector('[data-testid="gantt-task-bar-a"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 300)); });
-    act(() => { window.dispatchEvent(pointer('pointermove', 360)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 360)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 380)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 380)); });
 
     expect(onTaskUpdate).toHaveBeenCalledTimes(1);
     const [, changes] = onTaskUpdate.mock.calls[0];

--- a/packages/plugin-gantt/src/GanttView.tree.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.tree.test.tsx
@@ -254,6 +254,15 @@ describe('GanttView defaultCollapsedDepth (默认折叠)', () => {
   });
 });
 
+describe('GanttView leaf bar labels', () => {
+  it('renders the task title inside a leaf task bar (not just summary bars)', () => {
+    const { container } = renderViewWith(manufacturingTree());
+    const bar = container.querySelector('[data-testid="gantt-task-bar-wo"]') as HTMLElement;
+    expect(bar).toBeTruthy();
+    expect(bar.textContent).toContain('Task wo');
+  });
+});
+
 describe('GanttView locked nodes (仅查看)', () => {
   it('omits drag/resize/progress handles and the dependency dot on a locked bar', () => {
     const { container } = renderViewWith(manufacturingTree(), {

--- a/packages/plugin-gantt/src/GanttView.tree.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.tree.test.tsx
@@ -196,3 +196,74 @@ describe('GanttView task hierarchy', () => {
     expect(fill.style.backgroundColor).toBe('rgba(0, 0, 0, 0.2)');
   });
 });
+
+// A 4-level tree: 项目(L0,group) → 产品(L1,group) → 排产计划(L2) → 派工单(L3).
+function manufacturingTree(): GanttTask[] {
+  return [
+    makeTask('prj', '2024-06-01T00:00:00.000Z', '2024-06-30T00:00:00.000Z', { type: 'group' }),
+    makeTask('prod', '2024-06-01T00:00:00.000Z', '2024-06-30T00:00:00.000Z', { parent: 'prj', type: 'group' }),
+    makeTask('plan', '2024-06-03T00:00:00.000Z', '2024-06-10T00:00:00.000Z', { parent: 'prod' }),
+    makeTask('wo', '2024-06-03T00:00:00.000Z', '2024-06-06T00:00:00.000Z', { parent: 'plan', locked: true }),
+  ];
+}
+
+function renderViewWith(tasks: GanttTask[], extra: Record<string, unknown> = {}) {
+  return render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView
+        tasks={tasks}
+        startDate={new Date('2024-06-01T00:00:00.000Z')}
+        endDate={new Date('2024-06-30T00:00:00.000Z')}
+        {...extra}
+      />
+    </div>
+  );
+}
+
+describe('GanttView group nodes (无条 tree headers)', () => {
+  it('renders type:group rows with no bar but keeps the expand toggle', () => {
+    const { container } = renderViewWith(manufacturingTree());
+    // Group rows have neither a summary bracket nor a task bar.
+    expect(container.querySelector('[data-testid="gantt-summary-bar-prj"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-task-bar-prj"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-summary-bar-prod"]')).toBeFalsy();
+    // But they remain collapsible tree nodes.
+    expect(container.querySelector('[data-testid="gantt-row-toggle-prj"]')).toBeTruthy();
+    // The schedulable level below still draws its bar.
+    expect(container.querySelector('[data-testid="gantt-summary-bar-plan"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-task-bar-wo"]')).toBeTruthy();
+  });
+});
+
+describe('GanttView defaultCollapsedDepth (默认折叠)', () => {
+  it('seeds the collapsed set at the given depth so deeper rows start hidden', () => {
+    // depth 2 = 排产计划; its 派工单 child should start folded away.
+    const { container } = renderViewWith(manufacturingTree(), { defaultCollapsedDepth: 2 });
+    expect(container.querySelector('[data-testid="gantt-summary-bar-plan"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-task-bar-wo"]')).toBeFalsy();
+    // The plan node is collapsed (aria-expanded=false) and expandable by the user.
+    const toggle = container.querySelector('[data-testid="gantt-row-toggle-plan"]') as HTMLElement;
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(toggle);
+    expect(container.querySelector('[data-testid="gantt-task-bar-wo"]')).toBeTruthy();
+  });
+
+  it('leaves the tree fully expanded when the prop is omitted', () => {
+    const { container } = renderViewWith(manufacturingTree());
+    expect(container.querySelector('[data-testid="gantt-task-bar-wo"]')).toBeTruthy();
+  });
+});
+
+describe('GanttView locked nodes (仅查看)', () => {
+  it('omits drag/resize/progress handles and the dependency dot on a locked bar', () => {
+    const { container } = renderViewWith(manufacturingTree(), {
+      onTaskUpdate: () => {},
+      onDependencyCreate: () => {},
+    });
+    // The locked 派工单 keeps its bar but loses every write affordance.
+    expect(container.querySelector('[data-testid="gantt-task-bar-wo"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-wo"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-right-wo"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-link-dot-wo"]')).toBeFalsy();
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -1817,8 +1817,10 @@ export function GanttView({
     if (headerRef.current) {
         headerRef.current.scrollLeft = el.scrollLeft;
     }
-    // Sync vertical scroll to task list
-    if (listRef.current) {
+    // Sync vertical scroll to task list. Assign only when it differs so the
+    // browser fires no scroll event on the list (a no-op assignment is silent),
+    // which is what keeps the two-way sync below from looping.
+    if (listRef.current && listRef.current.scrollTop !== el.scrollTop) {
         listRef.current.scrollTop = el.scrollTop;
     }
     // Drive the virtualization windows.
@@ -1828,6 +1830,24 @@ export function GanttView({
         : { top: el.scrollTop, left: el.scrollLeft }
     );
     measureViewport();
+  };
+
+  // The task list is its own vertical scroller (so users can scroll the left
+  // pane directly with a wheel/trackpad/scrollbar, not only the timeline). Push
+  // its scrollTop onto the timeline — whose handleScroll then drives the shared
+  // virtualization window and mirrors back. The "assign only if different" guard
+  // on both sides makes this self-terminating: the mirror-back lands on an equal
+  // value, so the browser emits no further scroll event.
+  const handleListScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const listEl = e.currentTarget;
+    const timeline = scrollAreaRef.current;
+    if (timeline && timeline.scrollTop !== listEl.scrollTop) {
+      timeline.scrollTop = listEl.scrollTop;
+    }
+    // Drive virtualization directly too: the timeline's scroll event is queued
+    // (async), so updating here avoids a one-frame blank in the left pane during
+    // a fast drag of its scrollbar.
+    setScrollPos((prev) => (prev.top === listEl.scrollTop ? prev : { ...prev, top: listEl.scrollTop }));
   };
 
   const styleFor = (start: Date, end: Date) => {
@@ -2547,8 +2567,9 @@ export function GanttView({
         <div className="flex flex-1 overflow-hidden">
           {/* Left Side: Task List (Grid) */}
           <div
-            className="overflow-hidden border-r bg-card z-10 shadow-sm"
+            className="overflow-y-auto overflow-x-hidden border-r bg-card z-10 shadow-sm"
             ref={listRef}
+            onScroll={handleListScroll}
             style={{ width: taskListWidth, minWidth: taskListWidth }}
             role="tree"
             aria-label={t('gantt.aria.taskList')}

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3363,11 +3363,15 @@ export function GanttView({
                           />
                         )}
 
-                        {/* Progress drag handle — grip at the progress boundary */}
+                        {/* Progress drag handle — a triangle hugging the bottom
+                            edge at the progress boundary (dhtmlx-style). It only
+                            shows on hover / while dragging, and its hit area lives
+                            in the bottom half so grabbing it never competes with a
+                            bar move (top) or a link drag (the centred end dots). */}
                         {canDrag && liveStyle.width >= 30 && (
                           <div
                             className={cn(
-                              "absolute top-0 bottom-0 w-3 -translate-x-1/2 cursor-col-resize flex items-center justify-center",
+                              "absolute bottom-0 h-1/2 w-4 -translate-x-1/2 cursor-col-resize flex items-end justify-center pb-px",
                               progressDrag?.taskId === task.id
                                 ? "opacity-100"
                                 : "opacity-0 group-hover:opacity-100 transition-opacity"
@@ -3388,47 +3392,84 @@ export function GanttView({
                             }}
                             onClick={(e) => e.stopPropagation()}
                           >
-                            {/* Explicit colors: bg-white / ring-black-30 aren't
-                                emitted in the prebuilt components CSS. */}
+                            {/* Up-pointing triangle. Built from borders (no asset);
+                                white fill + drop-shadow so it reads on any bar color. */}
                             <div
-                              className="h-2.5 w-2.5 rounded-full"
-                              style={{ backgroundColor: '#fff', boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.25)' }}
+                              style={{
+                                width: 0,
+                                height: 0,
+                                borderLeft: '5px solid transparent',
+                                borderRight: '5px solid transparent',
+                                borderBottom: '7px solid #fff',
+                                filter: 'drop-shadow(0 1px 1px rgba(0, 0, 0, 0.35))',
+                              }}
                             />
                           </div>
                         )}
 
-                        {/* Connector dots — one at each end of the bar. Drag from
-                            the Start dot or the Finish dot onto another bar to
-                            create a dependency; the endpoint you drag FROM picks
-                            the first letter of the link type (Finish vs Start). */}
-                        {onDependencyCreate && !isLocked && (['start', 'end'] as const).map((end) => (
-                          <div
-                            key={end}
-                            className={cn(
-                              "absolute top-1/2 -translate-y-1/2 h-3 w-3 rounded-full bg-background z-10",
-                              linkDrag && String(linkDrag.sourceId) === String(task.id) && linkDrag.sourceEnd === end
-                                ? "opacity-100"
-                                : "opacity-0 group-hover:opacity-100 transition-opacity"
-                            )}
-                            style={{ [end === 'start' ? 'left' : 'right']: -8, cursor: 'crosshair', border: '2px solid hsl(var(--primary))' }}
-                            data-testid={`gantt-link-dot-${end}-${task.id}`}
-                            onPointerDown={(e) => {
-                              if (e.button !== 0) return;
-                              e.stopPropagation();
-                              e.preventDefault();
-                              const rect = contentRef.current?.getBoundingClientRect();
-                              setLinkDrag({
-                                sourceId: task.id,
-                                sourceEnd: end,
-                                x: rect ? e.clientX - rect.left : 0,
-                                y: rect ? e.clientY - rect.top : 0,
-                                targetId: null,
-                                targetEnd: null,
-                              });
-                            }}
-                            onClick={(e) => e.stopPropagation()}
-                          />
-                        ))}
+                        {/* Connector dots — a circle floating just OUTSIDE each end
+                            of the bar (dhtmlx-style). Sitting fully outside the bar
+                            body means grabbing one can never start a bar move or an
+                            edge resize. They appear on row hover (or while this bar
+                            is the link source) and have their own enlarged hit area
+                            so they're easy to grab. Drag one onto another bar to
+                            create a dependency; the endpoint you drag FROM picks the
+                            first letter of the link type (Finish vs Start). */}
+                        {onDependencyCreate && !isLocked && (['start', 'end'] as const).map((end) => {
+                          const isSource =
+                            linkDrag != null &&
+                            String(linkDrag.sourceId) === String(task.id) &&
+                            linkDrag.sourceEnd === end;
+                          const visible = isSource || hoveredTaskId === task.id;
+                          // Only grabbable when no drag is live yet — during a drag
+                          // the dots are pure visual hints, so the bar underneath
+                          // keeps reporting the hovered drop target.
+                          const grabbable = visible && linkDrag == null;
+                          return (
+                            <div
+                              key={end}
+                              // Enlarged transparent hit area; the circle is centred
+                              // inside it. Touches the bar edge (no gap) so the row
+                              // hover stays unbroken when the pointer moves onto it.
+                              className="absolute top-1/2 -translate-y-1/2 z-20 flex items-center justify-center transition-opacity"
+                              style={{
+                                [end === 'start' ? 'left' : 'right']: -18,
+                                height: 20,
+                                width: 20,
+                                cursor: 'crosshair',
+                                opacity: visible ? 1 : 0,
+                                pointerEvents: grabbable ? 'auto' : 'none',
+                              }}
+                              data-testid={`gantt-link-dot-${end}-${task.id}`}
+                              onPointerDown={(e) => {
+                                if (e.button !== 0) return;
+                                e.stopPropagation();
+                                e.preventDefault();
+                                const rect = contentRef.current?.getBoundingClientRect();
+                                setLinkDrag({
+                                  sourceId: task.id,
+                                  sourceEnd: end,
+                                  x: rect ? e.clientX - rect.left : 0,
+                                  y: rect ? e.clientY - rect.top : 0,
+                                  targetId: null,
+                                  targetEnd: null,
+                                });
+                              }}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <div
+                                className="rounded-full"
+                                style={{
+                                  height: 12,
+                                  width: 12,
+                                  backgroundColor: 'hsl(var(--background))',
+                                  border: '2px solid hsl(var(--primary))',
+                                  boxShadow: isSource ? '0 0 0 3px hsl(var(--primary) / 0.25)' : '0 1px 2px rgba(0,0,0,0.25)',
+                                }}
+                              />
+                            </div>
+                          );
+                        })}
 
                         {/* Bar label — the task title, shown like summary bars so
                             leaf bars aren't blank. Fades out on hover to reveal the

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -47,9 +47,9 @@ const COLUMN_WIDTH = 100; // Time column width
  * checks so the Gantt adapts to whatever slot it sits in (cards, sidebars, popups…).
  */
 function columnWidthForContainer(width: number) {
-  if (width < 640) return 35;
-  if (width < 1024) return 50;
-  return 60;
+  if (width < 640) return 44;
+  if (width < 1024) return 64;
+  return 80;
 }
 
 function taskListWidthForContainer(width: number) {
@@ -3434,17 +3434,26 @@ export function GanttView({
                           return (
                             <div
                               key={end}
-                              // Enlarged transparent hit area; the circle is centred
-                              // inside it. Touches the bar edge (no gap) so the row
-                              // hover stays unbroken when the pointer moves onto it.
-                              className="absolute top-1/2 -translate-y-1/2 z-20 flex items-center justify-center transition-opacity"
+                              // The visible circle sits OUT from the bar end with a
+                              // comfortable gap (dhtmlx-style) so it reads as its own
+                              // affordance, not crammed against the bar. But the
+                              // transparent hit area is wider and BRIDGES back to the
+                              // bar edge: it overlays z-20 above the dependency line's
+                              // hit-stroke (z-10) that can occupy that gap, and it
+                              // keeps the pointer inside the row's subtree the whole
+                              // way out — so crossing the gap never drops the hover and
+                              // the dot can be grabbed anywhere along the bridge.
+                              className="absolute top-1/2 -translate-y-1/2 z-20 flex items-center transition-opacity"
                               style={{
-                                [end === 'start' ? 'left' : 'right']: -18,
-                                height: 20,
-                                width: 20,
+                                [end === 'start' ? 'left' : 'right']: -28,
+                                height: 24,
+                                width: 30,
                                 cursor: 'crosshair',
                                 opacity: visible ? 1 : 0,
                                 pointerEvents: grabbable ? 'auto' : 'none',
+                                justifyContent: end === 'start' ? 'flex-start' : 'flex-end',
+                                paddingLeft: end === 'start' ? 4 : 0,
+                                paddingRight: end === 'end' ? 4 : 0,
                               }}
                               data-testid={`gantt-link-dot-${end}-${task.id}`}
                               onPointerDown={(e) => {

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -522,10 +522,10 @@ export function GanttView({
   React.useEffect(() => {
     if (viewModeProp && VIEW_MODES.includes(viewModeProp)) setViewMode(viewModeProp);
   }, [viewModeProp]);
-  const changeViewMode = React.useCallback((mode: GanttViewMode) => {
-    setViewMode(mode);
-    onViewChange?.(mode);
-  }, [onViewChange]);
+  // Date the user was looking at when they switched granularity, captured so the
+  // post-switch layout effect can re-centre on it (see `changeViewMode` below,
+  // defined after the date↔px mappings it needs).
+  const pendingViewAnchorRef = React.useRef<Date | null>(null);
   const [taskListCollapsed, setTaskListCollapsed] = React.useState<boolean>(
     restoredLayout ? restoredLayout.taskListCollapsed : false
   );
@@ -1483,6 +1483,39 @@ export function GanttView({
     },
     [timeColumns, colStartMs, colRealMs, colOffsets, timelineRange],
   );
+
+  // Switch granularity *without* the date window jumping. The scroll container
+  // keeps a raw pixel scrollLeft across a re-render, but a Day→Month switch
+  // shrinks the timeline ~5×, so that same pixel offset lands on a wildly
+  // different (usually clamped-to-edge) date — which is what users read as
+  // "乱". Instead we record the date sitting at the viewport centre *now* (via
+  // the current xToDate) and re-centre on it once the new layout is measured.
+  const changeViewMode = React.useCallback(
+    (mode: GanttViewMode) => {
+      const el = scrollAreaRef.current;
+      if (el && el.clientWidth > 0) {
+        pendingViewAnchorRef.current = xToDate(el.scrollLeft + el.clientWidth / 2);
+      }
+      setViewMode(mode);
+      onViewChange?.(mode);
+    },
+    [onViewChange, xToDate],
+  );
+  // Re-centre on the captured anchor after the granularity change has produced
+  // a new dateToX mapping and total width. useLayoutEffect runs post-DOM /
+  // pre-paint, so the scroll lands before the user sees the new view — no flash
+  // of the wrong window. The ref is null for any other dateToX change (zoom,
+  // fold toggle, task edits), so those are untouched.
+  React.useLayoutEffect(() => {
+    const anchor = pendingViewAnchorRef.current;
+    if (anchor == null) return;
+    pendingViewAnchorRef.current = null;
+    const el = scrollAreaRef.current;
+    if (!el || el.clientWidth === 0) return;
+    const maxLeft = Math.max(0, el.scrollWidth - el.clientWidth);
+    const target = Math.round(dateToX(anchor)) - el.clientWidth / 2;
+    el.scrollLeft = Math.max(0, Math.min(target, maxLeft));
+  }, [viewMode, dateToX]);
 
   // Shift a date by N visible columns honouring the fold: +1 column from a
   // Friday lands on Monday, skipping the dropped weekend. Used by drag/resize

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3279,6 +3279,14 @@ export function GanttView({
                       className="relative border-b hover:bg-accent/50"
                       style={{ height: rowHeight }}
                       onPointerMove={clearLinkTarget}
+                      // Hover is tracked on the FULL-WIDTH row, not the narrow bar.
+                      // The connector dots float just outside the bar's ends, so a
+                      // bar-scoped hover would drop the moment the cursor crossed the
+                      // bar edge toward a dot — the dot would vanish before it could
+                      // be grabbed. The row spans the whole timeline, so moving from
+                      // bar → dot never leaves the hover zone (dhtmlx-style).
+                      onMouseEnter={() => setHoveredTaskId(task.id)}
+                      onMouseLeave={() => setHoveredTaskId((cur) => (cur === task.id ? null : cur))}
                     >
                       {/* Ghost: original position rendered faded while dragging */}
                       {isDragging && (
@@ -3312,8 +3320,6 @@ export function GanttView({
                         }}
                         data-critical={isCrit ? 'true' : undefined}
                         data-testid={`gantt-task-bar-${task.id}`}
-                        onMouseEnter={() => setHoveredTaskId(task.id)}
-                        onMouseLeave={() => setHoveredTaskId((cur) => (cur === task.id ? null : cur))}
                         onClick={() => {
                           if (suppressNextClickRef.current) return;
                           onTaskClick?.(task);

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -1582,6 +1582,9 @@ export function GanttView({
   // pending timers that toggle it on/off (cleared on re-trigger and unmount).
   const [flashTaskId, setFlashTaskId] = React.useState<string | number | null>(null);
   const flashTimerRef = React.useRef<number[]>([]);
+  // Tears down an in-flight "scroll then flash" wait (scrollend listener + rAF)
+  // when a new locate fires or the view unmounts.
+  const flashCleanupRef = React.useRef<(() => void) | null>(null);
 
   // --- Virtualization ------------------------------------------------------
   // Rows and timeline columns render only what's in (or near) the viewport,
@@ -1728,29 +1731,64 @@ export function GanttView({
       const startX = dateToX(start);
       const endX = dateToX(end);
       const mid = (startX + endX) / 2;
-      el.scrollTo({ left: Math.max(0, mid - el.clientWidth / 2), behavior: 'smooth' });
-      // 闪烁高亮: pulse the located bar so the eye can catch it after the scroll.
-      // Toggle off → on (rAF) restarts the CSS animation when the same row is
-      // clicked repeatedly; auto-clear once the animation has run its course.
-      if (taskId != null) {
-        flashTimerRef.current.forEach((id) => window.clearTimeout(id));
-        flashTimerRef.current = [];
-        setFlashTaskId(null);
-        flashTimerRef.current.push(
-          window.setTimeout(() => setFlashTaskId(taskId), 40),
-        );
-        flashTimerRef.current.push(
-          window.setTimeout(
-            () => setFlashTaskId((cur) => (cur === taskId ? null : cur)),
-            40 + 1400,
-          ),
-        );
+      const maxLeft = Math.max(0, el.scrollWidth - el.clientWidth);
+      const target = Math.max(0, Math.min(mid - el.clientWidth / 2, maxLeft));
+
+      // Tear down any pending flash from a previous click before starting over.
+      flashTimerRef.current.forEach((id) => window.clearTimeout(id));
+      flashTimerRef.current = [];
+      flashCleanupRef.current?.();
+      flashCleanupRef.current = null;
+      setFlashTaskId(null);
+
+      // 闪烁高亮: pulse the bar *after* the scroll lands so the eye catches it
+      // where it settles, not mid-flight. rAF restarts the CSS animation cleanly
+      // even when the same row is located twice; auto-clears when it finishes.
+      const startFlash = () => {
+        if (taskId == null) return;
+        const raf = window.requestAnimationFrame(() => {
+          setFlashTaskId(taskId);
+          flashTimerRef.current.push(
+            window.setTimeout(
+              () => setFlashTaskId((cur) => (cur === taskId ? null : cur)),
+              1400,
+            ),
+          );
+        });
+        flashCleanupRef.current = () => window.cancelAnimationFrame(raf);
+      };
+
+      const needsScroll = Math.abs(el.scrollLeft - target) > 2;
+      el.scrollTo({ left: target, behavior: 'smooth' });
+      if (!needsScroll) {
+        startFlash();
+        return;
       }
+
+      // `scrollend` is the precise "smooth scroll finished" signal and drives
+      // the flash where supported; the timeout only backstops it. When the
+      // browser fires `scrollend` we give it a long leash (a wide chart can
+      // take ~1s to traverse) so the event — not the clock — wins; without it
+      // (older Safari) we fall back to a short, fixed delay.
+      const hasScrollEnd = 'onscrollend' in el;
+      let fired = false;
+      const onEnd = () => {
+        if (fired) return;
+        fired = true;
+        el.removeEventListener('scrollend', onEnd);
+        startFlash();
+      };
+      el.addEventListener('scrollend', onEnd);
+      flashTimerRef.current.push(window.setTimeout(onEnd, hasScrollEnd ? 1500 : 500));
+      flashCleanupRef.current = () => el.removeEventListener('scrollend', onEnd);
     },
     [dateToX],
   );
   React.useEffect(
-    () => () => flashTimerRef.current.forEach((id) => window.clearTimeout(id)),
+    () => () => {
+      flashTimerRef.current.forEach((id) => window.clearTimeout(id));
+      flashCleanupRef.current?.();
+    },
     [],
   );
   const jumpToWeek = React.useCallback(
@@ -2509,7 +2547,7 @@ export function GanttView({
               <div
                 key={task.id}
                 className={cn(
-                  "group/task-row flex items-center border-b px-2 sm:px-4 hover:bg-accent/50 cursor-pointer transition-colors",
+                  "group/task-row relative flex items-center border-b px-2 sm:px-4 hover:bg-accent/50 cursor-pointer transition-colors",
                   isSelected && "bg-accent/50"
                 )}
                 style={{ height: rowHeight, touchAction: 'manipulation' }}
@@ -2637,24 +2675,27 @@ export function GanttView({
                       onClick={(e) => e.stopPropagation()}
                     />
                   ) : (
-                    <span className="inline-flex items-center justify-end gap-1">
-                      {row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })}
-                      {/* 定位到甘特图: scroll the timeline to center this row's bar. */}
-                      <button
-                        type="button"
-                        title={t('gantt.row.locate')}
-                        aria-label={t('gantt.row.locate')}
-                        className="gantt-locate-btn shrink-0"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          scrollToTask(row.start, row.end, row.task.id);
-                        }}
-                      >
-                        <Crosshair className="w-3 h-3" />
-                      </button>
-                    </span>
+                    row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })
                   )}
                 </div>
+                {/* 定位到甘特图: scroll the timeline to center this row's bar.
+                    Pinned to the row's right edge (flush with the chart divider)
+                    so it sits in a stable slot and never shifts the date column
+                    on hover. */}
+                {!isEditing && (
+                  <button
+                    type="button"
+                    title={t('gantt.row.locate')}
+                    aria-label={t('gantt.row.locate')}
+                    className="gantt-locate-btn hidden sm:block absolute right-1 top-1/2 -translate-y-1/2"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      scrollToTask(row.start, row.end, row.task.id);
+                    }}
+                  >
+                    <Crosshair className="w-3 h-3" />
+                  </button>
+                )}
                 {/* Row actions removed: View / Edit / Delete are reachable
                     from the side drawer that opens on row click (DetailView
                     has inline-edit + a delete in its more-actions menu).

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -1728,11 +1728,22 @@ export function GanttView({
     (start: Date, end: Date, taskId?: string | number) => {
       const el = scrollAreaRef.current;
       if (!el) return;
+      // Align to the bar's *start* (not its midpoint): a long bar centered on
+      // its middle pushes its beginning off the left edge, so the start — the
+      // part the user is looking for — is what we bring into view, with a small
+      // margin so it isn't jammed against the panel divider. When the whole bar
+      // fits this also shows it in full.
       const startX = dateToX(start);
       const endX = dateToX(end);
-      const mid = (startX + endX) / 2;
       const maxLeft = Math.max(0, el.scrollWidth - el.clientWidth);
-      const target = Math.max(0, Math.min(mid - el.clientWidth / 2, maxLeft));
+      const leftMargin = Math.min(96, el.clientWidth * 0.15);
+      // For a bar that already fits, prefer centering it; otherwise pin the
+      // start near the left so its beginning is always visible.
+      const fits = endX - startX <= el.clientWidth - leftMargin;
+      const desired = fits
+        ? (startX + endX) / 2 - el.clientWidth / 2
+        : startX - leftMargin;
+      const target = Math.max(0, Math.min(desired, maxLeft));
 
       // Tear down any pending flash from a previous click before starting over.
       flashTimerRef.current.forEach((id) => window.clearTimeout(id));
@@ -2678,16 +2689,18 @@ export function GanttView({
                     row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })
                   )}
                 </div>
-                {/* 定位到甘特图: scroll the timeline to center this row's bar.
-                    Pinned to the row's right edge (flush with the chart divider)
-                    so it sits in a stable slot and never shifts the date column
-                    on hover. */}
+                {/* 定位到甘特图: scroll the timeline to this row's bar. Pinned to
+                    the row's right edge (flush with the chart divider) so it sits
+                    in a stable slot and never shifts the date column on hover. The
+                    `right` offset is inline because Tailwind's fractional `right-*`
+                    utilities aren't in the prebuilt CSS shipped to consumers. */}
                 {!isEditing && (
                   <button
                     type="button"
                     title={t('gantt.row.locate')}
                     aria-label={t('gantt.row.locate')}
-                    className="gantt-locate-btn hidden sm:block absolute right-1 top-1/2 -translate-y-1/2"
+                    className="gantt-locate-btn hidden sm:block absolute top-1/2 -translate-y-1/2"
+                    style={{ right: 1 }}
                     onClick={(e) => {
                       e.stopPropagation();
                       scrollToTask(row.start, row.end, row.task.id);

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -110,6 +110,15 @@ export interface GanttTask {
    */
   type?: GanttTaskType
   /**
+   * Per-node lock (仅查看/跳转). When true this row is view-only: its bar can't be
+   * dragged/resized, progress can't be dragged, no dependency can be drawn from
+   * it, and inline-edit / context-menu edit+delete are hidden. Clicking the bar
+   * (onTaskClick — open drawer / jump) still works. Independent of the global
+   * `readOnly`; use to lock individual levels (e.g. 派工单) while others stay
+   * editable. Maps from the view's `lockField` in ObjectGantt.
+   */
+  locked?: boolean
+  /**
    * Baseline (planned) start/end. When both are present a thin reference bar is
    * drawn beneath the live bar so planned-vs-actual drift is visible at a glance.
    */
@@ -288,6 +297,17 @@ export interface GanttViewProps {
   /** Label for the bucket collecting tasks whose `groupBy` returns null. */
   ungroupedLabel?: string
   /**
+   * Auto-collapse tree nodes at or below this depth on first render (默认折叠).
+   * Depth is 0-indexed: roots are 0, their children 1, etc. Every node whose
+   * depth is `>= defaultCollapsedDepth` AND which has children is seeded into the
+   * collapsed set once, so its subtree starts hidden. The user can still expand
+   * any of them — this only sets the initial state. Example: a 项目→产品→排产计划→派工单
+   * tree where 排产计划 sits at depth 2 uses `defaultCollapsedDepth={2}` to start
+   * with every 排产计划 (and its 派工单 children) folded. Omit (or pass a depth past
+   * the deepest node) to start fully expanded.
+   */
+  defaultCollapsedDepth?: number
+  /**
    * Persist the user's layout tweaks (granularity + column/task-list widths)
    * to `localStorage` under this key. On mount the saved layout is restored;
    * the "保存布局" toolbar button writes the current layout. Omit to disable
@@ -448,6 +468,7 @@ export function GanttView({
   mobileReadOnly = false,
   groupBy,
   ungroupedLabel = 'Ungrouped',
+  defaultCollapsedDepth,
   persistLayoutKey,
   onLayoutChange,
 }: GanttViewProps) {
@@ -1107,6 +1128,40 @@ export function GanttView({
       return next;
     });
   }, []);
+  // Seed the collapsed set once from `defaultCollapsedDepth` (默认折叠). We walk
+  // the parent chain to derive each node's 0-indexed depth and fold every node
+  // at/below the threshold that actually has children. Runs a single time so the
+  // user's later expand/collapse is never clobbered by a data refresh.
+  const defaultCollapseSeeded = React.useRef(false);
+  React.useEffect(() => {
+    if (defaultCollapseSeeded.current) return;
+    if (defaultCollapsedDepth == null || displayTasks.length === 0) return;
+    defaultCollapseSeeded.current = true;
+    const byId = new Map(displayTasks.map((t) => [String(t.id), t]));
+    const hasChildren = new Set<string>();
+    for (const t of displayTasks) {
+      const p = t.parent != null && t.parent !== '' ? String(t.parent) : null;
+      if (p && p !== String(t.id) && byId.has(p)) hasChildren.add(p);
+    }
+    // Depth via parent walk, cycle-guarded.
+    const depthOf = (t: GanttTask): number => {
+      let depth = 0;
+      const seen = new Set<string>([String(t.id)]);
+      let cur = t.parent != null && t.parent !== '' ? byId.get(String(t.parent)) : undefined;
+      while (cur && !seen.has(String(cur.id))) {
+        depth += 1;
+        seen.add(String(cur.id));
+        cur = cur.parent != null && cur.parent !== '' ? byId.get(String(cur.parent)) : undefined;
+      }
+      return depth;
+    };
+    const seed = new Set<string>();
+    for (const t of displayTasks) {
+      const key = String(t.id);
+      if (hasChildren.has(key) && depthOf(t) >= defaultCollapsedDepth) seed.add(key);
+    }
+    if (seed.size) setCollapsedIds((prev) => (prev.size ? prev : seed));
+  }, [defaultCollapsedDepth, displayTasks]);
 
   const rows = React.useMemo<GanttRow[]>(() => {
     const ids = new Set(displayTasks.map((t) => String(t.id)));
@@ -2462,7 +2517,7 @@ export function GanttView({
                 aria-level={row.depth + 1}
                 aria-selected={isSelected}
                 aria-expanded={row.hasChildren ? !isCollapsed : undefined}
-                draggable={!!onTaskReorder && !isEditing}
+                draggable={!!onTaskReorder && !isEditing && !task.locked}
                 onDragStart={onTaskReorder ? (e) => {
                   e.dataTransfer.setData('text/plain', String(task.id));
                   e.dataTransfer.effectAllowed = 'move';
@@ -2490,7 +2545,7 @@ export function GanttView({
                   if (!isEditing) onTaskClick?.(task);
                 }}
                 onDoubleClick={() => {
-                  if (inlineEdit && onTaskUpdate && !row.isSummary) {
+                  if (inlineEdit && onTaskUpdate && !row.isSummary && !task.locked) {
                     setEditingTask(task.id);
                     setEditValues({
                       title: task.title,
@@ -2711,7 +2766,10 @@ export function GanttView({
                    const inDragGroup = dragGroupIds?.has(String(task.id)) ?? false;
                    const inDragStretch = dragStretchAncestorIds?.has(String(task.id)) ?? false;
                    const liveStyle = isDragging || inDragGroup || inDragStretch ? getLiveRowStyle(row) : baseStyle;
-                   const canDrag = !!onTaskUpdate && !row.isSummary;
+                   // Per-node lock (仅查看): treat like read-only for this row —
+                   // no move/resize/progress/link, but onTaskClick still fires.
+                   const isLocked = !!task.locked;
+                   const canDrag = !!onTaskUpdate && !row.isSummary && !isLocked;
                    const isLinkTarget =
                      linkDrag != null &&
                      linkDrag.targetId != null &&
@@ -3028,7 +3086,7 @@ export function GanttView({
                         )}
 
                         {/* Connector dot — drag onto another bar to create a dependency */}
-                        {onDependencyCreate && (
+                        {onDependencyCreate && !isLocked && (
                           <div
                             className={cn(
                               "absolute top-1/2 -translate-y-1/2 h-3 w-3 rounded-full bg-background z-10",
@@ -3222,7 +3280,7 @@ export function GanttView({
                 {t('gantt.menu.view')}
               </button>
             )}
-            {inlineEdit && onTaskUpdate && row && !row.isSummary && (
+            {inlineEdit && onTaskUpdate && row && !row.isSummary && !task.locked && (
               <button
                 type="button"
                 role="menuitem"
@@ -3242,7 +3300,7 @@ export function GanttView({
                 {t('gantt.menu.edit')}
               </button>
             )}
-            {onDependencyCreate && row && !row.isMilestone && (
+            {onDependencyCreate && row && !row.isMilestone && !task.locked && (
               <>
                 <button
                   type="button"
@@ -3272,7 +3330,7 @@ export function GanttView({
                 </button>
               </>
             )}
-            {onTaskDelete && (
+            {onTaskDelete && !task.locked && (
               <button
                 type="button"
                 role="menuitem"

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -327,6 +327,8 @@ export interface GanttLayout {
   /** Effective day-column width in px, or null when auto-fit. */
   columnWidth: number | null
   taskListCollapsed: boolean
+  /** User-dragged task-list (name column) width in px, or null when auto-sized. */
+  taskListWidth?: number | null
 }
 
 // --- Export helpers (导出 PNG / PDF) — module-level, no React deps. ---
@@ -427,7 +429,9 @@ function readSavedLayout(key: string | undefined): GanttLayout | null {
     if (!viewMode) return null;
     const columnWidth =
       typeof p.columnWidth === 'number' && isFinite(p.columnWidth) ? p.columnWidth : null;
-    return { viewMode, columnWidth, taskListCollapsed: !!p.taskListCollapsed };
+    const taskListWidth =
+      typeof p.taskListWidth === 'number' && isFinite(p.taskListWidth) ? p.taskListWidth : null;
+    return { viewMode, columnWidth, taskListCollapsed: !!p.taskListCollapsed, taskListWidth };
   } catch {
     return null;
   }
@@ -511,6 +515,10 @@ export function GanttView({
   const [columnWidthOverride, setColumnWidthOverride] = React.useState<number | null>(
     restoredLayout ? restoredLayout.columnWidth : null
   );
+  // User-dragged task-list (name column) width. null → auto-size from container.
+  const [taskListWidthOverride, setTaskListWidthOverride] = React.useState<number | null>(
+    restoredLayout ? restoredLayout.taskListWidth ?? null : null
+  );
   // Timeline granularity. The prop seeds (and can later override) the state;
   // the toolbar segmented control switches it interactively. A persisted layout
   // seeds it when no explicit prop is given.
@@ -558,7 +566,15 @@ export function GanttView({
       collapsedAutoSet.current = true;
     }
   }, [isNarrow]);
-  const taskListWidth = taskListCollapsed ? 0 : taskListWidthForContainer(effectiveWidth);
+  // Task-list pane width. A user drag (taskListWidthOverride) wins over the
+  // auto-size, clamped so it can't collapse to nothing or swallow the timeline.
+  const TASK_LIST_MIN_W = 160;
+  const taskListMaxW = Math.max(TASK_LIST_MIN_W, effectiveWidth - 200);
+  const taskListWidth = taskListCollapsed
+    ? 0
+    : taskListWidthOverride != null
+      ? Math.max(TASK_LIST_MIN_W, Math.min(taskListWidthOverride, taskListMaxW))
+      : taskListWidthForContainer(effectiveWidth);
   // Fit-to-width ("zoom to fit"): in coarse modes a short project's natural grid
   // (span × base px/day) is far narrower than the timeline area, leaving the
   // right side blank. Rather than pad the calendar with years of empty units, we
@@ -2340,11 +2356,12 @@ export function GanttView({
       viewMode,
       columnWidth: columnWidthOverride,
       taskListCollapsed,
+      taskListWidth: taskListWidthOverride,
     };
     if (persistLayoutKey) writeSavedLayout(persistLayoutKey, layout);
     onLayoutChange?.(layout);
     setLayoutSaved(true);
-  }, [viewMode, columnWidthOverride, taskListCollapsed, persistLayoutKey, onLayoutChange]);
+  }, [viewMode, columnWidthOverride, taskListCollapsed, taskListWidthOverride, persistLayoutKey, onLayoutChange]);
   // Briefly reflect a save in the button's aria-pressed for feedback/testability.
   React.useEffect(() => {
     if (!layoutSaved) return;
@@ -2673,11 +2690,48 @@ export function GanttView({
 
       {/* Gantt Body — focusable for keyboard row navigation */}
       <div
-        className="flex flex-col flex-1 overflow-hidden outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="relative flex flex-col flex-1 overflow-hidden outline-none focus-visible:ring-1 focus-visible:ring-ring"
         tabIndex={0}
         onKeyDown={handleKeyDown}
         data-testid="gantt-body"
       >
+        {/* Task-list resize splitter — drag the divider between the name grid
+            and the timeline to widen/narrow the name column. Spans both the
+            header and content rows. Hidden while the list is collapsed. */}
+        {!taskListCollapsed && taskListWidth > 0 && (
+          <div
+            className="absolute top-0 bottom-0 z-30 group/splitter"
+            style={{ left: taskListWidth - 3, width: 7, cursor: 'col-resize' }}
+            data-testid="gantt-list-resize"
+            role="separator"
+            aria-orientation="vertical"
+            onPointerDown={(e) => {
+              if (e.button !== 0) return;
+              e.preventDefault();
+              const startX = e.clientX;
+              const startW = taskListWidth;
+              const maxW = Math.max(TASK_LIST_MIN_W, effectiveWidth - 200);
+              const onMove = (ev: PointerEvent) => {
+                const next = Math.max(TASK_LIST_MIN_W, Math.min(startW + (ev.clientX - startX), maxW));
+                setTaskListWidthOverride(next);
+              };
+              const onUp = () => {
+                window.removeEventListener('pointermove', onMove);
+                window.removeEventListener('pointerup', onUp);
+                window.removeEventListener('pointercancel', onUp);
+                document.body.style.cursor = '';
+              };
+              document.body.style.cursor = 'col-resize';
+              window.addEventListener('pointermove', onMove);
+              window.addEventListener('pointerup', onUp);
+              window.addEventListener('pointercancel', onUp);
+            }}
+            onDoubleClick={() => setTaskListWidthOverride(null)}
+          >
+            {/* Visible hairline that thickens on hover/drag for an easy grab. */}
+            <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-px bg-border group-hover/splitter:w-[3px] group-hover/splitter:bg-primary transition-all" />
+          </div>
+        )}
         {/* Headers Row */}
         <div className="flex border-b bg-muted/30 shrink-0 h-10 gantt-sm-h50">
           {/* List Header */}

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -986,9 +986,11 @@ export function GanttView({
   const contentRef = React.useRef<HTMLDivElement>(null);
   const [linkDrag, setLinkDrag] = React.useState<{
     sourceId: string | number;
+    sourceEnd: 'start' | 'end';
     x: number;
     y: number;
     targetId: string | number | null;
+    targetEnd: 'start' | 'end' | null;
   } | null>(null);
   const linkDragRef = React.useRef<typeof linkDrag>(null);
   React.useEffect(() => { linkDragRef.current = linkDrag; }, [linkDrag]);
@@ -1007,7 +1009,13 @@ export function GanttView({
       if (cur && cur.targetId != null && String(cur.targetId) !== String(cur.sourceId) && onDependencyCreate) {
         const source = tasks.find((t) => String(t.id) === String(cur.sourceId));
         const target = tasks.find((t) => String(t.id) === String(cur.targetId));
-        if (source && target) onDependencyCreate(source, target, 'fs');
+        // Derive the link type from which endpoint we dragged FROM and which
+        // endpoint we dropped ONTO (dhtmlx-style): the source endpoint picks
+        // Finish (end) vs Start (start), the target endpoint picks the second
+        // letter. end→start = FS, end→end = FF, start→start = SS, start→end = SF.
+        const targetEnd = cur.targetEnd ?? 'start';
+        const type: GanttLinkType = `${cur.sourceEnd === 'end' ? 'f' : 's'}${targetEnd === 'end' ? 'f' : 's'}` as GanttLinkType;
+        if (source && target) onDependencyCreate(source, target, type);
       }
       suppressNextClickRef.current = true;
       window.setTimeout(() => { suppressNextClickRef.current = false; }, 0);
@@ -3021,16 +3029,23 @@ export function GanttView({
                    // While a connector drag is live, bars report themselves as
                    // the drop target on pointermove; the row clears it when the
                    // pointer is over empty row space (target === currentTarget).
-                   const captureLinkTarget = linkDrag ? () => {
+                   const captureLinkTarget = linkDrag ? (e: React.PointerEvent) => {
+                     // Which half of the target bar is the pointer over? The left
+                     // half snaps to the Start endpoint, the right half to Finish.
+                     // This is what makes the dropped-onto endpoint pick FS vs FF
+                     // (or SS vs SF) — the second letter of the link type.
+                     const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                     const half: 'start' | 'end' =
+                       r.width > 0 && e.clientX - r.left > r.width / 2 ? 'end' : 'start';
                      setLinkDrag((prev) =>
                        prev && String(prev.sourceId) !== String(task.id)
-                         ? { ...prev, targetId: task.id }
+                         ? { ...prev, targetId: task.id, targetEnd: half }
                          : prev
                      );
                    } : undefined;
                    const clearLinkTarget = linkDrag ? (e: React.PointerEvent) => {
                      if (e.target === e.currentTarget) {
-                       setLinkDrag((prev) => (prev ? { ...prev, targetId: null } : prev));
+                       setLinkDrag((prev) => (prev ? { ...prev, targetId: null, targetEnd: null } : prev));
                      }
                    } : undefined;
                    const durationDays = Math.max(1, Math.round(
@@ -3328,17 +3343,21 @@ export function GanttView({
                           </div>
                         )}
 
-                        {/* Connector dot — drag onto another bar to create a dependency */}
-                        {onDependencyCreate && !isLocked && (
+                        {/* Connector dots — one at each end of the bar. Drag from
+                            the Start dot or the Finish dot onto another bar to
+                            create a dependency; the endpoint you drag FROM picks
+                            the first letter of the link type (Finish vs Start). */}
+                        {onDependencyCreate && !isLocked && (['start', 'end'] as const).map((end) => (
                           <div
+                            key={end}
                             className={cn(
                               "absolute top-1/2 -translate-y-1/2 h-3 w-3 rounded-full bg-background z-10",
-                              linkDrag && String(linkDrag.sourceId) === String(task.id)
+                              linkDrag && String(linkDrag.sourceId) === String(task.id) && linkDrag.sourceEnd === end
                                 ? "opacity-100"
                                 : "opacity-0 group-hover:opacity-100 transition-opacity"
                             )}
-                            style={{ right: -8, cursor: 'crosshair', border: '2px solid hsl(var(--primary))' }}
-                            data-testid={`gantt-link-dot-${task.id}`}
+                            style={{ [end === 'start' ? 'left' : 'right']: -8, cursor: 'crosshair', border: '2px solid hsl(var(--primary))' }}
+                            data-testid={`gantt-link-dot-${end}-${task.id}`}
                             onPointerDown={(e) => {
                               if (e.button !== 0) return;
                               e.stopPropagation();
@@ -3346,14 +3365,16 @@ export function GanttView({
                               const rect = contentRef.current?.getBoundingClientRect();
                               setLinkDrag({
                                 sourceId: task.id,
+                                sourceEnd: end,
                                 x: rect ? e.clientX - rect.left : 0,
                                 y: rect ? e.clientY - rect.top : 0,
                                 targetId: null,
+                                targetEnd: null,
                               });
                             }}
                             onClick={(e) => e.stopPropagation()}
                           />
-                        )}
+                        ))}
 
                         {/* Bar label — the task title, shown like summary bars so
                             leaf bars aren't blank. Fades out on hover to reveal the
@@ -3483,7 +3504,12 @@ export function GanttView({
                       const si = rows.findIndex((r) => String(r.task.id) === String(linkDrag.sourceId));
                       if (si < 0) return null;
                       const s = getLiveRowStyle(rows[si]);
-                      const sx = rows[si].isMilestone ? s.left + milestoneHalfTip : s.left + s.width;
+                      // Anchor the rubber band at the endpoint we dragged FROM:
+                      // the Start dot draws from the bar's left edge, the Finish
+                      // dot from its right edge (milestones collapse to the tip).
+                      const sx = rows[si].isMilestone
+                        ? s.left + (linkDrag.sourceEnd === 'start' ? -milestoneHalfTip : milestoneHalfTip)
+                        : linkDrag.sourceEnd === 'start' ? s.left : s.left + s.width;
                       const sy = si * rowHeight + rowHeight / 2;
                       return (
                         <path
@@ -3498,6 +3524,28 @@ export function GanttView({
                     })()}
                   </svg>
                 )}
+                {/* Drag hint — names the source/target endpoints so the user can
+                    see which link type (FS/FF/SS/SF) the drop will create. */}
+                {linkDrag && (() => {
+                  const source = tasks.find((tk) => String(tk.id) === String(linkDrag.sourceId));
+                  if (!source) return null;
+                  const target = linkDrag.targetId != null
+                    ? tasks.find((tk) => String(tk.id) === String(linkDrag.targetId))
+                    : null;
+                  const endLabel = (e: 'start' | 'end') => t(`gantt.linkEnd.${e}`);
+                  const label = target
+                    ? `${source.title} (${endLabel(linkDrag.sourceEnd)}) → ${target.title} (${endLabel(linkDrag.targetEnd ?? 'start')})`
+                    : `${source.title} (${endLabel(linkDrag.sourceEnd)})`;
+                  return (
+                    <div
+                      className="absolute z-30 pointer-events-none rounded-md border bg-popover text-popover-foreground px-2 py-1 text-[11px] font-medium shadow-md whitespace-nowrap"
+                      style={{ left: linkDrag.x + 12, top: linkDrag.y + 12 }}
+                      data-testid="gantt-link-draft-hint"
+                    >
+                      {label}
+                    </div>
+                  );
+                })()}
 
               </div>
             </div>

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -1762,7 +1762,7 @@ export function GanttView({
           flashTimerRef.current.push(
             window.setTimeout(
               () => setFlashTaskId((cur) => (cur === taskId ? null : cur)),
-              1400,
+              1500, // matches the gantt-flash animation duration
             ),
           );
         });
@@ -2226,18 +2226,25 @@ export function GanttView({
         .gantt-locate-btn { opacity: 0; transition: opacity 0.15s ease; }
         .group\\/task-row:hover .gantt-locate-btn { opacity: 0.6; }
         .gantt-locate-btn:hover, .gantt-locate-btn:focus-visible { opacity: 1; }
-        /* 定位闪烁: pulse the located bar with a ring. Outline (not box-shadow)
-           so it never clashes with the critical-path bar's inline box-shadow. */
+        /* 定位闪烁: blink the located bar 3× with a thick ring + colored glow so
+           it's hard to miss. The ring is an outline (not box-shadow) and the glow
+           is a drop-shadow *filter* — both stay clear of the critical-path bar's
+           inline box-shadow, which they'd otherwise clobber. */
         @keyframes gantt-flash {
-          0%, 100% { outline-color: rgba(59, 130, 246, 0); }
-          20% { outline-color: rgba(59, 130, 246, 0.95); }
-          45% { outline-color: rgba(59, 130, 246, 0.25); }
-          70% { outline-color: rgba(59, 130, 246, 0.95); }
+          0%, 25%, 50%, 100% {
+            outline-color: rgba(37, 99, 235, 0);
+            filter: drop-shadow(0 0 0 rgba(37, 99, 235, 0));
+          }
+          12%, 37%, 62% {
+            outline-color: rgba(37, 99, 235, 1);
+            filter: drop-shadow(0 0 9px rgba(37, 99, 235, 0.9));
+          }
         }
         .gantt-flash {
-          outline: 2px solid transparent;
-          outline-offset: 2px;
-          animation: gantt-flash 1.4s ease-in-out;
+          outline: 3px solid transparent;
+          outline-offset: 3px;
+          border-radius: 2px;
+          animation: gantt-flash 1.5s ease-in-out;
         }
         @media (min-width: 640px) {
           .gantt-sm-h50 { height: 50px; }

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -522,10 +522,31 @@ export function GanttView({
   React.useEffect(() => {
     if (viewModeProp && VIEW_MODES.includes(viewModeProp)) setViewMode(viewModeProp);
   }, [viewModeProp]);
-  // Date the user was looking at when they switched granularity, captured so the
-  // post-switch layout effect can re-centre on it (see `changeViewMode` below,
-  // defined after the date↔px mappings it needs).
+  // Date sitting at the viewport's left edge when the user switched granularity,
+  // captured so the post-switch layout effect can re-pin it to the left edge
+  // (see `changeViewMode` below, defined after the date↔px mappings it needs).
   const pendingViewAnchorRef = React.useRef<Date | null>(null);
+  // The date the user actually wants pinned to the left edge, kept at full
+  // precision and updated ONLY by genuine user scrolling — never re-derived from
+  // a programmatic (and possibly clamped) scrollLeft. This is what survives a
+  // multi-step granularity change: switching to a coarser scale whose *entire*
+  // timeline fits the viewport clamps scrollLeft to 0, which would otherwise
+  // poison the next switch by capturing "0 → timeline start" as the new anchor.
+  // Holding the precise intent here means Day(Apr 9)→Week→Month→Day returns to
+  // Apr 9, not the timeline's left edge.
+  const viewAnchorDateRef = React.useRef<Date | null>(null);
+  // Gate that blocks scroll events from updating viewAnchorDateRef until the
+  // next *genuine* user-input scroll (wheel / touch / keyboard / scrollbar drag).
+  // A granularity change arms this. It's needed because switching into a
+  // narrower view makes the browser auto-clamp scrollLeft (e.g. 720 → 53) and
+  // fire a scroll event we never initiated — a one-shot "suppress the next
+  // event" flag can't catch that (the clamp may fire zero, one, or several
+  // events), and it would overwrite the precise anchor with the clamped
+  // position (→ Dec 17 → Day clamps to the timeline start). User-input
+  // listeners on the scroll container clear this gate, so only real scrolling
+  // re-captures the anchor. Starts armed so the mount scroll-to-today doesn't
+  // seed a bogus anchor before the user has touched anything.
+  const blockAnchorUntilUserScrollRef = React.useRef(true);
   const [taskListCollapsed, setTaskListCollapsed] = React.useState<boolean>(
     restoredLayout ? restoredLayout.taskListCollapsed : false
   );
@@ -1488,24 +1509,35 @@ export function GanttView({
   // keeps a raw pixel scrollLeft across a re-render, but a Day→Month switch
   // shrinks the timeline ~5×, so that same pixel offset lands on a wildly
   // different (usually clamped-to-edge) date — which is what users read as
-  // "乱". Instead we record the date sitting at the viewport centre *now* (via
-  // the current xToDate) and re-centre on it once the new layout is measured.
+  // "乱". Instead we record the date sitting at the *left edge* of the viewport
+  // now (via the current xToDate) and pin that same date back to the left edge
+  // once the new layout is measured — so the leftmost visible date never moves.
   const changeViewMode = React.useCallback(
     (mode: GanttViewMode) => {
       const el = scrollAreaRef.current;
-      if (el && el.clientWidth > 0) {
-        pendingViewAnchorRef.current = xToDate(el.scrollLeft + el.clientWidth / 2);
+      // Seed the persistent anchor from the current left edge the first time (or
+      // if a programmatic scroll left it unset); afterwards user scrolls keep it
+      // fresh. Crucially we re-pin THIS precise date, not a freshly-read (and
+      // possibly clamped) scrollLeft — so a coarser intermediate view that can't
+      // scroll to it doesn't corrupt the anchor for the next switch.
+      if (viewAnchorDateRef.current == null && el && el.clientWidth > 0) {
+        viewAnchorDateRef.current = xToDate(el.scrollLeft);
       }
+      pendingViewAnchorRef.current = viewAnchorDateRef.current;
+      // Freeze the anchor across the switch: ignore the programmatic re-pin AND
+      // any browser auto-clamp scroll the narrower layout triggers, until the
+      // user genuinely scrolls again.
+      blockAnchorUntilUserScrollRef.current = true;
       setViewMode(mode);
       onViewChange?.(mode);
     },
     [onViewChange, xToDate],
   );
-  // Re-centre on the captured anchor after the granularity change has produced
-  // a new dateToX mapping and total width. useLayoutEffect runs post-DOM /
-  // pre-paint, so the scroll lands before the user sees the new view — no flash
-  // of the wrong window. The ref is null for any other dateToX change (zoom,
-  // fold toggle, task edits), so those are untouched.
+  // Re-pin the captured anchor to the left edge after the granularity change has
+  // produced a new dateToX mapping and total width. useLayoutEffect runs
+  // post-DOM / pre-paint, so the scroll lands before the user sees the new view
+  // — no flash of the wrong window. The ref is null for any other dateToX change
+  // (zoom, fold toggle, task edits), so those are untouched.
   React.useLayoutEffect(() => {
     const anchor = pendingViewAnchorRef.current;
     if (anchor == null) return;
@@ -1513,8 +1545,19 @@ export function GanttView({
     const el = scrollAreaRef.current;
     if (!el || el.clientWidth === 0) return;
     const maxLeft = Math.max(0, el.scrollWidth - el.clientWidth);
-    const target = Math.round(dateToX(anchor)) - el.clientWidth / 2;
-    el.scrollLeft = Math.max(0, Math.min(target, maxLeft));
+    // Snap the left edge to the start of the period the anchor falls in (the
+    // week/month/quarter/year that contains it), so the leftmost column is a
+    // full, aligned cell instead of a partial slice with a mismatched header
+    // (e.g. Apr 9 in Week view would otherwise leave a stub of the Apr 6 week
+    // showing, labelled by the *next* full week). The precise anchor is still
+    // held in viewAnchorDateRef, so a later switch back to a finer scale lands
+    // on the exact day — snapping only affects what coarser views display.
+    const target = Math.max(0, Math.min(Math.round(dateToX(startOfUnit(anchor, viewMode))), maxLeft));
+    // The gate (armed in changeViewMode) already keeps this programmatic move —
+    // and any browser auto-clamp it triggers — from re-capturing the anchor.
+    if (el.scrollLeft !== target) {
+      el.scrollLeft = target;
+    }
   }, [viewMode, dateToX]);
 
   // Shift a date by N visible columns honouring the fold: +1 column from a
@@ -1609,6 +1652,37 @@ export function GanttView({
   // Wrapper around the scroll-syncing timeline body, so the pinch handler
   // and the "Today" button can target a stable node.
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
+
+  // Clear the anchor gate on genuine user-input scrolling. A scroll *event*
+  // alone can't tell a user wheel from a browser auto-clamp, so we key off the
+  // input events that precede a real scroll: wheel, touch, scrollbar drag
+  // (pointerdown), and keyboard (arrows/page/space/home/end). Once cleared,
+  // handleScroll resumes tracking the left-edge date as the anchor — until the
+  // next granularity switch re-arms the gate.
+  React.useEffect(() => {
+    const el = scrollAreaRef.current;
+    if (!el) return;
+    const unblock = () => {
+      blockAnchorUntilUserScrollRef.current = false;
+    };
+    const SCROLL_KEYS = new Set([
+      'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+      'PageUp', 'PageDown', 'Home', 'End', ' ', 'Spacebar',
+    ]);
+    const onKey = (ev: KeyboardEvent) => {
+      if (SCROLL_KEYS.has(ev.key)) unblock();
+    };
+    el.addEventListener('wheel', unblock, { passive: true });
+    el.addEventListener('touchstart', unblock, { passive: true });
+    el.addEventListener('pointerdown', unblock, { passive: true });
+    el.addEventListener('keydown', onKey);
+    return () => {
+      el.removeEventListener('wheel', unblock);
+      el.removeEventListener('touchstart', unblock);
+      el.removeEventListener('pointerdown', unblock);
+      el.removeEventListener('keydown', onKey);
+    };
+  }, []);
 
   // 定位闪烁: id of the bar currently pulsing after a "locate" click, plus the
   // pending timers that toggle it on/off (cleared on re-trigger and unmount).
@@ -1845,6 +1919,14 @@ export function GanttView({
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const el = e.currentTarget;
+    // Track the left-edge date as the user's anchor intent — but only for
+    // genuine user scrolling. The gate stays armed through a granularity switch
+    // (programmatic re-pin + browser auto-clamp of the narrower layout) and is
+    // cleared only by real user input, so those synthetic scrolls can't
+    // overwrite the precise date we're preserving.
+    if (!blockAnchorUntilUserScrollRef.current && el.clientWidth > 0) {
+      viewAnchorDateRef.current = xToDate(el.scrollLeft);
+    }
     // Sync horizontal scroll to header
     if (headerRef.current) {
         headerRef.current.scrollLeft = el.scrollLeft;
@@ -2303,6 +2385,53 @@ export function GanttView({
           .gantt-sm-w20 { width: 80px; }
           .gantt-sm-hidden { display: none; }
         }
+        /* Persistent, grabbable timeline scrollbars. macOS (and iOS) default to
+           overlay scrollbars that collapse to 0px and auto-hide, so the
+           timeline's vertical scrollbar was nearly impossible to find. Defining
+           ::-webkit-scrollbar opts this pane into a classic, always-visible bar
+           regardless of the OS overlay preference. The thumb gets a min size so
+           that with thousands of virtualized rows (scrollHeight in the hundreds
+           of thousands of px) it never shrinks to an un-grabbable sliver. Scoped
+           to the gantt pane so the host app's own scrollbars are untouched, and
+           themed with neutral rgba (not theme utilities, which don't always
+           reach a consuming app) so it's visible on any background. */
+        /* Firefox (and any engine without ::-webkit-scrollbar) only: the
+           standard props. We must NOT set these unconditionally — modern Chrome
+           now honors scrollbar-width and, when it's present, IGNORES the
+           ::-webkit-scrollbar rule below, falling back to the 0px auto-hiding
+           overlay bar we're trying to replace. */
+        @supports not selector(::-webkit-scrollbar) {
+          [data-testid="gantt-timeline"] {
+            scrollbar-width: thin;
+            scrollbar-color: rgba(130,130,130,0.55) transparent;
+          }
+        }
+        [data-testid="gantt-timeline"]::-webkit-scrollbar {
+          width: 14px;
+          height: 14px;
+        }
+        [data-testid="gantt-timeline"]::-webkit-scrollbar-track {
+          background: transparent;
+        }
+        [data-testid="gantt-timeline"]::-webkit-scrollbar-thumb {
+          background-color: rgba(130,130,130,0.55);
+          border-radius: 8px;
+          border: 3px solid transparent;
+          background-clip: padding-box;
+          min-height: 40px;
+          min-width: 40px;
+        }
+        [data-testid="gantt-timeline"]::-webkit-scrollbar-thumb:hover {
+          background-color: rgba(110,110,110,0.85);
+        }
+        [data-testid="gantt-timeline"]::-webkit-scrollbar-corner {
+          background: transparent;
+        }
+        /* The task-list pane scrolls in lockstep with the timeline, so its own
+           vertical scrollbar (butted against the divider) was a confusing second
+           bar. Hide it — the pane stays wheel/drag-scrollable and synced. */
+        .gantt-task-list::-webkit-scrollbar { width: 0; height: 0; }
+        .gantt-task-list { scrollbar-width: none; }
       `}</style>
       {/* Toolbar */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 p-2 border-b bg-card">
@@ -2599,7 +2728,7 @@ export function GanttView({
         <div className="flex flex-1 overflow-hidden">
           {/* Left Side: Task List (Grid) */}
           <div
-            className="overflow-y-auto overflow-x-hidden border-r bg-card z-10 shadow-sm"
+            className="gantt-task-list overflow-y-auto overflow-x-hidden border-r bg-card z-10 shadow-sm"
             ref={listRef}
             onScroll={handleListScroll}
             style={{ width: taskListWidth, minWidth: taskListWidth }}

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -47,9 +47,12 @@ const COLUMN_WIDTH = 100; // Time column width
  * checks so the Gantt adapts to whatever slot it sits in (cards, sidebars, popups…).
  */
 function columnWidthForContainer(width: number) {
-  if (width < 640) return 44;
-  if (width < 1024) return 64;
-  return 80;
+  // Day/week/month columns stay readable at a 110px floor — even in narrow
+  // embeds (user-specified minimum). A short project still fills a roomy
+  // timeline via the fit-stretch below; manual zoom can override either way.
+  if (width < 640) return 110;
+  if (width < 1024) return 110;
+  return 110;
 }
 
 function taskListWidthForContainer(width: number) {

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -18,7 +18,6 @@ import {
   Calendar as CalendarIcon,
   PanelLeftClose,
   PanelLeft,
-  CalendarDays,
   Maximize2,
   Minimize2,
   Download,
@@ -2375,14 +2374,14 @@ export function GanttView({
           </Button>
           <Button
             variant="ghost"
-            size="icon"
-            className="h-8 w-8"
+            size="sm"
+            className="h-8 px-2 text-xs"
             onClick={jumpToToday}
             disabled={todayLeftPx == null}
             aria-label={t('gantt.toolbar.jumpToToday')}
             data-testid="gantt-jump-today"
           >
-            <CalendarDays className="h-4 w-4" />
+            {t('gantt.toolbar.today')}
           </Button>
           <Button
             variant="ghost"

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3173,8 +3173,15 @@ export function GanttView({
                           />
                         )}
 
-                        {/* Hover Details / drag tooltip */}
-                        <span className="text-[10px] text-white font-medium truncate opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                        {/* Bar label — the task title, shown like summary bars so
+                            leaf bars aren't blank. Fades out on hover to reveal the
+                            progress / drag overlay below. */}
+                        <span className="relative text-[10px] text-white font-medium truncate pointer-events-none group-hover:opacity-0 transition-opacity">
+                          {task.title}
+                        </span>
+                        {/* Hover Details / drag tooltip — overlays the title so the
+                            bar's text width never shifts on hover. */}
+                        <span className="absolute inset-0 flex items-center px-2 text-[10px] text-white font-medium truncate opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
                           {isDragging
                             ? `${computeDragChanges(dragState!).start.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })} → ${computeDragChanges(dragState!).end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })}`
                             : `${Math.round(liveProgress)}%`}

--- a/packages/plugin-gantt/src/GanttView.virtual.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.virtual.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Phase 5 tests: row/column virtualization, fullscreen toggle, custom markers.
  *
- * Conventions match the other suites: innerWidth=1280 → columnWidth 60,
+ * Conventions match the other suites: innerWidth=1280 → columnWidth 80,
  * rowHeight 40. jsdom reports clientWidth/Height of 0, so GanttView falls
  * back to a 4000×600 virtual viewport — large enough that the small fixtures
  * in the other suites render fully, small enough that big fixtures window.

--- a/packages/plugin-gantt/src/GanttView.virtual.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.virtual.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Phase 5 tests: row/column virtualization, fullscreen toggle, custom markers.
  *
- * Conventions match the other suites: innerWidth=1280 → columnWidth 80,
+ * Conventions match the other suites: innerWidth=1280 → columnWidth 110,
  * rowHeight 40. jsdom reports clientWidth/Height of 0, so GanttView falls
  * back to a 4000×600 virtual viewport — large enough that the small fixtures
  * in the other suites render fully, small enough that big fixtures window.

--- a/packages/plugin-gantt/src/GanttView.workaxis.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.workaxis.test.tsx
@@ -23,7 +23,7 @@ beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 });
 
-const COLUMN_WIDTH = 80;
+const COLUMN_WIDTH = 110;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // June 2024 (local): 1=Sat, 2=Sun, 3=Mon … 7=Fri, 8=Sat, 9=Sun, 10=Mon.
@@ -120,7 +120,7 @@ describe('GanttView non-linear working-time axis', () => {
     const linearWidth = barGeometry(linear.container, 'a').width;
     const foldedWidth = barGeometry(folded.container, 'a').width;
 
-    // Un-folded: 3 days × 60px. Folded: Sat/Sun removed → one column wide.
+    // Un-folded: 3 days × 110px. Folded: Sat/Sun removed → one column wide.
     expect(linearWidth).toBeCloseTo(3 * COLUMN_WIDTH, 0);
     expect(foldedWidth).toBeCloseTo(COLUMN_WIDTH, 0);
   });
@@ -137,9 +137,9 @@ describe('GanttView non-linear working-time axis', () => {
 
     const bar = container.querySelector('[data-testid="gantt-task-bar-a"]') as HTMLElement;
     act(() => { bar.dispatchEvent(pointer('pointerdown', 300)); });
-    // +60px = one visible column = one working day = Fri → Mon (+3 calendar days).
-    act(() => { window.dispatchEvent(pointer('pointermove', 360)); });
-    act(() => { window.dispatchEvent(pointer('pointerup', 360)); });
+    // +110px = one visible column = one working day = Fri → Mon (+3 calendar days).
+    act(() => { window.dispatchEvent(pointer('pointermove', 410)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 410)); });
 
     expect(captured).not.toBeNull();
     expect(captured!.start.getTime() - task.start.getTime()).toBe(3 * MS_PER_DAY);

--- a/packages/plugin-gantt/src/GanttView.workaxis.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.workaxis.test.tsx
@@ -23,7 +23,7 @@ beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 });
 
-const COLUMN_WIDTH = 60;
+const COLUMN_WIDTH = 80;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // June 2024 (local): 1=Sat, 2=Sun, 3=Mon … 7=Fri, 8=Sat, 9=Sun, 10=Mon.

--- a/packages/plugin-gantt/src/ObjectGantt.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.test.tsx
@@ -9,12 +9,12 @@ import { DataSource } from '@object-ui/types';
 // for "Create", "View", and "Delete" so CRUD wiring can be unit-tested
 // without rendering the full timeline.
 vi.mock('./GanttView', () => ({
-  GanttView: ({ tasks, onTaskClick, onTaskUpdate, onTaskDelete, onDependencyCreate, onDependencyDelete, rescheduleOnConflict, persistLayoutKey, mobileReadOnly }: any) => {
+  GanttView: ({ tasks, onTaskClick, onTaskUpdate, onTaskDelete, onDependencyCreate, onDependencyDelete, rescheduleOnConflict, persistLayoutKey, mobileReadOnly, defaultCollapsedDepth }: any) => {
     const byId = (id: any) => tasks.find((t: any) => String(t.id) === String(id));
     return (
-      <div data-testid="gantt-view" data-reschedule-on-conflict={String(!!rescheduleOnConflict)} data-persist-layout-key={persistLayoutKey || ''} data-mobile-readonly={String(!!mobileReadOnly)}>
+      <div data-testid="gantt-view" data-reschedule-on-conflict={String(!!rescheduleOnConflict)} data-persist-layout-key={persistLayoutKey || ''} data-mobile-readonly={String(!!mobileReadOnly)} data-default-collapsed-depth={defaultCollapsedDepth == null ? '' : String(defaultCollapsedDepth)}>
         {tasks.map((t: any) => (
-          <div key={t.id} data-testid="gantt-task">
+          <div key={t.id} data-testid="gantt-task" data-type={t.type ?? ''} data-locked={String(!!t.locked)}>
             <span>{t.title}</span>
             {t.fields ? (
               <div data-testid={`gv-fields-${t.id}`}>
@@ -404,6 +404,34 @@ describe('ObjectGantt', () => {
     render(<ObjectGantt schema={noMobile} dataSource={ds} />);
     await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeDefined());
     expect(screen.getByTestId('gantt-view').getAttribute('data-mobile-readonly')).toBe('false');
+  });
+
+  it('maps lockField onto task.locked and forwards defaultCollapsedDepth (config-driven, not hardcoded)', async () => {
+    const treeData = [
+      { id: 'p', name: 'Project', start_date: '2024-01-01', end_date: '2024-01-31', kind: 'group' },
+      { id: 'plan', name: 'Plan', start_date: '2024-01-02', end_date: '2024-01-10', kind: 'task', parent: 'p', frozen: false },
+      { id: 'wo', name: 'Work order', start_date: '2024-01-02', end_date: '2024-01-05', kind: 'task', parent: 'plan', frozen: true },
+    ];
+    const schema: any = {
+      type: 'gantt',
+      gantt: {
+        titleField: 'name', startDateField: 'start_date', endDateField: 'end_date',
+        parentField: 'parent', typeField: 'kind', lockField: 'frozen', defaultCollapsedDepth: 2,
+      },
+      data: { provider: 'object', object: 'tasks' },
+    };
+    const ds: DataSource = { ...mockDataSource, find: vi.fn().mockResolvedValue({ data: treeData }) };
+    render(<ObjectGantt schema={schema} dataSource={ds} />);
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeDefined());
+
+    // defaultCollapsedDepth is forwarded verbatim to GanttView.
+    expect(screen.getByTestId('gantt-view').getAttribute('data-default-collapsed-depth')).toBe('2');
+    // typeField 'group' → group node (无条); lockField truthiness → task.locked.
+    const byTitle = (title: string) =>
+      screen.getByText(title).closest('[data-testid="gantt-task"]') as HTMLElement;
+    expect(byTitle('Project').getAttribute('data-type')).toBe('group');
+    expect(byTitle('Plan').getAttribute('data-locked')).toBe('false');
+    expect(byTitle('Work order').getAttribute('data-locked')).toBe('true');
   });
 });
 

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -86,6 +86,23 @@ type GanttConfigEx = GanttConfig & {
    * that only group, never schedule.
    */
   typeField?: string;
+  /**
+   * Record field marking a node as view-only / 仅查看 (truthy → locked). A locked
+   * row's bar can't be dragged/resized, its progress can't be dragged, no
+   * dependency can be drawn from it, and its inline-edit / context-menu
+   * edit+delete are hidden — but clicking it (open drawer / jump) still works.
+   * Independent of the global `readOnly`; use to freeze individual levels (e.g.
+   * 派工单) while siblings stay editable. Maps to {@link GanttTask.locked}.
+   */
+  lockField?: string;
+  /**
+   * Auto-collapse tree nodes at/below this 0-indexed depth on first render
+   * (默认折叠). Roots are depth 0. Every node at depth `>= defaultCollapsedDepth`
+   * with children starts folded; the user can still expand them. Example: a
+   * 项目→产品→排产计划→派工单 tree uses `defaultCollapsedDepth: 2` so every 排产计划
+   * (and its 派工单) starts collapsed. Forwarded to {@link GanttView}.
+   */
+  defaultCollapsedDepth?: number;
   /** Baseline (planned) start/end fields → planned-vs-actual reference bars. */
   baselineStartField?: string;
   baselineEndField?: string;
@@ -253,6 +270,8 @@ function getGanttConfig(schema: ObjectGridSchema | any): GanttConfigEx | null {
           colorField: schema.colorField,
           parentField: schema.parentField,
           typeField: schema.typeField,
+          lockField: schema.lockField,
+          defaultCollapsedDepth: schema.defaultCollapsedDepth,
           tooltipFields: schema.tooltipFields,
           baselineStartField: schema.baselineStartField,
           baselineEndField: schema.baselineEndField,
@@ -386,7 +405,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       return [];
     }
 
-    const { startDateField, endDateField, titleField, progressField, dependenciesField, colorField, parentField, typeField, tooltipFields, baselineStartField, baselineEndField } = ganttConfig;
+    const { startDateField, endDateField, titleField, progressField, dependenciesField, colorField, parentField, typeField, lockField, tooltipFields, baselineStartField, baselineEndField } = ganttConfig;
     const fieldDefs: Record<string, any> = objectSchema?.fields ?? {};
 
     // Resolve a value through nested paths like "account.name". Returns the
@@ -542,6 +561,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         dependencies: normalizeDependencies(dependencies),
         parent: parentField ? record[parentField] ?? null : undefined,
         type: typeField ? normalizeTaskType(record[typeField]) : undefined,
+        locked: lockField ? !!record[lockField] : undefined,
         color,
         baselineStart: baselineStart && !isNaN(baselineStart.getTime()) ? baselineStart : undefined,
         baselineEnd: baselineEnd && !isNaN(baselineEnd.getTime()) ? baselineEnd : undefined,
@@ -1080,6 +1100,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
               : `${schema.objectName || (dataConfig?.provider === 'object' ? dataConfig.object : '') || 'gantt'}:${(schema as any).viewName || 'default'}`
           }
           groupBy={groupByAccessor}
+          defaultCollapsedDepth={ganttConfig?.defaultCollapsedDepth}
           inlineEdit
         />
         )}

--- a/packages/plugin-gantt/src/useGanttTranslation.test.tsx
+++ b/packages/plugin-gantt/src/useGanttTranslation.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Mutable host translation table the mock resolves against. i18next returns the
+// raw key on a miss, so the mock mirrors that contract.
+let hostDict: Record<string, string> = {};
+const hostT = (key: string) => hostDict[key] ?? key;
+
+vi.mock('@object-ui/react', () => ({
+  useObjectTranslation: () => ({ t: hostT, language: 'zh' }),
+}));
+
+import { useGanttTranslation, GANTT_DEFAULT_TRANSLATIONS } from './useGanttTranslation';
+
+describe('useGanttTranslation per-key fallback', () => {
+  beforeEach(() => {
+    hostDict = {};
+  });
+
+  it('uses the host translation when the key is present', () => {
+    hostDict = { 'gantt.linkType.fs': '完成 → 开始' };
+    const { result } = renderHook(() => useGanttTranslation());
+    expect(result.current.t('gantt.linkType.fs')).toBe('完成 → 开始');
+  });
+
+  it('falls back to bundled default ONLY for keys the host is missing (partial dictionary)', () => {
+    // The exact os-tianshun-ehr symptom: a host that translates the *common*
+    // gantt keys but lags on newer ones. The all-or-nothing probe would trust
+    // the host for everything and leak raw keys like `gantt.linkType.fs`.
+    hostDict = { 'gantt.column.taskName': '任务名称' };
+    const { result } = renderHook(() => useGanttTranslation());
+    const { t } = result.current;
+    // Present in host → host wins.
+    expect(t('gantt.column.taskName')).toBe('任务名称');
+    // Missing in host → bundled English default, NOT the raw key.
+    expect(t('gantt.linkType.fs')).toBe(GANTT_DEFAULT_TRANSLATIONS['gantt.linkType.fs']);
+    expect(t('gantt.menu.removeDependency')).toBe(
+      GANTT_DEFAULT_TRANSLATIONS['gantt.menu.removeDependency'],
+    );
+    // Never the raw key.
+    expect(t('gantt.linkType.fs')).not.toBe('gantt.linkType.fs');
+  });
+
+  it('threads the host language through', () => {
+    const { result } = renderHook(() => useGanttTranslation());
+    expect(result.current.language).toBe('zh');
+  });
+});

--- a/packages/plugin-gantt/src/useGanttTranslation.ts
+++ b/packages/plugin-gantt/src/useGanttTranslation.ts
@@ -59,6 +59,8 @@ export const GANTT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'gantt.linkType.ss': 'Start → Start',
   'gantt.linkType.ff': 'Finish → Finish',
   'gantt.linkType.sf': 'Start → Finish',
+  'gantt.linkEnd.start': 'start',
+  'gantt.linkEnd.end': 'end',
   'gantt.conflict.title': 'Schedule conflict',
   'gantt.conflict.body': 'This move conflicts with dependency constraints. Auto-reschedule {count} affected task(s)?',
   'gantt.conflict.confirm': 'Auto-reschedule',

--- a/packages/plugin-gantt/src/useGanttTranslation.ts
+++ b/packages/plugin-gantt/src/useGanttTranslation.ts
@@ -71,8 +71,6 @@ export const GANTT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'gantt.readOnlyHint': 'Editing is disabled for this view.',
 };
 
-const TEST_KEY = 'gantt.column.taskName';
-
 function fallback(key: string, options?: Record<string, unknown>): string {
   let v = GANTT_DEFAULT_TRANSLATIONS[key] || key;
   if (options) {
@@ -91,11 +89,20 @@ export function useGanttTranslation() {
     // language as the chrome, instead of silently following the browser
     // locale (which can diverge — English UI but Chinese dates).
     const language = result.language as string | undefined;
-    const testValue = result.t(TEST_KEY);
-    if (testValue === TEST_KEY) {
-      return { t: fallback, language };
-    }
-    return { t: result.t, language };
+    // Per-key fallback. A consuming app's i18n dictionary commonly translates
+    // the *common* gantt keys (column headers, toolbar) but lags behind on
+    // newer ones (link types, dependency context-menu). i18next returns the
+    // raw key string for a miss, which would surface untranslated keys like
+    // `gantt.linkType.fs` in the UI. So for every key we let the host resolve
+    // it first and fall back to our bundled English default ONLY when the host
+    // returns the key unchanged (a miss). An all-or-nothing probe on a single
+    // key can't catch a partially-translated host dictionary.
+    const t = (key: string, options?: Record<string, unknown>): string => {
+      const hostValue = result.t(key, options as never) as unknown;
+      if (typeof hostValue === 'string' && hostValue !== key) return hostValue;
+      return fallback(key, options);
+    };
+    return { t, language };
   } catch {
     // No I18nProvider on the tree (standalone embed / unit tests): keep the
     // English fallback and let dates follow the browser locale (language

--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -329,6 +329,8 @@ When pages need heavy widgets (grids, forms, kanbans, charts), import the plugin
       "parentField": "parent_id",
       "dependenciesField": "depends_on",
       "typeField": "item_type",
+      "lockField": "is_locked",
+      "defaultCollapsedDepth": 2,
       "colorField": "status",
       "baselineStartField": "planned_start",
       "baselineEndField": "planned_end",
@@ -355,7 +357,8 @@ When pages need heavy widgets (grids, forms, kanbans, charts), import the plugin
 `titleField` / `startDateField` / `endDateField` are required; the rest are
 optional. `parentField` builds the summary tree (parents roll up their
 children's span + weighted progress), `typeField` distinguishes
-`task` / `summary` / `milestone`, `dependenciesField` draws the dependency
+`task` / `summary` (alias `project` / `phase`) / `milestone` / `group`
+(alias `folder`), `dependenciesField` draws the dependency
 arrows (accepts CSV, an id array, or `[{ id, type: 'fs'|'ss'|'ff'|'sf' }]`).
 Setting `dependenciesField` also makes links **editable** (unless `readOnly`):
 drag a bar's connector dot to create a FS link, right-click a link to switch its
@@ -375,6 +378,15 @@ baseline strip under each bar. `groupByField` swimlanes the rows by any field
 bucket). `assigneeField` / `effortField` configure the **resource / workload
 view** (see below). The gantt field config may also be hoisted to top-level
 `props` instead of nesting under `gantt`.
+
+**Multi-level trees (无条分组层 / 默认折叠 / 仅查看)** — for deep hierarchies like
+项目 → 产品 → 排产计划 → 派工单, drive the shape from data, not hardcoded logic:
+
+| Field mapping (under `gantt`) | Effect |
+|--------|--------|
+| `typeField: "…"` with a `group` (or `folder`) value | Renders that record as a **pure tree header with NO timeline bar** (无条) — expandable/collapsible like a summary but never scheduled. Use for grouping-only levels (项目/产品) that organize rows without their own dates. `summary` (and aliases `project`/`phase`) still render a bar-carrying rollup bracket. |
+| `lockField: "is_locked"` | Marks a row **view-only / 仅查看** when the field is truthy: its bar can't be dragged/resized, progress can't be dragged, no dependency connector dot, and inline-edit + context-menu edit/delete are hidden. **Clicking still works** (open drawer / jump). Independent of `readOnly`, so you can freeze just one level (e.g. 派工单) while siblings stay editable. |
+| `defaultCollapsedDepth: 2` | **Auto-collapse 默认折叠** every tree node at or below this 0-indexed depth that has children, on first render. Roots are depth 0. The user can still expand any of them — this only seeds the initial state. Example: in a 项目(0)→产品(1)→排产计划(2)→派工单(3) tree, `2` starts with every 排产计划 (and its 派工单) folded. Omit to start fully expanded. |
 
 **Top-level display / behavior options** (siblings of `gantt` on `props`, not
 field mappings):
@@ -398,7 +410,10 @@ field mappings):
 The toolbar also carries **navigation** (今天 / 本周 / 本月 jump-to buttons that
 scroll the timeline to the start of today/this-week/this-month) and **export**
 (导出 PNG and a dependency-free single-page 导出 PDF of the whole chart) controls,
-always available regardless of `readOnly`.
+always available regardless of `readOnly`. Each task-list row also has a **定位
+(locate)** icon by its End cell that smooth-scrolls the timeline to center that
+row's bar and pulses it (闪烁) so it's easy to spot after the jump — handy in
+deep/long trees.
 
 Import plugins in your app entry point to trigger registration:
 ```typescript


### PR DESCRIPTION
## ObjectGantt — interaction & layout improvements

A batch of `@object-ui/plugin-gantt` fixes and features. Each was verified in-browser and is covered by the unit suite (201 passing, type-check clean).

### Dependencies (drag-to-link)
- **Drag-to-link from either bar endpoint**, dhtmlx-style. Each leaf bar exposes a connector dot at *both* its start and finish. The link type is auto-derived from which endpoint you drag **from** and which half of the target bar you drop **onto**: `end→start = FS`, `end→end = FF`, `start→start = SS`, `start→end = SF`. A draft hint (`Task A (end) → Task B (end)`) names the endpoints during the drag.

### Handle ergonomics (stop mis-operation)
- **Connector dots float fully outside each bar end** (detached circles in an enlarged hit area), so grabbing one can never start a bar move or an edge-resize. They appear on row hover / while the bar is the link source.
- **Progress handle is now an up-pointing triangle** hugging the bar's bottom edge at the progress %, with its hit area confined to the bottom half — clear of the move body and the centred end dots.

### Layout
- **Resizable task-list (name) column**: drag the divider between the name grid and the timeline to widen/narrow it (clamped 160px ↔ container−200px); double-click to reset to auto-size. The width persists in the saved layout.
- **Independent vertical scroller** for the task-list pane, and a **visible custom timeline scrollbar** (the OS overlay scrollbar was effectively invisible/ungrabbable on macOS).

### View switching
- **Exact-day anchoring across granularity switches**: switching Day→Week→Month→Day (and any round-trip) returns to the same day instead of drifting. The viewport-centre date is anchored and snapped to the active bucket.
- 'Today' is a text button matching 'This week' / 'This month'.

### Config & i18n
- Config-driven per-node lock + `defaultCollapsedDepth`.
- Per-key i18n fallback so a partially-translated host dictionary no longer leaks raw keys (e.g. `gantt.linkType.fs`); added `gantt.linkEnd.*` keys.
- Locate flash/alignment fixes; leaf bars show their task title.

### Demo
- Manufacturing 4-level scheduling fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
