### PR TITLE
feat(metadata-admin): derive create defaults from the spec create seed (/meta/types)

### DIFF
--- a/.changeset/designer-consume-create-seed.md
+++ b/.changeset/designer-consume-create-seed.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Designer derives create defaults from the spec's create seed (/meta/types)
+
+The metadata create flow now builds a new item's body from the server's authoritative `createSeed` (delivered per type on the `/meta/types` registry entry — the single source of truth in `@objectstack/spec`) instead of the locally hardcoded `createDefaults`, falling back to `createDefaults` when the server provides no seed (older server, or canvas-create types). This closes the drift loop behind the "designer emits a minimal shape the spec rejects → create→save 422" family (dashboard `layout`, action `body`): the structural create defaults now come from the same place the spec validates against, so they cannot diverge. Extracted as the pure, unit-tested `buildCreateModeBody`.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -106,6 +106,7 @@ import { detectLocale, t, tFormat, translateValidationMessage } from './i18n';
 import { JsonSourceEditor } from './JsonSourceEditor';
 import { validateMetadataDraft, hasClientValidator } from './clientValidation';
 import { describeIssuePath } from './issuePath';
+import { buildCreateModeBody } from './createBody';
 
 // react-resizable-panels' `direction` prop type does not always narrow
 // cleanly in our TS config; cast at the boundary (precedent:
@@ -952,10 +953,14 @@ function MetadataResourceEditPageImpl({
       // or `{ list: { data: { object } } }` for view) is present so
       // the saved body satisfies its JSONSchema. User-supplied values
       // always win over the defaults.
+      // Prefer the server's authoritative create seed (from /meta/types — the
+      // single source of truth in @objectstack/spec) over the locally hardcoded
+      // createDefaults, so the create shape can't drift from the spec's required
+      // fields (the dashboard-`layout` / action-`body` 422 family). `createSeed`
+      // is a runtime field absent from the bundled GetMetaTypes type, hence the cast.
+      const specCreateSeed = (entry as { createSeed?: Record<string, unknown> } | undefined)?.createSeed;
       let builtBody = createMode
-        ? (config.createBuildBody
-            ? config.createBuildBody(draft)
-            : { ...(config.createDefaults ?? {}), ...draft })
+        ? buildCreateModeBody(config, draft, specCreateSeed)
         // Edit mode: serialise the editor draft back to the wire shape
         // (inverse of `toDraft` — e.g. `view` folds the `{ list | form }`
         // family key back into the ViewItem `config` wrapper).

--- a/packages/app-shell/src/views/metadata-admin/createBody.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/createBody.test.ts
@@ -1,0 +1,49 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildCreateModeBody } from './createBody';
+
+describe('buildCreateModeBody', () => {
+  it('prefers the server create seed over the hardcoded createDefaults', () => {
+    const out = buildCreateModeBody(
+      { createDefaults: { foo: 'stale' } }, // incomplete/stale local default
+      { name: 'x', label: 'X' },
+      { type: 'script', body: { language: 'js', source: 'return {};' } }, // authoritative seed
+    );
+    expect(out).toMatchObject({ type: 'script', body: { language: 'js' }, name: 'x', label: 'X' });
+    expect(out).not.toHaveProperty('foo'); // seed replaces the stale default
+  });
+
+  it('falls back to createDefaults when the server sends no seed (older server)', () => {
+    const out = buildCreateModeBody({ createDefaults: { widgets: [] } }, { name: 'd' }, undefined);
+    expect(out).toEqual({ widgets: [], name: 'd' });
+  });
+
+  it('lets user draft values win over the seed placeholders', () => {
+    const out = buildCreateModeBody(
+      {},
+      { name: 'real', label: 'Real' },
+      { name: 'new_x', label: 'New', widgets: [] },
+    );
+    expect(out).toMatchObject({ name: 'real', label: 'Real', widgets: [] });
+  });
+
+  it('uses createBuildBody (dynamic identity) when present, ignoring the static seed', () => {
+    const out = buildCreateModeBody(
+      { createBuildBody: (d) => ({ name: `obj.${String(d.name)}`, viewKind: 'list' }) },
+      { name: 'v' },
+      { name: 'example.new_view' },
+    );
+    expect(out).toEqual({ name: 'obj.v', viewKind: 'list' });
+  });
+
+  it('is empty when nothing is provided', () => {
+    expect(buildCreateModeBody({}, {}, undefined)).toEqual({});
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/createBody.ts
+++ b/packages/app-shell/src/views/metadata-admin/createBody.ts
@@ -1,0 +1,37 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { MetadataResourceConfig } from './registry';
+
+/**
+ * Build the create-mode save body for a new metadata item.
+ *
+ * Prefers the server's authoritative **create seed** (delivered per type on the
+ * `/meta/types` registry entry — the single source of truth in
+ * `@objectstack/spec`) over the locally hardcoded `createDefaults`. This is the
+ * drift-stop for the recurring "the designer emits a minimal shape the spec
+ * rejects, so create→save 422s" family (dashboard `layout`, action `body`):
+ * the structural defaults now come from the same place the spec validates
+ * against, so they cannot diverge. Falls back to `createDefaults` when the
+ * server provides no seed (older server, or canvas-create types whose shape is
+ * built interactively).
+ *
+ * User-supplied draft values always win over the seed's placeholders.
+ * `createBuildBody` (dynamic identity, e.g. a view's qualified name) still takes
+ * precedence — it incorporates user input the static seed cannot.
+ */
+export function buildCreateModeBody(
+  config: Pick<MetadataResourceConfig, 'createBuildBody' | 'createDefaults'>,
+  draft: Record<string, unknown>,
+  specCreateSeed: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (config.createBuildBody) {
+    return config.createBuildBody(draft) as Record<string, unknown>;
+  }
+  return { ...(specCreateSeed ?? config.createDefaults ?? {}), ...draft };
+}


### PR DESCRIPTION
## Why

Final piece of the **spec-derived create-shape contract** (framework #2270 added the seeds; #2276 exposed them on `/meta/types`). The metadata create flow hardcoded `createDefaults` per type in `anchors.ts`, which drifted from the spec's required fields with nothing tying them together — the root of the "designer emits a minimal shape the spec rejects → create→save **422**" family (dashboard `layout`, action `body`).

## What

`ResourceEditPage.doSave` now builds a new item's body from the server's authoritative **`createSeed`** (per-type on the `/meta/types` registry entry — the single source of truth in `@objectstack/spec`) instead of the local `createDefaults`:

- Falls back to `createDefaults` when the server sends no seed (**older server**, or canvas-create types like `report`).
- User draft values still win over the seed's placeholders; `createBuildBody` (dynamic identity, e.g. a view's qualified name) still takes precedence.
- Extracted as the pure `buildCreateModeBody(config, draft, specCreateSeed)` helper.

Net effect: the structural create defaults now come from the same place the spec validates against, so they **cannot diverge** going forward — the family is closed at the root, not just guarded.

## Verification

- `buildCreateModeBody` unit test — **5 pass** (seed preferred over createDefaults; fallback when absent; user draft wins; createBuildBody precedence; empty case).
- Full `metadata-admin` suite — **414 pass**, no regression from the `doSave` refactor.

Pairs with framework #2270 / #2276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)