### PR TITLE
feat(core,react): scoped style-object rendering (ADR-0065)

### DIFF
--- a/.changeset/sdui-scoped-styles.md
+++ b/.changeset/sdui-scoped-styles.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/core": minor
+"@object-ui/react": patch
+"@object-ui/components": patch
+---
+
+feat: scoped style-object rendering (ADR-0065)
+
+A metadata node may carry `responsiveStyles` (per-breakpoint CSS-property maps);
+`SchemaRenderer` compiles it to **id-scoped CSS** injected as a `<style>` tag and
+appends a scope class to the node. Build-independent (arbitrary values + design
+tokens pass through verbatim — no Tailwind JIT), collision-free (per-node scope,
+unlayered so it beats base utilities), responsive-correct (model breakpoint maps
+→ generated `@media`, never `md:` variant classes). Adds `compileScopedStyles`/
+`scopeClassFor`/`hasResponsiveStyles` to `@object-ui/core` and an SDUI design-token
+palette (`--space-*`, `--surface`, `--brand`, …) to the theme. Mirrors Builder.io.

--- a/apps/console/src/index.css
+++ b/apps/console/src/index.css
@@ -164,8 +164,33 @@
     --success-foreground: 0 0% 100%;
     --warning: 38 92% 50%;
     --warning-foreground: 0 0% 100%;
+
+    /* SDUI design tokens (ADR-0065) — the curated palette author
+       `responsiveStyles` resolve against. Spacing/radius/shadow are
+       theme-independent; the semantic color tokens alias the theme so they
+       track light/dark automatically (resolved at use-site). */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.25rem;
+    --space-6: 1.5rem;
+    --space-8: 2rem;
+    --space-10: 2.5rem;
+    --space-12: 3rem;
+    --radius-xl: 1rem;
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --shadow-md: 0 4px 12px -2px rgb(0 0 0 / 0.12);
+    --shadow-lg: 0 10px 30px -5px rgb(0 0 0 / 0.25);
+    --surface: hsl(var(--card));
+    --surface-sunken: hsl(var(--muted));
+    --text-strong: hsl(var(--foreground));
+    --text-muted: hsl(var(--muted-foreground));
+    --brand: hsl(var(--primary));
+    --brand-foreground: hsl(var(--primary-foreground));
+    --hairline: hsl(var(--border));
   }
- 
+
   .dark {
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;

--- a/packages/components/src/index.css
+++ b/packages/components/src/index.css
@@ -109,6 +109,32 @@
   --sidebar-border: 220 13% 91%;
   --sidebar-ring: 217.2 91.2% 59.8%;
 
+  /* SDUI design tokens (ADR-0065) — the curated palette that author
+     `responsiveStyles` resolve against. Spacing/radius/shadow are
+     theme-independent; the semantic color tokens alias the shadcn theme so
+     they track light/dark automatically (resolved at use-site). */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 12px -2px rgb(0 0 0 / 0.12);
+  --shadow-lg: 0 10px 30px -5px rgb(0 0 0 / 0.25);
+  --surface: hsl(var(--card));
+  --surface-sunken: hsl(var(--muted));
+  --text-strong: hsl(var(--foreground));
+  --text-muted: hsl(var(--muted-foreground));
+  --brand: hsl(var(--primary));
+  --brand-foreground: hsl(var(--primary-foreground));
+  --hairline: hsl(var(--border));
+
   font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export * from './utils/debug-collector.js';
 export * from './utils/merge-views-into-objects.js';
 export * from './utils/freeze-schema.js';
 export * from './protocols/index.js';
+export * from './styling/scoped-styles.js';
 
 /**
  * @deprecated Import `composeStacks` from `@objectstack/spec` instead.

--- a/packages/core/src/styling/scoped-styles.test.ts
+++ b/packages/core/src/styling/scoped-styles.test.ts
@@ -1,0 +1,76 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  compileScopedStyles,
+  scopeClassFor,
+  hasResponsiveStyles,
+  STYLE_BREAKPOINTS,
+} from './scoped-styles.js';
+
+describe('scoped-styles compiler (ADR-0065)', () => {
+  it('scopes every rule to the selector — never a global rule', () => {
+    const css = compileScopedStyles('.os-s-card', {
+      large: { padding: '24px', display: 'flex' },
+      small: { padding: '12px' },
+    });
+    expect(css).toContain('.os-s-card { padding: 24px; display: flex; }');
+    expect(css).toContain('@media (max-width: 640px) { .os-s-card { padding: 12px; } }');
+    // No declaration ever sits outside a `.selector { … }` block.
+    expect(css).not.toMatch(/(^|\n)\s*padding:/);
+  });
+
+  it('generates @media for each breakpoint; base is unconditional', () => {
+    const css = compileScopedStyles('.x', {
+      large: { gap: '16px' },
+      medium: { gap: '12px' },
+      small: { gap: '8px' },
+      xsmall: { gap: '4px' },
+    });
+    expect(css.split('\n')[0]).toBe('.x { gap: 16px; }');
+    expect(css).toContain(`@media (max-width: ${STYLE_BREAKPOINTS.medium}px)`);
+    expect(css).toContain(`@media (max-width: ${STYLE_BREAKPOINTS.small}px)`);
+    expect(css).toContain(`@media (max-width: ${STYLE_BREAKPOINTS.xsmall}px)`);
+    expect(css).not.toContain('md:'); // never a variant class
+  });
+
+  it('passes arbitrary values + design tokens through verbatim (build-independent)', () => {
+    const css = compileScopedStyles('.y', {
+      large: {
+        fontSize: '44px',
+        color: '#1a2b3c',
+        padding: 'var(--space-6)',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+      },
+    });
+    expect(css).toContain('font-size: 44px;');
+    expect(css).toContain('color: #1a2b3c;');
+    expect(css).toContain('padding: var(--space-6);');
+    expect(css).toContain('grid-template-columns: repeat(3, 1fr);'); // camel→kebab, value intact
+  });
+
+  it('emits nothing for empty / absent styles', () => {
+    expect(compileScopedStyles('.z', {})).toBe('');
+    expect(compileScopedStyles('.z', { large: {} })).toBe('');
+  });
+
+  it('scopeClassFor sanitizes ids to CSS-safe class names', () => {
+    expect(scopeClassFor('plan_solo')).toBe('os-s-plan_solo');
+    expect(scopeClassFor(':r0:')).toBe('os-s--r0-'); // React useId() shape
+    expect(scopeClassFor('a.b c')).toBe('os-s-a-b-c');
+  });
+
+  it('hasResponsiveStyles detects real style payloads', () => {
+    expect(hasResponsiveStyles({ large: { padding: '1px' } })).toBe(true);
+    expect(hasResponsiveStyles({ small: { gap: '1px' } })).toBe(true);
+    expect(hasResponsiveStyles(undefined)).toBe(false);
+    expect(hasResponsiveStyles({})).toBe(false);
+    expect(hasResponsiveStyles('nope')).toBe(false);
+  });
+});

--- a/packages/core/src/styling/scoped-styles.ts
+++ b/packages/core/src/styling/scoped-styles.ts
@@ -1,0 +1,82 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Scoped style-object → CSS compiler (framework ADR-0065).
+ *
+ * The SDUI styling primitive: a metadata node carries a `responsiveStyles`
+ * object (per-breakpoint CSS-property maps); at render time it compiles to
+ * **id-scoped CSS** injected as a `<style>` tag. This is build-independent
+ * (arbitrary values + design tokens pass through verbatim — no Tailwind JIT
+ * needed), collision-free (scoped to one node's class — two independently-built
+ * stylesheets cannot fight), and responsive-correct (model breakpoint maps →
+ * generated `@media`, never author-written `md:` variant classes).
+ *
+ * Mirrors Builder.io's SDK (`createCssClass` / `responsiveStyles`). Desktop-first:
+ * `large` is the unconditional base; `medium`/`small`/`xsmall` are `max-width`
+ * overrides.
+ */
+
+export type StyleMap = Record<string, string | number>;
+
+export interface ResponsiveStyles {
+  /** Unconditional base (desktop-first). */
+  large?: StyleMap;
+  medium?: StyleMap;
+  small?: StyleMap;
+  xsmall?: StyleMap;
+}
+
+/** max-width breakpoints (px), mirroring Builder.io's default device sizes. */
+export const STYLE_BREAKPOINTS: Record<'medium' | 'small' | 'xsmall', number> = {
+  medium: 991,
+  small: 640,
+  xsmall: 479,
+};
+
+const camelToKebab = (k: string): string =>
+  k.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+
+/** Style-map → `prop: value;` declarations. Values pass through **verbatim** —
+ * that is the whole point: arbitrary values (`13px`, `#1a2b3c`) and design
+ * tokens (`var(--space-6)`) work with zero build step. */
+const declarations = (m: StyleMap): string =>
+  Object.entries(m)
+    .filter(([, v]) => v != null && v !== '')
+    .map(([k, v]) => `${camelToKebab(k)}: ${typeof v === 'number' ? String(v) : v};`)
+    .join(' ');
+
+/** True when a node actually carries responsive styles worth compiling. */
+export function hasResponsiveStyles(rs: unknown): rs is ResponsiveStyles {
+  if (!rs || typeof rs !== 'object') return false;
+  const r = rs as ResponsiveStyles;
+  return Boolean(r.large || r.medium || r.small || r.xsmall);
+}
+
+/** Deterministic, CSS-safe scope class for a node id. */
+export function scopeClassFor(id: string): string {
+  return `os-s-${String(id).replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+}
+
+/**
+ * Compile a node's responsive styles to CSS scoped to `selector`.
+ * Returns '' when there is nothing to emit. No unscoped/global rule is ever
+ * produced — that scoping is what makes per-node styles collision-free.
+ */
+export function compileScopedStyles(selector: string, rs: ResponsiveStyles): string {
+  const rules: string[] = [];
+  if (rs.large) {
+    const base = declarations(rs.large);
+    if (base) rules.push(`${selector} { ${base} }`);
+  }
+  for (const size of ['medium', 'small', 'xsmall'] as const) {
+    const s = rs[size];
+    if (!s) continue;
+    const d = declarations(s);
+    if (d) rules.push(`@media (max-width: ${STYLE_BREAKPOINTS[size]}px) { ${selector} { ${d} } }`);
+  }
+  return rules.join('\n');
+}

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -19,6 +19,9 @@ import {
   debugTimeEnd,
   DebugCollector,
   validateSchema,
+  hasResponsiveStyles,
+  scopeClassFor,
+  compileScopedStyles,
 } from '@object-ui/core';
 import { SchemaRendererContext } from './context/SchemaRendererContext';
 import { usePredicateScope } from './hooks/useExpression';
@@ -207,6 +210,8 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
     return unsubscribe;
   }, []);
   const [lazyError, setLazyError] = useState<Error | null>(null);
+  // Stable fallback id for scoping a styled node that didn't declare an `id`.
+  const autoStyleId = React.useId();
 
   // Evaluate schema expressions against the data source
   const evaluatedSchema = useMemo(() => {
@@ -368,8 +373,25 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
     disabledOn: _disabledOn,
     _hidden: __hidden,    // stripped: internal visibility flag
     _disabled: __disabled, // stripped: internal disabled flag
+    responsiveStyles: _responsiveStyles, // stripped: compiled to scoped CSS, not a DOM prop
     ...componentProps
   } = evaluatedSchema;
+
+  // SDUI scoped styling (ADR-0065): a node's `responsiveStyles` compiles to
+  // id-scoped CSS injected as a <style> tag, and a scope class is appended to
+  // the node's className. Build-independent, collision-free, responsive-correct.
+  const hasScopedStyles = hasResponsiveStyles(_responsiveStyles);
+  const scopeClass = hasScopedStyles ? scopeClassFor(evaluatedSchema.id ?? autoStyleId) : '';
+  const scopedCss = hasScopedStyles ? compileScopedStyles(`.${scopeClass}`, _responsiveStyles) : '';
+  const mergedClassName = scopeClass
+    ? [evaluatedSchema.className, scopeClass].filter(Boolean).join(' ')
+    : evaluatedSchema.className;
+  // Some renderers read `schema.className` directly (e.g. element:text) while
+  // others read the `className` prop (e.g. flex/container). Set both so the
+  // scope class lands regardless of which channel a renderer honours.
+  const schemaForComponent = scopeClass
+    ? { ...evaluatedSchema, className: mergedClassName }
+    : evaluatedSchema;
 
   // Extract AriaPropsSchema properties for accessibility
   const ariaProps = resolveAriaProps(evaluatedSchema);
@@ -391,14 +413,17 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
       componentType={evaluatedSchema.type}
       resetKey={evaluatedSchema.id ?? null}
     >
+      {scopedCss ? (
+        <style data-os-scope={scopeClass} dangerouslySetInnerHTML={{ __html: scopedCss }} />
+      ) : null}
       {React.createElement(Component, {
-        schema: evaluatedSchema,
+        schema: schemaForComponent,
         ...componentProps,  // Spread non-metadata schema properties as props
         ...(evaluatedSchema.props || {}),  // Override with explicit props if provided
         ...ariaProps,  // Inject ARIA attributes from AriaPropsSchema
         ...debugAttrs, // Debug-mode data attributes
         disabled: __disabled || undefined,
-        className: evaluatedSchema.className,
+        className: mergedClassName,
         'data-obj-id': evaluatedSchema.id,
         'data-obj-type': evaluatedSchema.type,
         ...(__DEV__ && !_validation.valid ? { 'data-obj-schema-invalid': 'true' } : {}),


### PR DESCRIPTION
Implements the **ADR-0065** SDUI styling mechanism (objectstack-ai/framework ADR-0065): metadata-authored styling as a **scoped style-object** instead of arbitrary Tailwind classes.

## What

- **`@object-ui/core`** — `compileScopedStyles(selector, responsiveStyles)` / `scopeClassFor(id)` / `hasResponsiveStyles()` (`packages/core/src/styling/`). Pure `data → CSS string`, desktop-first, mirrors Builder.io's `createCssClass`/`responsiveStyles`.
- **`SchemaRenderer`** — for any node with `responsiveStyles`, compiles id-scoped CSS, injects a `<style data-os-scope>` tag, and appends the scope class to the node (set on both the `className` prop and `schema.className` so every renderer honours it).
- **Theme** — an SDUI design-token palette (`--space-*`, `--radius-xl`, `--shadow-*`, `--surface`, `--brand`, `--text-strong`, `--hairline`, …) added to `apps/console` + `@object-ui/components` `:root`. Color tokens alias the shadcn theme → auto light/dark.

## Why it's correct

- **Build-independent** — styles are data compiled at render; arbitrary values (`44px`, `#1a2b3c`) and tokens (`var(--space-6)`) pass through verbatim, no Tailwind JIT needed.
- **Collision-free** — each node's CSS is scoped to its own class and injected **unlayered**, so it reliably beats base Tailwind utilities (which are in `@layer utilities`) without `@layer` gymnastics. No two-build cascade war.
- **Responsive-correct** — breakpoint maps → generated `@media (max-width)`, never author-written `md:` classes.

## Verification

- Core unit test **6/6** (`scoped-styles.test.ts`): scoping, generated `@media`, arbitrary-value + token passthrough, sanitization.
- **No regression**: `@object-ui/react` suite **4284 passed / 24 skipped**.
- **End-to-end in a real `SchemaRenderer` render** (a Pricing page authored purely with `responsiveStyles` + tokens, zero class strings): **89 per-node scoped `<style>` tags** injected; the `$29` price node computes **`font-size: 40px`** — the unlayered scoped rule correctly beats the layered `text-sm`. (Screenshot in the linked thread.)

Consumed by cloud (bumps `.objectui-sha`, migrates its built-in pages off raw className).

🤖 Generated with [Claude Code](https://claude.com/claude-code)