### PR TITLE
fix(components):弹窗内下拉点空白处不再误关整个弹窗

### DIFF
--- a/.changeset/dialog-popper-outside-close.md
+++ b/.changeset/dialog-popper-outside-close.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/components': patch
+---
+
+fix(components): keep MobileDialogContent open when interacting with a portalled dropdown
+
+Radix Select / Popover / DropdownMenu render their flyout into a portal at
+`document.body`, outside the dialog's DOM. Clicking an empty part of an open
+dropdown registered as an "interact outside" and closed the entire dialog
+(create/edit forms). `MobileDialogContent` now guards `onInteractOutside`:
+interactions whose real target is inside a Radix popper layer are ignored
+(the popper dismisses itself), while a genuine backdrop click still closes the
+dialog as before.

--- a/packages/components/src/__tests__/mobile-dialog-content.test.tsx
+++ b/packages/components/src/__tests__/mobile-dialog-content.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * MobileDialogContent guards against a portalled dropdown closing the whole
+ * dialog. Radix Select / Popover render their flyout into a portal at
+ * `document.body` (outside the dialog DOM), so clicking empty space inside an
+ * open dropdown reads as an "interact outside" and used to dismiss the dialog.
+ * `isInsidePopperLayer` is the predicate that suppresses that case while
+ * leaving a genuine backdrop click (which still closes the dialog) untouched.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { isInsidePopperLayer } from '../custom/mobile-dialog-content';
+
+function mount(html: string): HTMLElement {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  document.body.appendChild(host);
+  return host;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('isInsidePopperLayer', () => {
+  it("treats a click inside a Radix popper wrapper as the dialog's own dropdown", () => {
+    const host = mount(
+      '<div data-radix-popper-content-wrapper><div role="listbox"><div id="opt">option</div></div></div>',
+    );
+    expect(isInsidePopperLayer(host.querySelector('#opt'))).toBe(true);
+  });
+
+  it('matches the select content / viewport variants too', () => {
+    const host = mount(
+      '<div data-radix-select-content><div data-radix-select-viewport><span id="item">x</span></div></div>',
+    );
+    expect(isInsidePopperLayer(host.querySelector('#item'))).toBe(true);
+    expect(isInsidePopperLayer(host.querySelector('[data-radix-select-content]'))).toBe(true);
+  });
+
+  it('does NOT match a genuine backdrop / outside-the-dropdown target', () => {
+    const host = mount('<div id="overlay" data-radix-dialog-overlay></div>');
+    expect(isInsidePopperLayer(host.querySelector('#overlay'))).toBe(false);
+  });
+
+  it('is null/undefined safe', () => {
+    expect(isInsidePopperLayer(null)).toBe(false);
+    expect(isInsidePopperLayer(undefined)).toBe(false);
+  });
+});

--- a/packages/components/src/custom/mobile-dialog-content.tsx
+++ b/packages/components/src/custom/mobile-dialog-content.tsx
@@ -23,14 +23,48 @@ import { X } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { DialogOverlay, DialogPortal } from '../ui/dialog';
 
+/**
+ * Radix Select / Popover / DropdownMenu render their flyout into a portal at
+ * `document.body` — physically OUTSIDE this DialogContent's DOM. So clicking an
+ * empty part of an open dropdown reads as an "interact outside" and would close
+ * the whole dialog. Suppress that: if the interaction's real target sits inside
+ * a Radix popper layer, keep the dialog open (the popper closes itself). A real
+ * backdrop click (target = overlay) is untouched and still closes the dialog.
+ */
+const POPPER_LAYER_SELECTOR =
+  '[data-radix-popper-content-wrapper],[data-radix-select-content],[data-radix-select-viewport]';
+
+/**
+ * True when `target` sits inside a Radix popper flyout (Select / Popover /
+ * DropdownMenu). Such elements are portalled to `document.body`, so an
+ * "interact outside" the dialog whose target is one of them is really an
+ * interaction with the dialog's own dropdown — it must not close the dialog.
+ */
+export function isInsidePopperLayer(target: Element | null | undefined): boolean {
+  return !!target?.closest?.(POPPER_LAYER_SELECTOR);
+}
+
 export const MobileDialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, onInteractOutside, ...props }, ref) => {
+  const handleInteractOutside = React.useCallback(
+    (event: Parameters<NonNullable<typeof onInteractOutside>>[0]) => {
+      const target = (event.detail?.originalEvent?.target ?? null) as Element | null;
+      if (isInsidePopperLayer(target)) {
+        event.preventDefault();
+        return;
+      }
+      onInteractOutside?.(event);
+    },
+    [onInteractOutside],
+  );
+  return (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      onInteractOutside={handleInteractOutside}
       className={cn(
         // Mobile-first: full-screen
         'fixed inset-0 z-50 w-full bg-background p-4 shadow-lg duration-200',
@@ -63,5 +97,6 @@ export const MobileDialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-));
+  );
+});
 MobileDialogContent.displayName = 'MobileDialogContent';


### PR DESCRIPTION
## 问题

新建 / 编辑记录弹窗里点开下拉字段(适用对象、触发类型等)的选项后,**不选项、点到别处**,整个弹窗会直接关闭消失,而不是只收起下拉。

## 根因

`ModalForm` → `MobileDialogContent` → Radix `DialogPrimitive.Content` 没处理 `onInteractOutside`。Radix `Select` / `Popover` 的弹层内容是 **portal 到 `document.body`**(position=popper),物理上在 `DialogContent` 的 DOM 之外。点这个 portal 弹层区域(下拉很大,盖住半个弹窗)时,Dialog 的 DismissableLayer 判定为"点击弹窗外部",触发 `onOpenChange(false)` 关掉整个弹窗。

## 改动

`packages/components/src/custom/mobile-dialog-content.tsx`:给 `DialogPrimitive.Content` 加 `onInteractOutside` 守卫——当本次外部交互的真实目标落在 Radix 弹层内(`[data-radix-popper-content-wrapper]` / select content / viewport)时 `preventDefault()` 抑制误关,弹层照常自行收起;真正点遮罩仍走原 `onOpenChange` 关闭逻辑。判定逻辑抽成导出的 `isInsidePopperLayer` 并配单测。

- 与调用方自带的 `onInteractOutside` 组合(先守卫,放行后再调用方处理)。
- 修复对所有用 `MobileDialogContent` 的弹窗生效。

## 自测

- `type-check` ✅
- 新增 `mobile-dialog-content.test.tsx`:4 passed(弹层内目标 → 拦截;遮罩 / 弹层外 → 放行;null/undefined 安全)
- changeset:`@object-ui/components` patch

Closes #2071