### PR TITLE
feat(auth): Cloud Admin sends platformScope=all for cross-org list views

### DIFF
--- a/packages/auth/src/__tests__/createAuthenticatedFetch.test.tsx
+++ b/packages/auth/src/__tests__/createAuthenticatedFetch.test.tsx
@@ -84,3 +84,75 @@ describe('createAuthenticatedFetch', () => {
     expect(calls[0].headers.get('Accept-Language')).toBe('ja');
   });
 });
+
+describe('createAuthenticatedFetch — cloud_control cross-org signal (platformScope)', () => {
+  const DATA_ENV = 'http://localhost/api/v1/data/sys_environment';
+
+  beforeEach(() => {
+    ActiveOrganizationStorage.clear();
+    vi.spyOn(TokenStorage, 'get').mockReturnValue(null);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    window.history.pushState({}, '', '/'); // reset route between tests
+  });
+
+  const inApp = (appName: string) => window.history.pushState({}, '', `/apps/${appName}/sys_environment`);
+
+  it('appends platformScope=all for a cross-org object while in the cloud_control app', async () => {
+    inApp('cloud_control');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(DATA_ENV);
+    expect(calls[0].url).toBe(`${DATA_ENV}?platformScope=all`);
+  });
+
+  it('uses & when the request already has a query string', async () => {
+    inApp('cloud_control');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(`${DATA_ENV}?top=50`);
+    expect(calls[0].url).toBe(`${DATA_ENV}?top=50&platformScope=all`);
+  });
+
+  it('honors a basename prefix in the route (/_console/apps/cloud_control/…)', async () => {
+    window.history.pushState({}, '', '/_console/apps/cloud_control/sys_team');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()('http://localhost/api/v1/data/sys_team');
+    expect(calls[0].url).toContain('platformScope=all');
+  });
+
+  it('does NOT append for a non-cross-org object, even in cloud_control', async () => {
+    inApp('cloud_control');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()('http://localhost/api/v1/data/sys_user');
+    expect(calls[0].url).toBe('http://localhost/api/v1/data/sys_user');
+  });
+
+  it('does NOT append a partial-name match (sys_environment_log) — exact segment only', async () => {
+    inApp('cloud_control');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()('http://localhost/api/v1/data/sys_environment_log');
+    expect(calls[0].url).not.toContain('platformScope');
+  });
+
+  it('still matches sys_environment_member (whitelisted) distinctly from sys_environment', async () => {
+    inApp('cloud_control');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()('http://localhost/api/v1/data/sys_environment_member');
+    expect(calls[0].url).toContain('platformScope=all');
+  });
+
+  it('does NOT append when a different app is active', async () => {
+    inApp('crm');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(DATA_ENV);
+    expect(calls[0].url).toBe(DATA_ENV);
+  });
+
+  it('does not double-append when the caller already set platformScope', async () => {
+    inApp('cloud_control');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(`${DATA_ENV}?platformScope=all`);
+    expect(calls[0].url).toBe(`${DATA_ENV}?platformScope=all`);
+  });
+});

--- a/packages/auth/src/createAuthenticatedFetch.ts
+++ b/packages/auth/src/createAuthenticatedFetch.ts
@@ -21,6 +21,31 @@ export interface AuthenticatedAdapterOptions {
 const ACTIVE_ORG_STORAGE_KEY = 'auth-active-organization-id';
 
 /**
+ * Control-plane objects whose Cloud Admin (`cloud_control`) list views may read
+ * across organizations for a platform super-admin. The server-side org-scope
+ * hook recognizes AND strips the `platformScope=all` signal for EXACTLY these
+ * objects, so we only ever attach it to their requests — never to any other
+ * object, whose query the unrecognized param would otherwise corrupt.
+ */
+const CROSS_ORG_OBJECTS_RE =
+  /\/api\/v1\/data\/(sys_environment_member|sys_environment|sys_app|sys_team|sys_invitation|sys_organization)(?:[/?#]|$)/i;
+
+/**
+ * True when the platform Cloud Admin app (`cloud_control`) is the active app —
+ * the only app allowed to request cross-org scope. Read from the route
+ * (`/apps/cloud_control/…`, basename-agnostic) so this non-React middleware
+ * needs no context wiring; fails closed off the browser.
+ */
+function isCloudControlAppActive(): boolean {
+  try {
+    return typeof window !== 'undefined'
+      && /\/apps\/cloud_control(?:[/?#]|$)/.test(window.location.pathname);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Get/set the active organization ID for tenant-scoped API requests.
  * Used by createAuthenticatedFetch to inject X-Tenant-ID header.
  */
@@ -100,6 +125,24 @@ export function createAuthenticatedFetch(): (input: RequestInfo | URL, init?: Re
       if (lang) {
         headers.set('Accept-Language', lang);
       }
+    }
+    // Cloud Admin (cloud_control) cross-org reads: a platform super-admin
+    // browsing the Cloud Admin should see every org's environments / teams /
+    // apps / invitations, not just their own. Signal the server with
+    // `?platformScope=all`, scoped to (a) the cloud_control app and (b) the
+    // control-plane objects the server recognizes + strips — so it can never
+    // alter another app's or object's query. The server HONORS it only for a
+    // VERIFIED super-admin (and audits it); for anyone else it is ignored and
+    // stripped, so attaching it is always safe.
+    if (
+      isApiCall
+      && (typeof input === 'string' || input instanceof URL)
+      && CROSS_ORG_OBJECTS_RE.test(url)
+      && !/[?&]platformScope=/.test(url)
+      && isCloudControlAppActive()
+    ) {
+      const sep = url.includes('?') ? '&' : '?';
+      return fetch(`${url}${sep}platformScope=all`, { ...init, headers });
     }
     return fetch(input, { ...init, headers });
   };


### PR DESCRIPTION
## What

Companion to **objectstack-ai/cloud** — the cloud control-plane change that lets a **verified platform super-admin** read control-plane objects across **all orgs** in the Cloud Admin (`cloud_control`), instead of only their own org's.

When the `cloud_control` app is active, the authenticated-fetch middleware appends `?platformScope=all` to `GET /api/v1/data/<object>` requests for the org-owned control-plane objects (`sys_environment`, `sys_environment_member`, `sys_app`, `sys_team`, `sys_invitation`, `sys_organization`). This mirrors the existing `X-Tenant-ID` injection in the same middleware.

## Why this is safe (strictly scoped)

The server-side org-scope hook **recognizes and strips** this signal for exactly these objects, and only **honors** it for a verified super-admin (and audits it). So:

- **Gated on the active app** being `cloud_control` — read from the route (`/apps/cloud_control/…`, basename-agnostic), so this non-React middleware needs no context plumbing.
- **Whitelisted to the exact objects** the server strips — never attached to any other object (whose query the unrecognized param would otherwise corrupt). The server has no stripper for non-whitelisted objects, hence the strict list.
- **Exact-segment match** (`sys_environment` ≠ `sys_environment_log`), and **never double-appended**.
- For a non-super-admin who somehow sends it, the server strips it and the read stays org-scoped — so attaching it is always safe.

## Tests

`packages/auth/src/__tests__/createAuthenticatedFetch.test.tsx` — 8 new cases: append + `&`-join when a query already exists + basename prefix + non-whitelisted object skipped + partial-name skipped + `sys_environment_member` matched + other app skipped + no double-append. **15/15 pass.**

## Companion

Server change (the actual scope bypass + super-admin gate + audit): objectstack-ai/cloud `fix/cloud-admin-cross-org-env-read`. This UI change is a no-op without it.