### PR TITLE
fix(metadata): create form reflects fields published after first build

### DIFF
--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -543,6 +543,12 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
   // NOT gated to preview-drafts mode: the live world every tree reads changed.
   useEffect(() => {
     return subscribeMetadataRefresh(() => {
+      // The adapter keeps its OWN object-schema cache (getObjectSchema) that the
+      // context refresh below does not touch. A publish/install just changed the
+      // live schema, so drop it too — otherwise create/edit forms (which read
+      // the adapter's getObjectSchema, NOT this context) keep showing the
+      // pre-publish field set until the adapter cache's 5-minute TTL lapses.
+      try { adapterRef.current?.clearCache?.(); } catch { /* adapter mid-swap */ }
       void refresh();
     });
   }, [refresh]);

--- a/packages/data-objectstack/src/getObjectSchema.test.ts
+++ b/packages/data-objectstack/src/getObjectSchema.test.ts
@@ -1,0 +1,77 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectStackAdapter, clearSharedDiscoveryCache } from './index';
+
+/**
+ * A fetch mock that answers discovery + records the `GET /meta/object/:name`
+ * read so we can assert how it was issued.
+ */
+function makeFetch(objectBody: unknown) {
+  const calls: Array<{ url: string; init?: any }> = [];
+  const fetchImpl = vi.fn(async (url: any, init?: any) => {
+    const u = String(url);
+    calls.push({ url: u, init });
+    if (u.includes('/api/v1/discovery')) {
+      return { ok: true, status: 200, statusText: 'OK', json: async () => ({ success: true, data: { version: 'v1', routes: {} } }) } as any;
+    }
+    if (u.includes('/api/v1/meta/object/')) {
+      return { ok: true, status: 200, statusText: 'OK', json: async () => objectBody } as any;
+    }
+    return { ok: true, status: 200, statusText: 'OK', json: async () => ({}) } as any;
+  });
+  return { fetchImpl, calls };
+}
+
+describe('ObjectStackAdapter.getObjectSchema', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('reads with cache: "no-cache" so a freshly published field is not masked by the server max-age', async () => {
+    // The server marks single-object metadata `public, max-age=3600`; without
+    // revalidation the browser HTTP cache would keep serving the pre-publish
+    // schema and the create/edit form would miss fields published this session.
+    const { fetchImpl, calls } = makeFetch({
+      name: 'leave_request',
+      fields: { employee_name: { type: 'text' }, department: { type: 'text' } },
+    });
+    const adapter = new ObjectStackAdapter({
+      baseUrl: 'http://localhost:3000',
+      token: 'tok_123',
+      autoReconnect: false,
+      fetch: fetchImpl as any,
+    });
+
+    const schema: any = await adapter.getObjectSchema('leave_request');
+
+    // Returns the (unwrapped) object schema with its fields.
+    expect(Object.keys(schema.fields)).toEqual(['employee_name', 'department']);
+
+    const get = calls.find((c) => c.url.includes('/api/v1/meta/object/'))!;
+    expect(get.url).toBe('http://localhost:3000/api/v1/meta/object/leave_request');
+    expect(get.init.method).toBe('GET');
+    // The crux of the fix: revalidate the HTTP cache instead of serving the
+    // stale `max-age` body.
+    expect(get.init.cache).toBe('no-cache');
+    expect(get.init.headers.Authorization).toBe('Bearer tok_123');
+  });
+
+  it('unwraps the { item } envelope when the server wraps the object', async () => {
+    const { fetchImpl } = makeFetch({ item: { name: 'account', fields: { x: { type: 'text' } } } });
+    const adapter = new ObjectStackAdapter({
+      baseUrl: 'http://localhost:3000',
+      autoReconnect: false,
+      fetch: fetchImpl as any,
+    });
+
+    const schema: any = await adapter.getObjectSchema('account');
+
+    expect(schema.name).toBe('account');
+    expect(Object.keys(schema.fields)).toEqual(['x']);
+  });
+});

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1296,16 +1296,16 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       // shell's locale remount (issue #1319). Keeping the key locale-free here
       // means a metadata *write* still invalidates the single entry it knows
       // about, without having to fan out across every cached locale.
-      const schema = await this.metadataCache.get(objectName, async () => {
-        const result: any = await this.client.meta.getItem('object', objectName);
-        
-        // Unwrap 'item' property if present (common API response wrapper)
-        if (result && result.item) {
-          return result.item;
-        }
-
-        return result;
-      });
+      // Read through a cache-revalidating fetch (see fetchObjectSchemaFresh):
+      // the server marks single-object metadata `public, max-age=3600`, so a
+      // plain fetch would keep serving the pre-publish schema from the browser
+      // HTTP cache for up to an hour — and the create/edit form (which reads
+      // getObjectSchema) would never show a field added + published in this
+      // session. The list endpoint is uncached, which is why list views already
+      // refresh on publish.
+      const schema = await this.metadataCache.get(objectName, () =>
+        this.fetchObjectSchemaFresh(objectName),
+      );
       
       return schema;
     } catch (error: unknown) {
@@ -1322,6 +1322,59 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       
       throw createErrorFromResponse(errorObj, `getObjectSchema(${objectName})`);
     }
+  }
+
+  /**
+   * Fetch a single object's schema while always revalidating the browser cache.
+   *
+   * The server serves `GET /api/v1/meta/object/:name` with
+   * `Cache-Control: public, max-age=3600`, so the default `fetch` the SDK uses
+   * keeps returning the same response from the browser HTTP cache for up to an
+   * hour without contacting the origin. Because the create/edit form reads the
+   * object schema through {@link getObjectSchema}, a field added + published in
+   * the same session never appears in the form even though it is live (the LIST
+   * endpoint, `/meta/object`, is uncached — which is why list views update).
+   *
+   * Issuing the read with `cache: 'no-cache'` forces a conditional revalidation
+   * (`If-None-Match`): a changed ETag returns the fresh schema, an unchanged one
+   * still gets a cheap `304`. We go through `fetchImpl` (the adapter's
+   * authenticated fetch) rather than `client.meta.getItem` because the SDK does
+   * not expose the request cache mode.
+   */
+  private async fetchObjectSchemaFresh(objectName: string): Promise<unknown> {
+    const baseUrl = (this.baseUrl || '').replace(/\/$/, '');
+    // Avoid doubling /api/v1 when baseUrl already carries the version suffix
+    // (mirrors rawFindWithPopulate).
+    const hasApiVersionSuffix = /\/api\/v\d+$/i.test(baseUrl);
+    const metaPath = hasApiVersionSuffix ? '/meta' : '/api/v1/meta';
+    const url = `${baseUrl}${metaPath}/object/${encodeURIComponent(objectName)}`;
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    // Bearer (server-to-server) callers configure `this.token`; cookie/console
+    // auth is injected by `fetchImpl` (the authenticated fetch wrapper).
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+
+    const res = await this.fetchImpl(url, {
+      method: 'GET',
+      headers,
+      // Revalidate instead of serving the stale `max-age` body (see doc above).
+      cache: 'no-cache',
+    });
+
+    if (!res.ok) {
+      const errBody: any = await res.json().catch(() => ({ message: res.statusText }));
+      const err: any = new Error(errBody?.error?.message || errBody?.message || res.statusText);
+      err.status = res.status;
+      throw err;
+    }
+
+    const body: any = await res.json();
+    // Unwrap defensively across server/SDK response shapes: the standard
+    // `{ success, data }` envelope, an `{ item }` wrapper, or the bare item.
+    const data = body && typeof body === 'object' && 'success' in body && 'data' in body ? body.data : body;
+    return data && typeof data === 'object' && 'item' in data ? data.item : data;
   }
 
   /**


### PR DESCRIPTION
## Problem
The AI-built object **New** create form keeps showing the original field set after a field is added via the AI flow and published — it survives normal reloads and IndexedDB/localStorage clears.

## Root cause
`GET /api/v1/meta/object/:name` is served with `Cache-Control: public, max-age=3600`, so the browser HTTP-caches the object schema for up to an hour **without revalidating**. The create form (`ModalForm`) reads the schema via `ObjectStackAdapter.getObjectSchema` (a default `fetch`) → served the stale body. The **list** endpoint `/meta/object` is uncached, which is why list views refresh on publish but the create form doesn't. The server itself is fresh (new ETag after publish — confirmed via a cache-bypass fetch), so this is the HTTP cache, **not** registry staleness.

## Fix
- **data-objectstack** — `getObjectSchema` now reads via `fetchObjectSchemaFresh()` with `cache: 'no-cache'`, forcing an `If-None-Match` revalidation (fresh schema on change, cheap `304` when unchanged). + unit test.
- **app-shell `MetadataProvider`** — the publish/install (`emitMetadataRefresh`) pulse also clears the shared adapter's metadata cache, so open forms refresh without a page reload.

## Verification
E2E in the local stack: built a Leave Request app, added + published Department then Position; the published app's create form showed all fields **with no hard reload**, while a default-cache probe still returned the stale schema (proving the fix bypasses it). Unit suites: data-objectstack 209/209, MetadataProvider 11/11.

## Follow-up (framework, separate)
The principled root fix is server-side: change that endpoint's `Cache-Control` to `no-cache`/`must-revalidate` (and fix the malformed `public, max-age, max-age=3600`) so all consumers/CDNs revalidate. This PR fixes the console symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)