### PR TITLE
feat(metadata-admin): variable data-picker for flow expression/template fields (#1934)

### DIFF
--- a/.changeset/flow-variable-picker.md
+++ b/.changeset/flow-variable-picker.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Flow builder: variable data-picker for expression / template config fields. Expression and template surfaces (decision Branches, edge Condition, Assignment values, Screen description, CRUD field values / filter, subflow / script inputs) now show a "{x}" picker listing the references in scope at that node — flow variables, upstream node outputs, the trigger record's fields, and any enclosing loop item — resolved graph-aware by walking the flow back from the node. Selecting a reference inserts the correctly-braced token at the cursor (bare CEL in `expression` fields, `{var}` in template fields), handling the ADR-0032 brace-in-CEL trap for the author. Free-text typing is unchanged and an empty scope degrades to a plain input.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
@@ -29,6 +29,8 @@ import {
 import { Label } from '@object-ui/components';
 import { edgeKey, conditionText } from '../previews/flow-canvas-layout';
 import { validateExpressionClient } from './expression-validate';
+import { useFlowScope } from './useFlowScope';
+import { VariableTextInput } from './VariableTextInput';
 
 interface FlowEdge {
   id?: string;
@@ -57,6 +59,9 @@ export function FlowEdgeInspector({ selection, draft, onPatch, onClearSelection,
   const edges = Array.isArray((draft as any).edges) ? ((draft as any).edges as FlowEdge[]) : [];
   const index = edges.findIndex((e, i) => edgeKey(e, i) === selection.id);
   const edge = index >= 0 ? edges[index] : null;
+  // References available on this edge are those in scope at its SOURCE node
+  // (#1934). Called unconditionally — `edge?.source` is undefined when missing.
+  const { groups: scopeGroups } = useFlowScope(draft as Record<string, unknown>, edge?.source);
 
   if (!edge) {
     return (
@@ -212,14 +217,18 @@ export function FlowEdgeInspector({ selection, draft, onPatch, onClearSelection,
         placeholder={t('engine.inspector.flowEdge.labelHint', locale)}
         disabled={readOnly || isDefault}
       />
-      <InspectorTextField
-        label={t('engine.inspector.flowEdge.condition', locale)}
-        value={conditionText(edge.condition) ?? ''}
-        onCommit={(v) => patchEdge({ condition: v || undefined })}
-        placeholder={t('engine.inspector.flowEdge.conditionHint', locale)}
-        disabled={readOnly || isDefault}
-        mono
-      />
+      <div className="space-y-1">
+        <Label className="text-xs text-muted-foreground">{t('engine.inspector.flowEdge.condition', locale)}</Label>
+        <VariableTextInput
+          mode="expression"
+          mono
+          value={conditionText(edge.condition) ?? ''}
+          onValueChange={(v) => patchEdge({ condition: v || undefined })}
+          groups={scopeGroups}
+          placeholder={t('engine.inspector.flowEdge.conditionHint', locale)}
+          disabled={readOnly || isDefault}
+        />
+      </div>
       {(() => {
         // ADR-0032 — flag a malformed edge guard (e.g. `{record.x}` brace-in-CEL)
         // inline, with the same corrective message as build/agent validation.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowKeyValueField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowKeyValueField.tsx
@@ -21,6 +21,8 @@ import * as React from 'react';
 import { Plus, X } from 'lucide-react';
 import { Button, Input, Label } from '@object-ui/components';
 import { uniqueId } from './_shared';
+import { VariableTextInput } from './VariableTextInput';
+import type { ScopeGroup } from './useFlowScope';
 
 interface Row {
   id: string;
@@ -101,6 +103,8 @@ export interface FlowKeyValueFieldProps {
   valueLabel: string;
   removeLabel: string;
   emptyLabel: string;
+  /** In-scope variable references for the data-picker (#1934). */
+  scopeGroups?: ScopeGroup[];
 }
 
 export function FlowKeyValueField({
@@ -114,6 +118,7 @@ export function FlowKeyValueField({
   valueLabel,
   removeLabel,
   emptyLabel,
+  scopeGroups,
 }: FlowKeyValueFieldProps) {
   const external = isPlainObject(value) ? value : {};
   const [rows, setRows] = React.useState<Row[]>(() => toRows(external, []));
@@ -171,16 +176,18 @@ export function FlowKeyValueField({
               disabled={disabled}
               className="h-8 flex-1 font-mono text-xs"
             />
-            <Input
+            <VariableTextInput
+              mode="template"
               value={row.raw}
-              onChange={(e) => setRowField(row.id, { raw: e.target.value })}
+              onValueChange={(v) => setRowField(row.id, { raw: v })}
               onBlur={() => flush(rows)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
               }}
+              groups={scopeGroups ?? []}
               placeholder={valueLabel}
               disabled={disabled}
-              className="h-8 flex-1 text-xs"
+              className="flex-1"
             />
             <Button
               type="button"

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
@@ -10,7 +10,6 @@ import * as React from 'react';
 import type { FlowConfigField } from './flow-node-config';
 import { t } from '../i18n';
 import {
-  InspectorTextField,
   InspectorNumberField,
   InspectorSelectField,
   InspectorCheckboxField,
@@ -21,6 +20,8 @@ import { FlowStringListField } from './FlowStringListField';
 import { FlowObjectListField } from './FlowObjectListField';
 import { FlowReferenceField, type FlowReferenceContext } from './FlowReferenceField';
 import { validateExpressionClient } from './expression-validate';
+import { VariableTextInput } from './VariableTextInput';
+import type { ScopeGroup } from './useFlowScope';
 
 export interface FlowNodeConfigFieldProps {
   field: FlowConfigField;
@@ -30,9 +31,11 @@ export interface FlowNodeConfigFieldProps {
   locale?: string;
   /** Draft + node context so `reference` fields can resolve their options. */
   context?: FlowReferenceContext;
+  /** In-scope variable references for the data-picker (#1934). */
+  scopeGroups?: ScopeGroup[];
 }
 
-export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, context }: FlowNodeConfigFieldProps) {
+export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, context, scopeGroups }: FlowNodeConfigFieldProps) {
   const control = (() => {
     switch (field.kind) {
       case 'reference':
@@ -57,6 +60,7 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
             valueLabel={t('engine.inspector.flowNode.kv.value', locale)}
             removeLabel={t('engine.inspector.flowNode.kv.remove', locale)}
             emptyLabel={t('engine.inspector.flowNode.kv.empty', locale)}
+            scopeGroups={scopeGroups}
           />
         );
       case 'stringList':
@@ -84,6 +88,7 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
             removeLabel={t('engine.inspector.flowNode.list.remove', locale)}
             emptyLabel={t('engine.inspector.flowNode.list.empty', locale)}
             context={context}
+            scopeGroups={scopeGroups}
           />
         );
       case 'number':
@@ -119,13 +124,15 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
         return (
           <div className="space-y-1">
             <Label className="text-xs text-muted-foreground">{field.label}</Label>
-            <textarea
+            <VariableTextInput
+              multiline
+              rows={4}
+              mode="template"
               value={value != null ? String(value) : ''}
-              onChange={(e) => onCommit(e.target.value)}
+              onValueChange={(v) => onCommit(v)}
+              groups={scopeGroups ?? []}
               placeholder={field.placeholder}
               disabled={disabled}
-              rows={4}
-              className="w-full rounded border bg-background px-2 py-1.5 font-mono text-xs"
             />
           </div>
         );
@@ -133,14 +140,18 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
       case 'text':
       default:
         return (
-          <InspectorTextField
-            label={field.label}
-            value={value != null ? String(value) : ''}
-            placeholder={field.placeholder}
-            onCommit={(v) => onCommit(v)}
-            disabled={disabled}
-            mono={field.kind === 'expression'}
-          />
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">{field.label}</Label>
+            <VariableTextInput
+              mode={field.kind === 'expression' ? 'expression' : 'template'}
+              mono={field.kind === 'expression'}
+              value={value != null ? String(value) : ''}
+              onValueChange={(v) => onCommit(v)}
+              groups={scopeGroups ?? []}
+              placeholder={field.placeholder}
+              disabled={disabled}
+            />
+          </div>
         );
     }
   })();

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
@@ -34,6 +34,7 @@ import {
 import { jsonSchemaToFlowFields } from './json-schema-to-fields';
 import { useActionConfigSchemas } from '../previews/useFlowNodePalette';
 import { FlowNodeConfigField } from './FlowNodeConfigField';
+import { useFlowScope } from './useFlowScope';
 import { ScreenPreview } from '../previews/ScreenPreview';
 
 interface FlowNode {
@@ -130,6 +131,8 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
   // with the backend. Falls back to the hardcoded field group when no schema is
   // published (offline / plugin absent / older backend).
   const configSchemas = useActionConfigSchemas();
+  // In-scope variable references for this node, for the data-picker (#1934).
+  const { groups: scopeGroups } = useFlowScope(draft as Record<string, unknown>, node?.id);
   const fields = React.useMemo(() => {
     const schema = node?.type ? configSchemas[node.type] : undefined;
     const serverFields = schema !== undefined ? jsonSchemaToFlowFields(schema) : null;
@@ -286,6 +289,7 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
           disabled={readOnly}
           locale={locale}
           context={{ draft, node }}
+          scopeGroups={scopeGroups}
         />
       ))}
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx
@@ -17,6 +17,8 @@ import { Button, Input, Label, Checkbox } from '@object-ui/components';
 import { uniqueId } from './_shared';
 import type { FlowConfigColumn } from './flow-node-config';
 import { ReferenceCombobox, resolveRefKind, type FlowReferenceContext } from './FlowReferenceField';
+import { VariableTextInput } from './VariableTextInput';
+import type { ScopeGroup } from './useFlowScope';
 
 type Cell = string | boolean;
 interface Row {
@@ -73,6 +75,8 @@ export interface FlowObjectListFieldProps {
   emptyLabel: string;
   /** Draft + node context so `reference` columns can resolve their options. */
   context?: FlowReferenceContext;
+  /** In-scope variable references for `expression` columns (#1934). */
+  scopeGroups?: ScopeGroup[];
 }
 
 export function FlowObjectListField({
@@ -85,6 +89,7 @@ export function FlowObjectListField({
   removeLabel,
   emptyLabel,
   context,
+  scopeGroups,
 }: FlowObjectListFieldProps) {
   const external = React.useMemo(
     () =>
@@ -186,6 +191,22 @@ export function FlowObjectListField({
                         showHint={false}
                       />
                     </div>
+                  ) : col.kind === 'expression' ? (
+                    <div className="flex-1">
+                      <VariableTextInput
+                        mode="expression"
+                        mono
+                        value={typeof row.values[col.key] === 'string' ? (row.values[col.key] as string) : ''}
+                        onValueChange={(v) => setCell(row.id, col.key, v)}
+                        onBlur={() => flush(rows)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                        }}
+                        groups={scopeGroups ?? []}
+                        placeholder={col.placeholder}
+                        disabled={disabled}
+                      />
+                    </div>
                   ) : (
                     <Input
                       value={typeof row.values[col.key] === 'string' ? (row.values[col.key] as string) : ''}
@@ -196,7 +217,7 @@ export function FlowObjectListField({
                       }}
                       placeholder={col.placeholder}
                       disabled={disabled}
-                      className={`h-8 flex-1 text-xs${col.kind === 'expression' ? ' font-mono' : ''}`}
+                      className="h-8 flex-1 text-xs"
                     />
                   )}
                 </div>

--- a/packages/app-shell/src/views/metadata-admin/inspectors/VariableTextInput.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/VariableTextInput.tsx
@@ -1,0 +1,195 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * VariableTextInput — a single-line input (or textarea) for an expression /
+ * template flow-config value, with a "{x}" data-picker (#1934) that inserts an
+ * in-scope reference at the cursor.
+ *
+ * Brace handling is done FOR the author (ADR-0032): the picker inserts the BARE
+ * reference (`discount_pct`) in `expression` fields and the braced
+ * `{discount_pct}` in `template` (text / textarea) fields — killing the
+ * recurring `{record.x}` brace-in-CEL trap. Free-text typing is untouched, and
+ * the picker button is hidden entirely when nothing is in scope, so an empty
+ * scope degrades to a plain input.
+ */
+
+import * as React from 'react';
+import { Braces } from 'lucide-react';
+import {
+  cn,
+  Input,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@object-ui/components';
+import type { ScopeGroup } from './useFlowScope';
+
+export type VariableFieldMode = 'expression' | 'template';
+
+/** Wrap a bare reference token for insertion into the given field mode. */
+export function formatToken(token: string, mode: VariableFieldMode): string {
+  return mode === 'template' ? `{${token}}` : token;
+}
+
+export interface VariableTextInputProps {
+  value: string;
+  onValueChange: (v: string) => void;
+  onBlur?: () => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  /** Brace rule: bare token for `expression`, `{token}` for `template`. */
+  mode: VariableFieldMode;
+  /** In-scope reference groups (from useFlowScope). Empty → no picker button. */
+  groups: ScopeGroup[];
+  placeholder?: string;
+  disabled?: boolean;
+  /** Render a multi-line `<textarea>` instead of a single-line input. */
+  multiline?: boolean;
+  rows?: number;
+  /** Monospace the input text (expressions). Textareas are always mono. */
+  mono?: boolean;
+  className?: string;
+}
+
+const PICK_LABEL = 'Insert a reference';
+const SEARCH_LABEL = 'Search references…';
+const EMPTY_LABEL = 'No matching references.';
+
+export function VariableTextInput({
+  value,
+  onValueChange,
+  onBlur,
+  onKeyDown,
+  mode,
+  groups,
+  placeholder,
+  disabled,
+  multiline,
+  rows = 4,
+  mono,
+  className,
+}: VariableTextInputProps) {
+  const inputRef = React.useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+  // Remember the caret across the button press (which blurs the field) so the
+  // token lands where the author was typing — not appended at the end.
+  const caret = React.useRef<{ start: number; end: number }>({ start: 0, end: 0 });
+  const [open, setOpen] = React.useState(false);
+
+  const setRef = (el: HTMLInputElement | HTMLTextAreaElement | null) => {
+    inputRef.current = el;
+  };
+
+  const rememberCaret = () => {
+    const el = inputRef.current;
+    if (el) {
+      caret.current = {
+        start: el.selectionStart ?? value.length,
+        end: el.selectionEnd ?? value.length,
+      };
+    }
+  };
+
+  const insert = (token: string) => {
+    const text = formatToken(token, mode);
+    const start = Math.min(caret.current.start, value.length);
+    const end = Math.min(caret.current.end, value.length);
+    const next = value.slice(0, start) + text + value.slice(end);
+    onValueChange(next);
+    setOpen(false);
+    // Restore focus + place the caret just after the inserted token.
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      const pos = start + text.length;
+      try {
+        el.setSelectionRange(pos, pos);
+      } catch {
+        /* some input types disallow setSelectionRange */
+      }
+      caret.current = { start: pos, end: pos };
+    });
+  };
+
+  const hasScope = groups.some((g) => g.refs.length > 0);
+
+  const shared = {
+    value,
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onValueChange(e.target.value),
+    onBlur,
+    onKeyDown,
+    onSelect: rememberCaret,
+    onKeyUp: rememberCaret,
+    onClick: rememberCaret,
+    placeholder,
+    disabled,
+  };
+
+  return (
+    <div className={cn('relative', className)}>
+      {multiline ? (
+        <textarea
+          ref={setRef}
+          {...shared}
+          rows={rows}
+          className="w-full rounded border bg-background px-2 py-1.5 pr-8 font-mono text-xs"
+        />
+      ) : (
+        <Input ref={setRef} {...shared} className={cn('h-8 pr-8 text-sm', mono && 'font-mono')} />
+      )}
+
+      {hasScope && !disabled && (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label={PICK_LABEL}
+              title={PICK_LABEL}
+              // Capture the caret on mousedown (fires before the input blur), so
+              // the insertion point is the author's last position.
+              onMouseDown={rememberCaret}
+              className="absolute right-1 top-1 inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <Braces className="h-3.5 w-3.5" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="w-72 p-0"
+            // Keep our rAF focus-restore from fighting Radix's focus return.
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
+            <Command>
+              <CommandInput placeholder={SEARCH_LABEL} className="h-9" />
+              <CommandList>
+                <CommandEmpty>{EMPTY_LABEL}</CommandEmpty>
+                {groups.map((g) => (
+                  <CommandGroup key={g.id} heading={g.label}>
+                    {g.refs.map((ref) => (
+                      <CommandItem
+                        key={`${g.id}:${ref.token}`}
+                        value={`${ref.token} ${ref.label} ${ref.detail ?? ''}`}
+                        onSelect={() => insert(ref.token)}
+                        className="flex items-center justify-between gap-2"
+                      >
+                        <span className="truncate font-mono text-xs">{formatToken(ref.token, mode)}</span>
+                        {ref.detail && (
+                          <span className="shrink-0 truncate text-[10px] text-muted-foreground">{ref.detail}</span>
+                        )}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ))}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-scope.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-scope.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { flowAncestors, nodeOutputRefs, resolveFlowScope, triggerFieldRefs } from './flow-scope';
+
+const tokens = (refs: ReadonlyArray<{ token: string }>) => refs.map((r) => r.token);
+const groupTokens = (scope: { refs: Array<{ token: string; group: string }> }, group: string) =>
+  scope.refs.filter((r) => r.group === group).map((r) => r.token);
+
+describe('flowAncestors', () => {
+  const edges = [
+    { source: 'start', target: 'a' },
+    { source: 'a', target: 'b' },
+    { source: 'b', target: 'c' },
+  ];
+  it('collects all transitive predecessors, excluding the node itself', () => {
+    expect([...flowAncestors('c', edges)].sort()).toEqual(['a', 'b', 'start']);
+    expect(flowAncestors('c', edges).has('c')).toBe(false);
+  });
+  it('a node with no incoming edge has no ancestors', () => {
+    expect([...flowAncestors('start', edges)]).toEqual([]);
+  });
+  it('does not count downstream nodes as ancestors', () => {
+    expect(flowAncestors('a', edges).has('b')).toBe(false);
+    expect(flowAncestors('a', edges).has('c')).toBe(false);
+  });
+  it('is cycle-safe (a back-edge revise loop does not spin)', () => {
+    const cyclic = [
+      { source: 'a', target: 'b' },
+      { source: 'b', target: 'c' },
+      { source: 'c', target: 'a' }, // back-edge
+    ];
+    const anc = flowAncestors('b', cyclic);
+    expect(anc.has('a')).toBe(true);
+    expect(anc.has('c')).toBe(true);
+    expect(anc.has('b')).toBe(false);
+  });
+  it('handles branch/merge (diamond) graphs', () => {
+    const diamond = [
+      { source: 's', target: 'l' },
+      { source: 's', target: 'r' },
+      { source: 'l', target: 'm' },
+      { source: 'r', target: 'm' },
+    ];
+    expect([...flowAncestors('m', diamond)].sort()).toEqual(['l', 'r', 's']);
+  });
+});
+
+describe('nodeOutputRefs', () => {
+  it('reads a single outputVariable', () => {
+    expect(tokens(nodeOutputRefs({ id: 'g', type: 'get_record', config: { outputVariable: 'records' } }))).toEqual(['records']);
+  });
+  it('reads a list of outputVariables (script)', () => {
+    expect(tokens(nodeOutputRefs({ id: 's', type: 'script', config: { outputVariables: ['lead_score', 'qualified'] } }))).toEqual(['lead_score', 'qualified']);
+  });
+  it('flags a loop/map iterator as a loop ref and collects its output', () => {
+    const refs = nodeOutputRefs({ id: 'm', type: 'map', config: { iteratorVariable: 'item', outputVariable: 'results' } });
+    expect(refs.find((r) => r.token === 'item')!.group).toBe('loop');
+    expect(refs.find((r) => r.token === 'results')!.group).toBe('outputs');
+  });
+  it('reads assignment keys from the array shape', () => {
+    expect(tokens(nodeOutputRefs({ id: 'a', type: 'assignment', config: { assignments: [{ variable: 'lead_score', value: 0 }, { variable: 'qualified', value: false }] } }))).toEqual(['lead_score', 'qualified']);
+  });
+  it('reads assignment keys from the map shape', () => {
+    expect(tokens(nodeOutputRefs({ id: 'a', type: 'assignment', config: { assignments: { foo: 1, bar: 2 } } }))).toEqual(['foo', 'bar']);
+  });
+  it('reads screen collected field names', () => {
+    expect(tokens(nodeOutputRefs({ id: 'sc', type: 'screen', config: { fields: [{ name: 'discount' }, { name: 'reason' }] } }))).toEqual(['discount', 'reason']);
+  });
+  it('returns nothing for a node that introduces no variables', () => {
+    expect(nodeOutputRefs({ id: 'd', type: 'decision', config: { conditions: [] } })).toEqual([]);
+  });
+});
+
+describe('resolveFlowScope — graph-aware in-scope references', () => {
+  // start(record-after-update crm_lead) -> assign -> get -> decide
+  const draft = {
+    variables: [
+      { name: 'lead_score', type: 'number' },
+      { name: 'qualified', type: 'boolean' },
+    ],
+    nodes: [
+      { id: 'start', type: 'start', config: { triggerType: 'record-after-update', objectName: 'crm_lead' } },
+      { id: 'assign', type: 'assignment', config: { assignments: [{ variable: 'lead_score', value: 0 }] } },
+      { id: 'get', type: 'get_record', label: 'Fetch Account', config: { outputVariable: 'account_data' } },
+      { id: 'decide', type: 'decision', config: {} },
+    ],
+    edges: [
+      { source: 'start', target: 'assign' },
+      { source: 'assign', target: 'get' },
+      { source: 'get', target: 'decide' },
+    ],
+  };
+
+  it('always offers flow variables', () => {
+    expect(groupTokens(resolveFlowScope(draft, 'decide'), 'variables')).toEqual(['lead_score', 'qualified']);
+  });
+
+  it('offers an upstream node output at a downstream node', () => {
+    expect(groupTokens(resolveFlowScope(draft, 'decide'), 'outputs')).toContain('account_data');
+  });
+
+  it('does NOT offer a downstream output at an upstream node (graph-aware)', () => {
+    // `account_data` is produced by `get`, which is downstream of `assign`.
+    expect(groupTokens(resolveFlowScope(draft, 'assign'), 'outputs')).not.toContain('account_data');
+  });
+
+  it('offers the trigger record (record.* prefix) downstream, plus previous', () => {
+    const scope = resolveFlowScope(draft, 'decide');
+    expect(groupTokens(scope, 'trigger')).toContain('record');
+    expect(groupTokens(scope, 'trigger')).toContain('previous');
+    expect(scope.trigger).toEqual({ objectName: 'crm_lead', fieldPrefix: 'record.' });
+  });
+
+  it('uses a BARE field prefix on the start node itself (entry condition)', () => {
+    const scope = resolveFlowScope(draft, 'start');
+    expect(scope.trigger).toEqual({ objectName: 'crm_lead', fieldPrefix: '' });
+    // No whole-`record` token on the start node (fields are the bare context).
+    expect(groupTokens(scope, 'trigger')).not.toContain('record');
+    // `previous` is still available on an update trigger.
+    expect(groupTokens(scope, 'trigger')).toContain('previous');
+  });
+
+  it('omits the trigger record for a non-record trigger', () => {
+    const manual = { ...draft, nodes: [{ id: 'start', type: 'start', config: { triggerType: 'manual' } }, ...draft.nodes.slice(1)] };
+    const scope = resolveFlowScope(manual, 'decide');
+    expect(scope.trigger).toBeUndefined();
+    expect(groupTokens(scope, 'trigger')).toEqual([]);
+  });
+
+  it('omits `previous` for a create trigger', () => {
+    const create = { ...draft, nodes: [{ id: 'start', type: 'start', config: { triggerType: 'record-after-create', objectName: 'crm_lead' } }, ...draft.nodes.slice(1)] };
+    expect(groupTokens(resolveFlowScope(create, 'decide'), 'trigger')).not.toContain('previous');
+  });
+
+  it('de-dupes a name that is both a declared variable and an upstream output', () => {
+    // `lead_score` is declared AND assigned upstream — it should appear once.
+    const scope = resolveFlowScope(draft, 'decide');
+    expect(tokens(scope.refs).filter((t) => t === 'lead_score')).toHaveLength(1);
+  });
+
+  it('surfaces an enclosing loop iterator as a loop ref downstream, not at the loop itself', () => {
+    const loopDraft = {
+      nodes: [
+        { id: 'start', type: 'start', config: { triggerType: 'manual' } },
+        { id: 'loop', type: 'loop', config: { iteratorVariable: 'currentItem', collection: '{items}' } },
+        { id: 'body', type: 'assignment', config: {} },
+      ],
+      edges: [
+        { source: 'start', target: 'loop' },
+        { source: 'loop', target: 'body' },
+      ],
+    };
+    expect(groupTokens(resolveFlowScope(loopDraft, 'body'), 'loop')).toEqual(['currentItem']);
+    // The iterator is NOT in scope at the loop node itself (it defines it).
+    expect(groupTokens(resolveFlowScope(loopDraft, 'loop'), 'loop')).toEqual([]);
+  });
+
+  it('returns only flow variables for an unknown / disconnected node', () => {
+    const scope = resolveFlowScope(draft, 'orphan');
+    expect(groupTokens(scope, 'outputs')).toEqual([]);
+    expect(scope.trigger).toBeUndefined();
+    expect(groupTokens(scope, 'variables')).toEqual(['lead_score', 'qualified']);
+  });
+});
+
+describe('triggerFieldRefs', () => {
+  const fields = [
+    { name: 'amount', label: 'Deal Amount', type: 'number' },
+    { name: 'status', type: 'text' },
+  ];
+  it('prefixes fields with record. downstream', () => {
+    expect(tokens(triggerFieldRefs({ objectName: 'o', fieldPrefix: 'record.' }, fields))).toEqual(['record.amount', 'record.status']);
+  });
+  it('uses bare field names on the start node', () => {
+    expect(tokens(triggerFieldRefs({ objectName: 'o', fieldPrefix: '' }, fields))).toEqual(['amount', 'status']);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-scope.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-scope.ts
@@ -1,0 +1,271 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * flow-scope — pure, framework-free resolution of the in-scope variable
+ * references at a given flow node, for the inspector's variable data-picker
+ * (#1934).
+ *
+ * "In scope" is GRAPH-AWARE: a reference is offered at node N only if it can
+ * actually exist when N runs. Concretely:
+ *
+ *   - Flow variables — every entry in `draft.variables[]` (declared up-front, so
+ *     always in scope).
+ *   - Upstream outputs — the `outputVariable(s)` / collected screen
+ *     `fields[].name` / `assignments` keys / `idVariable` of every ANCESTOR node
+ *     (a node from which N is reachable, found by walking edges backwards). A
+ *     node's OWN outputs and any DOWNSTREAM node's outputs are deliberately
+ *     excluded — they don't exist yet when N runs. This is the property the
+ *     picker's "a downstream output is not offered upstream" guarantee rests on.
+ *   - Loop / map iterators — the `iteratorVariable` of an enclosing loop/map
+ *     ancestor, surfaced as its own group.
+ *   - Trigger record — on a record-triggered flow, the trigger object's fields.
+ *     Referenced BARE on the start node's own entry condition (`status`,
+ *     matching the engine's trigger-evaluation context where the changed
+ *     record's fields are top-level) and as `record.<field>` on every
+ *     downstream node (the convention the showcase flows use). The object's
+ *     field list is fetched lazily by the React layer (see useFlowScope); this
+ *     module only resolves the object NAME and the correct token prefix.
+ *
+ * The graph-walk here is the unit-tested heart of the picker; async field-list
+ * expansion and rendering live in the React layer so this module stays pure.
+ */
+
+/** Which group a reference belongs to (drives the picker's section headers). */
+export type ScopeGroupId = 'variables' | 'outputs' | 'loop' | 'trigger';
+
+/**
+ * One pickable reference. `token` is the BARE form (no braces); the picker
+ * inserts it as-is into CEL `expression` fields and wraps it as `{token}` for
+ * `text` / `textarea` template fields (ADR-0032 — the brace rule is handled for
+ * the author).
+ */
+export interface ScopeRef {
+  token: string;
+  /** Primary display text (the token, or the bare field name). */
+  label: string;
+  /** Secondary, muted text — a type, an origin node label, etc. */
+  detail?: string;
+  group: ScopeGroupId;
+}
+
+/** The trigger object whose fields the UI layer should fetch and expand. */
+export interface TriggerScope {
+  objectName: string;
+  /** Per-field token prefix: '' on the start node (bare), 'record.' downstream. */
+  fieldPrefix: string;
+}
+
+export interface FlowScope {
+  /**
+   * References resolvable WITHOUT a network fetch: flow variables, upstream
+   * outputs, loop iterators, and the whole-record `record` / `previous` tokens.
+   */
+  refs: ScopeRef[];
+  /** Present when a record trigger is in scope — the UI expands its fields. */
+  trigger?: TriggerScope;
+}
+
+interface FlowNodeLike {
+  id?: unknown;
+  type?: unknown;
+  label?: unknown;
+  config?: unknown;
+}
+interface FlowEdgeLike {
+  source?: unknown;
+  target?: unknown;
+}
+
+/** Trigger types that fire on a single record (so `record` is in scope). */
+const RECORD_TRIGGER_TYPES = new Set([
+  'record-after-create',
+  'record-after-update',
+  'record-before-update',
+  'record-after-delete',
+  'record-change',
+]);
+/** Trigger types that carry a meaningful `previous` snapshot of the record. */
+const PREVIOUS_TRIGGER_TYPES = new Set([
+  'record-after-update',
+  'record-before-update',
+  'record-change',
+]);
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v ? v : undefined;
+}
+
+/**
+ * Ancestor node ids of `nodeId` — every node from which `nodeId` is reachable
+ * by following edges forward (equivalently, a reverse breadth-first walk from
+ * `nodeId`). Cycle-safe (a declared `back`-edge revise loop won't spin) and
+ * never includes `nodeId` itself.
+ */
+export function flowAncestors(nodeId: string, edges: FlowEdgeLike[]): Set<string> {
+  const rev = new Map<string, string[]>();
+  for (const e of edges) {
+    const s = str(e.source);
+    const t = str(e.target);
+    if (!s || !t) continue;
+    const list = rev.get(t);
+    if (list) list.push(s);
+    else rev.set(t, [s]);
+  }
+  const seen = new Set<string>();
+  const stack = [...(rev.get(nodeId) ?? [])];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    if (cur === nodeId || seen.has(cur)) continue;
+    seen.add(cur);
+    for (const p of rev.get(cur) ?? []) stack.push(p);
+  }
+  return seen;
+}
+
+/**
+ * The variable names a node INTRODUCES into scope for its successors — mirroring
+ * what the simulator (flow-simulator.ts) and engine actually write:
+ * `outputVariable` (single), `outputVariables` (list), an assignment node's
+ * `assignments` keys (map / array / flat shapes), a screen's collected
+ * `fields[].name`, a screen object-form's `idVariable`, and a loop/map
+ * `iteratorVariable` (flagged as a `loop` ref). The start node is NOT handled
+ * here — its trigger record is resolved separately.
+ */
+export function nodeOutputRefs(node: FlowNodeLike): ScopeRef[] {
+  const type = str(node.type);
+  const cfg = asRecord(node.config);
+  const nodeId = str(node.id) ?? '';
+  const label = str(node.label);
+  const detail = label && label !== nodeId ? label : nodeId || undefined;
+  const out: ScopeRef[] = [];
+  const add = (token: string | undefined, group: ScopeGroupId = 'outputs') => {
+    if (token && !out.some((r) => r.token === token)) {
+      out.push({ token, label: token, detail, group });
+    }
+  };
+
+  // Loop / map iterator — its own group.
+  if (type === 'loop' || type === 'map') add(str(cfg.iteratorVariable), 'loop');
+
+  // Single + multi output variables (create/get/http/subflow/map/end/script).
+  add(str(cfg.outputVariable));
+  for (const name of asArray(cfg.outputVariables)) add(str(name));
+
+  // Screen object-form: the saved record's id is bound to a variable.
+  add(str(cfg.idVariable));
+
+  // Assignment node — the assigned variable names. Accepts the three authoring
+  // shapes the simulator/engine accept: an array of `{variable|name|key}`, a
+  // flat `{ var: value }` map, or (legacy) keys directly on config.
+  if (type === 'assignment') {
+    const raw = cfg.assignments;
+    if (Array.isArray(raw)) {
+      for (const item of raw) {
+        const e = asRecord(item);
+        add(str(e.variable) ?? str(e.name) ?? str(e.key));
+      }
+    } else if (raw && typeof raw === 'object') {
+      for (const k of Object.keys(raw as Record<string, unknown>)) add(k);
+    }
+  }
+
+  // Screen — collected input field names become variables for downstream nodes.
+  if (type === 'screen' || type === 'user_task') {
+    for (const f of asArray(cfg.fields)) add(str(asRecord(f).name));
+  }
+
+  return out;
+}
+
+/** De-duplicate by token, keeping the first (group-priority) occurrence. */
+function dedupeByToken(refs: ScopeRef[]): ScopeRef[] {
+  const seen = new Set<string>();
+  return refs.filter((r) => (seen.has(r.token) ? false : (seen.add(r.token), true)));
+}
+
+/**
+ * Resolve the in-scope reference set at `nodeId` (graph-aware). Pure: the
+ * trigger object's fields are NOT expanded here (that needs an async fetch) —
+ * the returned `trigger` carries the object name and per-field token prefix for
+ * the UI layer to expand. Order: flow variables, upstream outputs, loop
+ * iterators, then trigger refs, de-duplicated by token.
+ */
+export function resolveFlowScope(draft: Record<string, unknown>, nodeId: string | undefined): FlowScope {
+  const nodes = asArray(draft.nodes).map(asRecord) as FlowNodeLike[];
+  const edges = asArray(draft.edges) as FlowEdgeLike[];
+  const refs: ScopeRef[] = [];
+
+  // 1. Flow variables — always in scope (declared up-front).
+  for (const v of asArray(draft.variables)) {
+    const rec = asRecord(v);
+    const name = str(rec.name);
+    if (!name) continue;
+    const type = str(rec.type);
+    refs.push({ token: name, label: name, detail: type ? `variable · ${type}` : 'variable', group: 'variables' });
+  }
+
+  if (!nodeId) return { refs: dedupeByToken(refs) };
+
+  // 2. Upstream outputs + loop iterators — from ANCESTOR nodes only.
+  const ancestors = flowAncestors(nodeId, edges);
+  const startNode = nodes.find((n) => str(n.type) === 'start');
+  const startId = str(startNode?.id);
+  for (const node of nodes) {
+    const id = str(node.id);
+    if (!id || id === nodeId || !ancestors.has(id)) continue;
+    if (id === startId) continue; // the start node contributes the trigger record, below
+    for (const ref of nodeOutputRefs(node)) refs.push(ref);
+  }
+
+  // 3. Trigger record — on a record-triggered flow, when the start node is in
+  //    scope: either we ARE the start node (editing its own entry condition) or
+  //    the start node is an ancestor (it is the ancestor of everything reachable).
+  if (startNode) {
+    const cfg = asRecord(startNode.config);
+    const triggerType = str(cfg.triggerType);
+    const objectName = str(cfg.objectName);
+    const isRecordTrigger = !!triggerType && RECORD_TRIGGER_TYPES.has(triggerType);
+    const startInScope = startId === nodeId || (!!startId && ancestors.has(startId));
+    if (isRecordTrigger && objectName && startInScope) {
+      const onStart = startId === nodeId;
+      // On the start node the record's fields ARE the bare evaluation context
+      // (`status`), so the whole record is not a named ref there; `previous` is
+      // (`previous.status`). Downstream the record is the named `record` object.
+      if (!onStart) {
+        refs.push({ token: 'record', label: 'record', detail: `trigger record · ${objectName}`, group: 'trigger' });
+      }
+      if (PREVIOUS_TRIGGER_TYPES.has(triggerType)) {
+        refs.push({ token: 'previous', label: 'previous', detail: 'record values before the change', group: 'trigger' });
+      }
+      return { refs: dedupeByToken(refs), trigger: { objectName, fieldPrefix: onStart ? '' : 'record.' } };
+    }
+  }
+
+  return { refs: dedupeByToken(refs) };
+}
+
+/**
+ * Expand a trigger object's fields into per-field refs — `record.<field>`
+ * downstream, bare `<field>` on the start node — given an already-fetched field
+ * list. Split out from {@link resolveFlowScope} so it is unit-testable without a
+ * metadata client.
+ */
+export function triggerFieldRefs(
+  trigger: TriggerScope,
+  fields: ReadonlyArray<{ name: string; label?: string; type?: string }>,
+): ScopeRef[] {
+  const out: ScopeRef[] = [];
+  for (const f of fields) {
+    if (!f?.name) continue;
+    const token = `${trigger.fieldPrefix}${f.name}`;
+    const detail = f.label && f.label !== f.name ? f.label : f.type;
+    out.push({ token, label: token, detail, group: 'trigger' });
+  }
+  return out;
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/useFlowScope.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/useFlowScope.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * useFlowScope — React adapter over the pure {@link resolveFlowScope} graph-walk
+ * that powers the inspector's variable data-picker (#1934).
+ *
+ * It resolves the graph-aware refs synchronously, then lazily fetches the
+ * trigger object's field catalog (via the shared metadata client) and merges
+ * the expanded `record.<field>` refs in — grouping everything into the ordered
+ * sections the picker renders. An empty result (`isEmpty`) tells the field to
+ * degrade to a plain input.
+ */
+
+import * as React from 'react';
+import {
+  resolveFlowScope,
+  triggerFieldRefs,
+  type ScopeGroupId,
+  type ScopeRef,
+} from './flow-scope';
+import { useObjectFields } from '../previews/useObjectFields';
+
+export interface ScopeGroup {
+  id: ScopeGroupId;
+  label: string;
+  refs: ScopeRef[];
+}
+
+export interface UseFlowScopeResult {
+  /** Non-empty groups, in display order. */
+  groups: ScopeGroup[];
+  /** Flat, de-duplicated ref list (all groups). */
+  refs: ScopeRef[];
+  /** True while the trigger object's fields are still loading. */
+  loading: boolean;
+  /** No references in scope — the field should render as a plain input. */
+  isEmpty: boolean;
+}
+
+const GROUP_ORDER: ScopeGroupId[] = ['variables', 'outputs', 'loop', 'trigger'];
+const GROUP_LABELS: Record<ScopeGroupId, string> = {
+  variables: 'Flow variables',
+  outputs: 'Upstream outputs',
+  loop: 'Loop item',
+  trigger: 'Trigger record',
+};
+
+/**
+ * Resolve + (async) expand the in-scope references at a flow node. `draft` is
+ * the whole flow draft; `nodeId` the node being edited (for an edge, pass its
+ * source node id — references available on an edge are those in scope at its
+ * source).
+ */
+export function useFlowScope(
+  draft: Record<string, unknown> | undefined,
+  nodeId: string | undefined,
+): UseFlowScopeResult {
+  const scope = React.useMemo(() => resolveFlowScope(draft ?? {}, nodeId), [draft, nodeId]);
+  const { fields, loading } = useObjectFields(scope.trigger?.objectName);
+
+  return React.useMemo(() => {
+    const all: ScopeRef[] = [...scope.refs];
+    if (scope.trigger) all.push(...triggerFieldRefs(scope.trigger, fields));
+    // Global de-dup by token (a declared var also written upstream shows once).
+    const seen = new Set<string>();
+    const refs = all.filter((r) => (seen.has(r.token) ? false : (seen.add(r.token), true)));
+    const groups = GROUP_ORDER.map((id) => ({
+      id,
+      label: GROUP_LABELS[id],
+      refs: refs.filter((r) => r.group === id),
+    })).filter((g) => g.refs.length > 0);
+    return { groups, refs, loading: !!scope.trigger && loading, isEmpty: refs.length === 0 };
+  }, [scope, fields, loading]);
+}


### PR DESCRIPTION
Closes #1934.

## What

Business users authored CEL expressions and `{var}` templates in the Studio **flow builder** by typing reference names from memory — there was no way to discover or insert the references actually in scope. This adds a **`{x}` data-picker** (like Power Automate "Dynamic content" / Salesforce's resource picker) to every expression / template config surface.

A trigger button on the field opens a searchable, grouped popover of the references **in scope at that node**, and picking one inserts the correctly-braced token at the cursor.

## In scope (graph-aware)

Resolved by walking the flow graph back from the current node, so only what's reachable is offered:

- **Flow variables** — `draft.variables[]`.
- **Upstream outputs** — each *ancestor* node's `outputVariable(s)` / collected screen `fields[].name` / `assignments` keys / `idVariable`. A node's own and any **downstream** output is excluded — a downstream output is never offered upstream.
- **Loop / map item** — the enclosing `iteratorVariable`.
- **Trigger record** — on a record-triggered flow, the start node's `objectName` schema is fetched and expanded: bare `<field>` on the start node's own entry condition, `record.<field>` (+ `record` / `previous`) downstream — matching how the showcase flows and the engine reference the record.

## Brace handling (ADR-0032)

Insertion handles the recurring `{record.x}` brace-in-CEL trap **for** the author:

- **`expression` fields** → bare CEL (`record.name`)
- **template fields** (text / textarea / key-value values) → `{record.company}`

Free-text typing is untouched, and an empty scope degrades to a plain input.

## Surfaces

decision **Branches** (`expression`), edge **Condition**, **Assignment** / CRUD / subflow values, screen **description**, and `http` fields — via one shared `VariableTextInput`.

## Code

- `inspectors/flow-scope.ts` — pure, framework-free graph-walk + ref resolution (unit-tested).
- `inspectors/useFlowScope.ts` — React adapter; lazily fetches + expands the trigger object's fields.
- `inspectors/VariableTextInput.tsx` — input/textarea + cmdk popover; cursor insertion + brace rule.
- Wiring in `FlowNodeConfigField`, `FlowNodeInspector`, `FlowObjectListField`, `FlowKeyValueField`, `FlowEdgeInspector`.

## Tests / verification

- `flow-scope.test.ts` — 24 unit tests for the scope-resolution graph-walk (ancestors, downstream-not-upstream, trigger prefix, de-dup, loop iterator, non-record trigger).
- `pnpm build` (tsc) clean; full `metadata-admin` suite green (442 tests).
- Browser-verified against the CRM showcase `lead_qualification_conversion` flow: picker lists flow variables + `record.<field>` (from `crm_lead`); bare insertion in the decision Branches expression and `{record.company}` in the http URL field; graph-aware trigger scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)