### PR TITLE
fix(app-shell): restore admin design surface after ADR-0068 role migration

### DIFF
--- a/.changeset/restore-admin-design-surface.md
+++ b/.changeset/restore-admin-design-surface.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/app-shell': patch
+---
+
+fix(app-shell): restore admin design surface gated on the removed `user.role='admin'` overwrite
+
+ADR-0068 (a3a5abff8) stopped the server `customSession` from overwriting
+`user.role = 'admin'` for workspace owners/admins — canonical roles now arrive
+in `user.roles[]` (`org_owner` / `org_admin`) with `user.isPlatformAdmin` as a
+derived alias, and `useIsWorkspaceAdmin()` was introduced to read them. Four
+runtime views were missed in that migration and still gated their admin design
+tools on the now-defunct `user?.role === 'admin'`, so workspace owners/admins
+silently lost:
+
+- **ObjectView** — the list "+ New view" button plus rename/delete/pin/
+  set-default/config/manage-views and the view config panel.
+- **PageView / DashboardView / ReportView** — the inline "Edit"/config entry
+  points for the shared page / dashboard / report definitions.
+
+All four now call `useIsWorkspaceAdmin()` (same helper already adopted by
+AppSidebar, UnifiedSidebar, HomePage, Marketplace…). No behavior change for
+genuine platform admins; restores the surface for org owners/admins.

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -13,7 +13,7 @@ import { DrillNavigationProvider } from '@object-ui/react';
 import { useOpenRecordList } from './useOpenRecordList';
 import { ModalForm } from '@object-ui/plugin-form';
 import { DashboardConfigPanel } from './DashboardConfigPanel';
-import { useAuth } from '@object-ui/auth';
+import { useIsWorkspaceAdmin } from '@object-ui/auth';
 import { toast } from 'sonner';
 import type { ModalHandler, ActionDef, ActionContext, ActionResult } from '@object-ui/core';
 import {
@@ -106,8 +106,7 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
   const { dashboardLabel, dashboardDescription } = useObjectLabel();
   // Editing a dashboard mutates the SHARED definition, so it is an admin-only
   // quick-edit affordance (mirrors ObjectView's view-config gate).
-  const { user } = useAuth();
-  const isAdmin = user?.role === 'admin';
+  const isAdmin = useIsWorkspaceAdmin();
   const [isLoading, setIsLoading] = useState(true);
   const [configPanelOpen, setConfigPanelOpen] = useState(false);
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -51,7 +51,7 @@ import { resolveManagedByEmptyState } from '../utils/managedByEmptyState';
 import { useObjectActions } from '../hooks/useObjectActions';
 import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
-import { useAuth } from '@object-ui/auth';
+import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useRealtimeSubscription, useConflictResolution } from '@object-ui/collaboration';
 import { ActionProvider, useNavigationOverlay, SchemaRenderer } from '@object-ui/react';
 import { toast } from 'sonner';
@@ -299,7 +299,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     
     // Admin users automatically get design tools (no toggle needed)
     const { user, activeOrganization } = useAuth();
-    const isAdmin = user?.role === 'admin';
+    const isAdmin = useIsWorkspaceAdmin();
     const { can } = usePermissions();
     
     // Get Object Definition. The outer ObjectView wrapper already guards the

--- a/packages/app-shell/src/views/PageView.tsx
+++ b/packages/app-shell/src/views/PageView.tsx
@@ -15,7 +15,7 @@ import { SchemaRenderer, useAdapter } from '@object-ui/react';
 import { Empty, EmptyTitle, EmptyDescription, Spinner } from '@object-ui/components';
 import { FileText, Pencil } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
-import { useAuth } from '@object-ui/auth';
+import { useIsWorkspaceAdmin } from '@object-ui/auth';
 import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useExpressionContext } from '../providers/ExpressionProvider';
@@ -32,8 +32,7 @@ export function PageView() {
   const location = useLocation();
   // Editing a page mutates the shared metadata definition, so the entry point
   // is admin-only (mirrors the view/report/dashboard runtime editors).
-  const { user } = useAuth();
-  const isAdmin = user?.role === 'admin';
+  const isAdmin = useIsWorkspaceAdmin();
 
   const { pages, objects, getTypeStatus } = useMetadata();
   // ADR-0048 Phase 2 — prefer the page owned by the current app's package so

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -19,7 +19,7 @@ import { preferLocal } from '../utils/preferLocal';
 import { useAdapter } from '../providers/AdapterProvider';
 import { useMetadataClient } from './metadata-admin/useMetadata';
 import { persistRuntimeMetadata } from './runtime-metadata-persistence';
-import { useAuth } from '@object-ui/auth';
+import { useIsWorkspaceAdmin } from '@object-ui/auth';
 import type { DataSource, ReportViewerSchema } from '@object-ui/types';
 import type { DatasetDrillArgs } from '@object-ui/plugin-report';
 import { DrillDownDrawer } from '@object-ui/plugin-dashboard';
@@ -47,8 +47,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   const metadataClient = useMetadataClient();
   // Editing a report mutates the SHARED definition, so it is an admin-only
   // quick-edit affordance (mirrors ObjectView's view-config gate).
-  const { user } = useAuth();
-  const isAdmin = user?.role === 'admin';
+  const isAdmin = useIsWorkspaceAdmin();
   const [configPanelOpen, setConfigPanelOpen] = useState(false);
   // Version counter — incremented on save to refresh the stable config reference
   const [configVersion, setConfigVersion] = useState(0);

--- a/packages/app-shell/src/views/__tests__/PageView.test.tsx
+++ b/packages/app-shell/src/views/__tests__/PageView.test.tsx
@@ -28,6 +28,7 @@ vi.mock('react-router-dom', () => ({
 const authFetchSpy = vi.fn();
 vi.mock('@object-ui/auth', () => ({
   useAuth: () => ({ user: { id: 'u1', name: 'User', role: 'user', image: null }, activeOrganization: null }),
+  useIsWorkspaceAdmin: () => false,
   createAuthenticatedFetch: () => authFetchSpy,
 }));
 


### PR DESCRIPTION
## What

ADR-0068 (`a3a5abff8`) stopped the server `customSession` from overwriting `user.role = 'admin'` for workspace owners/admins. Canonical roles now arrive in `user.roles[]` (`org_owner` / `org_admin`) with `user.isPlatformAdmin` as a derived alias, and `useIsWorkspaceAdmin()` was introduced to read them.

**Four runtime views were missed in that migration** and kept gating their admin design tools on the now-defunct `user?.role === 'admin'`, so workspace owners/admins silently lost their design surface (reported: the list **"+ New view"** button vanished).

## Fix

Switch all four to the existing `useIsWorkspaceAdmin()` helper — already adopted by AppSidebar, UnifiedSidebar, HomePage, Marketplace, etc.

| View | Restored |
|---|---|
| `ObjectView` | list **+ New view**, rename / delete / pin / set-default / config / manage-views, view config panel |
| `PageView` | inline **Edit** entry for the shared page definition |
| `DashboardView` | dashboard config panel entry |
| `ReportView` | report config panel entry |

## Notes

- No behavior change for genuine platform admins.
- `useIsWorkspaceAdmin()` accepts `activeMember.role`, the back-compat `user.role` scalar, **and** the canonical `user.roles[]` — so all deployment shapes (single-tenant platform admin, multi-tenant org owner/admin, preview/no-auth) resolve correctly.
- Verified: `@object-ui/app-shell` `tsc --noEmit` clean (28/28 turbo tasks).
- Companion server-side straggler tracked separately in framework (the `/admin/toggle-disabled` OAuth route had the same `role !== 'admin'` gate).