### PR TITLE
feat(studio): make the flow-canvas error banner clickable (reveal on click)

### DIFF
--- a/.changeset/flow-canvas-error-banner-clickable.md
+++ b/.changeset/flow-canvas-error-banner-clickable.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(studio): make the flow-canvas error banner clickable
+
+The inline structural-error banner (ADR-0044 cycle surfacing) is now driven by
+the unified `problems` list, and each row with a concrete target is clickable —
+clicking it selects and pans-to-reveal the offending node/edge (the same reveal
+the Problems panel performs). So the always-visible banner is actionable without
+opening the panel. Drops the now-redundant `validationErrors` string prop: the
+banner, the Problems panel, and the on-canvas badges all share one source.

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
@@ -1,15 +1,18 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { FlowCanvas } from './FlowCanvas';
+import type { FlowProblem } from './flow-problems';
 
 afterEach(cleanup);
 
 /**
  * ADR-0044: an un-declared cycle is surfaced INLINE on the canvas — the
  * offending edges/nodes are painted red (data-invalid) and an error banner
- * shows the message — so the author needn't open the Debug panel.
+ * shows the message. Each banner row with a concrete target is clickable and
+ * reveals (selects + pans to) the offending element — the same reveal the
+ * Problems panel does — so the always-visible banner is actionable.
  */
 describe('FlowCanvas — inline cycle/error surfacing', () => {
   const nodes = [
@@ -20,8 +23,15 @@ describe('FlowCanvas — inline cycle/error surfacing', () => {
     { source: 'a', target: 'w', label: 'revise' },
     { source: 'w', target: 'a', label: 'resubmit' }, // unmarked cycle
   ];
+  const cycleProblem: FlowProblem = {
+    id: 'cyc1',
+    level: 'error',
+    message: 'Cycle detected (a → w → a). Mark the closing edge as a back-edge.',
+    target: { kind: 'edge', edgeKey: 'w->a#1', source: 'w', target: 'a' },
+    source: 'structural',
+  };
 
-  it('renders the error banner and marks invalid edges + nodes', () => {
+  it('renders the error banner (from problems) and marks invalid edges + nodes', () => {
     const { container } = render(
       <FlowCanvas
         nodes={nodes}
@@ -32,13 +42,45 @@ describe('FlowCanvas — inline cycle/error surfacing', () => {
         onSelect={() => {}}
         invalidNodeIds={['a', 'w']}
         invalidEdges={new Set(['a->w', 'w->a'])}
-        validationErrors={['Cycle detected (a → w → a). Mark the closing edge as a back-edge.']}
+        problems={[cycleProblem]}
       />,
     );
-    // Banner message is visible on the canvas.
     expect(screen.getByText(/Cycle detected/)).toBeInTheDocument();
     // Two cycle edges + two cycle nodes carry the data-invalid marker.
     expect(container.querySelectorAll('[data-invalid="true"]').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('reveals the offending element when a banner row is clicked', () => {
+    const onRevealProblem = vi.fn();
+    render(
+      <FlowCanvas
+        nodes={nodes}
+        edges={edges}
+        editable={false}
+        designMode={false}
+        selectedId={null}
+        onSelect={() => {}}
+        problems={[cycleProblem]}
+        onRevealProblem={onRevealProblem}
+      />,
+    );
+    fireEvent.click(screen.getByText(/Cycle detected/));
+    expect(onRevealProblem).toHaveBeenCalledWith(cycleProblem);
+  });
+
+  it('only counts error-level problems in the banner (warnings are not shown)', () => {
+    render(
+      <FlowCanvas
+        nodes={nodes}
+        edges={edges}
+        editable={false}
+        designMode={false}
+        selectedId={null}
+        onSelect={() => {}}
+        problems={[{ id: 'w1', level: 'warning', message: 'Just a heads-up', target: { kind: 'flow' }, source: 'structural' }]}
+      />,
+    );
+    expect(screen.queryByText(/Just a heads-up/)).toBeNull();
   });
 
   it('shows no banner and no invalid markers for a clean flow', () => {

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -88,8 +88,12 @@ export interface FlowCanvasProps {
   invalidNodeIds?: string[];
   /** Structural-validation: edges (keyed `${source}->${target}`) to paint red. */
   invalidEdges?: ReadonlySet<string>;
-  /** Structural-validation error messages shown in an inline canvas banner. */
-  validationErrors?: string[];
+  /**
+   * Select + reveal a problem when its inline-banner row is clicked — wired to
+   * the same handler the Problems panel uses, so the always-visible banner is
+   * actionable without opening the panel.
+   */
+  onRevealProblem?: (problem: FlowProblem) => void;
   /**
    * Unified validation issues (structural + server) rendered as per-element
    * badges; the Problems panel shares the same list.
@@ -120,7 +124,7 @@ export function FlowCanvas({
   traversedEdgeIds,
   invalidNodeIds,
   invalidEdges,
-  validationErrors,
+  onRevealProblem,
   problems,
   revealSignal,
   onSelect,
@@ -159,6 +163,10 @@ export function FlowCanvas({
     () => indexProblemBadges(problems ?? []),
     [problems],
   );
+
+  // Error-level problems shown in the always-visible inline banner — driven by
+  // the same `problems` list as the panel/badges so the three stay in lock-step.
+  const bannerErrors = React.useMemo(() => (problems ?? []).filter((p) => p.level === 'error'), [problems]);
 
   const positionOf = React.useCallback(
     (id: string): Point => {
@@ -450,21 +458,34 @@ export function FlowCanvas({
   return (
     <div className="relative h-full min-h-[320px] w-full overflow-hidden">
       {/* Inline structural-validation banner (ADR-0044 cycle surfacing): shows
-          errors directly on the canvas so the author needn't open Debug. */}
-      {validationErrors && validationErrors.length > 0 && (
+          errors directly on the canvas so the author needn't open Debug. Each row
+          with a concrete target is clickable — it selects + pans to the offending
+          node/edge (the same reveal the Problems panel does). */}
+      {bannerErrors.length > 0 && (
         <div className="absolute left-2 top-2 z-30 max-w-[min(60%,420px)] space-y-1">
-          {validationErrors.slice(0, 3).map((msg, i) => (
-            <div
-              key={i}
-              role="alert"
-              className="flex items-start gap-1.5 rounded-lg border border-destructive/40 bg-destructive/10 px-2.5 py-1.5 text-[11px] leading-snug text-destructive shadow-sm backdrop-blur-sm"
-            >
-              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>{msg}</span>
-            </div>
-          ))}
-          {validationErrors.length > 3 && (
-            <div className="px-2.5 text-[10px] text-destructive/80">+{validationErrors.length - 3} more…</div>
+          {bannerErrors.slice(0, 3).map((p) => {
+            const clickable = !!onRevealProblem && p.target.kind !== 'flow';
+            return (
+              <button
+                key={p.id}
+                type="button"
+                role="alert"
+                disabled={!clickable}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={clickable ? (e) => { e.stopPropagation(); onRevealProblem!(p); } : undefined}
+                title={clickable ? 'Reveal on canvas' : undefined}
+                className={cn(
+                  'flex w-full items-start gap-1.5 rounded-lg border border-destructive/40 bg-destructive/10 px-2.5 py-1.5 text-left text-[11px] leading-snug text-destructive shadow-sm backdrop-blur-sm transition-colors',
+                  clickable && 'cursor-pointer hover:border-destructive/60 hover:bg-destructive/20',
+                )}
+              >
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>{p.message}</span>
+              </button>
+            );
+          })}
+          {bannerErrors.length > 3 && (
+            <div className="px-2.5 text-[10px] text-destructive/80">+{bannerErrors.length - 3} more…</div>
           )}
         </div>
       )}

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -95,11 +95,11 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
     traversedEdgeIds: string[];
   } | null>(null);
 
-  // Continuous structural validation surfaced INLINE on the canvas (ADR-0044):
-  // an un-declared cycle (and other structural errors) paints the offending
-  // edges/nodes red and shows a banner — so the author sees it without opening
-  // the Debug panel. Same `validateFlowDraft` the simulator preflight uses.
-  const { invalidNodeIds, invalidEdges, validationErrors } = React.useMemo(() => {
+  // Continuous structural validation paints the offending edges/nodes red on the
+  // canvas (ADR-0044) — so an un-declared cycle is visible without opening Debug.
+  // Same `validateFlowDraft` the simulator preflight uses; the inline banner and
+  // per-element badges are driven by the unified `problems` list below.
+  const { invalidNodeIds, invalidEdges } = React.useMemo(() => {
     const v = validateFlowDraft(nodes as unknown as SimNode[], edges as unknown as SimEdge[]);
     const nodeSet = new Set<string>();
     const edgeSet = new Set<string>();
@@ -113,11 +113,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
         }
       }
     }
-    return {
-      invalidNodeIds: [...nodeSet],
-      invalidEdges: edgeSet,
-      validationErrors: v.errors.map((diag) => diag.message),
-    };
+    return { invalidNodeIds: [...nodeSet], invalidEdges: edgeSet };
   }, [nodes, edges]);
 
   // Unified problem list (structural + server `_diagnostics`) shared by the
@@ -298,7 +294,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                 traversedEdgeIds={runHL?.traversedEdgeIds}
                 invalidNodeIds={invalidNodeIds}
                 invalidEdges={invalidEdges}
-                validationErrors={validationErrors}
+                onRevealProblem={handleSelectProblem}
                 problems={problems}
                 revealSignal={reveal}
                 onSelect={(n) =>


### PR DESCRIPTION
## What & why

The inline structural-error banner on the flow canvas (ADR-0044 cycle surfacing, #1958) was **display-only**. Since then a full **Problems panel** landed — clickable rows that select + pan-to-reveal the offending node/edge — but the always-visible canvas banner still just showed text via a separate `validationErrors: string[]`, duplicating the panel's data.

## Change

- **Clickable banner** — drive the banner from the unified `problems` list and make each row with a concrete target a button. Clicking it calls the **same `onSelectProblem`/reveal handler the Problems panel uses** (`onRevealProblem`), so it selects and pans-to-center the offending node/edge. Flow-level problems (no specific element) stay non-clickable.
- **Dedup** — remove the redundant `validationErrors` prop and its duplicate `validateFlowDraft` message-mapping in `FlowPreview`. The banner, Problems panel, and on-canvas badges now share **one source** (`buildFlowProblems`). The red edge/node highlighting (its own `invalidNodeIds`/`invalidEdges`) is unchanged.

## Verification

- `FlowCanvas` tests **4 passing** (banner renders from `problems`; **click → `onRevealProblem` called with the problem**; warnings excluded from the banner; clean flow → no banner/markers).
- Full metadata-admin suite **463 passing** (no regression).
- `type-check` 0 errors; `eslint` 0 errors (3 pre-existing warnings untouched).

> Note: the click-to-reveal capability already existed in the side **Problems panel**; this makes the *always-visible* banner equally actionable and removes the duplicate data path. Completes the #3 UX-polish follow-up to #1958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
