### PR TITLE
fix(metadata-admin): re-base a dataset when its base object changes

### DIFF
--- a/.changeset/dataset-rebase-on-object-change.md
+++ b/.changeset/dataset-rebase-on-object-change.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(metadata-admin): re-base a dataset when its base object changes
+
+A dataset's joins (`include`), dimensions, measures, and filter all reference the
+base object's fields. Changing the base object left those referencing the OLD
+object — stale field refs that silently produce broken/ambiguous queries. Now a
+real object change clears the object-dependent config (selecting the same object
+is a no-op), and a heads-up note appears while there is config that a change would
+clear. Found by dogfooding (G1).

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
@@ -13,7 +13,7 @@ vi.mock('./useDatasetFields', () => ({
   fieldTypeToDimensionType: (t: string) => (t === 'date' ? 'date' : 'string'),
 }));
 
-import { DatasetDefaultInspector } from './DatasetDefaultInspector';
+import { DatasetDefaultInspector, objectChangePatch } from './DatasetDefaultInspector';
 
 afterEach(cleanup);
 
@@ -131,5 +131,16 @@ describe('DatasetDefaultInspector', () => {
     render(<DatasetDefaultInspector {...baseProps} draft={draft} onPatch={vi.fn()} readOnly={false} />);
     expect(screen.getByText('Scope filter')).toBeInTheDocument();
     expect(screen.getByText('Filter (measure-scoped)')).toBeInTheDocument();
+  });
+});
+
+describe('objectChangePatch (re-base on base-object change)', () => {
+  it('clears object-dependent config (include/dimensions/measures/filter) when the object changes', () => {
+    expect(objectChangePatch('showcase_account', 'showcase_project')).toEqual({
+      object: 'showcase_account', include: [], dimensions: [], measures: [], filter: undefined,
+    });
+  });
+  it('is a no-op (only sets object) when the object is unchanged', () => {
+    expect(objectChangePatch('showcase_project', 'showcase_project')).toEqual({ object: 'showcase_project' });
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
@@ -262,6 +262,18 @@ function DatasetFilterField({ label, help, value, onCommit, fields, disabled }: 
   );
 }
 
+/**
+ * Patch for a base-object change. A dataset's joins (`include`), `dimensions`,
+ * `measures`, and `filter` all reference the OLD object's fields, so a real
+ * object change re-bases the dataset and clears them — preventing stale field
+ * refs from silently producing broken/ambiguous queries. Selecting the SAME
+ * object is a no-op (only sets `object`).
+ */
+export function objectChangePatch(next: string, current: string): Record<string, unknown> {
+  if (next === current) return { object: next };
+  return { object: next, include: [], dimensions: [], measures: [], filter: undefined };
+}
+
 export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: MetadataDefaultInspectorProps) {
   const label = typeof draft.label === 'string' ? draft.label : '';
   const description = typeof draft.description === 'string' ? draft.description : '';
@@ -369,7 +381,7 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: Meta
       <InspectorComboField
         label="Base object"
         value={object}
-        onCommit={(v) => onPatch({ object: v })}
+        onCommit={(v) => onPatch(objectChangePatch(v, object))}
         options={objectComboOptions}
         loading={objectsLoading}
         placeholder="Select an object…"
@@ -377,6 +389,9 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: Meta
         disabled={readOnly}
         mono
       />
+      {object && (dimensions.length > 0 || measures.length > 0 || include.length > 0 || !!datasetFilter) && (
+        <p className="text-[10px] text-muted-foreground">Changing the base object clears its dimensions, measures, joins &amp; filters.</p>
+      )}
 
       {/* Included relationships (the join allowlist) */}
       <div className="border-t pt-3 space-y-1.5">


### PR DESCRIPTION
Found by **dogfooding** (G1): a dataset's joins (`include`), dimensions, measures, and `filter` all reference the base object's fields. Changing the base object left them pointing at the **old** object — stale refs that silently produce broken/ambiguous queries (e.g. a scope filter on a field that no longer exists).

**Fix:** a real object change now re-bases the dataset, clearing `include`/`dimensions`/`measures`/`filter` (selecting the **same** object is a no-op). A heads-up note shows while there's config a change would clear. Logic is a pure `objectChangePatch()` (+2 unit tests; 15 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)