### PR TITLE
fix(plugin-form): call useRecordContext unconditionally; clear render-purity lint

### DIFF
--- a/.changeset/plugin-form-hooks-purity-lint.md
+++ b/.changeset/plugin-form-hooks-purity-lint.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/plugin-form": patch
+---
+
+fix(plugin-form): call `useRecordContext` unconditionally; drop impure render-time `Date.now()`
+
+`LineItemsPanel` wrapped `useRecordContext()` in a `try/catch`, which ESLint flagged
+as `react-hooks/rules-of-hooks` ("React Hook is called conditionally") — a genuine
+hook-order hazard if the `catch` ever fired part-way through render. `useRecordContext`
+returns `null` outside a `<RecordContextProvider>` and never throws, so the guard was
+dead code; it's now called unconditionally at the top level and the `null` case is
+handled by the existing optional chaining.
+
+Also clears a second pre-existing lint error: `EmbeddableForm` now seeds `mountedAtRef`
+from `0` instead of calling the impure `Date.now()` during render (the mount effect
+already overwrites it before any submit, so the anti-bot min-fill check is unchanged),
+fixing the react-compiler "Cannot call impure function during render" error. No
+behavior change.

--- a/packages/plugin-form/src/EmbeddableForm.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.tsx
@@ -208,7 +208,9 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
   const [consentError, setConsentError] = useState<string | null>(null);
 
   const honeypotRef = useRef<HTMLInputElement | null>(null);
-  const mountedAtRef = useRef<number>(Date.now());
+  // Seeded lazily by the mount effect below — Date.now() is impure and must not
+  // run during render. The effect always overwrites this before any submit.
+  const mountedAtRef = useRef<number>(0);
   useEffect(() => {
     // Reset the mount timestamp whenever the form returns from the thank-you
     // screen so anti-bot timing measures the next interaction, not the first.

--- a/packages/plugin-form/src/LineItemsPanel.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.tsx
@@ -49,13 +49,11 @@ export interface LineItemsPanelSchema {
 export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ schema }) => {
   const ctx = useSchemaContext() as any;
   const dataSource = ctx?.dataSource;
-  let record: any;
-  try {
-    // useRecordContext throws outside a provider in some builds; guard it.
-    record = useRecordContext();
-  } catch {
-    record = undefined;
-  }
+  // useRecordContext returns null outside a <RecordContextProvider> (e.g. in the
+  // Studio designer/palette), so it never throws — call it unconditionally to
+  // keep hook order stable across renders. A null record just means "no parent
+  // record bound", which the optional chaining below already handles.
+  const record = useRecordContext() as any;
 
   const parentObject = schema.parentObject || record?.objectName;
   const parentId =


### PR DESCRIPTION
## Summary

Cleanup of **pre-existing** ESLint **errors** in `@object-ui/plugin-form` (not introduced by recent screen-preview work). Lint is non-blocking for merges here, so this is housekeeping — but the first one is a genuine correctness hazard.

The package now has **0 ESLint errors**. No behavior change.

### 1. `LineItemsPanel.tsx` — `react-hooks/rules-of-hooks` (the real bug)

`useRecordContext()` was called inside a `try/catch`, which ESLint flags as *"React Hook is called conditionally"*. A hook called conditionally can crash or corrupt hook state if the condition flips between renders.

The `try/catch` was dead defensive code: `useRecordContext` is just `React.useContext(RecordContext)` and **returns `null`** outside a `<RecordContextProvider>` — it never throws. So the guard is removed and the hook is now called unconditionally at the top level. The existing optional chaining (`record?.objectName`, `record?.recordId`) already handles the `null` case.

```diff
-  let record: any;
-  try {
-    // useRecordContext throws outside a provider in some builds; guard it.
-    record = useRecordContext();
-  } catch {
-    record = undefined;
-  }
+  // useRecordContext returns null outside a <RecordContextProvider> … call it
+  // unconditionally to keep hook order stable across renders.
+  const record = useRecordContext() as any;
```

### 2. `EmbeddableForm.tsx:211` — react-compiler "Cannot call impure function during render"

`useRef<number>(Date.now())` evaluates the impure `Date.now()` during render. The ref is seeded from `0` instead; the existing mount effect (`if (!submitted) mountedAtRef.current = Date.now()`) already overwrites it before any submit, so the anti-bot min-fill-time check is unchanged.

> An earlier revision of this PR also removed a dead `e = formData;` assignment in `ObjectForm.tsx` (`no-useless-assignment`). That same fix landed independently on `main` in #1960, so it dropped out on rebase — the package is still error-free.

## Verification (rebased on current `main`)

- `npx eslint src/` → **0 errors** (style warnings remain, all pre-existing `no-explicit-any` etc.)
- `npx vitest run` → **140 passed** (incl. `MasterDetailForm.test.tsx`)
- `vite build` (the package's authoritative type-gate — plugin-form has no `type-check` script; dts generation resolves workspace deps to their built `.d.ts`) → **clean**

> Note on `tsc --noEmit`: running raw `tsc` directly on the package surfaces unrelated `TS6059 rootDir` / `TS2322` noise because it resolves `@object-ui/types` to *source* rather than its built `.d.ts`. Verified those appear on a pristine tree (stash → re-run) and are not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
