### PR TITLE
feat(types): type object-chart `colors` as palette or value→color map

### DIFF
--- a/.changeset/object-chart-colors-schema.md
+++ b/.changeset/object-chart-colors-schema.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/types": patch
+---
+
+feat(types): type `object-chart` `colors` as a palette OR a value→color map
+
+`ObjectChartSchema.colors` now accepts either a positional palette (`string[]`)
+or an explicit value→color map (`Record<value, color>`, kanban-style). This
+matches the chart renderer, which resolves a select/lookup dimension's option
+colors per category and lets them (and any explicit map) win over the
+positional palette — so health green/red/yellow paints semantically.

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -465,6 +465,15 @@ export const ObjectChartSchema = BaseSchema.extend({
   dataset: z.string().optional().describe('Semantic-layer dataset name (ADR-0021)'),
   dimensions: z.array(z.string()).optional().describe('Dataset dimension names'),
   values: z.array(z.string()).optional().describe('Dataset measure names'),
+  // Colors are overloaded kanban-style: a string[] is the positional palette
+  // (applied per category in order; fallback only), while a Record<value,color>
+  // is an explicit value→color map. A select/lookup dimension's option colors —
+  // and any explicit map — take precedence over the positional palette per
+  // category, so health green/red/yellow paints semantically.
+  colors: z.union([
+    z.array(z.string()),
+    z.record(z.string(), z.string()),
+  ]).optional().describe('Positional palette (string[]) OR a value→color map ({ value: color }, kanban-style). Select/lookup option colors and explicit maps win over the palette per category.'),
 });
 
 /**


### PR DESCRIPTION
## What

Types `ObjectChartSchema.colors` as a discriminated **union**: either a positional palette (`string[]`) **or** an explicit value→color map (`Record<value, color>`, kanban-style).

## Why

Completes the `object-chart` semantic-color work whose **renderer already shipped in #1932**. The renderer resolves a select/lookup dimension's option colors per category and lets them — and any explicit author map — win over the positional palette (health green/red/yellow paints semantically). Before this, `ObjectChartSchema` had no `colors` field at all, so the explicit-map authoring path was untyped/undocumented.

This is additive and backward-compatible: the field is optional, the array form is unchanged, and the runtime already handles both shapes.

## Test

- Runtime-validated the union accepts both an array palette and a `{ value: color }` map, and rejects invalid shapes.
- Renderer behavior covered by `AdvancedChartImpl.colors.test.tsx` (shipped in #1932).

🤖 Generated with [Claude Code](https://claude.com/claude-code)