### PR TITLE
fix(dashboard): loading skeletons (not empty/0 states) while dataset & chart queries are pending

### DIFF
--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useContext, useCallback, useMemo, useRef } 
 import { useDataScope, SchemaRendererContext, SchemaRenderer, useDrillNavigation } from '@object-ui/react';
 import { ChartRenderer } from './ChartRenderer';
 import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveDateMacros, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, type CompareToConfig, type DrillEvent } from '@object-ui/core';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator, Button } from '@object-ui/components';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator, Button, ChartSkeleton } from '@object-ui/components';
 import { AlertCircle, ArrowUpRight } from 'lucide-react';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
 
@@ -635,8 +635,23 @@ export const ObjectChart = (props: any) => {
     ...(mergedCategoryColors ? { categoryColors: mergedCategoryColors } : {}),
   };
 
+  // Pending with nothing to draw yet → a chart-shaped skeleton (placeholder
+  // bars), not a 0-value axis or a thin text line. Reads as "loading", never as
+  // an empty/broken chart on the first paint. Once any data is present the chart
+  // renders and a RefreshIndicator covers subsequent refetches.
   if (loading && finalData.length === 0) {
-      return <div className={"flex items-center justify-center text-muted-foreground text-sm p-4 " + (schema.className || '')} data-testid="chart-loading">Loading chart data…</div>;
+      return (
+        <div
+          className={"p-2 " + (schema.className || '')}
+          data-testid="chart-loading"
+          role="status"
+          aria-busy="true"
+          aria-live="polite"
+        >
+          <span className="sr-only">Loading chart data…</span>
+          <ChartSkeleton className="h-full" />
+        </div>
+      );
   }
 
   // Error state — show the error prominently so issues are not hidden

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -38,9 +38,9 @@ import {
   buildDatasetDrillFilter,
   type DatasetResultField,
 } from '@object-ui/core';
-import { cn } from '@object-ui/components';
+import { cn, Skeleton, ChartSkeleton, GridSkeleton } from '@object-ui/components';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
-import { Loader2, BarChart3, AlertTriangle, Download } from 'lucide-react';
+import { BarChart3, AlertTriangle, Download } from 'lucide-react';
 import { resolveDateMacros } from './utils';
 import { DrillDownDrawer } from './DrillDownDrawer';
 
@@ -253,8 +253,38 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   if (values.length === 0) {
     return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground">{tt('dashboard.pickMeasures', 'Pick measures (values) for this dataset widget.')}</div>;
   }
+  // Pending → a SHAPE-MATCHED skeleton, not a 0-value chart or an empty table.
+  // The widget's eventual footprint (chart bars / table rows / a KPI number) is
+  // hinted while `queryDataset` is in flight so the first paint reads as
+  // "loading", never as "broken / empty". Three states stay distinct: this is
+  // loading; `state.rows.length === 0 && status==='ok'` is the empty state
+  // ("No rows" / a KPI 0) handled below; data renders last.
   if (state.status === 'loading' || state.status === 'idle') {
-    return <div className="flex h-full w-full items-center justify-center p-4 text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /></div>;
+    return (
+      <div
+        className="h-full w-full p-2"
+        data-testid="dataset-loading"
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <span className="sr-only">{tt('dashboard.loading', 'Loading…')}</span>
+        {isMetric ? (
+          <div className="flex h-full w-full flex-col items-start justify-center gap-2 p-2">
+            <Skeleton className="h-8 w-32 rounded" />
+            <Skeleton className="h-3 w-20 rounded" />
+          </div>
+        ) : isTable ? (
+          <GridSkeleton
+            className="h-full"
+            rows={5}
+            columns={Math.max(2, dimensions.length + values.length)}
+          />
+        ) : (
+          <ChartSkeleton className="h-full" />
+        )}
+      </div>
+    );
   }
   if (state.status === 'error') {
     return (

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -95,6 +95,46 @@ describe('DatasetWidget', () => {
     expect(src.queryDataset).not.toHaveBeenCalled();
   });
 
+  // ── loading skeleton (three distinct states: loading ≠ empty ≠ data) ──────
+  // A query that never settles keeps the widget in its pending state so we can
+  // assert what the FIRST paint shows. The bug this guards: pending used to read
+  // as empty/0 (a 0-value axis / blank table) instead of "loading".
+  const pendingSource = () => ({ queryDataset: vi.fn(() => new Promise<{ rows: any[] }>(() => {})) });
+
+  it('shows a chart skeleton (not "No rows", not a 0-axis) while a chart query is pending', () => {
+    const src = pendingSource();
+    const { container } = render(<DatasetWidget widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
+    expect(screen.getByTestId('dataset-loading')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="chart-skeleton"]')).toBeInTheDocument();
+    // The empty state must NOT show while loading — that was the bug.
+    expect(screen.queryByText('No rows')).not.toBeInTheDocument();
+  });
+
+  it('shows a row (grid) skeleton while a table query is pending', () => {
+    const src = pendingSource();
+    const { container } = render(<DatasetWidget widget={{ type: 'table', dataset: 'tasks', dimensions: ['status'], values: ['task_count'] }} dataSource={src} />);
+    expect(screen.getByTestId('dataset-loading')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="grid-skeleton"]')).toBeInTheDocument();
+  });
+
+  it('shows a skeleton (not a premature 0) while a metric query is pending', () => {
+    const src = pendingSource();
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'sales', values: ['revenue'] }} dataSource={src} />);
+    expect(screen.getByTestId('dataset-loading')).toBeInTheDocument();
+    // The loading state must not pre-render the empty-metric "0".
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('clears the loading skeleton once the chart query resolves with rows', async () => {
+    const src = makeSource(async () => ({ rows: [{ stage: 'won', revenue: 100 }, { stage: 'lost', revenue: 20 }] }));
+    render(<DatasetWidget widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
+    // Skeleton first…
+    expect(screen.getByTestId('dataset-loading')).toBeInTheDocument();
+    // …then it clears once data arrives (status → ok, rows present).
+    await waitFor(() => expect(screen.queryByTestId('dataset-loading')).not.toBeInTheDocument());
+    expect(screen.queryByText('No rows')).not.toBeInTheDocument();
+  });
+
   it('shows 0 (not "No rows") for a metric over an empty dataset', async () => {
     const src = makeSource(async () => ({ rows: [] }));
     render(<DatasetWidget widget={{ type: 'metric', dataset: 'books', values: ['count'] }} dataSource={src} />);


### PR DESCRIPTION
## Symptom (live, ObjectOS tenant app)

Opening an app's home dashboard, for the ~seconds a `dataset` query is in flight:
- the bar chart shows an **all-zero / empty axis**, then snaps to real data once the query returns;
- a table/list widget shows **blank**, then fills.

There was **no loading affordance**, so the first paint reads as *broken / empty* before it self-heals — it erodes first-impression trust. (This transient "0-then-fill" state previously got misread as a value/label counting bug — see cloud#667 close notes. The real issue is just the missing loading placeholder.)

## Root cause — which component's loading state wasn't (properly) consumed

The three states *were* distinguished already, but the **loading placeholder was too weak to read as "loading"** inside a tall dashboard card:

| Path | File | Before | Problem |
|------|------|--------|---------|
| Dataset-bound dashboard widgets (chart / table / pivot / metric) | [`DatasetWidget.tsx`](packages/plugin-dashboard/src/DatasetWidget.tsx) | a bare centered `Loader2` **16px spinner** for every widget type | a tiny spinner in a 220px+ card reads as empty/broken |
| Object-bound (non-dataset) chart, incl. the chart view | [`ObjectChart.tsx`](packages/plugin-charts/src/ObjectChart.tsx) | a one-line **"Loading chart data…" text** | thin text, not a chart shape |

> Note: the standalone **list/grid view** ([`ListView.tsx`](packages/plugin-list/src/ListView.tsx)) already renders a proper three-state row skeleton (`data-testid="list-loading"`) on initial load — **left unchanged**. On the dashboard, the "list/table" is the `DatasetWidget` table branch, which this PR fixes.

## Change

Render a **shape-matched skeleton** during the pending state, reusing the existing skeletons from `@object-ui/components` (`ChartSkeleton`, `GridSkeleton`, `Skeleton`) — no new primitives:

- **`DatasetWidget`**: `ChartSkeleton` (placeholder bars) for charts · `GridSkeleton` (header + rows) for table/pivot · a KPI skeleton (value + label bars) for metrics. Removed the now-unused `Loader2` import.
- **`ObjectChart`**: `ChartSkeleton` for the object-bound chart path (preserves `data-testid="chart-loading"`).

Three states stay distinct and explicit:
- **loading** → skeleton
- **query done but empty** (`status === 'ok' && rows.length === 0`) → "No rows" / KPI `0` (unchanged)
- **data** → render

a11y: the loading wrappers carry `role="status"`, `aria-busy`, `aria-live`, and an `sr-only` label.

## Verification

- ✅ **objectui full vitest suite green**: `4726 passed | 24 skipped | 0 failed` (354 test files) — no regressions.
- ✅ **4 new `DatasetWidget` tests** (38/38 in that file pass): a never-resolving `queryDataset` holds the widget in `loading` and asserts the **skeleton renders, not the empty/0 state**, for chart / table / metric; plus a loading→data transition once the query resolves.
- ✅ **Build green**: `pnpm --filter "@object-ui/plugin-dashboard..." --filter "@object-ui/plugin-charts..." build` exits 0 (the `TS6059 rootDir` lines are pre-existing dts noise in the unmodified `fields` package).
- ⚠️ **Not done — live browser visual confirmation.** The real loading window on a localhost backend is sub-second, so observing the skeleton "live" would need an artificially slowed dataset query (a framework-side change) plus standing up the `:3000` backend + console. Verification is at the **build + component/unit level**, which exercises the exact pending state deterministically. Honestly flagged rather than half-done.

## After merge

Requires a cloud `.objectui-sha` bump to reach the runtime stack — **not bumped here**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)