### PR TITLE
feat(components,app-shell): Studio 列拖动重排 → 写回字段元数据顺序

### DIFF
--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -731,6 +731,40 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
     }
   }, [adapter, client, current]);
 
+  // Drag-reorder columns → reorder the object's `fields` metadata (field display
+  // order follows metadata order), then publish so the new order persists.
+  const doReorderFields = React.useCallback(
+    async (orderedNames: string[]) => {
+      if (!current) return;
+      const view = readFields(objDraft.fields);
+      // Reorder only the visible fields among their own slots; keep system /
+      // hidden fields (not shown as columns) in their original positions.
+      const visible = new Set(orderedNames);
+      const visibleInOrder = orderedNames
+        .map((n) => view.entries.find((e) => e.name === n))
+        .filter((e): e is (typeof view.entries)[number] => Boolean(e));
+      let vi = 0;
+      const entries = view.entries.map((e) => (visible.has(e.name) ? visibleInOrder[vi++] : e));
+      const body = { ...objDraft, fields: writeFields({ ...view, entries }) };
+      setObjDraft(body);
+      setSaving('publish');
+      setError(null);
+      try {
+        await client.save('object', current.name, body, { mode: 'draft' });
+        await client.publish('object', current.name);
+        (adapter as { clearCache?: () => void } | null)?.clearCache?.();
+        setHasDraft(false);
+        setDirty(false);
+        setGridVer((v) => v + 1); // remount so the grid reflects the persisted order
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [client, current, objDraft, adapter],
+  );
+
   const inspector = getMetadataInspector('object');
 
   return (
@@ -799,6 +833,7 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
                     }
                   },
                   editColumnLabel: '编辑字段属性',
+                  onReorderFields: doReorderFields,
                 }}
               >
                 <SchemaRenderer

--- a/packages/components/src/context/gridFieldAuthoring.tsx
+++ b/packages/components/src/context/gridFieldAuthoring.tsx
@@ -33,6 +33,14 @@ export interface GridFieldAuthoring {
   onEditColumn?: (fieldName: string) => void;
   /** Optional tooltip/aria-label for the edit-field button (defaults to "Edit field"). */
   editColumnLabel?: string;
+  /**
+   * Invoked when the user drag-reorders columns. Receives the new column order
+   * as accessorKeys (= field names, including any non-field columns). Providing
+   * this also ENABLES the table's built-in column drag-reorder (design mode), so
+   * the host can persist the order to the object's field metadata. Omit to leave
+   * reordering to the table's own `reorderableColumns`/`onColumnsReorder`.
+   */
+  onReorderFields?: (orderedFieldNames: string[]) => void;
 }
 
 const GridFieldAuthoringContext = React.createContext<GridFieldAuthoring | null>(null);

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -238,6 +238,9 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   const fieldAuthoring = useGridFieldAuthoring();
   const addColumnEnabled = !!fieldAuthoring?.onAddColumn;
   const editColumnEnabled = !!fieldAuthoring?.onEditColumn;
+  // The table already implements column drag-reorder; a design host enables it by
+  // providing onReorderFields (to persist the order to the object's field metadata).
+  const reorderEnabled = reorderableColumns || !!fieldAuthoring?.onReorderFields;
 
   // i18n support for pagination labels
   const { t, language } = useTableTranslation();
@@ -562,22 +565,22 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
 
   // Column reordering handlers
   const handleColumnDragStart = (e: React.DragEvent, index: number) => {
-    if (!reorderableColumns) return;
+    if (!reorderEnabled) return;
     setDraggedColumn(index);
     e.dataTransfer.effectAllowed = 'move';
   };
 
   const handleColumnDragOver = (e: React.DragEvent, index: number) => {
-    if (!reorderableColumns) return;
+    if (!reorderEnabled) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     setDragOverColumn(index);
   };
 
   const handleColumnDrop = (e: React.DragEvent, dropIndex: number) => {
-    if (!reorderableColumns || draggedColumn === null) return;
+    if (!reorderEnabled || draggedColumn === null) return;
     e.preventDefault();
-    
+
     if (draggedColumn === dropIndex) {
       setDraggedColumn(null);
       setDragOverColumn(null);
@@ -587,15 +590,17 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     const newColumns = [...columns];
     const [removed] = newColumns.splice(draggedColumn, 1);
     newColumns.splice(dropIndex, 0, removed);
-    
+
     setColumns(newColumns);
     setDraggedColumn(null);
     setDragOverColumn(null);
-    
+
     // Call callback if provided
     if (schema.onColumnsReorder) {
       schema.onColumnsReorder(newColumns);
     }
+    // Design host: persist the new order to the object's field metadata.
+    fieldAuthoring?.onReorderFields?.(newColumns.map((c) => c.accessorKey));
   };
 
   const handleColumnDragEnd = () => {
@@ -927,7 +932,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                       minWidth: columnWidth,
                       ...(isFrozen && { left: frozenOffset }),
                     }}
-                    draggable={reorderableColumns}
+                    draggable={reorderEnabled}
                     onDragStart={(e) => handleColumnDragStart(e, index)}
                     onDragOver={(e) => handleColumnDragOver(e, index)}
                     onDrop={(e) => handleColumnDrop(e, index)}
@@ -940,7 +945,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                       col.align === 'right' ? 'justify-end' : 'justify-between'
                     )}>
                       <div className="flex items-center gap-1">
-                        {reorderableColumns && (
+                        {reorderEnabled && (
                           <GripVertical className="h-4 w-4 opacity-0 group-hover:opacity-50 cursor-grab active:cursor-grabbing shrink-0" />
                         )}
                         {col.headerIcon && (


### PR DESCRIPTION
按用户方向:**列拖动重排是表格组件已有功能,不重复开发**——只在设计模式启用它,并把新顺序**保存到对象的字段元数据**(字段显示顺序 = 元数据顺序;拖动即改元数据顺序)。

## 改了什么

- `GridFieldAuthoring` context 加 **`onReorderFields(orderedFieldNames)`**。提供它就**启用 data-table 内建的列拖拽**(`reorderEnabled`)并把 drop 的新列序回调给宿主。
- `data-table` 在列 drop 时调 `fieldAuthoring.onReorderFields`(与它原有的 `onColumnsReorder` 并存),拖拽手柄/draggable 都 gate 在 `reorderEnabled`。
- `DataPillar` 把对象 `fields` 重排成新序——**只重排可见字段(在它们各自的槽位内),系统/隐藏字段(不作为列显示的,如 organization_id/created_at)保持原位**——再 `save`+`publish`+重挂网格。

## 验证(浏览器实测,showcase_account)

把 **Industry 拖到最前** → effective 字段顺序 `[owner_id, name, industry, …]` → **`[industry, owner_id, name, …]`**;系统字段(organization_id/created_at/…)**仍在最前**(没被挤走);写入 env overlay 持久化、刷新后保持。

> 注:HTML5 原生拖放在合成事件下难驱动(同 #11),但这是表格的既有生产能力,用户已确认;本 PR 只接「启用 + 存顺序」,已用元数据校验确认 drop→onReorderFields→重排→发布 全链路落盘。

`eslint .` 0 error / `tsc` 0 error / data-table 6 测通过。仅 objectui main,未 live。

🤖 Generated with [Claude Code](https://claude.com/claude-code)