### PR TITLE
fix(studio): drop unused index param in ObjectFormDesigner container map

### DIFF
--- a/packages/app-shell/src/views/studio-design/ObjectFormDesigner.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectFormDesigner.tsx
@@ -441,7 +441,7 @@ export function ObjectFormDesigner({
         onDragCancel={() => setActiveId(null)}
       >
         <div className="mx-auto flex max-w-3xl flex-col gap-3">
-          {containerOrder.map((c, i) => {
+          {containerOrder.map((c) => {
             const isUngrouped = c === cid(UNGROUPED);
             // Hide the ungrouped bucket only when it is empty AND groups exist.
             if (isUngrouped && (items[c]?.length ?? 0) === 0 && groups.length > 0) return null;


### PR DESCRIPTION
`ObjectFormDesigner.tsx` line 444 declared an unused index param `i` in `containerOrder.map((c, i) => …)`. Under `noUnusedLocals`, `tsc` fails with TS6133, which broke `@object-ui/app-shell`'s build — and therefore the vendored `@objectstack/console` build in the downstream framework release pipeline (`scripts/build-console.sh`).

Verified: framework `build-console.sh` at this commit builds 35/35 tasks and produces `packages/console/dist` cleanly.

One-line fix: `(c, i)` → `(c)`.