### PR TITLE
feat(chatbot): frame extend builds in the plan card (Adding to existing app X)

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -522,6 +522,9 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   nextStepsLabel?: string;
   /** Heading for the pre-build proposed-plan card (default "Proposed plan"). */
   planTitleLabel?: string;
+  /** Extend mode: prefix shown when proposedPlan.targetApp is set, framing
+   *  the build as additive (e.g. "Adding to existing app"). */
+  planExtendLabel?: string;
   /** Heading above the structure-deciding questions in the plan card (default "Confirm before building"). */
   planQuestionsLabel?: string;
   /** Heading above the agent's assumptions in the plan card (default "Assumptions"). */
@@ -915,6 +918,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       verifiedLabel = 'Verified',
       nextStepsLabel = "What's next",
       planTitleLabel = 'Proposed plan',
+      planExtendLabel = 'Adding to existing app',
       planQuestionsLabel = 'Confirm before building',
       planAssumptionsLabel = 'Assumptions',
       planApproveHintLabel = 'Reply to approve or adjust this plan.',
@@ -1577,6 +1581,14 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                   <ClipboardList className="size-3.5" />
                   {planTitleLabel}
                 </span>
+                {tool.proposedPlan.targetApp ? (
+                  <span
+                    className="inline-flex w-fit items-center gap-1 rounded-md border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-700 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-300"
+                    data-testid="proposed-plan-extend"
+                  >
+                    + {planExtendLabel} 「{tool.proposedPlan.targetApp}」
+                  </span>
+                ) : null}
                 {tool.proposedPlan.summary ? (
                   <p className="text-xs text-muted-foreground">{tool.proposedPlan.summary}</p>
                 ) : null}


### PR DESCRIPTION
When `propose_blueprint` returns a `targetApp` (extend / follow-up build), the plan card now shows a small badge — **"Adding to existing app 「X」"** — so the user sees the build is **additive** (growing an existing app), not a new one. The exact moment to catch "wait, why is it making a *new* app?".

`targetApp` was already plumbed end-to-end (cloud emits it in the `blueprint_proposed` envelope; `detectProposedPlan` lifts it) but was never rendered. This adds the render + a `planExtendLabel` prop (English default).

Completes the "extend-diff framing" item from the confirm-before-change work (#521 / #2003). Built clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)