### PR TITLE
feat(console-ai): make the "Proposed plan" card an actionable confirm gate

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1190,6 +1190,14 @@ function ChatPane({
         planApproveHintLabel={t('console.ai.planApproveHint', {
           defaultValue: 'Reply to approve or adjust this plan.',
         })}
+        planApproveLabel={t('console.ai.planApprove', { defaultValue: 'Build it' })}
+        planAdjustLabel={t('console.ai.planAdjust', { defaultValue: 'Adjust' })}
+        planApproveMessage={t('console.ai.planApproveMessage', {
+          defaultValue: 'Looks good — build it as proposed.',
+        })}
+        planApproveDefaultsMessage={t('console.ai.planApproveDefaultsMessage', {
+          defaultValue: 'Build it with your best assumptions; use sensible defaults for the open questions.',
+        })}
         // Self-use "magic moment": when the plan enables it, publish the drafted
         // app automatically the moment the agent finishes — no manual click; the
         // user refreshes and sees it live WITH data. Same governed endpoint.

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -132,6 +132,10 @@ function buildChatLocale(
       planQuestions: '搭建前请确认',
       planAssumptions: '假设',
       planApproveHint: '回复以确认或调整该方案。',
+      planApprove: '开始搭建',
+      planAdjust: '调整方案',
+      planApproveMessage: '就按这个方案搭建吧。',
+      planApproveDefaultsMessage: '就按你的合理假设直接搭建，未决问题用默认即可。',
       publishOk: '已发布，对象已生效。',
       publishFailed: '发布失败',
       seedWarn: '已发布，但部分示例数据未能载入。',
@@ -183,6 +187,10 @@ function buildChatLocale(
     planQuestions: 'Confirm before building',
     planAssumptions: 'Assumptions',
     planApproveHint: 'Reply to approve or adjust this plan.',
+    planApprove: 'Build it',
+    planAdjust: 'Adjust',
+    planApproveMessage: 'Looks good — build it as proposed.',
+    planApproveDefaultsMessage: 'Build it with your best assumptions; use sensible defaults for the open questions.',
     publishOk: 'Published — objects are now live.',
     publishFailed: 'Publish failed',
     seedWarn: 'Published, but some sample data failed to load.',
@@ -679,6 +687,10 @@ function ChatbotInner({
         planQuestionsLabel={locale.planQuestions}
         planAssumptionsLabel={locale.planAssumptions}
         planApproveHintLabel={locale.planApproveHint}
+        planApproveLabel={locale.planApprove}
+        planAdjustLabel={locale.planAdjust}
+        planApproveMessage={locale.planApproveMessage}
+        planApproveDefaultsMessage={locale.planApproveDefaultsMessage}
         publishedLabel={locale.published}
         // Self-use "magic moment": when the plan enables it, auto-publish the
         // drafted app the instant the agent finishes — the success path above

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -492,8 +492,16 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   planQuestionsLabel?: string;
   /** Heading above the agent's assumptions in the plan card (default "Assumptions"). */
   planAssumptionsLabel?: string;
-  /** Footer hint inviting the user to approve or adjust the plan (default "Reply to approve or adjust this plan."). */
+  /** Footer hint inviting the user to approve or adjust the plan (default "Reply to approve or adjust this plan."). Shown only when `onSendMessage` is absent (no one-click gate). */
   planApproveHintLabel?: string;
+  /** Label for the plan card's primary one-click "build it" button (default "Build it"). */
+  planApproveLabel?: string;
+  /** Label for the plan card's secondary "adjust" button, which focuses the chat input (default "Adjust"). */
+  planAdjustLabel?: string;
+  /** Message sent when the user approves a plan with no open questions (default "Looks good — build it as proposed."). */
+  planApproveMessage?: string;
+  /** Message sent when the user approves a plan that still has open questions — tells the agent to proceed on sensible defaults (default "Build it with your best assumptions; use sensible defaults for the open questions."). */
+  planApproveDefaultsMessage?: string;
   /**
    * Live draft-status resolver: how many drafts are still PENDING in a
    * package (e.g. `GET /metadata/_drafts?packageId=` count). When provided,
@@ -839,6 +847,10 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       planQuestionsLabel = 'Confirm before building',
       planAssumptionsLabel = 'Assumptions',
       planApproveHintLabel = 'Reply to approve or adjust this plan.',
+      planApproveLabel = 'Build it',
+      planAdjustLabel = 'Adjust',
+      planApproveMessage = 'Looks good — build it as proposed.',
+      planApproveDefaultsMessage = 'Build it with your best assumptions; use sensible defaults for the open questions.',
       fetchPendingDraftCount,
       autoPublishDrafts = false,
       processVisibility = 'summary',
@@ -1103,6 +1115,28 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       },
       [onSendMessage]
     );
+
+    // The "Proposed plan" card's one-click confirm gate. Approving sends a plain
+    // chat message — the same channel the user would type into — so the agent
+    // proceeds to apply_blueprint. When the plan still carries open questions,
+    // approval explicitly authorizes sensible defaults so a click never silently
+    // drops them.
+    const promptInputWrapRef = React.useRef<HTMLDivElement>(null);
+    const handlePlanApprove = React.useCallback(
+      (hasOpenQuestions: boolean) => {
+        onSendMessage?.(hasOpenQuestions ? planApproveDefaultsMessage : planApproveMessage);
+      },
+      [onSendMessage, planApproveMessage, planApproveDefaultsMessage]
+    );
+    // "Adjust" doesn't send anything — it just drops the cursor into the input so
+    // the user can describe the change in their own words.
+    const handlePlanAdjust = React.useCallback(() => {
+      const textarea = promptInputWrapRef.current?.querySelector('textarea');
+      if (textarea) {
+        textarea.focus();
+        textarea.scrollIntoView({ block: 'nearest' });
+      }
+    }, []);
 
     const handleCopy = React.useCallback((message: ChatMessage) => {
       void navigator.clipboard?.writeText(message.content);
@@ -1476,9 +1510,40 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     ))}
                   </div>
                 ) : null}
-                <span className="text-[11px] italic text-muted-foreground/80">
-                  {planApproveHintLabel}
-                </span>
+                {/* One-click confirm gate: "Build it" sends an approval message
+                    (accepting defaults when questions remain), "Adjust" focuses
+                    the input so the user types changes. Falls back to a text hint
+                    when the host hasn't wired message sending. */}
+                {onSendMessage ? (
+                  <div
+                    className="flex flex-wrap items-center gap-1.5 pt-0.5"
+                    data-testid="proposed-plan-actions"
+                  >
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handlePlanApprove(tool.proposedPlan!.questions.length > 0)
+                      }
+                      className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                      data-testid="proposed-plan-approve"
+                    >
+                      <Rocket className="size-3.5" />
+                      {planApproveLabel}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handlePlanAdjust}
+                      className="inline-flex h-7 items-center rounded-md border bg-background px-3 text-xs font-medium hover:bg-accent"
+                      data-testid="proposed-plan-adjust"
+                    >
+                      {planAdjustLabel}
+                    </button>
+                  </div>
+                ) : (
+                  <span className="text-[11px] italic text-muted-foreground/80">
+                    {planApproveHintLabel}
+                  </span>
+                )}
               </div>
             ) : null}
           </ToolContent>
@@ -1766,6 +1831,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         ) : null}
 
         <div
+          ref={promptInputWrapRef}
           className={cn(
             'relative',
             isPlainSurface && 'mx-auto w-full max-w-2xl px-4 pb-4 sm:px-0',

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -76,6 +76,64 @@ describe('ChatbotEnhanced (AI Elements composition)', () => {
     expect(screen.getByText(/Track loans separately/)).toBeInTheDocument();
   });
 
+  const planMessage = (questions: string[]): ChatMessage[] => [
+    {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      toolInvocations: [
+        {
+          toolCallId: 't1',
+          toolName: 'propose_blueprint',
+          state: 'output-available',
+          proposedPlan: {
+            summary: 'A reading list',
+            objects: [{ name: 'book', label: 'Book', fieldCount: 2 }],
+            counts: { objects: 1, views: 0, dashboards: 0, seedData: 0 },
+            questions,
+            assumptions: ['One shelf for now'],
+          },
+        },
+      ],
+    },
+  ];
+
+  it('"Build it" on a plan with open questions approves with the accept-defaults message', () => {
+    const onSendMessage = vi.fn();
+    render(
+      <ChatbotEnhanced
+        messages={planMessage(['Track loans separately?'])}
+        onSendMessage={onSendMessage}
+        planApproveMessage="APPROVE_PLAIN"
+        planApproveDefaultsMessage="APPROVE_DEFAULTS"
+      />,
+    );
+    fireEvent.click(screen.getByTestId('proposed-plan-approve'));
+    // Open questions → the click must authorize defaults, not silently drop them.
+    expect(onSendMessage).toHaveBeenCalledWith('APPROVE_DEFAULTS');
+  });
+
+  it('"Build it" on a plan with no open questions approves with the plain message', () => {
+    const onSendMessage = vi.fn();
+    render(
+      <ChatbotEnhanced
+        messages={planMessage([])}
+        onSendMessage={onSendMessage}
+        planApproveMessage="APPROVE_PLAIN"
+        planApproveDefaultsMessage="APPROVE_DEFAULTS"
+      />,
+    );
+    expect(screen.queryByTestId('proposed-plan-questions')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('proposed-plan-approve'));
+    expect(onSendMessage).toHaveBeenCalledWith('APPROVE_PLAIN');
+  });
+
+  it('falls back to the static hint (no action buttons) when message sending is not wired', () => {
+    render(<ChatbotEnhanced messages={planMessage([])} planApproveHintLabel="HINT_TEXT" />);
+    expect(screen.queryByTestId('proposed-plan-actions')).not.toBeInTheDocument();
+    expect(screen.getByText('HINT_TEXT')).toBeInTheDocument();
+  });
+
   it('shows an error banner with a retry affordance', () => {
     const onReload = vi.fn();
     render(


### PR DESCRIPTION
## Why
The plan card (#1875/#1878) was **read-only** — to proceed the user had to *type* "build it". This adds the one-click confirm gate, matching Airtable Omni's **Build it**.

## What
- **「开始搭建」/ Build it** — sends an approval message via the existing `onSendMessage` channel (the same path suggestion chips use) → the agent proceeds to `apply_blueprint`. **Context-aware:** when the plan still has open questions, approval sends an *accept-defaults* message so a click never silently drops them.
- **「调整方案」/ Adjust** — focuses the chat input so the user types changes in their own words.
- Falls back to the existing static hint when `onSendMessage` isn't wired. Localized on both surfaces (AiChatPage `t()`, ConsoleFloatingChatbot `locale`; en + zh).

Per-question canned quick-replies are intentionally **not** added: `propose_blueprint` returns free-text questions with no structured options, so *Build-it-with-defaults + type-to-answer* is the honest affordance. A structured `questions:[{text,options}]` from the backend would enable per-question chips later.

## Verification
3 new render tests (approve-with-defaults when questions exist; plain approve when none; hint-fallback when sending unwired) — **ChatbotEnhanced 40 green**; plugin-chatbot + app-shell **type-check clean** (forced, non-cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)