### PR TITLE
fix(data-objectstack): send $search to the server (ADR-0061)

### DIFF
--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -603,7 +603,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       // which parses `populate` (comma-separated) into an array for lookup expansion.
       // We use a raw request because the client SDK's data.find() QueryOptions
       // interface does not include populate/expand fields.
-      if (params?.$expand && params.$expand.length > 0) {
+      if ((params?.$expand && params.$expand.length > 0)
+          || (params?.$search != null && String(params.$search).trim() !== '')) {
+        // The client SDK's data.find() QueryOptions drops `$search`; route through
+        // the raw GET so the term reaches protocol.findData → the metadata-driven
+        // search executor (ADR-0061).
         const result = await this.rawFindWithPopulate(resource, params);
         return this.normalizeQueryResult(result, params);
       }
@@ -1093,6 +1097,15 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       queryParams.set('skip', String(params.$skip));
     }
 
+    // Full-text search (ADR-0061). The server resolves which fields to match
+    // from object metadata; the client only sends the term (+ optional override).
+    if (params.$search != null && String(params.$search).trim() !== '') {
+      queryParams.set('search', String(params.$search).trim());
+    }
+    if (params.$searchFields && params.$searchFields.length > 0) {
+      queryParams.set('searchFields', params.$searchFields.join(','));
+    }
+
     // Selection — always include `id` to ensure records can be identified
     // for navigation/selection even when callers omit it from $select.
     if (params.$select && params.$select.length > 0) {
@@ -1248,6 +1261,13 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
 
     if (params.$top !== undefined) {
       options.top = params.$top;
+    }
+
+    if (params.$search != null && String(params.$search).trim() !== '') {
+      (options as Record<string, unknown>).search = String(params.$search).trim();
+    }
+    if (params.$searchFields && params.$searchFields.length > 0) {
+      (options as Record<string, unknown>).searchFields = params.$searchFields;
     }
 
     return options;


### PR DESCRIPTION
Found by real-browser testing: the data adapter dropped $search/$searchFields in convertQueryParams(), so the picker/list/command-palette never sent the term (requests went out as ?top=10). Route $search finds through rawFindWithPopulate (raw GET → protocol.findData → metadata-driven executor) and emit search/searchFields params. Verified e2e via agent-browser (real CDP input): 'retail' filters the Account picker to 3 retail-industry accounts (Northwind/Acme Retail/Wonka Brands) by industry label, request ?top=10&skip=0&search=retail. Completes ADR-0061 end-to-end through the UI; pairs with framework #2134/#2142.