### PR TITLE
feat(chatbot): surface the AI model picker on the full-page Build/Ask surface (ADR-0028)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -41,6 +41,7 @@ import {
   ChatbotEnhanced,
   useAgents,
   useObjectChat,
+  useAiModels,
   useHitlInChat,
   resolveDefaultAgentName,
   PLATFORM_DEFAULT_AGENT,
@@ -1009,6 +1010,14 @@ function ChatPane({
   const { errorSuppressed, handleChatError, setMessagesRef, resetSuppression } =
     useReconcileOnError({ chatApi, conversationId });
 
+  // ADR-0028: plan-filtered selectable AI model on the full-page Build/Ask
+  // surface. The footer <select> in ChatbotEnhanced renders only for 2+ models,
+  // so free / single-model envs see nothing. Mirrors ConsoleFloatingChatbot;
+  // the chosen model rides each request via useObjectChat's `model` below.
+  const { models: aiModels, defaultModelId } = useAiModels({ apiBase });
+  const [selectedModelId, setSelectedModelId] = useState<string | undefined>(undefined);
+  const effectiveModelId = selectedModelId ?? defaultModelId;
+
   const {
     messages,
     isLoading,
@@ -1021,6 +1030,8 @@ function ChatPane({
   } = useObjectChat({
     api: chatApi,
     conversationId,
+    // ADR-0028: the user's picked model (or the env default) rides each request.
+    model: effectiveModelId,
     onError: handleChatError,
     body: {
       context: {
@@ -1194,6 +1205,12 @@ function ChatPane({
           trace: t('console.ai.trace'),
           viewTrace: t('console.ai.viewTrace'),
         }}
+        // ADR-0028: selectable AI model — ChatbotEnhanced renders the footer
+        // <select> only when 2+ models are offered (free / single-model envs
+        // see none). The picked model flows to useObjectChat above.
+        models={aiModels}
+        selectedModelId={effectiveModelId}
+        onModelChange={setSelectedModelId}
         suggestions={suggestions}
         onSendMessage={handleSend}
         onClear={clear}


### PR DESCRIPTION
## What
Surface the ADR-0028 AI model picker on the full-page **Build / Ask** surface (`/_console/ai/build`, `/ai/ask`).

## Why
The picker (#2010) was only wired into the **floating** chatbot (`ConsoleFloatingChatbot`). The dedicated full-page AI surface — the primary "Build with AI" / "Ask AI" entry — rendered `ChatbotEnhanced` **without** the model props, so a paid-tier user had no way to switch models on the very surface the feature is named for ("switch model during *build*"). Found during live staging verification of ADR-0028.

## Change
`AiChatPage` → `ChatPane`, mirroring `ConsoleFloatingChatbot` exactly (the chat component already accepts these optional props):
- `useAiModels({ apiBase })` → plan-filtered allowlist
- `selectedModelId` state, `effectiveModelId = selectedModelId ?? defaultModelId`
- pass `model: effectiveModelId` into `useObjectChat`
- pass `models` / `selectedModelId` / `onModelChange` into `ChatbotEnhanced`

`ChatbotEnhanced` renders the footer `<select>` only for **2+ models**, so free / single-model envs see nothing — no behavior change there.

## Verify
Typechecks clean against the built dep closure. Mirrors the already-tested floating-chatbot wiring; `useObjectChat` keeps the model in a ref so mid-session switches route correctly. Requires a cloud `.objectui-sha` bump to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)