### PR TITLE
feat(fields): inline-edit structured-value fields (color/address/location/code/…)

### DIFF
--- a/.changeset/inline-edit-structured-widgets.md
+++ b/.changeset/inline-edit-structured-widgets.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/fields": patch
+---
+
+feat(fields): inline-edit structured-value fields (color, address, location, geolocation, code, qrcode)
+
+Completes the inline-editor ↔ form-widget parity from the previous fix: the six
+structured types that already had lightweight form widgets — `color`,
+`address`, `location`, `geolocation`, `code`, `qrcode` — now edit inline with
+those same widgets instead of being deferred. All are dependency-light (no map
+or code-editor libraries) and use the standard `FieldWidgetProps`. Verified
+inline on the field-zoo: color → a color picker, code → a textarea, the rest
+their value editors. The drift-guard's exclusion set now contains only the
+genuinely-non-inline types (computed, binary, heavy editors, containers).

--- a/packages/fields/src/FieldEditWidget.test.ts
+++ b/packages/fields/src/FieldEditWidget.test.ts
@@ -51,4 +51,11 @@ describe('inline editor ↔ form widget parity', () => {
       expect(INLINE_EXCLUDED_FIELD_TYPES.has(t)).toBe(true);
     }
   });
+
+  it('structured-value types edit inline with their form widget (color/address/location/code/…)', () => {
+    for (const t of ['color', 'address', 'location', 'geolocation', 'code', 'qrcode']) {
+      expect(hasFieldEditWidget(t)).toBe(true);
+      expect(INLINE_EXCLUDED_FIELD_TYPES.has(t)).toBe(false);
+    }
+  });
 });

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -36,6 +36,14 @@ import { UrlField } from './widgets/UrlField';
 // provides), so they drop straight into an inline cell.
 import { LookupField } from './widgets/LookupField';
 import { UserField } from './widgets/UserField';
+// Structured-value editors — lightweight (no map/code-editor deps), same
+// widgets the form uses. Drop into a cell like the rest.
+import { ColorField } from './widgets/ColorField';
+import { AddressField } from './widgets/AddressField';
+import { LocationField } from './widgets/LocationField';
+import { GeolocationField } from './widgets/GeolocationField';
+import { CodeField } from './widgets/CodeField';
+import { QRCodeField } from './widgets/QRCodeField';
 
 /**
  * Field types that edit in place with a dedicated widget. Keyed by the raw
@@ -72,6 +80,13 @@ const EDIT_WIDGETS: Record<string, React.ComponentType<FieldWidgetProps<any>>> =
   master_detail: LookupField,
   user: UserField,
   owner: UserField,
+  // Structured-value editors — same widgets the form uses.
+  color: ColorField,
+  address: AddressField,
+  location: LocationField,
+  geolocation: GeolocationField,
+  code: CodeField,
+  qrcode: QRCodeField,
 };
 
 /**
@@ -91,9 +106,6 @@ export const INLINE_EXCLUDED_FIELD_TYPES = new Set<string>([
   // Containers / non-authorable — a sub-form / sub-grid / embedding vector
   // doesn't belong in a single cell.
   'object', 'grid', 'vector',
-  // Structured editors that DO have a form widget — deferred, not blocked.
-  // Move into EDIT_WIDGETS when wired + verified inline.
-  'location', 'geolocation', 'address', 'color', 'code', 'qrcode',
 ]);
 
 /** Field types whose value is chosen in one discrete gesture (no free typing). */


### PR DESCRIPTION
## What

The six structured field types that already had **lightweight form widgets** — `color`, `address`, `location`, `geolocation`, `code`, `qrcode` — now edit **inline** with those same widgets, instead of being deferred to the exclusion list. Finishes the inline ↔ form parity started by #2122 (relational) and #2121 (read-only gating).

## Why safe

All six are **dependency-light** (no Leaflet/Mapbox/Monaco/CodeMirror — GeolocationField uses a `MapPin` *icon*, CodeField is a textarea, ColorField an `<input type=color>`) and use the standard `FieldWidgetProps`, so they drop into a cell like select/lookup.

## Verified inline (:5417 field-zoo)

- **Color → `input[color]` + hex `input[text]`** and **Code → `textarea`** — unambiguously the real widgets (the text fallback can *only* produce `input[text]`).
- Address / Location / Geolocation / QR → their value editors.

## Result

`INLINE_EXCLUDED_FIELD_TYPES` now contains **only** the genuinely-non-inline types (computed, binary, heavy full-editors, containers). The drift-guard test keeps the two widget maps in lockstep. `+1` regression test (5/5 in file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)