### PR TITLE
fix(console-ai): graceful handling when the build agent isn't deployed (routing + home CTA)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -43,6 +43,7 @@ import {
   PLATFORM_DEFAULT_AGENT,
   agentRouteName,
   resolveAgentParam,
+  isBuiltinAgentName,
   isBuildAgent,
   isAskAgent,
   publishHealthFromResponse,
@@ -522,9 +523,18 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   }, [agents.length, agentSegment, segmentIsAgent, catalogNames, fallbackAgent]);
   const activeAgentRoute = activeAgent ? agentRouteName(activeAgent) : undefined;
 
-  // A first segment that ISN'T an agent is a legacy bare conversation id.
+  // A KNOWN built-in agent (build/ask/…) that the live catalog doesn't serve —
+  // e.g. `/ai/build` on a deployment without the cloud AI Studio plugin. It's
+  // an unavailable AGENT, not a conversation id, so we fall back to the default
+  // surface instead of treating "build" as a chat to load.
+  const unavailableKnownAgent = Boolean(
+    agentSegment && segmentIsAgent === false && isBuiltinAgentName(agentSegment),
+  );
+
+  // A first segment that ISN'T an agent and ISN'T a known (unavailable) agent
+  // name is a legacy bare conversation id.
   const legacyConversationId =
-    agentSegment && segmentIsAgent === false ? agentSegment : undefined;
+    agentSegment && segmentIsAgent === false && !unavailableKnownAgent ? agentSegment : undefined;
 
   const chatApi = activeAgent
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`
@@ -560,11 +570,18 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
       navigate(`/ai/${friendly}${preservedQuery}`, { replace: true });
       return;
     }
+    // A known agent that isn't deployed here (e.g. `/ai/build` with no cloud AI
+    // Studio): land cleanly on the default surface rather than treating the
+    // segment as a conversation id (which produced the junk `/ai/ask/build`).
+    if (unavailableKnownAgent) {
+      navigate(`/ai/${friendly}${preservedQuery}`, { replace: true });
+      return;
+    }
     if (segmentIsAgent && agentSegment !== friendly) {
       const tail = urlConversationId ? `/${encodeURIComponent(urlConversationId)}` : '';
       navigate(`/ai/${friendly}${tail}${preservedQuery}`, { replace: true });
     }
-  }, [agents.length, activeAgent, agentSegment, segmentIsAgent, urlConversationId, searchString, navigate]);
+  }, [agents.length, activeAgent, agentSegment, segmentIsAgent, unavailableKnownAgent, urlConversationId, searchString, navigate]);
 
   // ── Legacy `/ai/:conversationId` (bare id) ──────────────────────────────
   // Resolve the conversation's own agent and 301 to `/ai/:agent/:conversationId`

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -23,6 +23,7 @@ import { useRecentItems } from '../../hooks/useRecentItems';
 import { useFavorites } from '../../hooks/useFavorites';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
+import { useAgents, isBuildAgent } from '@object-ui/plugin-chatbot';
 import { HomeAppsStrip } from './HomeAppsStrip';
 import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
@@ -31,6 +32,78 @@ import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/componen
 import { Sparkles, Star, Clock, ArrowDown, ShieldAlert, X, UploadCloud, MessageSquareText } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
+
+/** Resolve the AI service base, mirroring AiChatPage/ConsoleFloatingChatbot. */
+function resolveAiApiBase(): string {
+  const env = (import.meta as any).env ?? {};
+  const fromEnv = env.VITE_AI_BASE_URL as string | undefined;
+  if (fromEnv) return fromEnv.replace(/\/$/, '');
+  const serverUrl = (env.VITE_SERVER_URL as string | undefined) ?? '';
+  return `${serverUrl.replace(/\/$/, '')}/api/v1/ai`;
+}
+
+/**
+ * Which AI home CTAs to surface, driven by the live agent catalog (the single
+ * source of truth):
+ *  - `aiEnabled` — the backend served any agent (AI is on here).
+ *  - `buildAvailable` — a build/authoring agent is actually deployed. That's a
+ *    cloud / AI-Studio feature, ABSENT on open-source builds, so "Build with AI"
+ *    must not be shown (and silently fall back to Ask) where it can't build.
+ * Returns false/false while the catalog loads or when AI is off, so no AI CTA
+ * flashes before we know what's available.
+ */
+function useHomeAiAvailability(): { aiEnabled: boolean; buildAvailable: boolean } {
+  const apiBase = useMemo(() => resolveAiApiBase(), []);
+  const { agents } = useAgents({ apiBase });
+  return {
+    aiEnabled: agents.length > 0,
+    buildAvailable: agents.some((a) => isBuildAgent(a.name)),
+  };
+}
+
+/**
+ * Home AI call-to-action(s). "Build with AI" only when the build agent is
+ * actually available; "Ask AI" whenever AI is on. Renders nothing when AI is
+ * off. `layout="stack"` is used by the empty-state; the hero uses the default
+ * inline row. Availability is passed in so the host fetches the catalog once.
+ */
+function HomeAiActions({
+  aiEnabled,
+  buildAvailable,
+  navigate,
+  t,
+  layout = 'row',
+}: {
+  aiEnabled: boolean;
+  buildAvailable: boolean;
+  navigate: (to: string) => void;
+  t: (key: string, opts?: any) => string;
+  layout?: 'row' | 'stack';
+}) {
+  if (!aiEnabled) return null;
+  const container =
+    layout === 'stack'
+      ? 'mt-6 flex flex-col sm:flex-row items-center gap-3'
+      : 'flex shrink-0 items-center gap-2';
+  return (
+    <div className={container}>
+      {buildAvailable && (
+        <Button onClick={() => navigate('/ai/build')} data-testid="home-build-with-ai">
+          <Sparkles className="mr-2 h-4 w-4" />
+          {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
+        </Button>
+      )}
+      <Button
+        variant={buildAvailable ? 'outline' : 'default'}
+        onClick={() => navigate('/ai/ask')}
+        data-testid="home-ask-ai"
+      >
+        <MessageSquareText className="mr-2 h-4 w-4" />
+        {t('home.askAI', { defaultValue: 'Ask AI' })}
+      </Button>
+    </div>
+  );
+}
 
 function pickGreetingKey(hour: number): string {
   if (hour < 5) return 'home.greetingNight';
@@ -198,6 +271,9 @@ export function HomePage() {
   const { user } = useAuth();
   const isAdmin = useIsWorkspaceAdmin();
   const { pendingApprovalsCount, notifications, activities } = useHomeInbox();
+  // AI CTA gating: "Build with AI" only when the build agent is actually
+  // deployed (cloud / AI Studio); open-source builds get "Ask AI" instead.
+  const { aiEnabled, buildAvailable } = useHomeAiAvailability();
 
   const activeApps = apps.filter((a: any) => a.active !== false && a.hidden !== true);
 
@@ -239,21 +315,23 @@ export function HomePage() {
           <Empty>
             <EmptyTitle>{t('home.welcome', { defaultValue: 'Welcome to ObjectUI' })}</EmptyTitle>
             <EmptyDescription>
-              {t('home.welcomeAdminDescription', {
-                defaultValue:
-                  'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or set things up yourself from the Administration menu on the left.',
-              })}
+              {buildAvailable
+                ? t('home.welcomeAdminDescription', {
+                    defaultValue:
+                      'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or set things up yourself from the Administration menu on the left.',
+                  })
+                : t('home.welcomeAdminDescriptionNoBuild', {
+                    defaultValue:
+                      'Set up your first application from the Administration menu on the left. Once you have data, the AI assistant can help you explore it.',
+                  })}
             </EmptyDescription>
-            <div className="mt-6 flex flex-col sm:flex-row items-center gap-3">
-              <Button onClick={() => navigate('/ai/build')} data-testid="build-with-ai-btn">
-                <Sparkles className="mr-2 h-4 w-4" />
-                {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
-              </Button>
-              <Button variant="outline" onClick={() => navigate('/ai/ask')} data-testid="ask-ai-btn">
-                <MessageSquareText className="mr-2 h-4 w-4" />
-                {t('home.askAI', { defaultValue: 'Ask AI' })}
-              </Button>
-            </div>
+            <HomeAiActions
+              aiEnabled={aiEnabled}
+              buildAvailable={buildAvailable}
+              navigate={navigate}
+              t={t}
+              layout="stack"
+            />
           </Empty>
         ) : (
           <Empty>
@@ -293,16 +371,12 @@ export function HomePage() {
                 {t('home.heroTagline', { defaultValue: 'Pick up where you left off, or explore something new.' })}
               </p>
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <Button variant="outline" onClick={() => navigate('/ai/ask')} data-testid="home-ask-ai">
-                <MessageSquareText className="mr-2 h-4 w-4" />
-                {t('home.askAI', { defaultValue: 'Ask AI' })}
-              </Button>
-              <Button onClick={() => navigate('/ai/build')} data-testid="home-build-with-ai">
-                <Sparkles className="mr-2 h-4 w-4" />
-                {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
-              </Button>
-            </div>
+            <HomeAiActions
+              aiEnabled={aiEnabled}
+              buildAvailable={buildAvailable}
+              navigate={navigate}
+              t={t}
+            />
           </div>
 
           {starredApps.length === 0 && recentApps.length === 0 && (

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -23,7 +23,7 @@ import { useRecentItems } from '../../hooks/useRecentItems';
 import { useFavorites } from '../../hooks/useFavorites';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
-import { useAgents, isBuildAgent } from '@object-ui/plugin-chatbot';
+import { useAgents, isBuildAgent, isAskAgent } from '@object-ui/plugin-chatbot';
 import { HomeAppsStrip } from './HomeAppsStrip';
 import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
@@ -44,43 +44,51 @@ function resolveAiApiBase(): string {
 
 /**
  * Which AI home CTAs to surface, driven by the live agent catalog (the single
- * source of truth):
- *  - `aiEnabled` — the backend served any agent (AI is on here).
- *  - `buildAvailable` — a build/authoring agent is actually deployed. That's a
- *    cloud / AI-Studio feature, ABSENT on open-source builds, so "Build with AI"
- *    must not be shown (and silently fall back to Ask) where it can't build.
- * Returns false/false while the catalog loads or when AI is off, so no AI CTA
- * flashes before we know what's available.
+ * source of truth) — gated PER agent, because the community edition can be in
+ * any of three states:
+ *  - `askAvailable` — a data/query agent (`ask`/`data_chat`) is deployed → "Ask AI".
+ *  - `buildAvailable` — a build/authoring agent is deployed → "Build with AI".
+ *    That's a cloud / AI-Studio feature, ABSENT on open-source builds.
+ *  - `aiEnabled` — any agent at all (AI is on here in some form).
+ * All false while the catalog loads or when AI isn't enabled, so nothing
+ * flashes and no AI CTA appears where there's no agent to back it.
  */
-function useHomeAiAvailability(): { aiEnabled: boolean; buildAvailable: boolean } {
+function useHomeAiAvailability(): {
+  aiEnabled: boolean;
+  askAvailable: boolean;
+  buildAvailable: boolean;
+} {
   const apiBase = useMemo(() => resolveAiApiBase(), []);
   const { agents } = useAgents({ apiBase });
   return {
     aiEnabled: agents.length > 0,
+    askAvailable: agents.some((a) => isAskAgent(a.name)),
     buildAvailable: agents.some((a) => isBuildAgent(a.name)),
   };
 }
 
 /**
- * Home AI call-to-action(s). "Build with AI" only when the build agent is
- * actually available; "Ask AI" whenever AI is on. Renders nothing when AI is
- * off. `layout="stack"` is used by the empty-state; the hero uses the default
- * inline row. Availability is passed in so the host fetches the catalog once.
+ * Home AI call-to-action(s). "Build with AI" only when a build agent is
+ * deployed; "Ask AI" only when a data/query agent is deployed. Renders nothing
+ * when neither exists (AI off, or only custom agents — those are reachable via
+ * the assistant launcher / FAB). `layout="stack"` is used by the empty-state;
+ * the hero uses the default inline row. Availability is passed in so the host
+ * fetches the catalog once.
  */
 function HomeAiActions({
-  aiEnabled,
+  askAvailable,
   buildAvailable,
   navigate,
   t,
   layout = 'row',
 }: {
-  aiEnabled: boolean;
+  askAvailable: boolean;
   buildAvailable: boolean;
   navigate: (to: string) => void;
   t: (key: string, opts?: any) => string;
   layout?: 'row' | 'stack';
 }) {
-  if (!aiEnabled) return null;
+  if (!askAvailable && !buildAvailable) return null;
   const container =
     layout === 'stack'
       ? 'mt-6 flex flex-col sm:flex-row items-center gap-3'
@@ -93,14 +101,16 @@ function HomeAiActions({
           {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
         </Button>
       )}
-      <Button
-        variant={buildAvailable ? 'outline' : 'default'}
-        onClick={() => navigate('/ai/ask')}
-        data-testid="home-ask-ai"
-      >
-        <MessageSquareText className="mr-2 h-4 w-4" />
-        {t('home.askAI', { defaultValue: 'Ask AI' })}
-      </Button>
+      {askAvailable && (
+        <Button
+          variant={buildAvailable ? 'outline' : 'default'}
+          onClick={() => navigate('/ai/ask')}
+          data-testid="home-ask-ai"
+        >
+          <MessageSquareText className="mr-2 h-4 w-4" />
+          {t('home.askAI', { defaultValue: 'Ask AI' })}
+        </Button>
+      )}
     </div>
   );
 }
@@ -271,9 +281,10 @@ export function HomePage() {
   const { user } = useAuth();
   const isAdmin = useIsWorkspaceAdmin();
   const { pendingApprovalsCount, notifications, activities } = useHomeInbox();
-  // AI CTA gating: "Build with AI" only when the build agent is actually
-  // deployed (cloud / AI Studio); open-source builds get "Ask AI" instead.
-  const { aiEnabled, buildAvailable } = useHomeAiAvailability();
+  // AI CTA gating, per agent: "Build with AI" only when a build agent is
+  // deployed (cloud / AI Studio); "Ask AI" only when a data agent is; neither
+  // when AI isn't enabled. Community builds typically land in the ask-only state.
+  const { askAvailable, buildAvailable } = useHomeAiAvailability();
 
   const activeApps = apps.filter((a: any) => a.active !== false && a.hidden !== true);
 
@@ -320,13 +331,18 @@ export function HomePage() {
                     defaultValue:
                       'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or set things up yourself from the Administration menu on the left.',
                   })
-                : t('home.welcomeAdminDescriptionNoBuild', {
-                    defaultValue:
-                      'Set up your first application from the Administration menu on the left. Once you have data, the AI assistant can help you explore it.',
-                  })}
+                : askAvailable
+                  ? t('home.welcomeAdminDescriptionNoBuild', {
+                      defaultValue:
+                        'Set up your first application from the Administration menu on the left. Once you have data, the AI assistant can help you explore it.',
+                    })
+                  : t('home.welcomeAdminDescriptionNoAi', {
+                      defaultValue:
+                        'Set up your first application from the Administration menu on the left.',
+                    })}
             </EmptyDescription>
             <HomeAiActions
-              aiEnabled={aiEnabled}
+              askAvailable={askAvailable}
               buildAvailable={buildAvailable}
               navigate={navigate}
               t={t}
@@ -372,7 +388,7 @@ export function HomePage() {
               </p>
             </div>
             <HomeAiActions
-              aiEnabled={aiEnabled}
+              askAvailable={askAvailable}
               buildAvailable={buildAvailable}
               navigate={navigate}
               t={t}

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1618,6 +1618,7 @@ const en = {
     welcome: 'Build your business system with AI',
     welcomeDescription: 'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or start from scratch.',
     welcomeAdminDescription: 'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or set things up yourself from the menu on the left.',
+    welcomeAdminDescriptionNoBuild: 'Set up your first application from the Administration menu on the left. Once you have data, the AI assistant can help you explore it.',
     noAppsTitle: 'No applications yet',
     noAppsDescription: 'There are no applications available to you yet. Please contact your workspace administrator.',
     buildWithAI: 'Build with AI',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1619,6 +1619,7 @@ const en = {
     welcomeDescription: 'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or start from scratch.',
     welcomeAdminDescription: 'Describe your business in one sentence — AI generates the objects, screens, APIs and agent tools. Or set things up yourself from the menu on the left.',
     welcomeAdminDescriptionNoBuild: 'Set up your first application from the Administration menu on the left. Once you have data, the AI assistant can help you explore it.',
+    welcomeAdminDescriptionNoAi: 'Set up your first application from the Administration menu on the left.',
     noAppsTitle: 'No applications yet',
     noAppsDescription: 'There are no applications available to you yet. Please contact your workspace administrator.',
     buildWithAI: 'Build with AI',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1628,6 +1628,7 @@ const zh = {
     welcomeDescription: '用一句话描述你的业务，AI 帮你生成对象、界面、API 和 agent 工具。也可以手动从零开始。',
     welcomeAdminDescription: '用一句话描述你的业务，AI 会为你生成对象、界面、API 和智能体工具；也可以从左侧菜单自行搭建。',
     welcomeAdminDescriptionNoBuild: '从左侧的「管理」菜单创建你的第一个应用。有了数据后，AI 助手可以帮你查询和分析。',
+    welcomeAdminDescriptionNoAi: '从左侧的「管理」菜单创建你的第一个应用。',
     noAppsTitle: '还没有应用',
     noAppsDescription: '当前还没有可用的应用。请联系你的工作区管理员。',
     buildWithAI: '用 AI 搭建',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1627,6 +1627,7 @@ const zh = {
     welcome: '用 AI 搭建你的业务系统',
     welcomeDescription: '用一句话描述你的业务，AI 帮你生成对象、界面、API 和 agent 工具。也可以手动从零开始。',
     welcomeAdminDescription: '用一句话描述你的业务，AI 会为你生成对象、界面、API 和智能体工具；也可以从左侧菜单自行搭建。',
+    welcomeAdminDescriptionNoBuild: '从左侧的「管理」菜单创建你的第一个应用。有了数据后，AI 助手可以帮你查询和分析。',
     noAppsTitle: '还没有应用',
     noAppsDescription: '当前还没有可用的应用。请联系你的工作区管理员。',
     buildWithAI: '用 AI 搭建',

--- a/packages/plugin-chatbot/src/__tests__/agentAliases.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/agentAliases.test.ts
@@ -12,6 +12,7 @@ import {
   agentAliasGroup,
   agentRouteName,
   resolveAgentParam,
+  isBuiltinAgentName,
   isBuildAgent,
   isAskAgent,
 } from '../agentAliases';
@@ -68,6 +69,31 @@ describe('resolveAgentParam', () => {
     expect(resolveAgentParam(undefined, LEGACY)).toBeUndefined();
     // A friendly name whose target isn't served (empty catalog) is unresolvable.
     expect(resolveAgentParam('build', [])).toBeUndefined();
+  });
+});
+
+describe('isBuiltinAgentName', () => {
+  it('recognizes built-in agents by friendly name or legacy id, catalog-independent', () => {
+    expect(isBuiltinAgentName('build')).toBe(true);
+    expect(isBuiltinAgentName('metadata_assistant')).toBe(true);
+    expect(isBuiltinAgentName('ask')).toBe(true);
+    expect(isBuiltinAgentName('data_chat')).toBe(true);
+  });
+  it('returns false for custom agents and non-agent segments (conversation ids)', () => {
+    expect(isBuiltinAgentName('showcase_assistant')).toBe(false);
+    expect(isBuiltinAgentName('conv_abc-123')).toBe(false);
+    expect(isBuiltinAgentName(undefined)).toBe(false);
+  });
+  it('distinguishes "known agent, just not in this catalog" from "not an agent"', () => {
+    // `/ai/build` on a deployment without the cloud build agent: not in the
+    // catalog (resolveAgentParam → undefined) BUT a known agent (→ fall back to
+    // the default surface, not treat "build" as a conversation id).
+    const catalogWithoutBuild = ['ask', 'showcase_assistant'];
+    expect(resolveAgentParam('build', catalogWithoutBuild)).toBeUndefined();
+    expect(isBuiltinAgentName('build')).toBe(true);
+    // A real conversation id: not resolvable AND not a known agent.
+    expect(resolveAgentParam('conv_x', catalogWithoutBuild)).toBeUndefined();
+    expect(isBuiltinAgentName('conv_x')).toBe(false);
   });
 });
 

--- a/packages/plugin-chatbot/src/agentAliases.ts
+++ b/packages/plugin-chatbot/src/agentAliases.ts
@@ -65,6 +65,17 @@ export function resolveAgentParam(
   return undefined;
 }
 
+/**
+ * True when `name` is a KNOWN built-in agent identifier (a friendly name or a
+ * legacy id in an alias group: build/metadata_assistant, ask/data_chat) —
+ * regardless of whether the live catalog currently serves it. Lets a router
+ * tell "an agent that's simply not deployed here" (fall back to the default
+ * surface) apart from "a bare conversation id" (resolve its own agent).
+ */
+export function isBuiltinAgentName(name: string | undefined): boolean {
+  return name != null && AGENT_ALIAS_GROUPS.some((g) => g.includes(name));
+}
+
 /** True when `name` is the authoring/build agent (either `build` or `metadata_assistant`). */
 export function isBuildAgent(name: string | undefined): boolean {
   return name != null && agentRouteName(name) === 'build';

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -263,6 +263,7 @@ export {
   agentAliasGroup,
   agentRouteName,
   resolveAgentParam,
+  isBuiltinAgentName,
   isBuildAgent,
   isAskAgent,
 } from './agentAliases';


### PR DESCRIPTION
## Symptom
On a backend **without** a given built-in agent, opening `/ai/build` bounced to the junk URL **`/ai/ask/build`** and there was no way to select build mode. Reproduced on `examples/app-showcase` (catalog: `ask` + `showcase_assistant` only — it doesn't load the cloud AI Studio plugin, so the build agent isn't registered).

## Cause
The router treated any unresolved first segment as a **legacy conversation id**. So `/ai/build` (when `build`/`metadata_assistant` isn't in the catalog) was read as "open a conversation called `build`" → redirect to the default agent surface *carrying* that segment → `/ai/ask/build`.

## Fix
Distinguish **"a known agent that's merely not deployed here"** from **"a real conversation id"**:
- New `isBuiltinAgentName()` — true for `build`/`metadata_assistant`/`ask`/`data_chat` regardless of the live catalog.
- `AiChatPage`: a known built-in name that the catalog doesn't serve (`unavailableKnownAgent`) is excluded from the legacy-conversation-id path and the canonicalization effect redirects it cleanly to the default surface (`/ai/ask`). Only a *truly* unknown segment is still treated as a conversation id.

## Verified live
- **app-showcase (no build agent)**: `/ai/build` & `/ai/metadata_assistant` → `/ai/ask/…` (clean, no `/build` junk); launcher correctly lists only `Ask` + the custom `Delivery Assistant`.
- **custom agent**: `/ai/showcase_assistant` → its own surface (generic routing).
- **regression (backend WITH the build agent, :3100)**: `/ai/build` → `/ai/build/…` still resolves — the fix only changes the *unavailable* case.
- Unit tests: 17 pass (+3 for `isBuiltinAgentName`).

## Note on availability
The build agent is a **cloud / EE feature** (ships in `@objectstack/service-ai-studio`). On open-source deployments like app-showcase it's intentionally absent, so this PR makes the absence degrade gracefully rather than enabling build there. To actually use build mode, the backend must load the AI Studio plugin.

Follow-up to [objectui#1868](https://github.com/objectstack-ai/objectui/pull/1868).

🤖 Generated with [Claude Code](https://claude.com/claude-code)