### PR TITLE
fix(core): $expand user/tree reference columns in list & grid views (not just lookup/master_detail)

### DIFF
--- a/packages/core/src/utils/__tests__/expand-fields.test.ts
+++ b/packages/core/src/utils/__tests__/expand-fields.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildExpandFields } from '../expand-fields';
+import {
+  buildExpandFields,
+  isExpandableFieldType,
+  EXPANDABLE_FIELD_TYPES,
+} from '../expand-fields';
 
 describe('buildExpandFields', () => {
   const sampleFields = {
@@ -116,5 +120,81 @@ describe('buildExpandFields', () => {
       detail1: { type: 'master_detail', reference_to: 'obj1' },
     };
     expect(buildExpandFields(fields)).toEqual(['detail1']);
+  });
+
+  // ── Reference-bearing types beyond lookup/master_detail ────────────────────
+  // A list/grid that shows a `user` or `tree` relation column must still
+  // request `$expand` for it, or the cell receives a bare id and renders "—".
+  // This is the regression these cases lock in: previously only `lookup` /
+  // `master_detail` were collected, so `user`/`tree` columns silently broke.
+  const relationalZoo = {
+    name: { type: 'text', label: 'Name' },
+    f_lookup: { type: 'lookup', label: 'Account', reference: 'showcase_account' },
+    f_master_detail: { type: 'master_detail', label: 'Project', reference: 'showcase_project' },
+    f_tree: { type: 'tree', label: 'Category', reference: 'showcase_category' },
+    f_user: { type: 'user', label: 'Assignee', reference: 'sys_user' },
+    status: { type: 'select', label: 'Status' },
+    cover: { type: 'image', label: 'Cover' },
+  };
+
+  it('should include user and tree reference types (not just lookup/master_detail)', () => {
+    expect(buildExpandFields(relationalZoo)).toEqual([
+      'f_lookup',
+      'f_master_detail',
+      'f_tree',
+      'f_user',
+    ]);
+  });
+
+  it('should NOT include non-reference field types in $expand', () => {
+    const result = buildExpandFields(relationalZoo);
+    expect(result).not.toContain('name');
+    expect(result).not.toContain('status');
+    expect(result).not.toContain('cover');
+  });
+
+  it('should scope to ONLY the visible reference columns (the default behavior)', () => {
+    // A grid showing [name, f_lookup, f_user, status] must expand exactly the
+    // two visible reference columns — never the unshown f_master_detail / f_tree.
+    const columns = ['name', 'f_lookup', 'f_user', 'status'];
+    expect(buildExpandFields(relationalZoo, columns)).toEqual(['f_lookup', 'f_user']);
+  });
+
+  it('should produce an EMPTY set when no visible column is a reference (omit $expand)', () => {
+    expect(buildExpandFields(relationalZoo, ['name', 'status', 'cover'])).toEqual([]);
+  });
+
+  it('should expand a lone user-type column once it is visible', () => {
+    // The exact bug: a `user` column ("technician") shown in a list view.
+    const fields = { title: { type: 'text' }, technician: { type: 'user', reference: 'sys_user' } };
+    expect(buildExpandFields(fields, ['title'])).toEqual([]);
+    expect(buildExpandFields(fields, ['title', 'technician'])).toEqual(['technician']);
+  });
+});
+
+describe('EXPANDABLE_FIELD_TYPES / isExpandableFieldType', () => {
+  it('covers exactly the reference-bearing types', () => {
+    expect([...EXPANDABLE_FIELD_TYPES].sort()).toEqual(
+      ['lookup', 'master_detail', 'tree', 'user'].sort(),
+    );
+  });
+
+  it('treats reference field defs as expandable', () => {
+    for (const type of ['lookup', 'master_detail', 'tree', 'user']) {
+      expect(isExpandableFieldType({ type })).toBe(true);
+    }
+  });
+
+  it('treats scalar/non-reference field defs as NOT expandable', () => {
+    for (const type of ['text', 'number', 'select', 'image', 'formula', 'summary', 'date']) {
+      expect(isExpandableFieldType({ type })).toBe(false);
+    }
+  });
+
+  it('is null/shape safe', () => {
+    expect(isExpandableFieldType(null)).toBe(false);
+    expect(isExpandableFieldType(undefined)).toBe(false);
+    expect(isExpandableFieldType('lookup')).toBe(false);
+    expect(isExpandableFieldType({})).toBe(false);
   });
 });

--- a/packages/core/src/utils/expand-fields.ts
+++ b/packages/core/src/utils/expand-fields.ts
@@ -7,31 +7,74 @@
  */
 
 /**
+ * Relational ("reference-bearing") field types whose stored value is a foreign
+ * key into another object — and which therefore benefit from `$expand` so a
+ * list / grid / detail cell can render the related record's display name
+ * instead of a bare id placeholder ("—").
+ *
+ * This mirrors the form layer's `DATA_SOURCE_FIELD_TYPES`
+ * (`lookup` / `master_detail` / `tree`) and additionally covers `user` — a
+ * lookup specialised to `sys_user`. The server resolves `user` through the
+ * same expand path as `lookup` / `master_detail` (it carries the same
+ * `reference` + id storage), so a `user` column that is NOT requested for
+ * expansion comes back as a raw user id and renders as "—". Keeping the set
+ * here as the single source of truth is what closes that gap.
+ *
+ * Note on `tree`: a self-referencing hierarchy field is a reference too, so it
+ * belongs in this set; whether the backend materialises the expanded object
+ * for it is a server concern — requesting it is harmless and forward-compatible.
+ */
+export const EXPANDABLE_FIELD_TYPES: ReadonlySet<string> = new Set([
+  'lookup',
+  'master_detail',
+  'tree',
+  'user',
+]);
+
+/**
+ * Whether a field definition is a reference-bearing type that can be `$expand`-ed.
+ * Only the field's `type` matters here — the `reference` / `reference_to` target
+ * is irrelevant to the decision, so this works regardless of which canonical key
+ * the schema uses to name the related object.
+ */
+export function isExpandableFieldType(fieldDef: unknown): boolean {
+  return (
+    !!fieldDef &&
+    typeof fieldDef === 'object' &&
+    EXPANDABLE_FIELD_TYPES.has((fieldDef as { type?: unknown }).type as string)
+  );
+}
+
+/**
  * Build an array of field names that should be included in `$expand`
  * when fetching data. This scans the given object schema fields
- * (and optional column configuration) for `lookup` and `master_detail`
- * field types, so the backend (e.g. objectql) returns expanded objects
- * instead of raw foreign-key IDs.
+ * (and optional column configuration) for reference-bearing field types
+ * (see {@link EXPANDABLE_FIELD_TYPES}: `lookup` / `master_detail` / `tree` /
+ * `user`), so the backend (e.g. objectql) returns expanded objects instead of
+ * raw foreign-key IDs.
  *
  * @param schemaFields - Object map of field metadata from `getObjectSchema()`,
- *   e.g. `{ account: { type: 'lookup', reference_to: 'accounts' }, ... }`.
+ *   e.g. `{ account: { type: 'lookup', reference: 'accounts' }, ... }`.
  * @param columns - Optional explicit column list. When provided, only
- *   lookup/master_detail fields that appear in `columns` are expanded.
- *   Accepts `string[]` or `ListColumn[]` (objects with a `field` property).
- * @returns Array of field names to pass as `$expand`.
+ *   reference fields that appear in `columns` are expanded — list/grid/kanban
+ *   views pass their VISIBLE columns here so wide objects don't pay to expand
+ *   relations no cell will show. Accepts `string[]` or `ListColumn[]` (objects
+ *   with a `field` property).
+ * @returns Array of field names to pass as `$expand` (empty → omit `$expand`).
  *
  * @example
  * ```ts
  * const fields = {
  *   name: { type: 'text' },
- *   account: { type: 'lookup', reference_to: 'accounts' },
- *   parent: { type: 'master_detail', reference_to: 'contacts' },
+ *   account: { type: 'lookup', reference: 'accounts' },
+ *   parent: { type: 'master_detail', reference: 'contacts' },
+ *   assignee: { type: 'user', reference: 'sys_user' },
  * };
  * buildExpandFields(fields);
- * // → ['account', 'parent']
+ * // → ['account', 'parent', 'assignee']
  *
  * buildExpandFields(fields, ['name', 'account']);
- * // → ['account']
+ * // → ['account']   (only the visible reference columns)
  * ```
  */
 export function buildExpandFields(
@@ -42,23 +85,19 @@ export function buildExpandFields(
     return [];
   }
 
-  // Collect all lookup / master_detail field names from the schema
-  const lookupFieldNames: string[] = [];
+  // Collect every reference-bearing field name from the schema.
+  const referenceFieldNames: string[] = [];
   for (const [fieldName, fieldDef] of Object.entries(schemaFields)) {
-    if (
-      fieldDef &&
-      typeof fieldDef === 'object' &&
-      (fieldDef.type === 'lookup' || fieldDef.type === 'master_detail')
-    ) {
-      lookupFieldNames.push(fieldName);
+    if (isExpandableFieldType(fieldDef)) {
+      referenceFieldNames.push(fieldName);
     }
   }
 
-  if (lookupFieldNames.length === 0) {
+  if (referenceFieldNames.length === 0) {
     return [];
   }
 
-  // When columns are provided, restrict expansion to visible columns only
+  // When columns are provided, restrict expansion to visible columns only.
   if (columns && Array.isArray(columns) && columns.length > 0) {
     const columnFieldNames = new Set<string>();
     for (const col of columns) {
@@ -69,8 +108,8 @@ export function buildExpandFields(
         if (name) columnFieldNames.add(name);
       }
     }
-    return lookupFieldNames.filter((f) => columnFieldNames.has(f));
+    return referenceFieldNames.filter((f) => columnFieldNames.has(f));
   }
 
-  return lookupFieldNames;
+  return referenceFieldNames;
 }


### PR DESCRIPTION
## The bug

In list / grid (and kanban / calendar / gallery / …) views, **reference columns of type `user` render a bare id (or a "—" placeholder) instead of the related record's name**. Record **detail** views render the same fields correctly.

Example: a grid showing a `user`-type "technician"/"owner" column shows `VYVspo4Eb9vx9AwqV4ThlA4WNt8CeJ80` instead of `Dev Admin`.

## Root cause

List/grid views derive their `$expand` set from `buildExpandFields()` in `@object-ui/core` ([`packages/core/src/utils/expand-fields.ts`](packages/core/src/utils/expand-fields.ts)). It recognised **only** `lookup` and `master_detail` field types:

```ts
fieldDef.type === 'lookup' || fieldDef.type === 'master_detail'
```

So for a `user` (or `tree`) reference column the view **never requested `$expand`** → the API returned the raw foreign-key id → the cell had no related record to read a display name from → it rendered the raw id / `—`.

The objectql backend already resolves `user` through the **same** expand path as `lookup`/`master_detail` (it carries the same `reference` + id storage). So the gap was purely on the request side, in objectui.

`lookup` / `master_detail` columns were already fine (the previous fix added scoped `$expand` for them) — which is why the bug looked type-specific.

## The fix

Extend the expandable-type set to the full **reference-bearing** set — `lookup` / `master_detail` / `tree` / `user` — behind a single exported constant + predicate, and route the existing collection logic through it:

```ts
export const EXPANDABLE_FIELD_TYPES = new Set(['lookup', 'master_detail', 'tree', 'user']);
export function isExpandableFieldType(fieldDef): boolean { /* type ∈ EXPANDABLE_FIELD_TYPES */ }
```

- **`user`** is the field type the backend can expand but the frontend wasn't requesting — this is the end-to-end fix.
- **`tree`** matches the form layer's `DATA_SOURCE_FIELD_TYPES` (`lookup`/`master_detail`/`tree`); it's a reference too, so it belongs in the set. Requesting it is harmless and forward-compatible (see follow-up below).

Every `$expand` caller (list, grid, kanban, calendar, gallery, timeline, gantt, tree, map, detail) routes through `buildExpandFields`, so this one change fixes them uniformly.

### Why only the *visible* reference columns (unchanged, but the key design point)

`buildExpandFields(fields, columns)` already intersects with the view's columns, and that's preserved. A list is N rows; expanding a relation per row has a cost, and a list typically shows only 2–3 reference columns. So the default is:

> `$expand` = **view columns ∩ reference-typed fields**; empty set → omit `$expand` (original behavior).

Wide objects never pay to expand relations no cell will show. Detail view keeps expanding all reference fields (no `columns` arg), as before.

This is a pure-function change with the type set extracted as the single source of truth (`EXPANDABLE_FIELD_TYPES` / `isExpandableFieldType`), unit-tested for: mixed columns pick out only reference types; non-reference columns never enter `$expand`; the visible-column intersection; and empty → no `$expand`.

## Verification (framework `examples/app-showcase`)

Stood up the app-showcase backend + the objectui console against it, on the `showcase_field_zoo` object (which has one field of every type) via a small grid view exposing the relational columns. Seeded a record with a real `user` reference.

| Column (type) | Before | After |
|---|---|---|
| `f_lookup` (lookup) | **Northwind** | **Northwind** |
| `f_master_detail` (master_detail) | **Website Relaunch** | **Website Relaunch** |
| `f_user` (**user**) | `VYVspo4Eb9vx9…` (raw id) | **Dev Admin** ✅ |
| `f_owner` (**user**) | `VYVspo4Eb9vx9…` (raw id) | **Dev Admin** ✅ |
| `f_tree` (**tree**) | `—` | `—` (see follow-up) |

Confirmed at the API layer too: with `$expand=f_user` the backend returns `f_user: { name: "Dev Admin", … }`; without it (today's behavior) it stays a raw id.

## Tests / build

- `@object-ui/core` unit tests: **4683 passed** (incl. the extended `expand-fields` suite — 23 cases).
- `@object-ui/plugin-list`: **131 passed**; `@object-ui/core` & `@object-ui/plugin-grid` build clean.

## Follow-ups (intentionally NOT in this PR)

- **`tree` display**: the frontend now *requests* `$expand` for `tree`, but objectql's expand resolver currently materialises only `lookup`/`master_detail`/`user`, so `tree` columns still show `—` until the backend expands `tree` too. That's a framework change.
- **Cross-repo rollout**: no `.objectui-sha` / `.framework-sha` bumped here. After this merges, it reaches the cloud runtime via a framework `.objectui-sha` bump (then cloud's own pin) — left to a human to time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
