### PR TITLE
fix(grid): list column header falls back to field label, not prettified name

### DIFF
--- a/.changeset/grid-column-header-field-label.md
+++ b/.changeset/grid-column-header-field-label.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+fix(grid): list column headers fall back to the field's label, not the prettified machine name
+
+A view column declared as a bare `{ field: 'request_title' }` (no explicit `label`) rendered
+its header from the prettified machine name ("Request title") even when the field had a
+localized label ("申请标题"). On a non-English app that surfaced English column headers despite
+fully-localized field labels. ObjectGrid now resolves the header as
+`column.label → schema field label → prettified name`, matching the other header-resolution
+sites in the same file. Found dogfooding AI-built Chinese apps.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -860,7 +860,13 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
           return (cols as ListColumn[])
             .filter((col) => col?.field && typeof col.field === 'string' && !col.hidden)
             .map((col, colIndex) => {
-              const rawHeader = resolveColumnLabel(col.label) || col.field.charAt(0).toUpperCase() + col.field.slice(1).replace(/_/g, ' ');
+              // Fall back to the SCHEMA FIELD's label before prettifying the machine
+              // name — otherwise a column declared as bare { field } shows an English
+              // name-derived header (e.g. "Request title") even when the field has a
+              // localized label (e.g. "申请标题") on a non-English app.
+              const rawHeader = resolveColumnLabel(col.label)
+                || resolveColumnLabel(objectSchema?.fields?.[col.field]?.label)
+                || col.field.charAt(0).toUpperCase() + col.field.slice(1).replace(/_/g, ' ');
               const header = schema.objectName ? resolveFieldLabel(schema.objectName, col.field, rawHeader) : rawHeader;
 
               // Build custom cell renderer based on column configuration


### PR DESCRIPTION
## Problem (found dogfooding AI-built Chinese apps)

A list view whose columns are declared as bare `{ field: 'request_title' }` (no explicit `label`) rendered **English column headers** ("Request title", "Applicant") **even though the fields had Chinese labels** ("申请标题", "申请人"). So an app that was otherwise fully localized (object/field/option/flow labels all Chinese) still showed English in the list header.

Root cause — `ObjectGrid.tsx:863`:
```js
const rawHeader = resolveColumnLabel(col.label) || col.field.charAt(0)... // prettified machine name
```
It fell back from the column's explicit label **straight to the prettified field name**, never consulting the **schema field's label**. The other header-resolution sites in the same file (≈1027, 1104) already use `fieldDef.label` — this `{field}`-only path was the one that didn't.

## Fix

```js
const rawHeader = resolveColumnLabel(col.label)
  || resolveColumnLabel(objectSchema?.fields?.[col.field]?.label)
  || col.field.charAt(0)... ;
```
Header resolution is now `column.label → field label → prettified name`.

## Verification

- Existing ObjectGrid render tests pass (column-features + index → 32/32) — no regression.
- The blueprint side is correct (field labels are localized, columns reference fields); this was purely the renderer's fallback. New-behavior unit test would need mocking the async `dataSource.getObjectSchema`; the fix mirrors the already-correct sibling sites and is live-verifiable on a Chinese AI-built app's list view.

Completes the i18n story (sibling: cloud blueprint label fix) — the last English text on a Chinese app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)