### PR TITLE
fix(ai-chat): route AI-built apps by packageId, not the app name (ADR-0048)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -873,7 +873,7 @@ function ChatPane({
   // drafted app rendered as-if-published (`?preview=draft`) beside the chat.
   // Per-artifact signals coalesce (800 ms) into one pane refresh so a
   // whole-app build doesn't trigger an invalidation storm.
-  const [canvasApp, setCanvasApp] = useState<{ name: string; materialized: boolean } | null>(null);
+  const [canvasApp, setCanvasApp] = useState<{ name: string; segment?: string; materialized: boolean } | null>(null);
   const [canvasRefreshKey, setCanvasRefreshKey] = useState(0);
   const canvasTimerRef = useRef<number | null>(null);
   useEffect(() => () => {
@@ -887,9 +887,10 @@ function ChatPane({
   }, [canvasOpen, onCanvasOpenChange]);
   // Draggable chat ↔ preview split (active only while the preview is open).
   const split = useResizableChatPane(canvasOpen);
-  const handleDraftArtifacts = useCallback((artifacts: Array<{ type: string; name: string }>) => {
+  const handleDraftArtifacts = useCallback((artifacts: Array<{ type: string; name: string }>, appSegment?: string) => {
     const app = artifacts.find((a) => a.type === 'app');
-    if (app) setCanvasApp((prev) => prev ?? { name: app.name, materialized: false });
+    // Route the preview on the app's package id (ADR-0048), not its name.
+    if (app) setCanvasApp((prev) => prev ?? { name: app.name, segment: appSegment, materialized: false });
     if (canvasTimerRef.current) window.clearTimeout(canvasTimerRef.current);
     canvasTimerRef.current = window.setTimeout(() => setCanvasRefreshKey((k) => k + 1), 800);
   }, []);
@@ -899,7 +900,7 @@ function ChatPane({
   const handleBuildMaterialized = useCallback((appName: string) => {
     setCanvasApp((prev) =>
       prev && prev.name === appName && !prev.materialized
-        ? { name: appName, materialized: true }
+        ? { ...prev, materialized: true } // keep the package-id segment
         : prev ?? { name: appName, materialized: true },
     );
   }, []);
@@ -1126,7 +1127,8 @@ function ChatPane({
         toolDenyLabel="Reject"
         toolDenyReason="Operator rejected from chat"
         // Build-tree "Open app": jump straight into the app the agent just built.
-        onOpenBuiltApp={(appName) => navigate(`/apps/${encodeURIComponent(appName)}`)}
+        onOpenBuiltApp={(appName, appSegment) =>
+          navigate(`/apps/${encodeURIComponent(appSegment ?? appName)}`)}
         openBuiltAppLabel={t('console.ai.openBuiltApp', { defaultValue: 'Open app' })}
         // Live lifecycle truth for draft cards: the server's pending count per
         // package, so reloaded conversations show Published/Publish honestly.
@@ -1217,7 +1219,7 @@ function ChatPane({
         // agent's artifacts land; Preview buttons deep-link the same route.
         onDraftArtifacts={handleDraftArtifacts}
         onPreviewDraftApp={(appName, opts) =>
-          setCanvasApp({ name: appName, materialized: opts?.materialized === true })}
+          setCanvasApp({ name: appName, segment: opts?.appSegment, materialized: opts?.materialized === true })}
         // ADR-0045: build materialized → canvas leaves the draft overlay for
         // the real (unlisted) app; the reload shows live seed rows.
         onBuildMaterialized={handleBuildMaterialized}
@@ -1255,6 +1257,7 @@ function ChatPane({
           </div>
           <LiveCanvas
             appName={canvasApp.name}
+            appSegment={canvasApp.segment}
             materialized={canvasApp.materialized}
             refreshKey={canvasRefreshKey}
             onClose={() => setCanvasApp(null)}

--- a/packages/app-shell/src/console/ai/LiveCanvas.tsx
+++ b/packages/app-shell/src/console/ai/LiveCanvas.tsx
@@ -25,8 +25,14 @@ import { Button } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 
 export interface LiveCanvasProps {
-  /** The drafted app to render (its `app` metadata name). */
+  /** The drafted app to render (its `app` metadata name) — used for display. */
   appName: string;
+  /**
+   * ADR-0048: the app's ROUTE SEGMENT — its package id (`app.<slug>`), which is
+   * globally unique, unlike the display name (two AI apps can both be `library`).
+   * The iframe URL keys on this; falls back to `appName` when absent.
+   */
+  appSegment?: string;
   /**
    * ADR-0045: the build was materialized — the app is live (real tables and
    * seed rows) but unlisted. The canvas then renders the REAL app URL: full
@@ -55,20 +61,22 @@ function canvasSrc(appName: string, materialized: boolean): string {
   return materialized ? base : `${base}?preview=draft`;
 }
 
-export function LiveCanvas({ appName, materialized = false, refreshKey, onClose }: LiveCanvasProps) {
+export function LiveCanvas({ appName, appSegment, materialized = false, refreshKey, onClose }: LiveCanvasProps) {
   const { t } = useObjectTranslation();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  // Route on the package-id segment (unique), display by name (friendly).
+  const routeSeg = appSegment && appSegment.length ? appSegment : appName;
   // Materialized world swap: changing src on the SAME iframe element
   // navigates it in place (no white-flash remount).
   useEffect(() => {
     if (!iframeRef.current) return;
-    const next = canvasSrc(appName, materialized);
+    const next = canvasSrc(routeSeg, materialized);
     try {
       if (iframeRef.current.getAttribute('src') !== next) iframeRef.current.setAttribute('src', next);
     } catch {
       /* not ready — the mount src covers it */
     }
-  }, [appName, materialized]);
+  }, [routeSeg, materialized]);
 
   // Refresh in place (src reload) instead of remounting the iframe — keeps
   // the pane from flashing white on every invalidation.
@@ -104,7 +112,7 @@ export function LiveCanvas({ appName, materialized = false, refreshKey, onClose 
       <iframe
         ref={iframeRef}
         title={`Draft preview: ${appName}`}
-        src={canvasSrc(appName, materialized)}
+        src={canvasSrc(routeSeg, materialized)}
         className="h-full w-full flex-1 border-0 bg-background"
         data-testid="live-canvas-frame"
       />

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -471,7 +471,7 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    * into what was just built. The host wires this to its router (e.g.
    * `navigate('/apps/<name>')`).
    */
-  onOpenBuiltApp?: (appName: string) => void;
+  onOpenBuiltApp?: (appName: string, appSegment?: string) => void;
   /** Label for the open-built-app action (default "Open app"). */
   openBuiltAppLabel?: string;
   /**
@@ -483,7 +483,10 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    * true and the host should open the REAL app URL (no preview flag) — the
    * app is live-but-unlisted, with actual tables and seed data.
    */
-  onPreviewDraftApp?: (appName: string, opts?: { materialized?: boolean }) => void;
+  onPreviewDraftApp?: (
+    appName: string,
+    opts?: { materialized?: boolean; appSegment?: string },
+  ) => void;
   /** Label for the preview-draft action (default "Preview"). */
   previewDraftLabel?: string;
   /**
@@ -492,7 +495,10 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    * envelopes), with the cumulative deduped set. Hosts use it to open and
    * refresh the live draft-preview pane while the agent builds.
    */
-  onDraftArtifacts?: (artifacts: Array<{ type: string; name: string }>) => void;
+  onDraftArtifacts?: (
+    artifacts: Array<{ type: string; name: string }>,
+    appSegment?: string,
+  ) => void;
   /**
    * ADR-0045: fires once per build whose tool result reports `materialized`
    * with an `app` in the draft set — the app is live (tables + seed data)
@@ -1092,14 +1098,19 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
     React.useEffect(() => {
       if (!onDraftArtifacts) return;
       const artifacts = new Map<string, { type: string; name: string }>();
+      // The preview pane routes on the app's PACKAGE id (ADR-0048), not its
+      // name — take it from the draft set that includes the app.
+      let appSegment: string | undefined;
       for (const message of messages) {
         for (const item of message.buildProgress?.items ?? []) {
           if (item?.type && item?.name) artifacts.set(`${item.type}:${item.name}`, item);
         }
         for (const tool of message.toolInvocations ?? []) {
-          for (const item of tool.draftReview?.items ?? []) {
+          const dr = tool.draftReview;
+          for (const item of dr?.items ?? []) {
             if (item?.type && item?.name) artifacts.set(`${item.type}:${item.name}`, item);
           }
+          if (dr?.packageId && dr.items?.some((i) => i.type === 'app')) appSegment = dr.packageId;
         }
       }
       const seen = draftArtifactKeysRef.current;
@@ -1110,7 +1121,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
           grew = true;
         }
       }
-      if (grew) onDraftArtifacts([...artifacts.values()]);
+      if (grew) onDraftArtifacts([...artifacts.values()], appSegment);
     }, [messages, onDraftArtifacts]);
 
     // ADR-0045: announce materialized builds (real app live, unlisted) so the
@@ -1390,7 +1401,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                         return app ? (
                           <button
                             type="button"
-                            onClick={() => onPreviewDraftApp(app.name, { materialized: tool.draftReview!.materialized === true })}
+                            onClick={() => onPreviewDraftApp(app.name, { materialized: tool.draftReview!.materialized === true, appSegment: tool.draftReview!.packageId })}
                             className="inline-flex h-7 items-center gap-1.5 rounded-md border px-3 text-xs font-medium hover:bg-muted"
                             data-testid="draft-preview-app"
                           >

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -701,6 +701,50 @@ describe('ChatbotEnhanced — streaming build preview (live build tree)', () => 
     rerender(<ChatbotEnhanced messages={[buildMsg('done')]} onOpenBuiltApp={onOpenBuiltApp} />);
     expect(screen.queryByTestId('build-progress-open-app')).not.toBeInTheDocument();
   });
+
+  // ADR-0048: AI-built apps route on their PACKAGE id (globally unique), not the
+  // LLM's display name (`library`, which can collide across apps).
+  it('the draft Preview button passes the app package id as the route segment', () => {
+    const onPreviewDraftApp = vi.fn();
+    const msg: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      toolInvocations: [
+        {
+          toolCallId: 't1',
+          toolName: 'apply_blueprint',
+          state: 'output-available',
+          draftReview: { items: [{ type: 'app', name: 'library' }], packageId: 'app.fh79', materialized: true },
+        },
+      ],
+    };
+    render(<ChatbotEnhanced messages={[msg]} onPreviewDraftApp={onPreviewDraftApp} onPublishDrafts={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('draft-preview-app'));
+    expect(onPreviewDraftApp).toHaveBeenCalledWith('library', expect.objectContaining({ appSegment: 'app.fh79' }));
+  });
+
+  it('onDraftArtifacts carries the app package id for the auto-opened preview pane', () => {
+    const onDraftArtifacts = vi.fn();
+    const msg: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      toolInvocations: [
+        {
+          toolCallId: 't1',
+          toolName: 'apply_blueprint',
+          state: 'output-available',
+          draftReview: {
+            items: [{ type: 'app', name: 'library' }, { type: 'object', name: 'fh79_book' }],
+            packageId: 'app.fh79',
+          },
+        },
+      ],
+    };
+    render(<ChatbotEnhanced messages={[msg]} onDraftArtifacts={onDraftArtifacts} onPublishDrafts={vi.fn()} />);
+    expect(onDraftArtifacts).toHaveBeenCalledWith(expect.any(Array), 'app.fh79');
+  });
 });
 
 /**


### PR DESCRIPTION
Founder-spotted, same theme as objectstack-ai/cloud#449. The AI build chat's **Open app** / **Preview** (and the auto-opened LiveCanvas preview) navigated to `/apps/<appName>` (e.g. `/apps/library`) using the app's machine **name**. Per **ADR-0048** the `/apps/<segment>` route is keyed on the app's **package id** (`app.<slug>`, globally unique) — the name is the LLM's free choice and isn't unique (two AI apps can both be `library`). The launcher already does this via `appRouteSegment`; only the AI-chat paths regressed.

## Fix
Thread the app's package id (route segment) through the chat callbacks:
- `onOpenBuiltApp` / `onPreviewDraftApp` / `onDraftArtifacts` gain the package segment.
- The draft **Preview** button and the artifact-stream emit pass `draftReview.packageId`.
- `AiChatPage` navigates / sets the canvas to `appSegment ?? appName`.
- `LiveCanvas` keys its iframe URL on the segment (display still uses the name).

The `BuildProgressPanel` "Open app" still falls back to the name (build-progress carries no package id) — no regression; the package-bearing paths are fixed.

## Verification
- Live-confirmed the bug on the EE rig (`/apps/library/fh79_book`, app in `app.fh79`).
- plugin-chatbot + app-shell typecheck clean; 49 ChatbotEnhanced tests pass (2 new: Preview passes the package segment; `onDraftArtifacts` carries it).

Reaches prod via framework `.objectui-sha` pin → cloud pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)