### PR TITLE
feat(metadata-admin): dataset create opens the rich designer + dual-axis preview

### DIFF
--- a/.changeset/dataset-create-canvas-dual-axis.md
+++ b/.changeset/dataset-create-canvas-dual-axis.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(metadata-admin): dataset create opens the rich designer + dual-axis preview
+
+- **Create → rich designer.** `dataset` joins `object` / `report` in
+  `CREATE_MODE_CANVAS_TYPES`, so "New dataset" opens the structured designer
+  (base-object picker, joins, dimension/measure editors, live preview) instead
+  of the degraded generic SchemaForm. `DatasetDefaultInspector` gains a
+  create-mode **Name** field that auto-derives a snake_case identifier from the
+  label until edited (mirrors `ReportDefaultInspector` / `ObjectDefaultInspector`),
+  so a dataset created through the canvas saves with a valid identity instead of
+  dead-ending.
+- **Mixed-scale preview.** When a dataset preview mixes a ratio/percent measure
+  (e.g. `utilization`, `0.0%`) with magnitude measures (currency in the
+  hundred-thousands), the ratio measures now plot as a line on a secondary
+  (right) Y axis via the existing `combo` chart — they're no longer crushed to an
+  invisible sliver beside the large bars. Same-scale selections stay a plain bar
+  chart.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -118,7 +118,7 @@ const PanelGroup = ResizablePanelGroup as React.FC<any>;
  * editable via the no-selection default inspector. Other types keep
  * the conventional "name it first, design after save" create flow.
  */
-const CREATE_MODE_CANVAS_TYPES = new Set<string>(['object', 'report']);
+const CREATE_MODE_CANVAS_TYPES = new Set<string>(['object', 'report', 'dataset']);
 
 /**
  * Top-level metadata keys that a type's canvas PreviewComponent owns and

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
@@ -106,4 +106,18 @@ describe('DatasetDefaultInspector', () => {
     // …and no longer the free-text "$0,0.00" numeral field.
     expect(screen.queryByPlaceholderText('$0,0.00')).not.toBeInTheDocument();
   });
+
+  it('shows an editable Name field in create mode (empty name) that slugs from the label', () => {
+    const onPatch = vi.fn();
+    render(<DatasetDefaultInspector {...baseProps} name="" draft={{ object: 'opportunity', dimensions: [], measures: [] }} onPatch={onPatch} readOnly={false} />);
+    expect(screen.getByPlaceholderText('snake_case identifier')).toBeInTheDocument();
+    // Typing the Name commits a snake_case identifier.
+    fireEvent.change(screen.getByPlaceholderText('snake_case identifier'), { target: { value: 'Win Rate' } });
+    expect(onPatch).toHaveBeenCalledWith({ name: 'win_rate' });
+  });
+
+  it('hides the create-mode Name field once the dataset has a name (edit mode)', () => {
+    render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={vi.fn()} readOnly={false} />);
+    expect(screen.queryByPlaceholderText('snake_case identifier')).not.toBeInTheDocument();
+  });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
@@ -31,6 +31,7 @@ import {
   spliceArray,
 } from './_shared';
 import { InspectorComboField, type InspectorComboOption } from './InspectorComboField';
+import { toFieldName } from '../previews/object-fields-io';
 import { formatMeasure } from '@object-ui/core';
 import {
   useObjectOptions,
@@ -213,7 +214,7 @@ function RelWarning({ rel, onAdd, disabled }: { rel: string; onAdd?: () => void;
   );
 }
 
-export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDefaultInspectorProps) {
+export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: MetadataDefaultInspectorProps) {
   const label = typeof draft.label === 'string' ? draft.label : '';
   const description = typeof draft.description === 'string' ? draft.description : '';
   const object = typeof draft.object === 'string' ? draft.object : '';
@@ -221,6 +222,15 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
   const dimensions: Dimension[] = Array.isArray(draft.dimensions) ? (draft.dimensions as Dimension[]) : [];
   const measures: Measure[] = Array.isArray(draft.measures) ? (draft.measures as Measure[]) : [];
   const datasetName = typeof draft.name === 'string' ? draft.name : undefined;
+
+  // In create mode the host passes an empty `name` (the PK is assigned on first
+  // save). Mirror ReportDefaultInspector: expose an editable Name that auto-
+  // derives a snake_case slug from the label until the author edits it directly,
+  // so a dataset created through the canvas saves with a valid identifier instead
+  // of dead-ending on the empty-name identity rule.
+  const createMode = !name;
+  const nameTouched = React.useRef(false);
+  const nameValue = typeof draft.name === 'string' ? (draft.name as string) : '';
 
   const { options: objectOptions, loading: objectsLoading } = useObjectOptions();
   const { relationships, fieldOptions, loading: catalogLoading } = useDatasetFieldCatalog(object, include);
@@ -278,7 +288,28 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly }: MetadataDe
         </p>
       )}
 
-      <InspectorTextField label="Label" value={label} onCommit={(v) => onPatch({ label: v })} disabled={readOnly} />
+      {createMode && (
+        <InspectorTextField
+          label="Name"
+          value={nameValue}
+          onCommit={(v) => { nameTouched.current = true; onPatch({ name: toFieldName(v) }); }}
+          placeholder="snake_case identifier"
+          disabled={readOnly}
+          mono
+        />
+      )}
+      <InspectorTextField
+        label="Label"
+        value={label}
+        onCommit={(v) => {
+          // Live-derive the snake_case name from the label until the author edits
+          // the Name field directly (create mode only).
+          const patch: Record<string, unknown> = { label: v };
+          if (createMode && !nameTouched.current) patch.name = toFieldName(v);
+          onPatch(patch);
+        }}
+        disabled={readOnly}
+      />
       <InspectorTextField label="Description" value={description} onCommit={(v) => onPatch({ description: v })} disabled={readOnly} />
       <InspectorComboField
         label="Base object"

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
@@ -89,4 +89,27 @@ describe('DatasetPreview', () => {
     expect(screen.getByText(/Pick a base object/i)).toBeInTheDocument();
     expect(queryDataset).not.toHaveBeenCalled();
   });
+  it('plots a ratio measure on a secondary (right) axis when scales are mixed', async () => {
+    queryDataset.mockResolvedValue({
+      rows: [{ region: 'NA', revenue: 600000, rate: 0.7 }],
+      object: 'opportunity',
+      fields: [
+        { name: 'region', type: 'string' },
+        { name: 'revenue', type: 'number', format: '0,0', currency: 'USD' },
+        { name: 'rate', type: 'number', format: '0.0%' },
+      ],
+    });
+    const mixedDraft = {
+      ...draft,
+      measures: [
+        { name: 'revenue', aggregate: 'sum', field: 'amount' },
+        { name: 'rate', derived: { op: 'ratio', of: ['revenue', 'revenue'] } },
+      ],
+    };
+    render(<DatasetPreview {...baseProps} draft={mixedDraft} />);
+    // The ratio measure (percent-formatted) is moved to the right axis — surfaced
+    // by the caption (combo chart). A same-scale selection shows no such note.
+    expect(await screen.findByText(/use the right axis/)).toBeInTheDocument();
+  });
+
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx
@@ -120,6 +120,18 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
   const { measureField, headerLabel } = buildDatasetFieldHelpers(resultFields, resultObject, fieldLabel);
   const columns = [...dimensionNames, ...measureNames];
 
+  // A ratio/percent measure (format like `0.0%`) on the same axis as a
+  // magnitude measure (currency in the hundred-thousands) renders as an
+  // invisible sliver. When the selection MIXES the two scales, plot the ratio
+  // measures as a line on a secondary (right) Y axis via the `combo` chart —
+  // bars (magnitude) keep the left axis. Same-scale selections stay a plain bar.
+  const isRatioMeasure = (m: string) => {
+    const f = measureField(m)?.format;
+    return typeof f === 'string' && f.includes('%');
+  };
+  const ratioMeasures = measureNames.filter(isRatioMeasure);
+  const mixedScale = ratioMeasures.length > 0 && ratioMeasures.length < measureNames.length;
+
   return (
     <PreviewShell hint={`dataset · ${objectName}${dimensionNames.length ? ' · by ' + dimensionNames.join(', ') : ''}`}>
       <div className="p-3 space-y-2">
@@ -163,9 +175,19 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
                   schema={{
                     data: state.rows as Array<Record<string, unknown>>,
                     xAxisKey: dimensionNames[0],
-                    series: measureNames.map((m) => ({ dataKey: m, label: headerLabel(m), chartType: 'bar' as const })),
+                    chartType: mixedScale ? 'combo' : 'bar',
+                    series: measureNames.map((m) => ({
+                      dataKey: m,
+                      label: headerLabel(m),
+                      chartType: mixedScale ? (isRatioMeasure(m) ? 'line' : 'bar') : ('bar' as const),
+                    })),
                   } as any}
                 />
+                {mixedScale && (
+                  <p className="mt-1 px-1 text-[10px] text-muted-foreground">
+                    Ratio measures ({ratioMeasures.map(headerLabel).join(', ')}) use the right axis.
+                  </p>
+                )}
               </div>
             </React.Suspense>
           </PreviewErrorBoundary>


### PR DESCRIPTION
## Summary
Two dataset-designer UX wins found while dogfooding online dataset design in Studio — the two highest-value items deferred from objectui#1931 (they were blocked then because the report-create canvas work was in flight; it has since merged, so both are now safe to build on).

### 1. Create → the rich designer (not the generic form)
`dataset` joins `object` / `report` in `CREATE_MODE_CANVAS_TYPES`, so **"New dataset" opens the structured designer** (base-object picker, joins, dimension/measure editors, **live preview**) instead of the degraded generic `SchemaForm`. `DatasetDefaultInspector` gains a **create-mode Name field** that auto-derives a snake_case identifier from the label until edited (mirrors `ReportDefaultInspector` / `ObjectDefaultInspector`), so a dataset created through the canvas saves with a valid identity instead of dead-ending on the empty-name rule.

### 2. Mixed-scale preview → secondary (right) Y axis
When a preview mixes a **ratio/percent** measure (e.g. `utilization`, `0.0%`) with **magnitude** measures (currency in the hundred-thousands), the ratio measures now plot as a **line on a secondary right Y axis** via the existing `combo` chart — no longer crushed to an invisible sliver next to the bars. Same-scale selections stay a plain bar chart. (No change to the shared chart component — reuses `combo`'s existing dual-axis.)

## Verification
- Tests: `DatasetDefaultInspector` +2 (create-mode Name shown/hidden + slug), `DatasetPreview` +1 (dual-axis caption); **metadata-admin sweep 339 pass**.
- **Browser-verified** in showcase Studio (console rebuilt + vendored):
  - `…/metadata/dataset/new` opens the **DATASET designer** (Name `snake_case identifier`, Base object picker, Included relationships, live preview) — the generic "Basics/Groupable axes" form is gone.
  - A mixed-scale dataset preview renders a **left axis (¥, 80万→0)** + **right axis (ratio, 1→0)**, Budget/Spent as bars + Utilization as a line, caption "Ratio measures (Utilization) use the right axis", table `64.0% / 96.0% / 97.8% / 0.0%`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)