### PR TITLE
fix(grid): don't inline-edit read-only / computed / binary fields

### DIFF
--- a/.changeset/inline-edit-readonly-computed-fields.md
+++ b/.changeset/inline-edit-readonly-computed-fields.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/plugin-grid": patch
+---
+
+fix(grid): don't open an inline editor for read-only / computed / binary fields
+
+Inline editing fell back to a plain text box for every field without a
+dedicated widget — including ones you can never author a value for. Found by
+browser-testing the field-zoo: a **Formula**, **Roll-up**, or **Auto Number**
+cell (system-computed) opened an editable text input, as did **File / Image /
+Avatar / Video / Audio / Signature** (binary). Typing into a computed cell is
+meaningless and, if the server accepted it, would clobber the derived value.
+
+Gate it: a column is marked `editable: false` (which the data-table already
+honors — it won't enter edit mode) when the field is `readonly` or an
+inherently non-authorable type (`formula`, `summary`/`rollup`, `autonumber`,
+`file`, `image`, `avatar`, `video`, `audio`, `signature`). Ordinary types
+(text, number, date, select, boolean, …) are unaffected. Relational/structured
+types (lookup, master-detail, json, …) intentionally keep their text fallback
+for now — they want a proper picker, not a hard read-only lock.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -27,7 +27,7 @@ import type { I18nLabel } from '@objectstack/spec/ui';
 import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useObjectTranslation, useSafeFieldLabel } from '@object-ui/react';
 import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses, FieldEditWidget, hasFieldEditWidget, DISCRETE_EDIT_TYPES } from '@object-ui/fields';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
-import { stateMachineNextValues } from './inline-edit-options';
+import { stateMachineNextValues, isFieldInlineEditable } from './inline-edit-options';
 import {
   Badge, Button, NavigationOverlay, EmptyValue,
   Popover, PopoverContent, PopoverTrigger,
@@ -1368,6 +1368,13 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     if (next.type == null && fieldDef.type) next.type = fieldDef.type;
     if (next.options == null && fieldDef.options) {
       next.options = translateOptions(schema.objectName, col.accessorKey, fieldDef.options);
+    }
+    // Read-only / computed / binary fields are not value-editable in place —
+    // mark the column so the data-table never opens an editor (otherwise it
+    // falls back to a plain text box for e.g. a Formula or File cell). Only
+    // force `false`; leave editable unset otherwise so the grid-level flag wins.
+    if (next.editable !== false && !isFieldInlineEditable(fieldDef)) {
+      next.editable = false;
     }
     return next;
   });

--- a/packages/plugin-grid/src/inline-edit-options.test.ts
+++ b/packages/plugin-grid/src/inline-edit-options.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { stateMachineNextValues } from './inline-edit-options';
+import { stateMachineNextValues, isFieldInlineEditable } from './inline-edit-options';
 
 // Mirrors examples/app-showcase task.object.ts — the state machine that rejected
 // done → in_review live (done only transitions to in_progress).
@@ -76,5 +76,42 @@ describe('stateMachineNextValues', () => {
     };
     const r = stateMachineNextValues(numeric, 'level', 1);
     expect([...(r as Set<string>)].sort()).toEqual(['1', '2', '3']);
+  });
+});
+
+describe('isFieldInlineEditable', () => {
+  it('blocks computed / system-generated types (would open a text box for a derived value)', () => {
+    for (const type of ['formula', 'summary', 'rollup', 'autonumber', 'auto_number']) {
+      expect(isFieldInlineEditable({ type })).toBe(false);
+    }
+  });
+
+  it('blocks binary / attachment types (no inline text control)', () => {
+    for (const type of ['file', 'image', 'avatar', 'video', 'audio', 'signature']) {
+      expect(isFieldInlineEditable({ type })).toBe(false);
+    }
+  });
+
+  it('blocks an explicitly readonly field regardless of type', () => {
+    expect(isFieldInlineEditable({ type: 'text', readonly: true })).toBe(false);
+    expect(isFieldInlineEditable({ type: 'select', readonly: true })).toBe(false);
+  });
+
+  it('allows ordinary editable types', () => {
+    for (const type of ['text', 'number', 'select', 'boolean', 'date', 'multiselect', 'currency']) {
+      expect(isFieldInlineEditable({ type })).toBe(true);
+    }
+  });
+
+  it('treats relational / structured types as editable (text fallback today, not a hard lock)', () => {
+    for (const type of ['lookup', 'master_detail', 'user', 'json', 'address']) {
+      expect(isFieldInlineEditable({ type })).toBe(true);
+    }
+  });
+
+  it('treats a null/unknown field as editable so the grid flag still governs', () => {
+    expect(isFieldInlineEditable(null)).toBe(true);
+    expect(isFieldInlineEditable(undefined)).toBe(true);
+    expect(isFieldInlineEditable({})).toBe(true);
   });
 });

--- a/packages/plugin-grid/src/inline-edit-options.ts
+++ b/packages/plugin-grid/src/inline-edit-options.ts
@@ -46,3 +46,35 @@ export function stateMachineNextValues(
   if (!Array.isArray(allowed)) return null; // undeclared from-state → unconstrained
   return new Set<string>([from, ...allowed.map((s) => String(s))]);
 }
+
+/**
+ * Field types that can never be edited as a value in an inline cell:
+ *  - computed / system-generated — the value is derived, not authored, so an
+ *    edit is meaningless (and would be discarded or rejected);
+ *  - binary / attachment — there is no text/inline control for a file's bytes.
+ *
+ * Without this gate the grid falls back to a plain text box for these (you
+ * could type into a Formula or File cell), which is wrong. Relational and
+ * structured types are intentionally NOT here — they degrade to a text editor
+ * today and want a proper picker later, not a hard read-only lock.
+ */
+const NON_EDITABLE_FIELD_TYPES = new Set<string>([
+  // computed / system-generated
+  'formula', 'summary', 'rollup', 'autonumber', 'auto_number',
+  // binary / attachment
+  'file', 'image', 'avatar', 'video', 'audio', 'signature',
+]);
+
+/**
+ * Whether a field may be edited in place in the grid. False for explicitly
+ * `readonly` fields and for inherently computed / binary types (see
+ * {@link NON_EDITABLE_FIELD_TYPES}). A null/unknown field is treated as
+ * editable so the grid's own `editable` flag still governs.
+ */
+export function isFieldInlineEditable(
+  fieldDef: { type?: unknown; readonly?: unknown } | null | undefined,
+): boolean {
+  if (!fieldDef) return true;
+  if (fieldDef.readonly === true) return false;
+  return !(typeof fieldDef.type === 'string' && NON_EDITABLE_FIELD_TYPES.has(fieldDef.type));
+}


### PR DESCRIPTION
## What

Inline cell editing opened a plain text box for **every** field lacking a dedicated widget — including ones you can never author a value for.

## Found by browser-testing

Drove the showcase **Field Zoo** (57 field types) cell-by-cell. Result:
- The 23 mapped types all render their correct type-aware editor ✓ (text→input, number→number, date→picker, boolean→switch, select→dropdown, multiselect→popover, radio→radiogroup, …).
- **But** `Formula`, `Roll-up`, `Auto Number` (system-computed) and `File / Image / Avatar / Video / Audio / Signature` (binary) opened an **editable `input[text]`**. Typing into a computed cell is meaningless; if the server accepted it, it would clobber the derived value.

## Fix

- `isFieldInlineEditable(fieldDef)` → `false` for `readonly` fields and inherently non-authorable types.
- ObjectGrid's column enrichment marks those columns `editable: false`. The data-table already honors per-column editable (`startEdit` returns early), so the cell just doesn't enter edit mode. Ordinary types are untouched.

## Verified live (:5417, re-ran the matrix)

| | before | after |
|---|---|---|
| Formula / Roll-up / Auto Number | `input[text]` | **read-only** |
| File / Image | `input[text]` | **read-only** |
| Number / Currency / Date / Boolean / Select | edits | **still edits** |

## Scope note

Relational/structured types (lookup, master-detail, json, composite…) keep their text fallback for now — they want a proper picker, not a hard read-only lock. Not data-unsafe: the server validates and rejected saves now surface (#2106).

`+6` tests (14 total in the file pass). ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)