### PR TITLE
feat(ai-build): event-driven blueprint-design progress (live "Designing…" panel)

### DIFF
--- a/.changeset/ai-build-blueprint-progress.md
+++ b/.changeset/ai-build-blueprint-progress.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/plugin-chatbot': minor
+---
+
+feat(ai-build): event-driven "Designing your app…" progress for the blueprint-design stream (Refs cloud#657, cloud#655)
+
+`propose_blueprint` now streams a reconciled `data-blueprint-progress` part while it drafts the plan (a tens-of-seconds, otherwise-opaque LLM call), so the chat shows the app taking shape — objects appearing one-by-one with their field counts, the summary / extend target revealed progressively, and a `seq`-driven liveness cue — instead of a purely presentational rotating-hint placeholder.
+
+- `mapMessages`: `uiMessageToChatMessage` lifts the latest `data-blueprint-progress` frame onto `ChatMessage.blueprintProgress` (same single-reconciled-part mechanism as `data-build-progress`; transient, never persisted). This is the shared streaming converter both the full-page AI Build surface (`AiChatPage` via `useObjectChat`) and the floating console chatbot already route through.
+- `ChatbotEnhanced`: a new `BlueprintProgressPanel` renders the live "Designing…" card (object chips + summary + running counts + liveness). It supersedes the rotating-hint placeholder while events flow, and yields to the authoritative "Proposed plan" card the instant the `propose_blueprint` result lands.
+- Graceful degradation: with no `data-blueprint-progress` events (older runtimes / non-streaming turns) the existing rotating-hint placeholder behaves exactly as before — zero regression. On reload the persisted "Proposed plan" card is the record (the live panel is transient by design).

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -106,6 +106,15 @@ export interface ChatMessage {
    */
   buildProgress?: ChatBuildProgress;
   /**
+   * Live blueprint-DESIGN progress from the long, atomic `propose_blueprint`
+   * call, lifted from the stream's reconciled `data-blueprint-progress` part.
+   * When present, the chat renders a "Designing…" panel whose object chips
+   * appear one-by-one — upgrading the purely-presentational rotating-hint
+   * placeholder to real, event-driven progress. Transient (never persisted):
+   * on reload the authoritative "Proposed plan" card is the record instead.
+   */
+  blueprintProgress?: ChatBlueprintProgress;
+  /**
    * Charts to render inline in the assistant bubble, lifted from the stream's
    * `data-chart` parts (emitted by the `visualize_data` tool via
    * `ctx.onProgress`). Each renders through the platform's SDUI `<chart>`
@@ -158,6 +167,43 @@ export interface ChatBuildProgress {
    * awaits — so it's the reliable "a fresh byte just arrived" signal the build
    * panel keys its liveness off (content fields stay identical across a
    * heartbeat). Absent from older runtimes.
+   */
+  seq?: number;
+}
+
+/**
+ * A reconciled snapshot of an in-flight blueprint DESIGN (`propose_blueprint`).
+ * The plan-design step is a long, atomic LLM request; the server now streams a
+ * reconciled `data-blueprint-progress` part as the schema takes shape, so the
+ * chat can show objects appearing one-by-one instead of a static spinner.
+ * Mirrors `ChatBuildProgress` (apply_blueprint's BUILD progress) but for the
+ * pre-build PLAN — it is superseded by the authoritative "Proposed plan" card
+ * the instant the tool result lands.
+ */
+export interface ChatBlueprintProgress {
+  /**
+   * Coarse phase. `designing` while the plan is being drafted; `done` once the
+   * authoritative blueprint has arrived (on the `propose_blueprint` tool
+   * result). Anything unrecognised — including absent — is treated as designing.
+   */
+  phase: 'designing' | 'done';
+  /** Human one-liner for the app being designed (revealed progressively). */
+  summary?: string;
+  /** Human label for the new app (absent in extend mode). */
+  appLabel?: string;
+  /** Extend mode: the existing app the new objects would be added into. */
+  targetApp?: string;
+  /**
+   * Objects surfaced so far, cumulative — they appear one-by-one as the design
+   * streams. `fields` is the field count for the chip's "· N" suffix.
+   */
+  objects: Array<{ name: string; label?: string; fields?: number }>;
+  /** Running totals for a compact "N objects · N views · …" line. */
+  counts?: { objects?: number; views?: number; dashboards?: number };
+  /**
+   * Monotonic emit counter from the server — the reliable "a fresh byte just
+   * arrived" liveness signal (advances on keep-alive heartbeats too, where the
+   * content fields are identical). Absent from older runtimes.
    */
   seq?: number;
 }
@@ -2133,16 +2179,36 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                 const reasoning = message.reasoning?.trim();
                 const sources = message.sources ?? [];
                 const buildProgress = !isUser ? message.buildProgress : undefined;
+                // The live "Designing…" panel is a hand-off affordance: it
+                // yields to the authoritative "Proposed plan" card the instant
+                // the propose_blueprint result lands. Suppress it once any tool
+                // on this turn carries a structured plan — which also makes it a
+                // no-op on reload (only the persisted plan card exists then).
+                const blueprintProgress =
+                  !isUser && !tools.some((t) => Boolean(t.proposedPlan))
+                    ? message.blueprintProgress
+                    : undefined;
                 const isEmptyAssistantStreaming =
                   !isUser &&
                   Boolean(message.streaming) &&
                   !message.content &&
                   tools.length === 0 &&
                   !reasoning &&
-                  !buildProgress; // a streaming build shows its tree, not the dots
+                  !buildProgress &&
+                  !blueprintProgress; // a streaming design/build shows its panel, not the dots
                 const summaryTools =
                   !isUser && processVisibility === 'summary'
-                    ? tools.filter((tool) => !shouldRenderDetailedTool(tool))
+                    ? tools.filter(
+                        (tool) =>
+                          !shouldRenderDetailedTool(tool) &&
+                          // While the live design panel is up it already
+                          // represents the running propose_blueprint, so don't
+                          // also surface that tool's rotating-hint row in the
+                          // activity strip (the panel supersedes the
+                          // placeholder). With no events the row stays and shows
+                          // the placeholder as before.
+                          !(blueprintProgress && tool.toolName === 'propose_blueprint'),
+                      )
                     : [];
                 const detailedTools =
                   !isUser && processVisibility === 'debug'
@@ -2176,6 +2242,16 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                         )}
                       >
                     <MessageContent>
+                      {blueprintProgress ? (
+                        <BlueprintProgressPanel
+                          progress={blueprintProgress}
+                          designingLabel={L.designingPlanLabel}
+                          extendLabel={planExtendLabel}
+                          waitingLabel={L.connectionWaiting}
+                          stalledLabel={L.connectionStalledLabel}
+                          offlineLabel={L.connectionOfflineLabel}
+                        />
+                      ) : null}
                       {buildProgress ? (
                         <BuildProgressPanel
                           progress={buildProgress}
@@ -2888,6 +2964,115 @@ const BUILD_GROUP_LABEL: Record<string, string> = {
   app: 'App',
   seed: 'Sample data',
 };
+
+/**
+ * Live "Designing…" panel for an in-flight blueprint DESIGN (`propose_blueprint`).
+ * The plan-design call is a long, atomic LLM request; the server now streams a
+ * reconciled `data-blueprint-progress` part as the schema takes shape, so this
+ * panel shows objects appearing one-by-one (label + field count) with the
+ * summary / extend target revealed progressively — replacing the purely
+ * presentational rotating-hint placeholder with real, event-driven progress.
+ *
+ * It is a LIVE affordance only: the caller stops rendering it the instant the
+ * `propose_blueprint` result lands (a structured `proposedPlan` exists on the
+ * turn), so the authoritative "Proposed plan" card takes over cleanly. With no
+ * progress events (older runtimes / non-streaming turns) this never renders and
+ * the rotating-hint placeholder remains — zero regression.
+ */
+function BlueprintProgressPanel({
+  progress,
+  designingLabel = 'Designing your app…',
+  extendLabel = 'Adding to existing app',
+  waitingLabel = 'Waiting for server…',
+  stalledLabel = 'Still working…',
+  offlineLabel = 'Connection lost — reconnecting…',
+}: {
+  progress: ChatBlueprintProgress;
+  designingLabel?: string;
+  extendLabel?: string;
+  waitingLabel?: string;
+  stalledLabel?: string;
+  offlineLabel?: string;
+}) {
+  const { phase, summary, appLabel, targetApp, objects, counts, seq } = progress;
+  const isDone = phase === 'done';
+  // Real activity key, mirroring BuildProgressPanel: prefer the server's
+  // monotonic `seq` (it also advances on keep-alive heartbeats, where the
+  // content fields don't change), else a content signature for older runtimes.
+  // Drives the liveness indicator off observed bytes so the wait reads as
+  // "designing" rather than a hang.
+  const activityKey = seq ?? `${phase}:${objects.length}`;
+  // At `done` the app's own summary/label is the most informative header; while
+  // designing, the localized "Designing your app…" lead-in pairs with the
+  // summary shown on its own line below.
+  const headerText = isDone ? summary || appLabel || designingLabel : designingLabel;
+  const countBits: string[] = [];
+  if (counts?.objects)
+    countBits.push(`${counts.objects} object${counts.objects === 1 ? '' : 's'}`);
+  if (counts?.views) countBits.push(`${counts.views} view${counts.views === 1 ? '' : 's'}`);
+  if (counts?.dashboards)
+    countBits.push(`${counts.dashboards} dashboard${counts.dashboards === 1 ? '' : 's'}`);
+  return (
+    <div className="rounded-lg border bg-muted/30 p-3 text-sm" data-testid="blueprint-progress">
+      <div className="mb-2 flex items-center gap-2 font-medium">
+        {isDone ? (
+          <CheckCircle2 className="size-4 shrink-0 text-emerald-600" />
+        ) : (
+          <Loader2 className="size-4 shrink-0 animate-spin text-primary" />
+        )}
+        <span className="min-w-0 truncate">{headerText}</span>
+        {targetApp ? (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded-md border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-300"
+            data-testid="blueprint-progress-extend"
+          >
+            + {extendLabel} 「{targetApp}」
+          </span>
+        ) : null}
+        {!isDone ? (
+          <span className="ml-auto shrink-0">
+            <LivenessIndicator
+              active
+              activityKey={activityKey}
+              waitingLabel={waitingLabel}
+              stalledLabel={stalledLabel}
+              offlineLabel={offlineLabel}
+            />
+          </span>
+        ) : null}
+      </div>
+      {/* Summary one-liner — revealed progressively as the design streams. At
+          `done` it's already promoted into the header, so only show it here
+          while designing. */}
+      {!isDone && (summary || appLabel) ? (
+        <p className="mb-2 text-xs text-muted-foreground">{summary || appLabel}</p>
+      ) : null}
+      {objects.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5" data-testid="blueprint-progress-objects">
+          {objects.map((o) => (
+            // `key` on the stable object name fades each chip in exactly once as
+            // it first appears, so the panel reads as objects materialising one
+            // by one rather than a list snapping into place.
+            <span
+              key={o.name}
+              className="inline-flex animate-in fade-in items-center gap-1 rounded-md border bg-background px-1.5 py-0.5 text-[11px] text-foreground/80 duration-500"
+              title={o.name}
+            >
+              <Table2 className="size-3 text-foreground/40" />
+              {o.label || o.name}
+              {o.fields ? <span className="text-foreground/40">· {o.fields}</span> : null}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {countBits.length > 0 ? (
+        <span className="mt-2 block text-[11px] text-muted-foreground">
+          {countBits.join(' · ')}
+        </span>
+      ) : null}
+    </div>
+  );
+}
 
 /**
  * Live "build tree" for an in-flight app build (apply_blueprint). Renders the

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -1492,3 +1492,201 @@ describe('ChatbotEnhanced — design-wait staging (dots + forward progress)', ()
     expect(container.querySelector('[data-testid="build-proposal-progress-dots"]')).toBeNull();
   });
 });
+
+describe('ChatbotEnhanced — propose_blueprint live design progress (data-blueprint-progress)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  // A running propose_blueprint whose stream has begun emitting the reconciled
+  // `data-blueprint-progress` part — lifted onto the message as blueprintProgress
+  // by uiMessageToChatMessage (see mapMessages.test.ts for the event→data half).
+  const designing = (
+    blueprintProgress: NonNullable<ChatMessage['blueprintProgress']>,
+  ): ChatMessage[] => [
+    { id: 'u1', role: 'user', content: 'build me a recruiting app' },
+    {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      streaming: true,
+      toolInvocations: [
+        { toolCallId: 't1', toolName: 'propose_blueprint', state: 'input-available' },
+      ],
+      blueprintProgress,
+    },
+  ];
+
+  it('renders the live design panel with object chips (label + field count) and the summary', () => {
+    const { container } = render(
+      <ChatbotEnhanced
+        isLoading
+        messages={designing({
+          phase: 'designing',
+          summary: '招聘管理系统',
+          appLabel: '招聘管理',
+          objects: [
+            { name: 'candidate', label: '候选人', fields: 5 },
+            { name: 'job', label: '职位', fields: 4 },
+          ],
+          counts: { objects: 2, views: 2, dashboards: 1 },
+          seq: 3,
+        })}
+        labels={{ designingPlanLabel: 'Designing your app…' }}
+      />,
+    );
+    const panel = container.querySelector('[data-testid="blueprint-progress"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.textContent).toContain('Designing your app…');
+    // Summary one-liner revealed progressively.
+    expect(panel?.textContent).toContain('招聘管理系统');
+    const chips = container.querySelector('[data-testid="blueprint-progress-objects"]');
+    expect(chips).not.toBeNull();
+    expect(chips?.textContent).toContain('候选人');
+    expect(chips?.textContent).toContain('职位');
+    // Field-count suffix on the chips.
+    expect(chips?.textContent).toContain('5');
+    expect(chips?.textContent).toContain('4');
+    // Compact counts line.
+    expect(panel?.textContent).toContain('2 objects');
+  });
+
+  it('object chips reflect the latest streamed frame as objects accrue one by one', () => {
+    const { container, rerender } = render(
+      <ChatbotEnhanced
+        isLoading
+        messages={designing({
+          phase: 'designing',
+          objects: [{ name: 'candidate', label: '候选人', fields: 5 }],
+          seq: 1,
+        })}
+      />,
+    );
+    let chips = container.querySelector('[data-testid="blueprint-progress-objects"]');
+    expect(chips?.querySelectorAll('span[title]').length).toBe(1);
+    // The next reconciled frame reveals a second object — in place.
+    rerender(
+      <ChatbotEnhanced
+        isLoading
+        messages={designing({
+          phase: 'designing',
+          objects: [
+            { name: 'candidate', label: '候选人', fields: 5 },
+            { name: 'job', label: '职位', fields: 4 },
+          ],
+          seq: 2,
+        })}
+      />,
+    );
+    chips = container.querySelector('[data-testid="blueprint-progress-objects"]');
+    expect(chips?.querySelectorAll('span[title]').length).toBe(2);
+    expect(chips?.textContent).toContain('职位');
+  });
+
+  it('supersedes the rotating-hint placeholder once real progress events arrive', () => {
+    const { container } = render(
+      <ChatbotEnhanced
+        isLoading
+        messages={designing({
+          phase: 'designing',
+          objects: [{ name: 'candidate', label: '候选人', fields: 5 }],
+          seq: 1,
+        })}
+        labels={{ designingPlanLabel: 'Designing your app…', designingPlanHints: ['HINT_A'] }}
+      />,
+    );
+    // The event-driven panel is up…
+    expect(container.querySelector('[data-testid="blueprint-progress"]')).not.toBeNull();
+    // …and the purely-presentational rotating hint is NOT also shown in the
+    // activity strip (no duplicate "designing" affordance).
+    expect(container.querySelector('[data-testid="build-proposal-progress"]')).toBeNull();
+  });
+
+  it('falls back to the rotating-hint placeholder when NO progress events arrive (older runtimes)', () => {
+    const { container } = render(
+      <ChatbotEnhanced
+        isLoading
+        messages={[
+          { id: 'u1', role: 'user', content: 'build me a CRM' },
+          {
+            id: 'a1',
+            role: 'assistant',
+            content: '',
+            streaming: true,
+            toolInvocations: [
+              { toolCallId: 't1', toolName: 'propose_blueprint', state: 'input-available' },
+            ],
+          },
+        ]}
+        labels={{ designingPlanLabel: 'Designing your app…', designingPlanHints: ['HINT_A'] }}
+      />,
+    );
+    // No blueprintProgress → no panel, and the placeholder behaves exactly as before.
+    expect(container.querySelector('[data-testid="blueprint-progress"]')).toBeNull();
+    expect(container.querySelector('[data-testid="build-proposal-progress"]')).not.toBeNull();
+  });
+
+  it('hands off to the authoritative "Proposed plan" card once the result lands (panel goes away)', () => {
+    render(
+      <ChatbotEnhanced
+        messages={[
+          { id: 'u1', role: 'user', content: 'build me a recruiting app' },
+          {
+            id: 'a1',
+            role: 'assistant',
+            content: '',
+            // A late 'done' progress frame can momentarily co-exist with the
+            // tool result; the authoritative plan card must win, the panel must go.
+            blueprintProgress: {
+              phase: 'done',
+              summary: '招聘管理系统',
+              objects: [{ name: 'candidate', label: '候选人', fields: 5 }],
+            },
+            toolInvocations: [
+              {
+                toolCallId: 't1',
+                toolName: 'propose_blueprint',
+                state: 'output-available',
+                proposedPlan: {
+                  summary: '招聘管理系统',
+                  objects: [{ name: 'candidate', label: '候选人', fieldCount: 5 }],
+                  counts: { objects: 1, views: 0, dashboards: 0, seedData: 0 },
+                  questions: [],
+                  assumptions: [],
+                },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(document.querySelector('[data-testid="blueprint-progress"]')).toBeNull();
+    expect(screen.getByTestId('proposed-plan')).toBeInTheDocument();
+  });
+
+  it('shows the extend-mode badge with the target app when extending', () => {
+    const { container } = render(
+      <ChatbotEnhanced
+        isLoading
+        messages={designing({
+          phase: 'designing',
+          targetApp: 'recruiting',
+          objects: [{ name: 'interview', label: '面试', fields: 3 }],
+        })}
+        labels={{ planExtendLabel: 'Adding to' }}
+      />,
+    );
+    const badge = container.querySelector('[data-testid="blueprint-progress-extend"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain('Adding to');
+    expect(badge?.textContent).toContain('recruiting');
+  });
+});

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -189,6 +189,131 @@ describe('uiMessageToChatMessage', () => {
     expect(out.buildProgress).toBeUndefined();
   });
 
+  it('lifts a reconciled data-blueprint-progress part into blueprintProgress', () => {
+    const out = uiMessageToChatMessage({
+      id: 'mbp1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'data-blueprint-progress',
+          id: 'blueprint-progress',
+          data: {
+            phase: 'designing',
+            summary: '招聘管理系统',
+            appLabel: '招聘管理',
+            objects: [
+              { name: 'candidate', label: '候选人', fields: 5 },
+              { name: 'job', label: '职位', fields: 4 },
+            ],
+            counts: { objects: 2, views: 2, dashboards: 1 },
+            seq: 7,
+          },
+        },
+      ],
+    });
+    expect(out.blueprintProgress).toEqual({
+      phase: 'designing',
+      summary: '招聘管理系统',
+      appLabel: '招聘管理',
+      objects: [
+        { name: 'candidate', label: '候选人', fields: 5 },
+        { name: 'job', label: '职位', fields: 4 },
+      ],
+      counts: { objects: 2, views: 2, dashboards: 1 },
+      seq: 7,
+    });
+  });
+
+  it('reconciles to the latest data-blueprint-progress frame (objects appear one by one)', () => {
+    // The SDK keeps a single reconciled part per stable id; given two frames we
+    // take the most recent — the one with more objects revealed + higher seq.
+    const out = uiMessageToChatMessage({
+      id: 'mbp2',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'data-blueprint-progress',
+          id: 'blueprint-progress',
+          data: { phase: 'designing', objects: [{ name: 'candidate' }], seq: 1 },
+        },
+        {
+          type: 'data-blueprint-progress',
+          id: 'blueprint-progress',
+          data: {
+            phase: 'designing',
+            objects: [{ name: 'candidate' }, { name: 'job' }],
+            seq: 2,
+          },
+        },
+      ],
+    });
+    expect(out.blueprintProgress?.objects).toHaveLength(2);
+    expect(out.blueprintProgress?.seq).toBe(2);
+  });
+
+  it('maps phase:done with the extend target and drops malformed objects/fields', () => {
+    const out = uiMessageToChatMessage({
+      id: 'mbp3',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'data-blueprint-progress',
+          id: 'blueprint-progress',
+          data: {
+            phase: 'done',
+            targetApp: 'recruiting',
+            objects: [
+              { name: 'candidate' },
+              { label: 'no name — dropped' },
+              { name: 'job', fields: 'not-a-number' },
+            ],
+          },
+        },
+      ],
+    });
+    expect(out.blueprintProgress?.phase).toBe('done');
+    expect(out.blueprintProgress?.targetApp).toBe('recruiting');
+    // Nameless object dropped; non-numeric `fields` omitted (chip shows no "· N").
+    expect(out.blueprintProgress?.objects).toEqual([{ name: 'candidate' }, { name: 'job' }]);
+  });
+
+  it('defaults an unknown/absent phase to designing and tolerates a missing objects array', () => {
+    const out = uiMessageToChatMessage({
+      id: 'mbp4',
+      role: 'assistant',
+      parts: [
+        { type: 'data-blueprint-progress', id: 'blueprint-progress', data: { summary: 'CRM' } },
+      ],
+    });
+    expect(out.blueprintProgress?.phase).toBe('designing');
+    expect(out.blueprintProgress?.objects).toEqual([]);
+    expect(out.blueprintProgress?.summary).toBe('CRM');
+  });
+
+  it('drops counts entirely when none of its numeric fields are present', () => {
+    const out = uiMessageToChatMessage({
+      id: 'mbp5',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'data-blueprint-progress',
+          id: 'blueprint-progress',
+          data: { phase: 'designing', objects: [], counts: { objects: 'x' } },
+        },
+      ],
+    });
+    expect(out.blueprintProgress?.counts).toBeUndefined();
+  });
+
+  it('leaves blueprintProgress undefined when there is no blueprint-progress part', () => {
+    const out = uiMessageToChatMessage({
+      id: 'mbp6',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'hi' }],
+    });
+    expect(out.blueprintProgress).toBeUndefined();
+  });
+
   it('lifts data-chart parts into charts[] (visualize_data)', () => {
     const out = uiMessageToChatMessage({
       id: 'm8',

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -14,7 +14,7 @@
  * apps that drive `useChat` themselves (e.g. Studio, which needs a custom
  * `prepareSendMessagesRequest` transport).
  */
-import type { ChatMessage, ChatToolInvocation, ChatSource, ChatBuildProgress, ChatChart } from './ChatbotEnhanced';
+import type { ChatMessage, ChatToolInvocation, ChatSource, ChatBuildProgress, ChatBlueprintProgress, ChatChart } from './ChatbotEnhanced';
 
 interface AnyPart {
   type?: string;
@@ -511,6 +511,54 @@ function extractBuildProgress(parts: AnyPart[]): ChatBuildProgress | undefined {
 }
 
 /**
+ * Lift the live blueprint-DESIGN progress from the stream's reconciled
+ * `data-blueprint-progress` part (emitted by `propose_blueprint` via
+ * `ctx.onProgress` while it drafts the plan). Same single-reconciled-part
+ * mechanism as `data-build-progress` — a stable id keeps one in-place-updated
+ * part, so we read the latest frame (objects accrue across frames). Transient:
+ * never persisted, so on reload the authoritative `proposedPlan` card (lifted
+ * from the persisted tool result) is the record instead of this panel.
+ */
+function extractBlueprintProgress(parts: AnyPart[]): ChatBlueprintProgress | undefined {
+  const part = parts.filter((p) => p.type === 'data-blueprint-progress').pop();
+  const data = part?.data;
+  if (!data || typeof data !== 'object') return undefined;
+  const d = data as Record<string, unknown>;
+  const objects = Array.isArray(d.objects)
+    ? (d.objects as Array<Record<string, unknown>>)
+        .filter((o) => typeof o?.name === 'string')
+        .map((o) => ({
+          name: o.name as string,
+          ...(typeof o.label === 'string' ? { label: o.label } : {}),
+          ...(typeof o.fields === 'number' ? { fields: o.fields } : {}),
+        }))
+    : [];
+  // Only `done` is authoritative; anything else (incl. absent) is still designing.
+  const phase: ChatBlueprintProgress['phase'] = d.phase === 'done' ? 'done' : 'designing';
+  let counts: ChatBlueprintProgress['counts'];
+  if (d.counts && typeof d.counts === 'object') {
+    const c = d.counts as Record<string, unknown>;
+    const out: { objects?: number; views?: number; dashboards?: number } = {};
+    if (typeof c.objects === 'number') out.objects = c.objects;
+    if (typeof c.views === 'number') out.views = c.views;
+    if (typeof c.dashboards === 'number') out.dashboards = c.dashboards;
+    if (Object.keys(out).length > 0) counts = out;
+  }
+  return {
+    phase,
+    ...(typeof d.summary === 'string' ? { summary: d.summary } : {}),
+    ...(typeof d.appLabel === 'string' ? { appLabel: d.appLabel } : {}),
+    ...(typeof d.targetApp === 'string' ? { targetApp: d.targetApp } : {}),
+    objects,
+    ...(counts ? { counts } : {}),
+    // Monotonic emit counter — advances even on keep-alive heartbeats (identical
+    // content), so the design panel keeps its liveness "live" during the long,
+    // quiet plan-design await. Absent on older runtimes.
+    ...(typeof d.seq === 'number' ? { seq: d.seq } : {}),
+  };
+}
+
+/**
  * Lift charts from the stream's `data-chart` parts (emitted by the
  * `visualize_data` tool via `ctx.onProgress`). Unlike `data-build-progress`
  * (one reconciled part), each chart is emitted with its OWN id, so a single
@@ -584,6 +632,10 @@ export function uiMessageToChatMessage(
     toolInvocations: resolvedTools,
     sources: extractSources(parts),
     buildProgress,
+    // Live blueprint-DESIGN progress (propose_blueprint) — a transient stream
+    // part like buildProgress. No persisted fallback needed: the `proposedPlan`
+    // card (from the persisted tool result) is the post-reload record.
+    blueprintProgress: extractBlueprintProgress(parts),
     charts: extractCharts(parts),
     streaming: opts.streaming,
   };


### PR DESCRIPTION
## What

Renders the **blueprint-design streaming** half of the AI Build "magic" flow. cloud#657 (Refs cloud#655) ships the backend: while `propose_blueprint` drafts the plan — a tens-of-seconds, otherwise-opaque LLM call — it now emits a progressive, reconciled `data-blueprint-progress` part along the agent SSE stream. This PR is the frontend renderer: objects appear **one-by-one** in a live "Designing…" card instead of a spinner + rotating placeholder, then the card hands off to the authoritative "Proposed plan" the instant the tool result lands.

Before this PR (#2036/#2039) the wait was a purely *presentational* "Designing your app…" + rotating-copy placeholder. This upgrades it to real, event-driven progress, keeping that placeholder as the no-event fallback.

## Event contract (same mechanism as `apply_blueprint`'s `data-build-progress`, reconciled in place by stable `id`)

```jsonc
{
  "type": "data-blueprint-progress",
  "id": "blueprint-progress",        // stable id → client replaces the prior frame
  "data": {
    "phase": "designing" | "done",
    "summary": "招聘管理系统",          // optional, appears progressively
    "appLabel": "招聘管理",            // optional (no appLabel in extend mode)
    "targetApp": "recruiting",        // extend mode only
    "objects": [{ "name": "candidate", "label": "候选人", "fields": 5 }],
    "counts": { "objects": 3, "views": 2, "dashboards": 1 },
    "seq": 7                          // monotonic liveness signal
  }
}
```

## How it's wired (detect → route → converter → render)

- **Detect / map** — `mapMessages.ts`: `extractBlueprintProgress(parts)` lifts the latest reconciled frame; `uiMessageToChatMessage` puts it on `ChatMessage.blueprintProgress` (mirrors `extractBuildProgress`). This is the **shared streaming converter** that *both* the full-page AI Build surface (`AiChatPage` → `useObjectChat`) and the floating console chatbot already route through — so one wiring point covers both surfaces.
- **Type** — `ChatBlueprintProgress` + `ChatMessage.blueprintProgress` in `ChatbotEnhanced.tsx`.
- **Render** — new `BlueprintProgressPanel`: object chips (label + `fields`), summary / extend badge revealed progressively, `seq`-driven `LivenessIndicator`. Rendered at message level next to `BuildProgressPanel`.
- **Route / hand-off** — the panel renders only while the turn has **no** structured `proposedPlan` yet; the moment the `propose_blueprint` result lands it yields to the authoritative "Proposed plan" card. While the panel is up, the running `propose_blueprint`'s rotating-hint row is suppressed in the activity strip (the panel supersedes the placeholder).
- **Hydration converter unchanged (by design):** `AiChatPage.hydratedMessagesToChatMessages` only sees *persisted* history, and `data-blueprint-progress` is transient like `data-build-progress` — never persisted. On reload the persisted "Proposed plan" card is the record, so no synthesis is needed there (unlike `buildProgress`, whose "Built X" panel had no other persisted form).

## Graceful degradation / zero regression

No `data-blueprint-progress` events (older cloud / non-streaming turn) → no panel, and the existing rotating-hint "Designing your app…" placeholder behaves exactly as before.

## Tests (12 new)

- `mapMessages.test.ts` (event→data): full mapping, reconcile-to-latest-frame, `phase:done` + extend target, malformed-object/field filtering, phase default, counts-drop, absence.
- `ChatbotEnhanced.test.tsx` (event→render): chips with label+field-count + summary + counts line, chips accruing across frames, placeholder superseded when events present, placeholder fallback with no events, hand-off to the Proposed-plan card, extend-mode badge.
- Full `plugin-chatbot` suite green (154 tests, 8 files). No new type errors / lint errors from the change.

## Browser verification (recorded event stream)

Drove `ChatbotEnhanced` through a scripted `data-blueprint-progress` sequence in a real browser and captured each state:
1. **Designing (empty)** — panel header + summary + live liveness.
2. **Designing (accruing)** — 4 chips with field counts (候选人·5, 职位·4, 面试·6, 部门·3) + "4 objects · 3 views · 1 dashboard".
3. **Hand-off** — live panel gone, authoritative "Proposed plan" card shown (same chips carry over → seamless).
4. **Fallback** — no events → existing rotating placeholder, unchanged.

## Shipping note

This is the objectui half. To actually ship the streamed UX end-to-end it still needs the deploy-chain pins bumped: framework `.objectui-sha` pin bump → cloud re-pin (per the standard objectui deployment flow). cloud#657 is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)