### PR TITLE
test(metadata-admin): Studio object-designer dogfood gate (F1-F6) + restore F6 wording

### DIFF
--- a/e2e/live/studio-object-designer.spec.ts
+++ b/e2e/live/studio-object-designer.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Live e2e for the Studio OBJECT designer — a "dogfood" gate that drives the
+ * metadata-admin object editor as a business user would and pins the UX
+ * regressions found in objectstack-ai/objectui#1926. Runs against the real
+ * stack (console at LIVE_APP_URL, backend at :3000).
+ *
+ * Why these specifically: each is a class that static gates (build, unit,
+ * spec-liveness) cannot catch because the break only appears when a real user
+ * drives the real controlled inputs against the real spec validator:
+ *   F2 — per-keystroke identifier sanitisation (must TYPE, not fill)
+ *   F1 — cross-component reactivity (create package → switcher refresh)
+ *   F3 — label→api-name derivation on blur
+ *   F4 — empty picklist row must not trip spec validation
+ */
+
+const STUDIO = '/apps/com.objectstack.studio';
+const PKG = 'com.example.showcase';
+const NEW_OBJ = `${STUDIO}/metadata/object/new?package=${PKG}`;
+
+/** Add a field of the given palette type into the open object designer. */
+async function addField(page: Page, typeName: string) {
+  await page.getByRole('button', { name: /Add field/i }).first().click();
+  await page.getByPlaceholder(/Search field type/i).fill(typeName);
+  // Target the palette *button* by exact accessible name — not getByText,
+  // which also matches the category header ("Text") and the type badge.
+  await page.getByRole('button', { name: typeName, exact: true }).first().click();
+}
+
+test('F2: object Name accepts a typed underscore (no per-keystroke trim)', async ({ page }) => {
+  await page.goto(NEW_OBJ);
+  const name = page.getByTestId('object-name-input');
+  await expect(name).toBeVisible();
+  await name.click();
+  // MUST type char-by-char: .fill() would set the value in one shot and hide
+  // the per-keystroke bug. Pre-fix this yields "repairticket".
+  await name.pressSequentially('repair_ticket');
+  await expect(name).toHaveValue('repair_ticket');
+});
+
+test('F3: a field API name derives from its label on blur', async ({ page }) => {
+  await page.goto(NEW_OBJ);
+  await page.getByTestId('object-name-input').fill('asset');
+  await addField(page, 'Text');
+  const label = page.getByTestId('field-label-input');
+  await label.fill('Asset Code');
+  await label.blur();
+  await expect(page.getByTestId('field-apiname-input')).toHaveValue('asset_code');
+});
+
+test('F4: adding a picklist + an empty option row does not trip spec validation', async ({ page }) => {
+  await page.goto(NEW_OBJ);
+  await page.getByTestId('object-name-input').fill('asset');
+  await addField(page, 'Picklist');
+  await page.getByRole('button', { name: /Add value/i }).click();
+  // Live spec validation is debounced, so settle before a NEGATIVE assertion:
+  // the empty option row must NOT surface the developer-oriented
+  // "System identifier must be at least 2 characters" spec error. (With the
+  // bug the row persists to def.options and this banner appears.)
+  await page.waitForTimeout(1200);
+  await expect(page.getByTestId('metadata-validation-banner')).toHaveCount(0);
+  await expect(page.getByText(/System identifier must be/i)).toHaveCount(0);
+});
+
+test('F1: a newly created package appears in the switcher without a reload', async ({ page }) => {
+  const pkgId = `com.e2e.dogfood${Date.now()}`;
+  const pkgName = `E2E Dogfood ${Date.now()}`;
+  await page.goto(`${STUDIO}/component/developer/packages`);
+  await page.getByRole('button', { name: /New Package/i }).click();
+  await page.getByTestId('package-id-input').fill(pkgId);
+  await page.getByTestId('package-name-input').fill(pkgName);
+  await page.getByRole('button', { name: /Create package/i }).click();
+
+  // No reload: open the sidebar package switcher and expect the new package.
+  await page.getByTestId('package-switcher').click();
+  await expect(page.getByRole('option', { name: pkgName })).toBeVisible();
+
+  // Cleanup so we don't pollute the shared dev stack.
+  await page.evaluate(async (id) => {
+    const tok = localStorage.getItem('auth-session-token');
+    await fetch(`/api/v1/packages/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${tok}` },
+    }).catch(() => {});
+  }, pkgId);
+});

--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -263,6 +263,7 @@ function SelectorControl({
     >
       <SelectTrigger
         aria-label={label}
+        data-testid="package-switcher"
         className="h-9 w-full gap-2 rounded-md border-sidebar-border/70 bg-sidebar/80 px-2 text-xs font-medium text-sidebar-foreground shadow-none transition-colors hover:bg-sidebar-accent focus:ring-1 focus:ring-sidebar-ring data-[state=open]:bg-sidebar-accent [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:shrink-0"
       >
         <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.fallback.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.fallback.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * F5 (objectui#1926): when Monaco can't paint — offline / air-gapped / CSP /
+ * blocked web workers — the Source tab must NOT be a blank panel. It falls back
+ * to a plain, editable textarea showing the JSON source. We simulate the
+ * "Monaco renders nothing" condition by mocking the editor to render null, so
+ * no `.view-line` ever appears and the fallback engages.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@monaco-editor/react', () => ({ default: () => null }));
+
+import { JsonSourceEditor } from './JsonSourceEditor';
+
+describe('JsonSourceEditor — F5 textarea fallback', () => {
+  it('shows an editable textarea with the JSON source when Monaco does not paint', async () => {
+    const draft = { name: 'work_order', fields: { title: { type: 'text' } } };
+    render(<JsonSourceEditor value={draft} onChange={() => {}} fallbackDelayMs={20} />);
+
+    const ta = (await screen.findByLabelText(
+      'JSON source',
+      {},
+      { timeout: 2000 },
+    )) as HTMLTextAreaElement;
+
+    expect(ta.value).toContain('work_order');
+    expect(ta.value).toContain('title');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
@@ -46,6 +46,8 @@ export interface JsonSourceEditorProps {
   issues?: JsonIssue[];
   /** Pixel or CSS-length height. Defaults to `60vh`. */
   height?: string | number;
+  /** Grace period (ms) before the textarea fallback engages. Test-tunable. */
+  fallbackDelayMs?: number;
 }
 
 function stringify(v: unknown): string {
@@ -71,6 +73,7 @@ export function JsonSourceEditor({
   readOnly,
   issues,
   height = '60vh',
+  fallbackDelayMs = 4000,
 }: JsonSourceEditorProps) {
   const locale = React.useMemo(() => detectLocale(), []);
   const [text, setText] = React.useState<string>(() => stringify(value));
@@ -95,9 +98,9 @@ export function JsonSourceEditor({
     const id = setTimeout(() => {
       const el = containerRef.current;
       if (!el || !el.querySelector('.view-line')) setMonacoUnavailable(true);
-    }, 4000);
+    }, fallbackDelayMs);
     return () => clearTimeout(id);
-  }, [monacoUnavailable]);
+  }, [monacoUnavailable, fallbackDelayMs]);
 
   // Match against the dark class our app-shell toggles on <html>; pick
   // a Monaco theme that doesn't fight the rest of the chrome.

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
@@ -214,6 +214,7 @@ export function JsonSourceEditor({
     <div className="flex flex-col gap-2">
       <div
         ref={containerRef}
+        data-testid="source-editor"
         className="border rounded overflow-hidden bg-background"
         style={{ height: typeof height === 'number' ? `${height}px` : height }}
       >

--- a/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
@@ -222,6 +222,7 @@ function CreatePackageDialog({
             <Label htmlFor="pkg-id">{t('engine.packages.create.id', locale)}</Label>
             <Input
               id="pkg-id"
+              data-testid="package-id-input"
               placeholder="com.acme.crm"
               value={id}
               onChange={(e) => setId(e.target.value)}
@@ -237,6 +238,7 @@ function CreatePackageDialog({
             <Label htmlFor="pkg-name">{t('engine.packages.create.name', locale)}</Label>
             <Input
               id="pkg-name"
+              data-testid="package-name-input"
               placeholder="Acme CRM"
               value={name}
               onChange={(e) => setName(e.target.value)}

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -1775,7 +1775,7 @@ function MetadataResourceEditPageImpl({
                 folded into the lock banner). Only render it for the
                 non-locked read-only cases. */}
             {readOnly && !isLocked && (
-              <div className="text-xs text-amber-800 border border-amber-300/70 bg-amber-50/70 rounded-md px-3 py-2.5 dark:text-amber-200 dark:border-amber-700/40 dark:bg-amber-950/20 flex items-start gap-3">
+              <div data-testid="readonly-banner" className="text-xs text-amber-800 border border-amber-300/70 bg-amber-50/70 rounded-md px-3 py-2.5 dark:text-amber-200 dark:border-amber-700/40 dark:bg-amber-950/20 flex items-start gap-3">
                 <div className="flex-1">
                   {showArtifactLockedBanner ? (
                     /* Type allows runtime-create but THIS item ships from
@@ -1921,6 +1921,7 @@ function MetadataResourceEditPageImpl({
                 return (
                   <div
                     key={kind}
+                    data-testid={kind === 'error' ? 'metadata-validation-banner' : undefined}
                     className={`flex items-start gap-2 text-xs border rounded p-2.5 ${cls}`}
                   >
                     <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />

--- a/packages/app-shell/src/views/metadata-admin/artifact-locked-banner.i18n.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/artifact-locked-banner.i18n.test.ts
@@ -1,0 +1,24 @@
+/**
+ * F6 (objectui#1926): a user's own object, after publishing it to a project
+ * package, used to be told it was "shipped by a code package" — misleading,
+ * with no stated edit path. This pins the corrected wording in both locales:
+ * accurate ("installed package") and actionable ("republish" / 重新发布).
+ */
+import { describe, it, expect } from 'vitest';
+import { t } from './i18n';
+
+describe('artifactLockedBanner wording — F6', () => {
+  it('[en] is accurate (not "shipped by a code package") and states the edit path', () => {
+    const msg = t('engine.edit.artifactLockedBanner', 'en');
+    expect(msg).not.toMatch(/shipped by a code package/i);
+    expect(msg).toMatch(/installed package/i);
+    expect(msg).toMatch(/republish/i);
+  });
+
+  it('[zh] is accurate (not 由代码包提供) and states the edit path', () => {
+    const msg = t('engine.edit.artifactLockedBanner', 'zh');
+    expect(msg).not.toMatch(/由代码包提供/);
+    expect(msg).toMatch(/已安装的包/);
+    expect(msg).toMatch(/重新发布/);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -469,7 +469,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.edit.readOnlyTypeBanner':
     'This metadata type is read-only for safety: it ships executable code or sensitive configuration and cannot be overlaid at runtime. Edit the source in your package and redeploy. To override this lock (use with caution), set {flag} to include {type}, or flip {override} in the registry.',
   'engine.edit.artifactLockedBanner':
-    'This item is shipped by a code package and cannot be modified at runtime. You can still create your own {type} from scratch and freely edit or delete it.',
+    'This {type} is provided by an installed package, so it is read-only at runtime. To change it, edit it in its source package and republish — or create a new {type} from scratch.',
   'engine.badge.createOnly': 'create-only',
   'engine.repeater.empty': 'No items. Click + to add.',
   'engine.badge.writable': 'writable',
@@ -1152,7 +1152,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.edit.readOnlyTypeBanner':
     '出于安全考虑，此元数据类型为只读：它包含可执行代码或敏感配置，不允许在运行时通过覆盖层修改。请编辑包内源代码后重新部署。如需临时解除限制（请谨慎使用），可将 {flag} 设置为包含 {type}，或在注册表中开启 {override}。',
   'engine.edit.artifactLockedBanner':
-    '此条目由代码包提供，无法在运行时修改。但您可以新建自己的 {type}，并自由地编辑或删除。',
+    '此 {type} 来自已安装的包，因此在运行时为只读。如需修改，请在其所属包的源中编辑并重新发布——或从零新建一个 {type}。',
   'engine.badge.createOnly': '仅可新建',
   'engine.repeater.empty': '暂无条目。点击 + 添加。',
   'engine.badge.writable': '可写',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.tsx
@@ -73,6 +73,7 @@ export function ObjectDefaultInspector({
             onCommit={setName}
             disabled={readOnly || !createMode}
             mono
+            testId="object-name-input"
             placeholder={tr('designer.object.namePlaceholder')}
           />
         </Field>

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -314,6 +314,7 @@ export function ObjectFieldInspector({
           onCommit={setKey}
           disabled={readOnly}
           mono
+          testId="field-apiname-input"
         />
         <InspectorTextField
           label={tr('designer.field.label')}
@@ -321,6 +322,7 @@ export function ObjectFieldInspector({
           onCommit={(v) => patchDef({ label: v })}
           onBlur={maybeDeriveName}
           disabled={readOnly}
+          testId="field-label-input"
         />
         <InspectorSelectField
           label={tr('designer.field.type')}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
@@ -139,6 +139,7 @@ export function InspectorTextField({
   placeholder,
   disabled,
   mono,
+  testId,
 }: {
   label: string;
   value: string;
@@ -148,6 +149,8 @@ export function InspectorTextField({
   placeholder?: string;
   disabled?: boolean;
   mono?: boolean;
+  /** Stable hook for e2e/dogfood selectors. */
+  testId?: string;
 }) {
   return (
     <div className="space-y-1">
@@ -158,6 +161,7 @@ export function InspectorTextField({
         onBlur={(e) => onBlur?.(e.target.value)}
         placeholder={placeholder}
         disabled={disabled}
+        data-testid={testId}
         className={cn('h-8 text-sm', mono && 'font-mono')}
       />
     </div>


### PR DESCRIPTION
## Summary

A regression gate that drives the **Studio object designer as a business user** and pins the six UX classes fixed in #1926 — the kind static gates (build / unit / spec-liveness) miss because the break only appears when a real user drives the real controlled inputs against the real spec validator.

Two layers, matching the repo's existing split:

**Live e2e** — `e2e/live/studio-object-designer.spec.ts` (the `test:e2e:live` suite, run against a real stack; excluded from the default CI e2e via the existing `testIgnore: ['**/live/**']`):
- **F2** — object Name accepts a **typed** underscore. Uses `pressSequentially`, not `.fill()` — `.fill()` sets the value in one shot and would hide the per-keystroke trim.
- **F3** — a field API name derives from its label on blur.
- **F4** — adding a picklist + an empty option row does **not** trip spec validation (negative assertion settles first, since live validation is debounced).
- **F1** — a newly created package appears in the switcher **without a reload** (creates + cleans up a throwaway package).

**Component / unit** (fast layer, CI-gated by the existing `Test` job):
- **F5** — `JsonSourceEditor` falls back to an editable textarea when Monaco can't paint (offline / CSP / blocked workers). Added a test-tunable `fallbackDelayMs`.
- **F6** — `artifactLockedBanner` wording (en + zh): not "shipped by a code package", and states the real edit path.

## Plus a hooks-only commit

`data-testid` hooks for stable selectors (no behavior change): `object-name-input`, `field-apiname-input`, `field-label-input` (via an optional `InspectorTextField` `testId`), `package-id-input`/`package-name-input`, `package-switcher`, `source-editor`, `metadata-validation-banner`, `readonly-banner`.

## This gate immediately earned its keep

The **F6 test failed on its first run**: a parallel PR (#1937, branched off pre-#1926 `main`) had silently **reverted** the banner wording back to "shipped by a code package". Re-applied here (`i18n.ts`) — exactly the regression class this gate exists to catch.

## Verification

- Live e2e: 4/4 pass against a real stack. Red-on-bug **proven** — F2 goes red when the trailing-`_` trim is reintroduced; F4 goes red when empty option rows are persisted again.
- Component/unit: F5 + F6 (en/zh) pass; F6 red-on-bug was demonstrated organically (it caught #1937's revert).
- Changed files: 0 new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)