### PR TITLE
fix(grid,dashboard): 汇总/指标把 precision(总位数)当小数位显示多余的 0

### DIFF
--- a/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
@@ -166,7 +166,9 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
     if (format) return format;
     if (!valueFieldDef) return undefined;
     if (valueFieldDef.type === 'currency') {
-      const decimals = valueFieldDef.precision ?? valueFieldDef.scale ?? 0;
+      // Decimal places come from `scale`, not `precision` (the total digit
+      // count of a decimal(p, s) column) — see #2131.
+      const decimals = valueFieldDef.scale ?? 0;
       return decimals > 0 ? `0,0.${'0'.repeat(decimals)}` : '0,0';
     }
     if (valueFieldDef.type === 'percent') return '0,0%';

--- a/packages/plugin-dashboard/src/recordFields.tsx
+++ b/packages/plugin-dashboard/src/recordFields.tsx
@@ -143,7 +143,8 @@ export function buildFieldMeta(params: BuildFieldMetaParams): FieldMeta {
     referenceTo,
     format: overrides.format ?? meta?.format,
     currency: overrides.currency ?? meta?.currency ?? meta?.defaultCurrency,
-    decimals: overrides.decimals ?? meta?.decimals ?? meta?.precision ?? meta?.scale,
+    // `scale` (decimal places), not `precision` (total digit count) — see #2131.
+    decimals: overrides.decimals ?? meta?.decimals ?? meta?.scale,
   };
 }
 

--- a/packages/plugin-grid/src/useColumnSummary.test.tsx
+++ b/packages/plugin-grid/src/useColumnSummary.test.tsx
@@ -49,4 +49,26 @@ describe('useColumnSummary tenant-default currency', () => {
     const label = result.current.summaries.get('amount')?.label ?? '';
     expect(label).toMatch(/\$|US\$/);
   });
+
+  // Regression (#2134): `precision` is the total digit count of a decimal(p, s)
+  // column, NOT the decimal places. It must not drive fraction digits, or a
+  // decimal(10, 0) sum renders as "…0000000000".
+  it('does not pad a currency sum using precision (total digits)', () => {
+    const cols: any[] = [{ field: 'amount', summary: 'sum', type: 'currency', currency: 'USD', precision: 10, scale: 0 }];
+    const { result } = renderHook(() => useColumnSummary(cols, [{ amount: 1000 }, { amount: 234 }]), {
+      wrapper: wrapper('USD'),
+    });
+    const label = result.current.summaries.get('amount')?.label ?? '';
+    expect(label).not.toMatch(/\.0{3,}/);
+    expect(label).toMatch(/1,234/);
+  });
+
+  it('honours a currency column scale for fraction digits', () => {
+    const cols: any[] = [{ field: 'amount', summary: 'sum', type: 'currency', currency: 'USD', precision: 12, scale: 2 }];
+    const { result } = renderHook(() => useColumnSummary(cols, [{ amount: 1000 }, { amount: 234 }]), {
+      wrapper: wrapper('USD'),
+    });
+    const label = result.current.summaries.get('amount')?.label ?? '';
+    expect(label).toMatch(/1,234\.00/);
+  });
 });

--- a/packages/plugin-grid/src/useColumnSummary.ts
+++ b/packages/plugin-grid/src/useColumnSummary.ts
@@ -85,7 +85,10 @@ function formatSummaryLabel(
   let formatted: string;
   if (type !== 'count' && colType === 'currency') {
     const currency = resolveFieldCurrency(column, tenantDefault);
-    const decimals = column?.precision ?? column?.scale ?? 0;
+    // Decimal places come from `scale`, not `precision` (the total digit count
+    // of a decimal(p, s) column) — see #2131. Reading `precision` padded a
+    // decimal(10, 0) sum out to "…0000000000".
+    const decimals = column?.scale ?? 0;
     try {
       formatted = currency
         ? new Intl.NumberFormat(undefined, {


### PR DESCRIPTION
## 问题

与 #2131 同源。网格列汇总(SUM/AVG…)和 Dashboard 指标/记录字段格式化数值时,把字段的 `precision`(`decimal(p, s)` 的总位数 `p`)当成了小数位,于是 `decimal(10, 0)` 的汇总值会显示成 `…0000000000`。

Closes #2134

## 改动

小数位统一改用 `scale`,不再回退到 `precision`(总位数):

- `useColumnSummary.ts`:currency 分支的 `decimals` 由 `precision ?? scale ?? 0` 改为 `scale ?? 0`
- `ObjectMetricWidget.tsx`:currency 格式的 `decimals` 改用 `scale ?? 0`
- `recordFields.tsx`:`decimals` 回退到 `scale`,去掉 `precision`

## 说明

- percent 分支([useColumnSummary.ts:108](packages/plugin-grid/src/useColumnSummary.ts#L108))仍用 `precision`——percent 字段沿用把 `precision` 当显示小数位的既有约定(与 `PercentField` 一致),故保持不动。
- 纯 `number` 汇总本就走 `toLocaleString()`(不强制补零),不受影响。

## 验证

- `useColumnSummary.test.tsx` 新增 2 例回归(precision 大值不补零 / scale 生效补零)
- `plugin-grid` summary + `plugin-dashboard` 全套:103 passed(24 skipped)