### PR TITLE
fix(metadata-admin): remove unwired "Certified" measure toggle from dataset designer

### DIFF
--- a/.changeset/remove-dataset-certified-toggle.md
+++ b/.changeset/remove-dataset-certified-toggle.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(metadata-admin): remove the unwired "Certified" measure toggle from the dataset designer
+
+`measure.certified` is dead in the spec liveness ledger (declared but read by
+nothing — no certifier authority, no provenance, not surfaced at point-of-use).
+A self-asserted checkbox the dataset author flips on their own work isn't
+certification — it's a fake trust signal. Drop the toggle (and the create
+default) until real metric governance exists (separate `dataset.certify`
+authority + `certifiedBy`/`certifiedAt` + a badge where reports pick measures).
+The spec field stays (dormant, liveness=dead) so existing data is untouched.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
@@ -50,7 +50,8 @@ describe('DatasetDefaultInspector', () => {
     expect(onPatch).toHaveBeenCalledTimes(1);
     const patch = onPatch.mock.calls[0][0];
     expect(patch.measures).toHaveLength(2);
-    expect(patch.measures[1]).toMatchObject({ aggregate: 'sum', certified: false });
+    expect(patch.measures[1]).toMatchObject({ aggregate: 'sum' });
+    expect(patch.measures[1]).not.toHaveProperty('certified');
   });
 
   it('adds a dimension via onPatch', () => {
@@ -119,5 +120,10 @@ describe('DatasetDefaultInspector', () => {
   it('hides the create-mode Name field once the dataset has a name (edit mode)', () => {
     render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={vi.fn()} readOnly={false} />);
     expect(screen.queryByPlaceholderText('snake_case identifier')).not.toBeInTheDocument();
+  });
+
+  it('does not surface a Certified toggle (governance flag is unwired/dead — no fake stamp)', () => {
+    render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={vi.fn()} readOnly={false} />);
+    expect(screen.queryByText('Certified')).not.toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
@@ -8,7 +8,7 @@
  *   - base `object`,
  *   - `include` relationships (the join allowlist — D-C),
  *   - `dimensions` (name + field/`relationship.field` + type + granularity), and
- *   - `measures` (name + aggregate + field + certified + format/currency/derived).
+ *   - `measures` (name + aggregate + field + format/currency/derived).
  *
  * The base object, the included relationships, and every `field` are picked
  * from the live object graph (a searchable combo over {@link useDatasetFieldCatalog})
@@ -428,7 +428,7 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: Meta
           title="Measures"
           count={measures.length}
           addLabel="Add measure"
-          onAdd={readOnly ? undefined : () => onPatch({ measures: appendArray(measures, { name: '', aggregate: 'sum', field: '', certified: false }) })}
+          onAdd={readOnly ? undefined : () => onPatch({ measures: appendArray(measures, { name: '', aggregate: 'sum', field: '' }) })}
         />
         {measures.map((m, i) => {
           const otherMeasures = measures.filter((_, idx) => idx !== i).map((x) => x.name).filter((n): n is string => !!n);
@@ -465,7 +465,6 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: Meta
                 mono
               />
               {(() => { const rel = missingRelationship(m.field, include); return rel ? <RelWarning rel={rel} disabled={readOnly} onAdd={() => onPatch({ include: appendArray(include, rel) })} /> : null; })()}
-              <InspectorCheckboxField label="Certified" value={!!m.certified} onCommit={(v) => patchMeasure(i, { certified: v })} disabled={readOnly} />
               <Advanced>
                 <InspectorTextField label="Label (optional)" value={m.label ?? ''} onCommit={(v) => patchMeasure(i, { label: v || undefined })} placeholder={m.name || 'Display label'} disabled={readOnly} />
                 <MeasureFormatField measure={m} onPatch={(pp) => patchMeasure(i, pp)} disabled={readOnly} />


### PR DESCRIPTION
measure.certified is `dead` in the spec liveness ledger — declared but read by nothing (no certifier authority, no provenance, not surfaced where reports pick measures). A checkbox the author flips on their own work is a fake trust signal, not certification. Remove the toggle + the create default; the spec field stays dormant (liveness=dead) so existing data is untouched. Bring it back only with real governance (separate `dataset.certify` authority + `certifiedBy/At` + a badge at point-of-consumption). Tests: DatasetDefaultInspector 12 pass (new test asserts no Certified toggle renders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)