### PR TITLE
feat(console): entitlement- & state-aware environment create actions

### DIFF
--- a/.changeset/environment-entitlement-aware-actions.md
+++ b/.changeset/environment-entitlement-aware-actions.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(console): entitlement- & state-aware environment actions
+
+The `sys_environment` list now presents the right create affordance for the
+org's state (born-with-env) instead of POST-then-error:
+
+- **No production env** (historical orgs) → "Set up your production environment";
+  the create POST provisions the org's one production env — this path never errors.
+- **Has prod env, free plan** → an "Add environment" button that opens a friendly
+  upgrade prompt (CTA to billing) instead of POSTing into a 403.
+- **Has prod env, paid plan** → "Add development environment" creates a dev env.
+
+The action runtime's `apiHandler` now also turns the cloud env-create entitlement
+403s (`DEV_ENV_PLAN_LOCKED` / `DEV_ENV_LIMIT` / `PRODUCTION_ENV_LIMIT`) into a
+friendly upgrade/limit dialog with a CTA rather than a red error toast — a safety
+net that covers any path. State is resolved from the new org-scoped
+`GET /cloud/environment-entitlements` summary, with a row-derived `hasProductionEnv`
+fallback so the production-setup path works even against an older control plane.

--- a/packages/app-shell/src/environment/EnvironmentEntitlementDialog.tsx
+++ b/packages/app-shell/src/environment/EnvironmentEntitlementDialog.tsx
@@ -1,0 +1,100 @@
+/**
+ * EnvironmentEntitlementDialog — a friendly upgrade / limit dialog shown instead
+ * of a raw red error toast when an environment-create is gated by plan or
+ * capacity (DEV_ENV_PLAN_LOCKED / DEV_ENV_LIMIT / PRODUCTION_ENV_LIMIT).
+ *
+ * Driven by a single {@link EntitlementDialogSpec}, opened from two places:
+ *   • proactively, from the env-list toolbar (a free-plan org clicking
+ *     "Add environment" — see EnvironmentListToolbar), and
+ *   • reactively, from the action runtime's apiHandler when the create POST
+ *     comes back with an entitlement 403 (the safety net).
+ *
+ * The CTA renders as an anchor (not an SPA navigation) so a control-plane URL
+ * like `/settings/billing` always lands on the real page regardless of the
+ * console's own router. Relative URLs resolve against the control-plane origin
+ * (`apiBase`); absolute / mailto URLs are used as-is.
+ */
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogCancel,
+  Button,
+} from '@object-ui/components';
+import type { EntitlementCta, EntitlementDialogSpec } from './entitlements';
+
+export interface EntitlementDialogState {
+  open: boolean;
+  spec?: EntitlementDialogSpec;
+}
+
+/** Resolve a CTA URL to a concrete href + whether it should open in a new tab. */
+export function resolveCtaHref(url: string, apiBase: string): { href: string; external: boolean } {
+  if (/^https?:\/\//i.test(url) || url.startsWith('mailto:')) {
+    return { href: url, external: !url.startsWith('mailto:') };
+  }
+  const base = (apiBase || '').replace(/\/+$/, '');
+  // A control-plane-relative path: prefix the API origin when we have one (dev:
+  // split SPA + backend). Empty base → same-origin relative (prod).
+  return { href: `${base}${url}`, external: Boolean(base) };
+}
+
+function CtaButton({
+  cta,
+  apiBase,
+  primary,
+  onNavigate,
+}: {
+  cta: EntitlementCta;
+  apiBase: string;
+  primary: boolean;
+  onNavigate: () => void;
+}) {
+  const { href, external } = resolveCtaHref(cta.url, apiBase);
+  return (
+    <Button asChild variant={primary ? 'default' : 'outline'} size="sm">
+      <a
+        href={href}
+        onClick={onNavigate}
+        {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+        data-testid={`entitlement-cta-${primary ? 'primary' : 'secondary'}`}
+      >
+        {cta.label}
+      </a>
+    </Button>
+  );
+}
+
+interface Props {
+  state: EntitlementDialogState;
+  /** Control-plane origin used to resolve relative CTA URLs. */
+  apiBase: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EnvironmentEntitlementDialog({ state, apiBase, onOpenChange }: Props) {
+  const spec = state.spec;
+  return (
+    <AlertDialog open={state.open} onOpenChange={(open) => { if (!open) onOpenChange(false); }}>
+      <AlertDialogContent data-testid="environment-entitlement-dialog">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{spec?.title}</AlertDialogTitle>
+          <AlertDialogDescription>{spec?.message}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Close</AlertDialogCancel>
+          {spec?.secondaryCta && (
+            <CtaButton cta={spec.secondaryCta} apiBase={apiBase} primary={false} onNavigate={() => onOpenChange(false)} />
+          )}
+          {spec?.cta && (
+            <CtaButton cta={spec.cta} apiBase={apiBase} primary onNavigate={() => onOpenChange(false)} />
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/app-shell/src/environment/EnvironmentListToolbar.tsx
+++ b/packages/app-shell/src/environment/EnvironmentListToolbar.tsx
@@ -1,0 +1,98 @@
+/**
+ * EnvironmentListToolbar — the state-aware replacement for the generic
+ * `list_toolbar` action bar on the `sys_environment` list.
+ *
+ * The cloud serves ONE `create_environment` action; born-with-env makes its
+ * meaning depend on org state (which the action metadata can't express). This
+ * component reads the resolved entitlement state and renders the right
+ * affordance:
+ *   • no production env          → "Set up your production environment" (primary);
+ *                                  the create POST provisions the org's one
+ *                                  production env — the historical-data path that
+ *                                  must never error.
+ *   • has prod + dev allowed     → "Add development environment" (the create POST
+ *                                  makes a dev env).
+ *   • has prod + dev NOT allowed → "Add environment" that opens an UPGRADE prompt
+ *                                  instead of POST-ing into a 403.
+ *   • still resolving / unknown  → the action's default label (neutral), with the
+ *                                  apiHandler entitlement dialog as the safety net.
+ *
+ * Create flows reuse the standard `action:bar` runner (name modal → apiHandler),
+ * so only the label/variant changes — no duplicate POST logic here.
+ */
+
+import { SchemaRenderer } from '@object-ui/react';
+import { Button } from '@object-ui/components';
+import { Plus } from 'lucide-react';
+import {
+  decideEnvironmentCta,
+  upgradeDialogSpec,
+  type EntitlementDialogSpec,
+  type EnvironmentEntitlementsState,
+} from './entitlements';
+
+const CREATE_ACTION = 'create_environment';
+
+interface Props {
+  /** Toolbar actions already localized by the caller (ObjectView). */
+  actions: any[];
+  /** Resolved entitlement state, or null while still loading. */
+  entitlements: EnvironmentEntitlementsState | null;
+  /** Open the shared entitlement dialog (proactive upgrade prompt). */
+  onUpgrade: (spec: EntitlementDialogSpec) => void;
+}
+
+export function EnvironmentListToolbar({ actions, entitlements, onUpgrade }: Props) {
+  const toolbarActions = (actions || []).filter((a: any) => a?.locations?.includes('list_toolbar'));
+  if (toolbarActions.length === 0) return null;
+
+  const ctaKind = entitlements?.ready ? decideEnvironmentCta(entitlements) : null;
+
+  // Upgrade state: a free-plan org clicking "create" must NOT POST-then-403.
+  // Render a primary button that opens the upgrade prompt, plus any other
+  // (non-create) toolbar actions through the normal bar.
+  if (ctaKind === 'upgrade_for_development') {
+    const others = toolbarActions.filter((a: any) => a?.name !== CREATE_ACTION);
+    return (
+      <>
+        {others.length > 0 && (
+          <SchemaRenderer
+            schema={{ type: 'action:bar', location: 'list_toolbar', actions: others, size: 'sm', variant: 'outline' }}
+          />
+        )}
+        <Button
+          size="sm"
+          onClick={() => onUpgrade(upgradeDialogSpec(entitlements!))}
+          className="shadow-none gap-1.5 sm:gap-2 h-8 sm:h-9"
+          data-testid="environment-add-upgrade"
+        >
+          <Plus className="h-4 w-4" />
+          <span>Add environment</span>
+        </Button>
+      </>
+    );
+  }
+
+  // setup_production / add_development / loading: render the bar, overriding only
+  // the create action's label (and promoting production setup to a primary CTA).
+  const renderedActions = toolbarActions.map((a: any) => {
+    if (a?.name !== CREATE_ACTION || ctaKind == null) return a;
+    if (ctaKind === 'setup_production') {
+      return { ...a, label: 'Set up your production environment', variant: 'primary' };
+    }
+    // add_development
+    return { ...a, label: 'Add development environment' };
+  });
+
+  return (
+    <SchemaRenderer
+      schema={{
+        type: 'action:bar',
+        location: 'list_toolbar',
+        actions: renderedActions,
+        size: 'sm',
+        variant: 'outline',
+      }}
+    />
+  );
+}

--- a/packages/app-shell/src/environment/__tests__/EnvironmentEntitlementDialog.test.tsx
+++ b/packages/app-shell/src/environment/__tests__/EnvironmentEntitlementDialog.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * EnvironmentEntitlementDialog renders the friendly upgrade/limit dialog and a
+ * CTA that lands on the (control-plane-resolved) upgrade URL.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { EnvironmentEntitlementDialog, resolveCtaHref } from '../EnvironmentEntitlementDialog';
+
+describe('resolveCtaHref', () => {
+  it('passes absolute urls through (new tab); mailto is not a new tab', () => {
+    expect(resolveCtaHref('https://x.com/p', '')).toEqual({ href: 'https://x.com/p', external: true });
+    expect(resolveCtaHref('mailto:a@b.com', 'https://api')).toEqual({ href: 'mailto:a@b.com', external: false });
+  });
+  it('prefixes a relative url with the api base (dev split origin → new tab)', () => {
+    expect(resolveCtaHref('/settings/billing', 'https://cp.example.com'))
+      .toEqual({ href: 'https://cp.example.com/settings/billing', external: true });
+  });
+  it('keeps a relative url same-origin when no api base (prod)', () => {
+    expect(resolveCtaHref('/settings/billing', '')).toEqual({ href: '/settings/billing', external: false });
+  });
+});
+
+describe('EnvironmentEntitlementDialog', () => {
+  it('renders the spec + a CTA anchor to the resolved url and closes on click', async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <EnvironmentEntitlementDialog
+        apiBase=""
+        onOpenChange={onOpenChange}
+        state={{
+          open: true,
+          spec: {
+            code: 'DEV_ENV_PLAN_LOCKED',
+            title: 'Development environments are a paid feature',
+            message: 'Upgrade to add them.',
+            cta: { label: 'Upgrade plan', url: '/settings/billing' },
+          },
+        }}
+      />,
+    );
+    expect(await screen.findByText('Development environments are a paid feature')).toBeTruthy();
+    const cta = screen.getByTestId('entitlement-cta-primary');
+    expect(cta.getAttribute('href')).toBe('/settings/billing');
+    fireEvent.click(cta);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders nothing when closed', () => {
+    render(<EnvironmentEntitlementDialog apiBase="" onOpenChange={vi.fn()} state={{ open: false }} />);
+    expect(screen.queryByText('Development environments are a paid feature')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/environment/__tests__/EnvironmentListToolbar.test.tsx
+++ b/packages/app-shell/src/environment/__tests__/EnvironmentListToolbar.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * EnvironmentListToolbar renders the right create affordance per org state.
+ * SchemaRenderer is stubbed to surface the action label/variant it would render
+ * (the real action:bar + runner are covered elsewhere); we assert the decision,
+ * not the rendering of the bar.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('@object-ui/react', async (importActual) => ({
+  ...(await importActual<any>()),
+  SchemaRenderer: ({ schema }: any) => (
+    <div data-testid="action-bar">
+      {(schema.actions || []).map((a: any) => (
+        <button key={a.name} data-variant={a.variant}>{a.label}</button>
+      ))}
+    </div>
+  ),
+}));
+
+import { EnvironmentListToolbar } from '../EnvironmentListToolbar';
+import type { EnvironmentEntitlementsState } from '../entitlements';
+
+const CREATE = {
+  name: 'create_environment', label: 'Create Environment',
+  type: 'api', variant: 'primary', locations: ['list_toolbar'],
+};
+const st = (o: Partial<EnvironmentEntitlementsState>): EnvironmentEntitlementsState =>
+  ({ ready: true, hasProductionEnv: true, upgradeUrl: '/settings/billing', source: 'summary', ...o });
+
+describe('EnvironmentListToolbar', () => {
+  it('no production env → "Set up your production environment" (primary)', () => {
+    render(<EnvironmentListToolbar actions={[CREATE]} entitlements={st({ hasProductionEnv: false })} onUpgrade={vi.fn()} />);
+    const btn = screen.getByText('Set up your production environment');
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute('data-variant')).toBe('primary');
+    expect(screen.queryByTestId('environment-add-upgrade')).toBeNull();
+  });
+
+  it('has prod + dev allowed (paid) → "Add development environment"', () => {
+    render(<EnvironmentListToolbar actions={[CREATE]} entitlements={st({ canCreateDevelopmentEnv: true })} onUpgrade={vi.fn()} />);
+    expect(screen.getByText('Add development environment')).toBeTruthy();
+    expect(screen.queryByTestId('environment-add-upgrade')).toBeNull();
+  });
+
+  it('has prod + dev locked (free) → upgrade button, NO create POST affordance', () => {
+    const onUpgrade = vi.fn();
+    render(<EnvironmentListToolbar actions={[CREATE]} entitlements={st({ canCreateDevelopmentEnv: false, plan: 'free' })} onUpgrade={onUpgrade} />);
+    // The create action is NOT rendered as a bar button (no POST-then-403).
+    expect(screen.queryByText('Create Environment')).toBeNull();
+    expect(screen.queryByText('Add development environment')).toBeNull();
+    fireEvent.click(screen.getByTestId('environment-add-upgrade'));
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+    expect(onUpgrade.mock.calls[0][0]).toMatchObject({ code: 'DEV_ENV_PLAN_LOCKED', cta: { url: '/settings/billing' } });
+  });
+
+  it('still resolving (null) → neutral default label, no upgrade button', () => {
+    render(<EnvironmentListToolbar actions={[CREATE]} entitlements={null} onUpgrade={vi.fn()} />);
+    expect(screen.getByText('Create Environment')).toBeTruthy();
+    expect(screen.queryByTestId('environment-add-upgrade')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/environment/__tests__/entitlements.test.ts
+++ b/packages/app-shell/src/environment/__tests__/entitlements.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit coverage for the React-free environment entitlement decision layer:
+ *   - entitlementDialogFromError: cloud 403 body → friendly dialog spec (or null)
+ *   - decideEnvironmentCta: org state → which toolbar affordance
+ *   - upgradeDialogSpec: proactive upgrade prompt
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isEntitlementErrorCode,
+  entitlementDialogFromError,
+  decideEnvironmentCta,
+  upgradeDialogSpec,
+  type EnvironmentEntitlementsState,
+} from '../entitlements';
+
+const base = (over: Partial<EnvironmentEntitlementsState>): EnvironmentEntitlementsState => ({
+  ready: true,
+  hasProductionEnv: true,
+  upgradeUrl: '/settings/billing',
+  source: 'summary',
+  ...over,
+});
+
+describe('isEntitlementErrorCode', () => {
+  it('recognizes only the three entitlement codes', () => {
+    expect(isEntitlementErrorCode('DEV_ENV_PLAN_LOCKED')).toBe(true);
+    expect(isEntitlementErrorCode('DEV_ENV_LIMIT')).toBe(true);
+    expect(isEntitlementErrorCode('PRODUCTION_ENV_LIMIT')).toBe(true);
+    expect(isEntitlementErrorCode('SOMETHING_ELSE')).toBe(false);
+    expect(isEntitlementErrorCode(undefined)).toBe(false);
+  });
+});
+
+describe('entitlementDialogFromError', () => {
+  it('returns null for non-entitlement errors (so a normal toast still fires)', () => {
+    expect(entitlementDialogFromError({ error: 'Boom' })).toBeNull();
+    expect(entitlementDialogFromError(null)).toBeNull();
+    expect(entitlementDialogFromError({ code: 'VALIDATION' })).toBeNull();
+  });
+
+  it('maps DEV_ENV_PLAN_LOCKED to an upgrade dialog with the server upgrade_url', () => {
+    const spec = entitlementDialogFromError({
+      error: 'Development environments are a paid feature...',
+      code: 'DEV_ENV_PLAN_LOCKED',
+      upgrade_url: '/settings/billing',
+      plan: 'free',
+    });
+    expect(spec).not.toBeNull();
+    expect(spec!.code).toBe('DEV_ENV_PLAN_LOCKED');
+    expect(spec!.title).toBe('Development environments are a paid feature');
+    expect(spec!.message).toContain('paid feature'); // server message preserved
+    expect(spec!.cta).toEqual({ label: 'Upgrade plan', url: '/settings/billing' });
+  });
+
+  it('maps DEV_ENV_LIMIT to an upgrade dialog (limit-reached title)', () => {
+    const spec = entitlementDialogFromError({ code: 'DEV_ENV_LIMIT', upgrade_url: '/u' });
+    expect(spec!.title).toBe('Development environment limit reached');
+    expect(spec!.cta!.url).toBe('/u');
+  });
+
+  it('maps PRODUCTION_ENV_LIMIT to a contact-sales dialog (no upgrade CTA)', () => {
+    const spec = entitlementDialogFromError({
+      code: 'PRODUCTION_ENV_LIMIT',
+      error: 'You already have your production environment.',
+      contact_url: 'mailto:sales@objectos.ai',
+    });
+    expect(spec!.cta).toEqual({ label: 'Contact sales', url: 'mailto:sales@objectos.ai' });
+  });
+
+  it('falls back to a default upgrade_url when the server omits one', () => {
+    const spec = entitlementDialogFromError({ code: 'DEV_ENV_PLAN_LOCKED' });
+    expect(spec!.cta!.url).toBe('/settings/billing');
+    expect(spec!.message).toBeTruthy(); // default copy when server message absent
+  });
+});
+
+describe('decideEnvironmentCta', () => {
+  it('no production env → set up production (the never-error path)', () => {
+    expect(decideEnvironmentCta(base({ hasProductionEnv: false }))).toBe('setup_production');
+  });
+  it('has prod + dev allowed → add development', () => {
+    expect(decideEnvironmentCta(base({ canCreateDevelopmentEnv: true }))).toBe('add_development');
+  });
+  it('has prod + dev NOT allowed → upgrade prompt (no POST)', () => {
+    expect(decideEnvironmentCta(base({ canCreateDevelopmentEnv: false }))).toBe('upgrade_for_development');
+  });
+  it('has prod + dev unknown (no summary) → add development (POST + dialog decides)', () => {
+    expect(decideEnvironmentCta(base({ canCreateDevelopmentEnv: undefined, source: 'derived' }))).toBe('add_development');
+  });
+});
+
+describe('upgradeDialogSpec', () => {
+  it('builds a DEV_ENV_PLAN_LOCKED prompt pointing at the upgrade url', () => {
+    const spec = upgradeDialogSpec(base({ plan: 'free', upgradeUrl: '/settings/billing', canCreateDevelopmentEnv: false }));
+    expect(spec.code).toBe('DEV_ENV_PLAN_LOCKED');
+    expect(spec.cta).toEqual({ label: 'Upgrade plan', url: '/settings/billing' });
+    expect(spec.message).toContain('free plan');
+  });
+});

--- a/packages/app-shell/src/environment/entitlements.ts
+++ b/packages/app-shell/src/environment/entitlements.ts
@@ -1,0 +1,147 @@
+/**
+ * Environment entitlement logic — the React-free decision layer behind the
+ * state-aware "create environment" affordance and the entitlement-error dialog.
+ *
+ * The Console environment list (`sys_environment`) renders a single
+ * `create_environment` toolbar action. Whether that should read "Set up your
+ * production environment", "Add development environment", or open an upgrade
+ * prompt depends on org state the action metadata can't express (does the org
+ * already own its one production env? is its plan allowed development envs?).
+ * This module turns the org-scoped capacity summary
+ * (GET /cloud/environment-entitlements) — with a row-derived fallback — into
+ * that decision, and maps the cloud env-create 403 bodies to a friendly dialog
+ * so a confused user never sees a raw red error toast.
+ *
+ * Kept dependency-free so it is trivially unit-testable.
+ */
+
+export type EntitlementErrorCode = 'DEV_ENV_PLAN_LOCKED' | 'DEV_ENV_LIMIT' | 'PRODUCTION_ENV_LIMIT';
+
+const ENTITLEMENT_ERROR_CODES = new Set<string>([
+  'DEV_ENV_PLAN_LOCKED',
+  'DEV_ENV_LIMIT',
+  'PRODUCTION_ENV_LIMIT',
+]);
+
+export function isEntitlementErrorCode(code: unknown): code is EntitlementErrorCode {
+  return typeof code === 'string' && ENTITLEMENT_ERROR_CODES.has(code);
+}
+
+/** A CTA link rendered in the entitlement dialog. */
+export interface EntitlementCta {
+  label: string;
+  /** Absolute (http/mailto) or a control-plane-relative path (e.g. `/settings/billing`). */
+  url: string;
+}
+
+/** Declarative spec the {@link EnvironmentEntitlementDialog} renders. */
+export interface EntitlementDialogSpec {
+  code: string;
+  title: string;
+  message: string;
+  /** Primary CTA (e.g. Upgrade plan). */
+  cta?: EntitlementCta;
+  /** Secondary CTA (e.g. Contact sales). */
+  secondaryCta?: EntitlementCta;
+}
+
+export const DEFAULT_UPGRADE_URL = '/settings/billing';
+
+/**
+ * Map a cloud env-create 403 body
+ * (`{ error, code, upgrade_url, contact_url, plan, current, limit }`) to a
+ * dialog spec. Returns `null` for any non-entitlement error so the caller falls
+ * back to its normal error handling (a red toast). This is the safety net: it
+ * fires regardless of whether the up-front state-aware presentation was right.
+ */
+export function entitlementDialogFromError(body: any): EntitlementDialogSpec | null {
+  const code = body?.code;
+  if (!isEntitlementErrorCode(code)) return null;
+  const serverMessage =
+    typeof body?.error === 'string' && body.error ? body.error
+      : typeof body?.message === 'string' ? body.message : '';
+  const upgradeUrl =
+    typeof body?.upgrade_url === 'string' && body.upgrade_url ? body.upgrade_url : DEFAULT_UPGRADE_URL;
+  const contactUrl = typeof body?.contact_url === 'string' && body.contact_url ? body.contact_url : '';
+
+  if (code === 'PRODUCTION_ENV_LIMIT') {
+    return {
+      code,
+      title: 'You already have your production environment',
+      message:
+        serverMessage ||
+        'Each organization includes exactly one production environment. Create a separate organization for another, or contact us about an Enterprise arrangement.',
+      cta: contactUrl ? { label: 'Contact sales', url: contactUrl } : undefined,
+    };
+  }
+  // DEV_ENV_PLAN_LOCKED / DEV_ENV_LIMIT — both resolve via an upgrade CTA.
+  return {
+    code,
+    title:
+      code === 'DEV_ENV_PLAN_LOCKED'
+        ? 'Development environments are a paid feature'
+        : 'Development environment limit reached',
+    message:
+      serverMessage ||
+      (code === 'DEV_ENV_PLAN_LOCKED'
+        ? 'Your free plan includes one production environment. Upgrade to add development environments — build in dev, then publish to production.'
+        : 'Capacity scales with AI seats. Add an AI seat, or archive an unused development environment to free one up.'),
+    cta: { label: 'Upgrade plan', url: upgradeUrl },
+  };
+}
+
+/** Server summary shape (GET /cloud/environment-entitlements → `data`). */
+export interface EnvironmentEntitlementsSummary {
+  plan?: string;
+  hasProductionEnv?: boolean;
+  production?: { used: number; limit: number; canCreate: boolean };
+  development?: { used: number; limit: number; canCreate: boolean };
+  seatCount?: number;
+  upgradeUrl?: string;
+  contactSalesUrl?: string;
+}
+
+/** Combined client state (authoritative summary, or a row-derived fallback). */
+export interface EnvironmentEntitlementsState {
+  /** True once a usable signal exists (summary OR derived rows). */
+  ready: boolean;
+  hasProductionEnv: boolean;
+  /** Authoritative dev-create capability; `undefined` when unknown (no summary). */
+  canCreateDevelopmentEnv?: boolean;
+  plan?: string;
+  upgradeUrl: string;
+  contactSalesUrl?: string;
+  /** Where the signal came from — telemetry + degradation note + tests. */
+  source: 'summary' | 'derived' | 'unknown';
+}
+
+export type EnvironmentCtaKind = 'setup_production' | 'add_development' | 'upgrade_for_development';
+
+/**
+ * Decide which toolbar affordance to present:
+ *   • no production env          → set up production (the create POST makes one;
+ *                                  the critical historical-data path — never errors)
+ *   • has prod + dev allowed     → add development (POST makes a dev env)
+ *   • has prod + dev NOT allowed → upgrade prompt (no POST)
+ *   • has prod + dev unknown     → add development (let the POST + dialog decide)
+ */
+export function decideEnvironmentCta(state: EnvironmentEntitlementsState): EnvironmentCtaKind {
+  if (!state.hasProductionEnv) return 'setup_production';
+  if (state.canCreateDevelopmentEnv === false) return 'upgrade_for_development';
+  return 'add_development';
+}
+
+/**
+ * The proactive (pre-POST) upgrade dialog shown when a free-plan org clicks
+ * "Add environment" but development envs aren't in its plan. Mirrors the copy
+ * of the reactive DEV_ENV_PLAN_LOCKED error so both paths read identically.
+ */
+export function upgradeDialogSpec(state: EnvironmentEntitlementsState): EntitlementDialogSpec {
+  const planLabel = state.plan && state.plan !== 'free' ? `your ${state.plan} plan` : 'your free plan';
+  return {
+    code: 'DEV_ENV_PLAN_LOCKED',
+    title: 'Development environments are a paid feature',
+    message: `${planLabel} includes one production environment. Upgrade to add development environments — build in dev, then publish to production.`,
+    cta: { label: 'Upgrade plan', url: state.upgradeUrl || DEFAULT_UPGRADE_URL },
+  };
+}

--- a/packages/app-shell/src/environment/useEnvironmentEntitlements.ts
+++ b/packages/app-shell/src/environment/useEnvironmentEntitlements.ts
@@ -1,0 +1,128 @@
+/**
+ * useEnvironmentEntitlements — resolve the org's environment-capacity state so
+ * the `sys_environment` list can present the right "create" affordance up front.
+ *
+ * Two signals, in priority order:
+ *   1. AUTHORITATIVE — GET /cloud/environment-entitlements (org-scoped, computed
+ *      by the same helper the create guard uses). Gives plan + dev-create
+ *      capability precisely, including the seat-scaled / subscription cases the
+ *      client can't derive from rows.
+ *   2. FALLBACK — when that endpoint is unavailable (older control plane / error),
+ *      derive `hasProductionEnv` from the org's env rows via the data API (which
+ *      is org-scoped on the control plane). This keeps the critical
+ *      "set up your production environment" path working without a backend deploy;
+ *      free-vs-paid is left unknown, and a stray create POST is caught by the
+ *      entitlement dialog safety net.
+ *
+ * Returns `null` when disabled (not the environment list) so callers can cheaply
+ * branch. Re-resolves when `refreshKey` changes (e.g. after a create).
+ */
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@object-ui/auth';
+import {
+  DEFAULT_UPGRADE_URL,
+  type EnvironmentEntitlementsState,
+  type EnvironmentEntitlementsSummary,
+} from './entitlements';
+
+const TERMINAL_STATUSES = new Set(['archived', 'failed']);
+
+/** Mirror of the server `classifyEnvironmentType`: explicit type, else default→prod. */
+function classifyEnvironmentType(row: any): 'production' | 'development' {
+  const t = String(row?.environment_type ?? '').trim().toLowerCase();
+  if (t === 'production' || t === 'prod') return 'production';
+  if (t) return 'development';
+  return row?.is_default === true || row?.is_default === 1 ? 'production' : 'development';
+}
+
+export interface UseEnvironmentEntitlementsOptions {
+  /** Only fetch when this is the environment list (objectName === 'sys_environment'). */
+  enabled: boolean;
+  dataSource: any;
+  /** Authenticated fetch (Bearer + tenant + cookies) — from the action runtime. */
+  authFetch: (url: string, init?: any) => Promise<Response>;
+  /** Control-plane origin (VITE_SERVER_URL); '' in same-origin production. */
+  apiBase: string;
+  /** Bump to re-resolve (e.g. the list's refreshKey after a successful create). */
+  refreshKey?: unknown;
+}
+
+export function useEnvironmentEntitlements(
+  opts: UseEnvironmentEntitlementsOptions,
+): EnvironmentEntitlementsState | null {
+  const { enabled, dataSource, authFetch, apiBase, refreshKey } = opts;
+  const { activeOrganization } = useAuth();
+  const orgId = activeOrganization?.id;
+  const [state, setState] = useState<EnvironmentEntitlementsState | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setState(null);
+      return;
+    }
+    let cancelled = false;
+
+    const fromSummary = async (): Promise<EnvironmentEntitlementsState | null> => {
+      try {
+        const base = (apiBase || '').replace(/\/+$/, '');
+        const qs = orgId ? `?organizationId=${encodeURIComponent(orgId)}` : '';
+        const res = await authFetch(`${base}/api/v1/cloud/environment-entitlements${qs}`, {
+          method: 'GET',
+          credentials: 'include',
+        });
+        if (!res.ok) return null;
+        const json = await res.json().catch(() => null);
+        const data = (json?.data ?? json) as EnvironmentEntitlementsSummary | undefined;
+        if (!data || typeof data !== 'object') return null;
+        return {
+          ready: true,
+          hasProductionEnv: data.hasProductionEnv === true,
+          canCreateDevelopmentEnv: data.development?.canCreate,
+          plan: data.plan,
+          upgradeUrl: data.upgradeUrl || DEFAULT_UPGRADE_URL,
+          contactSalesUrl: data.contactSalesUrl,
+          source: 'summary',
+        };
+      } catch {
+        return null;
+      }
+    };
+
+    const fromRows = async (): Promise<EnvironmentEntitlementsState> => {
+      try {
+        const params: any = { $top: 200 };
+        if (orgId) params.$filter = { organization_id: orgId };
+        const res = await dataSource.find('sys_environment', params);
+        const rows: any[] = Array.isArray(res) ? res : res?.data ?? [];
+        const active = rows.filter((r) => !TERMINAL_STATUSES.has(String(r?.status ?? '')));
+        const hasProductionEnv = active.some((r) => classifyEnvironmentType(r) === 'production');
+        return {
+          ready: true,
+          hasProductionEnv,
+          canCreateDevelopmentEnv: undefined,
+          upgradeUrl: DEFAULT_UPGRADE_URL,
+          source: 'derived',
+        };
+      } catch {
+        return {
+          ready: false,
+          hasProductionEnv: false,
+          canCreateDevelopmentEnv: undefined,
+          upgradeUrl: DEFAULT_UPGRADE_URL,
+          source: 'unknown',
+        };
+      }
+    };
+
+    (async () => {
+      const summary = await fromSummary();
+      const next = summary ?? (await fromRows());
+      if (!cancelled) setState(next);
+    })();
+
+    return () => { cancelled = true; };
+  }, [enabled, orgId, apiBase, authFetch, dataSource, refreshKey]);
+
+  return state;
+}

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -92,6 +92,42 @@ describe('useConsoleActionRuntime — authenticated handlers', () => {
     expect(onRefresh).not.toHaveBeenCalled();
   });
 
+  it('apiHandler turns an entitlement 403 into the upgrade dialog, not a red error toast', async () => {
+    // Free org that already has its production env clicks "create" → the control
+    // plane 403s with DEV_ENV_PLAN_LOCKED. The runtime must open a friendly
+    // dialog and NOT return an `error` (which the ActionRunner would toast red).
+    authFetchSpy.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        error: 'Development environments are a paid feature. Upgrade to add them.',
+        code: 'DEV_ENV_PLAN_LOCKED',
+        upgrade_url: '/settings/billing',
+        plan: 'free',
+      }),
+    });
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], onRefresh }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.apiHandler({
+        type: 'api', name: 'create_environment',
+        target: '/api/v1/cloud/environments', params: { displayName: 'x' },
+      } as any);
+    });
+
+    // No `error` key → ActionRunner.handlePostExecution suppresses the red toast.
+    expect(res).toEqual({ success: false });
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    // …and the shared entitlement dialog is now open with the upgrade title.
+    render(<>{result.current.dialogs}</>);
+    expect(await screen.findByText('Development environments are a paid feature')).toBeTruthy();
+  });
+
   it('apiHandler merges bodyExtra into the dataSource update payload (pure-confirmation action)', async () => {
     // A pure-confirmation action carries no params array; its mutation lives in
     // `bodyExtra`. Without merging it, `fields` is empty and the update below is

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -44,6 +44,8 @@ import { ActionParamDialog, type ParamDialogState } from '../views/ActionParamDi
 import { ActionResultDialog, type ResultDialogState } from '../views/ActionResultDialog';
 import { FlowRunner, type ScreenFlowState } from '../views/FlowRunner';
 import { resolveActionParams } from '../utils/resolveActionParams';
+import { EnvironmentEntitlementDialog, type EntitlementDialogState } from '../environment/EnvironmentEntitlementDialog';
+import { entitlementDialogFromError, type EntitlementDialogSpec } from '../environment/entitlements';
 import { resolvePageVarTokens } from '../utils/resolvePageVarTokens';
 
 const FALLBACK_USER = { id: 'current-user', name: 'Demo User', isPlatformAdmin: false };
@@ -71,6 +73,8 @@ export interface ConsoleActionRuntime {
   serverActionHandler: (action: ActionDef, context?: ActionContext) => Promise<ActionResult>;
   /** Authenticated fetch wrapper (Bearer + tenant + cookies). */
   authFetch: ReturnType<typeof createAuthenticatedFetch>;
+  /** Open the shared environment entitlement (upgrade / limit) dialog. */
+  openEntitlementDialog: (spec: EntitlementDialogSpec) => void;
   /** Props to spread onto `<ActionProvider>`. */
   actionProviderProps: {
     context: Record<string, any>;
@@ -118,6 +122,9 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   const [resultDialogState, setResultDialogState] = useState<ResultDialogState>({ open: false });
   // A paused `screen`-node flow awaiting user input.
   const [screenFlow, setScreenFlow] = useState<ScreenFlowState | null>(null);
+  // Plan/capacity gate dialog (upgrade / limit), shared by the env-list toolbar
+  // (proactive) and the api-action error path below (reactive safety net).
+  const [entitlementDialog, setEntitlementDialog] = useState<EntitlementDialogState>({ open: false });
   // Guards against double-firing a server action (slow SSO handoff, etc.).
   const serverActionInFlight = useRef<Set<string>>(new Set());
 
@@ -198,6 +205,10 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   // Authenticated fetch for direct backend calls. Declared before apiHandler.
   const authFetch = useMemo(() => createAuthenticatedFetch(), []);
 
+  const openEntitlementDialog = useCallback((spec: EntitlementDialogSpec) => {
+    setEntitlementDialog({ open: true, spec });
+  }, []);
+
   const apiHandler = useCallback(async (action: ActionDef, context?: ActionContext): Promise<ActionResult> => {
     try {
       const target = action.target || action.name;
@@ -263,11 +274,20 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
         }
         const res = await authFetch(url, init);
         if (!res.ok) {
-          let detail = `HTTP ${res.status}`;
-          try {
-            const j = await res.json();
-            detail = (j as any)?.error || (j as any)?.message || detail;
-          } catch { /* response body not JSON */ }
+          let body: any = null;
+          try { body = await res.json(); } catch { /* response body not JSON */ }
+          // Plan/capacity gates (e.g. creating an environment the org's plan
+          // doesn't include) come back as coded 403s. Surface them as a friendly
+          // upgrade/limit DIALOG with a CTA — never a generic red error toast.
+          // Returning success:false WITHOUT an `error` suppresses the runner's
+          // error toast (ActionRunner.handlePostExecution); the dialog owns the
+          // messaging.
+          const entitlementSpec = entitlementDialogFromError(body);
+          if (entitlementSpec) {
+            openEntitlementDialog(entitlementSpec);
+            return { success: false };
+          }
+          const detail = (body as any)?.error || (body as any)?.message || `HTTP ${res.status}`;
           return { success: false, error: detail };
         }
         const data = await res.json().catch(() => ({}));
@@ -328,7 +348,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     } catch (error) {
       return { success: false, error: (error as Error).message };
     }
-  }, [dataSource, objApiName, authFetch, activeOrganization, refresh]);
+  }, [dataSource, objApiName, authFetch, activeOrganization, refresh, openEntitlementDialog]);
 
   // Flow action handler — POST to /api/v1/automation/{name}/trigger.
   // `context` is the shared ActionRunner context (registered handlers are
@@ -578,6 +598,11 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
         onClose={() => setScreenFlow(null)}
         onComplete={() => { setScreenFlow(null); refresh(); }}
       />
+      <EnvironmentEntitlementDialog
+        state={entitlementDialog}
+        apiBase={import.meta.env.VITE_SERVER_URL || ''}
+        onOpenChange={(open) => { if (!open) setEntitlementDialog({ open: false }); }}
+      />
     </>
   );
 
@@ -591,6 +616,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     flowHandler,
     serverActionHandler,
     authFetch,
+    openEntitlementDialog,
     actionProviderProps,
     dialogs,
   };

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -56,6 +56,8 @@ import { useRealtimeSubscription, useConflictResolution } from '@object-ui/colla
 import { ActionProvider, useNavigationOverlay, SchemaRenderer } from '@object-ui/react';
 import { toast } from 'sonner';
 import { useConsoleActionRuntime } from '../hooks/useConsoleActionRuntime';
+import { useEnvironmentEntitlements } from '../environment/useEnvironmentEntitlements';
+import { EnvironmentListToolbar } from '../environment/EnvironmentListToolbar';
 
 /** Map view types to Lucide icons (Airtable-style) */
 const VIEW_TYPE_ICONS: Record<string, ComponentType<{ className?: string }>> = {
@@ -321,6 +323,31 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         onRefresh: () => setRefreshKey((k) => k + 1),
     });
     const { confirmHandler, toastHandler } = actionRuntime;
+
+    // Environment list (sys_environment) is entitlement- + state-aware: born
+    // with one production env per org, its single `create_environment` action
+    // means different things — "Set up your production environment", "Add
+    // development environment", or an upgrade prompt — depending on org state.
+    // Resolved org-side here; the hook is a no-op for every other object.
+    const isEnvironmentList = objectDef.name === 'sys_environment';
+    const environmentEntitlements = useEnvironmentEntitlements({
+        enabled: isEnvironmentList,
+        dataSource,
+        authFetch: actionRuntime.authFetch,
+        apiBase: (import.meta as any).env?.VITE_SERVER_URL || '',
+        refreshKey,
+    });
+    // Localized `list_toolbar` actions, shared by the generic action bar and the
+    // environment-aware toolbar (the action:bar renderer filters by location).
+    const localizedToolbarActions = useMemo(
+        () => (objectDef.actions || []).map((a: any) => ({
+            ...a,
+            label: actionLabel(objectDef.name, a.name, a.label || a.name),
+            ...(a.confirmText !== undefined && { confirmText: actionConfirm(objectDef.name, a.name, a.confirmText) }),
+            ...(a.successMessage !== undefined && { successMessage: actionSuccess(objectDef.name, a.name, a.successMessage) }),
+        })),
+        [objectDef, actionLabel, actionConfirm, actionSuccess],
+    );
 
     // Resolve which generic CRUD affordances belong in the toolbar for
     // this object's lifecycle bucket (`managedBy`).  config tables show
@@ -1526,19 +1553,17 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
 
                     {/* Schema-driven toolbar actions */}
                     {objectDef.actions?.some((a: any) => a.locations?.includes('list_toolbar')) && (
+                      isEnvironmentList ? (
+                        <EnvironmentListToolbar
+                          actions={localizedToolbarActions}
+                          entitlements={environmentEntitlements}
+                          onUpgrade={actionRuntime.openEntitlementDialog}
+                        />
+                      ) : (
                       <SchemaRenderer schema={{
                         type: 'action:bar',
                         location: 'list_toolbar',
-                        actions: (objectDef.actions || []).map((a: any) => ({
-                          ...a,
-                          label: actionLabel(objectDef.name, a.name, a.label || a.name),
-                          ...(a.confirmText !== undefined && {
-                            confirmText: actionConfirm(objectDef.name, a.name, a.confirmText),
-                          }),
-                          ...(a.successMessage !== undefined && {
-                            successMessage: actionSuccess(objectDef.name, a.name, a.successMessage),
-                          }),
-                        })),
+                        actions: localizedToolbarActions,
                         size: 'sm',
                         variant: 'outline',
                         // On mobile, collapse all schema-driven toolbar actions
@@ -1547,6 +1572,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                         // title off-screen.
                         mobileMaxVisible: 0,
                       }} />
+                      )
                     )}
 
                     {/*


### PR DESCRIPTION
## What

Makes the Cloud Control console's `sys_environment` list actions **entitlement- and state-aware** so a user never hits a confusing error when clicking "Create Environment".

## The bug

Every org is born with exactly one production environment. On a **free** org that already has it, the generic `create_environment` toolbar action opened a name modal and, on confirm, POSTed and surfaced the `403 DEV_ENV_PLAN_LOCKED` as a **red error toast** — confusing for a user who has one environment, clicked "create", and filled in a form.

## What changed

**1. State-aware create affordance** (`EnvironmentListToolbar`, driven by `useEnvironmentEntitlements`):

| Org state | Affordance | Behaviour |
|---|---|---|
| No production env (historical / failed provisioning) | **"Set up your production environment"** (primary) | create POST provisions the org's one production env — never errors |
| Has prod env, **paid** plan | **"Add development environment"** | create POST makes a dev env |
| Has prod env, **free** plan | **"Add environment"** | opens an **upgrade prompt** (CTA → billing) — no POST |

**2. Entitlement-error safety net** (`useConsoleActionRuntime` `apiHandler`): any env-create that still comes back with `DEV_ENV_PLAN_LOCKED` / `DEV_ENV_LIMIT` / `PRODUCTION_ENV_LIMIT` is now shown as a friendly upgrade/limit **dialog with a CTA** instead of a red error toast. Returning `{ success: false }` without an `error` suppresses the runner's toast; the shared dialog owns the messaging. This covers every path (stale state, multi-org, or an older control plane).

## Signal source

State is resolved from the new org-scoped `GET /api/v1/cloud/environment-entitlements` summary ([cloud#512](https://github.com/objectstack-ai/cloud/pull/512)), with a **row-derived `hasProductionEnv` fallback** (the control-plane data API is org-scoped) so the critical production-setup path works even before the cloud change ships. born-with-env is preserved — there is no generic "create production environment" affordance for an org that already has one.

## Tests

- `environment/__tests__/entitlements.test.ts` — error→dialog mapping, CTA decision for all states, upgrade-prompt builder.
- `environment/__tests__/EnvironmentListToolbar.test.tsx` — the 3 states + loading; the free state renders the upgrade button (no create POST) and fires `onUpgrade`.
- `environment/__tests__/EnvironmentEntitlementDialog.test.tsx` — renders the spec + a CTA anchor resolved against the API base.
- `hooks/__tests__/useConsoleActionRuntime.test.tsx` — a coded 403 opens the dialog and returns `{ success:false }` (no toast); an uncoded 403 still toasts (unchanged).
- Full `@object-ui/app-shell` suite green (909 tests); `turbo run build` clean.

## Coordination

Depends on the companion cloud PR ([cloud#512](https://github.com/objectstack-ai/cloud/pull/512)) for the authoritative summary, but degrades gracefully without it (row-derived state + the error-dialog safety net). Safe to merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
