### PR TITLE
fix(metadata-admin): Studio authoring UX — typeable identifiers + 5 dogfood fixes

### DIFF
--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -85,7 +85,7 @@ function rowPasses(row: any, filters: ContextSelectorFilter[] | undefined): bool
   return true;
 }
 
-function useSelectorOptions(def: ContextSelectorDef): Option[] {
+function useSelectorOptions(def: ContextSelectorDef): { options: Option[]; refetch: () => void } {
   const [options, setOptions] = React.useState<Option[]>([]);
   const endpoint = def.optionsSource.endpoint;
   const valueKey = def.optionsSource.valueKey || 'id';
@@ -93,39 +93,45 @@ function useSelectorOptions(def: ContextSelectorDef): Option[] {
   const filters = def.optionsSource.filter;
   const filterKey = JSON.stringify(filters ?? []);
 
-  React.useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch(endpoint, {
-          credentials: 'include',
-          headers: { Accept: 'application/json' },
-        });
-        if (!res.ok) return;
-        const json = await res.json();
-        if (cancelled) return;
-        const rows = extractRows(json);
-        const opts: Option[] = [];
-        const seen = new Set<string>();
-        for (const row of rows) {
-          if (!rowPasses(row, filters)) continue;
-          const value = getByPath(row, valueKey);
-          if (value == null || typeof value !== 'string' || seen.has(value)) continue;
-          seen.add(value);
-          const labelRaw = getByPath(row, labelKey);
-          opts.push({ value, label: typeof labelRaw === 'string' && labelRaw ? labelRaw : value });
-        }
-        opts.sort((a, b) => a.label.localeCompare(b.label));
-        setOptions(opts);
-      } catch {
-        /* offline / unauthorized — render with no options */
+  // Stable, re-runnable fetch. Without an explicit refetch the option list is
+  // read once on mount, so a package created elsewhere (PackagesPage) stays
+  // invisible in this dropdown until a full page reload. We refetch on
+  // dropdown-open and on a global `objectui:packages-changed` signal.
+  const load = React.useCallback(async () => {
+    try {
+      const res = await fetch(endpoint, {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) return;
+      const json = await res.json();
+      const rows = extractRows(json);
+      const opts: Option[] = [];
+      const seen = new Set<string>();
+      for (const row of rows) {
+        if (!rowPasses(row, filters)) continue;
+        const value = getByPath(row, valueKey);
+        if (value == null || typeof value !== 'string' || seen.has(value)) continue;
+        seen.add(value);
+        const labelRaw = getByPath(row, labelKey);
+        opts.push({ value, label: typeof labelRaw === 'string' && labelRaw ? labelRaw : value });
       }
-    })();
-    return () => { cancelled = true; };
+      opts.sort((a, b) => a.label.localeCompare(b.label));
+      setOptions(opts);
+    } catch {
+      /* offline / unauthorized — render with no options */
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [endpoint, valueKey, labelKey, filterKey]);
 
-  return options;
+  React.useEffect(() => {
+    void load();
+    const onChanged = () => { void load(); };
+    window.addEventListener('objectui:packages-changed', onChanged);
+    return () => window.removeEventListener('objectui:packages-changed', onChanged);
+  }, [load]);
+
+  return { options, refetch: load };
 }
 
 /**
@@ -221,7 +227,7 @@ function SelectorControl({
   onChange: (raw: string) => void;
   t?: (key: string, options?: any) => string;
 }) {
-  const options = useSelectorOptions(def);
+  const { options, refetch } = useSelectorOptions(def);
   const Icon = getIcon(def.icon);
   const rawLabel = resolveI18nLabel(def.label as any, t) || def.id;
   const label = rawLabel === 'Package'
@@ -250,7 +256,11 @@ function SelectorControl({
   const current = hasConcrete ? value : '';
 
   return (
-    <Select value={current} onValueChange={onChange}>
+    <Select
+      value={current}
+      onValueChange={onChange}
+      onOpenChange={(open) => { if (open) refetch(); }}
+    >
       <SelectTrigger
         aria-label={label}
         className="h-9 w-full gap-2 rounded-md border-sidebar-border/70 bg-sidebar/80 px-2 text-xs font-medium text-sidebar-foreground shadow-none transition-colors hover:bg-sidebar-accent focus:ring-1 focus:ring-sidebar-ring data-[state=open]:bg-sidebar-accent [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:shrink-0"

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
@@ -82,6 +82,23 @@ export function JsonSourceEditor({
   const editorRef = React.useRef<any>(null);
   const monacoRef = React.useRef<any>(null);
 
+  // Monaco's core is fetched lazily and, by default, from a public CDN, and it
+  // also spins up web workers. When any of that is blocked — offline /
+  // air-gapped / CSP-restricted installs — the editor mounts an empty shell
+  // with no error and the Source tab looks blank. Detect "nothing actually
+  // painted" via the rendered `.view-line` rows and fall back to a plain
+  // textarea so the source is always readable and editable.
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [monacoUnavailable, setMonacoUnavailable] = React.useState(false);
+  React.useEffect(() => {
+    if (monacoUnavailable) return;
+    const id = setTimeout(() => {
+      const el = containerRef.current;
+      if (!el || !el.querySelector('.view-line')) setMonacoUnavailable(true);
+    }, 4000);
+    return () => clearTimeout(id);
+  }, [monacoUnavailable]);
+
   // Match against the dark class our app-shell toggles on <html>; pick
   // a Monaco theme that doesn't fight the rest of the chrome.
   const [theme, setTheme] = React.useState<'vs-dark' | 'light'>(() => {
@@ -196,33 +213,43 @@ export function JsonSourceEditor({
   return (
     <div className="flex flex-col gap-2">
       <div
+        ref={containerRef}
         className="border rounded overflow-hidden bg-background"
         style={{ height: typeof height === 'number' ? `${height}px` : height }}
       >
-        <React.Suspense
-          fallback={<Skeleton className="w-full h-full" />}
-        >
-          <LazyMonaco
+        {monacoUnavailable ? (
+          <textarea
             value={text}
-            language="json"
-            theme={theme}
-            onChange={handleChange}
-            onMount={handleMount}
-            options={{
-              readOnly,
-              minimap: { enabled: false },
-              fontSize: 12,
-              lineNumbers: 'on',
-              scrollBeyondLastLine: false,
-              automaticLayout: true,
-              folding: true,
-              wordWrap: 'on',
-              tabSize: 2,
-              renderLineHighlight: 'line',
-              scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
-            }}
+            onChange={(e) => handleChange(e.target.value)}
+            readOnly={readOnly}
+            spellCheck={false}
+            aria-label="JSON source"
+            className="w-full h-full resize-none bg-background p-3 font-mono text-xs leading-relaxed outline-none"
           />
-        </React.Suspense>
+        ) : (
+          <React.Suspense fallback={<Skeleton className="w-full h-full" />}>
+            <LazyMonaco
+              value={text}
+              language="json"
+              theme={theme}
+              onChange={handleChange}
+              onMount={handleMount}
+              options={{
+                readOnly,
+                minimap: { enabled: false },
+                fontSize: 12,
+                lineNumbers: 'on',
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+                folding: true,
+                wordWrap: 'on',
+                tabSize: 2,
+                renderLineHighlight: 'line',
+                scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
+              }}
+            />
+          </React.Suspense>
+        )}
       </div>
       {parseError && (
         <div className="text-xs text-destructive flex items-start gap-1.5">

--- a/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
@@ -193,6 +193,13 @@ function CreatePackageDialog({
         }),
       });
       onCreated(id.trim());
+      // Let context selectors (e.g. the sidebar package switcher) pick up the
+      // new package without a full page reload.
+      try {
+        window.dispatchEvent(new CustomEvent('objectui:packages-changed'));
+      } catch {
+        /* non-DOM env */
+      }
       onOpenChange(false);
     } catch (e: any) {
       setError(e?.message ?? t('engine.packages.create.failed', locale));

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -459,7 +459,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.edit.readOnlyTypeBanner':
     'This metadata type is read-only for safety: it ships executable code or sensitive configuration and cannot be overlaid at runtime. Edit the source in your package and redeploy. To override this lock (use with caution), set {flag} to include {type}, or flip {override} in the registry.',
   'engine.edit.artifactLockedBanner':
-    'This item is shipped by a code package and cannot be modified at runtime. You can still create your own {type} from scratch and freely edit or delete it.',
+    'This {type} is provided by an installed package, so it is read-only at runtime. To change it, edit it in its source package and republish — or create a new {type} from scratch.',
   'engine.badge.createOnly': 'create-only',
   'engine.repeater.empty': 'No items. Click + to add.',
   'engine.badge.writable': 'writable',
@@ -1112,7 +1112,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.edit.readOnlyTypeBanner':
     '出于安全考虑，此元数据类型为只读：它包含可执行代码或敏感配置，不允许在运行时通过覆盖层修改。请编辑包内源代码后重新部署。如需临时解除限制（请谨慎使用），可将 {flag} 设置为包含 {type}，或在注册表中开启 {override}。',
   'engine.edit.artifactLockedBanner':
-    '此条目由代码包提供，无法在运行时修改。但您可以新建自己的 {type}，并自由地编辑或删除。',
+    '此 {type} 来自已安装的包，因此在运行时为只读。如需修改，请在其所属包的源中编辑并重新发布——或从零新建一个 {type}。',
   'engine.badge.createOnly': '仅可新建',
   'engine.repeater.empty': '暂无条目。点击 + 添加。',
   'engine.badge.writable': '可写',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.tsx
@@ -23,7 +23,8 @@ import * as React from 'react';
 import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
 import { InspectorShell, InspectorTextField } from './_shared';
 import { Label } from '@object-ui/components';
-import { toFieldName } from '../previews/object-fields-io';
+import { toFieldNameLoose } from '../previews/object-fields-io';
+import { slugify } from '../createDerive';
 import { t } from '../i18n';
 
 export function ObjectDefaultInspector({
@@ -43,12 +44,12 @@ export function ObjectDefaultInspector({
 
   const setLabel = (v: string) => {
     const patch: Record<string, unknown> = { label: v || undefined };
-    if (createMode && !nameTouched.current) patch.name = toFieldName(v);
+    if (createMode && !nameTouched.current) patch.name = slugify(v);
     onPatch(patch);
   };
   const setName = (v: string) => {
     nameTouched.current = true;
-    onPatch({ name: toFieldName(v) });
+    onPatch({ name: toFieldNameLoose(v) });
   };
 
   const nameValue = createMode ? str('name') : name || str('name');

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -22,6 +22,7 @@
  */
 
 import * as React from 'react';
+import { slugify } from '../createDerive';
 import type { MetadataInspectorProps } from '../inspector-registry';
 import { MetadataClient } from '@object-ui/data-objectstack';
 import { useMetadataClient } from '../useMetadata';
@@ -194,6 +195,27 @@ export function ObjectFieldInspector({
     onSelectionChange?.({ kind: 'field', id: nextName, label: String(def.label ?? nextName) });
   };
 
+  // Derive the API name from the label (on blur, so we use the complete
+  // string — not per keystroke, which would churn the field key) while the
+  // name is still an auto-generated default and the user hasn't customised it.
+  // Mirrors the object Name behaviour; slugify() returns '' for non-Latin
+  // labels, in which case the unique default name is kept.
+  const maybeDeriveName = (label: string) => {
+    if (readOnly) return;
+    const base = type === 'select' ? 'status' : type;
+    const isAutoName =
+      entry.name === base ||
+      (entry.name.startsWith(`${base}_`) && /^\d+$/.test(entry.name.slice(base.length + 1)));
+    if (!isAutoName) return;
+    const derived = slugify(label);
+    if (!derived || derived === entry.name) return;
+    if (view.entries.some((e, i) => i !== idx && e.name === derived)) return;
+    const nextEntries = [...view.entries];
+    nextEntries[idx] = { ...entry, name: derived };
+    writeView({ shape: view.shape, entries: nextEntries });
+    onSelectionChange?.({ kind: 'field', id: derived, label: String(def.label ?? derived) });
+  };
+
   const removeField = () => {
     const nextEntries = view.entries.filter((_, i) => i !== idx);
     writeView({ shape: view.shape, entries: nextEntries });
@@ -297,6 +319,7 @@ export function ObjectFieldInspector({
           label={tr('designer.field.label')}
           value={typeof def.label === 'string' ? (def.label as string) : ''}
           onCommit={(v) => patchDef({ label: v })}
+          onBlur={maybeDeriveName}
           disabled={readOnly}
         />
         <InspectorSelectField
@@ -352,6 +375,7 @@ export function ObjectFieldInspector({
         <Section title={tFormat('designer.field.section.options', locale, { type: typeMetaLabel ?? type })}>
           {isPicklist(type) && (
             <OptionsEditor
+              key={entry.name}
               options={options}
               onChange={patchOptions}
               disabled={readOnly}
@@ -685,26 +709,38 @@ function OptionsEditor({
   disabled?: boolean;
   locale?: string;
 }) {
-  const update = (i: number, patch: Partial<Option>) => {
-    const next = [...options];
-    next[i] = { ...next[i], ...patch };
-    onChange(next);
+  // Local editing buffer. We keep a blank trailing row visible for input but
+  // only PERSIST rows whose `value` is non-empty — otherwise the blank row
+  // fails the spec identifier rule ("System identifier must be at least 2
+  // characters") and shows a confusing error mid-edit. The editor is remounted
+  // per field (key={entry.name}), so seeding from `options` once is correct.
+  const [rows, setRows] = React.useState<Option[]>(
+    () => (options.length > 0 ? options : [{ value: '', label: '' }]),
+  );
+  const commit = (next: Option[]) => {
+    setRows(next);
+    onChange(next.filter((o) => o.value.trim() !== ''));
   };
-  const remove = (i: number) => onChange(options.filter((_, j) => j !== i));
-  const move = (i: number, to: number) => onChange(moveArray(options, i, to));
-  const add = () => onChange([...options, { value: '', label: '' }]);
+  const update = (i: number, patch: Partial<Option>) => {
+    const next = [...rows];
+    next[i] = { ...next[i], ...patch };
+    commit(next);
+  };
+  const remove = (i: number) => commit(rows.filter((_, j) => j !== i));
+  const move = (i: number, to: number) => commit(moveArray(rows, i, to));
+  const add = () => commit([...rows, { value: '', label: '' }]);
 
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
         <Label className="text-xs text-muted-foreground">{t('designer.field.picklistValues', locale)}</Label>
-        <Badge variant="outline" className="text-[10px]">{options.length}</Badge>
+        <Badge variant="outline" className="text-[10px]">{rows.length}</Badge>
       </div>
-      {options.length === 0 ? (
+      {rows.length === 0 ? (
         <div className="text-[11px] italic text-muted-foreground px-1">{t('designer.field.noValues', locale)}</div>
       ) : (
         <div className="space-y-1">
-          {options.map((o, i) => (
+          {rows.map((o, i) => (
             <div key={i} className="flex items-center gap-1">
               <Input
                 value={o.value}
@@ -743,7 +779,7 @@ function OptionsEditor({
                 size="sm"
                 className="h-7 w-7 p-0"
                 onClick={() => move(i, i + 1)}
-                disabled={disabled || i === options.length - 1}
+                disabled={disabled || i === rows.length - 1}
                 aria-label={t('designer.field.moveDown', locale)}
               >
                 <ArrowDown className="h-3 w-3" />

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -43,7 +43,7 @@ import { useObjectFields } from '../previews/useObjectFields';
 import {
   readFields,
   writeFields,
-  toFieldName,
+  toFieldNameLoose,
   indexOfField,
   type FieldsView,
   type FieldEntry,
@@ -184,7 +184,7 @@ export function ObjectFieldInspector({
   };
 
   const setKey = (rawNext: string) => {
-    const nextName = toFieldName(rawNext);
+    const nextName = toFieldNameLoose(rawNext);
     if (!nextName || nextName === entry.name) return;
     // Disallow collision
     if (view.entries.some((e, i) => i !== idx && e.name === nextName)) return;

--- a/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
@@ -135,6 +135,7 @@ export function InspectorTextField({
   label,
   value,
   onCommit,
+  onBlur,
   placeholder,
   disabled,
   mono,
@@ -142,6 +143,8 @@ export function InspectorTextField({
   label: string;
   value: string;
   onCommit: (v: string) => void;
+  /** Fired on blur with the final value — e.g. to derive a dependent field. */
+  onBlur?: (v: string) => void;
   placeholder?: string;
   disabled?: boolean;
   mono?: boolean;
@@ -152,6 +155,7 @@ export function InspectorTextField({
       <Input
         value={value}
         onChange={(e) => onCommit(e.target.value)}
+        onBlur={(e) => onBlur?.(e.target.value)}
         placeholder={placeholder}
         disabled={disabled}
         className={cn('h-8 text-sm', mono && 'font-mono')}

--- a/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.test.ts
@@ -4,6 +4,8 @@ import { describe, it, expect } from 'vitest';
 import {
   readFields,
   writeFields,
+  toFieldName,
+  toFieldNameLoose,
   readGroups,
   genGroupKey,
   addGroup,
@@ -258,5 +260,72 @@ describe('diffFields', () => {
       { a: { label: 'A', type: 'text' } },
     );
     expect(d.byName.a.status).toBe('unchanged');
+  });
+});
+
+
+/* ─────────────── toFieldName / toFieldNameLoose ─────────────── */
+
+/**
+ * Simulate typing `text` char-by-char into a *controlled* text input whose
+ * onChange re-normalizes via `fn` (exactly how InspectorTextField wires the
+ * object Name and field API-name fields). The controlled value after each
+ * keystroke is `fn(previousValue + char)`.
+ */
+function simulateTyping(fn: (s: string) => string, text: string): string {
+  let value = '';
+  for (const ch of text) value = fn(value + ch);
+  return value;
+}
+
+describe('toFieldName (strict — for complete strings)', () => {
+  it('normalizes complete labels and trims a trailing underscore', () => {
+    expect(toFieldName('Repair Ticket')).toBe('repair_ticket');
+    expect(toFieldName('order-item')).toBe('order_item');
+    expect(toFieldName('report_')).toBe('report'); // trailing trimmed (intended for complete input)
+    expect(toFieldName('a__b')).toBe('a_b');
+    expect(toFieldName('1abc')).toBe('f_1abc');
+    expect(toFieldName('')).toBe('field');
+    expect(toFieldName('报修工单')).toBe('field'); // non-Latin → placeholder
+  });
+
+  it('REGRESSION: typing a multi-word name char-by-char drops underscores', () => {
+    // This is the user-facing bug that motivates toFieldNameLoose: the strict
+    // normalizer eats the trailing "_" the instant it is typed.
+    expect(simulateTyping(toFieldName, 'repair_ticket')).toBe('repairticket');
+  });
+});
+
+describe('toFieldNameLoose (prefix-stable — for live keystroke input)', () => {
+  it('keeps a trailing underscore so mid-word "_" survives typing', () => {
+    expect(toFieldNameLoose('repair_')).toBe('repair_');
+    expect(toFieldNameLoose('a_b')).toBe('a_b');
+    expect(toFieldNameLoose('in_progress')).toBe('in_progress');
+  });
+
+  it('still trims leading underscores, collapses repeats, lowercases', () => {
+    expect(toFieldNameLoose('_x')).toBe('x');
+    expect(toFieldNameLoose('a__b')).toBe('a_b');
+    expect(toFieldNameLoose('Repair Ticket')).toBe('repair_ticket');
+    expect(toFieldNameLoose('order-item')).toBe('order_item');
+    expect(toFieldNameLoose('1abc')).toBe('f_1abc');
+  });
+
+  it('returns "" (not "field") on empty / non-Latin input so the box can clear', () => {
+    expect(toFieldNameLoose('')).toBe('');
+    expect(toFieldNameLoose('   ')).toBe('');
+    expect(toFieldNameLoose('报修工单')).toBe(''); // empty → UI prompts for manual entry
+  });
+
+  it('is idempotent (safe to re-apply every keystroke on a controlled input)', () => {
+    for (const v of ['repair_', 'repair_ticket', 'a_b', 'x']) {
+      expect(toFieldNameLoose(toFieldNameLoose(v))).toBe(toFieldNameLoose(v));
+    }
+  });
+
+  it('FIX: typing a multi-word identifier char-by-char preserves underscores', () => {
+    expect(simulateTyping(toFieldNameLoose, 'repair_ticket')).toBe('repair_ticket');
+    expect(simulateTyping(toFieldNameLoose, 'in_progress')).toBe('in_progress');
+    expect(simulateTyping(toFieldNameLoose, 'estimated_cost')).toBe('estimated_cost');
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts
@@ -73,9 +73,11 @@ export function indexOfField(view: FieldsView, name: string): number {
 /** Build a fresh field definition for the given type. */
 export function newField(name: string, type: FieldTypeId, label?: string): FieldEntry {
   const def: Record<string, unknown> = { type, label: label ?? toLabel(name) };
-  // Seed a single empty option so picklist editor renders a row to fill in.
+  // Picklist-style fields start with no options; the OptionsEditor shows a
+  // blank input row locally and only persists rows once they have a value, so
+  // an unfilled row never trips the spec's identifier validation.
   if (type === 'select' || type === 'multiselect' || type === 'radio' || type === 'checkboxes') {
-    def.options = [{ value: '', label: '' }];
+    def.options = [];
   }
   return { name, def };
 }

--- a/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts
@@ -103,6 +103,38 @@ export function toFieldName(raw: string): string {
 }
 
 /**
+ * Prefix-stable variant of {@link toFieldName} for *live keystroke* input.
+ *
+ * The strict `toFieldName` trims a trailing `_`, which makes it impossible
+ * to TYPE a multi-word identifier into a controlled input: the field's
+ * `onChange` re-normalizes on every keystroke, so the instant the user
+ * presses `_` the value is `"repair_"` -> trimmed to `"repair"` -> the
+ * underscore vanishes before the next letter arrives, yielding
+ * `"repairticket"` instead of `"repair_ticket"`. (Authors of non-Latin
+ * locales hit this hardest: their label cannot derive a Latin slug, so
+ * they MUST type the identifier by hand.)
+ *
+ * This variant keeps a single trailing `_` so typing can continue, and
+ * returns `''` (not the `'field'` placeholder) on empty input so clearing
+ * the box actually clears it. A trailing `_` is itself a valid identifier
+ * per the spec ("starts with a letter, may contain letters/digits/`_`"),
+ * so no separate commit-time trim is required for correctness; callers
+ * that need a canonical form for a *complete* string (label->name
+ * derivation, group keys) should keep using strict `toFieldName`.
+ */
+export function toFieldNameLoose(raw: string): string {
+  const sanitized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+/g, '') // trim leading only -- a trailing `_` must survive
+    .replace(/_{2,}/g, '_');
+  if (!sanitized) return '';
+  if (!/^[a-z_]/.test(sanitized)) return `f_${sanitized}`;
+  return sanitized;
+}
+
+/**
  * A declared field group (a.k.a. "section"). Lives at the object's
  * top level as `draft.fieldGroups`; individual fields opt into a group
  * via `Field.group === FieldGroup.key`.


### PR DESCRIPTION
## Summary

Six fixes for the Studio metadata designer, found by dogfooding the console as a business user (building an object end-to-end, then exercising it at runtime). The platform's **runtime** data layer proved solid (CRUD + required/picklist/number/date validation all enforced server-side); every issue was in the **authoring UX**.

Each fix was verified in the browser against a live backend via the dev console (`pnpm dev` → Vite on :5181, `/api` proxied to a real :3000 instance).

| # | Problem | Fix |
|---|---------|-----|
| **F2** | Object **Name** / field **API-name** silently drop `_` while typing (`repair_ticket` → `repairticket`); non-Latin labels collapse to the literal `field`. Root cause: `InspectorTextField` is a controlled input that re-runs the strict `toFieldName` on every keystroke, and its trailing-`_` trim eats the underscore the instant it's typed. | Add prefix-stable `toFieldNameLoose` (keeps a trailing `_`, returns `''` not `field` on empty) for live-typing inputs; keep strict `toFieldName` for complete-string callers (group keys); switch label→name derivation to `slugify` (its documented "empty for non-Latin → prompt" contract). |
| **F1** | A newly created package doesn't appear in the active-package switcher until a full page reload. | `useSelectorOptions` refetches on dropdown-open and on a global `objectui:packages-changed` event, which `PackagesPage` dispatches after a successful create. |
| **F3** | A field's API-name never derives from its label (only the object Name does). | Optional `onBlur` on `InspectorTextField`; the field inspector derives the API-name from the label on blur — only while the name is still an auto-generated default (`text`, `text_2`, …), so manual names are never clobbered. |
| **F4** | Adding a picklist / clicking "Add value" creates an empty option row that immediately fails spec validation with a developer-oriented "System identifier must be at least 2 characters". | `newField` seeds no options; `OptionsEditor` keeps blank rows in a local buffer and persists only rows whose value is non-empty. |
| **F5** | The Source tab renders a permanent blank when Monaco's (CDN-loaded) core or web workers are unavailable — offline / air-gapped / CSP-restricted installs. | `JsonSourceEditor` detects that nothing painted (`.view-line`) and falls back to a plain, editable textarea showing the JSON source. |
| **F6** | A user's own object, after publishing to a project package, shows "This item is shipped by a code package and cannot be modified at runtime" — misleading, with no stated edit path. | Reworded `artifactLockedBanner` (en + zh) to "provided by an installed package … edit it in its source package and republish — or create a new {type} from scratch" — accurate for both platform and project packages, and states the real edit path. (The read-only-after-publish behavior itself is intentional governance and is unchanged.) |

## Verification

- **Unit:** `object-fields-io.test.ts` — 32 pass, incl. a controlled-input typing simulation that reproduces the old `repairticket` regression and proves the fix yields `repair_ticket`.
- **In-browser (live backend):** F1 (new package appears without reload), F2 (`work_order` typed keystroke-by-keystroke through the real onChange pipeline), F3 (`Asset Code` → `asset_code` on blur), F4 (no validation banner on empty rows), F5 (textarea fallback shows the draft JSON), F6 (accurate banner on a published object).
- Changed files add **zero** new lint errors/warnings.

## Notes

- Console UI only; no schema/runtime changes.
- F5 also improves the offline/air-gapped story (Monaco core is CDN-loaded by default with no fallback today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)