### PR TITLE
feat(metadata-admin): visual filter authoring in the dataset designer

### DIFF
--- a/.changeset/dataset-designer-filter-authoring.md
+++ b/.changeset/dataset-designer-filter-authoring.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(metadata-admin): visual filter authoring in the dataset designer
+
+The dataset designer gains a visual filter editor (reusing the shared
+`FilterBuilder`) for both the dataset-level **Scope filter** (`dataset.filter`)
+and per-measure **Filter** (`measure.filter`) — previously only settable via the
+raw Source/JSON tab. Both are backed by real runtime: the analytics executor ANDs
+the scope filter into every query and runs measure-scoped filters as supplementary
+grouped queries, so e.g. `won_amount = sum(amount) where stage = won` and an
+"exclude archived" dataset scope are now authorable without hand-writing JSON.
+
+A small, unit-tested converter bridges the builder's flat `{field, op, value}`
+group ⇄ the spec `FilterCondition` (Mongo-style `$and` / `$op`). Conditions it
+can't faithfully round-trip (nested groups, `$or`, multi-operator objects) are
+detected and shown as "edit in Source" rather than being silently rewritten.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
@@ -126,4 +126,10 @@ describe('DatasetDefaultInspector', () => {
     render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={vi.fn()} readOnly={false} />);
     expect(screen.queryByText('Certified')).not.toBeInTheDocument();
   });
+
+  it('exposes a dataset Scope filter and a per-measure filter editor', () => {
+    render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={vi.fn()} readOnly={false} />);
+    expect(screen.getByText('Scope filter')).toBeInTheDocument();
+    expect(screen.getByText('Filter (measure-scoped)')).toBeInTheDocument();
+  });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
@@ -20,8 +20,8 @@
  */
 
 import * as React from 'react';
-import { AlertTriangle, ArrowRight, Plus, Trash2, X } from 'lucide-react';
-import { Badge, Button, Label } from '@object-ui/components';
+import { AlertTriangle, ArrowRight, ChevronDown, Plus, Trash2, X } from 'lucide-react';
+import { Badge, Button, FilterBuilder, Label, Popover, PopoverContent, PopoverTrigger } from '@object-ui/components';
 import {
   InspectorShell,
   InspectorTextField,
@@ -33,6 +33,7 @@ import {
 import { InspectorComboField, type InspectorComboOption } from './InspectorComboField';
 import { toFieldName } from '../previews/object-fields-io';
 import { formatMeasure } from '@object-ui/core';
+import { conditionToGroup, groupToCondition, type FilterCondition } from './datasetFilterCondition';
 import {
   useObjectOptions,
   useDatasetFieldCatalog,
@@ -111,6 +112,7 @@ type Measure = {
   format?: string;
   currency?: string;
   derived?: DerivedSpec;
+  filter?: FilterCondition;
 };
 
 function SectionHeader({ title, count, onAdd, addLabel }: { title: string; count: number; onAdd?: () => void; addLabel: string }) {
@@ -214,6 +216,52 @@ function RelWarning({ rel, onAdd, disabled }: { rel: string; onAdd?: () => void;
   );
 }
 
+/**
+ * Visual filter editor for a dataset/measure `FilterCondition`. Wraps the shared
+ * {@link FilterBuilder} (a flat AND of `field op value` rows) and converts to/from
+ * the spec's Mongo-style `FilterCondition`. Filters it can't faithfully edit
+ * (nested / `$or` / multi-op) degrade to a "edit in Source" note rather than being
+ * silently rewritten. See {@link conditionToGroup} / {@link groupToCondition}.
+ */
+function DatasetFilterField({ label, help, value, onCommit, fields, disabled }: {
+  label: string;
+  help?: string;
+  value: FilterCondition | undefined;
+  onCommit: (fc: FilterCondition | undefined) => void;
+  fields: Array<{ value: string; label?: string; type?: string }>;
+  disabled?: boolean;
+}) {
+  const { group, representable } = conditionToGroup(value);
+  const count = group.conditions.length;
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      {!representable ? (
+        <p className="rounded-md border border-dashed bg-muted/30 px-2.5 py-1.5 text-[11px] text-muted-foreground">
+          Advanced filter (nested / OR) — edit it in the <span className="font-medium">Source</span> tab.
+        </p>
+      ) : (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button type="button" variant="outline" size="sm" disabled={disabled} className="h-8 w-full justify-between text-xs font-normal">
+              <span className="truncate text-left">{count ? `${count} condition${count === 1 ? '' : 's'}` : <span className="text-muted-foreground">+ Add filter…</span>}</span>
+              <ChevronDown className="h-3.5 w-3.5 opacity-60 shrink-0" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-[440px] max-w-[90vw] p-3">
+            {fields.length === 0 ? (
+              <p className="text-xs text-muted-foreground">Pick a base object to add filter conditions.</p>
+            ) : (
+              <FilterBuilder fields={fields as any} value={group as any} onChange={(g: any) => onCommit(groupToCondition(g))} />
+            )}
+          </PopoverContent>
+        </Popover>
+      )}
+      {help && <p className="text-[10px] text-muted-foreground">{help}</p>}
+    </div>
+  );
+}
+
 export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: MetadataDefaultInspectorProps) {
   const label = typeof draft.label === 'string' ? draft.label : '';
   const description = typeof draft.description === 'string' ? draft.description : '';
@@ -248,6 +296,13 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: Meta
     () => fieldOptions.map((f) => ({ value: f.value, label: f.label, hint: f.type, group: f.group })),
     [fieldOptions],
   );
+  // Base-object fields for the filter builders (scope + measure filters operate on
+  // the base table; relationship-path filters are out of scope for v1).
+  const filterFields = React.useMemo(
+    () => fieldOptions.filter((f) => !f.value.includes('.')).map((f) => ({ value: f.value, label: f.label, type: f.type })),
+    [fieldOptions],
+  );
+  const datasetFilter = draft.filter && typeof draft.filter === 'object' ? (draft.filter as FilterCondition) : undefined;
 
   const baseLabel = objectComboOptions.find((o) => o.value === object)?.label ?? object;
 
@@ -372,6 +427,18 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: Meta
         )}
       </div>
 
+      {/* Scope filter — the dataset's intrinsic FilterCondition */}
+      <div className="border-t pt-3">
+        <DatasetFilterField
+          label="Scope filter"
+          help="Intrinsic scope, ANDed into every query (e.g. exclude soft-deleted records)."
+          value={datasetFilter}
+          onCommit={(fc) => onPatch({ filter: fc })}
+          fields={filterFields}
+          disabled={readOnly}
+        />
+      </div>
+
       {/* Dimensions */}
       <div className="border-t pt-3 space-y-2">
         <SectionHeader
@@ -468,6 +535,14 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: Meta
               <Advanced>
                 <InspectorTextField label="Label (optional)" value={m.label ?? ''} onCommit={(v) => patchMeasure(i, { label: v || undefined })} placeholder={m.name || 'Display label'} disabled={readOnly} />
                 <MeasureFormatField measure={m} onPatch={(pp) => patchMeasure(i, pp)} disabled={readOnly} />
+                <DatasetFilterField
+                  label="Filter (measure-scoped)"
+                  help="Only rows matching this filter feed this measure (e.g. won_amount = sum(amount) where stage = won)."
+                  value={m.filter}
+                  onCommit={(fc) => patchMeasure(i, { filter: fc })}
+                  fields={filterFields}
+                  disabled={readOnly}
+                />
                 <InspectorCheckboxField
                   label="Derived — computed from other measures"
                   value={!!derived}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+import { describe, it, expect } from 'vitest';
+import { groupToCondition, conditionToGroup } from './datasetFilterCondition';
+
+describe('datasetFilterCondition', () => {
+  it('serializes a single condition without an $and wrapper', () => {
+    expect(groupToCondition({ logic: 'and', conditions: [{ field: 'status', operator: 'equals', value: 'won' }] }))
+      .toEqual({ status: { $eq: 'won' } });
+  });
+
+  it('serializes multiple conditions as a flat $and', () => {
+    expect(groupToCondition({ logic: 'and', conditions: [
+      { field: 'stage', operator: 'equals', value: 'won' },
+      { field: 'amount', operator: 'greaterThan', value: 1000 },
+    ] })).toEqual({ $and: [{ stage: { $eq: 'won' } }, { amount: { $gt: 1000 } }] });
+  });
+
+  it('maps isEmpty/isNotEmpty to $exists', () => {
+    expect(groupToCondition({ logic: 'and', conditions: [{ field: 'closed_at', operator: 'isNotEmpty' }] }))
+      .toEqual({ closed_at: { $exists: true } });
+  });
+
+  it('drops unmapped operators rather than emitting a bad filter', () => {
+    expect(groupToCondition({ logic: 'and', conditions: [{ field: 'x', operator: 'notContains', value: 'a' }] }))
+      .toBeUndefined();
+  });
+
+  it('empty group → undefined', () => {
+    expect(groupToCondition({ logic: 'and', conditions: [] })).toBeUndefined();
+  });
+
+  it('round-trips representable conditions (condition → group → condition)', () => {
+    for (const c of [
+      { status: { $eq: 'won' } },
+      { $and: [{ stage: { $eq: 'won' } }, { amount: { $gt: 1000 } }] },
+      { region: { $in: ['NA', 'EU'] } },
+      { closed_at: { $exists: false } },
+    ]) {
+      const { group, representable } = conditionToGroup(c);
+      expect(representable).toBe(true);
+      expect(groupToCondition(group)).toEqual(c);
+    }
+  });
+
+  it('parses implicit equality {field: scalar}', () => {
+    const { group, representable } = conditionToGroup({ status: 'active' });
+    expect(representable).toBe(true);
+    expect(group.conditions).toEqual([{ id: 'c0', field: 'status', operator: 'equals', value: 'active' }]);
+  });
+
+  it('flags non-representable shapes (nested $or / multi-op) for the source editor', () => {
+    expect(conditionToGroup({ $or: [{ a: { $eq: 1 } }] }).representable).toBe(false);
+    expect(conditionToGroup({ amount: { $gt: 1, $lt: 9 } }).representable).toBe(false);
+    expect(conditionToGroup({ $and: [{ $or: [{ a: { $eq: 1 } }] }] }).representable).toBe(false);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Bridge between the visual {@link FilterBuilder} (a flat `FilterGroup` of
+ * `{field, operator, value}` rows, camelCase operators) and the spec
+ * `FilterCondition` (Mongo-style `{ field: { $op: value } }`, conjoined with
+ * `$and`) stored on `dataset.filter` / `measure.filter`.
+ *
+ * Scope (deliberate): the visual editor supports the common case — a flat AND
+ * of simple `field op value` conditions. Anything it can't faithfully round-trip
+ * (nested groups, `$or`, multi-operator objects, unmapped operators) is reported
+ * as NOT representable so the caller can fall back to the source editor instead
+ * of silently corrupting the author's filter.
+ */
+
+/** FilterBuilder camelCase operator → FilterCondition Mongo operator. */
+const OP_TO_MONGO: Record<string, string> = {
+  equals: '$eq', notEquals: '$ne',
+  greaterThan: '$gt', greaterOrEqual: '$gte', lessThan: '$lt', lessOrEqual: '$lte',
+  after: '$gt', before: '$lt',
+  contains: '$contains', in: '$in', notIn: '$nin',
+};
+const MONGO_TO_OP: Record<string, string> = {
+  $eq: 'equals', $ne: 'notEquals',
+  $gt: 'greaterThan', $gte: 'greaterOrEqual', $lt: 'lessThan', $lte: 'lessOrEqual',
+  $contains: 'contains', $in: 'in', $nin: 'notIn',
+};
+
+export interface BuilderCondition { id?: string; field: string; operator: string; value?: unknown }
+export interface BuilderGroup { id?: string; logic: 'and' | 'or'; conditions: BuilderCondition[] }
+export type FilterCondition = Record<string, any>;
+
+/** Serialize the visual group → a spec FilterCondition (flat `$and`). */
+export function groupToCondition(group: BuilderGroup | undefined): FilterCondition | undefined {
+  const conds = (group?.conditions ?? []).filter((c) => c && c.field);
+  const parts: FilterCondition[] = [];
+  for (const c of conds) {
+    if (c.operator === 'isEmpty') { parts.push({ [c.field]: { $exists: false } }); continue; }
+    if (c.operator === 'isNotEmpty') { parts.push({ [c.field]: { $exists: true } }); continue; }
+    const mop = OP_TO_MONGO[c.operator];
+    if (!mop) continue; // unmapped (e.g. notContains/between) — drop rather than emit a bad filter
+    parts.push({ [c.field]: { [mop]: c.value } });
+  }
+  if (parts.length === 0) return undefined;
+  if (parts.length === 1) return parts[0];
+  return { $and: parts };
+}
+
+/**
+ * Parse a stored FilterCondition → the visual group. `representable: false` when
+ * the condition uses shapes the flat builder can't faithfully edit (nested
+ * `$and`/`$or`, multi-op objects, unmapped operators) — callers should then show
+ * the source editor instead.
+ */
+export function conditionToGroup(cond: FilterCondition | undefined | null): { group: BuilderGroup; representable: boolean } {
+  const empty: BuilderGroup = { id: 'g', logic: 'and', conditions: [] };
+  if (cond == null) return { group: empty, representable: true };
+  if (typeof cond !== 'object' || Array.isArray(cond)) return { group: empty, representable: false };
+  if ('$or' in cond) return { group: empty, representable: false };
+
+  const list: FilterCondition[] = Array.isArray((cond as any).$and) ? (cond as any).$and : [cond];
+  const conditions: BuilderCondition[] = [];
+  for (let i = 0; i < list.length; i++) {
+    const c = list[i];
+    if (!c || typeof c !== 'object' || Array.isArray(c)) return { group: empty, representable: false };
+    if ('$and' in c || '$or' in c) return { group: empty, representable: false };
+    const keys = Object.keys(c);
+    if (keys.length !== 1) return { group: empty, representable: false };
+    const field = keys[0];
+    const v = (c as any)[field];
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      const opKeys = Object.keys(v);
+      if (opKeys.length !== 1) return { group: empty, representable: false };
+      const mop = opKeys[0];
+      if (mop === '$exists') {
+        conditions.push({ id: `c${i}`, field, operator: v.$exists ? 'isNotEmpty' : 'isEmpty', value: '' });
+      } else {
+        const op = MONGO_TO_OP[mop];
+        if (!op) return { group: empty, representable: false };
+        conditions.push({ id: `c${i}`, field, operator: op, value: v[mop] });
+      }
+    } else {
+      conditions.push({ id: `c${i}`, field, operator: 'equals', value: v }); // implicit equality
+    }
+  }
+  return { group: { id: 'g', logic: 'and', conditions }, representable: true };
+}


### PR DESCRIPTION
Adds a visual filter editor (shared FilterBuilder) for the dataset Scope filter (`dataset.filter`) and per-measure Filter (`measure.filter`) — previously only editable via the raw Source tab, despite both being applied at runtime (dataset-executor ANDs scope into every query; measure filters run as supplementary grouped queries). New unit-tested `datasetFilterCondition.ts` bridges the builder's flat group ⇄ spec Mongo-style FilterCondition; non-representable shapes (nested/$or/multi-op) degrade to 'edit in Source'. Tests: converter 8 + inspector 13. Reuses the FilterBuilder already shipped in list/page filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)