### PR TITLE
fix(console-ai): actually render the "Proposed plan" card on /ai/build

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -48,6 +48,7 @@ import {
   isAskAgent,
   publishHealthFromResponse,
   detectDraftResult,
+  detectProposedPlan,
   buildProgressFromDraftReview,
   type AgentDescriptor,
   type ChatbotEnhancedToolInvocation,
@@ -131,12 +132,17 @@ export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): C
         const result =
           (part as { output?: unknown }).output ?? (part as { result?: unknown }).result;
         const draftReview = detectDraftResult(result);
+        // The pre-build PLAN (propose_blueprint → blueprint_proposed) rides the
+        // same merged tool result; lift it so the "Proposed plan" review card
+        // survives a reload on this surface, not just in the floating chat.
+        const proposedPlan = detectProposedPlan(result);
         toolInvocations.push({
           toolCallId,
           toolName,
           ...(state ? { state } : {}),
           ...(result !== undefined ? { result } : {}),
           ...(draftReview ? { draftReview } : {}),
+          ...(proposedPlan ? { proposedPlan } : {}),
           ...(part.errorText ? { errorText: String(part.errorText) } : {}),
         });
         if (!buildProgress) {

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
@@ -45,4 +45,36 @@ describe('AiChatPage hydration — tool invocation states', () => {
       { toolCallId: 't2', toolName: 'verify_build', state: 'output-denied' },
     ]);
   });
+
+  it('lifts the pre-build proposed plan so the review card survives a reload on this surface', () => {
+    // propose_blueprint's `blueprint_proposed` result rides the merged tool
+    // output (here the persisted `{type:text,value}` envelope). Without lifting
+    // it on THIS converter the "Proposed plan" card only shows in the floating
+    // chat, never on /ai/build after a refresh.
+    const envelope = JSON.stringify({
+      status: 'blueprint_proposed',
+      blueprint: {
+        summary: 'A reading list',
+        assumptions: ['One shelf for now'],
+        objects: [{ name: 'book', label: 'Book', fields: [{ name: 'title' }, { name: 'author' }] }],
+      },
+      counts: { objects: 1, views: 0, dashboards: 0, seedData: 0 },
+      questions: [],
+    });
+    const [msg] = hydratedMessagesToChatMessages(
+      assistantWith([
+        {
+          type: 'tool-call',
+          toolCallId: 't1',
+          toolName: 'propose_blueprint',
+          output: { type: 'text', value: envelope },
+        },
+      ]),
+    );
+    expect(msg.toolInvocations?.[0]?.proposedPlan).toMatchObject({
+      summary: 'A reading list',
+      objects: [{ name: 'book', label: 'Book', fieldCount: 2 }],
+      assumptions: ['One shelf for now'],
+    });
+  });
 });

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -679,7 +679,10 @@ function shouldRenderDetailedTool(tool: ChatToolInvocation): boolean {
     state === 'awaiting' ||
     state === 'failed' ||
     Boolean(tool.pendingActionId) ||
-    Boolean(tool.draftReview?.items.length)
+    Boolean(tool.draftReview?.items.length) ||
+    // The pre-build "Proposed plan" card lives in the detailed tool body; route
+    // a propose_blueprint result there instead of collapsing it into a chip.
+    Boolean(tool.proposedPlan)
   );
 }
 

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -43,6 +43,39 @@ describe('ChatbotEnhanced (AI Elements composition)', () => {
     expect(screen.getByText(/How can I help/i)).toBeInTheDocument();
   });
 
+  it('renders the pre-build "Proposed plan" card instead of collapsing the propose tool into a chip', () => {
+    // Regression: a propose_blueprint tool carries `proposedPlan` but no
+    // draftReview — it must route to the DETAILED tool body (where the card
+    // lives), not the summary chip strip, or the confirm-gate card never shows.
+    const messages: ChatMessage[] = [
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '',
+        toolInvocations: [
+          {
+            toolCallId: 't1',
+            toolName: 'propose_blueprint',
+            state: 'output-available',
+            proposedPlan: {
+              summary: 'A reading list',
+              objects: [{ name: 'book', label: 'Book', fieldCount: 2 }],
+              counts: { objects: 1, views: 0, dashboards: 0, seedData: 0 },
+              questions: ['Track loans separately?'],
+              assumptions: ['One shelf for now'],
+            },
+          },
+        ],
+      },
+    ];
+    render(<ChatbotEnhanced messages={messages} />);
+    expect(screen.getByTestId('proposed-plan')).toBeInTheDocument();
+    expect(screen.getByText('Proposed plan')).toBeInTheDocument();
+    expect(screen.getByText(/A reading list/)).toBeInTheDocument();
+    expect(screen.getByTestId('proposed-plan-questions')).toBeInTheDocument();
+    expect(screen.getByText(/Track loans separately/)).toBeInTheDocument();
+  });
+
   it('shows an error banner with a retry affordance', () => {
     const onReload = vi.fn();
     render(

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -312,9 +312,10 @@ export {
   uiMessageToChatMessage,
   uiMessagesToChatMessages,
   detectDraftResult,
+  detectProposedPlan,
   buildProgressFromDraftReview,
 } from './mapMessages';
-export type { DraftReview } from './mapMessages';
+export type { DraftReview, ProposedPlan } from './mapMessages';
 
 // Display helpers used internally by ChatbotEnhanced. Exported so app
 // authors composing their own chat surface get the same pretty tool-call


### PR DESCRIPTION
## Problem
#1875 added the propose_blueprint review card (detector + ChatbotEnhanced body + labels), but it **never rendered in the product**. Two wiring gaps the detector-level unit tests couldn't catch — surfaced by a live browser test on /ai/build:

1. **Routing** — `ChatbotEnhanced.shouldRenderDetailedTool` only routed a tool to the *detailed* body (where the card lives) when it had `draftReview` items / was awaiting / failed. A `propose_blueprint` result carries `proposedPlan` but **no** `draftReview`, so it collapsed into the summary **chip** strip and the card block was never reached. → route on `proposedPlan` too.
2. **Surface converter** — `AiChatPage` has its **own** history converter (`hydratedMessagesToChatMessages`, the /ai/build surface), separate from `mapMessages` (the floating chat). It wired `draftReview` but not `proposedPlan`, dropping the card on reload there. → lift `proposedPlan` alongside `draftReview`; export `detectProposedPlan` + `ProposedPlan` from the package index.

## Verification
- **Live** on the EE rig: a propose-only prompt on `/ai/build` now renders the **Proposed plan** card (object chips w/ field counts, totals line, assumptions, confirm-questions, approve hint).
- **Tests**: ChatbotEnhanced renders the card for a `proposedPlan` tool (not a chip); AiChatPage hydration lifts `proposedPlan` from the merged tool output. plugin-chatbot **119** + app-shell hydration green; type-check clean.

Follow-up to #1875.

🤖 Generated with [Claude Code](https://claude.com/claude-code)