### PR TITLE
feat(studio): WYSIWYG form-layout designer in the Data pillar

### DIFF
--- a/.changeset/studio-form-layout-designer.md
+++ b/.changeset/studio-form-layout-designer.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(studio): WYSIWYG form-layout designer in the Data pillar
+
+The Data pillar's Form view gains a **布局 (Layout)** designer: the object's default
+form rendered WYSIWYG, where an admin adds **sections**, drag-reorders fields within
+a section and drags them **across** sections, and clicks a field to edit it in the
+**same** protocol inspector the grid uses — one screen, no Data↔Interface switch.
+
+Sections persist as the object's `fieldGroups`, and membership/order as `field.group`
+plus field order, via the existing draft → publish. The drag/section chrome (dnd-kit)
+is the only new code; the data model and all mutations reuse the existing, tested
+`object-fields-io` helpers (`readGroups`/`addGroup`/`renameGroup`/`removeGroup`/
+`moveGroup`/`clearFieldGroup`/`groupEntries`).
+
+Also fixes the Data pillar clobbering an in-progress draft when the metadata client
+identity churned (e.g. toggling the live preview): the object baseline is now loaded
+exactly once per selected object.

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -31,6 +31,9 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@object-ui/auth": "workspace:*",
     "@object-ui/collaboration": "workspace:*",

--- a/packages/app-shell/src/views/studio-design/ObjectFormDesigner.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectFormDesigner.tsx
@@ -1,0 +1,480 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ObjectFormDesigner — the WYSIWYG form-layout designer for the Studio Data
+ * pillar's Form view. An admin arranges the object's default form exactly as
+ * end users will see it: fields grouped into **sections** (the object's
+ * `fieldGroups`), drag-reordered within a section and dragged **across**
+ * sections, with per-field selection opening the same protocol field inspector
+ * the grid uses.
+ *
+ * Build boundary: this component is only the drag/section CHROME. The data
+ * model + all mutations are the existing, tested `object-fields-io` helpers
+ * (readFields/writeFields · readGroups/addGroup/renameGroup/removeGroup/
+ * moveGroup · clearFieldGroup · groupEntries), and section membership +
+ * in-group order persist to the object draft (`fields[].group` + `fieldGroups`)
+ * via the pillar's existing draft → publish. No new metadata shape.
+ */
+
+import * as React from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  pointerWithin,
+  type DragStartEvent,
+  type DragOverEvent,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, Plus, Trash2, ChevronUp, ChevronDown, Rows3 } from 'lucide-react';
+import {
+  readFields,
+  writeFields,
+  readGroups,
+  addGroup,
+  renameGroup,
+  removeGroup,
+  moveGroup,
+  clearFieldGroup,
+  type FieldEntry,
+  type FieldsView,
+} from '../metadata-admin/previews/object-fields-io';
+
+const UNGROUPED = '__ungrouped__';
+const cid = (key: string) => `g:${key}`; // container (section) droppable id
+const fid = (name: string) => `f:${name}`; // sortable field id
+const unCid = (id: string) => id.slice(2);
+const unFid = (id: string) => id.slice(2);
+
+export interface ObjectFormDesignerProps {
+  /** Object metadata draft (reads `fields` + `fieldGroups`). */
+  draft: Record<string, unknown>;
+  /** Field names to hide from the layout (system/audit) but preserve on write. */
+  systemFieldNames: Set<string>;
+  /** Persist a partial object-draft patch (fields / fieldGroups) + mark dirty. */
+  onChange: (patch: Record<string, unknown>) => void;
+  /** Currently selected field name (highlighted). */
+  selectedField?: string | null;
+  /** Select a field → opens the shared field inspector. */
+  onSelectField: (name: string) => void;
+  /** Append a new field (reuses the pillar's add-field). */
+  onAddField: () => void;
+}
+
+/** A faithful, non-interactive preview of a field's control (by type). */
+function FieldControlPreview({ type }: { type: string }): React.ReactElement {
+  const box = 'mt-1 flex items-center rounded-md border bg-muted/30 px-2 text-[11px] text-muted-foreground';
+  switch (type) {
+    case 'select':
+    case 'radio':
+    case 'lookup':
+    case 'reference':
+    case 'user':
+    case 'multiselect':
+      return (
+        <div className={`${box} h-7 justify-between`}>
+          <span>{type === 'lookup' || type === 'reference' || type === 'user' ? '搜索…' : '请选择…'}</span>
+          <span>▾</span>
+        </div>
+      );
+    case 'textarea':
+    case 'html':
+    case 'markdown':
+    case 'json':
+    case 'code':
+      return <div className={`${box} h-14 items-start pt-1.5`}>…</div>;
+    case 'boolean':
+    case 'checkbox':
+    case 'switch':
+      return (
+        <div className="mt-1 flex items-center">
+          <span className="h-4 w-7 rounded-full bg-muted" />
+        </div>
+      );
+    case 'number':
+    case 'currency':
+    case 'percent':
+      return <div className={`${box} h-7`}>0.00</div>;
+    case 'date':
+    case 'datetime':
+    case 'time':
+      return <div className={`${box} h-7`}>选择日期…</div>;
+    default:
+      return <div className={`${box} h-7`}>&nbsp;</div>;
+  }
+}
+
+/** One draggable field card inside a section. */
+function SortableField({
+  entry,
+  selected,
+  onSelect,
+}: {
+  entry: FieldEntry;
+  selected: boolean;
+  onSelect: () => void;
+}): React.ReactElement {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: fid(entry.name) });
+  const type = String(entry.def.type ?? 'text');
+  const label = String(entry.def.label ?? entry.name);
+  const required = !!entry.def.required;
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      onClick={onSelect}
+      {...attributes}
+      {...listeners}
+      aria-label={`${label} — 点选改属性,拖动排序`}
+      className={
+        'group relative flex cursor-grab touch-none select-none items-start gap-1.5 rounded-md border bg-background px-2 py-2 active:cursor-grabbing ' +
+        (selected ? 'ring-2 ring-primary' : 'hover:border-foreground/25') +
+        (isDragging ? ' opacity-40' : '')
+      }
+    >
+      <span className="mt-0.5 text-muted-foreground opacity-0 group-hover:opacity-100">
+        <GripVertical className="h-3.5 w-3.5" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1 text-xs font-medium">
+          <span className="truncate">{label}</span>
+          {required && <span className="text-destructive">*</span>}
+          <span className="ml-1 rounded bg-muted px-1 py-px text-[9px] uppercase text-muted-foreground">{type}</span>
+        </div>
+        <FieldControlPreview type={type} />
+      </div>
+    </div>
+  );
+}
+
+/** A section (declared group or the implicit ungrouped bucket) = a drop zone. */
+function Section({
+  containerId,
+  title,
+  fieldIds,
+  isDeclared,
+  canMoveUp,
+  canMoveDown,
+  entryByName,
+  selectedField,
+  onSelectField,
+  onRename,
+  onDelete,
+  onMove,
+}: {
+  containerId: string;
+  title: string;
+  fieldIds: string[];
+  isDeclared: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  entryByName: Map<string, FieldEntry>;
+  selectedField?: string | null;
+  onSelectField: (name: string) => void;
+  onRename: (label: string) => void;
+  onDelete: () => void;
+  onMove: (dir: -1 | 1) => void;
+}): React.ReactElement {
+  const { setNodeRef, isOver } = useDroppable({ id: containerId });
+  return (
+    <div className={'rounded-lg border ' + (isOver ? 'border-primary bg-primary/5' : 'bg-muted/20')}>
+      <div className="flex items-center gap-1 border-b px-3 py-1.5">
+        {isDeclared ? (
+          <input
+            defaultValue={title}
+            onBlur={(e) => e.target.value.trim() && e.target.value !== title && onRename(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+            }}
+            className="min-w-0 flex-1 rounded bg-transparent px-1 py-0.5 text-[13px] font-medium outline-none hover:bg-muted focus:bg-background focus:ring-1 focus:ring-primary"
+          />
+        ) : (
+          <span className="flex-1 px-1 text-[13px] font-medium text-muted-foreground">{title}</span>
+        )}
+        {isDeclared && (
+          <>
+            <button
+              type="button"
+              disabled={!canMoveUp}
+              onClick={() => onMove(-1)}
+              aria-label="上移分组"
+              className="rounded p-0.5 text-muted-foreground hover:bg-muted disabled:opacity-30"
+            >
+              <ChevronUp className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              disabled={!canMoveDown}
+              onClick={() => onMove(1)}
+              aria-label="下移分组"
+              className="rounded p-0.5 text-muted-foreground hover:bg-muted disabled:opacity-30"
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={onDelete}
+              aria-label="删除分组"
+              title="删除分组(字段归为未分组)"
+              className="rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+      </div>
+      <SortableContext items={fieldIds} strategy={verticalListSortingStrategy}>
+        <div ref={setNodeRef} className="grid min-h-[52px] grid-cols-2 gap-2 p-2.5">
+          {fieldIds.length === 0 && (
+            <div className="col-span-2 flex items-center justify-center rounded-md border border-dashed py-3 text-[11px] text-muted-foreground">
+              拖字段到这里
+            </div>
+          )}
+          {fieldIds.map((id) => {
+            const name = unFid(id);
+            const entry = entryByName.get(name);
+            if (!entry) return null;
+            return (
+              <SortableField
+                key={id}
+                entry={entry}
+                selected={selectedField === name}
+                onSelect={() => onSelectField(name)}
+              />
+            );
+          })}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}
+
+export function ObjectFormDesigner({
+  draft,
+  systemFieldNames,
+  onChange,
+  selectedField,
+  onSelectField,
+  onAddField,
+}: ObjectFormDesignerProps): React.ReactElement {
+  const view = React.useMemo(() => readFields(draft.fields), [draft.fields]);
+  const groups = React.useMemo(() => readGroups(draft.fieldGroups), [draft.fieldGroups]);
+  const entryByName = React.useMemo(() => new Map(view.entries.map((e) => [e.name, e] as const)), [view]);
+
+  // Container order: declared groups (in order) then the ungrouped bucket.
+  const containerOrder = React.useMemo(() => [...groups.map((g) => cid(g.key)), cid(UNGROUPED)], [groups]);
+  const labelOf = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const g of groups) m.set(cid(g.key), g.label || g.key);
+    m.set(cid(UNGROUPED), '未分组');
+    return m;
+  }, [groups]);
+
+  // Derive container → ordered field ids from the draft (editable fields only;
+  // system/audit fields are preserved on write but never shown in the layout).
+  const derived = React.useMemo(() => {
+    const map: Record<string, string[]> = {};
+    for (const c of containerOrder) map[c] = [];
+    for (const e of view.entries) {
+      if (systemFieldNames.has(e.name)) continue;
+      const g = typeof e.def.group === 'string' ? e.def.group : '';
+      const target = g && map[cid(g)] ? cid(g) : cid(UNGROUPED);
+      map[target].push(fid(e.name));
+    }
+    return map;
+  }, [view.entries, containerOrder, systemFieldNames]);
+
+  const [items, setItems] = React.useState<Record<string, string[]>>(derived);
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+  // Re-sync from the draft whenever it changes and we are not mid-drag.
+  React.useEffect(() => {
+    if (!activeId) setItems(derived);
+  }, [derived, activeId]);
+  // Latest items snapshot for drag-end math — robust whether or not onDragOver
+  // fired (e.g. synthetic/automated drags that skip intermediate move events).
+  const itemsRef = React.useRef(items);
+  React.useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const findContainer = React.useCallback(
+    (id: string): string | undefined => {
+      if (id.startsWith('g:')) return id;
+      return Object.keys(items).find((k) => items[k].includes(id));
+    },
+    [items],
+  );
+
+  /** Flatten the container map back to `fields` (stamping group + order) and persist. */
+  const commit = React.useCallback(
+    (next: Record<string, string[]>) => {
+      const editable: FieldEntry[] = [];
+      for (const c of containerOrder) {
+        const groupKey = unCid(c);
+        for (const id of next[c] ?? []) {
+          const e = entryByName.get(unFid(id));
+          if (!e) continue;
+          const def = { ...e.def };
+          if (groupKey === UNGROUPED) delete def.group;
+          else def.group = groupKey;
+          editable.push({ name: e.name, def });
+        }
+      }
+      const system = view.entries.filter((e) => systemFieldNames.has(e.name));
+      const finalView: FieldsView = { shape: view.shape, entries: [...system, ...editable] };
+      onChange({ fields: writeFields(finalView) });
+    },
+    [containerOrder, entryByName, view, systemFieldNames, onChange],
+  );
+
+  const onDragStart = (e: DragStartEvent) => setActiveId(String(e.active.id));
+
+  const onDragOver = (e: DragOverEvent) => {
+    const activeIdStr = String(e.active.id);
+    const overId = e.over ? String(e.over.id) : null;
+    if (!overId) return;
+    const from = findContainer(activeIdStr);
+    const to = findContainer(overId);
+    if (!from || !to || from === to) return;
+    setItems((prev) => {
+      const fromItems = prev[from] ?? [];
+      const toItems = prev[to] ?? [];
+      const overIndex = overId.startsWith('g:') ? toItems.length : toItems.indexOf(overId);
+      const insertAt = overIndex < 0 ? toItems.length : overIndex;
+      return {
+        ...prev,
+        [from]: fromItems.filter((i) => i !== activeIdStr),
+        [to]: [...toItems.slice(0, insertAt), activeIdStr, ...toItems.slice(insertAt)],
+      };
+    });
+  };
+
+  const onDragEnd = (e: DragEndEvent) => {
+    setActiveId(null);
+    const activeIdStr = String(e.active.id);
+    const overId = e.over ? String(e.over.id) : null;
+    if (!overId) return;
+    const prev = itemsRef.current;
+    const inContainer = (id: string): string | undefined =>
+      id.startsWith('g:') && id in prev ? id : Object.keys(prev).find((k) => prev[k].includes(id));
+    const from = inContainer(activeIdStr);
+    const to = inContainer(overId);
+    if (!from || !to) return;
+    let next: Record<string, string[]>;
+    if (from === to) {
+      const list = prev[from];
+      const oldIndex = list.indexOf(activeIdStr);
+      const newIndex = overId.startsWith('g:') ? list.length - 1 : list.indexOf(overId);
+      if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) {
+        commit(prev);
+        return;
+      }
+      next = { ...prev, [from]: arrayMove(list, oldIndex, newIndex) };
+    } else {
+      const fromItems = prev[from].filter((i) => i !== activeIdStr);
+      const toItems = prev[to];
+      const overIndex = overId.startsWith('g:') ? toItems.length : toItems.indexOf(overId);
+      const insertAt = overIndex < 0 ? toItems.length : overIndex;
+      next = {
+        ...prev,
+        [from]: fromItems,
+        [to]: [...toItems.slice(0, insertAt), activeIdStr, ...toItems.slice(insertAt)],
+      };
+    }
+    setItems(next);
+    commit(next);
+  };
+
+  const addSection = () => onChange({ fieldGroups: addGroup(groups, '新分组') });
+  const renameSection = (key: string, label: string) => onChange({ fieldGroups: renameGroup(groups, key, label) });
+  const moveSection = (key: string, dir: -1 | 1) => onChange({ fieldGroups: moveGroup(groups, key, dir) });
+  const deleteSection = (key: string) =>
+    onChange({ fieldGroups: removeGroup(groups, key), fields: writeFields(clearFieldGroup(view, key)) });
+
+  const activeEntry = activeId && !activeId.startsWith('g:') ? entryByName.get(unFid(activeId)) : null;
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto rounded-lg border bg-background p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+          <Rows3 className="h-3.5 w-3.5" /> 拖动字段排序 / 拖到其它分组 · 点选字段改属性
+        </span>
+        <button
+          type="button"
+          onClick={addSection}
+          className="ml-auto inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Plus className="h-3.5 w-3.5" /> 添加分组
+        </button>
+        <button
+          type="button"
+          onClick={onAddField}
+          className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Plus className="h-3.5 w-3.5" /> 添加字段
+        </button>
+      </div>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        onDragStart={onDragStart}
+        onDragOver={onDragOver}
+        onDragEnd={onDragEnd}
+        onDragCancel={() => setActiveId(null)}
+      >
+        <div className="mx-auto flex max-w-3xl flex-col gap-3">
+          {containerOrder.map((c, i) => {
+            const isUngrouped = c === cid(UNGROUPED);
+            // Hide the ungrouped bucket only when it is empty AND groups exist.
+            if (isUngrouped && (items[c]?.length ?? 0) === 0 && groups.length > 0) return null;
+            const declaredIdx = groups.findIndex((g) => cid(g.key) === c);
+            return (
+              <Section
+                key={c}
+                containerId={c}
+                title={labelOf.get(c) ?? '未分组'}
+                fieldIds={items[c] ?? []}
+                isDeclared={!isUngrouped}
+                canMoveUp={declaredIdx > 0}
+                canMoveDown={declaredIdx >= 0 && declaredIdx < groups.length - 1}
+                entryByName={entryByName}
+                selectedField={selectedField}
+                onSelectField={onSelectField}
+                onRename={(label) => renameSection(unCid(c), label)}
+                onDelete={() => deleteSection(unCid(c))}
+                onMove={(dir) => moveSection(unCid(c), dir)}
+              />
+            );
+          })}
+        </div>
+
+        <DragOverlay>
+          {activeEntry ? (
+            <div className="flex items-center gap-1.5 rounded-md border bg-background px-2 py-2 shadow-lg">
+              <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-xs font-medium">{String(activeEntry.def.label ?? activeEntry.name)}</span>
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -20,6 +20,7 @@ import { SchemaRenderer, useAdapter, SchemaRendererProvider } from '@object-ui/r
 import { GridFieldAuthoringProvider } from '@object-ui/components';
 import { ObjectView as PluginObjectView } from '@object-ui/plugin-view';
 import { ListView } from '@object-ui/plugin-list';
+import { ObjectForm } from '@object-ui/plugin-form';
 import {
   Boxes,
   FileText,
@@ -46,6 +47,7 @@ import { getMetadataInspector } from '../metadata-admin/inspector-registry';
 import { useMetadataClient } from '../metadata-admin/useMetadata';
 import { AppNavCanvas } from '../metadata-admin/previews/AppNavCanvas';
 import { readFields, writeFields, newField } from '../metadata-admin/previews/object-fields-io';
+import { ObjectFormDesigner } from './ObjectFormDesigner';
 
 const PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> = [
   { key: 'data', label: 'Data', Icon: Database },
@@ -699,6 +701,15 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
   const [hasDraft, setHasDraft] = React.useState(false);
   const [saving, setSaving] = React.useState<false | 'draft' | 'publish'>(false);
   const [gridVer, setGridVer] = React.useState(0);
+  // Records grid ⇄ Form — two views of the SAME object, both the runtime
+  // renderer (same-renderer principle). Form = WYSIWYG object form; clicking a
+  // rendered field selects it into the same field inspector the grid uses.
+  const [viewMode, setViewMode] = React.useState<'grid' | 'form'>('grid');
+  // Within the Form view: 布局 (WYSIWYG drag/section designer) ⇄ 预览 (live form).
+  const [formMode, setFormMode] = React.useState<'layout' | 'preview'>('layout');
+  // Tracks which object's baseline is currently loaded — so we (re)load exactly
+  // once per selected object and never clobber an in-progress draft.
+  const loadedNameRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -722,6 +733,11 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
 
   React.useEffect(() => {
     if (!current) return;
+    // Load once per selected object. Bail if this object's baseline is already
+    // loaded — a client-identity churn or a child remount must NOT re-fetch and
+    // clobber the in-progress form-layout draft the designer is editing.
+    if (loadedNameRef.current === current.name) return;
+    loadedNameRef.current = current.name;
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -899,8 +915,31 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
           ) : (
             <>
               <div className="mb-3 flex shrink-0 items-center gap-2">
+                {/* view toggle — Records grid ⇄ Form, both the runtime renderer */}
+                <div className="inline-flex rounded-md border p-0.5 text-[11px]">
+                  <button
+                    type="button"
+                    onClick={() => setViewMode('grid')}
+                    className={
+                      'rounded px-2.5 py-0.5 ' +
+                      (viewMode === 'grid' ? 'bg-muted font-medium' : 'text-muted-foreground hover:text-foreground')
+                    }
+                  >
+                    记录
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setViewMode('form')}
+                    className={
+                      'rounded px-2.5 py-0.5 ' +
+                      (viewMode === 'form' ? 'bg-muted font-medium' : 'text-muted-foreground hover:text-foreground')
+                    }
+                  >
+                    表单
+                  </button>
+                </div>
                 <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
-                  <Eye className="h-3 w-3" /> 运行态列表 · 同一渲染器
+                  <Eye className="h-3 w-3" /> {viewMode === 'grid' ? '运行态列表 · 同一渲染器' : '运行态表单 · 同一渲染器'}
                 </span>
                 <button
                   type="button"
@@ -916,6 +955,8 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
                   {error}
                 </div>
               )}
+              {viewMode === 'grid' ? (
+              <>
               {/* Records grid — fields are the columns. Header "+" adds a field, the
                 * per-column edit affordance opens the field editor, and dragging a
                 * column header reorders the object's fields (all via the context). */}
@@ -964,6 +1005,103 @@ function DataPillar({ packageId }: { packageId: string }): React.ReactElement {
               <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
                 <MousePointer2 className="h-3 w-3" /> 列头「+」加字段 · 笔形改属性 · 拖列头重排 · 改完「保存草稿」→「发布」
               </p>
+              </>
+              ) : (
+              <>
+              {/* form sub-mode: 布局 (WYSIWYG drag/section designer) ⇄ 预览 (live form) */}
+              <div className="mb-3 flex items-center gap-2">
+                <div className="inline-flex rounded-md border p-0.5 text-[11px]">
+                  <button
+                    type="button"
+                    onClick={() => setFormMode('layout')}
+                    className={
+                      'rounded px-2.5 py-0.5 ' +
+                      (formMode === 'layout' ? 'bg-muted font-medium' : 'text-muted-foreground hover:text-foreground')
+                    }
+                  >
+                    布局
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setFormMode('preview')}
+                    className={
+                      'rounded px-2.5 py-0.5 ' +
+                      (formMode === 'preview' ? 'bg-muted font-medium' : 'text-muted-foreground hover:text-foreground')
+                    }
+                  >
+                    预览
+                  </button>
+                </div>
+                <span className="text-[11px] text-muted-foreground">
+                  {formMode === 'layout' ? '布局设计器 · 分组与排序' : '运行态表单 · 同一渲染器'}
+                </span>
+              </div>
+              {formMode === 'layout' ? (
+                <ObjectFormDesigner
+                  draft={objDraft}
+                  systemFieldNames={STUDIO_SYSTEM_FIELD_NAMES}
+                  onChange={onPatch}
+                  selectedField={fieldSel?.kind === 'field' ? fieldSel.id : null}
+                  onSelectField={(name) => setFieldSel({ kind: 'field', id: name })}
+                  onAddField={addField}
+                />
+              ) : (
+              <>
+              {/* Form — the real runtime ObjectForm ("same renderer"): the object's
+                * form exactly as an end user sees it. Clicking any rendered field
+                * (event-delegated via the renderer's data-field) selects it into the
+                * SAME field inspector the grid uses — one screen, no pillar switch. */}
+              <style>{`
+                /* Design preview: the form is a click-to-select canvas, not a data-entry
+                 * form. Disable interaction on field contents so a click anywhere on a
+                 * field routes to its [data-field] wrapper (→ select), and neutralize the
+                 * create/cancel footer so nothing is submittable here. */
+                .os-form-authoring [data-field]{border-radius:8px;cursor:pointer;transition:box-shadow .12s;padding:8px;margin:-8px 0;}
+                .os-form-authoring [data-field] *{pointer-events:none;}
+                .os-form-authoring [data-field]:hover{box-shadow:0 0 0 1px hsl(var(--border));}
+                .os-form-authoring form > div:last-child:has(button){display:none;}
+                ${
+                  fieldSel?.kind === 'field'
+                    ? `.os-form-authoring [data-field="${String(fieldSel.id).replace(/[^\w-]/g, '')}"]{box-shadow:0 0 0 2px hsl(var(--primary));}`
+                    : ''
+                }
+              `}</style>
+              <div className="min-h-0 flex-1 overflow-auto rounded-lg border bg-background p-6">
+                <div
+                  className="os-form-authoring mx-auto max-w-2xl"
+                  onClick={(e) => {
+                    const el = (e.target as HTMLElement).closest('[data-field]');
+                    const name = el?.getAttribute('data-field');
+                    if (name && readFields(objDraft.fields).entries.some((f) => f.name === name)) {
+                      setFieldSel({ kind: 'field', id: name });
+                    }
+                  }}
+                >
+                  <SchemaRendererProvider dataSource={adapter as never}>
+                    <ObjectForm
+                      key={`${current.name}:${gridVer}:form`}
+                      schema={
+                        {
+                          type: 'object-form',
+                          objectName: current.name,
+                          mode: 'create',
+                          fields: readFields(objDraft.fields)
+                            .entries.map((e) => e.name)
+                            .filter((n) => !STUDIO_SYSTEM_FIELD_NAMES.has(n)),
+                        } as never
+                      }
+                      dataSource={adapter as never}
+                    />
+                  </SchemaRendererProvider>
+                </div>
+              </div>
+              <p className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground">
+                <MousePointer2 className="h-3 w-3" /> 点选任意字段 → 右侧改属性 · 「添加字段」加字段 · 改完「保存草稿」→「发布」
+              </p>
+              </>
+              )}
+              </>
+              )}
             </>
           )}
         </main>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,6 +634,15 @@ importers:
 
   packages/app-shell:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## What

Adds a **布局 (Layout)** designer to the Studio Data pillar's Form view — a WYSIWYG form-layout editor an admin uses to arrange the object's default form, on **one screen** (no Data↔Interface switch):

- **Add sections** (inline rename · move up/down · delete → members fall back to Ungrouped)
- **Drag-reorder** fields within a section
- **Drag across** sections
- **Select a field** → edits in the **same** protocol field inspector the grid already uses
- Faithful field previews (label + type-appropriate control) per field

## How it persists

Sections are the object's `fieldGroups`; membership/order are `field.group` + field order — all **object metadata**, saved via the existing **draft → publish**. No new metadata shape, no separate form entity.

## Build boundary (reuse-first)

The drag/section chrome (`ObjectFormDesigner.tsx`, dnd-kit) is the only new code. The data model + every mutation reuse the existing, tested `object-fields-io` helpers (`readGroups` / `addGroup` / `renameGroup` / `removeGroup` / `moveGroup` / `clearFieldGroup` / `groupEntries`) — these were written for a form-designer canvas that had never been built. Field selection reuses the grid's field inspector.

## Also fixed

The Data pillar reloaded the object baseline on every `[client, current]` change, **clobbering an in-progress draft** when the metadata-client identity churned (e.g. toggling the live preview). Now the baseline loads exactly once per selected object.

## Verified (browser, `/studio/:pkg/data` → 表单 → 布局)

Add group ✓ · drag within group ✓ · drag across groups ✓ · select field → inspector ✓ · layout survives 预览↔布局 toggle ✓ (was the clobber bug). `type-check`: 0 errors.

## Known follow-ups (not in this PR)

- The **预览** (live form) still reads the *published* schema, so it doesn't reflect the draft layout yet.
- Full save→publish loop needs a writable (non-package) object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)