### PR TITLE
feat(cloud): state-aware onboarding next-step widget for the Welcome page

### DIFF
--- a/.changeset/cloud-onboarding-next-widget.md
+++ b/.changeset/cloud-onboarding-next-widget.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/app-shell': minor
+---
+
+feat(cloud): state-aware onboarding next-step widget for the Cloud Welcome page
+
+The Cloud control-plane Welcome page is static SDUI, but the most useful thing it
+can show — "what do I do next?" — depends on live state the metadata can't carry:
+does the caller's org already have its production environment? New signups are
+auto-provisioned one, so a static "Step 1: create an environment" is wrong for
+most first-time users.
+
+Add `cloud:onboarding-next`, a registered SDUI widget that resolves
+`hasProductionEnv` from the same org-scoped `/cloud/environment-entitlements`
+endpoint the environment list uses, and renders the right primary action:
+
+- no production env → **Create your environment** (the real first step);
+- has production env → **Open Production** (full-page nav that follows the SSO
+  302 into the env) + **Manage environments**;
+- loading → a neutral skeleton (no CTA flash / layout jump);
+- unknown / error → degrades to the open-production actions, so the button
+  always works.
+
+Routes and the SSO endpoint come from the page metadata (`properties`), so the
+Cloud app owns its URLs and copy; the widget owns only the state logic.

--- a/packages/app-shell/src/console/home/CloudOnboardingNext.tsx
+++ b/packages/app-shell/src/console/home/CloudOnboardingNext.tsx
@@ -1,0 +1,173 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * CloudOnboardingNext — the state-aware "next step" block for the Cloud
+ * control-plane Welcome page, registered as the SDUI widget
+ * `cloud:onboarding-next`.
+ *
+ * The Welcome page is otherwise static SDUI, but the single most useful thing
+ * it can show — "what do I do next?" — depends on live state the metadata can't
+ * carry: does the caller's org already have its production environment? New
+ * signups are auto-provisioned one, so a static "Step 1: create an environment"
+ * is wrong for most first-time users. This widget resolves that one signal from
+ * the same `/cloud/environment-entitlements` endpoint the environment list uses
+ * and renders the right primary action:
+ *
+ *   • has production env  → "Open Production" (the doorway into the env, where
+ *                            building happens) + a "Manage environments" link.
+ *   • no production env   → "Create your environment" (the real first step).
+ *   • loading             → a neutral skeleton (no CTA flashes / layout jump).
+ *   • unknown / error     → degrade to BOTH actions, so the button always works.
+ *
+ * Routes and the "Open Production" endpoint come from the page metadata
+ * (`properties`) so the Cloud app owns its URLs; this component owns only the
+ * state logic. It mirrors `useEnvironmentEntitlements`' authoritative summary
+ * fetch (org-scoped GET) without its list-only gating.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Skeleton } from '@object-ui/components';
+import { Rocket, Plus, Settings2 } from 'lucide-react';
+import { useAuth } from '@object-ui/auth';
+import { createAuthenticatedFetch } from '@object-ui/auth';
+import { ComponentRegistry } from '@object-ui/core';
+
+/** Inline {en,zh} copy resolved against the active locale. */
+type I18n = { en: string; zh: string };
+
+interface CloudOnboardingNextProps {
+  properties?: {
+    /** Backend SSO-open endpoint (full-page nav that 302s into the prod env). */
+    openProductionUrl?: string;
+    /** SPA route to the environments list (create / open / manage). */
+    environmentsRoute?: string;
+  };
+}
+
+type Resolved =
+  | { phase: 'loading' }
+  | { phase: 'ready'; hasProductionEnv: boolean }
+  | { phase: 'unknown' };
+
+const DEFAULT_OPEN_PRODUCTION_URL = '/api/v1/cloud/environments/production/sso-open';
+const DEFAULT_ENVIRONMENTS_ROUTE = '/apps/cloud_control/sys_environment';
+
+/** Resolve the active locale's string (cheap; the page uses {en,zh} pairs). */
+function pick(label: I18n): string {
+  const lang =
+    (typeof document !== 'undefined' && document.documentElement.getAttribute('lang')) || 'en';
+  return lang.toLowerCase().startsWith('zh') ? label.zh : label.en;
+}
+
+/**
+ * Resolve `hasProductionEnv` from the org-scoped entitlements summary. Returns
+ * `unknown` on any failure so the caller degrades gracefully rather than
+ * blocking the user behind a wrong "create" CTA.
+ */
+function useProductionEnvState(): Resolved {
+  const { activeOrganization } = useAuth();
+  const orgId = activeOrganization?.id;
+  const authFetch = useMemo(() => createAuthenticatedFetch(), []);
+  const [state, setState] = useState<Resolved>({ phase: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    const apiBase = ((import.meta as any).env?.VITE_SERVER_URL || '').replace(/\/+$/, '');
+    const qs = orgId ? `?organizationId=${encodeURIComponent(orgId)}` : '';
+    (async () => {
+      try {
+        const res = await authFetch(`${apiBase}/api/v1/cloud/environment-entitlements${qs}`, {
+          method: 'GET',
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error(`entitlements ${res.status}`);
+        const json = await res.json().catch(() => null);
+        const data = (json?.data ?? json) as { hasProductionEnv?: boolean } | null;
+        if (cancelled) return;
+        if (!data || typeof data !== 'object') {
+          setState({ phase: 'unknown' });
+          return;
+        }
+        setState({ phase: 'ready', hasProductionEnv: data.hasProductionEnv === true });
+      } catch {
+        if (!cancelled) setState({ phase: 'unknown' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authFetch, orgId]);
+
+  return state;
+}
+
+/** Full-page nav to the backend SSO endpoint so the browser follows its 302. */
+function openProduction(url: string) {
+  window.location.href = url;
+}
+
+export function CloudOnboardingNext({ properties }: CloudOnboardingNextProps) {
+  const navigate = useNavigate();
+  const state = useProductionEnvState();
+  const openUrl = properties?.openProductionUrl || DEFAULT_OPEN_PRODUCTION_URL;
+  const envsRoute = properties?.environmentsRoute || DEFAULT_ENVIRONMENTS_ROUTE;
+
+  // Loading — a neutral skeleton sized like the button row, so the hero doesn't
+  // jump when the real CTA lands.
+  if (state.phase === 'loading') {
+    return (
+      <div className="flex flex-wrap items-center justify-center gap-3" data-onboarding="loading">
+        <Skeleton className="h-11 w-44 rounded-md" />
+        <Skeleton className="h-11 w-44 rounded-md" />
+      </div>
+    );
+  }
+
+  const hint: I18n =
+    state.phase === 'ready' && !state.hasProductionEnv
+      ? {
+          en: 'Spin up your first environment — a private workspace with its own URL, database, and plan. Building happens inside it.',
+          zh: '创建你的第一个环境——一个独立的工作区,有自己的网址、数据库和套餐。应用的搭建在里面进行。',
+        }
+      : {
+          en: 'Your production environment is ready. Open it to build and run your apps — that all happens inside the environment.',
+          zh: '你的生产环境已就绪。打开它来搭建和运行应用——这些都在环境内部进行。',
+        };
+
+  // No production env yet → the real first step is "create", not "open".
+  const showCreatePrimary = state.phase === 'ready' && !state.hasProductionEnv;
+
+  return (
+    <div className="flex flex-col items-center gap-3" data-onboarding={state.phase}>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        {showCreatePrimary ? (
+          <Button size="lg" onClick={() => navigate(envsRoute)}>
+            <Plus className="mr-2 h-4 w-4" />
+            {pick({ en: 'Create your environment', zh: '创建你的环境' })}
+          </Button>
+        ) : (
+          <Button size="lg" onClick={() => openProduction(openUrl)}>
+            <Rocket className="mr-2 h-4 w-4" />
+            {pick({ en: 'Open Production', zh: '打开生产环境' })}
+          </Button>
+        )}
+        <Button size="lg" variant="secondary" onClick={() => navigate(envsRoute)}>
+          <Settings2 className="mr-2 h-4 w-4" />
+          {pick({ en: 'Manage environments', zh: '管理环境' })}
+        </Button>
+      </div>
+      <p className="max-w-xl text-center text-sm text-muted-foreground">{pick(hint)}</p>
+    </div>
+  );
+}
+
+// SDUI registration — the Cloud Welcome page references this widget by type.
+ComponentRegistry.register('cloud:onboarding-next', (props: CloudOnboardingNextProps) => (
+  <CloudOnboardingNext {...props} />
+), {
+  namespace: 'app-shell',
+  label: 'Cloud Onboarding Next-Step',
+  category: 'plugin',
+  inputs: [],
+});

--- a/packages/app-shell/src/console/home/__tests__/CloudOnboardingNext.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/CloudOnboardingNext.test.tsx
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * CloudOnboardingNext resolves `hasProductionEnv` from the entitlements summary
+ * and shows the right primary next-step: "Create your environment" when the org
+ * has none, "Open Production" once it does, and a graceful both-actions fallback
+ * when the signal can't be resolved.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+const navigateMock = vi.fn();
+let fetchImpl: (url: string, init?: any) => Promise<any>;
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ activeOrganization: { id: 'org_1' } }),
+  createAuthenticatedFetch: () => (url: string, init?: any) => fetchImpl(url, init),
+}));
+
+import { CloudOnboardingNext } from '../CloudOnboardingNext';
+
+function summary(hasProductionEnv: boolean) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ data: { hasProductionEnv } }),
+  };
+}
+
+const PROPS = {
+  properties: {
+    openProductionUrl: '/api/v1/cloud/environments/production/sso-open',
+    environmentsRoute: '/apps/cloud_control/sys_environment',
+  },
+};
+
+describe('CloudOnboardingNext', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+  });
+
+  it('shows "Create your environment" when the org has no production env', async () => {
+    fetchImpl = async () => summary(false);
+    render(<CloudOnboardingNext {...PROPS} />);
+
+    const create = await screen.findByText('Create your environment');
+    expect(create).toBeTruthy();
+    expect(screen.queryByText('Open Production')).toBeNull();
+
+    fireEvent.click(create);
+    expect(navigateMock).toHaveBeenCalledWith('/apps/cloud_control/sys_environment');
+  });
+
+  it('shows "Open Production" once the org has a production env', async () => {
+    fetchImpl = async () => summary(true);
+    render(<CloudOnboardingNext {...PROPS} />);
+
+    expect(await screen.findByText('Open Production')).toBeTruthy();
+    expect(screen.queryByText('Create your environment')).toBeNull();
+  });
+
+  it('degrades to the open-production actions when the signal cannot be resolved', async () => {
+    fetchImpl = async () => ({ ok: false, status: 500, json: async () => null });
+    render(<CloudOnboardingNext {...PROPS} />);
+
+    // Unknown state is fail-safe: it must NEVER strand a real user behind a
+    // wrong "create" CTA, so it shows Open Production + Manage environments.
+    expect(await screen.findByText('Open Production')).toBeTruthy();
+    expect(screen.getByText('Manage environments')).toBeTruthy();
+    expect(screen.queryByText('Create your environment')).toBeNull();
+  });
+
+  it('renders a non-CTA skeleton while the signal is still loading', async () => {
+    let resolveFetch: (v: any) => void = () => {};
+    fetchImpl = () => new Promise((r) => { resolveFetch = r; });
+    const { container } = render(<CloudOnboardingNext {...PROPS} />);
+
+    // Before the fetch resolves: no CTA text, just the skeleton placeholder.
+    expect(screen.queryByText('Open Production')).toBeNull();
+    expect(screen.queryByText('Create your environment')).toBeNull();
+    expect(container.querySelector('[data-onboarding="loading"]')).toBeTruthy();
+
+    resolveFetch(summary(true));
+    await waitFor(() => expect(screen.getByText('Open Production')).toBeTruthy());
+  });
+});

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -211,6 +211,8 @@ import './services/builtinComponents';
 // SDUI widget for the metadata-driven Cloud Connection page (cloud ADR-0008).
 import './console/cloud-connection/CloudConnectionPanel';
 import './console/marketplace/InstalledListWidget';
+// SDUI widget for the Cloud Welcome page's state-aware onboarding next-step.
+import './console/home/CloudOnboardingNext';
 
 // Phase 3c — generic metadata admin engine. Re-exported so plugins
 // can call `registerMetadataResource()` to override the per-type


### PR DESCRIPTION
## Why

The Cloud control-plane Welcome page (`cloud#632`) is static SDUI. The single most useful thing it can show — "what do I do next?" — depends on **live state the metadata can't carry**: does the caller's org already have its production environment? New signups are auto-provisioned one, so the static "Step 1: create an environment" strip is wrong for most first-time users (they already have an env; the real next step is *open it and build*).

## What

Adds `cloud:onboarding-next`, a registered SDUI widget (`packages/app-shell/src/console/home/CloudOnboardingNext.tsx`) that resolves `hasProductionEnv` from the same org-scoped `GET /cloud/environment-entitlements` summary the environment list uses (`useEnvironmentEntitlements`), and renders the right primary action:

- **no production env** → "Create your environment" (the real first step)
- **has production env** → "Open Production" (full-page nav that follows the SSO 302 into the env) + "Manage environments"
- **loading** → a neutral skeleton (no CTA flash / layout jump)
- **unknown / error** → degrades to the open-production actions, so the button always works

Routes and the SSO endpoint are passed in via page metadata (`properties.openProductionUrl`, `properties.environmentsRoute`), so the Cloud app owns its URLs and copy; the widget owns only the state logic. Registered via `ComponentRegistry.register` + side-effect import in `app-shell/index.ts`, mirroring `marketplace:installed-list`.

The companion cloud PR wires the Welcome page (`welcome.page.ts`) to reference this widget and bumps `.objectui-sha`.

## Test

`packages/app-shell/src/console/home/__tests__/CloudOnboardingNext.test.tsx` — 4 cases (create vs open vs degraded-fallback vs loading-skeleton), all green. `tsc --noEmit` clean for the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)