### PR TITLE
fix(first-run): page-load race (blank body) + skip redundant launcher hop

### DIFF
--- a/.changeset/first-run-landing.md
+++ b/.changeset/first-run-landing.md
@@ -1,0 +1,8 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(first-run): two first-time-user friction fixes found via a full ObjectOS Cloud signup walkthrough.
+
+- **Page-load race**: an app whose landing is a `type:'page'` (SDUI page) flashed a false "page not found" / blank body on the very first render — `PageView` treated the lazily-loading (empty) `pages` array as "page doesn't exist". It now shows a loading state until the `page` metadata type is actually resolved (`getTypeStatus('page')`), then trusts the not-found. This is exactly the post-signup landing, where the app's home page is the first thing rendered.
+- **Redundant launcher hop**: after creating/switching a workspace, the user was hard-reloaded to `/home` (the workspace launcher) even when the workspace has a single app — an extra, contentless layer. `OrganizationsPage` and `WorkspaceSwitcher` now reload to the console ROOT (`resolveRootUrl`), so `RootLandingRedirect` resolves the right landing: a single-app workspace lands straight IN that app; multi-app workspaces still fall back to `/home`.

--- a/packages/app-shell/src/console/organizations/OrganizationsPage.tsx
+++ b/packages/app-shell/src/console/organizations/OrganizationsPage.tsx
@@ -24,7 +24,7 @@ import type { AuthOrganization } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { CreateWorkspaceDialog } from './CreateWorkspaceDialog';
-import { resolveHomeUrl } from './resolveHomeUrl';
+import { resolveRootUrl } from './resolveHomeUrl';
 
 function getOrgInitials(name: string): string {
   return name
@@ -94,7 +94,11 @@ export function OrganizationsPage() {
       if (org.id !== activeOrganization?.id) {
         await switchOrganization(org.id);
       }
-      window.location.href = resolveHomeUrl();
+      // Land on the console ROOT so RootLandingRedirect resolves the right
+      // landing — a single-app workspace (e.g. a fresh cloud signup, whose only
+      // app is Cloud) goes straight INTO that app instead of the redundant
+      // workspace launcher; multi-app workspaces still fall back to /home.
+      window.location.href = resolveRootUrl();
     } catch (err) {
       console.error('[OrganizationsPage] Failed to switch:', err);
       setSwitchingId(null);

--- a/packages/app-shell/src/console/organizations/__tests__/resolveHomeUrl.test.ts
+++ b/packages/app-shell/src/console/organizations/__tests__/resolveHomeUrl.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, expect, it } from 'vitest';
-import { resolveHomeUrl } from '../resolveHomeUrl';
+import { resolveHomeUrl, resolveRootUrl } from '../resolveHomeUrl';
 
 describe('resolveHomeUrl', () => {
   it('builds an absolute /_console/home URL when base href points at the console mount', () => {
@@ -27,5 +27,23 @@ describe('resolveHomeUrl', () => {
     const url = new URL(resolveHomeUrl('https://cloud.objectos.app/_console/'));
     expect(url.hostname.endsWith('.')).toBe(false);
     expect(url.pathname.startsWith('/_console/')).toBe(true);
+  });
+});
+
+describe('resolveRootUrl', () => {
+  it('returns the console MOUNT root (not /home) so RootLandingRedirect runs', () => {
+    expect(resolveRootUrl('https://cloud.objectos.app/_console/')).toBe(
+      'https://cloud.objectos.app/_console/',
+    );
+  });
+
+  it('returns the document root when the console mounts at /', () => {
+    expect(resolveRootUrl('https://host.example/')).toBe('https://host.example/');
+  });
+
+  it('resolves to the mount dir from a deeper route (drops the route segment)', () => {
+    expect(resolveRootUrl('https://host.example/_console/organizations')).toBe(
+      'https://host.example/_console/',
+    );
   });
 });

--- a/packages/app-shell/src/console/organizations/resolveHomeUrl.ts
+++ b/packages/app-shell/src/console/organizations/resolveHomeUrl.ts
@@ -19,9 +19,28 @@ export function resolveHomeUrl(baseURI?: string): string {
   if (baseURI !== undefined) {
     return new URL('home', baseURI).toString();
   }
+  return new URL('home', consoleRoot()).toString();
+}
+
+/** The deployment-mounted console root (`/_console/`, `/`, …). */
+function consoleRoot(): URL {
   const baseHref = document.querySelector('base')?.getAttribute('href');
-  const root = baseHref
+  return baseHref
     ? new URL(baseHref, window.location.origin)
     : new URL('/', window.location.origin);
-  return new URL('home', root).toString();
+}
+
+/**
+ * The console ROOT URL (not `/home`). Used after switching/creating an org so
+ * the SPA's root route runs `RootLandingRedirect`, which resolves the right
+ * landing: a single-app workspace lands IN that app (skipping the redundant
+ * launcher), and only a multi-app workspace falls back to `/home`.
+ */
+export function resolveRootUrl(baseURI?: string): string {
+  if (baseURI !== undefined) {
+    // The mount directory of the base URI ('.' resolves to the dir), e.g.
+    // '/_console/organizations' → '/_console/', '/_console/' → '/_console/'.
+    return new URL('.', baseURI).toString();
+  }
+  return consoleRoot().toString();
 }

--- a/packages/app-shell/src/layout/WorkspaceSwitcher.tsx
+++ b/packages/app-shell/src/layout/WorkspaceSwitcher.tsx
@@ -26,7 +26,7 @@ import {
   DropdownMenuSeparator,
 } from '@object-ui/components';
 import { ChevronsUpDown, Check, Plus, Users } from 'lucide-react';
-import { resolveHomeUrl } from '../console/organizations/resolveHomeUrl';
+import { resolveRootUrl } from '../console/organizations/resolveHomeUrl';
 
 function getOrgInitials(name: string): string {
   return name
@@ -89,9 +89,11 @@ export function WorkspaceSwitcher() {
     if (org.id === current.id) return;
     try {
       await switchOrganization(org.id);
-      // switchOrganization only updates state; reload to home so the new active
-      // org propagates to every data scope app-wide (same as OrganizationsPage).
-      window.location.href = resolveHomeUrl();
+      // switchOrganization only updates state; reload to the console root so the
+      // new active org propagates to every data scope app-wide AND
+      // RootLandingRedirect resolves the right landing (single-app workspace →
+      // that app, not the redundant launcher). Same as OrganizationsPage.
+      window.location.href = resolveRootUrl();
     } catch (err) {
       console.error('[WorkspaceSwitcher] switch failed', err);
     }

--- a/packages/app-shell/src/views/PageView.tsx
+++ b/packages/app-shell/src/views/PageView.tsx
@@ -12,7 +12,7 @@
 import { useState } from 'react';
 import { useParams, useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import { SchemaRenderer, useAdapter } from '@object-ui/react';
-import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
+import { Empty, EmptyTitle, EmptyDescription, Spinner } from '@object-ui/components';
 import { FileText, Pencil } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useAuth } from '@object-ui/auth';
@@ -35,7 +35,7 @@ export function PageView() {
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
 
-  const { pages, objects } = useMetadata();
+  const { pages, objects, getTypeStatus } = useMetadata();
   // ADR-0048 Phase 2 — prefer the page owned by the current app's package so
   // two packages shipping `page/<same-name>` each resolve within their own
   // container instead of by load order.
@@ -47,6 +47,20 @@ export function PageView() {
   const page = preferLocal(pages as any[], pageName, (activeApp as any)?._packageId);
 
   if (!page) {
+    // `page` metadata is lazy-loaded: on the very first access `pages` is an
+    // empty array while the fetch is in flight, which would flash a false
+    // "page not found" (or a blank body) — exactly the post-signup landing
+    // race where the app's home page is the first thing rendered. Show a
+    // loading state until the `page` type is actually resolved, then trust the
+    // not-found. (getTypeStatus absent = hand-rolled context = always ready.)
+    const pageStatus = getTypeStatus?.('page');
+    if (pageStatus === 'idle' || pageStatus === 'loading') {
+      return (
+        <div className="h-full flex items-center justify-center p-8" data-testid="page-loading">
+          <Spinner className="h-5 w-5 text-muted-foreground" />
+        </div>
+      );
+    }
     return (
       <div className="h-full flex items-center justify-center p-8">
         <Empty>


### PR DESCRIPTION
Two first-time-user friction fixes found by walking a full ObjectOS Cloud signup end-to-end.

## 1. Page-load race → blank landing
An app whose landing is a `type:'page'` SDUI page (e.g. the Cloud app's Welcome home) flashed a **false "page not found" / blank body** on the very first render right after signup. `PageView` treated the lazily-loading (still-empty) `pages` array as "this page doesn't exist".

**Fix:** guard on the existing `getTypeStatus('page')` signal — show a loading state until the `page` type is resolved, then trust the not-found. (`getTypeStatus` absent = hand-rolled context = always ready, so no regression.)

## 2. Redundant launcher hop
After creating or switching a workspace, the user was hard-reloaded to `/home` (the workspace launcher) **even when the workspace has a single app** — a contentless extra layer before they reach the only app.

**Fix:** `OrganizationsPage` and `WorkspaceSwitcher` now reload to the console **root** (`resolveRootUrl`), so `RootLandingRedirect` resolves the landing — a single-app workspace lands straight IN that app; multi-app workspaces still fall back to `/home`. Consistent with the normal post-login path.

## Verified
- Full multiOrg signup walkthrough: signup → "Create workspace" → (was: `/home` launcher) → now resolves into the app; production env auto-provisioned (Active).
- Typecheck clean; `resolveRootUrl` unit tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)