### PR TITLE
docs(agents): per-agent isolated test stack (own-port backend + console + e2e)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,12 +177,48 @@ export const SchemaRenderer = ({ schema }: { schema: UIComponent }) => {
 ### Local dev — console UI ↔ backend (read before debugging UI)
 
 - **启动前端**:仓根 `pnpm --filter @object-ui/console dev`(Vite,固定 **:5180**,见 `apps/console/vite.config.ts`)。
-- **后端默认连 `:3000`**:vite `/api` proxy → `DEV_PROXY_TARGET || http://localhost:3000`。**要测哪个后端就把它跑在 :3000**(framework 仓:`PORT=3000 pnpm dev:crm`,或 `PORT=3000 pnpm dev` = showcase)。经 `pnpm --filter` 传 `DEV_PROXY_TARGET` env 不一定透传到 vite 子进程——优先把后端跑在 :3000,别依赖 env 覆盖。
+- **后端默认连 `:3000`**:vite `/api` proxy → `DEV_PROXY_TARGET || http://localhost:3000`。**要测哪个后端就把它跑在 :3000**(framework 仓:`PORT=3000 pnpm dev:crm`,或 `PORT=3000 pnpm dev` = showcase)。经 `pnpm --filter @object-ui/console dev` 传 `DEV_PROXY_TARGET` env **不**可靠(不一定透传到 vite 子进程);要把 console 指向别的后端端口,`cd apps/console` 后内联设 env 才灵(已实测——见下「每个 agent 独立测试栈」)。
 - `framework` 的 `:3001/_console` 服务的是**已发布的** console(`packages/console/dist`),**不是本仓 src**;改 src 必须用上面的 :5180 dev 服务验证(或在 framework 跑 `pnpm objectui:refresh` 重新拉构建——慢)。
 - 路由用 app 的 **`name`**(如 `showcase_app`,不是 `showcase`);直接 URL 进对象可能落到 Setup「对象不存在」——先经启动台/应用切换进入该 app 设好 currentApp。
 - **清 localStorage 会登出**(session token 存 localStorage;首页应用磁贴也读 localStorage 缓存,跨会话会显示过期的 app 列表)。
 - better-auth 用 `localhost`(非 `127.0.0.1`)否则 Invalid origin。
 - 浏览器验证:优先用桌面 preview(`preview_*`,`.claude/launch.json` 里配 `showcase-console`);chrome-devtools MCP 掉线时切 preview。
+
+### 每个 agent 独立测试栈(端口隔离,多 agent 并行的推荐做法)
+
+上面是**单栈**约定(后端 :3000 + 前端 :5180);多 agent 并行时端口会打架。要彻底隔离,每人起**自己端口**的一整套栈(后端 + console),互不干扰。**下面这套已实测端到端跑通**(console 代理登录 + 从自己后端拉到 `showcase_account` 的 Northwind/Contoso):
+
+1. **后端(`../framework`)—— `--fresh` 临时库 + 自选端口**,数据与端口都隔离、退出自动清:
+   ```bash
+   # showcase(带 showcase_field_zoo / showcase_account 等):
+   cd ../framework/examples/app-showcase
+   pnpm exec objectstack dev --seed-admin --fresh -p 4010
+   #  --fresh        临时 sqlite 库(os.tmpdir()/objectstack-dev-*),SIGINT/SIGTERM 自动删,绝不碰别人的 .objectstack/data/dev.db
+   #  -p <port>      监听端口(等价 OS_PORT / PORT;dev 模式端口被占会自动顺延)
+   #  --seed-admin   默认开;空库播种 admin@objectos.ai / admin123
+   # CRM:  cd ../framework/examples/app-crm && pnpm exec objectstack dev --seed-admin --fresh -p <port>
+   # 要持久库(跨重启保留):去掉 --fresh,改用 --database "file:/tmp/agent-<port>.db"(或 OS_DATABASE_URL)
+   ```
+   干净 checkout 首次需先 `pnpm setup`(build `@objectstack/spec`);已装过的直接可跑。
+
+2. **Console(你的 objectui worktree)—— 自选端口 + 指向你的后端**:
+   ```bash
+   cd apps/console
+   DEV_PROXY_TARGET=http://localhost:4010 pnpm exec vite --port 5190 --strictPort
+   #  必须 cd 进 apps/console 让 env 直达 vite;用 `pnpm --filter … dev` 传 env 不可靠
+   #  --strictPort   端口被占直接报错,绝不静默顺延撞到别人的端口上
+   ```
+   自检:`curl 'http://localhost:5190/api/v1/data/showcase_account?$top=2'`(经 console 代理打到你的 :4010,应返回 Northwind/Contoso)。
+
+3. **Live E2E —— 全 env 参数化指向你的端口**(见 `playwright.live.config.ts` / `e2e/live/global-setup.ts`):
+   ```bash
+   LIVE_APP_URL=http://localhost:5190 LIVE_API_URL=http://localhost:4010 pnpm test:e2e:live
+   #  凭据用 LIVE_EMAIL / LIVE_PASSWORD 覆盖(默认 admin@objectos.ai / admin123)
+   ```
+
+4. **桌面 preview**:给 `.claude/launch.json` 加一条你自己的 console 配置,仿现成的 `console-build-test`(`cd apps/console && DEV_PROXY_TARGET=http://localhost:<后端> pnpm dev --port <前端> --strictPort`)。
+
+**纪律**:端口自选空闲高位(用前 `lsof -i :PORT` 确认没人占);收工只按**自己记下的 PID** 收(`kill $(lsof -ti tcp:<你的端口>)`),`--fresh` 临时库随进程退出自动清;**绝不动 :3000 / :5180**(通常是别人的单栈)。
 
 ### Edit sizing
 Keep single `edit`/`create` payloads under ~20000 bytes. If an edit fails, break it into multiple smaller ones.


### PR DESCRIPTION
## Why

Multiple agents work this repo (and `../framework`) in parallel, but AGENTS.md only documented a **single-stack** convention — backend on `:3000`, console on `:5180`. That forces everyone onto the same two ports, so agents collide (and the doc even said *"don't rely on the `DEV_PROXY_TARGET` env override"*). This adds a **verified** recipe for each agent to run its **own** isolated stack on its own ports.

## What

New AGENTS.md subsection **「每个 agent 独立测试栈」** documenting:

1. **Backend** (`../framework`): `objectstack dev --seed-admin --fresh -p <port>` — fresh **ephemeral tempdir sqlite** DB (auto-deleted on `SIGINT/SIGTERM`, never touches the shared `.objectstack/data/dev.db`), auto-seeded showcase + admin (`admin@objectos.ai`/`admin123`). Persistent variant via `--database file:…` / `OS_DATABASE_URL`.
2. **Console** (your worktree): `cd apps/console && DEV_PROXY_TARGET=http://localhost:<port> pnpm exec vite --port <port> --strictPort`. Must `cd` into `apps/console` so the env reaches vite directly; `--strictPort` prevents silent port drift onto someone else's port.
3. **Live E2E**: `LIVE_APP_URL` / `LIVE_API_URL` (+ `LIVE_EMAIL` / `LIVE_PASSWORD`) point `playwright.live.config.ts` at your ports.
4. **Preview**: add your own `.claude/launch.json` console entry (mirrors the existing `console-build-test`).

Also corrects the stale claim that `DEV_PROXY_TARGET` doesn't propagate — it's reliable from `cd apps/console` (the `pnpm --filter` path is the unreliable one).

## Verification (actually run, not theoretical)

- Booted an **isolated showcase backend** on `:4010` with `--fresh` → tempdir DB `…/T/objectstack-dev-*/data/dev.db`, seeded admin, served `showcase_account` (Northwind) + `showcase_field_zoo`.
- Started a **console** on `:5190` with `DEV_PROXY_TARGET=http://localhost:4010 … --port 5190 --strictPort`; signed in **through the console proxy** and fetched `showcase_account` → `['Northwind','Contoso']`.
- Confirmed the console `--port` override and the proxy target both take effect (`/api` → `:4010`, not the default `:3000`).
- Tore both down by PID; the shared `:3000` instance stayed up (`302`) and the tempdir auto-cleaned.

Docs-only change (no package src, no changeset). `scripts/check-doc-links.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)