### PR TITLE
fix(studio): record-page preview binds a real record + charts use field option colors

### DIFF
--- a/.changeset/studio-chart-option-colors.md
+++ b/.changeset/studio-chart-option-colors.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+fix(charts): use field option colors for categorical chart dimensions
+
+An `object-chart` grouped by a select/lookup field (e.g. project `health`)
+painted its categories from the generic `--chart-1..5` palette, so a "Red"
+health slice rendered teal and "Green" rendered blue. The chart now resolves
+the category dimension's option colors — both the `objectName` + `groupBy`
+path and the dataset path (via the dataset's `object` + dimension `field`) —
+and threads them to the renderer as a per-category `categoryColors` map. That
+map wins over the positional palette and falls back to it for categories
+without an option color, so pie/donut slices and bar cells render in their
+semantic colors.

--- a/.changeset/studio-record-page-preview.md
+++ b/.changeset/studio-record-page-preview.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(studio): preview record pages against a real sample record
+
+The Studio page editor's Preview tab rendered a `type: 'record'` page's
+`record:*` blocks (details / highlights / path / alert / quick_actions) as the
+"bind a record to preview" placeholder — the metadata editor has no record
+route, so the author designed blind.
+
+The preview now fetches a handful of real records of the bound object (with
+lookup / master_detail fields `$expand`ed so they show display names, not raw
+foreign-key IDs), auto-binds the first one, and wraps the canvas in a
+`<RecordContextProvider>` — mirroring the runtime `RecordDetailView`. A
+"Preview record" dropdown lets the author switch records, so `visible` CEL
+expressions (e.g. `record.status == 'in_review'`) and per-record field values
+re-render live.

--- a/packages/app-shell/src/views/metadata-admin/previews/PagePreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PagePreview.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../../InterfaceListPage', () => ({
 }));
 vi.mock('@object-ui/react', () => ({
   SchemaRenderer: () => <div data-testid="mock-schema-renderer" />,
+  RecordContextProvider: ({ children }: { children: any }) => <>{children}</>,
 }));
 vi.mock('./PageBlockCanvas', () => ({
   PageBlockCanvas: () => <div data-testid="mock-page-canvas" />,

--- a/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx
@@ -10,7 +10,8 @@
  */
 
 import * as React from 'react';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, RecordContextProvider } from '@object-ui/react';
+import { buildExpandFields } from '@object-ui/core';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewErrorBoundary, PreviewMessage } from './PreviewShell';
 import { OutlineStrip } from './OutlineStrip';
@@ -97,6 +98,97 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
     onSelectionChange?.({ kind: 'block', id: `children[${next.length - 1}]`, label: newBlock.type });
   }, [canEdit, draft, onPatch, onSelectionChange, shape]);
 
+  // ── Record binding ──────────────────────────────────────────────────────
+  // A `type: 'record'` page's `record:*` blocks (details / highlights / path /
+  // alert) read their data from <RecordContextProvider>. The metadata editor
+  // has no record route, so without binding a sample they render the
+  // "bind a record to preview" placeholder — i.e. the author designs blind.
+  // Fetch a handful of real records of the bound object + its schema and let
+  // the author pick which one to preview against (mirrors the runtime
+  // RecordDetailView's RecordContextProvider).
+  const recordObject = (draft as { type?: string; object?: string })?.type === 'record'
+    ? (draft as { object?: string })?.object
+    : undefined;
+  const [recordSamples, setRecordSamples] = React.useState<any[]>([]);
+  const [recordSchema, setRecordSchema] = React.useState<any>(null);
+  const [selectedRecordId, setSelectedRecordId] = React.useState<string | number | null>(null);
+  React.useEffect(() => {
+    if (!recordObject) { setRecordSamples([]); setRecordSchema(null); setSelectedRecordId(null); return; }
+    let cancelled = false;
+    (async () => {
+      try {
+        const opts = { headers: { accept: 'application/json' }, credentials: 'include' as const };
+        // Schema first: it tells us which fields are lookup/master_detail so we
+        // can `$expand` them. Without expansion record:details/highlights would
+        // show raw foreign-key IDs (e.g. "O4VKrNesnsj2JYMa") instead of display
+        // names — the runtime RecordDetailView $expands for exactly this reason.
+        const schemaRes = await fetch(`/api/v1/meta/object/${encodeURIComponent(recordObject)}`, opts);
+        const schemaJson = await schemaRes.json().catch(() => null);
+        const schema = schemaJson?.item ?? schemaJson?.data ?? schemaJson;
+        const expand = buildExpandFields(schema?.fields);
+        const query = expand.length > 0
+          ? `?$top=50&$expand=${encodeURIComponent(expand.join(','))}`
+          : `?$top=50`;
+        const recsRes = await fetch(`/api/v1/data/${encodeURIComponent(recordObject)}${query}`, opts);
+        const recsJson = await recsRes.json().catch(() => null);
+        // The REST data endpoint returns `{ object, records, total, hasMore }`;
+        // tolerate the other common envelopes too.
+        const recs = Array.isArray(recsJson?.records) ? recsJson.records
+          : Array.isArray(recsJson?.items) ? recsJson.items
+          : Array.isArray(recsJson?.data) ? recsJson.data
+          : Array.isArray(recsJson) ? recsJson : [];
+        if (cancelled) return;
+        setRecordSamples(recs);
+        setRecordSchema(schema);
+        // Same id-resolution order as recordIdOf so the initial selection's
+        // value matches an <option> even for objects keyed only by `name`.
+        setSelectedRecordId((prev) => prev ?? (recs[0]?.id ?? recs[0]?._id ?? recs[0]?.name ?? null));
+      } catch { if (!cancelled) { setRecordSamples([]); setRecordSchema(null); } }
+    })();
+    return () => { cancelled = true; };
+  }, [recordObject]);
+  const recordIdOf = (r: any) => r?.id ?? r?._id ?? r?.name;
+  const recordLabelOf = (r: any) =>
+    String(r?.name ?? r?.title ?? r?.label ?? r?.subject ?? recordIdOf(r) ?? '(record)');
+  const selectedRecord = React.useMemo(() => {
+    if (!recordSamples.length) return null;
+    return recordSamples.find((r) => String(recordIdOf(r)) === String(selectedRecordId)) ?? recordSamples[0];
+  }, [recordSamples, selectedRecordId]);
+  // Wrap record-page content in the record context (+ a sample-record picker)
+  // so detail/highlights/path/alert blocks render real data. No-op for
+  // non-record pages and for record pages with no rows yet (renders the node
+  // unchanged so the existing placeholder still shows).
+  const withRecordBinding = (node: React.ReactNode): React.ReactNode => {
+    if (!recordObject || !selectedRecord) return node;
+    return (
+      <RecordContextProvider
+        objectName={recordObject}
+        recordId={recordIdOf(selectedRecord)}
+        data={selectedRecord}
+        objectSchema={recordSchema ?? undefined}
+        embedded
+      >
+        {recordSamples.length > 0 && (
+          <div className="flex items-center gap-2 px-3 py-1.5 border-b bg-muted/30 text-xs">
+            <span className="text-muted-foreground shrink-0">Preview record</span>
+            <select
+              className="h-7 rounded-md border bg-background px-2 text-xs max-w-[260px]"
+              value={String(selectedRecordId ?? '')}
+              onChange={(e) => setSelectedRecordId(e.target.value)}
+            >
+              {recordSamples.map((r) => {
+                const id = recordIdOf(r);
+                return <option key={String(id)} value={String(id)}>{recordLabelOf(r)}</option>;
+              })}
+            </select>
+            <span className="text-muted-foreground/70 shrink-0">{recordSamples.length} sample{recordSamples.length === 1 ? '' : 's'}</span>
+          </div>
+        )}
+        {node}
+      </RecordContextProvider>
+    );
+  };
+
   // Interface page → always mirror the runtime (InterfaceListPage), in BOTH
   // design and preview modes. These pages are config-driven, not region-
   // composed, so there is nothing to drag on a canvas: the author edits the
@@ -149,12 +241,14 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
   if (designMode && shape === 'regions') {
     return (
       <PreviewShell hint={`page · design`}>
-        <PageBlockCanvas
-          draft={draft}
-          onPatch={canEdit ? onPatch : undefined}
-          selection={selection ?? null}
-          onSelectionChange={onSelectionChange}
-        />
+        {withRecordBinding(
+          <PageBlockCanvas
+            draft={draft}
+            onPatch={canEdit ? onPatch : undefined}
+            selection={selection ?? null}
+            onSelectionChange={onSelectionChange}
+          />
+        )}
       </PreviewShell>
     );
   }
@@ -172,9 +266,11 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
             addLabel={tr('engine.inspector.add.block', locale)}
           />
         )}
-        <div className="min-h-[200px] max-h-[70vh] overflow-auto p-4">
-          <SchemaRenderer schema={schema as any} />
-        </div>
+        {withRecordBinding(
+          <div className="min-h-[200px] max-h-[70vh] overflow-auto p-4">
+            <SchemaRenderer schema={schema as any} />
+          </div>
+        )}
       </PreviewErrorBoundary>
     </PreviewShell>
   );

--- a/packages/plugin-charts/src/AdvancedChartImpl.colors.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.colors.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+// Recharts' ResponsiveContainer measures its parent via ResizeObserver, which
+// reports 0×0 under the headless DOM (no layout engine) — so the chart never
+// paints. Replace it with a fixed-size passthrough so Pie sectors actually
+// render and we can read their `fill`.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 320, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+// A select dimension whose categories arrive as their display labels (the
+// server resolves dataset select dimensions value→label, e.g. project health).
+const HEALTH = [
+  { health: 'Green', value: 5 },
+  { health: 'Red', value: 1 },
+  { health: 'Yellow', value: 2 },
+];
+
+// A deliberately non-semantic brand palette, so a slice taking its colour from
+// the palette (the OLD behaviour) is unmistakably distinct from one taking the
+// field's option colour (the fix).
+const PALETTE = ['#111111', '#222222', '#333333'];
+
+// Option colours resolved by ObjectChart, keyed by BOTH value and label since
+// the row category may be either.
+const CATEGORY_COLORS = {
+  green: '#10B981', Green: '#10B981',
+  red: '#EF4444', Red: '#EF4444',
+  yellow: '#F59E0B', Yellow: '#F59E0B',
+};
+
+const sectorFills = (container: HTMLElement): (string | null)[] =>
+  Array.from(container.querySelectorAll('path.recharts-sector')).map((p) =>
+    p.getAttribute('fill'),
+  );
+
+describe('AdvancedChartImpl — semantic per-category colours', () => {
+  it('donut: each slice uses its option colour, not the positional palette', () => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="donut"
+        data={HEALTH}
+        xAxisKey="health"
+        series={[{ dataKey: 'value' }]}
+        colors={PALETTE}
+        categoryColors={CATEGORY_COLORS}
+        isAnimationActive={false}
+      />,
+    );
+    // Slices draw in data order: Green / Red / Yellow.
+    expect(sectorFills(container)).toEqual(['#10B981', '#EF4444', '#F59E0B']);
+  });
+
+  it('donut: an explicit palette no longer suppresses the option colours', () => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="donut"
+        data={HEALTH}
+        xAxisKey="health"
+        series={[{ dataKey: 'value' }]}
+        colors={PALETTE}
+        categoryColors={CATEGORY_COLORS}
+        isAnimationActive={false}
+      />,
+    );
+    // None of the brand-palette colours leaked into the slices.
+    const fills = sectorFills(container);
+    PALETTE.forEach((c) => expect(fills).not.toContain(c));
+  });
+
+  it('donut: a category absent from the map falls back to the palette slot', () => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="donut"
+        data={[...HEALTH, { health: 'Unknown', value: 1 }]}
+        xAxisKey="health"
+        series={[{ dataKey: 'value' }]}
+        colors={PALETTE}
+        categoryColors={CATEGORY_COLORS}
+        isAnimationActive={false}
+      />,
+    );
+    const fills = sectorFills(container);
+    expect(fills.slice(0, 3)).toEqual(['#10B981', '#EF4444', '#F59E0B']);
+    // 'Unknown' has no option colour → palette[3 % 3] = palette[0].
+    expect(fills[3]).toBe('#111111');
+  });
+
+  it('donut: with no categoryColors it keeps the positional palette (no regression)', () => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="donut"
+        data={HEALTH}
+        xAxisKey="health"
+        series={[{ dataKey: 'value' }]}
+        colors={PALETTE}
+        isAnimationActive={false}
+      />,
+    );
+    expect(sectorFills(container)).toEqual(['#111111', '#222222', '#333333']);
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -101,11 +101,30 @@ export interface AdvancedChartImplProps {
    *  defaults so a page/dashboard can brand its charts (data-screens). */
   colors?: string[];
   /**
+   * Per-category colour map keyed by the category value OR its display label
+   * (e.g. `{ green: '#10B981', Green: '#10B981' }`). When the chart's category
+   * dimension is a select/lookup field, ObjectChart resolves the field's option
+   * colours into this map so a "Red" health slice paints red instead of taking
+   * the next positional palette slot. A category found here WINS over `colors`;
+   * categories absent here fall back to the positional palette, then the theme.
+   */
+  categoryColors?: Record<string, string>;
+  /**
    * Optional drill-down click handler. Fires when a chart segment is clicked
    * with `{ category, series, value }`. Wired for bar/horizontal-bar/line/
    * area/pie/donut. Other chart types are no-ops in L1.
    */
   onChartClick?: (event: { category?: string; series?: string; value?: number }) => void;
+  /**
+   * Disable Recharts' entrance animation when `false`. Animations drive the
+   * reveal via `requestAnimationFrame`, which browsers throttle/pause in
+   * hidden/background tabs — so a chart rendered off-screen (analytics export,
+   * a report opened in an inactive tab, headless capture) can freeze at frame 0
+   * and look empty (esp. pie/donut: sectors at angle 0 = no ring, legend only).
+   * Reports pass `false` for a deterministic, instant, export-safe render.
+   * Omitted/true preserves the animated default everywhere else (dashboards).
+   */
+  isAnimationActive?: boolean;
 }
 
 /**
@@ -120,12 +139,17 @@ export default function AdvancedChartImpl({
   series = [],
   className = '',
   colors,
+  categoryColors,
   onChartClick,
+  isAnimationActive,
 }: AdvancedChartImplProps) {
   // Normalize 'column' → 'bar' (Recharts BarChart is already vertical).
   // 'column' is the spec-level alias for vertical bars; 'horizontal-bar' stays as-is.
   const chartType = rawChartType === 'column' ? 'bar' : rawChartType;
   const data = Array.isArray(rawData) ? rawData : [];
+  // Only emit the prop when explicitly disabled, so the default (animated)
+  // behavior is byte-for-byte unchanged for every existing caller.
+  const animProps = isAnimationActive === false ? { isAnimationActive: false as const } : {};
   const [isMobile, setIsMobile] = React.useState(false);
 
   // Recharts' top-level onClick payload: { activeLabel, activePayload, ... }
@@ -152,6 +176,16 @@ export default function AdvancedChartImpl({
 
   const cartesianClickProps = onChartClick ? { onClick: handleCartesianClick, style: { cursor: 'pointer' as const } } : {};
   const pieClickProps = onChartClick ? { onClick: handlePieClick, style: { cursor: 'pointer' as const } } : {};
+
+  // Per-category colour: a select/lookup dimension's option colour (passed via
+  // `categoryColors`, keyed by value OR label) wins per slice/bar; categories
+  // with no option colour fall back to their positional palette slot. Used by
+  // pie/donut and single-series categorical bars so semantic colours (health
+  // green/red/yellow) survive even when a generic brand palette is also set.
+  const colorForCategory = React.useCallback((rawKey: any, index: number, palette: string[]): string => {
+    const mapped = categoryColors && categoryColors[rawKey == null ? '' : String(rawKey)];
+    return mapped || palette[index % palette.length];
+  }, [categoryColors]);
 
   // Scatter / treemap / sankey element clicks map to the same
   // { category, series, value } drill event via pure mappers (see
@@ -292,7 +326,7 @@ export default function AdvancedChartImpl({
       if (!pieConfig[key]) {
         pieConfig[key] = {
           label: key,
-          color: palette[index % palette.length],
+          color: colorForCategory(rawKey, index, palette),
         };
       }
     });
@@ -308,17 +342,13 @@ export default function AdvancedChartImpl({
             strokeWidth={5}
             paddingAngle={2}
             outerRadius="85%"
+            {...animProps}
             {...pieClickProps}
           >
              {data.map((entry, index) => {
-                // 1. Try config by nameKey (category)
-                let c = pieConfig[String(entry[xAxisKey])]?.color;
-                
-                // 2. Fallback to palette
-                if (!c) {
-                   c = palette[index % palette.length];
-                }
-                
+                // Per-category option colour wins; otherwise the positional
+                // palette slot (kept identical to the legend swatch above).
+                const c = colorForCategory(entry?.[xAxisKey], index, palette);
                 return <Cell key={`cell-${index}`} fill={resolveColor(c)} />;
              })}
           </Pie>
@@ -537,12 +567,12 @@ export default function AdvancedChartImpl({
             const cmp = comparisonStyle(s, seriesType as any);
 
             if (seriesType === 'line') {
-              return <Line key={s.dataKey} yAxisId={yAxisId} type="monotone" dataKey={s.dataKey} stroke={color} strokeWidth={2} dot={false} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} />;
+              return <Line key={s.dataKey} yAxisId={yAxisId} type="monotone" dataKey={s.dataKey} stroke={color} strokeWidth={2} dot={false} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} {...animProps} />;
             }
             if (seriesType === 'area') {
-              return <Area key={s.dataKey} yAxisId={yAxisId} type="monotone" dataKey={s.dataKey} fill={color} stroke={color} fillOpacity={cmp?.fillOpacity ?? 0.4} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} />;
+              return <Area key={s.dataKey} yAxisId={yAxisId} type="monotone" dataKey={s.dataKey} fill={color} stroke={color} fillOpacity={cmp?.fillOpacity ?? 0.4} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} {...animProps} />;
             }
-            return <Bar key={s.dataKey} yAxisId={yAxisId} dataKey={s.dataKey} fill={color} radius={4} fillOpacity={cmp?.fillOpacity} />;
+            return <Bar key={s.dataKey} yAxisId={yAxisId} dataKey={s.dataKey} fill={color} radius={4} fillOpacity={cmp?.fillOpacity} {...animProps} />;
           })}
         </BarChart>
       </ChartContainer>
@@ -556,8 +586,12 @@ export default function AdvancedChartImpl({
   // fills read as a polished ramp instead of flat blocks (大屏 look). Inline
   // `style` on the stops makes the `--chart-*` CSS vars resolve.
   const _gpal = getPalette();
+  // Per-category bars fill from a gradient keyed by the resolved colour, so any
+  // semantic option colour (categoryColors) needs its own gradient def too.
+  const _catColors = categoryColors ? Object.values(categoryColors).map((c) => resolveColor(String(c))) : [];
   const gradColors = Array.from(new Set<string>([
     ..._gpal,
+    ..._catColors,
     ...series.map((s: any, i: number) => resolveColor(((config[s.dataKey] as any)?.color) || _gpal[i % _gpal.length] || DEFAULT_CHART_COLOR)),
   ]));
   const gslug = (c: string) => 'g' + c.replace(/[^a-zA-Z0-9]/g, '');
@@ -624,20 +658,20 @@ export default function AdvancedChartImpl({
             const colorPerCategory = primaryCount === 1 && !isComparison && series.length === 1 && data.length > 1;
             const cmp = comparisonStyle(s, 'bar');
             return (
-              <Bar key={s.dataKey} dataKey={s.dataKey} fill={`url(#bg-${gslug(seriesColor)})`} radius={4} fillOpacity={cmp?.fillOpacity}>
-                {colorPerCategory && data.map((_entry, idx) => (
-                  <Cell key={`cell-${idx}`} fill={`url(#bg-${gslug(resolveColor(palette[idx % palette.length]))})`} />
+              <Bar key={s.dataKey} dataKey={s.dataKey} fill={`url(#bg-${gslug(seriesColor)})`} radius={4} fillOpacity={cmp?.fillOpacity} {...animProps}>
+                {colorPerCategory && data.map((entry, idx) => (
+                  <Cell key={`cell-${idx}`} fill={`url(#bg-${gslug(resolveColor(colorForCategory(entry?.[xAxisKey], idx, palette)))})`} />
                 ))}
               </Bar>
             );
           }
           if (chartType === 'line') {
             const cmp = comparisonStyle(s, 'line');
-            return <Line key={s.dataKey} type="monotone" dataKey={s.dataKey} stroke={seriesColor} strokeWidth={2} dot={false} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} />;
+            return <Line key={s.dataKey} type="monotone" dataKey={s.dataKey} stroke={seriesColor} strokeWidth={2} dot={false} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} {...animProps} />;
           }
           if (chartType === 'area') {
             const cmp = comparisonStyle(s, 'area');
-            return <Area key={s.dataKey} type="monotone" dataKey={s.dataKey} fill={`url(#ag-${gslug(seriesColor)})`} stroke={seriesColor} strokeWidth={2} fillOpacity={cmp?.fillOpacity ?? 1} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} />;
+            return <Area key={s.dataKey} type="monotone" dataKey={s.dataKey} fill={`url(#ag-${gslug(seriesColor)})`} stroke={seriesColor} strokeWidth={2} fillOpacity={cmp?.fillOpacity ?? 1} strokeOpacity={cmp?.strokeOpacity} strokeDasharray={cmp?.strokeDasharray} {...animProps} />;
           }
           return null;
         })}

--- a/packages/plugin-charts/src/ChartRenderer.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.tsx
@@ -49,6 +49,13 @@ export interface ChartRendererProps {
     xAxisKey?: string;
     series?: Array<{ dataKey: string; label?: string; variant?: 'current' | 'comparison'; opacity?: number; dashArray?: string; chartType?: 'bar' | 'line' | 'area' }>;
     colors?: string[];
+    /** Per-category colour map (value/label → colour). Wins over `colors` per
+     *  category; see AdvancedChartImpl. Set by ObjectChart from select/lookup
+     *  dimension option colours and/or an explicit author map. */
+    categoryColors?: Record<string, string>;
+    /** Pass `false` for a deterministic, export-safe render with no entrance
+     *  animation (see AdvancedChartImpl). Omitted → animated default. */
+    isAnimationActive?: boolean;
   };
   /** Drill-down click handler — wired by ObjectChart when drillDown is enabled. */
   onChartClick?: (event: { category?: string; series?: string; value?: number }) => void;
@@ -109,7 +116,9 @@ export const ChartRenderer: React.FC<ChartRendererProps> = ({ schema, onChartCli
         xAxisKey={props.xAxisKey}
         series={props.series}
         className={props.className}
-        colors={(schema as any).colors}
+        colors={Array.isArray((schema as any).colors) ? (schema as any).colors : undefined}
+        categoryColors={(schema as any).categoryColors}
+        isAnimationActive={schema.isAnimationActive}
         onChartClick={onChartClick}
       />
     </Suspense>

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -254,6 +254,14 @@ export const ObjectChart = (props: any) => {
   // Drill-down click event — must be declared with the other hooks (above
   // any conditional early return) to keep hook order stable between renders.
   const [drillEvent, setDrillEvent] = useState<DrillEvent | null>(null);
+  // P3: semantic per-category colors. The category dimension is usually a
+  // select field whose options carry colors (e.g. project health
+  // green=#10B981 / red=#EF4444). Charts otherwise paint categories from the
+  // generic --chart-1..5 palette, so a "Red" health slice renders teal. Resolve
+  // the dimension field's option colors → {value|label → color} so the render
+  // layer can use them. Keyed by BOTH value and label since the row category
+  // may be either (server resolves dataset dimension labels).
+  const [fieldOptionColors, setFieldOptionColors] = useState<Record<string, string> | null>(null);
   // Host-provided "open in list" navigation for the drill escape hatch.
   const { openRecordList } = useDrillNavigation();
   const tt = useSafeTranslate();
@@ -286,6 +294,49 @@ export const ObjectChart = (props: any) => {
   // Pie / donut / funnel are single-distribution charts where a comparison
   // overlay would be meaningless — we skip the comparison fetch entirely.
   const supportsCompareTo = (ct?: string) => ct !== 'pie' && ct !== 'donut' && ct !== 'funnel';
+
+  // Resolve the category dimension's option colors (P3). Best-effort: any
+  // failure leaves categoryColors null and the chart keeps the theme palette.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const reqOpts = { headers: { accept: 'application/json' }, credentials: 'include' as const };
+        let objectName: string | undefined = schema.objectName;
+        let fieldName: string | undefined;
+        const gb = schema.aggregate?.groupBy as any;
+        if (objectName) {
+          fieldName = (gb && typeof gb === 'object' && !Array.isArray(gb)) ? gb.field
+            : (typeof gb === 'string' ? gb : schema.xAxisKey);
+        } else if (schema.dataset) {
+          // dataset path: dataset.object + first dimension's underlying field
+          const dim0 = Array.isArray(schema.dimensions) && schema.dimensions.length ? schema.dimensions[0] : undefined;
+          const defRes = await fetch(`/api/v1/meta/dataset/${encodeURIComponent(schema.dataset)}`, reqOpts);
+          const defJson = await defRes.json().catch(() => null);
+          const def = defJson?.item ?? defJson?.data ?? defJson;
+          objectName = def?.object;
+          const dim = (def?.dimensions || []).find((d: any) => d?.name === dim0) ?? (def?.dimensions || [])[0];
+          fieldName = dim?.field ?? dim0;
+        }
+        if (!objectName || !fieldName) { if (!cancelled) setFieldOptionColors(null); return; }
+        const schemaRes = await fetch(`/api/v1/meta/object/${encodeURIComponent(objectName)}`, reqOpts);
+        const sj = await schemaRes.json().catch(() => null);
+        const objSchema = sj?.item ?? sj?.data ?? sj;
+        const fieldOpts = objSchema?.fields?.[fieldName]?.options;
+        if (!Array.isArray(fieldOpts) || !fieldOpts.length) { if (!cancelled) setFieldOptionColors(null); return; }
+        const map: Record<string, string> = {};
+        for (const o of fieldOpts) {
+          if (o && typeof o === 'object' && o.color) {
+            if (o.value != null) map[String(o.value)] = o.color;
+            if (o.label != null) map[String(o.label)] = o.color;
+          }
+        }
+        if (!cancelled) setFieldOptionColors(Object.keys(map).length ? map : null);
+      } catch { if (!cancelled) setFieldOptionColors(null); }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [schema.objectName, schema.dataset, datasetKey, aggregateKey, schema.xAxisKey]);
 
   // Run a single aggregate query (used for both the current and comparison
   // windows). Extracted so the two queries share identical logic.
@@ -565,7 +616,33 @@ export const ObjectChart = (props: any) => {
   const finalSchema = datasetChart
     ? { ...schema, data: datasetChart.data, xAxisKey: datasetChart.xAxisKey, series: datasetChart.series }
     : { ...schema, data: finalData, ...(augmentedSeries ? { series: augmentedSeries } : {}) };
-  
+
+  // P3: per-category semantic colors. When the category dimension is a select/
+  // lookup field, its option colors (resolved above into `fieldOptionColors`)
+  // paint each slice/bar — a "Red" health category renders red, not the next
+  // positional palette slot. The render layer looks each category up in
+  // `categoryColors` first and only falls back to the positional palette, so an
+  // explicit brand `colors` palette no longer suppresses the semantic colors.
+  //
+  // `colors` is overloaded kanban-style: a string[] is the positional palette
+  // (fallback only); a Record<value, color> is an explicit author map that wins
+  // over the field's option colors. We split the two and pass the palette as
+  // `colors` and the merged map as `categoryColors`.
+  const explicitColorMap: Record<string, string> | null =
+    (schema as any).colors && !Array.isArray((schema as any).colors) && typeof (schema as any).colors === 'object'
+      ? ((schema as any).colors as Record<string, string>)
+      : null;
+  const paletteColors: string[] | undefined =
+    Array.isArray((schema as any).colors) ? ((schema as any).colors as string[]) : undefined;
+  const mergedCategoryColors = (fieldOptionColors || explicitColorMap)
+    ? { ...(fieldOptionColors || {}), ...(explicitColorMap || {}) }
+    : undefined;
+  const finalSchemaWithColors = {
+    ...finalSchema,
+    colors: paletteColors,
+    ...(mergedCategoryColors ? { categoryColors: mergedCategoryColors } : {}),
+  };
+
   if (loading && finalData.length === 0) {
       return <div className={"flex items-center justify-center text-muted-foreground text-sm p-4 " + (schema.className || '')} data-testid="chart-loading">Loading chart data…</div>;
   }
@@ -667,7 +744,7 @@ export const ObjectChart = (props: any) => {
   return (
     <div className="relative">
       <RefreshIndicator active={loading && finalData.length > 0} />
-      <ChartRenderer {...props} schema={finalSchema} onChartClick={onChartClick} />
+      <ChartRenderer {...props} schema={finalSchemaWithColors} onChartClick={onChartClick} />
       {drillDrawer}
     </div>
   );


### PR DESCRIPTION
Two fixes found dogfooding the Studio page designer (companion to framework page-schema fix #2254).

**1. Record-page Preview binds a real record (`@object-ui/app-shell`)** — the Preview tab showed `record:*` blocks as the 'bind a record to preview' placeholder. Now fetches real records (lookups $expanded), auto-binds the first, adds a 'Preview record' dropdown, wraps the canvas in `<RecordContextProvider>`. visible CEL + per-record values re-render live.

**2. Charts use field option colors (`@object-ui/plugin-charts`)** — an object-chart grouped by a select field (e.g. health) painted the generic palette (Red->teal, Green->blue). Now resolves the dimension's option colors (objectName+groupBy and dataset paths) into a per-category `categoryColors` map that wins over the palette. Pie/donut + bar cells render semantic colors. Adds a renderer test.

Verified in browser (record picker switching; health donut/status bars green/red/amber); AdvancedChartImpl.colors.test.tsx + PagePreview.test.tsx pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)