### PR TITLE
feat(studio): on-canvas validation badges + Problems panel for the flow builder

### DIFF
--- a/.changeset/flow-validation-badges.md
+++ b/.changeset/flow-validation-badges.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(studio): on-canvas validation badges + a Problems panel for the flow builder
+
+Flow validation only surfaced as a top banner ("…N error(s)") that didn't point
+to the offending element — in a non-trivial flow you couldn't tell *which* node
+or edge was wrong. The simulator's `validateFlowDraft` already detected the
+structural problems (no resolvable entry, unreachable nodes, a decision with no
+default branch, duplicate node ids, dangling edges, un-declared cycles); they
+just weren't shown on the canvas. This was a surfacing gap, not a detection one.
+
+The flow preview now:
+
+- renders an error / warning **badge** on each offending node and edge, with the
+  issue message(s) as its tooltip;
+- adds a **Problems panel** listing every issue (structural + the server
+  `_diagnostics` already attached to the layered record); clicking a row selects
+  and reveals (pans to) the node/edge;
+- clears badges + rows as issues are resolved (everything derives from the live
+  draft).
+
+`validateFlowDraft` now tags dangling-edge errors with their endpoints so they
+key to the offending connection, and a new `flow-problems` module maps both
+sources onto concrete canvas elements (node id / stable edge key). Server
+diagnostics reach the preview through a new optional `diagnostics` prop on
+`MetadataPreviewProps`.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -431,6 +431,29 @@ function MetadataResourceEditPageImpl({
     () => (createMode && !createDirty ? [] : issues),
     [createMode, createDirty, issues],
   );
+  // Server-computed diagnostics handed to a canvas Preview (e.g. the flow
+  // Problems panel + on-canvas badges). Errors prefer the live client-side Zod
+  // issues when a client validator exists (so they track every keystroke);
+  // warnings stay server-sourced. Mirrors the read-only banner's source
+  // selection, flattened to a path-keyed, severity-tagged list.
+  const previewDiagnostics = React.useMemo<
+    Array<{ path?: string; message: string; severity: 'error' | 'warning' }>
+  >(() => {
+    const diag = (layered as any)?._diagnostics as
+      | { errors?: Array<{ path: string; message: string }>; warnings?: Array<{ path: string; message: string }> }
+      | undefined;
+    const errs = hasClientValidator(type)
+      ? displayIssues.map((i) => ({ path: i.path, message: translateValidationMessage(i.message, locale) }))
+      : (diag?.errors ?? []).map((i) => ({ path: i.path, message: translateValidationMessage(i.message, locale) }));
+    const warns = (diag?.warnings ?? []).map((i) => ({
+      path: i.path,
+      message: translateValidationMessage(i.message, locale),
+    }));
+    return [
+      ...errs.map((e) => ({ path: e.path || undefined, message: e.message, severity: 'error' as const })),
+      ...warns.map((w) => ({ path: w.path || undefined, message: w.message, severity: 'warning' as const })),
+    ];
+  }, [layered, displayIssues, type, locale]);
   // Per-item draft pending publish (mode=draft saves land here).
   // When non-null, the editor is "viewing the draft" and we surface
   // Publish / Discard-draft actions.
@@ -2087,6 +2110,7 @@ function MetadataResourceEditPageImpl({
                           selection={previewOnly ? null : selection}
                           onSelectionChange={setSelection}
                           locale={locale}
+                          diagnostics={previewDiagnostics}
                           onPatch={(patch) =>
                             handleDraftChange((d) => ({ ...(d as Record<string, unknown>), ...patch }))
                           }

--- a/packages/app-shell/src/views/metadata-admin/preview-registry.ts
+++ b/packages/app-shell/src/views/metadata-admin/preview-registry.ts
@@ -89,6 +89,14 @@ export interface MetadataPreviewProps {
    * "click widget → edit widget in the right panel" pattern.
    */
   onSelectionChange?: (selection: MetadataSelection | null) => void;
+  /**
+   * Optional: server-computed validation diagnostics for the current draft
+   * (the layered record's `_diagnostics`, kept in sync with live client-side
+   * issues). Each entry carries a dotted JSON path so a preview can map it onto
+   * the offending sub-element. Used by the flow preview's Problems panel +
+   * on-canvas badges; ignored by previews that don't surface diagnostics.
+   */
+  diagnostics?: Array<{ path?: string; message: string; severity?: 'error' | 'warning' }>;
 }
 
 export type MetadataPreview = ComponentType<MetadataPreviewProps>;

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -22,13 +22,15 @@
  */
 
 import * as React from 'react';
-import { AlertTriangle, Maximize2, Plus, ZoomIn, ZoomOut } from 'lucide-react';
+import { AlertCircle, AlertTriangle, Maximize2, Plus, ZoomIn, ZoomOut } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import { uniqueId, appendArray, spliceArray } from '../inspectors/_shared';
 import { t as tr } from '../i18n';
 import {
   computeLayout,
   diagramSize,
+  NODE_W,
+  NODE_H,
   bottomAnchor,
   topAnchor,
   rightAnchor,
@@ -45,6 +47,7 @@ import {
 } from './flow-canvas-layout';
 import { NodeCard, NodePalette, defaultNodeLabel, defaultNodeExtras } from './flow-canvas-parts';
 import { useFlowNodePalette } from './useFlowNodePalette';
+import { indexProblemBadges, edgeProblemKey, type FlowProblem } from './flow-problems';
 
 const MIN_ZOOM = 0.4;
 const MAX_ZOOM = 1.6;
@@ -87,6 +90,17 @@ export interface FlowCanvasProps {
   invalidEdges?: ReadonlySet<string>;
   /** Structural-validation error messages shown in an inline canvas banner. */
   validationErrors?: string[];
+  /**
+   * Unified validation issues (structural + server) rendered as per-element
+   * badges; the Problems panel shares the same list.
+   */
+  problems?: FlowProblem[];
+  /**
+   * Imperative "reveal" request from the Problems panel: when `nonce` changes
+   * the canvas pans to center the targeted node/edge. Selection highlight is
+   * driven separately via `selectedId` / `selectedEdgeId`.
+   */
+  revealSignal?: { target: FlowProblem['target']; nonce: number } | null;
   onSelect: (node: FlowNode | null) => void;
   /** Select an edge (its `edgeKey`), or clear selection with `null`. */
   onSelectEdge?: (edge: FlowEdge | null, key: string) => void;
@@ -107,6 +121,8 @@ export function FlowCanvas({
   invalidNodeIds,
   invalidEdges,
   validationErrors,
+  problems,
+  revealSignal,
   onSelect,
   onSelectEdge,
   onPatch,
@@ -135,6 +151,14 @@ export function FlowCanvas({
   const traversedSet = React.useMemo(() => new Set(traversedEdgeIds ?? []), [traversedEdgeIds]);
   const invalidNodeSet = React.useMemo(() => new Set(invalidNodeIds ?? []), [invalidNodeIds]);
   const simRunning = (visitedNodeIds?.length ?? 0) > 0 || !!activeNodeId;
+
+  // Per-element validation badges (errors dominate warnings on the same
+  // element). Derived from the live `problems` list so badges clear as issues
+  // are resolved.
+  const { byNode: nodeBadges, byEdge: edgeBadges } = React.useMemo(
+    () => indexProblemBadges(problems ?? []),
+    [problems],
+  );
 
   const positionOf = React.useCallback(
     (id: string): Point => {
@@ -384,6 +408,26 @@ export function FlowCanvas({
     });
   }, [size.height, size.width]);
 
+  // Pan to center an element when the Problems panel asks to reveal it. Driven
+  // by a changing `nonce` so re-clicking the same problem re-centers it.
+  React.useEffect(() => {
+    if (!revealSignal) return;
+    const vp = viewportRef.current;
+    if (!vp) return;
+    const t = revealSignal.target;
+    let pt: Point | null = null;
+    if (t.kind === 'node') {
+      const p = layout.get(t.nodeId);
+      if (p) pt = { x: p.x + NODE_W / 2, y: p.y + NODE_H / 2 };
+    } else if (t.kind === 'edge') {
+      const s = layout.get(t.source);
+      const d = layout.get(t.target);
+      if (s && d) pt = { x: (s.x + d.x) / 2 + NODE_W / 2, y: (s.y + d.y) / 2 + NODE_H / 2 };
+    }
+    if (pt) setPan({ x: vp.clientWidth / 2 - pt.x * zoom, y: vp.clientHeight / 2 - pt.y * zoom });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revealSignal?.nonce]);
+
   // ── Keyboard: delete selected node ─────────────────────────────────────────
 
   const onKeyDown = React.useCallback(
@@ -582,6 +626,7 @@ export function FlowCanvas({
               const cond = conditionText(edge.condition);
               const branchLabel = edge.isDefault ? 'else' : cond ? `if ${cond}` : edge.label;
               const eid = edgeKey(edge, i);
+              const edgeBadge = edgeBadges.get(edgeProblemKey(edge.source, edge.target));
               const traversed = traversedSet.has(eid);
               const selected = selectedEdgeId === eid;
               const d = back ? backEdgePath(from, to) : edgePath(from, to);
@@ -655,6 +700,32 @@ export function FlowCanvas({
                       </div>
                     </foreignObject>
                   )}
+                  {edgeBadge && (
+                    <foreignObject
+                      x={labelPos.x - 9}
+                      y={labelPos.y - 30}
+                      width={18}
+                      height={18}
+                      className="pointer-events-auto overflow-visible"
+                    >
+                      <span
+                        title={edgeBadge.title}
+                        data-problem={edgeBadge.level}
+                        className={cn(
+                          'inline-flex h-[18px] w-[18px] items-center justify-center rounded-full border bg-background shadow-sm',
+                          edgeBadge.level === 'error'
+                            ? 'border-destructive/50 text-destructive'
+                            : 'border-amber-500/50 text-amber-600 dark:text-amber-400',
+                        )}
+                      >
+                        {edgeBadge.level === 'error' ? (
+                          <AlertCircle className="h-3 w-3" />
+                        ) : (
+                          <AlertTriangle className="h-3 w-3" />
+                        )}
+                      </span>
+                    </foreignObject>
+                  )}
                   {editable && !back && (
                     <foreignObject
                       // Sit the insert handle at the edge midpoint, but slide it
@@ -710,6 +781,7 @@ export function FlowCanvas({
                     : undefined
                 }
                 invalid={invalidNodeSet.has(node.id)}
+                badge={nodeBadges.get(node.id)}
               />
             );
           })}

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -20,6 +20,7 @@
 
 import * as React from 'react';
 import {
+  AlertCircle,
   Bug,
   CircleDot,
   GitBranch,
@@ -40,6 +41,8 @@ import { FlowSimulatorPanel } from './FlowSimulatorPanel';
 import { FlowRunsPanel } from './FlowRunsPanel';
 import { validateFlowDraft } from './simulator/flow-sim-validate';
 import type { SimEdge, SimNode } from './simulator/flow-sim-types';
+import { ProblemsPanel } from './ProblemsPanel';
+import { buildFlowProblems, type FlowProblem } from './flow-problems';
 
 interface FlowNode {
   id: string;
@@ -69,7 +72,7 @@ interface FlowVariable {
   isOutput?: boolean;
 }
 
-export function FlowPreview({ draft, editing, selection, onSelectionChange, onPatch, locale }: MetadataPreviewProps) {
+export function FlowPreview({ draft, editing, selection, onSelectionChange, onPatch, locale, diagnostics }: MetadataPreviewProps) {
   const d = draft as Record<string, unknown>;
   // Memoized so hook deps (validation memo, handleAddNode) get a stable array
   // reference across renders instead of a fresh `[]`/cast each time.
@@ -85,6 +88,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
   const [showDebug, setShowDebug] = React.useState(false);
   const [showVars, setShowVars] = React.useState(true);
   const [showRuns, setShowRuns] = React.useState(false);
+  const [showProblems, setShowProblems] = React.useState(false);
   const [runHL, setRunHL] = React.useState<{
     activeNodeId: string | null;
     visitedNodeIds: string[];
@@ -115,6 +119,34 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
       validationErrors: v.errors.map((diag) => diag.message),
     };
   }, [nodes, edges]);
+
+  // Unified problem list (structural + server `_diagnostics`) shared by the
+  // on-canvas badges and the Problems panel. Recomputed from the live draft so
+  // badges + rows clear as the author fixes each issue.
+  const problems = React.useMemo<FlowProblem[]>(
+    () => buildFlowProblems({ nodes, edges, serverDiagnostics: diagnostics }),
+    [nodes, edges, diagnostics],
+  );
+  const errorCount = problems.filter((p) => p.level === 'error').length;
+
+  // "Reveal" handshake with the canvas: a changing nonce pans to the element.
+  const [reveal, setReveal] = React.useState<{ target: FlowProblem['target']; nonce: number } | null>(null);
+  const selectedKey = selectedId ? `node:${selectedId}` : (selectedEdgeId ?? null);
+  const handleSelectProblem = React.useCallback(
+    (p: FlowProblem) => {
+      if (p.target.kind === 'node') {
+        // Destructure before the .find() closure — TS drops the union narrowing
+        // of `p.target` inside a nested callback, so capture nodeId as a string.
+        const { nodeId } = p.target;
+        const node = nodes.find((n) => n.id === nodeId);
+        onSelectionChange?.({ kind: 'node', id: nodeId, label: node?.label || nodeId });
+      } else if (p.target.kind === 'edge') {
+        onSelectionChange?.({ kind: 'edge', id: p.target.edgeKey, label: `${p.target.source} → ${p.target.target}` });
+      }
+      setReveal((r) => ({ target: p.target, nonce: (r?.nonce ?? 0) + 1 }));
+    },
+    [nodes, onSelectionChange],
+  );
 
   const handleAddNode = React.useCallback(() => {
     if (!canEdit) return;
@@ -162,7 +194,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
       <PreviewErrorBoundary fallbackHint="One of the flow nodes or edges is malformed.">
         <div className={
           'grid gap-0 h-full min-h-[440px] ' +
-          (showDebug || showVars || showRuns ? 'lg:grid-cols-[1fr_240px]' : 'grid-cols-1')
+          (showDebug || showVars || showRuns || showProblems ? 'lg:grid-cols-[1fr_240px]' : 'grid-cols-1')
         }>
           {/* Visual canvas */}
           <div className="flex flex-col min-w-0 min-h-0">
@@ -173,7 +205,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
               {version && <Pill label="v" value={version} />}
               {errorStrategy && <Pill icon={GitBranch} label="On error" value={errorStrategy} />}
               <div className="ml-auto flex items-center gap-1.5">
-                {!showDebug && !showRuns && (
+                {!showDebug && !showRuns && !showProblems && (
                   <button
                     type="button"
                     onClick={() => setShowVars((v) => !v)}
@@ -194,6 +226,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                     onClick={() => {
                       setShowRuns((v) => !v);
                       setShowDebug(false);
+                      setShowProblems(false);
                     }}
                     className={
                       'inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] font-medium transition-colors ' +
@@ -209,8 +242,36 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                 <button
                   type="button"
                   onClick={() => {
+                    setShowProblems((v) => !v);
+                    setShowDebug(false);
+                    setShowRuns(false);
+                  }}
+                  className={
+                    'inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] font-medium transition-colors ' +
+                    (showProblems
+                      ? 'border-rose-500 bg-rose-50 text-rose-700'
+                      : 'border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground')
+                  }
+                  title="Validation problems"
+                >
+                  <AlertCircle className="h-3 w-3" /> Problems
+                  {problems.length > 0 && (
+                    <span
+                      className={
+                        'ml-0.5 inline-flex min-w-[16px] items-center justify-center rounded-full px-1 text-[10px] font-semibold ' +
+                        (errorCount > 0 ? 'bg-destructive/15 text-destructive' : 'bg-amber-500/15 text-amber-600')
+                      }
+                    >
+                      {problems.length}
+                    </span>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
                     setShowDebug((v) => !v);
                     setShowRuns(false);
+                    setShowProblems(false);
                   }}
                   className={
                     'inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] font-medium transition-colors ' +
@@ -238,6 +299,8 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                 invalidNodeIds={invalidNodeIds}
                 invalidEdges={invalidEdges}
                 validationErrors={validationErrors}
+                problems={problems}
+                revealSignal={reveal}
                 onSelect={(n) =>
                   n
                     ? onSelectionChange?.({ kind: 'node', id: n.id, label: n.label || n.id })
@@ -256,7 +319,15 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
           {/* Right side panel: Variables (default), the debug simulator, or
               the engine run history. Collapsible so the canvas can use the
               full width. */}
-          {showDebug ? (
+          {showProblems ? (
+            <div className="border-l bg-muted/20">
+              <ProblemsPanel
+                problems={problems}
+                selectedKey={selectedKey}
+                onSelectProblem={handleSelectProblem}
+              />
+            </div>
+          ) : showDebug ? (
             <div className="border-l bg-muted/20">
               <FlowSimulatorPanel
                 nodes={nodes}

--- a/packages/app-shell/src/views/metadata-admin/previews/ProblemsPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ProblemsPanel.tsx
@@ -1,0 +1,103 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ProblemsPanel — lists every structural + server validation issue for the
+ * flow draft. Each row shows the severity icon and the message; clicking a row
+ * selects and reveals (pans to) the offending node/edge on the canvas. Mirrors
+ * the "Problems" tab of an IDE / the error panel in Salesforce Flow Builder.
+ *
+ * Pure presentation: the issue list is derived upstream (see `flow-problems`)
+ * from the live draft, so rows clear as the author fixes each problem.
+ */
+
+import * as React from 'react';
+import { AlertCircle, AlertTriangle, CheckCircle2, CircleDot, GitBranch } from 'lucide-react';
+import { cn } from '@object-ui/components';
+import type { FlowProblem } from './flow-problems';
+
+export interface ProblemsPanelProps {
+  problems: FlowProblem[];
+  /** Selected element key (`node:<id>` or an edge's `edgeKey`) to highlight matching rows. */
+  selectedKey?: string | null;
+  onSelectProblem: (problem: FlowProblem) => void;
+}
+
+function targetLabel(p: FlowProblem): string {
+  if (p.target.kind === 'node') return p.target.nodeId;
+  if (p.target.kind === 'edge') return `${p.target.source} → ${p.target.target}`;
+  return 'flow';
+}
+
+export function ProblemsPanel({ problems, selectedKey, onSelectProblem }: ProblemsPanelProps) {
+  const errorCount = problems.filter((p) => p.level === 'error').length;
+  const warningCount = problems.length - errorCount;
+
+  return (
+    <div className="flex h-full flex-col text-xs">
+      <div className="flex items-center gap-2 border-b px-3 py-2 font-medium text-muted-foreground">
+        <span>Problems</span>
+        {errorCount > 0 && (
+          <span className="inline-flex items-center gap-1 text-destructive">
+            <AlertCircle className="h-3 w-3" /> {errorCount}
+          </span>
+        )}
+        {warningCount > 0 && (
+          <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+            <AlertTriangle className="h-3 w-3" /> {warningCount}
+          </span>
+        )}
+      </div>
+      {problems.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-1.5 p-4 text-center text-muted-foreground">
+          <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+          <span>No problems — this flow is structurally valid.</span>
+        </div>
+      ) : (
+        <ul className="flex-1 overflow-auto p-1.5">
+          {problems.map((p) => {
+            const isEdge = p.target.kind === 'edge';
+            const isFlow = p.target.kind === 'flow';
+            const key =
+              p.target.kind === 'node'
+                ? `node:${p.target.nodeId}`
+                : p.target.kind === 'edge'
+                  ? p.target.edgeKey
+                  : null;
+            const active = !!key && key === selectedKey;
+            const Icon = p.level === 'error' ? AlertCircle : AlertTriangle;
+            const TargetIcon = isEdge ? GitBranch : CircleDot;
+            return (
+              <li key={p.id}>
+                <button
+                  type="button"
+                  disabled={isFlow}
+                  onClick={() => onSelectProblem(p)}
+                  className={cn(
+                    'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors',
+                    isFlow ? 'cursor-default' : 'cursor-pointer hover:bg-accent',
+                    active && 'bg-accent ring-1 ring-primary/40',
+                  )}
+                >
+                  <Icon
+                    className={cn(
+                      'mt-0.5 h-3.5 w-3.5 shrink-0',
+                      p.level === 'error' ? 'text-destructive' : 'text-amber-500',
+                    )}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block leading-snug text-foreground">{p.message}</span>
+                    <span className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground">
+                      <TargetIcon className="h-2.5 w-2.5 shrink-0" />
+                      <span className="truncate font-mono">{targetLabel(p)}</span>
+                      {p.source === 'server' && <span className="uppercase tracking-wide">· schema</span>}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -8,6 +8,8 @@
 
 import * as React from 'react';
 import {
+  AlertCircle,
+  AlertTriangle,
   Code,
   CircleDot,
   CircleStop,
@@ -383,6 +385,11 @@ export interface NodeCardProps {
   dimmed?: boolean;
   /** Structural-validation error highlight (e.g. part of an un-declared cycle). */
   invalid?: boolean;
+  /**
+   * Validation badge shown at the card's top-right corner (error or warning),
+   * with the issue message(s) as its tooltip. Cleared when the issue resolves.
+   */
+  badge?: { level: 'error' | 'warning'; title: string };
   onPointerDown?: (e: React.PointerEvent) => void;
   onSelect?: () => void;
   onAppend?: () => void;
@@ -409,6 +416,7 @@ export function NodeCard({
   runState,
   dimmed,
   invalid,
+  badge,
   onPointerDown,
   onSelect,
   onAppend,
@@ -482,6 +490,24 @@ export function NodeCard({
           </div>
         </div>
       </div>
+      {badge && (
+        <span
+          title={badge.title}
+          data-problem={badge.level}
+          className={cn(
+            'absolute -right-2 -top-2 z-20 inline-flex h-5 w-5 items-center justify-center rounded-full border bg-background shadow-sm',
+            badge.level === 'error'
+              ? 'border-destructive/50 text-destructive'
+              : 'border-amber-500/50 text-amber-600 dark:text-amber-400',
+          )}
+        >
+          {badge.level === 'error' ? (
+            <AlertCircle className="h-3 w-3" />
+          ) : (
+            <AlertTriangle className="h-3 w-3" />
+          )}
+        </span>
+      )}
       {editable && type !== 'end' && (
         <button
           type="button"

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-problems.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-problems.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { validateFlowDraft } from './simulator/flow-sim-validate';
+import { buildFlowProblems, indexProblemBadges } from './flow-problems';
+
+describe('validateFlowDraft — per-element keying', () => {
+  it('attaches the edge endpoints to a dangling-edge error', () => {
+    const v = validateFlowDraft([{ id: 'a', type: 'start' }], [{ source: 'a', target: 'ghost' }]);
+    const dangling = v.errors.find((e) => e.message.includes('target "ghost"'));
+    expect(dangling?.edge).toEqual({ source: 'a', target: 'ghost' });
+  });
+});
+
+describe('buildFlowProblems — structural mapping', () => {
+  it('maps a duplicate node id to a node target', () => {
+    const problems = buildFlowProblems({
+      nodes: [
+        { id: 'a', type: 'start' },
+        { id: 'a', type: 'end' },
+      ],
+      edges: [],
+    });
+    const dup = problems.find((p) => p.message.includes('Duplicate node id'));
+    expect(dup?.target).toEqual({ kind: 'node', nodeId: 'a' });
+    expect(dup?.level).toBe('error');
+    expect(dup?.source).toBe('structural');
+  });
+
+  it('maps a dangling edge to an edge target with a resolved edge key', () => {
+    const problems = buildFlowProblems({
+      nodes: [{ id: 'a', type: 'start' }],
+      edges: [{ id: 'e1', source: 'a', target: 'ghost' }],
+    });
+    const dangling = problems.find((p) => p.message.includes('"ghost"'));
+    expect(dangling?.target).toMatchObject({ kind: 'edge', source: 'a', target: 'ghost', edgeKey: 'e1' });
+  });
+
+  it('points an un-declared cycle at the closing edge', () => {
+    // a → b → a; the b→a hop closes the loop.
+    const problems = buildFlowProblems({
+      nodes: [
+        { id: 'a', type: 'decision' },
+        { id: 'b', type: 'create_record' },
+      ],
+      edges: [
+        { source: 'a', target: 'b' },
+        { source: 'b', target: 'a' },
+      ],
+    });
+    const cycle = problems.find((p) => p.message.includes('Cycle detected'));
+    expect(cycle?.target).toMatchObject({ kind: 'edge', source: 'b', target: 'a' });
+  });
+
+  it('maps a missing-default decision warning to its node', () => {
+    const problems = buildFlowProblems({
+      nodes: [
+        { id: 's', type: 'start' },
+        { id: 'd', type: 'decision' },
+        { id: 'x', type: 'end' },
+        { id: 'y', type: 'end' },
+      ],
+      edges: [
+        { source: 's', target: 'd' },
+        { source: 'd', target: 'x', condition: 'a > 1' },
+        { source: 'd', target: 'y', condition: 'a < 0' },
+      ],
+    });
+    const warn = problems.find((p) => p.level === 'warning' && p.message.includes('no default branch'));
+    expect(warn?.target).toEqual({ kind: 'node', nodeId: 'd' });
+  });
+
+  it('keeps a no-entry error as a flow-level problem', () => {
+    const problems = buildFlowProblems({
+      nodes: [
+        { id: 'a', type: 'create_record' },
+        { id: 'b', type: 'create_record' },
+      ],
+      // fully cyclic → no entry node; that error has no specific element.
+      edges: [
+        { source: 'a', target: 'b' },
+        { source: 'b', target: 'a' },
+      ],
+    });
+    const noEntry = problems.find((p) => p.message.toLowerCase().includes('entry'));
+    expect(noEntry?.target).toEqual({ kind: 'flow' });
+  });
+
+  it('lists errors before warnings', () => {
+    const problems = buildFlowProblems({
+      nodes: [
+        { id: 'a', type: 'start' },
+        { id: 'a', type: 'decision' },
+      ],
+      edges: [],
+    });
+    const levels = problems.map((p) => p.level);
+    expect(levels).toEqual([...levels].sort((x, y) => (x === y ? 0 : x === 'error' ? -1 : 1)));
+  });
+});
+
+describe('buildFlowProblems — server diagnostics', () => {
+  const nodes = [
+    { id: 's', type: 'start' },
+    { id: 'task', type: 'create_record' },
+  ];
+  const edges = [{ id: 'e1', source: 's', target: 'task' }];
+
+  it('maps a nodes.<i> path to the node', () => {
+    const problems = buildFlowProblems({
+      nodes,
+      edges,
+      serverDiagnostics: [{ path: 'nodes.1.config.objectName', message: 'Required', severity: 'error' }],
+    });
+    const p = problems.find((x) => x.source === 'server');
+    expect(p?.target).toEqual({ kind: 'node', nodeId: 'task' });
+    expect(p?.level).toBe('error');
+  });
+
+  it('maps an edges.<i> path (array form) to the edge', () => {
+    const problems = buildFlowProblems({
+      nodes,
+      edges,
+      serverDiagnostics: [{ path: ['edges', 0, 'target'], message: 'bad', severity: 'warning' }],
+    });
+    const p = problems.find((x) => x.source === 'server');
+    expect(p?.target).toMatchObject({ kind: 'edge', source: 's', target: 'task', edgeKey: 'e1' });
+    expect(p?.level).toBe('warning');
+  });
+
+  it('falls back to flow-level for an unmappable path (default severity error)', () => {
+    const problems = buildFlowProblems({
+      nodes,
+      edges,
+      serverDiagnostics: [{ path: 'name', message: 'flow name required' }],
+    });
+    const p = problems.find((x) => x.source === 'server');
+    expect(p?.target).toEqual({ kind: 'flow' });
+    expect(p?.level).toBe('error');
+  });
+});
+
+describe('indexProblemBadges', () => {
+  it('returns empty maps for no problems', () => {
+    const idx = indexProblemBadges([]);
+    expect(idx.byNode.size).toBe(0);
+    expect(idx.byEdge.size).toBe(0);
+  });
+
+  it('folds error over warning on the same element', () => {
+    const problems = buildFlowProblems({
+      nodes: [
+        { id: 's', type: 'start' },
+        { id: 'd', type: 'decision' },
+      ],
+      edges: [{ source: 's', target: 'd' }],
+      serverDiagnostics: [{ path: 'nodes.1.config', message: 'bad config', severity: 'error' }],
+    });
+    const { byNode } = indexProblemBadges(problems);
+    expect(byNode.get('d')?.level).toBe('error');
+    expect(byNode.get('d')?.count).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-problems.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-problems.ts
@@ -1,0 +1,206 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * flow-problems — unify the two flow-validation sources into one flat,
+ * per-element issue list that the canvas badges and the Problems panel both
+ * render.
+ *
+ *   1. `validateFlowDraft` (client, structural): no resolvable entry,
+ *      unreachable nodes, a decision with no default branch, duplicate node
+ *      ids, dangling edges, un-declared cycles.
+ *   2. The server `_diagnostics` already attached to the layered record
+ *      (schema validation), each keyed by a dotted JSON path.
+ *
+ * "Surfacing, not detection": detection already exists. This module only maps
+ * each detected issue onto a concrete canvas element — a node id or a stable
+ * edge key — so a badge can sit on the offending element and a Problems-panel
+ * row can select + reveal it. Flow-level issues (no specific element) are kept
+ * too: listed in the panel, but without a badge.
+ */
+
+import { validateFlowDraft } from './simulator/flow-sim-validate';
+import type { Diagnostic, DiagnosticLevel, SimEdge, SimNode } from './simulator/flow-sim-types';
+import { edgeKey, type FlowEdge, type FlowNode } from './flow-canvas-layout';
+
+/** What a problem points at on the canvas — drives badge placement + reveal. */
+export type FlowProblemTarget =
+  | { kind: 'node'; nodeId: string }
+  | { kind: 'edge'; edgeKey: string; source: string; target: string }
+  | { kind: 'flow' };
+
+/** Origin of a problem — labels the panel row and lets the UI group counts. */
+export type FlowProblemSource = 'structural' | 'server';
+
+/** One actionable issue, resolved onto a concrete canvas element. */
+export interface FlowProblem {
+  /** Stable-enough key for React lists. */
+  id: string;
+  level: DiagnosticLevel;
+  message: string;
+  target: FlowProblemTarget;
+  source: FlowProblemSource;
+}
+
+/** A server diagnostic entry (subset of the layered record's `_diagnostics`). */
+export interface ServerDiagnostic {
+  /** Dotted (or array) JSON path, e.g. `nodes.2.config.objectName`. */
+  path?: string | Array<string | number>;
+  message: string;
+  /** Defaults to `'error'`. */
+  severity?: DiagnosticLevel;
+}
+
+/** Stable `source->target` key matching an edge problem to a rendered edge. */
+export function edgeProblemKey(source: string, target: string): string {
+  return `${source}->${target}`;
+}
+
+/** Resolve an edge's selection key (`edgeKey`) from its endpoints. */
+function resolveEdgeKey(edges: FlowEdge[], source: string, target: string): string {
+  const idx = edges.findIndex((e) => e.source === source && e.target === target);
+  return idx >= 0 ? edgeKey(edges[idx], idx) : `${source}->${target}#-1`;
+}
+
+/** Normalize a dotted/array JSON path to segments (numbers stay numeric). */
+function pathSegments(path: ServerDiagnostic['path']): Array<string | number> {
+  if (Array.isArray(path)) return path;
+  if (typeof path !== 'string' || !path) return [];
+  return path.split('.').map((seg) => {
+    const n = Number(seg);
+    return Number.isInteger(n) && String(n) === seg ? n : seg;
+  });
+}
+
+/**
+ * Map a structural diagnostic's optional anchors (`edge`, `cycle`, `nodeId`)
+ * onto a single canvas target. A cycle points at the *closing* hop — the edge
+ * the author marks as a back-edge to resolve it.
+ */
+function structuralTarget(diag: Diagnostic, edges: FlowEdge[]): FlowProblemTarget {
+  if (diag.edge) {
+    const { source, target } = diag.edge;
+    return { kind: 'edge', source, target, edgeKey: resolveEdgeKey(edges, source, target) };
+  }
+  if (diag.cycle && diag.cycle.length >= 2) {
+    const source = diag.cycle[diag.cycle.length - 2];
+    const target = diag.cycle[diag.cycle.length - 1];
+    return { kind: 'edge', source, target, edgeKey: resolveEdgeKey(edges, source, target) };
+  }
+  if (diag.nodeId) return { kind: 'node', nodeId: diag.nodeId };
+  return { kind: 'flow' };
+}
+
+/** Map a server diagnostic's JSON path onto a node/edge/flow target. */
+function serverTarget(path: ServerDiagnostic['path'], nodes: FlowNode[], edges: FlowEdge[]): FlowProblemTarget {
+  const segs = pathSegments(path);
+  if (segs.length >= 2 && typeof segs[1] === 'number') {
+    const idx = segs[1];
+    if (segs[0] === 'nodes' && nodes[idx]?.id) return { kind: 'node', nodeId: nodes[idx].id };
+    if (segs[0] === 'edges' && edges[idx]) {
+      const e = edges[idx];
+      return { kind: 'edge', source: e.source, target: e.target, edgeKey: edgeKey(e, idx) };
+    }
+  }
+  return { kind: 'flow' };
+}
+
+/** Short stable token for a target, used in a problem's React key. */
+function targetKey(t: FlowProblemTarget): string {
+  if (t.kind === 'node') return `n:${t.nodeId}`;
+  if (t.kind === 'edge') return `e:${t.source}->${t.target}`;
+  return 'flow';
+}
+
+export interface BuildFlowProblemsArgs {
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+  /** Server `_diagnostics`, flattened to a severity-tagged, path-keyed list. */
+  serverDiagnostics?: ServerDiagnostic[];
+}
+
+/**
+ * Build the unified problem list from structural validation + server
+ * diagnostics. Errors are listed before warnings; within a level each source
+ * keeps its own emit order (structural before server).
+ */
+export function buildFlowProblems({ nodes, edges, serverDiagnostics }: BuildFlowProblemsArgs): FlowProblem[] {
+  const problems: FlowProblem[] = [];
+
+  const v = validateFlowDraft(nodes as unknown as SimNode[], edges as unknown as SimEdge[]);
+  const pushStructural = (level: DiagnosticLevel, list: Diagnostic[]) => {
+    list.forEach((diag, i) => {
+      const target = structuralTarget(diag, edges);
+      problems.push({
+        id: `structural:${level}:${i}:${targetKey(target)}`,
+        level,
+        message: diag.message,
+        target,
+        source: 'structural',
+      });
+    });
+  };
+  pushStructural('error', v.errors);
+  pushStructural('warning', v.warnings);
+
+  (serverDiagnostics ?? []).forEach((diag, i) => {
+    const level: DiagnosticLevel = diag.severity === 'warning' ? 'warning' : 'error';
+    const target = serverTarget(diag.path, nodes, edges);
+    problems.push({
+      id: `server:${i}:${targetKey(target)}`,
+      level,
+      message: diag.message,
+      target,
+      source: 'server',
+    });
+  });
+
+  // Errors first so the panel + counts lead with blockers (stable within level).
+  return problems
+    .map((p, i) => [p, i] as const)
+    .sort((a, b) => {
+      if (a[0].level !== b[0].level) return a[0].level === 'error' ? -1 : 1;
+      return a[1] - b[1];
+    })
+    .map(([p]) => p);
+}
+
+/** A folded badge for one canvas element (errors dominate warnings). */
+export interface ProblemBadge {
+  level: DiagnosticLevel;
+  /** Tooltip text — each problem message on its own line. */
+  title: string;
+  count: number;
+}
+
+function foldBadge(list: FlowProblem[]): ProblemBadge {
+  const level: DiagnosticLevel = list.some((p) => p.level === 'error') ? 'error' : 'warning';
+  return { level, title: list.map((p) => p.message).join('\n'), count: list.length };
+}
+
+export interface ProblemIndex {
+  byNode: Map<string, ProblemBadge>;
+  byEdge: Map<string, ProblemBadge>;
+}
+
+/** Group problems into per-node / per-edge badges for the canvas overlay. */
+export function indexProblemBadges(problems: FlowProblem[]): ProblemIndex {
+  const nodeLists = new Map<string, FlowProblem[]>();
+  const edgeLists = new Map<string, FlowProblem[]>();
+  for (const p of problems) {
+    if (p.target.kind === 'node') {
+      const l = nodeLists.get(p.target.nodeId) ?? [];
+      l.push(p);
+      nodeLists.set(p.target.nodeId, l);
+    } else if (p.target.kind === 'edge') {
+      const k = edgeProblemKey(p.target.source, p.target.target);
+      const l = edgeLists.get(k) ?? [];
+      l.push(p);
+      edgeLists.set(k, l);
+    }
+  }
+  const byNode = new Map<string, ProblemBadge>();
+  for (const [id, list] of nodeLists) byNode.set(id, foldBadge(list));
+  const byEdge = new Map<string, ProblemBadge>();
+  for (const [k, list] of edgeLists) byEdge.set(k, foldBadge(list));
+  return { byNode, byEdge };
+}

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-types.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-types.ts
@@ -89,7 +89,13 @@ export type DiagnosticLevel = 'error' | 'warning';
 
 export interface Diagnostic {
   level: DiagnosticLevel;
+  /** The node this diagnostic points at (for an inline badge + click-to-reveal). */
   nodeId?: string;
+  /**
+   * The edge this diagnostic points at (e.g. a dangling endpoint). Carries the
+   * endpoints so the designer can key the inline badge by `source->target`.
+   */
+  edge?: { source: string; target: string };
   message: string;
   /**
    * For a cycle error: the node path that closes the loop (e.g. `['a','b','a']`),

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-validate.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-validate.ts
@@ -109,8 +109,12 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValid
   }
 
   for (const e of edges) {
-    if (!idSet.has(e.source)) errors.push({ level: 'error', message: `Edge source "${e.source}" does not exist.` });
-    if (!idSet.has(e.target)) errors.push({ level: 'error', message: `Edge target "${e.target}" does not exist.` });
+    // Attach the endpoints so a dangling-edge error can badge the offending
+    // connection on the canvas (not just appear as a flow-level message).
+    if (!idSet.has(e.source))
+      errors.push({ level: 'error', edge: { source: e.source, target: e.target }, message: `Edge source "${e.source}" does not exist.` });
+    if (!idSet.has(e.target))
+      errors.push({ level: 'error', edge: { source: e.source, target: e.target }, message: `Edge target "${e.target}" does not exist.` });
   }
 
   // Entry resolution: prefer an explicit `start` node, else a node with no


### PR DESCRIPTION
Implements #1945 — on-canvas validation badges + a Problems panel for the Studio flow builder.

## Problem
Flow validation surfaced only as a top banner ("…N error(s)") that didn't point to the offending node/edge. Detection already existed in the simulator's `validateFlowDraft`; this was a **surfacing** gap, not a detection one.

## What's in this PR
- **Per-node / per-edge badges** — an error/warning icon on each offending element, with the issue message(s) in its tooltip.
- **Problems panel** — lists every issue; clicking a row selects + reveals (pans to) the node/edge.
- **Two sources, one list** — structural (`validateFlowDraft`) + the server `_diagnostics` already attached to the layered record.
- Badges + rows derive from the live draft, so they **clear as issues are resolved**.

## Changes
- `flow-sim-validate.ts` — dangling-edge errors now carry their endpoints so they key to the offending edge (per-element, not flow-level).
- `flow-problems.ts` (new) — maps both sources onto node/edge/flow targets; `indexProblemBadges` folds per-element badges (errors dominate warnings). Unit-tested (`flow-problems.test.ts`, 12 cases).
- `FlowCanvas.tsx` / `flow-canvas-parts.tsx` — per-element badges + a reveal-to-element pan driven by the panel.
- `ProblemsPanel.tsx` (new) — the panel.
- `FlowPreview.tsx` — live problems memo, Problems toggle (with count), reveal handshake.
- `preview-registry.ts` / `ResourceEditPage.tsx` — new optional `diagnostics` prop threads the server `_diagnostics` (errors track live client Zod issues; warnings server-sourced).
- Restored the `MockResults` type accidentally dropped from `flow-sim-types.ts` (build fix — it's imported by `flow-simulator.ts`).

## Verification
- `pnpm --filter @object-ui/app-shell build` (tsc) — clean.
- `vitest` — 12 new + 183 existing previews/simulator tests pass.
- Changeset included (`@object-ui/app-shell` patch).

Closes #1945

🤖 Generated with [Claude Code](https://claude.com/claude-code)
