### PR TITLE
fix(components): resolve page:card/header/tabs titles via pickLocalized

### DIFF
--- a/packages/components/src/__tests__/page-card-i18n-title.test.tsx
+++ b/packages/components/src/__tests__/page-card-i18n-title.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Regression: `page:card` title must resolve inline-i18n shapes (`{ en, zh }`)
+ * through `pickLocalized`, not the old `labelText` (which only understood
+ * `{ default, value }`).
+ *
+ * Before the fix, a server-driven page that titled its cards with `{ en, zh }`
+ * — e.g. the Cloud Pricing page's per-plan name + price headings — rendered a
+ * BLANK title in every locale (`labelText({en,zh})` → '' → CardHeader skipped).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+
+function PageCard({ schema }: { schema: any }) {
+  const Component = ComponentRegistry.get('page:card');
+  if (!Component) throw new Error('page:card not registered');
+  return <Component schema={schema} />;
+}
+
+const i18nTitle = { en: 'Solo — $29/mo', zh: 'Solo 版 — $29/月' };
+
+describe('PageCardRenderer — localized title', () => {
+  it('renders the English title for an { en, zh } shape by default', () => {
+    render(<PageCard schema={{ type: 'page:card', title: i18nTitle, body: [] }} />);
+    // The regression guard: this was '' (no heading) before pickLocalized.
+    expect(screen.getByText('Solo — $29/mo')).toBeTruthy();
+  });
+
+  it('still renders a plain string title unchanged', () => {
+    render(<PageCard schema={{ type: 'page:card', title: 'Business', body: [] }} />);
+    expect(screen.getByText('Business')).toBeTruthy();
+  });
+});

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -45,7 +45,7 @@ import {
   DropdownMenuItem,
 } from '../../ui';
 import { RecordTitleChip } from '../../custom/RecordTitleChip';
-import { useObjectLabel, useSafeFieldLabel } from '@object-ui/i18n';
+import { useObjectLabel, useSafeFieldLabel, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import { MoreHorizontal } from 'lucide-react';
 
 /**
@@ -297,6 +297,7 @@ const collectRelatedLists = (nodes: any, acc: any[] = []): any[] => {
 
 const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { designer } = splitDesignerProps(props);
+  const { language } = useObjectTranslation();
   const items: PageTabsItem[] = schema?.items || [];
   // Tab visual style lives at `properties.type` ('line'|'card'|'pill') — the
   // outer `schema.type` is always 'page:tabs' (the component dispatch key).
@@ -387,7 +388,9 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const itemsWithValue = items.map((it, idx) => ({
     ...it,
     value: `tab-${idx}`,
-    labelStr: translateLabel(labelText(it.label)),
+    // pickLocalized first (honours `{ en, zh }` / `{ default }`); translateLabel
+    // then maps any plain-English well-known token (Details/Related/…) to the locale.
+    labelStr: translateLabel(pickLocalized(it.label, language)),
     // Explicit spec count wins; otherwise fall back to the derived probe.
     count: it.count !== undefined && it.count !== null && it.count !== ''
       ? it.count
@@ -482,7 +485,12 @@ ComponentRegistry.register('page:tabs', PageTabsRenderer, {
 
 const PageCardRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { designer } = splitDesignerProps(props);
-  const title = labelText(schema?.title);
+  const { language } = useObjectTranslation();
+  // Resolve the title via pickLocalized so inline-i18n shapes (`{ en, zh }`)
+  // render in the active locale. `labelText` only understands `{ default, value }`
+  // and would silently blank an `{ en, zh }` title — e.g. the Cloud Pricing
+  // page's per-plan name + price headings vanished in both locales.
+  const title = pickLocalized(schema?.title, language);
   const bordered = schema?.bordered !== false;
   // Accept `children` as well as `body` — every other container (grid/flex/
   // section/tabs) renders `children`, so authors expect it to work here too.
@@ -526,6 +534,7 @@ interface PageAccordionItem {
 
 const PageAccordionRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { designer } = splitDesignerProps(props);
+  const { language } = useObjectTranslation();
   const items: PageAccordionItem[] = schema?.items || [];
   const allowMultiple = !!schema?.allowMultiple;
   // Variants:
@@ -541,7 +550,7 @@ const PageAccordionRenderer: React.FC<any> = ({ schema, className, ...props }) =
   const itemsWithValue = items.map((it, idx) => ({
     ...it,
     value: `panel-${idx}`,
-    labelStr: translateLabel(labelText(it.label)),
+    labelStr: translateLabel(pickLocalized(it.label, language)),
   }));
 
   const defaultOpen = itemsWithValue
@@ -658,6 +667,7 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { execute } = useAction();
   const { objectLabel: tObjectLabel, actionLabel: tActionLabel } = useObjectLabel();
   const { fieldOptionLabel } = useSafeFieldLabel();
+  const { language } = useObjectTranslation();
   // Spec bridge may either inline `properties.*` onto the node or preserve
   // the raw bag (see record:quick_actions for the same pattern). Read from
   // both so a `{ properties: { title } }` schema is rendered correctly.
@@ -666,14 +676,14 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const headerObjectSchema: any = (ctx as any)?.objectSchema;
   const headerObjectName: string | undefined = ctx?.objectName || headerObjectSchema?.name;
   const explicitTitle = interpolate(
-    labelText(titleSrc),
+    pickLocalized(titleSrc, language),
     ctx?.data,
     headerObjectSchema,
     fieldOptionLabel,
     headerObjectName,
   );
   const subtitle = interpolate(
-    labelText(subtitleSrc),
+    pickLocalized(subtitleSrc, language),
     ctx?.data,
     headerObjectSchema,
     fieldOptionLabel,


### PR DESCRIPTION
## Problem

`page:*` container renderers resolved their author-facing labels through `labelText()`, which only understands the `{ default, value }` i18n shape. A server-driven page that titles its blocks with inline `{ en, zh }` objects — the convention `element:text` / `element:button` already resolve via `pickLocalized` — got a **blank** title in every locale, because `labelText({ en, zh })` returns `''` and `page:card` then skips the `CardHeader` entirely.

This is exactly what happened to the **Cloud Pricing page**: every plan card's name + price heading silently disappeared (both `en` and `zh`).

## Fix

Route these label spots through `pickLocalized(value, language)` (language from `useObjectTranslation()`):

- `page:card` title
- `page:header` title + subtitle
- `page:tabs` item labels
- `page:accordion` item labels

`translateLabel()` is still chained after `pickLocalized` for the tabs/accordion well-known-English-token map (Details → 详情, …), so a plain-English `"Details"` label keeps translating.

`labelText` is retained for the object-schema label fallback (a different shape handled by `useObjectLabel`).

## Tests

- New `page-card-i18n-title.test.tsx`: an `{ en, zh }` title renders (regression guard — was blank) + plain-string title unchanged.
- All 38 existing renderer tests still green (incl. `page-header-actions`, which renders `PageHeaderRenderer` with no `I18nProvider` — confirms `useObjectTranslation` is safe without a provider).
- `pnpm type-check` clean.

## Consumed by

cloud pins objectui by SHA (`.objectui-sha`); the matching cloud PR bumps the pin and beautifies `pricing.page.ts` on top of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)