### PR TITLE
refactor(grid): inline cell editor reuses the @object-ui/fields widgets (not hand-rolled)

### DIFF
--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { SchemaRenderer, useAdapter } from '@object-ui/react';
+import { SchemaRenderer, useAdapter, SchemaRendererProvider } from '@object-ui/react';
 import { GridFieldAuthoringProvider } from '@object-ui/components';
 import { ObjectView as PluginObjectView } from '@object-ui/plugin-view';
 import { ListView } from '@object-ui/plugin-list';
@@ -934,26 +934,31 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
                     onReorderFields: doReorderFields,
                   }}
                 >
-                  <PluginObjectView
-                    key={`${current.name}:${gridVer}`}
-                    schema={
-                      {
-                        type: 'object-view',
-                        objectName: current.name,
-                        // No saved view exists in design mode, so show the object's
-                        // own fields as columns (in metadata order), dropping
-                        // framework-managed/audit fields so the grid opens on the
-                        // meaningful columns first — the way Airtable does.
-                        table: {
-                          fields: readFields(objDraft.fields)
-                            .entries.map((e) => e.name)
-                            .filter((n) => !STUDIO_SYSTEM_FIELD_NAMES.has(n)),
-                        },
-                      } as never
-                    }
-                    dataSource={adapter as never}
-                    renderListView={renderStudioGridList}
-                  />
+                  {/* Provide the adapter as the dataSource context so the object-grid's
+                    * inline-edit save can write back: the ListView only fetches and
+                    * passes data inline, leaving the grid itself without a write dataSource. */}
+                  <SchemaRendererProvider dataSource={adapter as never}>
+                    <PluginObjectView
+                      key={`${current.name}:${gridVer}`}
+                      schema={
+                        {
+                          type: 'object-view',
+                          objectName: current.name,
+                          // No saved view exists in design mode, so show the object's
+                          // own fields as columns (in metadata order), dropping
+                          // framework-managed/audit fields so the grid opens on the
+                          // meaningful columns first — the way Airtable does.
+                          table: {
+                            fields: readFields(objDraft.fields)
+                              .entries.map((e) => e.name)
+                              .filter((n) => !STUDIO_SYSTEM_FIELD_NAMES.has(n)),
+                          },
+                        } as never
+                      }
+                      dataSource={adapter as never}
+                      renderListView={renderStudioGridList}
+                    />
+                  </SchemaRendererProvider>
                 </GridFieldAuthoringProvider>
               </div>
               <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -662,6 +662,23 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     setEditValue('');
   };
 
+  // Stage an in-flight edit into pendingChanges WITHOUT closing the editor —
+  // used by injected widget editors (multi-value pickers, free text) that
+  // commit when the user moves on rather than on each keystroke/toggle. Mirrors
+  // what saveEdit stages, minus the close.
+  const stageEdit = (value: any) => {
+    if (!editingCell) return;
+    const { rowIndex, columnKey } = editingCell;
+    setEditValue(value);
+    setPendingChanges((prev) => {
+      const next = new Map(prev);
+      const rowChanges = { ...(next.get(rowIndex) || {}) };
+      rowChanges[columnKey] = value;
+      next.set(rowIndex, rowChanges);
+      return next;
+    });
+  };
+
   // Commit the in-flight edit when the input loses focus (e.g. the user clicks
   // another cell). Without this, switching cells discards the typed value.
   const handleEditBlur = () => {
@@ -1190,6 +1207,34 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                 // readable switch that's easy to extend.
                                 const editType = (col as any).type as string | undefined;
 
+                                // Host-injected editor: a higher layer (ObjectGrid) renders
+                                // the dedicated @object-ui/fields widget for this field's
+                                // type — the SAME control the form uses — so we don't
+                                // re-implement select/boolean/etc. down here in the
+                                // (fields-free) component layer. Returning null means "no
+                                // widget for this type" → fall through to the built-ins.
+                                const injectEditor = (schema as any).renderCellEditor as
+                                  | ((ctx: {
+                                      column: any;
+                                      row: any;
+                                      value: any;
+                                      stage: (v: any) => void;
+                                      commit: (v?: any) => void;
+                                      cancel: () => void;
+                                    }) => React.ReactNode)
+                                  | undefined;
+                                if (typeof injectEditor === 'function') {
+                                  const node = injectEditor({
+                                    column: col,
+                                    row,
+                                    value: editValue,
+                                    stage: stageEdit,
+                                    commit: (v?: any) => saveEdit(true, v),
+                                    cancel: cancelEdit,
+                                  });
+                                  if (node != null) return node;
+                                }
+
                                 if (editType === 'date') {
                                   return (
                                     <Input
@@ -1241,50 +1286,13 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                   );
                                 }
 
-                                // Select / single-choice: a dropdown of the field's options
-                                // (forwarded as `col.options` from ObjectGrid), matching the
-                                // form's select control. Opens immediately and commits on pick.
-                                const editOptions = (col as any).options as
-                                  | Array<{ value: unknown; label: string }>
-                                  | undefined;
-                                if (
-                                  (editType === 'select' || editType === 'status') &&
-                                  Array.isArray(editOptions) &&
-                                  editOptions.length > 0
-                                ) {
-                                  return (
-                                    <Select
-                                      defaultOpen
-                                      value={editValue == null ? '' : String(editValue)}
-                                      onValueChange={(v) => saveEdit(true, v)}
-                                    >
-                                      <SelectTrigger className="h-8 px-2 py-1">
-                                        <SelectValue placeholder="—" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        {editOptions.map((o) => (
-                                          <SelectItem key={String(o.value)} value={String(o.value)}>
-                                            {o.label}
-                                          </SelectItem>
-                                        ))}
-                                      </SelectContent>
-                                    </Select>
-                                  );
-                                }
+                                // Select / boolean / multi-select / etc. are NOT hand-rolled
+                                // here — the host (ObjectGrid) provides them via
+                                // `renderCellEditor` using the dedicated @object-ui/fields
+                                // widgets, so they exactly match the form's controls.
 
-                                // Boolean: a checkbox, like the form's boolean control.
-                                if (editType === 'boolean') {
-                                  return (
-                                    <div className="flex h-8 items-center px-2">
-                                      <Checkbox
-                                        checked={editValue === true || editValue === 'true' || editValue === 1}
-                                        onCheckedChange={(c) => saveEdit(true, !!c)}
-                                      />
-                                    </div>
-                                  );
-                                }
-
-                                // Fallback: plain text input (original behavior).
+                                // Fallback: plain text input (when no host editor matched and
+                                // the type isn't date/datetime/number).
                                 return (
                                   <Input
                                     ref={editInputRef}

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -1,0 +1,91 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import type { FieldWidgetProps } from './widgets/types';
+
+// The SAME dedicated widgets the form renders — reused for in-place editing
+// (e.g. the data grid's inline cell editor) so a select edits as a dropdown, a
+// boolean as a checkbox, a date as a date picker, etc. — never a bare text box.
+import { TextField } from './widgets/TextField';
+import { TextAreaField } from './widgets/TextAreaField';
+import { NumberField } from './widgets/NumberField';
+import { CurrencyField } from './widgets/CurrencyField';
+import { PercentField } from './widgets/PercentField';
+import { SliderField } from './widgets/SliderField';
+import { RatingField } from './widgets/RatingField';
+import { BooleanField } from './widgets/BooleanField';
+import { SelectField } from './widgets/SelectField';
+import { MultiSelectField } from './widgets/MultiSelectField';
+import { RadioField } from './widgets/RadioField';
+import { CheckboxesField } from './widgets/CheckboxesField';
+import { TagsField } from './widgets/TagsField';
+import { DateField } from './widgets/DateField';
+import { DateTimeField } from './widgets/DateTimeField';
+import { TimeField } from './widgets/TimeField';
+import { EmailField } from './widgets/EmailField';
+import { PhoneField } from './widgets/PhoneField';
+import { UrlField } from './widgets/UrlField';
+
+/**
+ * Field types that edit in place with a dedicated widget. Keyed by the raw
+ * field `type` (the widget map mirrors the form's `mapFieldTypeToFormType`).
+ * Rich/heavy types (file, image, lookup, richtext, …) are intentionally absent
+ * so callers fall back to their own simpler editor.
+ */
+const EDIT_WIDGETS: Record<string, React.ComponentType<FieldWidgetProps<any>>> = {
+  text: TextField,
+  textarea: TextAreaField,
+  number: NumberField,
+  currency: CurrencyField,
+  percent: PercentField,
+  slider: SliderField,
+  progress: SliderField,
+  rating: RatingField,
+  boolean: BooleanField,
+  toggle: BooleanField,
+  select: SelectField,
+  status: SelectField,
+  multiselect: MultiSelectField,
+  radio: RadioField,
+  checkboxes: CheckboxesField,
+  tags: TagsField,
+  date: DateField,
+  datetime: DateTimeField,
+  time: TimeField,
+  email: EmailField,
+  phone: PhoneField,
+  url: UrlField,
+};
+
+/** Field types whose value is chosen in one discrete gesture (no free typing). */
+export const DISCRETE_EDIT_TYPES = new Set<string>([
+  'boolean', 'toggle', 'select', 'status', 'radio', 'rating',
+]);
+
+/** True when a field type has a dedicated in-place edit widget. */
+export function hasFieldEditWidget(type: string | undefined): boolean {
+  return !!type && type in EDIT_WIDGETS;
+}
+
+/**
+ * Render the dedicated edit widget for a field's type — the SAME control the
+ * form uses — as a controlled `{ value, onChange, field }` input. Returns
+ * `null` for types without a registered widget so the caller can fall back to
+ * a plain editor.
+ */
+export function FieldEditWidget({
+  field,
+  value,
+  onChange,
+  readonly,
+}: FieldWidgetProps<any>): React.ReactElement | null {
+  const Widget = field?.type ? EDIT_WIDGETS[field.type] : undefined;
+  if (!Widget) return null;
+  return <Widget field={field} value={value} onChange={onChange} readonly={readonly} />;
+}

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -2130,6 +2130,7 @@ export function registerFields() {
 }
 
 export * from './widgets/types';
+export * from './FieldEditWidget';
 export * from './widgets/TextField';
 export * from './widgets/NumberField';
 export * from './widgets/BooleanField';

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -25,7 +25,7 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { ObjectGridSchema, DataSource, ListColumn, ViewData } from '@object-ui/types';
 import type { I18nLabel } from '@objectstack/spec/ui';
 import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useObjectTranslation, useSafeFieldLabel } from '@object-ui/react';
-import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses } from '@object-ui/fields';
+import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses, FieldEditWidget, hasFieldEditWidget, DISCRETE_EDIT_TYPES } from '@object-ui/fields';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import {
   Badge, Button, NavigationOverlay, EmptyValue,
@@ -1693,6 +1693,26 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     resizableColumns: schema.resizable ?? schema.resizableColumns ?? true,
     reorderableColumns: schema.reorderableColumns ?? false,
     editable: schema.editable ?? false,
+    // In-place cell editor: render the dedicated @object-ui/fields widget for
+    // the field's type — the SAME control the form uses (select→dropdown,
+    // boolean→checkbox, date→date picker, multi-select, …). Returning null lets
+    // DataTable fall back to its built-in text/number/date inputs. Discrete
+    // pickers commit-and-close on choose; everything else stages and closes when
+    // the user moves on.
+    renderCellEditor: schema.editable
+      ? (ctx: { column: any; value: any; stage: (v: any) => void; commit: (v?: any) => void }) => {
+          const fieldDef = (objectSchema as any)?.fields?.[ctx.column?.accessorKey];
+          if (!fieldDef || !hasFieldEditWidget(fieldDef.type)) return null;
+          const discrete = DISCRETE_EDIT_TYPES.has(fieldDef.type);
+          return (
+            <FieldEditWidget
+              field={{ name: ctx.column.accessorKey, ...fieldDef }}
+              value={ctx.value}
+              onChange={(v: any) => (discrete ? ctx.commit(v) : ctx.stage(v))}
+            />
+          );
+        }
+      : undefined,
     singleClickEdit: schema.singleClickEdit ?? true,
     className: schema.className,
     cellClassName: rowHeightMode === 'compact'


### PR DESCRIPTION
## Why
Review feedback: the inline editor shouldn't hand-roll controls — the system already has dedicated field widgets (the form renders through them). This **supersedes #2097's hand-rolled select/checkbox** with the real widgets.

## Changes
- **@object-ui/fields**: add `FieldEditWidget` — a type→widget resolver that renders the dedicated widget (`SelectField`/`BooleanField`/`DateField`/`MultiSelectField`/…) as a controlled `{value,onChange,field}` input. Plus `hasFieldEditWidget` + `DISCRETE_EDIT_TYPES`.
- **data-table**: add a `renderCellEditor` injection point; drop the hand-rolled select/checkbox; `stageEdit` stages into `pendingChanges` without closing (multi-value/free-text). The (fields-free) component layer no longer reimplements controls.
- **ObjectGrid** (depends on `@object-ui/fields`): provide `renderCellEditor` rendering `FieldEditWidget` by field type — discrete pickers commit-on-choose, others stage. **Exact same controls as the form.**
- **Studio**: wrap the grid in `SchemaRendererProvider` so the object-grid has a write-capable `dataSource` (the ListView only fetches + passes data inline).

## Verified (framework app-showcase backend, admin)
- 行业 (select) cell edits via the dedicated `SelectField` dropdown
- data-API write **persists** (admin, PATCH 200 + re-GET confirms)
- type-check + lint clean on fields / components / plugin-grid / app-shell

## CI note
Bundle Analysis is red from the **pre-existing** `@objectstack/spec` 11.2.0 breakage (`clientValidation.ts`/`PolicySchema`), unrelated to this PR.

## Follow-ups
- View-settings toggle for `inlineEdit` + Studio reads `viewDef.inlineEdit` (separate PR)
- Clean end-to-end UI persistence smoke (the Radix combobox is fiddly to drive headless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)