### PR TITLE
fix(console): route org-less users into guided org creation (multi-org)

### DIFF
--- a/packages/app-shell/src/console/ConsoleShell.tsx
+++ b/packages/app-shell/src/console/ConsoleShell.tsx
@@ -10,7 +10,7 @@
  * apps/console/src/App.tsx for one with custom system routes + CreateApp.
  */
 
-import { Suspense, useEffect, useRef, type ReactNode } from 'react';
+import { Suspense, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { AuthGuard, useAuth } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
@@ -175,11 +175,27 @@ function UserStateBridge() {
  * deployments (empty organizations list) render through.
  */
 export function RequireOrganization({ children }: { children: ReactNode }) {
-  const { activeOrganization, organizations, isOrganizationsLoading } = useAuth();
+  const { activeOrganization, organizations, isOrganizationsLoading, getAuthConfig } = useAuth();
+  // Multi-org (cloud) deployments route a brand-new, org-less user into the
+  // guided "Create your workspace" flow; single-tenant self-host renders through.
+  const [multiOrgEnabled, setMultiOrgEnabled] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getAuthConfig()
+      .then((cfg: any) => { if (!cancelled) setMultiOrgEnabled(cfg?.features?.multiOrgEnabled !== false); })
+      .catch(() => { if (!cancelled) setMultiOrgEnabled(false); });
+    return () => { cancelled = true; };
+  }, [getAuthConfig]);
   if (isOrganizationsLoading) return <LoadingFallback />;
   const orgList = organizations ?? [];
   const orgFeatureEnabled = orgList.length > 0 || !!activeOrganization;
   if (orgFeatureEnabled && !activeOrganization) return <Navigate to="/organizations" replace />;
+  // No org at all: on multi-org, send them to /organizations (the create
+  // screen); wait for the flag so we don't flash /home then redirect.
+  if (orgList.length === 0 && !activeOrganization) {
+    if (multiOrgEnabled === null) return <LoadingFallback />;
+    if (multiOrgEnabled) return <Navigate to="/organizations" replace />;
+  }
   return <>{children}</>;
 }
 


### PR DESCRIPTION
## Problem

`RequireOrganization` treated an **empty** organizations list as single-tenant and rendered through to `/home`. So on a **multi-org (cloud)** deployment, a brand-new, org-less user landed on a dead `/home` (a "Cloud" app with no org/env behind it) instead of being guided to create their workspace.

## Fix

When the runtime config has `features.multiOrgEnabled !== false` **and** the user has no orgs (and no active org), redirect to `/organizations` — the "Create your first organization" screen. Single-tenant self-host (`multiOrgEnabled === false`) still renders through unchanged. The config flag is read via the existing `getAuthConfig()` (same one OrganizationsPage/CreateWorkspaceDialog use); we wait for it before deciding so we don't flash `/home` then redirect.

## Why

Pairs with cloud's **guided org creation** (signup no longer auto-provisions a personal org with an auto-derived name). The new-user flow becomes: signup → org-less → **guided "Create your workspace"** (user picks name + slug) → `createOrganization` → born-with-env. Unifies the first org with "+ New organization".

## Verification

Browser-E2E'd on the live cloud control plane: fresh signup (0 orgs) → navigating into the console redirects to `/organizations` ("No organizations yet / Create your first organization") → created "Acme Corp" (slug auto-derived `acme-corp`) → switched in → org born with its `os-…` production env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
