### PR TITLE
fix(fields): inline-edit relational fields with the standard picker (not a text box)

### DIFF
--- a/.changeset/inline-edit-relational-widgets.md
+++ b/.changeset/inline-edit-relational-widgets.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/fields": patch
+---
+
+fix(fields): inline-edit relational fields with the standard picker (not a text box)
+
+Inline cell editing reuses the form's field widgets, but the inline map
+(`EDIT_WIDGETS`) was a hand-maintained subset of the form's (`fieldWidgetMap`)
+and had drifted: **lookup / master_detail / user / owner** had perfectly good
+form pickers yet fell back to a plain text box inline (you'd type a raw record
+id). Wire them up — `lookup`/`master_detail` → `LookupField`, `user`/`owner` →
+`UserField`, the exact widgets the form uses. They read the related-object
+dataSource from `SchemaRendererContext` (which the grid provides), so the
+record picker opens, fetches, and selects inline.
+
+To stop the two lists drifting again, `index` now exports `FORM_FIELD_TYPES`
+and a drift-guard test pins the contract: every form widget type must have an
+explicit inline decision — an editor in `EDIT_WIDGETS` or an entry in the new
+`INLINE_EXCLUDED_FIELD_TYPES` (computed/binary/heavy/container types, each with
+a reason). A future form widget can no longer silently become a text box (or a
+missing editor) in the grid.

--- a/packages/fields/src/FieldEditWidget.test.ts
+++ b/packages/fields/src/FieldEditWidget.test.ts
@@ -1,0 +1,54 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  FORM_FIELD_TYPES,
+  INLINE_EXCLUDED_FIELD_TYPES,
+  hasFieldEditWidget,
+} from './index';
+
+/**
+ * Drift-guard: the inline cell editor reuses the form's field widgets, but the
+ * two lists were hand-maintained separately and drifted — `lookup` (and other
+ * relational types) had a perfectly good form widget yet fell back to a plain
+ * text box inline, because nobody wired it up. This pins the contract: every
+ * type the FORM can render must have an explicit inline decision — an editor or
+ * a documented exclusion — so a new form widget can never again silently become
+ * an editable text box (or a missing one) in the grid.
+ */
+describe('inline editor ↔ form widget parity', () => {
+  it('every form field type either has an inline editor or is explicitly excluded', () => {
+    const undecided = FORM_FIELD_TYPES.filter(
+      (t) => !hasFieldEditWidget(t) && !INLINE_EXCLUDED_FIELD_TYPES.has(t),
+    );
+    // If this fails: a form widget type has no inline decision. Either add it to
+    // EDIT_WIDGETS (inline-editable) or to INLINE_EXCLUDED_FIELD_TYPES (with a
+    // reason) in FieldEditWidget.tsx.
+    expect(undecided).toEqual([]);
+  });
+
+  it('the exclusion set lists only real form types (no stale entries)', () => {
+    const known = new Set(FORM_FIELD_TYPES);
+    const stale = [...INLINE_EXCLUDED_FIELD_TYPES].filter((t) => !known.has(t));
+    expect(stale).toEqual([]);
+  });
+
+  it('relational fields use the standard picker inline (regression: lookup was a text box)', () => {
+    for (const t of ['lookup', 'master_detail', 'user', 'owner']) {
+      expect(hasFieldEditWidget(t)).toBe(true);
+    }
+  });
+
+  it('computed / binary form types are NOT inline-editable (excluded)', () => {
+    for (const t of ['formula', 'summary', 'auto_number', 'file', 'image']) {
+      expect(hasFieldEditWidget(t)).toBe(false);
+      expect(INLINE_EXCLUDED_FIELD_TYPES.has(t)).toBe(true);
+    }
+  });
+});

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -31,6 +31,11 @@ import { TimeField } from './widgets/TimeField';
 import { EmailField } from './widgets/EmailField';
 import { PhoneField } from './widgets/PhoneField';
 import { UrlField } from './widgets/UrlField';
+// Relational pickers — the SAME standard widgets the form uses. They read the
+// related-object dataSource from SchemaRendererContext (which the grid already
+// provides), so they drop straight into an inline cell.
+import { LookupField } from './widgets/LookupField';
+import { UserField } from './widgets/UserField';
 
 /**
  * Field types that edit in place with a dedicated widget. Keyed by the raw
@@ -61,7 +66,35 @@ const EDIT_WIDGETS: Record<string, React.ComponentType<FieldWidgetProps<any>>> =
   email: EmailField,
   phone: PhoneField,
   url: UrlField,
+  // Relational — the record/user pickers, same as the form (the form maps
+  // master_detail to the single-value LookupField too, see fieldWidgetMap).
+  lookup: LookupField,
+  master_detail: LookupField,
+  user: UserField,
+  owner: UserField,
 };
+
+/**
+ * Form field types that are deliberately NOT given an inline editor — every
+ * other form widget type must be in {@link EDIT_WIDGETS}. This pairing is
+ * enforced by a test against the form's widget map (`FORM_FIELD_TYPES`) so the
+ * two can't silently drift again (which is how `lookup` was missed). To add a
+ * type to inline editing, move it from here into EDIT_WIDGETS.
+ */
+export const INLINE_EXCLUDED_FIELD_TYPES = new Set<string>([
+  // Computed / read-only — the grid keeps these non-editable (no value to author).
+  'formula', 'summary', 'auto_number',
+  // Binary / attachment — edited from the record form, shown read-only in the grid.
+  'file', 'image', 'avatar', 'signature',
+  // Heavy / full editors — better in the record form than a cell.
+  'markdown', 'html', 'richtext', 'password',
+  // Containers / non-authorable — a sub-form / sub-grid / embedding vector
+  // doesn't belong in a single cell.
+  'object', 'grid', 'vector',
+  // Structured editors that DO have a form widget — deferred, not blocked.
+  // Move into EDIT_WIDGETS when wired + verified inline.
+  'location', 'geolocation', 'address', 'color', 'code', 'qrcode',
+]);
 
 /** Field types whose value is chosen in one discrete gesture (no free typing). */
 export const DISCRETE_EDIT_TYPES = new Set<string>([

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1977,6 +1977,14 @@ const fieldWidgetMap: Record<string, () => Promise<{ default: React.ComponentTyp
 };
 
 /**
+ * Every field type the form can render (the canonical list of supported types).
+ * Exported so inline editing can be checked against it — a form type must
+ * either have an inline editor or be explicitly excluded, see
+ * `INLINE_EXCLUDED_FIELD_TYPES` and its drift-guard test.
+ */
+export const FORM_FIELD_TYPES: readonly string[] = Object.freeze(Object.keys(fieldWidgetMap));
+
+/**
  * Register a specific field type lazily
  * @param fieldType - The field type to register (e.g., 'text', 'number')
  * 


### PR DESCRIPTION
## What

**lookup / master_detail / user / owner** fields now edit inline with the **standard record picker** — the same `LookupField` / `UserField` the form uses — instead of falling back to a plain text box.

## Why (caught in review)

Inline editing reuses the form's widgets, but the inline map (`EDIT_WIDGETS`) was a **hand-maintained subset** of the form's (`fieldWidgetMap`) and had **drifted** — relational types had perfectly good form pickers, but nobody wired them into the inline map, so they degraded to a text box (you'd type a raw record id). The form already supported them; this just reuses them.

## How

- `lookup` / `master_detail` → `LookupField`, `user` / `owner` → `UserField`. They read the related-object dataSource from `SchemaRendererContext`, which the grid already provides — drop-in, same `FieldWidgetProps` interface.

## Verified live (:5417 field-zoo)

Clicking a **Lookup → Account** cell opens the record picker ("选择…") with a search box and **13 fetched Account records** (Northwind, Contoso, Fabrikam, Initech…) — not a text box, not empty. master_detail / user / owner likewise render the picker.

## Drift-guard (so this can't recur)

`index` now exports `FORM_FIELD_TYPES`; a test pins that **every** form widget type has an explicit inline decision — an editor in `EDIT_WIDGETS`, or an entry in the new `INLINE_EXCLUDED_FIELD_TYPES` (computed / binary / heavy-editor / container types, each documented). A future form widget can no longer silently become a text box or a missing editor in the grid.

`+4` drift-guard tests; full `@object-ui/fields` suite (4918) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)