### PR TITLE
feat(console): hide the AI surface at runtime when the server serves no AI (Community Edition)

### DIFF
--- a/.changeset/ce-ai-runtime-gating.md
+++ b/.changeset/ce-ai-runtime-gating.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(console): hide the AI surface at runtime when the server serves no AI agent (Community Edition)
+
+A self-host Community Edition runtime (framework + this MIT console, without the
+cloud `@objectstack/service-ai-studio` package) serves no `ask`/`build` agent.
+The console now hides every AI entry point via runtime, server-pushed gating —
+no build-time edition flag, no tree-shake.
+
+Crucially, gating is driven off the **agent catalog** (`GET /api/v1/ai/agents`),
+not the discovery `services.ai` flag: the open-source framework keeps a headless
+`@objectstack/service-ai` that still reports `services.ai` as available, so a CE
+runtime can report AI "available" while serving zero agents. The catalog is the
+real "is there an agent to answer?" signal.
+
+- New `useAiSurfaceEnabled()` hook + `RequireAiSurface` route guard (exported).
+- `/ai*` routes redirect to home when no agent is served; the FAB, top-bar AI
+  link and the metadata designers' "Ask AI" buttons hide; `AiChatPage` shows a
+  graceful "AI unavailable" state instead of an agent-less echo chat.
+- Fully additive for cloud installs — when an agent is served, every AI surface
+  renders and works as before.

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -23,6 +23,7 @@ import {
   ConsoleShell,
   ConnectedShell,
   RequireOrganization,
+  RequireAiSurface,
   SystemRedirect,
   LoadingFallback,
   ConsoleToaster,
@@ -263,20 +264,27 @@ export function App() {
               back-compat redirects: bare `/ai` → the default agent surface, and
               a single-segment `/ai/:agent` that is actually a legacy bare
               conversation id → `/ai/:agent/:conversationId`.
+
+              `RequireAiSurface` keeps these from dead-ending on a runtime that
+              serves no AI (Community Edition): with AI unavailable a stale
+              bookmark / external link redirects to home instead of mounting a
+              chat with no agent to talk to. Cloud installs pass straight
+              through. Purely additive runtime gating — same server signal the
+              floating-chat FAB has always used.
             */}
             <Route path="/ai" element={
               <ProtectedRoute>
-                <DefaultAiChatPage />
+                <RequireAiSurface><DefaultAiChatPage /></RequireAiSurface>
               </ProtectedRoute>
             } />
             <Route path="/ai/:agent" element={
               <ProtectedRoute>
-                <DefaultAiChatPage />
+                <RequireAiSurface><DefaultAiChatPage /></RequireAiSurface>
               </ProtectedRoute>
             } />
             <Route path="/ai/:agent/:conversationId" element={
               <ProtectedRoute>
-                <DefaultAiChatPage />
+                <RequireAiSurface><DefaultAiChatPage /></RequireAiSurface>
               </ProtectedRoute>
             } />
             <Route path="/apps/:appName/*" element={

--- a/packages/app-shell/src/console/ConsoleShell.tsx
+++ b/packages/app-shell/src/console/ConsoleShell.tsx
@@ -18,6 +18,7 @@ import { SchemaRendererProvider } from '@object-ui/react';
 import { createObjectStackUserStateAdapter } from '@object-ui/data-objectstack';
 import { AdapterProvider, useAdapter } from '../providers/AdapterProvider';
 import { MetadataProvider, useMetadata } from '../providers/MetadataProvider';
+import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
 import { PreviewModeProvider } from '../preview/PreviewModeContext';
 import { NavigationProvider } from '../context/NavigationContext';
 import { FavoritesProvider } from '../context/FavoritesProvider';
@@ -179,6 +180,31 @@ export function RequireOrganization({ children }: { children: ReactNode }) {
   const orgList = organizations ?? [];
   const orgFeatureEnabled = orgList.length > 0 || !!activeOrganization;
   if (orgFeatureEnabled && !activeOrganization) return <Navigate to="/organizations" replace />;
+  return <>{children}</>;
+}
+
+/**
+ * RequireAiSurface — gate for the `/ai*` routes. The console is edition-agnostic
+ * (MIT, runtime-gated): a Community Edition runtime serves no AI agent, so a
+ * stale `/ai` bookmark or external link must not land on a broken/empty chat.
+ * When the server serves no agent it redirects to `redirectTo` (home) instead.
+ *
+ * Availability is the live agent catalog (see {@link useAiSurfaceEnabled}) — the
+ * same signal every other AI entry point now gates on, so the route is reachable
+ * from exactly the entry points that are visible (no shown CTA that bounces back
+ * to home, no hidden FAB to a working route). Waits for the catalog to resolve
+ * before deciding so the redirect never flashes on first paint.
+ */
+export function RequireAiSurface({
+  children,
+  redirectTo = '/home',
+}: {
+  children: ReactNode;
+  redirectTo?: string;
+}) {
+  const { enabled, isLoading } = useAiSurfaceEnabled();
+  if (isLoading) return <LoadingFallback />;
+  if (!enabled) return <Navigate to={redirectTo} replace />;
   return <>{children}</>;
 }
 

--- a/packages/app-shell/src/console/__tests__/RequireAiSurface.test.tsx
+++ b/packages/app-shell/src/console/__tests__/RequireAiSurface.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { RequireAiSurface } from '../ConsoleShell';
+import { useAiSurfaceEnabled } from '../../hooks/useAiSurface';
+
+// The guard gates purely on the AI-surface signal (the agent catalog); that
+// hook's own plumbing is covered by useAiSurface.test.ts.
+vi.mock('../../hooks/useAiSurface', () => ({
+  useAiSurfaceEnabled: vi.fn(() => ({ enabled: true, isLoading: false })),
+}));
+const mockSurface = vi.mocked(useAiSurfaceEnabled);
+
+function renderGuardedAi() {
+  return render(
+    <MemoryRouter initialEntries={['/ai']}>
+      <Routes>
+        <Route
+          path="/ai"
+          element={
+            <RequireAiSurface>
+              <div>AI CHAT</div>
+            </RequireAiSurface>
+          }
+        />
+        <Route path="/home" element={<div>HOME</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('RequireAiSurface', () => {
+  beforeEach(() => {
+    mockSurface.mockReturnValue({ enabled: true, isLoading: false });
+  });
+
+  it('renders the AI surface when the server serves agents (cloud install)', () => {
+    renderGuardedAi();
+    expect(screen.getByText('AI CHAT')).toBeInTheDocument();
+    expect(screen.queryByText('HOME')).not.toBeInTheDocument();
+  });
+
+  it('redirects to home when no agents are served (Community Edition) — no dead-end chat', () => {
+    mockSurface.mockReturnValue({ enabled: false, isLoading: false });
+    renderGuardedAi();
+    expect(screen.queryByText('AI CHAT')).not.toBeInTheDocument();
+    expect(screen.getByText('HOME')).toBeInTheDocument();
+  });
+
+  it('waits (neither chat nor redirect) while the agent catalog is still resolving', () => {
+    mockSurface.mockReturnValue({ enabled: false, isLoading: true });
+    renderGuardedAi();
+    expect(screen.queryByText('AI CHAT')).not.toBeInTheDocument();
+    expect(screen.queryByText('HOME')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -31,6 +31,9 @@ import {
   SheetDescription,
   SheetHeader,
   SheetTitle,
+  Empty,
+  EmptyTitle,
+  EmptyDescription,
   cn,
 } from '@object-ui/components';
 import { PanelLeft, PanelLeftClose, PanelLeftOpen, Share2 } from 'lucide-react';
@@ -493,8 +496,16 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   const env = (import.meta as any).env ?? {};
   const envDefaultAgent = env.VITE_AI_DEFAULT_AGENT as string | undefined;
 
-  const { agents, isLoading: agentsLoading, error: agentsError } = useAgents({ apiBase });
+  const { agents, isLoading: agentsLoading, error: agentsError, refetch: refetchAgents } =
+    useAgents({ apiBase });
   const catalogNames = useMemo(() => agents.map((a) => a.name), [agents]);
+  // Catalog resolved with no agent to talk to. The `/ai` route guard already
+  // redirects when discovery reports AI unavailable (Community Edition), so this
+  // is the secondary safety net: a deployment that reports AI enabled but serves
+  // no agent (misconfig), a transient `/agents` failure, or a `VITE_AI_BASE_URL`
+  // server that returns an empty list. Either way, degrade to a graceful state
+  // instead of the agent-less echo chat (autoResponse) that ChatPane falls into.
+  const noAgents = !agentsLoading && agents.length === 0;
 
   // Is the first path segment an agent? It is when it resolves to one (friendly
   // alias / new id / legacy id). When it doesn't, it's a legacy bare
@@ -739,40 +750,55 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   return (
     <div className="flex h-svh w-full flex-col bg-background" data-testid="ai-chat-page">
       <header className="sticky top-0 z-30 flex h-14 w-full shrink-0 items-center gap-2 border-b bg-background/95 px-2 backdrop-blur sm:px-4">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 shrink-0 md:hidden"
-          onClick={() => setMobileChatsOpen(true)}
-          aria-label={t('console.ai.openChats')}
-          data-testid="ai-chat-mobile-sidebar-trigger"
-        >
-          <PanelLeft className="h-4 w-4" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="hidden h-8 w-8 shrink-0 md:inline-flex"
-          onClick={toggleChatsCollapsed}
-          aria-label={
-            chatsCollapsed
-              ? t('console.ai.showChats', { defaultValue: 'Show chats' })
-              : t('console.ai.hideChats', { defaultValue: 'Hide chats' })
-          }
-          title={
-            chatsCollapsed
-              ? t('console.ai.showChats', { defaultValue: 'Show chats' })
-              : t('console.ai.hideChats', { defaultValue: 'Hide chats' })
-          }
-          data-testid="ai-chat-collapse-sidebar-trigger"
-          aria-pressed={chatsCollapsed}
-        >
-          {chatsCollapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
-        </Button>
+        {/* Chat-list toggles are meaningless with no agent/conversations, so
+            hide them in the graceful no-agents state. */}
+        {!noAgents && (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 md:hidden"
+              onClick={() => setMobileChatsOpen(true)}
+              aria-label={t('console.ai.openChats')}
+              data-testid="ai-chat-mobile-sidebar-trigger"
+            >
+              <PanelLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="hidden h-8 w-8 shrink-0 md:inline-flex"
+              onClick={toggleChatsCollapsed}
+              aria-label={
+                chatsCollapsed
+                  ? t('console.ai.showChats', { defaultValue: 'Show chats' })
+                  : t('console.ai.hideChats', { defaultValue: 'Hide chats' })
+              }
+              title={
+                chatsCollapsed
+                  ? t('console.ai.showChats', { defaultValue: 'Show chats' })
+                  : t('console.ai.hideChats', { defaultValue: 'Hide chats' })
+              }
+              data-testid="ai-chat-collapse-sidebar-trigger"
+              aria-pressed={chatsCollapsed}
+            >
+              {chatsCollapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
+            </Button>
+          </>
+        )}
         <div className="min-w-0 flex-1">
           <AppHeader variant="home" />
         </div>
       </header>
+      {noAgents ? (
+        <AiUnavailable
+          hasError={Boolean(agentsError)}
+          onRetry={refetchAgents}
+          onHome={() => navigate('/home')}
+          t={t}
+        />
+      ) : (
+      <>
       <Sheet open={mobileChatsOpen} onOpenChange={setMobileChatsOpen}>
         <SheetContent side="left" className="w-[320px] p-0 sm:max-w-[360px]" data-testid="ai-chat-mobile-sidebar">
           <SheetHeader className="sr-only">
@@ -829,6 +855,58 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
           />
         </main>
       </div>
+      </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Graceful state for `/ai` when the agent catalog resolved empty — shown
+ * instead of an agent-less echo chat. `hasError` distinguishes "AI not enabled
+ * on this deployment" (Community Edition) from "couldn't reach the AI service"
+ * (offline/misconfig), which also offers a retry. Either way there's a way out
+ * (back to home), so the route never dead-ends.
+ */
+function AiUnavailable({
+  hasError,
+  onRetry,
+  onHome,
+  t,
+}: {
+  hasError: boolean;
+  onRetry: () => void;
+  onHome: () => void;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  return (
+    <div className="flex flex-1 items-center justify-center p-6" data-testid="ai-unavailable">
+      <Empty>
+        <EmptyTitle>
+          {t('console.ai.unavailableTitle', { defaultValue: 'AI assistant unavailable' })}
+        </EmptyTitle>
+        <EmptyDescription>
+          {hasError
+            ? t('console.ai.unavailableError', {
+                defaultValue:
+                  "Couldn't reach the AI service. It may be temporarily offline — try again, or head back home.",
+              })
+            : t('console.ai.unavailableDescription', {
+                defaultValue:
+                  "This deployment doesn't have an AI assistant enabled. Everything else works as usual.",
+              })}
+        </EmptyDescription>
+        <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row">
+          {hasError && (
+            <Button variant="outline" onClick={onRetry} data-testid="ai-unavailable-retry">
+              {t('console.ai.unavailableRetry', { defaultValue: 'Try again' })}
+            </Button>
+          )}
+          <Button onClick={onHome} data-testid="ai-unavailable-home">
+            {t('console.ai.unavailableHome', { defaultValue: 'Back to home' })}
+          </Button>
+        </div>
+      </Empty>
     </div>
   );
 }

--- a/packages/app-shell/src/console/home/HomeLayout.tsx
+++ b/packages/app-shell/src/console/home/HomeLayout.tsx
@@ -11,7 +11,7 @@
 import React, { useEffect } from 'react';
 import { useNavigationContext } from '../../context/NavigationContext';
 import { AppHeader } from '../../layout/AppHeader';
-import { useDiscovery } from '@object-ui/react';
+import { useAiSurfaceEnabled } from '../../hooks/useAiSurface';
 import { useObjectTranslation } from '@object-ui/i18n';
 
 // Lightweight FAB stub — the heavy chat chunk graph only downloads on
@@ -29,13 +29,11 @@ interface HomeLayoutProps {
 
 export function HomeLayout({ children, userId }: HomeLayoutProps) {
   const { setContext } = useNavigationContext();
-  const { isAiEnabled } = useDiscovery();
   const { t } = useObjectTranslation();
-  // Render the chatbot whenever AI is reachable. If the developer has explicitly
-  // configured `VITE_AI_BASE_URL`, trust that opt-in even when discovery
-  // reports AI as disabled (e.g. framework started without `--preset full`).
-  const aiBaseUrlConfigured = Boolean(import.meta.env?.VITE_AI_BASE_URL);
-  const showChatbot = isAiEnabled || aiBaseUrlConfigured;
+  // Render the chatbot only when the server serves AI (or an explicit
+  // `VITE_AI_BASE_URL` opt-in is set) — same runtime signal as the rest of the
+  // console's AI surface. See useAiSurfaceEnabled.
+  const { enabled: showChatbot } = useAiSurfaceEnabled();
 
   useEffect(() => {
     setContext('home');

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -31,15 +31,7 @@ import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/componen
 import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
-
-/** Resolve the AI service base, mirroring AiChatPage/ConsoleFloatingChatbot. */
-function resolveAiApiBase(): string {
-  const env = (import.meta as any).env ?? {};
-  const fromEnv = env.VITE_AI_BASE_URL as string | undefined;
-  if (fromEnv) return fromEnv.replace(/\/$/, '');
-  const serverUrl = (env.VITE_SERVER_URL as string | undefined) ?? '';
-  return `${serverUrl.replace(/\/$/, '')}/api/v1/ai`;
-}
+import { resolveAiApiBase } from '../../hooks/useAiSurface';
 
 /**
  * Which AI home CTAs to surface, driven by the live agent catalog (the single

--- a/packages/app-shell/src/hooks/__tests__/useAiSurface.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/useAiSurface.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAgents } from '@object-ui/plugin-chatbot';
+import { useAiSurfaceEnabled } from '../useAiSurface';
+
+// The surface is gated on the live agent catalog, so we mock useAgents and
+// assert the catalog → enabled/loading mapping (incl. the not-yet-fetched latch).
+vi.mock('@object-ui/plugin-chatbot', () => ({ useAgents: vi.fn() }));
+const mockAgents = vi.mocked(useAgents);
+
+function agentsResult(names: string[], isLoading: boolean) {
+  return {
+    agents: names.map((name) => ({ name, label: name })),
+    isLoading,
+    error: undefined,
+    refetch: vi.fn(),
+  };
+}
+
+afterEach(() => mockAgents.mockReset());
+
+describe('useAiSurfaceEnabled', () => {
+  it('is enabled when the catalog serves at least one agent (cloud / agents present)', () => {
+    mockAgents.mockReturnValue(agentsResult(['ask'], false));
+    const { result } = renderHook(() => useAiSurfaceEnabled());
+    expect(result.current).toEqual({ enabled: true, isLoading: false });
+  });
+
+  it('reports loading on the first frame before the catalog fetch has started', () => {
+    // useAgents starts isLoading=false with an empty list — that is "not fetched
+    // yet", not "no agents", so the guard must keep waiting (not redirect).
+    mockAgents.mockReturnValue(agentsResult([], false));
+    const { result } = renderHook(() => useAiSurfaceEnabled());
+    expect(result.current).toEqual({ enabled: false, isLoading: true });
+  });
+
+  it('reports loading while the catalog fetch is in flight', () => {
+    mockAgents.mockReturnValue(agentsResult([], true));
+    const { result } = renderHook(() => useAiSurfaceEnabled());
+    expect(result.current).toEqual({ enabled: false, isLoading: true });
+  });
+
+  it('is disabled — not loading — once a fetch resolves empty (Community Edition: no agents)', () => {
+    // Simulate the real lifecycle: fetch in flight → resolves with an empty
+    // catalog. The latch records that a fetch ran, so the empty result is now
+    // definitive and the guard redirects instead of spinning forever.
+    mockAgents.mockReturnValue(agentsResult([], true));
+    const { result, rerender } = renderHook(() => useAiSurfaceEnabled());
+    expect(result.current.isLoading).toBe(true);
+
+    mockAgents.mockReturnValue(agentsResult([], false));
+    rerender();
+    expect(result.current).toEqual({ enabled: false, isLoading: false });
+  });
+});

--- a/packages/app-shell/src/hooks/useAiSurface.ts
+++ b/packages/app-shell/src/hooks/useAiSurface.ts
@@ -1,0 +1,82 @@
+/**
+ * useAiSurfaceEnabled
+ *
+ * Single source of truth for "should the in-UI AI surface be shown on this
+ * deployment?". The console ships under MIT and is edition-agnostic: it never
+ * knows at build time whether the runtime is a Community Edition (framework
+ * only, no cloud AI package) or a full cloud install. It decides purely at
+ * runtime from what the server reports — no `VITE_EDITION` flag, no tree-shake.
+ *
+ * The signal is **a non-empty agent catalog** (`GET /api/v1/ai/agents`), NOT
+ * the discovery `services.ai` flag. That distinction matters:
+ *
+ *   The `ask`/`build` agent *personas* are a commercial feature that moved to
+ *   the cloud-only `@objectstack/service-ai-studio` package; the open-source
+ *   framework keeps a HEADLESS `@objectstack/service-ai` that still
+ *   `registerService('ai')`s. So on a Community Edition runtime discovery can
+ *   STILL report `services.ai` as available (the service is running) while the
+ *   agent catalog is empty (no persona attached). Gating on `isAiEnabled` would
+ *   then leave the FAB / "Ask AI" affordances visible with nothing to talk to —
+ *   a dead end. The catalog is the real "is there an agent to answer?" signal,
+ *   and it's exactly what the Home "Build/Ask AI" CTAs already gate on, so every
+ *   AI entry point now agrees.
+ *
+ * The `VITE_AI_BASE_URL` opt-in flows through naturally: {@link resolveAiApiBase}
+ * points the catalog fetch at the configured server, so an external AI server
+ * with agents lights the surface up and an agent-less one keeps it hidden.
+ *
+ * `isLoading` is surfaced so the `/ai` route guard can wait for the catalog to
+ * resolve before redirecting — otherwise a stale bookmark would flash a redirect
+ * to home before the fetch even starts. Entry-point buttons (FAB, top-bar link,
+ * designer "Ask AI") ignore it: staying hidden during the brief load is the
+ * correct, flash-free behaviour for a control that must not appear unless AI can
+ * actually answer.
+ *
+ * @module
+ */
+
+import { useRef } from 'react';
+import { useAgents } from '@object-ui/plugin-chatbot';
+
+/**
+ * Resolve the AI service base URL, mirroring AiChatPage / the Home CTAs:
+ * an explicit `VITE_AI_BASE_URL` wins, otherwise `${VITE_SERVER_URL}/api/v1/ai`.
+ * Shared so every catalog fetch (route guard, layouts, Home) hits the same URL.
+ */
+export function resolveAiApiBase(): string {
+  const env = (import.meta as any).env ?? {};
+  const fromEnv = env.VITE_AI_BASE_URL as string | undefined;
+  if (fromEnv) return fromEnv.replace(/\/$/, '');
+  const serverUrl = (env.VITE_SERVER_URL as string | undefined) ?? '';
+  return `${serverUrl.replace(/\/$/, '')}/api/v1/ai`;
+}
+
+export interface AiSurfaceState {
+  /** True when the AI UI should be rendered (the server serves ≥1 agent). */
+  enabled: boolean;
+  /** True until the agent catalog has resolved; route guards wait on this. */
+  isLoading: boolean;
+}
+
+/**
+ * Whether the console's AI surface (FAB, `/ai` routes, "Ask AI" affordances)
+ * should be shown, driven off the live agent catalog.
+ */
+export function useAiSurfaceEnabled(): AiSurfaceState {
+  const { agents, isLoading } = useAgents({ apiBase: resolveAiApiBase() });
+
+  // useAgents starts `isLoading=false` and only kicks off the fetch in an effect
+  // a tick later, so the first render's empty list means "not fetched yet", not
+  // "no agents". Latch whether a fetch has actually been in flight so the route
+  // guard treats that initial frame as loading (not a definitive empty → redirect).
+  const fetchStartedRef = useRef(false);
+  if (isLoading) fetchStartedRef.current = true;
+
+  const enabled = agents.length > 0;
+  return {
+    enabled,
+    // Agents present → resolved/available. Otherwise we're loading until a fetch
+    // has both started and finished with an empty result.
+    isLoading: enabled ? false : isLoading || !fetchStartedRef.current,
+  };
+}

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -55,11 +55,18 @@ export {
   ConsoleShell,
   ConnectedShell,
   RequireOrganization,
+  RequireAiSurface,
   AuthenticatedRoute,
   RootRedirect,
   SystemRedirect,
   LoadingFallback,
 } from './console/ConsoleShell';
+
+// Runtime AI-availability signal — the single source of truth every AI entry
+// point gates on (FAB, /ai routes, designer "Ask AI"). Server-pushed, no
+// build-time edition flag. See ./hooks/useAiSurface.
+export { useAiSurfaceEnabled } from './hooks/useAiSurface';
+export type { AiSurfaceState } from './hooks/useAiSurface';
 
 // Layout chrome
 export {

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -70,6 +70,7 @@ import { useMobileViewSwitcher } from './MobileViewSwitcherContext';
 import { useNavigationContext } from '../context/NavigationContext';
 import { useCommandPalette } from '../context/CommandPaletteProvider';
 import { useUrlOverlay } from '../hooks/useUrlOverlay';
+import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
 import { getProductName } from '../runtime-config';
 import { LocalizedSidebarTrigger } from './LocalizedSidebarTrigger';
 
@@ -136,6 +137,10 @@ export function AppHeader({
     isOrganizationsLoading,
   } = useAuth();
   const dataSource = useAdapter();
+  // Runtime AI gating: hide the top-bar AI entry point when the server serves
+  // no AI (Community Edition) so it can't dead-end on a chat with no agent.
+  // Same signal as the FAB and the `/ai` route guard.
+  const { enabled: aiEnabled } = useAiSurfaceEnabled();
   const { t } = useObjectTranslation();
   const { objectLabel, dashboardLabel, pageLabel, reportLabel, viewLabel, appLabel } = useObjectLabel();
   const { apps: metadataApps, dashboards: metadataDashboards, pages: metadataPages, reports: metadataReports } = useMetadata();
@@ -818,18 +823,21 @@ export function AppHeader({
             onMarkRead={markNotificationRead}
           />
 
-          {/* AI Assistant */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 shrink-0"
-            asChild
-            aria-label={t('topbar.aiAssistant', { defaultValue: 'AI Assistant' })}
-          >
-            <Link to="/ai">
-              <Bot className="h-4 w-4" />
-            </Link>
-          </Button>
+          {/* AI Assistant — only when the runtime serves AI (hidden on
+              Community Edition so it can't dead-end on an agent-less chat). */}
+          {aiEnabled && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              asChild
+              aria-label={t('topbar.aiAssistant', { defaultValue: 'AI Assistant' })}
+            >
+              <Link to="/ai">
+                <Bot className="h-4 w-4" />
+              </Link>
+            </Button>
+          )}
 
           {/* Help & Documentation — an aggregated menu rather than a bare
               external link: contextual "This app's docs" (only when the

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -10,7 +10,6 @@
 
 import React, { useEffect } from 'react';
 import { AppShell } from '@object-ui/layout';
-import { useDiscovery } from '@object-ui/react';
 import { isBuildAgent } from '@object-ui/plugin-chatbot';
 
 // Lightweight FAB stub — the heavy chat chunk graph (plugin-chatbot,
@@ -23,6 +22,7 @@ import { UnifiedSidebar } from './UnifiedSidebar';
 import { AppHeader } from './AppHeader';
 import { MobileViewSwitcherProvider } from './MobileViewSwitcherContext';
 import { useResponsiveSidebar } from '../hooks/useResponsiveSidebar';
+import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
 import { useNavigationContext } from '../context/NavigationContext';
 import { CommandPaletteProvider } from '../context/CommandPaletteProvider';
 import { resolveI18nLabel } from '../utils';
@@ -68,11 +68,10 @@ export function ConsoleLayout({
   userId,
 }: ConsoleLayoutProps) {
   const appLabel = resolveI18nLabel(activeApp?.label) || activeAppName;
-  const { isAiEnabled } = useDiscovery();
-  // Trust an explicit `VITE_AI_BASE_URL` opt-in even when discovery reports
-  // AI as disabled (e.g. framework started without `--preset full`).
-  const aiBaseUrlConfigured = Boolean(import.meta.env?.VITE_AI_BASE_URL);
-  const showChatbot = isAiEnabled || aiBaseUrlConfigured;
+  // Runtime, server-pushed AI gating (shared with the `/ai` route guard and the
+  // top-bar AI link): show the chatbot only when the server actually serves AI,
+  // or when an explicit `VITE_AI_BASE_URL` opt-in points at an external server.
+  const { enabled: showChatbot } = useAiSurfaceEnabled();
   // AI Studio (AI-driven metadata authoring / "online development") can be
   // turned off per deployment. When off, suppress the metadata-authoring
   // assistant so the chatbot falls back to the generic data assistant — the

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.test.tsx
@@ -1,10 +1,22 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
 import { ObjectFormCanvas } from './ObjectFormCanvas';
 import { assistantBus } from '../../../assistant/assistantBus';
+import { useAiSurfaceEnabled } from '../../../hooks/useAiSurface';
 
+// The designer's "Ask AI" affordances are runtime-gated on the shared
+// AI-surface signal. Mock it so both states can be exercised without standing
+// up a discovery data source; every test starts with AI enabled (see
+// beforeEach), and the Community-Edition case overrides it to disabled.
+vi.mock('../../../hooks/useAiSurface', () => ({
+  useAiSurfaceEnabled: vi.fn(() => ({ enabled: true, isLoading: false })),
+}));
+
+beforeEach(() => {
+  vi.mocked(useAiSurfaceEnabled).mockReturnValue({ enabled: true, isLoading: false });
+});
 afterEach(cleanup);
 
 /* shared fixtures for the review/diff tests */
@@ -342,5 +354,28 @@ describe('ObjectFormCanvas — Ask AI entry point', () => {
       />,
     );
     expect(screen.queryByText('Ask AI')).not.toBeInTheDocument();
+  });
+
+  it('hides both Ask AI affordances when AI is unavailable (Community Edition)', () => {
+    vi.mocked(useAiSurfaceEnabled).mockReturnValue({ enabled: false, isLoading: false });
+
+    // Populated canvas: the toolbar "Ask AI" is gone, but the rest of the
+    // toolbar (Add field / Add section) stays.
+    const populated = render(
+      <ObjectFormCanvas
+        objectName="x"
+        draft={{ name: 'x', fields: { a: { type: 'text', label: 'A' } } }}
+        onPatch={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText('Ask AI')).not.toBeInTheDocument();
+    expect(screen.getByText('Add section')).toBeInTheDocument();
+    populated.unmount();
+
+    // Empty canvas: "Generate fields with AI" is gone, "Add field" remains so
+    // the designer is still usable without AI.
+    render(<ObjectFormCanvas objectName="x" draft={{ name: 'x', fields: {} }} onPatch={vi.fn()} />);
+    expect(screen.queryByText('Generate fields with AI')).not.toBeInTheDocument();
+    expect(screen.getByText('Add field')).toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ObjectFormCanvas.tsx
@@ -44,6 +44,7 @@ import {
 } from 'lucide-react';
 import type { MetadataSelection } from '../preview-registry';
 import { requestAssistantOpen } from '../../../assistant/assistantBus';
+import { useAiSurfaceEnabled } from '../../../hooks/useAiSurface';
 import {
   readFields,
   writeFields,
@@ -104,6 +105,10 @@ export function ObjectFormCanvas({
   locale,
 }: ObjectFormCanvasProps) {
   const readOnly = !onPatch;
+  // The "Ask AI" affordances arm the global chat FAB (requestAssistantOpen).
+  // Hide them when the runtime serves no AI — otherwise they'd dead-end with no
+  // FAB to open. Same server-pushed signal the FAB itself gates on.
+  const { enabled: aiEnabled } = useAiSurfaceEnabled();
 
   const view = React.useMemo(() => readFields((draft as any).fields), [draft]);
 
@@ -466,7 +471,7 @@ export function ObjectFormCanvas({
         )}
 
         {emptyState ? (
-          <EmptyCanvas onAdd={readOnly ? undefined : addField} locale={locale} />
+          <EmptyCanvas onAdd={readOnly ? undefined : addField} locale={locale} aiEnabled={aiEnabled} />
         ) : (
           <div className="space-y-5">
             {groups.map((g) => {
@@ -544,15 +549,17 @@ export function ObjectFormCanvas({
               <FolderPlus className="h-3.5 w-3.5" />
               {t('designer.canvas.addSection', locale)}
             </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="gap-1.5 ml-auto text-primary/80 hover:text-primary"
-              onClick={() => requestAssistantOpen()}
-            >
-              <Sparkles className="h-3.5 w-3.5" />
-              {t('designer.canvas.askAi', locale)}
-            </Button>
+            {aiEnabled && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-1.5 ml-auto text-primary/80 hover:text-primary"
+                onClick={() => requestAssistantOpen()}
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+                {t('designer.canvas.askAi', locale)}
+              </Button>
+            )}
           </div>
         )}
       </div>
@@ -1208,7 +1215,16 @@ function FieldRow({
   );
 }
 
-function EmptyCanvas({ onAdd, locale }: { onAdd?: (type: FieldTypeId) => void; locale?: string }) {
+function EmptyCanvas({
+  onAdd,
+  locale,
+  aiEnabled,
+}: {
+  onAdd?: (type: FieldTypeId) => void;
+  locale?: string;
+  /** Show the "Ask AI to generate" affordance only when the runtime serves AI. */
+  aiEnabled?: boolean;
+}) {
   return (
     <div className="rounded-lg border-2 border-dashed bg-background py-16 px-6 text-center space-y-3">
       <div className="text-sm font-medium">{t('designer.canvas.noFields', locale)}</div>
@@ -1218,15 +1234,17 @@ function EmptyCanvas({ onAdd, locale }: { onAdd?: (type: FieldTypeId) => void; l
       {onAdd && (
         <div className="pt-2 flex items-center justify-center gap-2">
           <AddFieldButton onPick={onAdd} locale={locale} />
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gap-1.5 text-primary/80 hover:text-primary"
-            onClick={() => requestAssistantOpen()}
-          >
-            <Sparkles className="h-3.5 w-3.5" />
-            {t('designer.canvas.askAiGenerate', locale)}
-          </Button>
+          {aiEnabled && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 text-primary/80 hover:text-primary"
+              onClick={() => requestAssistantOpen()}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              {t('designer.canvas.askAiGenerate', locale)}
+            </Button>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Why

The in-UI AI Q&A `ask` agent moved out of the open-source framework into the closed cloud package (`@objectstack/service-ai-studio`). A self-host **Community Edition** runtime = framework + this MIT console, **without** the cloud AI package → it serves **no** `ask`/`build` agent.

The console is supposed to hide its AI UI via runtime server-capability gating, but several entry points rendered **unconditionally**, and direct navigation to `/ai` could dead-end on an agent-less echo chat.

**Founder decision honored:** runtime, server-pushed gating only — **no** `VITE_EDITION` build flag, **no** tree-shake, **no** relicensing. The AI code stays MIT.

## Gate on the agent catalog, not discovery (the key correctness point)

The `ask`/`build` agent **personas** moved to cloud `service-ai-studio`, but the open-source framework keeps a **headless** `@objectstack/service-ai` that still `registerService('ai')`s. So a CE runtime reports `services.ai` as **available** in discovery while the **agent catalog is empty**.

Verified live against a fresh framework backend:
```
GET /api/v1/discovery → services.ai: { enabled: true, status: "available" }
GET /api/v1/ai/agents → { "agents": [] }
```

Gating on `isAiEnabled` (discovery) would leave the FAB / "Ask AI" affordances **visible with nothing to talk to** — a dead end. So every AI entry point now gates on a **non-empty agent catalog** (`GET /api/v1/ai/agents`) — the real "is there an agent to answer?" signal, and exactly what the Home CTAs already used.

## What changed

| Entry point | Before | After |
|---|---|---|
| Floating chat FAB | gated on `isAiEnabled` (discovery), duplicated in 2 layouts | gated via shared `useAiSurfaceEnabled()` (agent catalog) |
| `/ai*` routes | **unconditional** → echo chat | `RequireAiSurface` guard → redirect to `/home` when no agent |
| Top-bar AI link (AppHeader) | **unconditional** dead link | hidden when no agent |
| Designer "Ask AI" buttons (ObjectFormCanvas ×2) | **unconditional** → armed a hidden FAB | hidden when no agent |
| AiChatPage with empty catalog | echo chat (`autoResponse`) | graceful "AI unavailable" state (Back-to-home + Retry) |
| Home "Build with AI" / "Ask AI" CTAs | already per-agent gated | unchanged (verified) |

### New shared primitives
- `useAiSurfaceEnabled()` (+ `resolveAiApiBase()`) — single source of truth, driven by the agent catalog; handles the "fetch not started yet" frame so the route guard doesn't flash a redirect. De-dupes the FAB checks and HomePage's API-base resolver.
- `RequireAiSurface` — route guard, exported from app-shell alongside `RequireOrganization` / `SystemRedirect`.

## Verification

**Live, against a real framework runtime** (browser):
- **CE-shaped (services.ai *available*, empty agent catalog):** FAB hidden, top-bar AI link hidden, Home AI CTA hidden, `/ai/ask` → **redirects to `/home`** (no chat, no echo). This is the exact case `isAiEnabled`-gating would have failed.
- **Agent served (`showcase_assistant`):** FAB shown, top-bar AI link shown, `/ai` → real chat (`/ai/showcase_assistant/conv_…`), not the unavailable state.

**Build & tests:** app-shell `tsc` clean; console full `tsc && vite build` clean; full app-shell suite green (**872 passing**), incl. new tests:
- `useAiSurface.test.ts` — catalog → enabled/loading mapping, incl. the not-yet-fetched latch and resolved-empty → redirect.
- `RequireAiSurface.test.tsx` — renders when agents served, redirects to home when none, waits while the catalog resolves.
- `ObjectFormCanvas.test.tsx` — both "Ask AI" buttons hide when no agent; still work when present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)