### PR TITLE
fix(console-ai): keep draft/plan cards across cache-fallback reload + remap server tool-call type

### DIFF
--- a/packages/app-shell/src/hooks/__tests__/useChatConversation.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useChatConversation.test.tsx
@@ -8,9 +8,14 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+// The chat surface derives the draft/plan affordance cards from the tool result
+// via these mappers — round-tripping our cache through them is the real
+// production path (live render → cache → cache-fallback reload).
+import { uiMessageToChatMessage } from '@object-ui/plugin-chatbot';
 
 import {
   sanitizeChatMessagesForCache,
+  toUIMessages,
   useChatConversation,
   writeConversationMessagesCache,
 } from '../useChatConversation';
@@ -296,5 +301,187 @@ describe('useChatConversation — forceNew (the sidebar New button)', () => {
     expect(result.current.conversationId).toBe('conv-x');
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE}/conversations/conv-x`);
+  });
+});
+
+// Regression: a cache-fallback reload (server returns no/partial messages →
+// `readMessageCache`) must keep the draft/plan affordance cards, not just the
+// bare tool header. `sanitizeChatMessagesForCache` used to drop the tool
+// `output`, so `mapMessages.detect*` returned undefined for cache-restored
+// messages and the "Review N changes / Publish" card, the ADR-0038 verification
+// chip, and the "Proposed plan" card silently vanished.
+describe('sanitizeChatMessagesForCache — affordance cards survive a cache round-trip', () => {
+  // The raw tool outputs exactly as the build/propose tools return them.
+  const draftedOutput = {
+    status: 'drafted',
+    drafted: [
+      { type: 'app', name: 'tracker_app' },
+      { type: 'object', name: 'task' },
+    ],
+    summary: 'Built Tracker',
+    packageId: 'pkg_1',
+    autoPublishable: true,
+    failed: [{ type: 'view', name: 'broken' }],
+    materialized: true,
+    verification: { errors: 0, warnings: 1 },
+    issues: [{ severity: 'warning', code: 'lint_x', message: 'Consider X', fix: 'do Y' }],
+    nextSteps: ['Replace the sample data', 'Publish from the status panel'],
+  };
+  const proposedOutput = {
+    status: 'blueprint_proposed',
+    summary: 'A lightweight tracker',
+    counts: { objects: 2, views: 3, dashboards: 1, seedData: 2 },
+    questions: ['Track interviews separately?'],
+    targetApp: 'recruiting',
+    blueprint: {
+      assumptions: ['One pipeline for all roles'],
+      objects: [
+        { name: 'candidate', label: 'Candidate', fields: [{ name: 'full_name' }, { name: 'stage' }] },
+        { name: 'job', fields: [{ name: 'title' }] },
+      ],
+    },
+  };
+
+  // An assistant message carrying both an apply_blueprint (drafted) and a
+  // propose_blueprint (blueprint_proposed) tool output, as the live stream
+  // produces it.
+  const liveUiMessage = {
+    id: 'a1',
+    role: 'assistant' as const,
+    parts: [
+      { type: 'text', text: 'Done.' },
+      {
+        type: 'tool-apply_blueprint',
+        toolCallId: 'tc-draft',
+        state: 'output-available' as const,
+        input: {},
+        output: draftedOutput,
+      },
+      {
+        type: 'tool-propose_blueprint',
+        toolCallId: 'tc-plan',
+        state: 'output-available' as const,
+        input: {},
+        output: proposedOutput,
+      },
+    ],
+  };
+
+  it('preserves draftReview + proposedPlan through sanitize → localStorage → re-map', () => {
+    // 1. Live render derives the cards from the raw tool output (baseline).
+    const live = uiMessageToChatMessage(liveUiMessage);
+    expect(live.toolInvocations?.[0]?.draftReview?.items).toEqual(draftedOutput.drafted);
+    expect(live.toolInvocations?.[1]?.proposedPlan?.objects).toEqual([
+      { name: 'candidate', label: 'Candidate', fieldCount: 2 },
+      { name: 'job', fieldCount: 1 },
+    ]);
+
+    // 2. Cache it, then round-trip through JSON exactly like localStorage does.
+    const cached = sanitizeChatMessagesForCache([live]);
+    const persisted = JSON.parse(JSON.stringify(cached)) as typeof cached;
+
+    // The cached tool parts keep a compact `output` (no full blueprint).
+    const draftPart = persisted[0]?.parts.find((p) => p.type === 'tool-apply_blueprint');
+    const planPart = persisted[0]?.parts.find((p) => p.type === 'tool-propose_blueprint');
+    expect(draftPart?.output).toMatchObject({ status: 'drafted' });
+    expect(planPart?.output).toMatchObject({ status: 'blueprint_proposed' });
+    // Leanness: the field definitions are dropped, only the count is kept.
+    expect(JSON.stringify(planPart?.output)).not.toContain('full_name');
+
+    // 3. Cache-fallback reload re-derives the cards from the cached output.
+    const reloaded = uiMessageToChatMessage(persisted[0]);
+
+    const draftReview = reloaded.toolInvocations?.[0]?.draftReview;
+    expect(draftReview).toBeDefined();
+    expect(draftReview?.items).toEqual(draftedOutput.drafted);
+    expect(draftReview?.summary).toBe('Built Tracker');
+    expect(draftReview?.packageId).toBe('pkg_1');
+    expect(draftReview?.autoPublishable).toBe(true);
+    expect(draftReview?.materialized).toBe(true);
+    expect(draftReview?.failedCount).toBe(1);
+    expect(draftReview?.verification).toEqual({ errors: 0, warnings: 1 });
+    expect(draftReview?.issues).toEqual([
+      { severity: 'warning', code: 'lint_x', message: 'Consider X', fix: 'do Y' },
+    ]);
+    expect(draftReview?.nextSteps).toEqual([
+      'Replace the sample data',
+      'Publish from the status panel',
+    ]);
+
+    const proposedPlan = reloaded.toolInvocations?.[1]?.proposedPlan;
+    expect(proposedPlan).toBeDefined();
+    expect(proposedPlan?.objects).toEqual([
+      { name: 'candidate', label: 'Candidate', fieldCount: 2 },
+      { name: 'job', fieldCount: 1 },
+    ]);
+    expect(proposedPlan?.counts).toEqual({ objects: 2, views: 3, dashboards: 1, seedData: 2 });
+    expect(proposedPlan?.questions).toEqual(['Track interviews separately?']);
+    expect(proposedPlan?.assumptions).toEqual(['One pipeline for all roles']);
+    expect(proposedPlan?.summary).toBe('A lightweight tracker');
+    expect(proposedPlan?.targetApp).toBe('recruiting');
+  });
+
+  it('does not add an output to plain (non-draft/plan) tool invocations', () => {
+    const cached = sanitizeChatMessagesForCache([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'Counted.',
+        toolInvocations: [{ toolCallId: 'tc1', toolName: 'aggregate_data', state: 'output-available' }],
+      },
+    ]);
+    const toolPart = cached[0]?.parts.find((p) => p.type === 'tool-aggregate_data');
+    expect(toolPart).toBeDefined();
+    expect('output' in (toolPart as object)).toBe(false);
+  });
+});
+
+// The server persists conversations in ModelMessage format, where an assistant
+// tool CALL is the literal `type:'tool-call'` with the real tool in `toolName`.
+// Left as-is the chat step humanizes to "Call"; toUIMessages must remap it to
+// the AI SDK UI part type `tool-<toolName>` so the title (and the toolName the
+// mapper extracts) reflect the real tool after a clean server-backed reload.
+describe('toUIMessages — remaps the ModelMessage tool-call part type', () => {
+  it('rewrites assistant tool-call → tool-<toolName> and still merges the tool result', () => {
+    const ui = toUIMessages([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'tc1', toolName: 'apply_blueprint', input: { goal: 'tracker' } },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tc1',
+            output: { status: 'drafted', drafted: [{ type: 'app', name: 'tracker_app' }], summary: 'Built' },
+          },
+        ],
+      },
+    ]);
+
+    const part = ui[0]?.parts[0];
+    expect(part?.type).toBe('tool-apply_blueprint');
+    expect(part?.output).toEqual({
+      status: 'drafted',
+      drafted: [{ type: 'app', name: 'tracker_app' }],
+      summary: 'Built',
+    });
+
+    // Through the mapper the tool reads as the real tool, not "call", and its
+    // draft card survives because the result merged onto the remapped part.
+    const cm = uiMessageToChatMessage(ui[0]);
+    expect(cm.toolInvocations?.[0]?.toolName).toBe('apply_blueprint');
+    expect(cm.toolInvocations?.[0]?.draftReview?.items).toEqual([{ type: 'app', name: 'tracker_app' }]);
+  });
+
+  it('leaves a tool-call without a toolName untouched (no false remap)', () => {
+    const ui = toUIMessages([
+      { id: 'a1', role: 'assistant', content: [{ type: 'tool-call', toolCallId: 'tc1' }] },
+    ]);
+    expect(ui[0]?.parts[0]?.type).toBe('tool-call');
   });
 });

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -71,11 +71,51 @@ export interface UseChatConversationReturn {
   reset: () => Promise<void>;
 }
 
+/**
+ * The subset of plugin-chatbot's `DraftReview` (mapMessages.ts) that the chat's
+ * draft/publish + ADR-0038 verification cards are derived from. Mirrored here —
+ * rather than imported — to keep this low-level hook free of a `@object-ui/
+ * plugin-chatbot` dependency; the round-trip test in
+ * `useChatConversation.test.tsx` runs these through the REAL detectors, so any
+ * incompatible drift fails CI.
+ */
+interface CachedDraftReview {
+  items: Array<{ type: string; name: string }>;
+  summary?: string;
+  packageId?: string;
+  autoPublishable?: boolean;
+  failedCount?: number;
+  materialized?: boolean;
+  verification?: { errors: number; warnings: number };
+  issues?: Array<{ severity: 'error' | 'warning'; code: string; message: string; fix?: string }>;
+  nextSteps?: string[];
+}
+
+/** Mirrors the subset of plugin-chatbot's `ProposedPlan` the "Proposed plan" card needs. */
+interface CachedProposedPlan {
+  summary?: string;
+  objects: Array<{ name: string; label?: string; fieldCount: number }>;
+  counts: { objects: number; views: number; dashboards: number; seedData: number };
+  questions: string[];
+  assumptions: string[];
+  targetApp?: string;
+}
+
 interface CacheableChatToolInvocation {
   toolCallId: string;
   toolName: string;
   state?: string;
   errorText?: string;
+  /**
+   * The detect-relevant shapes the live render already derived from the tool
+   * result (`uiMessageToChatMessage`). Present on assistant tool invocations
+   * that staged a draft (`apply_blueprint` …) or proposed a plan
+   * (`propose_blueprint`). We re-serialize these into a COMPACT tool `output`
+   * so the cards survive a cache-fallback reload — see
+   * `sanitizeChatMessagesForCache`.
+   */
+  draftReview?: CachedDraftReview;
+  proposedPlan?: CachedProposedPlan;
 }
 
 interface CacheableChatMessage {
@@ -83,6 +123,55 @@ interface CacheableChatMessage {
   role: 'user' | 'assistant' | 'system';
   content?: string;
   toolInvocations?: CacheableChatToolInvocation[];
+}
+
+/**
+ * Rebuild the MINIMAL `{ status:'drafted', … }` envelope that
+ * `mapMessages.detectDraftResult` re-parses, from the already-derived
+ * `DraftReview`. Inverse of the detector: we keep only the fields it reads, so
+ * the draft "Review N changes / Publish" card and the ADR-0038 verification
+ * chip survive without re-storing the (potentially large) blueprint JSON.
+ * `failed` is materialized to the right length because the detector counts
+ * `failed.length`.
+ */
+function draftReviewToCachedResult(dr: CachedDraftReview): Record<string, unknown> {
+  return {
+    status: 'drafted',
+    drafted: dr.items,
+    ...(dr.summary ? { summary: dr.summary } : {}),
+    ...(dr.packageId ? { packageId: dr.packageId } : {}),
+    ...(dr.autoPublishable ? { autoPublishable: true } : {}),
+    ...(dr.failedCount ? { failed: Array.from({ length: dr.failedCount }, () => null) } : {}),
+    ...(dr.materialized ? { materialized: true } : {}),
+    ...(dr.verification ? { verification: dr.verification } : {}),
+    ...(dr.issues && dr.issues.length ? { issues: dr.issues } : {}),
+    ...(dr.nextSteps && dr.nextSteps.length ? { nextSteps: dr.nextSteps } : {}),
+  };
+}
+
+/**
+ * Rebuild the MINIMAL `{ status:'blueprint_proposed', … }` envelope that
+ * `mapMessages.detectProposedPlan` re-parses, from the already-derived
+ * `ProposedPlan`. Object `fields` are materialized to the right length because
+ * the detector reads `fields.length` as the per-object field count — the field
+ * definitions themselves are dropped (the lean win).
+ */
+function proposedPlanToCachedResult(pp: CachedProposedPlan): Record<string, unknown> {
+  return {
+    status: 'blueprint_proposed',
+    ...(pp.summary ? { summary: pp.summary } : {}),
+    counts: pp.counts,
+    questions: pp.questions,
+    ...(pp.targetApp ? { targetApp: pp.targetApp } : {}),
+    blueprint: {
+      objects: pp.objects.map((o) => ({
+        name: o.name,
+        ...(o.label ? { label: o.label } : {}),
+        fields: Array.from({ length: o.fieldCount }, () => null),
+      })),
+      assumptions: pp.assumptions,
+    },
+  };
 }
 
 const CACHE_PREFIX = 'objectstack:ai-chat-conversation-id';
@@ -162,12 +251,26 @@ export function sanitizeChatMessagesForCache(
       }
       if (message.role === 'assistant') {
         for (const tool of message.toolInvocations ?? []) {
+          // Re-serialize the draft/plan affordance into a compact tool `output`.
+          // Without it, a cache-fallback reload (server returns no messages →
+          // `readMessageCache`) drops the draft "Review N changes / Publish"
+          // card, the ADR-0038 verification chip, and the "Proposed plan" card,
+          // because `mapMessages.detect*` read the result `output` that the
+          // earlier cache shape never kept. `output` (not a custom part field)
+          // is used because the AI SDK preserves it through `useChat` init,
+          // exactly as the server-backed tool-result merge relies on.
+          const cachedOutput = tool.draftReview
+            ? draftReviewToCachedResult(tool.draftReview)
+            : tool.proposedPlan
+              ? proposedPlanToCachedResult(tool.proposedPlan)
+              : undefined;
           parts.push({
             type: `tool-${tool.toolName}`,
             toolCallId: tool.toolCallId,
             toolName: tool.toolName,
             state: tool.state ?? (tool.errorText ? 'output-error' : 'output-available'),
             ...(tool.errorText ? { errorText: tool.errorText } : {}),
+            ...(cachedOutput !== undefined ? { output: cachedOutput } : {}),
           });
         }
       }
@@ -280,6 +383,16 @@ export function toUIMessages(rows: ServerMessage[] | undefined): HydratedUIMessa
     if (parts.length === 0) return;
     if (role === 'assistant') {
       for (const part of parts) {
+        // ModelMessage format persists an assistant tool CALL as the literal
+        // `type:'tool-call'` with the real tool in `toolName`. Left as-is, the
+        // chat humanizes the step title to "Call" (and downstream toolName
+        // extraction yields "call"). Remap to the AI SDK UI part type
+        // `tool-<toolName>` so the step reads "Apply blueprint" / "Propose
+        // blueprint" after a clean server-backed reload; the result-merge below
+        // and `detect*` are unaffected (they key off toolCallId / output).
+        if (part.type === 'tool-call' && typeof part.toolName === 'string' && part.toolName) {
+          part.type = `tool-${part.toolName}`;
+        }
         const callId = typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
         if (callId && (part.type === 'tool-call' || part.type.startsWith('tool-'))) {
           toolPartByCallId.set(callId, part);


### PR DESCRIPTION
## Problem

Two independent reload regressions on the AI chat surface, both in app-shell's [`useChatConversation.ts`](../blob/fix/chat-cache-affordances/packages/app-shell/src/hooks/useChatConversation.ts):

1. **Cache-fallback strips the affordance cards.** `sanitizeChatMessagesForCache` rebuilt cached tool parts *without* the tool `output`. When the loader falls back to `readMessageCache` (server transiently returns no/partial messages, or offline), `mapMessages.detectDraftResult` / `detectProposedPlan` had nothing to parse → the draft **"Review N changes / Publish"** card, the **ADR-0038 verification chip**, and the #1875 **"Proposed plan"** card silently vanished. Only the bare tool header remained.

2. **Server `tool-call` → "Call" title.** `toUIMessages` passed the server's ModelMessage assistant tool-call part `type:'tool-call'` through verbatim. In the `ConsoleFloatingChatbot` path (`hydratedHistory = uiMessagesToChatMessages`, which derives `toolName` from the part *type*) this humanized the tool step to **"Call"** instead of "Apply blueprint" / "Propose blueprint" after a clean server-backed reload.

## Fix

1. **Compact `output` (lean).** Sanitize now re-serializes the already-derived `draftReview` / `proposedPlan` into a **minimal, re-parseable `output` envelope** — dropping the heavy blueprint JSON (object `fields` / `failed` are materialized only to the length the detectors *count*). Stored as `output` — a first-class SDK tool-part field, **not** a custom part key — because the AI SDK preserves `output` through `useChat` init exactly as the server-backed `mergeToolResultsInto` path already relies on (custom keys risk being stripped). **No `mapMessages` change:** the existing detectors re-parse the compact envelope.

2. **Remap in `toUIMessages`.** Assistant `type:'tool-call'` (with a `toolName`) → `tool-<toolName>`. The result-merge and detectors are unaffected (they key off `toolCallId` / `output`). `AiChatPage`'s own hydration mapper reads the `toolName` field directly and was already immune — the remap is harmless to it.

## Verification

- **4 new regression tests** in `useChatConversation.test.tsx`: a full live → cache → `localStorage` (JSON) → reload round-trip through `sanitizeChatMessagesForCache` + `uiMessageToChatMessage` asserting `draftReview` / `proposedPlan` (all fields) survive, a leanness check (no field defs in the cached plan), and the `tool-call` remap. Confirmed they **fail without the fix**.
- **app-shell suite: 576 passed** · **plugin-chatbot suite: 118 passed**.
- Type-check clean (after building deps) · lint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)