### PR TITLE
fix(console): resolve ctx.user-gated record-header actions for platform admins

### DIFF
--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -482,8 +482,20 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
   }
 
   const expressionUser = user
-    ? { name: user.name, email: user.email, role: user.role ?? 'user' }
-    : { name: 'Anonymous', email: '', role: 'guest' };
+    ? {
+        id: (user as any).id,
+        name: user.name,
+        email: user.email,
+        role: user.role ?? 'user',
+        roles: (user as any).roles,
+        // Surface the platform-admin flag so action `visible` CEL predicates
+        // gated on `ctx.user.isPlatformAdmin == true` (e.g. sys_environment
+        // "Change Plan (admin)") evaluate correctly. Previously only
+        // name/email/role were forwarded → isPlatformAdmin-gated actions were
+        // hidden even for platform admins.
+        isPlatformAdmin: (user as any).isPlatformAdmin ?? false,
+      }
+    : { name: 'Anonymous', email: '', role: 'guest', isPlatformAdmin: false };
 
   return (
     <ExpressionProvider user={expressionUser} app={activeApp} data={{}} features={features}>

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { ComponentRegistry, ExpressionEvaluator } from '@object-ui/core';
-import { useRecordContext, useAction } from '@object-ui/react';
+import { useRecordContext, useAction, usePredicateScope } from '@object-ui/react';
 import { renderChildren, cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { RelatedCountStore, useRelatedCount } from '../../hooks/related-count-store';
@@ -664,6 +664,13 @@ export function cleanupTitleSeparators(s: string): string {
 const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { designer } = splitDesignerProps(props);
   const ctx = useRecordContext();
+  // Ambient host scope (signed-in user / app / features), fed by app-shell's
+  // ExpressionProvider. Needed so header-action `visible` CEL predicates can
+  // gate on `ctx.user.*` (e.g. sys_environment "Change Plan (admin)" →
+  // `ctx.user.isPlatformAdmin == true`). Without it the action-visibility
+  // evalCtx below only had record fields, so every `ctx.user`-gated header
+  // action was silently filtered out.
+  const predicateScope = usePredicateScope();
   const { execute } = useAction();
   const { objectLabel: tObjectLabel, actionLabel: tActionLabel } = useObjectLabel();
   const { fieldOptionLabel } = useSafeFieldLabel();
@@ -717,10 +724,23 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     // this, bare identifiers fall through to the JS global scope and silently
     // resolve to e.g. `window.status` (empty string), causing every action
     // with a `visible` expression to be filtered out.
+    // Carry the ambient host scope (user / app / features) and expose the
+    // canonical `ctx.*` namespace so `ctx.user.isPlatformAdmin`-style
+    // predicates resolve — alongside the record fields spread for bare
+    // `status`/`is_default` CEL.
+    const scopeUser = (predicateScope as any)?.user;
     const evalCtx = {
       ...(recordData && typeof recordData === 'object' ? recordData : {}),
       record: recordData,
       data: recordData,
+      user: scopeUser,
+      ctx: {
+        user: scopeUser,
+        record: recordData,
+        data: recordData,
+        app: (predicateScope as any)?.app,
+        features: (predicateScope as any)?.features,
+      },
     };
     const evaluator = new ExpressionEvaluator(evalCtx);
     const evalExpr = (src: string): any => {
@@ -795,7 +815,7 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       out.push(a);
     }
     return out;
-  }, [rawHeaderActions, hostSystemActions, ctx?.data]);
+  }, [rawHeaderActions, hostSystemActions, ctx?.data, predicateScope]);
 
   const renderHeaderActions = () => {
     if (headerActions.length === 0) return null;


### PR DESCRIPTION
## Problem

Record-header action menus (the env detail "⋯" overflow, drawer peek + full-page) silently hid every action gated on `ctx.user.*`. Concretely, `sys_environment`'s **"Change Plan (admin)"** action (`visible: '… && ctx.user.isPlatformAdmin == true'`) never showed — even for platform admins — so super-admins had **no UI path** to comp/override an environment's plan; only the API/CLI worked.

## Root cause

The record-header overflow is rendered by `PageHeaderRenderer` (`packages/components/src/renderers/layout/containers.tsx`). Its `headerActions` filter built the visibility `evalCtx` from the **record only** (`{ ...record, record, data }`). So record-field predicates like `status == "active"` / `plan != "free"` resolved, but `ctx.user.isPlatformAdmin` hit an **undefined `ctx`** → the expression evaluated to `undefined` → `if (!result) return false` filtered the action out.

A second, contributing gap: `AppContent.tsx`'s `expressionUser` forwarded only `{ name, email, role }`, dropping `isPlatformAdmin` from the ambient predicate scope's user.

## Fix (2 files)

- **`containers.tsx`** — `PageHeaderRenderer` now reads `usePredicateScope()` and merges the ambient host scope's `user` plus a canonical `ctx.*` namespace (`{ user, record, data, app, features }`) into the header-action visibility `evalCtx`, alongside the existing record-field spread.
- **`AppContent.tsx`** — `expressionUser` now forwards `id / roles / isPlatformAdmin`, so the ambient scope's user carries the platform-admin flag the predicates gate on.

No metadata or backend changes — the action definition and the cloud `change_plan` handler were already correct.

## Verification

Browser-verified end-to-end against the local cloud console (platform admin, `sys_environment`):
- "Change Plan (admin)" now renders in **both** the record drawer peek and the full-page record view.
- Selecting a paid plan (Business) → Confirm → "Plan updated.", **no payment / checkout**; DB shows `plan=business` with `sys_billing_subscription=[]` and `sys_billing_transaction=[]`.
- Downgrade Business→Free via the same UI also works; record-field-gated actions (e.g. `buy_credits` on `plan != "free"`) continue to evaluate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)