### PR TITLE
feat(gantt): configurable 白班/夜班 shift segmentation (排班日)

### DIFF
--- a/packages/plugin-gantt/demo/main.tsx
+++ b/packages/plugin-gantt/demo/main.tsx
@@ -16,6 +16,7 @@ import { GanttView, type GanttTask, type GanttMarker, type GanttViewMode } from 
 import { ResourceWorkload } from '../src/ResourceWorkload';
 import { ObjectGantt } from '../src/ObjectGantt';
 import type { WorkingCalendar } from '../src/scheduling';
+import { normalizeShiftSegments } from '../src/shifts';
 
 /**
  * Simplified Chinese pack for the Gantt chrome. Nested to match i18next's
@@ -62,6 +63,8 @@ const GANTT_ZH = {
 };
 
 const d = (s: string) => new Date(`${s}T00:00:00`);
+/** Datetime parse (local time, no trailing Z) — for shift-precise 排班 fixtures. */
+const dt = (s: string) => new Date(s);
 
 /** Build a URL preserving current params but overriding one key. */
 function withParam(key: string, value: string): string {
@@ -178,55 +181,58 @@ function manufacturingFixture(): GanttTask[] {
     { label: '实际起止', value: f.actual },
     { label: '状态', value: f.status },
   ];
+  // 排班分段 (白班 08:00–20:00 / 夜班 20:00–次日08:00): 三级排产计划按整排班日
+  // (08:00→08:00) 排, 四级派工单落到具体白班 / 夜班 — 含一条跨午夜的夜班 (wo-002)。
   return [
     // ── 一级: 项目 (无条) ───────────────────────────────────────────────
-    { id: 'prj-A', title: '项目A（导管架制造）', start: d('2026-06-01'), end: d('2026-06-30'), progress: 0, parent: null, type: 'group' },
+    { id: 'prj-A', title: '项目A（导管架制造）', start: dt('2026-06-03T08:00'), end: dt('2026-06-08T08:00'), progress: 0, parent: null, type: 'group' },
 
     // ── 二级: 产品A-1 (无条) ────────────────────────────────────────────
-    { id: 'prod-A1', title: '产品A-1（XX项目导管架）', start: d('2026-06-01'), end: d('2026-06-30'), progress: 0, parent: 'prj-A', type: 'group' },
+    { id: 'prod-A1', title: '产品A-1（XX项目导管架）', start: dt('2026-06-03T08:00'), end: dt('2026-06-05T20:00'), progress: 0, parent: 'prj-A', type: 'group' },
 
-    // 三级 plan-1 — 03 已完成 (深绿, 100%)
-    { id: 'plan-1', title: '将军柱组焊（排产计划）', start: d('2026-06-03'), end: d('2026-06-10'), progress: 100, parent: 'prod-A1', color: PLAN_COLOR.done,
-      fields: plan3({ code: 'PP-2026-001', obj: '将军柱·KK节点', span: '06-03 ~ 06-10', quota: '120h', mgr: '李工', doers: '张三、李四', status: '已完成', progress: '100%' }) },
-    { id: 'wo-001', title: 'WO001 张三（派工单）', start: d('2026-06-03'), end: d('2026-06-06'), progress: 100, parent: 'plan-1', color: WORK_COLOR.done, locked: true,
-      baselineStart: d('2026-06-03'), baselineEnd: d('2026-06-07'),
-      fields: wo4({ code: 'WO-2026-001', doer: '张三', obj: '将军柱·KK节点', plan: '06-03 ~ 06-07', actual: '06-03 ~ 06-06', status: '已完成' }) },
-    { id: 'wo-002', title: 'WO002 李四（派工单）', start: d('2026-06-06'), end: d('2026-06-10'), progress: 60, parent: 'plan-1', color: WORK_COLOR.reported, locked: true,
-      baselineStart: d('2026-06-06'), baselineEnd: d('2026-06-09'),
-      fields: wo4({ code: 'WO-2026-002', doer: '李四', obj: '将军柱·KK节点', plan: '06-06 ~ 06-09', actual: '06-06 ~ 06-10', status: '已报工' }) },
+    // 三级 plan-1 — 03 已完成 (深绿, 100%) · 整排班日 06-03 (白+夜)
+    { id: 'plan-1', title: '将军柱组焊（排产计划）', start: dt('2026-06-03T08:00'), end: dt('2026-06-04T08:00'), progress: 100, parent: 'prod-A1', color: PLAN_COLOR.done,
+      fields: plan3({ code: 'PP-2026-001', obj: '将军柱·KK节点', span: '06-03 08:00 ~ 06-04 08:00', quota: '24h', mgr: '李工', doers: '张三、李四', status: '已完成', progress: '100%' }) },
+    { id: 'wo-001', title: 'WO001 张三（白班派工单）', start: dt('2026-06-03T08:00'), end: dt('2026-06-03T20:00'), progress: 100, parent: 'plan-1', color: WORK_COLOR.done, locked: true,
+      baselineStart: dt('2026-06-03T08:00'), baselineEnd: dt('2026-06-03T20:00'),
+      fields: wo4({ code: 'WO-2026-001', doer: '张三', obj: '将军柱·KK节点', plan: '06-03 白班 (08:00~20:00)', actual: '06-03 白班', status: '已完成' }) },
+    { id: 'wo-002', title: 'WO002 李四（夜班·跨午夜派工单）', start: dt('2026-06-03T20:00'), end: dt('2026-06-04T08:00'), progress: 60, parent: 'plan-1', color: WORK_COLOR.reported, locked: true,
+      baselineStart: dt('2026-06-03T20:00'), baselineEnd: dt('2026-06-04T08:00'),
+      fields: wo4({ code: 'WO-2026-002', doer: '李四', obj: '将军柱·KK节点', plan: '06-03 夜班 (20:00~次日08:00)', actual: '06-03 夜班', status: '已报工' }) },
 
-    // 三级 plan-2 — 02 进行中 (绿, 45%) · 依赖 plan-1 (FS)
-    { id: 'plan-2', title: '主腿管接长（排产计划）', start: d('2026-06-10'), end: d('2026-06-16'), progress: 45, parent: 'prod-A1', color: PLAN_COLOR.doing,
+    // 三级 plan-2 — 02 进行中 (绿, 45%) · 整排班日 06-04 · 依赖 plan-1 (FS)
+    { id: 'plan-2', title: '主腿管接长（排产计划）', start: dt('2026-06-04T08:00'), end: dt('2026-06-05T08:00'), progress: 45, parent: 'prod-A1', color: PLAN_COLOR.doing,
       dependencies: [{ id: 'plan-1', type: 'fs' }],
-      fields: plan3({ code: 'PP-2026-002', obj: '主腿管·D1800', span: '06-10 ~ 06-16', quota: '96h', mgr: '李工', doers: '王五、赵六', status: '进行中', progress: '45%' }) },
-    { id: 'wo-003', title: 'WO003 王五（派工单）', start: d('2026-06-10'), end: d('2026-06-13'), progress: 70, parent: 'plan-2', color: WORK_COLOR.doing, locked: true,
-      baselineStart: d('2026-06-10'), baselineEnd: d('2026-06-12'),
-      fields: wo4({ code: 'WO-2026-003', doer: '王五', obj: '主腿管·D1800', plan: '06-10 ~ 06-12', actual: '06-10 ~ —（超期中）', status: '进行中' }) },
-    { id: 'wo-004', title: 'WO004 赵六（派工单）', start: d('2026-06-13'), end: d('2026-06-16'), progress: 0, parent: 'plan-2', color: WORK_COLOR.todo, locked: true,
-      fields: wo4({ code: 'WO-2026-004', doer: '赵六', obj: '主腿管·D1800', plan: '06-13 ~ 06-16', actual: '— ~ —', status: '待开始' }) },
+      fields: plan3({ code: 'PP-2026-002', obj: '主腿管·D1800', span: '06-04 08:00 ~ 06-05 08:00', quota: '24h', mgr: '李工', doers: '王五、赵六', status: '进行中', progress: '45%' }) },
+    // 唯一未锁定的派工单 — 可拖动 / 拉伸, 松手吸附到 12h 班次边界 (白班↔夜班)。
+    { id: 'wo-003', title: 'WO003 王五（白班派工单·可拖）', start: dt('2026-06-04T08:00'), end: dt('2026-06-04T20:00'), progress: 70, parent: 'plan-2', color: WORK_COLOR.doing,
+      baselineStart: dt('2026-06-04T08:00'), baselineEnd: dt('2026-06-04T20:00'),
+      fields: wo4({ code: 'WO-2026-003', doer: '王五', obj: '主腿管·D1800', plan: '06-04 白班 (08:00~20:00)', actual: '06-04 白班 (进行中)', status: '进行中' }) },
+    { id: 'wo-004', title: 'WO004 赵六（夜班·跨午夜派工单）', start: dt('2026-06-04T20:00'), end: dt('2026-06-05T08:00'), progress: 0, parent: 'plan-2', color: WORK_COLOR.todo, locked: true,
+      fields: wo4({ code: 'WO-2026-004', doer: '赵六', obj: '主腿管·D1800', plan: '06-04 夜班 (20:00~次日08:00)', actual: '— ~ —', status: '待开始' }) },
 
     // 三级 里程碑 — 仍是一条普通排产计划 (有计划起止/时间条), 只是 `是否里程碑=是`,
-    // 显示时在条上文字最前面加 ◆ 前缀标记 (不画菱形)。依赖 plan-2 (FS)。
-    { id: 'ms-A1', title: '◆ 段建完成（排产计划·里程碑）', start: d('2026-06-16'), end: d('2026-06-17'), progress: 0, parent: 'prod-A1', color: PLAN_COLOR.todo,
+    // 显示时在条上文字最前面加 ◆ 前缀标记 (不画菱形)。06-05 白班 · 依赖 plan-2 (FS)。
+    { id: 'ms-A1', title: '◆ 段建完成（排产计划·里程碑）', start: dt('2026-06-05T08:00'), end: dt('2026-06-05T20:00'), progress: 0, parent: 'prod-A1', color: PLAN_COLOR.todo,
       dependencies: [{ id: 'plan-2', type: 'fs' }],
-      fields: plan3({ code: 'PP-2026-005', obj: '段建·阶段验收', span: '06-16 ~ 06-17', quota: '8h', mgr: '李工', doers: '李工', status: '待开始', progress: '0%' }).concat({ label: '是否里程碑', value: '是' }) },
+      fields: plan3({ code: 'PP-2026-005', obj: '段建·阶段验收', span: '06-05 白班 (08:00~20:00)', quota: '8h', mgr: '李工', doers: '李工', status: '待开始', progress: '0%' }).concat({ label: '是否里程碑', value: '是' }) },
 
     // ── 二级: 产品A-2 (无条) ────────────────────────────────────────────
-    { id: 'prod-A2', title: '产品A-2（YY项目导管架）', start: d('2026-06-12'), end: d('2026-06-30'), progress: 0, parent: 'prj-A', type: 'group' },
+    { id: 'prod-A2', title: '产品A-2（YY项目导管架）', start: dt('2026-06-05T08:00'), end: dt('2026-06-08T08:00'), progress: 0, parent: 'prj-A', type: 'group' },
 
-    // 三级 plan-3 — 01 已下推 (蓝, 0%) · 依赖 plan-2 (FS)
-    { id: 'plan-3', title: '分段预制（排产计划）', start: d('2026-06-17'), end: d('2026-06-23'), progress: 0, parent: 'prod-A2', color: PLAN_COLOR.pushed,
+    // 三级 plan-3 — 01 已下推 (蓝, 0%) · 整排班日 06-05 · 依赖 plan-2 (FS)
+    { id: 'plan-3', title: '分段预制（排产计划）', start: dt('2026-06-05T08:00'), end: dt('2026-06-06T08:00'), progress: 0, parent: 'prod-A2', color: PLAN_COLOR.pushed,
       dependencies: [{ id: 'plan-2', type: 'fs' }],
-      fields: plan3({ code: 'PP-2026-003', obj: '分段·S2', span: '06-17 ~ 06-23', quota: '80h', mgr: '陈工', doers: '钱七', status: '已下推', progress: '0%' }) },
-    { id: 'wo-005', title: 'WO005 钱七（派工单）', start: d('2026-06-17'), end: d('2026-06-23'), progress: 0, parent: 'plan-3', color: WORK_COLOR.todo, locked: true,
-      fields: wo4({ code: 'WO-2026-005', doer: '钱七', obj: '分段·S2', plan: '06-17 ~ 06-23', actual: '— ~ —', status: '待开始' }) },
+      fields: plan3({ code: 'PP-2026-003', obj: '分段·S2', span: '06-05 08:00 ~ 06-06 08:00', quota: '24h', mgr: '陈工', doers: '钱七', status: '已下推', progress: '0%' }) },
+    { id: 'wo-005', title: 'WO005 钱七（整排班日派工单）', start: dt('2026-06-05T08:00'), end: dt('2026-06-06T08:00'), progress: 0, parent: 'plan-3', color: WORK_COLOR.todo, locked: true,
+      fields: wo4({ code: 'WO-2026-005', doer: '钱七', obj: '分段·S2', plan: '06-05 08:00 ~ 06-06 08:00 (白+夜)', actual: '— ~ —', status: '待开始' }) },
 
-    // 三级 plan-4 — 00 待开始 (深灰) · 依赖 plan-3 (FS)
-    { id: 'plan-4', title: '总装合拢（排产计划）', start: d('2026-06-24'), end: d('2026-06-30'), progress: 0, parent: 'prod-A2', color: PLAN_COLOR.todo,
+    // 三级 plan-4 — 00 待开始 (深灰) · 跨两个排班日 06-06→06-08 · 依赖 plan-3 (FS)
+    { id: 'plan-4', title: '总装合拢（排产计划）', start: dt('2026-06-06T08:00'), end: dt('2026-06-08T08:00'), progress: 0, parent: 'prod-A2', color: PLAN_COLOR.todo,
       dependencies: [{ id: 'plan-3', type: 'fs' }],
-      fields: plan3({ code: 'PP-2026-004', obj: '导管架·总装', span: '06-24 ~ 06-30', quota: '140h', mgr: '陈工', doers: '孙八', status: '待开始', progress: '0%' }) },
-    { id: 'wo-006', title: 'WO006 孙八（派工单）', start: d('2026-06-24'), end: d('2026-06-30'), progress: 0, parent: 'plan-4', color: WORK_COLOR.todo, locked: true,
-      fields: wo4({ code: 'WO-2026-006', doer: '孙八', obj: '导管架·总装', plan: '06-24 ~ 06-30', actual: '— ~ —', status: '待开始' }) },
+      fields: plan3({ code: 'PP-2026-004', obj: '导管架·总装', span: '06-06 08:00 ~ 06-08 08:00', quota: '48h', mgr: '陈工', doers: '孙八', status: '待开始', progress: '0%' }) },
+    { id: 'wo-006', title: 'WO006 孙八（连两个排班日派工单）', start: dt('2026-06-06T08:00'), end: dt('2026-06-08T08:00'), progress: 0, parent: 'plan-4', color: WORK_COLOR.todo, locked: true,
+      fields: wo4({ code: 'WO-2026-006', doer: '孙八', obj: '导管架·总装', plan: '06-06 08:00 ~ 06-08 08:00', actual: '— ~ —', status: '待开始' }) },
   ];
 }
 
@@ -426,6 +432,24 @@ function ManufacturingLegend() {
   );
 }
 
+/**
+ * 班次/排班分段 config — wired into the 制造排班 (4层树) demo (?mfg=1). Splits
+ * each 排班日 into 白班 (08:00–20:00) and 夜班 (20:00–次日08:00), 12h each. The
+ * "day" column starts at dayStart (08:00) and runs a full 24h so a cross-midnight
+ * 夜班 sits wholly inside one column. Two-tier header: top = 排班日 date, bottom =
+ * 白班 | 夜班. Drag a bar and it snaps to the 12h band boundary instead of whole
+ * days. Off by default — a pure config feature gated like working-calendar folding
+ * (zero regression when unset). No `color` on the bands → 白班/夜班 render with no
+ * background tint.
+ */
+const SHIFTS = normalizeShiftSegments({
+  dayStart: '08:00',
+  bands: [
+    { key: 'day', label: '白班', start: '08:00', end: '20:00' },
+    { key: 'night', label: '夜班', start: '20:00', end: '08:00' },
+  ],
+});
+
 function App() {
   const params = new URLSearchParams(window.location.search);
   if (params.get('quickfilter') === '1') return <QuickFilterDemo />;
@@ -538,6 +562,8 @@ function App() {
           ungroupedLabel="未分组"
           // 制造排班示例: 三级排产计划 (depth 2) 默认折叠。
           defaultCollapsedDepth={mfg ? 2 : undefined}
+          // 制造排班示例: 启用班次分段 (白班/夜班), 排班日 08:00 起算。
+          shiftSegments={mfg ? SHIFTS : undefined}
           persistLayoutKey={mfg ? undefined : "demo-project"}
           onLayoutChange={(l) => console.log('[gantt-demo] layout saved', l)}
           inlineEdit

--- a/packages/plugin-gantt/demo/main.tsx
+++ b/packages/plugin-gantt/demo/main.tsx
@@ -442,8 +442,9 @@ function ManufacturingLegend() {
  * (zero regression when unset). No `color` on the bands → 白班/夜班 render with no
  * background tint.
  */
-const SHIFTS = normalizeShiftSegments({
+const shiftConfig = (showMidnight: boolean) => ({
   dayStart: '08:00',
+  showMidnight,
   bands: [
     { key: 'day', label: '白班', start: '08:00', end: '20:00' },
     { key: 'night', label: '夜班', start: '20:00', end: '08:00' },
@@ -456,6 +457,12 @@ function App() {
   const perf = Number(params.get('perf') || 0);
   const edge = params.has('edge');
   const mfg = params.has('mfg');
+  // 制造排班示例: 日历午夜虚线开关 (默认显示)。
+  const [showMidnight, setShowMidnight] = React.useState(true);
+  const shifts = React.useMemo(
+    () => normalizeShiftSegments(shiftConfig(showMidnight)),
+    [showMidnight],
+  );
   const workingCalendar: WorkingCalendar | undefined =
     params.get('cal') === '1' ? { skipWeekends: true } : undefined;
   const showBaselines = params.get('baselines') !== '0';
@@ -528,6 +535,17 @@ function App() {
         <a href="?resource=owner">resource: owner</a>
         <a href="?resource=status">resource: status</a>
         <a href="?quickfilter=1">quick filter</a>
+        {mfg && (
+          <label style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              data-testid="toggle-midnight"
+              checked={showMidnight}
+              onChange={(e) => setShowMidnight(e.target.checked)}
+            />
+            午夜虚线
+          </label>
+        )}
         <span style={{ marginLeft: 'auto' }}>
           {/* Language toggle: chrome + dates localize together. */}
           <a href={withParam('lang', 'en')}>English</a>
@@ -563,7 +581,7 @@ function App() {
           // 制造排班示例: 三级排产计划 (depth 2) 默认折叠。
           defaultCollapsedDepth={mfg ? 2 : undefined}
           // 制造排班示例: 启用班次分段 (白班/夜班), 排班日 08:00 起算。
-          shiftSegments={mfg ? SHIFTS : undefined}
+          shiftSegments={mfg ? shifts : undefined}
           persistLayoutKey={mfg ? undefined : "demo-project"}
           onLayoutChange={(l) => console.log('[gantt-demo] layout saved', l)}
           inlineEdit

--- a/packages/plugin-gantt/src/GanttView.shifts.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.shifts.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Shift segmentation (班次/排班分段) rendering + drag tests for GanttView.
+ *
+ * When a normalized shift config is supplied AND the scale is `day`, each day
+ * column is replaced by one column per band (白班 | 夜班), the upper header tier
+ * shows the 排班日 (shift-day starting at `dayStart`, e.g. 08:00), and a
+ * cross-midnight 夜班 sits wholly inside its shift-day's columns. Drag snaps to
+ * band boundaries (half-day steps) instead of whole days. The suite also guards
+ * that segmenting is gated to day mode and is a no-op without a config.
+ *
+ * Dates use the LOCAL Date constructor so shiftDayStart (local time-of-day math)
+ * is deterministic regardless of the runner's timezone.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+import { normalizeShiftSegments } from './shifts';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+});
+
+const COLUMN_WIDTH = 110; // one shift-day (24h) at 1280px container
+const HOUR = 60 * 60 * 1000;
+
+const d = (y: number, m: number, day: number, h = 0, min = 0) =>
+  new Date(y, m - 1, day, h, min);
+
+const SHIFTS = normalizeShiftSegments({
+  dayStart: '08:00',
+  bands: [
+    { key: 'day', label: '白班', start: '08:00', end: '20:00' },
+    { key: 'night', label: '夜班', start: '20:00', end: '08:00' },
+  ],
+})!;
+
+function makeTask(id: string, start: Date, end: Date): GanttTask {
+  return { id, title: `Task ${id}`, start, end, progress: 0 };
+}
+
+function renderView(
+  tasks: GanttTask[],
+  props: Partial<React.ComponentProps<typeof GanttView>> = {},
+) {
+  return render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView
+        tasks={tasks}
+        startDate={d(2024, 6, 1)}
+        endDate={d(2024, 6, 10)}
+        viewMode="day"
+        {...props}
+      />
+    </div>,
+  );
+}
+
+function unitCells(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll('[data-testid="gantt-header-units"] > div'),
+  ) as HTMLElement[];
+}
+
+function groupCells(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll('[data-testid="gantt-header-groups"] > div'),
+  ) as HTMLElement[];
+}
+
+function unitLabels(container: HTMLElement): string[] {
+  return unitCells(container).map((u) => (u.textContent || '').trim());
+}
+
+function barGeometry(container: HTMLElement, id: string) {
+  const bar = container.querySelector(`[data-testid="gantt-task-bar-${id}"]`) as HTMLElement;
+  expect(bar).toBeTruthy();
+  return { left: parseFloat(bar.style.left), width: parseFloat(bar.style.width) };
+}
+
+function pointer(type: string, clientX: number) {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX,
+    clientY: 100,
+    pointerType: 'mouse',
+    button: 0,
+    isPrimary: true,
+  } as PointerEventInit);
+}
+
+describe('GanttView shift segmentation', () => {
+  it('splits each day into 白班 | 夜班 band columns', () => {
+    const task = makeTask('a', d(2024, 6, 4, 8), d(2024, 6, 4, 20));
+    const plain = renderView([task]);
+    const shifted = renderView([task], { shiftSegments: SHIFTS });
+
+    // Two band columns per shift-day → materially more cells than the plain axis.
+    expect(unitCells(shifted.container).length).toBeGreaterThan(unitCells(plain.container).length);
+
+    const labels = unitLabels(shifted.container);
+    expect(labels[0]).toBe('白班');
+    expect(labels[1]).toBe('夜班');
+    expect(labels[2]).toBe('白班');
+    expect(labels[3]).toBe('夜班');
+    // Each band is half a shift-day wide.
+    expect(parseFloat(unitCells(shifted.container)[0].style.width)).toBeCloseTo(COLUMN_WIDTH / 2, 0);
+  });
+
+  it('groups the two bands under one 排班日 header cell', () => {
+    const { container } = renderView([makeTask('a', d(2024, 6, 4, 8), d(2024, 6, 4, 20))], {
+      shiftSegments: SHIFTS,
+    });
+    const groups = groupCells(container);
+    // One day-tier cell per shift-day, each spanning its two bands (full day wide).
+    expect(groups.length).toBeGreaterThan(1);
+    expect(parseFloat(groups[0].style.width)).toBeCloseTo(COLUMN_WIDTH, 0);
+  });
+
+  it('sizes a 白班 (12h) bar to one band and a full day to two', () => {
+    const dayBar = renderView([makeTask('a', d(2024, 6, 4, 8), d(2024, 6, 4, 20))], {
+      shiftSegments: SHIFTS,
+    });
+    const fullBar = renderView([makeTask('a', d(2024, 6, 4, 8), d(2024, 6, 5, 8))], {
+      shiftSegments: SHIFTS,
+    });
+    expect(barGeometry(dayBar.container, 'a').width).toBeCloseTo(COLUMN_WIDTH / 2, 0);
+    expect(barGeometry(fullBar.container, 'a').width).toBeCloseTo(COLUMN_WIDTH, 0);
+  });
+
+  it('places a cross-midnight 夜班 in the second band of its shift-day', () => {
+    // 夜班 6/4 20:00 → 6/5 08:00 belongs to the 6/4 shift-day (by start).
+    const dayBar = barGeometry(
+      renderView([makeTask('a', d(2024, 6, 4, 8), d(2024, 6, 4, 20))], { shiftSegments: SHIFTS })
+        .container,
+      'a',
+    );
+    const nightBar = barGeometry(
+      renderView([makeTask('a', d(2024, 6, 4, 20), d(2024, 6, 5, 8))], { shiftSegments: SHIFTS })
+        .container,
+      'a',
+    );
+    // Night sits directly after the day band, same width.
+    expect(nightBar.width).toBeCloseTo(COLUMN_WIDTH / 2, 0);
+    expect(nightBar.left - dayBar.left).toBeCloseTo(COLUMN_WIDTH / 2, 0);
+  });
+
+  it('drag snaps by one band (12h), not a whole day', () => {
+    let captured: { start: Date; end: Date } | null = null;
+    const task = makeTask('a', d(2024, 6, 4, 8), d(2024, 6, 4, 20)); // 白班
+    const { container } = renderView([task], {
+      shiftSegments: SHIFTS,
+      onTaskUpdate: (_t, changes) => {
+        captured = changes as { start: Date; end: Date };
+      },
+    });
+
+    const bar = container.querySelector('[data-testid="gantt-task-bar-a"]') as HTMLElement;
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 300)); });
+    // +55px = one band = +12h: 白班 6/4 08:00 → 夜班 6/4 20:00.
+    act(() => { window.dispatchEvent(pointer('pointermove', 355)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 355)); });
+
+    expect(captured).not.toBeNull();
+    expect(captured!.start.getTime() - task.start.getTime()).toBe(12 * HOUR);
+  });
+
+  it('does not segment outside day mode', () => {
+    const task = makeTask('a', d(2024, 6, 4, 8), d(2024, 6, 6, 8));
+    const plain = renderView([task], { viewMode: 'week' });
+    const withShifts = renderView([task], { viewMode: 'week', shiftSegments: SHIFTS });
+    expect(unitCells(withShifts.container).length).toBe(unitCells(plain.container).length);
+    expect(unitLabels(withShifts.container)).not.toContain('白班');
+  });
+
+  it('is a no-op when no shift config is supplied (regression guard)', () => {
+    const task = makeTask('a', d(2024, 6, 4, 0), d(2024, 6, 6, 0));
+    const a = renderView([task]);
+    const b = renderView([task], { shiftSegments: null });
+    expect(unitCells(a.container).length).toBe(unitCells(b.container).length);
+    expect(barGeometry(a.container, 'a').width).toBeCloseTo(barGeometry(b.container, 'a').width, 0);
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.shifts.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.shifts.test.tsx
@@ -180,6 +180,21 @@ describe('GanttView shift segmentation', () => {
     expect(first).toBeCloseTo(COLUMN_WIDTH / 2 + (COLUMN_WIDTH / 2) * (4 / 12), 0);
   });
 
+  it('hides the midnight marker when showMidnight is false', () => {
+    const noMid = normalizeShiftSegments({
+      dayStart: '08:00',
+      showMidnight: false,
+      bands: [
+        { key: 'day', label: '白班', start: '08:00', end: '20:00' },
+        { key: 'night', label: '夜班', start: '20:00', end: '08:00' },
+      ],
+    })!;
+    const { container } = renderView([makeTask('a', d(2024, 6, 4, 20), d(2024, 6, 5, 8))], {
+      shiftSegments: noMid,
+    });
+    expect(container.querySelectorAll('[data-testid^="gantt-midnight-"]').length).toBe(0);
+  });
+
   it('renders no midnight markers without a shift config', () => {
     const { container } = renderView([makeTask('a', d(2024, 6, 4, 0), d(2024, 6, 6, 0))]);
     expect(container.querySelectorAll('[data-testid^="gantt-midnight-"]').length).toBe(0);

--- a/packages/plugin-gantt/src/GanttView.shifts.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.shifts.test.tsx
@@ -166,6 +166,25 @@ describe('GanttView shift segmentation', () => {
     expect(captured!.start.getTime() - task.start.getTime()).toBe(12 * HOUR);
   });
 
+  it('draws a dashed calendar-midnight marker inside the cross-midnight 夜班', () => {
+    const { container } = renderView([makeTask('a', d(2024, 6, 4, 20), d(2024, 6, 5, 8))], {
+      shiftSegments: SHIFTS,
+    });
+    const marks = Array.from(
+      container.querySelectorAll('[data-testid^="gantt-midnight-"]'),
+    ) as HTMLElement[];
+    expect(marks.length).toBeGreaterThan(0);
+    // 0:00 falls 4h into the 12h 夜班 band → 1/3 of the way across a half-day
+    // column, which itself begins half a shift-day in.
+    const first = Math.min(...marks.map((m) => parseFloat(m.style.left)));
+    expect(first).toBeCloseTo(COLUMN_WIDTH / 2 + (COLUMN_WIDTH / 2) * (4 / 12), 0);
+  });
+
+  it('renders no midnight markers without a shift config', () => {
+    const { container } = renderView([makeTask('a', d(2024, 6, 4, 0), d(2024, 6, 6, 0))]);
+    expect(container.querySelectorAll('[data-testid^="gantt-midnight-"]').length).toBe(0);
+  });
+
   it('does not segment outside day mode', () => {
     const task = makeTask('a', d(2024, 6, 4, 8), d(2024, 6, 6, 8));
     const plain = renderView([task], { viewMode: 'week' });

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3157,6 +3157,37 @@ export function GanttView({
                   })}
                 </div>
 
+                {/* Calendar-midnight markers (日历午夜). A subtle dashed vertical
+                    line where the calendar date flips INSIDE a band — e.g. the
+                    夜班 (20:00→次日08:00) straddles 0:00. The 排班日 cell stays
+                    unbroken; the line is just a cue that the day rolled over. */}
+                {segmenting && shiftSegments && (
+                  <div className="absolute inset-0 pointer-events-none" style={{ zIndex: 0 }}>
+                    {timeColumns.slice(colWindow.start, colWindow.end).map((col, i) => {
+                      const idx = colWindow.start + i;
+                      const realMs = col.realMs ?? 0;
+                      if (!realMs) return null;
+                      const startMs = col.date.getTime();
+                      // Next LOCAL midnight after the band's start instant.
+                      const s = col.date;
+                      const mid = new Date(s.getFullYear(), s.getMonth(), s.getDate() + 1, 0, 0, 0, 0).getTime();
+                      // Only draw when midnight falls strictly inside the band
+                      // (excludes bands that begin or end exactly on midnight).
+                      if (mid <= startMs || mid >= startMs + realMs) return null;
+                      const x = colOffsets[idx] + ((mid - startMs) / realMs) * col.width;
+                      return (
+                        <div
+                          key={`midnight-${idx}`}
+                          className="absolute top-0 bottom-0"
+                          style={{ left: x, borderLeft: '1px dashed hsl(var(--muted-foreground) / 0.4)' }}
+                          data-testid={`gantt-midnight-${idx}`}
+                          aria-hidden="true"
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+
                 {/* Task Bars — windowed to the visible rows */}
                 {rowWindow.startIdx > 0 && (
                   <div style={{ height: rowWindow.startIdx * rowHeight }} aria-hidden="true" />

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -37,6 +37,7 @@ import {
   useResizeObserver,
 } from "@object-ui/components"
 import { computeCriticalPath, computeProjectReschedule, type WorkingCalendar, type RescheduleChange } from "./scheduling"
+import { shiftDayStart, type NormShiftSegments } from "./shifts"
 import { useGanttTranslation } from "./useGanttTranslation"
 
 const HEADER_HEIGHT = 50;
@@ -267,6 +268,15 @@ export interface GanttViewProps {
    * (ISO `yyyy-mm-dd` UTC keys) are skipped rather than consumed.
    */
   workingCalendar?: WorkingCalendar
+  /**
+   * Shift segmentation (班次/排班分段). When set AND the active granularity is
+   * `day`, each day column is replaced by one column per band (白班 | 夜班…), and
+   * the upper header tier shows the 排班日 (shift-day starting at `dayStart`, e.g.
+   * 08:00). Drag/resize then snaps to band boundaries instead of whole days.
+   * Off by default → existing gantts are unaffected (parity with `folding`).
+   * Mutually exclusive with weekend/holiday folding (segmenting wins).
+   */
+  shiftSegments?: NormShiftSegments | null
   /** Render planned-vs-actual baseline bars when tasks carry baseline dates. */
   showBaselines?: boolean
   /**
@@ -469,6 +479,7 @@ export function GanttView({
   rescheduleOnConflict: rescheduleOnConflictProp = false,
   criticalPathDefault = false,
   workingCalendar,
+  shiftSegments,
   showBaselines = true,
   readOnly = false,
   mobileReadOnly = false,
@@ -722,7 +733,13 @@ export function GanttView({
   const suppressNextClickRef = React.useRef(false);
 
   const computeDragChanges = React.useCallback((s: NonNullable<typeof dragState>) => {
-    const minDurationMs = MS_PER_DAY; // never collapse below 1 day
+    // In shift mode a bar can be as short as the smallest band (e.g. a 12h 白班);
+    // otherwise never collapse below one whole day.
+    const segActive = viewMode === 'day' && !!shiftSegments && shiftSegments.bands.length > 0;
+    const minDurationMs =
+      segActive && shiftSegments
+        ? Math.min(...shiftSegments.bands.map((b) => b.durMs))
+        : MS_PER_DAY;
     // Folded axes advance by working columns (Fri +1 → Mon); otherwise snap to
     // whole calendar units. foldShiftRef is set during render (below).
     const shift = (date: Date, n: number) =>
@@ -746,7 +763,7 @@ export function GanttView({
       }
     }
     return { start, end };
-  }, [viewMode]);
+  }, [viewMode, shiftSegments]);
 
   // --- Undo / redo (Phase 6) --------------------------------------------
   // GanttView is presentational — the parent owns task state — so we can't
@@ -880,10 +897,17 @@ export function GanttView({
   // commit via onTaskUpdate on pointerup, suppress the trailing click.
   React.useEffect(() => {
     if (!dragState) return;
+    // In shift mode each drag step is one band wide (smallest band, so every
+    // band boundary is reachable), not a whole day — so Δx / bandWidth = bands
+    // moved, matching shiftByWorkingColumns walking band columns.
+    const segActive = viewMode === 'day' && !!shiftSegments && shiftSegments.bands.length > 0;
+    const dragColWidth = segActive && shiftSegments
+      ? (pxPerDay * Math.min(...shiftSegments.bands.map((b) => b.durMs))) / MS_PER_DAY
+      : columnWidth;
     const onMove = (e: PointerEvent) => {
       const cur = dragStateRef.current;
       if (!cur) return;
-      const next = Math.round((e.clientX - cur.originClientX) / Math.max(columnWidth, 1));
+      const next = Math.round((e.clientX - cur.originClientX) / Math.max(dragColWidth, 1));
       if (next !== cur.unitDelta) {
         setDragState({ ...cur, unitDelta: next });
       }
@@ -929,7 +953,7 @@ export function GanttView({
       window.removeEventListener('pointerup', onUp);
       window.removeEventListener('pointercancel', onUp);
     };
-  }, [dragState, columnWidth, tasks, onTaskUpdate, computeDragChanges, collectDescendants, commitTaskUpdates, maybeFlagConflict]);
+  }, [dragState, columnWidth, pxPerDay, viewMode, shiftSegments, tasks, onTaskUpdate, computeDragChanges, collectDescendants, commitTaskUpdates, maybeFlagConflict]);
 
   const beginDrag = React.useCallback((
     task: GanttTask,
@@ -1370,8 +1394,14 @@ export function GanttView({
     }
     
     // Snap the start to a column boundary of the active granularity so
-    // bars (linear ms→px from range start) line up with the grid.
-    start = startOfUnit(start, viewMode);
+    // bars (linear ms→px from range start) line up with the grid. In shift mode
+    // the boundary is the 排班日 start (e.g. 08:00), not calendar midnight, so a
+    // cross-midnight 夜班 sits wholly inside one shift-day's band columns.
+    if (viewMode === 'day' && shiftSegments && shiftSegments.bands.length > 0) {
+      start = shiftDayStart(start, shiftSegments.dayStartMin);
+    } else {
+      start = startOfUnit(start, viewMode);
+    }
     end.setHours(23,59,59,999);
 
     // NOTE: we deliberately do NOT pad the calendar to fill the viewport.
@@ -1381,7 +1411,7 @@ export function GanttView({
     // and `fitColumnWidth` stretches the column width so a short project still
     // fills the area — the industry "zoom to fit" approach.
     return { start, end };
-  }, [startDate, endDate, tasks, viewMode]);
+  }, [startDate, endDate, tasks, viewMode, shiftSegments]);
 
   // Non-linear working-time axis (非线性工作时间轴). In day mode, when a working
   // calendar marks weekends/holidays as non-working, those columns are DROPPED
@@ -1389,7 +1419,15 @@ export function GanttView({
   // timeline shows only working time. This makes the date→px mapping non-linear
   // (a weekend spans zero pixels), which is why all positioning is routed
   // through `dateToX`/`xToDate` below rather than a flat ms→px factor.
+  // Shift segmentation (班次分段). In day mode, when a normalized shift config is
+  // supplied, each day column is subdivided into its bands (白班 | 夜班…). Like
+  // `folding` this makes the axis non-linear in px (bands have different widths),
+  // so all positioning routes through `dateToX`/`xToDate`. Off → zero regression.
+  const segmenting =
+    viewMode === 'day' && !!shiftSegments && shiftSegments.bands.length > 0;
+
   const folding =
+    !segmenting &&
     viewMode === 'day' &&
     !!workingCalendar &&
     (!!workingCalendar.skipWeekends || !!(workingCalendar.holidays && workingCalendar.holidays.size));
@@ -1414,7 +1452,40 @@ export function GanttView({
   // Widths follow the calendar at pxPerDay, so a 31-day month column is
   // slightly wider than a 30-day one and stays aligned with the bars.
   const timeColumns = React.useMemo(() => {
-    const cols: { date: Date; label: string; sublabel?: string; isWeekend: boolean; width: number }[] = [];
+    const cols: {
+      date: Date;
+      label: string;
+      sublabel?: string;
+      isWeekend: boolean;
+      width: number;
+      /** Real calendar ms this column spans (band duration in shift mode). */
+      realMs?: number;
+      /** Band accent color for the column tint (shift mode only). */
+      bandColor?: string;
+    }[] = [];
+
+    // Shift mode: emit one column per band, walking shift-day by shift-day.
+    // Bands sum to 24h, so advancing the cursor by each band's duration lands
+    // exactly on the next 排班日 start — columns stay time-contiguous.
+    if (segmenting && shiftSegments) {
+      let cursor = new Date(timelineRange.start);
+      while (cursor <= timelineRange.end) {
+        for (const band of shiftSegments.bands) {
+          const width = (band.durMs / MS_PER_DAY) * pxPerDay;
+          cols.push({
+            date: new Date(cursor),
+            label: band.label,
+            isWeekend: false,
+            width,
+            realMs: band.durMs,
+            bandColor: band.color,
+          });
+          cursor = new Date(cursor.getTime() + band.durMs);
+        }
+      }
+      return cols;
+    }
+
     let current = new Date(timelineRange.start);
 
     while (current <= timelineRange.end) {
@@ -1450,7 +1521,7 @@ export function GanttView({
     }
 
     return cols;
-  }, [timelineRange, viewMode, pxPerDay, dateLocale, folding, isWorkingColumn]);
+  }, [timelineRange, viewMode, pxPerDay, dateLocale, folding, isWorkingColumn, segmenting, shiftSegments]);
 
   // Prefix sums of column widths — left edge of column i, used both for
   // positioning the virtualized cells and for the visible-range search.
@@ -1474,7 +1545,10 @@ export function GanttView({
   // can't use a single ms→px factor; it interpolates within the owning column.
   const colStartMs = React.useMemo(() => timeColumns.map((c) => c.date.getTime()), [timeColumns]);
   const colRealMs = React.useMemo(
-    () => timeColumns.map((c) => addUnits(c.date, 1, viewMode).getTime() - c.date.getTime()),
+    () =>
+      timeColumns.map((c) =>
+        c.realMs != null ? c.realMs : addUnits(c.date, 1, viewMode).getTime() - c.date.getTime(),
+      ),
     [timeColumns, viewMode],
   );
 
@@ -1501,10 +1575,10 @@ export function GanttView({
       }
       const real = colRealMs[i] || MS_PER_DAY;
       let frac = (t - colStartMs[i]) / real;
-      if (folding) frac = Math.max(0, Math.min(frac, 1));
+      if (folding || segmenting) frac = Math.max(0, Math.min(frac, 1));
       return colOffsets[i] + frac * timeColumns[i].width;
     },
-    [timeColumns, colStartMs, colRealMs, colOffsets, folding],
+    [timeColumns, colStartMs, colRealMs, colOffsets, folding, segmenting],
   );
 
   // x (px) → date. Inverse of dateToX, used by drag/resize to read the date
@@ -1618,12 +1692,37 @@ export function GanttView({
   // the common case; when the axis folds, it routes through working columns so
   // a drag tracks the compressed grid. The ref keeps that callback stable.
   const foldShiftRef = React.useRef<((date: Date, n: number) => Date) | null>(null);
-  foldShiftRef.current = folding ? shiftByWorkingColumns : null;
+  // Both folding (skip non-working columns) and segmenting (snap to band
+  // boundaries) advance a drag by visible columns; shiftByWorkingColumns walks
+  // colStartMs, which is band starts in shift mode → a one-column drag = one band.
+  foldShiftRef.current = folding || segmenting ? shiftByWorkingColumns : null;
 
   // Upper scale row: month groups under day/week, year groups under
   // month/quarter, decade groups under year.
   const headerGroups = React.useMemo(() => {
     const groups: { key: string; label: string; width: number; offset: number }[] = [];
+    // Shift mode: the upper tier is the 排班日 (shift-day). All bands of one
+    // shift-day share its `shiftDayStart`, so grouping by it yields one cell per
+    // day spanning its 白班|夜班 columns, labelled by the day's date.
+    if (segmenting && shiftSegments) {
+      let acc = 0;
+      for (const col of timeColumns) {
+        const key = String(shiftDayStart(col.date, shiftSegments.dayStartMin).getTime());
+        const last = groups[groups.length - 1];
+        if (last && last.key === key) {
+          last.width += col.width;
+        } else {
+          groups.push({
+            key,
+            label: col.date.toLocaleDateString(dateLocale, { month: 'short', day: 'numeric' }),
+            width: col.width,
+            offset: acc,
+          });
+        }
+        acc += col.width;
+      }
+      return groups;
+    }
     const groupBy: 'decade' | 'year' | 'month' =
       viewMode === 'year' ? 'decade' : viewMode === 'month' || viewMode === 'quarter' ? 'year' : 'month';
     let acc = 0;
@@ -1651,7 +1750,7 @@ export function GanttView({
       acc += col.width;
     }
     return groups;
-  }, [timeColumns, viewMode, dateLocale]);
+  }, [timeColumns, viewMode, dateLocale, segmenting, shiftSegments]);
 
   // Normalized custom markers (invalid/out-of-range dates dropped), positioned
   // through the same date→px mapping the bars and the Today line use so they
@@ -1996,9 +2095,14 @@ export function GanttView({
     // non-working time folds out. For non-folded axes this is identical to the
     // old linear mapping (`(ms / MS_PER_DAY) * pxPerDay`).
     const left = dateToX(start);
-    // Min 1 day, and never thinner than 3px so the bar stays visible (and
-    // grabbable) at coarse granularities where a day is only ~2px.
-    const width = Math.max(dateToX(end) - left, pxPerDay, 3);
+    // Min one unit, and never thinner than 3px so the bar stays visible (and
+    // grabbable) at coarse granularities where a day is only ~2px. In shift mode
+    // the unit is the smallest band, so a single-shift bar isn't padded to a day.
+    const minUnitPx =
+      segmenting && shiftSegments
+        ? (pxPerDay * Math.min(...shiftSegments.bands.map((b) => b.durMs))) / MS_PER_DAY
+        : pxPerDay;
+    const width = Math.max(dateToX(end) - left, minUnitPx, 3);
 
     return { left, width };
   };
@@ -2775,7 +2879,13 @@ export function GanttView({
                       "absolute top-0 bottom-0 flex items-center justify-center gap-1 border-r text-xs text-muted-foreground overflow-hidden",
                       col.isWeekend && "bg-muted/50"
                     )}
-                    style={{ left: colOffsets[idx], width: col.width }}
+                    style={{
+                      left: colOffsets[idx],
+                      width: col.width,
+                      backgroundColor: col.bandColor
+                        ? `color-mix(in srgb, ${col.bandColor} 16%, transparent)`
+                        : undefined,
+                    }}
                   >
                     <span className="font-medium text-foreground truncate">{col.label}</span>
                     {col.sublabel && columnWidth >= 32 && (
@@ -3036,7 +3146,11 @@ export function GanttView({
                       style={{
                         left: colOffsets[idx],
                         width: col.width,
-                        backgroundColor: col.isWeekend ? 'hsl(var(--muted) / 0.4)' : undefined,
+                        backgroundColor: col.bandColor
+                          ? `color-mix(in srgb, ${col.bandColor} 8%, transparent)`
+                          : col.isWeekend
+                            ? 'hsl(var(--muted) / 0.4)'
+                            : undefined,
                       }}
                     />
                     );

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3161,7 +3161,7 @@ export function GanttView({
                     line where the calendar date flips INSIDE a band — e.g. the
                     夜班 (20:00→次日08:00) straddles 0:00. The 排班日 cell stays
                     unbroken; the line is just a cue that the day rolled over. */}
-                {segmenting && shiftSegments && (
+                {segmenting && shiftSegments && shiftSegments.showMidnight && (
                   <div className="absolute inset-0 pointer-events-none" style={{ zIndex: 0 }}>
                     {timeColumns.slice(colWindow.start, colWindow.end).map((col, i) => {
                       const idx = colWindow.start + i;

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -53,6 +53,7 @@ import { GanttView, type GanttTask, type GanttDependency, type GanttLinkType, ty
 import { ResourceWorkload } from './ResourceWorkload';
 import { QuickFilterBar, type QuickFilterField, type QuickFilterOption } from './QuickFilterBar';
 import type { WorkingCalendar } from './scheduling';
+import { normalizeShiftSegments, type ShiftSegmentsConfig } from './shifts';
 
 /**
  * One quick-filter dimension (快速筛选维度). Generic by design: the page configures
@@ -138,6 +139,17 @@ type GanttConfigEx = GanttConfig & {
    * (unfiltered) task set while filtering only hides bars.
    */
   autoZoomToFilter?: boolean;
+  /**
+   * Shift segmentation (班次/排班分段). When set, the day-mode timeline splits each
+   * 排班日 (shift-day, starting at `dayStart`) into the configured bands (白班 |
+   * 夜班…): a two-tier header (date over band), per-band column tints, and
+   * drag/resize snapping to band boundaries. Pure config data — no shift concept
+   * is hardcoded. Off by default → existing gantts are unchanged. Example:
+   * `{ dayStart: '08:00', bands: [
+   *     { key: 'day', label: '白班', start: '08:00', end: '20:00' },
+   *     { key: 'night', label: '夜班', start: '20:00', end: '08:00' } ] }`.
+   */
+  timeSegments?: ShiftSegmentsConfig;
 };
 
 /** Map a record's type value onto a GanttTaskType (undefined = infer). */
@@ -282,6 +294,7 @@ function getGanttConfig(schema: ObjectGridSchema | any): GanttConfigEx | null {
           capacity: schema.capacity,
           quickFilters: schema.quickFilters,
           autoZoomToFilter: schema.autoZoomToFilter,
+          timeSegments: schema.timeSegments,
       };
       return config;
   }
@@ -677,6 +690,14 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       holidays: hol && hol.length ? new Set(hol) : undefined,
     };
   }, [schema]);
+
+  // Shift segmentation (班次分段). Normalize the declarative `timeSegments` config
+  // once into the model GanttView lays band columns / snaps drags against. null
+  // (no/invalid config) leaves the timeline an ordinary day axis.
+  const shiftSegments = useMemo(
+    () => normalizeShiftSegments(ganttConfig?.timeSegments),
+    [ganttConfig?.timeSegments],
+  );
 
   // ── Quick filters (快速筛选) ─────────────────────────────────────────────
   // Resolve each task's value for a filter dimension into a stable key. Lookups
@@ -1091,6 +1112,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           rescheduleOnConflict={!!ganttConfig?.dependenciesField}
           criticalPathDefault={!!(schema as any).criticalPath}
           workingCalendar={workingCalendar}
+          shiftSegments={shiftSegments}
           showBaselines={(schema as any).showBaselines !== false}
           readOnly={!!(schema as any).readOnly}
           mobileReadOnly={(schema as any).mobileReadOnly !== false}

--- a/packages/plugin-gantt/src/index.tsx
+++ b/packages/plugin-gantt/src/index.tsx
@@ -35,6 +35,14 @@ export type {
 } from './GanttView';
 export { normalizeDependencies, normalizeTaskType } from './ObjectGantt';
 
+export { normalizeShiftSegments, parseHHMM, shiftDayStart, bandAt } from './shifts';
+export type {
+  ShiftSegmentsConfig,
+  ShiftBandConfig,
+  NormShiftSegments,
+  NormShiftBand,
+} from './shifts';
+
 export { ResourceWorkload } from './ResourceWorkload';
 export type { ResourceWorkloadProps } from './ResourceWorkload';
 export { computeWorkload } from './workload';

--- a/packages/plugin-gantt/src/shifts.test.ts
+++ b/packages/plugin-gantt/src/shifts.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseHHMM,
+  normalizeShiftSegments,
+  shiftDayStart,
+  bandAt,
+} from './shifts';
+
+const HOUR = 60 * 60 * 1000;
+
+describe('parseHHMM', () => {
+  it('parses valid times to minutes after midnight', () => {
+    expect(parseHHMM('00:00')).toBe(0);
+    expect(parseHHMM('08:00')).toBe(480);
+    expect(parseHHMM('20:30')).toBe(1230);
+    expect(parseHHMM('23:59')).toBe(1439);
+  });
+  it('rejects malformed / out-of-range values', () => {
+    expect(parseHHMM('24:00')).toBeNull();
+    expect(parseHHMM('8')).toBeNull();
+    expect(parseHHMM('08:60')).toBeNull();
+    expect(parseHHMM(undefined)).toBeNull();
+    expect(parseHHMM('')).toBeNull();
+  });
+});
+
+describe('normalizeShiftSegments', () => {
+  it('returns null for empty / missing config', () => {
+    expect(normalizeShiftSegments(null)).toBeNull();
+    expect(normalizeShiftSegments(undefined)).toBeNull();
+    expect(normalizeShiftSegments({ bands: [] })).toBeNull();
+  });
+
+  it('normalizes the 08:00/20:00 two-shift factory', () => {
+    const seg = normalizeShiftSegments({
+      dayStart: '08:00',
+      bands: [
+        { key: 'day', label: '白班', start: '08:00', end: '20:00' },
+        { key: 'night', label: '夜班', start: '20:00', end: '08:00' },
+      ],
+    });
+    expect(seg).not.toBeNull();
+    expect(seg!.dayStartMin).toBe(480);
+    expect(seg!.bands).toHaveLength(2);
+    // both halves are 12h
+    expect(seg!.bands[0].durMs).toBe(12 * HOUR);
+    expect(seg!.bands[1].durMs).toBe(12 * HOUR); // 20:00 → 08:00 crosses midnight
+  });
+
+  it('defaults dayStart to midnight and synthesizes band keys', () => {
+    const seg = normalizeShiftSegments({
+      bands: [
+        { label: 'AM', start: '00:00', end: '12:00' },
+        { label: 'PM', start: '12:00', end: '00:00' },
+      ],
+    });
+    expect(seg!.dayStartMin).toBe(0);
+    expect(seg!.bands[0].key).toBe('band0');
+    expect(seg!.bands[1].durMs).toBe(12 * HOUR); // 12:00 → 00:00 = 12h
+  });
+
+  it('rejects a config with a malformed band time', () => {
+    expect(
+      normalizeShiftSegments({ bands: [{ label: 'x', start: 'oops', end: '08:00' }] }),
+    ).toBeNull();
+  });
+});
+
+describe('shiftDayStart', () => {
+  const seg = normalizeShiftSegments({
+    dayStart: '08:00',
+    bands: [
+      { key: 'day', label: '白班', start: '08:00', end: '20:00' },
+      { key: 'night', label: '夜班', start: '20:00', end: '08:00' },
+    ],
+  })!;
+
+  it('floors an afternoon instant to the same-day 08:00', () => {
+    const r = shiftDayStart(new Date(2026, 5, 4, 15, 0), 480);
+    expect(r.getTime()).toBe(new Date(2026, 5, 4, 8, 0).getTime());
+  });
+
+  it('floors a post-midnight night-shift instant back to the PREVIOUS 08:00', () => {
+    // 6/5 03:00 is still 6/4 night shift → shift-day is 6/4 08:00
+    const r = shiftDayStart(new Date(2026, 5, 5, 3, 0), 480);
+    expect(r.getTime()).toBe(new Date(2026, 5, 4, 8, 0).getTime());
+  });
+
+  it('floors exactly 08:00 to itself', () => {
+    const r = shiftDayStart(new Date(2026, 5, 4, 8, 0), 480);
+    expect(r.getTime()).toBe(new Date(2026, 5, 4, 8, 0).getTime());
+  });
+
+  void seg;
+});
+
+describe('bandAt — attribution by start', () => {
+  const seg = normalizeShiftSegments({
+    dayStart: '08:00',
+    bands: [
+      { key: 'day', label: '白班', start: '08:00', end: '20:00' },
+      { key: 'night', label: '夜班', start: '20:00', end: '08:00' },
+    ],
+  })!;
+
+  it('08:00 start → 白班', () => {
+    expect(bandAt(new Date(2026, 5, 4, 8, 0), seg)!.key).toBe('day');
+  });
+  it('19:59 start → 白班 (boundary just before 20:00)', () => {
+    expect(bandAt(new Date(2026, 5, 4, 19, 59), seg)!.key).toBe('day');
+  });
+  it('20:00 start → 夜班', () => {
+    expect(bandAt(new Date(2026, 5, 4, 20, 0), seg)!.key).toBe('night');
+  });
+  it('post-midnight 03:00 → 夜班 of the PREVIOUS shift-day', () => {
+    expect(bandAt(new Date(2026, 5, 5, 3, 0), seg)!.key).toBe('night');
+  });
+});

--- a/packages/plugin-gantt/src/shifts.ts
+++ b/packages/plugin-gantt/src/shifts.ts
@@ -49,6 +49,11 @@ export interface ShiftSegmentsConfig {
   dayStart?: string;
   /** Ordered bands covering the 24h shift-day, beginning at `dayStart`. */
   bands: ShiftBandConfig[];
+  /**
+   * Draw the dashed calendar-midnight (日历午夜 0:00) cue inside cross-midnight
+   * bands. Defaults to `true`; set `false` to hide it.
+   */
+  showMidnight?: boolean;
 }
 
 /** Normalized band — duration in ms, ready for column layout. */
@@ -66,6 +71,8 @@ export interface NormShiftSegments {
   dayStartMin: number;
   /** Bands in order from `dayStart`; durations sum to ~24h. */
   bands: NormShiftBand[];
+  /** Whether to draw the dashed calendar-midnight cue. Default true. */
+  showMidnight: boolean;
 }
 
 /** Parse 'HH:mm' → minutes after midnight, or null when malformed. */
@@ -104,7 +111,7 @@ export function normalizeShiftSegments(
       durMs: durMin * MS_PER_MIN,
     });
   }
-  return { dayStartMin, bands };
+  return { dayStartMin, bands, showMidnight: cfg.showMidnight !== false };
 }
 
 /**

--- a/packages/plugin-gantt/src/shifts.ts
+++ b/packages/plugin-gantt/src/shifts.ts
@@ -1,0 +1,142 @@
+/**
+ * Shift segmentation (班次/排班) for the Gantt — pure, side-effect-free helpers.
+ *
+ * A factory's day is split into named time bands (白班 08:00–20:00, 夜班
+ * 20:00–次日08:00). The Gantt is positioned in continuous milliseconds, so a
+ * band is just a recurring time window; this module turns a declarative config
+ * into a normalized model the renderer can lay columns and snap drags against.
+ *
+ * Two ideas make cross-midnight shifts a non-problem:
+ *
+ *   - **Shift-day (排班日):** the "day" column does NOT start at calendar
+ *     midnight but at the configured `dayStart` (e.g. 08:00) and runs a full 24h
+ *     to the next `dayStart`. A night shift that crosses 00:00 therefore sits
+ *     wholly inside one shift-day column instead of straddling two date cells.
+ *
+ *   - **Attribution by start:** a record belongs to the shift-day that contains
+ *     its START instant. The 夜班 starting 6/4 20:00 belongs to 6/4 even though
+ *     it ends 6/5 08:00. {@link shiftDayStart} / {@link bandAt} encode this.
+ *
+ * Bands are laid out by *cumulative duration* from `dayStart`, never by absolute
+ * clock math, so a band whose `end` < `start` (crosses midnight) needs no
+ * special-casing — its duration is `(end - start + 24h) mod 24h`.
+ */
+
+const MS_PER_MIN = 60_000;
+const MS_PER_DAY = 24 * 60 * MS_PER_MIN;
+const MINS_PER_DAY = 24 * 60;
+
+/** Declarative band as authored in the view config. */
+export interface ShiftBandConfig {
+  /** Stable identifier (e.g. 'day' / 'night'); defaults to `band{index}`. */
+  key?: string;
+  /** Display label (白班 / 夜班) — already localized by the caller. */
+  label: string;
+  /** Band start, 'HH:mm' (24h). */
+  start: string;
+  /** Band end, 'HH:mm'. When `end <= start` the band crosses midnight. */
+  end: string;
+  /** Optional accent color (any CSS color) for the column tint. */
+  color?: string;
+}
+
+/** Declarative shift config attached to a Gantt view (`gantt.timeSegments`). */
+export interface ShiftSegmentsConfig {
+  /**
+   * Clock time the shift-day begins, 'HH:mm'. The day column starts here and
+   * runs 24h. Defaults to '00:00' (calendar day). For 8点交接 set '08:00'.
+   */
+  dayStart?: string;
+  /** Ordered bands covering the 24h shift-day, beginning at `dayStart`. */
+  bands: ShiftBandConfig[];
+}
+
+/** Normalized band — duration in ms, ready for column layout. */
+export interface NormShiftBand {
+  key: string;
+  label: string;
+  color?: string;
+  /** Band length in ms (cross-midnight resolved). */
+  durMs: number;
+}
+
+/** Normalized shift model produced by {@link normalizeShiftSegments}. */
+export interface NormShiftSegments {
+  /** Minutes after local midnight the shift-day starts (08:00 → 480). */
+  dayStartMin: number;
+  /** Bands in order from `dayStart`; durations sum to ~24h. */
+  bands: NormShiftBand[];
+}
+
+/** Parse 'HH:mm' → minutes after midnight, or null when malformed. */
+export function parseHHMM(value: string | undefined | null): number | null {
+  if (typeof value !== 'string') return null;
+  const m = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}
+
+/**
+ * Turn a declarative config into the normalized model, or return null when the
+ * config is absent or invalid (no usable bands). Bands are laid out by
+ * cumulative duration so a cross-midnight band (`end <= start`) is handled
+ * uniformly; a band with `end === start` is treated as a full 24h slot.
+ */
+export function normalizeShiftSegments(
+  cfg: ShiftSegmentsConfig | null | undefined,
+): NormShiftSegments | null {
+  if (!cfg || !Array.isArray(cfg.bands) || cfg.bands.length === 0) return null;
+  const dayStartMin = parseHHMM(cfg.dayStart) ?? 0;
+  const bands: NormShiftBand[] = [];
+  for (let i = 0; i < cfg.bands.length; i++) {
+    const b = cfg.bands[i];
+    const s = parseHHMM(b.start);
+    const e = parseHHMM(b.end);
+    if (s == null || e == null || !b.label) return null;
+    const durMin = ((e - s + MINS_PER_DAY) % MINS_PER_DAY) || MINS_PER_DAY;
+    bands.push({
+      key: b.key ?? `band${i}`,
+      label: b.label,
+      color: b.color,
+      durMs: durMin * MS_PER_MIN,
+    });
+  }
+  return { dayStartMin, bands };
+}
+
+/**
+ * Floor an instant to the start of the shift-day that contains it — the most
+ * recent moment whose local time-of-day equals `dayStartMin`. For dayStart
+ * 08:00, anything from 08:00 today up to (but not including) 08:00 tomorrow maps
+ * to today's 08:00.
+ */
+export function shiftDayStart(date: Date, dayStartMin: number): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  d.setMinutes(dayStartMin);
+  if (d.getTime() > date.getTime()) d.setDate(d.getDate() - 1);
+  return d;
+}
+
+/**
+ * The band a START instant falls into, by cumulative duration from its
+ * shift-day start. Used both to tint/label columns and to derive the band of a
+ * record (the 夜班/白班 of `startDateField`). Returns null only for an empty
+ * model.
+ */
+export function bandAt(date: Date, seg: NormShiftSegments): NormShiftBand | null {
+  if (seg.bands.length === 0) return null;
+  const base = shiftDayStart(date, seg.dayStartMin).getTime();
+  const offset = date.getTime() - base;
+  let acc = 0;
+  for (const b of seg.bands) {
+    acc += b.durMs;
+    if (offset < acc) return b;
+  }
+  return seg.bands[seg.bands.length - 1];
+}
+
+export { MS_PER_DAY as SHIFT_MS_PER_DAY };

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -184,6 +184,11 @@ export type GanttConfig = {
       /** Optional accent color (any CSS color) for the column tint. */
       color?: string;
     }>;
+    /**
+     * Draw the dashed calendar-midnight (日历午夜 0:00) cue inside cross-midnight
+     * bands. Defaults to `true`; set `false` to hide it.
+     */
+    showMidnight?: boolean;
   };
 };
 

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -157,6 +157,34 @@ export type GanttConfig = {
    * tooltip falls back to the built-in start → end · duration · progress line.
    */
   tooltipFields?: Array<string | { field: string; label?: string }>;
+  /**
+   * Shift segmentation (班次/排班分段). ObjectUI display extension — not part of the
+   * upstream GanttConfigSchema. When set, the day-mode timeline splits each
+   * 排班日 (shift-day starting at `dayStart`, default '00:00') into the configured
+   * time bands (白班 | 夜班…): a two-tier header (date over band), per-band tints,
+   * and drag/resize snapping to band boundaries. No shift concept is hardcoded —
+   * bands are pure config. Off by default. Example:
+   * `{ dayStart: '08:00', bands: [
+   *     { key: 'day', label: '白班', start: '08:00', end: '20:00' },
+   *     { key: 'night', label: '夜班', start: '20:00', end: '08:00' } ] }`.
+   */
+  timeSegments?: {
+    /** Clock time the shift-day begins, 'HH:mm' (24h). Defaults to '00:00'. */
+    dayStart?: string;
+    /** Ordered bands covering the 24h shift-day, beginning at `dayStart`. */
+    bands: Array<{
+      /** Stable id (e.g. 'day'/'night'); defaults to `band{index}`. */
+      key?: string;
+      /** Display label (白班 / 夜班). */
+      label: string;
+      /** Band start, 'HH:mm'. */
+      start: string;
+      /** Band end, 'HH:mm'; when `end <= start` the band crosses midnight. */
+      end: string;
+      /** Optional accent color (any CSS color) for the column tint. */
+      color?: string;
+    }>;
+  };
 };
 
 /**
@@ -2083,8 +2111,9 @@ export interface ObjectChartSchema extends BaseSchema {
   type: 'object-chart';
   /** ObjectQL object name (legacy inline path; optional under ADR-0021 dataset binding) */
   objectName?: string;
-  /** Chart type */
-  chartType: 'bar' | 'line' | 'pie' | 'area' | 'scatter';
+  /** Chart type. Includes donut / horizontal-bar / column — all rendered by
+   *  AdvancedChartImpl (previously only reachable by passing an untyped string). */
+  chartType: 'bar' | 'column' | 'horizontal-bar' | 'line' | 'area' | 'pie' | 'donut' | 'scatter';
   /** Field for X axis (categories) — legacy inline path */
   xAxisField?: string;
   /** Fields for Y axis (values) — legacy */


### PR DESCRIPTION
## 概要

给甘特图加上**可配置的白班/夜班(排班日)分段**能力。纯配置 DATA 驱动,默认关闭——不传 `shiftSegments` 时零回归,行为与 working-calendar `folding` 一致。

## 核心设计

- **排班日从 `dayStart`(如 08:00)起算,不是午夜**。「day」列跑满 24h,所以**跨午夜的夜班整段落在同一列内**。
- **不硬编码任何 班次/白班/夜班 概念**——bands 是配置数据,按 `start`/`end`/`label`/可选 `color` 渲染。
- **双层表头**:上层=排班日日期,下层=各 band 等宽。
- **拖拽/拉伸吸附到 band 边界(12h)**,而非整天。
- band 底色仅当配置了 `color` 时渲染(不配 → 无底色)。

## 改动

| 文件 | 内容 |
|---|---|
| `shifts.ts` (新) | `normalizeShiftSegments()` + 辅助函数(parseHHMM / shiftDayStart / bandAt) |
| `GanttView.tsx` | 双层表头、band 列(连续 ms 定位)、拖拽吸附班次边界 |
| `ObjectGantt.tsx` / `types/objectql.ts` | 透传 `shiftSegments` 配置 |
| `demo/main.tsx` | 把班次接入 **制造排班 (4层树)** 示例(`?mfg=1`),无 band 底色;放开一条派工单(WO003)用于体验吸附 |
| `shifts.test.ts` / `GanttView.shifts.test.tsx` (新) | 单元 + 组件测试 |

## 测试

`vitest run` —— **20 passed**(shifts.test.ts + GanttView.shifts.test.tsx)。

浏览器验证(`?mfg=1&lang=zh&mode=day`):四层树渲染正常,白班/夜班双层表头无底色,WO002 跨午夜夜班整段落在同一排班日列内;WO003 可拖拽并吸附到 12h 班次边界。