### PR TITLE
feat(console): "Edit with AI" — open the build agent pre-scoped to an app's package

### DIFF
--- a/apps/console/src/pages/system/AppManagementPage.tsx
+++ b/apps/console/src/pages/system/AppManagementPage.tsx
@@ -25,6 +25,7 @@ import {
   Star,
   ExternalLink,
   Search,
+  Sparkles,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useMetadata } from '@object-ui/app-shell';
@@ -241,6 +242,23 @@ export function AppManagementPage() {
                     >
                       <Pencil className="h-4 w-4" />
                     </Button>
+                    {app._packageId ? (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        title="Edit with AI"
+                        aria-label={`Edit ${app.label || app.name} with AI`}
+                        // ADR-0070 — open the build agent in a fresh conversation
+                        // pre-scoped to this app's package (passed as the chat
+                        // context.packageId the cloud seeds as the active package),
+                        // so the AI iterates within THIS app, not the whole env.
+                        onClick={() =>
+                          navigate(`/ai/build?package=${encodeURIComponent(app._packageId!)}&new=1`)
+                        }
+                      >
+                        <Sparkles className="h-4 w-4" />
+                      </Button>
+                    ) : null}
                     <Button
                       variant="ghost"
                       size="icon"

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -486,6 +486,11 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   // existing conversation, and the flag is stripped once the fresh id is
   // mirrored into the URL.
   const forceNewConversation = searchParams.get('new') !== null;
+  // ADR-0070 "Edit with AI": the package the user opened to edit (from the app
+  // list's per-app action). Forwarded to the build agent as `context.packageId`
+  // so its metadata reads scope to that app and edits bind to it from the first
+  // message (the agent seeds it as the conversation's active package).
+  const editPackageId = searchParams.get('package')?.trim() || undefined;
   const navigate = useNavigate();
   const { setContext } = useNavigationContext();
 
@@ -849,6 +854,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
             chatApi={chatApi}
             apiBase={apiBase}
             conversationId={conversationId}
+            editPackageId={editPackageId}
             initialMessages={initialMessages}
             onSent={handleSent}
             onShare={() => setShareOpen(true)}
@@ -920,6 +926,9 @@ interface ChatPaneProps {
   chatApi: string | undefined;
   apiBase: string;
   conversationId: string | undefined;
+  /** ADR-0070 "Edit with AI": the package the user opened to edit (from `?package=`),
+   *  forwarded to the build agent as `context.packageId` to scope it to that app. */
+  editPackageId?: string;
   initialMessages: HydratedUIMessage[];
   onSent: (firstUserMessage?: string) => void;
   onShare: () => void;
@@ -935,6 +944,7 @@ function ChatPane({
   chatApi,
   apiBase,
   conversationId,
+  editPackageId,
   initialMessages,
   onSent,
   onShare,
@@ -1040,6 +1050,9 @@ function ChatPane({
         // Tell the agent the environment's publish posture so its narration
         // matches reality (an auto-published build is live, not "to publish").
         autoPublishAiBuilds: getRuntimeConfig().features.autoPublishAiBuilds,
+        // ADR-0070 "Edit with AI": scope the build agent to the app the user
+        // opened to edit. Cloud seeds it as the conversation's active package.
+        ...(editPackageId ? { packageId: editPackageId } : {}),
       },
     },
     initialMessages: hydrated,


### PR DESCRIPTION
## What
Adds an **"Edit with AI"** action to each app in **App Management** that opens the build agent in a fresh conversation **pre-scoped to that app's package**.

- `AppManagementPage` — a `Sparkles` "Edit with AI" button beside "Edit app", shown for apps that have a package id. It navigates to `/ai/build?package=<packageId>&new=1`.
- `AiChatPage` — reads the `?package=` query param and forwards it to the build agent as `context.packageId` (threaded into `ChatPane`, the component that builds the chat request context).

## Why
ADR-0070 made the conversation's active package load-bearing (scoping + the keystone). Resuming a conversation already keeps editing the same app, but opening an **existing** app to edit in a **new** conversation had no signal — so the AI wasn't scoped to that app, and a granular edit could scatter into a fresh package unless the model remembered to call `set_active_package`. This supplies the signal: the cloud agent **seeds `context.packageId` as the conversation's active package**, so the AI's reads scope to THIS app and edits bind to it **from the first message**.

## Pairs with
The cloud seeding mechanism: **objectstack-ai/cloud#590** (already merged). `context.packageId` is optional and backward-compatible.

## Verification
- Type-check clean: `@object-ui/app-shell` (0 errors) + `apps/console` (0 errors).
- Tests: app-shell **927** + console **4656** pass, 0 regressions.
- (Caught + fixed in review: the forwarded value had to be threaded as a `ChatPane` prop — the chat context is built in the child component, not the page.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)