### PR TITLE
feat(metadata-admin): inline ref validation in flow repeater cells + previous.<field> picker refs (#1934)

### DIFF
--- a/.changeset/flow-repeater-validation.md
+++ b/.changeset/flow-repeater-validation.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Flow builder data-picker (#1934): inline validation now also shows on the repeater surfaces that carry the picker — decision **Branches** expressions, screen field **"visible when"**, and key/value **values** — not just single fields. Each shows the ADR-0032 brace error (red) or a scope-aware "unknown reference" warning (amber) via a shared `FlowExprIssue` line. The trigger-record picker also offers `previous.<field>` references on update / change / before-update triggers.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowExprIssue.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowExprIssue.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * FlowExprIssue — the shared inline validation line for an expression / template
+ * value in the flow inspector (#1934). Renders, in precedence order:
+ *   1. an ADR-0032 brace/shape ERROR (red) — CEL fields only; a genuine template
+ *      uses single-brace `{var}` legally, so the brace check never runs there;
+ *   2. else a scope-aware "unknown reference" WARNING (amber) — a referenced
+ *      root not in scope at the node, with a "did you mean?" hint.
+ * Returns null when the value is clean (or scope is unknown). Used by the picker
+ * repeater cells (decision Branches, screen visibleWhen, key/value values) that
+ * carry the picker but otherwise had no inline validation.
+ */
+
+import * as React from 'react';
+import { validateExpressionClient, type ExprFieldRole } from './expression-validate';
+import { findUnknownRefs, scopeRoots, describeUnknownRefs } from './flow-ref-check';
+import type { ScopeGroup } from './useFlowScope';
+
+export interface FlowExprIssueProps {
+  value: unknown;
+  /** `'predicate'` / `'value'` → CEL (brace-checked); `'template'` → `{…}` holes. */
+  role: ExprFieldRole;
+  scopeGroups?: ScopeGroup[];
+}
+
+export function FlowExprIssue({ value, role, scopeGroups }: FlowExprIssueProps): React.ReactElement | null {
+  // Brace / shape error — CEL roles only (single-brace is valid in a template).
+  const issue = role === 'template' ? null : validateExpressionClient(role, value);
+  if (issue) {
+    return (
+      <p className="text-[11px] leading-snug text-destructive" role="alert">
+        {issue.message}
+      </p>
+    );
+  }
+  const roots = scopeGroups && scopeGroups.length > 0 ? scopeRoots(scopeGroups.flatMap((g) => g.refs)) : null;
+  const unknown = roots ? findUnknownRefs(value, role, roots) : [];
+  return unknown.length > 0 ? (
+    <p className="text-[11px] leading-snug text-amber-600 dark:text-amber-400" role="note">
+      {describeUnknownRefs(unknown)}
+    </p>
+  ) : null;
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowKeyValueField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowKeyValueField.tsx
@@ -23,6 +23,7 @@ import { Button, Input, Label } from '@object-ui/components';
 import { uniqueId } from './_shared';
 import { VariableTextInput } from './VariableTextInput';
 import type { ScopeGroup } from './useFlowScope';
+import { FlowExprIssue } from './FlowExprIssue';
 
 export interface Row {
   id: string;
@@ -209,7 +210,8 @@ export function FlowKeyValueField({
           <p className="text-[11px] italic text-muted-foreground">{emptyLabel}</p>
         )}
         {rows.map((row) => (
-          <div key={row.id} className="flex items-center gap-1.5">
+          <div key={row.id} className="space-y-1">
+            <div className="flex items-center gap-1.5">
             <Input
               value={row.key}
               onChange={(e) => setRowField(row.id, { key: e.target.value })}
@@ -246,6 +248,8 @@ export function FlowKeyValueField({
             >
               <X className="h-3.5 w-3.5" />
             </Button>
+            </div>
+            <FlowExprIssue value={row.raw} role="template" scopeGroups={scopeGroups} />
           </div>
         ))}
       </div>

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx
@@ -19,6 +19,7 @@ import type { FlowConfigColumn } from './flow-node-config';
 import { ReferenceCombobox, resolveRefKind, type FlowReferenceContext } from './FlowReferenceField';
 import { VariableTextInput } from './VariableTextInput';
 import type { ScopeGroup } from './useFlowScope';
+import { FlowExprIssue } from './FlowExprIssue';
 
 type Cell = string | boolean;
 interface Row {
@@ -192,7 +193,7 @@ export function FlowObjectListField({
                       />
                     </div>
                   ) : col.kind === 'expression' ? (
-                    <div className="flex-1">
+                    <div className="flex-1 space-y-1">
                       <VariableTextInput
                         mode="expression"
                         mono
@@ -205,6 +206,11 @@ export function FlowObjectListField({
                         groups={scopeGroups ?? []}
                         placeholder={col.placeholder}
                         disabled={disabled}
+                      />
+                      <FlowExprIssue
+                        value={typeof row.values[col.key] === 'string' ? (row.values[col.key] as string) : ''}
+                        role="predicate"
+                        scopeGroups={scopeGroups}
                       />
                     </div>
                   ) : (

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-scope.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-scope.test.ts
@@ -109,12 +109,12 @@ describe('resolveFlowScope — graph-aware in-scope references', () => {
     const scope = resolveFlowScope(draft, 'decide');
     expect(groupTokens(scope, 'trigger')).toContain('record');
     expect(groupTokens(scope, 'trigger')).toContain('previous');
-    expect(scope.trigger).toEqual({ objectName: 'crm_lead', fieldPrefix: 'record.' });
+    expect(scope.trigger).toEqual({ objectName: 'crm_lead', fieldPrefix: 'record.', includePrevious: true });
   });
 
   it('uses a BARE field prefix on the start node itself (entry condition)', () => {
     const scope = resolveFlowScope(draft, 'start');
-    expect(scope.trigger).toEqual({ objectName: 'crm_lead', fieldPrefix: '' });
+    expect(scope.trigger).toEqual({ objectName: 'crm_lead', fieldPrefix: '', includePrevious: true });
     // No whole-`record` token on the start node (fields are the bare context).
     expect(groupTokens(scope, 'trigger')).not.toContain('record');
     // `previous` is still available on an update trigger.
@@ -170,9 +170,17 @@ describe('triggerFieldRefs', () => {
     { name: 'status', type: 'text' },
   ];
   it('prefixes fields with record. downstream', () => {
-    expect(tokens(triggerFieldRefs({ objectName: 'o', fieldPrefix: 'record.' }, fields))).toEqual(['record.amount', 'record.status']);
+    expect(tokens(triggerFieldRefs({ objectName: 'o', fieldPrefix: 'record.', includePrevious: false }, fields))).toEqual(['record.amount', 'record.status']);
   });
   it('uses bare field names on the start node', () => {
-    expect(tokens(triggerFieldRefs({ objectName: 'o', fieldPrefix: '' }, fields))).toEqual(['amount', 'status']);
+    expect(tokens(triggerFieldRefs({ objectName: 'o', fieldPrefix: '', includePrevious: false }, fields))).toEqual(['amount', 'status']);
+  });
+  it('also emits previous.<field> when the trigger carries a previous snapshot', () => {
+    expect(tokens(triggerFieldRefs({ objectName: 'o', fieldPrefix: 'record.', includePrevious: true }, fields))).toEqual([
+      'record.amount',
+      'previous.amount',
+      'record.status',
+      'previous.status',
+    ]);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-scope.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-scope.ts
@@ -53,6 +53,8 @@ export interface TriggerScope {
   objectName: string;
   /** Per-field token prefix: '' on the start node (bare), 'record.' downstream. */
   fieldPrefix: string;
+  /** Also emit `previous.<field>` refs (update / change / before-update triggers). */
+  includePrevious: boolean;
 }
 
 export interface FlowScope {
@@ -234,16 +236,17 @@ export function resolveFlowScope(draft: Record<string, unknown>, nodeId: string 
     const startInScope = startId === nodeId || (!!startId && ancestors.has(startId));
     if (isRecordTrigger && objectName && startInScope) {
       const onStart = startId === nodeId;
+      const includePrevious = PREVIOUS_TRIGGER_TYPES.has(triggerType);
       // On the start node the record's fields ARE the bare evaluation context
       // (`status`), so the whole record is not a named ref there; `previous` is
       // (`previous.status`). Downstream the record is the named `record` object.
       if (!onStart) {
         refs.push({ token: 'record', label: 'record', detail: `trigger record · ${objectName}`, group: 'trigger' });
       }
-      if (PREVIOUS_TRIGGER_TYPES.has(triggerType)) {
+      if (includePrevious) {
         refs.push({ token: 'previous', label: 'previous', detail: 'record values before the change', group: 'trigger' });
       }
-      return { refs: dedupeByToken(refs), trigger: { objectName, fieldPrefix: onStart ? '' : 'record.' } };
+      return { refs: dedupeByToken(refs), trigger: { objectName, fieldPrefix: onStart ? '' : 'record.', includePrevious } };
     }
   }
 
@@ -266,6 +269,14 @@ export function triggerFieldRefs(
     const token = `${trigger.fieldPrefix}${f.name}`;
     const detail = f.label && f.label !== f.name ? f.label : f.type;
     out.push({ token, label: token, detail, group: 'trigger' });
+    if (trigger.includePrevious) {
+      out.push({
+        token: `previous.${f.name}`,
+        label: `previous.${f.name}`,
+        detail: detail ? `prior ${detail}` : 'prior value',
+        group: 'trigger',
+      });
+    }
   }
   return out;
 }


### PR DESCRIPTION
Follow-ups to the flow-builder data-picker ([#1973](https://github.com/objectstack-ai/objectui/pull/1973)) and its inline validation ([#1975](https://github.com/objectstack-ai/objectui/pull/1975)).

## 1. Inline validation on the repeater surfaces
#1975 added the ADR-0032 brace error + scope-aware "unknown reference" warning to *single* expression/template fields and the edge condition — but the **decision Branches** expression (the headline surface), screen field **"visible when"**, and assignment / CRUD / subflow **key-value values** are repeater cells that carried the picker yet had **no inline validation**. They now do, via a shared `FlowExprIssue` line:
- expression columns → CEL brace check + scope check (`predicate`);
- key-value values → scope check on `{…}` holes (`template`; single-brace is legal there, so never brace-flagged).

## 2. `previous.<field>` picker references
The trigger-record group now offers `previous.<field>` (not just the whole `previous`) on update / change / before-update triggers — `previous.status` is a common entry-condition pattern.

## Tests / verification
- `flow-scope.test.ts` extended for `previous.<field>` (25 tests); full `metadata-admin` suite green (165), `pnpm build` (tsc) clean. The `FlowExprIssue` line composes the already-unit-tested `validateExpressionClient` + `findUnknownRefs` / `describeUnknownRefs` and renders the same red/amber `<p>` pattern already shipped on single fields in #1975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)