### PR TITLE
ci: drop pnpm cache from dependabot auto-merge job

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,9 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-          cache: 'pnpm'
+          # No `cache: 'pnpm'` here: this job never runs `pnpm install`, so the
+          # pnpm store doesn't exist and setup-node's post-job cache save fails
+          # with "Path Validation Error", which marks the whole job as failed.
 
       - name: Configure Git merge driver for pnpm-lock.yaml
         run: |


### PR DESCRIPTION
## 问题

每个 Dependabot PR 上，`Dependabot Auto-merge` 这个 check 都会变红（FAILURE），例如 #1837。但所有真正的 CI（Test / Build & E2E / Build Docs / Bundle Analysis / Changeset 等）其实都是 SUCCESS。

## 根因

[.github/workflows/dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml) 的 `Setup Node.js` 步骤设置了 `cache: 'pnpm'`，但这个 job 从不执行 `pnpm install`，所以 pnpm store 目录根本不存在。于是 `actions/setup-node@v6` 的 post-job 缓存保存步骤（"Post Setup Node.js"）报错：

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

在 v6 里这个 post 步骤会被判为 `failure`，进而把整个 job 标红 —— 与 PR 升级的依赖本身无关。

## 修复

移除该 job 的 `cache: 'pnpm'`。这个 job 不安装依赖，本来就不需要缓存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)