### PR TITLE
feat(dashboard): dataset chart widgets use select/lookup option colors

### DIFF
--- a/.changeset/dashboard-chart-option-colors.md
+++ b/.changeset/dashboard-chart-option-colors.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/plugin-dashboard": patch
+"@object-ui/core": patch
+"@object-ui/plugin-charts": patch
+---
+
+feat(dashboard): dataset chart widgets paint select/lookup dimensions in their option colors
+
+A dashboard `DatasetWidget` chart grouped by a select/lookup dimension (e.g.
+project `health`) painted its categories from the generic `--chart-1..5`
+palette — the same gap the chart view (`object-chart`) had before #1932. It now
+resolves the dimension field's option colors (using the dataset's base `object`
++ dimension→field map the query already returns) and threads them to the
+renderer as a per-category `categoryColors` map, so health green/red/yellow
+paints semantically.
+
+The value/label→color resolution is extracted into a shared `buildOptionColorMap`
+(`@object-ui/core`) now used by both `DatasetWidget` and `ObjectChart`.

--- a/packages/core/src/utils/__tests__/chart-series.test.ts
+++ b/packages/core/src/utils/__tests__/chart-series.test.ts
@@ -1,0 +1,54 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildOptionColorMap } from '../chart-series';
+
+describe('buildOptionColorMap', () => {
+  const health = [
+    { label: 'Green', value: 'green', color: '#10B981', default: true },
+    { label: 'Yellow', value: 'yellow', color: '#F59E0B' },
+    { label: 'Red', value: 'red', color: '#EF4444' },
+  ];
+
+  it('keys each option color by BOTH its value and its label', () => {
+    // A dataset row's category may carry the raw value (legacy aggregate path)
+    // or the resolved label (server-resolved dataset dimensions), so both work.
+    expect(buildOptionColorMap(health)).toEqual({
+      green: '#10B981', Green: '#10B981',
+      yellow: '#F59E0B', Yellow: '#F59E0B',
+      red: '#EF4444', Red: '#EF4444',
+    });
+  });
+
+  it('returns null when the field has no options', () => {
+    expect(buildOptionColorMap(undefined)).toBeNull();
+    expect(buildOptionColorMap(null)).toBeNull();
+    expect(buildOptionColorMap([])).toBeNull();
+  });
+
+  it('returns null when no option carries a color', () => {
+    expect(buildOptionColorMap([{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }])).toBeNull();
+  });
+
+  it('keeps only the options that carry a color', () => {
+    expect(buildOptionColorMap([{ value: 'a', color: '#111' }, { value: 'b' }])).toEqual({ a: '#111' });
+  });
+
+  it('ignores non-string colors and malformed entries', () => {
+    expect(
+      buildOptionColorMap([
+        { value: 'a', color: 123 },
+        { value: 'b', color: '' },
+        null,
+        'not-an-object',
+        { value: 'c', color: '#0f0' },
+      ]),
+    ).toEqual({ c: '#0f0' });
+  });
+});

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -119,3 +119,31 @@ export function findChartSeriesRow(
   }
   return safeRows.findIndex((r) => String(r[xDim] ?? '') === c);
 }
+
+/**
+ * Build a per-category colour map from a select/lookup field's `options`.
+ *
+ * Keyed by BOTH the option `value` AND its display `label`, because a chart
+ * row's category may carry either — the server resolves dataset select
+ * dimensions value→label, while the legacy aggregate path keeps the raw value.
+ * Returns `null` when the field has no options or none carry a colour, so the
+ * caller can fall back to the positional palette.
+ *
+ * Shared by `ObjectChart` (plugin-charts) and `DatasetWidget` (plugin-dashboard)
+ * so a select/lookup dimension's option colours (e.g. health green/red/yellow)
+ * paint identically across the chart view and dashboard widgets.
+ */
+export function buildOptionColorMap(options: unknown): Record<string, string> | null {
+  if (!Array.isArray(options) || options.length === 0) return null;
+  const map: Record<string, string> = {};
+  for (const opt of options) {
+    if (opt && typeof opt === 'object') {
+      const o = opt as { value?: unknown; label?: unknown; color?: unknown };
+      if (typeof o.color === 'string' && o.color) {
+        if (o.value != null) map[String(o.value)] = o.color;
+        if (o.label != null) map[String(o.label)] = o.color;
+      }
+    }
+  }
+  return Object.keys(map).length > 0 ? map : null;
+}

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useContext, useCallback, useMemo, useRef } from 'react';
 import { useDataScope, SchemaRendererContext, SchemaRenderer, useDrillNavigation } from '@object-ui/react';
 import { ChartRenderer } from './ChartRenderer';
-import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveDateMacros, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, type CompareToConfig, type DrillEvent } from '@object-ui/core';
+import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveDateMacros, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, type CompareToConfig, type DrillEvent } from '@object-ui/core';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator, Button } from '@object-ui/components';
 import { AlertCircle, ArrowUpRight } from 'lucide-react';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
@@ -322,16 +322,8 @@ export const ObjectChart = (props: any) => {
         const schemaRes = await fetch(`/api/v1/meta/object/${encodeURIComponent(objectName)}`, reqOpts);
         const sj = await schemaRes.json().catch(() => null);
         const objSchema = sj?.item ?? sj?.data ?? sj;
-        const fieldOpts = objSchema?.fields?.[fieldName]?.options;
-        if (!Array.isArray(fieldOpts) || !fieldOpts.length) { if (!cancelled) setFieldOptionColors(null); return; }
-        const map: Record<string, string> = {};
-        for (const o of fieldOpts) {
-          if (o && typeof o === 'object' && o.color) {
-            if (o.value != null) map[String(o.value)] = o.color;
-            if (o.label != null) map[String(o.label)] = o.color;
-          }
-        }
-        if (!cancelled) setFieldOptionColors(Object.keys(map).length ? map : null);
+        const map = buildOptionColorMap(objSchema?.fields?.[fieldName]?.options);
+        if (!cancelled) setFieldOptionColors(map);
       } catch { if (!cancelled) setFieldOptionColors(null); }
     })();
     return () => { cancelled = true; };

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -30,6 +30,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { SchemaRenderer } from '@object-ui/react';
 import {
   buildChartSeries,
+  buildOptionColorMap,
   findChartSeriesRow,
   formatMeasure,
   formatDimensionValue,
@@ -193,6 +194,12 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; totals?: DatasetTotals[]; error?: string }>({ status: 'idle', rows: [] });
   // Drill-through (ADR-0021 D2): the clicked bucket's record-list filter + title.
   const [drill, setDrill] = useState<{ filter: Record<string, unknown>; title: string } | null>(null);
+  // Per-category colors: when the chart's first dimension is a select/lookup
+  // field, paint each category in its option color (health green/red/yellow)
+  // instead of the generic --chart-1..5 palette — the same wiring the chart
+  // view uses (ObjectChart). The renderer's `categoryColors` map wins over the
+  // positional palette and falls back to it for categories without a color.
+  const [categoryColors, setCategoryColors] = useState<Record<string, string> | null>(null);
 
   // Signature uses the RAW filter (stable) — the resolved one carries a
   // render-time `now` and would otherwise force a refetch loop.
@@ -218,6 +225,30 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [signature]);
+
+  // Resolve the first dimension's select/lookup option colors (charts only;
+  // metric/table/pivot don't use per-category colors). The dataset query gives
+  // us the base `object` and the dimension→field map, so we fetch the object
+  // schema and build a {value|label → color} map. Best-effort: any failure
+  // leaves it null and the chart keeps the positional palette.
+  useEffect(() => {
+    if (isMetric || isTable) { setCategoryColors(null); return; }
+    const object = state.object;
+    const dim0 = dimensions[0];
+    const field = (state.dimensionFields && state.dimensionFields[dim0]) || dim0;
+    if (!object || !field) { setCategoryColors(null); return; }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/v1/meta/object/${encodeURIComponent(object)}`, { headers: { accept: 'application/json' }, credentials: 'include' });
+        const j = await res.json().catch(() => null);
+        const objSchema = j?.item ?? j?.data ?? j;
+        const map = buildOptionColorMap(objSchema?.fields?.[field]?.options);
+        if (!cancelled) setCategoryColors(map);
+      } catch { if (!cancelled) setCategoryColors(null); }
+    })();
+    return () => { cancelled = true; };
+  }, [state.object, state.dimensionFields, dimensions, isMetric, isTable]);
 
   if (values.length === 0) {
     return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground">{tt('dashboard.pickMeasures', 'Pick measures (values) for this dataset widget.')}</div>;
@@ -466,7 +497,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   return (
     <div className={cn('relative h-full w-full min-h-[220px]')}>
       <SchemaRenderer
-        schema={{ type: 'chart', chartType, data: chartData, xAxisKey, series } as any}
+        schema={{ type: 'chart', chartType, data: chartData, xAxisKey, series, ...(categoryColors ? { categoryColors } : {}) } as any}
         onChartClick={chartDrill}
         onSegmentClick={chartDrill}
       />


### PR DESCRIPTION
## What

Dashboard `DatasetWidget` charts grouped by a **select/lookup dimension** (e.g. project `health`) now paint each category in its **field option color** instead of the generic `--chart-1..5` palette.

## Why

This is the dashboard counterpart of the `object-chart` view fix (objectstack-ai/objectui#1932). Before, only the chart **view** resolved semantic option colors; dashboard widgets over the same dataset still showed health "Red" as teal. Now both surfaces match.

## How

- `DatasetWidget` resolves the first dimension's option colors using the dataset's base `object` + dimension→field map **the query already returns** (`state.object` / `state.dimensionFields`), fetches the object schema, and threads a per-category `categoryColors` map into the chart schema. The renderer (`AdvancedChartImpl`, shipped in #1932) already applies that map, with the positional palette as fallback.
- Extracts the value/label→color resolution into a shared **`buildOptionColorMap`** in `@object-ui/core`, now used by **both** `DatasetWidget` and `ObjectChart` (the chart view's inline loop is refactored to call it — behavior-preserving).

Keyed by BOTH option `value` and `label`, since the server resolves dataset select dimensions value→label while the legacy path keeps the raw value.

## Test

- `@object-ui/core` `buildOptionColorMap` unit test (5 cases: value+label keying, null/empty/no-color, partial, malformed) — passing.
- Renderer behavior covered by `AdvancedChartImpl.colors.test.tsx` (#1932) — still passing.
- Charts only; metric/table/pivot widgets are unaffected. Best-effort: any failure leaves the positional palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)