### PR TITLE
refactor(types): derive ListViewSchema.userActions from the spec (single-source pilot)

### DIFF
--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -80,6 +80,7 @@ import type {
   RowColorConfig,
   GalleryConfig,
   TimelineConfig,
+  UserActionsConfig,
 } from '@objectstack/spec/ui';
 
 /**
@@ -1942,23 +1943,25 @@ export interface ListViewSchema extends BaseSchema {
   virtualScroll?: boolean;
 
   /**
-   * User actions configuration.
-   * Controls what UI actions are available to end users.
-   * Aligned with @objectstack/spec ListViewSchema.userActions.
+   * User actions configuration — which toolbar affordances end users get.
+   *
+   * Derived from the spec's `UserActionsConfig` per this file's "never redefine
+   * types, always import them" rule (this field used to be a hand-maintained
+   * mirror — a drift hazard). `Partial<>` because authoring is opt-in: you write
+   * only the toggles you want, the rest fall back to the spec's defaults.
+   *
+   * `editInline` is carried as a transitional extension only because the pinned
+   * @objectstack/spec release predates it (added at the source in
+   * framework#2468). Once the spec dep is bumped, `Partial<UserActionsConfig>`
+   * supplies `editInline` itself and this `&`-extension becomes redundant.
    */
-  userActions?: {
-    sort?: boolean;
-    search?: boolean;
-    filter?: boolean;
-    rowHeight?: boolean;
-    addRecordForm?: boolean;
+  userActions?: Partial<UserActionsConfig> & {
     /**
      * Allow end users to edit records inline (click a cell → type-aware editor,
      * the same widgets the form uses). Default off: a list is read-only unless
      * the author opts in. Read by InterfaceListPage → `inlineEdit`.
      */
     editInline?: boolean;
-    buttons?: string[];
   };
 
   /**


### PR DESCRIPTION
## What

`ListViewSchema.userActions` was a **hand-maintained mirror** of the spec's `UserActionsConfig`. Replace it with a derivation:

```ts
userActions?: Partial<UserActionsConfig> & { editInline?: boolean };
```

## Why

This file literally states the rule **"Never Redefine Types. ALWAYS import them."** — and `userActions` was violating it. A hand mirror is a drift hazard: the type and the spec can silently diverge. The recent `editInline` work was exactly that pain — the same field touched by hand in three layers.

This is a small **pilot for the "spec single-source derivation" direction**: prove objectui types can be *derived* from the spec rather than copied, and work out how to handle the realistic wrinkles.

## Details

- `Partial<UserActionsConfig>` because authoring is opt-in — you write only the toggles you set, the rest fall back to the spec's defaults. This is **shape-identical** to the old hand-written type, so there are **no consumer changes** (types + app-shell type-check clean).
- `editInline` is carried as a transitional `&`-extension **only because the pinned `@objectstack/spec` release predates it** (it's in the source via framework#2468, not yet released to npm). Once the spec dep is bumped, `Partial<UserActionsConfig>` supplies `editInline` itself and the extension is redundant. This is the **release-lag** that #1 has to design around — made explicit here rather than hidden.
- Follows the existing precedent in this file (`ListViewGalleryConfig = GalleryConfig & { …legacy… }`).

## Verification

`@object-ui/types` + `@object-ui/app-shell` `tsc --noEmit` clean; ESLint clean. No behavior change; **no changeset** (shape-identical, type-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)