### PR TITLE
test(data-objectstack): guard getObjectSchema's validations pass-through (inert-metadata regression)

### DIFF
--- a/packages/data-objectstack/src/getObjectSchema.test.ts
+++ b/packages/data-objectstack/src/getObjectSchema.test.ts
@@ -74,4 +74,40 @@ describe('ObjectStackAdapter.getObjectSchema', () => {
     expect(schema.name).toBe('account');
     expect(Object.keys(schema.fields)).toEqual(['x']);
   });
+
+  it('preserves `validations` (incl. state_machine transitions) — the seam the inline editor depends on', async () => {
+    // Inert-metadata regression guard. The inline select editor filters its
+    // options by the object's `state_machine` validation (objectui#2110). That
+    // feature only works because `getObjectSchema` passes the served
+    // `validations` through untouched — the server enforces the same rule. If a
+    // future change here started stripping or reshaping top-level metadata, the
+    // filter would silently no-op (valid-but-inert) with no error. Pin the
+    // pass-through so the data path can't go dark unnoticed.
+    const { fetchImpl } = makeFetch({
+      name: 'showcase_task',
+      fields: { status: { type: 'select', options: [{ value: 'done', label: 'Done' }] } },
+      validations: [
+        {
+          type: 'state_machine',
+          field: 'status',
+          transitions: { in_review: ['done', 'in_progress'], done: ['in_progress'] },
+        },
+      ],
+    });
+    const adapter = new ObjectStackAdapter({
+      baseUrl: 'http://localhost:3000',
+      autoReconnect: false,
+      fetch: fetchImpl as any,
+    });
+
+    const schema: any = await adapter.getObjectSchema('showcase_task');
+
+    const sm = (schema.validations ?? []).find((v: any) => v?.type === 'state_machine');
+    expect(sm).toBeTruthy();
+    expect(sm.field).toBe('status');
+    // The exact map the consumer filters on — `done` only transitions to
+    // `in_progress` (so the editor must not offer `in_review`).
+    expect(sm.transitions.done).toEqual(['in_progress']);
+    expect(sm.transitions.in_review).toEqual(['done', 'in_progress']);
+  });
 });


### PR DESCRIPTION
## What

A fetch-mocked seam test pinning that `ObjectStackAdapter.getObjectSchema` passes the served `validations` (incl. `state_machine` transitions) through **untouched**.

## Why

The inline select editor filters its dropdown by the object's `state_machine` validation (#2110). That feature is only alive because the adapter doesn't strip `validations` from the served schema — which today is verified **only by hand** (curl the endpoint + grep the adapter).

This is the **valid-but-inert** failure mode: if a future change here started stripping or reshaping top-level metadata, the filter would silently no-op with no error, no crash — "shipped but runtime-dead" (the same class as several prior bugs the platform's completeness gates target). This test turns that silent failure into a red CI check.

It's the smallest, non-noisy version of "make inert-metadata catchable": rather than warning on every absent config (which can't tell a legitimate default from dropped data), it pins the one seam the feature depends on.

## Test

`getObjectSchema.test.ts` — asserts the state machine survives the adapter with its exact transition map (`done → [in_progress]`, so the editor must not offer `in_review`). 3/3 in the file pass. Test-only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)