### PR TITLE
fix(console): render shared AI conversations with real chat cards, not raw JSON

### DIFF
--- a/apps/console/src/pages/SharedRecordPage.tsx
+++ b/apps/console/src/pages/SharedRecordPage.tsx
@@ -10,9 +10,10 @@
  *   • Returns the underlying record with redacted fields stripped
  *
  * For `ai_conversations`, we also fetch the linked messages and render
- * a read-only transcript using `streamdown` so markdown / code blocks
- * look the same as in the live chat. Other object kinds fall back to a
- * generic JSON preview.
+ * a read-only transcript with the SAME `ChatbotEnhanced` renderer the live
+ * chat uses (in `readOnly` mode — no composer), so assistant tool calls show
+ * as proper proposed-plan / draft cards instead of a raw tool-result JSON
+ * dump. Other object kinds fall back to a generic JSON preview.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -25,6 +26,13 @@ import {
   Label,
   Badge,
 } from '@object-ui/components';
+import {
+  aiMessageRowsToServerMessages,
+  hydratedMessagesToChatMessages,
+  toUIMessages,
+  type RawAiMessageRow,
+} from '@object-ui/app-shell';
+import { ChatbotEnhanced } from '@object-ui/plugin-chatbot';
 
 interface ResolvedShare {
   link: {
@@ -41,30 +49,11 @@ interface ResolvedShare {
   redactedFields?: string[];
 }
 
-interface AiMessage {
-  id: string;
-  role: 'system' | 'user' | 'assistant' | 'tool';
-  content?: string | null;
-  parts?: Array<{ type?: string; text?: string; content?: string }>;
-  created_at?: string;
-}
-
 function resolveServerUrl(): string {
   const env = (import.meta as any).env ?? {};
   const explicit = (env.VITE_SERVER_URL as string | undefined) ?? '';
   if (explicit) return explicit.replace(/\/$/, '');
   if (typeof window !== 'undefined') return window.location.origin;
-  return '';
-}
-
-function extractMessageText(m: AiMessage): string {
-  if (typeof m.content === 'string' && m.content.trim()) return m.content;
-  if (Array.isArray(m.parts)) {
-    return m.parts
-      .map((p) => p.text ?? p.content ?? '')
-      .filter(Boolean)
-      .join('\n\n');
-  }
   return '';
 }
 
@@ -78,7 +67,7 @@ export default function SharedRecordPage() {
   const [loading, setLoading] = useState(true);
   const [needsPassword, setNeedsPassword] = useState(false);
   const [password, setPassword] = useState('');
-  const [messages, setMessages] = useState<AiMessage[] | null>(null);
+  const [messages, setMessages] = useState<RawAiMessageRow[] | null>(null);
 
   const fetchResolve = useCallback(
     async (pw?: string) => {
@@ -150,6 +139,20 @@ export default function SharedRecordPage() {
       .then((body) => setMessages(body?.data ?? []))
       .catch(() => setMessages([]));
   }, [apiBase, data]);
+
+  // Reconstruct the same renderable chat messages the authenticated chat builds
+  // (tool CALLS merged with their RESULTS → proposed-plan / draft cards) instead
+  // of dumping the raw `{"type":"tool-result",…}` envelope as text. The share
+  // endpoint returns FLAT `ai_messages` rows, so we first re-assemble the
+  // ModelMessage shape (`aiMessageRowsToServerMessages`) that the live path gets
+  // server-side, then run the identical hydrate → map pipeline.
+  const chatMessages = useMemo(
+    () =>
+      messages
+        ? hydratedMessagesToChatMessages(toUIMessages(aiMessageRowsToServerMessages(messages)))
+        : [],
+    [messages],
+  );
 
   if (loading) {
     return (
@@ -225,47 +228,26 @@ export default function SharedRecordPage() {
             {data.link.permission}
           </Badge>
         </header>
-        <main className="flex-1 overflow-y-auto px-4 py-6">
-          {messages == null && (
-            <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+        <main className="flex min-h-0 flex-1 flex-col">
+          {messages == null ? (
+            <div className="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground">
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               Loading messages…
             </div>
-          )}
-          {messages && messages.length === 0 && (
+          ) : messages.length === 0 ? (
             <p className="py-12 text-center text-sm text-muted-foreground">
               This conversation has no messages yet.
             </p>
+          ) : (
+            <ChatbotEnhanced
+              readOnly
+              surface="plain"
+              messages={chatMessages}
+              showAvatars
+              maxHeight="100%"
+              className="flex-1"
+            />
           )}
-          <ul className="space-y-4">
-            {messages?.map((m) => {
-              const text = extractMessageText(m);
-              if (!text) return null;
-              const isUser = m.role === 'user';
-              return (
-                <li
-                  key={m.id}
-                  className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
-                >
-                  <div
-                    className={`max-w-[85%] rounded-lg px-3 py-2 text-sm leading-relaxed ${
-                      isUser
-                        ? 'bg-primary text-primary-foreground'
-                        : 'bg-muted text-foreground'
-                    }`}
-                  >
-                    {isUser ? (
-                      <p className="whitespace-pre-wrap">{text}</p>
-                    ) : (
-                      <pre className="whitespace-pre-wrap font-sans text-sm leading-relaxed">
-                        {text}
-                      </pre>
-                    )}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
         </main>
         <footer className="border-t bg-muted/30 px-4 py-2 text-center text-[11px] text-muted-foreground">
           Powered by ObjectStack

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, it, expect } from 'vitest';
 import { hydratedMessagesToChatMessages } from '../AiChatPage';
-import type { HydratedUIMessage } from '../../../hooks/useChatConversation';
+import {
+  aiMessageRowsToServerMessages,
+  toUIMessages,
+  type HydratedUIMessage,
+} from '../../../hooks/useChatConversation';
 
 function assistantWith(parts: HydratedUIMessage['parts']): HydratedUIMessage[] {
   return [{ id: 'm1', role: 'assistant', parts }];
@@ -75,6 +79,58 @@ describe('AiChatPage hydration — tool invocation states', () => {
       summary: 'A reading list',
       objects: [{ name: 'book', label: 'Book', fieldCount: 2 }],
       assumptions: ['One shelf for now'],
+    });
+  });
+});
+
+describe('shared-conversation render — flat ai_messages rows → proposed-plan card', () => {
+  // Reproduces the public `/s/:token` share bug: the endpoint returns FLAT
+  // `ai_messages` rows, which the read-only page must put through the SAME
+  // hydrate pipeline as the live chat. Before the fix it dumped the raw
+  // `{"type":"tool-result",…}` envelope as text; this pins that the full
+  // raw-rows → ServerMessage → toUIMessages → map chain yields the card.
+  it('recovers the Proposed plan card from the raw shared rows', () => {
+    const envelope = JSON.stringify({
+      status: 'blueprint_proposed',
+      blueprint: {
+        summary: 'A simple MES',
+        assumptions: ['Single production line'],
+        objects: [{ name: 'work_order', label: '工单', fields: [{ name: 'no' }, { name: 'qty' }] }],
+      },
+      counts: { objects: 1, views: 0, dashboards: 0, seedData: 0 },
+      questions: [],
+    });
+    const chat = hydratedMessagesToChatMessages(
+      toUIMessages(
+        aiMessageRowsToServerMessages([
+          { id: 'u1', role: 'user', content: '帮我开发一个mes' },
+          {
+            id: 'a1',
+            role: 'assistant',
+            content: '我来帮您开发一个MES。',
+            tool_calls: JSON.stringify([
+              { type: 'tool-call', toolCallId: 'c1', toolName: 'propose_blueprint', input: {} },
+            ]),
+          },
+          {
+            id: 't1',
+            role: 'tool',
+            tool_call_id: 'c1',
+            content: JSON.stringify([
+              { type: 'tool-result', toolCallId: 'c1', toolName: 'propose_blueprint', output: { type: 'text', value: envelope } },
+            ]),
+          },
+        ]),
+      ),
+    );
+    // No standalone tool message leaks into the transcript.
+    expect(chat.map((m) => m.role)).toEqual(['user', 'assistant']);
+    const assistant = chat[1];
+    expect(assistant.content).toBe('我来帮您开发一个MES。');
+    expect(assistant.toolInvocations?.[0]?.proposedPlan).toMatchObject({
+      summary: 'A simple MES',
+      objects: [{ name: 'work_order', label: '工单', fieldCount: 2 }],
+      assumptions: ['Single production line'],
     });
   });
 });

--- a/packages/app-shell/src/hooks/useChatConversation.test.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.test.ts
@@ -12,7 +12,7 @@
  * draft affordances after a refresh.
  */
 import { describe, it, expect } from 'vitest';
-import { toUIMessages } from './useChatConversation';
+import { aiMessageRowsToServerMessages, toUIMessages } from './useChatConversation';
 
 describe('toUIMessages — merging tool-results onto the call (refresh survival)', () => {
   const draftEnvelope = {
@@ -83,5 +83,87 @@ describe('toUIMessages — merging tool-results onto the call (refresh survival)
     const out = toUIMessages(plain as never);
     expect(out.map((m) => m.role)).toEqual(['user', 'assistant']);
     expect(out[1].parts).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+});
+
+describe('aiMessageRowsToServerMessages — flat share rows → ModelMessage shape', () => {
+  // The public share endpoint (`/s/:token/messages`) returns the raw, FLAT
+  // `ai_messages` columns: an assistant turn's tool CALLS sit in a separate
+  // `tool_calls` column, and a `tool` row's RESULTS are a JSON-stringified
+  // array in `content`. Mirrors `ObjqlConversationService.toMessage`.
+  it('lifts assistant tool_calls into a content array alongside the text', () => {
+    const [msg] = aiMessageRowsToServerMessages([
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'I will build it.',
+        tool_calls: JSON.stringify([
+          { type: 'tool-call', toolCallId: 'call_1', toolName: 'propose_blueprint', input: {} },
+        ]),
+      },
+    ]);
+    expect(msg.content).toEqual([
+      { type: 'text', text: 'I will build it.' },
+      { type: 'tool-call', toolCallId: 'call_1', toolName: 'propose_blueprint', input: {} },
+    ]);
+  });
+
+  it('parses a stringified tool-result array back into structured content', () => {
+    const result = {
+      type: 'tool-result',
+      toolCallId: 'call_1',
+      toolName: 'propose_blueprint',
+      output: { type: 'text', value: '{"status":"blueprint_proposed"}' },
+    };
+    const [msg] = aiMessageRowsToServerMessages([
+      { id: 't1', role: 'tool', tool_call_id: 'call_1', content: JSON.stringify([result]) },
+    ]);
+    expect(msg.content).toEqual([result]);
+  });
+
+  it('reconstructs the FULL flat transcript so toUIMessages recovers the tool output', () => {
+    // The end-to-end share path: flat rows → ModelMessage shape → hydrate. The
+    // tool RESULT must land back on the assistant CALL part, or the shared
+    // transcript loses its proposed-plan / draft card (the original bug).
+    const envelope = { type: 'text', value: '{"status":"blueprint_proposed"}' };
+    const rows = aiMessageRowsToServerMessages([
+      { id: 'u1', role: 'user', content: '帮我开发一个mes' },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '我来帮您开发一个MES。',
+        tool_calls: JSON.stringify([
+          { type: 'tool-call', toolCallId: 'call_1', toolName: 'propose_blueprint', input: {} },
+        ]),
+      },
+      {
+        id: 't1',
+        role: 'tool',
+        tool_call_id: 'call_1',
+        content: JSON.stringify([
+          { type: 'tool-result', toolCallId: 'call_1', toolName: 'propose_blueprint', output: envelope },
+        ]),
+      },
+    ]);
+    const out = toUIMessages(rows);
+    // The `tool` row is merged away — user + assistant only.
+    expect(out.map((m) => m.role)).toEqual(['user', 'assistant']);
+    const callPart = out[1].parts.find((p) => p.toolCallId === 'call_1');
+    expect((callPart as { output?: unknown }).output).toEqual(envelope);
+    expect((callPart as { state?: string }).state).toBe('output-available');
+  });
+
+  it('falls back to a synthetic tool-result for legacy plain-string tool rows', () => {
+    const [msg] = aiMessageRowsToServerMessages([
+      { id: 't1', role: 'tool', tool_call_id: 'call_9', content: 'plain old string output' },
+    ]);
+    expect(msg.content).toEqual([
+      {
+        type: 'tool-result',
+        toolCallId: 'call_9',
+        toolName: 'unknown',
+        output: { type: 'text', value: 'plain old string output' },
+      },
+    ]);
   });
 });

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -408,6 +408,84 @@ export function toUIMessages(rows: ServerMessage[] | undefined): HydratedUIMessa
   return out;
 }
 
+/**
+ * A FLAT `ai_messages` row as returned by the public share endpoint
+ * (`GET /api/v1/share-links/:token/messages`), which streams the raw object
+ * rows rather than the reconstructed ModelMessage history that the
+ * authenticated `GET /conversations/:id` returns.
+ */
+export interface RawAiMessageRow {
+  id?: string;
+  role: string;
+  /** Persisted text (assistant/user/system) OR a JSON-stringified tool-result array (tool role). */
+  content?: unknown;
+  /** Assistant tool CALLS, JSON-stringified (`tool-call` parts). */
+  tool_calls?: string | null;
+  /** Tool RESULT's owning call id (legacy plain-string tool rows). */
+  tool_call_id?: string | null;
+}
+
+function safeParseArray(value: unknown): Array<Record<string, unknown>> | undefined {
+  if (typeof value !== 'string' || !value) return undefined;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? (parsed as Array<Record<string, unknown>>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Reconstruct the ModelMessage-shaped `content` that {@link toUIMessages}
+ * expects from the FLAT columns the public share endpoint returns raw.
+ *
+ * The authenticated path gets this reconstruction server-side
+ * (`ObjqlConversationService.toMessage`): an assistant turn's tool CALLS live
+ * in the separate `tool_calls` column, and a `tool` row's RESULTS are a
+ * JSON-stringified array in `content`. The share endpoint skips that step and
+ * dumps the rows verbatim — so the shared transcript previously rendered the
+ * raw `{"type":"tool-result",…}` envelope as text instead of a card. Mirroring
+ * `toMessage` here lets the share page reuse the exact same hydrate → render
+ * pipeline as the live chat. Keep this in lockstep with `toMessage`.
+ */
+export function aiMessageRowsToServerMessages(rows: RawAiMessageRow[] | undefined): ServerMessage[] {
+  if (!rows) return [];
+  return rows.map((row) => {
+    const id = row.id;
+    const text = typeof row.content === 'string' ? row.content : '';
+    if (row.role === 'assistant') {
+      const toolCalls = safeParseArray(row.tool_calls);
+      if (toolCalls && toolCalls.length > 0) {
+        const content: Array<Record<string, unknown>> = [];
+        if (text) content.push({ type: 'text', text });
+        content.push(...toolCalls);
+        return { id, role: 'assistant', content };
+      }
+      return { id, role: 'assistant', content: text };
+    }
+    if (row.role === 'tool') {
+      const results = safeParseArray(row.content);
+      if (results && results.length > 0 && results[0]?.type === 'tool-result') {
+        return { id, role: 'tool', content: results };
+      }
+      // Back-compat: pre-array tool rows persisted a plain string.
+      return {
+        id,
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: row.tool_call_id ?? '',
+            toolName: 'unknown',
+            output: { type: 'text', value: text },
+          },
+        ],
+      };
+    }
+    return { id, role: row.role, content: text };
+  });
+}
+
 export async function fetchConversation(apiBase: string, id: string): Promise<ServerConversation | null> {
   const res = await fetch(`${apiBase}/conversations/${encodeURIComponent(id)}`, {
     credentials: 'include',

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -171,8 +171,21 @@ export { MembersPage as DefaultMembersPage } from './console/organizations/manag
 export { InvitationsPage as DefaultInvitationsPage } from './console/organizations/manage/InvitationsPage';
 export { SettingsPage as DefaultSettingsPage } from './console/organizations/manage/SettingsPage';
 export { AcceptInvitationPage as DefaultAcceptInvitationPage } from './console/organizations/manage/AcceptInvitationPage';
-export { AiChatPage as DefaultAiChatPage, AiChatPage } from './console/ai/AiChatPage';
+export {
+  AiChatPage as DefaultAiChatPage,
+  AiChatPage,
+  hydratedMessagesToChatMessages,
+} from './console/ai/AiChatPage';
 export { ConversationsSidebar } from './console/ai/ConversationsSidebar';
+// Conversation-history hydration helpers — reused by the public read-only
+// share page (`/s/:token`) so a shared transcript renders identically to the
+// live chat (tool cards included) instead of dumping raw envelopes.
+export {
+  toUIMessages,
+  aiMessageRowsToServerMessages,
+  type HydratedUIMessage,
+  type RawAiMessageRow,
+} from './hooks/useChatConversation';
 
 // Phase 3b: Component nav registry — plugins use this to register
 // admin/setup UI surfaces that are addressable from App metadata via

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -333,6 +333,15 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    */
   onUpgrade?: () => void;
   disabled?: boolean;
+  /**
+   * Render a static, non-interactive transcript: hides the prompt-input
+   * composer entirely so the conversation can be embedded in a public /
+   * read-only surface (e.g. a `/s/:token` share page). The detailed tool
+   * cards (proposed-plan, drafts) still render — but their action buttons
+   * stay hidden because the host passes no `onSendMessage`/`onPublishDrafts`
+   * callbacks, so the cards degrade to their read-only/summary form.
+   */
+  readOnly?: boolean;
   /** Whether the assistant is currently generating a response */
   isLoading?: boolean;
   /** Current streaming/API error */
@@ -812,6 +821,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       onReload,
       onUpgrade,
       disabled = false,
+      readOnly = false,
       isLoading = false,
       error,
       showTimestamp = false,
@@ -1861,6 +1871,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
           <ErrorBanner error={error} onReload={onReload} onUpgrade={onUpgrade} />
         ) : null}
 
+        {readOnly ? null : (
         <div
           ref={promptInputWrapRef}
           className={cn(
@@ -1945,6 +1956,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             </PromptInputFooter>
           </PromptInput>
         </div>
+        )}
 
       </div>
     );


### PR DESCRIPTION
## Problem

The public `/s/:token` share page dumped a shared AI conversation's raw `{"type":"tool-result",…}` envelope as a wall of text instead of the proper chat cards. Reported on a shared MES conversation.

**Before → After** (verified against the live shared conversation):

The share page rendered `ai_messages.content` verbatim, so assistant tool turns showed the raw blueprint JSON instead of the "Proposed plan" card.

## Root causes (both objectui-side)

1. **Own renderer.** `SharedRecordPage.tsx` had a one-off `extractMessageText()` instead of the live chat pipeline (`toUIMessages → hydratedMessagesToChatMessages → ChatbotEnhanced`, which merges a tool CALL with its RESULT and lifts the `proposedPlan`/`draftReview` cards). Same divergence class as the AiChatPage-has-its-own-converter gotcha.
2. **Shape mismatch.** The framework share endpoint (`plugin-sharing` `GET /:token/messages`) returns **flat `ai_messages` rows** (tool CALLS in a separate `tool_calls` column, RESULTS as a JSON-stringified array in `content`) — *not* the reconstructed `ModelMessage[]` that authenticated `GET /conversations/:id` returns via `ObjqlConversationService.toMessage`. So `toUIMessages` couldn't consume the raw rows.

## Fix

- **`aiMessageRowsToServerMessages`** (new, in `useChatConversation.ts`) mirrors the server's `toMessage` row→ModelMessage mapping client-side, so the share page reconstructs the exact shape the live chat already trusts, then reuses the identical hydrate chain.
- **`readOnly` prop on `ChatbotEnhanced`** — hides the composer; tool cards already degrade to read-only when no action callbacks are passed.
- Rewrote the share page's `ai_conversations` branch to render `<ChatbotEnhanced readOnly>`.

The shared transcript now shows the same user bubble, "Propose blueprint ✓ Completed" card, "Proposed plan" card (object chips + field counts, "N objects · N views · N dashboards", assumptions) and formatted markdown as the live chat — no raw JSON, no input box.

## Verification

- Live-verified against the real prod share link (local console `pnpm dev` with `VITE_SERVER_URL` pointed at the prod share API — resolve/messages routes are anonymous/public).
- Typecheck clean across app-shell / plugin-chatbot / console (turbo, 34 tasks).
- Added unit + e2e tests: flat-row reconstruction in `useChatConversation.test.ts`, and a raw-rows → "Proposed plan" card e2e in `AiChatPage.hydration.test.ts` (reproduces this exact MES case). 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)