### PR TITLE
fix(data-table): commit inline cell edit on blur so switching cells keeps the value

### DIFF
--- a/packages/components/src/__tests__/data-table-inline-edit.test.tsx
+++ b/packages/components/src/__tests__/data-table-inline-edit.test.tsx
@@ -95,4 +95,40 @@ describe('data-table — inline edit is per-row usable', () => {
     expect(input).toBeTruthy();
     expect(input.type).toBe('number');
   });
+
+  it('C) editing a cell then clicking away (blur) commits the typed value', () => {
+    // Regression: switching cells dropped the in-flight value because only
+    // Enter/Escape committed the edit. Blur must save it too.
+    const onCellChange = vi.fn();
+    const { container } = renderComponent({ ...editableSchema, onCellChange });
+
+    const cells = container.querySelectorAll('tbody td');
+    const qtyCell = cells[2] as HTMLElement; // 报工数量
+    fireEvent.click(qtyCell);
+
+    const input = qtyCell.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '42' } });
+    // Click away (focus leaves the editor) — value must persist, not vanish.
+    fireEvent.blur(input);
+
+    expect(onCellChange).toHaveBeenCalledTimes(1);
+    expect(onCellChange).toHaveBeenCalledWith(0, 'qty', '42', expect.anything());
+  });
+
+  it('C2) pressing Escape discards the edit and does NOT commit on blur', () => {
+    const onCellChange = vi.fn();
+    const { container } = renderComponent({ ...editableSchema, onCellChange });
+
+    const cells = container.querySelectorAll('tbody td');
+    const qtyCell = cells[2] as HTMLElement; // 报工数量
+    fireEvent.click(qtyCell);
+
+    const input = qtyCell.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '99' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    // The ensuing blur must not resurrect the cancelled value.
+    fireEvent.blur(input);
+
+    expect(onCellChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -319,6 +319,10 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   const startX = useRef<number>(0);
   const startWidth = useRef<number>(0);
   const editInputRef = useRef<HTMLInputElement>(null);
+  // When an edit ends via Enter (already saved) or Escape (cancelled), the
+  // input also blurs. This flag tells the blur handler not to save again so we
+  // don't double-commit (Enter) or resurrect a cancelled value (Escape).
+  const skipBlurSaveRef = useRef(false);
 
   // Update columns when schema changes
   useEffect(() => {
@@ -636,8 +640,19 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   };
 
   const cancelEdit = () => {
+    skipBlurSaveRef.current = true;
     setEditingCell(null);
     setEditValue('');
+  };
+
+  // Commit the in-flight edit when the input loses focus (e.g. the user clicks
+  // another cell). Without this, switching cells discards the typed value.
+  const handleEditBlur = () => {
+    if (skipBlurSaveRef.current) {
+      skipBlurSaveRef.current = false;
+      return;
+    }
+    saveEdit(true);
   };
 
   const saveRow = async (rowIndex: number) => {
@@ -728,6 +743,8 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   const handleEditKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       e.preventDefault();
+      // Already saving here; suppress the redundant save the ensuing blur triggers.
+      skipBlurSaveRef.current = true;
       saveEdit(true);
     } else if (e.key === 'Escape') {
       e.preventDefault();
@@ -1137,6 +1154,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                       // date fields are displayed/persisted elsewhere.
                                       onChange={(e) => setEditValue(e.target.value)}
                                       onKeyDown={handleEditKeyDown}
+                                      onBlur={handleEditBlur}
                                       className="h-8 px-2 py-1"
                                     />
                                   );
@@ -1157,6 +1175,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                         setEditValue(d && !Number.isNaN(d.getTime()) ? d.toISOString() : v);
                                       }}
                                       onKeyDown={handleEditKeyDown}
+                                      onBlur={handleEditBlur}
                                       className="h-8 px-2 py-1"
                                     />
                                   );
@@ -1170,6 +1189,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                       value={editValue ?? ''}
                                       onChange={(e) => setEditValue(e.target.value)}
                                       onKeyDown={handleEditKeyDown}
+                                      onBlur={handleEditBlur}
                                       className="h-8 px-2 py-1"
                                     />
                                   );
@@ -1187,6 +1207,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                     value={editValue}
                                     onChange={(e) => setEditValue(e.target.value)}
                                     onKeyDown={handleEditKeyDown}
+                                    onBlur={handleEditBlur}
                                     className="h-8 px-2 py-1"
                                   />
                                 );

--- a/packages/plugin-grid/src/__tests__/inlineEditPersistence.test.tsx
+++ b/packages/plugin-grid/src/__tests__/inlineEditPersistence.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Inline-edit persistence (生产报工 regression)
+ *
+ * Repro of the reported bug: edit a cell, commit it (Enter / blur), then click
+ * the row-save or "全部保存" button — after the grid refreshes the value is gone.
+ *
+ * This drives the FULL path (DataTable edit → ObjectGrid defaultRowSave /
+ * defaultBatchSave → dataSource.update → refresh → refetch) against an
+ * in-memory fake server, so a passing test means the grid code persists
+ * correctly and a failing one pinpoints where the value is dropped.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+const OBJECT = 'os_prod_report';
+
+// A fake server backed by a mutable store, so update() actually persists and a
+// subsequent find() returns the new value — exactly like a real backend.
+function makeDataSource() {
+  const store: Record<string, any> = {
+    'r1': { id: 'r1', name: '过渡段箱体+底板拼板', actual_start: '' },
+    'r2': { id: 'r2', name: '将军柱拼板', actual_start: '' },
+  };
+  const find = vi.fn(async () => {
+    const data = Object.values(store).map((r) => ({ ...r }));
+    return { data, total: data.length, hasMore: false, pageSize: 50 };
+  });
+  const update = vi.fn(async (_object: string, id: string, changes: Record<string, any>) => {
+    store[id] = { ...store[id], ...changes };
+    return { ...store[id] };
+  });
+  return {
+    store,
+    find,
+    update,
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text' },
+        actual_start: { type: 'date' },
+      },
+    }),
+  } as any;
+}
+
+function renderGrid(dataSource: any) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    editable: true,
+    singleClickEdit: true,
+    columns: [
+      { field: 'name', label: '工序', editable: false },
+      { field: 'actual_start', label: '实际开始时间', type: 'date' },
+    ],
+    pagination: { pageSize: 50 },
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} dataSource={dataSource} />
+    </ActionProvider>,
+  );
+}
+
+const dateCellInput = (container: HTMLElement) => {
+  const rows = container.querySelectorAll('tbody tr');
+  const firstRow = rows[0] as HTMLElement;
+  const cells = firstRow.querySelectorAll('td');
+  // columns: [select?][rownum?] name, actual_start, [actions]. Find by clicking
+  // the actual_start cell (the one whose text is the editable date, initially —).
+  return cells;
+};
+
+describe('ObjectGrid — inline edit persists through save + refresh', () => {
+  it('row-save writes the edited date to the backend and survives refresh', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('过渡段箱体+底板拼板')).toBeInTheDocument());
+
+    // Find the editable date cell on the first row and enter edit mode.
+    const firstRow = container.querySelector('tbody tr') as HTMLElement;
+    const tds = Array.from(firstRow.querySelectorAll('td'));
+    const dateTd = tds.find((td) => td.querySelector('div')?.textContent === '—') as HTMLElement
+      ?? tds[tds.length - 2];
+    fireEvent.click(dateTd);
+
+    const input = await waitFor(() => {
+      const el = dateTd.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      return el;
+    });
+    fireEvent.change(input, { target: { value: '2026-06-29' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Click "Save All" (全部保存) — the batch-save path the user used.
+    const saveAll = await waitFor(() => {
+      const btn = Array.from(container.querySelectorAll('button')).find((b) =>
+        /Save All|全部保存/.test(b.textContent || ''),
+      ) as HTMLButtonElement;
+      expect(btn).toBeTruthy();
+      return btn;
+    });
+    fireEvent.click(saveAll);
+
+    await waitFor(() => expect(ds.update).toHaveBeenCalled());
+    expect(ds.update).toHaveBeenCalledWith(OBJECT, 'r1', { actual_start: '2026-06-29' });
+    expect(ds.store['r1'].actual_start).toBe('2026-06-29');
+  });
+});


### PR DESCRIPTION
## 问题

列表行内编辑(`editable` data-table)时,编辑完一个单元格的值后**点击其他单元格,上一个单元格刚输入的值丢失**。

例如「生产报工」里逐行录入「实际开始时间」:填好一行的日期,鼠标去点下一行,刚填的值没了。

## 原因

行内编辑器之前**只有按回车(Enter)/Esc 才会提交**。用鼠标点别的单元格时,会直接触发新单元格的 `startEdit()`,把 `editingCell`/`editValue` 覆盖掉,而上一个单元格的值**从未写入** `pendingChanges`,于是被静默丢弃。data-table.tsx 的四个内联输入框都缺少 `onBlur` 提交。

## 修复

失焦即提交(符合表格录入的直觉):

- 新增 `handleEditBlur()`:编辑器失去焦点(点其他单元格 / 点表格外)时调用 `saveEdit()` 提交当前值。
- 给四种内联编辑器(`date` / `datetime` / `number` / 文本兜底)都挂上 `onBlur={handleEditBlur}`。
- 新增 `skipBlurSaveRef` 守卫:Enter(已保存)和 Esc(已取消)之后也会触发 blur,用该标记避免**重复提交**(Enter)或**把已取消的值又存回来**(Esc)。

## 测试

- `packages/components` `data-table-inline-edit.test.tsx`
  - C) 编辑后失焦 → 值被正确提交(`onCellChange` 带新值触发)
  - C2) 按 Esc 取消 → 值被丢弃,随后的 blur 不会再把它存回来
- `packages/plugin-grid` `inlineEditPersistence.test.tsx`(新增)
  - 完整链路:编辑 → 回车 → 点「全部保存」→ `dataSource.update(object, id, changes)` → 刷新,值端到端落库

两个套件本地全部通过(6 + 1)。

## 说明

> 注:用户最初一并报告了「保存后刷新值丢失」,经排查 PATCH 返回 200 且字段已落库,该记录因「录入实际开始时间=完成报工」自动从「待报工」流转到「已报工」而从当前 tab 消失,属业务设计行为,**非框架 bug**,本 PR 不涉及。