### PR TITLE
fix(actions): warn when an action is hidden by a throwing visible predicate

### DIFF
--- a/.changeset/action-engine-warn-hidden.md
+++ b/.changeset/action-engine-warn-hidden.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/core": patch
+---
+
+fix(actions): warn when an action is hidden by a throwing `visible` predicate
+
+`ActionEngine.getActionsForLocation` is fail-closed: a `visible` predicate that
+throws hides the action. The most common cause is an authoring bug — a BARE
+field reference (`done` instead of `record.done`), which is undeclared in the
+`{ record, recordId, objectName, user }` eval scope. Hiding it silently made
+that bug invisible (a long debugging hunt). The catch now emits a one-time
+`console.warn` naming the action + predicate + error, with the `record.<field>`
+tip. Deduped per predicate so re-renders don't spam.

--- a/packages/core/src/actions/ActionEngine.ts
+++ b/packages/core/src/actions/ActionEngine.ts
@@ -65,6 +65,30 @@ function normalizeShortcut(keys: string): string {
   return keys.toLowerCase().split('+').map(k => k.trim()).sort().join('+');
 }
 
+/** De-dupe key set so a broken predicate warns once, not every re-render. */
+const _warnedPredicates = new Set<string>();
+
+/**
+ * Surface an action whose `visible` predicate threw (and was therefore
+ * fail-closed hidden). Almost always an authoring bug — typically a bare field
+ * reference that should be `record.<field>`. Warned once per predicate.
+ */
+function warnHiddenPredicate(name: unknown, raw: unknown, err: unknown): void {
+  const src = typeof raw === 'string'
+    ? raw
+    : (raw && typeof raw === 'object' && typeof (raw as any).source === 'string' ? (raw as any).source : String(raw));
+  const key = `${String(name)}::${src}`;
+  if (_warnedPredicates.has(key)) return;
+  _warnedPredicates.add(key);
+  const msg = err instanceof Error ? err.message : String(err);
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[ActionEngine] action "${String(name)}" hidden: its \`visible\` predicate threw — ${msg}. ` +
+    `Predicate: ${src}. Action predicates evaluate against { record, recordId, objectName, user, … }; ` +
+    `use \`record.<field>\` (not a bare field).`,
+  );
+}
+
 export class ActionEngine {
   private actions = new Map<string, RegisteredAction>();
   private mappings: ActionMapping[] = [];
@@ -193,7 +217,15 @@ export class ActionEngine {
           // failed (e.g. `ctx` undefined). Surface the error so our catch
           // below can hide the action.
           return evaluator.evaluateCondition(expr as any, { throwOnError: true } as any);
-        } catch {
+        } catch (err) {
+          // Fail-closed: hide the action. But a *thrown* predicate is almost
+          // always an authoring bug, not a real precondition — most often a
+          // BARE field reference (`done` instead of `record.done`), which is
+          // an undeclared variable in the `{ record, recordId, objectName,
+          // user }` eval scope. Silently hiding it makes that bug invisible
+          // (the #2183 hunt). Warn once per predicate so it is diagnosable
+          // without spamming re-renders.
+          warnHiddenPredicate((ra.action as any).name, raw, err);
           return false;
         }
       })

--- a/packages/core/src/actions/__tests__/ActionEngine.visibility.test.ts
+++ b/packages/core/src/actions/__tests__/ActionEngine.visibility.test.ts
@@ -146,4 +146,33 @@ describe('ActionEngine.getActionsForLocation — visibility filter', () => {
     engine.registerAction({ name: 'c', type: 'api', visible: false } as any, { locations: ['record_section'], priority: 5 });
     expect(engine.getActionsForLocation('record_section').map(a => a.name)).toEqual(['b', 'a']);
   });
+  it('hides a throwing (bare-field) predicate AND warns once (diagnose #2183 silent hide)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const engine = makeEngine(ctx);
+      // bare `done` is undeclared in the eval scope → throws → fail-closed hide
+      engine.registerAction({ name: 'mark_done', type: 'script', visible: '!done' } as any, { locations: ['record_section'] });
+      expect(engine.getActionsForLocation('record_section')).toHaveLength(0);
+      // re-querying must NOT spam the warning (deduped per predicate)
+      engine.getActionsForLocation('record_section');
+      const hits = warn.mock.calls.filter(c => String(c[0]).includes('mark_done'));
+      expect(hits).toHaveLength(1);
+      expect(String(hits[0][0])).toMatch(/record\.<field>/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not warn for a correct record-qualified predicate', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const engine = makeEngine(ctx);
+      engine.registerAction({ name: 'ok_action', type: 'script', visible: '!record.two_factor_enabled' } as any, { locations: ['record_section'] });
+      expect(engine.getActionsForLocation('record_section').map(a => a.name)).toEqual(['ok_action']);
+      expect(warn.mock.calls.filter(c => String(c[0]).includes('ok_action'))).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
 });


### PR DESCRIPTION
Defense-in-depth companion to framework#2185. `ActionEngine.getActionsForLocation` is fail-closed: a `visible` predicate that throws hides the action silently — usually a bare field ref (`!done` vs `!record.done`), undeclared in the `{ record, recordId, objectName, user }` scope. This made the #2183 bug nearly invisible. The catch now emits a one-time `console.warn` (deduped per predicate) naming the action + error with the `record.<field>` tip; behaviour is unchanged (still fail-closed hidden). 2 new tests; suite 10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)