### PR TITLE
feat(chatbot): reveal Build/Ask switcher in the app FAB when AI dev is unlocked

### DIFF
--- a/.changeset/floating-ai-build-ask-picker.md
+++ b/.changeset/floating-ai-build-ask-picker.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(chatbot): reveal the Build/Ask switcher in the app floating assistant when AI dev is unlocked
+
+The bottom-right FAB assistant bound each app to a single agent and hid the
+agent picker unless `VITE_AI_SHOW_AGENT_PICKER` was set, so a user on an
+AI-unlocked environment could not switch from `ask` (read-only data/query) to
+`build` (authoring) without leaving for the full `/ai` page.
+
+The picker now auto-reveals when AI development is unlocked for the viewer — the
+live agent catalog serves BOTH an `ask` and a `build` agent (alias-aware, so
+legacy `data_chat`/`metadata_assistant` count) AND authoring isn't
+deployment-disabled (`aiStudio`). Pure end-user apps (only `ask`) stay clean and
+never see a picker. An explicit `showAgentPicker` prop or
+`VITE_AI_SHOW_AGENT_PICKER` still forces it on.

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -47,6 +47,7 @@ import { useAssistant, requestAssistantReview, emitCanvasInvalidate, type Assist
 import { fetchPendingDraftCount } from '../preview/draftStatus';
 import { getRuntimeConfig } from '../runtime-config';
 import { cloudPricingDeepLink } from '../console/marketplace/marketplaceApi';
+import { shouldShowAgentPicker } from './agentPicker';
 
 /**
  * Display names for the two built-in platform agents (ADR-0063: `ask` / `build`,
@@ -236,10 +237,12 @@ export interface ConsoleFloatingChatbotProps {
    */
   defaultAgent?: string;
   /**
-   * Show the in-header agent switcher. Off by default: end users get the
-   * single agent bound to their app and never have to choose. Enable for
-   * power users / admins (or via `VITE_AI_SHOW_AGENT_PICKER`) when a
-   * surface genuinely exposes multiple agents.
+   * Force the in-header agent switcher on (`true`) or off (`false`),
+   * overriding the default. When left undefined the switcher auto-reveals
+   * only when AI development is unlocked for the viewer — the live catalog
+   * serves BOTH an `ask` and a `build` agent and `aiStudio` isn't disabled —
+   * so pure end-user apps (only `ask`) stay clean while builders can flip
+   * Ask↔Build inline. `VITE_AI_SHOW_AGENT_PICKER=true` also forces it on.
    */
   showAgentPicker?: boolean;
   /** Whether the floating panel should open immediately on mount. */
@@ -497,10 +500,10 @@ function ChatbotInner({
     },
   });
 
-  // Agent switcher — deliberately hidden by default. End users get the
-  // single agent bound to their app (Studio → metadata_assistant, others
-  // → data_chat) and are never asked to choose. Only surfaces when the
-  // host explicitly opts in AND there is more than one agent to pick.
+  // Agent switcher — Ask ↔ Build (plus any custom agents). Restrained by
+  // design: end users bound to a single agent never see it. `showAgentPicker`
+  // is true when AI development is unlocked (catalog serves both ask & build)
+  // or forced on; it still needs more than one agent to be a real choice.
   const headerExtra =
     showAgentPicker && agents.length > 1 ? (
       <Select
@@ -738,12 +741,20 @@ export default function ConsoleFloatingChatbot({
   const apiBase = React.useMemo(() => resolveApiBase(apiBaseProp), [apiBaseProp]);
   const env = (import.meta as any).env ?? {};
   const envDefaultAgent = env.VITE_AI_DEFAULT_AGENT as string | undefined;
-  // Power-user / admin escape hatch: force the picker on globally without
-  // touching app metadata.
-  const showAgentPicker =
-    showAgentPickerProp ?? env.VITE_AI_SHOW_AGENT_PICKER === 'true';
 
   const { agents, isLoading: agentsLoading, error: agentsError } = useAgents({ apiBase });
+
+  // Reveal the Build/Ask switcher only when AI development is unlocked for this
+  // viewer — the live catalog serves BOTH an `ask` and a `build` agent and
+  // authoring isn't deployment-disabled. Pure end-user apps (only `ask`) stay
+  // clean; builders can flip "ask about my data" ↔ "extend my app" inline. An
+  // explicit prop or `VITE_AI_SHOW_AGENT_PICKER` still forces it. See agentPicker.
+  const showAgentPicker = shouldShowAgentPicker({
+    agents,
+    showAgentPickerProp,
+    envOptIn: env.VITE_AI_SHOW_AGENT_PICKER === 'true',
+    aiStudioEnabled: getRuntimeConfig().features.aiStudio !== false,
+  });
 
   const [activeAgent, setActiveAgent] = React.useState<string | undefined>(undefined);
   React.useEffect(() => {

--- a/packages/app-shell/src/layout/__tests__/agentPicker.test.ts
+++ b/packages/app-shell/src/layout/__tests__/agentPicker.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowAgentPicker, isAiDevUnlocked } from '../agentPicker';
+
+const ask = { name: 'ask' };
+const build = { name: 'build' };
+const dataChat = { name: 'data_chat' }; // legacy alias of `ask`
+const metadataAssistant = { name: 'metadata_assistant' }; // legacy alias of `build`
+const custom = { name: 'sales_assistant' };
+
+describe('isAiDevUnlocked', () => {
+  it('is true only when the catalog serves BOTH an ask and a build agent', () => {
+    expect(isAiDevUnlocked([ask, build])).toBe(true);
+  });
+
+  it('is alias-aware (legacy data_chat + metadata_assistant counts)', () => {
+    expect(isAiDevUnlocked([dataChat, metadataAssistant])).toBe(true);
+  });
+
+  it('is false for a pure end-user catalog (ask only)', () => {
+    expect(isAiDevUnlocked([ask])).toBe(false);
+  });
+
+  it('is false when only a build agent is present (no ask)', () => {
+    expect(isAiDevUnlocked([build])).toBe(false);
+  });
+
+  it('is false for an empty catalog or custom-only agents', () => {
+    expect(isAiDevUnlocked([])).toBe(false);
+    expect(isAiDevUnlocked([custom])).toBe(false);
+  });
+});
+
+describe('shouldShowAgentPicker', () => {
+  describe('auto-reveal (no explicit override)', () => {
+    it('shows when AI development is unlocked (ask + build)', () => {
+      expect(shouldShowAgentPicker({ agents: [ask, build] })).toBe(true);
+    });
+
+    it('shows for the legacy alias catalog too', () => {
+      expect(shouldShowAgentPicker({ agents: [dataChat, metadataAssistant] })).toBe(true);
+    });
+
+    it('stays hidden for a pure end-user app (ask only)', () => {
+      expect(shouldShowAgentPicker({ agents: [ask] })).toBe(false);
+    });
+
+    it('stays hidden when only custom agents exist', () => {
+      expect(shouldShowAgentPicker({ agents: [ask, custom] })).toBe(false);
+    });
+
+    it('is suppressed when AI Studio (authoring) is deployment-disabled', () => {
+      expect(
+        shouldShowAgentPicker({ agents: [ask, build], aiStudioEnabled: false }),
+      ).toBe(false);
+    });
+  });
+
+  describe('env opt-in (VITE_AI_SHOW_AGENT_PICKER)', () => {
+    it('forces the picker on even for a single-agent end-user catalog', () => {
+      expect(shouldShowAgentPicker({ agents: [ask], envOptIn: true })).toBe(true);
+    });
+  });
+
+  describe('explicit prop wins outright', () => {
+    it('true forces on even with an empty catalog', () => {
+      expect(shouldShowAgentPicker({ agents: [], showAgentPickerProp: true })).toBe(true);
+    });
+
+    it('false forces off even when AI development is unlocked', () => {
+      expect(
+        shouldShowAgentPicker({ agents: [ask, build], showAgentPickerProp: false }),
+      ).toBe(false);
+    });
+
+    it('false beats the env opt-in', () => {
+      expect(
+        shouldShowAgentPicker({ agents: [ask], showAgentPickerProp: false, envOptIn: true }),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/app-shell/src/layout/agentPicker.ts
+++ b/packages/app-shell/src/layout/agentPicker.ts
@@ -1,0 +1,72 @@
+/**
+ * agentPicker
+ *
+ * Pure decision logic for the floating assistant's Build/Ask switcher. Kept in
+ * its own module (no React, no chat deps) so it can be unit-tested without
+ * dragging in the heavy chat component graph (FloatingChatbot → streamdown →
+ * shiki → @ai-sdk, ~20MB) that `ConsoleFloatingChatbot` pulls in.
+ * @module
+ */
+import { isAskAgent, isBuildAgent, type AgentDescriptor } from '@object-ui/plugin-chatbot';
+
+/** Minimal catalog shape the decision needs — just the agent name. */
+type AgentLike = Pick<AgentDescriptor, 'name'>;
+
+export interface AgentPickerDecisionInput {
+  /** Live agent catalog from `useAgents` (the single source of truth). */
+  agents: AgentLike[];
+  /**
+   * Explicit host override. When defined it wins outright — `true` forces the
+   * switcher on, `false` forces it off — regardless of catalog or env.
+   */
+  showAgentPickerProp?: boolean;
+  /**
+   * `VITE_AI_SHOW_AGENT_PICKER === 'true'` — the power-user / admin global
+   * escape hatch that forces the switcher on without touching app metadata.
+   */
+  envOptIn?: boolean;
+  /**
+   * Whether AI Studio (authoring / "online development") is enabled for this
+   * deployment. When off, the build agent must not be reachable from the panel,
+   * so the auto-reveal is suppressed even if the catalog still serves `build`.
+   * Mirrors `ConsoleLayout`'s `aiStudioEnabled` gate. Defaults to true.
+   */
+  aiStudioEnabled?: boolean;
+}
+
+/**
+ * True when the live catalog exposes BOTH a data/query (`ask`) and an authoring
+ * (`build`) agent — alias-aware via {@link isAskAgent}/{@link isBuildAgent}, so
+ * a catalog still serving the legacy `data_chat`/`metadata_assistant` ids counts
+ * too. This is the "AI development is unlocked for this viewer" signal, the same
+ * `askAvailable && buildAvailable` notion HomePage uses to surface "Build with AI".
+ */
+export function isAiDevUnlocked(agents: AgentLike[]): boolean {
+  return (
+    agents.some((a) => isAskAgent(a.name)) && agents.some((a) => isBuildAgent(a.name))
+  );
+}
+
+/**
+ * Decide whether the floating assistant should reveal its Build/Ask switcher.
+ *
+ * Restrained by design (the original "end users shouldn't have to choose" rule):
+ * a pure end-user surface bound to a single `ask` agent never sees it. Precedence:
+ *  1. `showAgentPickerProp` — explicit host override wins (`true`/`false`).
+ *  2. `envOptIn` — `VITE_AI_SHOW_AGENT_PICKER` forces it on globally.
+ *  3. Auto-reveal — AI development is unlocked ({@link isAiDevUnlocked}) AND
+ *     authoring isn't deployment-disabled (`aiStudioEnabled`).
+ *
+ * Returns the *intent* only: the render site still requires more than one agent
+ * (`agents.length > 1`) to draw an actual choice.
+ */
+export function shouldShowAgentPicker({
+  agents,
+  showAgentPickerProp,
+  envOptIn = false,
+  aiStudioEnabled = true,
+}: AgentPickerDecisionInput): boolean {
+  if (showAgentPickerProp !== undefined) return showAgentPickerProp;
+  if (envOptIn) return true;
+  return aiStudioEnabled && isAiDevUnlocked(agents);
+}


### PR DESCRIPTION
## What & why

The bottom-right floating assistant (FAB) bound each app to a single agent and **hid the agent picker** unless `VITE_AI_SHOW_AGENT_PICKER` was set. So a user on an AI-unlocked environment who wanted to "keep developing" couldn't switch from `ask` (read-only data/query) to `build` (authoring) inside the panel — `ask` only suggests, it won't model/extend. Only the full `/ai` page exposed the switch.

## Change

The picker now **auto-reveals only when AI development is unlocked for the viewer** — the live agent catalog (`GET /api/v1/ai/agents`) serves **both** an `ask` and a `build` agent (alias-aware, so legacy `data_chat`/`metadata_assistant` count) **and** authoring isn't deployment-disabled (`aiStudio`). Pure end-user apps (only `ask`) stay clean and never see a picker — preserving the original "end users shouldn't have to choose" design. An explicit `showAgentPicker` prop or `VITE_AI_SHOW_AGENT_PICKER` still forces it on.

Precedence (in the new `agentPicker.ts` helper): explicit prop → `VITE_AI_SHOW_AGENT_PICKER` → AI-dev-unlocked auto-reveal.

- `agentPicker.ts` — new pure, unit-tested helper (`shouldShowAgentPicker` / `isAiDevUnlocked`); extracted because `ConsoleFloatingChatbot` is too heavy to unit-test in isolation.
- `ConsoleFloatingChatbot.tsx` — computes `showAgentPicker` via the helper; updated prop JSDoc + header comment.
- `agentPicker.test.ts` — 14 cases (both-present, alias catalog, ask-only, custom-only, aiStudio-off, env force, prop-override precedence).

No call-site edits: `ConsoleLayout` and `HomeLayout` already render the FAB without `showAgentPicker`, so auto-reveal covers both surfaces. Switching to `build` remounts the chat onto the build endpoint via the existing `key`, so propose/apply + `create_object` run from the panel (all build props are already wired in the render). The concept mirrors `HomePage`'s existing `askAvailable && buildAvailable`.

## Verification

- ✅ `vitest run src/layout` — 15/15 pass
- ✅ `tsc --noEmit` — clean (deps built in worktree)
- ✅ `eslint` — 0 errors, 0 new warnings
- ✅ `pnpm build` — clean, emits `agentPicker.{js,d.ts}`
- ⚠️ Live browser e2e not run here — needs an AI-unlocked backend (both agents) which requires the `scripts/dev-local` stack + `OS_CLOUD_API_KEY` + AI key, absent in CI/this checkout. Manual check: open an app in an AI-unlocked env → open FAB → confirm the 构建/智能助手 picker is visible → switch to 构建 → send "加个对象" → confirm it routes to the build agent (plan/propose-apply or `create_object`), not advice.

## Rollout

SDUI/SPA change — ships via objectui PR → framework `.objectui-sha` bump → cloud pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)