### PR TITLE
fix(metadata-admin): dataset filter builder ignores incomplete conditions

### DIFF
--- a/.changeset/dataset-filter-drop-empty-conditions.md
+++ b/.changeset/dataset-filter-drop-empty-conditions.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(metadata-admin): dataset filter builder ignores incomplete conditions
+
+`groupToCondition` emitted a condition for any row that had a `field`, even when
+its value was still blank — producing a silently-wrong filter like
+`{ organization_id: { $eq: "" } }` (matches only empty → excludes everything)
+instead of "no filter". Now rows with an empty/`undefined`/`[]` value are skipped
+(value-less operators like is-empty / is-not-empty are still kept). Applies to both
+the dataset Scope filter and per-measure filters. Found by dogfooding.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.test.ts
@@ -29,6 +29,21 @@ describe('datasetFilterCondition', () => {
     expect(groupToCondition({ logic: 'and', conditions: [] })).toBeUndefined();
   });
 
+  it('drops incomplete rows (empty/blank value) instead of emitting {field:{$op:""}}', () => {
+    // a row whose value hasn't been typed yet must NOT become a garbage filter
+    expect(groupToCondition({ logic: 'and', conditions: [{ field: 'organization_id', operator: 'equals', value: '' }] })).toBeUndefined();
+    expect(groupToCondition({ logic: 'and', conditions: [{ field: 'x', operator: 'equals', value: undefined }] })).toBeUndefined();
+    expect(groupToCondition({ logic: 'and', conditions: [{ field: 'x', operator: 'in', value: [] }] })).toBeUndefined();
+    // a complete row alongside an incomplete one keeps only the complete one
+    expect(groupToCondition({ logic: 'and', conditions: [
+      { field: 'stage', operator: 'equals', value: 'won' },
+      { field: 'amount', operator: 'greaterThan', value: '' },
+    ] })).toEqual({ stage: { $eq: 'won' } });
+    // value-less operators are still kept
+    expect(groupToCondition({ logic: 'and', conditions: [{ field: 'closed_at', operator: 'isNotEmpty', value: '' }] }))
+      .toEqual({ closed_at: { $exists: true } });
+  });
+
   it('round-trips representable conditions (condition → group → condition)', () => {
     for (const c of [
       { status: { $eq: 'won' } },

--- a/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.ts
@@ -39,7 +39,11 @@ export function groupToCondition(group: BuilderGroup | undefined): FilterConditi
     if (c.operator === 'isNotEmpty') { parts.push({ [c.field]: { $exists: true } }); continue; }
     const mop = OP_TO_MONGO[c.operator];
     if (!mop) continue; // unmapped (e.g. notContains/between) — drop rather than emit a bad filter
-    parts.push({ [c.field]: { [mop]: c.value } });
+    // Skip incomplete rows (no value typed yet) — emitting `{field:{$op:''}}` would
+    // be a silently-wrong filter (matches only empty), not "no filter".
+    const v = c.value;
+    if (v == null || v === '' || (Array.isArray(v) && v.length === 0)) continue;
+    parts.push({ [c.field]: { [mop]: v } });
   }
   if (parts.length === 0) return undefined;
   if (parts.length === 1) return parts[0];


### PR DESCRIPTION
Found by **dogfooding** the create-canvas scope filter (#1959): adding a filter row but leaving its **value blank** serialized to `{ organization_id: { $eq: "" } }` — a silently-wrong filter (matches only empty → excludes everything) instead of "no filter".

`groupToCondition` now **skips rows with an empty/`undefined`/`[]` value** (value-less operators like is-empty / is-not-empty are still kept). Applies to both the dataset **Scope filter** and **per-measure** filters (shared converter). +1 unit test (9 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)