### PR TITLE
fix(list): inline-edit toggle, reference-cell [object Object], and i18n

### DIFF
--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -102,6 +102,31 @@ function toDateTimeInputValue(value: unknown): string {
 // Field types that should edit as a numeric `<Input type="number">`.
 const NUMERIC_EDIT_TYPES = new Set(['number', 'currency', 'percent', 'int', 'integer', 'float', 'double']);
 
+/**
+ * Human label for an object/array cell value (e.g. an expanded reference like
+ * `{ id, name: 'Dev Admin' }`) shown in the read-only inline editor so we never
+ * render "[object Object]". Mirrors @object-ui/fields' `coerceToSafeValue`
+ * (which @object-ui/components can't import — it would be a circular dep).
+ */
+function safeObjectLabel(value: unknown): string {
+  if (value == null) return '';
+  if (Array.isArray(value)) {
+    return value
+      .map((v) =>
+        v != null && typeof v === 'object'
+          ? safeObjectLabel(v)
+          : String(v),
+      )
+      .filter(Boolean)
+      .join(', ');
+  }
+  if (typeof value === 'object') {
+    const o = value as Record<string, unknown>;
+    return String(o.name ?? o.label ?? o.externalId ?? o.id ?? o._id ?? '');
+  }
+  return String(value);
+}
+
 // Default English fallback translations for the data table
 const TABLE_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'table.rowsPerPage': 'Rows per page',
@@ -1356,6 +1381,27 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                 // here — the host (ObjectGrid) provides them via
                                 // `renderCellEditor` using the dedicated @object-ui/fields
                                 // widgets, so they exactly match the form's controls.
+
+                                // Object/array values (e.g. an expanded reference like
+                                // `{ id, name }`) have no safe free-text editor: a plain
+                                // <input> renders them as "[object Object]", and blur
+                                // auto-saves (saveEdit) would clobber the object with that
+                                // string. Show the coerced label read-only and cancel (not
+                                // save) on blur so the value is never corrupted — such
+                                // fields are edited from the record form / a dedicated picker.
+                                if (editValue != null && typeof editValue === 'object') {
+                                  return (
+                                    <Input
+                                      ref={editInputRef}
+                                      value={safeObjectLabel(editValue)}
+                                      readOnly
+                                      onKeyDown={handleEditKeyDown}
+                                      onBlur={cancelEdit}
+                                      className="h-8 px-2 py-1 text-muted-foreground cursor-default"
+                                      title={safeObjectLabel(editValue)}
+                                    />
+                                  );
+                                }
 
                                 // Fallback: plain text input (when no host editor matched and
                                 // the type isn't date/datetime/number).

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -309,6 +309,9 @@ const en = {
     addGroup: 'Add group field',
     collapsedByDefault: 'Collapsed by default',
     removeGroup: 'Remove',
+    inlineEditShort: 'Edit inline',
+    inlineEditLabel: 'Edit records inline (click a cell to edit)',
+    recordEditingTitle: 'Record editing',
   },
   kanban: {
     addCard: 'Add card',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -309,6 +309,9 @@ const zh = {
     addGroup: '添加分组字段',
     collapsedByDefault: '默认折叠',
     removeGroup: '删除',
+    inlineEditShort: '行内编辑',
+    inlineEditLabel: '行内编辑记录(点击单元格进行编辑)',
+    recordEditingTitle: '记录编辑',
   },
   kanban: {
     addCard: '添加卡片',

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -637,6 +637,24 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   );
   const [showHideFields, setShowHideFields] = React.useState(false);
 
+  // Inline-edit State (initialized from schema). Kept local — like hiddenFields
+  // — so the toolbar toggle flips the grid immediately. The parent persists via
+  // onInlineEditChange (debounced) and doesn't update the `inlineEdit` prop
+  // synchronously, so reading `schema.inlineEdit` directly would make the button
+  // appear dead until a full reload.
+  const [inlineEdit, setInlineEdit] = React.useState<boolean>(() => !!schema.inlineEdit);
+  React.useEffect(() => {
+    setInlineEdit(!!schema.inlineEdit);
+  }, [schema.inlineEdit]);
+  // Setter that also notifies parent for persistence (debounced upstream).
+  const updateInlineEdit = React.useCallback(
+    (next: boolean) => {
+      setInlineEdit(next);
+      onInlineEditChange?.(next);
+    },
+    [onInlineEditChange]
+  );
+
   // Export State
   const [showExport, setShowExport] = React.useState(false);
   // Server-streamed export (xlsx / type-aware csv|json) in-flight + last error.
@@ -1294,7 +1312,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           ...baseProps,
           columns: effectiveFields,
           ...(schema.conditionalFormatting ? { conditionalFormatting: schema.conditionalFormatting } : {}),
-          ...(schema.inlineEdit != null ? { editable: schema.inlineEdit } : {}),
+          editable: inlineEdit,
           ...(schema.wrapHeaders != null ? { wrapHeaders: schema.wrapHeaders } : {}),
           ...(schema.virtualScroll != null ? { virtualScroll: schema.virtualScroll } : {}),
           ...(schema.resizable != null ? { resizable: schema.resizable } : {}),
@@ -1725,10 +1743,10 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => onInlineEditChange(!schema.inlineEdit)}
+              onClick={() => updateInlineEdit(!inlineEdit)}
               className={cn(
                 "hidden sm:inline-flex h-7 px-2 text-muted-foreground hover:text-primary text-xs transition-colors duration-150",
-                schema.inlineEdit && "text-primary"
+                inlineEdit && "text-primary"
               )}
               title={t('list.inlineEditLabel', { defaultValue: 'Edit records inline (click a cell to edit)' })}
               data-testid="toolbar-inline-edit-toggle"
@@ -2081,8 +2099,8 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
               hiddenFields={hiddenFields}
               updateHiddenFields={updateHiddenFields}
               showInlineEdit={currentView === 'grid'}
-              inlineEdit={!!schema.inlineEdit}
-              setInlineEdit={(v) => onInlineEditChange?.(v)}
+              inlineEdit={inlineEdit}
+              setInlineEdit={updateInlineEdit}
             />
           )}
 


### PR DESCRIPTION
Closes #2136

## 问题
列表页(grid 视图)行内编辑存在三个问题:

1. **点击 "Edit inline" 无反应** —— 工具栏切换按钮点了没效果,必须刷新页面才生效。
2. **引用字段行内编辑显示 `[object Object]`** —— 例如「营销人员」列(读模式正常显示 "Dev Admin"),进入行内编辑后输入框里是 `[object Object]`。
3. **"Edit inline" 按钮没有国际化** —— 中文界面下按钮仍是英文。

## 原因
1. `ListView` 直接读 `schema.inlineEdit`,而父组件 `onInlineEditChange` 只做了 debounced 持久化,不会同步更新 `inlineEdit` prop,所以按钮看起来"死了"。
2. `data-table` 的兜底文本编辑器把展开的引用对象(`{ id, name }`)直接绑到 `<input>`,渲染成 `[object Object]`;而且失焦 `saveEdit` 会把对象覆盖成这个字符串,存在数据损坏风险。
3. `list.inlineEditShort` / `inlineEditLabel` / `recordEditingTitle` 三个 i18n key 缺失。

## 修复
- **plugin-list**:把 `inlineEdit` 提为本地 state(参照 `hiddenFields` 的写法),工具栏切换即时翻转表格;仍通过 `onInlineEditChange` 通知父组件持久化。
- **components/data-table**:对象/数组类型的单元格值改用 `safeObjectLabel` 提取的只读标签展示(不再出现 `[object Object]`),并在失焦时 **cancel 而非 save**,彻底避免把对象覆盖成字符串。此类字段仍从记录表单 / 专用选择器编辑。
- **i18n**:补齐 `inlineEditShort` / `inlineEditLabel` / `recordEditingTitle`(en + zh)。

## 验证
- `@object-ui/components`、`@object-ui/plugin-list`、`@object-ui/i18n` 三个包 `type-check` 均 **0 error**;对 `data-table.tsx` 做了 stash 前后对比,新增代码 **未引入任何新的类型错误**。
- Bug 1 已在实现过程中由用户截图确认修复。