### PR TITLE
feat(metadata-admin): surface flow expression problems in the Problems panel + canvas badges (#1934)

### DIFF
--- a/.changeset/flow-expr-problems.md
+++ b/.changeset/flow-expr-problems.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Flow builder (#1934): expression problems — ADR-0032 brace/shape errors and scope-aware "unknown reference" warnings — now also surface in the flow **Problems panel** and as on-canvas **node/edge badges** (#1972), not just inline in the inspector. A `{record.x}` brace-in-CEL mistake or a typo'd variable is now visible at the flow level without opening each node. The start node's bare trigger-record fields are excluded from the ref check to avoid false positives (the inline inspector check still covers them).

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -120,8 +120,8 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
   // on-canvas badges and the Problems panel. Recomputed from the live draft so
   // badges + rows clear as the author fixes each issue.
   const problems = React.useMemo<FlowProblem[]>(
-    () => buildFlowProblems({ nodes, edges, serverDiagnostics: diagnostics }),
-    [nodes, edges, diagnostics],
+    () => buildFlowProblems({ nodes, edges, serverDiagnostics: diagnostics, variables }),
+    [nodes, edges, diagnostics, d.variables],
   );
   const errorCount = problems.filter((p) => p.level === 'error').length;
 

--- a/packages/app-shell/src/views/metadata-admin/previews/ProblemsPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ProblemsPanel.tsx
@@ -90,6 +90,7 @@ export function ProblemsPanel({ problems, selectedKey, onSelectProblem }: Proble
                       <TargetIcon className="h-2.5 w-2.5 shrink-0" />
                       <span className="truncate font-mono">{targetLabel(p)}</span>
                       {p.source === 'server' && <span className="uppercase tracking-wide">· schema</span>}
+                      {p.source === 'expression' && <span className="uppercase tracking-wide">· expression</span>}
                     </span>
                   </span>
                 </button>

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-expr-problems.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-expr-problems.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { flowExpressionProblems } from './flow-expr-problems';
+
+const startUpdate = { id: 'start', type: 'start', config: { triggerType: 'record-after-update', objectName: 'crm_lead' } };
+
+describe('flowExpressionProblems', () => {
+  it('flags a brace-in-CEL error on a decision branch expression (node target)', () => {
+    const draft = {
+      variables: [],
+      nodes: [
+        startUpdate,
+        { id: 'd', type: 'decision', config: { conditions: [{ label: 'Big', expression: '{record.amount} > 10' }] } },
+      ],
+      edges: [{ source: 'start', target: 'd' }],
+    };
+    const ps = flowExpressionProblems(draft);
+    const brace = ps.find((p) => p.level === 'error');
+    expect(brace).toBeDefined();
+    expect(brace!.target).toEqual({ kind: 'node', nodeId: 'd' });
+    expect(brace!.message).toMatch(/Big:.*map literal/);
+  });
+
+  it('flags an unknown reference (warning) on a downstream decision condition', () => {
+    const draft = {
+      variables: [{ name: 'lead_score' }],
+      nodes: [
+        startUpdate,
+        { id: 'd', type: 'decision', config: { condition: 'lead_scor >= 60' } },
+      ],
+      edges: [{ source: 'start', target: 'd' }],
+    };
+    const ps = flowExpressionProblems(draft);
+    const warn = ps.find((p) => p.level === 'warning');
+    expect(warn).toBeDefined();
+    expect(warn!.target).toEqual({ kind: 'node', nodeId: 'd' });
+    expect(warn!.message).toMatch(/did you mean `lead_score`/);
+  });
+
+  it('does NOT flag bare trigger fields on the START node (skipped)', () => {
+    const draft = {
+      variables: [],
+      nodes: [{ id: 'start', type: 'start', config: { triggerType: 'record-after-update', objectName: 'crm_lead', condition: 'status == "qualifying" && previous.status != "qualifying"' } }],
+      edges: [],
+    };
+    expect(flowExpressionProblems(draft)).toEqual([]);
+  });
+
+  it('flags a brace error on an edge guard (edge target)', () => {
+    const draft = {
+      variables: [],
+      nodes: [startUpdate, { id: 'a', type: 'assignment', config: {} }, { id: 'b', type: 'end' }],
+      edges: [
+        { source: 'start', target: 'a' },
+        { source: 'a', target: 'b', condition: '{record.x} == 1' },
+      ],
+    };
+    const ps = flowExpressionProblems(draft);
+    const edgeP = ps.find((p) => p.target.kind === 'edge');
+    expect(edgeP).toBeDefined();
+    expect(edgeP!.level).toBe('error');
+    expect(edgeP!.target).toEqual({ kind: 'edge', source: 'a', target: 'b' });
+  });
+
+  it('ignores default edges and empty conditions', () => {
+    const draft = {
+      variables: [],
+      nodes: [startUpdate, { id: 'a', type: 'assignment', config: {} }],
+      edges: [{ source: 'start', target: 'a', isDefault: true, condition: '{bad}' }],
+    };
+    expect(flowExpressionProblems(draft)).toEqual([]);
+  });
+
+  it('returns nothing for a clean flow', () => {
+    const draft = {
+      variables: [{ name: 'lead_score' }],
+      nodes: [startUpdate, { id: 'd', type: 'decision', config: { condition: 'lead_score >= 60 && record.amount > 0' } }],
+      edges: [{ source: 'start', target: 'd' }],
+    };
+    expect(flowExpressionProblems(draft)).toEqual([]);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-expr-problems.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-expr-problems.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * flow-expr-problems — pure, client-side detection of EXPRESSION issues across a
+ * whole flow draft, for surfacing in the Problems panel + canvas badges (#1934).
+ *
+ * Two kinds, mirroring the inline inspector checks but aggregated per node/edge:
+ *   • ADR-0032 brace / shape ERRORS on every CEL field (decision conditions +
+ *     branch expressions, screen `visibleWhen`, loop collection, edge guards…).
+ *     Deterministic, scope-free → zero false positives.
+ *   • Scope-aware "unknown reference" WARNINGS — a bare root not in scope at the
+ *     node. The START node is skipped: its entry condition legitimately uses the
+ *     trigger record's fields *bare* (`status`), which can't be told apart from a
+ *     typo without the object schema (an async fetch this pure pass avoids); the
+ *     inline inspector check, which does fetch, still covers it.
+ *
+ * Only CEL (`expression`) surfaces are scanned — template (`{var}`) values use
+ * single braces legally and are left to the inline check.
+ */
+
+import { fieldsForNodeType, getFieldValue } from '../inspectors/flow-node-config';
+import { resolveFlowScope } from '../inspectors/flow-scope';
+import { scopeRoots, findUnknownRefs, describeUnknownRefs } from '../inspectors/flow-ref-check';
+import { validateExpressionClient } from '../inspectors/expression-validate';
+import type { DiagnosticLevel } from './simulator/flow-sim-types';
+
+export interface ExprProblem {
+  target: { kind: 'node'; nodeId: string } | { kind: 'edge'; source: string; target: string };
+  level: DiagnosticLevel;
+  message: string;
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v ? v : undefined;
+}
+
+/** Brace error (error) else unknown-ref (warning, when `roots` given) for one CEL value. */
+function checkCel(value: unknown, roots: Set<string> | null): { level: DiagnosticLevel; message: string } | null {
+  const issue = validateExpressionClient('predicate', value);
+  if (issue) return { level: 'error', message: issue.message };
+  if (roots && roots.size > 0) {
+    const unknown = findUnknownRefs(value, 'predicate', roots);
+    if (unknown.length > 0) return { level: 'warning', message: describeUnknownRefs(unknown) };
+  }
+  return null;
+}
+
+/**
+ * Scan a flow draft for expression problems, resolved onto node / edge targets.
+ * Pure: no network — the trigger object's fields are not expanded (root-only
+ * scope), which is why the start node is excluded from the ref check.
+ */
+export function flowExpressionProblems(draft: Record<string, unknown>): ExprProblem[] {
+  const nodes = asArray(draft.nodes).map(asRecord);
+  const edges = asArray(draft.edges).map(asRecord);
+  const startId = str(nodes.find((n) => str(n.type) === 'start')?.id);
+  const out: ExprProblem[] = [];
+
+  for (const node of nodes) {
+    const nodeId = str(node.id);
+    const type = str(node.type);
+    if (!nodeId || !type) continue;
+    // Root-only scope at this node; skip the ref check on the start node (its
+    // bare trigger-record fields are indistinguishable from typos here).
+    const roots = nodeId === startId ? null : scopeRoots(resolveFlowScope(draft, nodeId).refs);
+
+    for (const field of fieldsForNodeType(type)) {
+      if (field.kind === 'expression') {
+        const hit = checkCel(getFieldValue(node, field), roots);
+        if (hit) out.push({ target: { kind: 'node', nodeId }, level: hit.level, message: hit.message });
+      } else if (field.kind === 'objectList' && field.columns) {
+        const exprCols = field.columns.filter((c) => c.kind === 'expression');
+        if (exprCols.length === 0) continue;
+        for (const row of asArray(getFieldValue(node, field))) {
+          const r = asRecord(row);
+          const rowLabel = str(r.label);
+          for (const col of exprCols) {
+            const hit = checkCel(r[col.key], roots);
+            if (hit) {
+              const prefix = rowLabel || col.label;
+              out.push({ target: { kind: 'node', nodeId }, level: hit.level, message: prefix ? `${prefix}: ${hit.message}` : hit.message });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for (const edge of edges) {
+    const source = str(edge.source);
+    const target = str(edge.target);
+    if (!source || !target || edge.isDefault === true) continue;
+    const roots = source === startId ? null : scopeRoots(resolveFlowScope(draft, source).refs);
+    const hit = checkCel(edge.condition, roots);
+    if (hit) out.push({ target: { kind: 'edge', source, target }, level: hit.level, message: hit.message });
+  }
+
+  return out;
+}

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-problems.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-problems.ts
@@ -21,6 +21,7 @@
 import { validateFlowDraft } from './simulator/flow-sim-validate';
 import type { Diagnostic, DiagnosticLevel, SimEdge, SimNode } from './simulator/flow-sim-types';
 import { edgeKey, type FlowEdge, type FlowNode } from './flow-canvas-layout';
+import { flowExpressionProblems } from './flow-expr-problems';
 
 /** What a problem points at on the canvas — drives badge placement + reveal. */
 export type FlowProblemTarget =
@@ -29,7 +30,7 @@ export type FlowProblemTarget =
   | { kind: 'flow' };
 
 /** Origin of a problem — labels the panel row and lets the UI group counts. */
-export type FlowProblemSource = 'structural' | 'server';
+export type FlowProblemSource = 'structural' | 'server' | 'expression';
 
 /** One actionable issue, resolved onto a concrete canvas element. */
 export interface FlowProblem {
@@ -116,6 +117,8 @@ export interface BuildFlowProblemsArgs {
   edges: FlowEdge[];
   /** Server `_diagnostics`, flattened to a severity-tagged, path-keyed list. */
   serverDiagnostics?: ServerDiagnostic[];
+  /** Declared flow variables — needed to resolve scope for the expression check. */
+  variables?: unknown[];
 }
 
 /**
@@ -123,7 +126,7 @@ export interface BuildFlowProblemsArgs {
  * diagnostics. Errors are listed before warnings; within a level each source
  * keeps its own emit order (structural before server).
  */
-export function buildFlowProblems({ nodes, edges, serverDiagnostics }: BuildFlowProblemsArgs): FlowProblem[] {
+export function buildFlowProblems({ nodes, edges, serverDiagnostics, variables }: BuildFlowProblemsArgs): FlowProblem[] {
   const problems: FlowProblem[] = [];
 
   const v = validateFlowDraft(nodes as unknown as SimNode[], edges as unknown as SimEdge[]);
@@ -151,6 +154,27 @@ export function buildFlowProblems({ nodes, edges, serverDiagnostics }: BuildFlow
       message: diag.message,
       target,
       source: 'server',
+    });
+  });
+
+  // Client-side EXPRESSION issues (ADR-0032 braces + scope-aware unknown refs),
+  // resolved onto node / edge targets — see flow-expr-problems.
+  flowExpressionProblems({ nodes, edges, variables: variables ?? [] }).forEach((ep, i) => {
+    const target: FlowProblemTarget =
+      ep.target.kind === 'edge'
+        ? {
+            kind: 'edge',
+            source: ep.target.source,
+            target: ep.target.target,
+            edgeKey: resolveEdgeKey(edges, ep.target.source, ep.target.target),
+          }
+        : { kind: 'node', nodeId: ep.target.nodeId };
+    problems.push({
+      id: `expression:${ep.level}:${i}:${targetKey(target)}`,
+      level: ep.level,
+      message: ep.message,
+      target,
+      source: 'expression',
     });
   });
 


### PR DESCRIPTION
Builds on the inline data-picker validation ([#1975](https://github.com/objectstack-ai/objectui/pull/1975) / [#1978](https://github.com/objectstack-ai/objectui/pull/1978)) by feeding client-side **expression issues** into the unified flow-problems list ([#1972](https://github.com/objectstack-ai/objectui/pull/1972)) — so they appear as **Problems-panel rows** and **on-canvas node/edge badges**, discoverable at the flow level instead of only when a node is open.

## What it scans
New pure `flow-expr-problems.ts` walks every CEL surface in the draft:
- decision conditions + **branch expressions**, screen **`visibleWhen`**, loop **collection**, and **edge guards**;
- **ADR-0032 brace / shape errors** (deterministic, scope-free → zero false positives), level **error**;
- **scope-aware unknown-reference warnings** (a bare root not in scope at the node), level **warning**.

The **start node is skipped for the ref check**: its entry condition references the trigger record's fields *bare* (`status`), which can't be told from a typo without the object schema (an async fetch this pure pass avoids). The inline inspector check — which does fetch — still covers the start node. Template (`{var}`) values are left to the inline check (single braces are legal there).

`buildFlowProblems` merges these as a third source (`'expression'`); `ProblemsPanel` labels the rows "· expression"; the existing canvas badge/reveal path renders them unchanged.

## Tests / verification
- New `flow-expr-problems.test.ts` (6): brace error on a branch (node target), unknown ref on a downstream condition (warning + suggestion), **start-node bare fields not flagged**, edge-guard brace error (edge target), default-edge/empty skipped, clean flow → none.
- `flow-problems.test.ts` still green (the existing structural/server cases are unaffected). Full `metadata-admin` suite green (489), `pnpm build` (tsc) clean. Badge/panel rendering reuses the proven #1972 path; this PR only adds correctly-targeted entries to the same `FlowProblem[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)