### PR TITLE
fix(grid): keep import wizard open on backdrop / dropdown outside-click

### DIFF
--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -785,7 +785,15 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={(v) => { if (!v) handleClose(); else onOpenChange?.(v); }}>
-      <DialogContent className="flex max-h-[85vh] flex-col gap-4 overflow-hidden sm:max-w-4xl">
+      <DialogContent
+        className="flex max-h-[85vh] flex-col gap-4 overflow-hidden sm:max-w-4xl"
+        // The wizard holds unsaved upload + mapping progress, so a stray click
+        // must not close it. This blocks two accidental dismissals: (1) clicking
+        // the gray overlay, and (2) clicking a Radix Select's dropdown flyout,
+        // which is portalled to document.body and would otherwise read as an
+        // "interact outside" the dialog. Users still close via the X, Cancel, or Esc.
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FileSpreadsheet className="h-5 w-5" /> {t('grid.import.title', { object: label })}


### PR DESCRIPTION
## 问题

数据导入向导(`ImportWizard`,「导入线索」)会被误触关闭,丢失已上传数据与映射进度:

1. **点击灰色遮罩层** → 整个导入窗口立即关闭。
2. **字段映射步骤展开下拉框后,点击下拉项以外的地方** → 下拉框和整个导入窗口一起被关闭。

## 根因

- 问题 1:Radix Dialog 默认的「点击外部关闭」(`onInteractOutside`)。
- 问题 2:Radix `Select` 下拉内容被 portal 到 `document.body`,物理上位于 `DialogContent` 之外,点击浮层被 Dialog 判定为「interact outside」而触发关闭。

## 方案

给 `ImportWizard` 的 `DialogContent` 增加 `onInteractOutside={(e) => e.preventDefault()}`,一次性阻止两类误触(遮罩层点击 + Select 浮层点击)。用户仍可通过右上角 **X**、底部**取消**按钮或 **Esc** 显式关闭。与仓库既有先例(`ActionResultDialog` 阻止外部关闭、`mobile-dialog-content` 的 `isInsidePopperLayer`)一致。

## 验证

- `vite build` 通过;`tsc` 无新增类型错误。
- 单文件改动:`packages/plugin-grid/src/ImportWizard.tsx`。

Closes #2126