### PR TITLE
feat(detail): relatedLayout 'tabs' — surface related tables as peer tabs via config

### DIFF
--- a/.changeset/related-layout-tabs.md
+++ b/.changeset/related-layout-tabs.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/plugin-detail': minor
+'@object-ui/app-shell': minor
+---
+
+feat(detail): `relatedLayout: 'tabs'` — surface related tables as peer tabs via config
+
+Record detail pages can now show each related table as its own top-level tab
+instead of stacking them all inside a single **Related** tab — no custom page
+required. Set `detail.relatedLayout: 'tabs'` on the object; the synthesized
+record page then emits one tab per related list (label = the related list's
+`title`, falling back to its `objectName`, carrying its `icon`), slotted between
+the **Details** tab and **Activity** / **History**.
+
+- `buildDefaultPageSchema` (`@object-ui/plugin-detail`): new
+  `BuildPageOptions.relatedLayout?: 'stack' | 'tabs'` threaded through
+  `buildDefaultTabs` (the single choke point for the related-tab emission).
+  `'tabs'` fans the related children out into peer tabs; `'stack'` (default)
+  keeps the legacy single **Related** tab — **zero regression** when omitted.
+  Still honours `hideRelatedTab` (no related tabs emitted) in both modes.
+- `RecordDetailView` (`@object-ui/app-shell`): reads
+  `objectDef.detail.relatedLayout` per object and forwards it to the synth.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1748,6 +1748,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
             (objectDef as any)?.detail?.hideReferenceRail === true || undefined,
           hideRelatedTab:
             (objectDef as any)?.detail?.hideRelatedTab === true || undefined,
+          relatedLayout:
+            (objectDef as any)?.detail?.relatedLayout === 'tabs' ? 'tabs' : undefined,
           ...(assignedSlots ? { slots: assignedSlots } : {}),
         });
     return (

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -421,6 +421,90 @@ describe('buildDefaultPageSchema', () => {
         'History',
       ]);
     });
+
+    describe("relatedLayout: 'tabs'", () => {
+      const related = [
+        {
+          objectName: 'task',
+          relationshipField: 'lead_id',
+          title: 'Tasks',
+          limit: 10,
+          icon: 'check',
+        },
+        {
+          objectName: 'note',
+          relationshipField: 'parent_id',
+        },
+      ];
+
+      it("gives each related list its own peer tab instead of one shared Related tab", () => {
+        const page = buildDefaultPageSchema(leadDef, {
+          related,
+          relatedLayout: 'tabs',
+        });
+        const tabs = page.regions[0].components.find(
+          (c: any) => c.type === 'page:tabs',
+        );
+        // Details + one tab per related child (no shared 'Related' tab).
+        expect(tabs.items.map((t: any) => t.label)).toEqual([
+          'Details',
+          'Tasks',
+          'note',
+        ]);
+        const tasksTab = tabs.items[1];
+        expect(tasksTab.icon).toBe('check');
+        expect(tasksTab.children).toHaveLength(1);
+        expect(tasksTab.children[0].type).toBe('record:related_list');
+        expect(tasksTab.children[0].objectName).toBe('task');
+        expect(tasksTab.children[0].relationshipField).toBe('lead_id');
+        expect(tasksTab.children[0].limit).toBe(10);
+        // The second related child (no title) falls back to its objectName.
+        expect(tabs.items[2].children[0].objectName).toBe('note');
+      });
+
+      it("defaults to the stacked 'Related' tab when relatedLayout is omitted", () => {
+        const page = buildDefaultPageSchema(leadDef, { related });
+        const tabs = page.regions[0].components.find(
+          (c: any) => c.type === 'page:tabs',
+        );
+        expect(tabs.items.map((t: any) => t.label)).toEqual([
+          'Details',
+          'Related',
+        ]);
+        expect(tabs.items[1].children).toHaveLength(2);
+      });
+
+      it("still honours hideRelatedTab (no related tabs emitted)", () => {
+        const page = buildDefaultPageSchema(leadDef, {
+          related,
+          relatedLayout: 'tabs',
+          hideRelatedTab: true,
+        });
+        const tabs = page.regions[0].components.find(
+          (c: any) => c.type === 'page:tabs',
+        );
+        expect(tabs.items.map((t: any) => t.label)).toEqual(['Details']);
+      });
+
+      it("keeps Activity / History after the per-table tabs", () => {
+        const page = buildDefaultPageSchema(leadDef, {
+          related,
+          relatedLayout: 'tabs',
+          showActivity: true,
+          history: { entries: [], loading: false },
+        });
+        const tabs = page.regions[0].components.find(
+          (c: any) => c.type === 'page:tabs',
+        );
+        expect(tabs.items.map((t: any) => t.label)).toEqual([
+          'Details',
+          'Tasks',
+          'note',
+          'Activity',
+          'History',
+        ]);
+      });
+    });
   });
 
   describe('slice I — slot overrides', () => {

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -111,6 +111,21 @@ export interface BuildPageOptions {
     icon?: string;
   }>;
   /**
+   * How the related child lists are laid out under the tab strip.
+   *
+   * - `'stack'` (default) — all related lists stack vertically inside a
+   *   single `Related` tab. Preserves the legacy behavior.
+   * - `'tabs'` — each related child gets its OWN tab (label = the child's
+   *   `title`, falling back to `objectName`) instead of sharing one
+   *   `Related` tab. Lets authors surface related tables as peer tabs
+   *   purely via config (per object: `detail.relatedLayout`).
+   *
+   * Ignored when the `Related` tab is suppressed (`hideRelatedTab`).
+   *
+   * @default 'stack'
+   */
+  relatedLayout?: 'stack' | 'tabs';
+  /**
    * When true, emit an Activity tab that renders `record:activity`.
    * The activity renderer fetches its own data via RecordContext.
    */
@@ -370,7 +385,7 @@ export function buildDefaultDetails(
 export function buildDefaultTabs(
   def: ObjectDefLike | undefined,
   options: Pick<BuildPageOptions,
-    'sections' | 'related' | 'showActivity' | 'history' | 'highlightFields' | 'statusField' | 'hideRelatedTab'
+    'sections' | 'related' | 'showActivity' | 'history' | 'highlightFields' | 'statusField' | 'hideRelatedTab' | 'relatedLayout'
   > = {},
 ): any {
   const statusField = options.statusField ?? detectStatusField(def);
@@ -384,18 +399,31 @@ export function buildDefaultTabs(
     Array.isArray(options.related) &&
     options.related.length > 0
   ) {
-    items.push({
-      label: 'Related',
-      children: options.related.map((rel) => ({
-        type: 'record:related_list',
-        title: rel.title,
-        objectName: rel.objectName,
-        relationshipField: rel.relationshipField,
-        ...(rel.columns ? { columns: rel.columns } : {}),
-        ...(rel.limit ? { limit: rel.limit } : {}),
-        ...(rel.icon ? { icon: rel.icon } : {}),
-      })),
+    const relatedNode = (rel: NonNullable<BuildPageOptions['related']>[number]) => ({
+      type: 'record:related_list',
+      title: rel.title,
+      objectName: rel.objectName,
+      relationshipField: rel.relationshipField,
+      ...(rel.columns ? { columns: rel.columns } : {}),
+      ...(rel.limit ? { limit: rel.limit } : {}),
+      ...(rel.icon ? { icon: rel.icon } : {}),
     });
+    if (options.relatedLayout === 'tabs') {
+      // One peer tab per related child, instead of a single shared
+      // `Related` tab that stacks them all vertically.
+      for (const rel of options.related) {
+        items.push({
+          label: rel.title || rel.objectName,
+          ...(rel.icon ? { icon: rel.icon } : {}),
+          children: [relatedNode(rel)],
+        });
+      }
+    } else {
+      items.push({
+        label: 'Related',
+        children: options.related.map(relatedNode),
+      });
+    }
   }
   if (options.showActivity) {
     items.push({ label: 'Activity', children: [{ type: 'record:activity' }] });
@@ -524,6 +552,7 @@ export function buildDefaultPageSchema(
       highlightFields: options.highlightFields,
       statusField: options.statusField,
       hideRelatedTab,
+      relatedLayout: options.relatedLayout,
     });
     // Replace the first tab's children (Details) with the override.
     if (Array.isArray(tabsNode.items) && tabsNode.items.length > 0) {
@@ -539,6 +568,7 @@ export function buildDefaultPageSchema(
       highlightFields: options.highlightFields,
       statusField: options.statusField,
       hideRelatedTab,
+      relatedLayout: options.relatedLayout,
     }));
   }
 


### PR DESCRIPTION
## What

Record detail pages can now render **each related table as its own top-level tab** instead of stacking them all inside a single **Related** tab — configured purely via `detail.relatedLayout: 'tabs'` on the object. No custom page authoring required.

Motivation: users with several related tables (e.g. a master plan with multiple child lists) want them surfaced as peer tabs rather than scrolling one long stacked **Related** tab. Today the only way to get tabbed related lists is to hand-author a `page:tabs` record page.

## How

- **`buildDefaultPageSchema`** (`@object-ui/plugin-detail`) — new `BuildPageOptions.relatedLayout?: 'stack' | 'tabs'`, threaded through `buildDefaultTabs` (the single choke point for related-tab emission):
  - `'tabs'` → fans the related children out into **one peer tab each** (label = the related list's `title`, falling back to `objectName`; carries its `icon`), slotted between **Details** and **Activity** / **History**.
  - `'stack'` (default) → keeps the legacy single **Related** tab. **Zero regression** when the option is omitted.
  - Still honours `hideRelatedTab` (no related tabs emitted) in both modes.
- **`RecordDetailView`** (`@object-ui/app-shell`) — reads `objectDef.detail.relatedLayout` per object and forwards it to the synth (mirrors how `hideRelatedTab` / `showReferenceRail` are read).

## Usage

```ts
// object metadata
detail: {
  relatedLayout: 'tabs',   // each related list becomes its own tab
}
```

## Tests

4 new cases in `buildDefaultPageSchema.test.ts`:
- each related list gets its own peer tab (title fallback to objectName, icon carried)
- defaults to the stacked **Related** tab when `relatedLayout` is omitted
- still honours `hideRelatedTab`
- **Activity** / **History** remain ordered after the per-table tabs

`vitest run` (54 passed) + `turbo type-check` (plugin-detail + app-shell) green. The one preexisting `no-empty` lint error at `RecordDetailView.tsx:191` is unrelated to this change (present on `main`).