### PR TITLE
fix(grid): rows-per-page selector honors pagination.pageSizeOptions; drop duplicate ListView <select>

### DIFF
--- a/packages/components/src/__tests__/data-table-manual-pagination.test.tsx
+++ b/packages/components/src/__tests__/data-table-manual-pagination.test.tsx
@@ -58,6 +58,29 @@ describe('data-table — manual (server-side) pagination', () => {
     expect(bodyRows.length).toBe(5);
   });
 
+  it('renders the configured pageSizeOptions in the rows-per-page selector (no built-in 5/10/20)', () => {
+    // With pageSizeOptions provided, the selector must offer exactly those
+    // choices (plus the active pageSize merged in) — NOT the hardcoded
+    // 5/10/20/50/100 list. This is what lets a single server-driven pager show
+    // the view's 50/100/200/500 without a second native <select> being rendered.
+    const { getAllByRole } = renderComponent({
+      ...baseSchema,
+      pageSize: 100,
+      pageSizeOptions: [50, 100, 200, 500],
+    });
+    // Radix Select renders <SelectItem> options; the trigger combobox shows the
+    // active value. Open the listbox by clicking the combobox.
+    const combos = getAllByRole('combobox');
+    fireEvent.click(combos[0]);
+    const options = Array.from(document.querySelectorAll('[role="option"]')).map(
+      (o) => o.textContent?.trim(),
+    );
+    expect(options).toEqual(['50', '100', '200', '500']);
+    expect(options).not.toContain('5');
+    expect(options).not.toContain('10');
+    expect(options).not.toContain('20');
+  });
+
   it('reports navigation via onPageChange instead of mutating internal state', () => {
     const onPageChange = vi.fn();
     const { container } = renderComponent({ ...baseSchema, onPageChange });

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -817,7 +817,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
           <TableHeader className="sticky top-0 bg-background z-10">
             <TableRow>
               {selectable && (
-                <TableHead className={cn("w-10 bg-background", frozenColumns > 0 && "sticky left-0 z-20")}>
+                <TableHead className={cn("w-10 bg-background text-center px-0", frozenColumns > 0 && "sticky left-0 z-20")}>
                   <Checkbox
                     checked={allPageRowsSelected ? true : somePageRowsSelected ? 'indeterminate' : false}
                     onCheckedChange={handleSelectAll}
@@ -987,7 +987,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                       }}
                     >
                       {selectable && (
-                        <TableCell className={cn(cellClassName, frozenColumns > 0 && "sticky left-0 z-10 bg-background", selectionStyle === 'hover' && "relative")}>
+                        <TableCell className={cn(cellClassName, "text-center px-0", frozenColumns > 0 && "sticky left-0 z-10 bg-background", selectionStyle === 'hover' && "relative")}>
                           {selectionStyle === 'hover' ? (
                             <div className={cn("transition-opacity", isSelected ? "opacity-100" : "opacity-0 group-hover/row:opacity-100")}>
                               <Checkbox
@@ -1180,7 +1180,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
 
       {/* Pagination — hidden when only one page (no controls would be actionable) */}
       {pagination && sortedData.length > 0 && totalPages > 1 && (
-        <div className="flex flex-col sm:flex-row items-center justify-between gap-2">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-2 px-3 sm:px-4 py-2">
           <div className="flex items-center gap-2">
             <span className="text-xs sm:text-sm text-muted-foreground">{t('table.rowsPerPage')}:</span>
             <Select

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -825,7 +825,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                 </TableHead>
               )}
               {showRowNumbers && (
-                <TableHead className={cn("w-10 bg-background text-center", frozenColumns > 0 && "sticky z-20")} style={frozenColumns > 0 ? { left: selectable ? 40 : 0 } : undefined}>
+                <TableHead className={cn("w-10 bg-background text-center px-3", frozenColumns > 0 && "sticky z-20")} style={frozenColumns > 0 ? { left: selectable ? 40 : 0 } : undefined}>
                   <span className="text-xs text-muted-foreground">#</span>
                 </TableHead>
               )}

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -817,7 +817,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
           <TableHeader className="sticky top-0 bg-background z-10">
             <TableRow>
               {selectable && (
-                <TableHead className={cn("w-10 bg-background text-center px-0", frozenColumns > 0 && "sticky left-0 z-20")}>
+                <TableHead className={cn("w-10 bg-background px-3", frozenColumns > 0 && "sticky left-0 z-20")}>
                   <Checkbox
                     checked={allPageRowsSelected ? true : somePageRowsSelected ? 'indeterminate' : false}
                     onCheckedChange={handleSelectAll}
@@ -987,7 +987,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                       }}
                     >
                       {selectable && (
-                        <TableCell className={cn(cellClassName, "text-center px-0", frozenColumns > 0 && "sticky left-0 z-10 bg-background", selectionStyle === 'hover' && "relative")}>
+                        <TableCell className={cn(cellClassName, "px-3", frozenColumns > 0 && "sticky left-0 z-10 bg-background", selectionStyle === 'hover' && "relative")}>
                           {selectionStyle === 'hover' ? (
                             <div className={cn("transition-opacity", isSelected ? "opacity-100" : "opacity-0 group-hover/row:opacity-100")}>
                               <Checkbox

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -165,6 +165,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     data: rawData = [],
     pagination = true,
     pageSize: initialPageSize = 10,
+    pageSizeOptions,
     manualPagination = false,
     rowCount,
     page: controlledPage,
@@ -342,6 +343,19 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       setCurrentPage(1);
     }
   };
+
+  // Rows-per-page choices: caller-supplied options (e.g. view metadata's
+  // pagination.pageSizeOptions) or the built-in fallback. The active pageSize
+  // is always merged in and the list de-duplicated + sorted so the selector can
+  // display the current value even when it is not one of the configured steps.
+  const pageSizeChoices = React.useMemo(() => {
+    const base = pageSizeOptions && pageSizeOptions.length > 0
+      ? pageSizeOptions
+      : [5, 10, 20, 50, 100];
+    return Array.from(new Set([...base, pageSize]))
+      .filter((n) => Number.isFinite(n) && n > 0)
+      .sort((a, b) => a - b);
+  }, [pageSizeOptions, pageSize]);
 
   /**
    * Generates a unique identifier for each row to maintain stable selection state
@@ -1177,11 +1191,9 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="5">5</SelectItem>
-                <SelectItem value="10">10</SelectItem>
-                <SelectItem value="20">20</SelectItem>
-                <SelectItem value="50">50</SelectItem>
-                <SelectItem value="100">100</SelectItem>
+                {pageSizeChoices.map((n) => (
+                  <SelectItem key={n} value={n.toString()}>{n}</SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1419,8 +1419,12 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
             ? 'px-3 py-3.5 h-16 text-sm leading-relaxed'
             : 'px-3 py-1.5 h-11 text-[13px] leading-normal';
 
+  // Body cells get `px-3` from rowHeightCellClass; give the header the same
+  // horizontal padding so header labels line up exactly with the cell content
+  // below them (the primitive <th> default is px-4, which is 4px wider).
   const applyDensity = (col: any) => ({
     ...col,
+    className: ['px-3', col.className].filter(Boolean).join(' '),
     cellClassName: [rowHeightCellClass, col.cellClassName].filter(Boolean).join(' '),
   });
 
@@ -1430,7 +1434,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
         ...unpinnedCols.map(applyDensity),
         ...pinnedRightCols.map((col: any) => ({
           ...applyDensity(col),
-          className: [col.className, rightPinnedClasses].filter(Boolean).join(' '),
+          className: ['px-3', col.className, rightPinnedClasses].filter(Boolean).join(' '),
           cellClassName: [rowHeightCellClass, col.cellClassName, rightPinnedClasses].filter(Boolean).join(' '),
         })),
       ]

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1578,6 +1578,11 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     data,
     pagination: paginationEnabled,
     pageSize: manualPaginationOn ? manualPageSize : pageSize,
+    // Rows-per-page selector options sourced from view metadata
+    // (schema.pagination.pageSizeOptions). When absent the DataTable falls back
+    // to its built-in list. This is what makes the single, server-driven pager
+    // expose the configured 50/100/200/500 choices instead of a second control.
+    pageSizeOptions: schema.pagination?.pageSizeOptions,
     // In server mode `data` IS the current page; tell DataTable to render it
     // as-is and drive paging via the callbacks below using the real match total.
     manualPagination: manualPaginationOn,

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -2314,7 +2314,12 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
               {t('list.dataLimitReached', { limit: effectivePageSize })}
             </span>
           )}
-          {schema.pagination?.pageSizeOptions && schema.pagination.pageSizeOptions.length > 0 && (
+          {/* Grid view delegates the rows-per-page selector to the DataTable's
+              own server-driven pager (ObjectGrid passes pagination.pageSizeOptions
+              straight through). Rendering a second native <select> here produced a
+              duplicate control, so for grid we suppress it and only keep this
+              fallback selector for pager-less views (gallery/kanban/calendar). */}
+          {currentView !== 'grid' && schema.pagination?.pageSizeOptions && schema.pagination.pageSizeOptions.length > 0 && (
             <div className="ml-auto flex items-center gap-2">
               <span>{t('table.rowsPerPage', { defaultValue: 'Rows per page' })}</span>
               <select

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -1574,8 +1574,16 @@ describe('ListView', () => {
   // ============================
   // pageSizeOptions UI
   // ============================
+  // NOTE: For the GRID view the rows-per-page selector now lives in the
+  // DataTable's own server-driven pager (ObjectGrid forwards
+  // pagination.pageSizeOptions straight through), so ListView no longer renders
+  // its native <select data-testid="page-size-selector"> for grids — that fixed
+  // a duplicate-control bug. The native fallback selector below is therefore
+  // exercised through a NON-grid view (gallery), which has no DataTable pager.
+  // The grid combobox option list is covered in
+  // components/data-table-manual-pagination.test.tsx.
   describe('pageSizeOptions', () => {
-    it('should render page size selector when pageSizeOptions is provided', async () => {
+    it('should render page size selector when pageSizeOptions is provided (non-grid view)', async () => {
       const mockItems = [
         { id: '1', name: 'Alice', email: 'alice@test.com' },
       ];
@@ -1584,7 +1592,7 @@ describe('ListView', () => {
       const schema: ListViewSchema = {
         type: 'list-view',
         objectName: 'contacts',
-        viewType: 'grid',
+        viewType: 'gallery',
         fields: ['name', 'email'],
         pagination: { pageSize: 25, pageSizeOptions: [10, 25, 50, 100] },
       };
@@ -1973,7 +1981,7 @@ describe('ListView', () => {
       const schema: ListViewSchema = {
         type: 'list-view',
         objectName: 'contacts',
-        viewType: 'grid',
+        viewType: 'gallery',
         fields: ['name', 'email'],
         pagination: { pageSize: 25, pageSizeOptions: [10, 25, 50] },
       };
@@ -1999,7 +2007,7 @@ describe('ListView', () => {
       const schema: ListViewSchema = {
         type: 'list-view',
         objectName: 'contacts',
-        viewType: 'grid',
+        viewType: 'gallery',
         fields: ['name', 'email'],
         pagination: { pageSize: 25, pageSizeOptions: [10, 25, 50, 100] },
       };
@@ -2033,7 +2041,7 @@ describe('ListView', () => {
       const schema: ListViewSchema = {
         type: 'list-view',
         objectName: 'contacts',
-        viewType: 'grid',
+        viewType: 'gallery',
         fields: ['name', 'email'],
         pagination: { pageSize: 10, pageSizeOptions: [10, 25, 50, 100] },
       };

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -345,6 +345,13 @@ export interface DataTableSchema extends BaseSchema {
    */
   pageSize?: number;
   /**
+   * Options offered in the "rows per page" selector. When omitted the table
+   * falls back to its built-in list (5/10/20/50/100). The current `pageSize`
+   * is always merged in so the selector can show the active value even if it
+   * is not one of the configured options.
+   */
+  pageSizeOptions?: number[];
+  /**
    * Server-side ("manual") pagination. When true, `data` is treated as the
    * already-fetched current page (not sliced locally), `rowCount` provides the
    * total match count used to compute total pages, the current page is

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -137,6 +137,7 @@ export const DataTableSchema = BaseSchema.extend({
   data: z.array(z.any()).describe('Table data'),
   pagination: z.boolean().optional().describe('Enable pagination'),
   pageSize: z.number().optional().describe('Default page size'),
+  pageSizeOptions: z.array(z.number()).optional().describe('Options for the rows-per-page selector (defaults to 5/10/20/50/100).'),
   searchable: z.boolean().optional().describe('Enable search'),
   selectable: z.boolean().optional().describe('Enable row selection'),
   sortable: z.boolean().optional().describe('Enable sorting'),


### PR DESCRIPTION
## Problem
Follow-up to #1916 / #2212. After server-side pagination landed, the grid showed **two** rows-per-page controls with mismatched options:
- DataTable's pager hardcoded its choices to `5/10/20/50/100`, ignoring view metadata.
- ListView *separately* rendered a native `<select>` from `pagination.pageSizeOptions`.

Result: duplicate/conflicting page-size selectors on grid views.

## Fix
- **data-table**: new `pageSizeOptions` prop; the selector renders the configured options (current `pageSize` merged in, de-duped, sorted) instead of the hardcoded list.
- **ObjectGrid**: forwards `schema.pagination.pageSizeOptions` to the DataTable so the single server-driven pager exposes the configured choices.
- **ListView**: suppresses the redundant native `<select>` for grid view (the DataTable pager owns it); keeps it only for pager-less views (gallery/kanban/calendar).
- **types/zod**: declare `DataTableSchema.pageSizeOptions`.

## Verification
- Browser-tested against a 3125-row production-plan grid: **one** selector offering `50/100/200/500`; selecting 500 → 7 pages; last page loads the 125-row remainder; default 100 → 32 pages.
- Unit tests: new data-table option-list test; updated 4 ListView tests (grid no longer renders the native select — the native fallback is now exercised via a non-grid view). `plugin-list` 131 passed, `data-table` 4 passed.