### PR TITLE
fix(auth): cloud login SPA follows the oauth2/authorize redirect (env→cloud SSO)

### DIFF
--- a/apps/console/src/pages/auth/LoginPage.tsx
+++ b/apps/console/src/pages/auth/LoginPage.tsx
@@ -22,6 +22,7 @@ import { useAuth, LoginForm } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Card } from '@object-ui/components';
 import { AuthLayout } from './AuthLayout';
+import { followOauthAuthorize } from './followAuthorize';
 
 /** Restrict the post-login redirect to same-origin paths. */
 function isSafeRedirect(target: string | null): target is string {
@@ -67,6 +68,9 @@ export function LoginPage() {
 
   const [signUpDisabled, setSignUpDisabled] = useState(false);
   const [autoSelectingOrg, setAutoSelectingOrg] = useState(false);
+  // The OAuth hand-off fetch must fire at most once even though the post-login
+  // effect re-runs as org state settles (it navigates away on success).
+  const ssoHandoffStartedRef = useRef(false);
 
   // `isLoading` from useAuth() is overloaded: it is true both during the
   // initial session check AND during every in-flight signIn. The full-page
@@ -114,11 +118,18 @@ export function LoginPage() {
     if (!user) return;
 
     // 1. OAuth provider hand-off (see file header). Replay the signed
-    //    authorize params verbatim so the IdP can issue the code.
+    //    authorize params so the IdP issues the code, then FOLLOW the redirect
+    //    it hands back. better-auth's oauth-provider answers a same-origin
+    //    fetch with `200 { redirect: true, url }` (NOT a 302), so a plain
+    //    navigation to /authorize would just render that JSON and strand the
+    //    user on this spinner — we must fetch + navigate ourselves.
     if (typeof window !== 'undefined') {
       const sp = new URLSearchParams(window.location.search);
       if (sp.has('client_id') && sp.has('redirect_uri')) {
-        window.location.assign(`/api/v1/auth/oauth2/authorize${window.location.search}`);
+        if (!ssoHandoffStartedRef.current) {
+          ssoHandoffStartedRef.current = true;
+          followOauthAuthorize(window.location.search);
+        }
         return;
       }
     }

--- a/apps/console/src/pages/auth/RegisterPage.tsx
+++ b/apps/console/src/pages/auth/RegisterPage.tsx
@@ -13,12 +13,13 @@
  *    here mid-SSO so the IdP can continue the flow post-signup.
  */
 
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth, RegisterForm } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Card } from '@object-ui/components';
 import { AuthLayout } from './AuthLayout';
+import { followOauthAuthorize } from './followAuthorize';
 
 function isSafeRedirect(target: string | null): target is string {
   return !!target && target.startsWith('/') && !target.startsWith('//');
@@ -57,6 +58,8 @@ export function RegisterPage() {
 
   const [signUpDisabled, setSignUpDisabled] = useState<boolean | null>(null);
   const [autoSelectingOrg, setAutoSelectingOrg] = useState(false);
+  // Fire the OAuth hand-off fetch at most once (see LoginPage).
+  const ssoHandoffStartedRef = useRef(false);
 
   // See LoginPage: `isLoading` is overloaded (initial session check + every
   // in-flight signUp). Latch once the first check resolves so a failed
@@ -95,7 +98,10 @@ export function RegisterPage() {
     if (typeof window !== 'undefined') {
       const sp = new URLSearchParams(window.location.search);
       if (sp.has('client_id') && sp.has('redirect_uri')) {
-        window.location.assign(`/api/v1/auth/oauth2/authorize${window.location.search}`);
+        if (!ssoHandoffStartedRef.current) {
+          ssoHandoffStartedRef.current = true;
+          followOauthAuthorize(window.location.search);
+        }
         return;
       }
     }

--- a/apps/console/src/pages/auth/followAuthorize.ts
+++ b/apps/console/src/pages/auth/followAuthorize.ts
@@ -1,0 +1,51 @@
+/**
+ * Complete an OAuth2 / OIDC authorization hand-off after the user has
+ * authenticated on this (the cloud / IdP) origin.
+ *
+ * When an environment federates login to the cloud ("Continue with
+ * ObjectStack"), the env (relying party) sends the browser to the cloud's
+ * `/oauth2/authorize`. better-auth's oauth-provider, finding an active
+ * session + a consent-skipped client, wants to hand a `?code=&state=` back
+ * to the env's callback. Crucially it answers a **same-origin fetch** with
+ * `200 { redirect: true, url }` and only emits a real `302` for a top-level
+ * navigation (see `authorize.mjs` → `handleRedirect` / `isBrowserFetchRequest`
+ * in @better-auth/oauth-provider).
+ *
+ * So a plain `window.location.assign('/oauth2/authorize?…')` is wrong: for a
+ * browser-fetch-shaped request it renders the JSON body and strands the user
+ * on the "Signing you in…" spinner. We instead fetch the endpoint and follow
+ * the `url` it returns ourselves — the same pattern {@link OAuthConsentPage}
+ * already uses for the consent POST.
+ *
+ * If the response isn't the expected JSON shape (an error, a consent page,
+ * an opaque redirect, …) we fall back to a top-level navigation so the
+ * server can drive its own 302 / error / consent flow rather than leaving
+ * the user stuck.
+ *
+ * @param search the current `window.location.search` (the signed authorize
+ *   params better-auth handed us when it redirected here).
+ */
+export function followOauthAuthorize(search: string): void {
+  const authorizeUrl = `/api/v1/auth/oauth2/authorize${search}`;
+  const navigateTopLevel = () => window.location.assign(authorizeUrl);
+
+  fetch(authorizeUrl, {
+    credentials: 'include',
+    // 200-JSON is expected for a fetch; never chase a cross-origin 302 into
+    // a CORS error — fall back to a top-level navigation instead.
+    redirect: 'manual',
+    headers: { accept: 'application/json' },
+  })
+    .then(async (res) => {
+      const data = (await res.json().catch(() => null)) as
+        | { url?: string; redirect_uri?: string; redirectURI?: string; redirect?: boolean }
+        | null;
+      const next = data?.url ?? data?.redirect_uri ?? data?.redirectURI;
+      if (res.ok && next) {
+        window.location.href = next;
+        return;
+      }
+      navigateTopLevel();
+    })
+    .catch(navigateTopLevel);
+}


### PR DESCRIPTION
## Problem

"Continue with ObjectStack" (env → cloud OIDC SSO, ADR-0024 D3) never completes — the cloud login lands on `/_console/login?<oidc params>` and shows **"Signing you in…"** forever.

Root cause: the post-login hand-off used a full-page navigation:

```ts
window.location.assign(`/api/v1/auth/oauth2/authorize${window.location.search}`);
```

`@better-auth/oauth-provider`'s `authorize.mjs → handleRedirect` answers a **browser-fetch-shaped** request with `200 { redirect: true, url }` and only emits a real `302` for a top-level navigation. So the SPA's request comes back as a 200-JSON body that nothing follows → the spinner loops. (Manually copying that `url` out of the loop replays a *stale single-use code* → the misleading "redirects back to authorize".)

## Fix

Fetch the authorize endpoint and navigate to the `url` it returns — the same pattern `OAuthConsentPage` already uses:

- New `apps/console/src/pages/auth/followAuthorize.ts` — `fetch('/oauth2/authorize'+search)` then `window.location.href = data.url` (`url` / `redirect_uri` / `redirectURI`); falls back to a top-level navigation if the response isn't the expected JSON.
- `LoginPage.tsx` + `RegisterPage.tsx` call it behind a once-guard ref (the post-login effect re-runs as org state settles).

## Verification (local, full stack)

- **curl E2E**: env `/sign-in/oauth2` → cloud authorize (fetch-shape → `200 {redirect,url}`; top-level → `302`) → env `/oauth2/callback/objectstack-cloud` exchanges the code, JIT-provisions the env `sys_user` + `sys_account(provider_id='objectstack-cloud')`, mints the env session.
- **Browser E2E**: the SPA carries the browser from `localhost:4200/_console/login?<oidc>` to the env callback host; the full flow lands authenticated on the env `/_console/home` (env DB shows a `sys_session` with a real browser UA).

The env-runtime callback itself is **not** broken — no env-side change was needed.

## Companion

Requires **framework#2333** (`sys_verification.value` `unique:true`→`false`) so the cloud authorize endpoint stops returning `503 UNIQUE constraint failed: sys_verification.value`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)