### PR TITLE
fix(grid): ObjectGrid 真正的服务端分页 (#2212)

### DIFF
--- a/packages/components/src/__tests__/data-table-manual-pagination.test.tsx
+++ b/packages/components/src/__tests__/data-table-manual-pagination.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Server-side ("manual") pagination for DataTable (framework issue #2212).
+ *
+ * In manual mode the `data` prop is ONE page already fetched from the server,
+ * so DataTable must NOT slice it client-side. Total page count comes from
+ * `rowCount` (the real match total), the visible page index from `page`, and
+ * navigation is reported via `onPageChange` instead of mutating internal state.
+ * This is what lets a grid reach records beyond the first batch.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { renderComponent } from './test-utils';
+
+beforeAll(async () => {
+  await import('../renderers');
+}, 30000);
+
+describe('data-table — manual (server-side) pagination', () => {
+  // 5 rows that represent page 2 of a 3125-row result set, page size 50.
+  const pageData = Array.from({ length: 5 }, (_, i) => ({
+    id: `r${i}`,
+    name: `Row ${i}`,
+  }));
+
+  const baseSchema = {
+    type: 'data-table' as const,
+    columns: [{ header: 'Name', accessorKey: 'name' }],
+    data: pageData,
+    pagination: true,
+    pageSize: 50,
+    manualPagination: true,
+    rowCount: 3125,
+    page: 2,
+  } as any;
+
+  it('derives total pages from rowCount, not from the page-local data length', () => {
+    const { container } = renderComponent(baseSchema);
+    // ceil(3125 / 50) = 63 pages. The footer shows "2 / 63" (or localized
+    // equivalent). Assert the real total page count is rendered somewhere.
+    expect(container.textContent).toContain('63');
+    expect(container.textContent).toContain('2');
+  });
+
+  it('renders the page data as-is without client-side slicing', () => {
+    const { container } = renderComponent(baseSchema);
+    const bodyRows = container.querySelectorAll('tbody tr');
+    // All 5 server-provided rows must be visible — none sliced away by the
+    // 50-per-page setting (the data IS the page).
+    expect(bodyRows.length).toBe(5);
+  });
+
+  it('reports navigation via onPageChange instead of mutating internal state', () => {
+    const onPageChange = vi.fn();
+    const { container } = renderComponent({ ...baseSchema, onPageChange });
+
+    // Find the "next page" control. Nav buttons are the footer's icon buttons;
+    // click the one that advances from page 2 -> 3.
+    const buttons = Array.from(container.querySelectorAll('button')).filter(
+      (b) => !(b as HTMLButtonElement).disabled,
+    );
+    // The last-page and next-page buttons live at the tail of the footer.
+    // Click each enabled button and assert at least one requests a forward page.
+    buttons.forEach((b) => fireEvent.click(b));
+    expect(onPageChange).toHaveBeenCalled();
+    const requested = onPageChange.mock.calls.map((c) => c[0]);
+    // Forward navigation from page 2 should request page 3 and/or the last (63).
+    expect(requested.some((p) => p === 3 || p === 63)).toBe(true);
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -165,6 +165,11 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     data: rawData = [],
     pagination = true,
     pageSize: initialPageSize = 10,
+    manualPagination = false,
+    rowCount,
+    page: controlledPage,
+    onPageChange,
+    onPageSizeChange,
     searchable = true,
     selectable = false,
     sortable = true,
@@ -307,11 +312,36 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     });
   }, [filteredData, sortColumn, sortDirection]);
 
-  // Pagination
-  const totalPages = Math.ceil(sortedData.length / pageSize);
-  const paginatedData = pagination
+  // Pagination. Under manual (server-side) pagination the parent controls the
+  // page and supplies the grand total via `rowCount`; `data` already IS the
+  // current page, so we never slice it locally. Otherwise we paginate the
+  // in-memory rows client-side (legacy behavior).
+  const effectivePage = manualPagination
+    ? Math.max(1, controlledPage ?? 1)
+    : currentPage;
+  const totalPages = manualPagination
+    ? Math.max(1, Math.ceil((rowCount ?? sortedData.length) / pageSize))
+    : Math.ceil(sortedData.length / pageSize);
+  const paginatedData = (pagination && !manualPagination)
     ? sortedData.slice((currentPage - 1) * pageSize, currentPage * pageSize)
     : sortedData;
+
+  // Route page / page-size changes to the parent under manual pagination,
+  // otherwise drive the internal state.
+  const goToPage = (p: number) => {
+    const clamped = Math.min(totalPages, Math.max(1, p));
+    if (manualPagination) onPageChange?.(clamped);
+    else setCurrentPage(clamped);
+  };
+  const changePageSize = (size: number) => {
+    setPageSize(size);
+    if (manualPagination) {
+      onPageSizeChange?.(size);
+      onPageChange?.(1);
+    } else {
+      setCurrentPage(1);
+    }
+  };
 
   /**
    * Generates a unique identifier for each row to maintain stable selection state
@@ -366,7 +396,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     const newSelected = new Set<any>();
     if (checked) {
       paginatedData.forEach((row, idx) => {
-        const globalIndex = (currentPage - 1) * pageSize + idx;
+        const globalIndex = (effectivePage - 1) * pageSize + idx;
         const rowId = getRowId(row, globalIndex);
         newSelected.add(rowId);
       });
@@ -531,8 +561,10 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     if (!force && editingCell === null) return;
     
     const { rowIndex, columnKey } = editingCell;
-    const globalIndex = (currentPage - 1) * pageSize + rowIndex;
-    const row = sortedData[globalIndex];
+    const globalIndex = (effectivePage - 1) * pageSize + rowIndex;
+    // Under manual pagination `sortedData` IS the current page, so address it
+    // page-locally; otherwise it's the full in-memory set indexed absolutely.
+    const row = sortedData[manualPagination ? rowIndex : globalIndex];
     
     // Update pending changes
     const newPendingChanges = new Map(pendingChanges);
@@ -556,8 +588,8 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   };
 
   const saveRow = async (rowIndex: number) => {
-    const globalIndex = (currentPage - 1) * pageSize + rowIndex;
-    const row = sortedData[globalIndex];
+    const globalIndex = (effectivePage - 1) * pageSize + rowIndex;
+    const row = sortedData[manualPagination ? rowIndex : globalIndex];
     const rowChanges = pendingChanges.get(rowIndex);
     
     if (!rowChanges || Object.keys(rowChanges).length === 0) return;
@@ -591,8 +623,8 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     setIsSaving(true);
     try {
       const changesToSave = Array.from(pendingChanges.entries()).map(([rowIndex, changes]) => {
-        const globalIndex = (currentPage - 1) * pageSize + rowIndex;
-        const row = sortedData[globalIndex];
+        const globalIndex = (effectivePage - 1) * pageSize + rowIndex;
+        const row = sortedData[manualPagination ? rowIndex : globalIndex];
         return { rowIndex: globalIndex, changes, row };
       });
       
@@ -617,8 +649,8 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     // Copy cell value with Ctrl+C / Cmd+C
     if ((e.ctrlKey || e.metaKey) && e.key === 'c' && !editingCell) {
       e.preventDefault();
-      const globalIdx = (currentPage - 1) * pageSize + rowIndex;
-      const row = sortedData[globalIdx];
+      const globalIdx = (effectivePage - 1) * pageSize + rowIndex;
+      const row = sortedData[manualPagination ? rowIndex : globalIdx];
       if (row) {
         const value = row[columnKey];
         const text = value != null ? String(value) : '';
@@ -668,13 +700,13 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
 
   // Check if all rows on current page are selected
   const allPageRowsSelected = paginatedData.length > 0 && paginatedData.every((row, idx) => {
-    const globalIndex = (currentPage - 1) * pageSize + idx;
+    const globalIndex = (effectivePage - 1) * pageSize + idx;
     const rowId = getRowId(row, globalIndex);
     return selectedRowIds.has(rowId);
   });
   
   const somePageRowsSelected = paginatedData.some((row, idx) => {
-    const globalIndex = (currentPage - 1) * pageSize + idx;
+    const globalIndex = (effectivePage - 1) * pageSize + idx;
     const rowId = getRowId(row, globalIndex);
     return selectedRowIds.has(rowId);
   }) && !allPageRowsSelected;
@@ -885,7 +917,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
             ) : (
               <>
                 {paginatedData.map((row, rowIndex) => {
-                  const globalIndex = (currentPage - 1) * pageSize + rowIndex;
+                  const globalIndex = (effectivePage - 1) * pageSize + rowIndex;
                   const rowId = getRowId(row, globalIndex);
                   const isSelected = selectedRowIds.has(rowId);
                   const rowHasChanges = pendingChanges.has(rowIndex);
@@ -1139,10 +1171,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
             <span className="text-xs sm:text-sm text-muted-foreground">{t('table.rowsPerPage')}:</span>
             <Select
               value={pageSize.toString()}
-              onValueChange={(value) => {
-                setPageSize(Number(value));
-                setCurrentPage(1);
-              }}
+              onValueChange={(value) => changePageSize(Number(value))}
             >
               <SelectTrigger className="w-20">
                 <SelectValue />
@@ -1159,38 +1188,38 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
 
           <div className="flex items-center gap-2">
             <span className="text-xs sm:text-sm text-muted-foreground">
-              {t('table.pageInfo', { current: currentPage, total: totalPages })}
+              {t('table.pageInfo', { current: effectivePage, total: totalPages })}
             </span>
             <div className="flex items-center gap-1">
               <Button
                 variant="outline"
                 size="icon"
-                onClick={() => setCurrentPage(1)}
-                disabled={currentPage === 1}
+                onClick={() => goToPage(1)}
+                disabled={effectivePage === 1}
               >
                 <ChevronsLeft className="h-4 w-4" />
               </Button>
               <Button
                 variant="outline"
                 size="icon"
-                onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
-                disabled={currentPage === 1}
+                onClick={() => goToPage(effectivePage - 1)}
+                disabled={effectivePage === 1}
               >
                 <ChevronLeft className="h-4 w-4" />
               </Button>
               <Button
                 variant="outline"
                 size="icon"
-                onClick={() => setCurrentPage(Math.min(totalPages, currentPage + 1))}
-                disabled={currentPage === totalPages}
+                onClick={() => goToPage(effectivePage + 1)}
+                disabled={effectivePage === totalPages}
               >
                 <ChevronRight className="h-4 w-4" />
               </Button>
               <Button
                 variant="outline"
                 size="icon"
-                onClick={() => setCurrentPage(totalPages)}
-                disabled={currentPage === totalPages}
+                onClick={() => goToPage(totalPages)}
+                disabled={effectivePage === totalPages}
               >
                 <ChevronsRight className="h-4 w-4" />
               </Button>

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1062,16 +1062,22 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       };
     }
 
-    const resultObj = result as { records?: T[]; total?: number; value?: T[]; count?: number };
+    const resultObj = result as { records?: T[]; total?: number; value?: T[]; count?: number; hasMore?: boolean };
     const records = resultObj.records || resultObj.value || [];
     const total = resultObj.total ?? resultObj.count ?? records.length;
+    // Prefer the server's `hasMore` (real server-side pagination, framework
+    // issue #2212). Fall back to the page-local estimate (a full page implies
+    // there may be more) only when the server doesn't report it.
+    const hasMore = typeof resultObj.hasMore === 'boolean'
+      ? resultObj.hasMore
+      : (params?.$top ? records.length === params.$top : false);
     return {
       data: records,
       total,
       // Calculate page number safely
       page: params?.$skip && params.$top ? Math.floor(params.$skip / params.$top) + 1 : 1,
       pageSize: params?.$top,
-      hasMore: params?.$top ? records.length === params.$top : false,
+      hasMore,
     };
   }
 

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -374,6 +374,16 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const schemaPagination = schema.pagination;
   const schemaPageSize = schema.pageSize;
 
+  // Server-side ("manual") pagination for the flat list view. The fetch window
+  // ($top/$skip) and the DataTable's display page size are the SAME number here
+  // — the records we hold ARE one page, so paging means refetching the next
+  // slice from the server instead of slicing an in-memory batch. This is what
+  // makes records beyond the first batch reachable at all (framework #2212).
+  const [serverPage, setServerPage] = useState(1);
+  const [serverPageSize, setServerPageSize] = useState<number>(
+    (schema.pagination as any)?.pageSize ?? schema.pageSize ?? 50,
+  );
+
   // --- Inline data effect (synchronous, no fetch needed) ---
   useEffect(() => {
     if (hasInlineData && dataConfig?.provider === 'value') {
@@ -478,7 +488,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
 
           const params: any = {
             $select: getSelectFields(),
-            $top: (schemaPagination as any)?.pageSize || schemaPageSize || 50,
+            $top: serverPageSize,
+            $skip: (serverPage - 1) * serverPageSize,
           };
 
           // Support new filter format
@@ -537,7 +548,15 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [objectName, schemaFields, schemaColumns, schemaFilter, schemaSort, schemaPagination, schemaPageSize, dataSource, hasInlineData, dataConfig, refreshKey]);
+  }, [objectName, schemaFields, schemaColumns, schemaFilter, schemaSort, schemaPagination, schemaPageSize, serverPage, serverPageSize, dataSource, hasInlineData, dataConfig, refreshKey]);
+
+  // Reset to page 1 whenever the query itself changes (object / filter / sort),
+  // so we never request a page index that no longer exists for the new result
+  // set (e.g. applying a filter while sitting on page 5 of the old query).
+  React.useEffect(() => {
+    setServerPage(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [objectName, schemaFilter, schemaSort]);
 
   // --- NavigationConfig support ---
   // Must be called before any early returns to satisfy React hooks rules
@@ -1518,13 +1537,28 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     ? schema.searchableFields.length > 0
     : (schema.showSearch !== undefined ? schema.showSearch : true);
 
+  // Server-side pagination applies to the flat, server-fetched list only.
+  // Inline/static data and the grouped view paginate in-memory (grouped mode
+  // keeps whole groups together via its own groupedPage state), so they stay
+  // on DataTable's default client-side slicing.
+  const useServerPagination = !hasInlineData && !isGrouped;
+
   const dataTableSchema: any = {
     type: 'data-table',
     caption: schema.label || schema.title,
     columns: orderedColumns,
     data,
     pagination: paginationEnabled,
-    pageSize: pageSize,
+    pageSize: useServerPagination ? serverPageSize : pageSize,
+    // In server mode `data` IS the current page; tell DataTable to render it
+    // as-is and drive paging via the callbacks below using the real match total.
+    manualPagination: useServerPagination,
+    rowCount: useServerPagination ? totalMatching : undefined,
+    page: useServerPagination ? serverPage : undefined,
+    onPageChange: useServerPagination ? setServerPage : undefined,
+    onPageSizeChange: useServerPagination
+      ? (size: number) => { setServerPageSize(size); setServerPage(1); }
+      : undefined,
     searchable: searchEnabled,
     selectable: selectionMode,
     sortable: true,

--- a/packages/plugin-grid/src/__tests__/serverPagination.test.tsx
+++ b/packages/plugin-grid/src/__tests__/serverPagination.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Server-side pagination (framework issue #2212)
+ *
+ * Before the fix ObjectGrid fetched ONE batch (`$top`, no `$skip`) and let
+ * DataTable slice it in memory, so records beyond the first batch were never
+ * fetched — and the footer showed a single page because the backend reported
+ * `total = page size`.
+ *
+ * After the fix ObjectGrid drives true server-side pagination:
+ *   - the footer's total page count comes from the server's real match `total`
+ *   - turning the page REFETCHES from the server with `$skip = (page-1)*size`
+ *   - the page size selector refetches and resets to page 1
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+// Radix Select relies on pointer-capture + scrollIntoView, which jsdom does
+// not implement. Stub them so the dropdown can open in tests.
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = vi.fn(() => false) as any;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = vi.fn() as any;
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+const TOTAL = 3125;
+const PAGE_SIZE = 50;
+
+// A fake server: returns the requested window and ALWAYS the real match total
+// + a correct hasMore, exactly like the fixed framework `findData`.
+function makeDataSource() {
+  const find = vi.fn(async (_object: string, params: any) => {
+    const top = params.$top ?? PAGE_SIZE;
+    const skip = params.$skip ?? 0;
+    const rows = Array.from({ length: Math.max(0, Math.min(top, TOTAL - skip)) }, (_, i) => ({
+      id: `id-${skip + i}`,
+      name: `Row ${skip + i}`,
+    }));
+    return {
+      data: rows,
+      total: TOTAL,
+      hasMore: skip + rows.length < TOTAL,
+      pageSize: top,
+    };
+  });
+  return {
+    find,
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: { id: { type: 'text' }, name: { type: 'text' } },
+    }),
+  } as any;
+}
+
+function renderGrid(dataSource: any, opts?: Record<string, any>) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'os_tianshun_ehr_production_plan',
+    columns: [{ field: 'name', label: 'Name' }],
+    pagination: { pageSize: PAGE_SIZE },
+    ...opts,
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} dataSource={dataSource} />
+    </ActionProvider>,
+  );
+}
+
+const lastFindParams = (ds: any) => ds.find.mock.calls[ds.find.mock.calls.length - 1][1];
+
+describe('ObjectGrid — server-side pagination (#2212)', () => {
+  it('fetches the first page with $skip=0 and a page-sized $top', async () => {
+    const ds = makeDataSource();
+    renderGrid(ds);
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    const p = lastFindParams(ds);
+    expect(p.$top).toBe(PAGE_SIZE);
+    expect(p.$skip ?? 0).toBe(0);
+    // First page rows are visible.
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+  });
+
+  it('shows the real total page count from the server total, not the page length', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    // ceil(3125 / 50) = 63 pages — proves the footer uses the match total.
+    // The footer renders it as "Page 1 of 63", so match on the container text.
+    await waitFor(() => expect(container.textContent).toContain('63'));
+  });
+
+  it('REFETCHES with $skip when advancing the page (reaches records beyond batch 1)', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+    const before = ds.find.mock.calls.length;
+
+    // Click the "next page" nav button in the footer.
+    const navButtons = Array.from(container.querySelectorAll('button')).filter(
+      (b) => !(b as HTMLButtonElement).disabled,
+    );
+    // last-page button guarantees a forward jump; click it to reach the tail.
+    fireEvent.click(navButtons[navButtons.length - 1]);
+
+    await waitFor(() => expect(ds.find.mock.calls.length).toBeGreaterThan(before));
+    const p = lastFindParams(ds);
+    expect(p.$skip).toBeGreaterThan(0); // a server refetch for a later window
+    // The fetched window is record #101+ territory — unreachable before the fix.
+    await waitFor(() =>
+      expect(container.textContent).toMatch(/Row 3(0|1)\d\d/), // rows on the last page
+    );
+  });
+
+  it('changing page size refetches with the new $top and resets to page 1', async () => {
+    const ds = makeDataSource();
+    const user = userEvent.setup();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    // First advance off page 1 so we can prove the size change RESETS to page 1.
+    const navButtons = Array.from(container.querySelectorAll('button')).filter(
+      (b) => !(b as HTMLButtonElement).disabled,
+    );
+    fireEvent.click(navButtons[navButtons.length - 1]); // jump to last page
+    await waitFor(() => expect(lastFindParams(ds).$skip).toBeGreaterThan(0));
+
+    // The rows-per-page control is a Radix Select (role="combobox").
+    const trigger = container.querySelector('[role="combobox"]') as HTMLElement;
+    expect(trigger).toBeTruthy();
+    await user.click(trigger);
+
+    // Pick the "100" option from the opened listbox (rendered in a portal).
+    const option = await screen.findByRole('option', { name: '100' });
+    await user.click(option);
+
+    await waitFor(() => {
+      const p = lastFindParams(ds);
+      expect(p.$top).toBe(100);
+      expect(p.$skip ?? 0).toBe(0); // reset to first page
+    });
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -345,6 +345,33 @@ export interface DataTableSchema extends BaseSchema {
    */
   pageSize?: number;
   /**
+   * Server-side ("manual") pagination. When true, `data` is treated as the
+   * already-fetched current page (not sliced locally), `rowCount` provides the
+   * total match count used to compute total pages, the current page is
+   * controlled via `page`, and page/size changes are reported through
+   * `onPageChange` / `onPageSizeChange` so the caller can re-fetch. Without it
+   * the table paginates the in-memory `data` client-side (legacy behavior).
+   * @default false
+   */
+  manualPagination?: boolean;
+  /**
+   * Total number of rows matching the query on the server. Only used when
+   * `manualPagination` is true — drives the total-page count.
+   */
+  rowCount?: number;
+  /**
+   * Controlled current page (1-based) for `manualPagination`.
+   */
+  page?: number;
+  /**
+   * Called when the user navigates to another page under `manualPagination`.
+   */
+  onPageChange?: (page: number) => void;
+  /**
+   * Called when the user changes the page size under `manualPagination`.
+   */
+  onPageSizeChange?: (pageSize: number) => void;
+  /**
    * Enable search
    * @default true
    */


### PR DESCRIPTION
配合框架修复 objectstack-ai/framework#2212(`findData` 返回真实 `total`/`hasMore`)。

后端报对了匹配总数与 `hasMore` 之后,前端还必须**真正用上**它:按页用 `$skip` 取数、翻页时重新请求,而不是一次取一批后在内存里切片——后者会让第一批之后的记录永远翻不到。

## 改动
- **ObjectGrid** (`packages/plugin-grid/src/ObjectGrid.tsx`):新增 `serverPage`/`serverPageSize` 状态;以 `$top` + `$skip = (page-1)*size` 取数;对象/筛选/排序变化时重置到第 1 页。对扁平的服务端列表(非内联数据、非分组视图),以 manual 模式驱动 DataTable:`rowCount` = 真实总数,`onPageChange`/`onPageSizeChange` 触发服务端重新取数。
- **DataTable** (`packages/components/src/renderers/complex/data-table.tsx`):新增 `manualPagination`/`rowCount`/`page`/`onPageChange`/`onPageSizeChange`。manual 模式下把 `data` 当作当前页**原样渲染、不做客户端切片**,并按 `rowCount` 计算总页数。
- **data-objectstack 适配器** (`packages/data-objectstack/src/index.ts`):优先采用服务端 `hasMore`,缺失时才退化为页内估计。
- **types** (`packages/types/src/data-display.ts`):声明 DataTable 的 manual 分页属性。

## 测试
- 新增 `data-table-manual-pagination.test.tsx`(3 例):按 `rowCount` 推总页数、不做客户端切片、`onPageChange` 上报翻页。
- 新增 `plugin-grid/.../serverPagination.test.tsx`(4 例):渲染**真实 ObjectGrid** + mock 服务端,断言首页 `$skip=0`、翻页 `$skip>0` 重新取数、总页数取自真实 total、改页大小重新取数并回到第 1 页。
- **全量套件通过:4227 passed | 24 skipped(301 文件)**。

> 后端配套 PR:objectstack-ai/framework#2222