### PR TITLE
fix(console): let single-org users reach "New organization" (manage mode)

### DIFF
--- a/packages/app-shell/src/console/organizations/OrganizationsPage.tsx
+++ b/packages/app-shell/src/console/organizations/OrganizationsPage.tsx
@@ -22,7 +22,7 @@ import { Plus, Search, Loader2 } from 'lucide-react';
 import { useAuth } from '@object-ui/auth';
 import type { AuthOrganization } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { CreateWorkspaceDialog } from './CreateWorkspaceDialog';
 import { resolveHomeUrl } from './resolveHomeUrl';
 
@@ -38,6 +38,11 @@ function getOrgInitials(name: string): string {
 export function OrganizationsPage() {
   const { t } = useObjectTranslation();
   const navigate = useNavigate();
+  // `?manage=1` (set by the avatar menu's "My Organizations" entry) means the
+  // user explicitly came to manage / create orgs — don't auto-skip the picker
+  // for a single-org user, or they could never reach "New organization".
+  const [searchParams] = useSearchParams();
+  const manageMode = searchParams.get('manage') === '1';
   const {
     organizations,
     activeOrganization,
@@ -112,16 +117,17 @@ export function OrganizationsPage() {
   useEffect(() => {
     if (autoSelectedRef.current) return;
     if (isOrganizationsLoading) return;
+    if (manageMode) return;
     if (orgList.length !== 1) return;
     autoSelectedRef.current = true;
     void handleSelect(orgList[0]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOrganizationsLoading, orgList.length]);
+  }, [isOrganizationsLoading, orgList.length, manageMode]);
 
   // Show a spinner while we're either still loading, or about to auto-redirect
   // because there's only one org. This prevents the picker from briefly
   // flashing on screen for single-org users.
-  const willAutoSelect = !isOrganizationsLoading && orgList.length === 1;
+  const willAutoSelect = !manageMode && !isOrganizationsLoading && orgList.length === 1;
   if (isOrganizationsLoading || willAutoSelect) {
     return (
       <div className="flex flex-1 items-center justify-center py-20">

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -945,7 +945,7 @@ export function AppHeader({
                 {t('user.profile', { defaultValue: 'Profile' })}
               </DropdownMenuItem>
               {hasOrgSection && (
-                <DropdownMenuItem onClick={() => navigate('/organizations')} className="cursor-pointer">
+                <DropdownMenuItem onClick={() => navigate('/organizations?manage=1')} className="cursor-pointer">
                   <Boxes className="mr-2 h-4 w-4" />
                   {t('organizations.mine', { defaultValue: 'My Organizations' })}
                 </DropdownMenuItem>


### PR DESCRIPTION
## Problem

A user who belongs to exactly one organization can't reach the **"New organization"** button. The Organizations page (`/organizations`) auto-skips the picker for single-org users and redirects to `/home` (`OrganizationsPage.tsx` — `willAutoSelect` when `orgList.length === 1`). So clicking the avatar menu's **"My Organizations"** bounces them straight back to home — no UI path to create a second org.

Discovered while enabling cloud multi-org self-service (cloud#507 / framework#2323): the backend now lists a user's orgs and births each org with a production env, but a single-org user still had no way to *create* their 2nd org from the UI.

## Fix

Distinguish the two purposes of `/organizations`:
- **Post-login picker** (no param) — keep auto-skipping for single-org users (zero friction).
- **Explicit management** (avatar → "My Organizations") — never auto-skip, so the user can switch *or* create.

The avatar menu now navigates to `/organizations?manage=1`; `OrganizationsPage` suppresses the auto-skip when `manage=1` is present.

## Verification

Root cause + fix confirmed by reading the redirect logic; a contained, low-risk param check (10 lines). **Not yet browser-verified against the live console** — the cloud serves a prebuilt console bundle, so the faithful verify needs a pass after the cloud bumps the objectui SHA (`scripts/bump-objectui.sh`). The backend half of multi-org (org listing + born-with-env) is browser-verified separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
