### PR TITLE
feat(charts,layout): full-bleed pages, container-scaled donuts, gradient fills (大屏)

### DIFF
--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -424,6 +424,15 @@ export const PageRenderer: React.FC<{
     }
   }, [schema, pageType]);
 
+  // Full-bleed: a page whose `main` region is declared `width: 'full'` fills
+  // the viewport with NO centered max-width cap — for dashboards / 大屏 /
+  // kiosk screens that should use the whole width. Falls back to the
+  // page-type max-width otherwise.
+  const fullBleed = (schema.regions ?? []).some(
+    (r) => r.name?.toLowerCase() === 'main' && (r.width as string) === 'full',
+  );
+  const maxWidthClass = fullBleed ? 'max-w-none' : getPageMaxWidth(pageType);
+
   const pageContent = (
     <div
       className={cn(
@@ -436,7 +445,7 @@ export const PageRenderer: React.FC<{
       style={style}
       {...pageProps}
     >
-      <div className={cn('mx-auto space-y-6', getPageMaxWidth(pageType))}>
+      <div className={cn(fullBleed ? 'space-y-6' : 'mx-auto space-y-6', maxWidthClass)}>
         {/* Page header — suppressed on record pages (the page:header component
             in the header region renders the record-bound title instead). */}
         {pageType !== 'record' && (schema.title || schema.description) && (

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -272,7 +272,7 @@ export default function AdvancedChartImpl({
 
   // Pie and Donut charts
   if (chartType === 'pie' || chartType === 'donut') {
-    const innerRadius = chartType === 'donut' ? 60 : 0;
+    const innerRadius = chartType === 'donut' ? '52%' : 0;
     const palette = getPalette();
     // Augment the chart config with one entry per category value so that
     // `ChartLegendContent` (which resolves item labels via `config[key]`)
@@ -302,7 +302,7 @@ export default function AdvancedChartImpl({
             innerRadius={innerRadius}
             strokeWidth={5}
             paddingAngle={2}
-            outerRadius={80}
+            outerRadius="85%"
             {...pieClickProps}
           >
              {data.map((entry, index) => {

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -547,9 +547,33 @@ export default function AdvancedChartImpl({
   // Horizontal bar — swap X/Y axis types and orientation.
   const isHorizontal = chartType === 'horizontal-bar';
 
+  // Build vertical fill gradients (bar + area) for every colour in play, so
+  // fills read as a polished ramp instead of flat blocks (大屏 look). Inline
+  // `style` on the stops makes the `--chart-*` CSS vars resolve.
+  const _gpal = getPalette();
+  const gradColors = Array.from(new Set<string>([
+    ..._gpal,
+    ...series.map((s: any, i: number) => resolveColor(((config[s.dataKey] as any)?.color) || _gpal[i % _gpal.length] || DEFAULT_CHART_COLOR)),
+  ]));
+  const gslug = (c: string) => 'g' + c.replace(/[^a-zA-Z0-9]/g, '');
+
   return (
     <ChartContainer config={config} className={className}>
       <ChartComponent data={data} layout={isHorizontal ? 'vertical' : 'horizontal'} {...cartesianClickProps}>
+        <defs>
+          {gradColors.map((c) => (
+            <React.Fragment key={gslug(c)}>
+              <linearGradient id={`bg-${gslug(c)}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" style={{ stopColor: c }} stopOpacity={0.95} />
+                <stop offset="100%" style={{ stopColor: c }} stopOpacity={0.5} />
+              </linearGradient>
+              <linearGradient id={`ag-${gslug(c)}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" style={{ stopColor: c }} stopOpacity={0.5} />
+                <stop offset="95%" style={{ stopColor: c }} stopOpacity={0.05} />
+              </linearGradient>
+            </React.Fragment>
+          ))}
+        </defs>
         <CartesianGrid vertical={false} />
         {isHorizontal ? (
           <>
@@ -595,9 +619,9 @@ export default function AdvancedChartImpl({
             const colorPerCategory = primaryCount === 1 && !isComparison && series.length === 1 && data.length > 1;
             const cmp = comparisonStyle(s, 'bar');
             return (
-              <Bar key={s.dataKey} dataKey={s.dataKey} fill={seriesColor} radius={4} fillOpacity={cmp?.fillOpacity}>
+              <Bar key={s.dataKey} dataKey={s.dataKey} fill={`url(#bg-${gslug(seriesColor)})`} radius={4} fillOpacity={cmp?.fillOpacity}>
                 {colorPerCategory && data.map((_entry, idx) => (
-                  <Cell key={`cell-${idx}`} fill={resolveColor(palette[idx % palette.length])} />
+                  <Cell key={`cell-${idx}`} fill={`url(#bg-${gslug(resolveColor(palette[idx % palette.length]))})`} />
                 ))}
               </Bar>
             );
@@ -608,7 +632,7 @@ export default function AdvancedChartImpl({
           }
           if (chartType === 'area') {
             const cmp = comparisonStyle(s, 'area');
-            return <Area key={s.dataKey} type="monotone" dataKey={s.dataKey} fill={seriesColor} stroke={seriesColor} fillOpacity={cmp?.fillOpacity ?? 0.4} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} />;
+            return <Area key={s.dataKey} type="monotone" dataKey={s.dataKey} fill={`url(#ag-${gslug(seriesColor)})`} stroke={seriesColor} strokeWidth={2} fillOpacity={cmp?.fillOpacity ?? 1} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} />;
           }
           return null;
         })}


### PR DESCRIPTION
Three **additive** renderer capabilities that let metadata-authored SDUI pages reach "data-screen / 大屏" quality. Motivated by building a Command Center big-screen in the framework showcase, where the frame was fully styleable (ADR-0065) but the data widgets were not.

## Commits
1. **full-bleed page when main region `width:'full'`** — the page main area spans the full content width instead of being capped, so a `width:'full'` region truly fills a wide screen. Opt-in / backward compatible (only affects `width:'full'` regions). — `packages/components/src/renderers/layout/page.tsx`
2. **pie/donut scale to container** — donut/pie radius scales to the chart container instead of a fixed 80px, so rings fill their panel (no more tiny ring in empty space). Responsive; affects all pie/donut charts. — `packages/plugin-charts/src/AdvancedChartImpl.tsx`
3. **gradient fills for bar & area** — series render with a subtle vertical gradient from the series colour. Pure visual polish. — `packages/plugin-charts/src/AdvancedChartImpl.tsx`

## Why
Charts/metrics rendered at "admin-dashboard" quality regardless of frame styling. These close the biggest gaps for big-screen / dashboard pages and are reusable by any page or dashboard.

## Risk
Low. (1) is opt-in (`width:'full'` only); (2)/(3) are visual with no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)