### PR TITLE
fix(actions): handle type:'form' in ActionRunner

### DIFF
--- a/.changeset/action-runner-form-case.md
+++ b/.changeset/action-runner-form-case.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/core": patch
+---
+
+fix(actions): handle `type: 'form'` in ActionRunner
+
+A `form` action had no `case` in `ActionRunner`'s execution switch, so it fell
+through to `executeActionSchema` and silently no-opped — clicking a Log-Time /
+"open form" action did nothing. Add `executeForm`, which opens the FormView as a
+routed page (`/forms/:name`, per the action spec) via the navigation handler,
+forwarding the current record id as `?recordId=` for hosts that support it.
+Covered by ActionRunner unit tests.

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -473,6 +473,9 @@ export class ActionRunner {
         case 'api':
           result = await this.executeAPI(action);
           break;
+        case 'form':
+          result = await this.executeForm(action);
+          break;
         case 'navigation':
           result = await this.executeNavigation(action);
           break;
@@ -805,6 +808,31 @@ export class ActionRunner {
   /**
    * Execute navigation action
    */
+  /**
+   * `form` action — open a FormView as a routed page (`/forms/:name`, per the
+   * spec). `target` is the FormView name. Without this case the action fell
+   * through to `executeActionSchema` and silently no-opped (the "Log Time does
+   * nothing" report). The current record id is forwarded as `?recordId=` for
+   * hosts that support it; the form route ignores unknown query params.
+   */
+  private async executeForm(action: ActionDef): Promise<ActionResult> {
+    const name = this.evaluator.evaluate(action.target) as string;
+    if (!name || typeof name !== 'string') {
+      return { success: false, error: 'No form target (FormView name) provided for form action' };
+    }
+    const recordId =
+      (this.context.record && (this.context.record as { id?: unknown }).id) ??
+      (this.context.data && (this.context.data as { id?: unknown }).id);
+    const base = `/forms/${name}`;
+    const to = recordId != null ? `${base}?recordId=${encodeURIComponent(String(recordId))}` : base;
+
+    if (this.navigationHandler) {
+      this.navigationHandler(to, { external: false });
+      return { success: true };
+    }
+    return { success: true, redirect: to };
+  }
+
   private async executeNavigation(action: ActionDef): Promise<ActionResult> {
     const nav = action.navigate || action;
     const to = this.evaluator.evaluate(nav.to || nav.target) as string;

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -494,6 +494,40 @@ describe('ActionRunner', () => {
     });
   });
 
+  describe('form action type', () => {
+    it('opens the form route with the record id (regression: Log Time no-op)', async () => {
+      const result = await runner.execute({
+        type: 'form',
+        target: 'showcase_task.default',
+      });
+      expect(result.success).toBe(true);
+      expect(result.redirect).toBe('/forms/showcase_task.default?recordId=1');
+    });
+
+    it('uses the navigation handler when provided', async () => {
+      const navHandler = vi.fn();
+      runner.setNavigationHandler(navHandler);
+      const result = await runner.execute({ type: 'form', target: 'showcase_task.default' });
+      expect(result.success).toBe(true);
+      expect(navHandler).toHaveBeenCalledWith(
+        '/forms/showcase_task.default?recordId=1',
+        expect.objectContaining({ external: false }),
+      );
+    });
+
+    it('falls back to a bare form route when there is no record id', async () => {
+      const bare = new ActionRunner({ user: { id: 'u1' } } as ActionContext);
+      const result = await bare.execute({ type: 'form', target: 'showcase_task.default' });
+      expect(result.redirect).toBe('/forms/showcase_task.default');
+    });
+
+    it('errors when no form target is given', async () => {
+      const result = await runner.execute({ type: 'form' } as never);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/form target/i);
+    });
+  });
+
   // ==========================================================================
   // Post-execution: toast, refreshAfter
   // ==========================================================================


### PR DESCRIPTION
## Problem

`ActionRunner`'s execution switch had cases for `script` / `url` / `modal` / `flow` / `api` / `navigation` but **none for `form`**. A `type: 'form'` action therefore fell through to the legacy `executeActionSchema` path and silently no-opped — e.g. a "Log Time" / open-form button did nothing when clicked (no navigation, no error, no network).

## Fix

Add `executeForm`, which opens the FormView as a routed page (`/forms/:name`, the route the action spec documents) via the injected navigation handler, forwarding the current record id as `?recordId=` (hosts that don't support it ignore the param). Falls back to a `redirect` result when no navigation handler is set, mirroring `executeUrl` / `executeNavigation`.

## Tests

4 new cases in `ActionRunner.test.ts` (record-id route, navigation-handler delegation, bare-route fallback, missing-target error). Full suite: **58 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)