### PR TITLE
fix(ai-build): recover the chat composer from a failed send instead of dropping it silently

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1264,6 +1264,13 @@ function ChatPane({
           submit: t('console.ai.submit'),
           uploadFiles: t('console.ai.uploadFiles'),
           stopResponse: t('console.ai.stopResponse'),
+          sendFailedRateLimited: t('console.ai.sendFailedRateLimited', {
+            defaultValue:
+              "You're sending messages too quickly. Your message is kept below — wait a moment and try again.",
+          }),
+          sendFailedGeneric: t('console.ai.sendFailedGeneric', {
+            defaultValue: "Couldn't send your message. It's kept below — please try again.",
+          }),
           trace: t('console.ai.trace'),
           viewTrace: t('console.ai.viewTrace'),
         }}

--- a/packages/app-shell/src/hooks/__tests__/useReconcileOnError.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/useReconcileOnError.test.ts
@@ -62,6 +62,28 @@ describe('useReconcileOnError', () => {
     expect(result.current.errorSuppressed).toBe(false);
   });
 
+  it('notSent failure (429/network) → never suppresses and never re-fetches', async () => {
+    // A request rejected before any reply streamed must SURFACE (composer shows
+    // the error + restores the input). Without the guard a 429 looked like a
+    // completed turn (the thread still ends with the prior assistant reply) and
+    // got silently reconciled away — the reported "message vanished" bug.
+    (isReconcilableCompletedTurn as any).mockReturnValue(true);
+    const setMessages = vi.fn();
+    const { result } = renderHook(() =>
+      useReconcileOnError({ chatApi: API, conversationId: 'c1' }),
+    );
+    result.current.setMessagesRef.current = setMessages;
+
+    const err = Object.assign(new Error('Too Many Requests'), { notSent: true, status: 429 });
+    await act(async () => {
+      await result.current.handleChatError(err);
+    });
+
+    expect(fetchConversation).not.toHaveBeenCalled();
+    expect(setMessages).not.toHaveBeenCalled();
+    expect(result.current.errorSuppressed).toBe(false);
+  });
+
   it('no conversationId → no fetch, never suppresses', async () => {
     const { result } = renderHook(() =>
       useReconcileOnError({ chatApi: API, conversationId: undefined }),

--- a/packages/app-shell/src/hooks/useReconcileOnError.ts
+++ b/packages/app-shell/src/hooks/useReconcileOnError.ts
@@ -50,6 +50,18 @@ export function useReconcileOnError(opts: {
 
   const handleChatError = useCallback(
     async (_err: Error) => {
+      // A request rejected BEFORE any reply streamed (429 rate-limit, 5xx, or a
+      // network failure — tagged `notSent` by sendAwareFetch) never reached the
+      // server: there is no completed turn to reconcile and NOTHING to suppress.
+      // Surfacing it is the whole point — the composer shows the error + restores
+      // the input (useObjectChat already rolled back the optimistic user bubble).
+      // Without this guard, a 429 after a few turns looked like a completed turn
+      // (the thread still ends with the PREVIOUS assistant reply) and got
+      // silently reconciled away — the reported "message vanished, no error".
+      if ((_err as { notSent?: boolean })?.notSent) {
+        setErrorSuppressed(false);
+        return;
+      }
       const aiBase = chatApi?.replace(/\/agents\/[^/]+\/chat$/, '');
       if (!conversationId || !aiBase) {
         setErrorSuppressed(false);

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -135,6 +135,8 @@ function buildChatLocale(
         submit: '发送',
         uploadFiles: '上传文件',
         stopResponse: '停止生成',
+        sendFailedRateLimited: '发送过于频繁，请稍候再试。你的消息已保留在输入框中。',
+        sendFailedGeneric: '消息发送失败，请重试。你的消息已保留在输入框中。',
         trace: '调试 trace',
         viewTrace: '查看调试 trace',
       },
@@ -214,6 +216,9 @@ function buildChatLocale(
       submit: 'Submit',
       uploadFiles: 'Upload files',
       stopResponse: 'Stop response',
+      sendFailedRateLimited:
+        "You're sending messages too quickly. Your message is kept below — wait a moment and try again.",
+      sendFailedGeneric: "Couldn't send your message. It's kept below — please try again.",
       trace: 'trace',
       viewTrace: 'View trace',
     },

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1122,6 +1122,10 @@ const en = {
       conversationReady: 'Conversation ready',
       preparingConversation: 'Preparing a new conversation',
       offlineDemoMode: 'Offline demo mode — agent list unavailable',
+      sendFailedRateLimited:
+        "You're sending messages too quickly. Your message is kept below — wait a moment and try again.",
+      sendFailedGeneric:
+        "Couldn't send your message. It's kept below — please try again.",
       askAgent: 'Ask {{agent}}...',
       assistant: 'Assistant',
       loadingAgents: 'Loading agents...',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1121,6 +1121,8 @@ const zh = {
       conversationReady: '对话已就绪',
       preparingConversation: '正在准备新对话',
       offlineDemoMode: '离线演示模式 — 无法获取助手列表',
+      sendFailedRateLimited: '发送过于频繁，请稍候再试。你的消息已保留在输入框中。',
+      sendFailedGeneric: '消息发送失败，请重试。你的消息已保留在输入框中。',
       askAgent: '向 {{agent}} 提问...',
       assistant: '助手',
       loadingAgents: '正在加载助手...',

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -24,6 +24,8 @@ import { AlertCircle, ArrowRight, Copy, Check, RefreshCw, CornerDownLeft, Bot, E
 import type { ChatStatus } from 'ai';
 import {
   humanizeToolName,
+  isRateLimitError,
+  isUnsentSendError,
   parseAiQuotaError,
   summarizeChatError,
   unwrapToolResult,
@@ -351,6 +353,18 @@ export interface ChatbotLabels {
   uploadFiles?: string;
   /** Accessible label for the stop-streaming button. */
   stopResponse?: string;
+  /**
+   * Inline notice shown when a message couldn't be sent because of rate-limiting
+   * (HTTP 429). The user's text is restored to the composer, so the copy should
+   * reassure them it isn't lost — e.g. "You're sending too quickly — your message
+   * is kept below, wait a moment and try again."
+   */
+  sendFailedRateLimited?: string;
+  /**
+   * Inline notice for any other send failure (network / 5xx). Like
+   * {@link sendFailedRateLimited}, the text is restored, so reassure the user.
+   */
+  sendFailedGeneric?: string;
   /** Trace link label in debug mode. */
   trace?: string;
   /** Trace link tooltip in debug mode. */
@@ -1118,6 +1132,13 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
     const promptStatus: ChatStatus = isLoading ? 'streaming' : 'ready';
     const isPlainSurface = surface === 'plain';
     const [copiedId, setCopiedId] = React.useState<string | null>(null);
+    // Last text submitted from the composer — used to RESTORE it when a send is
+    // rejected before it reaches the model (rate-limit / network), so the user
+    // never loses what they typed. Set on submit, read by the restore effect.
+    const lastSubmittedRef = React.useRef<string>('');
+    // Guards the restore effect so it fires once per failure (not on every
+    // re-render while the error sits in state).
+    const restoredErrorRef = React.useRef<unknown>(null);
 
     // Resolve localizable strings once, English defaults preserved.
     const L = React.useMemo(
@@ -1143,6 +1164,12 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         submit: labels?.submit ?? 'Submit',
         uploadFiles: labels?.uploadFiles ?? 'Upload files',
         stopResponse: labels?.stopResponse ?? 'Stop response',
+        sendFailedRateLimited:
+          labels?.sendFailedRateLimited ??
+          "You're sending messages too quickly. Your message is kept below — wait a moment and try again.",
+        sendFailedGeneric:
+          labels?.sendFailedGeneric ??
+          "Couldn't send your message. It's kept below — please try again.",
         trace: labels?.trace ?? 'trace',
         viewTrace: labels?.viewTrace ?? 'View trace',
         connectionWaiting: labels?.connectionWaiting ?? 'Waiting for server…',
@@ -1371,7 +1398,13 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
           .filter(Boolean) as File[] | undefined;
         const hasFiles = Boolean(files && files.length > 0);
         if (!(hasText || hasFiles)) return;
-        onSendMessage?.(payload.text?.trim() ?? '', files);
+        const text = payload.text?.trim() ?? '';
+        // Remember the text so a rejected send can restore it (the composer's
+        // own form.reset clears the box optimistically). A fresh attempt also
+        // clears any prior send-failure restore guard.
+        lastSubmittedRef.current = text;
+        restoredErrorRef.current = null;
+        onSendMessage?.(text, files);
       },
       [onSendMessage]
     );
@@ -1404,6 +1437,26 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         textarea.scrollIntoView({ block: 'nearest' });
       }
     }, []);
+
+    // Restore the composer text when a send was REJECTED before reaching the
+    // model (rate-limit / network — `notSent`). The composer's own form.reset
+    // clears the box optimistically and the optimistic user bubble was rolled
+    // back (useObjectChat), so without this the typed message would just vanish.
+    // Runs once per failure and never clobbers text the user has since typed.
+    React.useEffect(() => {
+      if (!error || !isUnsentSendError(error)) return;
+      if (restoredErrorRef.current === error) return;
+      restoredErrorRef.current = error;
+      const text = lastSubmittedRef.current;
+      if (!text) return;
+      const textarea = promptInputWrapRef.current?.querySelector('textarea');
+      if (textarea && textarea.value.trim() === '') {
+        textarea.value = text;
+        // Nudge the auto-grow sizing + any onInputChange listener.
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        textarea.focus();
+      }
+    }, [error]);
 
     const handleCopy = React.useCallback((message: ChatMessage) => {
       void navigator.clipboard?.writeText(message.content);
@@ -2406,7 +2459,20 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         </Conversation>
 
         {error ? (
-          <ErrorBanner error={error} onReload={onReload} onUpgrade={onUpgrade} />
+          // A never-sent failure (rate-limit / network) gets a friendly "your
+          // message is kept" notice — the input was restored above, so a
+          // "Response failed / Retry" banner (which regenerates the wrong turn
+          // after rollback) would mislead. Quota 429s still use ErrorBanner so
+          // its upgrade / top-up CTA shows; mid-stream failures keep Retry.
+          isUnsentSendError(error) && !parseAiQuotaError(error) ? (
+            <SendErrorNotice
+              error={error}
+              rateLimitedLabel={L.sendFailedRateLimited}
+              genericLabel={L.sendFailedGeneric}
+            />
+          ) : (
+            <ErrorBanner error={error} onReload={onReload} onUpgrade={onUpgrade} />
+          )
         ) : null}
 
         {readOnly ? null : (
@@ -3296,6 +3362,40 @@ function getToolSummaryStatus(
     case 'completed':
       return labels.toolCompleted;
   }
+}
+
+/**
+ * Inline notice for a message that couldn't be SENT (rejected before reaching
+ * the model — rate-limit 429 / network / 5xx). Distinct from {@link ErrorBanner}
+ * (a streamed response that failed): here the typed text has been restored to
+ * the composer, so the copy reassures the user it isn't lost rather than
+ * offering a Retry that would regenerate the wrong (rolled-back) turn. A
+ * rate-limit gets the "you're sending too quickly" wording; anything else the
+ * generic one.
+ */
+function SendErrorNotice({
+  error,
+  rateLimitedLabel,
+  genericLabel,
+}: {
+  error: Error;
+  rateLimitedLabel: string;
+  genericLabel: string;
+}) {
+  const text = React.useMemo(
+    () => (isRateLimitError(error) ? rateLimitedLabel : genericLabel),
+    [error, rateLimitedLabel, genericLabel],
+  );
+  return (
+    <div className="border-t bg-background px-3 py-2 text-sm" role="alert" data-testid="chat-send-error">
+      <div className="rounded-md border border-amber-300/40 bg-amber-50/60 px-3 py-2 text-foreground dark:bg-amber-950/20">
+        <div className="flex items-start gap-2">
+          <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+          <div className="min-w-0 flex-1 break-words leading-snug">{text}</div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function ErrorBanner({

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.sendError.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.sendError.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Composer send-failure UX: when a message is rejected before it reaches the
+ * model (rate-limit / network — `notSent`), the typed text must be RESTORED to
+ * the box (not silently dropped) and a clear inline notice shown — NOT the
+ * "Response failed / Retry" banner (which would regenerate the rolled-back turn).
+ * A streamed-response error still shows the banner. A clean submit clears the box.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ChatbotEnhanced } from '../ChatbotEnhanced';
+
+const LABELS = {
+  sendFailedRateLimited: 'RATE_LIMIT_MSG',
+  sendFailedGeneric: 'GENERIC_MSG',
+};
+
+/** Tagged error shaped like one from sendAwareFetch. */
+function notSentError(status?: number): Error {
+  const e = new Error(status === 429 ? '{"error":"rate_limited"}' : 'boom') as Error & {
+    notSent?: boolean;
+    status?: number;
+  };
+  e.notSent = true;
+  if (status) e.status = status;
+  return e;
+}
+
+async function submit(text: string, onSendMessage: () => void) {
+  const textarea = screen.getByPlaceholderText('Ask…') as HTMLTextAreaElement;
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.submit(textarea.closest('form')!);
+  // prompt-input calls onSubmit in a microtask (after blob conversion).
+  await waitFor(() => expect(onSendMessage).toHaveBeenCalled());
+  return textarea;
+}
+
+describe('ChatbotEnhanced send-failure UX', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('restores the input and shows a rate-limit notice on a 429 (no Retry banner)', async () => {
+    const onSendMessage = vi.fn();
+    const { rerender } = render(
+      <ChatbotEnhanced placeholder="Ask…" onSendMessage={onSendMessage} labels={LABELS} />,
+    );
+
+    const textarea = await submit('build me a CRM', onSendMessage);
+    expect(onSendMessage.mock.calls[0][0]).toBe('build me a CRM');
+    // The composer optimistically cleared the box on submit…
+    expect(textarea.value).toBe('');
+
+    // …then the send is rejected with a 429.
+    rerender(
+      <ChatbotEnhanced
+        placeholder="Ask…"
+        onSendMessage={onSendMessage}
+        labels={LABELS}
+        error={notSentError(429)}
+      />,
+    );
+
+    // ① input restored, ② clear error shown, and NOT the generic "Response failed" banner.
+    await waitFor(() => expect(textarea.value).toBe('build me a CRM'));
+    expect(screen.getByTestId('chat-send-error')).toHaveTextContent('RATE_LIMIT_MSG');
+    expect(screen.queryByText(/Response failed/i)).not.toBeInTheDocument();
+  });
+
+  it('uses the generic notice for a non-429 not-sent failure (network / 5xx)', async () => {
+    const onSendMessage = vi.fn();
+    const { rerender } = render(
+      <ChatbotEnhanced placeholder="Ask…" onSendMessage={onSendMessage} labels={LABELS} />,
+    );
+    const textarea = await submit('hello there', onSendMessage);
+
+    rerender(
+      <ChatbotEnhanced
+        placeholder="Ask…"
+        onSendMessage={onSendMessage}
+        labels={LABELS}
+        error={notSentError(503)}
+      />,
+    );
+
+    await waitFor(() => expect(textarea.value).toBe('hello there'));
+    expect(screen.getByTestId('chat-send-error')).toHaveTextContent('GENERIC_MSG');
+  });
+
+  it('shows the Response-failed banner (not the send notice) for a streamed-response error', async () => {
+    const onSendMessage = vi.fn();
+    render(
+      <ChatbotEnhanced
+        placeholder="Ask…"
+        onSendMessage={onSendMessage}
+        labels={LABELS}
+        onReload={vi.fn()}
+        error={new Error('stream dropped mid-turn')}
+      />,
+    );
+
+    expect(screen.getByText(/Response failed/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-send-error')).not.toBeInTheDocument();
+  });
+
+  it('a clean submit (no error) leaves the box cleared — text is only kept on failure', async () => {
+    const onSendMessage = vi.fn();
+    render(<ChatbotEnhanced placeholder="Ask…" onSendMessage={onSendMessage} labels={LABELS} />);
+    const textarea = await submit('all good', onSendMessage);
+    // No error prop → nothing restored; the optimistic clear stands.
+    expect(textarea.value).toBe('');
+    expect(screen.queryByTestId('chat-send-error')).not.toBeInTheDocument();
+  });
+});

--- a/packages/plugin-chatbot/src/__tests__/useObjectChat.sendFailure.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/useObjectChat.sendFailure.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression tests for AI-build chat send-failure handling. A rejected chat POST
+ * (429 rate-limit / 5xx / network) used to vanish silently — the input cleared,
+ * no message appeared, no error showed. These lock in the mechanism that makes a
+ * failed send recoverable: the request is tagged (`notSent` + `status`) and the
+ * optimistic user bubble is rolled back, so the composer can restore the text +
+ * surface a clear error, and reconcile-on-error never suppresses it.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { useObjectChat, sendAwareFetch } from '../useObjectChat';
+
+const API = 'https://example.test/api/v1/ai/agents/build/chat';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('sendAwareFetch', () => {
+  it('tags a 429 with status + notSent and preserves the response body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{"error":"rate_limited"}', { status: 429, statusText: 'Too Many Requests' })),
+    );
+    await expect(sendAwareFetch(API)).rejects.toMatchObject({ status: 429, notSent: true });
+    await expect(sendAwareFetch(API)).rejects.toThrow(/rate_limited/);
+  });
+
+  it('tags a 5xx with status + notSent', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('boom', { status: 503 })));
+    await expect(sendAwareFetch(API)).rejects.toMatchObject({ status: 503, notSent: true });
+  });
+
+  it('tags a network failure as notSent (no status)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    );
+    await expect(sendAwareFetch(API)).rejects.toMatchObject({ notSent: true });
+  });
+
+  it('passes a 2xx response through untouched', async () => {
+    const ok = new Response('hi', { status: 200 });
+    vi.stubGlobal('fetch', vi.fn(async () => ok));
+    await expect(sendAwareFetch(API)).resolves.toBe(ok);
+  });
+});
+
+describe('useObjectChat send-failure (API mode)', () => {
+  it('a 429 send calls onError with notSent+status and rolls back the optimistic user message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{"error":"rate_limited"}', { status: 429 })),
+    );
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useObjectChat({ api: API, conversationId: 'c1', onError }),
+    );
+
+    await act(async () => {
+      result.current.sendMessage('please build me an app');
+    });
+
+    await waitFor(() => expect(onError).toHaveBeenCalled());
+    const err = onError.mock.calls[0][0] as { notSent?: boolean; status?: number };
+    expect(err.notSent).toBe(true);
+    expect(err.status).toBe(429);
+
+    // The never-sent turn must NOT linger as a "sent" user bubble.
+    await waitFor(() => {
+      expect(
+        result.current.messages.find((m) => m.content === 'please build me an app'),
+      ).toBeUndefined();
+    });
+  });
+
+  it('a network failure also surfaces a notSent error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    );
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useObjectChat({ api: API, conversationId: 'c1', onError }),
+    );
+
+    await act(async () => {
+      result.current.sendMessage('hi');
+    });
+
+    await waitFor(() => expect(onError).toHaveBeenCalled());
+    expect((onError.mock.calls[0][0] as { notSent?: boolean }).notSent).toBe(true);
+  });
+});

--- a/packages/plugin-chatbot/src/tool-display.test.ts
+++ b/packages/plugin-chatbot/src/tool-display.test.ts
@@ -1,7 +1,52 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import { parseAiQuotaError } from './tool-display';
+import {
+  isRateLimitError,
+  isUnsentSendError,
+  parseAiQuotaError,
+  sendErrorStatus,
+} from './tool-display';
+
+/** Build an error shaped like one from sendAwareFetch. */
+function tagged(status: number | undefined, message = 'x'): Error {
+  const e = new Error(message) as Error & { status?: number; notSent?: boolean };
+  e.notSent = true;
+  if (status) e.status = status;
+  return e;
+}
+
+describe('isUnsentSendError', () => {
+  it('is true only when the error is tagged notSent', () => {
+    expect(isUnsentSendError(tagged(429))).toBe(true);
+    expect(isUnsentSendError(tagged(undefined))).toBe(true);
+    expect(isUnsentSendError(new Error('stream dropped'))).toBe(false);
+    expect(isUnsentSendError(undefined)).toBe(false);
+    expect(isUnsentSendError(null)).toBe(false);
+  });
+});
+
+describe('sendErrorStatus', () => {
+  it('returns the tagged HTTP status when present', () => {
+    expect(sendErrorStatus(tagged(429))).toBe(429);
+    expect(sendErrorStatus(tagged(503))).toBe(503);
+    expect(sendErrorStatus(tagged(undefined))).toBeUndefined();
+    expect(sendErrorStatus(new Error('boom'))).toBeUndefined();
+  });
+});
+
+describe('isRateLimitError', () => {
+  it('detects a 429 via the tagged status', () => {
+    expect(isRateLimitError(tagged(429))).toBe(true);
+    expect(isRateLimitError(tagged(503))).toBe(false);
+  });
+  it('falls back to a message probe when the status was dropped', () => {
+    expect(isRateLimitError(new Error('429 Too Many Requests'))).toBe(true);
+    expect(isRateLimitError(new Error('rate limit exceeded'))).toBe(true);
+    expect(isRateLimitError(new Error('rate_limited'))).toBe(true);
+    expect(isRateLimitError(new Error('internal server error'))).toBe(false);
+  });
+});
 
 describe('parseAiQuotaError', () => {
   const body = (extra: Record<string, unknown>) =>

--- a/packages/plugin-chatbot/src/tool-display.ts
+++ b/packages/plugin-chatbot/src/tool-display.ts
@@ -206,3 +206,39 @@ export function parseAiQuotaError(err: unknown): AiQuotaError | null {
   };
 }
 
+/**
+ * The chat POST was rejected BEFORE any assistant tokens streamed — an HTTP
+ * error (429 rate-limit, 5xx, …) or an outright network failure. `sendAwareFetch`
+ * (useObjectChat) tags these with `notSent: true` because the AI SDK otherwise
+ * surfaces a bare Error that can't be told apart from a mid-stream drop (which
+ * may have completed server-side and is *reconciled*, not retried).
+ *
+ * A "not sent" failure means the user's message never reached the model: the
+ * composer must RESTORE the text and show a clear error instead of silently
+ * dropping it (the rate-limit incident this fixes).
+ */
+export function isUnsentSendError(err: unknown): boolean {
+  return Boolean(
+    err && typeof err === 'object' && (err as { notSent?: unknown }).notSent === true,
+  );
+}
+
+/** HTTP status tagged onto an unsent send failure (e.g. 429), when one was received. */
+export function sendErrorStatus(err: unknown): number | undefined {
+  const status =
+    err && typeof err === 'object' ? (err as { status?: unknown }).status : undefined;
+  return typeof status === 'number' ? status : undefined;
+}
+
+/**
+ * True when a send failure was a rate-limit (HTTP 429), so the composer can show
+ * "you're sending too quickly — wait a moment" rather than a generic failure.
+ * Prefers the tagged status; falls back to a message probe (the AI SDK drops the
+ * status, and older runtimes / proxies phrase 429s in the body).
+ */
+export function isRateLimitError(err: unknown): boolean {
+  if (sendErrorStatus(err) === 429) return true;
+  const raw = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  return /\b429\b|too many requests|rate[\s_-]?limit/i.test(raw);
+}
+

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -13,6 +13,59 @@ import { DefaultChatTransport } from 'ai';
 import { generateUniqueId } from './utils';
 import { uiMessagesToChatMessages } from './mapMessages';
 
+/** An error from {@link sendAwareFetch}: a chat POST rejected before streaming. */
+export interface SendFailure extends Error {
+  /** HTTP status when a response was received (e.g. 429); absent on network errors. */
+  status?: number;
+  /** Always true — the request never produced a reply, so nothing was sent. */
+  notSent?: boolean;
+}
+
+/**
+ * `fetch` for the chat transport that turns a REJECTED request into a tagged
+ * error. The Vercel AI SDK otherwise hands `onError` a bare Error whose message
+ * is the response body and DROPS the HTTP status — so the UI can't tell a 429
+ * rate-limit (nothing streamed: restore the input, say "slow down") apart from a
+ * mid-stream transport drop (the turn may have completed server-side: reconcile
+ * it, don't re-run). We tag:
+ *   - `notSent: true` whenever the POST was rejected (non-2xx) or the network
+ *     failed, i.e. no assistant tokens ever arrived;
+ *   - `status` with the HTTP code when there was a response.
+ * The body text is preserved as the Error message so `parseAiQuotaError` (the
+ * cloud quota guardrail's friendly JSON) keeps working. Exported for tests.
+ */
+export async function sendAwareFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  let response: Response;
+  try {
+    response = await fetch(input, init);
+  } catch (err) {
+    // Network failure: the request never reached the server (or no response came
+    // back), so the message was not sent.
+    const e: SendFailure = err instanceof Error ? err : new Error(String(err));
+    e.notSent = true;
+    throw e;
+  }
+  if (!response.ok) {
+    // Non-2xx (429 rate-limit, 5xx, …): rejected before any reply streamed.
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      /* body unavailable — fall back to status text */
+    }
+    const e: SendFailure = new Error(
+      body || response.statusText || `Request failed with status ${response.status}`,
+    );
+    e.status = response.status;
+    e.notSent = true;
+    throw e;
+  }
+  return response;
+}
+
 /**
  * Stamp a stable per-turn idempotency key (ADR-0013 D1) onto the outgoing
  * request body, derived from the id of the user message that triggered the
@@ -269,6 +322,10 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
     if (!isApiMode) return undefined;
     return new DefaultChatTransport({
       api: api!,
+      // Tag rejected requests (429 rate-limit / 5xx / network) with status +
+      // `notSent` so the composer can restore the input and show a clear error
+      // instead of silently dropping the message (see sendAwareFetch).
+      fetch: sendAwareFetch,
       headers: { ...headers },
       body: {
         ...body,
@@ -290,11 +347,35 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
   }, [isApiMode, api, headers, body, model, systemPrompt, streamingEnabled, conversationId]);
 
   // --- @ai-sdk/react useChat (always called to satisfy Rules of Hooks, but only active in API mode) ---
+  // Ref so `onError` (fired later, async) can reach the live setMessages/messages
+  // without re-creating useChat — needed to roll back the optimistic user bubble.
+  const chatRef = useRef<any>(null);
   const chatResult = useChat({
     transport,
     messages: isApiMode && aiInitialMessages.length > 0 ? (aiInitialMessages as any) : undefined,
-    onError: isApiMode ? (err: Error) => { onError?.(err); } : undefined,
+    onError: isApiMode
+      ? (err: Error) => {
+          // The POST was rejected before any reply streamed (see sendAwareFetch).
+          // The AI SDK keeps the optimistic user message; drop it so a never-sent
+          // turn isn't left looking "sent". The composer restores the text and
+          // surfaces the error; reconcile-on-error leaves it unsuppressed.
+          if ((err as { notSent?: boolean }).notSent) {
+            const chat = chatRef.current;
+            const cur = chat?.messages as Array<{ role?: string }> | undefined;
+            if (
+              chat?.setMessages &&
+              cur &&
+              cur.length > 0 &&
+              cur[cur.length - 1]?.role === 'user'
+            ) {
+              chat.setMessages(cur.slice(0, -1));
+            }
+          }
+          onError?.(err);
+        }
+      : undefined,
   } as any);
+  chatRef.current = chatResult;
 
   // --- Local/legacy mode state ---
   const [localMessages, setLocalMessages] = useState<OuiChatMessage[]>(


### PR DESCRIPTION
## Problem (live-confirmed + network capture)

In the ObjectOS console AI Build chat (`/_console/ai/build/...`), after a few iterations the `POST /api/v1/ai/agents/build/chat` returns **429 (rate-limited)**. The frontend then **silently loses the message**:

- the composer **clears as if the message was sent**,
- but **no message appears**, the agent never replies, and **no error/toast shows**,
- a refresh confirms it was never persisted — the user's typed text is just **gone**, with no idea why.

Any send failure (429 / network / 5xx) hit this silent-loss path; the 429 is just the easiest trigger.

## Root cause (a chain, not one line)

1. **Optimistic clear, no failure handling** — the vendored `PromptInput` clears the textarea on submit (`form.reset()` in `packages/plugin-chatbot/src/elements/prompt-input.tsx`) and the send is fire-and-forget, so nothing restores the text when the request fails.
2. **Status is lost** — the AI SDK transport hands `onError` a bare `Error` whose message is the response body and **drops the HTTP status**, so a 429 is indistinguishable from any other error.
3. **The failure is mis-reconciled away** — `useReconcileOnError` is meant for a *mid-stream transport drop after the turn completed*. On a 429 the server thread still ends with the **previous** assistant reply, so `isReconcilableCompletedTurn` returns `true`: it **re-hydrates the thread (wiping the optimistic bubble) and suppresses the error banner** — exactly the reported "message vanished, no error".

## Fix

- **`sendAwareFetch`** (`useObjectChat.ts`) tags a rejected chat POST with `status` + `notSent`, so a *never-sent* failure is distinguishable from a mid-stream drop (which may have completed server-side → reconcile, don't re-run). Body text is preserved so the quota guardrail's friendly JSON still parses.
- **`useObjectChat`** rolls back the optimistic user bubble on a `notSent` failure (so a never-sent turn isn't left looking "sent").
- **`useReconcileOnError`** surfaces `notSent` failures instead of suppressing them.
- **`ChatbotEnhanced`** **restores the typed text** to the composer and shows a clear, status-aware **inline notice** — friendly "you're sending too quickly" wording for 429, generic otherwise — while keeping the existing upgrade CTA for quota 429s. **Only a confirmed 2xx clears the box.**

Both AI surfaces are fixed (full-page `AiChatPage` + console floating chatbot) since both share `useObjectChat` / `useReconcileOnError` / `ChatbotEnhanced`. New i18n strings (en/zh) for the notice.

## Verification

- **Component / unit (incl. a faithful AI-SDK integration test)** — green:
  - `useObjectChat.sendFailure` uses the **real `@ai-sdk/react` `useChat` + real transport with a mocked `fetch`**: a 429 -> `onError` gets `{ notSent: true, status: 429 }`; the optimistic user message is rolled back; network failures tag `notSent` too; a 2xx passes through.
  - `ChatbotEnhanced.sendError` — after a submit + 429: **input is restored**, the **rate-limit notice shows** (and the generic one for 5xx/network), the **"Response failed/Retry" banner does NOT show**; a clean submit leaves the box cleared.
  - `useReconcileOnError` — `notSent` never suppresses / never re-fetches; existing completed-turn reconcile preserved.
  - `tool-display` — classifier units (`isUnsentSendError` / `sendErrorStatus` / `isRateLimitError`).
  - Full `plugin-chatbot` suite green (**182**); `tsc --noEmit` clean for `plugin-chatbot` + `i18n`; `app-shell` label-to-`ChatbotLabels` contract type-checked (remaining `app-shell` tsc errors are pre-existing unbuilt-workspace-dep noise, none on changed lines).
- **NOT done:** did not stand up the full live stack to reproduce an on-demand 429 (rate limits are timing-dependent and hard to trigger deterministically). The integration test exercises the same `fetch -> 429 -> onError -> reconcile -> composer` chain through the real AI SDK, so the gap is small.

## Unresolved / follow-ups

- The dead `setApiInput('')` optimistic clear in `useObjectChat` is left in place (the console composer is uncontrolled, so it's harmless) to keep the diff focused.
- `Retry-After` from a 429 is not surfaced yet (the notice says "wait a moment" generically).

## Merge note

This is objectui-only. It reaches the runtime stack **only after** cloud bumps `.objectui-sha` — **not** bumped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
