### PR TITLE
fix(metadata-admin): flow data-picker — scope-aware ref validation + array assignments + script bare mode (#1934)

### DIFF
--- a/.changeset/flow-ref-validation.md
+++ b/.changeset/flow-ref-validation.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Flow builder data-picker follow-ups (#1934): (1) a scope-aware "unknown reference" warning pairs the picker with inline validation — a typed reference whose root isn't in scope at the node is flagged with a nearest-match "did you mean?" hint (conservative: root-only, skips function calls / string literals / runtime globals; non-blocking amber). (2) Assignment values authored in the array form `[{ variable, value }]` now render in the key/value editor (and get the picker) instead of falling back to Advanced JSON; the editor reads both the object-map and array shapes and preserves whichever was authored. (3) A script `code` body (JS/TS, not a `{var}` template) now inserts bare references via a `refMode` field override — `{x}` is a syntax error in a script.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
@@ -31,6 +31,7 @@ import { edgeKey, conditionText } from '../previews/flow-canvas-layout';
 import { validateExpressionClient } from './expression-validate';
 import { useFlowScope } from './useFlowScope';
 import { VariableTextInput } from './VariableTextInput';
+import { findUnknownRefs, scopeRoots, describeUnknownRefs } from './flow-ref-check';
 
 interface FlowEdge {
   id?: string;
@@ -233,9 +234,21 @@ export function FlowEdgeInspector({ selection, draft, onPatch, onClearSelection,
         // ADR-0032 — flag a malformed edge guard (e.g. `{record.x}` brace-in-CEL)
         // inline, with the same corrective message as build/agent validation.
         const issue = isDefault ? null : validateExpressionClient('predicate', edge.condition);
-        return issue ? (
-          <p className="text-[11px] leading-snug text-destructive" role="alert">
-            {issue.message}
+        if (issue) {
+          return (
+            <p className="text-[11px] leading-snug text-destructive" role="alert">
+              {issue.message}
+            </p>
+          );
+        }
+        // #1934 — gentle scope-aware "unknown reference" warning (refs in scope
+        // at the edge's SOURCE node), once the guard is structurally valid.
+        const unknown = isDefault
+          ? []
+          : findUnknownRefs(conditionText(edge.condition), 'predicate', scopeRoots(scopeGroups.flatMap((g) => g.refs)));
+        return unknown.length > 0 ? (
+          <p className="text-[11px] leading-snug text-amber-600 dark:text-amber-400" role="note">
+            {describeUnknownRefs(unknown)}
           </p>
         ) : null;
       })()}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowKeyValueField.shape.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowKeyValueField.shape.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { toEntries, rowsToValue, type Row } from './FlowKeyValueField';
+
+const row = (key: string, raw: string): Row => ({ id: key, key, raw });
+
+describe('FlowKeyValueField shape handling (#1934 — assignment array form)', () => {
+  it('reads the object-map shape into entries', () => {
+    expect(toEntries({ a: 1, b: 'x' })).toEqual([
+      ['a', 1],
+      ['b', 'x'],
+    ]);
+  });
+
+  it('reads the assignment ARRAY shape ({variable|name|key, value}) into entries', () => {
+    expect(toEntries([{ variable: 'lead_score', value: 0 }, { variable: 'qualified', value: false }])).toEqual([
+      ['lead_score', 0],
+      ['qualified', false],
+    ]);
+    expect(toEntries([{ name: 'a', value: 1 }, { key: 'b', value: 2 }])).toEqual([
+      ['a', 1],
+      ['b', 2],
+    ]);
+  });
+
+  it('ignores a non-object / non-array value', () => {
+    expect(toEntries('nope')).toEqual([]);
+    expect(toEntries(null)).toEqual([]);
+  });
+
+  it('writes back the OBJECT shape, smart-parsing + de-duping', () => {
+    const out = rowsToValue([row('amount', '30'), row('flag', 'true'), row('', 'skip'), row('amount', 'dupe')], false);
+    expect(out).toEqual({ amount: 30, flag: true });
+  });
+
+  it('writes back the ARRAY shape, preserving [{variable, value}]', () => {
+    const out = rowsToValue([row('lead_score', '0'), row('qualified', 'false'), row('ref', '{record.id}')], true);
+    expect(out).toEqual([
+      { variable: 'lead_score', value: 0 },
+      { variable: 'qualified', value: false },
+      { variable: 'ref', value: '{record.id}' },
+    ]);
+  });
+
+  it('round-trips an array-shape assignment without changing its shape', () => {
+    const stored = [{ variable: 'lead_score', value: 0 }, { variable: 'enrichment_data', value: null }];
+    const rows = toEntries(stored).map(([k, v]) => row(k, v == null ? '' : String(v)));
+    const out = rowsToValue(rows, /* arrayShape */ true);
+    expect(Array.isArray(out)).toBe(true);
+    expect((out as Array<Record<string, unknown>>).map((e) => e.variable)).toEqual(['lead_score', 'enrichment_data']);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowKeyValueField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowKeyValueField.tsx
@@ -24,7 +24,7 @@ import { uniqueId } from './_shared';
 import { VariableTextInput } from './VariableTextInput';
 import type { ScopeGroup } from './useFlowScope';
 
-interface Row {
+export interface Row {
   id: string;
   key: string;
   /** Display string for the value cell. */
@@ -64,27 +64,64 @@ function parseValue(raw: string): unknown {
   return raw;
 }
 
-function toRows(obj: Record<string, unknown>, existingIds: string[]): Row[] {
+/**
+ * Read the stored value as `[key, value]` entries, accepting BOTH shapes a
+ * key/value config field can hold: the common object map (`{ var: value }`) and
+ * the assignment-node ARRAY form (`[{ variable|name|key, value }]`). The shape
+ * is preserved on write (see {@link rowsToValue}).
+ */
+export function toEntries(value: unknown): Array<[string, unknown]> {
+  if (Array.isArray(value)) {
+    return value
+      .filter((it): it is Record<string, unknown> => isPlainObject(it))
+      .map((it) => {
+        const k = it.variable ?? it.name ?? it.key;
+        return [typeof k === 'string' ? k : '', it.value] as [string, unknown];
+      });
+  }
+  if (isPlainObject(value)) return Object.entries(value);
+  return [];
+}
+
+function toRows(value: unknown, existingIds: string[]): Row[] {
   const ids = [...existingIds];
-  return Object.entries(obj).map(([key, value]) => {
+  return toEntries(value).map(([key, val]) => {
     const id = uniqueId('kv', ids);
     ids.push(id);
-    return { id, key, raw: toRaw(value) };
+    return { id, key, raw: toRaw(val) };
   });
 }
 
-/** Flush rows to an object, skipping empty/duplicate keys (first wins). */
-function rowsToObject(rows: Row[]): Record<string, unknown> {
+/** Flush rows back to the SAME shape, skipping empty/duplicate keys (first wins). */
+export function rowsToValue(
+  rows: Row[],
+  arrayShape: boolean,
+): Record<string, unknown> | Array<Record<string, unknown>> {
+  const seen = new Set<string>();
+  if (arrayShape) {
+    const list: Array<Record<string, unknown>> = [];
+    for (const r of rows) {
+      const k = r.key.trim();
+      if (!k || seen.has(k)) continue;
+      seen.add(k);
+      list.push({ variable: k, value: parseValue(r.raw) });
+    }
+    return list;
+  }
   const out: Record<string, unknown> = {};
   for (const r of rows) {
     const k = r.key.trim();
-    if (!k || k in out) continue;
+    if (!k || seen.has(k)) continue;
+    seen.add(k);
     out[k] = parseValue(r.raw);
   }
   return out;
 }
 
-function serialize(obj: Record<string, unknown>): string {
+/** Stable serialization for the resync guard (order-insensitive for objects). */
+function serialize(value: Record<string, unknown> | Array<Record<string, unknown>> | undefined): string {
+  if (Array.isArray(value)) return JSON.stringify(value);
+  const obj = value ?? {};
   const sorted = Object.keys(obj).sort().reduce<Record<string, unknown>>((acc, k) => {
     acc[k] = obj[k];
     return acc;
@@ -95,7 +132,7 @@ function serialize(obj: Record<string, unknown>): string {
 export interface FlowKeyValueFieldProps {
   label: string;
   value: unknown;
-  onCommit: (value: Record<string, unknown> | undefined) => void;
+  onCommit: (value: Record<string, unknown> | Array<Record<string, unknown>> | undefined) => void;
   disabled?: boolean;
   help?: string;
   addLabel: string;
@@ -120,24 +157,32 @@ export function FlowKeyValueField({
   emptyLabel,
   scopeGroups,
 }: FlowKeyValueFieldProps) {
-  const external = isPlainObject(value) ? value : {};
-  const [rows, setRows] = React.useState<Row[]>(() => toRows(external, []));
-  // Track the last value we committed so an external change (node switch) can
-  // resync rows without clobbering an in-progress edit of the same node.
-  const lastCommitted = React.useRef(serialize(external));
+  // Preserve whichever shape the value was authored in (object map vs the
+  // assignment-node array form) across edits.
+  const arrayShape = Array.isArray(value);
+  // Normalized serialization of the stored value — used only to detect an
+  // EXTERNAL change (node switch) that should resync the rows.
+  const external = React.useMemo(
+    () => serialize(rowsToValue(toRows(value, []), arrayShape)),
+    [value, arrayShape],
+  );
+  const [rows, setRows] = React.useState<Row[]>(() => toRows(value, []));
+  // Track the last value we committed so an external change can resync rows
+  // without clobbering an in-progress edit of the same node.
+  const lastCommitted = React.useRef(external);
 
   React.useEffect(() => {
-    const next = serialize(external);
-    if (next !== lastCommitted.current) {
-      setRows(toRows(external, []));
-      lastCommitted.current = next;
+    if (external !== lastCommitted.current) {
+      setRows(toRows(value, []));
+      lastCommitted.current = external;
     }
-  }, [external]);
+  }, [external, value]);
 
   const flush = (nextRows: Row[]) => {
-    const obj = rowsToObject(nextRows);
-    lastCommitted.current = serialize(obj);
-    onCommit(Object.keys(obj).length ? obj : undefined);
+    const out = rowsToValue(nextRows, arrayShape);
+    lastCommitted.current = serialize(out);
+    const empty = Array.isArray(out) ? out.length === 0 : Object.keys(out).length === 0;
+    onCommit(empty ? undefined : out);
   };
 
   const setRowField = (id: string, patch: Partial<Row>) => {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
@@ -22,6 +22,7 @@ import { FlowReferenceField, type FlowReferenceContext } from './FlowReferenceFi
 import { validateExpressionClient } from './expression-validate';
 import { VariableTextInput } from './VariableTextInput';
 import type { ScopeGroup } from './useFlowScope';
+import { findUnknownRefs, scopeRoots, describeUnknownRefs } from './flow-ref-check';
 
 export interface FlowNodeConfigFieldProps {
   field: FlowConfigField;
@@ -36,6 +37,8 @@ export interface FlowNodeConfigFieldProps {
 }
 
 export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, context, scopeGroups }: FlowNodeConfigFieldProps) {
+  const refMode: 'expression' | 'template' =
+    field.refMode ?? (field.kind === 'expression' ? 'expression' : 'template');
   const control = (() => {
     switch (field.kind) {
       case 'reference':
@@ -127,7 +130,7 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
             <VariableTextInput
               multiline
               rows={4}
-              mode="template"
+              mode={refMode}
               value={value != null ? String(value) : ''}
               onValueChange={(v) => onCommit(v)}
               groups={scopeGroups ?? []}
@@ -143,7 +146,7 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
           <div className="space-y-1">
             <Label className="text-xs text-muted-foreground">{field.label}</Label>
             <VariableTextInput
-              mode={field.kind === 'expression' ? 'expression' : 'template'}
+              mode={refMode}
               mono={field.kind === 'expression'}
               value={value != null ? String(value) : ''}
               onValueChange={(v) => onCommit(v)}
@@ -157,10 +160,25 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
   })();
 
   // ADR-0032 — surface a malformed condition (e.g. the `{record.x}` brace-in-CEL
-  // mistake) inline, as the author types, with the same corrective message the
-  // build and the agent tool emit. Only checked for expression-bearing fields.
+  // mistake) inline, with the same corrective message the build/agent emit. Only
+  // for expression fields (a genuine template uses single-brace `{var}` legally).
   const exprIssue =
     field.kind === 'expression' ? validateExpressionClient('predicate', value) : null;
+
+  // #1934 — pair the picker with a gentle, scope-aware "unknown reference"
+  // warning: CEL for expression fields, `{…}` holes for template fields. Skipped
+  // for free-form code (refMode 'expression' on a textarea, e.g. a script body)
+  // and when scope is unknown. The brace error above takes precedence.
+  const scopeRole: 'predicate' | 'template' | null =
+    field.kind === 'expression'
+      ? 'predicate'
+      : refMode === 'template' && (field.kind === 'text' || field.kind === 'textarea')
+        ? 'template'
+        : null;
+  const unknownRefs =
+    !exprIssue && scopeRole && scopeGroups && scopeGroups.length > 0
+      ? findUnknownRefs(value, scopeRole, scopeRoots(scopeGroups.flatMap((g) => g.refs)))
+      : [];
 
   return (
     <div className="space-y-1">
@@ -170,7 +188,12 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
           {exprIssue.message}
         </p>
       )}
-      {field.help && !exprIssue && (
+      {!exprIssue && unknownRefs.length > 0 && (
+        <p className="text-[11px] leading-snug text-amber-600 dark:text-amber-400" role="note">
+          {describeUnknownRefs(unknownRefs)}
+        </p>
+      )}
+      {field.help && !exprIssue && unknownRefs.length === 0 && (
         <p className="text-[11px] leading-snug text-muted-foreground">{field.help}</p>
       )}
     </div>

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -139,6 +139,13 @@ export interface FlowConfigField {
   columns?: FlowConfigColumn[];
   /** Reference target for `reference` fields — drives the combobox data source. */
   ref?: FlowReferenceSpec;
+  /**
+   * Data-picker brace mode override (#1934). Defaults by kind (`expression` →
+   * bare CEL, `text` / `textarea` → `{var}` template). Set `'expression'` on a
+   * code field (e.g. a script body) so the picker inserts bare references, not
+   * `{var}` — `{x}` is a syntax error in a JS/TS script.
+   */
+  refMode?: 'expression' | 'template';
 }
 
 /** Convenience: a `['config', key]`-rooted field (the common case). */
@@ -319,6 +326,7 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
     cfg('script', 'Code', 'textarea', {
       placeholder: 'return { ok: true };',
       help: 'Script body (JS/TS).',
+      refMode: 'expression',
       showWhen: { field: 'actionType', equals: ['code'] },
     }),
     cfg('outputVariables', 'Output variables', 'stringList', {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-ref-check.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-ref-check.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { findUnknownRefs, scopeRoots } from './flow-ref-check';
+import type { ScopeRef } from './flow-scope';
+
+const roots = (...tokens: string[]) =>
+  scopeRoots(tokens.map((t) => ({ token: t, label: t, group: 'variables' }) as ScopeRef));
+
+describe('scopeRoots', () => {
+  it('reduces ref tokens to their path roots, de-duped', () => {
+    const s = roots('lead_score', 'record', 'record.email', 'record.account');
+    expect([...s].sort()).toEqual(['lead_score', 'record']);
+  });
+});
+
+describe('findUnknownRefs (predicate)', () => {
+  const known = roots('lead_score', 'record', 'previous', 'account_data');
+
+  it('accepts in-scope roots and any path under them', () => {
+    expect(findUnknownRefs('lead_score >= 60', 'predicate', known)).toEqual([]);
+    expect(findUnknownRefs('record.email != null && previous.status == "x"', 'predicate', known)).toEqual([]);
+    expect(findUnknownRefs('account_data.annual_revenue > 1000', 'predicate', known)).toEqual([]);
+  });
+
+  it('flags a typo with a nearest-match suggestion', () => {
+    const u = findUnknownRefs('recrod.email != null', 'predicate', known);
+    expect(u).toHaveLength(1);
+    expect(u[0]).toEqual({ token: 'recrod', suggestion: 'record' });
+  });
+
+  it('flags a genuinely unknown ref with no close match (no suggestion)', () => {
+    const u = findUnknownRefs('discount_pct > 30', 'predicate', known);
+    expect(u.map((x) => x.token)).toEqual(['discount_pct']);
+    expect(u[0].suggestion).toBeUndefined();
+  });
+
+  it('skips function / macro calls', () => {
+    expect(findUnknownRefs('daysFromNow(90) > record.close_date', 'predicate', known)).toEqual([]);
+    expect(findUnknownRefs('has(record.x) && size(account_data) > 0', 'predicate', known)).toEqual([]);
+  });
+
+  it('skips runtime globals and $-prefixed roots', () => {
+    expect(findUnknownRefs('env.KEY != "" && $error.message == null', 'predicate', known)).toEqual([]);
+    expect(findUnknownRefs('data.lead_score > 0', 'predicate', known)).toEqual([]);
+  });
+
+  it('ignores identifiers inside string literals', () => {
+    expect(findUnknownRefs('record.status == "qualifying"', 'predicate', known)).toEqual([]);
+    // a bareword that only appears inside a string is not a reference
+    expect(findUnknownRefs('record.stage == "discount_pct"', 'predicate', known)).toEqual([]);
+  });
+
+  it('only checks the root, never members', () => {
+    // `email` is a member of the in-scope `record`; never flagged on its own.
+    expect(findUnknownRefs('record.email.bogus', 'predicate', known)).toEqual([]);
+  });
+
+  it('skips CEL keywords/literals', () => {
+    expect(findUnknownRefs('record.active == true && record.x != null', 'predicate', known)).toEqual([]);
+  });
+
+  it('returns nothing when scope is unknown (empty roots)', () => {
+    expect(findUnknownRefs('totally_made_up', 'predicate', new Set())).toEqual([]);
+  });
+
+  it('de-dupes a repeated unknown root', () => {
+    const u = findUnknownRefs('foo > 1 && foo < 9', 'predicate', known);
+    expect(u.map((x) => x.token)).toEqual(['foo']);
+  });
+});
+
+describe('findUnknownRefs (template)', () => {
+  const known = roots('approval_path', 'record');
+
+  it('only scans inside {…} holes', () => {
+    expect(findUnknownRefs('Hello world, contact us', 'template', known)).toEqual([]);
+    expect(findUnknownRefs('Path: {approval_path} for {record.name}', 'template', known)).toEqual([]);
+  });
+
+  it('flags an unknown reference inside a hole, with a suggestion', () => {
+    const u = findUnknownRefs('Path: {aproval_path}', 'template', known);
+    expect(u).toHaveLength(1);
+    expect(u[0]).toEqual({ token: 'aproval_path', suggestion: 'approval_path' });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-ref-check.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-ref-check.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * flow-ref-check — pure, scope-aware "unknown reference" detection for the flow
+ * inspector's inline validation (#1934 follow-up). Pairs the data-picker with a
+ * gentle warning when an authored expression / template references a name that
+ * is NOT in scope at the node — catching typos (`recrod.email`) and stale
+ * references the picker would have prevented.
+ *
+ * Deliberately conservative — a warning that cries wolf is worse than none:
+ *   • Only the ROOT of a reference path is checked (`record.email` → `record`),
+ *     so a field list is never needed; if `record` is in scope the whole path is
+ *     accepted.
+ *   • Function / macro calls (`daysFromNow(90)`, `has(...)`, `size(...)`) are
+ *     skipped — an identifier immediately followed by `(` is never a reference.
+ *   • String-literal contents are stripped before scanning.
+ *   • Runtime globals the engine injects (`env`, `$error`, `data`, …) and CEL
+ *     keywords/literals are allow-listed.
+ *   • For templates only the inside of single-brace `{…}` holes is scanned.
+ *
+ * The caller supplies the in-scope ROOT names (see {@link scopeRoots}); an empty
+ * set means "scope unknown" and the check is skipped (returns nothing).
+ */
+
+import type { ExprFieldRole } from './expression-validate';
+import type { ScopeRef } from './flow-scope';
+
+/** CEL keywords / literals that are never flow references. */
+const CEL_RESERVED = new Set(['true', 'false', 'null', 'in']);
+/**
+ * Roots the engine provides at runtime that won't show up in the graph-resolved
+ * scope. Conservative allow-list — better to miss a typo than flag a valid ref.
+ */
+const RUNTIME_GLOBALS = new Set(['env', 'request', 'context', 'user', 'now', 'today', 'self', 'data']);
+
+export interface UnknownRef {
+  /** The unresolved root identifier, as authored. */
+  token: string;
+  /** Nearest in-scope root within edit distance 2, when one exists (typo hint). */
+  suggestion?: string;
+}
+
+/** The set of valid root identifiers from a resolved scope's refs. */
+export function scopeRoots(refs: ReadonlyArray<ScopeRef>): Set<string> {
+  const roots = new Set<string>();
+  for (const r of refs) {
+    const root = r.token.split('.')[0];
+    if (root) roots.add(root);
+  }
+  return roots;
+}
+
+/** Bounded Levenshtein distance, giving up (returns max+1) once it exceeds `max`. */
+function editDistance(a: string, b: string, max = 2): number {
+  if (Math.abs(a.length - b.length) > max) return max + 1;
+  const prev = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    let diag = prev[0];
+    prev[0] = i;
+    let rowMin = prev[0];
+    for (let j = 1; j <= b.length; j++) {
+      const tmp = prev[j];
+      prev[j] = Math.min(prev[j] + 1, prev[j - 1] + 1, diag + (a[i - 1] === b[j - 1] ? 0 : 1));
+      diag = tmp;
+      if (prev[j] < rowMin) rowMin = prev[j];
+    }
+    if (rowMin > max) return max + 1;
+  }
+  return prev[b.length];
+}
+
+/** Extract reference-position root identifiers (skipping members and calls). */
+function rootIdentifiers(src: string): string[] {
+  // Strip string literals so their contents aren't scanned as references.
+  const noStrings = src
+    .replace(/'(?:[^'\\]|\\.)*'/g, ' ')
+    .replace(/"(?:[^"\\]|\\.)*"/g, ' ');
+  const out: string[] = [];
+  // Lookbehind keeps this to ROOTS: an identifier not preceded by `.` (member),
+  // a word char, or `$`. Zero-width, so adjacent tokens are never swallowed.
+  const re = /(?<![.\w$])([A-Za-z_$][\w$]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(noStrings))) {
+    const name = m[1];
+    // A trailing `(` (after optional spaces) marks a function / macro call.
+    if (/^\s*\(/.test(noStrings.slice(m.index + name.length))) continue;
+    if (CEL_RESERVED.has(name)) continue;
+    out.push(name);
+  }
+  return out;
+}
+
+/**
+ * Find referenced roots that are not in scope. Returns [] when clean, when the
+ * source is empty, or when `knownRoots` is empty (scope unknown → don't guess).
+ */
+export function findUnknownRefs(source: unknown, role: ExprFieldRole, knownRoots: Set<string>): UnknownRef[] {
+  let raw = '';
+  if (typeof source === 'string') raw = source;
+  else if (source && typeof source === 'object') raw = String((source as { source?: string }).source ?? '');
+  if (!raw.trim() || knownRoots.size === 0) return [];
+
+  let scan = raw;
+  if (role === 'template') {
+    const holes = raw.match(/\{([^{}]+)\}/g);
+    if (!holes) return [];
+    scan = holes.map((h) => h.slice(1, -1)).join(' ; ');
+  }
+
+  const seen = new Set<string>();
+  const unknown: UnknownRef[] = [];
+  for (const root of rootIdentifiers(scan)) {
+    if (seen.has(root)) continue;
+    seen.add(root);
+    if (knownRoots.has(root) || RUNTIME_GLOBALS.has(root) || root.startsWith('$')) continue;
+    let suggestion: string | undefined;
+    let best = 3;
+    for (const k of knownRoots) {
+      const d = editDistance(root, k, 2);
+      if (d < best) {
+        best = d;
+        suggestion = k;
+      }
+    }
+    unknown.push({ token: root, suggestion: best <= 2 ? suggestion : undefined });
+  }
+  return unknown;
+}
+
+/** Build a one-line inspector warning from unknown refs (shared by the field
+ *  and edge inspectors). */
+export function describeUnknownRefs(unknown: ReadonlyArray<UnknownRef>): string {
+  if (unknown.length === 1) {
+    const u = unknown[0];
+    return u.suggestion
+      ? `Unknown reference \`${u.token}\` — did you mean \`${u.suggestion}\`?`
+      : `\`${u.token}\` is not a reference in scope at this step.`;
+  }
+  return `Not in scope: ${unknown.map((u) => `\`${u.token}\``).join(', ')}.`;
+}


### PR DESCRIPTION
Follow-ups to the flow-builder variable data-picker ([#1973](https://github.com/objectstack-ai/objectui/pull/1973)), addressing #1934's "pair the picker with inline validation" AC plus two gaps found while dogfooding it.

## 1. Scope-aware "unknown reference" warning
Pairs the picker with the inline validation the issue called for: a typed reference whose **root** isn't in scope at the node is flagged inline, with a nearest-match *"did you mean?"* hint.

Deliberately conservative — a warning that cries wolf is worse than none:
- **root-only** — `record.<anything>` is accepted when `record` is in scope (no need to enumerate fields);
- skips **function / macro calls** (`daysFromNow(90)`, `has(...)`), **string literals**, CEL keywords, and runtime globals (`env`, `$error`, `data`, …);
- typo hint only within **edit distance ≤ 2**;
- **non-blocking amber** — the ADR-0032 brace error still takes precedence.

CEL for `expression` fields, `{…}` holes for templates. New pure `flow-ref-check.ts` module (`findUnknownRefs` / `scopeRoots` / `describeUnknownRefs`) with 13 unit tests; wired into `FlowNodeConfigField` + `FlowEdgeInspector`.

## 2. Assignment array-form values get the picker
Assignment values authored in the array form `[{ variable, value }]` (used by the showcase `lead_qualification_conversion`) silently fell back to the Advanced-JSON block — the key/value editor only understood the object-map shape, so those values got **no picker**. The editor now reads **both** shapes and **preserves whichever was authored** on write. Round-trip unit tests (`FlowKeyValueField.shape.test.ts`).

## 3. Script code inserts bare references
A script `code` body is **JS/TS, not a `{var}` template** — `{x}` is a syntax error there. #1973 treated every `textarea` as a template, so the picker inserted `{record.x}` into script code. Added a `refMode` field-schema override and set the script `code` field to `'expression'` so it inserts **bare** refs. Validation is skipped for that free-form field.

## Tests / verification
- New unit tests: `flow-ref-check.test.ts` (13), `FlowKeyValueField.shape.test.ts` (6). Full `metadata-admin` suite green (161), `pnpm build` (tsc) clean.
- The picker UI itself (render, grouped graph-aware list, cursor insertion of bare CEL vs `{var}`) was browser-verified in #1973 against the same components; these changes compose on that proven base (the amber warning mirrors the proven brace-error render; array rows reuse the proven value-cell picker; bare insertion is the proven `formatToken` path). Note: incremental browser re-verification was constrained by a contended shared browser under parallel-session load, so coverage rests on the unit tests above + the #1973 browser run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)