### PR TITLE
chore: drop unrendered blank/record_review page types (align with framework#2265)

### DIFF
--- a/.changeset/drop-blank-page-type.md
+++ b/.changeset/drop-blank-page-type.md
@@ -1,0 +1,19 @@
+---
+"@object-ui/types": minor
+"@object-ui/react": minor
+---
+
+chore: drop the unrendered `blank` / `record_review` page types and their config
+
+The `blank` and `record_review` page types have no renderer and were removed
+from `@objectstack/spec`'s `PageTypeSchema` (framework#2265, enforce-or-remove).
+This drops their now-dead references in objectui so the upstream spec can hard-
+remove `BlankPageLayoutSchema` / `RecordReviewConfigSchema`:
+
+- `PageType` union: removed `dashboard` / `form` / `record_detail` /
+  `record_review` / `overview` / `blank` (grid/gallery/kanban/calendar/timeline
+  remain — those are list *visualizations*, a separate cleanup).
+- Removed `blankLayout` from `PageLayout` and the `blankLayout` / `recordReview`
+  handling in the spec→SDUI page bridge.
+- Removed the redundant `BlankPageLayout{,Schema,Item,ItemSchema}` re-import from
+  `@objectstack/spec/ui` (it was never used).

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -384,7 +384,6 @@ export const PageRenderer: React.FC<{
     description: _descriptionProp,
     object: _objectProp,
     variables: _variablesProp,
-    blankLayout: _blankLayoutProp,
     body: _bodyProp,
     isDefault: _isDefaultProp,
     assignedProfiles: _assignedProfilesProp,

--- a/packages/react/src/spec-bridge/__tests__/P1SpecBridge.test.ts
+++ b/packages/react/src/spec-bridge/__tests__/P1SpecBridge.test.ts
@@ -524,9 +524,7 @@ describe('P1 SpecBridge Protocol Alignment', () => {
       const bridge = new SpecBridge();
       const pageTypes = [
         'record', 'home', 'app', 'utility',
-        'dashboard', 'grid', 'list', 'gallery',
-        'kanban', 'calendar', 'timeline', 'form',
-        'record_detail', 'record_review', 'overview', 'blank',
+        'grid', 'list', 'gallery', 'kanban', 'calendar', 'timeline',
       ];
 
       pageTypes.forEach((pageType) => {
@@ -538,26 +536,9 @@ describe('P1 SpecBridge Protocol Alignment', () => {
       });
     });
 
-    it('should map blank page layout', () => {
-      const bridge = new SpecBridge();
-      const node = bridge.transformPage({
-        name: 'blank_page',
-        type: 'blank',
-        blankLayout: {
-          columns: 12,
-          rowHeight: 60,
-          gap: 8,
-          items: [
-            { componentId: 'header', x: 0, y: 0, width: 12, height: 2 },
-            { componentId: 'chart', x: 0, y: 2, width: 6, height: 4 },
-          ],
-        },
-      });
-
-      expect(node.blankLayout).toBeDefined();
-      expect(node.blankLayout.columns).toBe(12);
-      expect(node.blankLayout.items).toHaveLength(2);
-    });
+    // (Removed "should map blank page layout" — the bridge no longer maps
+    // blankLayout; the `blank` page type has no renderer, dropped from
+    // @objectstack/spec (framework#2265).)
 
     it('should map page variables with source', () => {
       const bridge = new SpecBridge();

--- a/packages/react/src/spec-bridge/bridges/page.ts
+++ b/packages/react/src/spec-bridge/bridges/page.ts
@@ -36,14 +36,6 @@ interface PageVariable {
   source?: string;
 }
 
-interface BlankPageLayoutItem {
-  componentId: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
 interface PageSpec {
   name?: string;
   label?: string;
@@ -54,14 +46,8 @@ interface PageSpec {
   regions?: PageRegion[];
   template?: string;
   object?: string;
-  // P1.4 additions
-  blankLayout?: {
-    columns?: number;
-    rowHeight?: number;
-    gap?: number;
-    items?: BlankPageLayoutItem[];
-  };
-  recordReview?: any;
+  // NOTE: blankLayout/recordReview removed — the `blank`/`record_review` page
+  // types have no renderer and were dropped from @objectstack/spec (framework#2265).
   isDefault?: boolean;
   assignedProfiles?: string[];
   interfaceConfig?: any;
@@ -129,11 +115,8 @@ export const bridgePage: BridgeFn<PageSpec> = (
   if (spec.template) node.template = spec.template;
   if (spec.object) node.object = spec.object;
 
-  // P1.4 — Blank page layout
-  if (spec.blankLayout) node.blankLayout = spec.blankLayout;
-
-  // P1.4 — Additional page properties
-  if (spec.recordReview) node.recordReview = spec.recordReview;
+  // Additional page properties (blankLayout/recordReview dropped — their page
+  // types have no renderer and were removed from @objectstack/spec, framework#2265)
   if (spec.isDefault != null) node.isDefault = spec.isDefault;
   if (spec.assignedProfiles) node.assignedProfiles = spec.assignedProfiles;
   if (spec.interfaceConfig) node.interfaceConfig = spec.interfaceConfig;

--- a/packages/types/src/__tests__/p1-spec-alignment.test.ts
+++ b/packages/types/src/__tests__/p1-spec-alignment.test.ts
@@ -409,12 +409,14 @@ describe('P1.3 Dashboard Spec Alignment', () => {
 // P1.4 Page Composition Spec Alignment
 // ============================================================================
 describe('P1.4 Page Composition Spec Alignment', () => {
-  it('should accept all 16 page types', () => {
+  it('should accept all page types', () => {
+    // The roadmap types (dashboard/form/record_detail/record_review/overview/
+    // blank) were removed — no renderer, dropped from @objectstack/spec
+    // PageTypeSchema (framework#2265). grid/gallery/kanban/calendar/timeline
+    // remain pending a separate "visualizations are not page types" cleanup.
     const allTypes: PageType[] = [
       'record', 'home', 'app', 'utility',
-      'dashboard', 'grid', 'list', 'gallery',
-      'kanban', 'calendar', 'timeline', 'form',
-      'record_detail', 'record_review', 'overview', 'blank',
+      'grid', 'list', 'gallery', 'kanban', 'calendar', 'timeline',
     ];
     allTypes.forEach((type) => {
       const page: PageSchema = {
@@ -435,25 +437,8 @@ describe('P1.4 Page Composition Spec Alignment', () => {
     expect(variable.source).toBe('url_param');
   });
 
-  it('should accept blank page layout', () => {
-    const page: PageSchema = {
-      type: 'page',
-      pageType: 'blank',
-      blankLayout: {
-        columns: 12,
-        rowHeight: 60,
-        gap: 8,
-        items: [
-          { componentId: 'header-1', x: 0, y: 0, width: 12, height: 2 },
-          { componentId: 'chart-1', x: 0, y: 2, width: 6, height: 4 },
-          { componentId: 'metric-1', x: 6, y: 2, width: 6, height: 4 },
-        ],
-      },
-    };
-    expect(page.blankLayout?.columns).toBe(12);
-    expect(page.blankLayout?.items).toHaveLength(3);
-    expect(page.blankLayout?.items![0].componentId).toBe('header-1');
-  });
+  // (Removed "should accept blank page layout" — the `blank` page type and its
+  // blankLayout config were dropped: no renderer (framework#2265).)
 
   it('should accept page ARIA properties', () => {
     const page: PageSchema = {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1187,10 +1187,8 @@ export type {
   PageTypeSchema as SpecPageTypeSchema,
   PageVariable as SpecPageVariable,
   PageVariableSchema as SpecPageVariableSchema,
-  BlankPageLayout,
-  BlankPageLayoutSchema,
-  BlankPageLayoutItem,
-  BlankPageLayoutItemSchema,
+  // BlankPageLayout{,Schema,Item,ItemSchema} dropped — `blank` page type has no
+  // renderer; removed from @objectstack/spec PageTypeSchema (framework#2265).
 } from '@objectstack/spec/ui';
 
 // ============================================================================

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -434,18 +434,17 @@ export type PageType =
   | 'home'
   | 'app'
   | 'utility'
-  | 'dashboard'
+  // The roadmap page types (dashboard/form/record_detail/record_review/overview/
+  // blank) were removed: they have no renderer and were dropped from
+  // @objectstack/spec PageTypeSchema (framework#2265, enforce-or-remove).
+  // NOTE: grid/list/gallery/kanban/calendar/timeline below are list
+  // VISUALIZATIONS, not page kinds — retained pending a separate cleanup.
   | 'grid'
   | 'list'
   | 'gallery'
   | 'kanban'
   | 'calendar'
-  | 'timeline'
-  | 'form'
-  | 'record_detail'
-  | 'record_review'
-  | 'overview'
-  | 'blank';
+  | 'timeline';
 
 /**
  * Page Variable
@@ -540,32 +539,8 @@ export interface PageSchema extends BaseSchema {
    * (Aligned with @objectstack/spec Page.regions)
    */
   regions?: PageRegion[];
-  /**
-   * Blank page grid layout
-   * Used when pageType is 'blank' for free-form grid canvas.
-   * Aligned with @objectstack/spec BlankPageLayoutSchema.
-   */
-  blankLayout?: {
-    /** Number of grid columns */
-    columns?: number;
-    /** Row height in pixels */
-    rowHeight?: number;
-    /** Gap between grid items in pixels */
-    gap?: number;
-    /** Items placed on the grid */
-    items?: Array<{
-      /** Component ID reference */
-      componentId: string;
-      /** Grid column position */
-      x: number;
-      /** Grid row position */
-      y: number;
-      /** Width in grid columns */
-      width: number;
-      /** Height in grid rows */
-      height: number;
-    }>;
-  };
+  // blankLayout removed — the `blank` page type has no renderer and was dropped
+  // from @objectstack/spec PageTypeSchema (framework#2265, enforce-or-remove).
   /**
    * Main content array (Legacy/Simple mode)
    */


### PR DESCRIPTION
Companion to framework#2265 (enforce-or-remove of unrendered roadmap page types). Drops objectui's now-dead references to `blank` / `record_review` so the upstream spec can **hard-remove** `BlankPageLayoutSchema` / `RecordReviewConfigSchema`.

## Changes
- **`PageType` union** (`types/layout.ts`): removed `dashboard` / `form` / `record_detail` / `record_review` / `overview` / `blank` — none have a renderer; dropped from `@objectstack/spec` PageTypeSchema. (`grid/gallery/kanban/calendar/timeline` stay — those are list *visualizations* mislabeled as page kinds, a separate cleanup.)
- **`PageLayout.blankLayout`** removed; **spec→SDUI bridge** no longer maps `spec.blankLayout` / `spec.recordReview`, and its local `BlankPageLayoutItem` interface is gone.
- Removed the **redundant `BlankPageLayout{,Schema,Item,ItemSchema}` re-import** from `@objectstack/spec/ui` in `types/index.ts` (it was never used — objectui has its own local types).
- Updated the two tests that asserted the old 16-type union / blank layout mapping.

## Verification
- ✅ `tsc --noEmit` clean across `@object-ui/types`, `@object-ui/react`, `@object-ui/components` (incl. the updated test files).
- Note: a parallel PR (#1948) already shipped the slotted-Preview render fix; this is unrelated and orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)