### PR TITLE
fix(actions): first-class openIn for url actions (new-tab) (#2043)

### DIFF
--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -90,6 +90,9 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
           label: schema.label,
           description: (schema as any).description,
           target: schema.target,
+          // Static "open in new tab" switch for url actions — forward so the
+          // runner's executeUrl honors it (dropped, the toggle is silently lost).
+          openIn: (schema as any).openIn,
           execute: schema.execute,
           endpoint: schema.endpoint,
           method: schema.method,

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -133,6 +133,7 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
           type: action.type,
           name: action.name,
           target: action.target,
+          openIn: (action as any).openIn,
           execute: action.execute,
           endpoint: action.endpoint,
           method: action.method,

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -57,6 +57,7 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
           type: schema.type,
           name: schema.name,
           target: schema.target,
+          openIn: (schema as any).openIn,
           execute: schema.execute,
           endpoint: schema.endpoint,
           method: schema.method,

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -127,6 +127,7 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
             type: action.type,
             name: action.name,
             target: action.target,
+            openIn: (action as any).openIn,
             execute: action.execute,
             endpoint: action.endpoint,
             method: action.method,

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -227,6 +227,7 @@ function ElementButtonRenderer({ schema }: { schema: any }) {
         label: action.label,
         description: action.description,
         target: action.target,
+        openIn: (action as any).openIn,
         endpoint: action.endpoint,
         method: action.method,
         navigate: action.navigate,

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -132,6 +132,12 @@ export interface ActionDef {
   execute?: string;
   /** Target URL or identifier (for type: 'url', 'modal', 'flow') */
   target?: string;
+  /** For type: 'url' — where to open `target`. `'new-tab'` forces a new
+   *  browser tab/window, `'self'` forces same-page navigation. When omitted,
+   *  external URLs open in a new tab and relative URLs navigate in place.
+   *  This is the public, static "open in new tab" switch (ActionSchema.openIn),
+   *  distinct from the async-handler `opensInNewTab` pre-open dance. */
+  openIn?: 'self' | 'new-tab';
   /** Modal schema to open (for type: 'modal') */
   modal?: any;
   /** Chained actions to execute after this one */
@@ -728,7 +734,13 @@ export class ActionRunner {
       window.location.href = url;
       return { success: true };
     }
-    const newTab = action.params?.newTab ?? isExternal;
+    // `openIn` is the first-class, declarative switch (ActionSchema.openIn);
+    // it wins over the legacy `params.newTab` escape hatch and the
+    // external-URL heuristic.
+    const newTab =
+      action.openIn === 'new-tab' ? true
+        : action.openIn === 'self' ? false
+          : (action.params?.newTab ?? isExternal);
 
     if (this.navigationHandler) {
       this.navigationHandler(url, { external: isExternal, newTab });

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -269,6 +269,38 @@ describe('ActionRunner', () => {
       });
     });
 
+    it('should force a new tab for a relative URL when openIn is "new-tab"', async () => {
+      const navHandler = vi.fn();
+      runner.setNavigationHandler(navHandler);
+
+      await runner.execute({
+        type: 'url',
+        target: '/print/a3',
+        openIn: 'new-tab',
+      });
+
+      expect(navHandler).toHaveBeenCalledWith('/print/a3', {
+        external: false,
+        newTab: true,
+      });
+    });
+
+    it('should force same-page navigation for an external URL when openIn is "self"', async () => {
+      const navHandler = vi.fn();
+      runner.setNavigationHandler(navHandler);
+
+      await runner.execute({
+        type: 'url',
+        target: 'https://example.com',
+        openIn: 'self',
+      });
+
+      expect(navHandler).toHaveBeenCalledWith('https://example.com', {
+        external: true,
+        newTab: false,
+      });
+    });
+
     it('should reject javascript: URLs', async () => {
       const result = await runner.execute({
         type: 'url',

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -162,7 +162,28 @@ export interface ActionSchema {
   
   /** Target for the action (URL, script name, etc.) */
   target?: string;
-  
+
+  /**
+   * For `type: 'url'`: where to open `target`.
+   * - `'new-tab'` — open `target` in a new browser tab/window.
+   * - `'self'` — navigate the current page (in-app router when available).
+   *
+   * When omitted, the legacy heuristic applies: absolute/external URLs
+   * (`http(s)://…`) open in a new tab, relative URLs navigate in place.
+   *
+   * This is a **static execution option**, NOT user input — keep it out of
+   * {@link params}, which is exclusively for collecting input before
+   * execution. Putting `newTab` inside `params` is rejected at build (an
+   * object where an `ActionParam[]` is expected) and, as an array entry,
+   * is mis-rendered as a checkbox in the param-collection dialog.
+   *
+   * Note: this is distinct from the runner-internal `opensInNewTab` /
+   * `newTabUrl` pair, which pre-opens `about:blank` synchronously for async
+   * handlers that resolve a redirect URL after a fetch (SSO flows). For a
+   * static `target`, prefer `openIn`.
+   */
+  openIn?: 'self' | 'new-tab';
+
   /** Script to execute (for type: 'script') */
   execute?: string;
   
@@ -174,7 +195,15 @@ export interface ActionSchema {
   
   // === Parameters ===
   
-  /** Input parameters to collect before execution */
+  /**
+   * Input parameters to collect from the user before execution (renders a
+   * dialog). This field is **exclusively** for user-input collection — it is
+   * always an `ActionParam[]`. Do NOT use it to carry static execution
+   * options (e.g. new-tab behavior — use {@link openIn}); a non-array value
+   * fails build validation, and an array entry like
+   * `{ name: 'newTab', type: 'checkbox' }` is mis-rendered as a user-facing
+   * checkbox instead of being treated as an instruction.
+   */
   params?: ActionParam[];
   
   // === Feedback ===


### PR DESCRIPTION
Closes #2043.

## 问题确认

Issue #2043 的描述准确(已逐条核对):
- `packages/types/src/ui-action.ts` 的公开 `ActionSchema.params` 确为 `ActionParam[]`(L178)。
- `ActionRunner.ts` 靠 `Array.isArray` 把 `params` 重载分流为「输入收集弹框」vs「静态选项对象」(L432-435)。
- `executeUrl` 仅有 `const newTab = action.params?.newTab ?? isExternal`(L731),无一等开关。
- 内部 `ActionDef` 有 `opensInNewTab`/`newTabUrl`(L148/L154),但从未提升到公开 schema —— 且这两者是给 **异步 handler 预开 about:blank**(SSO 跳转)用的,语义和「静态 target 开新标签」不同,复用会导致开两个标签页。

> 注:`@objectstack/spec` 的 zod 校验在 framework 仓库(downstream pinned),本 PR 只改 objectui 控制的 **运行时 + 公开 TS 类型**。spec 侧补 `openIn` 字段 + skill 文档已另开任务跟进(否则 spec 会在 build 时 strip 掉未知 key)。

## 改动

采纳 issue 推荐方案二:新增一等字段 `openIn?: 'self' | 'new-tab'`,与 `params`(仅用于用户输入收集)彻底分开。

- `packages/types/src/ui-action.ts` — 公开 `ActionSchema` 增 `openIn`;并收紧 `params` 文档为「专用于输入收集」。
- `packages/core/src/actions/ActionRunner.ts` — `ActionDef` 增 `openIn`;`executeUrl` 优先读 `openIn`,回退到旧的 `params.newTab ?? isExternal`。
- 五个渲染器转发白名单补 `openIn`:action-button / action-icon / action-menu / action-group / basic/elements。

用法:

```ts
defineAction({ name: 'print_a3', label: '打印总表(A3)', type: 'url',
  target: '/print/a3?id=${record.id}', openIn: 'new-tab' });
```

## 验证

- `ActionRunner.test.ts` 新增 2 个用例(相对 URL + `openIn:'new-tab'` 强制开新标签;外链 + `openIn:'self'` 强制原页导航),全套 60 passed。
- `@object-ui/types` / `core` / `components` 构建通过。