### PR TITLE
fix(ai-chat): assistant UX pass — real New chat, ask-fresh/build-resume, Ask/Build tabs, hide single model & single-org, collapse to bottom-left, uniform chat bg

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -24,6 +24,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Tabs,
+  TabsList,
+  TabsTrigger,
   Button,
   ShareDialog,
   Sheet,
@@ -1217,33 +1220,62 @@ function ChatPane({
     <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/50 px-4 pb-2 pt-3 sm:px-6">
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {showAgentLauncher ? (
-          <Select
-            value={activeAgent}
-            onValueChange={(name) => navigate(`/ai/${agentRouteName(name)}`)}
-            disabled={agentsLoading}
-          >
-            <SelectTrigger
-              className="h-7 w-auto min-w-0 border-0 bg-transparent px-1.5 text-xs shadow-none hover:bg-accent focus:ring-0 focus:ring-offset-0 focus-visible:ring-1 focus-visible:ring-border/80 focus-visible:ring-offset-0 sm:min-w-[160px]"
-              data-testid="ai-chat-agent-picker"
-              aria-label={t('console.ai.switchAssistant', { defaultValue: 'Switch assistant' })}
+          agents.length <= 3 ? (
+            // Claude-Code-style segmented switcher (mirrors the floating
+            // assistant) so Ask/Build read as visible peer modes, not a hidden
+            // dropdown. Each tab navigates to that agent's surface. Falls back
+            // to the Select when many custom agents would overflow the header.
+            <Tabs
+              value={activeAgent}
+              onValueChange={(name) => navigate(`/ai/${agentRouteName(name)}`)}
             >
-              <SelectValue placeholder={t('console.ai.chooseAgent', { defaultValue: 'Choose assistant…' })} />
-            </SelectTrigger>
-            <SelectContent align="start">
-              {agents.map((agent) => (
-                <SelectItem key={agent.name} value={agent.name} className="text-xs">
-                  <span className="font-medium">
+              <TabsList
+                className="h-7 gap-0.5 p-0.5"
+                data-testid="ai-chat-agent-picker"
+                aria-label={t('console.ai.switchAssistant', { defaultValue: 'Switch assistant' })}
+              >
+                {agents.map((agent) => (
+                  <TabsTrigger
+                    key={agent.name}
+                    value={agent.name}
+                    disabled={agentsLoading}
+                    title={agent.description || undefined}
+                    className="h-6 px-2.5 text-xs"
+                  >
                     {localizeAgentLabel(t, agent.name, agent.label)}
-                  </span>
-                  {agent.description ? (
-                    <span className="block text-muted-foreground text-[10px] truncate max-w-[260px]">
-                      {agent.description}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          ) : (
+            <Select
+              value={activeAgent}
+              onValueChange={(name) => navigate(`/ai/${agentRouteName(name)}`)}
+              disabled={agentsLoading}
+            >
+              <SelectTrigger
+                className="h-7 w-auto min-w-0 border-0 bg-transparent px-1.5 text-xs shadow-none hover:bg-accent focus:ring-0 focus:ring-offset-0 focus-visible:ring-1 focus-visible:ring-border/80 focus-visible:ring-offset-0 sm:min-w-[160px]"
+                data-testid="ai-chat-agent-picker"
+                aria-label={t('console.ai.switchAssistant', { defaultValue: 'Switch assistant' })}
+              >
+                <SelectValue placeholder={t('console.ai.chooseAgent', { defaultValue: 'Choose assistant…' })} />
+              </SelectTrigger>
+              <SelectContent align="start">
+                {agents.map((agent) => (
+                  <SelectItem key={agent.name} value={agent.name} className="text-xs">
+                    <span className="font-medium">
+                      {localizeAgentLabel(t, agent.name, agent.label)}
                     </span>
-                  ) : null}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+                    {agent.description ? (
+                      <span className="block text-muted-foreground text-[10px] truncate max-w-[260px]">
+                        {agent.description}
+                      </span>
+                    ) : null}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )
         ) : (
           <span className="truncate text-xs font-medium text-foreground/85">
             {activeAgentLabel}

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -900,7 +900,11 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
           onOpenChange={setDebugOpen}
         />
       )}
-      <div className="flex min-h-0 flex-1 w-full bg-muted/20">
+      {/* Uniform `bg-background` across the chat area: the centered chat column
+          is `bg-background`, so a `bg-muted` backdrop here produced a hard
+          seam between the column and its side gutters (read as accidental). The
+          conversations sidebar keeps its own `bg-muted/30` for hierarchy. */}
+      <div className="flex min-h-0 flex-1 w-full bg-background">
         {/* Desktop chats column. The collapse/expand control sits at the
             BOTTOM-LEFT (mirroring the app shell's sidebar toggle) rather than
             intruding into the top navigation bar. Collapsed → a slim rail with

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -835,41 +835,21 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   return (
     <div className="flex h-svh w-full flex-col bg-background" data-testid="ai-chat-page">
       <header className="sticky top-0 z-30 flex h-14 w-full shrink-0 items-center gap-2 border-b bg-background/95 px-2 backdrop-blur sm:px-4">
-        {/* Chat-list toggles are meaningless with no agent/conversations, so
-            hide them in the graceful no-agents state. */}
+        {/* Mobile: open the chats list as a sheet. The DESKTOP collapse toggle
+            is NOT in the top nav — it lives at the bottom-left of the chats
+            column (see below), mirroring the app shell's sidebar toggle. Chat
+            controls are meaningless with no agent, so hide in that state. */}
         {!noAgents && (
-          <>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 shrink-0 md:hidden"
-              onClick={() => setMobileChatsOpen(true)}
-              aria-label={t('console.ai.openChats')}
-              data-testid="ai-chat-mobile-sidebar-trigger"
-            >
-              <PanelLeft className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="hidden h-8 w-8 shrink-0 md:inline-flex"
-              onClick={toggleChatsCollapsed}
-              aria-label={
-                chatsCollapsed
-                  ? t('console.ai.showChats', { defaultValue: 'Show chats' })
-                  : t('console.ai.hideChats', { defaultValue: 'Hide chats' })
-              }
-              title={
-                chatsCollapsed
-                  ? t('console.ai.showChats', { defaultValue: 'Show chats' })
-                  : t('console.ai.hideChats', { defaultValue: 'Hide chats' })
-              }
-              data-testid="ai-chat-collapse-sidebar-trigger"
-              aria-pressed={chatsCollapsed}
-            >
-              {chatsCollapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
-            </Button>
-          </>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 md:hidden"
+            onClick={() => setMobileChatsOpen(true)}
+            aria-label={t('console.ai.openChats')}
+            data-testid="ai-chat-mobile-sidebar-trigger"
+          >
+            <PanelLeft className="h-4 w-4" />
+          </Button>
         )}
         <div className="min-w-0 flex-1">
           <AppHeader variant="home" />
@@ -921,16 +901,45 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
         />
       )}
       <div className="flex min-h-0 flex-1 w-full bg-muted/20">
-        {!chatsCollapsed && (
-          <ConversationsSidebar
-            userId={userId}
-            apiBase={apiBase}
-            activeAgent={activeAgent}
-            refreshKey={refreshKey}
-            titleHints={titleHints}
-            className="hidden w-72 shrink-0 border-r md:flex"
-          />
-        )}
+        {/* Desktop chats column. The collapse/expand control sits at the
+            BOTTOM-LEFT (mirroring the app shell's sidebar toggle) rather than
+            intruding into the top navigation bar. Collapsed → a slim rail with
+            just the expand button; expanded → the list with the toggle in a
+            footer. */}
+        <div className="hidden shrink-0 flex-col border-r md:flex">
+          {!chatsCollapsed && (
+            <ConversationsSidebar
+              userId={userId}
+              apiBase={apiBase}
+              activeAgent={activeAgent}
+              refreshKey={refreshKey}
+              titleHints={titleHints}
+              className="w-72 min-h-0 flex-1 border-r-0"
+            />
+          )}
+          <div className={cn('mt-auto p-2', chatsCollapsed ? 'w-12' : 'w-72 border-t')}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={toggleChatsCollapsed}
+              aria-label={
+                chatsCollapsed
+                  ? t('console.ai.showChats', { defaultValue: 'Show chats' })
+                  : t('console.ai.hideChats', { defaultValue: 'Hide chats' })
+              }
+              title={
+                chatsCollapsed
+                  ? t('console.ai.showChats', { defaultValue: 'Show chats' })
+                  : t('console.ai.hideChats', { defaultValue: 'Hide chats' })
+              }
+              data-testid="ai-chat-collapse-sidebar-trigger"
+              aria-pressed={chatsCollapsed}
+            >
+              {chatsCollapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
+            </Button>
+          </div>
+        </div>
         <main className="flex min-w-0 flex-1 flex-col">
           <ChatPane
             key={`${chatApi ?? 'local'}:${conversationId ?? 'pending'}`}

--- a/packages/app-shell/src/hooks/__tests__/useChatConversation.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useChatConversation.test.tsx
@@ -304,6 +304,98 @@ describe('useChatConversation — forceNew (the sidebar New button)', () => {
   });
 });
 
+// The floating assistant's ASK surface opens a FRESH thread each visit
+// (`resumeMode: 'fresh'`) instead of resuming the last conversation, while
+// avoiding empty-row spam by reusing an untouched cached conversation. Its
+// "New chat" button calls startNew(), which mints a fresh conversation WITHOUT
+// deleting the current one (contrast reset()).
+describe('useChatConversation — resumeMode "fresh" + startNew (the floating ask surface)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reuses an untouched (zero-message) cached conversation rather than minting another', async () => {
+    localStorage.setItem(`${CACHE_PREFIX}:u1`, 'conv-empty');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'conv-empty', messages: [] }));
+
+    const { result } = renderHook(() =>
+      useChatConversation({ userId: 'u1', apiBase: API_BASE, resumeMode: 'fresh' }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.conversationId).toBe('conv-empty');
+    expect(result.current.initialMessages).toEqual([]);
+    // GET only — the empty conversation is reused, NOT a fresh POST (no spam).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE}/conversations/conv-empty`);
+  });
+
+  it('starts a fresh conversation when the cached one was actually used, leaving it in history', async () => {
+    localStorage.setItem(`${CACHE_PREFIX}:u1`, 'conv-used');
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'conv-used',
+          messages: [{ id: 'm1', role: 'user', content: 'an earlier question' }],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 'conv-fresh', messages: [] }));
+
+    const { result } = renderHook(() =>
+      useChatConversation({ userId: 'u1', apiBase: API_BASE, resumeMode: 'fresh' }),
+    );
+
+    await waitFor(() => expect(result.current.conversationId).toBe('conv-fresh'));
+    expect(result.current.initialMessages).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE}/conversations/conv-used`);
+    expect(fetchMock.mock.calls[1][0]).toBe(`${API_BASE}/conversations`);
+    expect((fetchMock.mock.calls[1][1] as RequestInit).method).toBe('POST');
+    // The used conversation is NOT deleted; the cache simply repoints to the new one.
+    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit | undefined)?.method ?? 'GET');
+    expect(methods).not.toContain('DELETE');
+    expect(localStorage.getItem(`${CACHE_PREFIX}:u1`)).toBe('conv-fresh');
+  });
+
+  it('startNew() mints a fresh conversation and switches to it without deleting the current one', async () => {
+    localStorage.setItem(`${CACHE_PREFIX}:u1`, 'conv-current');
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'conv-current',
+          messages: [{ id: 'm1', role: 'user', content: 'hi' }],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 'conv-next', messages: [] }));
+
+    const { result } = renderHook(() =>
+      useChatConversation({ userId: 'u1', apiBase: API_BASE }),
+    );
+    await waitFor(() => expect(result.current.conversationId).toBe('conv-current'));
+
+    await act(async () => {
+      await result.current.startNew();
+    });
+
+    expect(result.current.conversationId).toBe('conv-next');
+    expect(result.current.initialMessages).toEqual([]);
+    expect(localStorage.getItem(`${CACHE_PREFIX}:u1`)).toBe('conv-next');
+    // Crucially: NO delete — the prior thread survives in history.
+    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit | undefined)?.method ?? 'GET');
+    expect(methods).not.toContain('DELETE');
+    expect(fetchMock.mock.calls[1][0]).toBe(`${API_BASE}/conversations`);
+    expect((fetchMock.mock.calls[1][1] as RequestInit).method).toBe('POST');
+  });
+});
+
 // Regression: a cache-fallback reload (server returns no/partial messages →
 // `readMessageCache`) must keep the draft/plan affordance cards, not just the
 // bare tool header. `sanitizeChatMessagesForCache` used to drop the tool

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -54,6 +54,21 @@ export interface UseChatConversationOptions {
    * conversation is created. Ignored while `activeId` is set.
    */
   forceNew?: boolean;
+  /**
+   * How a plain visit (no `activeId`, no `forceNew`) treats the cached
+   * conversation:
+   *   - `'resume'` (default): re-open the last conversation. Right for the full
+   *     `/ai` page and the stateful BUILD surface, where losing an in-progress
+   *     build (staged drafts, the awaiting-confirm plan) is harmful.
+   *   - `'fresh'`: open a clean thread instead. Used by the floating assistant's
+   *     ASK/data surface, where each open should feel new. To avoid littering
+   *     the history (the list endpoint keeps empty rows — there's no prune), an
+   *     UNTOUCHED (zero-message) cached conversation is REUSED rather than
+   *     re-created; a cached conversation that the user actually used is left in
+   *     history and a fresh one is minted.
+   * Ignored when `activeId` or `forceNew` is set.
+   */
+  resumeMode?: 'resume' | 'fresh';
 }
 
 export interface UseChatConversationReturn {
@@ -69,6 +84,13 @@ export interface UseChatConversationReturn {
   isLoading: boolean;
   /** Delete the current conversation + start a fresh one. */
   reset: () => Promise<void>;
+  /**
+   * Start a NEW conversation WITHOUT deleting the current one (the floating
+   * assistant's "New chat" button). Mints a fresh row and switches to it; the
+   * prior thread stays in history (reachable from the `/ai` sidebar). Contrast
+   * with {@link reset}, which deletes the current conversation first.
+   */
+  startNew: () => Promise<void>;
 }
 
 /**
@@ -518,7 +540,7 @@ async function deleteConversation(apiBase: string, id: string): Promise<void> {
 export function useChatConversation(
   options: UseChatConversationOptions,
 ): UseChatConversationReturn {
-  const { userId, scope, apiBase, activeId, forceNew } = options;
+  const { userId, scope, apiBase, activeId, forceNew, resumeMode = 'resume' } = options;
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
   const [initialMessages, setInitialMessages] = useState<HydratedUIMessage[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(Boolean(userId));
@@ -596,15 +618,34 @@ export function useChatConversation(
             const existing = await fetchConversation(apiBase, cached);
             if (cancelled) return;
             if (existing) {
-              setConversationId(existing.id);
               const messages = toUIMessages(existing.messages);
-              setInitialMessages(messages.length > 0 ? messages : readMessageCache(existing.id));
-              resolvedForUserRef.current = userId;
-              resolvedScopeRef.current = scope;
-              return;
+              // 'fresh' (the floating ASK surface): only reuse the cached
+              // conversation while it's untouched — once the user has actually
+              // used it, start a clean thread instead so opening the assistant
+              // feels new. Reusing an empty conversation (rather than minting
+              // another) keeps repeated opens from littering the history with
+              // empty rows. 'resume' (default) re-opens the prior thread.
+              const reuse = resumeMode !== 'fresh' || messages.length === 0;
+              if (reuse) {
+                setConversationId(existing.id);
+                setInitialMessages(
+                  resumeMode === 'fresh'
+                    ? []
+                    : messages.length > 0
+                      ? messages
+                      : readMessageCache(existing.id),
+                );
+                resolvedForUserRef.current = userId;
+                resolvedScopeRef.current = scope;
+                return;
+              }
+              // 'fresh' + a used conversation: fall through to create a fresh
+              // one; the used thread stays in history (writeCache below repoints
+              // the cache to the new conversation).
+            } else {
+              writeCache(key, undefined);
+              writeConversationMessagesCache(cached, []);
             }
-            writeCache(key, undefined);
-            writeConversationMessagesCache(cached, []);
           }
         }
         const fresh = await createConversation(apiBase);
@@ -631,7 +672,7 @@ export function useChatConversation(
     // short-circuit guard, which is governed by the ref. Including it would
     // re-run the effect after we successfully resolved an id.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userId, scope, apiBase, activeId, forceNew]);
+  }, [userId, scope, apiBase, activeId, forceNew, resumeMode]);
 
   const reset = useCallback(async () => {
     if (!userId) return;
@@ -657,8 +698,33 @@ export function useChatConversation(
     }
   }, [conversationId, userId, scope, apiBase]);
 
+  const startNew = useCallback(async () => {
+    if (!userId) return;
+    const key = cacheKey(userId, scope);
+    setIsLoading(true);
+    try {
+      // Mint a fresh conversation and switch to it. The current conversation is
+      // intentionally NOT deleted — it stays in history (reachable from the
+      // `/ai` sidebar), unlike reset(). The remount keyed on `conversationId`
+      // in the host clears the visible thread.
+      const fresh = await createConversation(apiBase);
+      writeCache(key, fresh.id);
+      writeConversationMessagesCache(fresh.id, []);
+      if (!mountedRef.current) return;
+      setConversationId(fresh.id);
+      setInitialMessages([]);
+      resolvedForUserRef.current = userId;
+      resolvedScopeRef.current = scope;
+    } catch {
+      // Keep the current conversation on failure — better than dropping the
+      // user into a broken empty state.
+    } finally {
+      if (mountedRef.current) setIsLoading(false);
+    }
+  }, [userId, scope, apiBase]);
+
   // `resolvedScopeRef` is updated in lockstep with every `setConversationId`
   // (same async tick), so at render time it always describes the scope the
   // current `conversationId` was resolved under.
-  return { conversationId, conversationScope: resolvedScopeRef.current, initialMessages, isLoading, reset };
+  return { conversationId, conversationScope: resolvedScopeRef.current, initialMessages, isLoading, reset, startNew };
 }

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -31,6 +31,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Tabs,
+  TabsList,
+  TabsTrigger,
   Button,
   ShareDialog,
 } from '@object-ui/components';
@@ -564,33 +567,57 @@ function ChatbotInner({
   // design: end users bound to a single agent never see it. `showAgentPicker`
   // is true when AI development is unlocked (catalog serves both ask & build)
   // or forced on; it still needs more than one agent to be a real choice.
-  const headerExtra =
-    showAgentPicker && agents.length > 1 ? (
-      <Select
-        value={activeAgent}
-        onValueChange={onAgentChange}
-        disabled={agentsLoading}
+  //
+  // For the common 2–3 agent case (Ask/Build) render a Claude-Code-style
+  // segmented switcher so BOTH modes are visible at a glance — a dropdown hid
+  // the distinction. Fall back to the compact Select when an env exposes many
+  // custom agents and the inline pills would overflow the header.
+  const isZh = (language ?? '').toLowerCase().startsWith('zh');
+  const headerExtra = !(showAgentPicker && agents.length > 1) ? null : agents.length <= 3 ? (
+    <Tabs value={activeAgent} onValueChange={onAgentChange}>
+      <TabsList
+        className="h-7 gap-0.5 p-0.5"
+        data-testid="floating-chatbot-agent-picker"
       >
-        <SelectTrigger
-          className="h-7 w-[180px] text-xs"
-          data-testid="floating-chatbot-agent-picker"
-        >
-          <SelectValue placeholder="Choose agent..." />
-        </SelectTrigger>
-        <SelectContent align="end">
-          {agents.map((agent: AgentDescriptor) => (
-            <SelectItem key={agent.name} value={agent.name} className="text-xs">
-              <span className="font-medium">{agent.label}</span>
-              {agent.description ? (
-                <span className="block text-muted-foreground text-[10px] truncate max-w-[220px]">
-                  {agent.description}
-                </span>
-              ) : null}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    ) : null;
+        {agents.map((agent: AgentDescriptor) => (
+          <TabsTrigger
+            key={agent.name}
+            value={agent.name}
+            disabled={agentsLoading}
+            title={agent.description || undefined}
+            className="h-6 px-2.5 text-xs"
+          >
+            {localizeAgentLabel(isZh, agent.name, agent.label)}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  ) : (
+    <Select
+      value={activeAgent}
+      onValueChange={onAgentChange}
+      disabled={agentsLoading}
+    >
+      <SelectTrigger
+        className="h-7 w-[180px] text-xs"
+        data-testid="floating-chatbot-agent-picker"
+      >
+        <SelectValue placeholder="Choose agent..." />
+      </SelectTrigger>
+      <SelectContent align="end">
+        {agents.map((agent: AgentDescriptor) => (
+          <SelectItem key={agent.name} value={agent.name} className="text-xs">
+            <span className="font-medium">{agent.label}</span>
+            {agent.description ? (
+              <span className="block text-muted-foreground text-[10px] truncate max-w-[220px]">
+                {agent.description}
+              </span>
+            ) : null}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
 
   // Share-link control. Sits to the left of the panel's built-in
   // fullscreen / close buttons so users can mint a public link without

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -406,6 +406,13 @@ interface ChatbotInnerProps {
    * instead of an empty "welcome" thread.
    */
   initialMessages?: HydratedUIMessage[];
+  /**
+   * Start a brand-new server conversation (the "New chat" button). Mints a
+   * fresh `ai_conversations` row and switches to it — the old thread stays in
+   * history. Without this the button only cleared the local message array while
+   * the next turn kept appending to the SAME conversation server-side.
+   */
+  onNewChat: () => void;
 }
 
 function ChatbotInner({
@@ -422,6 +429,7 @@ function ChatbotInner({
   defaultOpen = false,
   conversationId,
   initialMessages: persistedMessages,
+  onNewChat,
 }: ChatbotInnerProps) {
   const { language } = useObjectTranslation();
   const navigate = useNavigate();
@@ -602,7 +610,7 @@ function ChatbotInner({
           aria-label={locale.newChat}
           title={locale.newChat}
           data-testid="floating-chatbot-new"
-          onClick={clear}
+          onClick={onNewChat}
         >
           <SquarePen className="h-4 w-4" />
         </Button>
@@ -831,15 +839,23 @@ export default function ConsoleFloatingChatbot({
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`
     : undefined;
 
+  // The stateful BUILD surface resumes its in-progress conversation (staged
+  // drafts + the awaiting-confirm plan would otherwise be orphaned on reload);
+  // the ASK/data surface opens a fresh thread each visit (each question is
+  // largely self-contained, and resuming stale data answers is confusing). See
+  // `resumeMode` in useChatConversation.
+  const isBuildAgent = activeAgent ? agentRouteName(activeAgent) === 'build' : false;
+
   // Server-backed conversation. Scoped by agent so each agent gets its own
   // persistent history. Hook is inert until `userId` is provided; without it
   // the FAB continues to work in local-only mode (no persistence). Gate `userId`
   // on the agent being resolved so the conversation binds to the right scope
   // from the first resolve (not a scopeless one during the catalog load).
-  const { conversationId, initialMessages } = useChatConversation({
+  const { conversationId, initialMessages, startNew } = useChatConversation({
     userId: activeAgent ? userId : undefined,
     scope: activeAgent,
     apiBase,
+    resumeMode: isBuildAgent ? 'resume' : 'fresh',
   });
 
   // `key` forces a clean remount whenever the chat endpoint OR the resolved
@@ -862,6 +878,7 @@ export default function ConsoleFloatingChatbot({
       defaultOpen={defaultOpen}
       conversationId={conversationId}
       initialMessages={initialMessages}
+      onNewChat={startNew}
     />
   );
 }

--- a/packages/app-shell/src/layout/WorkspaceSwitcher.tsx
+++ b/packages/app-shell/src/layout/WorkspaceSwitcher.tsx
@@ -4,8 +4,10 @@
  * Header-left organization (workspace) switcher — the standard place users
  * expect "which org am I in / switch org" to live (Linear/Vercel/GitHub style).
  *
- * - Single-org users (the vast majority): just the org name, NO dropdown. There
- *   is nothing to switch to, so a one-item menu would be pure friction.
+ * - Single-org users (the vast majority): render NOTHING. With one org there is
+ *   nothing to switch to and the name isn't actionable, so it's pure chrome —
+ *   the product logo already carries branding / "go home". The switcher is a
+ *   multi-org affordance.
  * - Multi-org users: the active org name + a dropdown to switch orgs inline
  *   (full-page reload so the active-org context refreshes app-wide, mirroring
  *   OrganizationsPage), plus shortcuts to manage members / create a workspace.
@@ -72,18 +74,10 @@ export function WorkspaceSwitcher() {
   // nothing rather than an empty switcher.
   if (!current) return null;
 
-  // Single-org: static label, no dropdown.
-  if (orgList.length <= 1) {
-    return (
-      <span
-        className="ml-2 hidden max-w-[12rem] items-center gap-1.5 sm:inline-flex"
-        data-testid="workspace-name"
-      >
-        <OrgBadge name={current.name} />
-        <span className="truncate text-sm font-medium text-foreground/80">{current.name}</span>
-      </span>
-    );
-  }
+  // Single-org: render nothing. With only one org there's nothing to switch to
+  // and the name carries no actionable meaning, so it's just noise next to the
+  // product logo. The switcher appears only once a second org exists.
+  if (orgList.length <= 1) return null;
 
   const handleSwitch = async (org: AuthOrganization) => {
     if (org.id === current.id) return;

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -2524,7 +2524,10 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     </PromptInputActionMenuContent>
                   </PromptInputActionMenu>
                 ) : null}
-                {models && models.length > 0 ? (
+                {/* Only a real CHOICE warrants a picker: free / single-model
+                    envs (the backend returns one entry) get no dropdown — the
+                    lone model is still sent via `selectedModelId`. */}
+                {models && models.length > 1 ? (
                   <select
                     aria-label={L.model}
                     value={selectedModelId ?? models[0].id}

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -495,6 +495,19 @@ describe('ChatbotEnhanced (AI Elements composition)', () => {
     expect(onModelChange).toHaveBeenCalledWith('claude-3-5-sonnet');
   });
 
+  it('hides the model picker when only one model is offered (no real choice)', () => {
+    // Free / single-model envs return one model — a dropdown with a single
+    // option is pure noise. The lone model is still sent via selectedModelId.
+    render(
+      <ChatbotEnhanced
+        models={[{ id: 'gpt-4o-mini', label: 'GPT-4o mini', provider: 'openai' }]}
+        selectedModelId="gpt-4o-mini"
+        onModelChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByLabelText(/Model/i)).toBeNull();
+  });
+
   // Improvement 1: a propose_blueprint can FINISH without its result parsing
   // into a structured `proposedPlan` (a thin/odd envelope, or a prose proposal).
   // Before, that collapsed into a "Completed" chip and the user was left with


### PR DESCRIPTION
## Problem

The floating FAB assistant (bottom-right) had two conversation bugs reported in prod:

1. **"New chat" was a no-op server-side.** The button called `useObjectChat`'s `clear`, which only empties the local message array — `conversationId` never changed, so the next turn kept appending to the **same** `ai_conversations` row. Old and new messages ended up in one conversation ("点了新聊天，记录都在一起").
2. **Opening the FAB always resumed the previous conversation.** It seeded `useChatConversation` with no intent → read the cached id and replayed the last thread, even for the stateless ask/data surface ("始终显示上次的聊天记录").

## Why per-mode, not a global toggle

`ask` and `build` have **opposite** conversation semantics:

| | ask (data Q&A) | build (magic-flow) |
|---|---|---|
| shape | largely self-contained questions | stateful multi-turn workflow |
| state carried | old answers | seeded packageId, staged drafts, awaiting-confirm plan |
| value of resuming | ~0 (stale data answers confuse) | high — a fresh-on-reload **orphans** an in-progress build |

So: **ask opens fresh, build resumes.**

## Platform constraint that shaped "fresh"

The conversations list endpoint does **not** filter empty conversations, and there's **no prune/TTL** (`@objectstack/service-ai`). So naive create-on-every-open would litter the `/ai` sidebar with empty rows forever. `'fresh'` therefore **reuses an untouched (zero-message) cached conversation** instead of minting another — bounding empty rows to ~1 at a time.

## Changes

**`useChatConversation.ts`**
- add `resumeMode: 'resume' | 'fresh'` (default `'resume'` — full `/ai` page + build unchanged). `'fresh'` opens a clean thread but reuses an empty cached conversation; a used one stays in history and a fresh one is minted.
- add `startNew()`: mint a fresh conversation and switch to it **without deleting** the current one (contrast `reset()`), backing the "New chat" button.

**`ConsoleFloatingChatbot.tsx`**
- build surface → `resumeMode: 'resume'`; ask/data + custom agents → `'fresh'`.
- "New chat" button now calls `startNew()` (was local `clear`).

## Tests

3 new cases (reuse-empty vs mint-fresh under `'fresh'`; `startNew()` creates without deleting) — **19/19 pass**. Changed files typecheck clean.

## Rollout (follow-ups, not in this PR)

objectui merge → framework `.objectui-sha` bump (rebuilds `console/dist`) → cloud pin bump → deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)