### PR TITLE
feat(studio): package-first create flow — prompt/redirect to a writable base (ADR-0070 D3)

### DIFF
--- a/.changeset/adr-0070-studio-package-first.md
+++ b/.changeset/adr-0070-studio-package-first.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(studio): package-first create flow — prompt or redirect to a writable base (ADR-0070 D3)
+
+Studio's create entry points no longer let a new metadata item land in a code
+package or the package-less "Local / Custom" bucket. ResourceListPage's create
+gate (`handleCreate`) now: opens the create-base dialog when no writable base
+exists; redirects into the first base when the active scope is Local/none but
+bases exist; otherwise proceeds normally. Adds package-scope helpers
+(`isLocalScope` / `writableBaseOptions`) with tests, surfaces the kernel's
+`writable_package_required` (422) as an actionable error in ResourceEditPage,
+and exports `CreatePackageDialog` from PackagesPage for reuse.

--- a/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
@@ -144,7 +144,7 @@ function StatusBadge({ pkg }: { pkg: InstalledPackage }) {
 const ID_RE = /^[a-z0-9][a-z0-9._-]{1,254}$/i;
 const VERSION_RE = /^\d+\.\d+\.\d+$/;
 
-function CreatePackageDialog({
+export function CreatePackageDialog({
   open,
   onOpenChange,
   onCreated,

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -1060,6 +1060,14 @@ function MetadataResourceEditPageImpl({
         setDestructiveIssues(Array.isArray(i) ? i : []);
         setPendingItem(draft);
       }
+      // ADR-0070 D1/D3 — the kernel rejects authoring into a read-only
+      // code/installed package (`writable_package_required`, also HTTP 422,
+      // so this MUST precede the generic invalid_metadata branch below).
+      // Surface an actionable message guiding the author to pick or create a
+      // writable base rather than mangling it into phantom field issues.
+      else if (err?.code === 'writable_package_required') {
+        setError(t('engine.package.writableRequired', locale));
+      }
       // Map schema validation → inline field errors.
       else if (err?.status === 422 || err?.code === 'invalid_metadata' || err?.code === 'invalid_payload') {
         const i = err?.body?.issues ?? [];

--- a/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx
@@ -28,6 +28,7 @@ import {
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
 import { PageShell } from './PageShell';
 import { MetadataTypeActions } from './MetadataTypeActions';
+import { CreatePackageDialog } from './PackagesPage';
 import {
   useMetadataClient,
   useMetadataTypes,
@@ -39,7 +40,7 @@ import {
   resolveResourceConfig,
 } from './registry';
 import { t, tFormat, translateMetadataType, detectLocale } from './i18n';
-import { buildPackageScopeOptions, LOCAL_PACKAGE_ID } from './package-scope';
+import { buildPackageScopeOptions, LOCAL_PACKAGE_ID, isLocalScope } from './package-scope';
 
 export interface MetadataResourceListPageProps {
   type?: string;
@@ -221,6 +222,23 @@ function DefaultMetadataList({ type, appName }: { type: string; appName?: string
     ? `?package=${encodeURIComponent(activePackage)}`
     : '';
 
+  // ADR-0070 D3 — never start a create that would orphan the item. When a real
+  // writable base exists, create into it (defaulting away from the Local/null
+  // scope); when none exists yet, prompt to create a base first.
+  const [showCreateBase, setShowCreateBase] = React.useState(false);
+  const handleCreate = React.useCallback(() => {
+    const realBases = (projectPackages ?? []).filter((p) => !isLocalScope(p.id));
+    if (projectPackages !== null && realBases.length === 0) {
+      setShowCreateBase(true);
+      return;
+    }
+    if (realBases.length > 0 && (!activePackage || isLocalScope(activePackage))) {
+      navigate(`./new?package=${encodeURIComponent(realBases[0].id)}`);
+      return;
+    }
+    navigate(`./new${pkgSuffix}`);
+  }, [projectPackages, activePackage, pkgSuffix, navigate]);
+
   React.useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -384,7 +402,7 @@ function DefaultMetadataList({ type, appName }: { type: string; appName?: string
             <Button
               size="sm"
               variant={config.createFields ? 'default' : 'outline'}
-              onClick={() => navigate(`./new${pkgSuffix}`)}
+              onClick={handleCreate}
               title={
                 config.createFields
                   ? tFormat('engine.list.createHint', locale, { type: typeLabel })
@@ -399,6 +417,11 @@ function DefaultMetadataList({ type, appName }: { type: string; appName?: string
       }
     >
       <div className="p-6 space-y-4">
+        <CreatePackageDialog
+          open={showCreateBase}
+          onOpenChange={setShowCreateBase}
+          onCreated={(id) => navigate(`./new?package=${encodeURIComponent(id)}`)}
+        />
         {/* Filter row */}
         <div className="flex items-center gap-3 flex-wrap">
           <div className="relative flex-1 min-w-[200px] max-w-md">
@@ -455,7 +478,7 @@ function DefaultMetadataList({ type, appName }: { type: string; appName?: string
             </EmptyDescription>
             {scopedItems.length === 0 && (entry?.allowOrgOverride || entry?.allowRuntimeCreate) && (
               <div className="mt-4">
-                <Button onClick={() => navigate(`./new${pkgSuffix}`)}>
+                <Button onClick={handleCreate}>
                   <Plus className="h-4 w-4 mr-1" />
                   {t('engine.list.create', locale)}
                 </Button>

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -213,6 +213,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.list.allSources': 'All sources',
   'engine.list.allPackages': 'All packages',
   'engine.package.local': 'Local / Custom (this env)',
+  'engine.package.writableRequired': 'Pick or create a writable base (package) first — this item cannot be authored into a read-only code package.',
   'engine.list.packageFilter': 'Package',
   'engine.list.source.artifact': 'Artifact',
   'engine.list.source.runtime': 'Runtime',
@@ -840,6 +841,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
 };
 
 const ENGINE_STRINGS_ZH: Record<string, string> = {
+  'engine.package.writableRequired': '请先选择或新建一个可写的基座（package）——只读的代码包中无法新建该项。',
   'engine.directory.title': '元数据',
   'engine.directory.description':
     '平台协议共暴露 {count} 个元数据类型（其中 {writable} 个支持运行时覆盖）。点击任意卡片即可浏览、覆盖或创建实例。',

--- a/packages/app-shell/src/views/metadata-admin/package-scope.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/package-scope.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildPackageScopeOptions,
+  writableBaseOptions,
+  isLocalScope,
+  LOCAL_PACKAGE_ID,
+} from './package-scope';
+
+describe('package-scope (ADR-0070)', () => {
+  const raw = [
+    { item: { manifest: { id: 'app.acme.crm', name: 'CRM', scope: 'project' } } },
+    { item: { manifest: { id: 'platform.core', name: 'Core', scope: 'system' } } },
+    { manifest: { id: 'app.acme.hr', name: 'HR', scope: 'project' } },
+  ];
+
+  it('buildPackageScopeOptions filters system/cloud and appends the Local sentinel last', () => {
+    const ids = buildPackageScopeOptions(raw).map((o) => o.id);
+    expect(ids).toContain('app.acme.crm');
+    expect(ids).toContain('app.acme.hr');
+    expect(ids).not.toContain('platform.core'); // system scope filtered out
+    expect(ids[ids.length - 1]).toBe(LOCAL_PACKAGE_ID);
+  });
+
+  it('writableBaseOptions excludes the Local sentinel AND code/installed packages', () => {
+    const ids = writableBaseOptions(raw).map((o) => o.id);
+    expect(ids).toEqual(['app.acme.crm', 'app.acme.hr']); // sorted by name, no Local, no system
+    expect(ids).not.toContain(LOCAL_PACKAGE_ID);
+  });
+
+  it('writableBaseOptions is empty when only code/installed packages exist', () => {
+    expect(writableBaseOptions([{ manifest: { id: 'platform.core', scope: 'system' } }])).toEqual([]);
+    expect(writableBaseOptions(null)).toEqual([]);
+  });
+
+  it('isLocalScope treats null / undefined / the sentinel as local, real bases as not', () => {
+    expect(isLocalScope(null)).toBe(true);
+    expect(isLocalScope(undefined)).toBe(true);
+    expect(isLocalScope(LOCAL_PACKAGE_ID)).toBe(true);
+    expect(isLocalScope('app.acme.crm')).toBe(false);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/package-scope.ts
+++ b/packages/app-shell/src/views/metadata-admin/package-scope.ts
@@ -51,3 +51,23 @@ export function buildPackageScopeOptions(
   // preserved; the user opts into the local scope explicitly.
   return [...opts, { id: LOCAL_PACKAGE_ID, name: t('engine.package.local', detectLocale()) }];
 }
+
+/**
+ * True for the runtime/null "Local / Custom" sentinel scope. Per ADR-0070 D5
+ * this is a *migration* surface (move loose items into a base), never a valid
+ * create destination — callers gate "create" on a real writable base.
+ */
+export function isLocalScope(id: string | null | undefined): boolean {
+  return !id || id === LOCAL_PACKAGE_ID;
+}
+
+/**
+ * The writable bases (project-scoped DB packages) from the raw package list —
+ * the only valid authoring destinations (ADR-0070 D2). Excludes code/installed
+ * (system|cloud) packages AND the Local sentinel.
+ */
+export function writableBaseOptions(
+  rawList: unknown[] | null | undefined,
+): { id: string; name: string }[] {
+  return buildPackageScopeOptions(rawList).filter((o) => o.id !== LOCAL_PACKAGE_ID);
+}


### PR DESCRIPTION
## What

Implements ADR-0070 **D3 (select-or-create-a-base-first)** on the Studio (human) surface.

- **Create gate** (`ResourceListPage.handleCreate`): when no writable base exists → open the create-base dialog; when the active scope is Local/none but bases exist → create into the first base; otherwise proceed. Both "New" buttons route through it.
- **package-scope helpers**: `isLocalScope()` + `writableBaseOptions()` (excludes the `sys_metadata` sentinel and `system`/`cloud` packages) + unit tests.
- **Error surfacing**: the kernel's `writable_package_required` (422) renders as an actionable toast in `ResourceEditPage` (before the generic field-validation branch).
- `CreatePackageDialog` is exported from `PackagesPage` for reuse.

## Why

Pairs with the kernel enforcement (framework ADR-0070 D1/D2) so a user authoring in Studio never orphans a new item or lands it in a read-only code package. See `docs/adr/0070-package-first-authoring.md`.

## Verification

- `@object-ui/app-shell`: `tsc` clean; 418 metadata-admin tests + 4 new `package-scope` tests green.
- Follow-up (tracked): same gate on `StudioHomePage` quick-create + browser dogfood of the full create→base→publish→still-editable flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)