### PR TITLE
fix(home): product-name the empty-state title (was hardcoded "ObjectUI")

### DIFF
--- a/.changeset/home-empty-brand.md
+++ b/.changeset/home-empty-brand.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(home): the workspace empty-state title hardcoded "Welcome to ObjectUI" — a stale brand a first-time user sees on their empty `/home`. Read the product name from the runtime-config branding (`getRuntimeConfig().branding.productName`, server-pushed, fallback "ObjectOS") like LoadingScreen does, so it shows the deployment's real product (e.g. "Welcome to ObjectOS Cloud").

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -32,6 +32,7 @@ import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText } from 'lucide
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
 import { resolveAiApiBase } from '../../hooks/useAiSurface';
+import { getRuntimeConfig } from '../../runtime-config';
 
 /**
  * Which AI home CTAs to surface, driven by the live agent catalog (the single
@@ -271,7 +272,7 @@ export function HomePage() {
         */}
         {isAdmin ? (
           <Empty>
-            <EmptyTitle>{t('home.welcome', { defaultValue: 'Welcome to ObjectUI' })}</EmptyTitle>
+            <EmptyTitle>{t('home.welcome', { product: getRuntimeConfig().branding.productName, defaultValue: 'Welcome to {{product}}' })}</EmptyTitle>
             <EmptyDescription>
               {buildAvailable
                 ? t('home.welcomeAdminDescription', {


### PR DESCRIPTION
## What
A brand-new user landing on an empty `/home` saw **"Welcome to ObjectUI"** — a stale brand string baked into `HomePage.tsx`, regardless of the deployment's product name. On ObjectOS Cloud it should read "Welcome to ObjectOS Cloud".

## Fix
Read the product name from the runtime-config branding singleton (`getRuntimeConfig().branding.productName`, server-pushed, fallback `"ObjectOS"`) — the exact source `LoadingScreen` already uses — and interpolate it into the title. Generic component, so it now reflects whatever product/brand each deployment configures.

## Found via
A first-time-user signup walkthrough of ObjectOS Cloud (the env-internal empty state is the first thing a new user sees once inside their environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)