### PR TITLE
feat(react): wire page-local state (PageSchema.variables) end-to-end (ADR-0049)

### DIFF
--- a/packages/components/src/__tests__/page-variables.test.tsx
+++ b/packages/components/src/__tests__/page-variables.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * End-to-end proof for page-local state (PageSchema.variables):
+ *   1. usePageVariableBinding resolves a variable from a component id (source).
+ *   2. SchemaRenderer injects `page.<var>` into the expression context so a
+ *      component's `visible` / `visibility` predicate gates on page state, and
+ *      re-evaluates LIVE when a variable changes.
+ *   3. element:record_picker reads its bound variable and queries its object.
+ */
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { render, renderHook, act, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import {
+  SchemaRenderer,
+  PageVariablesProvider,
+  usePageVariables,
+  usePageVariableBinding,
+  AdapterCtx,
+} from '@object-ui/react';
+
+beforeAll(async () => {
+  await import('../renderers');
+}, 30000);
+
+// ---------------------------------------------------------------------------
+// usePageVariableBinding — resolve writer binding from a component id
+// ---------------------------------------------------------------------------
+
+describe('usePageVariableBinding', () => {
+  const wrap =
+    (defs: any[]) =>
+    ({ children }: { children: React.ReactNode }) =>
+      <PageVariablesProvider definitions={defs}>{children}</PageVariablesProvider>;
+
+  it('resolves the variable whose `source` matches the component id', () => {
+    const { result } = renderHook(() => usePageVariableBinding('picker1'), {
+      wrapper: wrap([{ name: 'selectedId', type: 'string', source: 'picker1' }]),
+    });
+    expect(result.current?.name).toBe('selectedId');
+    expect(result.current?.value).toBe(''); // string default
+  });
+
+  it('writes through setValue', () => {
+    const { result } = renderHook(() => usePageVariableBinding('picker1'), {
+      wrapper: wrap([{ name: 'selectedId', type: 'string', source: 'picker1' }]),
+    });
+    act(() => result.current!.setValue('rec_42'));
+    expect(result.current?.value).toBe('rec_42');
+  });
+
+  it('returns null when no variable targets the component', () => {
+    const { result } = renderHook(() => usePageVariableBinding('other'), {
+      wrapper: wrap([{ name: 'selectedId', type: 'string', source: 'picker1' }]),
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null outside a PageVariablesProvider', () => {
+    const { result } = renderHook(() => usePageVariableBinding('picker1'));
+    expect(result.current).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SchemaRenderer — page variables drive component visibility, live
+// ---------------------------------------------------------------------------
+
+describe('SchemaRenderer page-variable visibility', () => {
+  // A minimal writer that flips a page variable on click — stands in for an
+  // interactive element (record picker / filter) without driving Radix in the
+  // test renderer. Not registered: rendered directly as a sibling.
+  function Writer({ name, value }: { name: string; value: any }) {
+    const { setVariable } = usePageVariables();
+    return (
+      <button type="button" onClick={() => setVariable(name, value)}>
+        write
+      </button>
+    );
+  }
+
+  function renderGated(predicateKey: 'visible' | 'visibility') {
+    return render(
+      <PageVariablesProvider definitions={[{ name: 'sel', type: 'string', source: 'w' }]}>
+        <Writer name="sel" value="rec_1" />
+        <SchemaRenderer
+          schema={{
+            type: 'element:text',
+            id: 'gated',
+            properties: { content: 'NOW VISIBLE' },
+            [predicateKey]: "page.sel != ''",
+          }}
+        />
+      </PageVariablesProvider>,
+    );
+  }
+
+  it('hides a node whose `visible` references an unset page variable, then reveals it live', () => {
+    const { queryByText, getByText } = renderGated('visible');
+    expect(queryByText('NOW VISIBLE')).toBeNull();
+    act(() => {
+      fireEvent.click(getByText('write'));
+    });
+    expect(getByText('NOW VISIBLE')).toBeTruthy();
+  });
+
+  it('also gates on the spec-canonical `visibility` predicate', () => {
+    const { queryByText, getByText } = renderGated('visibility');
+    expect(queryByText('NOW VISIBLE')).toBeNull();
+    act(() => {
+      fireEvent.click(getByText('write'));
+    });
+    expect(getByText('NOW VISIBLE')).toBeTruthy();
+  });
+
+  it('gates on a `visibility` Expression envelope { dialect, source } (the spec-bridge form)', () => {
+    // definePage normalizes a bare predicate string into { dialect: 'cel',
+    // source } and the spec→node bridge carries that envelope onto the node —
+    // this is the exact shape the showcase page produces at runtime.
+    const { queryByText, getByText } = render(
+      <PageVariablesProvider definitions={[{ name: 'sel', type: 'record_id', source: 'w' }]}>
+        <Writer name="sel" value="rec_1" />
+        <SchemaRenderer
+          schema={{
+            type: 'element:text',
+            id: 'gated',
+            properties: { content: 'NOW VISIBLE' },
+            visibility: { dialect: 'cel', source: "page.sel != ''" },
+          }}
+        />
+      </PageVariablesProvider>,
+    );
+    expect(queryByText('NOW VISIBLE')).toBeNull();
+    act(() => {
+      fireEvent.click(getByText('write'));
+    });
+    expect(getByText('NOW VISIBLE')).toBeTruthy();
+  });
+
+  it('does not leak the `visibility` predicate string onto the DOM node', () => {
+    const { container } = render(
+      <PageVariablesProvider definitions={[{ name: 'sel', type: 'string' }]}>
+        <SchemaRenderer
+          schema={{
+            type: 'element:text',
+            id: 'always',
+            properties: { content: 'shown' },
+            visibility: "page.sel == ''", // truthy initially → visible
+          }}
+        />
+      </PageVariablesProvider>,
+    );
+    expect(container.querySelector('[visibility]')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// element:record_picker — fetches its object and binds to a page variable
+// ---------------------------------------------------------------------------
+
+describe('element:record_picker', () => {
+  it('is registered', () => {
+    expect(ComponentRegistry.get('element:record_picker')).toBeTruthy();
+  });
+
+  it('queries the bound object via the adapter on mount', async () => {
+    const find = vi.fn().mockResolvedValue({
+      data: [
+        { id: 'p1', name: 'Apollo' },
+        { id: 'p2', name: 'Zephyr' },
+      ],
+    });
+    const adapter = { find } as any;
+
+    render(
+      <AdapterCtx.Provider value={adapter}>
+        <PageVariablesProvider
+          definitions={[{ name: 'sel', type: 'record_id', source: 'picker' }]}
+        >
+          <SchemaRenderer
+            schema={{
+              type: 'element:record_picker',
+              id: 'picker',
+              dataSource: { object: 'showcase_project' },
+              properties: { placeholder: 'Pick a project' },
+            }}
+          />
+        </PageVariablesProvider>
+      </AdapterCtx.Provider>,
+    );
+
+    await waitFor(() =>
+      expect(find).toHaveBeenCalledWith('showcase_project', expect.any(Object)),
+    );
+  });
+
+  it('renders an empty state without an adapter (safe to drop anywhere)', () => {
+    const { getByTestId } = render(
+      <SchemaRenderer
+        schema={{
+          type: 'element:record_picker',
+          id: 'picker',
+          properties: { object: 'showcase_project', emptyText: 'No projects' },
+        }}
+      />,
+    );
+    expect(getByTestId('record-picker')).toBeTruthy();
+  });
+});

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -15,9 +15,9 @@
  *   - element:divider                            (no-props separator)
  *   - ElementButtonProps  -> element:button
  *
- * Heavier interactive elements (element:filter, element:form,
- * element:record_picker) live in their owning plugins and are left to
- * those packages.
+ * Heavier interactive elements (element:filter, element:form) live in their
+ * owning plugins and are left to those packages. element:record_picker — which
+ * writes its selection into a page variable — ships alongside in `./record-picker`.
  *
  * All props are read off `schema.properties` per the spec's
  * `UIComponent.properties` convention; `schema.props` is also accepted

--- a/packages/components/src/renderers/basic/index.ts
+++ b/packages/components/src/renderers/basic/index.ts
@@ -19,3 +19,4 @@ import './navigation-menu';
 import './elements';
 import './metadata-viewer';
 import './data-list';
+import './record-picker';

--- a/packages/components/src/renderers/basic/record-picker.tsx
+++ b/packages/components/src/renderers/basic/record-picker.tsx
@@ -1,0 +1,189 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * element:record_picker — an interactive element that lets the user pick one
+ * record of an object and writes the selection into a page variable.
+ *
+ * Data binding follows the spec's ElementDataSource (`schema.dataSource`):
+ *   { object, filter?, sort?, limit? }
+ * with `properties.object` accepted as a fallback. Display config is read off
+ * `schema.properties`:
+ *   { labelField='name', valueField='id', label?, placeholder?, emptyText? }
+ *
+ * The selection is written through `usePageVariableBinding(schema.id)`: the
+ * page variable whose `source` equals this picker's id receives the selected
+ * record's `valueField` (default the record id). With no bound variable the
+ * picker is uncontrolled (still usable, just inert) so it never throws outside
+ * a Page. The written value drives any predicate referencing `page.<var>`
+ * (e.g. another component's `visible` / `visibility`).
+ */
+
+import * as React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { useAdapter, usePageVariableBinding } from '@object-ui/react';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '../../ui';
+import { cn } from '../../lib/utils';
+
+function readProps<T extends Record<string, any>>(schema: any): T {
+  // Per spec, element components carry their config in `schema.properties`.
+  // Tolerate `schema.props` (legacy alias) so JSON written either way works.
+  const fromProperties = (schema?.properties ?? {}) as T;
+  const fromProps = (schema?.props ?? {}) as T;
+  return { ...fromProps, ...fromProperties };
+}
+
+function toText(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (typeof v === 'object') {
+    const o = v as Record<string, any>;
+    return String(o.label ?? o.name ?? o.title ?? o.en ?? '');
+  }
+  return String(v);
+}
+
+function ElementRecordPickerRenderer({ schema }: { schema: any }) {
+  const props = readProps<{
+    object?: string;
+    labelField?: string;
+    valueField?: string;
+    label?: unknown;
+    placeholder?: string;
+    emptyText?: string;
+    filter?: unknown;
+    sort?: any;
+    limit?: number;
+  }>(schema);
+
+  // Per-element data binding (ElementDataSourceSchema) takes precedence over the
+  // flat `properties.object` shorthand.
+  const ds = (schema?.dataSource ?? {}) as {
+    object?: string;
+    filter?: unknown;
+    sort?: unknown;
+    limit?: number;
+  };
+  const object = ds.object ?? props.object;
+  const filter = ds.filter ?? props.filter;
+  const sort = ds.sort ?? props.sort;
+  const limit = ds.limit ?? props.limit ?? 50;
+  const labelField = props.labelField ?? 'name';
+  const valueField = props.valueField ?? 'id';
+
+  const adapter = useAdapter() as any;
+  const binding = usePageVariableBinding(schema?.id);
+
+  const [rows, setRows] = React.useState<any[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const filterKey = React.useMemo(() => (filter ? JSON.stringify(filter) : ''), [filter]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!adapter || !object || typeof adapter.find !== 'function') {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const query: any = {};
+        if (filter) query.$filter = filter;
+        if (sort) query.$orderby = sort;
+        if (limit) query.$top = limit;
+        const res = await adapter.find(object, query);
+        const data: any[] = res?.data ?? res?.records ?? (Array.isArray(res) ? res : []);
+        if (!cancelled) setRows(data);
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message ?? 'Failed to load');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [adapter, object, filterKey, limit]);
+
+  // Reflect the bound variable's value back into the control. When a variable
+  // targets this picker we stay controlled for its whole lifetime (empty string
+  // = no selection) so React never warns about an uncontrolled->controlled switch
+  // once the first value lands. With no binding the picker is uncontrolled and
+  // Radix manages its own state. shadcn Select keys on exact string values, so
+  // coerce the id to a string.
+  const current = binding?.value;
+  const value = binding ? String(current ?? '') : undefined;
+
+  const handleChange = React.useCallback(
+    (next: string) => {
+      binding?.setValue(next);
+    },
+    [binding],
+  );
+
+  const label = toText(props.label);
+  const placeholder = props.placeholder ?? 'Select a record…';
+
+  return (
+    <div
+      className={cn('space-y-1.5', schema?.className)}
+      data-testid="record-picker"
+      data-picker-id={schema?.id}
+    >
+      {label && <label className="text-sm font-medium text-foreground">{label}</label>}
+      <Select
+        value={value}
+        onValueChange={handleChange}
+        disabled={loading || !!error || !object}
+      >
+        <SelectTrigger className="w-full max-w-xs" data-testid="record-picker-trigger">
+          <SelectValue
+            placeholder={loading ? 'Loading…' : error ? 'Failed to load' : placeholder}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          {rows.map((row, i) => {
+            const v = row?.[valueField];
+            const key = v == null ? String(i) : String(v);
+            return (
+              <SelectItem key={key} value={key}>
+                {toText(row?.[labelField]) || key}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+      {!loading && !error && rows.length === 0 && (
+        <p className="text-xs text-muted-foreground">{props.emptyText ?? 'No records'}</p>
+      )}
+    </div>
+  );
+}
+
+ComponentRegistry.register('element:record_picker', ElementRecordPickerRenderer, {
+  namespace: 'element',
+  label: 'Record Picker',
+  category: 'input',
+  inputs: [
+    { name: 'object', type: 'string', label: 'Object' },
+    { name: 'labelField', type: 'string', label: 'Label Field' },
+    { name: 'valueField', type: 'string', label: 'Value Field' },
+    { name: 'placeholder', type: 'string', label: 'Placeholder' },
+    { name: 'label', type: 'string', label: 'Label' },
+  ],
+});
+
+export { ElementRecordPickerRenderer };

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -25,6 +25,7 @@ import {
 } from '@object-ui/core';
 import { SchemaRendererContext } from './context/SchemaRendererContext';
 import { usePredicateScope } from './hooks/useExpression';
+import { usePageVariables } from './hooks/usePageVariables';
 import { resolveI18nLabel } from './utils/i18n';
 
 /**
@@ -195,6 +196,11 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
   // ExpressionProvider. Threaded into `visible`/expression evaluation so
   // component predicates can gate on the signed-in user & deployment flags.
   const predicateScope = usePredicateScope();
+  // Page-local state (PageSchema.variables), provided by PageVariablesProvider.
+  // Exposed to predicates/bindings under `page.<var>` so an interactive element
+  // (e.g. element:record_picker) writing a variable can drive another
+  // component's `visible`/`visibility`. Empty object outside a Page.
+  const { variables: pageVariables } = usePageVariables();
 
   // Re-render trigger when the global ComponentRegistry mutates (e.g. a
   // lazy-loaded plugin finishes registering its components).
@@ -219,11 +225,14 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
 
     // `data` (record/datasource) plus the ambient host scope. `current_user`
     // is aliased to `user` so both `user.email` and `current_user.email`
-    // resolve in component `visible`/`visibleOn` expressions.
+    // resolve in component `visible`/`visibleOn` expressions. `page` exposes
+    // page-local state so predicates can gate on `page.<var>` (e.g. a record
+    // picker's selection toggling another component's visibility).
     const evaluator = new ExpressionEvaluator({
       ...predicateScope,
       current_user: (predicateScope as any)?.user,
       data: dataSource,
+      page: pageVariables,
     });
     // Shallow copy
     const newSchema = { ...schema };
@@ -263,13 +272,20 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
       newSchema.props = newProps;
     }
 
-    // Evaluate visibility: visible / visibleOn / hidden / hiddenOn
+    // Evaluate visibility: visible / visibleOn / visibility / hidden / hiddenOn
     const shouldHide = (() => {
       if (newSchema.visible !== undefined) {
         return !evaluator.evaluateCondition(newSchema.visible);
       }
       if (newSchema.visibleOn !== undefined) {
         return !evaluator.evaluateCondition(newSchema.visibleOn);
+      }
+      // `visibility` is the spec-canonical predicate (PageComponentSchema.visibility,
+      // an ExpressionInput) — show-when-truthy, same semantics as `visibleOn`. The
+      // spec→node bridge preserves it verbatim on the node, so this is where it
+      // finally gates rendering (previously it was inert and leaked as a DOM prop).
+      if (newSchema.visibility !== undefined) {
+        return !evaluator.evaluateCondition(newSchema.visibility);
       }
       if (newSchema.hidden !== undefined) {
         return evaluator.evaluateCondition(newSchema.hidden);
@@ -300,7 +316,7 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
     }
 
     return newSchema;
-  }, [schema, dataSource, predicateScope]);
+  }, [schema, dataSource, predicateScope, pageVariables]);
 
   if (!evaluatedSchema) return null;
   // Handle visibility: if evaluated schema is hidden, render nothing
@@ -367,6 +383,7 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
     schema: _schema,
     visible: _visible,
     visibleOn: _visibleOn,
+    visibility: _visibility,
     hidden: _hidden,
     hiddenOn: _hiddenOn,
     disabled: _disabled,

--- a/packages/react/src/hooks/usePageVariables.tsx
+++ b/packages/react/src/hooks/usePageVariables.tsx
@@ -16,6 +16,13 @@ import type { PageVariable } from '@object-ui/types';
 export interface PageVariablesContextValue {
   /** Current variable values */
   variables: Record<string, any>;
+  /**
+   * The variable definitions backing this provider. Exposed so writer
+   * elements can resolve which variable they feed via `PageVariable.source`
+   * (the component id that writes to the variable) — see
+   * {@link usePageVariableBinding}.
+   */
+  definitions: PageVariable[];
   /** Set a single variable value */
   setVariable: (name: string, value: any) => void;
   /** Set multiple variable values at once */
@@ -108,9 +115,11 @@ export const PageVariablesProvider: React.FC<PageVariablesProviderProps> = ({
     setVariablesState(initializeVariables(definitions));
   }, [definitions]);
 
+  const defs = useMemo<PageVariable[]>(() => definitions ?? [], [definitions]);
+
   const value = useMemo<PageVariablesContextValue>(
-    () => ({ variables, setVariable, setVariables, resetVariables }),
-    [variables, setVariable, setVariables, resetVariables]
+    () => ({ variables, definitions: defs, setVariable, setVariables, resetVariables }),
+    [variables, defs, setVariable, setVariables, resetVariables]
   );
 
   return (
@@ -141,6 +150,7 @@ export function usePageVariables(): PageVariablesContextValue {
     // Graceful fallback — allows components to work outside a Page
     return {
       variables: {},
+      definitions: [],
       setVariable: () => {},
       setVariables: () => {},
       resetVariables: () => {},
@@ -154,4 +164,51 @@ export function usePageVariables(): PageVariablesContextValue {
  */
 export function useHasPageVariables(): boolean {
   return useContext(PageVariablesContext) !== null;
+}
+
+/**
+ * A writer binding for a page variable, resolved from a component id.
+ */
+export interface PageVariableBinding {
+  /** The bound variable's name */
+  name: string;
+  /** The bound variable's current value */
+  value: any;
+  /** Write a new value into the bound variable */
+  setValue: (value: any) => void;
+}
+
+/**
+ * Resolve the page variable that a given component writes to.
+ *
+ * Per `@objectstack/spec`'s `PageVariableSchema`, a variable's `source`
+ * names the **component id** that feeds it — e.g. a `variables` entry
+ * `{ name: 'selectedProjectId', source: 'project_picker' }` is written by the
+ * component whose `id` is `project_picker`. An interactive element (record
+ * picker, filter, …) calls this with its own `schema.id` and writes the
+ * user's selection through the returned `setValue`.
+ *
+ * Returns `null` when no variable targets the given component (or when called
+ * outside a {@link PageVariablesProvider}), so callers can treat themselves as
+ * uncontrolled in that case.
+ *
+ * @example
+ * ```tsx
+ * const binding = usePageVariableBinding(schema.id);
+ * // on selection:
+ * binding?.setValue(record.id);
+ * ```
+ */
+export function usePageVariableBinding(componentId?: string): PageVariableBinding | null {
+  const { variables, definitions, setVariable } = usePageVariables();
+  return useMemo(() => {
+    if (!componentId) return null;
+    const def = definitions.find((d) => d.source === componentId);
+    if (!def) return null;
+    return {
+      name: def.name,
+      value: variables[def.name],
+      setValue: (value: any) => setVariable(def.name, value),
+    };
+  }, [componentId, definitions, variables, setVariable]);
 }


### PR DESCRIPTION
## What

Completes **ADR-0049** — page-local state (`PageSchema.variables`) was half-wired and inert: the runtime mounted `PageVariablesProvider` + `usePageVariables`, but nothing read or wrote the variables, no shipped element wrote one, and page state was never injected into the `visible`/expression context. Authoring `variables` did nothing.

## Changes

- **`SchemaRenderer`** — inject page variables as `page.<var>` into the expression context so predicates resolve `page.selectedId` etc., re-evaluated **live** when a variable changes.
- **`usePageVariables`** — expose `definitions`; add **`usePageVariableBinding(componentId)`**, which resolves the variable a component writes via `PageVariableSchema.source` (= the writer's component id).
- **`element:record_picker`** (new) — fetches records via the adapter and writes the selection into its bound page variable. The element was referenced by the spec but had never been registered.
- **`visibility` predicate fix** — the spec→node bridge preserved the spec-canonical `visibility` predicate on the node, but `SchemaRenderer` never gated on it (and leaked it as a DOM prop). It now gates show-when-truthy like `visibleOn` and is stripped from DOM props.

## Verification

- **11 new unit/integration tests** (`packages/components/src/__tests__/page-variables.test.tsx`): binding resolution, live `visible`/`visibility`/`{dialect,source}`-envelope gating, DOM-strip, `record_picker` adapter fetch + no-adapter fallback. ✅
- **107 regression tests** (spec-bridge, basic-renderers, …) green. ✅
- **Browser E2E** against a live framework backend: the showcase page renders gated-off; picking a project writes the variable and the detail panel appears live, no reload; no `visibility` DOM leak; no React controlled/uncontrolled warning.

Paired with the framework PR (showcase page + spec docs + dogfood test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)