### PR TITLE
feat(console-ai): post-build "What's next" checklist

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1160,6 +1160,7 @@ function ChatPane({
         }}
         publishDraftsLabel={t('console.ai.publishDrafts', { defaultValue: 'Publish' })}
         publishedLabel={t('console.ai.published', { defaultValue: 'Published' })}
+        nextStepsLabel={t('console.ai.nextSteps', { defaultValue: "What's next" })}
         // Self-use "magic moment": when the plan enables it, publish the drafted
         // app automatically the moment the agent finishes — no manual click; the
         // user refreshes and sees it live WITH data. Same governed endpoint.

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -127,6 +127,7 @@ function buildChatLocale(
       reviewDraft: (n: number) => `查看 ${n} 项变更`,
       publishDrafts: '发布',
       published: '已发布',
+      nextSteps: '下一步',
       publishOk: '已发布，对象已生效。',
       publishFailed: '发布失败',
       seedWarn: '已发布，但部分示例数据未能载入。',
@@ -173,6 +174,7 @@ function buildChatLocale(
     reviewDraft: (n: number) => `Review ${n} change${n === 1 ? '' : 's'}`,
     publishDrafts: 'Publish',
     published: 'Published',
+    nextSteps: "What's next",
     publishOk: 'Published — objects are now live.',
     publishFailed: 'Publish failed',
     seedWarn: 'Published, but some sample data failed to load.',
@@ -664,6 +666,7 @@ function ChatbotInner({
           }
         }}
         publishDraftsLabel={locale.publishDrafts}
+        nextStepsLabel={locale.nextSteps}
         publishedLabel={locale.published}
         // Self-use "magic moment": when the plan enables it, auto-publish the
         // drafted app the instant the agent finishes — the success path above

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -228,6 +228,11 @@ export interface ChatToolInvocation {
      * of being a dead-end badge.
      */
     issues?: Array<{ severity: 'error' | 'warning'; code: string; message: string; fix?: string }>;
+    /**
+     * Post-build "what's next" steps (apply_blueprint `nextSteps`). Rendered as
+     * a short getting-started checklist under the build summary.
+     */
+    nextSteps?: string[];
   };
 }
 
@@ -463,6 +468,8 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   publishedLabel?: string;
   /** Label for the clean ADR-0038 verification chip (default "Verified"). */
   verifiedLabel?: string;
+  /** Heading for the post-build "what's next" checklist (default "What's next"). */
+  nextStepsLabel?: string;
   /**
    * Live draft-status resolver: how many drafts are still PENDING in a
    * package (e.g. `GET /metadata/_drafts?packageId=` count). When provided,
@@ -800,6 +807,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       publishDraftsLabel = 'Publish',
       publishedLabel = 'Published',
       verifiedLabel = 'Verified',
+      nextStepsLabel = "What's next",
       fetchPendingDraftCount,
       autoPublishDrafts = false,
       processVisibility = 'summary',
@@ -1329,6 +1337,27 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     data; "Published" alone never implies "verified". */}
                 {publishedToolCalls.has(tool.toolCallId) ? (
                   <PublishHealthLine health={publishHealthByToolCall.get(tool.toolCallId)} />
+                ) : null}
+                {/* Post-build getting-started checklist — concrete next actions
+                    (make the data yours, refine, automate, publish) so a finished
+                    build isn't a dead end. Backend supplies these as
+                    `nextSteps` on the apply_blueprint result; lifecycle-neutral. */}
+                {tool.draftReview.nextSteps && tool.draftReview.nextSteps.length > 0 ? (
+                  <div
+                    className="flex flex-col gap-1 border-t bg-muted/20 px-3 py-2"
+                    data-testid="draft-next-steps"
+                  >
+                    <span className="text-xs font-medium text-foreground/80">{nextStepsLabel}</span>
+                    {tool.draftReview.nextSteps.map((step, idx) => (
+                      <div
+                        key={idx}
+                        className="flex items-start gap-1.5 text-xs text-muted-foreground"
+                      >
+                        <span className="mt-px shrink-0 text-foreground/40">→</span>
+                        <span>{step}</span>
+                      </div>
+                    ))}
+                  </div>
                 ) : null}
               </>
             ) : null}

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -285,6 +285,21 @@ describe('draftReview detection (ADR-0033)', () => {
     expect(dr?.items).toEqual([{ type: 'view', name: 'grid_v' }]);
   });
 
+  it('lifts apply_blueprint nextSteps for the getting-started checklist (drops blanks)', () => {
+    const dr = draftReviewOf({
+      status: 'drafted',
+      drafted: [{ type: 'app', name: 'recruiting' }],
+      summary: 'built 13 artifact(s)',
+      nextSteps: ['Make the data yours', '', '   ', 'Publish from the status panel'],
+    });
+    expect(dr?.nextSteps).toEqual(['Make the data yours', 'Publish from the status panel']);
+  });
+
+  it('omits nextSteps when absent or not a string array', () => {
+    expect(draftReviewOf({ status: 'drafted', type: 'object', name: 'x' })?.nextSteps).toBeUndefined();
+    expect(draftReviewOf({ status: 'drafted', type: 'object', name: 'x', nextSteps: 'nope' })?.nextSteps).toBeUndefined();
+  });
+
   it('does NOT surface blueprint_proposed (no draft yet) or plain results', () => {
     expect(draftReviewOf({ status: 'blueprint_proposed', counts: { objects: 3 } })).toBeUndefined();
     expect(draftReviewOf({ users: [] })).toBeUndefined();

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -142,6 +142,15 @@ export interface DraftReview {
    * carries an agent-actionable `message`; `fix` is the mechanical hint.
    */
   issues?: Array<{ severity: 'error' | 'warning'; code: string; message: string; fix?: string }>;
+  /**
+   * Concrete post-build "what's next" steps the assistant returns on a whole-app
+   * build (apply_blueprint `nextSteps`), e.g. "replace the sample data",
+   * "publish from the status panel". Rendered as a short getting-started
+   * checklist under the build summary so the user has an obvious next action
+   * instead of a dead end. Lifecycle-neutral (publishing is described via the
+   * status panel, never asserted as done).
+   */
+  nextSteps?: string[];
 }
 
 export function detectDraftResult(result: unknown): DraftReview | undefined {
@@ -201,12 +210,19 @@ export function detectDraftResult(result: unknown): DraftReview | undefined {
         ];
       })
     : [];
+  // Post-build "what's next" steps (apply_blueprint `nextSteps: string[]`).
+  // Surfaced as a getting-started checklist; only well-formed non-empty strings.
+  const rawNextSteps = (obj as { nextSteps?: unknown }).nextSteps;
+  const nextSteps = Array.isArray(rawNextSteps)
+    ? rawNextSteps.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    : [];
   return {
     items,
     summary: typeof obj.summary === 'string' ? obj.summary : undefined,
     ...(typeof obj.packageId === 'string' && obj.packageId ? { packageId: obj.packageId } : {}),
     ...(obj.autoPublishable === true ? { autoPublishable: true } : {}),
     ...(failedCount > 0 ? { failedCount } : {}),
+    ...(nextSteps.length ? { nextSteps } : {}),
     // ADR-0045: the build was materialized in-turn (real tables + data, app
     // hidden). The canvas then previews the REAL app URL, not the draft overlay.
     ...(obj.materialized === true ? { materialized: true } : {}),


### PR DESCRIPTION
Surface apply_blueprint `nextSteps` as a getting-started checklist under the build panel (parity with Airtable Omni). detectDraftResult lifts nextSteps into DraftReview; ChatbotEnhanced renders it (new nextStepsLabel prop); localized heading (en + zh 下一步). Unit-tested (mapMessages 32 green) + verified live on /ai/build. Lands on #1868's agent-scoped surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)