### PR TITLE
feat(detail): detail.stageField:false 关闭自动状态进度条

### DIFF
--- a/.changeset/stagefield-false-optout.md
+++ b/.changeset/stagefield-false-optout.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+detail synth: `stageField: false` (or `null`) now explicitly opts a record page
+out of the auto status-path stepper.
+
+`detectStatusField()` previously only treated a truthy `stageField` (a field
+name) specially and otherwise auto-detected a `status` / `stage` / `state` /
+`phase` field by name or type. Objects with a non-linear `status` picklist
+(e.g. 正常 / 暂停 / 作废) had no way to suppress the inappropriate ordered
+`record:path` stepper. Setting `stageField: false` / `null` on the object def
+now short-circuits detection and renders no path. Default behavior unchanged.

--- a/.changeset/stagefield-false-optout.md
+++ b/.changeset/stagefield-false-optout.md
@@ -2,12 +2,20 @@
 '@object-ui/plugin-detail': patch
 ---
 
-detail synth: `stageField: false` (or `null`) now explicitly opts a record page
-out of the auto status-path stepper.
+detail synth: `detail.stageField: false` (or `null`) now explicitly opts a
+record page out of the auto status-path stepper.
 
 `detectStatusField()` previously only treated a truthy `stageField` (a field
 name) specially and otherwise auto-detected a `status` / `stage` / `state` /
 `phase` field by name or type. Objects with a non-linear `status` picklist
 (e.g. 正常 / 暂停 / 作废) had no way to suppress the inappropriate ordered
-`record:path` stepper. Setting `stageField: false` / `null` on the object def
-now short-circuits detection and renders no path. Default behavior unchanged.
+`record:path` stepper.
+
+The hint is now read from the spec's `detail` block (`object.zod.ts` — a
+`.passthrough()` object already documented as "Detail-page UI hints consumed by
+@object-ui/plugin-detail synth"), which is the author-reachable location:
+`ObjectSchema.create()` rejects unknown *top-level* keys, so a bare top-level
+`stageField` could never be set on a spec-authored object. Authors now write
+`detail: { stageField: false }` to opt out, or `detail: { stageField: 'field' }`
+to pick the path field. The top-level `stageField` is kept as a back-compat
+fallback for raw/duck-typed defs. Default behavior unchanged.

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -50,23 +50,48 @@ describe('detectStatusField', () => {
     expect(detectStatusField(undefined)).toBeNull();
   });
 
-  it('honours explicit stageField', () => {
+  it('honours detail.stageField (author-reachable location)', () => {
+    expect(
+      detectStatusField({ detail: { stageField: 'pipeline' }, fields: { pipeline: {} } }),
+    ).toBe('pipeline');
+  });
+
+  it('opts out when detail.stageField is false', () => {
+    // A `status` picklist would normally be auto-detected by name; `false`
+    // explicitly suppresses the path stepper and skips detection.
+    expect(
+      detectStatusField({ detail: { stageField: false }, fields: { status: {} } }),
+    ).toBeNull();
+  });
+
+  it('opts out when detail.stageField is null', () => {
+    expect(
+      detectStatusField({ detail: { stageField: null }, fields: { status: {} } }),
+    ).toBeNull();
+  });
+
+  it('honours top-level stageField (back-compat for raw defs)', () => {
     expect(detectStatusField({ stageField: 'pipeline', fields: { pipeline: {} } }))
       .toBe('pipeline');
   });
 
-  it('opts out when stageField is false', () => {
-    // A `status` picklist would normally be auto-detected by name; `false`
-    // explicitly suppresses the path stepper and skips detection.
+  it('opts out via top-level stageField:false (back-compat)', () => {
     expect(
       detectStatusField({ stageField: false, fields: { status: {} } }),
     ).toBeNull();
   });
 
-  it('opts out when stageField is null', () => {
+  it('detail.stageField takes precedence over top-level', () => {
+    // detail block wins; here it opts out even though top-level names a field.
     expect(
-      detectStatusField({ stageField: null, fields: { status: {} } }),
+      detectStatusField({ detail: { stageField: false }, stageField: 'status', fields: { status: {} } }),
     ).toBeNull();
+  });
+
+  it('detail without stageField defers to top-level / detection', () => {
+    expect(
+      detectStatusField({ detail: { hideRelatedTab: true }, fields: { status: {} } }),
+    ).toBe('status');
   });
 
   it('picks status by name', () => {

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -55,6 +55,20 @@ describe('detectStatusField', () => {
       .toBe('pipeline');
   });
 
+  it('opts out when stageField is false', () => {
+    // A `status` picklist would normally be auto-detected by name; `false`
+    // explicitly suppresses the path stepper and skips detection.
+    expect(
+      detectStatusField({ stageField: false, fields: { status: {} } }),
+    ).toBeNull();
+  });
+
+  it('opts out when stageField is null', () => {
+    expect(
+      detectStatusField({ stageField: null, fields: { status: {} } }),
+    ).toBeNull();
+  });
+
   it('picks status by name', () => {
     expect(detectStatusField(leadDef)).toBe('status');
   });

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -30,8 +30,17 @@ export interface ObjectDefLike {
   name?: string;
   label?: string;
   fields?: Record<string, ObjectFieldLike>;
-  /** Optional stage hints — a field name emits a `record:path`; an explicit
-   *  `false` / `null` opts out of the auto status stepper entirely. */
+  /** Detail-page UI hints — the spec's `detail` block (object.zod.ts), a
+   *  `.passthrough()` object that is the author-reachable home for synth hints.
+   *  `stageField`: a field name selects the `record:path` status field; an
+   *  explicit `false` / `null` opts out of the auto status stepper entirely. */
+  detail?: {
+    stageField?: string | false | null;
+    [k: string]: unknown;
+  };
+  /** @deprecated Back-compat top-level alias of `detail.stageField`, kept for
+   *  raw/duck-typed defs. Spec-authored objects must use `detail.stageField`
+   *  (top-level unknown keys are rejected by `ObjectSchema.create()`). */
   stageField?: string | false | null;
   stages?: Array<{ value: any; label: string }>;
   /** Optional list of fields to surface in the highlight strip. */
@@ -189,20 +198,27 @@ function toNodeArray(slot: any | any[] | undefined): any[] {
 /**
  * Detect the canonical "status" / "stage" field on an object definition.
  *
- * Heuristic — same as DetailView's `autoSummaryFields`:
- *   0) `stageField === false | null` → explicit opt-out, never render a path
- *   1) prefer an explicit `objectDef.stageField` (field name)
+ * The stage hint comes from `def.detail.stageField` (spec's passthrough detail
+ * block — the author-reachable location) and falls back to a top-level
+ * `def.stageField` for raw/duck-typed defs. Heuristic:
+ *   0) stage hint === false | null → explicit opt-out, never render a path
+ *   1) stage hint is a field name → use it
  *   2) else first field named status / stage / state / phase
  *   3) else first field whose type is status / stage
  *   4) else null
  */
 export function detectStatusField(def?: ObjectDefLike): string | null {
   if (!def) return null;
+  // Prefer the spec's `detail` block (author-reachable; top-level unknown keys
+  // are rejected by `ObjectSchema.create()`), fall back to top-level for raw
+  // defs. `?? undefined` so a `detail` without `stageField` defers to top-level.
+  const stageHint =
+    def.detail?.stageField !== undefined ? def.detail.stageField : def.stageField;
   // Explicit opt-out: `stageField: false` (or null) declares "this object has
   // no ordered status pipeline" — suppress the auto `record:path` stepper and
   // skip name/type-based detection. Lets non-linear `status` picklists hide it.
-  if (def.stageField === false || def.stageField === null) return null;
-  if (def.stageField) return def.stageField;
+  if (stageHint === false || stageHint === null) return null;
+  if (stageHint) return stageHint;
   const fields = def.fields || {};
   const candidates = ['status', 'stage', 'state', 'phase'];
   for (const key of candidates) {

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -30,8 +30,9 @@ export interface ObjectDefLike {
   name?: string;
   label?: string;
   fields?: Record<string, ObjectFieldLike>;
-  /** Optional stage hints — when present we emit a `record:path`. */
-  stageField?: string;
+  /** Optional stage hints — a field name emits a `record:path`; an explicit
+   *  `false` / `null` opts out of the auto status stepper entirely. */
+  stageField?: string | false | null;
   stages?: Array<{ value: any; label: string }>;
   /** Optional list of fields to surface in the highlight strip. */
   highlightFields?: string[];
@@ -189,12 +190,18 @@ function toNodeArray(slot: any | any[] | undefined): any[] {
  * Detect the canonical "status" / "stage" field on an object definition.
  *
  * Heuristic — same as DetailView's `autoSummaryFields`:
- *   1) prefer an explicit `objectDef.stageField`
+ *   0) `stageField === false | null` → explicit opt-out, never render a path
+ *   1) prefer an explicit `objectDef.stageField` (field name)
  *   2) else first field named status / stage / state / phase
- *   3) else null
+ *   3) else first field whose type is status / stage
+ *   4) else null
  */
 export function detectStatusField(def?: ObjectDefLike): string | null {
   if (!def) return null;
+  // Explicit opt-out: `stageField: false` (or null) declares "this object has
+  // no ordered status pipeline" — suppress the auto `record:path` stepper and
+  // skip name/type-based detection. Lets non-linear `status` picklists hide it.
+  if (def.stageField === false || def.stageField === null) return null;
   if (def.stageField) return def.stageField;
   const fields = def.fields || {};
   const candidates = ['status', 'stage', 'state', 'phase'];


### PR DESCRIPTION
## 问题

详情/记录页 synth 会**自动**在记录顶部渲染有序状态进度条(`record:path`)。判定逻辑 `detectStatusField()` 在没有显式 stage 提示时,会按名(`status`/`stage`/`state`/`phase`)或按类型自动命中一个字段。

很多对象的 `status` 其实是**非线性 picklist**(正常 / 暂停 / 作废),被强行渲染成有序进度条,语义与视觉都不对,且用户**无法关闭**。

## 方案(已修正承载位置)

> ⚠️ 初版把开关读在**顶层** `def.stageField`,但 spec 的 `ObjectSchema.create()` **拒绝未知顶层键**(`NoExcessObjectKeys` → `never` + build 报错),作者根本设不上去,对真实对象不可达。已改为读 spec 现成的 `detail` 块。

spec 的 `object.zod.ts` 有一个 `.passthrough()` 的 `detail` 块,描述就是 "Detail-page UI hints consumed by @object-ui/plugin-detail synth"(已有 `renderViaSchema` / `hideReferenceRail` / `hideRelatedTab`)。它是**作者可达**的 UI 提示落点。

- `detectStatusField()` 改读 `def.detail?.stageField`,顶层 `def.stageField` 保留为裸对象/单测的 **back-compat 回退**。
- 作者用法:
  - `detail: { stageField: false }`(或 `null`)→ 不渲染进度条,跳过自动探测;
  - `detail: { stageField: 'my_field' }` → 指定进度条字段。
- **仅改 objectui**:`detail` 块本身就是 `.passthrough()`,该键无需进 framework spec 即可合法通过校验并透传到客户端。默认行为零回归。

## 测试

- `type-check`:通过
- 单测:**60 passed**(新增 `detail.stageField` opt-out / 选字段、`detail` 优先于顶层、顶层 back-compat、`detail` 无 stageField 时回退等用例)

Closes #2065
