### PR TITLE
fix(studio): render slotted record pages in the page-editor Preview tab

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/PagePreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PagePreview.test.tsx
@@ -1,7 +1,12 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+
+// Capture the schema handed to the runtime SchemaRenderer so slotted-page
+// tests can assert what was actually rendered (synthesized regions vs the raw
+// empty draft). `vi.hoisted` lets the mock factory reference it despite hoisting.
+const { schemaSpy } = vi.hoisted(() => ({ schemaSpy: vi.fn() }));
 
 // Mock the heavy runtime/canvas children so the test isolates PagePreview's
 // routing decision (which child it picks), not their internals.
@@ -9,7 +14,10 @@ vi.mock('../../InterfaceListPage', () => ({
   InterfaceListPage: () => <div data-testid="mock-interface-list" />,
 }));
 vi.mock('@object-ui/react', () => ({
-  SchemaRenderer: () => <div data-testid="mock-schema-renderer" />,
+  SchemaRenderer: ({ schema }: { schema: any }) => {
+    schemaSpy(schema);
+    return <div data-testid="mock-schema-renderer" />;
+  },
   RecordContextProvider: ({ children }: { children: any }) => <>{children}</>,
 }));
 vi.mock('./PageBlockCanvas', () => ({
@@ -59,5 +67,81 @@ describe('PagePreview — interface-page routing (ADR-0047)', () => {
     render(<PagePreview draft={regionDraft} />);
     expect(screen.queryByTestId('mock-interface-list')).not.toBeInTheDocument();
     expect(screen.getByTestId('mock-schema-renderer')).toBeInTheDocument();
+  });
+});
+
+describe('PagePreview — slotted record page synthesis', () => {
+  beforeEach(() => {
+    schemaSpy.mockClear();
+    // Record binding fetches the object schema + sample records. Resolve both
+    // to empty so the effect settles deterministically; synthesis falls back to
+    // a def-less default page (structure only), which is all this test asserts.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: async () => ({}) }));
+  });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  // A slotted page overrides `highlights` + `tabs`; header/details/discussion
+  // are omitted and must be filled by the synthesizer.
+  const slottedDraft = {
+    name: 'showcase_account_record',
+    type: 'record',
+    object: 'showcase_account',
+    kind: 'slotted',
+    regions: [], // slotted pages carry an empty regions[] — the blank-canvas trap
+    slots: {
+      highlights: [{ type: 'record:highlights', fields: ['industry', 'website'] }],
+      tabs: [{ type: 'page:tabs', items: [{ label: 'Custom', children: [] }] }],
+    },
+  };
+
+  it('renders synthesized default regions (not the empty draft) so the preview is not blank', async () => {
+    render(<PagePreview draft={slottedDraft} />);
+    await waitFor(() => expect(schemaSpy).toHaveBeenCalled());
+    const rendered = schemaSpy.mock.calls.at(-1)![0];
+
+    // The raw draft has regions:[] — synthesis must replace it with the
+    // canonical record layout so SchemaRenderer has something to walk.
+    expect(rendered.type).toBe('record');
+    const main = (rendered.regions ?? []).find((r: any) => r.name === 'main');
+    expect(main).toBeTruthy();
+    expect(main.components.length).toBeGreaterThan(0);
+  });
+
+  it('fills omitted slots with synthesized defaults and applies authored overrides', async () => {
+    render(<PagePreview draft={slottedDraft} />);
+    await waitFor(() => expect(schemaSpy).toHaveBeenCalled());
+    const rendered = schemaSpy.mock.calls.at(-1)![0];
+    const main = rendered.regions.find((r: any) => r.name === 'main');
+    const comps: any[] = main.components;
+    const types = comps.map((c) => c.type);
+
+    // Omitted slots → synthesized defaults.
+    expect(types).toContain('page:header');
+    expect(types).toContain('record:discussion');
+
+    // Authored highlights override is applied verbatim (replaces the default
+    // chips + chevron path).
+    const highlights = comps.find((c) => c.type === 'record:highlights');
+    expect(highlights?.fields).toEqual(['industry', 'website']);
+
+    // Authored tabs override wins — the custom tab is present.
+    const tabs = comps.find((c) => c.type === 'page:tabs');
+    expect(tabs?.items?.[0]?.label).toBe('Custom');
+  });
+
+  it('renders the authored schema unchanged for a non-slotted (full) record page', async () => {
+    const fullDraft = {
+      name: 'acct_full',
+      type: 'record',
+      object: 'showcase_account',
+      kind: 'full',
+      regions: [{ name: 'main', components: [{ type: 'record:details' }] }],
+    };
+    render(<PagePreview draft={fullDraft} />);
+    await waitFor(() => expect(schemaSpy).toHaveBeenCalled());
+    const rendered = schemaSpy.mock.calls.at(-1)![0];
+    // No synthesis — the authored single-region layout passes through as-is.
+    expect(rendered.regions).toHaveLength(1);
+    expect(rendered.regions[0].components).toEqual([{ type: 'record:details' }]);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx
@@ -12,6 +12,7 @@
 import * as React from 'react';
 import { SchemaRenderer, RecordContextProvider } from '@object-ui/react';
 import { buildExpandFields } from '@object-ui/core';
+import { buildDefaultPageSchema } from '@object-ui/plugin-detail';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewErrorBoundary, PreviewMessage } from './PreviewShell';
 import { OutlineStrip } from './OutlineStrip';
@@ -106,9 +107,13 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
   // Fetch a handful of real records of the bound object + its schema and let
   // the author pick which one to preview against (mirrors the runtime
   // RecordDetailView's RecordContextProvider).
-  const recordObject = (draft as { type?: string; object?: string })?.type === 'record'
-    ? (draft as { object?: string })?.object
-    : undefined;
+  // Match the runtime resolver (usePageAssignment): a record page is keyed by
+  // either bare `type: 'record'` (editor draft shape) or `pageType: 'record'`
+  // (persisted envelope shape). Both must bind a sample record so record:*
+  // blocks render real data.
+  const isRecordPage = (draft as { type?: string; pageType?: string })?.type === 'record'
+    || (draft as { pageType?: string })?.pageType === 'record';
+  const recordObject = isRecordPage ? (draft as { object?: string })?.object : undefined;
   const [recordSamples, setRecordSamples] = React.useState<any[]>([]);
   const [recordSchema, setRecordSchema] = React.useState<any>(null);
   const [selectedRecordId, setSelectedRecordId] = React.useState<string | number | null>(null);
@@ -154,6 +159,28 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
     if (!recordSamples.length) return null;
     return recordSamples.find((r) => String(recordIdOf(r)) === String(selectedRecordId)) ?? recordSamples[0];
   }, [recordSamples, selectedRecordId]);
+
+  // ── Slotted record page synthesis ────────────────────────────────────────
+  // A `kind: 'slotted'` page carries an empty `regions: []` plus a `slots` map
+  // of overrides, so the raw draft renders blank through SchemaRenderer (there
+  // are no regions to walk). Mirror the runtime RecordDetailView: synthesize the
+  // canonical default page from the bound object's schema and apply the slot
+  // overrides via the SAME `buildDefaultPageSchema(objectDef, { slots })` path,
+  // so omitted slots fall through to the synthesized header/details/discussion
+  // while authored slots (highlights/tabs/…) override in place. Non-slotted
+  // pages render their authored schema unchanged.
+  const isSlotted = (draft as { kind?: string })?.kind === 'slotted';
+  const renderSchema = React.useMemo(() => {
+    if (!isSlotted) return schema;
+    try {
+      const slots = (draft as { slots?: Record<string, unknown> })?.slots ?? {};
+      // `recordSchema` arrives async; until then synthesize with no objectDef
+      // (structure renders immediately, field-level detail fills in on load).
+      return buildDefaultPageSchema(recordSchema ?? undefined, { slots }) as Record<string, unknown>;
+    } catch {
+      return schema;
+    }
+  }, [isSlotted, schema, draft, recordSchema]);
   // Wrap record-page content in the record context (+ a sample-record picker)
   // so detail/highlights/path/alert blocks render real data. No-op for
   // non-record pages and for record pages with no rows yet (renders the node
@@ -268,7 +295,7 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
         )}
         {withRecordBinding(
           <div className="min-h-[200px] max-h-[70vh] overflow-auto p-4">
-            <SchemaRenderer schema={schema as any} />
+            <SchemaRenderer schema={renderSchema as any} />
           </div>
         )}
       </PreviewErrorBoundary>


### PR DESCRIPTION
## Problem

A `kind: 'slotted'` record page renders **blank in the Studio page-editor Preview tab**, while the **Design tab works correctly** (shows each slot — header/actions/alerts/highlights/details/tabs/discussion — marking inherited ones "Inherited from the default page" and showing authored overrides).

**Root cause:** [`PagePreview.tsx`](https://github.com/objectstack-ai/objectui/blob/main/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx) renders the runtime `<SchemaRenderer>` on the raw draft, whose `regions` is an empty `[]` for a slotted page (overrides live in `slots`). With no regions to walk, the `record` page renderer paints nothing.

The runtime (`RecordDetailView`) never renders slotted pages directly — it synthesizes the canonical default layout via `buildDefaultPageSchema(objectDef, { slots })` and applies the slot overrides. The Studio Preview now does the same.

## Fix

- **Reuse the runtime synthesis path:** when `draft.kind === 'slotted'`, build the render schema via `buildDefaultPageSchema(recordSchema, { slots })` — identical to `RecordDetailView` — so omitted slots fall through to the synthesized header/details/discussion while authored slots (highlights/tabs/…) override in place. Non-slotted pages render their authored schema unchanged.
- **Bind a real sample record:** the synthesized `record:*` blocks render against the existing record-picker binding (from the P2 fix), so the author sees live data.
- **Broaden record-page detection** to `type: 'record' || pageType: 'record'`, matching `usePageAssignment`, so the sample-record binding fires for both the editor-draft and persisted-envelope shapes.

## Verification

- **Unit:** 3 new tests in `PagePreview.test.tsx` assert the synthesized `regions` contain the default `page:header`/`record:discussion` plus the authored `highlights` (fields preserved) and `tabs` (custom tab) overrides; a control test confirms non-slotted pages pass through unchanged. Full previews suite green (124/124).
- **End-to-end (browser, real backend):** created a slotted `showcase_account` page overriding `highlights` + `tabs`, opened the Preview tab — no longer blank. Renders the synthesized **Northwind** header, the authored highlights strip with **live data** (Industry: Retail · Annual Revenue: 8,000,000 · Website · Lifecycle: Active), the authored **Custom Slot Tab**, the Overview details, and the synthesized Discussion footer. No new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)