### PR TITLE
fix(ai-build): deliver the empty-state first message instead of dropping it on the conversation-id remount

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -469,6 +469,74 @@ export function matchAiChatShortcut(e: {
   }
 }
 
+/** A composer submission held until the conversation id that will carry it exists. */
+export interface PendingFirstMessage {
+  content: string;
+  files?: File[];
+}
+
+/**
+ * Guards the empty-state FIRST send against the conversation-id remount race.
+ *
+ * On a fresh `/ai/:agent` the composer (and its suggestion chips) go live the
+ * instant the agent resolves — BEFORE `POST /conversations` has minted the id.
+ * `<ChatPane>` is keyed on that id (`…:pending` → `…:<id>`), so the moment it
+ * resolves React UNMOUNTS the pane and mounts a fresh one. A first message
+ * submitted in that window lives inside the doomed pane: its optimistic bubble
+ * is discarded and the just-started `…/chat` request is aborted before it
+ * reaches the wire — so it vanishes silently (input cleared, no bubble, no
+ * error). Distinct from the #2047 path, where `…/chat` WAS sent and failed.
+ *
+ * The fix: when we have a server endpoint but no id yet, stash the send in a ref
+ * the PAGE owns (so it outlives the pane remount) and replay it the moment an id
+ * exists — in the freshly-mounted pane (or in place if no remount happened). A
+ * send made once the id is present (the normal path, and every send after the
+ * first) goes straight through. Local/echo mode (no `chatApi`) also sends
+ * immediately, so the offline-demo bot keeps responding.
+ *
+ * Exported for unit testing.
+ */
+export function useDeferredFirstSend(opts: {
+  /** The chat endpoint — defined once an agent is resolved (server-backed mode). */
+  chatApi: string | undefined;
+  /** The conversation id; undefined while `POST /conversations` is in flight. */
+  conversationId: string | undefined;
+  /** Page-owned stash that OUTLIVES the keyed `<ChatPane>` remount. */
+  pendingRef: React.MutableRefObject<PendingFirstMessage | null>;
+  /** The real send (resetSuppression + sendMessage + onSent). */
+  doSend: (content: string, files?: File[]) => void;
+}): (content: string, files?: File[]) => void {
+  const { chatApi, conversationId, pendingRef, doSend } = opts;
+  const apiMode = Boolean(chatApi);
+
+  // Replay a deferred first message the instant a conversation id exists — in
+  // the freshly-mounted pane after the remount, or in place if none happened.
+  // Clearing the ref before sending makes the replay fire at most once even
+  // though `doSend` (and StrictMode's double-invoke) re-run this effect.
+  useEffect(() => {
+    if (!apiMode || !conversationId) return;
+    const pending = pendingRef.current;
+    if (!pending) return;
+    pendingRef.current = null;
+    doSend(pending.content, pending.files);
+  }, [apiMode, conversationId, pendingRef, doSend]);
+
+  return useCallback(
+    (content: string, files?: File[]) => {
+      // Server-backed, but the id is still being minted: sending now would be
+      // lost — a convId-less `/chat` the server won't persist, or a request torn
+      // down when the pane remounts as the id resolves. Stash it; the effect
+      // above replays it once the id lands.
+      if (apiMode && !conversationId) {
+        pendingRef.current = { content, files };
+        return;
+      }
+      doSend(content, files);
+    },
+    [apiMode, conversationId, pendingRef, doSend],
+  );
+}
+
 export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentProp }: AiChatPageProps = {}) {
   const { user } = useAuth();
   const { t } = useObjectTranslation();
@@ -727,6 +795,12 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     );
   }, [conversationId, initialMessages]);
 
+  // Holds an empty-state first message submitted before the conversation id was
+  // minted. Owned by the PAGE (not the keyed <ChatPane>) so it survives the
+  // remount that the id-resolution triggers; the freshly-mounted pane replays it
+  // via useDeferredFirstSend. See that hook for the full race.
+  const pendingFirstMessageRef = useRef<PendingFirstMessage | null>(null);
+
   const handleSent = useCallback(
     (firstUserMessage?: string) => {
       // New user turn → bump sidebar list so the row's preview/timestamp refreshes.
@@ -866,6 +940,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
             conversationId={conversationId}
             editPackageId={editPackageId}
             initialMessages={initialMessages}
+            pendingFirstMessageRef={pendingFirstMessageRef}
             onSent={handleSent}
             onShare={() => setShareOpen(true)}
             onDebug={() => setDebugOpen(true)}
@@ -942,6 +1017,9 @@ interface ChatPaneProps {
    *  forwarded to the build agent as `context.packageId` to scope it to that app. */
   editPackageId?: string;
   initialMessages: HydratedUIMessage[];
+  /** Page-owned stash for a first message sent before the conversation id resolved
+   *  (survives this pane's id-keyed remount). See {@link useDeferredFirstSend}. */
+  pendingFirstMessageRef: React.MutableRefObject<PendingFirstMessage | null>;
   onSent: (firstUserMessage?: string) => void;
   onShare: () => void;
   /** Opens the Build Doctor drawer (build agent only). */
@@ -962,6 +1040,7 @@ function ChatPane({
   conversationId,
   editPackageId,
   initialMessages,
+  pendingFirstMessageRef,
   onSent,
   onShare,
   onDebug,
@@ -1112,14 +1191,27 @@ function ChatPane({
     },
   });
 
-  const handleSend = useCallback(
+  // The real send, shared by a normal submit and by the deferred-first-message
+  // replay below (resetSuppression → send → onSent, in that order).
+  const doSend = useCallback(
     (content: string, files?: File[]) => {
       resetSuppression();
       sendMessage(content, files);
       onSent(content);
     },
-    [sendMessage, onSent],
+    [resetSuppression, sendMessage, onSent],
   );
+
+  // Guards the empty-state first send against the conversation-id remount race:
+  // a send made before the id is minted is stashed in the page-owned ref and
+  // replayed once the id lands, so the magic-moment first message reliably
+  // reaches `…/chat` instead of being dropped. See useDeferredFirstSend.
+  const handleSend = useDeferredFirstSend({
+    chatApi,
+    conversationId,
+    pendingRef: pendingFirstMessageRef,
+    doSend,
+  });
 
   const headerSlot = (
     <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/50 px-4 pb-2 pt-3 sm:px-6">

--- a/packages/app-shell/src/console/ai/__tests__/useDeferredFirstSend.test.tsx
+++ b/packages/app-shell/src/console/ai/__tests__/useDeferredFirstSend.test.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Regression tests for the AI-build empty-state FIRST-message drop.
+ *
+ * On a fresh `/ai/:agent` the composer goes live before `POST /conversations`
+ * has minted the conversation id, and `<ChatPane>` is keyed on that id — so the
+ * instant it resolves the pane REMOUNTS. A first message submitted in that
+ * window used to die with the doomed pane: its optimistic bubble was discarded
+ * and the just-started `…/chat` request was aborted before it reached the wire,
+ * so the message vanished silently (input cleared, no bubble, no error, no
+ * `…/chat`). The user had to send a second time.
+ *
+ * Distinct from the #2047 path, where `…/chat` WAS sent and then failed
+ * (429/5xx/network) — there is a failure to recover from. Here the send never
+ * happened, so these lock in that `useDeferredFirstSend` STASHES such a send and
+ * REPLAYS it the moment a conversation id exists — including across the pane
+ * remount — so `doSend` (which fires `…/chat`) is reliably invoked and the
+ * message is never dropped.
+ */
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook, render, screen, fireEvent } from '@testing-library/react';
+import { useDeferredFirstSend, type PendingFirstMessage } from '../AiChatPage';
+
+const API = 'https://example.test/api/v1/ai/agents/build/chat';
+
+function setup(initial: { chatApi?: string; conversationId?: string }) {
+  const pendingRef: React.MutableRefObject<PendingFirstMessage | null> = { current: null };
+  const doSend = vi.fn();
+  const { result, rerender } = renderHook(
+    ({ chatApi, conversationId }) =>
+      useDeferredFirstSend({ chatApi, conversationId, pendingRef, doSend }),
+    { initialProps: { chatApi: initial.chatApi, conversationId: initial.conversationId } },
+  );
+  return { result, rerender, pendingRef, doSend };
+}
+
+describe('useDeferredFirstSend', () => {
+  it('defers a send made before the conversation id exists, then replays it once it lands', () => {
+    const { result, rerender, pendingRef, doSend } = setup({ chatApi: API, conversationId: undefined });
+
+    // Empty-state first send: id not minted yet → stash, do NOT send (a send now
+    // would be a convId-less /chat or aborted by the imminent remount).
+    act(() => result.current('please build me a CRM'));
+    expect(doSend).not.toHaveBeenCalled();
+    expect(pendingRef.current).toEqual({ content: 'please build me a CRM', files: undefined });
+
+    // POST /conversations resolved → the stashed message is replayed exactly once.
+    act(() => rerender({ chatApi: API, conversationId: 'c1' }));
+    expect(doSend).toHaveBeenCalledTimes(1);
+    expect(doSend).toHaveBeenCalledWith('please build me a CRM', undefined);
+    expect(pendingRef.current).toBeNull();
+
+    // A later id change (URL mirror / switch) must not re-fire the consumed send.
+    act(() => rerender({ chatApi: API, conversationId: 'c2' }));
+    expect(doSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends straight through when a conversation id is already present', () => {
+    const { result, pendingRef, doSend } = setup({ chatApi: API, conversationId: 'c1' });
+
+    act(() => result.current('second message'));
+    expect(doSend).toHaveBeenCalledTimes(1);
+    expect(doSend).toHaveBeenCalledWith('second message', undefined);
+    expect(pendingRef.current).toBeNull();
+  });
+
+  it('carries file attachments through the deferral', () => {
+    const { result, rerender, pendingRef, doSend } = setup({ chatApi: API, conversationId: undefined });
+    const file = new File(['hi'], 'spec.txt', { type: 'text/plain' });
+
+    act(() => result.current('with a file', [file]));
+    expect(doSend).not.toHaveBeenCalled();
+    expect(pendingRef.current).toEqual({ content: 'with a file', files: [file] });
+
+    act(() => rerender({ chatApi: API, conversationId: 'c1' }));
+    expect(doSend).toHaveBeenCalledWith('with a file', [file]);
+  });
+
+  it('local/echo mode (no chatApi) sends immediately so the offline-demo bot still responds', () => {
+    const { result, pendingRef, doSend } = setup({ chatApi: undefined, conversationId: undefined });
+
+    act(() => result.current('hello echo'));
+    expect(doSend).toHaveBeenCalledWith('hello echo', undefined);
+    expect(pendingRef.current).toBeNull();
+  });
+
+  // The crux of the bug: the stash lives in the PAGE, so it survives the keyed
+  // <ChatPane> remount and the replay fires in the FRESHLY-mounted pane. This
+  // harness mirrors that structure — a parent owns the ref + id, the child is
+  // keyed on the id (so resolving it unmounts/remounts the child).
+  it('replays the first message across the id-keyed pane REMOUNT (reproduces the reported bug)', () => {
+    const pendingRef: React.MutableRefObject<PendingFirstMessage | null> = { current: null };
+    const doSend = vi.fn();
+    let mounts = 0;
+
+    function Pane({ conversationId }: { conversationId: string | undefined }) {
+      React.useEffect(() => {
+        mounts += 1;
+      }, []);
+      const submit = useDeferredFirstSend({ chatApi: API, conversationId, pendingRef, doSend });
+      return (
+        <button data-testid="send" onClick={() => submit('first message')}>
+          send
+        </button>
+      );
+    }
+
+    function Page() {
+      const [conversationId, setConversationId] = React.useState<string | undefined>(undefined);
+      return (
+        <>
+          {/* Keyed exactly like the real <ChatPane>: pending → real id remounts it. */}
+          <Pane key={conversationId ?? 'pending'} conversationId={conversationId} />
+          <button data-testid="resolve" onClick={() => setConversationId('c1')}>
+            resolve
+          </button>
+        </>
+      );
+    }
+
+    render(<Page />);
+    expect(mounts).toBe(1);
+
+    // Submit while the id is still pending → deferred, nothing sent yet.
+    fireEvent.click(screen.getByTestId('send'));
+    expect(doSend).not.toHaveBeenCalled();
+    expect(pendingRef.current).toEqual({ content: 'first message', files: undefined });
+
+    // Conversation id resolves → the pane REMOUNTS, and the new instance replays
+    // the stashed message (this is what used to be silently dropped).
+    fireEvent.click(screen.getByTestId('resolve'));
+    expect(mounts).toBe(2); // proves the remount actually happened
+    expect(doSend).toHaveBeenCalledTimes(1);
+    expect(doSend).toHaveBeenCalledWith('first message', undefined);
+    expect(pendingRef.current).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

In a **brand-new** AI Build session (the empty "Build with AI" placeholder), sending the **first** message silently fails:

- **Network:** `POST /api/v1/ai/conversations → 201` (conversation created), but **no** `POST /api/v1/ai/agents/build/chat` (the message is never sent).
- **UI:** the input is cleared (looks sent), but the thread stays empty — no bubble, no agent response, **no error/toast**.
- **Recovery:** the **second** send works normally. The user loses their very first action at the magic moment.

## Root cause — a conversation-id remount race

On a fresh `/ai/build` the composer (and its suggestion chips) go live the instant the agent resolves — **before** `POST /conversations` has minted the conversation id. [`AiChatPage.tsx`](packages/app-shell/src/console/ai/AiChatPage.tsx) keys `<ChatPane>` on that id:

```tsx
<ChatPane key={`${chatApi ?? 'local'}:${conversationId ?? 'pending'}`} … />
```

So the moment the id resolves (`…:pending` → `…:<id>`), React **unmounts the pane and mounts a fresh one**. A first message submitted in that window lives inside the doomed pane:

- its optimistic user bubble is discarded with the unmount, and
- the just-started `…/agents/build/chat` request is **aborted before it reaches the wire** (the AI SDK's `useChat` aborts on unmount).

The abort is silent (no `onError`), so nothing is restored and the new composer is simply empty → the message vanishes. The second send works because the key is now stable (no remount).

### Why this is **not** #2047
[#2047](https://github.com/objectstack-ai/objectui/pull/2047) fixed the case where `…/chat` **was** sent and then **failed** (429/5xx/network): it tags the request `notSent`, rolls back the optimistic bubble, and restores the composer. Here `…/chat` **never happens**, so there is no failure to recover from and that path never triggers. Different bug, same surface.

## The fix

A small, focused `useDeferredFirstSend` guard (exported from `AiChatPage.tsx`, mirroring the file's existing exported test-helpers):

- When the pane is **server-backed but has no id yet**, a send is **stashed in a ref the _page_ owns** — so it survives the keyed `<ChatPane>` remount — instead of being fired into the void.
- The instant a conversation id exists, an effect **replays** the stashed message **in the freshly-mounted pane**, so `…/chat` is reliably called **with** the conversation id and the message enters the thread.
- A send made once the id is present (the normal path, and every send after the first) goes **straight through**. Local/echo mode (no `chatApi`) also sends immediately, so the offline-demo bot still responds.
- If the replayed send then fails, it follows the existing #2047 recovery path rather than vanishing.

Net effect: `…/chat` is **always** called before the first message can be considered "sent" — the message is never silently dropped.

## Changes
- `packages/app-shell/src/console/ai/AiChatPage.tsx` — add `useDeferredFirstSend` + `PendingFirstMessage`; page owns `pendingFirstMessageRef`; `ChatPane` routes its send through the guard (splitting the old `handleSend` into a reusable `doSend` + the guard).
- `packages/app-shell/src/console/ai/__tests__/useDeferredFirstSend.test.tsx` — new regression suite.

## Verification
- ✅ **New tests reproduce the exact race**, including a **keyed-remount harness** that proves the deferred first message is replayed in the *new* pane (`doSend`, which fires `…/chat`) and is **not** dropped; plus defer→replay-once, immediate-send-when-id-present, file-attachment carry, and local/echo passthrough.
- ✅ All **243** existing ai-chat / `plugin-chatbot` tests stay green (21 files).
- ✅ `@object-ui/app-shell` **type-check clean** (`tsc --noEmit`, exit 0) against built deps; **lint clean** (0 errors; the one `react-refresh/only-export-components` warning matches the file's existing exported-helper pattern).
- ⚠️ **Not** verified in a live browser against a real AI backend: that requires the cloud magic-flow rig (`service-ai` + the build agent + an LLM key; the `scripts/dev-local/MAGIC-FLOW-TEST-RUNBOOK.md` runbook lives in the **cloud** repo), which the objectui Vite preview can't exercise. The integration test is the faithful reproduction of the remount mechanism at the React-tree layer; a live magic-flow repro is the remaining manual check.

## Rollout note
This lives in objectui; it reaches the running stack only after a cloud `.objectui-sha` bump. **Not bumped here** — that's a follow-up after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)