### PR TITLE
feat(app-shell): Studio 设计面 MVP (ADR-0080 slice-1) — 三支柱 + 真实元数据 + 开源 AI slot

### DIFF
--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -181,7 +181,8 @@ export function App() {
             {/* Dev-only (ADR-0080 slice-1): Studio WYSIWYG design surface
               * harness. Public + backend-free so it renders from a fixture.
               * Purely additive — touches no existing surface. Not product nav. */}
-            <Route path="/dev/studio-design" element={
+            <Route path="/studio/:packageId" element={<Navigate to="interfaces" replace />} />
+            <Route path="/studio/:packageId/:tab" element={
               <ProtectedRoute>
                 <StudioDesignSurface />
               </ProtectedRoute>

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -19,6 +19,7 @@ import { DevMasterDetail } from './dev/DevMasterDetail';
 import { DevLists } from './dev/DevLists';
 import { DevModal } from './dev/DevModal';
 import { DevLookup } from './dev/DevLookup';
+import { DevStudioDesign } from './dev/DevStudioDesign';
 import {
   ConsoleShell,
   ConnectedShell,
@@ -177,6 +178,10 @@ export function App() {
               * REST API and renders a read-only view.
               */}
             <Route path="/s/:token" element={<SharedRecordPage />} />
+            {/* Dev-only (ADR-0080 slice-1): Studio WYSIWYG design surface
+              * harness. Public + backend-free so it renders from a fixture.
+              * Purely additive — touches no existing surface. Not product nav. */}
+            <Route path="/dev/studio-design" element={<DevStudioDesign />} />
             {/* Internal authed form — same renderer, different submit path. */}
             <Route path="/forms/:name" element={
               <ProtectedRoute>

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -181,7 +181,11 @@ export function App() {
             {/* Dev-only (ADR-0080 slice-1): Studio WYSIWYG design surface
               * harness. Public + backend-free so it renders from a fixture.
               * Purely additive — touches no existing surface. Not product nav. */}
-            <Route path="/dev/studio-design" element={<StudioDesignSurface />} />
+            <Route path="/dev/studio-design" element={
+              <ProtectedRoute>
+                <StudioDesignSurface />
+              </ProtectedRoute>
+            } />
             {/* Internal authed form — same renderer, different submit path. */}
             <Route path="/forms/:name" element={
               <ProtectedRoute>

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -19,7 +19,6 @@ import { DevMasterDetail } from './dev/DevMasterDetail';
 import { DevLists } from './dev/DevLists';
 import { DevModal } from './dev/DevModal';
 import { DevLookup } from './dev/DevLookup';
-import { DevStudioDesign } from './dev/DevStudioDesign';
 import {
   ConsoleShell,
   ConnectedShell,
@@ -37,6 +36,7 @@ import {
   DefaultInvitationsPage,
   DefaultSettingsPage,
   DefaultAiChatPage,
+  StudioDesignSurface,
 } from '@object-ui/app-shell';
 
 import { AppContent } from './AppContent';
@@ -181,7 +181,7 @@ export function App() {
             {/* Dev-only (ADR-0080 slice-1): Studio WYSIWYG design surface
               * harness. Public + backend-free so it renders from a fixture.
               * Purely additive — touches no existing surface. Not product nav. */}
-            <Route path="/dev/studio-design" element={<DevStudioDesign />} />
+            <Route path="/dev/studio-design" element={<StudioDesignSurface />} />
             {/* Internal authed form — same renderer, different submit path. */}
             <Route path="/forms/:name" element={
               <ProtectedRoute>

--- a/apps/console/src/dev/DevStudioDesign.tsx
+++ b/apps/console/src/dev/DevStudioDesign.tsx
@@ -1,0 +1,317 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Dev-only harness — Studio WYSIWYG design surface, slice-1 (ADR-0080).
+ *
+ * Proves the four-zone shell with ZERO new editor code: it REUSES the
+ * existing metadata-admin registry (`getMetadataPreview` / `getMetadataInspector`)
+ * and the runtime `SchemaRenderer`, so design-time === run-time (same renderer).
+ *
+ *   ┌────────┬────────┬─────────────────┬──────────┐
+ *   │ AI 副驾 │ 单 App │ 预览即运行画布   │ inspector │
+ *   │(可折叠) │ 导航   │ (选中→改→重渲)   │ (选中积木)│
+ *   └────────┴────────┴─────────────────┴──────────┘
+ *
+ * Purely additive: touches NO existing surface (ResourceEditPage, registries,
+ * previews all untouched). Mounted at a public dev route /dev/studio-design so
+ * it renders standalone from a fixture — no backend required. Not product nav.
+ */
+
+import * as React from 'react';
+import {
+  getMetadataPreview,
+  getMetadataInspector,
+  type MetadataSelection,
+} from '@object-ui/app-shell';
+import { SchemaRenderer } from '@object-ui/react';
+import {
+  Zap,
+  Send,
+  ChevronLeft,
+  ChevronRight,
+  Lock,
+  Eye,
+  Boxes,
+  Layers3,
+  ShieldCheck,
+  SlidersHorizontal,
+  MousePointer2,
+} from 'lucide-react';
+
+// ── Fixture: one "Interface" page draft. Built from element blocks that
+//    render with no backend (same family the /dev/lists harness uses). ──
+const FIXTURE_PAGE: Record<string, unknown> = {
+  type: 'page',
+  name: 'projects_overview',
+  label: '项目与任务',
+  regions: [
+    {
+      name: 'main',
+      components: [
+        {
+          type: 'element:definition-list',
+          id: 'summary',
+          properties: {
+            columns: 2,
+            items: [
+              { term: '负责人', description: 'Sophia Rodriguez' },
+              { term: '状态', description: '进行中' },
+              { term: '截止', description: '2026-07-15' },
+              { term: '进度', description: '60%' },
+            ],
+          },
+        },
+        {
+          type: 'element:definition-list',
+          id: 'meta',
+          properties: {
+            columns: 1,
+            items: [
+              { term: '团队', description: '平台组' },
+              { term: '优先级', description: '高' },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+// ── Mock single-App nav. slice-1 keeps it static; the permission chips
+//    illustrate the role-projection model (ADR-0080 D4). ──
+const NAV: Array<{
+  group: string;
+  locked?: boolean;
+  items: Array<{ icon: React.ComponentType<{ className?: string }>; label: string; perm?: string; active?: boolean }>;
+}> = [
+  {
+    group: '工作区',
+    items: [
+      { icon: Layers3, label: '我的任务', perm: '所有人' },
+      { icon: Boxes, label: '项目与任务', perm: '项目成员', active: true },
+      { icon: SlidersHorizontal, label: '看板', perm: '项目成员' },
+    ],
+  },
+  {
+    group: '管理',
+    locked: true,
+    items: [
+      { icon: ShieldCheck, label: '团队', perm: '管理员' },
+      { icon: Eye, label: '洞察看板', perm: '管理员' },
+    ],
+  },
+];
+
+const PILLARS = ['Data', 'Automations', 'Interfaces'] as const;
+
+export function DevStudioDesign(): React.ReactElement {
+  const [draft, setDraft] = React.useState<Record<string, unknown>>(FIXTURE_PAGE);
+  const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
+  const [aiCollapsed, setAiCollapsed] = React.useState(false);
+  const locale = 'zh-CN';
+
+  // Reuse the REAL registered surfaces. Fallback to the bare renderer if the
+  // registry side-effect hasn't run (keeps the harness from white-screening).
+  const Preview = getMetadataPreview('page');
+  const Inspector = getMetadataInspector('page');
+
+  const onPatch = React.useCallback(
+    (patch: Record<string, unknown>) => setDraft((d) => ({ ...d, ...patch })),
+    [],
+  );
+
+  return (
+    <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
+      {/* ── Zone 1 · AI copilot (far left, collapsible, recessed = auxiliary) ── */}
+      {aiCollapsed ? (
+        <button
+          type="button"
+          onClick={() => setAiCollapsed(false)}
+          aria-label="展开搭建助手"
+          className="flex w-10 shrink-0 flex-col items-center gap-2 border-r bg-muted/40 py-3 text-muted-foreground hover:text-foreground"
+        >
+          <Zap className="h-4 w-4" />
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      ) : (
+        <aside className="flex w-56 shrink-0 flex-col border-r bg-muted/40">
+          <header className="flex items-center justify-between border-b px-3 py-2.5">
+            <span className="flex items-center gap-1.5 text-[13px] font-medium">
+              <Zap className="h-4 w-4" /> 搭建助手
+            </span>
+            <button
+              type="button"
+              onClick={() => setAiCollapsed(true)}
+              aria-label="收起"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+          </header>
+          <div className="flex flex-1 flex-col gap-2 overflow-auto p-3">
+            <div className="self-end max-w-[88%] rounded-md bg-primary/10 px-2.5 py-1.5 text-[11px] text-primary">
+              状态做成看板视图
+            </div>
+            <div className="text-[11px] leading-relaxed text-muted-foreground">
+              已在 Interfaces 加「看板」页,绑定 Tasks。要我顺手加筛选吗?
+            </div>
+          </div>
+          <footer className="border-t p-3">
+            <div className="flex items-center gap-2 rounded-md border bg-background px-2.5 py-1.5 text-[11px] text-muted-foreground">
+              <span className="flex-1">描述要改的地方…</span>
+              <Send className="h-3.5 w-3.5" />
+            </div>
+            <p className="mt-1.5 text-center text-[11px] text-muted-foreground">
+              辅助 · 不挡你直接改
+            </p>
+          </footer>
+        </aside>
+      )}
+
+      {/* ── Studio (tabs + body) ── */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        {/* top bar: three pillars + publish */}
+        <header className="flex items-center justify-between border-b px-3 py-2">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="flex items-center gap-1.5 whitespace-nowrap text-[13px] font-medium">
+              <Boxes className="h-4 w-4" /> 项目管理包
+            </span>
+            <span className="text-muted-foreground">·</span>
+            <nav className="flex gap-1">
+              {PILLARS.map((p) => (
+                <span
+                  key={p}
+                  className={
+                    'rounded-md px-2.5 py-1 text-xs ' +
+                    (p === 'Interfaces'
+                      ? 'bg-primary/10 font-medium text-primary'
+                      : 'text-muted-foreground')
+                  }
+                >
+                  {p}
+                </span>
+              ))}
+            </nav>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <button className="rounded-md border px-2.5 py-1 text-xs hover:bg-muted">
+              <Eye className="mr-1 inline h-3.5 w-3.5 align-[-2px]" />预览
+            </button>
+            <button className="rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground">
+              发布
+            </button>
+          </div>
+        </header>
+
+        <div className="flex min-h-0 flex-1">
+          {/* ── Zone 2 · single-App nav (multi-level + permission chips) ── */}
+          <nav className="w-44 shrink-0 overflow-auto border-r p-2">
+            <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">
+              单一 App
+            </p>
+            {NAV.map((g) => (
+              <div key={g.group}>
+                <p className="flex items-center gap-1 px-2 pb-1 pt-3 text-[11px] text-muted-foreground">
+                  {g.group}
+                  {g.locked && <Lock className="h-3 w-3" />}
+                </p>
+                {g.items.map((it) => (
+                  <div
+                    key={it.label}
+                    className={
+                      'flex items-center gap-2 rounded-md px-2 py-1.5 text-xs ' +
+                      (it.active ? 'bg-muted font-medium' : 'text-foreground/90')
+                    }
+                  >
+                    <it.icon className="h-3.5 w-3.5 shrink-0" />
+                    <span className="flex-1 truncate">{it.label}</span>
+                    {it.perm && (
+                      <span className="flex items-center gap-0.5 whitespace-nowrap rounded bg-muted px-1.5 py-px text-[10px] text-muted-foreground">
+                        <Lock className="h-2.5 w-2.5" />
+                        {it.perm}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </nav>
+
+          {/* ── Zone 3 · canvas (live render = runtime) ── */}
+          <main className="min-w-0 flex-1 overflow-auto bg-muted/30 p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
+                <Eye className="h-3 w-3" /> 预览即运行 · 同一渲染器
+              </span>
+              <span className="text-[11px] text-muted-foreground">草稿</span>
+            </div>
+            <div className="rounded-lg border bg-background p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-[13px] font-medium">
+                  {String((draft as { label?: string }).label ?? '项目与任务')}
+                </span>
+                <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                  对象视图 / page
+                </span>
+              </div>
+              {Preview ? (
+                <Preview
+                  type="page"
+                  name="projects_overview"
+                  draft={draft}
+                  editing
+                  selection={selection}
+                  onSelectionChange={setSelection}
+                  onPatch={onPatch}
+                  locale={locale}
+                />
+              ) : (
+                <SchemaRenderer schema={{ ...draft, type: 'page' } as never} />
+              )}
+            </div>
+            <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
+              <MousePointer2 className="h-3 w-3" /> 点选积木 → 右侧直接改
+            </p>
+          </main>
+
+          {/* ── Zone 4 · inspector (selected block's property schema) ── */}
+          <aside className="w-72 shrink-0 overflow-auto border-l">
+            <header className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background/95 px-3 py-2 backdrop-blur">
+              <SlidersHorizontal className="h-3.5 w-3.5" />
+              <span className="text-[13px] font-medium">属性</span>
+              {selection?.label && (
+                <span className="truncate rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                  {selection.label}
+                </span>
+              )}
+            </header>
+            <div className="p-3">
+              {selection && Inspector ? (
+                <Inspector
+                  type="page"
+                  name="projects_overview"
+                  draft={draft}
+                  selection={selection}
+                  onPatch={onPatch}
+                  onClearSelection={() => setSelection(null)}
+                  onSelectionChange={setSelection}
+                  readOnly={false}
+                  locale={locale}
+                />
+              ) : (
+                <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">
+                  <MousePointer2 className="h-5 w-5" />
+                  在画布里点选一个积木,
+                  <br />
+                  它的属性会在这里直接编辑。
+                </div>
+              )}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DevStudioDesign;

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -256,6 +256,13 @@ export type {
   MetadataInspectorProps,
 } from './views/metadata-admin';
 
+// Studio WYSIWYG design surface (ADR-0080) — the open-source design surface.
+// The left AI copilot is an injected `aiSlot`; OSS renders three zones.
+export {
+  StudioDesignSurface,
+  type StudioDesignSurfaceProps,
+} from './views/studio-design/StudioDesignSurface';
+
 // AI assistant bus — connects the metadata designers to the global chat.
 export {
   assistantBus,

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -3,12 +3,12 @@
 /**
  * StudioDesignSurface — the open-source WYSIWYG design surface (ADR-0080).
  *
- * Routed as /studio/:packageId/{data|automations|interfaces} — the three
- * pillars are real routes, scoped to the package being designed. Each pillar
- * is composed AROUND existing renderers (no new editor code):
- *   - Interfaces: the App nav + live canvas (getMetadataPreview) + inspector
- *     (getMetadataInspector), edits persisting through draft → publish.
- *   - Data / Automations: object + flow surfaces (in progress).
+ * Routed as /studio/:packageId/{data|automations|interfaces} — three pillars,
+ * each composed AROUND existing renderers (no new editor code):
+ *   - Interfaces: the real App navigation tree → live canvas (getMetadataPreview)
+ *     + inspector (getMetadataInspector), edits persisting via draft → publish.
+ *   - Data: the package's objects → fields + record grid.
+ *   - Automations: flows → FlowPreview (default OFF / review-then-enable).
  *
  * Open-core boundary: the left AI copilot is NOT part of the open-source
  * surface — it is an injected slot (`aiSlot`) the cloud edition fills.
@@ -20,13 +20,19 @@ import { SchemaRenderer } from '@object-ui/react';
 import {
   Boxes,
   FileText,
+  Database,
+  LayoutDashboard,
+  BarChart3,
+  Table2,
+  Folder,
+  Compass,
+  Workflow,
   SlidersHorizontal,
   MousePointer2,
   Eye,
   Loader2,
   Save,
-  Database,
-  Workflow,
+  type LucideIcon,
 } from 'lucide-react';
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
@@ -38,10 +44,64 @@ const PILLARS = [
   { key: 'interfaces', label: 'Interfaces' },
 ] as const;
 
-interface NavItem {
+interface Surface {
   type: string;
   name: string;
   label: string;
+}
+
+interface NavNode {
+  id?: string;
+  label?: string;
+  type?: string;
+  icon?: string;
+  children?: NavNode[];
+  pageName?: string;
+  page?: string;
+  objectName?: string;
+  object?: string;
+  dashboardName?: string;
+  dashboard?: string;
+  reportName?: string;
+  report?: string;
+  viewName?: string;
+  view?: string;
+  [k: string]: unknown;
+}
+
+const KIND_ICON: Record<string, LucideIcon> = {
+  group: Folder,
+  page: FileText,
+  object: Database,
+  dashboard: LayoutDashboard,
+  report: BarChart3,
+  view: Table2,
+};
+const navIcon = (type?: string): LucideIcon => KIND_ICON[type ?? ''] ?? Compass;
+
+/** Resolve a leaf nav node → the surface {type,name} it binds to. */
+function resolveSurface(node: NavNode): Surface | null {
+  const label = String(node.label ?? '');
+  switch (node.type) {
+    case 'page':
+      return node.pageName || node.page ? { type: 'page', name: String(node.pageName || node.page), label } : null;
+    case 'object':
+      return node.objectName || node.object
+        ? { type: 'object', name: String(node.objectName || node.object), label }
+        : null;
+    case 'dashboard':
+      return node.dashboardName || node.dashboard
+        ? { type: 'dashboard', name: String(node.dashboardName || node.dashboard), label }
+        : null;
+    case 'report':
+      return node.reportName || node.report
+        ? { type: 'report', name: String(node.reportName || node.report), label }
+        : null;
+    case 'view':
+      return node.viewName || node.view ? { type: 'view', name: String(node.viewName || node.view), label } : null;
+    default:
+      return null;
+  }
 }
 
 /** Normalize the framework draft envelope `{ type, name, item }` → body | null. */
@@ -66,13 +126,9 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
 
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
-      {/* ── AI copilot — OPEN-CORE SLOT (cloud-injected; absent in OSS) ── */}
-      {aiSlot ? (
-        <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside>
-      ) : null}
+      {aiSlot ? <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside> : null}
 
       <div className="flex min-w-0 flex-1 flex-col">
-        {/* shell header: package + three pillar routes */}
         <header className="flex items-center gap-3 border-b px-3 py-2">
           <span className="flex items-center gap-1.5 whitespace-nowrap text-[13px] font-medium">
             <Boxes className="h-4 w-4" /> {packageId}
@@ -98,17 +154,9 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
 
         <div className="min-h-0 flex-1">
           {tab === 'data' ? (
-            <PillarPlaceholder
-              icon={<Database className="h-6 w-6" />}
-              title="Data — 对象 / 字段 / 记录"
-              detail="数据层:列出包内对象,查看字段与记录网格。建设中。"
-            />
+            <DataPillar />
           ) : tab === 'automations' ? (
-            <PillarPlaceholder
-              icon={<Workflow className="h-6 w-6" />}
-              title="Automations — flow / 触发器 / 审批"
-              detail="自动化:列出 flow,默认 OFF / 审阅再启用(ADR-0080)。建设中。"
-            />
+            <AutomationsPillar />
           ) : (
             <InterfacesPillar packageId={packageId} />
           )}
@@ -118,36 +166,67 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   );
 }
 
-function PillarPlaceholder({
-  icon,
-  title,
-  detail,
+/** Recursive App-navigation tree (groups + typed leaves). */
+function NavTree({
+  nodes,
+  active,
+  onPick,
 }: {
-  icon: React.ReactNode;
-  title: string;
-  detail: string;
+  nodes: NavNode[];
+  active: Surface | null;
+  onPick: (s: Surface) => void;
 }): React.ReactElement {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
-      <div className="opacity-60">{icon}</div>
-      <p className="text-sm font-medium text-foreground">{title}</p>
-      <p className="max-w-sm text-xs">{detail}</p>
-    </div>
+    <>
+      {nodes.map((node, i) => {
+        if (node.type === 'group' || (Array.isArray(node.children) && node.children.length)) {
+          return (
+            <div key={node.id ?? i} className="mb-1">
+              <p className="flex items-center gap-1 px-2 pb-1 pt-3 text-[11px] text-muted-foreground">
+                <Folder className="h-3 w-3" /> {node.label}
+              </p>
+              <div className="pl-1.5">
+                <NavTree nodes={node.children ?? []} active={active} onPick={onPick} />
+              </div>
+            </div>
+          );
+        }
+        const surface = resolveSurface(node);
+        const Icon = navIcon(node.type);
+        const isActive = !!surface && active?.type === surface.type && active?.name === surface.name;
+        return (
+          <button
+            key={node.id ?? i}
+            onClick={() => surface && onPick(surface)}
+            disabled={!surface}
+            title={surface ? `${surface.type} · ${surface.name}` : node.label}
+            className={
+              'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs disabled:opacity-40 ' +
+              (isActive ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
+            }
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+            <span className="flex-1 truncate">{node.label}</span>
+            {surface && surface.type !== 'page' && (
+              <span className="rounded bg-muted px-1 py-px text-[9px] uppercase text-muted-foreground">
+                {surface.type}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </>
   );
 }
 
-/**
- * The Interfaces pillar — single-App nav · live canvas · inspector. Drives the
- * real MetadataClient: pages become menu items, clicking loads that surface,
- * the toolbar saves drafts / publishes. (A later slice swaps the page list for
- * the real App.navigation tree with view/dashboard/object items.)
- */
-function InterfacesPillar({ packageId: _packageId }: { packageId: string }): React.ReactElement {
+/** Interfaces pillar — real App nav · live canvas · inspector. */
+function InterfacesPillar({ packageId }: { packageId: string }): React.ReactElement {
   const client = useMetadataClient();
   const locale = 'zh-CN';
 
-  const [nav, setNav] = React.useState<NavItem[]>([]);
-  const [current, setCurrent] = React.useState<NavItem | null>(null);
+  const [appLabel, setAppLabel] = React.useState<string>(packageId);
+  const [navTree, setNavTree] = React.useState<NavNode[]>([]);
+  const [current, setCurrent] = React.useState<Surface | null>(null);
   const [draft, setDraft] = React.useState<Record<string, unknown>>({});
   const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
   const [loading, setLoading] = React.useState(false);
@@ -155,17 +234,41 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
   const [hasDraft, setHasDraft] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
+  // Resolve the App by package id → load its navigation tree.
   React.useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const list = (await client.list('page')) as Array<Record<string, unknown>>;
+        const apps = (await client.list('app')) as Array<Record<string, unknown>>;
         if (cancelled) return;
-        const items: NavItem[] = (list || [])
-          .map((p) => ({ type: 'page', name: String(p.name ?? ''), label: String(p.label ?? p.name ?? '') }))
-          .filter((p) => !!p.name);
-        setNav(items);
-        setCurrent((cur) => cur ?? items[0] ?? null);
+        const app =
+          (apps || []).find(
+            (a) => a._packageId === packageId || a.packageId === packageId || a.name === packageId,
+          ) ?? (apps || [])[0];
+        if (!app) return;
+        setAppLabel(String(app.label ?? app.name ?? packageId));
+        const lay = (await client.layered<Record<string, unknown>>('app', String(app.name))) as {
+          effective?: Record<string, unknown>;
+          code?: Record<string, unknown>;
+        };
+        if (cancelled) return;
+        const eff = lay.effective ?? lay.code ?? {};
+        const tree = Array.isArray(eff.navigation) ? (eff.navigation as NavNode[]) : [];
+        setNavTree(tree);
+        // auto-open the first resolvable leaf
+        const firstLeaf = (function find(nodes: NavNode[]): Surface | null {
+          for (const n of nodes) {
+            if (n.type === 'group' || n.children?.length) {
+              const r = find(n.children ?? []);
+              if (r) return r;
+            } else {
+              const s = resolveSurface(n);
+              if (s) return s;
+            }
+          }
+          return null;
+        })(tree);
+        setCurrent((cur) => cur ?? firstLeaf);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -173,10 +276,19 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
     return () => {
       cancelled = true;
     };
-  }, [client]);
+  }, [client, packageId]);
 
+  const Preview = getMetadataPreview(current?.type ?? '');
+  const Inspector = getMetadataInspector(current?.type ?? '');
+  const isEditable = !!Preview; // page / dashboard have a design preview + draft
+
+  // Load the selected surface's draft (only for editable preview types).
   React.useEffect(() => {
-    if (!current) return;
+    if (!current || !isEditable) {
+      setDraft({});
+      setHasDraft(false);
+      return;
+    }
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -191,9 +303,9 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
         const baseline = ((lay as { effective?: unknown; code?: unknown }).effective ??
           (lay as { code?: unknown }).code ??
           {}) as Record<string, unknown>;
-        const draftBody = extractDraftBody(draftResp);
-        setDraft(draftBody ? { ...baseline, ...draftBody } : baseline);
-        setHasDraft(!!draftBody);
+        const body = extractDraftBody(draftResp);
+        setDraft(body ? { ...baseline, ...body } : baseline);
+        setHasDraft(!!body);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
@@ -203,17 +315,15 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
     return () => {
       cancelled = true;
     };
-  }, [client, current]);
+  }, [client, current, isEditable]);
 
   const onPatch = React.useCallback(
     (patch: Record<string, unknown>) => setDraft((d) => ({ ...d, ...patch })),
     [],
   );
-
   const doSave = React.useCallback(async () => {
     if (!current) return;
     setSaving('draft');
-    setError(null);
     try {
       await client.save(current.type, current.name, draft, { mode: 'draft' });
       setHasDraft(true);
@@ -223,11 +333,9 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
       setSaving(false);
     }
   }, [client, current, draft]);
-
   const doPublish = React.useCallback(async () => {
     if (!current) return;
     setSaving('publish');
-    setError(null);
     try {
       await client.publish(current.type, current.name);
       setHasDraft(false);
@@ -238,12 +346,8 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
     }
   }, [client, current]);
 
-  const Preview = getMetadataPreview(current?.type ?? 'page');
-  const Inspector = getMetadataInspector(current?.type ?? 'page');
-
   return (
     <div className="flex h-full flex-col">
-      {/* pillar toolbar: draft / publish */}
       <div className="flex items-center justify-end gap-2 border-b px-3 py-1.5">
         {hasDraft && (
           <span className="rounded bg-amber-400/15 px-2 py-0.5 text-[11px] text-amber-600 dark:text-amber-300">
@@ -252,7 +356,7 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
         )}
         <button
           onClick={doSave}
-          disabled={!current || !!saving}
+          disabled={!current || !isEditable || !!saving}
           className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-muted disabled:opacity-50"
         >
           {saving === 'draft' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
@@ -260,7 +364,7 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
         </button>
         <button
           onClick={doPublish}
-          disabled={!current || !hasDraft || !!saving}
+          disabled={!current || !isEditable || !hasDraft || !!saving}
           className="inline-flex items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
         >
           {saving === 'publish' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
@@ -269,28 +373,17 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
       </div>
 
       <div className="flex min-h-0 flex-1">
-        {/* nav (real pages; click switches the canvas) */}
-        <nav className="w-48 shrink-0 overflow-auto border-r p-2">
-          <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">单一 App · 页面</p>
-          {nav.length === 0 && (
+        {/* real App navigation tree */}
+        <nav className="w-52 shrink-0 overflow-auto border-r p-2">
+          <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">{appLabel} · 导航</p>
+          {navTree.length === 0 ? (
             <p className="px-2 py-3 text-[11px] text-muted-foreground">{error ? '加载失败' : '加载中…'}</p>
+          ) : (
+            <NavTree nodes={navTree} active={current} onPick={setCurrent} />
           )}
-          {nav.map((it) => (
-            <button
-              key={it.name}
-              onClick={() => setCurrent(it)}
-              className={
-                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs ' +
-                (current?.name === it.name ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
-              }
-            >
-              <FileText className="h-3.5 w-3.5 shrink-0" />
-              <span className="flex-1 truncate">{it.label}</span>
-            </button>
-          ))}
         </nav>
 
-        {/* canvas (live render = runtime) */}
+        {/* canvas */}
         <main className="min-w-0 flex-1 overflow-auto bg-muted/30 p-4">
           <div className="mb-3 flex items-center gap-2">
             <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
@@ -308,7 +401,9 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
             </div>
           )}
           <div className="rounded-lg border bg-background p-4">
-            {loading || !current ? (
+            {!current ? (
+              <div className="py-16 text-center text-sm text-muted-foreground">从左侧选择一个菜单项</div>
+            ) : loading ? (
               <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
               </div>
@@ -323,16 +418,22 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
                 onPatch={onPatch}
                 locale={locale}
               />
+            ) : current.type === 'object' ? (
+              <SchemaRenderer schema={{ type: 'object-grid', objectName: current.name } as never} />
             ) : (
-              <SchemaRenderer schema={{ ...draft, type: current.type } as never} />
+              <div className="py-12 text-center text-xs text-muted-foreground">
+                {current.type} 暂用只读预览,设计能力建设中。
+              </div>
             )}
           </div>
-          <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
-            <MousePointer2 className="h-3 w-3" /> 点选积木 → 右侧直接改 · 改完「保存草稿」→「发布」
-          </p>
+          {isEditable && (
+            <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
+              <MousePointer2 className="h-3 w-3" /> 点选积木 → 右侧直接改 · 改完「保存草稿」→「发布」
+            </p>
+          )}
         </main>
 
-        {/* inspector (selected block's property schema) */}
+        {/* inspector */}
         <aside className="w-72 shrink-0 overflow-auto border-l">
           <header className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background/95 px-3 py-2 backdrop-blur">
             <SlidersHorizontal className="h-3.5 w-3.5" />
@@ -367,6 +468,252 @@ function InterfacesPillar({ packageId: _packageId }: { packageId: string }): Rea
           </div>
         </aside>
       </div>
+    </div>
+  );
+}
+
+/** Data pillar — the package's objects: list → fields + record grid. */
+function DataPillar(): React.ReactElement {
+  const client = useMetadataClient();
+  const [objects, setObjects] = React.useState<Surface[]>([]);
+  const [current, setCurrent] = React.useState<Surface | null>(null);
+  const [obj, setObj] = React.useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = (await client.list('object')) as Array<Record<string, unknown>>;
+        if (cancelled) return;
+        const items = (list || [])
+          .map((o) => ({ type: 'object', name: String(o.name ?? ''), label: String(o.label ?? o.name ?? '') }))
+          .filter((o) => o.name);
+        setObjects(items);
+        setCurrent((c) => c ?? items[0] ?? null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  React.useEffect(() => {
+    if (!current) return;
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const lay = (await client.layered<Record<string, unknown>>('object', current.name)) as {
+          effective?: Record<string, unknown>;
+          code?: Record<string, unknown>;
+        };
+        if (!cancelled) setObj(lay.effective ?? lay.code ?? null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, current]);
+
+  const fields: Array<{ name: string; label?: string; type?: string }> = React.useMemo(() => {
+    const raw = obj?.fields;
+    if (Array.isArray(raw)) return raw as never;
+    if (raw && typeof raw === 'object')
+      return Object.entries(raw).map(([name, f]) => ({ name, ...(f as object) })) as never;
+    return [];
+  }, [obj]);
+
+  return (
+    <div className="flex h-full">
+      <nav className="w-52 shrink-0 overflow-auto border-r p-2">
+        <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">对象</p>
+        {objects.length === 0 && (
+          <p className="px-2 py-3 text-[11px] text-muted-foreground">{error ? '加载失败' : '加载中…'}</p>
+        )}
+        {objects.map((o) => (
+          <button
+            key={o.name}
+            onClick={() => setCurrent(o)}
+            className={
+              'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs ' +
+              (current?.name === o.name ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
+            }
+          >
+            <Database className="h-3.5 w-3.5 shrink-0" />
+            <span className="flex-1 truncate">{o.label}</span>
+          </button>
+        ))}
+      </nav>
+      <main className="min-w-0 flex-1 overflow-auto p-4">
+        {!current ? (
+          <div className="py-16 text-center text-sm text-muted-foreground">选择一个对象</div>
+        ) : (
+          <>
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-[13px] font-medium">{current.label}</span>
+              <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                object · {current.name}
+              </span>
+              <span className="text-[11px] text-muted-foreground">{fields.length} 字段</span>
+            </div>
+            <div className="mb-4 rounded-lg border bg-background p-2">
+              <SchemaRenderer schema={{ type: 'object-grid', objectName: current.name } as never} />
+            </div>
+            <div className="rounded-lg border bg-background">
+              <table className="w-full text-xs">
+                <thead className="border-b text-left text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">字段</th>
+                    <th className="px-3 py-2 font-medium">类型</th>
+                    <th className="px-3 py-2 font-medium">名称</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading ? (
+                    <tr>
+                      <td colSpan={3} className="px-3 py-6 text-center text-muted-foreground">
+                        加载中…
+                      </td>
+                    </tr>
+                  ) : (
+                    fields.map((f) => (
+                      <tr key={f.name} className="border-b last:border-0">
+                        <td className="px-3 py-1.5">{f.label ?? f.name}</td>
+                        <td className="px-3 py-1.5 text-muted-foreground">{f.type ?? '—'}</td>
+                        <td className="px-3 py-1.5 font-mono text-[11px] text-muted-foreground">{f.name}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}
+
+/** Automations pillar — flows: list → FlowPreview (default OFF / review-then-enable). */
+function AutomationsPillar(): React.ReactElement {
+  const client = useMetadataClient();
+  const locale = 'zh-CN';
+  const [flows, setFlows] = React.useState<Surface[]>([]);
+  const [current, setCurrent] = React.useState<Surface | null>(null);
+  const [draft, setDraft] = React.useState<Record<string, unknown>>({});
+  const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const Preview = getMetadataPreview('flow');
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = (await client.list('flow')) as Array<Record<string, unknown>>;
+        if (cancelled) return;
+        const items = (list || [])
+          .map((f) => ({ type: 'flow', name: String(f.name ?? ''), label: String(f.label ?? f.name ?? '') }))
+          .filter((f) => f.name);
+        setFlows(items);
+        setCurrent((c) => c ?? items[0] ?? null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  React.useEffect(() => {
+    if (!current) return;
+    let cancelled = false;
+    setLoading(true);
+    setSelection(null);
+    (async () => {
+      try {
+        const lay = (await client.layered<Record<string, unknown>>('flow', current.name)) as {
+          effective?: Record<string, unknown>;
+          code?: Record<string, unknown>;
+        };
+        if (!cancelled) setDraft(lay.effective ?? lay.code ?? {});
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, current]);
+
+  return (
+    <div className="flex h-full">
+      <nav className="w-52 shrink-0 overflow-auto border-r p-2">
+        <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">自动化 · flow</p>
+        <p className="px-2 pb-2 text-[10px] text-muted-foreground">默认 OFF · 审阅后再启用</p>
+        {flows.length === 0 && (
+          <p className="px-2 py-3 text-[11px] text-muted-foreground">{error ? '加载失败' : '加载中…'}</p>
+        )}
+        {flows.map((f) => (
+          <button
+            key={f.name}
+            onClick={() => setCurrent(f)}
+            className={
+              'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs ' +
+              (current?.name === f.name ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
+            }
+          >
+            <Workflow className="h-3.5 w-3.5 shrink-0" />
+            <span className="flex-1 truncate">{f.label}</span>
+          </button>
+        ))}
+      </nav>
+      <main className="min-w-0 flex-1 overflow-auto bg-muted/30 p-4">
+        {!current ? (
+          <div className="py-16 text-center text-sm text-muted-foreground">选择一个自动化</div>
+        ) : (
+          <>
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-[13px] font-medium">{current.label}</span>
+              <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                flow · {current.name}
+              </span>
+            </div>
+            <div className="rounded-lg border bg-background p-4">
+              {loading ? (
+                <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
+                </div>
+              ) : Preview ? (
+                <Preview
+                  type="flow"
+                  name={current.name}
+                  draft={draft}
+                  editing={false}
+                  selection={selection}
+                  onSelectionChange={setSelection}
+                  locale={locale}
+                />
+              ) : (
+                <pre className="overflow-auto text-[11px] text-muted-foreground">
+                  {JSON.stringify(draft, null, 2)}
+                </pre>
+              )}
+            </div>
+          </>
+        )}
+      </main>
     </div>
   );
 }

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -154,9 +154,9 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
 
         <div className="min-h-0 flex-1">
           {tab === 'data' ? (
-            <DataPillar />
+            <DataPillar packageId={packageId} />
           ) : tab === 'automations' ? (
-            <AutomationsPillar />
+            <AutomationsPillar packageId={packageId} />
           ) : (
             <InterfacesPillar packageId={packageId} />
           )}
@@ -473,7 +473,7 @@ function InterfacesPillar({ packageId }: { packageId: string }): React.ReactElem
 }
 
 /** Data pillar — the package's objects: list → fields + record grid. */
-function DataPillar(): React.ReactElement {
+function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
   const client = useMetadataClient();
   const [objects, setObjects] = React.useState<Surface[]>([]);
   const [current, setCurrent] = React.useState<Surface | null>(null);
@@ -485,7 +485,7 @@ function DataPillar(): React.ReactElement {
     let cancelled = false;
     (async () => {
       try {
-        const list = (await client.list('object')) as Array<Record<string, unknown>>;
+        const list = (await client.list('object', { packageId })) as Array<Record<string, unknown>>;
         if (cancelled) return;
         const items = (list || [])
           .map((o) => ({ type: 'object', name: String(o.name ?? ''), label: String(o.label ?? o.name ?? '') }))
@@ -577,7 +577,7 @@ function DataPillar(): React.ReactElement {
 }
 
 /** Automations pillar — flows: list → FlowPreview (default OFF / review-then-enable). */
-function AutomationsPillar(): React.ReactElement {
+function AutomationsPillar({ packageId }: { packageId: string }): React.ReactElement {
   const client = useMetadataClient();
   const locale = 'zh-CN';
   const [flows, setFlows] = React.useState<Surface[]>([]);
@@ -592,7 +592,7 @@ function AutomationsPillar(): React.ReactElement {
     let cancelled = false;
     (async () => {
       try {
-        const list = (await client.list('flow')) as Array<Record<string, unknown>>;
+        const list = (await client.list('flow', { packageId })) as Array<Record<string, unknown>>;
         if (cancelled) return;
         const items = (list || [])
           .map((f) => ({ type: 'flow', name: String(f.name ?? ''), label: String(f.label ?? f.name ?? '') }))

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -5,98 +5,52 @@
  *
  * Three zones — single-App nav · live canvas · property inspector — composed
  * AROUND the existing metadata-admin registry (`getMetadataPreview` /
- * `getMetadataInspector`) and the runtime `SchemaRenderer`, so design-time is
- * literally run-time (same renderer, same metadata).
+ * `getMetadataInspector`), the runtime `SchemaRenderer`, and the shared
+ * `MetadataClient`. Design-time is literally run-time (same renderer, same
+ * metadata), and edits persist through the real draft → publish pipeline.
  *
  * Open-core boundary: the left AI copilot is NOT part of the open-source
- * surface. It is an injected slot (`aiSlot`) that the cloud edition fills; the
- * OSS build renders three zones. Everything else — nav, canvas, inspector,
- * the select→edit→re-render loop — lives here, in the open package.
- *
- * slice-1 drives a fixture page with no backend so the surface is demoable
- * standalone. Real metadata load/save (useMetadataClient) and nav-driven
- * surface switching land in follow-up slices.
+ * surface. It is an injected slot (`aiSlot`) the cloud edition fills; the OSS
+ * build renders three zones.
  */
 
 import * as React from 'react';
 import { SchemaRenderer } from '@object-ui/react';
 import {
   Boxes,
-  Layers3,
-  ShieldCheck,
+  FileText,
   SlidersHorizontal,
   MousePointer2,
   Eye,
-  Lock,
+  Loader2,
+  Save,
+  Send,
 } from 'lucide-react';
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
-
-// ── Fixture: one "Interface" page draft. Built from element blocks that
-//    render with no backend. Replaced by real metadata in a later slice. ──
-const FIXTURE_PAGE: Record<string, unknown> = {
-  type: 'page',
-  name: 'projects_overview',
-  label: '项目与任务',
-  regions: [
-    {
-      name: 'main',
-      components: [
-        {
-          type: 'element:definition-list',
-          id: 'summary',
-          properties: {
-            columns: 2,
-            items: [
-              { term: '负责人', description: 'Sophia Rodriguez' },
-              { term: '状态', description: '进行中' },
-              { term: '截止', description: '2026-07-15' },
-              { term: '进度', description: '60%' },
-            ],
-          },
-        },
-        {
-          type: 'element:definition-list',
-          id: 'meta',
-          properties: {
-            columns: 1,
-            items: [
-              { term: '团队', description: '平台组' },
-              { term: '优先级', description: '高' },
-            ],
-          },
-        },
-      ],
-    },
-  ],
-};
-
-// ── Mock single-App nav. The permission chips illustrate the role-projection
-//    model (ADR-0080 D4). Replaced by a real App nav model in a later slice. ──
-const NAV: Array<{
-  group: string;
-  locked?: boolean;
-  items: Array<{ icon: React.ComponentType<{ className?: string }>; label: string; perm?: string; active?: boolean }>;
-}> = [
-  {
-    group: '工作区',
-    items: [
-      { icon: Layers3, label: '我的任务', perm: '所有人' },
-      { icon: Boxes, label: '项目与任务', perm: '项目成员', active: true },
-      { icon: SlidersHorizontal, label: '看板', perm: '项目成员' },
-    ],
-  },
-  {
-    group: '管理',
-    locked: true,
-    items: [
-      { icon: ShieldCheck, label: '团队', perm: '管理员' },
-      { icon: Eye, label: '洞察看板', perm: '管理员' },
-    ],
-  },
-];
+import { useMetadataClient } from '../metadata-admin/useMetadata';
 
 const PILLARS = ['Data', 'Automations', 'Interfaces'] as const;
+
+interface NavItem {
+  type: string;
+  name: string;
+  label: string;
+}
+
+/**
+ * Normalize the framework draft envelope `{ type, name, item }` into the draft
+ * body or null (mirrors ResourceEditPage.extractDraftBody — a "no draft" stub
+ * still carries type/name/label keys, so the `item` key is the only signal).
+ */
+function extractDraftBody(resp: unknown): Record<string, unknown> | null {
+  if (!resp || typeof resp !== 'object') return null;
+  const env = resp as Record<string, unknown>;
+  if (!('item' in env)) return null;
+  const body = env.item;
+  if (!body || typeof body !== 'object') return null;
+  return Object.keys(body as object).length > 0 ? (body as Record<string, unknown>) : null;
+}
 
 export interface StudioDesignSurfaceProps {
   /**
@@ -108,18 +62,108 @@ export interface StudioDesignSurfaceProps {
 }
 
 export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React.ReactElement {
-  const [draft, setDraft] = React.useState<Record<string, unknown>>(FIXTURE_PAGE);
-  const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
+  const client = useMetadataClient();
   const locale = 'zh-CN';
 
-  // Reuse the REAL registered surfaces — no new editor code.
-  const Preview = getMetadataPreview('page');
-  const Inspector = getMetadataInspector('page');
+  const [nav, setNav] = React.useState<NavItem[]>([]);
+  const [current, setCurrent] = React.useState<NavItem | null>(null);
+  const [draft, setDraft] = React.useState<Record<string, unknown>>({});
+  const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [saving, setSaving] = React.useState<false | 'draft' | 'publish'>(false);
+  const [hasDraft, setHasDraft] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Load the single-App nav: the env's pages become the menu items (a later
+  // slice resolves the real App.navigation tree; pages are the demonstrable
+  // Interface surfaces today). First item auto-opens.
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = (await client.list('page')) as Array<Record<string, unknown>>;
+        if (cancelled) return;
+        const items: NavItem[] = (list || [])
+          .map((p) => ({ type: 'page', name: String(p.name ?? ''), label: String(p.label ?? p.name ?? '') }))
+          .filter((p) => !!p.name);
+        setNav(items);
+        setCurrent((cur) => cur ?? items[0] ?? null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  // Load the selected surface's draft (effective baseline + pending overlay),
+  // mirroring ResourceEditPage's load.
+  React.useEffect(() => {
+    if (!current) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSelection(null);
+    (async () => {
+      try {
+        const [lay, draftResp] = await Promise.all([
+          client.layered<Record<string, unknown>>(current.type, current.name),
+          client.getDraft<Record<string, unknown>>(current.type, current.name).catch(() => null),
+        ]);
+        if (cancelled) return;
+        const baseline = ((lay as { effective?: unknown; code?: unknown }).effective ??
+          (lay as { code?: unknown }).code ??
+          {}) as Record<string, unknown>;
+        const draftBody = extractDraftBody(draftResp);
+        setDraft(draftBody ? { ...baseline, ...draftBody } : baseline);
+        setHasDraft(!!draftBody);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, current]);
 
   const onPatch = React.useCallback(
     (patch: Record<string, unknown>) => setDraft((d) => ({ ...d, ...patch })),
     [],
   );
+
+  const doSave = React.useCallback(async () => {
+    if (!current) return;
+    setSaving('draft');
+    setError(null);
+    try {
+      await client.save(current.type, current.name, draft, { mode: 'draft' });
+      setHasDraft(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }, [client, current, draft]);
+
+  const doPublish = React.useCallback(async () => {
+    if (!current) return;
+    setSaving('publish');
+    setError(null);
+    try {
+      await client.publish(current.type, current.name);
+      setHasDraft(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }, [client, current]);
+
+  const Preview = getMetadataPreview(current?.type ?? 'page');
+  const Inspector = getMetadataInspector(current?.type ?? 'page');
 
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
@@ -129,11 +173,11 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
       ) : null}
 
       <div className="flex min-w-0 flex-1 flex-col">
-        {/* top bar: three pillars + publish */}
+        {/* top bar: three pillars + draft/publish */}
         <header className="flex items-center justify-between border-b px-3 py-2">
           <div className="flex min-w-0 items-center gap-3">
             <span className="flex items-center gap-1.5 whitespace-nowrap text-[13px] font-medium">
-              <Boxes className="h-4 w-4" /> 项目管理包
+              <Boxes className="h-4 w-4" /> Showcase
             </span>
             <span className="text-muted-foreground">·</span>
             <nav className="flex gap-1">
@@ -153,68 +197,80 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
             </nav>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <button className="rounded-md border px-2.5 py-1 text-xs hover:bg-muted">
-              <Eye className="mr-1 inline h-3.5 w-3.5 align-[-2px]" />预览
+            {hasDraft && (
+              <span className="rounded bg-amber-400/15 px-2 py-0.5 text-[11px] text-amber-600 dark:text-amber-300">
+                未发布草稿
+              </span>
+            )}
+            <button
+              onClick={doSave}
+              disabled={!current || !!saving}
+              className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-muted disabled:opacity-50"
+            >
+              {saving === 'draft' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+              保存草稿
             </button>
-            <button className="rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground">
+            <button
+              onClick={doPublish}
+              disabled={!current || !hasDraft || !!saving}
+              className="inline-flex items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {saving === 'publish' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
               发布
             </button>
           </div>
         </header>
 
         <div className="flex min-h-0 flex-1">
-          {/* ── Zone 1 · single-App nav (multi-level + permission chips) ── */}
-          <nav className="w-44 shrink-0 overflow-auto border-r p-2">
-            <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">单一 App</p>
-            {NAV.map((g) => (
-              <div key={g.group}>
-                <p className="flex items-center gap-1 px-2 pb-1 pt-3 text-[11px] text-muted-foreground">
-                  {g.group}
-                  {g.locked && <Lock className="h-3 w-3" />}
-                </p>
-                {g.items.map((it) => (
-                  <div
-                    key={it.label}
-                    className={
-                      'flex items-center gap-2 rounded-md px-2 py-1.5 text-xs ' +
-                      (it.active ? 'bg-muted font-medium' : 'text-foreground/90')
-                    }
-                  >
-                    <it.icon className="h-3.5 w-3.5 shrink-0" />
-                    <span className="flex-1 truncate">{it.label}</span>
-                    {it.perm && (
-                      <span className="flex items-center gap-0.5 whitespace-nowrap rounded bg-muted px-1.5 py-px text-[10px] text-muted-foreground">
-                        <Lock className="h-2.5 w-2.5" />
-                        {it.perm}
-                      </span>
-                    )}
-                  </div>
-                ))}
-              </div>
+          {/* ── Zone 1 · single-App nav (real pages; click switches the canvas) ── */}
+          <nav className="w-48 shrink-0 overflow-auto border-r p-2">
+            <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">单一 App · 页面</p>
+            {nav.length === 0 && (
+              <p className="px-2 py-3 text-[11px] text-muted-foreground">
+                {error ? '加载失败' : '加载中…'}
+              </p>
+            )}
+            {nav.map((it) => (
+              <button
+                key={it.name}
+                onClick={() => setCurrent(it)}
+                className={
+                  'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs ' +
+                  (current?.name === it.name ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
+                }
+              >
+                <FileText className="h-3.5 w-3.5 shrink-0" />
+                <span className="flex-1 truncate">{it.label}</span>
+              </button>
             ))}
           </nav>
 
-          {/* ── Zone 2 · canvas (live render = runtime) ── */}
+          {/* ── Zone 2 · canvas (live render of the real surface = runtime) ── */}
           <main className="min-w-0 flex-1 overflow-auto bg-muted/30 p-4">
             <div className="mb-3 flex items-center gap-2">
               <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
                 <Eye className="h-3 w-3" /> 预览即运行 · 同一渲染器
               </span>
-              <span className="text-[11px] text-muted-foreground">草稿</span>
+              {current && (
+                <span className="text-[11px] text-muted-foreground">
+                  {current.type} · {current.name}
+                </span>
+              )}
             </div>
-            <div className="rounded-lg border bg-background p-4">
-              <div className="mb-3 flex items-center justify-between">
-                <span className="text-[13px] font-medium">
-                  {String((draft as { label?: string }).label ?? '项目与任务')}
-                </span>
-                <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
-                  对象视图 / page
-                </span>
+            {error && (
+              <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                {error}
               </div>
-              {Preview ? (
+            )}
+            <div className="rounded-lg border bg-background p-4">
+              {loading || !current ? (
+                <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
+                </div>
+              ) : Preview ? (
                 <Preview
-                  type="page"
-                  name="projects_overview"
+                  type={current.type}
+                  name={current.name}
                   draft={draft}
                   editing
                   selection={selection}
@@ -223,11 +279,11 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
                   locale={locale}
                 />
               ) : (
-                <SchemaRenderer schema={{ ...draft, type: 'page' } as never} />
+                <SchemaRenderer schema={{ ...draft, type: current.type } as never} />
               )}
             </div>
             <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
-              <MousePointer2 className="h-3 w-3" /> 点选积木 → 右侧直接改
+              <MousePointer2 className="h-3 w-3" /> 点选积木 → 右侧直接改 · 改完「保存草稿」→「发布」
             </p>
           </main>
 
@@ -243,10 +299,10 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
               )}
             </header>
             <div className="p-3">
-              {selection && Inspector ? (
+              {selection && Inspector && current ? (
                 <Inspector
-                  type="page"
-                  name="projects_overview"
+                  type={current.type}
+                  name={current.name}
                   draft={draft}
                   selection={selection}
                   onPatch={onPatch}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -586,7 +586,7 @@ function AutomationsPillar({ packageId }: { packageId: string }): React.ReactEle
   const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
-  const Preview = getMetadataPreview('flow');
+  const Preview = getMetadataPreview(current?.type ?? '');
 
   React.useEffect(() => {
     let cancelled = false;
@@ -670,15 +670,15 @@ function AutomationsPillar({ packageId }: { packageId: string }): React.ReactEle
                   <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
                 </div>
               ) : Preview ? (
-                <Preview
-                  type="flow"
-                  name={current.name}
-                  draft={draft}
-                  editing={false}
-                  selection={selection}
-                  onSelectionChange={setSelection}
-                  locale={locale}
-                />
+                React.createElement(Preview, {
+                  type: current.type,
+                  name: current.name,
+                  draft,
+                  editing: false,
+                  selection,
+                  onSelectionChange: setSelection,
+                  locale,
+                })
               ) : (
                 <pre className="overflow-auto text-[11px] text-muted-foreground">
                   {JSON.stringify(draft, null, 2)}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -1,45 +1,39 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * Dev-only harness — Studio WYSIWYG design surface, slice-1 (ADR-0080).
+ * StudioDesignSurface — the open-source WYSIWYG design surface (ADR-0080).
  *
- * Proves the four-zone shell with ZERO new editor code: it REUSES the
- * existing metadata-admin registry (`getMetadataPreview` / `getMetadataInspector`)
- * and the runtime `SchemaRenderer`, so design-time === run-time (same renderer).
+ * Three zones — single-App nav · live canvas · property inspector — composed
+ * AROUND the existing metadata-admin registry (`getMetadataPreview` /
+ * `getMetadataInspector`) and the runtime `SchemaRenderer`, so design-time is
+ * literally run-time (same renderer, same metadata).
  *
- *   ┌────────┬────────┬─────────────────┬──────────┐
- *   │ AI 副驾 │ 单 App │ 预览即运行画布   │ inspector │
- *   │(可折叠) │ 导航   │ (选中→改→重渲)   │ (选中积木)│
- *   └────────┴────────┴─────────────────┴──────────┘
+ * Open-core boundary: the left AI copilot is NOT part of the open-source
+ * surface. It is an injected slot (`aiSlot`) that the cloud edition fills; the
+ * OSS build renders three zones. Everything else — nav, canvas, inspector,
+ * the select→edit→re-render loop — lives here, in the open package.
  *
- * Purely additive: touches NO existing surface (ResourceEditPage, registries,
- * previews all untouched). Mounted at a public dev route /dev/studio-design so
- * it renders standalone from a fixture — no backend required. Not product nav.
+ * slice-1 drives a fixture page with no backend so the surface is demoable
+ * standalone. Real metadata load/save (useMetadataClient) and nav-driven
+ * surface switching land in follow-up slices.
  */
 
 import * as React from 'react';
-import {
-  getMetadataPreview,
-  getMetadataInspector,
-  type MetadataSelection,
-} from '@object-ui/app-shell';
 import { SchemaRenderer } from '@object-ui/react';
 import {
-  Zap,
-  Send,
-  ChevronLeft,
-  ChevronRight,
-  Lock,
-  Eye,
   Boxes,
   Layers3,
   ShieldCheck,
   SlidersHorizontal,
   MousePointer2,
+  Eye,
+  Lock,
 } from 'lucide-react';
+import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
+import { getMetadataInspector } from '../metadata-admin/inspector-registry';
 
 // ── Fixture: one "Interface" page draft. Built from element blocks that
-//    render with no backend (same family the /dev/lists harness uses). ──
+//    render with no backend. Replaced by real metadata in a later slice. ──
 const FIXTURE_PAGE: Record<string, unknown> = {
   type: 'page',
   name: 'projects_overview',
@@ -77,8 +71,8 @@ const FIXTURE_PAGE: Record<string, unknown> = {
   ],
 };
 
-// ── Mock single-App nav. slice-1 keeps it static; the permission chips
-//    illustrate the role-projection model (ADR-0080 D4). ──
+// ── Mock single-App nav. The permission chips illustrate the role-projection
+//    model (ADR-0080 D4). Replaced by a real App nav model in a later slice. ──
 const NAV: Array<{
   group: string;
   locked?: boolean;
@@ -104,14 +98,21 @@ const NAV: Array<{
 
 const PILLARS = ['Data', 'Automations', 'Interfaces'] as const;
 
-export function DevStudioDesign(): React.ReactElement {
+export interface StudioDesignSurfaceProps {
+  /**
+   * Open-core slot. The cloud edition injects its AI copilot panel here
+   * (rendered as the far-left zone). The open-source build leaves it
+   * undefined, so the surface renders three zones.
+   */
+  aiSlot?: React.ReactNode;
+}
+
+export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React.ReactElement {
   const [draft, setDraft] = React.useState<Record<string, unknown>>(FIXTURE_PAGE);
   const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
-  const [aiCollapsed, setAiCollapsed] = React.useState(false);
   const locale = 'zh-CN';
 
-  // Reuse the REAL registered surfaces. Fallback to the bare renderer if the
-  // registry side-effect hasn't run (keeps the harness from white-screening).
+  // Reuse the REAL registered surfaces — no new editor code.
   const Preview = getMetadataPreview('page');
   const Inspector = getMetadataInspector('page');
 
@@ -122,53 +123,11 @@ export function DevStudioDesign(): React.ReactElement {
 
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
-      {/* ── Zone 1 · AI copilot (far left, collapsible, recessed = auxiliary) ── */}
-      {aiCollapsed ? (
-        <button
-          type="button"
-          onClick={() => setAiCollapsed(false)}
-          aria-label="展开搭建助手"
-          className="flex w-10 shrink-0 flex-col items-center gap-2 border-r bg-muted/40 py-3 text-muted-foreground hover:text-foreground"
-        >
-          <Zap className="h-4 w-4" />
-          <ChevronRight className="h-4 w-4" />
-        </button>
-      ) : (
-        <aside className="flex w-56 shrink-0 flex-col border-r bg-muted/40">
-          <header className="flex items-center justify-between border-b px-3 py-2.5">
-            <span className="flex items-center gap-1.5 text-[13px] font-medium">
-              <Zap className="h-4 w-4" /> 搭建助手
-            </span>
-            <button
-              type="button"
-              onClick={() => setAiCollapsed(true)}
-              aria-label="收起"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-          </header>
-          <div className="flex flex-1 flex-col gap-2 overflow-auto p-3">
-            <div className="self-end max-w-[88%] rounded-md bg-primary/10 px-2.5 py-1.5 text-[11px] text-primary">
-              状态做成看板视图
-            </div>
-            <div className="text-[11px] leading-relaxed text-muted-foreground">
-              已在 Interfaces 加「看板」页,绑定 Tasks。要我顺手加筛选吗?
-            </div>
-          </div>
-          <footer className="border-t p-3">
-            <div className="flex items-center gap-2 rounded-md border bg-background px-2.5 py-1.5 text-[11px] text-muted-foreground">
-              <span className="flex-1">描述要改的地方…</span>
-              <Send className="h-3.5 w-3.5" />
-            </div>
-            <p className="mt-1.5 text-center text-[11px] text-muted-foreground">
-              辅助 · 不挡你直接改
-            </p>
-          </footer>
-        </aside>
-      )}
+      {/* ── Zone 0 · AI copilot — OPEN-CORE SLOT (cloud-injected; absent in OSS) ── */}
+      {aiSlot ? (
+        <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside>
+      ) : null}
 
-      {/* ── Studio (tabs + body) ── */}
       <div className="flex min-w-0 flex-1 flex-col">
         {/* top bar: three pillars + publish */}
         <header className="flex items-center justify-between border-b px-3 py-2">
@@ -204,11 +163,9 @@ export function DevStudioDesign(): React.ReactElement {
         </header>
 
         <div className="flex min-h-0 flex-1">
-          {/* ── Zone 2 · single-App nav (multi-level + permission chips) ── */}
+          {/* ── Zone 1 · single-App nav (multi-level + permission chips) ── */}
           <nav className="w-44 shrink-0 overflow-auto border-r p-2">
-            <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">
-              单一 App
-            </p>
+            <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">单一 App</p>
             {NAV.map((g) => (
               <div key={g.group}>
                 <p className="flex items-center gap-1 px-2 pb-1 pt-3 text-[11px] text-muted-foreground">
@@ -237,7 +194,7 @@ export function DevStudioDesign(): React.ReactElement {
             ))}
           </nav>
 
-          {/* ── Zone 3 · canvas (live render = runtime) ── */}
+          {/* ── Zone 2 · canvas (live render = runtime) ── */}
           <main className="min-w-0 flex-1 overflow-auto bg-muted/30 p-4">
             <div className="mb-3 flex items-center gap-2">
               <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
@@ -274,7 +231,7 @@ export function DevStudioDesign(): React.ReactElement {
             </p>
           </main>
 
-          {/* ── Zone 4 · inspector (selected block's property schema) ── */}
+          {/* ── Zone 3 · inspector (selected block's property schema) ── */}
           <aside className="w-72 shrink-0 overflow-auto border-l">
             <header className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background/95 px-3 py-2 backdrop-blur">
               <SlidersHorizontal className="h-3.5 w-3.5" />
@@ -314,4 +271,4 @@ export function DevStudioDesign(): React.ReactElement {
   );
 }
 
-export default DevStudioDesign;
+export default StudioDesignSurface;

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -552,48 +552,22 @@ function DataPillar(): React.ReactElement {
           </button>
         ))}
       </nav>
-      <main className="min-w-0 flex-1 overflow-auto p-4">
+      <main className="flex min-w-0 flex-1 flex-col overflow-hidden p-4">
         {!current ? (
           <div className="py-16 text-center text-sm text-muted-foreground">选择一个对象</div>
         ) : (
           <>
-            <div className="mb-3 flex items-center gap-2">
+            <div className="mb-3 flex shrink-0 items-center gap-2">
               <span className="text-[13px] font-medium">{current.label}</span>
               <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
                 object · {current.name}
               </span>
               <span className="text-[11px] text-muted-foreground">{fields.length} 字段</span>
             </div>
-            <div className="mb-4 rounded-lg border bg-background p-2">
+            {/* Data mode = the records themselves, as a directly-viewable grid
+              * (Airtable parity). Fields are the columns — no separate table. */}
+            <div className="min-h-0 flex-1 overflow-auto rounded-lg border bg-background">
               <SchemaRenderer schema={{ type: 'object-grid', objectName: current.name } as never} />
-            </div>
-            <div className="rounded-lg border bg-background">
-              <table className="w-full text-xs">
-                <thead className="border-b text-left text-muted-foreground">
-                  <tr>
-                    <th className="px-3 py-2 font-medium">字段</th>
-                    <th className="px-3 py-2 font-medium">类型</th>
-                    <th className="px-3 py-2 font-medium">名称</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {loading ? (
-                    <tr>
-                      <td colSpan={3} className="px-3 py-6 text-center text-muted-foreground">
-                        加载中…
-                      </td>
-                    </tr>
-                  ) : (
-                    fields.map((f) => (
-                      <tr key={f.name} className="border-b last:border-0">
-                        <td className="px-3 py-1.5">{f.label ?? f.name}</td>
-                        <td className="px-3 py-1.5 text-muted-foreground">{f.type ?? '—'}</td>
-                        <td className="px-3 py-1.5 font-mono text-[11px] text-muted-foreground">{f.name}</td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
             </div>
           </>
         )}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -3,18 +3,19 @@
 /**
  * StudioDesignSurface — the open-source WYSIWYG design surface (ADR-0080).
  *
- * Three zones — single-App nav · live canvas · property inspector — composed
- * AROUND the existing metadata-admin registry (`getMetadataPreview` /
- * `getMetadataInspector`), the runtime `SchemaRenderer`, and the shared
- * `MetadataClient`. Design-time is literally run-time (same renderer, same
- * metadata), and edits persist through the real draft → publish pipeline.
+ * Routed as /studio/:packageId/{data|automations|interfaces} — the three
+ * pillars are real routes, scoped to the package being designed. Each pillar
+ * is composed AROUND existing renderers (no new editor code):
+ *   - Interfaces: the App nav + live canvas (getMetadataPreview) + inspector
+ *     (getMetadataInspector), edits persisting through draft → publish.
+ *   - Data / Automations: object + flow surfaces (in progress).
  *
  * Open-core boundary: the left AI copilot is NOT part of the open-source
- * surface. It is an injected slot (`aiSlot`) the cloud edition fills; the OSS
- * build renders three zones.
+ * surface — it is an injected slot (`aiSlot`) the cloud edition fills.
  */
 
 import * as React from 'react';
+import { useParams, Link } from 'react-router-dom';
 import { SchemaRenderer } from '@object-ui/react';
 import {
   Boxes,
@@ -24,13 +25,18 @@ import {
   Eye,
   Loader2,
   Save,
-  Send,
+  Database,
+  Workflow,
 } from 'lucide-react';
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
 import { useMetadataClient } from '../metadata-admin/useMetadata';
 
-const PILLARS = ['Data', 'Automations', 'Interfaces'] as const;
+const PILLARS = [
+  { key: 'data', label: 'Data' },
+  { key: 'automations', label: 'Automations' },
+  { key: 'interfaces', label: 'Interfaces' },
+] as const;
 
 interface NavItem {
   type: string;
@@ -38,11 +44,7 @@ interface NavItem {
   label: string;
 }
 
-/**
- * Normalize the framework draft envelope `{ type, name, item }` into the draft
- * body or null (mirrors ResourceEditPage.extractDraftBody — a "no draft" stub
- * still carries type/name/label keys, so the `item` key is the only signal).
- */
+/** Normalize the framework draft envelope `{ type, name, item }` → body | null. */
 function extractDraftBody(resp: unknown): Record<string, unknown> | null {
   if (!resp || typeof resp !== 'object') return null;
   const env = resp as Record<string, unknown>;
@@ -53,15 +55,94 @@ function extractDraftBody(resp: unknown): Record<string, unknown> | null {
 }
 
 export interface StudioDesignSurfaceProps {
-  /**
-   * Open-core slot. The cloud edition injects its AI copilot panel here
-   * (rendered as the far-left zone). The open-source build leaves it
-   * undefined, so the surface renders three zones.
-   */
+  /** Open-core slot — the cloud edition injects its AI copilot panel here. */
   aiSlot?: React.ReactNode;
 }
 
 export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React.ReactElement {
+  const params = useParams<{ packageId?: string; tab?: string }>();
+  const packageId = params.packageId ?? 'com.example.showcase';
+  const tab = params.tab ?? 'interfaces';
+
+  return (
+    <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
+      {/* ── AI copilot — OPEN-CORE SLOT (cloud-injected; absent in OSS) ── */}
+      {aiSlot ? (
+        <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside>
+      ) : null}
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        {/* shell header: package + three pillar routes */}
+        <header className="flex items-center gap-3 border-b px-3 py-2">
+          <span className="flex items-center gap-1.5 whitespace-nowrap text-[13px] font-medium">
+            <Boxes className="h-4 w-4" /> {packageId}
+          </span>
+          <span className="text-muted-foreground">·</span>
+          <nav className="flex gap-1">
+            {PILLARS.map((p) => (
+              <Link
+                key={p.key}
+                to={`/studio/${packageId}/${p.key}`}
+                className={
+                  'rounded-md px-2.5 py-1 text-xs ' +
+                  (tab === p.key
+                    ? 'bg-primary/10 font-medium text-primary'
+                    : 'text-muted-foreground hover:bg-muted')
+                }
+              >
+                {p.label}
+              </Link>
+            ))}
+          </nav>
+        </header>
+
+        <div className="min-h-0 flex-1">
+          {tab === 'data' ? (
+            <PillarPlaceholder
+              icon={<Database className="h-6 w-6" />}
+              title="Data — 对象 / 字段 / 记录"
+              detail="数据层:列出包内对象,查看字段与记录网格。建设中。"
+            />
+          ) : tab === 'automations' ? (
+            <PillarPlaceholder
+              icon={<Workflow className="h-6 w-6" />}
+              title="Automations — flow / 触发器 / 审批"
+              detail="自动化:列出 flow,默认 OFF / 审阅再启用(ADR-0080)。建设中。"
+            />
+          ) : (
+            <InterfacesPillar packageId={packageId} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PillarPlaceholder({
+  icon,
+  title,
+  detail,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  detail: string;
+}): React.ReactElement {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+      <div className="opacity-60">{icon}</div>
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="max-w-sm text-xs">{detail}</p>
+    </div>
+  );
+}
+
+/**
+ * The Interfaces pillar — single-App nav · live canvas · inspector. Drives the
+ * real MetadataClient: pages become menu items, clicking loads that surface,
+ * the toolbar saves drafts / publishes. (A later slice swaps the page list for
+ * the real App.navigation tree with view/dashboard/object items.)
+ */
+function InterfacesPillar({ packageId: _packageId }: { packageId: string }): React.ReactElement {
   const client = useMetadataClient();
   const locale = 'zh-CN';
 
@@ -74,9 +155,6 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   const [hasDraft, setHasDraft] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
-  // Load the single-App nav: the env's pages become the menu items (a later
-  // slice resolves the real App.navigation tree; pages are the demonstrable
-  // Interface surfaces today). First item auto-opens.
   React.useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -97,8 +175,6 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
     };
   }, [client]);
 
-  // Load the selected surface's draft (effective baseline + pending overlay),
-  // mirroring ResourceEditPage's load.
   React.useEffect(() => {
     if (!current) return;
     let cancelled = false;
@@ -166,162 +242,130 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   const Inspector = getMetadataInspector(current?.type ?? 'page');
 
   return (
-    <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
-      {/* ── Zone 0 · AI copilot — OPEN-CORE SLOT (cloud-injected; absent in OSS) ── */}
-      {aiSlot ? (
-        <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside>
-      ) : null}
+    <div className="flex h-full flex-col">
+      {/* pillar toolbar: draft / publish */}
+      <div className="flex items-center justify-end gap-2 border-b px-3 py-1.5">
+        {hasDraft && (
+          <span className="rounded bg-amber-400/15 px-2 py-0.5 text-[11px] text-amber-600 dark:text-amber-300">
+            未发布草稿
+          </span>
+        )}
+        <button
+          onClick={doSave}
+          disabled={!current || !!saving}
+          className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-muted disabled:opacity-50"
+        >
+          {saving === 'draft' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+          保存草稿
+        </button>
+        <button
+          onClick={doPublish}
+          disabled={!current || !hasDraft || !!saving}
+          className="inline-flex items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {saving === 'publish' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          发布
+        </button>
+      </div>
 
-      <div className="flex min-w-0 flex-1 flex-col">
-        {/* top bar: three pillars + draft/publish */}
-        <header className="flex items-center justify-between border-b px-3 py-2">
-          <div className="flex min-w-0 items-center gap-3">
-            <span className="flex items-center gap-1.5 whitespace-nowrap text-[13px] font-medium">
-              <Boxes className="h-4 w-4" /> Showcase
+      <div className="flex min-h-0 flex-1">
+        {/* nav (real pages; click switches the canvas) */}
+        <nav className="w-48 shrink-0 overflow-auto border-r p-2">
+          <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">单一 App · 页面</p>
+          {nav.length === 0 && (
+            <p className="px-2 py-3 text-[11px] text-muted-foreground">{error ? '加载失败' : '加载中…'}</p>
+          )}
+          {nav.map((it) => (
+            <button
+              key={it.name}
+              onClick={() => setCurrent(it)}
+              className={
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs ' +
+                (current?.name === it.name ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
+              }
+            >
+              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <span className="flex-1 truncate">{it.label}</span>
+            </button>
+          ))}
+        </nav>
+
+        {/* canvas (live render = runtime) */}
+        <main className="min-w-0 flex-1 overflow-auto bg-muted/30 p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
+              <Eye className="h-3 w-3" /> 预览即运行 · 同一渲染器
             </span>
-            <span className="text-muted-foreground">·</span>
-            <nav className="flex gap-1">
-              {PILLARS.map((p) => (
-                <span
-                  key={p}
-                  className={
-                    'rounded-md px-2.5 py-1 text-xs ' +
-                    (p === 'Interfaces'
-                      ? 'bg-primary/10 font-medium text-primary'
-                      : 'text-muted-foreground')
-                  }
-                >
-                  {p}
-                </span>
-              ))}
-            </nav>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {hasDraft && (
-              <span className="rounded bg-amber-400/15 px-2 py-0.5 text-[11px] text-amber-600 dark:text-amber-300">
-                未发布草稿
+            {current && (
+              <span className="text-[11px] text-muted-foreground">
+                {current.type} · {current.name}
               </span>
             )}
-            <button
-              onClick={doSave}
-              disabled={!current || !!saving}
-              className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-muted disabled:opacity-50"
-            >
-              {saving === 'draft' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
-              保存草稿
-            </button>
-            <button
-              onClick={doPublish}
-              disabled={!current || !hasDraft || !!saving}
-              className="inline-flex items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
-            >
-              {saving === 'publish' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-              发布
-            </button>
           </div>
-        </header>
-
-        <div className="flex min-h-0 flex-1">
-          {/* ── Zone 1 · single-App nav (real pages; click switches the canvas) ── */}
-          <nav className="w-48 shrink-0 overflow-auto border-r p-2">
-            <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">单一 App · 页面</p>
-            {nav.length === 0 && (
-              <p className="px-2 py-3 text-[11px] text-muted-foreground">
-                {error ? '加载失败' : '加载中…'}
-              </p>
-            )}
-            {nav.map((it) => (
-              <button
-                key={it.name}
-                onClick={() => setCurrent(it)}
-                className={
-                  'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs ' +
-                  (current?.name === it.name ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
-                }
-              >
-                <FileText className="h-3.5 w-3.5 shrink-0" />
-                <span className="flex-1 truncate">{it.label}</span>
-              </button>
-            ))}
-          </nav>
-
-          {/* ── Zone 2 · canvas (live render of the real surface = runtime) ── */}
-          <main className="min-w-0 flex-1 overflow-auto bg-muted/30 p-4">
-            <div className="mb-3 flex items-center gap-2">
-              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
-                <Eye className="h-3 w-3" /> 预览即运行 · 同一渲染器
-              </span>
-              {current && (
-                <span className="text-[11px] text-muted-foreground">
-                  {current.type} · {current.name}
-                </span>
-              )}
+          {error && (
+            <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {error}
             </div>
-            {error && (
-              <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-                {error}
+          )}
+          <div className="rounded-lg border bg-background p-4">
+            {loading || !current ? (
+              <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
+              </div>
+            ) : Preview ? (
+              <Preview
+                type={current.type}
+                name={current.name}
+                draft={draft}
+                editing
+                selection={selection}
+                onSelectionChange={setSelection}
+                onPatch={onPatch}
+                locale={locale}
+              />
+            ) : (
+              <SchemaRenderer schema={{ ...draft, type: current.type } as never} />
+            )}
+          </div>
+          <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
+            <MousePointer2 className="h-3 w-3" /> 点选积木 → 右侧直接改 · 改完「保存草稿」→「发布」
+          </p>
+        </main>
+
+        {/* inspector (selected block's property schema) */}
+        <aside className="w-72 shrink-0 overflow-auto border-l">
+          <header className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background/95 px-3 py-2 backdrop-blur">
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            <span className="text-[13px] font-medium">属性</span>
+            {selection?.label && (
+              <span className="truncate rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                {selection.label}
+              </span>
+            )}
+          </header>
+          <div className="p-3">
+            {selection && Inspector && current ? (
+              <Inspector
+                type={current.type}
+                name={current.name}
+                draft={draft}
+                selection={selection}
+                onPatch={onPatch}
+                onClearSelection={() => setSelection(null)}
+                onSelectionChange={setSelection}
+                readOnly={false}
+                locale={locale}
+              />
+            ) : (
+              <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">
+                <MousePointer2 className="h-5 w-5" />
+                在画布里点选一个积木,
+                <br />
+                它的属性会在这里直接编辑。
               </div>
             )}
-            <div className="rounded-lg border bg-background p-4">
-              {loading || !current ? (
-                <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
-                </div>
-              ) : Preview ? (
-                <Preview
-                  type={current.type}
-                  name={current.name}
-                  draft={draft}
-                  editing
-                  selection={selection}
-                  onSelectionChange={setSelection}
-                  onPatch={onPatch}
-                  locale={locale}
-                />
-              ) : (
-                <SchemaRenderer schema={{ ...draft, type: current.type } as never} />
-              )}
-            </div>
-            <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
-              <MousePointer2 className="h-3 w-3" /> 点选积木 → 右侧直接改 · 改完「保存草稿」→「发布」
-            </p>
-          </main>
-
-          {/* ── Zone 3 · inspector (selected block's property schema) ── */}
-          <aside className="w-72 shrink-0 overflow-auto border-l">
-            <header className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background/95 px-3 py-2 backdrop-blur">
-              <SlidersHorizontal className="h-3.5 w-3.5" />
-              <span className="text-[13px] font-medium">属性</span>
-              {selection?.label && (
-                <span className="truncate rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
-                  {selection.label}
-                </span>
-              )}
-            </header>
-            <div className="p-3">
-              {selection && Inspector && current ? (
-                <Inspector
-                  type={current.type}
-                  name={current.name}
-                  draft={draft}
-                  selection={selection}
-                  onPatch={onPatch}
-                  onClearSelection={() => setSelection(null)}
-                  onSelectionChange={setSelection}
-                  readOnly={false}
-                  locale={locale}
-                />
-              ) : (
-                <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">
-                  <MousePointer2 className="h-5 w-5" />
-                  在画布里点选一个积木,
-                  <br />
-                  它的属性会在这里直接编辑。
-                </div>
-              )}
-            </div>
-          </aside>
-        </div>
+          </div>
+        </aside>
       </div>
     </div>
   );

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -419,7 +419,7 @@ function InterfacesPillar({ packageId }: { packageId: string }): React.ReactElem
                 locale={locale}
               />
             ) : current.type === 'object' ? (
-              <SchemaRenderer schema={{ type: 'object-grid', objectName: current.name } as never} />
+              <SchemaRenderer schema={{ type: 'object-view', objectName: current.name } as never} />
             ) : (
               <div className="py-12 text-center text-xs text-muted-foreground">
                 {current.type} 暂用只读预览,设计能力建设中。
@@ -567,7 +567,7 @@ function DataPillar(): React.ReactElement {
             {/* Data mode = the records themselves, as a directly-viewable grid
               * (Airtable parity). Fields are the columns — no separate table. */}
             <div className="min-h-0 flex-1 overflow-auto rounded-lg border bg-background">
-              <SchemaRenderer schema={{ type: 'object-grid', objectName: current.name } as never} />
+              <SchemaRenderer schema={{ type: 'object-view', objectName: current.name } as never} />
             </div>
           </>
         )}


### PR DESCRIPTION
## 什么

Studio 从「通用元数据 CRUD admin」重构为**预览优先的 WYSIWYG 设计面**的 slice-1（ADR-0080，决策与深度设计文档已合并 cloud#697）。新增 `packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx`，从 `@object-ui/app-shell` 导出，挂在 `apps/console` 的 `/studio/:packageId/:tab` 路由。

**核心理念：设计态 = 运行态**——同一个 objectui 渲染器，给每次编辑一条不依赖 AI 的兜底（补 Airtable 拆解暴露的「阶段二迭代面」缺口）。

## 三支柱（全真实数据，零新渲染器，复用现成 preview/inspector 注册表）

- **Interfaces** — `/studio/:packageId/interfaces`：左侧导航树镜像**真实 App** 的多级菜单（Workspace / Data Model / Analytics / Pages），菜单项绑定到对象 / 看板 / 报表 / 页面；点选 leaf 进画布，用同一渲染器预览（"预览即运行 · 同一渲染器"）；画布点选积木 → 右侧 inspector 直接改属性 → `保存草稿` / `发布`。
- **Data** — `/studio/:packageId/data`：用**我们的视图模型**（object-view 列表视图，非 Airtable 裸 grid），整版主视图；**按当前软件包过滤**对象。
- **Automations** — `/studio/:packageId/automations`：flow 列表 + FlowPreview 流程图；**按当前软件包过滤**。

## 开源/闭源边界

AI 副驾是注入式 `aiSlot` prop——开源版留空，cloud 版填左栏聊天。开放机制、闭源智能，沿用 ai-studio open-core 模式。

## 不进产品 nav

只挂 `/studio` 路由，**暂不进控制台导航**——MVP，opt-in，零回归面。

## 验证

- ✅ `eslint .` — 0 errors（5 个 warning，CI 不拦）
- ✅ `tsc --noEmit`（app-shell，依赖已构建）— 0 errors
- ✅ **edit→save→publish→落盘 实测**（本地全栈，真实后端）：inspector 改 grid `Columns` 3→2 → 画布即时回流（onPatch→同一渲染器重渲）→ 保存草稿（"未发布草稿" badge）→ 发布 → 元数据 overlay 层持久化 `columns:2`（`overlayScope:env`），effective 解析为 2，draft 已清。

| layer | columns |
|---|---|
| code（包源） | 3 |
| overlay（发布写入） | **2** |
| effective（运行态） | **2** |

## 后续 PR（已记 TODO，不在本 PR）

- Data 列表接全功能 object 视图宿主（视图切换 tab + 添加视图）
- Interface 导航左栏拖拽编辑（复用 AppNavCanvas）
- grid 列头动态加字段（用户点名的下一步优化重点）

🤖 Generated with [Claude Code](https://claude.com/claude-code)