### PR TITLE
fix(metadata-admin): drop policy client-validator (PolicySchema removed in spec 11.2.0)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -38,7 +38,12 @@ type SchemaLoader = () => Promise<ZodLikeSchema | undefined>;
 // Types still falling through to server-only validation:
 //   - `validation`: not a top-level metadata file; lives inside object. (DataValidationRuleSchema
 //     exists but has empty shape, so it's not useful for client validation.)
-//   - `profile`: spec ships no top-level ProfileSchema (7.1 confirmed).
+//   - `policy`: spec 11.2.0 (PR #2078) removed the generic `PolicySchema` (the org-wide
+//     password/network/session/audit policy) from `@objectstack/spec/security`, and the
+//     canonical metadata-type→schema registry (spec kernel/metadata-type-schemas.ts) has
+//     no `policy` entry — so there is no client schema. `RowLevelSecurityPolicySchema`
+//     remains on /security but is a different shape (a per-object RLS rule), NOT the
+//     `policy` metadata file, so it must not be substituted.
 //   - `trigger`: no standalone TriggerSchema export at runtime (only
 //     ConnectorTriggerSchema / WebhookEventSchema variants).
 //   - `sharing_rule`: SharingRuleSchema is declared but has empty shape — server-only.
@@ -89,7 +94,8 @@ const LOADERS: Record<string, SchemaLoader> = {
   // packages/spec/src/kernel/metadata-type-schemas.ts for the canonical mapping.
   permission: async () => (await import('@objectstack/spec/security')).PermissionSetSchema as unknown as ZodLikeSchema,
   profile: async () => (await import('@objectstack/spec/security')).PermissionSetSchema as unknown as ZodLikeSchema,
-  policy: async () => (await import('@objectstack/spec/security')).PolicySchema as unknown as ZodLikeSchema,
+  // `policy` intentionally omitted — spec 11.2.0 dropped `PolicySchema` and the metadata-type
+  // registry has no `policy` schema; drafts fall through to server-side validation (see top).
 
   // identity
   role: async () => (await import('@objectstack/spec/identity')).RoleSchema as unknown as ZodLikeSchema,


### PR DESCRIPTION
## Problem

`@object-ui/app-shell`'s build (`tsc`) fails on `main` after the `@objectstack/spec` 11.0.0 → 11.2.0 bump (#2078):

```
src/views/metadata-admin/clientValidation.ts(92,68): error TS2339:
Property 'PolicySchema' does not exist on type
'typeof import("@objectstack/spec@11.2.0/.../security/index")'
```

This breaks the **Bundle Analysis** CI check on every PR. (Build & E2E / Test use vite/esbuild, which don't type-check, so they don't catch it.)

## Root cause

Spec 11.2.0 **removed the entire generic org-policy family** from `@objectstack/spec/security` — `PolicySchema`, `PolicyInput`, `definePolicy`, plus `Password`/`Network`/`Session`/`AuditPolicySchema`. It wasn't moved or renamed; it's gone from every subpath and the root export. `clientValidation.ts` mapped the `policy` metadata type to that now-removed schema.

## Why not swap to `RowLevelSecurityPolicySchema`

They model different things:

| | old `PolicySchema` (removed) | `RowLevelSecurityPolicySchema` (kept) |
|---|---|---|
| shape | org-wide policy: `password`, `network`, `session`, `audit`, `assignedProfiles` | per-object RLS rule: `object`, `operation`, `using`, `check`, `roles` |

The framework's canonical `metadata-type-schemas.ts` registry (now on 11.2.0) has **no `policy` entry at all**, so there is no client schema for the `policy` metadata type. Substituting the RLS schema would wrongly reject valid drafts.

## Fix

Drop the `policy` loader so it falls through to **server-side validation** — the file's documented pattern for unschematized types (`trigger`, `sharing_rule`, …). Also corrected a stale adjacent comment that claimed `profile` falls through (it actually maps to `PermissionSetSchema`).

`policy` is not an authorable resource in the console registry, so the loader was effectively defensive/dead code → **zero user-facing impact**.

## Verification

- ✅ Reproduced the exact CI error on spec 11.2.0, then `turbo run build --filter=@object-ui/app-shell` → **28/28 tasks pass**, app-shell `tsc` clean.
- ✅ Every other loader resolves in 11.2.0 (`PermissionSetSchema`, `RoleSchema`, `MappingSchema`, `CubeSchema`, `ThemeSchema`, `WebhookSchema`, `EmailTemplateSchema`, `ApiEndpointSchema`, …) — `PolicySchema` was the only break.
- ✅ Repo-wide sweep: no other code consumed any removed Policy-family export.
- ✅ `createConformance.test.ts` → 11/11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
