### PR TITLE
fix(build): resolve @object-ui/sdui-parser in CI (alias to src)

### DIFF
--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -64,6 +64,7 @@ const isCI = !!(process.env.VERCEL || process.env.CI);
 const workspaceAliases: Record<string, string> = {
   '@object-ui/components': path.resolve(__dirname, '../../packages/components/src'),
   '@object-ui/core': path.resolve(__dirname, '../../packages/core/src'),
+  '@object-ui/sdui-parser': path.resolve(__dirname, '../../packages/sdui-parser/src'),
   '@object-ui/fields': path.resolve(__dirname, '../../packages/fields/src'),
   '@object-ui/layout': path.resolve(__dirname, '../../packages/layout/src'),
   '@object-ui/plugin-dashboard': path.resolve(__dirname, '../../packages/plugin-dashboard/src'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,8 @@
       "@object-ui/types/*": ["packages/types/src/*"],
       "@object-ui/core": ["packages/core/src"],
       "@object-ui/core/*": ["packages/core/src/*"],
+      "@object-ui/sdui-parser": ["packages/sdui-parser/src"],
+      "@object-ui/sdui-parser/*": ["packages/sdui-parser/src/*"],
       "@object-ui/protocol": ["packages/core/src"],
       "@object-ui/protocol/*": ["packages/core/src/*"],
       "@object-ui/engine": ["packages/engine/src"],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -82,6 +82,7 @@ export default defineConfig({
     alias: {
       '@object-ui/i18n': path.resolve(__dirname, './packages/i18n/src'),
       '@object-ui/core': path.resolve(__dirname, './packages/core/src'),
+      '@object-ui/sdui-parser': path.resolve(__dirname, './packages/sdui-parser/src'),
       '@object-ui/types/zod': path.resolve(__dirname, './packages/types/src/zod/index.zod.ts'),
       '@object-ui/types': path.resolve(__dirname, './packages/types/src'),
       '@object-ui/react': path.resolve(__dirname, './packages/react/src'),


### PR DESCRIPTION
**Hotfix for main.** #2056 (auto-)merged while Build/E2E + Test were red — those checks aren't required by branch protection, so auto-merge didn't gate on them. Root cause: `packages/components/src/renderers/layout/page.tsx` imports `@object-ui/sdui-parser`, but the new package wasn't added to the workspace `src` alias maps, so vitest and the console vite build couldn't resolve it (364 suites + E2E failed).

Adds `@object-ui/sdui-parser → packages/sdui-parser/src` to `vitest.config.mts`, `apps/console/vite.config.ts`, and `tsconfig.json` — mirroring `@object-ui/core`. Verified: a previously-failing console suite now passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)