### PR TITLE
feat(components,app-shell): Studio Data 网格列头「+ 添加字段」(Airtable 式)

### DIFF
--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -16,7 +16,8 @@
 
 import * as React from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, useAdapter } from '@object-ui/react';
+import { GridFieldAuthoringProvider } from '@object-ui/components';
 import {
   Boxes,
   FileText,
@@ -587,14 +588,54 @@ function InterfacesPillar({ packageId }: { packageId: string }): React.ReactElem
   );
 }
 
+const NEW_FIELD_TYPES: Array<{ value: string; label: string }> = [
+  { value: 'text', label: '文本' },
+  { value: 'textarea', label: '长文本' },
+  { value: 'number', label: '数字' },
+  { value: 'boolean', label: '勾选' },
+  { value: 'date', label: '日期' },
+  { value: 'datetime', label: '日期时间' },
+];
+
+/** Slugify a label into a safe field name, unique against existing names. */
+function toFieldName(label: string, existing: string[]): string {
+  const base =
+    label
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '') || `field_${existing.length + 1}`;
+  let name = base;
+  let i = 2;
+  while (existing.includes(name)) name = `${base}_${i++}`;
+  return name;
+}
+
+/** Append a field to an object body, honoring keyed-map or array `fields`. */
+function appendField(
+  body: Record<string, unknown>,
+  field: { name: string; type: string; label: string },
+): Record<string, unknown> {
+  const raw = body.fields;
+  if (Array.isArray(raw)) return { ...body, fields: [...raw, field] };
+  return { ...body, fields: { ...((raw as object) ?? {}), [field.name]: field } };
+}
+
 /** Data pillar — the package's objects: list → fields + record grid. */
 function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
   const client = useMetadataClient();
+  const adapter = useAdapter();
   const [objects, setObjects] = React.useState<Surface[]>([]);
   const [current, setCurrent] = React.useState<Surface | null>(null);
   const [obj, setObj] = React.useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  // add-field (Airtable-style "+" on the grid column header)
+  const [addOpen, setAddOpen] = React.useState(false);
+  const [fLabel, setFLabel] = React.useState('');
+  const [fType, setFType] = React.useState('text');
+  const [saving, setSaving] = React.useState(false);
+  const [gridVer, setGridVer] = React.useState(0);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -646,6 +687,34 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
     return [];
   }, [obj]);
 
+  const doAddField = React.useCallback(async () => {
+    if (!current || !obj || !fLabel.trim()) return;
+    const name = toFieldName(
+      fLabel,
+      fields.map((f) => f.name),
+    );
+    const body = appendField(obj, { name, type: fType, label: fLabel.trim() });
+    setSaving(true);
+    setError(null);
+    try {
+      await client.save('object', current.name, body, { mode: 'draft' });
+      await client.publish('object', current.name);
+      // Bust the data-layer object-schema cache so the remounted grid re-fetches
+      // the new column without a full page reload (the grid reads its columns from
+      // dataSource.getObjectSchema, a separate cache from the metadata client).
+      (adapter as { clearCache?: () => void } | null)?.clearCache?.();
+      setObj(body); // optimistic
+      setGridVer((v) => v + 1);
+      setAddOpen(false);
+      setFLabel('');
+      setFType('text');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }, [adapter, client, current, obj, fLabel, fType, fields]);
+
   return (
     <div className="flex h-full">
       <nav className="w-52 shrink-0 overflow-auto border-r p-2">
@@ -680,13 +749,80 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
               <span className="text-[11px] text-muted-foreground">{fields.length} 字段</span>
             </div>
             {/* Data mode = the records themselves, as a directly-viewable grid
-              * (Airtable parity). Fields are the columns — no separate table. */}
+              * (Airtable parity). Fields are the columns; the trailing "+" column
+              * header (via GridFieldAuthoringProvider) adds a new field. */}
             <div className="min-h-0 flex-1 overflow-auto rounded-lg border bg-background">
-              <SchemaRenderer schema={{ type: 'object-view', objectName: current.name } as never} />
+              <GridFieldAuthoringProvider
+                value={{ onAddColumn: () => setAddOpen(true), addColumnLabel: '添加字段' }}
+              >
+                <SchemaRenderer
+                  key={`${current.name}:${gridVer}`}
+                  schema={{ type: 'object-view', objectName: current.name } as never}
+                />
+              </GridFieldAuthoringProvider>
             </div>
           </>
         )}
       </main>
+      {addOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+          onClick={() => !saving && setAddOpen(false)}
+        >
+          <div
+            className="w-80 rounded-lg border bg-background p-4 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="mb-3 text-sm font-medium">添加字段 · {current?.label}</p>
+            {error && (
+              <div className="mb-2 rounded border border-destructive/40 bg-destructive/10 px-2 py-1 text-[11px] text-destructive">
+                {error}
+              </div>
+            )}
+            <label className="mb-1 block text-[11px] text-muted-foreground">字段名称</label>
+            <input
+              autoFocus
+              value={fLabel}
+              onChange={(e) => setFLabel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && fLabel.trim() && !saving) doAddField();
+                if (e.key === 'Escape') setAddOpen(false);
+              }}
+              placeholder="例如 备注"
+              className="mb-3 w-full rounded border bg-background px-2 py-1 text-sm outline-none focus:border-primary"
+            />
+            <label className="mb-1 block text-[11px] text-muted-foreground">类型</label>
+            <select
+              value={fType}
+              onChange={(e) => setFType(e.target.value)}
+              className="mb-4 w-full rounded border bg-background px-2 py-1 text-sm outline-none focus:border-primary"
+            >
+              {NEW_FIELD_TYPES.map((ft) => (
+                <option key={ft.value} value={ft.value}>
+                  {ft.label}
+                </option>
+              ))}
+            </select>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setAddOpen(false)}
+                disabled={saving}
+                className="rounded-md border px-3 py-1 text-xs hover:bg-muted disabled:opacity-50"
+              >
+                取消
+              </button>
+              <button
+                onClick={doAddField}
+                disabled={!fLabel.trim() || saving}
+                className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
+              >
+                {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                添加并发布
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/components/src/context/gridFieldAuthoring.tsx
+++ b/packages/components/src/context/gridFieldAuthoring.tsx
@@ -1,0 +1,51 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * GridFieldAuthoring — an ambient, opt-in affordance that lets a *design*
+ * surface (Studio) add an "+ add field" control to a data-table's column
+ * header without coupling the runtime table renderer to design concerns.
+ *
+ * The data-table reads this context via {@link useGridFieldAuthoring}. With no
+ * provider it returns `null`, so every runtime table renders byte-identically —
+ * the trailing "+" column only appears when a host wraps the table in
+ * {@link GridFieldAuthoringProvider} (e.g. the Studio Data pillar), which owns
+ * the add-field form + metadata save/publish.
+ */
+
+import React from 'react';
+
+export interface GridFieldAuthoring {
+  /** Invoked when the user clicks the trailing "+" add-column header affordance. */
+  onAddColumn: () => void;
+  /** Optional tooltip/aria-label for the add-column button (defaults to "Add field"). */
+  addColumnLabel?: string;
+}
+
+const GridFieldAuthoringContext = React.createContext<GridFieldAuthoring | null>(null);
+
+export function GridFieldAuthoringProvider({
+  value,
+  children,
+}: {
+  value: GridFieldAuthoring | null;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <GridFieldAuthoringContext.Provider value={value}>{children}</GridFieldAuthoringContext.Provider>
+  );
+}
+
+/**
+ * Read the ambient grid field-authoring affordances. Returns `null` outside a
+ * provider — design surfaces opt in by wrapping the table tree in
+ * {@link GridFieldAuthoringProvider}.
+ */
+export function useGridFieldAuthoring(): GridFieldAuthoring | null {
+  return React.useContext(GridFieldAuthoringContext);
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -44,6 +44,14 @@ export { getLazyIcon, LazyIcon, toKebabIconName } from './lib/lazy-icon';
 // Export placeholder registration
 export { registerPlaceholders } from './renderers/placeholders';
 
+// Export grid field-authoring context — a design surface (Studio) opts into the
+// data-table "+ add field" column header by wrapping the table in the provider.
+export {
+  GridFieldAuthoringProvider,
+  useGridFieldAuthoring,
+  type GridFieldAuthoring,
+} from './context/gridFieldAuthoring';
+
 // Export raw Shadcn UI components
 export * from './ui';
 export * from './custom';

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -9,6 +9,7 @@
 // Enterprise-level DataTable Component (Airtable-like)
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { cn } from '../../lib/utils';
+import { useGridFieldAuthoring } from '../../context/gridFieldAuthoring';
 import { ComponentRegistry } from '@object-ui/core';
 import type { DataTableSchema } from '@object-ui/types';
 import { useObjectTranslation } from '@object-ui/react';
@@ -230,6 +231,12 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     borderless = false,
     disableInnerScroll = false,
   } = schema;
+
+  // Ambient design-surface affordance: when a host (Studio) provides it, render
+  // a trailing "+ add field" column header. `null` for every runtime table, so
+  // existing tables render unchanged.
+  const fieldAuthoring = useGridFieldAuthoring();
+  const addColumnEnabled = !!fieldAuthoring?.onAddColumn;
 
   // i18n support for pagination labels
   const { t, language } = useTableTranslation();
@@ -955,13 +962,27 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
               {rowActions && (
                 <TableHead className="w-24 text-right bg-background">{t('common.actions')}</TableHead>
               )}
+              {addColumnEnabled && (
+                <TableHead className="w-10 bg-background px-1 text-center">
+                  <button
+                    type="button"
+                    onClick={fieldAuthoring!.onAddColumn}
+                    title={fieldAuthoring!.addColumnLabel ?? 'Add field'}
+                    aria-label={fieldAuthoring!.addColumnLabel ?? 'Add field'}
+                    data-testid="grid-add-column"
+                    className="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <Plus className="h-4 w-4" />
+                  </button>
+                </TableHead>
+              )}
             </TableRow>
           </TableHeader>
           <TableBody>
             {paginatedData.length === 0 ? (
               <TableRow className="hover:bg-transparent">
                 <TableCell
-                  colSpan={columns.length + (selectable ? 1 : 0) + (showRowNumbers ? 1 : 0) + (rowActions ? 1 : 0)}
+                  colSpan={columns.length + (selectable ? 1 : 0) + (showRowNumbers ? 1 : 0) + (rowActions ? 1 : 0) + (addColumnEnabled ? 1 : 0)}
                   className="h-48 text-center text-muted-foreground border-0"
                 >
                   <div className="flex flex-col items-center justify-center gap-3">
@@ -1284,6 +1305,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                           </div>
                         </TableCell>
                       )}
+                      {addColumnEnabled && <TableCell aria-hidden className="w-10" />}
                     </TableRow>
                   );
                 })}
@@ -1295,7 +1317,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                     onClick={() => schema.onAddRecord?.()}
                   >
                     <TableCell
-                      colSpan={columns.length + (selectable ? 1 : 0) + (showRowNumbers ? 1 : 0) + (rowActions ? 1 : 0)}
+                      colSpan={columns.length + (selectable ? 1 : 0) + (showRowNumbers ? 1 : 0) + (rowActions ? 1 : 0) + (addColumnEnabled ? 1 : 0)}
                       className="h-9 px-3 py-1.5"
                     >
                       <span className="flex items-center gap-1.5 text-muted-foreground text-sm hover:text-foreground transition-colors">


### PR DESCRIPTION
## 什么

Studio Data 支柱的对象网格现在支持 **Airtable 式「列头末尾 + 添加字段」**(#8,用户点名的下一步优化重点)。

## 机制 — 不耦合运行时网格(零回归)

网格是 3 层 SDUI 间接(`object-view` → `object-grid` → `data-table`),每层 schema 都序列化,所以"列头上的 + 回调"既不能走 schema,也不该把设计态焊进共享 `data-table`。方案:**opt-in React context**。

- 新增 `@object-ui/components` 的 `GridFieldAuthoring` context(`useGridFieldAuthoring` / `GridFieldAuthoringProvider`)。
- `data-table` 读它:**有 provider 才**渲染末尾「+」列头(+ 行内占位 cell + 两处 colSpan +1);**无 provider 时每个运行时表格字节级不变**。
- Studio `DataPillar` 用 provider 包住对象网格,「+」打开加字段表单(名称 + 类型)→ 写对象 `fields` → `save(draft)` + `publish` 到 env overlay → `adapter.clearCache()` 冲数据层 schema 缓存 + 重挂网格 → **新列免刷新即现**。

## ⚠️ 对象默认锁定(平台策略)

打包对象 schema 默认 `allowOrgOverride: false`(对象/字段改动 = 迁移,刻意锁)。加字段需运行时经 **`OS_METADATA_WRITABLE`** 放开 object 覆盖 —— 这是 Studio/设计环境该开的开关。未放开时,后端清晰的 `not_overridable` 错误会直接显示在表单里(含修复提示)。

## 验证(浏览器实测,showcase_account,`OS_METADATA_WRITABLE=object`)

「+」→ 表单(客户备注/text、回访日期/date)→ 添加并发布:

| 层 | 字段数 |
|---|---|
| `code`(包源) | 16 未动 |
| `overlay`(发布) / `effective` | **18**(+2 新字段,`overlayScope:env`) |

新列**免整页刷新**即出现(`clearCache` + 重挂);非拉丁标签 slug 成 `field_N`(如 `field_18`)。`eslint .` 0 error / `tsc` 0 error(`@object-ui/components` 那个 `sdui-parser` 报错是 main 上既有、与本 PR 无关)。

## 限制 / 后续
- 「+」目前总是显示;理想应按运行时对象可写性(`allowOrgOverride`/`OS_METADATA_WRITABLE`)门控,避免在锁定环境点了报错(后续可加)。
- 类型限 text/textarea/number/boolean/date/datetime(无需额外配置);select/lookup 等需选项的留后续。
- 仍只在 `/studio/:packageId/data`,未进产品 nav,仅 objectui main 未 live(需 `.objectui-sha` bump + cloud pin)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)