### PR TITLE
feat(studio): surface flow validation errors inline on the canvas

### DIFF
--- a/.changeset/studio-flow-canvas-cycle-highlight.md
+++ b/.changeset/studio-flow-canvas-cycle-highlight.md
@@ -1,0 +1,9 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(studio): surface flow validation errors inline on the canvas
+
+The flow designer's structural validation (an un-declared cycle, missing entry node, duplicate ids, dangling edges, …) was only visible in the Debug panel. It now surfaces **inline on the canvas**: an un-declared cycle paints its offending edges + nodes red — using the same `validateFlowDraft` the simulator preflight runs — and an error banner lists the messages, so the author sees a broken graph without opening Debug. Each edge that closes the cycle carries a tooltip pointing at the fix ("mark the edge that closes the loop as a back-edge"). A declared revise loop (ADR-0044 back-edge) is excluded from cycle detection and stays un-flagged.
+
+Follows #1954 (revise-loop authoring) and #1955 (simulating approval decisions).

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { FlowCanvas } from './FlowCanvas';
+
+afterEach(cleanup);
+
+/**
+ * ADR-0044: an un-declared cycle is surfaced INLINE on the canvas — the
+ * offending edges/nodes are painted red (data-invalid) and an error banner
+ * shows the message — so the author needn't open the Debug panel.
+ */
+describe('FlowCanvas — inline cycle/error surfacing', () => {
+  const nodes = [
+    { id: 'a', type: 'approval' },
+    { id: 'w', type: 'wait' },
+  ];
+  const edges = [
+    { source: 'a', target: 'w', label: 'revise' },
+    { source: 'w', target: 'a', label: 'resubmit' }, // unmarked cycle
+  ];
+
+  it('renders the error banner and marks invalid edges + nodes', () => {
+    const { container } = render(
+      <FlowCanvas
+        nodes={nodes}
+        edges={edges}
+        editable={false}
+        designMode={false}
+        selectedId={null}
+        onSelect={() => {}}
+        invalidNodeIds={['a', 'w']}
+        invalidEdges={new Set(['a->w', 'w->a'])}
+        validationErrors={['Cycle detected (a → w → a). Mark the closing edge as a back-edge.']}
+      />,
+    );
+    // Banner message is visible on the canvas.
+    expect(screen.getByText(/Cycle detected/)).toBeInTheDocument();
+    // Two cycle edges + two cycle nodes carry the data-invalid marker.
+    expect(container.querySelectorAll('[data-invalid="true"]').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('shows no banner and no invalid markers for a clean flow', () => {
+    const { container } = render(
+      <FlowCanvas
+        nodes={nodes}
+        edges={[{ source: 'a', target: 'w', label: 'revise' }]}
+        editable={false}
+        designMode={false}
+        selectedId={null}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/Cycle detected/)).toBeNull();
+    expect(container.querySelectorAll('[data-invalid="true"]').length).toBe(0);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -22,7 +22,7 @@
  */
 
 import * as React from 'react';
-import { Maximize2, Plus, ZoomIn, ZoomOut } from 'lucide-react';
+import { AlertTriangle, Maximize2, Plus, ZoomIn, ZoomOut } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import { uniqueId, appendArray, spliceArray } from '../inspectors/_shared';
 import { t as tr } from '../i18n';
@@ -81,6 +81,12 @@ export interface FlowCanvasProps {
   visitedNodeIds?: string[];
   /** Simulation overlay: ids of edges that were traversed. */
   traversedEdgeIds?: string[];
+  /** Structural-validation: node ids to paint with a red error ring. */
+  invalidNodeIds?: string[];
+  /** Structural-validation: edges (keyed `${source}->${target}`) to paint red. */
+  invalidEdges?: ReadonlySet<string>;
+  /** Structural-validation error messages shown in an inline canvas banner. */
+  validationErrors?: string[];
   onSelect: (node: FlowNode | null) => void;
   /** Select an edge (its `edgeKey`), or clear selection with `null`. */
   onSelectEdge?: (edge: FlowEdge | null, key: string) => void;
@@ -98,6 +104,9 @@ export function FlowCanvas({
   activeNodeId,
   visitedNodeIds,
   traversedEdgeIds,
+  invalidNodeIds,
+  invalidEdges,
+  validationErrors,
   onSelect,
   onSelectEdge,
   onPatch,
@@ -124,6 +133,7 @@ export function FlowCanvas({
   // Simulation overlay sets (display-only; never drives engine behavior).
   const visitedSet = React.useMemo(() => new Set(visitedNodeIds ?? []), [visitedNodeIds]);
   const traversedSet = React.useMemo(() => new Set(traversedEdgeIds ?? []), [traversedEdgeIds]);
+  const invalidNodeSet = React.useMemo(() => new Set(invalidNodeIds ?? []), [invalidNodeIds]);
   const simRunning = (visitedNodeIds?.length ?? 0) > 0 || !!activeNodeId;
 
   const positionOf = React.useCallback(
@@ -395,6 +405,25 @@ export function FlowCanvas({
 
   return (
     <div className="relative h-full min-h-[320px] w-full overflow-hidden">
+      {/* Inline structural-validation banner (ADR-0044 cycle surfacing): shows
+          errors directly on the canvas so the author needn't open Debug. */}
+      {validationErrors && validationErrors.length > 0 && (
+        <div className="absolute left-2 top-2 z-30 max-w-[min(60%,420px)] space-y-1">
+          {validationErrors.slice(0, 3).map((msg, i) => (
+            <div
+              key={i}
+              role="alert"
+              className="flex items-start gap-1.5 rounded-lg border border-destructive/40 bg-destructive/10 px-2.5 py-1.5 text-[11px] leading-snug text-destructive shadow-sm backdrop-blur-sm"
+            >
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{msg}</span>
+            </div>
+          ))}
+          {validationErrors.length > 3 && (
+            <div className="px-2.5 text-[10px] text-destructive/80">+{validationErrors.length - 3} more…</div>
+          )}
+        </div>
+      )}
       {/* Toolbar */}
       <div className="absolute right-2 top-2 z-30 flex items-center gap-1.5">
         {editable && (
@@ -520,6 +549,18 @@ export function FlowCanvas({
               >
                 <path d="M 0 0 L 10 5 L 0 10 z" className="fill-amber-500/80" />
               </marker>
+              {/* Red arrowhead for edges flagged by structural validation. */}
+              <marker
+                id="flow-arrow-error"
+                viewBox="0 0 10 10"
+                refX="8"
+                refY="5"
+                markerWidth="7"
+                markerHeight="7"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" className="fill-destructive" />
+              </marker>
             </defs>
             {edges.map((edge, i) => {
               const sp = layout.get(edge.source);
@@ -530,6 +571,9 @@ export function FlowCanvas({
               // dashed amber return arc — visually distinct from the forward
               // top-to-bottom flow.
               const back = isBackEdge(edge);
+              // Structural-validation error (e.g. part of an un-declared cycle).
+              // Back-edges are excluded from cycle detection, so they're never invalid.
+              const invalid = !back && !!invalidEdges?.has(`${edge.source}->${edge.target}`);
               const sPos = dragPos?.id === edge.source ? positionOf(edge.source) : sp;
               const tPos = dragPos?.id === edge.target ? positionOf(edge.target) : tp;
               const from = back ? rightAnchor(sPos) : bottomAnchor(sPos);
@@ -546,7 +590,7 @@ export function FlowCanvas({
               // beyond the 1.5px visible stroke without altering the visuals.
               const selectable = designMode && !!onSelectEdge;
               return (
-                <g key={edge.id || `${edge.source}-${edge.target}-${i}`}>
+                <g key={edge.id || `${edge.source}-${edge.target}-${i}`} data-invalid={invalid || undefined}>
                   <path
                     d={d}
                     strokeLinecap="round"
@@ -557,14 +601,16 @@ export function FlowCanvas({
                         ? 'stroke-sky-500'
                         : selected
                           ? 'stroke-primary'
-                          : back
-                            ? 'stroke-amber-500/70'
-                            : simRunning
-                              ? 'stroke-muted-foreground/20'
-                              : 'stroke-muted-foreground/40',
+                          : invalid
+                            ? 'stroke-destructive'
+                            : back
+                              ? 'stroke-amber-500/70'
+                              : simRunning
+                                ? 'stroke-muted-foreground/20'
+                                : 'stroke-muted-foreground/40',
                     )}
-                    strokeWidth={traversed || selected ? 2.5 : 1.75}
-                    markerEnd={back ? 'url(#flow-arrow-back)' : 'url(#flow-arrow)'}
+                    strokeWidth={traversed || selected || invalid ? 2.5 : 1.75}
+                    markerEnd={invalid ? 'url(#flow-arrow-error)' : back ? 'url(#flow-arrow-back)' : 'url(#flow-arrow)'}
                   />
                   {selectable && (
                     <path
@@ -577,7 +623,7 @@ export function FlowCanvas({
                         onSelectEdge!(edge, eid);
                       }}
                     >
-                      <title>{back ? `${edge.source} ↩ ${edge.target} (back-edge)` : `${edge.source} → ${edge.target}`}</title>
+                      <title>{invalid ? `${edge.source} → ${edge.target} — part of an un-declared cycle; mark the edge that closes the loop as a back-edge` : back ? `${edge.source} ↩ ${edge.target} (back-edge)` : `${edge.source} → ${edge.target}`}</title>
                     </path>
                   )}
                   {branchLabel && (
@@ -597,9 +643,11 @@ export function FlowCanvas({
                             selectable && 'cursor-pointer hover:border-primary/60',
                             selected
                               ? 'border-primary text-primary'
-                              : back
-                                ? 'border-amber-500/50 text-amber-600 dark:text-amber-400'
-                                : 'border-border text-muted-foreground',
+                              : invalid
+                                ? 'border-destructive/60 text-destructive'
+                                : back
+                                  ? 'border-amber-500/50 text-amber-600 dark:text-amber-400'
+                                  : 'border-border text-muted-foreground',
                           )}
                         >
                           {branchLabel}
@@ -661,6 +709,7 @@ export function FlowCanvas({
                     ? () => addReviseLoop(node.id)
                     : undefined
                 }
+                invalid={invalidNodeSet.has(node.id)}
               />
             );
           })}

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -38,6 +38,8 @@ import { FlowCanvas } from './FlowCanvas';
 import { edgeKey } from './flow-canvas-layout';
 import { FlowSimulatorPanel } from './FlowSimulatorPanel';
 import { FlowRunsPanel } from './FlowRunsPanel';
+import { validateFlowDraft } from './simulator/flow-sim-validate';
+import type { SimEdge, SimNode } from './simulator/flow-sim-types';
 
 interface FlowNode {
   id: string;
@@ -69,8 +71,10 @@ interface FlowVariable {
 
 export function FlowPreview({ draft, editing, selection, onSelectionChange, onPatch, locale }: MetadataPreviewProps) {
   const d = draft as Record<string, unknown>;
-  const nodes: FlowNode[] = Array.isArray(d.nodes) ? (d.nodes as FlowNode[]) : [];
-  const edges: FlowEdge[] = Array.isArray(d.edges) ? (d.edges as FlowEdge[]) : [];
+  // Memoized so hook deps (validation memo, handleAddNode) get a stable array
+  // reference across renders instead of a fresh `[]`/cast each time.
+  const nodes = React.useMemo<FlowNode[]>(() => (Array.isArray(d.nodes) ? (d.nodes as FlowNode[]) : []), [d.nodes]);
+  const edges = React.useMemo<FlowEdge[]>(() => (Array.isArray(d.edges) ? (d.edges as FlowEdge[]) : []), [d.edges]);
   const variables: FlowVariable[] = Array.isArray(d.variables) ? (d.variables as FlowVariable[]) : [];
 
   const designMode = !!(editing && onSelectionChange);
@@ -86,6 +90,31 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
     visitedNodeIds: string[];
     traversedEdgeIds: string[];
   } | null>(null);
+
+  // Continuous structural validation surfaced INLINE on the canvas (ADR-0044):
+  // an un-declared cycle (and other structural errors) paints the offending
+  // edges/nodes red and shows a banner — so the author sees it without opening
+  // the Debug panel. Same `validateFlowDraft` the simulator preflight uses.
+  const { invalidNodeIds, invalidEdges, validationErrors } = React.useMemo(() => {
+    const v = validateFlowDraft(nodes as unknown as SimNode[], edges as unknown as SimEdge[]);
+    const nodeSet = new Set<string>();
+    const edgeSet = new Set<string>();
+    for (const diag of v.errors) {
+      if (diag.nodeId) nodeSet.add(diag.nodeId);
+      // A cycle error carries its closing node path → mark each hop's edge red.
+      if (diag.cycle) {
+        for (let i = 0; i < diag.cycle.length - 1; i++) {
+          nodeSet.add(diag.cycle[i]);
+          edgeSet.add(`${diag.cycle[i]}->${diag.cycle[i + 1]}`);
+        }
+      }
+    }
+    return {
+      invalidNodeIds: [...nodeSet],
+      invalidEdges: edgeSet,
+      validationErrors: v.errors.map((diag) => diag.message),
+    };
+  }, [nodes, edges]);
 
   const handleAddNode = React.useCallback(() => {
     if (!canEdit) return;
@@ -206,6 +235,9 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                 activeNodeId={runHL?.activeNodeId ?? null}
                 visitedNodeIds={runHL?.visitedNodeIds}
                 traversedEdgeIds={runHL?.traversedEdgeIds}
+                invalidNodeIds={invalidNodeIds}
+                invalidEdges={invalidEdges}
+                validationErrors={validationErrors}
                 onSelect={(n) =>
                   n
                     ? onSelectionChange?.({ kind: 'node', id: n.id, label: n.label || n.id })

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -381,6 +381,8 @@ export interface NodeCardProps {
   runState?: 'active' | 'visited';
   /** Dim nodes not yet reached while a simulation is in progress. */
   dimmed?: boolean;
+  /** Structural-validation error highlight (e.g. part of an un-declared cycle). */
+  invalid?: boolean;
   onPointerDown?: (e: React.PointerEvent) => void;
   onSelect?: () => void;
   onAppend?: () => void;
@@ -406,6 +408,7 @@ export function NodeCard({
   editable,
   runState,
   dimmed,
+  invalid,
   onPointerDown,
   onSelect,
   onAppend,
@@ -418,6 +421,7 @@ export function NodeCard({
       // appear when the pointer is anywhere over the card, not only over the
       // tiny button itself.
       className="group absolute transition-opacity duration-200"
+      data-invalid={invalid || undefined}
       style={{ left: position.x, top: position.y, width: NODE_W, height: NODE_H, opacity: dimmed ? 0.35 : 1 }}
     >
       <div
@@ -446,7 +450,9 @@ export function NodeCard({
               ? 'border-emerald-500/70 ring-1 ring-emerald-400/40'
               : selected
                 ? 'border-primary shadow-md ring-2 ring-primary/30'
-                : 'border-border/80',
+                : invalid
+                  ? 'border-destructive ring-2 ring-destructive/50'
+                  : 'border-border/80',
         )}
       >
         <div

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-simulator.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-simulator.test.ts
@@ -57,6 +57,27 @@ describe('validateFlowDraft', () => {
     expect(v.errors.some((e) => /Cycle detected/.test(e.message))).toBe(true);
   });
 
+  it('cycle error carries the closing node path (for inline canvas highlighting)', () => {
+    const v = validateFlowDraft(
+      [
+        { id: 's', type: 'start' },
+        { id: 'a', type: 'approval' },
+        { id: 'w', type: 'wait' },
+      ],
+      [
+        { source: 's', target: 'a' },
+        { source: 'a', target: 'w', label: 'revise' },
+        { source: 'w', target: 'a', label: 'resubmit' },
+      ],
+    );
+    const cyc = v.errors.find((e) => e.cycle);
+    expect(cyc).toBeDefined();
+    // The path closes the loop and names the involved nodes.
+    expect(cyc!.cycle![0]).toBe(cyc!.cycle![cyc!.cycle!.length - 1]);
+    expect(cyc!.cycle).toContain('a');
+    expect(cyc!.cycle).toContain('w');
+  });
+
   it('accepts a declared revise loop (closing edge typed "back")', () => {
     const v = validateFlowDraft(
       [

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-types.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-types.ts
@@ -91,6 +91,11 @@ export interface Diagnostic {
   level: DiagnosticLevel;
   nodeId?: string;
   message: string;
+  /**
+   * For a cycle error: the node path that closes the loop (e.g. `['a','b','a']`),
+   * so the designer can paint the offending edges/nodes inline on the canvas.
+   */
+  cycle?: string[];
 }
 
 export interface FlowValidation {

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-validate.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-validate.ts
@@ -182,6 +182,7 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValid
     errors.push({
       level: 'error',
       nodeId: cycle[0],
+      cycle,
       message: `Cycle detected (${cycle.join(' → ')}). Mark the connection that closes the loop as a back-edge (Connection type → Back-edge) to declare an intentional revise/rework loop.`,
     });
   }


### PR DESCRIPTION
## What & why

Third in the ADR-0044 revise-loop series (after [#1954](https://github.com/objectstack-ai/objectui/pull/1954) authoring and [#1955](https://github.com/objectstack-ai/objectui/pull/1955) debugger). The flow designer's structural validation — an **un-declared cycle**, missing entry node, duplicate ids, dangling edges — was only visible in the **Debug** panel, which the author has to open. Now it surfaces **inline on the canvas**.

## Change

- **Un-declared cycle painted red on the canvas.** The cycle's offending edges and nodes are highlighted (red stroke / red ring), using the *same* `validateFlowDraft` the simulator preflight runs (no second rule). The edge that closes the loop carries a tooltip pointing at the fix: *"mark the edge that closes the loop as a back-edge"*. A **declared** revise loop (ADR-0044 `type: 'back'`) is excluded from cycle detection and stays un-flagged.
- **Inline error banner** on the canvas listing the structural-error messages — so even an off-screen cycle is discoverable.
- The cycle `Diagnostic` now carries the closing **node path**, so `FlowPreview` can derive the exact edges/nodes to highlight. It runs validation continuously and passes `invalidNodeIds` / `invalidEdges` / `validationErrors` to `FlowCanvas`. Invalid edges/nodes also expose a `data-invalid` attribute (styling + tests).

## Files

- `simulator/flow-sim-types.ts` / `flow-sim-validate.ts` — `Diagnostic.cycle` (closing node path) set on the cycle error.
- `previews/FlowCanvas.tsx` — red edge/marker/banner; `invalidNodeIds` / `invalidEdges` / `validationErrors` props; `data-invalid`.
- `previews/flow-canvas-parts.tsx` — `NodeCard` red error ring (`invalid` prop).
- `previews/FlowPreview.tsx` — continuous `validateFlowDraft`; derive + pass highlights (nodes/edges memoized for stable hook deps).

## Verification

- **Component test** (`FlowCanvas.test.tsx`): renders the real canvas with a cyclic flow → asserts the error banner shows the message and the cycle's edges + nodes carry `data-invalid`; a clean flow shows neither.
- **Unit**: the cycle `Diagnostic` carries the closing node path (`a → … → a`).
- Full metadata-admin suite **398 green**; `type-check` 0 errors; `eslint` 0 errors.

> Browser drivers (chrome-devtools / preview server) were occupied by parallel sessions this run, so the canvas rendering is covered by the component test (it mounts the real `FlowCanvas`) rather than a live screenshot.

Pairs with the canvas-validation direction noted in framework#1770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
