### PR TITLE
feat(app-shell): Build-history timeline + revert UI for AI builds (ADR-0067)

### DIFF
--- a/.changeset/adr-0067-commit-timeline.md
+++ b/.changeset/adr-0067-commit-timeline.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Build-history timeline + revert UI for AI builds (ADR-0067)
+
+The unpublished-app banner gains a **History** button that opens a commit timeline (`GET /packages/:id/commits`): every change an AI build/edit landed, newest-first, with **Revert** per apply commit (`POST /packages/:id/commits/:cid/revert`). The history-not-confirm model — review the timeline and revert, instead of approving each publish.
+
+- `commitHistory.ts` — `fetchCommits` / `revertCommit` helpers.
+- `CommitTimeline.tsx` — slide-over panel (sibling of `DraftChangesPanel`).
+- `UnpublishedAppBar` — History button + timeline mount (package-scoped).

--- a/packages/app-shell/src/preview/CommitTimeline.tsx
+++ b/packages/app-shell/src/preview/CommitTimeline.tsx
@@ -1,0 +1,174 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0067 — the package "Build history" timeline. Lists every commit an AI
+ * build (or edit) landed, newest-first, with "Revert" per apply commit: undo
+ * that change set (artifacts it created are soft-removed; ones it edited are
+ * restored) as a NEW append-only revert commit. This is the history-not-confirm
+ * surface — the user reviews and reverts instead of approving each publish.
+ *
+ * Sibling of DraftChangesPanel (which lists PENDING drafts before a publish);
+ * this lists what already LANDED, and can undo it.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { GitBranch, Undo2, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Badge,
+  Button,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@object-ui/components';
+import { useObjectTranslation } from '@object-ui/i18n';
+import { fetchCommits, revertCommit, type CommitEntry } from './commitHistory';
+
+export interface CommitTimelineProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  packageId: string;
+  /** Called after a successful revert so the host can refresh the app view. */
+  onReverted?: () => void;
+}
+
+function relativeTime(iso?: string): string {
+  if (!iso) return '';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '';
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return `${Math.round(hrs / 24)}d`;
+}
+
+export function CommitTimeline({ open, onOpenChange, packageId, onReverted }: CommitTimelineProps) {
+  const { t } = useObjectTranslation();
+  const [commits, setCommits] = useState<CommitEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reverting, setReverting] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setCommits(null);
+    setError(null);
+    try {
+      setCommits(await fetchCommits(packageId));
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, [packageId]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [open, load]);
+
+  const onRevert = async (commitId: string) => {
+    setReverting(commitId);
+    try {
+      await revertCommit(packageId, commitId);
+      toast.success(t('preview.history.reverted', { defaultValue: 'Reverted — the change has been undone.' }));
+      onReverted?.();
+      await load();
+    } catch (e) {
+      toast.error(
+        `${t('preview.history.revertFailed', { defaultValue: 'Revert failed' })}: ${(e as Error).message}`,
+      );
+    } finally {
+      setReverting(null);
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-[420px] sm:max-w-[420px]" data-testid="commit-timeline-panel">
+        <SheetHeader>
+          <SheetTitle>{t('preview.history.title', { defaultValue: 'Build history' })}</SheetTitle>
+          <SheetDescription>
+            {t('preview.history.description', {
+              defaultValue:
+                'Every change to this app, newest first. Revert any step to undo it — no publish confirmation needed.',
+            })}
+          </SheetDescription>
+        </SheetHeader>
+        <div className="mt-4 flex flex-col gap-2 overflow-y-auto px-4 pb-6">
+          {error ? (
+            <p className="text-sm text-destructive">
+              {t('preview.history.loadFailed', { defaultValue: 'Could not load history:' })} {error}
+            </p>
+          ) : commits === null ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t('preview.history.loading', { defaultValue: 'Loading history…' })}
+            </div>
+          ) : commits.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t('preview.history.empty', { defaultValue: 'No history yet for this app.' })}
+            </p>
+          ) : (
+            commits.map((c) => (
+              <div
+                key={c.id}
+                className="flex items-start gap-2.5 rounded-md border px-2.5 py-2 text-sm"
+                data-testid="commit-row"
+              >
+                <GitBranch
+                  className={`mt-0.5 h-4 w-4 shrink-0 ${c.operation === 'revert' ? 'text-muted-foreground' : 'text-primary'}`}
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium">
+                    {c.message ??
+                      (c.operation === 'revert'
+                        ? t('preview.history.revertLabel', { defaultValue: 'Reverted a change' })
+                        : t('preview.history.applyLabel', { defaultValue: 'Build change' }))}
+                  </p>
+                  <p className="mt-0.5 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                    {c.operation === 'revert' ? (
+                      <Badge variant="outline" className="border-muted-foreground/30">
+                        {t('preview.history.revert', { defaultValue: 'revert' })}
+                      </Badge>
+                    ) : null}
+                    <span>
+                      {c.itemCount} {t('preview.history.items', { defaultValue: 'item(s)' })}
+                    </span>
+                    {c.actor ? <span>· {c.actor}</span> : null}
+                    {c.createdAt ? <span>· {relativeTime(c.createdAt)}</span> : null}
+                  </p>
+                </div>
+                {c.operation === 'apply' ? (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="shrink-0"
+                    disabled={reverting !== null}
+                    onClick={() => onRevert(c.id)}
+                    data-testid="commit-revert"
+                  >
+                    {reverting === c.id ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <>
+                        <Undo2 className="mr-1 h-3.5 w-3.5" />
+                        {t('preview.history.revertAction', { defaultValue: 'Revert' })}
+                      </>
+                    )}
+                  </Button>
+                ) : null}
+              </div>
+            ))
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/app-shell/src/preview/UnpublishedAppBar.tsx
+++ b/packages/app-shell/src/preview/UnpublishedAppBar.tsx
@@ -21,12 +21,13 @@
 
 import { useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { EyeOff, Rocket } from 'lucide-react';
+import { EyeOff, History, Rocket } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useMetadata } from '../providers/MetadataProvider';
 import { matchAppBySegment } from '../utils/appRoute';
+import { CommitTimeline } from './CommitTimeline';
 import { usePreviewDrafts } from './PreviewModeContext';
 
 export function UnpublishedAppBar() {
@@ -36,6 +37,7 @@ export function UnpublishedAppBar() {
   const { apps, refresh } = useMetadata();
   const { t } = useObjectTranslation();
   const [publishing, setPublishing] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   // The draft-preview watermark owns the preview tree; never stack both bars.
   if (preview) return null;
@@ -43,6 +45,9 @@ export function UnpublishedAppBar() {
   if (!routeApp) return null;
   const app = matchAppBySegment(apps ?? [], routeApp);
   if (!app || (app as any).hidden !== true) return null;
+  // ADR-0067 — the package this app belongs to keys its commit timeline.
+  const packageId =
+    (app as { packageId?: string })?.packageId ?? (app as { _packageId?: string })?._packageId ?? null;
 
   const publish = async () => {
     setPublishing(true);
@@ -76,23 +81,44 @@ export function UnpublishedAppBar() {
   };
 
   return (
-    <div
-      className="sticky top-0 z-40 flex items-center gap-3 border-b border-amber-300/70 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-200"
-      data-testid="unpublished-app-bar"
-    >
-      <EyeOff className="h-4 w-4 shrink-0" />
-      <p className="min-w-0 flex-1 truncate">
-        {t('preview.unpublishedBar.message', {
-          defaultValue:
-            'Unpublished app — fully functional, but only builders can see it. Publish to make it visible to your users.',
-        })}
-      </p>
-      <Button size="sm" onClick={publish} disabled={publishing} data-testid="unpublished-app-publish">
-        <Rocket className="mr-1 h-3.5 w-3.5" />
-        {publishing
-          ? t('preview.unpublishedBar.publishing', { defaultValue: 'Publishing…' })
-          : t('preview.unpublishedBar.publish', { defaultValue: 'Publish' })}
-      </Button>
-    </div>
+    <>
+      <div
+        className="sticky top-0 z-40 flex items-center gap-3 border-b border-amber-300/70 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-200"
+        data-testid="unpublished-app-bar"
+      >
+        <EyeOff className="h-4 w-4 shrink-0" />
+        <p className="min-w-0 flex-1 truncate">
+          {t('preview.unpublishedBar.message', {
+            defaultValue:
+              'Unpublished app — fully functional, but only builders can see it. Publish to make it visible to your users.',
+          })}
+        </p>
+        {packageId ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setHistoryOpen(true)}
+            data-testid="unpublished-app-history"
+          >
+            <History className="mr-1 h-3.5 w-3.5" />
+            {t('preview.history.button', { defaultValue: 'History' })}
+          </Button>
+        ) : null}
+        <Button size="sm" onClick={publish} disabled={publishing} data-testid="unpublished-app-publish">
+          <Rocket className="mr-1 h-3.5 w-3.5" />
+          {publishing
+            ? t('preview.unpublishedBar.publishing', { defaultValue: 'Publishing…' })
+            : t('preview.unpublishedBar.publish', { defaultValue: 'Publish' })}
+        </Button>
+      </div>
+      {packageId ? (
+        <CommitTimeline
+          open={historyOpen}
+          onOpenChange={setHistoryOpen}
+          packageId={packageId}
+          onReverted={refresh}
+        />
+      ) : null}
+    </>
   );
 }

--- a/packages/app-shell/src/preview/commitHistory.ts
+++ b/packages/app-shell/src/preview/commitHistory.ts
@@ -1,0 +1,77 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0067 — package-scoped commit history reads/writes for the timeline.
+ *
+ * Each AI build (and Studio batch) lands as one revertible COMMIT on top of
+ * the metadata history. The history-not-confirm model: you don't approve each
+ * publish — you review this timeline and revert if a change was wrong. These
+ * helpers read the timeline (`GET /packages/:id/commits`) and revert one
+ * commit (`POST /packages/:id/commits/:cid/revert`). Cookie-authenticated like
+ * every console call; tolerant of the `{ data: ... }` / bare envelope shapes.
+ */
+
+export interface CommitEntry {
+  id: string;
+  operation: 'apply' | 'revert';
+  message?: string;
+  actor?: string;
+  aiModel?: string;
+  itemCount: number;
+  createdAt?: string;
+}
+
+export async function fetchCommits(packageId: string): Promise<CommitEntry[]> {
+  const res = await fetch(`/api/v1/packages/${encodeURIComponent(packageId)}/commits`, {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`commits HTTP ${res.status}`);
+  const data = (await res.json()) as
+    | unknown[]
+    | { commits?: unknown[]; data?: { commits?: unknown[] } };
+  const list = Array.isArray(data)
+    ? data
+    : (data as { commits?: unknown[] })?.commits ??
+      (data as { data?: { commits?: unknown[] } })?.data?.commits ??
+      [];
+  return (Array.isArray(list) ? list : []).map((raw) => {
+    const c = raw as Record<string, unknown>;
+    return {
+      id: String(c.id),
+      operation: c.operation === 'revert' ? 'revert' : 'apply',
+      message: typeof c.message === 'string' ? c.message : undefined,
+      actor: typeof c.actor === 'string' ? c.actor : undefined,
+      aiModel: typeof c.aiModel === 'string' ? c.aiModel : undefined,
+      itemCount: typeof c.itemCount === 'number' ? c.itemCount : 0,
+      createdAt: typeof c.createdAt === 'string' ? c.createdAt : undefined,
+    } satisfies CommitEntry;
+  });
+}
+
+export async function revertCommit(packageId: string, commitId: string): Promise<void> {
+  const res = await fetch(
+    `/api/v1/packages/${encodeURIComponent(packageId)}/commits/${encodeURIComponent(commitId)}/revert`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: '{}',
+    },
+  );
+  const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+  const inner = (payload?.data as Record<string, unknown> | undefined) ?? payload ?? undefined;
+  if (!res.ok || (inner as { success?: boolean })?.success === false) {
+    const err = payload?.error as { message?: string } | string | undefined;
+    throw new Error(
+      (typeof err === 'object' ? err?.message : err) ?? `HTTP ${res.status}`,
+    );
+  }
+}


### PR DESCRIPTION
Adds the user-facing half of ADR-0067: a **Build history** timeline with per-commit **Revert**, on the unpublished-app banner.

## What lands
- **`commitHistory.ts`** — `fetchCommits` (`GET /packages/:id/commits`) + `revertCommit` (`POST /packages/:id/commits/:cid/revert`), cookie-authenticated (mirrors `draftStatus.ts`).
- **`CommitTimeline.tsx`** — a `Sheet` slide-over listing commits newest-first (message · actor · time · apply/revert badge), with a **Revert** action per apply commit. Mirrors `DraftChangesPanel.tsx`.
- **`UnpublishedAppBar`** — a **History** button (package-scoped) that opens the timeline; reverting refreshes the app view.

The model: you don't approve each publish — you review the timeline and revert if a change was wrong.

## Verification
`pnpm --filter @object-ui/app-shell type-check` → exit 0, 0 errors. i18n via inline `defaultValue` (no locale-file parity churn). Pairs with framework + cloud ADR-0067 PRs (the timeline data comes from the framework commit routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)