### PR TITLE
feat(studio): live preview for flow Screen nodes (#1944)

### DIFF
--- a/.changeset/flow-screen-node-preview.md
+++ b/.changeset/flow-screen-node-preview.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Flow builder: live preview for Screen nodes (#1944)
+
+Screen-flow nodes were authored blind — there was no way to see the form an end user would get, and the Debug simulator showed only `paused` when it reached a screen. Add a live preview that renders the screen exactly as it runs.
+
+The runtime `FlowRunner`'s screen body (flat input fields + object-form mode) is extracted into a shared `ScreenView`, so the preview reuses the **same** renderer as runtime and can't drift (the design↔runtime divergence #1927 fixed). A new `ScreenPreview` builds a `ScreenSpec` from the node's authored `config` and feeds it to `ScreenView`.
+
+- Reflects `title`, `description` (with `{var}` interpolation), input `fields`, and object-form mode (`objectName` / `mode` / `defaults`, rendered via `plugin-form`'s `ObjectForm`).
+- Updates live as the node config changes.
+- Two homes: the **flow node inspector** (interpolates against the flow's declared variable defaults) and the **Debug simulator** when paused at a screen (interpolates against the live simulated run state, replacing the bare `paused`).

--- a/packages/app-shell/src/views/FlowRunner.tsx
+++ b/packages/app-shell/src/views/FlowRunner.tsx
@@ -9,6 +9,10 @@
  * On submit it POSTs `/api/v1/automation/{flow}/runs/{runId}/resume` with the
  * field values as `inputs`; a `paused` response renders the next screen
  * (multi-screen wizards), a terminal response closes and refreshes the view.
+ *
+ * The screen BODY (flat fields / object-form) is rendered by the shared
+ * {@link ScreenView} — the same renderer the Studio design preview reuses, so
+ * the two can never drift (cf. #1927).
  */
 import { useEffect, useState } from 'react';
 import {
@@ -19,46 +23,12 @@ import {
   DialogTitle,
   DialogDescription,
   Button,
-  Input,
-  Label,
-  Textarea,
-  Checkbox,
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
 } from '@object-ui/components';
-import { ObjectForm } from '@object-ui/plugin-form';
 import { toast } from 'sonner';
+import { ScreenView, isObjectFormScreen, initialScreenValues, type ScreenSpec } from './ScreenView';
 
-export interface ScreenFieldSpec {
-  name: string;
-  label?: string;
-  type?: string;
-  required?: boolean;
-  options?: Array<{ value: unknown; label: string }>;
-  defaultValue?: unknown;
-  placeholder?: string;
-}
-export interface ScreenSpec {
-  nodeId: string;
-  title?: string;
-  description?: string;
-  fields: ScreenFieldSpec[];
-  /**
-   * `'object-form'` renders the named object's FULL create/edit form — incl.
-   * inline master-detail child grids — as a wizard step (vs. the flat `fields`
-   * list). The form persists the record (and its children, atomically) itself,
-   * then resumes the run with the saved id bound to `idVariable`.
-   */
-  kind?: 'fields' | 'object-form';
-  objectName?: string;
-  mode?: 'create' | 'edit';
-  recordId?: string;
-  defaults?: Record<string, unknown>;
-  idVariable?: string;
-}
+export type { ScreenSpec, ScreenFieldSpec } from './ScreenView';
+
 export interface ScreenFlowState {
   flowName: string;
   runId: string;
@@ -89,12 +59,6 @@ export interface FlowRunnerProps {
   objects?: any[];
 }
 
-function initialValues(screen: ScreenSpec): Record<string, unknown> {
-  const v: Record<string, unknown> = {};
-  for (const f of screen.fields) if (f.defaultValue !== undefined) v[f.name] = f.defaultValue;
-  return v;
-}
-
 export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dataSource, objects }: FlowRunnerProps) {
   const [screen, setScreen] = useState<ScreenSpec | null>(null);
   const [runId, setRunId] = useState('');
@@ -107,7 +71,7 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
       setScreen(state.screen);
       setRunId(state.runId);
       setFlowName(state.flowName);
-      setValues(initialValues(state.screen));
+      setValues(initialScreenValues(state.screen));
     }
   }, [state]);
 
@@ -146,7 +110,7 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
     if (data.status === 'paused' && data.screen) {
       setScreen(data.screen);
       setRunId(data.runId || runId);
-      setValues(initialValues(data.screen));
+      setValues(initialScreenValues(data.screen));
       toast.success('Saved — next step');
     } else {
       // Terminal success — show the flow's declared completion message.
@@ -190,13 +154,7 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
     }
   };
 
-  const isObjectForm = screen.kind === 'object-form' && !!screen.objectName;
-  const objectDef = isObjectForm && Array.isArray(objects)
-    ? objects.find((o: any) => o?.name === screen.objectName)
-    : undefined;
-  const subforms = objectDef
-    ? ((objectDef as any).form?.subforms ?? (objectDef as any).formViews?.default?.subforms)
-    : undefined;
+  const isObjectForm = isObjectFormScreen(screen);
 
   return (
     <Dialog open onOpenChange={(o) => { if (!o && !submitting) onClose(); }}>
@@ -206,93 +164,29 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
           {screen.description && <DialogDescription>{screen.description}</DialogDescription>}
         </DialogHeader>
 
-        {isObjectForm ? (
-          // Full object create/edit form (with inline master-detail grids). The
-          // form owns its own Save/Cancel bar; on save it persists and calls
-          // onObjectFormSaved, which resumes the run to the next step.
-          <div className="py-2">
-            {dataSource ? (
-              <ObjectForm
-                key={screen.nodeId}
-                schema={{
-                  type: 'object-form',
-                  formType: 'simple',
-                  objectName: screen.objectName!,
-                  mode: screen.mode === 'edit' ? 'edit' : 'create',
-                  recordId: screen.mode === 'edit' ? screen.recordId : undefined,
-                  ...(screen.defaults ? { initialValues: screen.defaults } : {}),
-                  layout: 'vertical',
-                  subforms,
-                  onSuccess: onObjectFormSaved,
-                  onCancel: onClose,
-                  showSubmit: true,
-                  showCancel: true,
-                  submitText: 'Save & Continue',
-                  cancelText: 'Cancel',
-                } as any}
-                dataSource={dataSource}
-              />
-            ) : (
-              <div className="text-sm text-destructive py-4">
-                This step renders an object form but no data source is available.
-              </div>
-            )}
-          </div>
-        ) : (
-          <>
-            <div className="space-y-4 py-2">
-              {screen.fields.map((f) => (
-                <div key={f.name} className="space-y-1.5">
-                  <Label htmlFor={`ff-${f.name}`} className="text-sm">
-                    {f.label || f.name}
-                    {f.required && <span className="text-destructive"> *</span>}
-                  </Label>
-                  <FieldInput field={f} value={values[f.name]} onChange={(v) => setVal(f.name, v)} />
-                </div>
-              ))}
-            </div>
+        <ScreenView
+          screen={screen}
+          values={values}
+          onValueChange={setVal}
+          dataSource={dataSource}
+          objects={objects}
+          objectForm={{
+            onSuccess: onObjectFormSaved,
+            onCancel: onClose,
+            showSubmit: true,
+            showCancel: true,
+            submitText: 'Save & Continue',
+            cancelText: 'Cancel',
+          }}
+        />
 
-            <DialogFooter>
-              <Button variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
-              <Button onClick={submit} disabled={submitting}>{submitting ? 'Submitting…' : 'Submit'}</Button>
-            </DialogFooter>
-          </>
+        {!isObjectForm && (
+          <DialogFooter>
+            <Button variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
+            <Button onClick={submit} disabled={submitting}>{submitting ? 'Submitting…' : 'Submit'}</Button>
+          </DialogFooter>
         )}
       </DialogContent>
     </Dialog>
-  );
-}
-
-function FieldInput({ field, value, onChange }: { field: ScreenFieldSpec; value: unknown; onChange: (v: unknown) => void }) {
-  const id = `ff-${field.name}`;
-  const t = (field.type || 'text').toLowerCase();
-
-  if (Array.isArray(field.options) && field.options.length > 0) {
-    return (
-      <Select value={value != null ? String(value) : undefined} onValueChange={(v) => onChange(v)}>
-        <SelectTrigger id={id}><SelectValue placeholder={field.placeholder || 'Select…'} /></SelectTrigger>
-        <SelectContent>
-          {field.options.map((o, i) => (
-            <SelectItem key={i} value={String(o.value)}>{o.label}</SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    );
-  }
-  if (t === 'boolean' || t === 'checkbox') {
-    return <Checkbox id={id} checked={value === true} onCheckedChange={(c) => onChange(c === true)} />;
-  }
-  if (t === 'textarea' || t === 'markdown') {
-    return <Textarea id={id} value={(value as string) ?? ''} placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />;
-  }
-  const htmlType = t === 'number' || t === 'currency' ? 'number' : t === 'email' ? 'email' : t === 'date' ? 'date' : 'text';
-  return (
-    <Input
-      id={id}
-      type={htmlType}
-      value={(value as string) ?? ''}
-      placeholder={field.placeholder}
-      onChange={(e) => onChange(htmlType === 'number' ? (e.target.value === '' ? undefined : Number(e.target.value)) : e.target.value)}
-    />
   );
 }

--- a/packages/app-shell/src/views/ScreenView.tsx
+++ b/packages/app-shell/src/views/ScreenView.tsx
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ScreenView — the presentational body of a flow `screen` (framework
+ * screen-flow runtime, ADR-0019): the flat input-field list OR the named
+ * object's full create/edit form.
+ *
+ * Extracted from {@link FlowRunner} so the exact same renderer drives both the
+ * runtime (paused screen-flow → collect input → resume) and the Studio design
+ * preview ({@link ScreenPreview}). Keeping ONE renderer is deliberate: a
+ * separate preview reimplementation would drift from runtime — the
+ * simulator-vs-engine divergence fixed in #1927.
+ *
+ * It owns no submit/resume behaviour and no Dialog chrome — the caller frames
+ * it (the runtime wraps it in a Dialog + footer and resumes the run; the
+ * preview wraps it in a card and hides the persist bar).
+ */
+import {
+  Input,
+  Label,
+  Textarea,
+  Checkbox,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  cn,
+} from '@object-ui/components';
+import { ObjectForm } from '@object-ui/plugin-form';
+
+export interface ScreenFieldSpec {
+  name: string;
+  label?: string;
+  type?: string;
+  required?: boolean;
+  options?: Array<{ value: unknown; label: string }>;
+  defaultValue?: unknown;
+  placeholder?: string;
+}
+export interface ScreenSpec {
+  nodeId: string;
+  title?: string;
+  description?: string;
+  fields: ScreenFieldSpec[];
+  /**
+   * `'object-form'` renders the named object's FULL create/edit form — incl.
+   * inline master-detail child grids — as a wizard step (vs. the flat `fields`
+   * list). The form persists the record (and its children, atomically) itself,
+   * then resumes the run with the saved id bound to `idVariable`.
+   */
+  kind?: 'fields' | 'object-form';
+  objectName?: string;
+  mode?: 'create' | 'edit';
+  recordId?: string;
+  defaults?: Record<string, unknown>;
+  idVariable?: string;
+}
+
+/** Whether a screen renders the object-form body rather than the flat fields. */
+export function isObjectFormScreen(screen: ScreenSpec): boolean {
+  return screen.kind === 'object-form' && !!screen.objectName;
+}
+
+/** Seed flat-field values from each field's `defaultValue`. */
+export function initialScreenValues(screen: ScreenSpec): Record<string, unknown> {
+  const v: Record<string, unknown> = {};
+  for (const f of screen.fields) if (f.defaultValue !== undefined) v[f.name] = f.defaultValue;
+  return v;
+}
+
+/** Submit/cancel wiring for the object-form body — runtime persists & resumes;
+ *  the design preview hides the bar (`showSubmit`/`showCancel` false). */
+export interface ScreenObjectFormActions {
+  showSubmit?: boolean;
+  showCancel?: boolean;
+  submitText?: string;
+  cancelText?: string;
+  onSuccess?: (saved: any) => void;
+  onCancel?: () => void;
+  /** Overrides the "no data source" copy (the preview phrases it for authors). */
+  noDataSourceMessage?: React.ReactNode;
+}
+
+export interface ScreenViewProps {
+  screen: ScreenSpec;
+  /** Controlled values for the flat-fields body. */
+  values: Record<string, unknown>;
+  onValueChange: (name: string, value: unknown) => void;
+  /**
+   * Data source — required to render the `object-form` body. ObjectForm fetches
+   * the object schema (and persists) through this adapter.
+   */
+  dataSource?: any;
+  /**
+   * Object definitions — used to derive an `object-form` step's inline
+   * master-detail `subforms` (mirrors RecordFormPage's create form).
+   */
+  objects?: any[];
+  objectForm?: ScreenObjectFormActions;
+  className?: string;
+}
+
+export function ScreenView({ screen, values, onValueChange, dataSource, objects, objectForm, className }: ScreenViewProps) {
+  if (isObjectFormScreen(screen)) {
+    const objectDef = Array.isArray(objects) ? objects.find((o: any) => o?.name === screen.objectName) : undefined;
+    const subforms = objectDef
+      ? ((objectDef as any).form?.subforms ?? (objectDef as any).formViews?.default?.subforms)
+      : undefined;
+    // Full object create/edit form (with inline master-detail grids). At runtime
+    // the form owns its own Save/Cancel bar; the preview hides it.
+    return (
+      <div className={cn('py-2', className)}>
+        {dataSource ? (
+          <ObjectForm
+            key={screen.nodeId}
+            schema={{
+              type: 'object-form',
+              formType: 'simple',
+              objectName: screen.objectName!,
+              mode: screen.mode === 'edit' ? 'edit' : 'create',
+              recordId: screen.mode === 'edit' ? screen.recordId : undefined,
+              ...(screen.defaults ? { initialValues: screen.defaults } : {}),
+              layout: 'vertical',
+              subforms,
+              onSuccess: objectForm?.onSuccess,
+              onCancel: objectForm?.onCancel,
+              showSubmit: objectForm?.showSubmit ?? true,
+              showCancel: objectForm?.showCancel ?? true,
+              submitText: objectForm?.submitText ?? 'Save & Continue',
+              cancelText: objectForm?.cancelText ?? 'Cancel',
+            } as any}
+            dataSource={dataSource}
+          />
+        ) : (
+          <div className="text-sm text-destructive py-4">
+            {objectForm?.noDataSourceMessage ?? 'This step renders an object form but no data source is available.'}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-4 py-2', className)}>
+      {screen.fields.map((f) => (
+        <div key={f.name} className="space-y-1.5">
+          <Label htmlFor={`ff-${f.name}`} className="text-sm">
+            {f.label || f.name}
+            {f.required && <span className="text-destructive"> *</span>}
+          </Label>
+          <FieldInput field={f} value={values[f.name]} onChange={(v) => onValueChange(f.name, v)} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function FieldInput({ field, value, onChange }: { field: ScreenFieldSpec; value: unknown; onChange: (v: unknown) => void }) {
+  const id = `ff-${field.name}`;
+  const t = (field.type || 'text').toLowerCase();
+
+  if (Array.isArray(field.options) && field.options.length > 0) {
+    return (
+      <Select value={value != null ? String(value) : undefined} onValueChange={(v) => onChange(v)}>
+        <SelectTrigger id={id}><SelectValue placeholder={field.placeholder || 'Select…'} /></SelectTrigger>
+        <SelectContent>
+          {field.options.map((o, i) => (
+            <SelectItem key={i} value={String(o.value)}>{o.label}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+  if (t === 'boolean' || t === 'checkbox') {
+    return <Checkbox id={id} checked={value === true} onCheckedChange={(c) => onChange(c === true)} />;
+  }
+  if (t === 'textarea' || t === 'markdown') {
+    return <Textarea id={id} value={(value as string) ?? ''} placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />;
+  }
+  const htmlType = t === 'number' || t === 'currency' ? 'number' : t === 'email' ? 'email' : t === 'date' ? 'date' : 'text';
+  return (
+    <Input
+      id={id}
+      type={htmlType}
+      value={(value as string) ?? ''}
+      placeholder={field.placeholder}
+      onChange={(e) => onChange(htmlType === 'number' ? (e.target.value === '' ? undefined : Number(e.target.value)) : e.target.value)}
+    />
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
@@ -34,6 +34,7 @@ import {
 import { jsonSchemaToFlowFields } from './json-schema-to-fields';
 import { useActionConfigSchemas } from '../previews/useFlowNodePalette';
 import { FlowNodeConfigField } from './FlowNodeConfigField';
+import { ScreenPreview } from '../previews/ScreenPreview';
 
 interface FlowNode {
   id: string;
@@ -136,6 +137,15 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
   }, [configSchemas, node?.type]);
   const config = asConfig(node);
   const visibleFields = fields.filter((f) => isFieldVisible(f, node, fields));
+
+  // `{var}` interpolation source for the screen preview — the flow's declared
+  // variables and their defaults (the designer has no live run state).
+  const screenVars = React.useMemo(() => {
+    const decls = Array.isArray((draft as any).variables) ? ((draft as any).variables as Array<Record<string, unknown>>) : [];
+    const out: Record<string, unknown> = {};
+    for (const v of decls) if (v && typeof v.name === 'string') out[v.name] = v.defaultValue;
+    return out;
+  }, [draft]);
   // Only fields stored under `config` "own" a config key; spec-structured
   // blocks (waitEventConfig, etc.) and top-level timeoutMs never suppress an
   // Advanced key.
@@ -179,6 +189,9 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
   };
 
   const hasExtras = extraJson.trim() !== '';
+
+  // Screen nodes (and the `user_task` alias) get a live end-user preview.
+  const isScreen = node.type === 'screen' || node.type === 'user_task';
 
   const setField = (path: string[], value: unknown) => {
     const nextNode = setAtPath(node, path, value);
@@ -275,6 +288,8 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
           context={{ draft, node }}
         />
       ))}
+
+      {isScreen && <ScreenPreview node={node} variables={screenVars} className="mt-1" />}
 
       {hasExtras || advReveal ? (
         <details

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.tsx
@@ -11,6 +11,7 @@ import * as React from 'react';
 import { Play, StepForward, RotateCcw, ChevronRight, AlertTriangle, CircleAlert, Plus, Trash2 } from 'lucide-react';
 import { Button, Input, Label, cn } from '@object-ui/components';
 import { FlowSimulator } from './simulator/flow-simulator';
+import { ScreenPreview } from './ScreenPreview';
 import type { FlowValidation, SimEdge, SimNode, SimState, SimStep } from './simulator/flow-sim-types';
 
 export interface FlowVariableDecl {
@@ -190,6 +191,14 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
   const status = snapshot?.status ?? 'idle';
   const blocked = (validation?.errors.length ?? 0) > 0;
 
+  // When the run pauses at a `screen` node, preview the form the end user would
+  // see (the shared runtime renderer) instead of just showing "paused".
+  const screenPause = React.useMemo(() => {
+    if (snapshot?.status !== 'paused' || snapshot.pausedReason !== 'screen' || !snapshot.activeNodeId) return null;
+    const node = nodes.find((n) => n.id === snapshot.activeNodeId);
+    return node ? { node, variables: snapshot.variables } : null;
+  }, [snapshot, nodes]);
+
   return (
     <div className="flex h-full flex-col text-xs">
       <div className="flex items-center gap-1.5 border-b bg-muted/30 px-3 py-2">
@@ -229,6 +238,14 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
               </div>
             ))}
           </div>
+        )}
+
+        {/* Paused at a screen — render the end-user form the runtime would show. */}
+        {screenPause && (
+          <section className="space-y-1.5">
+            <div className="font-medium text-muted-foreground">Screen</div>
+            <ScreenPreview node={screenPause.node} variables={screenPause.variables} />
+          </section>
         )}
 
         {/* Seed inputs */}

--- a/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+// Capture the schema ObjectForm receives so object-form mode can be asserted
+// without standing up the real plugin-form runtime.
+const { objectFormSpy, adapterRef } = vi.hoisted(() => ({
+  objectFormSpy: vi.fn(),
+  adapterRef: { current: { fake: 'adapter' } as unknown },
+}));
+
+vi.mock('@object-ui/plugin-form', () => ({
+  ObjectForm: ({ schema }: { schema: unknown }) => {
+    objectFormSpy(schema);
+    return <div data-testid="object-form" />;
+  },
+}));
+
+vi.mock('../../../providers/AdapterProvider', () => ({
+  useAdapter: () => adapterRef.current,
+}));
+
+import { ScreenPreview } from './ScreenPreview';
+import { buildScreenSpec } from './screen-spec';
+
+afterEach(() => {
+  cleanup();
+  objectFormSpy.mockClear();
+  adapterRef.current = { fake: 'adapter' };
+});
+
+describe('ScreenPreview — flat fields', () => {
+  it('renders the title + description with {var} interpolation against supplied variables', () => {
+    render(
+      <ScreenPreview
+        node={{ id: 's1', config: { title: 'Discount for {customer}', description: 'Deal {deal_id} · owner {missing}' } }}
+        variables={{ customer: 'Acme', deal_id: 42 }}
+      />,
+    );
+    expect(screen.getByText('Discount for Acme')).toBeInTheDocument();
+    // Known var substituted; unknown ref kept literal so the author sees it.
+    expect(screen.getByText('Deal 42 · owner {missing}')).toBeInTheDocument();
+  });
+
+  it('renders each input field (label, required marker) and a non-functional Submit', () => {
+    const { container } = render(
+      <ScreenPreview
+        node={{
+          id: 's1',
+          config: {
+            title: 'Review',
+            fields: [
+              { name: 'amount', label: 'Amount', type: 'number', required: true },
+              { name: 'note', label: 'Note', type: 'textarea' },
+            ],
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText('Amount')).toBeInTheDocument();
+    expect(screen.getByText('Note')).toBeInTheDocument();
+    // Required marker.
+    expect(screen.getByText('*')).toBeInTheDocument();
+    // Field types map to the runtime inputs (number → spinbutton, textarea).
+    expect(container.querySelector('input[type="number"]')).toBeTruthy();
+    expect(container.querySelector('textarea')).toBeTruthy();
+    // The preview offers a disabled Submit — it never resumes a real run.
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    expect(submit).toBeDisabled();
+  });
+
+  it('live-updates when the node config changes', () => {
+    const { rerender } = render(<ScreenPreview node={{ id: 's1', config: { title: 'Step one' } }} />);
+    expect(screen.getByText('Step one')).toBeInTheDocument();
+
+    rerender(<ScreenPreview node={{ id: 's1', config: { title: 'Step two', fields: [{ name: 'x', label: 'Reason' }] }} } />);
+    expect(screen.queryByText('Step one')).not.toBeInTheDocument();
+    expect(screen.getByText('Step two')).toBeInTheDocument();
+    expect(screen.getByText('Reason')).toBeInTheDocument();
+  });
+
+  it('shows an empty-state hint when nothing is configured', () => {
+    render(<ScreenPreview node={{ id: 's1', config: {} }} />);
+    expect(screen.getByText(/Add a title, description, fields, or an object form/i)).toBeInTheDocument();
+  });
+});
+
+describe('ScreenPreview — object-form mode', () => {
+  it('renders the runtime ObjectForm with the configured object/mode/defaults', () => {
+    render(
+      <ScreenPreview
+        node={{ id: 's1', config: { objectName: 'crm_account', mode: 'edit', defaults: { stage: 'new' } } }}
+      />,
+    );
+    expect(screen.getByTestId('object-form')).toBeInTheDocument();
+    const schema = objectFormSpy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(schema.type).toBe('object-form');
+    expect(schema.objectName).toBe('crm_account');
+    expect(schema.mode).toBe('edit');
+    expect(schema.initialValues).toEqual({ stage: 'new' });
+    // Object-form owns no preview Submit (its own bar is hidden in preview).
+    expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+  });
+
+  it('falls back to a hint when no data source is available', () => {
+    adapterRef.current = null;
+    render(<ScreenPreview node={{ id: 's1', config: { objectName: 'crm_account' } }} />);
+    expect(screen.queryByTestId('object-form')).not.toBeInTheDocument();
+    expect(screen.getByText(/Connect to a backend to preview this object form/i)).toBeInTheDocument();
+  });
+});
+
+describe('buildScreenSpec', () => {
+  it('maps authored config keys onto the runtime ScreenSpec', () => {
+    const spec = buildScreenSpec({
+      id: 'n1',
+      config: {
+        title: 'T',
+        description: 'D',
+        fields: [{ name: 'a', label: 'A', type: 'text', required: true }, { bad: 'no-name' }],
+        idVariable: 'account_id',
+      },
+    });
+    expect(spec.nodeId).toBe('n1');
+    expect(spec.kind).toBe('fields');
+    expect(spec.fields).toEqual([{ name: 'a', label: 'A', type: 'text', required: true }]);
+    expect(spec.idVariable).toBe('account_id');
+  });
+
+  it('switches to object-form kind when objectName is set', () => {
+    const spec = buildScreenSpec({ id: 'n1', config: { objectName: 'crm_account', mode: 'create' } });
+    expect(spec.kind).toBe('object-form');
+    expect(spec.objectName).toBe('crm_account');
+    expect(spec.mode).toBe('create');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ScreenPreview — live design-time preview of a flow `screen` node, rendered
+ * exactly as the end user will see it at runtime.
+ *
+ * It builds a runtime `ScreenSpec` from the node's authored `config` and hands
+ * it to the shared {@link ScreenView} — the SAME renderer the runtime
+ * FlowRunner uses — so the preview can never drift from runtime (the
+ * design↔runtime divergence #1927 set out to kill). `{var}` references in the
+ * title/description are interpolated against the supplied `variables` (the
+ * flow's declared defaults in the inspector, or the live simulated values when
+ * paused in the Debug simulator).
+ *
+ * Homes: the flow node inspector (live-updates as the config is edited) and the
+ * Debug simulator's paused-at-screen state.
+ */
+
+import * as React from 'react';
+import { Button, cn } from '@object-ui/components';
+import { useAdapter } from '../../../providers/AdapterProvider';
+import { ScreenView, isObjectFormScreen, initialScreenValues, type ScreenSpec } from '../../ScreenView';
+import { buildScreenSpec, interpolate, type ScreenPreviewNode } from './screen-spec';
+
+export type { ScreenPreviewNode } from './screen-spec';
+
+export interface ScreenPreviewProps {
+  /** The screen node to preview. */
+  node: ScreenPreviewNode;
+  /**
+   * Variable values for `{var}` interpolation in the title/description. The
+   * inspector passes the flow's declared defaults; the simulator passes the
+   * live run state at the pause point. Unknown references are left visible as
+   * `{name}` so authors can see what the screen depends on.
+   */
+  variables?: Record<string, unknown>;
+  className?: string;
+}
+
+export function ScreenPreview({ node, variables, className }: ScreenPreviewProps) {
+  const adapter = useAdapter();
+  const spec = React.useMemo(() => buildScreenSpec(node), [node]);
+  const isObjectForm = isObjectFormScreen(spec);
+  const title = interpolate(spec.title, variables);
+  const description = interpolate(spec.description, variables);
+
+  // Reset transient input state when the screen's STRUCTURE changes (fields
+  // added/removed/retyped, or object-form target/mode); typing survives a
+  // label/title-only edit.
+  const structKey = isObjectForm
+    ? `obj:${spec.objectName}:${spec.mode ?? 'create'}`
+    : 'fields:' + spec.fields.map((f) => `${f.name}:${f.type ?? ''}:${f.required ? 1 : 0}`).join('|');
+
+  const empty = !title && !description && !isObjectForm && spec.fields.length === 0;
+
+  return (
+    <div className={cn('overflow-hidden rounded-md border bg-background', className)}>
+      <div className="flex items-center gap-1.5 border-b bg-muted/30 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        Preview
+      </div>
+      <div className="max-h-[60vh] overflow-auto p-4">
+        {empty ? (
+          <p className="text-sm italic text-muted-foreground">
+            Add a title, description, fields, or an object form to preview this screen.
+          </p>
+        ) : (
+          <>
+            {title && <h3 className="text-base font-semibold leading-tight">{title}</h3>}
+            {description && (
+              <p className={cn('whitespace-pre-line text-sm text-muted-foreground', title && 'mt-1')}>{description}</p>
+            )}
+            <ScreenFormPreview key={structKey} spec={spec} adapter={adapter} />
+            {!isObjectForm && spec.fields.length > 0 && (
+              <div className="mt-4 flex justify-end">
+                {/* Non-functional — the preview never resumes a real run. */}
+                <Button size="sm" disabled>Submit</Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Holds the transient field values so the preview is interactive (the author
+ * can type into it) while never persisting anything.
+ */
+function ScreenFormPreview({ spec, adapter }: { spec: ScreenSpec; adapter: unknown }) {
+  const [values, setValues] = React.useState<Record<string, unknown>>(() => initialScreenValues(spec));
+  return (
+    <ScreenView
+      screen={spec}
+      values={values}
+      onValueChange={(name, v) => setValues((p) => ({ ...p, [name]: v }))}
+      dataSource={adapter ?? undefined}
+      objectForm={{
+        showSubmit: false,
+        showCancel: false,
+        noDataSourceMessage: 'Connect to a backend to preview this object form.',
+      }}
+    />
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/previews/screen-spec.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/screen-spec.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * screen-spec — pure helpers that map a flow `screen` node's authored `config`
+ * onto the runtime `ScreenSpec` (the contract {@link ScreenView} renders), plus
+ * `{var}` interpolation for the title/description. Kept framework-free so
+ * {@link ScreenPreview} stays a thin component and these stay unit-testable.
+ */
+
+import type { ScreenSpec, ScreenFieldSpec } from '../../ScreenView';
+
+/** Minimal node shape the preview needs (id + authored config). */
+export interface ScreenPreviewNode {
+  id: string;
+  label?: string;
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Interpolate `{var}` references, mirroring the simulator's `{var}` syntax
+ * (flow-simulator.ts). Known vars are substituted; unknown refs stay literal so
+ * the author still sees the dependency in the design preview.
+ */
+export function interpolate(text: string | undefined, vars: Record<string, unknown> | undefined): string {
+  if (!text) return '';
+  if (!vars) return text;
+  return text.replace(/\{([^{}]+)\}/g, (m, k) => {
+    const v = vars[String(k).trim()];
+    return v === undefined || v === null ? m : String(v);
+  });
+}
+
+/** Coerce the authored `config.fields` rows into runtime `ScreenFieldSpec`s. */
+function toScreenFields(raw: unknown): ScreenFieldSpec[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ScreenFieldSpec[] = [];
+  for (const f of raw) {
+    if (!f || typeof f !== 'object') continue;
+    const row = f as Record<string, unknown>;
+    if (typeof row.name !== 'string' || !row.name) continue;
+    out.push({
+      name: row.name,
+      label: typeof row.label === 'string' ? row.label : undefined,
+      type: typeof row.type === 'string' ? row.type : undefined,
+      required: row.required === true,
+    });
+  }
+  return out;
+}
+
+/**
+ * Map a screen node's authored `config` onto the runtime `ScreenSpec` — the
+ * same keys the engine's `screen` executor reads (title / description / fields
+ * / objectName / mode / defaults / idVariable).
+ */
+export function buildScreenSpec(node: ScreenPreviewNode): ScreenSpec {
+  const c = (node.config && typeof node.config === 'object' ? node.config : {}) as Record<string, unknown>;
+  const objectName = typeof c.objectName === 'string' && c.objectName ? c.objectName : undefined;
+  const mode = c.mode === 'edit' ? 'edit' : c.mode === 'create' ? 'create' : undefined;
+  const defaults =
+    c.defaults && typeof c.defaults === 'object' && !Array.isArray(c.defaults)
+      ? (c.defaults as Record<string, unknown>)
+      : undefined;
+  return {
+    nodeId: node.id,
+    title: typeof c.title === 'string' ? c.title : undefined,
+    description: typeof c.description === 'string' ? c.description : undefined,
+    fields: toScreenFields(c.fields),
+    kind: objectName ? 'object-form' : 'fields',
+    objectName,
+    mode,
+    defaults,
+    idVariable: typeof c.idVariable === 'string' ? c.idVariable : undefined,
+  };
+}


### PR DESCRIPTION
Closes #1944.

## What & why
Screen-flow nodes let authors configure title / description / input `fields` / object-form (`objectName`), but there was no way to **see** the form an end user would get — you configured it blind, and the Debug simulator showed only `paused` when it reached a screen. This adds a live preview that renders the screen exactly as it runs, live-updating as the config changes.

## Approach — reuse the runtime renderer (no reimplementation)
The runtime `FlowRunner`'s screen body (the flat input-field list + the object-form `ObjectForm` schema) is extracted into a shared **`ScreenView`**. Both the runtime (`FlowRunner`) and the new preview render through it, so the preview **cannot drift** from runtime — the exact design↔runtime divergence #1927 set out to kill. `FlowRunner`'s resume/submit behaviour, Dialog chrome and footer are unchanged.

A new **`ScreenPreview`** builds a `ScreenSpec` from the node's authored `config` (`screen-spec.ts`, the same keys the engine's `screen` executor reads) and feeds it to `ScreenView`.

## Two homes
- **Flow node inspector** (`FlowNodeInspector`) — preview under the screen config, interpolating `{var}` against the flow's declared variable defaults. Updates live as you edit.
- **Debug simulator** (`FlowSimulatorPanel`) — when paused at a screen, renders the actual end-user form (interpolating `{var}` against the **live simulated run state**) instead of a bare `paused`.

## Acceptance criteria
- [x] Reflects `title`, `description` (with `{var}` interpolation), `fields`, and object-form mode (`objectName` / `mode` / `defaults`).
- [x] Updates live as the node config changes.
- [x] Reuses the runtime screen/form renderer (`ScreenView` + `plugin-form` `ObjectForm`) — not a reimplementation.

## Verification (browser, dev server proxied to a real backend)
On HotCRM's `quote_generation` (flat-fields screen) and an ad-hoc object-form node:
- **Flat fields** — inspector renders Quote Name\*, Valid For (Days)\* (number), Discount %, disabled Submit — matching the config.
- **Live update** — typing a Title/Description updated the preview in real time; `{quoteName}`/`{expirationDays}` stayed literal (no declared default).
- **Interpolation** — in the Debug simulator, seeding `quoteName=Premium Plan`, `expirationDays=45` and running paused at the screen rendered the description as **"Quote for Premium Plan — valid 45 days."**
- **Object-form mode** — setting `objectName: crm_quote` switched the preview to the full runtime `ObjectForm` (live schema: account/contact/opportunity pickers, status & payment-term selects, compound address fields).
- No console errors from the new components; the seeded showcase flow was left unmodified (changes were in-memory, discarded on reload).

## Tests
- `ScreenPreview.test.tsx` (8 cases): flat-field rendering, `{var}` interpolation (substituted vs. kept-literal), live-update on rerender, empty state, object-form `ObjectForm` schema (`objectName`/`mode`/`initialValues`), no-data-source fallback, and `buildScreenSpec` mapping.
- Existing `FlowRunner.test.tsx` still green (the extraction is behaviour-preserving).
- `pnpm turbo type-check` clean; lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
