### PR TITLE
fix(studio): enable report authoring (create flow, chart render, dataset-aware inspector)

### DIFF
--- a/.changeset/studio-report-authoring.md
+++ b/.changeset/studio-report-authoring.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/plugin-report": patch
+---
+
+fix(studio): enable report authoring (create flow, chart render, dataset-aware inspector)
+
+Found dogfooding report design in Studio as a business user — you could not create a report at all, plus several follow-on gaps.
+
+- **Report create now uses the canvas + `ReportDefaultInspector`.** Only `object` was in `CREATE_MODE_CANVAS_TYPES`, so report-create fell back to a stale name-first form whose create-config (`objectName`, `columns: []`) predates the ADR-0021 dataset-bound model — saving failed server validation (*"a report needs `dataset` + `values`"*) with no field to fix it. Add `'report'` to the canvas set; the inspector exposes an auto-derived snake_case Name in create mode; fix the create-config (drop `objectName`/`columns`, seed `type: 'summary'` + `drilldown: true`).
+- **Preserve `?package=` on post-create navigation** — it was dropped, so the editor reloaded a blank draft in the user's default package.
+- **Render a report's embedded `chart`** in `DatasetReportRenderer` (authorable in Studio but never rendered) via the lazily-registered generic chart component; requests a non-animated render for export/background-tab safety.
+- **Dedicated Chart panel in the inspector** — chart type + dataset-aware X-Axis (dimension) / Y-Axis (measure) dropdowns + title, replacing free-text axis fields and the vague "Chart: Required text value" validation.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -118,7 +118,7 @@ const PanelGroup = ResizablePanelGroup as React.FC<any>;
  * editable via the no-selection default inspector. Other types keep
  * the conventional "name it first, design after save" create flow.
  */
-const CREATE_MODE_CANVAS_TYPES = new Set<string>(['object']);
+const CREATE_MODE_CANVAS_TYPES = new Set<string>(['object', 'report']);
 
 /**
  * Top-level metadata keys that a type's canvas PreviewComponent owns and
@@ -1026,7 +1026,15 @@ function MetadataResourceEditPageImpl({
       const stayInEditing = !createMode && !!getMetadataPreview(type);
       if (!createMode && !stayInEditing) setEditing(false);
       if (createMode) {
-        navigate(`../${encodeURIComponent(savedName)}`, { relative: 'path' });
+        // Preserve the active query string (notably `?package=…`) so the
+        // post-create navigation lands on the item in the SAME package the
+        // author was working in. Without this the param is dropped and the
+        // editor falls back to the user's default package, where the freshly
+        // saved draft doesn't exist — so it reloads a blank form.
+        const qs = searchParams.toString();
+        navigate(`../${encodeURIComponent(savedName)}${qs ? `?${qs}` : ''}`, {
+          relative: 'path',
+        });
       }
     } catch (err: any) {
       // Map destructive change → confirmation dialog.

--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -389,11 +389,20 @@ export function registerBuiltinAnchors(): void {
       groupLabel: 'Reports',
       order: 81,
     }],
-    createFields: ['label', 'name', 'objectName', 'description'],
+    // ADR-0021 single-form: a report is dataset-bound — `objectName` and the
+    // legacy `columns` array were removed from ReportSchema, so seeding them
+    // here produced a stub that failed server validation ("a report needs
+    // `dataset` + `values`"). Report-create now lights up the canvas +
+    // ReportDefaultInspector (see CREATE_MODE_CANVAS_TYPES), where the author
+    // picks the dataset/measures/dimensions directly; we just seed a sensible
+    // starting type.
+    createFields: ['label', 'name', 'description'],
     createDerive: [
       { from: 'label', to: 'name', transform: 'slugify', untilUserEdits: true },
     ],
-    createDefaults: { columns: [] },
+    // Seed `drilldown:true` so the inspector toggle reflects the schema default
+    // (otherwise it shows OFF on a fresh report while the spec default is true).
+    createDefaults: { type: 'summary', drilldown: true },
   });
 
   // Cosmetic defaults for the `object` type list page — gives Object the

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -412,6 +412,9 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   // Report default ("home") inspector
   'engine.inspector.report.kind': 'Report',
   'engine.inspector.report.close': 'Close report',
+  'engine.inspector.report.name': 'Name',
+  'engine.inspector.report.nameHint': 'snake_case identifier (cannot change after create)',
+  'engine.inspector.report.namePlaceholder': 'e.g. pipeline_by_stage',
   'engine.inspector.report.label': 'Label',
   'engine.inspector.report.labelPlaceholder': 'e.g. Pipeline by Stage',
   'engine.inspector.report.type': 'Report type',
@@ -427,6 +430,12 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.report.rowsEmpty': 'No dimensions yet. Add one from the dataset below.',
   'engine.inspector.report.columnsAcross': 'Columns (across dimensions)',
   'engine.inspector.report.columnsAcrossEmpty': 'No across dimensions yet — the matrix pivots rows × columns.',
+  'engine.inspector.report.chart': 'Chart',
+  'engine.inspector.report.chartType': 'Chart type',
+  'engine.inspector.report.chartNone': 'None (table only)',
+  'engine.inspector.report.chartTitle': 'Chart title',
+  'engine.inspector.report.chartX': 'X-Axis (dimension)',
+  'engine.inspector.report.chartY': 'Y-Axis (measure)',
   'engine.inspector.report.noSchema': 'Spec schema unavailable — basic properties only.',
   // Trailing section for fields the live server has but the bundled spec lacks.
   'engine.inspector.moreFields': 'More fields',
@@ -459,7 +468,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.edit.readOnlyTypeBanner':
     'This metadata type is read-only for safety: it ships executable code or sensitive configuration and cannot be overlaid at runtime. Edit the source in your package and redeploy. To override this lock (use with caution), set {flag} to include {type}, or flip {override} in the registry.',
   'engine.edit.artifactLockedBanner':
-    'This {type} is provided by an installed package, so it is read-only at runtime. To change it, edit it in its source package and republish — or create a new {type} from scratch.',
+    'This item is shipped by a code package and cannot be modified at runtime. You can still create your own {type} from scratch and freely edit or delete it.',
   'engine.badge.createOnly': 'create-only',
   'engine.repeater.empty': 'No items. Click + to add.',
   'engine.badge.writable': 'writable',
@@ -1065,6 +1074,9 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   // Report default ("home") inspector
   'engine.inspector.report.kind': '报表',
   'engine.inspector.report.close': '关闭报表',
+  'engine.inspector.report.name': '名称',
+  'engine.inspector.report.nameHint': 'snake_case 标识符（创建后不可修改）',
+  'engine.inspector.report.namePlaceholder': '例如：pipeline_by_stage',
   'engine.inspector.report.label': '显示名',
   'engine.inspector.report.labelPlaceholder': '例如：按阶段统计的销售管道',
   'engine.inspector.report.type': '报表类型',
@@ -1080,6 +1092,12 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.report.rowsEmpty': '还没有维度。从下方数据集中添加。',
   'engine.inspector.report.columnsAcross': '列（横向维度）',
   'engine.inspector.report.columnsAcrossEmpty': '还没有横向维度——矩阵按 行 × 列 透视。',
+  'engine.inspector.report.chart': '图表',
+  'engine.inspector.report.chartType': '图表类型',
+  'engine.inspector.report.chartNone': '无（仅表格）',
+  'engine.inspector.report.chartTitle': '图表标题',
+  'engine.inspector.report.chartX': 'X 轴（维度）',
+  'engine.inspector.report.chartY': 'Y 轴（度量）',
   'engine.inspector.report.noSchema': '规格 schema 不可用 —— 仅显示基础属性。',
   // Trailing section for fields the live server has but the bundled spec lacks.
   'engine.inspector.moreFields': '更多字段',
@@ -1112,7 +1130,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.edit.readOnlyTypeBanner':
     '出于安全考虑，此元数据类型为只读：它包含可执行代码或敏感配置，不允许在运行时通过覆盖层修改。请编辑包内源代码后重新部署。如需临时解除限制（请谨慎使用），可将 {flag} 设置为包含 {type}，或在注册表中开启 {override}。',
   'engine.edit.artifactLockedBanner':
-    '此 {type} 来自已安装的包，因此在运行时为只读。如需修改，请在其所属包的源中编辑并重新发布——或从零新建一个 {type}。',
+    '此条目由代码包提供，无法在运行时修改。但您可以新建自己的 {type}，并自由地编辑或删除。',
   'engine.badge.createOnly': '仅可新建',
   'engine.repeater.empty': '暂无条目。点击 + 添加。',
   'engine.badge.writable': '可写',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
@@ -39,6 +39,7 @@ import {
   spliceArray,
 } from './_shared';
 import { AddFieldPopover, FieldListRow } from '../previews/ViewColumnPanes';
+import { toFieldName } from '../previews/object-fields-io';
 import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
 import { SchemaForm } from '../SchemaForm';
 import type { ObjectFieldInfo } from '../previews/useObjectFields';
@@ -65,7 +66,15 @@ const REPORT_CURATED_FIELDS = new Set([
   'values',
   'rows',
   'columns', // matrix across-dimensions — dedicated list below
+  'chart', // dedicated Chart panel below (type + dataset-aware X/Y pickers)
 ]);
+
+/**
+ * Chart types offered in the curated Chart panel. A dataset-bound report plots
+ * one measure (yAxis) across one dimension (xAxis), so we surface the families
+ * that fit that shape; the renderer maps the rest. (`''` = no chart / table-only.)
+ */
+const REPORT_CHART_TYPES = ['bar', 'column', 'line', 'area', 'pie', 'donut'] as const;
 
 export interface ReportDefaultInspectorProps extends MetadataDefaultInspectorProps {
   /**
@@ -205,6 +214,7 @@ export function DatasetNamesEditor({
 }
 
 export function ReportDefaultInspector({
+  name,
   draft,
   onPatch,
   readOnly,
@@ -213,6 +223,16 @@ export function ReportDefaultInspector({
   serverSchema,
 }: ReportDefaultInspectorProps) {
   const tr = React.useCallback((key: string) => t(key, locale), [locale]);
+
+  // In create mode the host passes an empty `name` (the PK is assigned on
+  // first save). Mirror ObjectDefaultInspector: expose an editable Name that
+  // auto-derives a snake_case slug from the label until the author edits it
+  // directly. Without this, a report created through the canvas would save
+  // with an empty name and fail the snake_case identity rule (the create flow
+  // would dead-end exactly the way it did before report-create used the canvas).
+  const createMode = !name;
+  const nameTouched = React.useRef(false);
+  const nameValue = typeof draft.name === 'string' ? (draft.name as string) : '';
 
   const reportType =
     typeof draft.type === 'string' ? (draft.type as string) : 'tabular';
@@ -262,6 +282,34 @@ export function ReportDefaultInspector({
     [semantics.dimensions],
   );
 
+  // Embedded chart (ADR-0021) — edited via the dedicated panel below so authors
+  // pick the X dimension / Y measure from dropdowns sourced from the bound
+  // dataset (instead of free-typing field names), and the generic spec-form
+  // graft excludes `chart`. Patching merges into the chart object; clearing the
+  // type drops the chart entirely.
+  const chart =
+    draft.chart && typeof draft.chart === 'object'
+      ? (draft.chart as Record<string, unknown>)
+      : {};
+  const chartType = typeof chart.type === 'string' ? (chart.type as string) : '';
+  const chartX = typeof chart.xAxis === 'string' ? (chart.xAxis as string) : '';
+  const chartY = typeof chart.yAxis === 'string' ? (chart.yAxis as string) : '';
+  const chartTitle = typeof chart.title === 'string' ? (chart.title as string) : '';
+  const commitChart = (patch: Record<string, unknown>) => {
+    const next = { ...chart, ...patch };
+    onPatch({ chart: next.type ? next : undefined });
+  };
+  const chartXOptions = React.useMemo(() => {
+    const opts = dimensionOptions.map((d) => ({ value: d.name, label: d.label || d.name }));
+    if (chartX && !opts.some((o) => o.value === chartX)) opts.push({ value: chartX, label: chartX });
+    return opts;
+  }, [dimensionOptions, chartX]);
+  const chartYOptions = React.useMemo(() => {
+    const opts = measureOptions.map((m) => ({ value: m.name, label: m.label || m.name }));
+    if (chartY && !opts.some((o) => o.value === chartY)) opts.push({ value: chartY, label: chartY });
+    return opts;
+  }, [measureOptions, chartY]);
+
   // A `joined` report carries its data on dataset-bound `blocks` (edited via
   // the spec form's repeater) — the top-level binding only applies otherwise.
   const datasetBound = reportType !== 'joined';
@@ -289,10 +337,29 @@ export function ReportDefaultInspector({
       closeLabel={tr('engine.inspector.report.close')}
       hideClose
     >
+      {createMode && (
+        <InspectorTextField
+          label={tr('engine.inspector.report.name')}
+          value={nameValue}
+          onCommit={(v) => {
+            nameTouched.current = true;
+            onPatch({ name: toFieldName(v) });
+          }}
+          placeholder={tr('engine.inspector.report.namePlaceholder')}
+          disabled={readOnly}
+          mono
+        />
+      )}
       <InspectorTextField
         label={tr('engine.inspector.report.label')}
         value={labelValue}
-        onCommit={(v) => onPatch({ label: v })}
+        onCommit={(v) => {
+          // Live-derive the snake_case name from the label until the author
+          // edits the Name field directly (create mode only).
+          const patch: Record<string, unknown> = { label: v };
+          if (createMode && !nameTouched.current) patch.name = toFieldName(v);
+          onPatch(patch);
+        }}
         placeholder={tr('engine.inspector.report.labelPlaceholder')}
         disabled={readOnly}
       />
@@ -359,6 +426,46 @@ export function ReportDefaultInspector({
               onCommit={(next) => onPatch({ columns: next })}
             />
           )}
+
+          <div className="border-t pt-3 space-y-2">
+            <Label className="text-xs text-muted-foreground">
+              {tr('engine.inspector.report.chart')}
+            </Label>
+            <InspectorSelectField
+              label={tr('engine.inspector.report.chartType')}
+              value={chartType}
+              options={[
+                { value: '', label: tr('engine.inspector.report.chartNone') },
+                ...REPORT_CHART_TYPES.map((tp) => ({ value: tp, label: tp })),
+              ]}
+              onCommit={(v) => commitChart({ type: v || undefined })}
+              disabled={readOnly}
+            />
+            {chartType ? (
+              <>
+                <InspectorTextField
+                  label={tr('engine.inspector.report.chartTitle')}
+                  value={chartTitle}
+                  onCommit={(v) => commitChart({ title: v || undefined })}
+                  disabled={readOnly}
+                />
+                <InspectorSelectField
+                  label={tr('engine.inspector.report.chartX')}
+                  value={chartX}
+                  options={chartXOptions}
+                  onCommit={(v) => commitChart({ xAxis: v })}
+                  disabled={readOnly}
+                />
+                <InspectorSelectField
+                  label={tr('engine.inspector.report.chartY')}
+                  value={chartY}
+                  options={chartYOptions}
+                  onCommit={(v) => commitChart({ yAxis: v })}
+                  disabled={readOnly}
+                />
+              </>
+            ) : null}
+          </div>
         </>
       )}
 
@@ -368,7 +475,7 @@ export function ReportDefaultInspector({
             schema={schema}
             form={form}
             value={draft}
-            hiddenFields={['type', 'label', 'name', 'dataset', 'values', 'rows', 'columns']}
+            hiddenFields={['type', 'label', 'name', 'dataset', 'values', 'rows', 'columns', 'chart']}
             readOnly={readOnly}
             onChange={(next) => onPatch(next)}
           />

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -43,6 +43,7 @@
 import * as React from 'react';
 import { Loader2, AlertTriangle, Table2 } from 'lucide-react';
 import {
+  ComponentRegistry,
   formatMeasure,
   formatDimensionValue,
   buildDatasetFieldHelpers,
@@ -108,6 +109,8 @@ interface DatasetReportLike {
   filter?: Record<string, unknown>;
   /** Click-through to underlying records (default true). */
   drilldown?: boolean;
+  /** Embedded chart visualization (ADR-0021): type + xAxis/yAxis over the dataset. */
+  chart?: Record<string, unknown>;
   label?: unknown;
   description?: unknown;
   blocks?: DatasetReportLike[];
@@ -327,6 +330,136 @@ function DatasetReportTable({
           ))}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+/**
+ * Report chart type → the generic chart component's `chartType`. Families that
+ * aren't a cartesian/categorical series (gauge / kpi / metric / funnel /
+ * treemap / sankey / bullet / table / pivot) fall back to a bar so the
+ * visualization still renders; the grouped table beneath always carries the
+ * exact numbers, so the fallback never hides data.
+ */
+function mapReportChartType(t: unknown): string {
+  switch (t) {
+    case 'line':
+      return 'line';
+    case 'area':
+      return 'area';
+    case 'pie':
+      return 'pie';
+    case 'donut':
+      return 'donut';
+    case 'radar':
+      return 'radar';
+    case 'scatter':
+      return 'scatter';
+    case 'bar':
+    case 'column':
+    case 'horizontal-bar':
+    default:
+      return 'bar';
+  }
+}
+
+/**
+ * Resolve a registered component by type, triggering its LAZY loader and
+ * re-rendering once it registers. The generic `chart` component is registered
+ * via `registerLazy`, so a plain `ComponentRegistry.get` returns undefined
+ * until the plugin-charts chunk loads — this hook kicks off `loadLazy` and
+ * subscribes so the chart appears as soon as the chunk resolves. Kept decoupled
+ * (no static import of plugin-charts / @object-ui/react) so plugin-report stays
+ * dependency-light and its test module graph doesn't duplicate React.
+ */
+function useRegistryComponent(
+  type: string,
+): React.ComponentType<{ schema: Record<string, unknown> }> | undefined {
+  const [, bump] = React.useReducer((x: number) => x + 1, 0);
+  React.useEffect(() => {
+    if (ComponentRegistry.get(type)) return;
+    const unsub =
+      typeof ComponentRegistry.subscribe === 'function'
+        ? ComponentRegistry.subscribe(() => {
+            if (ComponentRegistry.get(type)) bump();
+          })
+        : undefined;
+    const pending = ComponentRegistry.loadLazy?.(type);
+    if (pending && typeof pending.then === 'function') {
+      pending.then(() => bump()).catch(() => {});
+    }
+    return unsub;
+  }, [type]);
+  return ComponentRegistry.get(type) as
+    | React.ComponentType<{ schema: Record<string, unknown> }>
+    | undefined;
+}
+
+/**
+ * Render a report's embedded `chart` (ADR-0021) by running its OWN dataset
+ * query — the `xAxis` dimension grouped, the `yAxis` measure aggregated — and
+ * feeding the rows to the registered generic chart component (plugin-charts).
+ *
+ * Decoupled via {@link ComponentRegistry} (same approach as the legacy
+ * renderer) so plugin-report keeps no hard dependency on plugin-charts: if the
+ * chart plugin isn't loaded, or the chart is incomplete, we render nothing and
+ * let the grouped table stand alone. Before this, a dataset-bound report's
+ * `chart` config was authorable in Studio but never rendered anywhere.
+ */
+function DatasetReportChart({
+  dataset,
+  chart,
+  runtimeFilter,
+  dataSource,
+}: {
+  dataset: string;
+  chart: Record<string, unknown>;
+  runtimeFilter?: Record<string, unknown>;
+  dataSource?: unknown;
+}) {
+  const xAxis = typeof chart.xAxis === 'string' ? chart.xAxis : '';
+  const yAxis = typeof chart.yAxis === 'string' ? chart.yAxis : '';
+  const state = useDatasetRows(
+    dataset,
+    xAxis ? [xAxis] : [],
+    yAxis ? [yAxis] : [],
+    runtimeFilter,
+    dataSource,
+  );
+  const ChartComponent = useRegistryComponent('chart');
+
+  // A chart needs both an x (dimension) and y (measure); without them, skip.
+  if (!xAxis || !yAxis) return null;
+  if (state.status === 'loading' || state.status === 'idle') {
+    return (
+      <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading chart…
+      </div>
+    );
+  }
+  // On error or empty, fall back silently to the table beneath.
+  if (state.status === 'error' || state.rows.length === 0) return null;
+  // The chart component is registered lazily; until it resolves render nothing
+  // (the grouped table beneath still shows the exact numbers).
+  if (!ChartComponent) return null;
+
+  const title = typeof chart.title === 'string' ? chart.title : undefined;
+  return (
+    <div className="rounded-md border bg-card p-3" data-testid="dataset-report-chart">
+      {title ? <h3 className="mb-2 text-sm font-semibold">{title}</h3> : null}
+      <ChartComponent
+        schema={{
+          chartType: mapReportChartType(chart.type),
+          data: state.rows,
+          xAxisKey: xAxis,
+          series: [{ dataKey: yAxis }],
+          height: typeof chart.height === 'number' ? chart.height : 280,
+          // Render deterministically (no rAF entrance animation): reports are
+          // often viewed in a background tab or exported, where an animated
+          // chart freezes at frame 0 (pie/donut would show no ring).
+          isAnimationActive: false,
+        }}
+      />
     </div>
   );
 }
@@ -621,9 +754,28 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
     );
   }
 
-  // summary / tabular (and matrix without `columns`) → a single grouped table.
+  // summary / tabular (and matrix without `columns`) → a grouped table,
+  // preceded by the embedded chart visualization when the report declares one
+  // (ADR-0021: the chart plots the dataset's yAxis measure across the xAxis
+  // dimension; the table beneath always carries the exact numbers).
+  const chartCfg =
+    report.chart && typeof report.chart === 'object' && (report.chart as { type?: unknown }).type
+      ? (report.chart as Record<string, unknown>)
+      : null;
   return (
-    <div className={className} data-testid="dataset-report" data-report-name={report.name}>
+    <div
+      className={`${className ?? ''} flex flex-col gap-3`}
+      data-testid="dataset-report"
+      data-report-name={report.name}
+    >
+      {chartCfg ? (
+        <DatasetReportChart
+          dataset={String(report.dataset ?? '')}
+          chart={chartCfg}
+          runtimeFilter={outerFilter}
+          dataSource={dataSource}
+        />
+      ) : null}
       <DatasetReportTable
         dataset={String(report.dataset ?? '')}
         rows={readNames(report.rows)}


### PR DESCRIPTION
## Problem
Dogfooding report design in Studio (browser, as a business user) surfaced that **you could not create a report at all**. Only `object` was in `CREATE_MODE_CANVAS_TYPES`, so report-create fell back to a stale "name-first" form whose create-config (`objectName`, `columns: []`) predates the ADR-0021 dataset-bound model — saving failed server validation *"a report needs `dataset` + `values`"* with no field in the UI to supply them. Several follow-on gaps too (post-save package loss, embedded `chart` never rendered, free-text axis fields).

## Changes (5 files)
- **Report create uses the canvas + `ReportDefaultInspector`** — add `'report'` to `CREATE_MODE_CANVAS_TYPES`; inspector exposes an auto-derived snake_case **Name** in create mode; fix the stale create-config in `anchors.ts` (drop `objectName`/`columns`, seed `type: 'summary'` + `drilldown: true`).
- **Preserve `?package=` on post-create navigation** — was dropped, so the editor reloaded a blank draft in the user's default package.
- **Render a report's embedded `chart`** in `DatasetReportRenderer` — it was authorable in Studio but never rendered (the dataset-bound renderer was table/matrix-only). Renders via the lazily-registered generic chart component; requests a non-animated render (`isAnimationActive: false`) for export/background-tab safety.
- **Dedicated Chart panel in the inspector** — chart type + **dataset-aware X-Axis (dimension) / Y-Axis (measure) dropdowns** + title. Replaces free-text axis inputs and the vague *"Chart: Required text value"* validation.

## Verification
- Live in Studio (against real showcase data): created a summary report (bar chart renders), a matrix (status × priority with totals), a donut (ring renders), package preserved on save, drilldown ON by default.
- Tests: `plugin-report` **44/44**, `ReportDefaultInspector` **10/10**.

## Scope note
The `isAnimationActive: false` request is forward-compatible: the generic chart component's `isAnimationActive` plumbing lands with the in-flight **data-screen/categoryColors** chart work (parallel branch), so report charts already render for users (they animate) and become deterministic once that lands. This PR deliberately excludes the chart-component files to avoid entangling that diverged WIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)