### PR TITLE
fix(app-shell): Studio UX 加固 — Interfaces 对象=运行态网格 + 可发现的加字段入口

### DIFF
--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -35,6 +35,7 @@ import {
   Save,
   Pencil,
   Check,
+  Plus,
   type LucideIcon,
 } from 'lucide-react';
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
@@ -300,7 +301,9 @@ function InterfacesPillar({ packageId }: { packageId: string }): React.ReactElem
 
   const Preview = getMetadataPreview(current?.type ?? '');
   const Inspector = getMetadataInspector(current?.type ?? '');
-  const isEditable = !!Preview; // page / dashboard have a design preview + draft
+  // Object leaves render as a runtime records grid (preview = runtime); schema
+  // editing is the Data pillar's job, so they are not draft-editable in this canvas.
+  const isEditable = !!Preview && current?.type !== 'object';
 
   // Load the selected surface's draft (only for editable preview types).
   React.useEffect(() => {
@@ -523,6 +526,11 @@ function InterfacesPillar({ packageId }: { packageId: string }): React.ReactElem
               <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
               </div>
+            ) : current.type === 'object' ? (
+              // Object nav leaf = the records list as the running app shows it
+              // (preview = runtime). Schema editing lives in the Data pillar, so
+              // here we render the object-view grid, not the field-form preview.
+              <SchemaRenderer schema={{ type: 'object-view', objectName: current.name } as never} />
             ) : Preview ? (
               <Preview
                 type={current.type}
@@ -534,19 +542,21 @@ function InterfacesPillar({ packageId }: { packageId: string }): React.ReactElem
                 onPatch={onPatch}
                 locale={locale}
               />
-            ) : current.type === 'object' ? (
-              <SchemaRenderer schema={{ type: 'object-view', objectName: current.name } as never} />
             ) : (
               <div className="py-12 text-center text-xs text-muted-foreground">
                 {current.type} 暂用只读预览,设计能力建设中。
               </div>
             )}
           </div>
-          {isEditable && (
+          {isEditable ? (
             <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
               <MousePointer2 className="h-3 w-3" /> 点选积木 → 右侧直接改 · 改完「保存草稿」→「发布」
             </p>
-          )}
+          ) : current?.type === 'object' ? (
+            <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
+              <Database className="h-3 w-3" /> 运行态列表预览 · 改字段 / 结构请到 <span className="font-medium">Data</span> 支柱
+            </p>
+          ) : null}
         </main>
 
         {/* inspector */}
@@ -747,6 +757,14 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
                 object · {current.name}
               </span>
               <span className="text-[11px] text-muted-foreground">{fields.length} 字段</span>
+              <button
+                type="button"
+                onClick={() => setAddOpen(true)}
+                title="给该对象添加一个字段"
+                className="ml-auto inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <Plus className="h-3.5 w-3.5" /> 添加字段
+              </button>
             </div>
             {/* Data mode = the records themselves, as a directly-viewable grid
               * (Airtable parity). Fields are the columns; the trailing "+" column


### PR DESCRIPTION
对 Studio 设计面做了一轮**深度测试**(三支柱 × 各 surface 类型 × 交互 × 控制台错误),发现并修两处:

## 1. Interfaces 对象菜单 → 字段表单(应是记录网格)

点 Interfaces 导航里的**对象**叶子,画布渲染的是 `getMetadataPreview('object')` **字段表单**("18 个字段 · 3 个必填"那种输入卡),而**同一对象在 Data 支柱是记录网格** —— 不一致,也不符合"预览即运行"(运行态里对象菜单 = 记录列表)。而且那个字段表单把对象元数据(`pluralLabel`/`isSystem`/`active`/`abstract`)直接 spread 到 DOM 节点 → 8 条 React 警告。

**修**:对象叶子改渲染 object-view **记录网格**(与 Data + 运行态一致),排除出 `isEditable`(不再误加草稿/存草稿),底部加提示「运行态列表预览 · 改字段/结构请到 Data 支柱」。**控制台警告消失**(清 buffer 后重渲 Projects/Tasks 零警告)。

## 2. 加字段入口不好发现

网格末尾的「+」对宽对象在**屏幕右侧外**(要横向滚动才看到)。在 **Data 头部加可见的「+ 添加字段」按钮**(挨着"N 字段")作为第二入口,同一个表单。

## 验证(浏览器实测)

- Interfaces `Projects`/`Tasks` → 记录网格(Status/Health pill、Budget 等列),非字段表单;清空 console 后重渲零警告。
- Data 头部「+ 添加字段」点开加字段表单。
- `eslint .` 0 error / `tsc` 0 error。

## 仍是后续(不在本 PR)
- **对象 schema 编辑**(改字段类型/重排/删)目前只有"加字段";完整的字段编辑器(把那个 field-form preview 修好 DOM 警告后)可作为 Data 的「字段」模式 —— 与 #10 一道。
- 仅 objectui main,未 live(需 `.objectui-sha` bump + cloud pin)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)