### PR TITLE
fix(list): server-side pagination through ListView → ObjectGrid (#2212)

### DIFF
--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -361,6 +361,17 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   
   const hasInlineData = dataConfig?.provider === 'value';
 
+  // External (parent-driven) server pagination. When a host like ListView fetches
+  // the data itself, it passes the current window down as `data` AND hands us the
+  // real match total + page controls. We must forward those straight to DataTable
+  // instead of client-slicing the window — otherwise the footer would report
+  // "pages = window / pageSize" and records beyond the window stay unreachable
+  // (framework #2212). `data` arrives via `rest` (a prop), so do these too.
+  const externalManualPagination =
+    (rest as any).manualPagination === true &&
+    typeof (rest as any).rowCount === 'number' &&
+    typeof (rest as any).onPageChange === 'function';
+
   // Extract stable primitive/reference-stable values from schema for dependency arrays.
   // This prevents infinite re-render loops when schema is a new object on each render
   // (e.g. when rendered through SchemaRenderer which creates a fresh evaluatedSchema).
@@ -1543,22 +1554,37 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // on DataTable's default client-side slicing.
   const useServerPagination = !hasInlineData && !isGrouped;
 
+  // Either we own the server fetch (useServerPagination) or a parent does
+  // (externalManualPagination). Grouped mode always keeps in-memory slicing so
+  // whole groups stay together. Both server modes feed DataTable a manual pager
+  // backed by the real match total.
+  const manualPaginationOn = (useServerPagination || externalManualPagination) && !isGrouped;
+  const manualRowCount = externalManualPagination ? (rest as any).rowCount : totalMatching;
+  const manualPage = externalManualPagination ? (rest as any).page : serverPage;
+  const manualPageSize = externalManualPagination
+    ? ((rest as any).pageSize ?? serverPageSize)
+    : serverPageSize;
+  const manualOnPageChange = externalManualPagination
+    ? (rest as any).onPageChange
+    : setServerPage;
+  const manualOnPageSizeChange = externalManualPagination
+    ? (rest as any).onPageSizeChange
+    : (size: number) => { setServerPageSize(size); setServerPage(1); };
+
   const dataTableSchema: any = {
     type: 'data-table',
     caption: schema.label || schema.title,
     columns: orderedColumns,
     data,
     pagination: paginationEnabled,
-    pageSize: useServerPagination ? serverPageSize : pageSize,
+    pageSize: manualPaginationOn ? manualPageSize : pageSize,
     // In server mode `data` IS the current page; tell DataTable to render it
     // as-is and drive paging via the callbacks below using the real match total.
-    manualPagination: useServerPagination,
-    rowCount: useServerPagination ? totalMatching : undefined,
-    page: useServerPagination ? serverPage : undefined,
-    onPageChange: useServerPagination ? setServerPage : undefined,
-    onPageSizeChange: useServerPagination
-      ? (size: number) => { setServerPageSize(size); setServerPage(1); }
-      : undefined,
+    manualPagination: manualPaginationOn,
+    rowCount: manualPaginationOn ? manualRowCount : undefined,
+    page: manualPaginationOn ? manualPage : undefined,
+    onPageChange: manualPaginationOn ? manualOnPageChange : undefined,
+    onPageSizeChange: manualPaginationOn ? manualOnPageSizeChange : undefined,
     searchable: searchEnabled,
     selectable: selectionMode,
     sortable: true,

--- a/packages/plugin-grid/src/__tests__/serverPagination.test.tsx
+++ b/packages/plugin-grid/src/__tests__/serverPagination.test.tsx
@@ -154,3 +154,62 @@ describe('ObjectGrid — server-side pagination (#2212)', () => {
     });
   });
 });
+
+describe('ObjectGrid — external (host-driven) manual pagination (#2212)', () => {
+  // ListView fetches the data itself and passes the current window down as a
+  // `data` prop (which would make ObjectGrid treat it as inline/static data) PLUS
+  // manualPagination + the real match total + page controls. ObjectGrid must
+  // honour those external controls and forward them to its single DataTable
+  // pager instead of client-slicing the window — otherwise records past the
+  // first window stay unreachable and the footer shows "window / pageSize" pages.
+  function renderExternal(overrides?: Record<string, any>) {
+    const onPageChange = vi.fn();
+    const onPageSizeChange = vi.fn();
+    const window = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      id: `id-${i}`,
+      name: `Row ${i}`,
+    }));
+    const schema: any = {
+      type: 'object-grid',
+      objectName: 'os_tianshun_ehr_production_plan',
+      columns: [{ field: 'name', label: 'Name' }],
+    };
+    const utils = render(
+      <ActionProvider>
+        <ObjectGrid
+          schema={schema}
+          dataSource={makeDataSource()}
+          data={window}
+          manualPagination
+          rowCount={TOTAL}
+          page={1}
+          pageSize={PAGE_SIZE}
+          onPageChange={onPageChange}
+          onPageSizeChange={onPageSizeChange}
+          {...overrides}
+        />
+      </ActionProvider>,
+    );
+    return { ...utils, onPageChange, onPageSizeChange };
+  }
+
+  it('shows the page count from the external rowCount, not the inline window length', async () => {
+    const { container } = renderExternal();
+    // ceil(3125 / 50) = 63 — proves the footer uses the host total, not the
+    // 50-row window it was handed.
+    await waitFor(() => expect(container.textContent).toContain('63'));
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+  });
+
+  it('calls the external onPageChange when the footer turns the page (no client slice)', async () => {
+    const { container, onPageChange } = renderExternal();
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+    const navButtons = Array.from(container.querySelectorAll('button')).filter(
+      (b) => !(b as HTMLButtonElement).disabled,
+    );
+    // last-page button — a forward jump the host must service by refetching.
+    fireEvent.click(navButtons[navButtons.length - 1]);
+    await waitFor(() => expect(onPageChange).toHaveBeenCalled());
+    expect(onPageChange.mock.calls[onPageChange.mock.calls.length - 1][0]).toBeGreaterThan(1);
+  });
+});

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -512,6 +512,15 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   const [dynamicPageSize, setDynamicPageSize] = React.useState<number | undefined>(undefined);
   const effectivePageSize = dynamicPageSize ?? schema.pagination?.pageSize ?? 100;
 
+  // --- Server-side pagination (#2212) ---
+  // ListView owns the fetch, so it owns paging too: it requests one window at a
+  // time ($skip = (page-1)*size) and reads the real match `total` from the
+  // result. That total + page controls are handed DOWN to the flat grid view so
+  // its existing (single) DataTable pager becomes server-driven — records past
+  // the first window are reachable, and we never stack a second pager on top.
+  const [serverPage, setServerPage] = React.useState(1);
+  const [serverTotal, setServerTotal] = React.useState<number | null>(null);
+
   // Grouping state (initialized from schema, user can add/remove via popover).
   // Supports three input shapes from the schema:
   //   1. Spec-compliant `grouping: { fields: [...] }` (preferred — supports
@@ -991,10 +1000,17 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           ? finalFilter.length > 0
           : !!finalFilter && Object.keys(finalFilter).length > 0;
 
+        // Window the request only for the flat grid view. Grouped grids and the
+        // visual views (kanban/calendar/gantt/gallery) consume the whole batch,
+        // so they keep their single-window fetch and in-memory handling.
+        const paginate = currentView === 'grid' && !(groupingConfig?.fields?.length);
+        const skip = paginate ? (serverPage - 1) * effectivePageSize : 0;
+
         const results = await dataSource.find(schema.objectName, {
            ...(hasFilter ? { $filter: finalFilter } : {}),
            $orderby: sort,
            $top: effectivePageSize,
+           ...(skip > 0 ? { $skip: skip } : {}),
            ...(selectFields ? { $select: selectFields } : {}),
            ...(expandFields.length > 0 ? { $expand: expandFields } : {}),
            ...(searchTerm ? {
@@ -1022,7 +1038,19 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         }
         
         setData(items);
-        setDataLimitReached(items.length >= effectivePageSize);
+
+        // Capture the real match total (framework #2212: findData now returns it).
+        // With a known total the grid pages server-side, so the "showing first N"
+        // cap warning no longer applies; without one we fall back to the old
+        // single-window behaviour and keep the warning.
+        const rawTotal = (results && typeof results === 'object')
+          ? ((results as any).total ?? (results as any).count)
+          : undefined;
+        const knownTotal = typeof rawTotal === 'number' ? rawTotal : null;
+        setServerTotal(paginate ? knownTotal : null);
+        setDataLimitReached(
+          !(paginate && knownTotal != null) && items.length >= effectivePageSize,
+        );
       } catch (err) {
         // Only log + surface errors from the latest request. A failed fetch is
         // NOT an empty result — record it so the render shows an error panel
@@ -1040,9 +1068,28 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     };
 
     fetchData();
-    
+
     return () => { isMounted = false; };
-  }, [schema.objectName, schema.data, dataSource, schema.filters, effectivePageSize, currentSort, currentFilters, userFilterConditions, refreshKey, searchTerm, schema.searchableFields, expandFields, objectDefLoaded, schema.refreshTrigger, perms]); // Re-fetch on filter/sort/search/refreshTrigger/perms change
+  }, [schema.objectName, schema.data, dataSource, schema.filters, effectivePageSize, currentSort, currentFilters, userFilterConditions, refreshKey, searchTerm, schema.searchableFields, expandFields, objectDefLoaded, schema.refreshTrigger, perms, serverPage, currentView, groupingConfig]); // Re-fetch on filter/sort/search/refreshTrigger/perms/page change
+
+  // Any change to the result-defining inputs (object, filters, sort, search,
+  // grouping, page size) invalidates the current page number — snap back to
+  // page 1 so the user never lands on a now-out-of-range window. We compare by
+  // VALUE via a JSON signature (not effect deps): ListView re-initializes sort/
+  // grouping references during mount, which would otherwise reset the page out
+  // from under a user who just turned it. serverPage is deliberately NOT part of
+  // the signature, so turning the page never triggers a reset.
+  const pageResetSignature = JSON.stringify([
+    schema.objectName, schema.filters, effectivePageSize, currentSort,
+    currentFilters, userFilterConditions, searchTerm, currentView, groupingConfig,
+  ]);
+  const prevPageResetSignature = React.useRef(pageResetSignature);
+  React.useEffect(() => {
+    if (prevPageResetSignature.current !== pageResetSignature) {
+      prevPageResetSignature.current = pageResetSignature;
+      setServerPage(1);
+    }
+  }, [pageResetSignature]);
 
   // Available view types based on schema configuration
   const availableViews = React.useMemo(() => {
@@ -2169,12 +2216,26 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
             );
           })()
         ) : (
-          <SchemaRenderer 
-            schema={viewComponentSchema} 
-            {...props} 
+          <SchemaRenderer
+            schema={viewComponentSchema}
+            {...props}
             data={data}
             loading={loading}
             onRowSelect={setSelectedRows}
+            {...(currentView === 'grid' && !(groupingConfig?.fields?.length) && serverTotal != null
+              ? {
+                  // Drive the flat grid's single (DataTable) pager from the
+                  // server: it renders THIS window as the current page, the real
+                  // total sets the page count, and turning the page asks ListView
+                  // to refetch the next window. One pager, server-backed (#2212).
+                  manualPagination: true,
+                  rowCount: serverTotal,
+                  page: serverPage,
+                  pageSize: effectivePageSize,
+                  onPageChange: (p: number) => setServerPage(p),
+                  onPageSizeChange: (n: number) => { setDynamicPageSize(n); setServerPage(1); },
+                }
+              : {})}
           />
         )}
       </div>

--- a/packages/plugin-list/src/__tests__/ListView.serverPagination.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.serverPagination.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ListView server-side pagination (framework issue #2212).
+ *
+ * The earlier ObjectGrid-only fix never engaged for a real list view: ListView
+ * fetches the data itself and passes the window DOWN to the child `object-grid`
+ * as a `data` prop, which made the grid treat it as inline/static data and
+ * client-paginate the single window — capped at the first batch, total page
+ * count = window / pageSize.
+ *
+ * The fix makes ListView own server pagination and drive the child grid's single
+ * pager from the real match total:
+ *   - the first fetch requests one window ($top = size, $skip = 0)
+ *   - it reads the real `total` and hands the grid manualPagination + rowCount +
+ *     page + onPageChange (so the grid forwards them to its single DataTable pager)
+ *   - turning the page (grid calls onPageChange) REFETCHES with $skip
+ *
+ * plugin-grid is not a dependency of plugin-list (avoids a cycle), so we register
+ * a stub `object-grid` that records the props ListView feeds it and lets the test
+ * invoke onPageChange — exactly the ListView→grid composition the unit-level
+ * ObjectGrid test could not cover.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ListView } from '../ListView';
+import { SchemaRendererProvider } from '@object-ui/react';
+import type { ListViewSchema } from '@object-ui/types';
+
+const TOTAL = 3125;
+const PAGE_SIZE = 50;
+
+// Records the props ListView hands the child grid on the most recent render.
+let lastGridProps: any = null;
+
+function makeDataSource() {
+  const find = vi.fn(async (_object: string, params: any) => {
+    const top = params.$top ?? PAGE_SIZE;
+    const skip = params.$skip ?? 0;
+    const rows = Array.from(
+      { length: Math.max(0, Math.min(top, TOTAL - skip)) },
+      (_, i) => ({ id: `id-${skip + i}`, name: `Row ${skip + i}` }),
+    );
+    return { data: rows, total: TOTAL, hasMore: skip + rows.length < TOTAL };
+  });
+  return {
+    find,
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: { id: { type: 'text' }, name: { type: 'text' } },
+    }),
+  } as any;
+}
+
+const schema: ListViewSchema = {
+  type: 'list-view',
+  objectName: 'os_tianshun_ehr_production_plan',
+  fields: ['name'],
+  pagination: { pageSize: PAGE_SIZE },
+} as any;
+
+const lastFindParams = (ds: any) => ds.find.mock.calls[ds.find.mock.calls.length - 1][1];
+
+let prevObjectGrid: any;
+beforeAll(() => {
+  prevObjectGrid = ComponentRegistry.get('object-grid');
+  // Stub grid: capture the props ListView passes (manualPagination/rowCount/
+  // page/onPageChange/data) so we can assert the server-pagination contract.
+  ComponentRegistry.register('object-grid', (props: any) => {
+    lastGridProps = props;
+    return <div data-testid="grid-stub" />;
+  });
+});
+afterAll(() => {
+  if (prevObjectGrid) ComponentRegistry.register('object-grid', prevObjectGrid);
+  else ComponentRegistry.unregister('object-grid');
+});
+
+// lastGridProps is a module global written by EVERY mounted ListView's stub
+// grid. Unmount the previous test's ListView and clear the capture so a stale
+// instance can't clobber the props mid-assertion.
+beforeEach(() => { lastGridProps = null; });
+afterEach(() => { cleanup(); lastGridProps = null; });
+
+function renderList(ds: any) {
+  return render(
+    <SchemaRendererProvider dataSource={ds}>
+      <ListView schema={schema} dataSource={ds} />
+    </SchemaRendererProvider>,
+  );
+}
+
+describe('ListView — server-side pagination drives the child grid (#2212)', () => {
+  it('fetches the first window with $top=size and no $skip', async () => {
+    const ds = makeDataSource();
+    renderList(ds);
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    const p = lastFindParams(ds);
+    expect(p.$top).toBe(PAGE_SIZE);
+    expect(p.$skip ?? 0).toBe(0);
+  });
+
+  it('hands the grid manualPagination + the real match total + page 1', async () => {
+    const ds = makeDataSource();
+    renderList(ds);
+    await waitFor(() => expect(lastGridProps?.manualPagination).toBe(true));
+    expect(lastGridProps.rowCount).toBe(TOTAL); // real total, NOT the window length
+    expect(lastGridProps.page).toBe(1);
+    expect(typeof lastGridProps.onPageChange).toBe('function');
+    // The window passed down is the first batch only.
+    expect(Array.isArray(lastGridProps.data)).toBe(true);
+    expect(lastGridProps.data.length).toBe(PAGE_SIZE);
+  });
+
+  it('REFETCHES with $skip when the grid turns the page (reaches records past batch 1)', async () => {
+    const ds = makeDataSource();
+    renderList(ds);
+    await waitFor(() => expect(lastGridProps?.onPageChange).toBeTruthy());
+    const before = ds.find.mock.calls.length;
+
+    // Jump to the last page, like clicking the footer's last-page nav.
+    const lastPage = Math.ceil(TOTAL / PAGE_SIZE); // 63
+    await act(async () => { lastGridProps.onPageChange(lastPage); });
+
+    await waitFor(() => expect(ds.find.mock.calls.length).toBeGreaterThan(before));
+    const p = lastFindParams(ds);
+    expect(p.$skip).toBe((lastPage - 1) * PAGE_SIZE); // 3100 — unreachable before the fix
+    // The grid now holds the tail window (records #3100+).
+    await waitFor(() => {
+      expect(lastGridProps.page).toBe(lastPage);
+      expect(lastGridProps.data[0].id).toBe(`id-${(lastPage - 1) * PAGE_SIZE}`);
+    });
+  });
+
+  it('changing page size refetches with the new $top and resets to page 1', async () => {
+    const ds = makeDataSource();
+    renderList(ds);
+    await waitFor(() => expect(lastGridProps?.onPageSizeChange).toBeTruthy());
+
+    // Advance off page 1 first so the reset is observable.
+    await act(async () => { lastGridProps.onPageChange(3); });
+    await waitFor(() => expect(lastFindParams(ds).$skip).toBeGreaterThan(0));
+
+    await act(async () => { lastGridProps.onPageSizeChange(100); });
+    await waitFor(() => {
+      const p = lastFindParams(ds);
+      expect(p.$top).toBe(100);
+      expect(p.$skip ?? 0).toBe(0); // back to the first window
+    });
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #1913. That PR made **ObjectGrid** do true server-side pagination, but it never engaged for an actual **list view** — the original #2212 symptom persisted in the app.

Root cause: `ListView` fetches its own data and passes the window **down** to the child `object-grid` as a `data` prop. ObjectGrid treats a passed `data` array as inline/static value data (`hasInlineData = true`), which forces `useServerPagination = false`. So the inner `DataTable` client-paginated the single fetched window:

- footer showed `pages = window / pageSize` (e.g. "共 10 页" capped at 100 rows)
- records beyond the first window were unreachable

This is exactly #2212, layered on top of the now-fixed framework `findData` `total`/`hasMore` (objectstack-ai/framework#2222).

## What

Single pager, server-driven — **no second pager added** (the existing inner DataTable pager is reused):

- **ObjectGrid** — honour *external* manual-pagination props (`manualPagination` / `rowCount` / `page` / `onPageChange` / `onPageSizeChange`) supplied by a host even when data arrives inline, forwarding them straight to the one DataTable pager (gated `!isGrouped`). ObjectGrid's own-fetch server pagination from #1913 is unchanged.
- **ListView** — own server pagination for the flat grid view: track page + total, send `$skip = (page-1)*size`, read the real match `total`, and hand the window + manual-pagination props to the child grid. Reset to page 1 (by value signature, so ListView's own mount-time sort/grouping re-inits don't snap the page) on object/filter/sort/search/grouping/page-size change. Suppress the "showing first N" cap warning once a real total is known.

## Tests

- ObjectGrid external-manual passthrough with inline data (2)
- ListView → grid server-pagination contract: first window has no `$skip`, real total + manual props handed down, page turn refetches with `$skip`, page-size change resets to page 1 (4)
- Full suite green: 4233 passed.

## Live verification (EHR `production_plan`, 3125 rows)

- One pager reading **"第 1 页, 共 32 页"** (`ceil(3125/100)=32`), not "共 10 页".
- Last page reachable — shows records **#3101–3125** ("25 条记录"), impossible before the fix.
- `$skip=3100` round-trips with `total=3125`; exactly one pagination region in the DOM.

Refs #2212. Depends on framework `findData` total/hasMore fix (objectstack-ai/framework#2222).