### PR TITLE
feat(studio): simulate approval decisions in the flow debugger

### DIFF
--- a/.changeset/studio-flow-sim-approval-decisions.md
+++ b/.changeset/studio-flow-sim-approval-decisions.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(studio): simulate approval decisions in the flow debugger
+
+The designer-time flow simulator treated an `approval` node as a pass-through that fanned out to every out-edge at once — so an ADR-0044 revise loop couldn't be debugged: it walked approve / reject / revise simultaneously and hit the step ceiling on the back-edge.
+
+The simulator now models an approval as a durable pause (like `wait` / `screen`): it suspends at the node, and the Debug panel offers the node's out-edge labels (`approve` / `reject` / `revise`) as decision buttons. Resuming routes down ONLY the chosen branch — mirroring how the engine resumes a suspended approval by branch label — so a full revise loop is now walkable in the debugger: revise → wait → resubmit (back-edge) → round 2 → approve. An unmatched decision falls back to fanning out (mirroring the engine's label-fallback), logged so the author notices.
+
+Follows #1954 (ADR-0044 revise-loop authoring).

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.test.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { FlowSimulatorPanel } from './FlowSimulatorPanel';
+
+afterEach(cleanup);
+
+/**
+ * ADR-0044: the Debug panel models an approval as a durable pause and offers its
+ * out-edge labels (approve / reject / revise) as decision buttons, so an author
+ * can walk a revise loop instead of fanning out to every branch.
+ */
+const reviseFlow = {
+  nodes: [
+    { id: 's', type: 'start' },
+    { id: 'a', type: 'approval', label: 'Review' },
+    { id: 'w', type: 'wait', label: 'Awaiting Revision' },
+    { id: 'ok', type: 'end', label: 'Approved' },
+    { id: 'no', type: 'end', label: 'Rejected' },
+  ],
+  edges: [
+    { source: 's', target: 'a' },
+    { source: 'a', target: 'ok', label: 'approve' },
+    { source: 'a', target: 'no', label: 'reject' },
+    { source: 'a', target: 'w', label: 'revise' },
+    { source: 'w', target: 'a', label: 'resubmit', type: 'back' },
+  ],
+};
+
+describe('FlowSimulatorPanel — approval decisions', () => {
+  it('offers approve / reject / revise buttons when the run pauses at an approval', () => {
+    render(<FlowSimulatorPanel nodes={reviseFlow.nodes} edges={reviseFlow.edges} variables={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /revise/i })).toBeInTheDocument();
+  });
+
+  it('walks the full revise loop through the UI: revise → continue → approve → done', () => {
+    render(<FlowSimulatorPanel nodes={reviseFlow.nodes} edges={reviseFlow.edges} variables={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    // Round 1: send back for revision.
+    fireEvent.click(screen.getByRole('button', { name: /revise/i }));
+    // Paused at the wait node → a plain Continue resumes over the back-edge.
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    // Round 2: the approval suspends again → decide approve.
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }));
+    expect(screen.getByText('done')).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.tsx
@@ -162,6 +162,9 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
     // pressing Run again always reflects the new values.
     let sim = simRef.current;
     if (sim && sim.state.status === 'paused') {
+      // An approval pause needs an explicit decision (use the branch buttons);
+      // blind-resuming would fan out to every branch — so leave it for the user.
+      if (sim.state.pausedReason === 'approval') { sync(); return; }
       sim.resume();
     } else {
       reset();
@@ -175,9 +178,11 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
     sim.step();
     sync();
   };
-  const onResume = () => {
+  const onResume = () => onDecision();
+  /** Continue a paused run; `decision` routes an approval down one out-edge. */
+  const onDecision = (decision?: string) => {
     const sim = ensure();
-    sim.resume();
+    sim.resume(decision ? { decision } : {});
     sim.runToEnd();
     sync();
   };
@@ -199,6 +204,23 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
     return node ? { node, variables: snapshot.variables } : null;
   }, [snapshot, nodes]);
 
+  // When paused at an approval node, offer its out-edge labels (approve /
+  // reject / revise) as decision buttons so the run resumes down ONE branch —
+  // letting an author walk a revise loop instead of fanning out to every edge.
+  const approvalPause = React.useMemo(() => {
+    if (snapshot?.status !== 'paused' || snapshot.pausedReason !== 'approval' || !snapshot.activeNodeId) return null;
+    const node = nodes.find((n) => n.id === snapshot.activeNodeId);
+    if (!node) return null;
+    const decisions = [
+      ...new Set(
+        edges
+          .filter((e) => e.source === node.id && typeof e.label === 'string' && (e.label as string).trim())
+          .map((e) => (e.label as string).trim()),
+      ),
+    ];
+    return { node, decisions };
+  }, [snapshot, nodes, edges]);
+
   return (
     <div className="flex h-full flex-col text-xs">
       <div className="flex items-center gap-1.5 border-b bg-muted/30 px-3 py-2">
@@ -208,11 +230,27 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
         <Button size="sm" variant="outline" className="h-7 gap-1 px-2" onClick={onStep} disabled={blocked || status === 'done' || status === 'error'}>
           <StepForward className="h-3.5 w-3.5" /> Step
         </Button>
-        {status === 'paused' && (
-          <Button size="sm" variant="outline" className="h-7 gap-1 px-2" onClick={onResume}>
-            <ChevronRight className="h-3.5 w-3.5" /> Continue
-          </Button>
-        )}
+        {status === 'paused' &&
+          (approvalPause && approvalPause.decisions.length > 0 ? (
+            <div className="flex items-center gap-1">
+              {approvalPause.decisions.map((d) => (
+                <Button
+                  key={d}
+                  size="sm"
+                  variant="outline"
+                  className="h-7 gap-1 px-2 capitalize"
+                  onClick={() => onDecision(d)}
+                  title={`Resume down the "${d}" branch`}
+                >
+                  <ChevronRight className="h-3.5 w-3.5" /> {d}
+                </Button>
+              ))}
+            </div>
+          ) : (
+            <Button size="sm" variant="outline" className="h-7 gap-1 px-2" onClick={onResume}>
+              <ChevronRight className="h-3.5 w-3.5" /> Continue
+            </Button>
+          ))}
         <Button size="sm" variant="ghost" className="h-7 gap-1 px-2 text-muted-foreground" onClick={onReset}>
           <RotateCcw className="h-3.5 w-3.5" /> Reset
         </Button>

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-simulator.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-simulator.test.ts
@@ -254,7 +254,7 @@ describe('FlowSimulator', () => {
     sim.reset();
     sim.runToEnd();
     expect(sim.state.pausedReason).toBe('screen');
-    sim.resume({ discount: 10 });
+    sim.resume({ screenOutputs: { discount: 10 } });
     sim.runToEnd();
     expect(sim.state.variables.discount).toBe(10);
     expect(sim.state.status).toBe('done');
@@ -296,6 +296,92 @@ describe('FlowSimulator', () => {
     expect(sim.state.variables.who).toBe('Ada');
     expect(sim.state.variables.greeting).toBe('hi Ada');
     expect(sim.state.status).toBe('done');
+  });
+
+  it('pauses at an approval and routes only the chosen decision branch', () => {
+    const sim = new FlowSimulator(
+      [
+        { id: 's', type: 'start' },
+        { id: 'a', type: 'approval' },
+        { id: 'ok', type: 'end' },
+        { id: 'no', type: 'end' },
+      ],
+      [
+        { source: 's', target: 'a' },
+        { id: 'app', source: 'a', target: 'ok', label: 'approve' },
+        { id: 'rej', source: 'a', target: 'no', label: 'reject' },
+      ],
+    );
+    sim.reset();
+    sim.runToEnd();
+    expect(sim.state.status).toBe('paused');
+    expect(sim.state.pausedReason).toBe('approval');
+    expect(sim.state.activeNodeId).toBe('a');
+    sim.resume({ decision: 'approve' });
+    sim.runToEnd();
+    expect(sim.state.status).toBe('done');
+    expect(sim.state.visitedNodeIds).toContain('ok');
+    expect(sim.state.visitedNodeIds).not.toContain('no');
+  });
+
+  it('walks a full ADR-0044 revise loop: revise -> wait -> resubmit -> approve', () => {
+    const sim = new FlowSimulator(
+      [
+        { id: 's', type: 'start' },
+        { id: 'a', type: 'approval' },
+        { id: 'w', type: 'wait' },
+        { id: 'ok', type: 'end' },
+        { id: 'no', type: 'end' },
+      ],
+      [
+        { source: 's', target: 'a' },
+        { id: 'app', source: 'a', target: 'ok', label: 'approve' },
+        { id: 'rej', source: 'a', target: 'no', label: 'reject' },
+        { id: 'rev', source: 'a', target: 'w', label: 'revise' },
+        { id: 'back', source: 'w', target: 'a', label: 'resubmit', type: 'back' },
+      ],
+    );
+    sim.reset();
+    sim.runToEnd();                      // round 1 -> pause at approval
+    expect(sim.state.pausedReason).toBe('approval');
+    sim.resume({ decision: 'revise' });  // send back
+    sim.runToEnd();                      // -> pause at wait
+    expect(sim.state.pausedReason).toBe('wait');
+    sim.resume();                        // resubmit -> back-edge -> approval
+    sim.runToEnd();                      // round 2 -> pause at approval again
+    expect(sim.state.pausedReason).toBe('approval');
+    expect(sim.state.activeNodeId).toBe('a');
+    sim.resume({ decision: 'approve' }); // approve round 2
+    sim.runToEnd();
+    expect(sim.state.status).toBe('done');
+    expect(sim.state.visitedNodeIds).toContain('ok');
+    expect(sim.state.visitedNodeIds).not.toContain('no');
+    // The approval node suspended twice (two rounds) -> two paused steps.
+    const pausedAtApproval = sim.state.steps.filter((st) => st.nodeId === 'a' && st.status === 'paused');
+    expect(pausedAtApproval.length).toBe(2);
+  });
+
+  it('falls back to fanning out when an approval decision matches no out-edge', () => {
+    const sim = new FlowSimulator(
+      [
+        { id: 's', type: 'start' },
+        { id: 'a', type: 'approval' },
+        { id: 'ok', type: 'end' },
+        { id: 'no', type: 'end' },
+      ],
+      [
+        { source: 's', target: 'a' },
+        { id: 'app', source: 'a', target: 'ok', label: 'approve' },
+        { id: 'rej', source: 'a', target: 'no', label: 'reject' },
+      ],
+    );
+    sim.reset();
+    sim.runToEnd();
+    sim.resume({ decision: 'nope' });
+    sim.runToEnd();
+    // Unmatched label mirrors the engine's branch-label fallback: take all edges.
+    expect(sim.state.visitedNodeIds).toContain('ok');
+    expect(sim.state.visitedNodeIds).toContain('no');
   });
 
   it('guards against infinite loops with a step ceiling', () => {

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-simulator.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-simulator.ts
@@ -6,7 +6,8 @@
  *
  * Supported faithfully: start, decision (edge-first CEL routing), the CRUD /
  * get / http / connector / script(notification|code) side-effects (MOCKED), and
- * end. `wait` and `screen` PAUSE for manual continuation. `loop` resolves its
+ * end. `wait`, `screen`, and `approval` PAUSE for manual continuation (an approval
+ * resumes down the chosen decision's branch — approve / reject / revise). `loop` resolves its
  * collection and exposes the iterator but is a labelled single pass (the edge
  * model has no separate body/exit edge). `parallel_gateway` fans out WITHOUT
  * join synchronization; the ADR-0031 structured containers (`parallel`,
@@ -132,20 +133,52 @@ export class FlowSimulator {
     return this.state;
   }
 
-  /** Continue a flow paused on a `wait` / `screen` node. */
-  resume(screenOutputs?: Record<string, unknown>) {
+  /**
+   * Continue a flow paused on a `wait`, `screen`, or `approval` node.
+   *  - `screenOutputs` — inputs captured from a paused screen.
+   *  - `decision` — the branch an approval resumes down (ADR-0019/0044:
+   *    `approve` / `reject` / `revise`). The run takes ONLY the out-edge whose
+   *    label matches, mirroring how the engine resumes a suspended approval by
+   *    branch label — instead of fanning out to every out-edge.
+   */
+  resume(opts: { screenOutputs?: Record<string, unknown>; decision?: string } = {}) {
     const s = this.state;
     if (s.status !== 'paused' || !s.activeNodeId) return;
     const node = this.nodes.get(s.activeNodeId);
-    if (screenOutputs && node?.type === 'screen') {
-      Object.assign(s.variables, screenOutputs);
+    if (opts.screenOutputs && node?.type === 'screen') {
+      Object.assign(s.variables, opts.screenOutputs);
     }
     s.pausedReason = undefined;
     s.status = 'running';
-    if (node) this.enqueueSuccessors(node);
+    if (node?.type === 'approval') this.resumeApproval(node, opts.decision);
+    else if (node) this.enqueueSuccessors(node);
     if (s.frontier.length === 0) {
       s.status = 'done';
       s.activeNodeId = null;
+    }
+  }
+
+  /**
+   * Resume a suspended approval down the chosen decision's out-edge: the one
+   * whose `label` equals `decision` (case-insensitive — `approve` / `reject` /
+   * `revise`). With no match (or no decision) it falls back to fanning out —
+   * mirroring the engine's unmatched-`branchLabel` fallback — and logs that so
+   * the author notices the unrouted decision.
+   */
+  private resumeApproval(node: SimNode, decision?: string) {
+    const out = this.edges.map((e, i) => ({ e, i })).filter((x) => x.e.source === node.id);
+    const want = (decision ?? '').trim().toLowerCase();
+    const chosen = want ? out.find((x) => (x.e.label ?? '').trim().toLowerCase() === want) : undefined;
+    if (chosen) {
+      this.traverse(chosen.e, chosen.i);
+      this.record(node.id, 'approval', node.label, 'ok', { note: `Decision: ${decision} → ${chosen.e.target}` });
+    } else {
+      for (const x of out) this.traverse(x.e, x.i);
+      this.record(node.id, 'approval', node.label, 'ok', {
+        note: want
+          ? `No out-edge labelled "${decision}"; took all branches (engine label-fallback).`
+          : 'No decision supplied; took all branches.',
+      });
     }
   }
 
@@ -175,6 +208,16 @@ export class FlowSimulator {
       return this.record(node.id, type, node.label, 'ok', {
         note: 'Parallel split — branches fan out (no join synchronization is simulated).',
       });
+    }
+
+    if (type === 'approval') {
+      // ADR-0019: an approval node opens a request and SUSPENDS the run until a
+      // decision is recorded. Model that as a pause; the author resumes down the
+      // chosen approve / reject / revise out-edge (see resumeApproval) rather
+      // than fanning out to every out-edge at once.
+      this.state.status = 'paused';
+      this.state.pausedReason = 'approval';
+      return this.record(node.id, type, node.label, 'paused', { note: 'Approval reached — choose a decision to continue.' });
     }
 
     if (type === 'wait') {


### PR DESCRIPTION
## What & why

Follow-up to [#1954](https://github.com/objectstack-ai/objectui/pull/1954) (ADR-0044 revise-loop **authoring**). That PR let authors *draw* a revise loop, but the designer-time **Debug simulator** still couldn't *walk* one: it treated an `approval` node as a pass-through that **fanned out to every out-edge at once** (approve + reject + revise simultaneously), so a revise loop just bounced around the back-edge until it tripped the step ceiling. You could draw the loop but not simulate it.

## Change

Model an `approval` as a **durable pause** (like `wait` / `screen`) — which is what it is in the engine (ADR-0019):

- The run **suspends** at the approval node (`pausedReason: 'approval'`).
- The Debug panel offers the node's out-edge labels as **decision buttons** (`approve` / `reject` / `revise`).
- Resuming routes down **only the chosen branch** — mirroring how the engine resumes a suspended approval by `branchLabel` — instead of fanning out.
- A full revise loop is now walkable in the debugger: **revise → wait → resubmit (back-edge) → round 2 → approve → done**, with the approval node suspending once per round.
- An unmatched decision falls back to fanning out (mirroring the engine's label-fallback) and is logged so the author notices an unrouted decision.

## Files

- `previews/simulator/flow-simulator.ts` — `approval` pause case; `resume({ screenOutputs?, decision? })` + `resumeApproval()` (route by out-edge label).
- `previews/FlowSimulatorPanel.tsx` — per-decision **Continue** buttons when paused at an approval; `Run` no longer blind-resumes an approval pause (would fan out).

## Verification

- **Unit (simulator)**: approval pauses + routes only the chosen branch; **full revise-loop walk** (revise → wait → resubmit/back-edge → round 2 → approve → done, approval suspends twice); unmatched-decision fallback.
- **Component (panel UI)**: renders approve/reject/revise buttons on pause; clicking through **revise → Continue → approve** drives the run to `done` — the same path a browser check would exercise.
- Full metadata-admin suite **388 green** (5 new); `type-check` 0 errors; `eslint` clean.

> Browser drivers (chrome-devtools / preview server) were unavailable this run due to parallel-session contention, so the panel UI is covered by the component test above rather than a live screenshot.

Follows #1954.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
