### PR TITLE
fix(console-ai): register zh + en i18n for the "Proposed plan" card

### DIFF
--- a/packages/i18n/src/__tests__/i18n.test.ts
+++ b/packages/i18n/src/__tests__/i18n.test.ts
@@ -85,6 +85,19 @@ describe('@object-ui/i18n', () => {
       expect(i18n.t('console.objectView.toolbarEnabledCount', { count: 3, total: 5 })).toBe('已启用 3/5 项');
     });
 
+    it('translates the AI "Proposed plan" card keys in Chinese (not English fallback)', () => {
+      const i18n = createI18n({ defaultLanguage: 'zh', detectBrowserLanguage: false });
+      expect(i18n.t('console.ai.planTitle')).toBe('方案预览');
+      expect(i18n.t('console.ai.planQuestions')).toBe('搭建前请确认');
+      expect(i18n.t('console.ai.planAssumptions')).toBe('假设');
+      expect(i18n.t('console.ai.planApproveHint')).toBe('回复以确认或调整该方案。');
+      expect(i18n.t('console.ai.planApprove')).toBe('开始搭建');
+      expect(i18n.t('console.ai.planAdjust')).toBe('调整方案');
+      expect(i18n.t('console.ai.planApproveMessage')).toBe('就按这个方案搭建吧。');
+      expect(i18n.t('console.ai.planApproveDefaultsMessage')).toBe('就按你的合理假设直接搭建，未决问题用默认即可。');
+      expect(i18n.t('console.ai.nextSteps')).toBe('下一步');
+    });
+
     it('translates common keys in Japanese', () => {
       const i18n = createI18n({ defaultLanguage: 'ja', detectBrowserLanguage: false });
       expect(i18n.t('common.save')).toBe('保存');

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1141,6 +1141,18 @@ const en = {
       stopResponse: 'Stop response',
       trace: 'trace',
       viewTrace: 'View trace',
+      // Build-flow draft + "Proposed plan" confirm-gate card (AiChatPage /ai/build).
+      // Mirror the ConsoleFloatingChatbot locale object so both AI surfaces match.
+      nextSteps: "What's next",
+      planTitle: 'Proposed plan',
+      planQuestions: 'Confirm before building',
+      planAssumptions: 'Assumptions',
+      planApproveHint: 'Reply to approve or adjust this plan.',
+      planApprove: 'Build it',
+      planAdjust: 'Adjust',
+      planApproveMessage: 'Looks good — build it as proposed.',
+      planApproveDefaultsMessage:
+        'Build it with your best assumptions; use sensible defaults for the open questions.',
       justNow: 'just now',
       minutesAgo: '{{count}}m ago',
       hoursAgo: '{{count}}h ago',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1138,6 +1138,17 @@ const zh = {
       stopResponse: '停止生成',
       trace: '调试 trace',
       viewTrace: '查看调试 trace',
+      // 搭建流程的草稿与「方案预览」确认卡片（AiChatPage /ai/build）。
+      // 与 ConsoleFloatingChatbot 的 locale 对象保持一致，两个 AI 界面文案统一。
+      nextSteps: '下一步',
+      planTitle: '方案预览',
+      planQuestions: '搭建前请确认',
+      planAssumptions: '假设',
+      planApproveHint: '回复以确认或调整该方案。',
+      planApprove: '开始搭建',
+      planAdjust: '调整方案',
+      planApproveMessage: '就按这个方案搭建吧。',
+      planApproveDefaultsMessage: '就按你的合理假设直接搭建，未决问题用默认即可。',
       justNow: '刚刚',
       minutesAgo: '{{count}} 分钟前',
       hoursAgo: '{{count}} 小时前',


### PR DESCRIPTION
## Problem
On the `/ai/build` full-page surface (`AiChatPage`), the AI **"Proposed plan"** confirm-gate card renders its labels in English even when the UI locale is Chinese.

Root cause: the labels come from `t('console.ai.planTitle', { defaultValue: 'Proposed plan' })` etc., but the `console.ai.plan*` keys (and `nextSteps`) existed **nowhere in the translation bundles** (`packages/i18n/src/locales/*.ts`) — only as inline `defaultValue` fallbacks. So for zh users i18next found no key, fell back to the English `defaultValue`, and fired a dev missing-key warning per key. The floating chatbot (`ConsoleFloatingChatbot`) was unaffected because it hand-builds its own `locale` object that already carries the zh strings.

## Fix
Add the 9 keys to the `en` (canonical / `TranslationKeys` source) and `zh` bundles under `console.ai`, mirroring the `ConsoleFloatingChatbot` locale object:

`nextSteps`, `planTitle`, `planQuestions`, `planAssumptions`, `planApproveHint`, `planApprove`, `planAdjust`, `planApproveMessage`, `planApproveDefaultsMessage`.

- `en` values are byte-identical to the existing `defaultValue`s → English rendering unchanged.
- `zh` now displays 方案预览 / 假设 / 开始搭建 … instead of the English fallback; the missing-key warning for these keys is gone.
- Other locales fall back to `en` (unchanged behaviour); the locale parity tests only check top-level + `common` keys, so no other bundle needs touching.

## Tests
- Added a regression test asserting the zh plan-card keys resolve (no English fallback), matching the existing `toolbarEnabledCount` pattern.
- `pnpm --filter @object-ui/i18n test` → **157 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)