### PR TITLE
feat(console-ai): reviewable "Proposed plan" card before build

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1161,6 +1161,12 @@ function ChatPane({
         publishDraftsLabel={t('console.ai.publishDrafts', { defaultValue: 'Publish' })}
         publishedLabel={t('console.ai.published', { defaultValue: 'Published' })}
         nextStepsLabel={t('console.ai.nextSteps', { defaultValue: "What's next" })}
+        planTitleLabel={t('console.ai.planTitle', { defaultValue: 'Proposed plan' })}
+        planQuestionsLabel={t('console.ai.planQuestions', { defaultValue: 'Confirm before building' })}
+        planAssumptionsLabel={t('console.ai.planAssumptions', { defaultValue: 'Assumptions' })}
+        planApproveHintLabel={t('console.ai.planApproveHint', {
+          defaultValue: 'Reply to approve or adjust this plan.',
+        })}
         // Self-use "magic moment": when the plan enables it, publish the drafted
         // app automatically the moment the agent finishes — no manual click; the
         // user refreshes and sees it live WITH data. Same governed endpoint.

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -128,6 +128,10 @@ function buildChatLocale(
       publishDrafts: '发布',
       published: '已发布',
       nextSteps: '下一步',
+      planTitle: '方案预览',
+      planQuestions: '搭建前请确认',
+      planAssumptions: '假设',
+      planApproveHint: '回复以确认或调整该方案。',
       publishOk: '已发布，对象已生效。',
       publishFailed: '发布失败',
       seedWarn: '已发布，但部分示例数据未能载入。',
@@ -175,6 +179,10 @@ function buildChatLocale(
     publishDrafts: 'Publish',
     published: 'Published',
     nextSteps: "What's next",
+    planTitle: 'Proposed plan',
+    planQuestions: 'Confirm before building',
+    planAssumptions: 'Assumptions',
+    planApproveHint: 'Reply to approve or adjust this plan.',
     publishOk: 'Published — objects are now live.',
     publishFailed: 'Publish failed',
     seedWarn: 'Published, but some sample data failed to load.',
@@ -667,6 +675,10 @@ function ChatbotInner({
         }}
         publishDraftsLabel={locale.publishDrafts}
         nextStepsLabel={locale.nextSteps}
+        planTitleLabel={locale.planTitle}
+        planQuestionsLabel={locale.planQuestions}
+        planAssumptionsLabel={locale.planAssumptions}
+        planApproveHintLabel={locale.planApproveHint}
         publishedLabel={locale.published}
         // Self-use "magic moment": when the plan enables it, auto-publish the
         // drafted app the instant the agent finishes — the success path above

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -20,7 +20,7 @@
 import * as React from 'react';
 import { cn } from '@object-ui/components';
 import { SchemaRenderer } from '@object-ui/react';
-import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, Eye, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2, ShieldCheck, TriangleAlert } from 'lucide-react';
+import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, Eye, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2, ShieldCheck, TriangleAlert, ClipboardList, HelpCircle, Table2 } from 'lucide-react';
 import type { ChatStatus } from 'ai';
 import {
   humanizeToolName,
@@ -233,6 +233,22 @@ export interface ChatToolInvocation {
      * a short getting-started checklist under the build summary.
      */
     nextSteps?: string[];
+  };
+  /**
+   * ObjectStack extension. `propose_blueprint` returns a PLAN before anything
+   * is staged (`status: 'blueprint_proposed'`). `mapMessages.ts` lifts the
+   * reviewable shape here so chat UIs can render a "Proposed plan" card — the
+   * objects the build will create, the agent's assumptions, and any
+   * structure-deciding questions — and the user can approve or adjust before
+   * `apply_blueprint` runs. Nothing is created yet; this is the confirm gate.
+   */
+  proposedPlan?: {
+    summary?: string;
+    objects: Array<{ name: string; label?: string; fieldCount: number }>;
+    counts: { objects: number; views: number; dashboards: number; seedData: number };
+    questions: string[];
+    assumptions: string[];
+    targetApp?: string;
   };
 }
 
@@ -470,6 +486,14 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   verifiedLabel?: string;
   /** Heading for the post-build "what's next" checklist (default "What's next"). */
   nextStepsLabel?: string;
+  /** Heading for the pre-build proposed-plan card (default "Proposed plan"). */
+  planTitleLabel?: string;
+  /** Heading above the structure-deciding questions in the plan card (default "Confirm before building"). */
+  planQuestionsLabel?: string;
+  /** Heading above the agent's assumptions in the plan card (default "Assumptions"). */
+  planAssumptionsLabel?: string;
+  /** Footer hint inviting the user to approve or adjust the plan (default "Reply to approve or adjust this plan."). */
+  planApproveHintLabel?: string;
   /**
    * Live draft-status resolver: how many drafts are still PENDING in a
    * package (e.g. `GET /metadata/_drafts?packageId=` count). When provided,
@@ -808,6 +832,10 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       publishedLabel = 'Published',
       verifiedLabel = 'Verified',
       nextStepsLabel = "What's next",
+      planTitleLabel = 'Proposed plan',
+      planQuestionsLabel = 'Confirm before building',
+      planAssumptionsLabel = 'Assumptions',
+      planApproveHintLabel = 'Reply to approve or adjust this plan.',
       fetchPendingDraftCount,
       autoPublishDrafts = false,
       processVisibility = 'summary',
@@ -1137,7 +1165,8 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
           defaultOpen={
             state === 'output-error' ||
             state === 'approval-requested' ||
-            Boolean(tool.draftReview && tool.draftReview.items.length > 0)
+            Boolean(tool.draftReview && tool.draftReview.items.length > 0) ||
+            Boolean(tool.proposedPlan)
           }
         >
           <ToolHeader type={partType} state={state} title={titleNode} />
@@ -1360,6 +1389,94 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                   </div>
                 ) : null}
               </>
+            ) : null}
+            {/* Pre-build "Proposed plan" card — propose_blueprint returns a plan
+                (objects, assumptions, structure-deciding questions) before
+                anything is staged. Surfacing it as a reviewable card (not a bare
+                "Completed" step) gives the user the Airtable-style confirm gate:
+                see what will be built, then approve or adjust. Nothing is live
+                yet. */}
+            {tool.proposedPlan ? (
+              <div
+                className="flex flex-col gap-2 border-t bg-muted/20 px-3 py-2.5"
+                data-testid="proposed-plan"
+              >
+                <span className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground/80">
+                  <ClipboardList className="size-3.5" />
+                  {planTitleLabel}
+                </span>
+                {tool.proposedPlan.summary ? (
+                  <p className="text-xs text-muted-foreground">{tool.proposedPlan.summary}</p>
+                ) : null}
+                {tool.proposedPlan.objects.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {tool.proposedPlan.objects.map((o) => (
+                      <span
+                        key={o.name}
+                        className="inline-flex items-center gap-1 rounded-md border bg-background px-1.5 py-0.5 text-[11px] text-foreground/80"
+                        title={o.name}
+                      >
+                        <Table2 className="size-3 text-foreground/40" />
+                        {o.label || o.name}
+                        {o.fieldCount > 0 ? (
+                          <span className="text-foreground/40">· {o.fieldCount}</span>
+                        ) : null}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+                {(() => {
+                  const c = tool.proposedPlan!.counts;
+                  const bits: string[] = [];
+                  if (c.objects) bits.push(`${c.objects} object${c.objects === 1 ? '' : 's'}`);
+                  if (c.views) bits.push(`${c.views} view${c.views === 1 ? '' : 's'}`);
+                  if (c.dashboards)
+                    bits.push(`${c.dashboards} dashboard${c.dashboards === 1 ? '' : 's'}`);
+                  if (c.seedData) bits.push('sample data');
+                  return bits.length ? (
+                    <span className="text-[11px] text-muted-foreground">{bits.join(' · ')}</span>
+                  ) : null;
+                })()}
+                {tool.proposedPlan.assumptions.length > 0 ? (
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-[11px] font-medium text-foreground/70">
+                      {planAssumptionsLabel}
+                    </span>
+                    {tool.proposedPlan.assumptions.map((a, idx) => (
+                      <div
+                        key={idx}
+                        className="flex items-start gap-1.5 text-[11px] text-muted-foreground"
+                      >
+                        <span className="mt-px shrink-0 text-foreground/40">·</span>
+                        <span>{a}</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+                {tool.proposedPlan.questions.length > 0 ? (
+                  <div
+                    className="flex flex-col gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 dark:border-amber-900/50 dark:bg-amber-950/30"
+                    data-testid="proposed-plan-questions"
+                  >
+                    <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-amber-800 dark:text-amber-300">
+                      <HelpCircle className="size-3.5" />
+                      {planQuestionsLabel}
+                    </span>
+                    {tool.proposedPlan.questions.map((q, idx) => (
+                      <div
+                        key={idx}
+                        className="flex items-start gap-1.5 text-[11px] text-amber-900/90 dark:text-amber-200/90"
+                      >
+                        <span className="mt-px shrink-0">?</span>
+                        <span>{q}</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+                <span className="text-[11px] italic text-muted-foreground/80">
+                  {planApproveHintLabel}
+                </span>
+              </div>
             ) : null}
           </ToolContent>
         </Tool>

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -11,6 +11,7 @@ import {
   uiMessageToChatMessage,
   uiMessagesToChatMessages,
   detectDraftResult,
+  detectProposedPlan,
   buildProgressFromDraftReview,
 } from '../mapMessages';
 
@@ -341,6 +342,99 @@ describe('draftReview detection (ADR-0033)', () => {
   it('omits the issues key entirely when there are none (no envelope churn)', () => {
     const dr = draftReviewOf({ status: 'drafted', type: 'view', name: 'grid_v' });
     expect(dr).toEqual({ items: [{ type: 'view', name: 'grid_v' }] });
+  });
+});
+
+// propose_blueprint returns a PLAN before anything is staged. The chat surfaces
+// it as a reviewable "Proposed plan" card (the confirm gate), so detection must
+// lift the objects, counts, assumptions, and structure-deciding questions.
+describe('proposedPlan detection (propose_blueprint)', () => {
+  const fullEnvelope = {
+    status: 'blueprint_proposed',
+    summary: 'A lightweight applicant tracker',
+    counts: { objects: 2, views: 3, dashboards: 1, seedData: 2 },
+    questions: ['Track interviews as a separate object, or as a stage field?'],
+    blueprint: {
+      summary: 'A lightweight applicant tracker',
+      assumptions: ['One pipeline for all roles', 'No external job-board sync'],
+      objects: [
+        { name: 'candidate', label: 'Candidate', fields: [{ name: 'full_name' }, { name: 'stage' }] },
+        { name: 'job', label: 'Job', fields: [{ name: 'title' }] },
+      ],
+      views: [{ name: 'pipeline' }, { name: 'all' }, { name: 'archived' }],
+      questions: ['ignored — envelope questions win'],
+    },
+  };
+
+  it('lifts the plan shape (objects, counts, assumptions, questions) from the envelope', () => {
+    const plan = detectProposedPlan(fullEnvelope);
+    expect(plan).toEqual({
+      summary: 'A lightweight applicant tracker',
+      objects: [
+        { name: 'candidate', label: 'Candidate', fieldCount: 2 },
+        { name: 'job', label: 'Job', fieldCount: 1 },
+      ],
+      counts: { objects: 2, views: 3, dashboards: 1, seedData: 2 },
+      questions: ['Track interviews as a separate object, or as a stage field?'],
+      assumptions: ['One pipeline for all roles', 'No external job-board sync'],
+    });
+  });
+
+  it('parses a JSON-string result (what the tool actually returns) and wires onto the tool invocation', () => {
+    const msg = uiMessageToChatMessage({
+      id: 'm',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-propose_blueprint',
+          toolCallId: 'p1',
+          state: 'output-available' as const,
+          input: {},
+          output: JSON.stringify(fullEnvelope),
+        },
+      ],
+    });
+    expect(msg.toolInvocations?.[0]?.proposedPlan?.objects).toEqual([
+      { name: 'candidate', label: 'Candidate', fieldCount: 2 },
+      { name: 'job', label: 'Job', fieldCount: 1 },
+    ]);
+  });
+
+  it('derives counts from the blueprint when the envelope omits them, and drops malformed objects', () => {
+    const plan = detectProposedPlan({
+      status: 'blueprint_proposed',
+      blueprint: {
+        objects: [
+          { name: 'task', fields: [{ name: 'title' }] },
+          { label: 'no name → dropped' },
+          { name: 'note' }, // no fields → fieldCount 0
+        ],
+        views: [{ name: 'board' }],
+      },
+    });
+    expect(plan?.objects).toEqual([
+      { name: 'task', fieldCount: 1 },
+      { name: 'note', fieldCount: 0 },
+    ]);
+    expect(plan?.counts).toEqual({ objects: 2, views: 1, dashboards: 0, seedData: 0 });
+    expect(plan?.questions).toEqual([]);
+    expect(plan?.assumptions).toEqual([]);
+  });
+
+  it('surfaces the extend-mode targetApp', () => {
+    const plan = detectProposedPlan({
+      status: 'blueprint_proposed',
+      targetApp: 'recruiting',
+      blueprint: { objects: [{ name: 'offer', fields: [] }] },
+    });
+    expect(plan?.targetApp).toBe('recruiting');
+  });
+
+  it('returns undefined for non-proposal statuses and proposals with no nameable objects', () => {
+    expect(detectProposedPlan({ status: 'drafted', type: 'object', name: 'x' })).toBeUndefined();
+    expect(detectProposedPlan({ status: 'blueprint_proposed', blueprint: { objects: [] } })).toBeUndefined();
+    expect(detectProposedPlan({ status: 'blueprint_proposed' })).toBeUndefined();
+    expect(detectProposedPlan({ foo: 1 })).toBeUndefined();
   });
 });
 

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -153,6 +153,90 @@ export interface DraftReview {
   nextSteps?: string[];
 }
 
+/**
+ * The lifecycle stage BEFORE a draft. `propose_blueprint` returns
+ * `{ status:'blueprint_proposed', blueprint, counts, questions, assumptions }`
+ * — a PLAN the user reviews (and can adjust) before `apply_blueprint` stages
+ * it. Nothing is created yet; this is the confirm gate. We lift the reviewable
+ * shape so the chat can render a "Proposed plan" card — the objects it will
+ * create, the agent's assumptions, and any structure-deciding questions —
+ * instead of burying the proposal in a "Propose blueprint — Completed" step.
+ */
+export interface ProposedPlan {
+  summary?: string;
+  /** Objects (tables) the build will create — machine name, label, field count. */
+  objects: Array<{ name: string; label?: string; fieldCount: number }>;
+  /** Totals for a compact "N objects · N views · …" line. */
+  counts: { objects: number; views: number; dashboards: number; seedData: number };
+  /** ≤2 structure-deciding questions to confirm before building (may be empty). */
+  questions: string[];
+  /** Assumptions the agent made from an underspecified goal (may be empty). */
+  assumptions: string[];
+  /** Extend mode: the existing app the new objects would be added into. */
+  targetApp?: string;
+}
+
+/** Defensive: keep only non-empty strings from an unknown array. */
+function nonEmptyStrings(v: unknown): string[] {
+  return Array.isArray(v)
+    ? v.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    : [];
+}
+
+export function detectProposedPlan(result: unknown): ProposedPlan | undefined {
+  const obj = parseResultEnvelope(result);
+  if (!obj || obj.status !== 'blueprint_proposed') return undefined;
+  const rawBlueprint = (obj as { blueprint?: unknown }).blueprint;
+  const bp =
+    rawBlueprint && typeof rawBlueprint === 'object'
+      ? (rawBlueprint as Record<string, unknown>)
+      : {};
+
+  const objects = (Array.isArray(bp.objects) ? bp.objects : []).flatMap((o) => {
+    const r = o as { name?: unknown; label?: unknown; fields?: unknown };
+    if (typeof r?.name !== 'string' || !r.name) return [];
+    return [
+      {
+        name: r.name,
+        ...(typeof r.label === 'string' && r.label ? { label: r.label } : {}),
+        fieldCount: Array.isArray(r.fields) ? r.fields.length : 0,
+      },
+    ];
+  });
+  // No nameable objects → nothing reviewable; don't render an empty card.
+  if (objects.length === 0) return undefined;
+
+  const num = (v: unknown, fallback: number): number =>
+    typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+  const rawCounts = ((obj as { counts?: unknown }).counts ?? {}) as Record<string, unknown>;
+  const counts = {
+    objects: num(rawCounts.objects, objects.length),
+    views: num(rawCounts.views, Array.isArray(bp.views) ? bp.views.length : 0),
+    dashboards: num(rawCounts.dashboards, Array.isArray(bp.dashboards) ? bp.dashboards.length : 0),
+    seedData: num(rawCounts.seedData, Array.isArray(bp.seedData) ? bp.seedData.length : 0),
+  };
+
+  // `questions` ride on the envelope; older shapes carried them on the
+  // blueprint — accept either.
+  const questions = nonEmptyStrings((obj as { questions?: unknown }).questions);
+  const summary =
+    typeof obj.summary === 'string' && obj.summary
+      ? obj.summary
+      : typeof bp.summary === 'string' && bp.summary
+        ? bp.summary
+        : undefined;
+  const targetApp = (obj as { targetApp?: unknown }).targetApp;
+
+  return {
+    ...(summary ? { summary } : {}),
+    objects,
+    counts,
+    questions: questions.length ? questions : nonEmptyStrings(bp.questions),
+    assumptions: nonEmptyStrings(bp.assumptions),
+    ...(typeof targetApp === 'string' && targetApp ? { targetApp } : {}),
+  };
+}
+
 export function detectDraftResult(result: unknown): DraftReview | undefined {
   const obj = parseResultEnvelope(result);
   if (!obj || obj.status !== 'drafted') return undefined;
@@ -284,6 +368,7 @@ function extractToolInvocations(
       const result = p.output ?? p.result;
       const pending = detectPendingApproval(result);
       const draftReview = detectDraftResult(result);
+      const proposedPlan = detectProposedPlan(result);
       // Promote a dangling `input-*` state to a terminal one so a reloaded
       // conversation never shows "Running" forever (the server doesn't always
       // snapshot the terminal tool state). Two cases:
@@ -315,6 +400,7 @@ function extractToolInvocations(
         state,
         pendingActionId: pending?.pendingActionId,
         draftReview,
+        proposedPlan,
       } satisfies ChatToolInvocation;
     });
 }


### PR DESCRIPTION
## Why
`propose_blueprint` returns a plan (objects, assumptions, ≤2 structure-deciding questions) BEFORE anything is staged. Until now it surfaced only as a bare "Propose blueprint — Completed" step, so the confirm gate the backend's own note describes (*"present this and call apply_blueprint after they approve or edit it"*) had no UI. This adds the Airtable-Omni-style **see the plan → approve / adjust** affordance, on the `/ai/build` surface (#1868).

## What
- **mapMessages**: `detectProposedPlan` lifts the reviewable shape (objects + field counts, totals, assumptions, questions) from the `blueprint_proposed` envelope — defensive (drops malformed objects, derives counts from the blueprint when omitted, parses the JSON-string result the tool returns). Wired onto `ChatToolInvocation.proposedPlan`.
- **ChatbotEnhanced**: renders a **Proposed plan** card — summary, object chips with field counts, a totals line, the agent's assumptions, and any structure-deciding questions highlighted as the confirm gate, plus an "approve or adjust" hint. Nothing is live yet. New `plan*` label props.
- **Localized** headings: `AiChatPage` via `t()`; floating chatbot via its `locale` (en + zh 方案预览 / 搭建前请确认 / 假设).

## Verification
- 5 new unit tests (`detectProposedPlan`: lift, JSON-string path through the mapper, count-derivation + malformed-drop, extend-mode `targetApp`, non-proposal rejection) — mapMessages suite **37 green**.
- `plugin-chatbot` + `app-shell` **type-check clean** (turbo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)