### PR TITLE
fix(metadata-admin): new script action seeds a valid body; add create-roundtrip conformance guard

### DIFF
--- a/.changeset/action-create-body-and-conformance.md
+++ b/.changeset/action-create-body-and-conformance.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/app-shell': patch
+---
+
+New script action seeds a valid body; add create-roundtrip conformance guard
+
+A new action defaults to `type: 'script'`, which the spec requires to carry an executable `body` or `target` — the create form seeded neither, so "New action → Save" failed validation (422). Seed a no-op L2 body in `createDefaults` so the default create round-trips. Adds a conformance guard that asserts every authorable type's default create-form output passes spec validation (catches the "designer minimal shape ≠ spec required" family before it ships).

--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -363,6 +363,15 @@ export function registerBuiltinAnchors(): void {
     createDerive: [
       { from: 'label', to: 'name', transform: 'slugify', untilUserEdits: true },
     ],
+    // A new action defaults to `type: 'script'` (ActionType.default), which the
+    // spec requires to carry an executable `body` or `target` — otherwise the
+    // draft fails validation on save (422) and AppPlugin registers no engine
+    // handler (the #2169 "Mark Done" runtime miss). Seed a no-op L2 body so
+    // "New action -> name -> Save" round-trips; the author edits the source after.
+    createDefaults: {
+      type: 'script',
+      body: { language: 'js', source: 'return { success: true };' },
+    },
   });
 
   // dashboard / report — surface ones bound to a specific object.

--- a/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
@@ -1,0 +1,109 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// CONFORMANCE GUARD — every authorable metadata type's DEFAULT create-form
+// output must pass spec validation. Catches the recurring "the designer
+// produces a minimal shape the spec rejects, so create→save 422s" family
+// (dashboard `layout`, report stale anchors, action missing `body`, …) that
+// passes every other gate because code-authored examples always supply full
+// shapes. Reads the ACTUAL create config from the registry so it cannot drift
+// from what the designer emits.
+
+import { describe, it, expect } from 'vitest';
+import { registerBuiltinAnchors } from './anchors';
+import { listMetadataResources, type MetadataResourceConfig } from './registry';
+import { validateMetadataDraft, hasClientValidator } from './clientValidation';
+
+registerBuiltinAnchors();
+
+/** Placeholder value for a create-form field, mirroring what a user types.
+ *  Enum-ish fields (type/kind/isProfile) fall back to the create default so we
+ *  don't override them with a bogus string; unknown ones stay unset (schema
+ *  default applies). */
+// Enum createFields the create form forces the user to pick (rendered as a
+// required <select>) but that carry no createDefault. The guard supplies a valid
+// option to simulate the choice, exactly as the form requires one before save.
+const REQUIRED_PICKS: Record<string, Record<string, unknown>> = {
+  flow: { type: 'autolaunched' },
+};
+
+function placeholderFor(field: string, cfg: MetadataResourceConfig): unknown {
+  const pick = REQUIRED_PICKS[cfg.type]?.[field];
+  if (pick !== undefined) return pick;
+  switch (field) {
+    case 'label': return 'Conformance Probe';
+    case 'pluralLabel': return 'Conformance Probes';
+    case 'name': return `conf_${cfg.type.replace(/[^a-z0-9_]/g, '_')}`;
+    case 'object':
+    case 'objectName': return 'showcase_task';
+    case 'description': return '';
+    case 'message': return 'Validation message';
+    case 'icon': return 'Zap';
+    default:
+      return cfg.createDefaults && field in (cfg.createDefaults as Record<string, unknown>)
+        ? (cfg.createDefaults as Record<string, unknown>)[field]
+        : undefined;
+  }
+}
+
+/** Reproduce ResourceEditPage.doSave's create body:
+ *  createBuildBody(draft) ?? { ...createDefaults, ...draft }. */
+function buildCreateOutput(cfg: MetadataResourceConfig): Record<string, unknown> {
+  const draft: Record<string, unknown> = {};
+  for (const f of cfg.createFields ?? ['label', 'name']) {
+    const v = placeholderFor(f, cfg);
+    if (v !== undefined) draft[f] = v;
+  }
+  return cfg.createBuildBody
+    ? (cfg.createBuildBody(draft) as Record<string, unknown>)
+    : { ...((cfg.createDefaults as Record<string, unknown>) ?? {}), ...draft };
+}
+
+// Canvas-create types (mirror ResourceEditPage.CREATE_MODE_CANVAS_TYPES) build
+// their save shape INTERACTIVELY on the canvas — e.g. report's dataset/measures
+// are picked there — so `createDefaults` alone is intentionally incomplete and
+// this name-first-form guard does not apply to them.
+const CANVAS_CREATE_TYPES = new Set(['object', 'report']);
+
+// Authorable via the name-first create form: skip synthetic object sub-resources
+// (__object_field …), canvas-create types, and anything with no create affordance.
+const authorable = listMetadataResources().filter(
+  (c) => !c.type.startsWith('__') && !CANVAS_CREATE_TYPES.has(c.type) && (c.createFields || c.createDefaults || c.createBuildBody),
+);
+
+describe('create-roundtrip conformance: default create output passes spec validation', () => {
+  it('surfaces excluded canvas-create types + types without a client schema (no silent cap)', () => {
+    const noSchema = authorable.filter((c) => !hasClientValidator(c.type)).map((c) => c.type);
+    // eslint-disable-next-line no-console
+    console.log(`[conformance] canvas-create (interactive, excluded): ${[...CANVAS_CREATE_TYPES].join(', ')}`);
+    // eslint-disable-next-line no-console
+    console.log(`[conformance] name-first types covered: ${authorable.map((c) => c.type).join(', ')}`);
+    // eslint-disable-next-line no-console
+    if (noSchema.length) console.log(`[conformance] shape-only (no client schema): ${noSchema.join(', ')}`);
+    expect(authorable.length).toBeGreaterThan(4);
+  });
+
+  it('sanity: discovers the known authorable types', () => {
+    const types = new Set(authorable.map((c) => c.type));
+    for (const t of ['dashboard', 'action', 'page', 'view', 'flow']) {
+      expect(types.has(t), `authorable type '${t}' not discovered`).toBe(true);
+    }
+  });
+
+  for (const cfg of authorable) {
+    const checked = hasClientValidator(cfg.type);
+    it(`${cfg.type}: default create output is spec-valid${checked ? '' : ' (no client schema — shape only)'}`, async () => {
+      const output = buildCreateOutput(cfg);
+      const { issues } = await validateMetadataDraft(cfg.type, output);
+      expect(
+        issues,
+        `${cfg.type} create output rejected by spec: ${JSON.stringify(issues)}\noutput=${JSON.stringify(output)}`,
+      ).toHaveLength(0);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Found dogfooding the Studio metadata designers. A new **action** defaults to `type: 'script'` (`ActionType.default`), which the spec requires to carry an executable `body` **or** `target`. The action create form seeded **neither**, so "New action → fill name → Save" failed validation (**422**), and AppPlugin registered no engine handler (the #2169 "Mark Done" runtime miss).

This is one instance of a recurring family — **the designer produces a minimal shape the spec rejects, so create→save 422s** — that passes every other gate because code-authored examples always supply full shapes (same class as the dashboard-`layout` P1).

## Fix

1. **action create**: seed a no-op L2 body in `createDefaults` (`{ type: 'script', body: { language: 'js', source: 'return { success: true };' } }`) so the default create round-trips; the author edits the source after.
2. **conformance guard** (`createConformance.test.ts`): for every authorable type in the registry, build its DEFAULT create-form output (`createBuildBody` / `createDefaults` + minimal `createFields`, exactly as `ResourceEditPage.doSave`) and assert it passes spec validation. Reads the **actual registry config** so it can't drift from what the designer emits. Canvas-create types (object/report — dataset picked interactively) are excluded with a documented reason; the guard logs covered/excluded types.

## Verification

- The guard was **red on `action`** (`requires inline body`) before the fix, **green after** — 11 passed.
- It also surfaced `report` (canvas-create, correctly excluded) and a self-inflicted `flow` `type` gap (now simulates the required pick).
- Full `metadata-admin` suite: **362 passed**, no regressions.

Closes the "renders/creates in the designer ≠ persists" coverage gap for the metadata create flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)