### PR TITLE
fix(dashboard): scale fraction-stored percent measures to display magnitude

### DIFF
--- a/packages/core/src/utils/__tests__/dataset-format.test.ts
+++ b/packages/core/src/utils/__tests__/dataset-format.test.ts
@@ -31,8 +31,22 @@ describe('formatMeasure', () => {
   });
 
   it('applies percent and decimal hints', () => {
+    // Whole-percent storage (magnitude ≥ 1) passes through unchanged.
     expect(formatMeasure(50, '0%')).toBe('50%');
     expect(formatMeasure(12.5, '0.0')).toBe('12.5');
+  });
+
+  it('scales fraction-stored percents to display magnitude (×100), matching the list cell', () => {
+    // Percent fields store a FRACTION (0.75 ⇒ 75%); the list-view cell renderer
+    // multiplies by 100, so the dataset measure formatter must too — otherwise a
+    // metric card shows "0.6%" for an avg of 0.608 instead of "60.8%" (the bug).
+    expect(formatMeasure(0.75, '0%')).toBe('75%');
+    expect(formatMeasure(0.608_333_333, '0.0%')).toBe('60.8%');
+    // Boundary: exactly 0 and exactly 1 (100% stored as 1.0) — 1.0 passes
+    // through, mirroring the list renderer's strict `< 1` heuristic so the two
+    // surfaces stay in lockstep (a known shared limitation, not a new one).
+    expect(formatMeasure(0, '0%')).toBe('0%');
+    expect(formatMeasure(1, '0%')).toBe('1%');
   });
 
   it('falls back to plain formatting for an unknown currency code', () => {

--- a/packages/core/src/utils/dataset-format.ts
+++ b/packages/core/src/utils/dataset-format.ts
@@ -32,6 +32,22 @@ export interface DatasetResultField {
 }
 
 /**
+ * Scale a stored `percent`-field value to its DISPLAY magnitude.
+ *
+ * Percent fields store a FRACTION (0–1) by convention — a stored `0.75` means
+ * 75% (see the percent edit widget `PercentField`, which divides input by 100).
+ * A value already in whole-percent form (magnitude ≥ 1, e.g. a `progress` /
+ * `completion` field storing `57`) is passed through unchanged. This is the
+ * SINGLE source of truth for percent display scaling, shared by the list-view
+ * percent cell renderer (`formatPercent` in `@object-ui/fields`) and the dataset
+ * measure formatter ({@link formatMeasure}) so a percent renders identically as
+ * a row value and as an aggregated metric — the two surfaces can never drift.
+ */
+export function percentDisplayValue(value: number): number {
+  return value > -1 && value < 1 ? value * 100 : value;
+}
+
+/**
  * Format a MEASURE value. Currency comes from the field's declared `currency`
  * (locale-correct symbol via `Intl`), NOT from a "$" baked into the format
  * string — an amount with no declared currency must render as a plain number,
@@ -66,7 +82,12 @@ export function formatMeasure(v: unknown, format?: string, currency?: string): s
   // A legacy "$" literal in the format string is still honored (explicit author
   // choice) — but it is NOT how a real currency field gets its symbol.
   const legacyDollar = format.includes('$') ? '$' : '';
-  const body = v.toLocaleString(undefined, { minimumFractionDigits: decimals ?? 0, maximumFractionDigits: decimals ?? 0 });
+  // numeral's "0.0%" multiplies by 100, and a percent field stores a FRACTION
+  // (0.75 ⇒ 75%). Scale to display magnitude the SAME way the list-view cell
+  // renderer does — otherwise an avg of 0.608 renders as "0.6%" instead of
+  // "60.8%", disagreeing with the per-row "75%" the list already shows.
+  const display = isPercent ? percentDisplayValue(v) : v;
+  const body = display.toLocaleString(undefined, { minimumFractionDigits: decimals ?? 0, maximumFractionDigits: decimals ?? 0 });
   return `${legacyDollar}${body}${isPercent ? '%' : ''}`;
 }
 

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import type { FieldMetadata, SelectOptionMetadata } from '@object-ui/types';
-import { ComponentRegistry } from '@object-ui/core';
+import { ComponentRegistry, percentDisplayValue } from '@object-ui/core';
 import { useLocalization } from '@object-ui/i18n';
 import { Badge, Avatar, AvatarFallback, Button, Checkbox, EmptyValue, cn } from '@object-ui/components';
 import { Check, X, Copy, Phone as PhoneIcon, MapPin } from 'lucide-react';
@@ -341,8 +341,9 @@ export function formatNumber(value: number, decimals: number = 2): string {
  * Handles both decimal (0.8 = 80%) and whole number (80 = 80%) inputs.
  */
 export function formatPercent(value: number, precision: number = 0): string {
-  // If value is between -1 and 1 (exclusive), treat as decimal (e.g. 0.8 → 80%)
-  const displayValue = (value > -1 && value < 1) ? value * 100 : value;
+  // Scale a fraction-stored percent (0.8 → 80%) via the shared core helper, so
+  // the list cell and the dashboard measure formatter (`formatMeasure`) agree.
+  const displayValue = percentDisplayValue(value);
   return `${displayValue.toFixed(precision)}%`;
 }
 

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -26,6 +26,22 @@ describe('DatasetWidget', () => {
     expect(screen.getByText('Total Spent')).toBeInTheDocument();
   });
 
+  it('scales a fraction-stored percent measure to display magnitude (avg 0.608 → "60.8%", not "0.6%")', async () => {
+    // Reproduces the AI-built sales CRM bug: win_probability is a `percent`
+    // field stored as a FRACTION (0.75 ⇒ 75%); its avg over the seeded rows is
+    // 0.6083. The list view already shows each row as "75%", so the metric card
+    // must show "60.8%" — not the "0.6%" produced when the '0.0%' format was
+    // applied without numeral's ×100. The measure renders identically on both
+    // surfaces via the shared percentDisplayValue scaling.
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ avg_win_probability: 0.6083333333333333 }],
+      fields: [{ name: 'avg_win_probability', type: 'number', label: 'Average 赢单概率', format: '0.0%' }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'opportunity_ds', values: ['avg_win_probability'] }} dataSource={src} />);
+    expect(await screen.findByText('60.8%')).toBeInTheDocument();
+    expect(screen.queryByText('0.6%')).not.toBeInTheDocument();
+  });
+
   it('runs the dataset query for a dimensioned (chart) widget — rows→dimensions, values→measures', async () => {
     const src = makeSource(async () => ({ rows: [{ stage: 'won', revenue: 100 }, { stage: 'lost', revenue: 20 }] }));
     render(<DatasetWidget widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);


### PR DESCRIPTION
## Problem

On AI-built (and hand-authored) dashboards, a `percent` measure metric card renders at **1/100th scale** — e.g. an average win probability of `0.608` shows as **`0.6%`** instead of **`60.8%`**. The list view shows each row's percent correctly (`0.75 → "75%"`), so the two surfaces disagree.

## Root cause

`percent` fields store a **fraction (0–1)** (the percent edit widget `PercentField` divides input by 100 on save; confirmed live: a 12-row opportunity set had `win_probability_sum = 7.3`, `avg = 0.608`).

Two formatters scaled differently:

| Surface | Formatter | Behavior | `avg 0.608` + `'0.0%'` |
|---|---|---|---|
| List cell | `formatPercent` (`@object-ui/fields`) | `value<1 → ×100` | — (per-row `0.75 → "75%"` ✓) |
| Dashboard metric / table / pivot | `formatMeasure` (`@object-ui/core`) | appended `%`, **no ×100** | **`"0.6%"`** ✗ |

`formatMeasure` powers every dataset-bound surface (ADR-0021): `DatasetWidget` metric/table/pivot, `DatasetReportRenderer`, `DatasetPreview`. The `'0.0%'` format is valid numeral.js (which multiplies by 100), but `formatMeasure` is a hand-rolled formatter that omitted the ×100. The framework analytics layer does **no** server-side scaling, so this is purely a client render bug (no double-divide).

## Fix

Add `percentDisplayValue()` to `@object-ui/core` as the **single source of truth** for percent display scaling:
- `formatMeasure` applies it when the format contains `%` → `0.608 → "60.8%"`.
- `formatPercent` (list cell) rewired to call the same helper (behavior-identical) so the list cell and the dashboard metric can never drift again.

Whole-percent storage (magnitude ≥ 1, e.g. a `progress` field storing `57`) still passes through unchanged, matching the list renderer's existing heuristic exactly.

## Tests

- **Unit** (`dataset-format.test.ts`): `formatMeasure(0.6083, '0.0%') → "60.8%"`; `formatMeasure(50, '0%') → "50%"` (whole unaffected); boundary cases.
- **Component** (`DatasetWidget.test.tsx`): real metric widget fed the live value `0.6083` with format `'0.0%'` → renders **`60.8%`**, asserts `0.6%` is gone.
- Full workspace suite: **4278 passed**, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)