### PR TITLE
chore: align objectui version to objectstack major (7.3.0 → 11.0.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,12 @@ export const SchemaRenderer = ({ schema }: { schema: UIComponent }) => {
 - 任务结束:停**自己起的**后台服务(见下方"服务纪律";别按端口杀别人的)、清 `.playwright-mcp/`。
 - 改完代码提交时:功能改进(feature)需写 changeset(`pnpm changeset`);纯 bug 修复不需要。
 
+### 版本号策略(version alignment)
+- **objectui 的 major 与 `@objectstack`(spec/client/formula)的 major 保持一致**:依赖到 `@objectstack ^11.x` 时,objectui 这个固定版本组(`.changeset/config.json` 的 `fixed`,39 个包一起发)的 major 必须是 `11`。心智模型:**major 相同即兼容**。
+- minor/patch **独立演进**——objectstack 没动时不必跟发;objectui 自己的改动照常用 changeset 推进(从当前 major 起步,如 `11.0.0 → 11.1.0`)。
+- objectstack 跨 major(→12)时,下一次 objectui 发版一并把 major 提到 `12`。
+- 这是约定优先于 semver 纯粹性的取舍(为可维护/好记),因此 objectui 的 major 不代表「它自身 API 的破坏性变更次数」。`@object-ui/site` 与 `@object-ui/example-*` 在 `ignore` 列表,不随组联动。
+
 ### 多 agent 协作纪律(并行修改本仓库,务必遵守)
 
 本仓库有**多个 agent 并行**修改 —— 分支会被切换、共享文件会在你工作时被改动(正常现象,不是 bug):

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/console",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "description": "ObjectStack Console — opinionated, fork-ready runtime console built on @object-ui/app-shell with the full plugin set wired up. Ships as a Hono UI plugin serving a pre-built SPA.",
   "license": "MIT",
   "type": "module",

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/app-shell",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Minimal application shell for ObjectUI - framework-agnostic rendering engine",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/auth",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Authentication system for Object UI with AuthProvider, useAuth hook, AuthGuard, and form components.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/cli",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "description": "Standalone CLI for Object UI — scaffold, develop, build and validate JSON/YAML schema-driven applications.",
   "type": "module",
   "homepage": "https://www.objectui.org/docs/utilities/cli",

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/collaboration",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Real-time collaboration for Object UI with presence tracking, live cursors, conflict resolution, and comment threads.",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/components",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Standard UI component library for Object UI, built with Shadcn UI + Tailwind CSS",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/core",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/create-plugin",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "description": "CLI tool to scaffold ObjectUI plugins",
   "type": "module",
   "license": "MIT",

--- a/packages/data-objectstack/package.json
+++ b/packages/data-objectstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/data-objectstack",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "description": "ObjectStack Data Adapter for Object UI",
   "license": "MIT",
   "type": "module",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/fields",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "description": "Field renderers and registry for Object UI",
   "license": "MIT",
   "type": "module",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/i18n",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/layout",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "sideEffects": false,
   "main": "dist/index.umd.cjs",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/mobile",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Mobile optimization for Object UI with responsive components, PWA support, and touch gesture handling.",

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/permissions",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "RBAC permission system for Object UI with object/field/row-level access control, permission guards, and hooks.",

--- a/packages/plugin-ai/package.json
+++ b/packages/plugin-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-ai",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",

--- a/packages/plugin-calendar/package.json
+++ b/packages/plugin-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-calendar",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Calendar view plugins for Object UI - includes both ObjectQL-integrated and standalone calendar components",

--- a/packages/plugin-charts/package.json
+++ b/packages/plugin-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-charts",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Chart components plugin for Object UI, powered by Recharts",

--- a/packages/plugin-chatbot/package.json
+++ b/packages/plugin-chatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-chatbot",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Chatbot interface plugin for Object UI",

--- a/packages/plugin-dashboard/package.json
+++ b/packages/plugin-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-dashboard",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Dashboard plugin for Object UI",

--- a/packages/plugin-designer/package.json
+++ b/packages/plugin-designer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-designer",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Visual designer plugin for Object UI with page, data model, process, and report designers plus collaborative editing.",

--- a/packages/plugin-detail/package.json
+++ b/packages/plugin-detail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-detail",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "DetailView plugin for Object UI - comprehensive detail page with sections, tabs, and related lists",

--- a/packages/plugin-editor/package.json
+++ b/packages/plugin-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-editor",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Rich text editor plugin for Object UI, powered by Monaco Editor",

--- a/packages/plugin-form/package.json
+++ b/packages/plugin-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-form",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Form plugin for Object UI",

--- a/packages/plugin-gantt/package.json
+++ b/packages/plugin-gantt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-gantt",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Gantt chart plugin for Object UI",

--- a/packages/plugin-grid/package.json
+++ b/packages/plugin-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-grid",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Grid plugin for Object UI",

--- a/packages/plugin-kanban/package.json
+++ b/packages/plugin-kanban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-kanban",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Kanban board plugin for Object UI, powered by dnd-kit",

--- a/packages/plugin-list/package.json
+++ b/packages/plugin-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-list",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "ListView plugin for Object UI - unified view component with view type switching",

--- a/packages/plugin-map/package.json
+++ b/packages/plugin-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-map",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Map visualization plugin for Object UI",

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-markdown",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Markdown rendering plugin for Object UI, powered by react-markdown",

--- a/packages/plugin-report/package.json
+++ b/packages/plugin-report/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-report",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",

--- a/packages/plugin-timeline/package.json
+++ b/packages/plugin-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-timeline",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Timeline component plugin for Object UI",

--- a/packages/plugin-tree/package.json
+++ b/packages/plugin-tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-tree",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Tree / tree-grid visualization plugin for Object UI",

--- a/packages/plugin-view/package.json
+++ b/packages/plugin-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/plugin-view",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Object View plugin for Object UI",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/providers",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Reusable context providers for ObjectUI applications",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/react",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "React bindings and SchemaRenderer component for Object UI",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@object-ui/runner",
   "private": false,
-  "version": "7.3.0",
+  "version": "11.0.0",
   "description": "Universal Object UI Application Runner",
   "type": "module",
   "homepage": "https://www.objectui.org/docs/utilities/runner",

--- a/packages/tenant/package.json
+++ b/packages/tenant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/tenant",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "type": "module",
   "license": "MIT",
   "description": "Multi-tenancy support for Object UI with tenant isolation, scoped queries, and custom branding.",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@object-ui/types",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "description": "Pure TypeScript type definitions for Object UI - The Protocol Layer",
   "type": "module",
   "sideEffects": false,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "object-ui",
   "displayName": "Object UI",
   "description": "VSCode extension for Object UI - Schema-driven UI development with IntelliSense, validation, and live preview",
-  "version": "7.3.0",
+  "version": "11.0.0",
   "publisher": "objectui",
   "private": true,
   "icon": "icon.svg",


### PR DESCRIPTION
## 背景 / 决策
维护者决定:**objectui 的 major 与所依赖的 `@objectstack` major 保持一致**(「major 相同即兼容」),比维护两条独立版本线更好记。objectui 已在 [#2030](https://github.com/objectstack-ai/objectui/pull/2030) 依赖 `@objectstack ^11.x`,故本 PR 做一次性跳跃:把固定版本组(`.changeset/config.json` `fixed`,**39 个包一起发**)从 `7.3.0` 提到 `11.0.0`(跳过 8/9/10)。

## 变更
- 39 个 fixed-group 包 `version`:`7.3.0 → 11.0.0`(内部依赖为 `workspace:*`,无需改依赖区间;lockfile 不受影响)。
- `AGENTS.md` §9 新增「版本号策略」:major 跟随 objectstack,minor/patch 独立演进;objectstack 跨 major 时下次发版一并提 major。
- `@object-ui/site`(3.1.0)与 `@object-ui/example-*` 在 changeset `ignore` 列表,保持独立,不动。

## 为什么没有 changeset(重要)
本仓库 release 流程:`changeset-release.yml` 在 push main 时,**有** pending changeset → 走 `changeset version`(只能 +1,无法跳到 11);**无** changeset → 走 `changeset publish`,把 package.json 中尚未发到 npm 的版本直接发布。

因此本 PR **故意手动设版本且不加 changeset**,合并后 publish 路径会把 `11.0.0` 直接发到 npm。若加 changeset 反而会从 11.0.0 再 +1(如 11.1.0),跳过预期的 11.0.0。

> ⚠️ 合并即触发 39 个包以 `11.0.0` 发布到 npm。这是本次对齐的预期结果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)