### PR TITLE
fix(console): show real error state when verification resend fails

### DIFF
--- a/apps/console/src/pages/auth/VerifyEmailPromptPage.tsx
+++ b/apps/console/src/pages/auth/VerifyEmailPromptPage.tsx
@@ -32,6 +32,11 @@ export function VerifyEmailPromptPage() {
 
   const [resending, setResending] = useState(false);
   const [resent, setResent] = useState(false);
+  // Persistent error state: the server now reports a real failure when the
+  // verification email can't be sent (e.g. no transport configured) instead
+  // of silently succeeding, so surface it on the screen — not just a toast —
+  // so the user understands why no email arrives and isn't left stuck.
+  const [resendError, setResendError] = useState<string | null>(null);
 
   const handleResend = async () => {
     if (!email) {
@@ -49,6 +54,7 @@ export function VerifyEmailPromptPage() {
     }
 
     setResending(true);
+    setResendError(null);
     try {
       await sendVerificationEmail(email, redirect || '/');
       setResent(true);
@@ -63,11 +69,19 @@ export function VerifyEmailPromptPage() {
         },
       );
     } catch (err) {
+      const description =
+        (err as Error)?.message?.trim() ||
+        t('auth.verifyEmail.resendUnavailable', {
+          defaultValue:
+            'Email delivery may not be configured for this environment. Contact support if this persists.',
+        });
+      setResent(false);
+      setResendError(description);
       toast.error(
         t('auth.verifyEmail.resendFailed', {
           defaultValue: 'Failed to resend verification email',
         }),
-        { description: (err as Error).message },
+        { description },
       );
     } finally {
       setResending(false);
@@ -103,6 +117,20 @@ export function VerifyEmailPromptPage() {
                 {t('auth.verifyEmail.sentTo', { defaultValue: 'Sent to:' })}{' '}
                 <span className="font-medium text-foreground">{email}</span>
               </p>
+            ) : null}
+
+            {resendError ? (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                <p className="font-medium">
+                  {t('auth.verifyEmail.resendFailed', {
+                    defaultValue: 'Failed to resend verification email',
+                  })}
+                </p>
+                <p className="mt-1 text-destructive/90">{resendError}</p>
+              </div>
             ) : null}
 
             <Button


### PR DESCRIPTION
## What
The verify-email prompt always showed a "Verification email sent!" success toast on resend, even when the server failed to send.

## Changes
Now that the server surfaces send failures (see the `plugin-auth` PR), render a **persistent error alert** on the verify screen (and keep the toast) when resend fails, so the user understands why no email arrives instead of being left stuck. Falls back to a clear "email delivery may not be configured" message when the server returns no detail.

## Cross-repo
Part of the email-verification fix set with `objectstack-ai/framework` (loud send failures) and `objectstack-ai/cloud` (control-plane email wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
