### PR TITLE
feat(studio): gate flow Screen-preview fields by visibleWhen (follow-up #1944)

### DIFF
--- a/.changeset/flow-screen-preview-visiblewhen.md
+++ b/.changeset/flow-screen-preview-visiblewhen.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Flow Screen preview: gate fields by `visibleWhen` (follow-up to #1944)
+
+The Screen-node preview now evaluates each input field's `visibleWhen` against
+the active variables — reusing the simulator's own condition evaluator
+(`evalCondition`), normalising `{var}` placeholders to bare identifiers — so it
+hides/shows conditional fields exactly as the runtime `screen` executor does
+(which filters server-side before emitting the `ScreenSpec`).
+
+- Debug simulator (live run state): gates faithfully, e.g. a screen whose
+  `opportunityName`/`opportunityAmount` are `visibleWhen: "{createOpportunity} == true"`
+  hides them while `createOpportunity` is false.
+- Inspector (no run state): fails open — an unparseable or not-yet-decidable
+  condition keeps the field visible, so configured fields are never hidden on
+  missing data — and a footnote reports how many fields are gated out.

--- a/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.test.tsx
@@ -22,7 +22,7 @@ vi.mock('../../../providers/AdapterProvider', () => ({
 }));
 
 import { ScreenPreview } from './ScreenPreview';
-import { buildScreenSpec } from './screen-spec';
+import { buildScreenSpec, isFieldVisibleWhen, hiddenFieldCount } from './screen-spec';
 
 afterEach(() => {
   cleanup();
@@ -111,6 +111,58 @@ describe('ScreenPreview — object-form mode', () => {
   });
 });
 
+describe('ScreenPreview — visibleWhen field gating', () => {
+  const node = {
+    id: 's1',
+    config: {
+      fields: [
+        { name: 'createOpp', label: 'Create Opportunity?', type: 'boolean' },
+        { name: 'oppName', label: 'Opportunity Name', type: 'text', visibleWhen: '{createOpp} == true' },
+      ],
+    },
+  };
+
+  it('hides a conditional field when its visibleWhen is false, with a hint', () => {
+    render(<ScreenPreview node={node} variables={{ createOpp: false }} />);
+    expect(screen.getByText('Create Opportunity?')).toBeInTheDocument();
+    expect(screen.queryByText('Opportunity Name')).not.toBeInTheDocument();
+    expect(screen.getByText(/hidden by .*visible when/i)).toBeInTheDocument();
+  });
+
+  it('shows the conditional field when its visibleWhen is true (no hint)', () => {
+    render(<ScreenPreview node={node} variables={{ createOpp: true }} />);
+    expect(screen.getByText('Opportunity Name')).toBeInTheDocument();
+    expect(screen.queryByText(/hidden by .*visible when/i)).not.toBeInTheDocument();
+  });
+
+  it('fail-opens: an undecidable condition (no run state) keeps the field visible', () => {
+    // The inspector passes declared defaults; an unset controller can't decide.
+    render(<ScreenPreview node={node} variables={{}} />);
+    expect(screen.getByText('Opportunity Name')).toBeInTheDocument();
+  });
+});
+
+describe('isFieldVisibleWhen', () => {
+  it('shows when there is no condition or no variables', () => {
+    expect(isFieldVisibleWhen(undefined, { x: 1 })).toBe(true);
+    expect(isFieldVisibleWhen('', { x: 1 })).toBe(true);
+    expect(isFieldVisibleWhen('discount > 0', undefined)).toBe(true);
+  });
+
+  it('evaluates {var} and bare-var conditions against the variables', () => {
+    expect(isFieldVisibleWhen('{createOpp} == true', { createOpp: true })).toBe(true);
+    expect(isFieldVisibleWhen('{createOpp} == true', { createOpp: false })).toBe(false);
+    expect(isFieldVisibleWhen('stage == "review"', { stage: 'review' })).toBe(true);
+    expect(isFieldVisibleWhen('stage == "review"', { stage: 'draft' })).toBe(false);
+    expect(isFieldVisibleWhen('discount > 0', { discount: 5 })).toBe(true);
+    expect(isFieldVisibleWhen('discount > 0', { discount: 0 })).toBe(false);
+  });
+
+  it('fail-opens when a referenced variable is not set', () => {
+    expect(isFieldVisibleWhen('{createOpp} == true', {})).toBe(true);
+  });
+});
+
 describe('buildScreenSpec', () => {
   it('maps authored config keys onto the runtime ScreenSpec', () => {
     const spec = buildScreenSpec({
@@ -133,5 +185,23 @@ describe('buildScreenSpec', () => {
     expect(spec.kind).toBe('object-form');
     expect(spec.objectName).toBe('crm_account');
     expect(spec.mode).toBe('create');
+  });
+
+  it('gates fields by visibleWhen against the supplied variables', () => {
+    const cfg = {
+      id: 'n1',
+      config: {
+        fields: [
+          { name: 'createOpp', label: 'Create?', type: 'boolean' },
+          { name: 'oppName', label: 'Name', type: 'text', visibleWhen: '{createOpp} == true' },
+        ],
+      },
+    };
+    expect(buildScreenSpec(cfg, { createOpp: true }).fields.map((f) => f.name)).toEqual(['createOpp', 'oppName']);
+    expect(buildScreenSpec(cfg, { createOpp: false }).fields.map((f) => f.name)).toEqual(['createOpp']);
+    // No variables → keep every field (design preview never hides on missing data).
+    expect(buildScreenSpec(cfg).fields.map((f) => f.name)).toEqual(['createOpp', 'oppName']);
+    expect(hiddenFieldCount(cfg, { createOpp: false })).toBe(1);
+    expect(hiddenFieldCount(cfg, { createOpp: true })).toBe(0);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
@@ -8,9 +8,10 @@
  * it to the shared {@link ScreenView} — the SAME renderer the runtime
  * FlowRunner uses — so the preview can never drift from runtime (the
  * design↔runtime divergence #1927 set out to kill). `{var}` references in the
- * title/description are interpolated against the supplied `variables` (the
- * flow's declared defaults in the inspector, or the live simulated values when
- * paused in the Debug simulator).
+ * title/description are interpolated, and `fields` are gated by their
+ * `visibleWhen`, against the supplied `variables` (the flow's declared defaults
+ * in the inspector, or the live simulated values when paused in the Debug
+ * simulator).
  *
  * Homes: the flow node inspector (live-updates as the config is edited) and the
  * Debug simulator's paused-at-screen state.
@@ -20,7 +21,7 @@ import * as React from 'react';
 import { Button, cn } from '@object-ui/components';
 import { useAdapter } from '../../../providers/AdapterProvider';
 import { ScreenView, isObjectFormScreen, initialScreenValues, type ScreenSpec } from '../../ScreenView';
-import { buildScreenSpec, interpolate, type ScreenPreviewNode } from './screen-spec';
+import { buildScreenSpec, interpolate, hiddenFieldCount, type ScreenPreviewNode } from './screen-spec';
 
 export type { ScreenPreviewNode } from './screen-spec';
 
@@ -28,10 +29,12 @@ export interface ScreenPreviewProps {
   /** The screen node to preview. */
   node: ScreenPreviewNode;
   /**
-   * Variable values for `{var}` interpolation in the title/description. The
-   * inspector passes the flow's declared defaults; the simulator passes the
-   * live run state at the pause point. Unknown references are left visible as
-   * `{name}` so authors can see what the screen depends on.
+   * Variable values for `{var}` interpolation in the title/description AND for
+   * evaluating each field's `visibleWhen`. The inspector passes the flow's
+   * declared defaults; the simulator passes the live run state at the pause
+   * point. Unknown `{var}` refs stay literal, and fields whose `visibleWhen`
+   * can't be decided stay visible — the design preview never hides on missing
+   * data.
    */
   variables?: Record<string, unknown>;
   className?: string;
@@ -39,19 +42,20 @@ export interface ScreenPreviewProps {
 
 export function ScreenPreview({ node, variables, className }: ScreenPreviewProps) {
   const adapter = useAdapter();
-  const spec = React.useMemo(() => buildScreenSpec(node), [node]);
+  const spec = React.useMemo(() => buildScreenSpec(node, variables), [node, variables]);
   const isObjectForm = isObjectFormScreen(spec);
   const title = interpolate(spec.title, variables);
   const description = interpolate(spec.description, variables);
+  const hidden = isObjectForm ? 0 : hiddenFieldCount(node, variables);
 
   // Reset transient input state when the screen's STRUCTURE changes (fields
-  // added/removed/retyped, or object-form target/mode); typing survives a
+  // added/removed/retyped/gated, or object-form target/mode); typing survives a
   // label/title-only edit.
   const structKey = isObjectForm
     ? `obj:${spec.objectName}:${spec.mode ?? 'create'}`
     : 'fields:' + spec.fields.map((f) => `${f.name}:${f.type ?? ''}:${f.required ? 1 : 0}`).join('|');
 
-  const empty = !title && !description && !isObjectForm && spec.fields.length === 0;
+  const empty = !title && !description && !isObjectForm && spec.fields.length === 0 && hidden === 0;
 
   return (
     <div className={cn('overflow-hidden rounded-md border bg-background', className)}>
@@ -70,6 +74,12 @@ export function ScreenPreview({ node, variables, className }: ScreenPreviewProps
               <p className={cn('whitespace-pre-line text-sm text-muted-foreground', title && 'mt-1')}>{description}</p>
             )}
             <ScreenFormPreview key={structKey} spec={spec} adapter={adapter} />
+            {!isObjectForm && hidden > 0 && (
+              <p className="mt-3 text-[11px] italic text-muted-foreground">
+                {hidden} field{hidden === 1 ? '' : 's'} hidden by {hidden === 1 ? 'its' : 'their'} “visible when”
+                {' '}condition{hidden === 1 ? '' : 's'}.
+              </p>
+            )}
             {!isObjectForm && spec.fields.length > 0 && (
               <div className="mt-4 flex justify-end">
                 {/* Non-functional — the preview never resumes a real run. */}

--- a/packages/app-shell/src/views/metadata-admin/previews/screen-spec.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/screen-spec.ts
@@ -3,11 +3,13 @@
 /**
  * screen-spec — pure helpers that map a flow `screen` node's authored `config`
  * onto the runtime `ScreenSpec` (the contract {@link ScreenView} renders), plus
- * `{var}` interpolation for the title/description. Kept framework-free so
- * {@link ScreenPreview} stays a thin component and these stay unit-testable.
+ * `{var}` interpolation for the title/description and `visibleWhen` field
+ * gating. Kept framework-free so {@link ScreenPreview} stays a thin component
+ * and these stay unit-testable.
  */
 
 import type { ScreenSpec, ScreenFieldSpec } from '../../ScreenView';
+import { evalCondition } from './simulator/flow-sim-validate';
 
 /** Minimal node shape the preview needs (id + authored config). */
 export interface ScreenPreviewNode {
@@ -30,14 +32,41 @@ export function interpolate(text: string | undefined, vars: Record<string, unkno
   });
 }
 
-/** Coerce the authored `config.fields` rows into runtime `ScreenFieldSpec`s. */
-function toScreenFields(raw: unknown): ScreenFieldSpec[] {
+/**
+ * A field's `visibleWhen` gate, evaluated against the current variables using
+ * the SAME evaluator the simulator uses for edge conditions (so the preview
+ * agrees with the simulator). Real metadata mixes `{var}` and bare-var styles
+ * (e.g. `{createOpportunity} == true`, `stage == "review"`), so brace
+ * placeholders are normalised to bare identifiers first.
+ *
+ * Fail-OPEN: a missing condition, an unparseable one, or one that references a
+ * not-yet-set variable (the inspector has no run state) keeps the field
+ * visible — the design preview never hides a configured field just because it
+ * lacks the data to decide. With live run state (the simulator) it gates
+ * faithfully: `createOpportunity == false` hides the field.
+ */
+export function isFieldVisibleWhen(visibleWhen: unknown, variables: Record<string, unknown> | undefined): boolean {
+  if (typeof visibleWhen !== 'string' || !visibleWhen.trim()) return true;
+  if (!variables) return true;
+  const normalized = visibleWhen.replace(/\{([\w.]+)\}/g, '$1');
+  const { result, error } = evalCondition(normalized, variables);
+  return error ? true : result;
+}
+
+/**
+ * Coerce the authored `config.fields` rows into runtime `ScreenFieldSpec`s,
+ * dropping any whose `visibleWhen` evaluates false against `variables` — exactly
+ * what the runtime `screen` executor emits (it filters server-side before
+ * sending the ScreenSpec).
+ */
+function toScreenFields(raw: unknown, variables: Record<string, unknown> | undefined): ScreenFieldSpec[] {
   if (!Array.isArray(raw)) return [];
   const out: ScreenFieldSpec[] = [];
   for (const f of raw) {
     if (!f || typeof f !== 'object') continue;
     const row = f as Record<string, unknown>;
     if (typeof row.name !== 'string' || !row.name) continue;
+    if (!isFieldVisibleWhen(row.visibleWhen, variables)) continue;
     out.push({
       name: row.name,
       label: typeof row.label === 'string' ? row.label : undefined,
@@ -48,12 +77,27 @@ function toScreenFields(raw: unknown): ScreenFieldSpec[] {
   return out;
 }
 
+/** Count of authored field rows hidden by their `visibleWhen` against `variables`. */
+export function hiddenFieldCount(node: ScreenPreviewNode, variables: Record<string, unknown> | undefined): number {
+  const raw = (node.config as Record<string, unknown> | undefined)?.fields;
+  if (!Array.isArray(raw)) return 0;
+  let hidden = 0;
+  for (const f of raw) {
+    if (!f || typeof f !== 'object') continue;
+    const row = f as Record<string, unknown>;
+    if (typeof row.name !== 'string' || !row.name) continue;
+    if (!isFieldVisibleWhen(row.visibleWhen, variables)) hidden++;
+  }
+  return hidden;
+}
+
 /**
  * Map a screen node's authored `config` onto the runtime `ScreenSpec` — the
  * same keys the engine's `screen` executor reads (title / description / fields
- * / objectName / mode / defaults / idVariable).
+ * / objectName / mode / defaults / idVariable). `fields` are gated by their
+ * `visibleWhen` against `variables` (omit `variables` to keep every field).
  */
-export function buildScreenSpec(node: ScreenPreviewNode): ScreenSpec {
+export function buildScreenSpec(node: ScreenPreviewNode, variables?: Record<string, unknown>): ScreenSpec {
   const c = (node.config && typeof node.config === 'object' ? node.config : {}) as Record<string, unknown>;
   const objectName = typeof c.objectName === 'string' && c.objectName ? c.objectName : undefined;
   const mode = c.mode === 'edit' ? 'edit' : c.mode === 'create' ? 'create' : undefined;
@@ -65,7 +109,7 @@ export function buildScreenSpec(node: ScreenPreviewNode): ScreenSpec {
     nodeId: node.id,
     title: typeof c.title === 'string' ? c.title : undefined,
     description: typeof c.description === 'string' ? c.description : undefined,
-    fields: toScreenFields(c.fields),
+    fields: toScreenFields(c.fields, variables),
     kind: objectName ? 'object-form' : 'fields',
     objectName,
     mode,


### PR DESCRIPTION
Follow-up to #1944 (live preview for flow Screen nodes), implementing the `visibleWhen` field-visibility gap.

## What
Screen input fields can carry a `visibleWhen` condition (e.g. HotCRM `lead_conversion`'s `opportunityName`/`opportunityAmount` are `visibleWhen: "{createOpportunity} == true"`). At runtime the `screen` executor evaluates these server-side and only emits the visible fields in the `ScreenSpec`. The preview was showing **all** configured fields regardless — a fidelity gap. Now the preview gates fields the same way.

## How
- Reuses the simulator's own condition evaluator (`evalCondition` from `flow-sim-validate`) — the same one used for decision-edge routing — so the preview agrees with the simulator instead of inventing a second evaluator.
- Real metadata mixes `{var}` and bare-var styles, so `{ident}` placeholders are normalised to bare identifiers before evaluation (`{createOpportunity} == true` → `createOpportunity == true`; `stage == "review"` and `discount > 0` already work).
- **Fail-open**: a missing/unparseable condition, or one referencing a not-yet-set variable, keeps the field visible. So:
  - **Debug simulator** (live run state) gates faithfully.
  - **Inspector** (no run state) never hides a field on missing data; a small footnote reports how many fields are gated out.
- No wiring changes — both homes already pass `variables` to `ScreenPreview`; it now drives `visibleWhen` too.

## Verification (browser, HotCRM `lead_conversion` in the Debug simulator)
- `createOpportunity = false` → only **Create Opportunity?** shows; `opportunityName`/`opportunityAmount` hidden, with **"2 fields hidden by their 'visible when' conditions."**
- `createOpportunity = true` → all three fields show, no note. Matches the flow's own `decision_opportunity` branch (`createOpportunity == true`).

## Tests
`ScreenPreview.test.tsx` grows to 19 cases: `isFieldVisibleWhen` (`{var}`/bare-var/fail-open), `buildScreenSpec`/`hiddenFieldCount` gating, and the component hiding a field + showing the hint vs. showing it when the condition is true. Type-check clean; lint 0 problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
