### PR TITLE
fix(fields): inline lookup editor shows the selected record's name (#2125)

### DIFF
--- a/.changeset/lookup-inline-expanded-value-display.md
+++ b/.changeset/lookup-inline-expanded-value-display.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/fields": patch
+---
+
+fix(fields): inline lookup editor shows the selected record's name (not the "Select…" placeholder)
+
+When editing a `lookup` / `master_detail` / `user` / `owner` field inline in the
+data grid, the `LookupField` picker showed the placeholder instead of the
+current record's name. The grid requests `$expand` for visible reference
+columns, so a lookup cell's value arrives as the related record **object**
+(`{ id, name }`) rather than a bare id. The read cell (`LookupCellRenderer`)
+already resolves objects via the display-name path, but the inline editor only
+matched **primitive** ids (`findOption(value)` with a strict `===`), so an
+object value never resolved — and the hydration effect made it worse by calling
+`findOne(referenceTo, <object>)` with a bogus id.
+
+`LookupField` now resolves an expanded-reference object directly into its
+display option (mirroring the read cell), skips the pointless per-object fetch,
+and normalises object values to their id for option matching / multi-select
+toggle / removal. `FieldEditWidget` also renders the relational pickers
+`compact` inline — the same single-line, borderless trigger the line-item grid
+uses — so the record name shows **in** the trigger instead of a chip stacked
+above a "Select…" button.

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -119,6 +119,15 @@ export function hasFieldEditWidget(type: string | undefined): boolean {
 }
 
 /**
+ * Relational picker widgets (lookup / master_detail / user / owner) render best
+ * in a grid cell as a single-line, borderless trigger — so the selected
+ * record's NAME shows inside the trigger instead of a chip stacked above a
+ * separate "Select…" button (which double-stacks and wastes the row height).
+ * This mirrors how the line-item grid (`GridField`) renders its lookup cells.
+ */
+const COMPACT_EDIT_TYPES = new Set<string>(['lookup', 'master_detail', 'user', 'owner']);
+
+/**
  * Render the dedicated edit widget for a field's type — the SAME control the
  * form uses — as a controlled `{ value, onChange, field }` input. Returns
  * `null` for types without a registered widget so the caller can fall back to
@@ -132,5 +141,6 @@ export function FieldEditWidget({
 }: FieldWidgetProps<any>): React.ReactElement | null {
   const Widget = field?.type ? EDIT_WIDGETS[field.type] : undefined;
   if (!Widget) return null;
-  return <Widget field={field} value={value} onChange={onChange} readonly={readonly} />;
+  const compactProps = field?.type && COMPACT_EDIT_TYPES.has(field.type) ? { compact: true } : {};
+  return <Widget field={field} value={value} onChange={onChange} readonly={readonly} {...(compactProps as any)} />;
 }

--- a/packages/fields/src/complex-widgets.test.tsx
+++ b/packages/fields/src/complex-widgets.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LookupField } from './widgets/LookupField';
+import { FieldEditWidget } from './FieldEditWidget';
 import { MasterDetailField } from './widgets/MasterDetailField';
 import { GridField } from './widgets/GridField';
 import { FileField } from './widgets/FileField';
@@ -529,6 +530,93 @@ describe('Complex & Relationship Widgets', () => {
             await waitFor(() => {
                 expect(screen.getByText('Product A')).toBeInTheDocument();
             });
+        });
+    });
+
+    describe('LookupField — expanded-reference ($expand) value resolution (#2125)', () => {
+        // The data grid requests `$expand` for visible reference columns, so a
+        // lookup cell's value arrives as the related record OBJECT ({ id, name }),
+        // not a bare id. The inline editor must resolve that to the record's name —
+        // like the read cell (LookupCellRenderer) — instead of the "Select…"
+        // placeholder. Regression test for #2125.
+        const mockDataSource = {
+            find: vi.fn(),
+            findOne: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+        };
+
+        beforeEach(() => {
+            vi.clearAllMocks();
+            try { localStorage.clear(); } catch { /* jsdom */ }
+        });
+
+        it('resolves an expanded-object value into the record name (compact trigger) without a bogus fetch', () => {
+            render(
+                <LookupField
+                    value={{ id: 'Z63', name: 'Northwind' }}
+                    onChange={vi.fn()}
+                    field={{ name: 'account', type: 'lookup', reference: 'showcase_account' } as any}
+                    readonly={false}
+                    dataSource={mockDataSource}
+                    compact
+                />
+            );
+
+            // The name resolves directly from the expanded object — shown in the
+            // compact trigger, never the placeholder.
+            expect(screen.getByText('Northwind')).toBeInTheDocument();
+
+            // Must never fetch by passing the whole object as an id.
+            expect(mockDataSource.findOne).not.toHaveBeenCalled();
+            expect(mockDataSource.find).not.toHaveBeenCalled();
+        });
+
+        it('resolves an expanded-object value in full (badge) mode', () => {
+            render(
+                <LookupField
+                    value={{ id: 'Z63', name: 'Northwind' }}
+                    onChange={vi.fn()}
+                    field={{ name: 'account', type: 'lookup', reference: 'showcase_account' } as any}
+                    readonly={false}
+                    dataSource={mockDataSource}
+                />
+            );
+            expect(screen.getByText('Northwind')).toBeInTheDocument();
+        });
+
+        it('still hydrates a bare-id value via findOne (existing path preserved)', async () => {
+            mockDataSource.findOne.mockResolvedValue({ id: 'a1', name: 'Acme Corp' });
+            render(
+                <LookupField
+                    value="a1"
+                    onChange={vi.fn()}
+                    field={{ name: 'account', type: 'lookup', reference: 'showcase_account' } as any}
+                    readonly={false}
+                    dataSource={mockDataSource}
+                    compact
+                />
+            );
+            await waitFor(() => {
+                expect(mockDataSource.findOne).toHaveBeenCalledWith('showcase_account', 'a1');
+            });
+            await waitFor(() => {
+                expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+            });
+        });
+
+        it('FieldEditWidget renders a lookup cell compact and resolves the expanded object', () => {
+            // Proves FieldEditWidget forwards `compact` to the relational widget, so
+            // the grid cell shows the record name in the trigger (single line).
+            render(
+                <FieldEditWidget
+                    field={{ name: 'account', type: 'lookup', reference: 'showcase_account' } as any}
+                    value={{ id: 'Z63', name: 'Northwind' }}
+                    onChange={vi.fn()}
+                />
+            );
+            expect(screen.getByText('Northwind')).toBeInTheDocument();
         });
     });
 

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -463,9 +463,14 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
    */
   useEffect(() => {
     if (!hasDataSource || !dataSource || !referenceTo) return;
-    const ids: any[] = multiple
+    const raw: any[] = multiple
       ? Array.isArray(value) ? value : []
       : value != null && value !== '' ? [value] : [];
+    // Expanded-reference values (server `$expand`) already arrive as the related
+    // record object and resolve directly in `resolveSelectedOption` — only bare
+    // ids need a fetch. Passing an object to `findOne` would query for a bogus
+    // id and leave the trigger stuck on the placeholder.
+    const ids = raw.filter((v) => v != null && v !== '' && typeof v !== 'object');
     if (!ids.length) return;
     // Only fetch records we haven't resolved yet.
     const unresolved = ids.filter((v) => !findOption(v));
@@ -517,9 +522,32 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
     [staticOptions, fetchedOptions, pickerResolvedRecords],
   );
 
+  // Collapse an expanded-reference value (the related record object returned by
+  // server `$expand`) to its bare id — used for option matching / highlighting.
+  const normalizeId = useCallback(
+    (raw: any): any =>
+      raw != null && typeof raw === 'object' ? (raw[idField] ?? raw.id ?? raw._id) : raw,
+    [idField],
+  );
+
+  // Resolve a raw field value into its display option. An expanded-reference
+  // object is mapped directly (mirroring the read cell's display-name path) so
+  // the inline editor shows the record's name instead of the placeholder; a bare
+  // id resolves through the static / fetched / picker-hydrated option lists.
+  const resolveSelectedOption = useCallback(
+    (raw: any): LookupOption | undefined => {
+      if (raw == null || raw === '') return undefined;
+      if (typeof raw === 'object') {
+        return recordToOption(raw, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema);
+      }
+      return findOption(raw);
+    },
+    [findOption, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema],
+  );
+
   const selectedOptions = multiple
-    ? (Array.isArray(value) ? value : []).map(findOption).filter(Boolean)
-    : value ? [findOption(value)].filter(Boolean) : [];
+    ? (Array.isArray(value) ? value : []).map(resolveSelectedOption).filter(Boolean)
+    : value ? [resolveSelectedOption(value)].filter(Boolean) : [];
 
   // Optional: receive the FULL selected record (not just its id) so a host can
   // auto-fill sibling fields from it — e.g. a line-item grid copying a product's
@@ -530,7 +558,9 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   const handleSelect = useCallback(
     (option: LookupOption) => {
       if (multiple) {
-        const currentValues = Array.isArray(value) ? value : [];
+        // Normalise any expanded-reference objects to bare ids so toggling
+        // compares like-for-like and always persists ids (never mixed shapes).
+        const currentValues = (Array.isArray(value) ? value : []).map(normalizeId);
         const isSelected = currentValues.includes(option.value);
 
         if (isSelected) {
@@ -546,12 +576,12 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
         setIsOpen(false);
       }
     },
-    [multiple, value, onChange, onSelectRecord, referenceTo],
+    [multiple, value, onChange, onSelectRecord, referenceTo, normalizeId],
   );
 
   const handleRemove = (optionValue: any) => {
     if (multiple) {
-      const currentValues = Array.isArray(value) ? value : [];
+      const currentValues = (Array.isArray(value) ? value : []).map(normalizeId);
       onChange(currentValues.filter((v: any) => v !== optionValue));
     } else {
       onChange(null);
@@ -841,8 +871,8 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
                 <>
                   {visibleOptions.map((option, idx) => {
                     const isSelected = multiple
-                      ? (Array.isArray(value) ? value : []).includes(option.value)
-                      : value === option.value;
+                      ? (Array.isArray(value) ? value : []).map(normalizeId).includes(option.value)
+                      : normalizeId(value) === option.value;
                     const isActive = idx === activeIndex;
                     const showRecentHeader = recentCount > 0 && idx === 0;
                     const showResultsHeader = recentCount > 0 && idx === recentCount;


### PR DESCRIPTION
Closes #2125.

## Problem

Editing a `lookup` / `master_detail` / `user` / `owner` field **inline in the data grid** showed the **"选择… / Select…" placeholder** instead of the currently-selected record's name. The value was never wrong (the correct record **id** persisted, and the read-mode cell rendered the name) — only the inline **editor trigger** failed to display it.

## Root cause

The grid requests **`$expand`** for visible reference columns ([`buildExpandFields`](packages/core/src/utils/expand-fields.ts)), so a lookup cell's value arrives as the related record **object** `{ id, name, … }`, not a bare id.

- The **read** cell (`LookupCellRenderer`) resolves object values via the display-name path — so it always worked.
- The **inline editor** (`LookupField`) only matched **primitive** ids: `findOption(value)` does a strict `opt.value === value`. An object value never matches → `selectedOptions` stays empty → placeholder. The hydration effect then made it worse by calling `findOne(referenceTo, <object>)` with a bogus id (which is why waiting 2.5 s never helped).

This is exactly the "align the editor's resolution with the read renderer's" the issue asked for.

## Fix

**`LookupField.tsx`**
- Resolve an expanded-reference **object** value directly into its display option (via `recordToOption`, mirroring the read cell) — no fetch needed.
- Skip object values in the hydration effect so we never `findOne(<object>)`; only bare ids are fetched.
- Normalise object values to their id for option matching, multi-select toggle, and chip removal.

**`FieldEditWidget.tsx`**
- Render the relational pickers **`compact`** inline (the same single-line, borderless trigger the line-item `GridField` uses), so the record name shows **in** the trigger — in full mode the trigger always renders "Select" (the name lives in a chip stacked above), which is the double-stack `compact` was built to avoid in a cell.

## Tests

- New regression tests in `complex-widgets.test.tsx`: expanded-object value resolves in **compact** (trigger) and **full** (badge) mode with **no bogus fetch**; the bare-id `findOne` hydration path still works; `FieldEditWidget` forwards `compact` to the relational widget.
- Full `@object-ui/fields` suite green (**4977 passed / 24 skipped**), including the `FieldEditWidget` drift-guard, plus `turbo run build --filter=@object-ui/fields` (type gate) green.

## Related

- #2122 — wired relational fields into the inline editor (where this surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)