### PR TITLE
feat(studio): render inline master-detail subforms in flow Screen preview (follow-up #1944)

### DIFF
--- a/.changeset/flow-screen-preview-subforms.md
+++ b/.changeset/flow-screen-preview-subforms.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/plugin-form': patch
+---
+
+Flow Screen preview: render inline master-detail subforms (follow-up to #1944)
+
+The object-form mode of the Screen-node preview now renders inline master-detail
+child grids, matching runtime. `ScreenPreview` feeds the SAME enriched object
+list the runtime `FlowRunner` uses (`useMetadata().objects`, which derives
+`form.subforms` from `inlineEdit` relationships via `attachInlineSubforms`), so
+e.g. a `showcase_invoice` object-form step previews its **Line Items** grid
+(with live Subtotal/Tax/Total) — only fetched in object-form mode.
+
+To keep the preview non-persisting — consistent with the flat-field preview
+(disabled Submit) and the simple object-form preview (no Save) — `MasterDetailForm`
+now honours a `showSubmit` flag (default shown; backward-compatible) that
+`ObjectForm` forwards, so the preview hides the master-detail Save bar. Also drops
+a dead `e = formData` assignment in `ObjectForm` (lint `no-useless-assignment`).

--- a/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.test.tsx
@@ -5,9 +5,10 @@ import { render, screen, cleanup } from '@testing-library/react';
 
 // Capture the schema ObjectForm receives so object-form mode can be asserted
 // without standing up the real plugin-form runtime.
-const { objectFormSpy, adapterRef } = vi.hoisted(() => ({
+const { objectFormSpy, adapterRef, objectsRef } = vi.hoisted(() => ({
   objectFormSpy: vi.fn(),
   adapterRef: { current: { fake: 'adapter' } as unknown },
+  objectsRef: { current: [] as unknown[] },
 }));
 
 vi.mock('@object-ui/plugin-form', () => ({
@@ -21,6 +22,12 @@ vi.mock('../../../providers/AdapterProvider', () => ({
   useAdapter: () => adapterRef.current,
 }));
 
+// Enriched object defs (with derived master-detail subforms) come from here at
+// runtime; the preview feeds them straight to ObjectForm.
+vi.mock('../../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ objects: objectsRef.current }),
+}));
+
 import { ScreenPreview } from './ScreenPreview';
 import { buildScreenSpec, isFieldVisibleWhen, hiddenFieldCount } from './screen-spec';
 
@@ -28,6 +35,7 @@ afterEach(() => {
   cleanup();
   objectFormSpy.mockClear();
   adapterRef.current = { fake: 'adapter' };
+  objectsRef.current = [];
 });
 
 describe('ScreenPreview — flat fields', () => {
@@ -101,6 +109,20 @@ describe('ScreenPreview — object-form mode', () => {
     expect(schema.initialValues).toEqual({ stage: 'new' });
     // Object-form owns no preview Submit (its own bar is hidden in preview).
     expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+  });
+
+  it('passes derived master-detail subforms from the enriched object def to ObjectForm', () => {
+    // useMetadata().objects already carries `form.subforms` derived from inline-edit
+    // relationships (attachInlineSubforms) — the preview just forwards them.
+    objectsRef.current = [
+      { name: 'showcase_invoice', form: { subforms: [{ childObject: 'showcase_invoice_line', relationshipField: 'invoice', inlineMode: 'grid' }] } },
+    ];
+    render(<ScreenPreview node={{ id: 's1', config: { objectName: 'showcase_invoice', mode: 'create' } }} />);
+    const schema = objectFormSpy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(schema.objectName).toBe('showcase_invoice');
+    expect(schema.subforms).toEqual([
+      { childObject: 'showcase_invoice_line', relationshipField: 'invoice', inlineMode: 'grid' },
+    ]);
   });
 
   it('falls back to a hint when no data source is available', () => {

--- a/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
@@ -13,6 +13,10 @@
  * in the inspector, or the live simulated values when paused in the Debug
  * simulator).
  *
+ * Object-form mode is fed the SAME enriched object list the runtime uses
+ * (`useMetadata().objects`, which derives inline master-detail `subforms` from
+ * `inlineEdit` relationships) so the preview renders those child grids too.
+ *
  * Homes: the flow node inspector (live-updates as the config is edited) and the
  * Debug simulator's paused-at-screen state.
  */
@@ -20,6 +24,7 @@
 import * as React from 'react';
 import { Button, cn } from '@object-ui/components';
 import { useAdapter } from '../../../providers/AdapterProvider';
+import { useMetadata } from '../../../providers/MetadataProvider';
 import { ScreenView, isObjectFormScreen, initialScreenValues, type ScreenSpec } from '../../ScreenView';
 import { buildScreenSpec, interpolate, hiddenFieldCount, type ScreenPreviewNode } from './screen-spec';
 
@@ -42,8 +47,13 @@ export interface ScreenPreviewProps {
 
 export function ScreenPreview({ node, variables, className }: ScreenPreviewProps) {
   const adapter = useAdapter();
+  const meta = useMetadata();
   const spec = React.useMemo(() => buildScreenSpec(node, variables), [node, variables]);
   const isObjectForm = isObjectFormScreen(spec);
+  // Enriched object defs (incl. derived master-detail `subforms`) — the exact
+  // list the runtime FlowRunner gets. Only read in object-form mode so a plain
+  // field screen never triggers the all-objects fetch.
+  const objects = isObjectForm ? meta.objects : undefined;
   const title = interpolate(spec.title, variables);
   const description = interpolate(spec.description, variables);
   const hidden = isObjectForm ? 0 : hiddenFieldCount(node, variables);
@@ -73,7 +83,7 @@ export function ScreenPreview({ node, variables, className }: ScreenPreviewProps
             {description && (
               <p className={cn('whitespace-pre-line text-sm text-muted-foreground', title && 'mt-1')}>{description}</p>
             )}
-            <ScreenFormPreview key={structKey} spec={spec} adapter={adapter} />
+            <ScreenFormPreview key={structKey} spec={spec} adapter={adapter} objects={objects} />
             {!isObjectForm && hidden > 0 && (
               <p className="mt-3 text-[11px] italic text-muted-foreground">
                 {hidden} field{hidden === 1 ? '' : 's'} hidden by {hidden === 1 ? 'its' : 'their'} “visible when”
@@ -97,7 +107,7 @@ export function ScreenPreview({ node, variables, className }: ScreenPreviewProps
  * Holds the transient field values so the preview is interactive (the author
  * can type into it) while never persisting anything.
  */
-function ScreenFormPreview({ spec, adapter }: { spec: ScreenSpec; adapter: unknown }) {
+function ScreenFormPreview({ spec, adapter, objects }: { spec: ScreenSpec; adapter: unknown; objects?: unknown[] }) {
   const [values, setValues] = React.useState<Record<string, unknown>>(() => initialScreenValues(spec));
   return (
     <ScreenView
@@ -105,6 +115,7 @@ function ScreenFormPreview({ spec, adapter }: { spec: ScreenSpec; adapter: unkno
       values={values}
       onValueChange={(name, v) => setValues((p) => ({ ...p, [name]: v }))}
       dataSource={adapter ?? undefined}
+      objects={objects}
       objectForm={{
         showSubmit: false,
         showCancel: false,

--- a/packages/plugin-form/src/MasterDetailForm.test.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.test.tsx
@@ -180,3 +180,31 @@ describe('MasterDetailForm — parent-scoped line rules ("paid invoice → lock 
     expect((container.querySelector('input[name="status"]') as HTMLInputElement).value).toBe('paid');
   });
 });
+
+describe('MasterDetailForm — showSubmit gate (Studio screen preview)', () => {
+  const base = {
+    objectName: 'po',
+    mode: 'create',
+    fields: ['ref'],
+    details: [
+      { childObject: 'po_line', relationshipField: 'po', columns: [{ key: 'qty', label: 'Qty', type: 'number' } as any] },
+    ],
+  } as any;
+
+  it('renders its own Save/Create action bar by default', async () => {
+    render(<MasterDetailForm schema={base} dataSource={makeDataSource()} />);
+    await waitFor(() => expect(screen.getByTestId('md-form-submit')).toBeInTheDocument());
+  });
+
+  it('hides the action bar when showSubmit is false (non-persisting preview)', async () => {
+    const { container } = render(
+      <MasterDetailForm schema={{ ...base, showSubmit: false }} dataSource={makeDataSource()} />,
+    );
+    // The form/grid still renders — it just can never be submitted.
+    await waitFor(() => {
+      if (!container.querySelector('input[name="ref"]')) throw new Error('header not ready');
+    });
+    expect(screen.queryByTestId('md-form-submit')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /create|save/i })).not.toBeInTheDocument();
+  });
+});

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -79,6 +79,9 @@ export interface MasterDetailFormSchema {
   formType?: 'simple' | 'tabbed';
   title?: string;
   submitText?: string;
+  /** Hide the bottom Save/Cancel action bar — e.g. a non-persisting design
+   *  preview. Defaults to shown (the form owns the only Save in this layout). */
+  showSubmit?: boolean;
   /** One or more child collections. */
   details: MasterDetailDetailConfig[];
   /** Parent header field holding a tax rate (percent). When the parent form has
@@ -698,17 +701,20 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
         </Card>
       )}
 
-      {/* Single action bar at the bottom */}
-      <div className="flex items-center justify-end gap-2 border-t border-border pt-4">
-        {schema.onCancel && (
-          <Button type="button" variant="outline" onClick={schema.onCancel} disabled={saving} data-testid="md-form-cancel">
-            Cancel
+      {/* Single action bar at the bottom — suppressed when the host opts out
+          (e.g. the Studio screen-preview, which must never persist). */}
+      {schema.showSubmit !== false && (
+        <div className="flex items-center justify-end gap-2 border-t border-border pt-4">
+          {schema.onCancel && (
+            <Button type="button" variant="outline" onClick={schema.onCancel} disabled={saving} data-testid="md-form-cancel">
+              Cancel
+            </Button>
+          )}
+          <Button type="button" onClick={handleSave} disabled={saving || (needsDerive && !resolvedDetails)} data-testid="md-form-submit">
+            {saving ? 'Saving…' : submitText}
           </Button>
-        )}
-        <Button type="button" onClick={handleSave} disabled={saving || (needsDerive && !resolvedDetails)} data-testid="md-form-submit">
-          {saving ? 'Saving…' : submitText}
-        </Button>
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -125,6 +125,9 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
           fields: schema.fields as any,
           title: schema.title,
           submitText: schema.submitText,
+          // Forward the host's submit-visibility so a non-persisting preview
+          // can hide the master-detail Save bar (it owns the only Save here).
+          showSubmit: (schema as any).showSubmit,
           details: (schema as any).subforms,
           onSuccess: schema.onSuccess,
           onError: schema.onError,
@@ -567,7 +570,8 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
       // Proceed defensively - we can't do much if we don't have data, but let's try to not crash
       // If we are here, formData is actually the event
       if (e === undefined) {
-         e = formData;
+         // The event arrived as the first arg; discard it and submit empty data
+         // rather than the Event object. (`e` is unused beyond this guard.)
          formData = {}; // Reset to empty object or we try to submit the Event object
       }
     }


### PR DESCRIPTION
Follow-up to #1944 — implements the **object-form master-detail subforms** gap in the flow Screen-node preview.

## What
Object-form mode of the Screen preview rendered the parent fields but **not** the inline master-detail child grids the end user sees at runtime. Now it does — e.g. a screen with `objectName: showcase_invoice` previews the invoice form **and** its inline **Line Items** grid (with live Subtotal/Tax/Total).

## How
- `ScreenPreview` now feeds `ScreenView` the **same enriched object list the runtime `FlowRunner` receives** — `useMetadata().objects`, which derives `form.subforms` from `inlineEdit` master-detail relationships via `attachInlineSubforms`. (`useMetadata().objects` is exactly what `AppContent` passes down to `ObjectView` → `RecordDetailView` → `FlowRunner`, so the preview can't drift.) Read only in object-form mode, so plain field screens skip the all-objects fetch.
- **Preview safety:** `MasterDetailForm` owns its own Save bar (it ignored `showSubmit`), which would have given the preview a *functional* persist button — unlike the flat-field preview (disabled Submit) and the simple object-form preview (no Save). So `MasterDetailForm` now honours a `showSubmit` flag (default shown; backward-compatible — runtime is unaffected), forwarded by `ObjectForm`. The preview passes `showSubmit: false`, hiding the Save bar.
- Drive-by: removed a dead `e = formData` assignment in `ObjectForm` (surfaced by `no-useless-assignment` once the file's lint cache busted).

## Verification (browser, HotCRM `quote_generation` screen node)
Setting `objectName: showcase_invoice` switched the preview to the runtime `ObjectForm` rendering:
- the invoice header fields (number, customer, status, dates, tax rate), **and**
- the inline **Line Items** master-detail grid — columns #/Product/Description/Qty/Unit Price/Amount, an *Add line* button, and a live **Subtotal / Tax / Total** stack,
- with **no Save button** (preview never persists). Seeded showcase data left unmodified (in-memory edit, discarded on reload).

## Tests
- `MasterDetailForm.test.tsx` (+2): action bar renders by default; hidden when `showSubmit: false`.
- `ScreenPreview.test.tsx` (+1): object-form mode forwards the enriched def's `form.subforms` to `ObjectForm` as `schema.subforms`.
- Both suites green; `pnpm turbo type-check` clean; changed files lint clean.

Note: object-form steps are uncommon in the seeded data (one object, `showcase_invoice`, uses `inlineEdit`), so this is verified there; the wiring is identical to the runtime path for any object with inline subforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
