### PR TITLE
fix(studio): preview joined reports in the report editor (was "design blind")

### DIFF
--- a/.changeset/report-joined-preview.md
+++ b/.changeset/report-joined-preview.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(studio): preview joined reports in the report editor (was "design blind")
+
+Found dogfooding report design in Studio as a business user. The report editor's
+live preview only rendered single dataset-bound reports — a `joined` report
+(which carries its data on `blocks`, with no top-level `dataset`) fell through to
+the "Bind a dataset to preview this report" empty state, so an author building a
+joined report saw nothing and designed blind.
+
+`ReportPreview` now renders a joined report (≥1 dataset-bound block) through the
+same runtime `ReportRenderer` (→ `DatasetReportRenderer`, which already stacks
+the blocks), keeping the preview pixel-equal with the runtime, and shows a
+joined-aware empty state ("Add a block…") when no block is bound yet.

--- a/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx
@@ -77,3 +77,32 @@ describe('ReportPreview — dataset-bound report (ADR-0021 single-form)', () => 
     );
   });
 });
+
+describe('ReportPreview — joined report (stacked dataset-bound blocks)', () => {
+  const joinedReport = {
+    name: 'open_vs_done',
+    label: 'Open vs Done',
+    type: 'joined',
+    blocks: [
+      { name: 'open', type: 'summary', dataset: 'sales', rows: ['region'], values: ['revenue'] },
+    ],
+  };
+
+  it('renders joined blocks through the runtime renderer (not the "bind a dataset" empty state)', async () => {
+    queryDataset.mockResolvedValue({ rows: [{ region: 'finance', revenue: 450000 }], fields: [] });
+    render(<ReportPreview {...baseProps} draft={joinedReport} />);
+    // The block's dataset is queried (joined carries data on blocks, not a top-level dataset)...
+    await waitFor(() =>
+      expect(queryDataset).toHaveBeenCalledWith('sales', expect.objectContaining({ dimensions: ['region'], measures: ['revenue'] })),
+    );
+    // ...and its data renders, so the author no longer designs a joined report blind.
+    expect(await screen.findByText('finance')).toBeInTheDocument();
+    expect(screen.queryByText(/bind a dataset to preview/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a joined-aware empty state when no block is dataset-bound yet', async () => {
+    render(<ReportPreview {...baseProps} draft={{ name: 'j', label: 'J', type: 'joined', blocks: [] }} />);
+    expect(await screen.findByText(/add a block to preview/i)).toBeInTheDocument();
+    expect(queryDataset).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.tsx
@@ -6,15 +6,16 @@
  *
  * A 9.0 report binds a semantic-layer `dataset` and selects its measures
  * (`values`) grouped by dimensions (`rows`, plus `columns` across for a
- * matrix); rendering through plugin-report's `ReportRenderer` keeps the
- * studio preview pixel-equal with the runtime — including the matrix
- * cross-tab — and the numbers consistent with every other surface on the
- * same dataset (`adapter.queryDataset`). Drill-down stays inert here: the
- * preview passes no `onDrill` sink.
+ * matrix); a `joined` report instead stacks dataset-bound `blocks`. Both
+ * render through plugin-report's `ReportRenderer` (→ DatasetReportRenderer),
+ * keeping the studio preview pixel-equal with the runtime — including the
+ * matrix cross-tab and the joined block stack — and the numbers consistent
+ * with every other surface on the same dataset (`adapter.queryDataset`).
+ * Drill-down stays inert here: the preview passes no `onDrill` sink.
  *
- * A draft without a dataset binding (e.g. stored pre-9.0 query-form JSON)
- * gets an actionable empty state pointing at the inspector's Dataset control
- * instead of the retired legacy renderer.
+ * A draft with neither a dataset nor any dataset-bound block gets an
+ * actionable empty state pointing at the right inspector control instead of
+ * the retired pre-9.0 inline-query renderer.
  */
 
 import * as React from 'react';
@@ -29,12 +30,27 @@ const ReportRenderer = React.lazy(() =>
 
 export function ReportPreview({ draft }: MetadataPreviewProps) {
   const adapter = useAdapter();
+  const d = draft as any;
 
-  // ADR-0021 single-form: a report binds a semantic-layer dataset.
-  if (typeof (draft as any).dataset === 'string' && (draft as any).dataset) {
-    const rows = Array.isArray((draft as any).rows) ? ((draft as any).rows as string[]).filter(Boolean) : [];
+  // ADR-0021 single-form: a report binds a semantic-layer dataset; a `joined`
+  // report instead carries its data on dataset-bound `blocks`. Both render
+  // through plugin-report's ReportRenderer (→ DatasetReportRenderer, which
+  // stacks each block). Previously only the single-dataset shape was
+  // previewed, so a joined report fell through to the "bind a dataset" empty
+  // state and the author designed blind.
+  const hasDataset = typeof d.dataset === 'string' && !!d.dataset;
+  const isJoinedWithBlocks =
+    d.type === 'joined' &&
+    Array.isArray(d.blocks) &&
+    d.blocks.some((b: any) => typeof b?.dataset === 'string' && !!b.dataset);
+
+  if (hasDataset || isJoinedWithBlocks) {
+    const rows = Array.isArray(d.rows) ? (d.rows as string[]).filter(Boolean) : [];
+    const hint = isJoinedWithBlocks
+      ? `report · joined · ${d.blocks.length} block${d.blocks.length === 1 ? '' : 's'}`
+      : `report · dataset "${d.dataset}"${rows.length ? ' · by ' + rows.join(', ') : ''}`;
     return (
-      <PreviewShell hint={`report · dataset "${(draft as any).dataset}"${rows.length ? ' · by ' + rows.join(', ') : ''}`}>
+      <PreviewShell hint={hint}>
         <PreviewErrorBoundary fallbackHint="The Report references a dataset/measure that doesn't resolve, or its config is incomplete.">
           <React.Suspense
             fallback={
@@ -52,15 +68,20 @@ export function ReportPreview({ draft }: MetadataPreviewProps) {
     );
   }
 
-  // No dataset bound — either a fresh draft or stored pre-9.0 query-form
-  // JSON (objectName/columns), whose inline-query renderer was retired with
-  // the 9.0 cutover. Point the author at the dataset binding.
+  // Nothing renderable yet. A joined report needs at least one dataset-bound
+  // block; every other type needs a top-level dataset. Point the author at the
+  // right control instead of the retired pre-9.0 inline-query renderer.
+  const joined = d.type === 'joined';
   return (
     <PreviewShell>
       <PreviewEmptyState
         icon={<Database className="h-8 w-8" />}
-        title="Bind a dataset to preview this report"
-        description="Since the 9.0 single-form cutover a report renders its dataset's measures (values) grouped by dimensions (rows). Choose a Dataset in the right panel to start designing."
+        title={joined ? 'Add a block to preview this joined report' : 'Bind a dataset to preview this report'}
+        description={
+          joined
+            ? 'A joined report stacks dataset-bound blocks. Add a block and bind its dataset + measures in the right panel to start designing.'
+            : "Since the 9.0 single-form cutover a report renders its dataset's measures (values) grouped by dimensions (rows). Choose a Dataset in the right panel to start designing."
+        }
       />
     </PreviewShell>
   );


### PR DESCRIPTION
## Problem
Dogfooding report design in Studio as a business user: building a **joined** report, the live preview pane showed *"Bind a dataset to preview this report"* and never rendered anything — so the author designed **blind**.

Root cause: `ReportPreview` mounts the runtime `ReportRenderer` **only** when the draft has a top-level `dataset`. A joined report carries its data on `blocks` (no top-level `dataset`), so it fell through to the dataset-bound empty state — which is also semantically wrong for joined (joined reports don't bind a top-level dataset).

The runtime `DatasetReportRenderer` already renders joined reports (a vertical stack of dataset-bound blocks); only the **studio editor preview** lagged.

## Fix (1 file + tests)
`ReportPreview` now renders through the same `ReportRenderer` when the draft is **either** dataset-bound **or** a joined report with ≥1 dataset-bound block — pixel-equal with the runtime block stack — and shows a **joined-aware empty state** (*"Add a block to preview this joined report"*) when no block is bound yet.

## Verification
- **Browser** (showcase data): a joined report with an `open_tasks` block now renders the block's Status × Tasks table live in the editor preview (previously: empty state).
- **Tests**: `ReportPreview.dataset.test.tsx` — added 2 joined cases (renders blocks / joined-aware empty state); **7/7 pass** (5 existing dataset/matrix/filter cases unchanged).

## Scope
Pure studio-preview fix; no change to the runtime renderer, the report schema, or the inspector. Found alongside (not fixed here) some joined-block *authoring* UX gaps — the block editor uses the generic SchemaForm (free-text dataset, full inline chart schema, `*` markers on the optional chart) rather than the curated dataset-aware pickers the top-level report has; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)