### PR TITLE
fix(console): object-detail page uses valid `record` PageType (unbreak Bundle Analysis)

### DIFF
--- a/.changeset/console-pagetype-record-detail.md
+++ b/.changeset/console-pagetype-record-detail.md
@@ -1,0 +1,10 @@
+---
+"@object-ui/console": patch
+---
+
+fix(console): object-detail page uses the valid `record` PageType
+
+`buildObjectDetailPageSchema` emitted `pageType: 'record_detail'`, which was
+dropped from `PageType` (`record | home | app | utility`) in framework#2265 /
+objectui#1949 — a `tsc` error (TS2322) that broke the console build (Bundle
+Analysis). An object detail page is a `record` page; use that.

--- a/apps/console/src/schemas/objectDetailPageSchema.ts
+++ b/apps/console/src/schemas/objectDetailPageSchema.ts
@@ -50,7 +50,7 @@ export function buildObjectDetailPageSchema(
     title: label,
     description,
     icon: 'database',
-    pageType: 'record_detail',
+    pageType: 'record', // object detail = a 'record' page (record_detail was dropped from PageType in framework#2265)
     object: objectName,
     body: widgets,
   };


### PR DESCRIPTION
## Why
objectui main's **Bundle Analysis is red on every PR** — `apps/console/src/schemas/objectDetailPageSchema.ts:53` emits `pageType: 'record_detail'`, which was **dropped from `PageType`** (`record | home | app | utility`) in framework#2265 / #1949. The console build runs `tsc` and fails with TS2322.

## Fix
An object **detail** page is a `record` page (also the `PageType` default) → `pageType: 'record'`. One line.

## Note
Spotted while shipping the dataset-designer work (#1931/#1939/#1951) — not caused by it; this is a pre-existing drift from the page-type narrowing. Unblocks the console publish build for all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)