### PR TITLE
feat(core): curated PUBLIC block contract (ADR-0080 M5)

### DIFF
--- a/.changeset/sdui-public-tier.md
+++ b/.changeset/sdui-public-tier.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/core": minor
+---
+
+ADR-0080 M5: curated PUBLIC block contract (capability ≠ contract). Adds `PUBLIC_BLOCKS` — the single, reviewable list of ~36 object-aware + layout/content blocks that form the AI/contract surface (Salesforce-App-Builder-shaped). `getPublicConfigs()` now returns the curated set (plus any `tier:'public'` opt-in), keyed by bare tag and deduped across the registry's dual-key registrations. The full ~244 registered types remain a rendering capability.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@
 
 export type { SchemaNode, ComponentRendererProps } from './types/index.js';
 export * from './registry/Registry.js';
+export * from './registry/public-blocks.js';
 export * from './registry/PluginSystem.js';
 export * from './registry/PluginScopeImpl.js';
 export * from './registry/WidgetRegistry.js';

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -7,6 +7,7 @@
  */
 
 import type { SchemaNode } from '../types/index.js';
+import { PUBLIC_BLOCKS } from './public-blocks.js';
 
 export type ComponentRenderer<T = any> = T;
 
@@ -354,7 +355,25 @@ export class Registry<T = any> {
    * of the full rendering capability returned by {@link getAllConfigs}.
    */
   getPublicConfigs(): ComponentConfig<T>[] {
-    return Array.from(this.components.values()).filter((c) => c.tier === 'public');
+    // Dedupe by the config's canonical (namespaced) `type` — a component is
+    // registered under both a bare and a namespaced key pointing at the same
+    // canonical type, and we want one contract entry per component.
+    const seenCanonical = new Set<string>();
+    const out: ComponentConfig<T>[] = [];
+    const add = (tag: string, cfg: ComponentConfig<T> | undefined): void => {
+      if (!cfg || seenCanonical.has(cfg.type)) return;
+      seenCanonical.add(cfg.type);
+      // The contract surface is keyed by the bare/curated tag authors write,
+      // not the namespaced canonical stored on the config.
+      out.push({ ...cfg, type: tag });
+    };
+    // Curated contract list first (stable, reviewable order) …
+    for (const tag of PUBLIC_BLOCKS) add(tag, this.getConfig(tag));
+    // … plus any bare registration that opted in explicitly via `tier: 'public'`.
+    for (const [key, cfg] of this.components.entries()) {
+      if (cfg.tier === 'public' && !key.includes(':')) add(key, cfg);
+    }
+    return out;
   }
   
   /**

--- a/packages/core/src/registry/__tests__/public-tier.test.ts
+++ b/packages/core/src/registry/__tests__/public-tier.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { Registry } from '../Registry.js';
+import { PUBLIC_BLOCKS, PUBLIC_BLOCK_SET } from '../public-blocks.js';
+
+const C = () => null;
+
+describe('getPublicConfigs — ADR-0080 curated public tier (capability ≠ contract)', () => {
+  it('returns registered curated blocks + tier:public opt-ins, keyed by bare tag, deduped', () => {
+    const r = new Registry();
+    r.register('flex', C, { namespace: 'ui' });                  // curated
+    r.register('object-grid', C, { namespace: 'plugin-grid' });  // curated, dual-key
+    r.register('studio-admin', C, { namespace: 'app-shell' });   // capability only
+    r.register('my-widget', C, { namespace: 'x', tier: 'public' }); // explicit opt-in
+
+    const types = r.getPublicConfigs().map((c) => c.type).sort();
+    expect(types).toContain('flex');
+    expect(types).toContain('object-grid');
+    expect(types).toContain('my-widget');        // opt-in surfaces
+    expect(types).not.toContain('studio-admin'); // capability, not contract
+    // bare tag, not namespaced; no duplicates from dual-key registration
+    expect(types.filter((t) => t === 'object-grid')).toHaveLength(1);
+    expect(types.some((t) => t.includes(':'))).toBe(false);
+  });
+
+  it('skips curated tags that are not registered (aspirational-safe list)', () => {
+    const r = new Registry();
+    r.register('card', C, { namespace: 'ui' });
+    expect(r.getPublicConfigs().map((c) => c.type)).toEqual(['card']);
+  });
+
+  it('PUBLIC_BLOCKS is duplicate-free and matches its set', () => {
+    expect(new Set(PUBLIC_BLOCKS).size).toBe(PUBLIC_BLOCKS.length);
+    expect(PUBLIC_BLOCK_SET.size).toBe(PUBLIC_BLOCKS.length);
+  });
+});

--- a/packages/core/src/registry/public-blocks.ts
+++ b/packages/core/src/registry/public-blocks.ts
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0080 — the curated PUBLIC block contract (capability ≠ contract).
+ *
+ * The subset of registered components that form the platform's *contract* and
+ * AI-authoring vocabulary: type-checked, api-surface-ratcheted, documented, and
+ * offered to the JSX-source authoring surface. The full ~244 registered types
+ * remain a rendering *capability* (`getAllConfigs`); only these are the
+ * contract (`getPublicConfigs`).
+ *
+ * Shaped like Salesforce App Builder standard components — small, object-centric
+ * — plus a thin layout/content layer and one escape hatch. A component not yet
+ * registered is simply skipped (the list is aspirational-safe). Registrations
+ * may also opt in individually via `tier: 'public'`.
+ *
+ * This is a single, reviewable source of truth for the public surface — prefer
+ * editing this list over scattering `tier` flags across registration sites.
+ */
+export const PUBLIC_BLOCKS: readonly string[] = [
+  // ── Tier A — object-aware blocks (the contract core) ──────────────────────
+  'object-grid',
+  'list-view',
+  'object-form',
+  'embeddable-form',
+  'object-master-detail-form',
+  'object-kanban',
+  'object-calendar',
+  'object-gantt',
+  'object-timeline',
+  'object-map',
+  'object-metric',
+  'object-chart',
+  'dashboard',
+  'object-pivot',
+  'record:details',
+  'record:highlights',
+  'record:related_list',
+  'record:path',
+  'line_items',
+  // ── Tier B — layout / content primitives ──────────────────────────────────
+  'flex',
+  'grid',
+  'stack',
+  'card',
+  'tabs',
+  'accordion',
+  'container',
+  'page:header',
+  'text',
+  'image',
+  'icon',
+  'markdown',
+  'element:divider',
+  'badge',
+  'alert',
+  'button',
+  // ── Tier C — escape hatch (flagged, second-class) ─────────────────────────
+  'html',
+];
+
+/** Fast membership set built from {@link PUBLIC_BLOCKS}. */
+export const PUBLIC_BLOCK_SET: ReadonlySet<string> = new Set(PUBLIC_BLOCKS);


### PR DESCRIPTION
ADR-0080 **M5** — capability ≠ contract.

Adds `PUBLIC_BLOCKS` (packages/core/src/registry/public-blocks.ts): a single, reviewable list of the ~36 object-aware + layout/content blocks that form the platform's contract / AI-authoring vocabulary — Salesforce-App-Builder-shaped. `getPublicConfigs()` returns the curated set (plus any registration that opts in via `tier:'public'`), keyed by the bare tag and deduped across the registry's dual-key registrations. The full ~244 registered types remain a rendering *capability* (`getAllConfigs`).

Chose a central curated list over scattering `tier` flags across ~36 registration sites — one place to review the public surface. All 36 entries verified to match real `register()` tags (3 corrected: `divider`→`element:divider`, `record:line_items`→`line_items`, dropped non-existent `heading`).

Verified: unit test (curated + opt-in, deduped, bare-keyed, aspirational-safe) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)