### PR TITLE
feat(app-shell): global settle signal + region aria-busy (ADR-0054 Phase 3)

### DIFF
--- a/.changeset/settle-signal.md
+++ b/.changeset/settle-signal.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/plugin-list": patch
+"@object-ui/fields": patch
+---
+
+feat(app-shell): global settle signal (window.__objectui) + region aria-busy (ADR-0054 Phase 3)
+
+Adds a single machine-readable "is the app idle?" predicate (ADR-0054 C5). The
+data layer wraps the adapter's `fetch` to count in-flight requests, mirrored onto
+`window.__objectui` with live `idle` / `pendingRequests` getters plus `whenIdle()`
+and `subscribe()`. New `useSettleSignal()` React hook and lower-level exports
+(`getPendingRequests`, `subscribeSettle`, `whenIdle`, `withSettleSignal`,
+`installSettleSignalGlobal`). The list view and record-picker results regions now
+set `aria-busy` while fetching and `data-state="loading|idle"` for region-level
+waiting. Lets an automated (AI) driver wait for settle instead of hardcoding
+timeouts.

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -493,6 +493,30 @@ a `data-testid` onto their content element and emit Radix `data-state="open|clos
 so overlays are locatable and their open/closed state is machine-readable by
 construction (C4).
 
+## Settle signal (is the app idle?)
+
+`<ConsoleShell>` exposes one global "no requests in flight" predicate so an
+automated (AI) browser driver can wait for the app to settle instead of
+hardcoding timeouts (ADR-0054 C5). The data layer increments a counter around
+every outbound request (it wraps the adapter's `fetch`), mirrored onto
+`window.__objectui`:
+
+```js
+// In an e2e / browser driver:
+await page.waitForFunction(() => window.__objectui?.idle === true);
+// or:  window.__objectui.pendingRequests === 0
+// or:  await window.__objectui.whenIdle();   // resolves when settled (10s cap)
+```
+
+In React, `useSettleSignal()` returns `{ pending, idle }` for a global busy
+indicator; the lower-level `getPendingRequests` / `subscribeSettle` / `whenIdle`
+/ `withSettleSignal` / `installSettleSignalGlobal` are also exported.
+
+Async data regions additionally expose region-level state for finer waits: the
+list view and record-picker results set `aria-busy` while fetching and
+`data-state="loading|idle"`, complementing the Radix `data-state` already on
+overlays.
+
 ## Compatibility
 
 - **React:** 18.x or 19.x

--- a/packages/app-shell/src/hooks/index.ts
+++ b/packages/app-shell/src/hooks/index.ts
@@ -16,6 +16,7 @@ export { useObjectActions } from './useObjectActions';
 export { useRecentItems, type RecentItem } from './useRecentItems';
 export { useRecordApprovals, type ApprovalRequestLite } from './useRecordApprovals';
 export { useResponsiveSidebar } from './useResponsiveSidebar';
+export { useSettleSignal, type SettleSignalState } from './useSettleSignal';
 export {
   useUrlOverlay,
   type UseUrlOverlayOptions,

--- a/packages/app-shell/src/hooks/useSettleSignal.ts
+++ b/packages/app-shell/src/hooks/useSettleSignal.ts
@@ -1,0 +1,35 @@
+/**
+ * useSettleSignal — React binding for the global in-flight/idle signal.
+ *
+ * Subscribes to the app-shell settle counter (ADR-0054 C5) so a component can
+ * render a global busy indicator or gate UI on "no requests in flight".
+ *
+ * @example
+ * const { pending, idle } = useSettleSignal();
+ * return idle ? null : <GlobalSpinner count={pending} />;
+ *
+ * @module
+ */
+
+import { useSyncExternalStore } from 'react';
+import {
+  getPendingRequests,
+  subscribeSettle,
+} from '../observability/settleSignal';
+
+export interface SettleSignalState {
+  /** Number of requests currently in flight. */
+  pending: number;
+  /** Whether the app is idle (no requests in flight). */
+  idle: boolean;
+}
+
+export function useSettleSignal(): SettleSignalState {
+  const pending = useSyncExternalStore(
+    subscribeSettle,
+    getPendingRequests,
+    // SSR/server snapshot — there is no client request activity yet.
+    () => 0,
+  );
+  return { pending, idle: pending === 0 };
+}

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -17,6 +17,17 @@ export { ExpressionProvider, useExpressionContext, evaluateVisibility } from './
 export { useObjectActions } from './hooks/useObjectActions';
 export { useUrlOverlay } from './hooks/useUrlOverlay';
 export type { UseUrlOverlayOptions, UrlOverlayControls } from './hooks/useUrlOverlay';
+export { useSettleSignal } from './hooks/useSettleSignal';
+export type { SettleSignalState } from './hooks/useSettleSignal';
+export {
+  getPendingRequests,
+  isIdle,
+  subscribeSettle,
+  whenIdle,
+  withSettleSignal,
+  installSettleSignalGlobal,
+  type ObjectUiGlobal,
+} from './observability/settleSignal';
 export { useRecentItems } from './hooks/useRecentItems';
 
 // Types

--- a/packages/app-shell/src/observability/index.ts
+++ b/packages/app-shell/src/observability/index.ts
@@ -8,3 +8,14 @@
  */
 
 export { initSentry, captureError, setSentryUser, getSentry } from './sentry';
+export {
+  beginRequest,
+  endRequest,
+  getPendingRequests,
+  isIdle,
+  subscribeSettle,
+  whenIdle,
+  withSettleSignal,
+  installSettleSignalGlobal,
+  type ObjectUiGlobal,
+} from './settleSignal';

--- a/packages/app-shell/src/observability/settleSignal.test.ts
+++ b/packages/app-shell/src/observability/settleSignal.test.ts
@@ -1,0 +1,108 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  beginRequest,
+  endRequest,
+  getPendingRequests,
+  isIdle,
+  subscribeSettle,
+  whenIdle,
+  withSettleSignal,
+  installSettleSignalGlobal,
+  __resetSettleSignal,
+} from './settleSignal';
+
+beforeEach(() => {
+  __resetSettleSignal();
+});
+
+describe('settleSignal', () => {
+  it('counts begin/end and reports idle', () => {
+    expect(isIdle()).toBe(true);
+    expect(getPendingRequests()).toBe(0);
+
+    beginRequest();
+    beginRequest();
+    expect(getPendingRequests()).toBe(2);
+    expect(isIdle()).toBe(false);
+
+    endRequest();
+    expect(getPendingRequests()).toBe(1);
+    endRequest();
+    expect(getPendingRequests()).toBe(0);
+    expect(isIdle()).toBe(true);
+  });
+
+  it('clamps the counter at zero on extra end()', () => {
+    endRequest();
+    expect(getPendingRequests()).toBe(0);
+  });
+
+  it('notifies subscribers and supports unsubscribe', () => {
+    const seen: number[] = [];
+    const off = subscribeSettle((p) => seen.push(p));
+    beginRequest();
+    endRequest();
+    off();
+    beginRequest();
+    expect(seen).toEqual([1, 0]);
+  });
+
+  it('withSettleSignal increments during the request and decrements after success', async () => {
+    let pendingDuring = -1;
+    const fakeFetch = (async () => {
+      pendingDuring = getPendingRequests();
+      return new Response('ok');
+    }) as unknown as typeof fetch;
+
+    const counted = withSettleSignal(fakeFetch);
+    expect(getPendingRequests()).toBe(0);
+    await counted('https://example.test');
+    expect(pendingDuring).toBe(1);
+    expect(getPendingRequests()).toBe(0);
+  });
+
+  it('withSettleSignal decrements even when the request rejects', async () => {
+    const failing = (async () => {
+      throw new Error('boom');
+    }) as unknown as typeof fetch;
+    const counted = withSettleSignal(failing);
+    await expect(counted('https://example.test')).rejects.toThrow('boom');
+    expect(getPendingRequests()).toBe(0);
+  });
+
+  it('whenIdle resolves immediately when already idle', async () => {
+    await expect(whenIdle()).resolves.toBeUndefined();
+  });
+
+  it('whenIdle resolves once the last request settles', async () => {
+    beginRequest();
+    let resolved = false;
+    const p = whenIdle().then(() => {
+      resolved = true;
+    });
+    expect(resolved).toBe(false);
+    endRequest();
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('installSettleSignalGlobal exposes live window.__objectui accessors', () => {
+    installSettleSignalGlobal();
+    const ns = (window as any).__objectui;
+    expect(ns).toBeTruthy();
+    expect(ns.idle).toBe(true);
+    expect(ns.pendingRequests).toBe(0);
+    beginRequest();
+    // live getters reflect the current count without re-installing
+    expect(ns.pendingRequests).toBe(1);
+    expect(ns.idle).toBe(false);
+    expect(typeof ns.whenIdle).toBe('function');
+    expect(typeof ns.subscribe).toBe('function');
+    endRequest();
+  });
+});

--- a/packages/app-shell/src/observability/settleSignal.ts
+++ b/packages/app-shell/src/observability/settleSignal.ts
@@ -1,0 +1,150 @@
+/**
+ * settleSignal — global "is the app idle?" in-flight request counter.
+ *
+ * ADR-0054 "UI testability contract", invariant C5 (machine-readable async
+ * state). Gives an automated (AI) browser driver a single predicate to poll
+ * instead of hardcoding waits or scraping per-component spinners:
+ *
+ *   await page.waitForFunction(() => window.__objectui?.idle === true)
+ *   // or:  window.__objectui.pendingRequests === 0
+ *   // or:  await window.__objectui.whenIdle()
+ *
+ * The app-shell data layer increments the counter around every outbound request
+ * by wrapping the adapter's `fetch` with {@link withSettleSignal}. Async regions
+ * additionally expose `aria-busy`/`data-state` for region-level waiting.
+ *
+ * The counter is a module singleton (shared across the app); `window.__objectui`
+ * mirrors it via live getters installed by {@link installSettleSignalGlobal}.
+ *
+ * @module
+ */
+
+type Listener = (pending: number) => void;
+
+let pending = 0;
+const listeners = new Set<Listener>();
+let idleWaiters: Array<() => void> = [];
+
+function notify(): void {
+  for (const l of listeners) {
+    try {
+      l(pending);
+    } catch {
+      /* a listener throwing must not break request accounting */
+    }
+  }
+  if (pending === 0 && idleWaiters.length > 0) {
+    const waiters = idleWaiters;
+    idleWaiters = [];
+    for (const resolve of waiters) {
+      try {
+        resolve();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+/** Mark one request as in-flight. Pair with {@link endRequest}. */
+export function beginRequest(): void {
+  pending += 1;
+  notify();
+}
+
+/** Mark one in-flight request as settled (clamped at 0). */
+export function endRequest(): void {
+  pending = Math.max(0, pending - 1);
+  notify();
+}
+
+/** Current number of in-flight requests. */
+export function getPendingRequests(): number {
+  return pending;
+}
+
+/** Whether the app is idle (no requests in flight). */
+export function isIdle(): boolean {
+  return pending === 0;
+}
+
+/**
+ * Subscribe to in-flight count changes. Returns an unsubscribe function.
+ * Used by {@link useSettleSignal} and any consumer wanting a global busy state.
+ */
+export function subscribeSettle(cb: Listener): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/**
+ * Resolve once the app is idle (no in-flight requests). Resolves immediately if
+ * already idle. `timeoutMs` (default 10s, `0` to disable) caps the wait so a
+ * pathological never-idle app — e.g. a held-open stream — can't hang a driver.
+ */
+export function whenIdle(timeoutMs = 10_000): Promise<void> {
+  if (pending === 0) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    idleWaiters.push(finish);
+    if (timeoutMs > 0 && typeof setTimeout !== 'undefined') {
+      setTimeout(finish, timeoutMs);
+    }
+  });
+}
+
+/**
+ * Wrap a `fetch` so each call increments the in-flight counter before the
+ * request and decrements it when the promise settles (success or failure).
+ */
+export function withSettleSignal(fetchFn: typeof fetch): typeof fetch {
+  return (async (...args: Parameters<typeof fetch>) => {
+    beginRequest();
+    try {
+      return await fetchFn(...args);
+    } finally {
+      endRequest();
+    }
+  }) as typeof fetch;
+}
+
+/** Shape mirrored onto `window.__objectui` for automated drivers. */
+export interface ObjectUiGlobal {
+  /** Live in-flight request count. */
+  readonly pendingRequests: number;
+  /** Live idle flag (`pendingRequests === 0`). */
+  readonly idle: boolean;
+  /** Resolve once idle (see {@link whenIdle}). */
+  whenIdle: (timeoutMs?: number) => Promise<void>;
+  /** Subscribe to in-flight count changes. */
+  subscribe: (cb: (pending: number) => void) => () => void;
+}
+
+/**
+ * Install live `window.__objectui` accessors (idempotent). Safe to call in any
+ * environment — a no-op when `window` is undefined (SSR/tests).
+ */
+export function installSettleSignalGlobal(): void {
+  if (typeof window === 'undefined') return;
+  const w = window as unknown as { __objectui?: Record<string, unknown> };
+  const ns = (w.__objectui ??= {});
+  // Live getters so reads always reflect the current count.
+  Object.defineProperty(ns, 'pendingRequests', { get: getPendingRequests, configurable: true });
+  Object.defineProperty(ns, 'idle', { get: isIdle, configurable: true });
+  ns.whenIdle = whenIdle;
+  ns.subscribe = subscribeSettle;
+}
+
+/** Test-only: reset the counter and listeners to a clean state. */
+export function __resetSettleSignal(): void {
+  pending = 0;
+  listeners.clear();
+  idleWaiters = [];
+}

--- a/packages/app-shell/src/providers/AdapterProvider.tsx
+++ b/packages/app-shell/src/providers/AdapterProvider.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect, type ReactNode } from 'react';
 import { ObjectStackAdapter } from '@object-ui/data-objectstack';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import { AdapterCtx } from '@object-ui/react';
+import { installSettleSignalGlobal, withSettleSignal } from '../observability/settleSignal';
 
 export { useAdapter } from '@object-ui/react';
 
@@ -35,11 +36,16 @@ export function AdapterProvider({ children, adapter: externalAdapter }: AdapterP
 
     let cancelled = false;
 
+    // Expose window.__objectui.{pendingRequests,idle,whenIdle} so an automated
+    // (AI) browser driver has one "is the app settled?" predicate (ADR-0054 C5).
+    installSettleSignalGlobal();
+
     async function init() {
       try {
         const a = new ObjectStackAdapter({
           baseUrl: import.meta.env.VITE_SERVER_URL || '',
-          fetch: createAuthenticatedFetch(),
+          // Count every outbound request in the global in-flight signal (C5).
+          fetch: withSettleSignal(createAuthenticatedFetch()),
           autoReconnect: true,
           maxReconnectAttempts: 5,
           reconnectDelay: 1000,

--- a/packages/fields/src/widgets/RecordPickerDialog.tsx
+++ b/packages/fields/src/widgets/RecordPickerDialog.tsx
@@ -1056,6 +1056,8 @@ export function RecordPickerDialog({
             {!error && records.length > 0 && (
               <div
                 className="relative flex-1 overflow-auto min-h-0 border rounded-md"
+                aria-busy={loading || undefined}
+                data-state={loading ? 'loading' : 'idle'}
                 tabIndex={0}
                 onKeyDown={handleTableKeyDown}
                 role="grid"

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1514,6 +1514,8 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       {...(schema.aria?.describedBy ? { 'aria-describedby': schema.aria.describedBy } : {})}
       {...(schema.aria?.live ? { 'aria-live': schema.aria.live } : {})}
       role="region"
+      aria-busy={loading || undefined}
+      data-state={loading ? 'loading' : 'idle'}
     >
       {pullDistance > 0 && (
         <div


### PR DESCRIPTION
## What & why

**ADR-0054 "UI testability contract" — Phase 3 (machine-readable async state, C5).** Gives an automated (AI) browser driver one predicate — "is the app idle?" — so it can wait for settle instead of hardcoding timeouts or scraping per-component spinners.

## Changes

- **Global in-flight signal** (`observability/settleSignal`): a module counter incremented around every outbound request by wrapping the adapter's `fetch` with `withSettleSignal()` in `AdapterProvider`. `installSettleSignalGlobal()` installs live `window.__objectui.{pendingRequests, idle}` getters plus `whenIdle(timeoutMs?)` and `subscribe()`.
- **React binding**: `useSettleSignal()` → `{ pending, idle }` (via `useSyncExternalStore`). Lower-level `getPendingRequests` / `subscribeSettle` / `whenIdle` / `withSettleSignal` / `installSettleSignalGlobal` exported. 8 unit tests.
- **Region-level state**: the list-view root and record-picker results region set `aria-busy` while fetching and `data-state="loading|idle"` — complementing the Radix `data-state` already on overlays.
- README: "Settle signal" usage section.

```js
// e2e / AI driver:
await page.waitForFunction(() => window.__objectui?.idle === true);
// or window.__objectui.pendingRequests === 0  /  await window.__objectui.whenIdle()
```

## Verification (browser, agent-browser / CDP)

Worktree console (`:5182`, my `packages/*/src` via HMR) → `app-showcase` backend (`:3010`):

- `window.__objectui` present with live `idle`/`pendingRequests` + `whenIdle`/`subscribe`. ✅
- `pendingRequests` **peaks at 8** during app load and during a palette record search, then **settles to 0** (`idle === true`). ✅
- `whenIdle()` resolves. ✅
- List region reports `data-state="idle"` when settled (10 rows live); `aria-busy` correctly absent when not busy. ✅
- No auth/console regressions — the fetch wrapper preserves authenticated requests (verified zero stray failures on a clean load).

Unit/type: settleSignal (8) + app-shell (658) + plugin-list (127) + fields (4236) suites green; `tsc` build green.

## ADR rollout
Phases 1 (#1879) + 2 (#1882) merged. This is Phase 3. Next: Phase 4 (locator coverage), Phase 5 (ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)