### PR TITLE
fix(app-shell): command palette idempotent open + locators (ADR-0054 Phase 1)

### DIFF
--- a/.changeset/cmdk-idempotent-open.md
+++ b/.changeset/cmdk-idempotent-open.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/components": patch
+---
+
+fix(app-shell): command palette idempotent open + stable locators (ADR-0054 Phase 1)
+
+The top-bar "Search… ⌘K" button now opens the command palette directly via a
+shared, idempotent `openCommandPalette()` instead of re-dispatching a synthetic
+`⌘K` `KeyboardEvent` — so it works under automation and in ⌘K-reserving
+browsers. Open state is URL-addressable (`?palette=1`, `?cmdk=1` alias), making
+the palette deep-linkable and restore-on-reload. The dialog and header trigger
+emit stable `data-testid` locators (`overlay:command-palette`,
+`action:command-palette:open`) plus an ARIA name. New `useCommandPalette()` hook
+and `CommandPaletteProvider`; `CommandDialog` gains a `contentProps` passthrough
+for the dialog locator/ARIA. Implements invariants C1/C3/C4 of the UI
+testability contract.

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -424,6 +424,44 @@ for the adapter contract, backend schema, and how to plug in your own backend.
 
 <!-- release-metadata:v3.3.0 -->
 
+## Command palette (⌘K)
+
+`<ConsoleShell>` mounts a global ⌘K command palette for cross-app navigation and
+record search. Its open state and the command that opens it are provided by
+`CommandPaletteProvider` (wired in by `ConsoleLayout`) and exposed via
+`useCommandPalette()`.
+
+```tsx
+import { useCommandPalette } from '@object-ui/app-shell';
+
+function MyToolbarButton() {
+  const { openCommandPalette } = useCommandPalette();
+  // Idempotent: calling when already open is a no-op.
+  return <button onClick={openCommandPalette}>Search…</button>;
+}
+```
+
+Designed to be deterministic for automated (AI) browser testing — see
+[ADR-0054 "UI testability contract"](../../docs/adr/0054-ui-testability-contract.md):
+
+- **Idempotent, direct open (C1).** The top-bar search button, the ⌘K shortcut,
+  and the deep-link all call the *same* idempotent `openCommandPalette()`
+  (`setOpen(true)`), never a `toggle()`. The button calls the command directly —
+  it does **not** re-dispatch a synthetic `⌘K` `KeyboardEvent` (which silently
+  did nothing under automation and in ⌘K-reserving browsers). ⌘K stays a
+  keyboard *accelerator* and may still toggle (close-on-repeat).
+- **URL-addressable (C3).** Open state lives in the `?palette=1` search param, so
+  the palette is deep-linkable (`/apps/<app>?palette=1`), restores on reload, and
+  works with browser back/forward. `?cmdk=1` is accepted as an alias on read.
+- **Stable locators (C4).** The dialog carries `data-testid="overlay:command-palette"`
+  plus an ARIA role/name; the header trigger carries
+  `data-testid="action:command-palette:open"` (and `:open-mobile` for the compact
+  header). `CommandDialog` accepts `contentProps` to forward a `data-testid`/ARIA
+  name onto the underlying dialog element.
+- **Trusted-input note (C6).** The palette search is a controlled + debounced
+  input. Value-injection (`el.value = …`) does **not** fire React's `onChange`;
+  drive it with a real-input / CDP-keystroke driver so the debounced fetch fires.
+
 ## Compatibility
 
 - **React:** 18.x or 19.x

--- a/packages/app-shell/src/chrome/CommandPalette.tsx
+++ b/packages/app-shell/src/chrome/CommandPalette.tsx
@@ -118,11 +118,14 @@ export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSour
     <CommandDialog
       open={open}
       onOpenChange={setOpen}
+      // Accessible name/description (rendered visually-hidden as the required
+      // Radix DialogTitle/Description) — gives the dialog a stable ARIA name (C4).
+      title={t('console.commandPalette.title', { defaultValue: 'Command palette' })}
+      description={t('console.commandPalette.placeholder')}
       contentProps={{
-        // Stable locator + ARIA name so the overlay is addressable by an
-        // automated driver without relying on i18n-fragile visible text (C4).
+        // Stable locator so the overlay is addressable by an automated driver
+        // without relying on i18n-fragile visible text (C4).
         'data-testid': 'overlay:command-palette',
-        'aria-label': t('console.commandPalette.title', { defaultValue: 'Command palette' }),
       }}
     >
       <CommandInput

--- a/packages/app-shell/src/chrome/CommandPalette.tsx
+++ b/packages/app-shell/src/chrome/CommandPalette.tsx
@@ -35,6 +35,7 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { resolveI18nLabel, getRecordDisplayName, appRouteSegment } from '../utils';
 import { getIcon } from '../utils/getIcon';
 import { useRecentItems } from '../context/RecentItemsProvider';
+import { useCommandPalette } from '../context/CommandPaletteProvider';
 import { resolveHref } from '@object-ui/layout';
 import { useAuth } from '@object-ui/auth';
 
@@ -51,7 +52,7 @@ interface CommandPaletteProps {
 }
 
 export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSource }: CommandPaletteProps) {
-  const [open, setOpen] = useState(false);
+  const { open, setOpen } = useCommandPalette();
   const [inputValue, setInputValue] = useState('');
   const navigate = useNavigate();
   const { appName } = useParams();
@@ -59,17 +60,9 @@ export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSour
   const { evaluator } = useExpressionContext();
   const { t } = useObjectTranslation();
 
-  // ⌘+K / Ctrl+K shortcut
-  useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        setOpen(prev => !prev);
-      }
-    };
-    document.addEventListener('keydown', down);
-    return () => document.removeEventListener('keydown', down);
-  }, []);
+  // The ⌘K / Ctrl+K accelerator and the open-state source of truth now live in
+  // CommandPaletteProvider so the keyboard shortcut, the header button, and the
+  // ?palette=1 deep-link all drive the SAME idempotent open path (ADR-0054 C1/C3).
 
   // Reset query when the palette closes so reopening doesn't show stale state.
   useEffect(() => {
@@ -122,7 +115,16 @@ export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSour
   const showRecentRecords = open && inputValue.trim().length === 0 && recentRecords.length > 0;
 
   return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      contentProps={{
+        // Stable locator + ARIA name so the overlay is addressable by an
+        // automated driver without relying on i18n-fragile visible text (C4).
+        'data-testid': 'overlay:command-palette',
+        'aria-label': t('console.commandPalette.title', { defaultValue: 'Command palette' }),
+      }}
+    >
       <CommandInput
         placeholder={t('console.commandPalette.placeholder')}
         value={inputValue}

--- a/packages/app-shell/src/context/CommandPaletteProvider.tsx
+++ b/packages/app-shell/src/context/CommandPaletteProvider.tsx
@@ -1,0 +1,157 @@
+/**
+ * CommandPaletteProvider
+ *
+ * Single source of truth for whether the global ⌘K command palette is open,
+ * plus the shared, idempotent commands used to open / close it.
+ *
+ * Why this exists — ADR-0054 "UI testability contract", Phase 1:
+ *
+ *  - **C1 (idempotent, direct triggers).** Every "open the palette" affordance —
+ *    the top-bar search button, a programmatic caller, a deep-link — calls the
+ *    SAME `openCommandPalette()`, which is idempotent (`setOpen(true)`), never a
+ *    `toggle()`. Re-issuing "open" when already open is a no-op, so an automated
+ *    driver can always *ensure* it is open. The previous header button re-emitted
+ *    a synthetic `⌘K` `KeyboardEvent` and relied on the palette's global listener
+ *    being mounted and the browser/OS not having reserved `⌘K` — which silently
+ *    did nothing under automation (and in `⌘K`-reserving browsers).
+ *  - **C3 (URL-addressable state).** Open state lives in the `?palette=1` search
+ *    param, not component `useState`, so the palette is deep-linkable
+ *    (`/apps/foo?palette=1`), restores on reload, and works with back/forward.
+ *
+ * `⌘K` stays an *accelerator*: the keydown handler toggles (close-on-repeat is a
+ * keyboard nicety), but the OPEN path used by buttons / links / programmatic
+ * callers is the idempotent `openCommandPalette()`.
+ *
+ * @module
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+/** Canonical URL param reflecting the palette's open state. */
+const PALETTE_PARAM = 'palette';
+/** Legacy/alias param accepted on read (e.g. `?cmdk=1`). */
+const PALETTE_PARAM_ALIAS = 'cmdk';
+
+export interface CommandPaletteContextValue {
+  /** Whether the palette is currently open (derived from the URL). */
+  open: boolean;
+  /** Idempotent open — calling when already open is a no-op (C1). */
+  openCommandPalette: () => void;
+  /** Idempotent close. */
+  closeCommandPalette: () => void;
+  /** Toggle — reserved for the keyboard accelerator, not the open affordances. */
+  toggleCommandPalette: () => void;
+  /** Imperative setter, used by the dialog's `onOpenChange`. */
+  setOpen: (open: boolean) => void;
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | null>(null);
+
+function isOpenParam(params: URLSearchParams): boolean {
+  return params.get(PALETTE_PARAM) === '1' || params.get(PALETTE_PARAM_ALIAS) === '1';
+}
+
+export function CommandPaletteProvider({ children }: { children: ReactNode }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Open state is URL-derived (C3): one source of truth that makes the palette
+  // deep-linkable + restore-on-reload, and makes "ensure open" idempotent for
+  // free.
+  const open = isOpenParam(searchParams);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      // Truly idempotent: when already in the target state, do nothing — no
+      // redundant history navigation.
+      if (next === isOpenParam(searchParams)) return;
+      const sp = new URLSearchParams(searchParams);
+      if (next) {
+        sp.set(PALETTE_PARAM, '1');
+        sp.delete(PALETTE_PARAM_ALIAS);
+      } else {
+        sp.delete(PALETTE_PARAM);
+        sp.delete(PALETTE_PARAM_ALIAS);
+      }
+      // `replace` — toggling a transient overlay shouldn't pile up history.
+      setSearchParams(sp, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const openCommandPalette = useCallback(() => setOpen(true), [setOpen]);
+  const closeCommandPalette = useCallback(() => setOpen(false), [setOpen]);
+
+  // Toggle uses the functional updater so it never depends on `open` — keeping
+  // the keydown listener below stable across navigations.
+  const toggleCommandPalette = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const sp = new URLSearchParams(prev);
+        if (isOpenParam(sp)) {
+          sp.delete(PALETTE_PARAM);
+          sp.delete(PALETTE_PARAM_ALIAS);
+        } else {
+          sp.set(PALETTE_PARAM, '1');
+          sp.delete(PALETTE_PARAM_ALIAS);
+        }
+        return sp;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  // ⌘K / Ctrl+K accelerator. Lives here (not in CommandPalette) so the command
+  // and its shortcut share one definition and one open-state source. Toggle is
+  // fine for the *keyboard* (close-on-repeat); buttons/links/programmatic open
+  // paths use the idempotent openCommandPalette().
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        toggleCommandPalette();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [toggleCommandPalette]);
+
+  const value = useMemo<CommandPaletteContextValue>(
+    () => ({ open, openCommandPalette, closeCommandPalette, toggleCommandPalette, setOpen }),
+    [open, openCommandPalette, closeCommandPalette, toggleCommandPalette, setOpen],
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={value}>{children}</CommandPaletteContext.Provider>
+  );
+}
+
+/**
+ * Access the shared command-palette controls.
+ *
+ * Falls back to a no-op implementation when used outside a
+ * `<CommandPaletteProvider>` (e.g. an `AppHeader` rendered in the `home`/`orgs`
+ * variants, where no palette is mounted, or isolated unit tests). The trigger is
+ * then inert rather than throwing — matching the prior behavior where the
+ * synthetic `⌘K` had nothing to open.
+ */
+export function useCommandPalette(): CommandPaletteContextValue {
+  const ctx = useContext(CommandPaletteContext);
+  if (!ctx) {
+    return {
+      open: false,
+      openCommandPalette: () => {},
+      closeCommandPalette: () => {},
+      toggleCommandPalette: () => {},
+      setOpen: () => {},
+    };
+  }
+  return ctx;
+}

--- a/packages/app-shell/src/context/index.ts
+++ b/packages/app-shell/src/context/index.ts
@@ -4,6 +4,11 @@ export type { FavoriteItem } from './FavoritesProvider';
 export { RecentItemsProvider, useRecentItems } from './RecentItemsProvider';
 export type { RecentItem } from './RecentItemsProvider';
 export {
+  CommandPaletteProvider,
+  useCommandPalette,
+} from './CommandPaletteProvider';
+export type { CommandPaletteContextValue } from './CommandPaletteProvider';
+export {
   UserStateAdaptersProvider,
   useUserStateAdapter,
   useAttachUserStateAdapters,

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -132,11 +132,13 @@ export {
   useNavigationContext,
   FavoritesProvider,
   RecentItemsProvider,
+  CommandPaletteProvider,
+  useCommandPalette,
   UserStateAdaptersProvider,
   useUserStateAdapter,
   useAttachUserStateAdapters,
 } from './context';
-export type { UserDataAdapter, UserStateKind } from './context';
+export type { UserDataAdapter, UserStateKind, CommandPaletteContextValue } from './context';
 
 // Default page implementations (consumers can partial-override slots)
 export { AppContent as DefaultAppContent } from './console/AppContent';

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -67,6 +67,7 @@ import { resolveI18nLabel, preferLocal, matchAppBySegment, appRouteSegment } fro
 import { getIcon } from '../utils/getIcon';
 import { useMobileViewSwitcher } from './MobileViewSwitcherContext';
 import { useNavigationContext } from '../context/NavigationContext';
+import { useCommandPalette } from '../context/CommandPaletteProvider';
 import { getProductName } from '../runtime-config';
 import { LocalizedSidebarTrigger } from './LocalizedSidebarTrigger';
 
@@ -118,6 +119,9 @@ export function AppHeader({
   const params = useParams();
   const navigate = useNavigate();
   const { isOnline } = useOffline();
+  // Idempotent, direct open of the ⌘K command palette (ADR-0054 C1). Replaces a
+  // synthetic `⌘K` KeyboardEvent re-dispatch that did nothing under automation.
+  const { openCommandPalette } = useCommandPalette();
   const {
     user,
     signOut,
@@ -764,7 +768,11 @@ export function AppHeader({
         <div data-topbar-group className="flex items-center gap-0.5 sm:gap-1 shrink-0">
           {/* Search — desktop */}
           <button
-            onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))}
+            type="button"
+            data-testid="action:command-palette:open"
+            aria-label={t('console.search', { defaultValue: 'Search…' })}
+            aria-keyshortcuts="Meta+K Control+K"
+            onClick={openCommandPalette}
             className="hidden lg:flex relative items-center gap-2 w-48 xl:w-64 h-8 px-3 text-sm rounded-md border bg-muted/50 text-muted-foreground hover:bg-muted transition-colors"
           >
             <Search className="h-3.5 w-3.5 shrink-0" />
@@ -781,7 +789,8 @@ export function AppHeader({
             variant="ghost"
             size="icon"
             className="lg:hidden h-8 w-8 shrink-0"
-            onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))}
+            data-testid="action:command-palette:open-mobile"
+            onClick={openCommandPalette}
             aria-label={t('console.search', { defaultValue: 'Search…' })}
           >
             <Search className="h-4 w-4" />

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -24,6 +24,7 @@ import { AppHeader } from './AppHeader';
 import { MobileViewSwitcherProvider } from './MobileViewSwitcherContext';
 import { useResponsiveSidebar } from '../hooks/useResponsiveSidebar';
 import { useNavigationContext } from '../context/NavigationContext';
+import { CommandPaletteProvider } from '../context/CommandPaletteProvider';
 import { resolveI18nLabel } from '../utils';
 import { getProductName, getRuntimeConfig } from '../runtime-config';
 import type { ConnectionState } from '@object-ui/data-objectstack';
@@ -93,6 +94,9 @@ export function ConsoleLayout({
   }, [setContext, setCurrentAppName, activeAppName]);
 
   return (
+    // One shared, URL-addressable command-palette open state for both the
+    // AppHeader trigger (navbar) and the CommandPalette (children) — ADR-0054.
+    <CommandPaletteProvider>
     <MobileViewSwitcherProvider>
     <AppShell
       sidebar={
@@ -151,5 +155,6 @@ export function ConsoleLayout({
       )}
     </AppShell>
     </MobileViewSwitcherProvider>
+    </CommandPaletteProvider>
   );
 }

--- a/packages/components/src/ui/command.tsx
+++ b/packages/components/src/ui/command.tsx
@@ -14,7 +14,7 @@ import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "../lib/utils"
-import { Dialog, DialogContent } from "./dialog"
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from "./dialog"
 
 /**
  * Props for {@link CommandDialog}. Adds `contentProps` so callers can attach a
@@ -29,6 +29,15 @@ interface CommandDialogProps extends DialogProps {
   // ComponentPropsWithoutRef would reject `data-testid`.
   contentProps?: React.ComponentPropsWithoutRef<typeof DialogContent> &
     Record<`data-${string}`, string | undefined>
+  /**
+   * Accessible name for the dialog, rendered visually-hidden as the required
+   * Radix `DialogTitle`. Defaults to "Command Palette" so every CommandDialog is
+   * screen-reader accessible by construction (ADR-0054 C4). Pass a translated
+   * string to localize.
+   */
+  title?: React.ReactNode
+  /** Optional visually-hidden description (satisfies Radix's aria-describedby). */
+  description?: React.ReactNode
 }
 
 const Command = React.forwardRef<
@@ -46,11 +55,21 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-const CommandDialog = ({ children, contentProps, ...props }: CommandDialogProps) => {
+const CommandDialog = ({
+  children,
+  contentProps,
+  title = "Command Palette",
+  description,
+  ...props
+}: CommandDialogProps) => {
   const { className: contentClassName, ...restContent } = contentProps ?? {}
   return (
     <Dialog {...props}>
       <DialogContent className={cn("overflow-hidden p-0 shadow-lg", contentClassName)} {...restContent}>
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        {description ? (
+          <DialogDescription className="sr-only">{description}</DialogDescription>
+        ) : null}
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/packages/components/src/ui/command.tsx
+++ b/packages/components/src/ui/command.tsx
@@ -16,6 +16,21 @@ import { Search } from "lucide-react"
 import { cn } from "../lib/utils"
 import { Dialog, DialogContent } from "./dialog"
 
+/**
+ * Props for {@link CommandDialog}. Adds `contentProps` so callers can attach a
+ * stable locator + ARIA name to the underlying dialog element — e.g.
+ * `contentProps={{ 'data-testid': 'overlay:command-palette', 'aria-label': 'Command palette' }}`
+ * (ADR-0054 C4). Without this, `data-testid` spread onto `CommandDialog` lands on
+ * the Radix `Dialog` root (which renders no DOM) and never reaches the page.
+ */
+interface CommandDialogProps extends DialogProps {
+  // `data-*` is intersected in explicitly: React component prop types (unlike JSX
+  // intrinsic elements) have no `data-*` index signature, so a bare
+  // ComponentPropsWithoutRef would reject `data-testid`.
+  contentProps?: React.ComponentPropsWithoutRef<typeof DialogContent> &
+    Record<`data-${string}`, string | undefined>
+}
+
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
@@ -31,10 +46,11 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+const CommandDialog = ({ children, contentProps, ...props }: CommandDialogProps) => {
+  const { className: contentClassName, ...restContent } = contentProps ?? {}
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className={cn("overflow-hidden p-0 shadow-lg", contentClassName)} {...restContent}>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1061,6 +1061,7 @@ const en = {
       toggleDarkMode: 'Toggle dark mode',
     },
     commandPalette: {
+      title: 'Command palette',
       placeholder: 'Type a command or search...',
       noResults: 'No results found.',
       searching: 'Searching…',

--- a/packages/react/src/hooks/__tests__/useRecordSearch.test.ts
+++ b/packages/react/src/hooks/__tests__/useRecordSearch.test.ts
@@ -239,4 +239,57 @@ describe('useRecordSearch', () => {
 
     expect(result.current.results[0].recordId).toBe('OPP-9999');
   });
+
+  it('sends the query as $search (server-side full-text), not $filter', async () => {
+    // ADR-0054 §6 / ADR-0061: the palette delegates matching to the backend via
+    // `$search`; it must NOT silently fall back to a client-side `$filter`. The
+    // hook also trims surrounding whitespace before it leaves the page.
+    const ds = makeDataSource({ account: [{ id: 'a1', name: 'Acme Corp' }] });
+
+    renderHook(() =>
+      useRecordSearch({
+        query: '  Acme  ',
+        objects,
+        dataSource: ds,
+        objectNames: ['account'],
+        topPerObject: 5,
+        debounceMs: 0,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledTimes(1);
+    });
+
+    const [calledName, calledQuery] = ds.find.mock.calls[0];
+    expect(calledName).toBe('account');
+    // Exactly the trimmed $search + $top — no $filter, no $search_fields, etc.
+    expect(calledQuery).toEqual({ $search: 'Acme', $top: 5 });
+  });
+
+  it('re-fires $search as the (debounced) query changes', async () => {
+    const ds = makeDataSource({ account: [{ id: 'a1', name: 'Acme' }] });
+
+    const { rerender } = renderHook(
+      ({ q }: { q: string }) =>
+        useRecordSearch({
+          query: q,
+          objects,
+          dataSource: ds,
+          objectNames: ['account'],
+          debounceMs: 0,
+        }),
+      { initialProps: { q: 'ac' } },
+    );
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith('account', { $search: 'ac', $top: 3 });
+    });
+
+    rerender({ q: 'acme' });
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith('account', { $search: 'acme', $top: 3 });
+    });
+  });
 });


### PR DESCRIPTION
## What & why

**ADR-0054 "UI testability contract" — Phase 1 (the reference fix).** The top-bar "Search… ⌘K" button did **not** open the command palette under automation: it re-emitted a synthetic `⌘K` `KeyboardEvent` and relied on `CommandPalette`'s global listener being mounted and the browser not reserving `⌘K`. The open path was also a non-idempotent `toggle` and open state lived only in `useState` (not URL-addressable).

This makes the palette deterministic for AI browser testing by fixing the shared primitive — every generated app inherits it.

## Changes (invariants C1 / C3 / C4)

- **C1 — idempotent, direct triggers.** New `CommandPaletteProvider` / `useCommandPalette()` owns open state and a shared idempotent `openCommandPalette()` (`setOpen(true)`). The header search buttons call it directly; the synthetic `dispatchEvent(new KeyboardEvent(...))` is **deleted**. `⌘K` stays a keyboard accelerator (may toggle for close-on-repeat); the OPEN path used by buttons/links/programmatic callers is idempotent.
- **C3 — URL-addressable state.** Open state is the `?palette=1` search param (`?cmdk=1` alias on read) → deep-linkable, restores on reload, works with back/forward.
- **C4 — stable locators + ARIA.** Dialog: `data-testid="overlay:command-palette"` + a visually-hidden Radix `DialogTitle` (accessible `role="dialog"`/name). Trigger: `data-testid="action:command-palette:open"` (`:open-mobile` for the compact header). `CommandDialog` gains `contentProps` (forward a locator onto the dialog element) and `title`/`description` (accessible-by-construction).
- **Tests.** Added `useRecordSearch` unit tests for the `$search` query path (trimmed query, exact `{ $search, $top }` payload, re-fire on query change).
- **Docs.** New "Command palette" section in the app-shell README.

## Verification (browser, agent-browser / CDP-real keystrokes)

Worktree console (`packages/*/src` via HMR) on `:5182` → framework `app-showcase` backend on `:3000`:

- **(a) The original bug — fixed:** *clicking* the top-bar search trigger opens the palette under automation (overlay count 0→1, URL gains `?palette=1`).
- **(b) Record search:** real keystrokes drive the controlled+debounced input → `$search` fan-out to the backend (`/api/v1/data/showcase_*?top=3&search=…`, all 200) → "Records" group renders real hits.
- **(c) Deep-link:** `?palette=1` (and legacy `?cmdk=1`) open the palette on fresh page load.
- Also verified: `⌘K` toggles, Escape closes + clears the URL param, no Radix dialog a11y errors.

Unit/type: `@object-ui/{i18n,components,react,app-shell}` test suites green; `tsc` build green for touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)