### PR TITLE
feat(app-shell): testability ratchet — ban synthetic-event triggers (ADR-0054 Phase 5)

### DIFF
--- a/.changeset/testability-ratchet.md
+++ b/.changeset/testability-ratchet.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(app-shell): testability ratchet — ban synthetic-event triggers (ADR-0054 Phase 5)
+
+Locks in the testability contract so it can't regress. A conformance test (in the
+gating `pnpm test` job) fails the build if a new synthetic-event trigger
+(`dispatchEvent(new KeyboardEvent/MouseEvent/PointerEvent)`) appears anywhere in
+`packages/*/src` or `apps/*/src`; a matching local ESLint rule
+(`object-ui/no-synthetic-event-trigger`) flags it in-editor. The last two
+offenders — the sidebar swipe-to-open gestures (`UnifiedSidebar`, `AppSidebar`)
+— are converted to a direct, idempotent `setOpenMobile(true)` (C1), so the tree
+is clean at zero. Completes the ADR-0054 rollout.

--- a/docs/adr/0054-ui-testability-contract.md
+++ b/docs/adr/0054-ui-testability-contract.md
@@ -117,6 +117,8 @@ invariants and a rollout.
 
 ## Phasing (each an independent, browser-verified PR)
 
+> **Rollout status (2026-06):** all five phases shipped — Phase 1 (#1879), Phase 2 (#1882), Phase 3 (#1883), Phase 4 (#1887), Phase 5 (ratchet).
+
 This ADR + the audit land first as docs. Implementation is then incremental — each phase
 is shippable and browser-verified on its own:
 

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,0 +1,10 @@
+/**
+ * ObjectUI local ESLint plugin — testability ratchet rules (ADR-0054 Phase 5).
+ */
+import noSyntheticEventTrigger from './no-synthetic-event-trigger.js';
+
+export default {
+  rules: {
+    'no-synthetic-event-trigger': noSyntheticEventTrigger,
+  },
+};

--- a/eslint-rules/no-synthetic-event-trigger.js
+++ b/eslint-rules/no-synthetic-event-trigger.js
@@ -1,0 +1,54 @@
+/**
+ * ObjectUI ESLint rule: no-synthetic-event-trigger
+ *
+ * Bans dispatching a synthetic `KeyboardEvent` / `MouseEvent` / `PointerEvent`
+ * to *trigger* behavior (e.g. `el.dispatchEvent(new MouseEvent('click'))` or
+ * `document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))`).
+ *
+ * Such "synthetic triggers" depend on a global listener being mounted and the
+ * host (browser/OS) not intercepting the event first — neither of which an
+ * automated (AI) test can assume. They are the anti-pattern that hid the
+ * "command palette button doesn't open under automation" bug. Call the real
+ * command/handler directly instead (ADR-0054 invariant C1).
+ *
+ * NOT flagged: `CustomEvent` / `PopStateEvent` dispatch (legitimate event-bus /
+ * history-nudge patterns per the 2026-06 audit).
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+const BANNED = new Set(['KeyboardEvent', 'MouseEvent', 'PointerEvent']);
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow dispatching synthetic KeyboardEvent/MouseEvent/PointerEvent to trigger behavior; call the command directly (ADR-0054 C1).',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      banned:
+        'Do not dispatch a synthetic {{name}} to trigger behavior (ADR-0054 C1). Call the command/handler directly (e.g. an idempotent open()/toggle from context) instead of re-emitting an event a global listener must catch.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.computed ||
+          callee.property.type !== 'Identifier' ||
+          callee.property.name !== 'dispatchEvent'
+        ) {
+          return;
+        }
+        const arg = node.arguments[0];
+        if (arg && arg.type === 'NewExpression' && arg.callee.type === 'Identifier' && BANNED.has(arg.callee.name)) {
+          context.report({ node: arg, messageId: 'banned', data: { name: arg.callee.name } });
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/no-synthetic-event-trigger.test.js
+++ b/eslint-rules/no-synthetic-event-trigger.test.js
@@ -1,0 +1,36 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit test for the local ESLint rule that bans synthetic-event triggers
+ * (ADR-0054 Phase 5). Plain JS so it needs no package tsconfig.
+ */
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from './no-synthetic-event-trigger.js';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-synthetic-event-trigger', rule, {
+  valid: [
+    // Legitimate event-bus / history-nudge patterns are allowed.
+    "document.dispatchEvent(new CustomEvent('objectui:record-changed'))",
+    "window.dispatchEvent(new PopStateEvent('popstate'))",
+    // Calling a real handler directly is the correct pattern.
+    'openCommandPalette()',
+  ],
+  invalid: [
+    {
+      code: "document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))",
+      errors: [{ messageId: 'banned' }],
+    },
+    {
+      code: "el.dispatchEvent(new MouseEvent('click', { bubbles: true }))",
+      errors: [{ messageId: 'banned' }],
+    },
+  ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import objectUi from './eslint-rules/index.js'
 
 export default tseslint.config({ ignores: ['**/dist', '**/.next', '**/node_modules', '**/public'] }, {
   extends: [js.configs.recommended, ...tseslint.configs.recommended],
@@ -22,6 +23,7 @@ export default tseslint.config({ ignores: ['**/dist', '**/.next', '**/node_modul
   plugins: {
     'react-hooks': reactHooks,
     'react-refresh': reactRefresh,
+    'object-ui': objectUi,
   },
   rules: {
     ...reactHooks.configs.recommended.rules,
@@ -37,5 +39,9 @@ export default tseslint.config({ ignores: ['**/dist', '**/.next', '**/node_modul
     'react-hooks/set-state-in-effect': 'warn',
     'react-hooks/preserve-manual-memoization': 'warn',
     'react-hooks/use-memo': 'warn',
+    // ADR-0054 Phase 5 ratchet — ban synthetic-event triggers (C1). Error so a
+    // new violation fails CI; the existing surfaces were converted to direct
+    // idempotent commands first, so this lints clean today.
+    'object-ui/no-synthetic-event-trigger': 'error',
   },
 });

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -538,6 +538,21 @@ The object prefix is omitted (`field:{field}`) when a form has no owning object.
 This complements the action/overlay locators already emitted by the renderer
 (`overlay:command-palette`, `action:command-palette:open`, …).
 
+## Testability ratchet
+
+The invariants above are kept from regressing (ADR-0054 Phase 5, "counts can only
+go down"):
+
+- A conformance test (runs in the gating `pnpm test` job) fails the build if a new
+  **synthetic-event trigger** (`el.dispatchEvent(new KeyboardEvent/MouseEvent/
+  PointerEvent …)`) is introduced anywhere in `packages/*/src` or `apps/*/src`.
+  Legitimate `CustomEvent` / `PopStateEvent` dispatch (event bus / history nudge)
+  is allowed. Replace a synthetic trigger with a direct, idempotent command
+  (`useCommandPalette` / `useUrlOverlay`).
+- A matching ESLint rule `object-ui/no-synthetic-event-trigger` flags the same
+  pattern in-editor (the repo `Lint` workflow is manual, so the test is the CI
+  gate).
+
 ## Compatibility
 
 - **React:** 18.x or 19.x

--- a/packages/app-shell/src/adr0054-ratchet.test.ts
+++ b/packages/app-shell/src/adr0054-ratchet.test.ts
@@ -1,0 +1,79 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * ADR-0054 "UI testability contract" — Phase 5 ratchet (CI enforcement).
+ *
+ * Fails when a new synthetic-event trigger is introduced anywhere in the source
+ * tree. The repo's `Lint` workflow is manual (`workflow_dispatch`), so the
+ * matching ESLint rule (`object-ui/no-synthetic-event-trigger`) is a local-dev
+ * aid; THIS test — running in the gating `pnpm test` job — is the enforcement.
+ * "Counts can only go down."
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// packages/app-shell/src  ->  repo root
+const repoRoot = path.resolve(here, '../../..');
+
+/** Banned: dispatching a synthetic Keyboard/Mouse/PointerEvent to trigger behavior (C1). */
+const SYNTHETIC_TRIGGER = /\.dispatchEvent\(\s*new\s+(?:KeyboardEvent|MouseEvent|PointerEvent)\b/;
+
+function collectSourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const name = entry.name;
+      if (name === 'node_modules' || name === 'dist' || name.startsWith('.wt-') || name === '.next') {
+        continue;
+      }
+      const full = path.join(dir, name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.(ts|tsx)$/.test(name) && !/\.(test|spec)\.(ts|tsx)$/.test(name)) {
+        out.push(full);
+      }
+    }
+  };
+  for (const group of ['packages', 'apps']) {
+    const groupDir = path.join(repoRoot, group);
+    let pkgs: string[] = [];
+    try {
+      pkgs = readdirSync(groupDir);
+    } catch {
+      continue;
+    }
+    for (const pkg of pkgs) {
+      const srcDir = path.join(groupDir, pkg, 'src');
+      try {
+        if (statSync(srcDir).isDirectory()) walk(srcDir);
+      } catch {
+        /* package has no src/ */
+      }
+    }
+  }
+  return out;
+}
+
+describe('ADR-0054 testability ratchet', () => {
+  it('finds the source tree (guards against a broken scan path)', () => {
+    expect(collectSourceFiles().length).toBeGreaterThan(100);
+  });
+
+  it('has zero synthetic-event triggers across packages/apps src (C1)', () => {
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles()) {
+      if (SYNTHETIC_TRIGGER.test(readFileSync(file, 'utf8'))) {
+        offenders.push(path.relative(repoRoot, file));
+      }
+    }
+    // If this fails: replace the synthetic `dispatchEvent(new …Event())` with a
+    // direct, idempotent command (see ADR-0054 C1 / useCommandPalette /
+    // useUrlOverlay). Do not add files to an allowlist.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/app-shell/src/layout/AppSidebar.tsx
+++ b/packages/app-shell/src/layout/AppSidebar.tsx
@@ -137,7 +137,7 @@ function useNavOrder(appName: string) {
 const getIcon = resolveIcon;
 
 export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: string, onAppChange: (name: string) => void }) {
-  const { isMobile } = useSidebar();
+  const { isMobile, setOpenMobile } = useSidebar();
   const { user, signOut, isAuthEnabled } = useAuth();
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const navigate = useNavigate();
@@ -155,7 +155,8 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
     const handleTouchEnd = (e: TouchEvent) => {
       const deltaX = e.changedTouches[0].clientX - touchStartX;
       if (touchStartX < EDGE_THRESHOLD && deltaX > SWIPE_DISTANCE && isMobile) {
-        document.querySelector('[data-sidebar="trigger"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        // Idempotent direct open (ADR-0054 C1) — no synthetic click dispatch.
+        setOpenMobile(true);
       }
     };
     document.addEventListener('touchstart', handleTouchStart, { passive: true });
@@ -164,7 +165,7 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
       document.removeEventListener('touchstart', handleTouchStart);
       document.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [isMobile]);
+  }, [isMobile, setOpenMobile]);
 
   const { recentItems } = useRecentItems();
   const { favorites, removeFavorite } = useFavorites();

--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -164,7 +164,8 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
     const handleTouchEnd = (e: TouchEvent) => {
       const deltaX = e.changedTouches[0].clientX - touchStartX;
       if (touchStartX < EDGE_THRESHOLD && deltaX > SWIPE_DISTANCE && isMobile) {
-        document.querySelector('[data-sidebar="trigger"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        // Idempotent direct open (ADR-0054 C1) — no synthetic click dispatch.
+        setOpenMobile(true);
       }
     };
     document.addEventListener('touchstart', handleTouchStart, { passive: true });
@@ -173,7 +174,7 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
       document.removeEventListener('touchstart', handleTouchStart);
       document.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [isMobile]);
+  }, [isMobile, setOpenMobile]);
 
   const { recentItems } = useRecentItems();
   const { favorites, removeFavorite } = useFavorites();


### PR DESCRIPTION
ADR-0054 Phase 5 (ratchet). Conformance test in the gating `pnpm test` job fails on any new synthetic-event trigger (`dispatchEvent(new KeyboardEvent/MouseEvent/PointerEvent)`) across packages/apps src; local ESLint rule `object-ui/no-synthetic-event-trigger` flags it in-editor. Last two offenders (sidebar swipe-to-open in UnifiedSidebar/AppSidebar) converted to idempotent setOpenMobile(true) (C1). Docs: README ratchet section + ADR marked all 5 phases shipped. Verified: ratchet test 2 pass (zero triggers repo-wide), rule unit test 5 pass, app-shell suite 660 green, tsc green. Completes the ADR-0054 rollout (Phases 1 #1879, 2 #1882, 3 #1883, 4 #1887, 5 this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)