### PR TITLE
feat(plugin-tree): add tree / tree-grid object view type (#1885)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -36,6 +36,7 @@
       "@object-ui/plugin-markdown",
       "@object-ui/plugin-report",
       "@object-ui/plugin-timeline",
+      "@object-ui/plugin-tree",
       "@object-ui/plugin-view",
       "@object-ui/collaboration",
       "@object-ui/app-shell",

--- a/.changeset/plugin-tree-view.md
+++ b/.changeset/plugin-tree-view.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/plugin-tree": minor
+"@object-ui/types": minor
+"@object-ui/plugin-list": minor
+"@object-ui/plugin-view": minor
+"@object-ui/app-shell": minor
+"@object-ui/console": minor
+---
+
+feat(plugin-tree): add a `tree` / tree-grid object view type
+
+Renders a self-referencing object as an indented, expand/collapse tree-grid —
+the right view for arbitrary-depth hierarchies (business unit / org chart,
+category trees, BOMs, nested comments) that fixed-depth grouping can't express.
+New `@object-ui/plugin-tree` package (`object-tree`/`tree`), `tree` added to the
+`ViewType` union, and dispatch wired through plugin-list `ListView` +
+app-shell `ObjectView` (the console path).

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -82,6 +82,7 @@
     "@object-ui/plugin-markdown": "workspace:*",
     "@object-ui/plugin-report": "workspace:*",
     "@object-ui/plugin-timeline": "workspace:*",
+    "@object-ui/plugin-tree": "workspace:*",
     "@object-ui/plugin-view": "workspace:*",
     "@object-ui/providers": "workspace:*",
     "@object-ui/react": "workspace:*",

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -48,6 +48,15 @@ ComponentRegistry.registerLazy('map', () => import('@object-ui/plugin-map'), {
   category: 'view',
 });
 
+ComponentRegistry.registerLazy('object-tree', () => import('@object-ui/plugin-tree'), {
+  namespace: 'plugin-tree',
+  category: 'view',
+});
+ComponentRegistry.registerLazy('tree', () => import('@object-ui/plugin-tree'), {
+  namespace: 'view',
+  category: 'view',
+});
+
 // Dashboard plugin — only used on dashboard / home pages. Lazy-load all 8
 // component types so the ~150 KB widget/pivot/metric tree stays out of the
 // initial bundle for users who never visit a dashboard.

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -94,6 +94,7 @@ const workspaceAliases: Record<string, string> = {
   '@object-ui/plugin-map': path.resolve(__dirname, '../../packages/plugin-map/src'),
   '@object-ui/plugin-markdown': path.resolve(__dirname, '../../packages/plugin-markdown/src'),
   '@object-ui/plugin-timeline': path.resolve(__dirname, '../../packages/plugin-timeline/src'),
+  '@object-ui/plugin-tree': path.resolve(__dirname, '../../packages/plugin-tree/src'),
   '@object-ui/plugin-view': path.resolve(__dirname, '../../packages/plugin-view/src'),
   '@object-ui/plugin-designer': path.resolve(__dirname, '../../packages/plugin-designer/src'),
 };
@@ -205,6 +206,7 @@ export default defineConfig({
             { name: 'plugin-gantt', test: /[\\/]packages[\\/]plugin-gantt[\\/]/, priority: 70 },
             { name: 'plugin-markdown', test: /[\\/]packages[\\/]plugin-markdown[\\/]/, priority: 70 },
             { name: 'plugin-timeline', test: /[\\/]packages[\\/]plugin-timeline[\\/]/, priority: 70 },
+            { name: 'plugin-tree', test: /[\\/]packages[\\/]plugin-tree[\\/]/, priority: 70 },
             { name: 'plugin-calendar', test: /[\\/]packages[\\/]plugin-calendar[\\/]/, priority: 70 },
             { name: 'plugin-kanban', test: /[\\/]packages[\\/]plugin-kanban[\\/]/, priority: 70 },
             { name: 'plugin-chatbot', test: /[\\/]packages[\\/]plugin-chatbot[\\/]/, priority: 70 },

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1329,6 +1329,14 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                     endDateField: viewDef.gantt?.endDateField || 'end_date',
                     titleField: viewDef.gantt?.titleField || 'name',
                 },
+                tree: {
+                    // Self-referencing tree-grid config (plugin-tree). Spread the
+                    // full view-defined tree first so parentField/fields/
+                    // defaultExpandedDepth survive; labelField falls back to the
+                    // object title. parentField auto-detects when omitted.
+                    ...((viewDef as any).tree || {}),
+                    labelField: (viewDef as any).tree?.labelField || (viewDef as any).tree?.titleField || objectDef.titleField || 'name',
+                },
                 chart: {
                     chartType: viewDef.chart?.chartType,
                     xAxisField: viewDef.chart?.xAxisField,

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1081,9 +1081,14 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       resolvable.push('map');
     }
 
+    // Check for Tree capabilities — a self-referencing parent pointer.
+    if ((schema as any).tree?.parentField || schema.options?.tree?.parentField || schema.viewType === 'tree') {
+      resolvable.push('tree');
+    }
+
     // Always allow switching back to the viewType defined in schema
     if (schema.viewType && !resolvable.includes(schema.viewType as ViewType) &&
-       ['grid', 'kanban', 'calendar', 'timeline', 'gantt', 'map', 'gallery', 'chart'].includes(schema.viewType)) {
+       ['grid', 'kanban', 'calendar', 'timeline', 'gantt', 'map', 'gallery', 'chart', 'tree'].includes(schema.viewType)) {
       resolvable.push(schema.viewType as ViewType);
     }
 
@@ -1098,7 +1103,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     }
 
     return resolvable;
-  }, [schema.options, schema.viewType, schema.kanban, schema.calendar, schema.gantt, schema.gallery, schema.timeline, schema.appearance?.allowedVisualizations]);
+  }, [schema.options, schema.viewType, schema.kanban, schema.calendar, schema.gantt, schema.gallery, schema.timeline, (schema as any).tree, schema.appearance?.allowedVisualizations]);
 
   // Sync view from props
   React.useEffect(() => {
@@ -1333,6 +1338,21 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           locationField: schema.options?.map?.locationField || 'location',
           ...(schema.options?.map || {}),
         };
+      case 'tree': {
+        // Self-referencing tree-grid. Config lives under view.tree.* (direct)
+        // or options.tree.* (app-shell object pages). parentField auto-detects
+        // from the object's tree/self-reference field when omitted.
+        const treeCfg = (schema as any).tree || schema.options?.tree || {};
+        return {
+          type: 'object-tree',
+          ...baseProps,
+          parentField: treeCfg.parentField,
+          labelField: treeCfg.labelField || treeCfg.titleField || 'name',
+          fields: treeCfg.fields || effectiveFields,
+          defaultExpandedDepth: treeCfg.defaultExpandedDepth,
+          ...treeCfg,
+        };
+      }
       case 'chart': {
         // A `chart` list view renders an aggregated chart of the object's
         // records (e.g. sum of estimate_hours grouped by status), delegating

--- a/packages/plugin-list/src/ViewSwitcher.tsx
+++ b/packages/plugin-list/src/ViewSwitcher.tsx
@@ -17,6 +17,7 @@ import {
   GanttChartSquare, // gantt
   Map,        // map
   BarChart3,  // chart
+  ListTree,   // tree
   Check,
   ChevronDown,
 } from 'lucide-react';
@@ -29,7 +30,8 @@ export type ViewType =
   | 'timeline'
   | 'gantt'
   | 'map'
-  | 'chart';
+  | 'chart'
+  | 'tree';
 
 export interface ViewSwitcherProps {
   currentView: ViewType;
@@ -49,6 +51,7 @@ const VIEW_ICONS: Record<ViewType, React.ReactNode> = {
   gantt: <GanttChartSquare className="h-4 w-4" />,
   map: <Map className="h-4 w-4" />,
   chart: <BarChart3 className="h-4 w-4" />,
+  tree: <ListTree className="h-4 w-4" />,
 };
 
 const VIEW_LABELS: Record<ViewType, string> = {
@@ -60,6 +63,7 @@ const VIEW_LABELS: Record<ViewType, string> = {
   gantt: 'Gantt',
   map: 'Map',
   chart: 'Chart',
+  tree: 'Tree',
 };
 
 /**

--- a/packages/plugin-tree/README.md
+++ b/packages/plugin-tree/README.md
@@ -1,0 +1,46 @@
+# @object-ui/plugin-tree
+
+Tree / tree-grid view plugin for Object UI.
+
+Renders a **self-referencing object** as an indented, expand/collapse tree-grid —
+the right view for hierarchies of unbounded depth such as **business unit /
+org chart**, category trees, menu trees, BOMs, or nested comments. (Grouping
+handles *fixed-depth* hierarchies; a tree handles arbitrary depth.)
+
+It registers two component types via the `ComponentRegistry`:
+
+- `object-tree` — the object-bound renderer
+- `tree` — the view-type alias used by `ObjectView` / `ViewSwitcher`
+
+## Usage
+
+```ts
+// As a view inside an ObjectView
+{
+  type: 'object-view',
+  objectName: 'business_unit',
+  views: [
+    {
+      type: 'tree',
+      tree: {
+        parentField: 'parent',        // single-parent pointer (auto-detected if omitted)
+        labelField: 'name',           // indented first column
+        fields: ['name', 'manager'],  // additional flat columns
+        defaultExpandedDepth: 1,      // 0 = roots only; omit = expand all
+      },
+    },
+  ],
+}
+```
+
+### Config
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `parentField` | auto-detected | Field holding the parent reference. When omitted, the renderer picks the object's `tree` field (or a lookup/master_detail that references the same object). |
+| `labelField` | `name` | Field rendered indented in the first column. |
+| `fields` | `[]` | Additional fields rendered as flat columns. |
+| `defaultExpandedDepth` | _unset_ | Initial expansion depth. `0` = roots only; unset = expand everything. |
+
+Records whose parent is missing (or points outside the result set) are kept as
+roots, so nothing is silently dropped.

--- a/packages/plugin-tree/package.json
+++ b/packages/plugin-tree/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@object-ui/plugin-tree",
+  "version": "6.2.3",
+  "type": "module",
+  "license": "MIT",
+  "description": "Tree / tree-grid visualization plugin for Object UI",
+  "homepage": "https://www.objectui.org/docs/plugins/plugin-tree",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/objectstack-ai/objectui.git",
+    "directory": "packages/plugin-tree"
+  },
+  "bugs": {
+    "url": "https://github.com/objectstack-ai/objectui/issues"
+  },
+  "main": "dist/index.umd.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
+  },
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@object-ui/components": "workspace:*",
+    "@object-ui/core": "workspace:*",
+    "@object-ui/react": "workspace:*",
+    "@object-ui/types": "workspace:*",
+    "@objectstack/spec": "^9.5.1",
+    "lucide-react": "^1.18.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vite-plugin-dts": "^5.0.2"
+  },
+  "keywords": [
+    "objectui",
+    "sdui",
+    "schema-driven-ui",
+    "react",
+    "tailwind",
+    "shadcn",
+    "objectstack",
+    "plugin",
+    "tree",
+    "tree-grid",
+    "hierarchy"
+  ],
+  "author": "ObjectStack Team <team@objectstack.ai>",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ]
+}

--- a/packages/plugin-tree/src/ObjectTree.test.tsx
+++ b/packages/plugin-tree/src/ObjectTree.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { ObjectTree } from './ObjectTree';
+
+afterEach(cleanup);
+
+// A small self-referencing org hierarchy:
+//   Acme
+//   ├─ Engineering
+//   │  └─ Platform
+//   └─ Sales
+const orgUnits = [
+  { id: '1', name: 'Acme', parent_id: null, head: 'CEO' },
+  { id: '2', name: 'Engineering', parent_id: '1', head: 'VP Eng' },
+  { id: '3', name: 'Platform', parent_id: '2', head: 'Director' },
+  { id: '4', name: 'Sales', parent_id: '1', head: 'VP Sales' },
+];
+
+function renderTree(extra: any = {}) {
+  const schema: any = {
+    type: 'object-tree',
+    objectName: 'business_unit',
+    parentField: 'parent_id',
+    labelField: 'name',
+    fields: ['name', 'head'],
+    data: orgUnits,
+    ...extra,
+  };
+  return render(<ObjectTree schema={schema} data={orgUnits} />);
+}
+
+describe('ObjectTree', () => {
+  it('renders a nested forest from flat records (all expanded by default)', async () => {
+    renderTree();
+    await waitFor(() => expect(screen.getByTestId('object-tree')).toBeTruthy());
+    // Every record is visible when fully expanded.
+    expect(screen.getByText('Acme')).toBeTruthy();
+    expect(screen.getByText('Engineering')).toBeTruthy();
+    expect(screen.getByText('Platform')).toBeTruthy();
+    expect(screen.getByText('Sales')).toBeTruthy();
+  });
+
+  it('indents children by depth', async () => {
+    renderTree();
+    await waitFor(() => expect(screen.getByTestId('object-tree')).toBeTruthy());
+    const rows = screen.getAllByTestId('object-tree-row');
+    const byName = (n: string) =>
+      rows.find((r) => r.textContent?.includes(n))!;
+    expect(byName('Acme').getAttribute('data-depth')).toBe('0');
+    expect(byName('Engineering').getAttribute('data-depth')).toBe('1');
+    expect(byName('Platform').getAttribute('data-depth')).toBe('2');
+  });
+
+  it('collapses and expands a subtree on chevron click', async () => {
+    renderTree();
+    await waitFor(() => expect(screen.getByTestId('object-tree')).toBeTruthy());
+
+    // Collapse "Engineering" → Platform disappears, siblings stay.
+    const engRow = screen
+      .getAllByTestId('object-tree-row')
+      .find((r) => r.textContent?.includes('Engineering'))!;
+    const toggle = engRow.querySelector('button')!;
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(screen.queryByText('Platform')).toBeNull());
+    expect(screen.getByText('Sales')).toBeTruthy();
+
+    // Expand again → Platform returns.
+    fireEvent.click(toggle);
+    await waitFor(() => expect(screen.getByText('Platform')).toBeTruthy());
+  });
+
+  it('respects defaultExpandedDepth=0 (roots only)', async () => {
+    renderTree({ defaultExpandedDepth: 0 });
+    await waitFor(() => expect(screen.getByTestId('object-tree')).toBeTruthy());
+    expect(screen.getByText('Acme')).toBeTruthy();
+    // Children of the root are hidden until expanded.
+    expect(screen.queryByText('Engineering')).toBeNull();
+  });
+
+  it('keeps orphan records (parent outside the result set) as roots', async () => {
+    const orphans = [
+      { id: '10', name: 'Floating', parent_id: '999' },
+    ];
+    render(
+      <ObjectTree
+        schema={{ type: 'object-tree', objectName: 'x', parentField: 'parent_id', labelField: 'name', data: orphans }}
+        data={orphans}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Floating')).toBeTruthy());
+  });
+});

--- a/packages/plugin-tree/src/ObjectTree.tsx
+++ b/packages/plugin-tree/src/ObjectTree.tsx
@@ -1,0 +1,447 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ObjectTree Component (tree-grid)
+ *
+ * Renders a self-referencing object as an indented, expand/collapse tree-grid.
+ * Flat records are nested via a single-parent pointer field (`parentField`).
+ * The label column is indented per depth with a chevron toggle; any additional
+ * `fields` render as flat columns alongside it.
+ *
+ * Unlike Airtable (whose many-to-many links make a tree ambiguous), ObjectStack's
+ * `tree` field is a single-parent pointer, so the nesting is unambiguous and the
+ * parent field can be auto-detected from the object schema.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import type { DataSource, ViewData } from '@object-ui/types';
+import { useNavigationOverlay } from '@object-ui/react';
+import { NavigationOverlay, cn } from '@object-ui/components';
+import { extractRecords, buildExpandFields } from '@object-ui/core';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+
+export interface ObjectTreeProps {
+  schema: any;
+  dataSource?: DataSource;
+  className?: string;
+  onRowClick?: (record: any) => void;
+  /** Inline data (passed by ListView/ObjectView for non-grid views). */
+  data?: any[];
+  loading?: boolean;
+}
+
+interface TreeConfig {
+  parentField?: string;
+  labelField: string;
+  fields: string[];
+  defaultExpandedDepth?: number;
+}
+
+interface TreeNode {
+  id: string;
+  record: any;
+  depth: number;
+  children: TreeNode[];
+}
+
+function getDataConfig(schema: any): ViewData | null {
+  if (schema.data) return schema.data;
+  if (schema.staticData) return { provider: 'value', items: schema.staticData };
+  if (schema.objectName) return { provider: 'object', object: schema.objectName };
+  return null;
+}
+
+function getTreeConfig(schema: any): TreeConfig {
+  const nested = (schema.tree || schema.filter?.tree || {}) as Partial<TreeConfig>;
+  return {
+    parentField: schema.parentField ?? nested.parentField,
+    labelField: schema.labelField ?? nested.labelField ?? schema.titleField ?? 'name',
+    fields: Array.isArray(schema.fields)
+      ? schema.fields
+      : Array.isArray(nested.fields)
+        ? nested.fields
+        : [],
+    defaultExpandedDepth: schema.defaultExpandedDepth ?? nested.defaultExpandedDepth,
+  };
+}
+
+/**
+ * Auto-detect the single-parent pointer field from the object schema:
+ * the first field declared as `tree`, or a lookup/master_detail whose
+ * reference points back at this same object.
+ */
+function detectParentField(objectSchema: any, objectName?: string): string | undefined {
+  const fields = objectSchema?.fields;
+  if (!fields || typeof fields !== 'object') return undefined;
+  let firstSelfRef: string | undefined;
+  for (const [key, def] of Object.entries<any>(fields)) {
+    if (def?.type === 'tree') return key;
+    const ref = def?.reference || def?.reference_to || def?.referenceTo;
+    if (
+      !firstSelfRef &&
+      (def?.type === 'lookup' || def?.type === 'master_detail') &&
+      ref &&
+      objectName &&
+      ref === objectName
+    ) {
+      firstSelfRef = key;
+    }
+  }
+  return firstSelfRef;
+}
+
+/** Resolve a record's id (records may use `id` or `_id`). */
+function recordId(record: any): string | undefined {
+  const id = record?.id ?? record?._id;
+  return id == null ? undefined : String(id);
+}
+
+/** Resolve the parent id from a record's parent-pointer value. */
+function parentIdOf(record: any, parentField?: string): string | undefined {
+  if (!parentField) return undefined;
+  const raw = record?.[parentField];
+  if (raw == null) return undefined;
+  // Expanded lookup → object with id/_id; otherwise the raw scalar is the id.
+  if (typeof raw === 'object') {
+    const id = raw.id ?? raw._id;
+    return id == null ? undefined : String(id);
+  }
+  return String(raw);
+}
+
+/**
+ * Build a nested forest from flat records. Records whose parent is missing
+ * (or points outside the result set) become roots, so nothing is dropped.
+ */
+function buildForest(records: any[], parentField?: string): TreeNode[] {
+  const byId = new Map<string, TreeNode>();
+  const order: string[] = [];
+
+  for (const record of records) {
+    const id = recordId(record);
+    if (id == null) continue;
+    byId.set(id, { id, record, depth: 0, children: [] });
+    order.push(id);
+  }
+
+  const roots: TreeNode[] = [];
+  for (const id of order) {
+    const node = byId.get(id)!;
+    const pid = parentIdOf(node.record, parentField);
+    const parent = pid != null ? byId.get(pid) : undefined;
+    if (parent && parent !== node) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  // Assign depth top-down.
+  const assignDepth = (nodes: TreeNode[], depth: number) => {
+    for (const n of nodes) {
+      n.depth = depth;
+      assignDepth(n.children, depth + 1);
+    }
+  };
+  assignDepth(roots, 0);
+  return roots;
+}
+
+/** Flatten the forest into the rows currently visible given expansion state. */
+function flattenVisible(roots: TreeNode[], expanded: Set<string>): TreeNode[] {
+  const out: TreeNode[] = [];
+  const walk = (nodes: TreeNode[]) => {
+    for (const n of nodes) {
+      out.push(n);
+      if (n.children.length > 0 && expanded.has(n.id)) {
+        walk(n.children);
+      }
+    }
+  };
+  walk(roots);
+  return out;
+}
+
+/** Collect ids that should start expanded, honoring an optional depth cap. */
+function initialExpanded(roots: TreeNode[], depth?: number): Set<string> {
+  const set = new Set<string>();
+  const walk = (nodes: TreeNode[]) => {
+    for (const n of nodes) {
+      if (n.children.length === 0) continue;
+      if (depth == null || n.depth < depth) {
+        set.add(n.id);
+        walk(n.children);
+      }
+    }
+  };
+  walk(roots);
+  return set;
+}
+
+function formatValue(value: any): string {
+  if (value == null) return '';
+  if (typeof value === 'object') {
+    return String(value.name ?? value.label ?? value.id ?? value._id ?? '');
+  }
+  return String(value);
+}
+
+export const ObjectTree: React.FC<ObjectTreeProps> = ({
+  schema,
+  dataSource,
+  className,
+  onRowClick,
+  ...rest
+}) => {
+  const [records, setRecords] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [objectSchema, setObjectSchema] = useState<any>(null);
+
+  const dataConfig = useMemo(() => getDataConfig(schema), [schema]);
+  const hasInlineData =
+    Array.isArray((rest as any).data) ||
+    Array.isArray((schema as any).data) ||
+    dataConfig?.provider === 'value';
+
+  // Fetch object schema (for parent-field auto-detection + column labels).
+  useEffect(() => {
+    let cancelled = false;
+    const fetchSchema = async () => {
+      try {
+        if (!dataSource || typeof dataSource.getObjectSchema !== 'function') return;
+        const objectName =
+          dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
+        if (!objectName) return;
+        const result = await dataSource.getObjectSchema(objectName);
+        if (!cancelled) setObjectSchema(result);
+      } catch (err) {
+        console.error('[ObjectTree] Failed to fetch object schema:', err);
+      }
+    };
+    if (!hasInlineData) fetchSchema();
+    return () => {
+      cancelled = true;
+    };
+  }, [schema.objectName, dataSource, dataConfig, hasInlineData]);
+
+  // Fetch records.
+  useEffect(() => {
+    let cancelled = false;
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const passed = (rest as any).data ?? (schema as any).data;
+        if (Array.isArray(passed)) {
+          if (!cancelled) {
+            setRecords(passed);
+            setLoading(false);
+          }
+          return;
+        }
+
+        if (dataConfig?.provider === 'value') {
+          if (!cancelled) {
+            setRecords((dataConfig.items as any[]) ?? []);
+            setLoading(false);
+          }
+          return;
+        }
+
+        if (dataConfig?.provider === 'object') {
+          if (!dataSource || typeof dataSource.find !== 'function') {
+            throw new Error('DataSource required for the object provider');
+          }
+          const expand = buildExpandFields(objectSchema?.fields);
+          const result = await dataSource.find(dataConfig.object, {
+            $filter: schema.filter,
+            ...(expand.length > 0 ? { $expand: expand } : {}),
+          });
+          if (!cancelled) {
+            setRecords(extractRecords(result));
+            setLoading(false);
+          }
+          return;
+        }
+
+        if (!cancelled) {
+          setRecords([]);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err as Error);
+          setLoading(false);
+        }
+      }
+    };
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [dataConfig, dataSource, schema.filter, objectSchema, (rest as any).data]);
+
+  const config = useMemo(() => getTreeConfig(schema), [schema]);
+  const parentField = useMemo(
+    () => config.parentField ?? detectParentField(objectSchema, schema.objectName),
+    [config.parentField, objectSchema, schema.objectName],
+  );
+
+  const roots = useMemo(
+    () => buildForest(records, parentField),
+    [records, parentField],
+  );
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  // Re-seed expansion whenever the tree shape changes.
+  useEffect(() => {
+    setExpanded(initialExpanded(roots, config.defaultExpandedDepth));
+  }, [roots, config.defaultExpandedDepth]);
+
+  const toggle = (id: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const visibleRows = useMemo(
+    () => flattenVisible(roots, expanded),
+    [roots, expanded],
+  );
+
+  // Column labels from object schema (fall back to humanized field key).
+  const fieldLabel = (field: string): string => {
+    const def = objectSchema?.fields?.[field];
+    return def?.label || field.replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase());
+  };
+
+  const navigation = useNavigationOverlay({
+    navigation: (schema as any).navigation,
+    objectName: schema.objectName,
+    onRowClick,
+  });
+
+  if (error) {
+    return (
+      <div className={cn('flex items-center justify-center h-40 text-destructive', className)}>
+        <p>Failed to load tree: {error.message}</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className={cn('flex items-center justify-center h-40 text-muted-foreground', className)}>
+        <p>Loading…</p>
+      </div>
+    );
+  }
+
+  if (records.length === 0) {
+    return (
+      <div className={cn('flex items-center justify-center h-40 text-muted-foreground', className)}>
+        <p>No records</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('w-full overflow-auto', className)} data-testid="object-tree">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="px-3 py-2 font-medium">{fieldLabel(config.labelField)}</th>
+            {config.fields
+              .filter((f) => f !== config.labelField)
+              .map((f) => (
+                <th key={f} className="px-3 py-2 font-medium">
+                  {fieldLabel(f)}
+                </th>
+              ))}
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.map((node) => {
+            const hasChildren = node.children.length > 0;
+            const isOpen = expanded.has(node.id);
+            return (
+              <tr
+                key={node.id}
+                className="border-b hover:bg-accent/50 cursor-pointer"
+                data-testid="object-tree-row"
+                data-depth={node.depth}
+                onClick={(e) => navigation.handleClick(node.record, e)}
+              >
+                <td className="px-3 py-2">
+                  <div
+                    className="flex items-center gap-1"
+                    style={{ paddingLeft: `${node.depth * 20}px` }}
+                  >
+                    {hasChildren ? (
+                      <button
+                        type="button"
+                        aria-label={isOpen ? 'Collapse' : 'Expand'}
+                        className="flex h-5 w-5 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggle(node.id);
+                        }}
+                      >
+                        {isOpen ? (
+                          <ChevronDown className="h-4 w-4" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4" />
+                        )}
+                      </button>
+                    ) : (
+                      <span className="inline-block h-5 w-5" />
+                    )}
+                    <span className="truncate">
+                      {formatValue(node.record[config.labelField]) || '—'}
+                    </span>
+                  </div>
+                </td>
+                {config.fields
+                  .filter((f) => f !== config.labelField)
+                  .map((f) => (
+                    <td key={f} className="px-3 py-2 text-muted-foreground">
+                      {formatValue(node.record[f])}
+                    </td>
+                  ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {navigation.isOverlay && (
+        <NavigationOverlay {...navigation} title="Record Details">
+          {(record) => (
+            <div className="space-y-3">
+              {Object.entries(record).map(([key, value]) => (
+                <div key={key} className="flex flex-col">
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    {key.replace(/_/g, ' ')}
+                  </span>
+                  <span className="text-sm">{formatValue(value) || '—'}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </NavigationOverlay>
+      )}
+    </div>
+  );
+};
+
+export default ObjectTree;

--- a/packages/plugin-tree/src/ObjectTree.tsx
+++ b/packages/plugin-tree/src/ObjectTree.tsx
@@ -239,6 +239,26 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
         setLoading(true);
         setError(null);
 
+        // A live object dataSource takes precedence over any `data` the host
+        // passed down: the tree needs the FULL record (esp. the parent-pointer
+        // field), but a host like ListView pre-fetches only the view's display
+        // columns — which usually omit the parent field and would flatten the
+        // tree. Fetching our own records (no column projection) guarantees the
+        // parent field is present so the hierarchy resolves.
+        if (dataConfig?.provider === 'object' && dataSource && typeof dataSource.find === 'function') {
+          const expand = buildExpandFields(objectSchema?.fields);
+          const result = await dataSource.find(dataConfig.object, {
+            $filter: schema.filter,
+            ...(expand.length > 0 ? { $expand: expand } : {}),
+          });
+          if (!cancelled) {
+            setRecords(extractRecords(result));
+            setLoading(false);
+          }
+          return;
+        }
+
+        // Otherwise fall back to inline/static data (tests, value provider).
         const passed = (rest as any).data ?? (schema as any).data;
         if (Array.isArray(passed)) {
           if (!cancelled) {
@@ -251,22 +271,6 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
         if (dataConfig?.provider === 'value') {
           if (!cancelled) {
             setRecords((dataConfig.items as any[]) ?? []);
-            setLoading(false);
-          }
-          return;
-        }
-
-        if (dataConfig?.provider === 'object') {
-          if (!dataSource || typeof dataSource.find !== 'function') {
-            throw new Error('DataSource required for the object provider');
-          }
-          const expand = buildExpandFields(objectSchema?.fields);
-          const result = await dataSource.find(dataConfig.object, {
-            $filter: schema.filter,
-            ...(expand.length > 0 ? { $expand: expand } : {}),
-          });
-          if (!cancelled) {
-            setRecords(extractRecords(result));
             setLoading(false);
           }
           return;

--- a/packages/plugin-tree/src/index.tsx
+++ b/packages/plugin-tree/src/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { useSchemaContext } from '@object-ui/react';
+import { ObjectTree } from './ObjectTree';
+import type { ObjectTreeProps } from './ObjectTree';
+
+export { ObjectTree };
+export type { ObjectTreeProps };
+
+// Renderer wrapper: pulls the dataSource from schema context, mirroring the
+// other view plugins (object-map / object-gantt / …).
+export const ObjectTreeRenderer: React.FC<any> = ({ schema, ...props }) => {
+  const { dataSource } = useSchemaContext() || {};
+  return <ObjectTree schema={schema} dataSource={dataSource} {...props} />;
+};
+
+const treeInputs = [
+  { name: 'objectName', type: 'string' as const, label: 'Object Name', required: true },
+  {
+    name: 'tree',
+    type: 'object' as const,
+    label: 'Tree Config',
+    description: 'parentField, labelField, fields, defaultExpandedDepth',
+  },
+];
+
+ComponentRegistry.register('object-tree', ObjectTreeRenderer, {
+  namespace: 'plugin-tree',
+  label: 'Object Tree',
+  category: 'view',
+  inputs: treeInputs,
+});
+
+ComponentRegistry.register('tree', ObjectTreeRenderer, {
+  namespace: 'view',
+  label: 'Tree View',
+  category: 'view',
+  inputs: treeInputs,
+});

--- a/packages/plugin-tree/tsconfig.json
+++ b/packages/plugin-tree/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "noEmit": false,
+    "declaration": true,
+    "composite": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/plugin-tree/vite.config.ts
+++ b/packages/plugin-tree/vite.config.ts
@@ -1,0 +1,58 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import dts from 'vite-plugin-dts';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    dts({
+      insertTypesEntry: true,
+      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      aliasesExclude: [/^@object-ui\//],
+      include: ['src'],
+      exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      skipDiagnostics: true,
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+      '@object-ui/core': resolve(__dirname, '../core/src/index.ts'),
+    },
+  },
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.tsx'),
+      name: 'ObjectUIPluginTree',
+      fileName: 'index',
+    },
+    rollupOptions: {
+      external: (id) => !/^[./]/.test(id) && !id.startsWith(__dirname),
+      output: {
+        inlineDynamicImports: true,
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+          '@object-ui/components': 'ObjectUIComponents',
+          '@object-ui/core': 'ObjectUICore',
+          '@object-ui/react': 'ObjectUIReact',
+          '@object-ui/types': 'ObjectUITypes',
+          'lucide-react': 'LucideReact',
+        },
+      },
+    },
+  },
+  test: {
+    passWithNoTests: true,
+    environment: 'jsdom',
+  },
+});

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -756,6 +756,19 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           locationField: viewOptions.map?.locationField || 'location',
           ...(viewOptions.map || {}),
         };
+      case 'tree':
+        return {
+          type: 'object-tree',
+          ...baseProps,
+          // Single-parent pointer field; auto-detected from the object's
+          // `tree`/self-reference field when not specified.
+          parentField: viewOptions.tree?.parentField,
+          labelField: viewOptions.tree?.labelField || viewOptions.tree?.titleField || 'name',
+          // The view's columns double as the tree-grid's flat columns.
+          fields: viewOptions.tree?.fields || baseProps.fields,
+          defaultExpandedDepth: viewOptions.tree?.defaultExpandedDepth,
+          ...(viewOptions.tree || {}),
+        };
       case 'chart': {
         // Aggregated chart of the object's records, delegating to the same
         // object-chart component the dashboard uses.

--- a/packages/plugin-view/src/ViewSwitcher.tsx
+++ b/packages/plugin-view/src/ViewSwitcher.tsx
@@ -32,6 +32,7 @@ import {
   LayoutGrid,
   List,
   Map,
+  ListTree,
   Plus,
   Share2,
   Settings,
@@ -63,6 +64,7 @@ const DEFAULT_VIEW_LABELS: Record<ViewType, string> = {
   map: 'Map',
   gallery: 'Gallery',
   gantt: 'Gantt',
+  tree: 'Tree',
 };
 
 const DEFAULT_VIEW_ICONS: Record<ViewType, LucideIcon> = {
@@ -75,6 +77,7 @@ const DEFAULT_VIEW_ICONS: Record<ViewType, LucideIcon> = {
   map: Map,
   gallery: Images,
   gantt: GanttChartSquare,
+  tree: ListTree,
 };
 
 const viewSwitcherLayout = cva('flex gap-4', {

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1959,6 +1959,31 @@ export interface ObjectMapSchema extends BaseSchema {
 }
 
 /**
+ * Object Tree (tree-grid) Component Schema
+ *
+ * Renders a self-referencing object as an indented, expand/collapse tree-grid.
+ * Flat records are nested via a single-parent pointer field (`parentField`).
+ */
+export interface ObjectTreeSchema extends BaseSchema {
+  type: 'object-tree';
+  /** ObjectQL object name */
+  objectName: string;
+  /**
+   * Field holding the parent record reference (single-parent pointer).
+   * When omitted, the renderer auto-detects the object's `tree`/self-reference field.
+   */
+  parentField?: string;
+  /** Field rendered (indented) in the tree's first column. Defaults to `name`. */
+  labelField?: string;
+  /** Additional fields rendered as flat columns alongside the label. */
+  fields?: string[];
+  /**
+   * Default expansion depth (0 = roots only). When omitted, all nodes expand.
+   */
+  defaultExpandedDepth?: number;
+}
+
+/**
  * Object Gantt Component Schema
  */
 export interface ObjectGanttSchema extends BaseSchema {
@@ -2082,6 +2107,7 @@ export type ObjectQLComponentSchema =
   | ObjectFormSchema
   | ObjectViewSchema
   | ObjectMapSchema
+  | ObjectTreeSchema
   | ObjectGanttSchema
   | ObjectCalendarSchema
   | ObjectKanbanSchema

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -25,7 +25,7 @@ import type { SelectOptionMetadata } from './field-types';
 /**
  * View Type
  */
-export type ViewType = 'list' | 'detail' | 'grid' | 'kanban' | 'calendar' | 'timeline' | 'map' | 'gallery' | 'gantt' | 'chart';
+export type ViewType = 'list' | 'detail' | 'grid' | 'kanban' | 'calendar' | 'timeline' | 'map' | 'gallery' | 'gantt' | 'chart' | 'tree';
 
 /**
  * Detail View Field Configuration

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -389,6 +389,18 @@ export const ObjectMapSchema = BaseSchema.extend({
 });
 
 /**
+ * ObjectTree (tree-grid) Schema
+ */
+export const ObjectTreeSchema = BaseSchema.extend({
+  type: z.literal('object-tree'),
+  objectName: z.string().describe('ObjectQL object name'),
+  parentField: z.string().optional().describe('Single-parent pointer field (auto-detected when omitted)'),
+  labelField: z.string().optional().describe('Field rendered indented in the first column'),
+  fields: z.array(z.string()).optional().describe('Additional flat columns'),
+  defaultExpandedDepth: z.number().optional().describe('Default expansion depth (0 = roots only)'),
+});
+
+/**
  * ObjectGantt Schema
  */
 export const ObjectGanttSchema = BaseSchema.extend({
@@ -463,6 +475,7 @@ export const ObjectQLComponentSchema = z.union([
   ObjectFormSchema,
   ObjectViewSchema,
   ObjectMapSchema,
+  ObjectTreeSchema,
   ObjectGanttSchema,
   ObjectCalendarSchema,
   ObjectKanbanSchema,

--- a/packages/types/src/zod/views.zod.ts
+++ b/packages/types/src/zod/views.zod.ts
@@ -22,7 +22,7 @@ import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 /**
  * View Type Schema
  */
-export const ViewTypeSchema = z.enum(['list', 'detail', 'grid', 'kanban', 'calendar', 'timeline', 'map', 'gallery', 'gantt']).describe('View type');
+export const ViewTypeSchema = z.enum(['list', 'detail', 'grid', 'kanban', 'calendar', 'timeline', 'map', 'gallery', 'gantt', 'tree']).describe('View type');
 
 /**
  * Detail View Field Schema

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       '@object-ui/plugin-timeline':
         specifier: workspace:*
         version: link:../../packages/plugin-timeline
+      '@object-ui/plugin-tree':
+        specifier: workspace:*
+        version: link:../../packages/plugin-tree
       '@object-ui/plugin-view':
         specifier: workspace:*
         version: link:../../packages/plugin-view
@@ -2283,6 +2286,52 @@ importers:
       '@object-ui/data-objectstack':
         specifier: workspace:*
         version: link:../data-objectstack
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-plugin-dts:
+        specifier: ^5.0.2
+        version: 5.0.2(@microsoft/api-extractor@7.58.2(@types/node@25.9.3))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/plugin-tree:
+    dependencies:
+      '@object-ui/components':
+        specifier: workspace:*
+        version: link:../components
+      '@object-ui/core':
+        specifier: workspace:*
+        version: link:../core
+      '@object-ui/react':
+        specifier: workspace:*
+        version: link:../react
+      '@object-ui/types':
+        specifier: workspace:*
+        version: link:../types
+      '@objectstack/spec':
+        specifier: ^9.5.1
+        version: 9.5.1(ai@6.0.205(zod@4.4.3))
+      lucide-react:
+        specifier: ^1.18.0
+        version: 1.18.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17


### PR DESCRIPTION
## What

Adds a **`tree` / tree-grid object view type** — renders a self-referencing object as an indented, expand/collapse tree-grid. The right view for arbitrary-depth hierarchies (business unit / org chart, category trees, BOMs, nested comments) that fixed-depth grouping can't express.

Closes #1885. Pairs with framework PR (spec `tree` type + showcase example).

## Changes

- **`packages/plugin-tree`** (new): `ObjectTree` tree-grid renderer + `object-tree`/`tree` registration. Builds a nested forest from flat records via a single-parent pointer, auto-detects the parent field from the object's `tree`/self-reference field, depth-seeded expand/collapse, keeps orphan rows as roots. When a live object dataSource is present it fetches its own full records (the host's column-scoped data omits the parent pointer and would flatten the tree).
- **`types`**: `ViewType` + zod enum gain `tree`; `ObjectTreeSchema` added to the ObjectQL component union (interface + zod).
- **Dispatch**: `plugin-list/ListView` (the console path) and `plugin-view/ObjectView` both route `tree` → `object-tree`; `app-shell/ObjectView` passes the view's `tree` config through `options.tree`. Both `ViewSwitcher`s get a tree icon/label.
- **`apps/console`**: lazy-register `object-tree`/`tree`, dep + vite alias + manualChunk.

## Testing

- 5 unit tests in `plugin-tree` (forest building, depth indentation, expand/collapse, `defaultExpandedDepth`, orphan handling) — all green.
- Typecheck clean for `plugin-tree` + `types`.
- **Browser e2e**: ran the showcase backend + this console and confirmed `showcase_business_unit` → "Organization Chart" renders a 3-level indented tree-grid with working expand/collapse (Acme → Product & Engineering → Platform / Frontend Guild → Design Systems; Go-To-Market → Sales → Enterprise Sales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
