### PR TITLE
fix(ai): stop AI composer placeholder doubling to 'Ask Ask…' for the Ask agent

### DIFF
--- a/.changeset/ask-agent-placeholder.md
+++ b/.changeset/ask-agent-placeholder.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/app-shell': patch
+---
+
+fix(ai): stop the AI composer placeholder doubling to "Ask Ask…" for the Ask agent
+
+The composer placeholder is `Ask {agent}…`, which reads fine for most agents
+("Ask Build…") but doubles to "Ask Ask…" for the data-query agent whose label is
+literally "Ask". The Ask agent now uses its purpose-built placeholder
+(`console.ai.askAnything` → "Ask anything…", already localized) instead. Found
+dogfooding the AI Ask flow.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1083,7 +1083,11 @@ function ChatPane({
         messages={messages as ChatMessage[]}
         placeholder={
           activeAgent
-            ? t('console.ai.askAgent', { agent: activeAgentLabel })
+            ? agentRouteName(activeAgent) === 'ask'
+              // The generic "Ask {agent}…" doubles to "Ask Ask…" for the data-query
+              // agent whose label IS "Ask". Use its purpose-built placeholder instead.
+              ? t('console.ai.askAnything')
+              : t('console.ai.askAgent', { agent: activeAgentLabel })
             : agentsLoading
               ? t('console.ai.loadingAgents')
               : t('console.ai.askAnything')


### PR DESCRIPTION
## Problem (found dogfooding AI Ask)

The AI composer placeholder is `Ask {agent}…`. For most agents that reads fine ("Ask Build…"), but for the data-query agent — whose label is literally **"Ask"** — it doubles to **"Ask Ask…"**.

## Fix

Route the ask agent (`agentRouteName(activeAgent) === 'ask'`) to its purpose-built placeholder `console.ai.askAnything` ("Ask anything…", already present in every locale) instead of the generic `Ask {agent}…`. Keyed off the normalized agent route, not the localized label, so it holds across locales. Other agents are unchanged.

## Verification

- `tsc --noEmit` on `@object-ui/app-shell` → 0 errors.
- Browser-reproduced the "Ask Ask…" placeholder in the Ask composer before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)