### PR TITLE
feat(app-shell): detail.hidePath opt-out for the auto record:path stepper

### DIFF
--- a/.changeset/detail-hide-path.md
+++ b/.changeset/detail-hide-path.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/app-shell': minor
+---
+
+feat(app-shell): `detail.hidePath` opt-out for the auto record:path stepper
+
+Surface the synth's existing `hidePath` option through `objectDef.detail.hidePath`.
+Set `detail: { hidePath: true }` to suppress the auto-prepended Lightning
+Path-style status stepper on a record detail page — useful when the detected
+status picklist is not a linear pipeline (e.g. a field that folds a risk
+gradient into the status, where marking earlier options as "completed" is
+misleading). Default (unset) keeps the stepper — zero regression.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1750,6 +1750,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
             (objectDef as any)?.detail?.hideRelatedTab === true || undefined,
           relatedLayout:
             (objectDef as any)?.detail?.relatedLayout === 'tabs' ? 'tabs' : undefined,
+          // Suppress the auto-prepended `record:path` stepper for objects whose
+          // status picklist is not a linear pipeline (e.g. a field that folds a
+          // risk gradient into the status). Opt-out only — default keeps the path.
+          hidePath:
+            (objectDef as any)?.detail?.hidePath === true || undefined,
           ...(assignedSlots ? { slots: assignedSlots } : {}),
         });
     return (


### PR DESCRIPTION
## What

Surface the synth's existing `hidePath` option through `objectDef.detail.hidePath`:

```ts
detail: { hidePath: true }   // suppress the top status stepper for this object
```

One-line wiring in `RecordDetailView.tsx`, mirroring the existing `detail.hideRelatedTab` / `detail.relatedLayout` mappings. Default (unset) keeps the stepper — **zero regression**.

## Why

The record detail page auto-detects a "status/stage" field (`detectStatusField`) and renders it as a Salesforce Lightning Path-style stepper at the top, marking every option *before* the current value as "completed ✓" — purely by list position.

That's correct for a genuine linear pipeline, but wrong when the picklist isn't one. Real-world example: a `任务状态` field that folds a **risk gradient** into the status —

> 已完成 / 进行中-正常 / 进行中-低风险 / 进行中-中风险 / 进行中-高风险 / 进行中-特高风险 / 已逾期

The stepper then checks off `已完成` and every lower-risk state as "done" just because they sort earlier, which misrepresents the record. Until the data model is split (status vs. risk), authors need a config-level off switch. `detail.hidePath` is that switch.

This is the opt-out half; a follow-up may tighten auto-detection (only emit a path for an explicit `stage`-typed field / `stageField`), but that changes a global default and is out of scope here.

## Scope

- `packages/app-shell/src/views/RecordDetailView.tsx` — pass `hidePath` from `objectDef.detail.hidePath`.
- Changeset: `@object-ui/app-shell` minor.
- No synth change — `hidePath` (option + `buildHeaderRegion` consumption + unit tests) already exists.

## Verification

- `turbo type-check --filter=@object-ui/app-shell` → 28 tasks pass
- synth tests `buildDefaultPageSchema.test.ts` → 54 pass (incl. `hidePath` cases)
- eslint on the changed file → only the preexisting line-191 `no-empty` error (unrelated) + repo-wide `any` warnings