### PR TITLE
feat(ai-build): always show a "Build it" button after propose + friendlier design wait

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1239,6 +1239,18 @@ function ChatPane({
           connectionWaiting: t('console.ai.connectionWaiting', { defaultValue: 'Waiting for server…' }),
           connectionStalledLabel: t('console.ai.connectionStalled', { defaultValue: 'Still working…' }),
           connectionOfflineLabel: t('console.ai.connectionOffline', { defaultValue: 'Connection lost — reconnecting…' }),
+          // Friendly in-progress feedback for the long, atomic propose_blueprint
+          // call — a lead-in plus rotating hints so the wait reads as deliberate
+          // design work, not a hang. Each hint is translated individually (the
+          // established per-string pattern; avoids an i18n returnObjects array).
+          designingPlanLabel: t('console.ai.designingPlan', { defaultValue: 'Designing your app…' }),
+          designingPlanHints: [
+            t('console.ai.designingPlanHint.data', { defaultValue: 'Mapping out the data you’ll track…' }),
+            t('console.ai.designingPlanHint.objects', { defaultValue: 'Shaping objects and their fields…' }),
+            t('console.ai.designingPlanHint.relations', { defaultValue: 'Connecting related records…' }),
+            t('console.ai.designingPlanHint.views', { defaultValue: 'Planning the screens and views…' }),
+            t('console.ai.designingPlanHint.finalize', { defaultValue: 'Pulling the plan together…' }),
+          ],
           toolDetailsHidden: t('console.ai.toolDetailsHidden'),
           copy: t('console.ai.copy'),
           copied: t('console.ai.copied'),
@@ -1342,6 +1354,9 @@ function ChatPane({
         planApproveLabel={t('console.ai.planApprove', { defaultValue: 'Build it' })}
         planAdjustLabel={t('console.ai.planAdjust', { defaultValue: 'Adjust' })}
         planBuiltLabel={t('console.ai.planBuilt', { defaultValue: 'Built' })}
+        planReadyLabel={t('console.ai.planReady', {
+          defaultValue: 'The plan is ready. Build it now, or tell me what to adjust.',
+        })}
         planApproveMessage={t('console.ai.planApproveMessage', {
           defaultValue: 'Looks good — build it as proposed.',
         })}

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -114,6 +114,14 @@ function buildChatLocale(
         connectionWaiting: '正在等待服务器响应…',
         connectionStalledLabel: '仍在处理中…',
         connectionOfflineLabel: '网络已断开，正在重连…',
+        designingPlanLabel: '正在为你设计方案…',
+        designingPlanHints: [
+          '梳理需要记录的数据…',
+          '设计对象与字段…',
+          '关联相关记录…',
+          '规划页面与视图…',
+          '汇总成完整方案…',
+        ],
         toolDetailsHidden: '已隐藏工具参数和原始结果，仅保留过程摘要。',
         copy: '复制',
         copied: '已复制',
@@ -141,6 +149,7 @@ function buildChatLocale(
       planApprove: '开始搭建',
       planAdjust: '调整方案',
       planBuilt: '已搭建',
+      planReady: '方案已就绪。点击开始搭建，或告诉我需要调整什么。',
       // These messages the button SENDS must match the cloud confirm gate's
       // APPROVAL_RE (service-ai-studio confirm-gate.ts) or the agent re-proposes
       // and "开始搭建" looks inert — the gate anchors Chinese approval on 确认 /
@@ -178,6 +187,14 @@ function buildChatLocale(
       connectionWaiting: 'Waiting for server…',
       connectionStalledLabel: 'Still working…',
       connectionOfflineLabel: 'Connection lost — reconnecting…',
+      designingPlanLabel: 'Designing your app…',
+      designingPlanHints: [
+        'Mapping out the data you’ll track…',
+        'Shaping objects and their fields…',
+        'Connecting related records…',
+        'Planning the screens and views…',
+        'Pulling the plan together…',
+      ],
       toolDetailsHidden: 'Tool inputs and raw results are hidden in this view.',
       copy: 'Copy',
       copied: 'Copied',
@@ -205,6 +222,7 @@ function buildChatLocale(
     planApprove: 'Build it',
     planAdjust: 'Adjust',
     planBuilt: 'Built',
+    planReady: 'The plan is ready. Build it now, or tell me what to adjust.',
     planApproveMessage: 'Looks good — build it as proposed.',
     planApproveDefaultsMessage: 'Build it with your best assumptions; use sensible defaults for the open questions.',
     planAnswer: (question: string, option: string) => `For "${question}", go with: ${option}.`,
@@ -726,6 +744,7 @@ function ChatbotInner({
         planApproveLabel={locale.planApprove}
         planAdjustLabel={locale.planAdjust}
         planBuiltLabel={locale.planBuilt}
+        planReadyLabel={locale.planReady}
         planApproveMessage={locale.planApproveMessage}
         planApproveDefaultsMessage={locale.planApproveDefaultsMessage}
         planAnswerMessage={locale.planAnswer}

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -20,7 +20,7 @@
 import * as React from 'react';
 import { cn } from '@object-ui/components';
 import { SchemaRenderer } from '@object-ui/react';
-import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, Eye, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2, ShieldCheck, TriangleAlert, ClipboardList, HelpCircle, Table2, WifiOff } from 'lucide-react';
+import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, Eye, GitCompareArrows, Rocket, Clock3, CheckCircle2, XCircle, Loader2, ShieldCheck, TriangleAlert, ClipboardList, HelpCircle, Table2, WifiOff, Sparkles } from 'lucide-react';
 import type { ChatStatus } from 'ai';
 import {
   humanizeToolName,
@@ -326,6 +326,20 @@ export interface ChatbotLabels {
    * mid-turn — e.g. "Connection lost — reconnecting…". The honest disconnect cue.
    */
   connectionOfflineLabel?: string;
+  /**
+   * Lead-in shown while the build agent is designing a plan (the long, atomic
+   * `propose_blueprint` call) — e.g. "Designing your app…". Pairs with the live
+   * timer so the wait reads as deliberate work, not a hang.
+   */
+  designingPlanLabel?: string;
+  /**
+   * Rotating "what I'm doing now" hints cycled through during that same
+   * propose_blueprint wait (the call is a single atomic LLM request with no
+   * partial stream, so these are presentational reassurance, not live status).
+   * Defaults to a sensible English set when omitted; pass a localized list to
+   * override. An empty array disables rotation (only `designingPlanLabel` shows).
+   */
+  designingPlanHints?: string[];
 }
 
 export type ChatbotProcessVisibility = 'hidden' | 'summary' | 'debug';
@@ -537,6 +551,13 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   planAdjustLabel?: string;
   /** Static badge shown in place of the "Build it" button once this plan's build has run, so it can't be re-triggered (default "Built"). */
   planBuiltLabel?: string;
+  /**
+   * Body line of the FALLBACK confirm card shown when a propose_blueprint step
+   * finished but produced no structured plan (so the rich card can't render).
+   * The "Build it"/"Adjust" buttons (reusing `planApproveLabel`/`planAdjustLabel`)
+   * still appear, so the user never has to guess the confirmation phrase
+   * (default "The plan is ready. Build it now, or tell me what to adjust."). */
+  planReadyLabel?: string;
   /** Message sent when the user approves a plan with no open questions (default "Looks good — build it as proposed."). */
   planApproveMessage?: string;
   /** Message sent when the user approves a plan that still has open questions — tells the agent to proceed on sensible defaults (default "Build it with your best assumptions; use sensible defaults for the open questions."). */
@@ -753,6 +774,35 @@ function formatChangeRow(c: {
   return [verb, `${target}${typePart}`, c.details].filter(Boolean).join(' ');
 }
 
+/**
+ * True when this tool is the build agent's "propose a plan" step
+ * (`propose_blueprint`). Matched by name so we can recognise it even when its
+ * result did NOT parse into a structured `proposedPlan` — the case that used to
+ * leave the user with a bare "reply 确认 to build" text and no button.
+ */
+function isBuildProposalTool(tool: ChatToolInvocation): boolean {
+  return tool.toolName === 'propose_blueprint';
+}
+
+/**
+ * A COMPLETED propose_blueprint whose result the detector could not turn into a
+ * rich `proposedPlan` card (e.g. the model returned a thin/oddly-shaped envelope,
+ * or proposed in prose). We still owe the user an explicit confirm gate, so the
+ * detailed body renders a minimal "ready to build — Build it / Adjust" card
+ * instead of collapsing the step into a chip and forcing them to guess the magic
+ * "确认" phrase. Only the finished, non-error state qualifies: a running proposal
+ * keeps its live timer, an errored one keeps its error card.
+ */
+function isUnstructuredBuildProposal(tool: ChatToolInvocation): boolean {
+  return (
+    isBuildProposalTool(tool) &&
+    getToolState(tool) === 'completed' &&
+    !tool.proposedPlan &&
+    !tool.proposedChanges &&
+    !tool.draftReview?.items.length
+  );
+}
+
 function shouldRenderDetailedTool(tool: ChatToolInvocation): boolean {
   const state = getToolState(tool);
   return (
@@ -763,7 +813,11 @@ function shouldRenderDetailedTool(tool: ChatToolInvocation): boolean {
     // The pre-build "Proposed plan" card lives in the detailed tool body; route
     // a propose_blueprint result there instead of collapsing it into a chip.
     Boolean(tool.proposedPlan) ||
-    Boolean(tool.proposedChanges)
+    Boolean(tool.proposedChanges) ||
+    // A completed propose_blueprint that produced NO structured plan still needs
+    // the detailed body — that's where the fallback "Build it" confirm gate
+    // renders so the user is never left guessing the confirmation phrase.
+    isUnstructuredBuildProposal(tool)
   );
 }
 
@@ -925,6 +979,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       planApproveLabel = 'Build it',
       planAdjustLabel = 'Adjust',
       planBuiltLabel = 'Built',
+      planReadyLabel = 'The plan is ready. Build it now, or tell me what to adjust.',
       planApproveMessage = 'Looks good — build it as proposed.',
       planApproveDefaultsMessage = 'Build it with your best assumptions; use sensible defaults for the open questions.',
       planAnswerMessage = (question: string, option: string) => `For "${question}", go with: ${option}.`,
@@ -969,6 +1024,10 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         connectionWaiting: labels?.connectionWaiting ?? 'Waiting for server…',
         connectionStalledLabel: labels?.connectionStalledLabel ?? 'Still working…',
         connectionOfflineLabel: labels?.connectionOfflineLabel ?? 'Connection lost — reconnecting…',
+        designingPlanLabel: labels?.designingPlanLabel ?? 'Designing your app…',
+        // `?? DEFAULT_DESIGNING_PLAN_HINTS` (not `||`) so a caller can pass `[]`
+        // to deliberately disable the rotation while keeping the lead-in label.
+        designingPlanHints: labels?.designingPlanHints ?? DEFAULT_DESIGNING_PLAN_HINTS,
       }),
       [labels],
     );
@@ -1242,7 +1301,12 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       let order = 0;
       for (const message of messages) {
         for (const tool of message.toolInvocations ?? []) {
-          if (tool.proposedPlan && tool.toolCallId) plans.push({ id: tool.toolCallId, order });
+          // Both the structured plan card AND the fallback confirm card (an
+          // unstructured propose_blueprint) own a "Build it" button, so both must
+          // collapse to the inert "Built" badge once their build has run.
+          if ((tool.proposedPlan || isUnstructuredBuildProposal(tool)) && tool.toolCallId) {
+            plans.push({ id: tool.toolCallId, order });
+          }
           if (tool.toolName === 'apply_blueprint') lastBuildOrder = order;
           order += 1;
         }
@@ -1323,14 +1387,27 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       // static "Running" (issue #432).
       const isRunning = state === 'input-streaming' || state === 'input-available';
       const titleNode = (
-        <span className="inline-flex items-center gap-2">
+        <span className="inline-flex min-w-0 items-center gap-2">
           <span>{friendlyTitle || tool.toolName}</span>
           {showRawName ? (
             <code className="rounded bg-muted px-1 py-px text-[10px] font-mono text-muted-foreground">
               {tool.toolName}
             </code>
           ) : null}
-          {isRunning ? <ToolRunningTimer offlineLabel={L.connectionOfflineLabel} /> : null}
+          {isRunning ? (
+            // The plan-design step gets the friendly rotating-hint indicator
+            // (long atomic call, no stream); every other running tool keeps the
+            // compact timer. Mirrors the summary-strip treatment.
+            isBuildProposalTool(tool) ? (
+              <BuildProposalProgressHint
+                label={L.designingPlanLabel}
+                hints={L.designingPlanHints}
+                offlineLabel={L.connectionOfflineLabel}
+              />
+            ) : (
+              <ToolRunningTimer offlineLabel={L.connectionOfflineLabel} />
+            )
+          ) : null}
         </span>
       );
 
@@ -1342,7 +1419,10 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             state === 'approval-requested' ||
             Boolean(tool.draftReview && tool.draftReview.items.length > 0) ||
             Boolean(tool.proposedPlan) ||
-            Boolean(tool.proposedChanges)
+            Boolean(tool.proposedChanges) ||
+            // Fallback confirm gate (unstructured proposal) must open so its
+            // "Build it" button is visible without an extra click.
+            isUnstructuredBuildProposal(tool)
           }
         >
           <ToolHeader type={partType} state={state} title={titleNode} />
@@ -1720,6 +1800,67 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                       {planAdjustLabel}
                     </button>
                   </div>
+                  )
+                ) : (
+                  <span className="text-[11px] italic text-muted-foreground/80">
+                    {planApproveHintLabel}
+                  </span>
+                )}
+              </div>
+            ) : null}
+            {/* FALLBACK confirm gate — a propose_blueprint that FINISHED but whose
+                result didn't parse into the rich plan card above (a thin/oddly
+                shaped envelope, or a prose proposal). Previously this collapsed
+                into a "Propose blueprint · Completed" chip and the user was left
+                with the assistant's prose telling them to reply "确认" — no
+                button, guess-the-phrase. We always give them an explicit, one
+                click "Build it" / "Adjust" instead. Same approve/adjust handlers
+                and the same #432 built-state collapse as the structured card. */}
+            {isUnstructuredBuildProposal(tool) ? (
+              <div
+                className="flex flex-col gap-2 border-t bg-muted/20 px-3 py-2.5"
+                data-testid="proposed-plan-fallback"
+              >
+                <span className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground/80">
+                  <ClipboardList className="size-3.5" />
+                  {planTitleLabel}
+                </span>
+                <p className="text-xs text-muted-foreground">{planReadyLabel}</p>
+                {onSendMessage ? (
+                  builtPlanIds.has(tool.toolCallId) ? (
+                    <div className="flex flex-wrap items-center gap-1.5 pt-0.5" data-testid="proposed-plan-actions">
+                      <span
+                        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-3 text-xs font-medium text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:text-emerald-300"
+                        data-testid="proposed-plan-built"
+                      >
+                        <CheckCircle2 className="size-3.5" />
+                        {planBuiltLabel}
+                      </span>
+                    </div>
+                  ) : (
+                    <div
+                      className="flex flex-wrap items-center gap-1.5 pt-0.5"
+                      data-testid="proposed-plan-actions"
+                    >
+                      <button
+                        type="button"
+                        // No structured questions to default through → plain approve.
+                        onClick={() => handlePlanApprove(false)}
+                        className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                        data-testid="proposed-plan-approve"
+                      >
+                        <Rocket className="size-3.5" />
+                        {planApproveLabel}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handlePlanAdjust}
+                        className="inline-flex h-7 items-center rounded-md border bg-background px-3 text-xs font-medium hover:bg-accent"
+                        data-testid="proposed-plan-adjust"
+                      >
+                        {planAdjustLabel}
+                      </button>
+                    </div>
                   )
                 ) : (
                   <span className="text-[11px] italic text-muted-foreground/80">
@@ -2467,6 +2608,75 @@ function LivenessIndicator({
 }
 
 /**
+ * Default rotating hints for the propose_blueprint wait. Presentational
+ * reassurance — the call is one atomic LLM request with no partial stream, so
+ * these don't reflect real sub-steps; they just let the (tens-of-seconds) wait
+ * read as deliberate design work instead of a hang. Order roughly follows how a
+ * human would think a schema through. Overridable/localizable via the
+ * `designingPlanHints` label.
+ */
+const DEFAULT_DESIGNING_PLAN_HINTS = [
+  'Mapping out the data you’ll track…',
+  'Shaping objects and their fields…',
+  'Connecting related records…',
+  'Planning the screens and views…',
+  'Pulling the plan together…',
+];
+
+/** How long each rotating design hint stays up (ms) before the next one. */
+const DESIGNING_HINT_ROTATE_MS = 3500;
+
+/**
+ * Friendly in-progress indicator for the build agent's `propose_blueprint`
+ * step. Because that call is a SINGLE long, atomic LLM request (no token
+ * stream, no partial results), a bare elapsed timer made it look like the UI
+ * might be stuck. This pairs the live `ToolRunningTimer` with a short lead-in
+ * ("Designing your app…") and a hint that ROTATES every few seconds, so the
+ * wait visibly "moves" and reads as deliberate work. The rotation is purely
+ * presentational — it is NOT claiming real sub-step progress. An empty `hints`
+ * array (or a single entry) just pins the lead-in + timer with no rotation.
+ */
+function BuildProposalProgressHint({
+  label,
+  hints,
+  offlineLabel,
+}: {
+  label: string;
+  hints: string[];
+  offlineLabel: string;
+}) {
+  const [index, setIndex] = React.useState(0);
+  React.useEffect(() => {
+    if (hints.length <= 1) return; // nothing to rotate through
+    const id = setInterval(
+      () => setIndex((i) => (i + 1) % hints.length),
+      DESIGNING_HINT_ROTATE_MS,
+    );
+    return () => clearInterval(id);
+  }, [hints.length]);
+  // Guard the index against a shrinking `hints` list (label change mid-rotation).
+  const hint = hints.length > 0 ? hints[index % hints.length] : undefined;
+  return (
+    <span
+      className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
+      data-testid="build-proposal-progress"
+      aria-live="polite"
+    >
+      <Sparkles className="size-3 shrink-0 animate-pulse text-primary" aria-hidden />
+      <span className="font-medium text-foreground/80">{label}</span>
+      {hint ? (
+        // `key` on the hint text restarts the fade each time it swaps, so the
+        // rotation reads as a gentle change rather than an instant flicker.
+        <span key={hint} className="truncate animate-in fade-in duration-500">
+          {hint}
+        </span>
+      ) : null}
+      <ToolRunningTimer offlineLabel={offlineLabel} />
+    </span>
+  );
+}
+
+/**
  * Compact elapsed-timer + offline cue for a tool that is currently RUNNING
  * (issue #432) — e.g. the "Propose blueprint · Running" header. Counts up from
  * when the running card mounts so a long tool call (a blueprint can take tens of
@@ -2641,6 +2851,8 @@ interface ToolActivitySummaryLabels {
   toolAwaitingApproval: string;
   toolFailed: string;
   connectionOfflineLabel: string;
+  designingPlanLabel: string;
+  designingPlanHints: string[];
 }
 
 function ToolActivitySummary({
@@ -2674,8 +2886,19 @@ function ToolActivitySummary({
             {group.state === 'running' ? (
               // A running tool (e.g. "Propose blueprint") shows a LIVE elapsed
               // timer instead of a static "Running", and a red offline cue if
-              // the network drops (issue #432).
-              <ToolRunningTimer offlineLabel={labels.connectionOfflineLabel} />
+              // the network drops (issue #432). The build agent's plan-design
+              // step is special-cased: that one call is a long, atomic LLM
+              // request with no token stream, so a bare timer felt stuck — give
+              // it a friendly "Designing your app…" lead-in with rotating hints.
+              group.rawName === 'propose_blueprint' ? (
+                <BuildProposalProgressHint
+                  label={labels.designingPlanLabel}
+                  hints={labels.designingPlanHints}
+                  offlineLabel={labels.connectionOfflineLabel}
+                />
+              ) : (
+                <ToolRunningTimer offlineLabel={labels.connectionOfflineLabel} />
+              )
             ) : (
               <span
                 className={cn(

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -489,6 +489,129 @@ describe('ChatbotEnhanced (AI Elements composition)', () => {
     fireEvent.change(picker, { target: { value: 'claude-3-5-sonnet' } });
     expect(onModelChange).toHaveBeenCalledWith('claude-3-5-sonnet');
   });
+
+  // Improvement 1: a propose_blueprint can FINISH without its result parsing
+  // into a structured `proposedPlan` (a thin/odd envelope, or a prose proposal).
+  // Before, that collapsed into a "Completed" chip and the user was left with
+  // prose and no button — guess-the-"确认". Now a fallback confirm card with an
+  // explicit "Build it" / "Adjust" always renders.
+  describe('fallback confirm gate for an unstructured propose_blueprint', () => {
+    // A completed propose_blueprint with NO proposedPlan (detector returned
+    // undefined) — the regression case.
+    const unstructured: ChatMessage[] = [
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: "Here's a plan for a reading list. Reply to confirm and I'll build it.",
+        toolInvocations: [
+          { toolCallId: 't1', toolName: 'propose_blueprint', state: 'output-available' },
+        ],
+      },
+    ];
+
+    it('renders the fallback "Build it" card (not just prose) when the plan did not parse', () => {
+      render(
+        <ChatbotEnhanced messages={unstructured} onSendMessage={vi.fn()} planReadyLabel="READY_TEXT" />,
+      );
+      expect(screen.getByTestId('proposed-plan-fallback')).toBeInTheDocument();
+      // An explicit, one-click confirm gate — no guessing the "确认" phrase.
+      expect(screen.getByTestId('proposed-plan-approve')).toBeInTheDocument();
+      expect(screen.getByTestId('proposed-plan-adjust')).toBeInTheDocument();
+      expect(screen.getByText('READY_TEXT')).toBeInTheDocument();
+    });
+
+    it('"Build it" on the fallback card sends the plain approve message (no open questions to default)', () => {
+      const onSendMessage = vi.fn();
+      render(
+        <ChatbotEnhanced
+          messages={unstructured}
+          onSendMessage={onSendMessage}
+          planApproveMessage="APPROVE_PLAIN"
+          planApproveDefaultsMessage="APPROVE_DEFAULTS"
+        />,
+      );
+      fireEvent.click(screen.getByTestId('proposed-plan-approve'));
+      expect(onSendMessage).toHaveBeenCalledWith('APPROVE_PLAIN');
+    });
+
+    it('falls back to the static hint (no buttons) when message sending is not wired', () => {
+      render(<ChatbotEnhanced messages={unstructured} planApproveHintLabel="HINT_TEXT" />);
+      expect(screen.getByTestId('proposed-plan-fallback')).toBeInTheDocument();
+      expect(screen.queryByTestId('proposed-plan-actions')).not.toBeInTheDocument();
+      expect(screen.getByText('HINT_TEXT')).toBeInTheDocument();
+    });
+
+    it('collapses the fallback card to an inert "Built" badge once apply_blueprint has run', () => {
+      const built: ChatMessage[] = [
+        ...unstructured,
+        {
+          id: 'a2',
+          role: 'assistant',
+          content: '',
+          toolInvocations: [
+            { toolCallId: 't2', toolName: 'apply_blueprint', state: 'output-available' },
+          ],
+        },
+      ];
+      render(<ChatbotEnhanced messages={built} onSendMessage={vi.fn()} planBuiltLabel="BUILT_BADGE" />);
+      expect(screen.queryByTestId('proposed-plan-approve')).not.toBeInTheDocument();
+      expect(screen.getByTestId('proposed-plan-built')).toBeInTheDocument();
+      expect(screen.getByText('BUILT_BADGE')).toBeInTheDocument();
+    });
+
+    it('does NOT render the fallback card while the propose_blueprint is still running', () => {
+      // A running proposal keeps its live timer in the summary strip; the
+      // fallback confirm gate is only for the FINISHED-but-unstructured case.
+      render(
+        <ChatbotEnhanced
+          isLoading
+          messages={[
+            { id: 'u1', role: 'user', content: 'build me a CRM' },
+            {
+              id: 'a1',
+              role: 'assistant',
+              content: '',
+              streaming: true,
+              toolInvocations: [
+                { toolCallId: 't1', toolName: 'propose_blueprint', state: 'input-available' },
+              ],
+            },
+          ]}
+          onSendMessage={vi.fn()}
+        />,
+      );
+      expect(screen.queryByTestId('proposed-plan-fallback')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('proposed-plan-approve')).not.toBeInTheDocument();
+    });
+
+    it('prefers the RICH plan card over the fallback when the plan DID parse', () => {
+      const structured: ChatMessage[] = [
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '',
+          toolInvocations: [
+            {
+              toolCallId: 't1',
+              toolName: 'propose_blueprint',
+              state: 'output-available',
+              proposedPlan: {
+                summary: 'A reading list',
+                objects: [{ name: 'book', label: 'Book', fieldCount: 2 }],
+                counts: { objects: 1, views: 0, dashboards: 0, seedData: 0 },
+                questions: [],
+                assumptions: [],
+              },
+            },
+          ],
+        },
+      ];
+      render(<ChatbotEnhanced messages={structured} onSendMessage={vi.fn()} />);
+      // Rich card present, fallback absent — no double card.
+      expect(screen.getByTestId('proposed-plan')).toBeInTheDocument();
+      expect(screen.queryByTestId('proposed-plan-fallback')).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('ChatbotEnhanced — auto-publish drafts (self-use magic moment)', () => {
@@ -1016,5 +1139,94 @@ describe('ChatbotEnhanced — activity-driven liveness (not a fake clock)', () =
     // Never went amber — the heartbeats kept it honestly "receiving".
     expect(screen.queryByText(/Waiting for server/i)).not.toBeInTheDocument();
     expect(screen.getByText('0:08')).toBeInTheDocument();
+  });
+});
+
+// Improvement 2: the propose_blueprint call is a single long, atomic LLM request
+// (no token stream), so a bare timer felt stuck. While it runs, the summary strip
+// shows a friendly "Designing your app…" lead-in plus a hint that rotates every
+// few seconds — presentational reassurance that the wait is moving.
+describe('ChatbotEnhanced — propose_blueprint in-progress design hints', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  const runningProposal: ChatMessage[] = [
+    { id: 'u1', role: 'user', content: 'build me a CRM' },
+    {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      streaming: true,
+      toolInvocations: [
+        { toolCallId: 't1', toolName: 'propose_blueprint', state: 'input-available' },
+      ],
+    },
+  ];
+
+  it('shows the friendly designing indicator (lead-in + rotating hint + timer) for a running proposal', () => {
+    const { container } = render(
+      <ChatbotEnhanced
+        isLoading
+        messages={runningProposal}
+        labels={{
+          designingPlanLabel: 'DESIGNING',
+          designingPlanHints: ['HINT_A', 'HINT_B'],
+        }}
+      />,
+    );
+    const hint = container.querySelector('[data-testid="build-proposal-progress"]');
+    expect(hint).not.toBeNull();
+    expect(hint?.textContent).toContain('DESIGNING');
+    // First hint up immediately, plus the live elapsed timer beside it.
+    expect(hint?.textContent).toContain('HINT_A');
+    expect(hint?.querySelector('[data-tool-running-timer]')).not.toBeNull();
+  });
+
+  it('rotates to the next hint after the interval elapses', () => {
+    const { container } = render(
+      <ChatbotEnhanced
+        isLoading
+        messages={runningProposal}
+        labels={{ designingPlanLabel: 'DESIGNING', designingPlanHints: ['HINT_A', 'HINT_B'] }}
+      />,
+    );
+    const hint = () => container.querySelector('[data-testid="build-proposal-progress"]');
+    expect(hint()?.textContent).toContain('HINT_A');
+    act(() => {
+      vi.advanceTimersByTime(3500);
+    });
+    expect(hint()?.textContent).toContain('HINT_B');
+    expect(hint()?.textContent).not.toContain('HINT_A');
+  });
+
+  it('a non-proposal running tool keeps the plain timer, not the design hint', () => {
+    const { container } = render(
+      <ChatbotEnhanced
+        isLoading
+        messages={[
+          { id: 'u1', role: 'user', content: 'do something' },
+          {
+            id: 'a1',
+            role: 'assistant',
+            content: '',
+            streaming: true,
+            toolInvocations: [
+              { toolCallId: 't1', toolName: 'query_records', state: 'input-available' },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(container.querySelector('[data-testid="build-proposal-progress"]')).toBeNull();
+    expect(container.querySelector('[data-tool-running-timer]')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## What

Two UX fixes for the **AI Build** chat (the magic flow: describe an app → AI proposes a plan → you confirm → AI builds & publishes). Changes live in `plugin-chatbot` (the chat component) plus the two surfaces that drive it: the full-page `AiChatPage` and the floating `ConsoleFloatingChatbot`.

### 1 · `propose_blueprint` now ALWAYS gives an explicit "Build it" button

**Before (the bug):** the "Proposed plan" card — with its one-click **Build it** / **Adjust** gate — only renders when the tool result parses into a structured `proposedPlan` (i.e. `detectProposedPlan()` finds `status:'blueprint_proposed'` **and** at least one nameable object). When `propose_blueprint` *finished* but returned a thin / oddly-shaped envelope, or the model proposed in prose, `detectProposedPlan` returned `undefined`, so:

- `shouldRenderDetailedTool()` was false → the step collapsed into a **"Propose blueprint · Completed" summary chip**, and
- the user was left with only the assistant's text telling them to *"reply 确认 or 直接搭建"* — **no button, guess-the-phrase.** Inconsistent and confusing, exactly the reported symptom.

**Fix:** a *finished-but-unstructured* `propose_blueprint` (`isUnstructuredBuildProposal`) now routes to the detailed body and renders a **fallback confirm card** with the same explicit **Build it** / **Adjust** buttons, the same approve/adjust handlers, and the same #432 built-state collapse (turns into an inert "Built" badge once `apply_blueprint` runs). The **rich** plan card still wins whenever the plan parses — no double card. When the host hasn't wired `onSendMessage`, it degrades to the same static hint the rich card uses.

### 2 · A friendlier "we're designing" wait during `propose_blueprint`

`propose_blueprint` is a single long, **atomic** LLM call (no token stream / partial results), so the previous bare elapsed timer made the UI look stuck for tens of seconds. While it runs, the activity summary strip (and the detailed-tool header, for parity) now show a **"Designing your app…"** lead-in plus a hint that **rotates every 3.5s** — *Mapping out the data → Shaping objects and their fields → Connecting related records → Planning the screens and views → Pulling the plan together* — beside the live count-up timer. So the wait visibly **moves**.

This is the pragmatic option from the brief: the rotation is **presentational reassurance only** (it does **not** claim real sub-step progress — there's no partial stream to show), it's fully localizable, and an empty hints array disables it. No backend/protocol changes.

## Why #1 used to degrade to plain text

The card↔chip routing is gated entirely on `tool.proposedPlan` being truthy, and that field is only populated by `detectProposedPlan()`, which is strict (needs the exact envelope status + ≥1 parseable object). Any propose result the detector can't lift — a lean envelope, a differently-shaped `blueprint`, or a model that answered in prose instead of the tool — fell through to the generic "Completed" chip with no confirm affordance. The fix decouples "show a confirm gate" from "did the rich plan parse": a completed build-proposal step always earns at least the minimal gate.

## Copy / i18n

All strings are label-driven. English defaults live in `plugin-chatbot`; both surfaces wire zh + en (`AiChatPage` via `t()` per-string, `ConsoleFloatingChatbot` via its locale object). Note: the floating-chat fallback button still **sends** the existing `确认`-anchored approve message, so it matches the cloud confirm-gate regex (`service-ai-studio` `confirm-gate.ts`) and isn't inert.

## Verification

- **Unit / DOM (real component, jsdom + Testing Library):** `plugin-chatbot` **133 → 142** tests. New tests cover, for #1: fallback card renders (not just prose), "Build it" sends the plain approve message, static-hint fallback with no `onSendMessage`, collapse to "Built" after `apply_blueprint`, **not** shown while still running, and the rich card preferred when the plan parses; for #2: the designing indicator (lead-in + rotating hint + timer) shows for a running proposal, rotates on the interval, and a non-proposal running tool keeps the plain timer.
- **Rendered-DOM spot check** of the real component confirmed the produced markup: fallback card = `"Proposed plan"` + `"The plan is ready. Build it now, or tell me what to adjust."` + **Build it** + **Adjust**; running hint cycled `Mapping… → Shaping… → Connecting…` with `0:00 / 0:03 / 0:07`.
- **app-shell:** full suite **938 tests green**.
- **Build / type-check:** `plugin-chatbot` and `app-shell` both `tsc --noEmit` clean and build (incl. DTS) clean. (Pre-existing, unrelated `plugin-view` DTS `rootDir` warnings were present on the baseline and are untouched by this change.)
- **NOT done — live UI in a real AI-build session.** `examples/app-showcase` is a framework data/back-end example and does **not** mount `plugin-chatbot` or run the AI build flow, so these two surfaces can't be reproduced there. Reproducing them live needs the full cloud + objectos stack (an AI-enabled tenant env), which is out of scope here. Verification is therefore code + compile + unit/DOM (real component render), not a screenshotted end-to-end session.

## Deploy note (for a human, later)

This is objectui-only. To reach the running stack it needs a framework `.objectui-sha` bump + a cloud pin bump after merge — **intentionally not bumped here**; leave the timing to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)