### PR TITLE
feat(detail): 详情页支持对象 fieldGroups 分组 + 详情提示迁移到 spec 可写的 detail.* 块 (#2148)

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -8,7 +8,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
-import { DetailView, RecordChatterPanel, buildDefaultPageSchema, extractMentions } from '@object-ui/plugin-detail';
+import { DetailView, RecordChatterPanel, buildDefaultPageSchema, deriveFieldGroupDetailSections, extractMentions } from '@object-ui/plugin-detail';
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
 import { useAuth, createAuthenticatedFetch } from '@object-ui/auth';
 import { ActionProvider, useObjectTranslation, useObjectLabel, usePageAssignment, RecordContextProvider, SchemaRenderer, DiscussionContextProvider, HighlightFieldsProvider, useGlobalUndo } from '@object-ui/react';
@@ -1225,8 +1225,14 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         (key) => key === 'name' || key === 'title'
       );
 
-    // Build sections: prefer form sections from objectDef, fallback to flat field list
-    const formSections = objectDef.views?.form?.sections;
+    // Build sections, in priority order:
+    //   1) explicit sections — the spec-writable `detail.sections` block,
+    //      else legacy `views.form.sections` (the spec's ObjectSchema has no
+    //      `views` key, so that source only exists on non-spec metadata);
+    //   2) sections derived from the designer's `fieldGroups` metadata
+    //      (see the fieldGroups branch in the fallback below);
+    //   3) auto-grouping (primary + collapsible "More details").
+    const formSections = (objectDef as any).detail?.sections ?? objectDef.views?.form?.sections;
     const sections = formSections && formSections.length > 0
       ? formSections.map((sec: any) => ({
           title: sec.name ? sectionLabel(objectDef.name, sec.name, sec.title || sec.name) : sec.title,
@@ -1262,14 +1268,6 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           }),
         }))
       : (() => {
-          // Auto-grouping (platform B): when no form sections are authored,
-          // split fields into a primary section and a collapsible
-          // "More details" section so long-form/secondary fields don't
-          // dilute the main grid. The primary section stays untitled so
-          // DetailSection still flattens its chrome when alone.
-          const allFields = Object.keys(objectDef.fields || {})
-            .filter((key) => !AUDIT_FIELD_NAMES.has(key) && !HIDDEN_SYSTEM_FIELD_NAMES.has(key) && !objectDef.fields[key]?.hidden);
-
           const toField = (key: string) => {
             const fieldDef = objectDef.fields[key];
             const refTarget = fieldDef.reference_to || fieldDef.reference;
@@ -1284,35 +1282,70 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
             };
           };
 
-          const primaryKeys = allFields.filter((k) => !isSecondaryField(k, objectDef.fields[k]));
-          const secondaryKeys = allFields.filter((k) => isSecondaryField(k, objectDef.fields[k]));
+          // Auto-grouping (platform B): split fields into a primary section
+          // and a collapsible "More details" section so long-form/secondary
+          // fields don't dilute the main grid. The primary section stays
+          // untitled so DetailSection still flattens its chrome when alone.
+          // Shared by the pure-fallback path and the ungrouped remainder of
+          // the fieldGroups path below.
+          const splitPrimarySecondary = (keys: string[]) => {
+            const primaryKeys = keys.filter((k) => !isSecondaryField(k, objectDef.fields[k]));
+            const secondaryKeys = keys.filter((k) => isSecondaryField(k, objectDef.fields[k]));
 
-          // Below ~6 primary fields the second section often looks awkward
-          // — keep the legacy single-untitled-section behaviour. Also
-          // honour the "no secondary fields" case the same way.
-          if (secondaryKeys.length === 0 || primaryKeys.length === 0) {
+            // Keep the legacy single-untitled-section behaviour when the
+            // split would leave one side empty.
+            if (secondaryKeys.length === 0 || primaryKeys.length === 0) {
+              return [
+                {
+                  showBorder: false as const,
+                  fields: keys.map(toField),
+                },
+              ];
+            }
+
             return [
               {
                 showBorder: false as const,
-                fields: allFields.map(toField),
+                fields: primaryKeys.map(toField),
+              },
+              {
+                name: 'details',
+                title: sectionLabel(objectDef.name, 'details', t('detail.sectionMoreDetails', 'More details')),
+                collapsible: true,
+                defaultCollapsed: false,
+                showBorder: true as const,
+                fields: secondaryKeys.map(toField),
               },
             ];
+          };
+
+          // 2) fieldGroups-derived sections (object-designer metadata,
+          //    same source the runtime form honours). Declared groups
+          //    render as titled cards in declared order; the helper's
+          //    trailing untitled bucket (ungrouped fields) still goes
+          //    through the primary/"More details" split so long-form
+          //    fields stay tucked away. Objects can opt out via
+          //    `detail.useFieldGroups: false`.
+          const grouped = deriveFieldGroupDetailSections(objectDef as any);
+          if (grouped) {
+            return grouped.flatMap((sec: any) => {
+              if (!sec.name) {
+                return splitPrimarySecondary(
+                  (sec.fields as any[]).map((f: any) => f.name),
+                );
+              }
+              return [{
+                ...sec,
+                title: sectionLabel(objectDef.name, sec.name, sec.title),
+                showBorder: true as const,
+              }];
+            });
           }
 
-          return [
-            {
-              showBorder: false as const,
-              fields: primaryKeys.map(toField),
-            },
-            {
-              name: 'details',
-              title: sectionLabel(objectDef.name, 'details', t('detail.sectionMoreDetails', 'More details')),
-              collapsible: true,
-              defaultCollapsed: false,
-              showBorder: true as const,
-              fields: secondaryKeys.map(toField),
-            },
-          ];
+          // 3) Pure auto-grouping fallback.
+          const allFields = Object.keys(objectDef.fields || {})
+            .filter((key) => !AUDIT_FIELD_NAMES.has(key) && !HIDDEN_SYSTEM_FIELD_NAMES.has(key) && !objectDef.fields[key]?.hidden);
+          return splitPrimarySecondary(allFields);
         })();
 
     // Audit fields (created_at/created_by/updated_at/updated_by) are NOT
@@ -1385,12 +1418,33 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       return base;
     })();
 
-    // Build highlightFields: exclusively from objectDef metadata (no hardcoded fallback)
-    const highlightFields: HighlightField[] = objectDef.views?.detail?.highlightFields ?? [];
+    // Build highlightFields: exclusively from objectDef metadata (no
+    // hardcoded fallback). The spec-writable `detail.highlightFields`
+    // wins; `views.detail.highlightFields` stays as back-compat for
+    // non-spec metadata (the spec's ObjectSchema has no `views` key).
+    // Entries may be bare field names — normalize them to the
+    // HighlightField shape by resolving label/type from the field def.
+    const rawHighlightFields =
+      (objectDef as any).detail?.highlightFields ?? objectDef.views?.detail?.highlightFields ?? [];
+    const highlightFields: HighlightField[] = (Array.isArray(rawHighlightFields) ? rawHighlightFields : [])
+      .map((f: any): HighlightField | null => {
+        const name = typeof f === 'string' ? f : f?.name;
+        if (!name) return null;
+        if (typeof f === 'object' && f.label) return f as HighlightField;
+        const fieldDef = objectDef.fields?.[name];
+        return {
+          name,
+          label: fieldDef?.label || name,
+          ...(fieldDef?.type ? { type: fieldDef.type } : {}),
+        };
+      })
+      .filter((f): f is HighlightField => !!f);
 
     // Build sectionGroups from objectDef detail/form config if available
     const sectionGroups: SectionGroup[] | undefined =
-      objectDef.views?.detail?.sectionGroups ?? objectDef.views?.form?.sectionGroups;
+      (objectDef as any).detail?.sectionGroups
+      ?? objectDef.views?.detail?.sectionGroups
+      ?? objectDef.views?.form?.sectionGroups;
 
     // Build related entries from reverse-reference child objects.
     // `referenceField` is the FK field on the child pointing back to this

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -110,6 +110,8 @@ export {
   detectStatusField,
   deriveStages,
   deriveHighlightFields,
+  deriveFieldGroupDetailSections,
+  resolveDetailSections,
 } from './synth/buildDefaultPageSchema';
 export type {
   ObjectDefLike,

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -17,6 +17,8 @@ import {
   detectStatusField,
   deriveStages,
   deriveHighlightFields,
+  deriveFieldGroupDetailSections,
+  resolveDetailSections,
   type ObjectDefLike,
 } from '../buildDefaultPageSchema';
 
@@ -666,5 +668,226 @@ describe('buildDefaultPageSchema', () => {
     it('buildDefaultDiscussion returns the record:discussion node', () => {
       expect(buildDefaultDiscussion()).toEqual({ type: 'record:discussion' });
     });
+  });
+});
+
+// #2148 — spec-writable `detail.*` hints + fieldGroups-derived sections.
+describe('detail.* hints (#2148 / #2065)', () => {
+  describe('detectStatusField', () => {
+    it('detail.stageField wins over top-level stageField and heuristics', () => {
+      expect(
+        detectStatusField({
+          detail: { stageField: 'pipeline' },
+          stageField: 'legacy_stage',
+          fields: { pipeline: {}, legacy_stage: {}, status: {} },
+        }),
+      ).toBe('pipeline');
+    });
+
+    it('detail.stageField: false suppresses detection entirely', () => {
+      expect(
+        detectStatusField({
+          detail: { stageField: false },
+          stageField: 'status',
+          fields: { status: { type: 'status' } },
+        }),
+      ).toBeNull();
+    });
+
+    it('falls back to top-level stageField, then heuristic, when detail hint absent', () => {
+      expect(
+        detectStatusField({ detail: {}, stageField: 'stage_x', fields: { stage_x: {} } }),
+      ).toBe('stage_x');
+      expect(detectStatusField({ detail: {}, fields: { status: {} } })).toBe('status');
+    });
+  });
+
+  describe('deriveHighlightFields', () => {
+    it('detail.highlightFields wins over top-level highlightFields', () => {
+      expect(
+        deriveHighlightFields(
+          {
+            ...leadDef,
+            detail: { highlightFields: ['phone', 'rating'] },
+            highlightFields: ['email'],
+          },
+          'status',
+        ),
+      ).toEqual(['phone', 'rating']);
+    });
+
+    it('accepts { name } object entries and drops malformed ones', () => {
+      expect(
+        deriveHighlightFields(
+          { ...leadDef, detail: { highlightFields: [{ name: 'email' }, 'phone', {} as any, ''] } },
+          'status',
+        ),
+      ).toEqual(['email', 'phone']);
+    });
+
+    it('caps the detail list at max', () => {
+      expect(
+        deriveHighlightFields(
+          { detail: { highlightFields: ['a', 'b', 'c', 'd', 'e'] }, fields: {} },
+          null,
+          3,
+        ),
+      ).toEqual(['a', 'b', 'c']);
+    });
+  });
+});
+
+describe('deriveFieldGroupDetailSections (#2148)', () => {
+  const groupedDef: ObjectDefLike = {
+    name: 'account',
+    fieldGroups: [
+      { key: 'basic', label: '基本信息' },
+      { key: 'finance', label: '财务', collapsible: true, collapsed: true },
+      { key: 'unused', label: 'Empty group' },
+    ],
+    fields: {
+      name: { label: 'Name', type: 'text', group: 'basic' },
+      industry: { label: 'Industry', type: 'select', group: 'basic' },
+      revenue: { label: 'Revenue', type: 'currency', group: 'finance' },
+      website: { label: 'Website', type: 'url' },
+      secret: { label: 'Secret', type: 'text', group: 'basic', hidden: true },
+      created_at: { label: 'Created', type: 'datetime' },
+      organization_id: { label: 'Org', type: 'text' },
+    },
+  };
+
+  it('returns sections in declared order with collapse passthrough, dropping empty groups', () => {
+    const sections = deriveFieldGroupDetailSections(groupedDef)!;
+    expect(sections.map((s: any) => s.name)).toEqual(['basic', 'finance', undefined]);
+    expect(sections[0].title).toBe('基本信息');
+    expect(sections[0].fields.map((f: any) => f.name)).toEqual(['name', 'industry']);
+    expect(sections[1]).toMatchObject({
+      name: 'finance',
+      title: '财务',
+      collapsible: true,
+      defaultCollapsed: true,
+    });
+    // 'unused' group has no fields → dropped.
+    expect(sections.some((s: any) => s.name === 'unused')).toBe(false);
+  });
+
+  it('collects ungrouped fields into a trailing untitled section, skipping audit/system fields', () => {
+    const sections = deriveFieldGroupDetailSections(groupedDef)!;
+    const trailing = sections[sections.length - 1];
+    expect(trailing.name).toBeUndefined();
+    expect(trailing.title).toBeUndefined();
+    expect(trailing.fields.map((f: any) => f.name)).toEqual(['website']);
+  });
+
+  it('keeps audit fields an author EXPLICITLY grouped', () => {
+    const def: ObjectDefLike = {
+      fieldGroups: [{ key: 'meta', label: 'Meta' }],
+      fields: {
+        title: { type: 'text' },
+        created_at: { type: 'datetime', group: 'meta' },
+      },
+    };
+    const sections = deriveFieldGroupDetailSections(def)!;
+    expect(sections[0].fields.map((f: any) => f.name)).toEqual(['created_at']);
+  });
+
+  it('skips hidden fields even when grouped', () => {
+    const sections = deriveFieldGroupDetailSections(groupedDef)!;
+    const basic = sections.find((s: any) => s.name === 'basic')!;
+    expect(basic.fields.map((f: any) => f.name)).not.toContain('secret');
+  });
+
+  it('emits rich field descriptors (label / type / options)', () => {
+    const sections = deriveFieldGroupDetailSections(groupedDef)!;
+    expect(sections[0].fields[1]).toMatchObject({
+      name: 'industry',
+      label: 'Industry',
+      type: 'select',
+    });
+  });
+
+  it('returns null when grouping does not apply', () => {
+    // No fieldGroups at all.
+    expect(deriveFieldGroupDetailSections(leadDef)).toBeNull();
+    // Declared groups but no field references one.
+    expect(
+      deriveFieldGroupDetailSections({
+        fieldGroups: [{ key: 'g1' }],
+        fields: { a: {}, b: {} },
+      }),
+    ).toBeNull();
+    // Explicit opt-out.
+    expect(
+      deriveFieldGroupDetailSections({ ...groupedDef, detail: { useFieldGroups: false } }),
+    ).toBeNull();
+    // Undefined def.
+    expect(deriveFieldGroupDetailSections(undefined)).toBeNull();
+  });
+
+  it('ignores keyless / malformed group entries', () => {
+    expect(
+      deriveFieldGroupDetailSections({
+        fieldGroups: [{ label: 'No key' } as any, null as any],
+        fields: { a: { group: 'x' } },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('resolveDetailSections priority (#2148)', () => {
+  const groupedDef: ObjectDefLike = {
+    fieldGroups: [{ key: 'g', label: 'G' }],
+    fields: { a: { group: 'g' }, b: {} },
+  };
+
+  it('explicit options.sections wins', () => {
+    const explicit = [{ title: 'Explicit', fields: ['a'] }];
+    expect(resolveDetailSections(groupedDef, explicit)).toBe(explicit);
+  });
+
+  it('falls back to detail.sections next', () => {
+    const declared = [{ title: 'Declared', fields: ['a'] }];
+    expect(
+      resolveDetailSections({ ...groupedDef, detail: { sections: declared } }),
+    ).toBe(declared);
+  });
+
+  it('derives from fieldGroups last, else undefined', () => {
+    const derived = resolveDetailSections(groupedDef)!;
+    expect(derived[0]).toMatchObject({ name: 'g', title: 'G' });
+    expect(resolveDetailSections(leadDef)).toBeUndefined();
+    expect(resolveDetailSections(undefined)).toBeUndefined();
+  });
+
+  it('empty options.sections array does not shadow the fallbacks', () => {
+    const derived = resolveDetailSections(groupedDef, [])!;
+    expect(derived[0]).toMatchObject({ name: 'g' });
+  });
+});
+
+describe('buildDefaultPageSchema integration (#2148)', () => {
+  it('record:details picks up fieldGroups-derived sections when no options.sections', () => {
+    const def: ObjectDefLike = {
+      name: 'account',
+      fieldGroups: [{ key: 'basic', label: 'Basic' }],
+      fields: {
+        name: { type: 'text', group: 'basic' },
+        website: { type: 'url' },
+      },
+    };
+    const page = buildDefaultPageSchema(def);
+    const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
+    const details = tabs.items[0].children[0];
+    expect(details.type).toBe('record:details');
+    expect(details.sections[0]).toMatchObject({ name: 'basic', title: 'Basic' });
+  });
+
+  it('detail.stageField: false drops record:path', () => {
+    const def: ObjectDefLike = {
+      ...leadDef,
+      detail: { stageField: false },
+    };
+    const types = buildDefaultPageSchema(def).regions[0].components.map((c: any) => c.type);
+    expect(types).not.toContain('record:path');
   });
 });

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -41,6 +41,37 @@ export interface ObjectDefLike {
   primaryField?: string;
   /** Optional section grouping for the details region. */
   sections?: Array<{ title?: string; columns?: number; fields?: any[] }>;
+  /**
+   * Declared field groups from the object designer. Fields opt in via
+   * `field.group === group.key`; the detail synthesizer derives sections
+   * from them when no explicit sections are provided.
+   */
+  fieldGroups?: Array<{
+    key?: string;
+    label?: string;
+    collapsible?: boolean;
+    collapsed?: boolean;
+  }>;
+  /**
+   * Author-facing detail hints. This block is the ONLY spec-writable home
+   * for detail-page hints: `@objectstack/spec`'s ObjectSchema rejects
+   * unknown top-level keys (`views`, top-level `stageField`, …) but keeps
+   * the `detail` block passthrough. Keys read here:
+   * - `stageField` — explicit status field, or `false` to suppress the
+   *   `record:path` stepper entirely (#2065).
+   * - `highlightFields` — explicit highlight strip (string names or
+   *   `{ name }` objects).
+   * - `sections` — explicit detail sections, same shape as
+   *   `BuildPageOptions['sections']`.
+   * - `useFieldGroups: false` — opt out of fieldGroups-derived sections.
+   */
+  detail?: {
+    stageField?: string | false;
+    highlightFields?: Array<string | { name?: string }>;
+    sections?: Array<{ title?: string; columns?: number; fields?: any[] }>;
+    useFieldGroups?: boolean;
+    [key: string]: any;
+  };
 }
 
 export interface ObjectFieldLike {
@@ -48,6 +79,10 @@ export interface ObjectFieldLike {
   label?: string;
   type?: string;
   options?: Array<{ value: any; label: string }>;
+  /** Declared group membership — matches a `fieldGroups[].key`. */
+  group?: string;
+  /** Hidden fields never surface in derived sections. */
+  hidden?: boolean;
 }
 
 export interface BuildPageOptions {
@@ -189,12 +224,18 @@ function toNodeArray(slot: any | any[] | undefined): any[] {
  * Detect the canonical "status" / "stage" field on an object definition.
  *
  * Heuristic — same as DetailView's `autoSummaryFields`:
- *   1) prefer an explicit `objectDef.stageField`
- *   2) else first field named status / stage / state / phase
- *   3) else null
+ *   1) `objectDef.detail.stageField` — the spec-writable hint. `false`
+ *      suppresses stage detection entirely (no `record:path`, #2065).
+ *   2) else an explicit top-level `objectDef.stageField` (legacy /
+ *      non-spec metadata; the spec strips this key)
+ *   3) else first field named status / stage / state / phase
+ *   4) else null
  */
 export function detectStatusField(def?: ObjectDefLike): string | null {
   if (!def) return null;
+  const hint = def.detail?.stageField;
+  if (hint === false) return null;
+  if (typeof hint === 'string' && hint) return hint;
   if (def.stageField) return def.stageField;
   const fields = def.fields || {};
   const candidates = ['status', 'stage', 'state', 'phase'];
@@ -232,6 +273,15 @@ export function deriveHighlightFields(
   max = 4,
 ): string[] {
   if (!def) return [];
+  // Spec-writable hint first: `detail.highlightFields` accepts string
+  // names or `{ name }` objects (the shape RecordDetailView's legacy
+  // schema uses).
+  const declared = (Array.isArray(def.detail?.highlightFields) ? def.detail!.highlightFields! : [])
+    .map((f) => (typeof f === 'string' ? f : f?.name))
+    .filter((n): n is string => typeof n === 'string' && n.length > 0);
+  if (declared.length > 0) {
+    return declared.slice(0, max);
+  }
   if (Array.isArray(def.highlightFields) && def.highlightFields.length > 0) {
     return def.highlightFields.slice(0, max);
   }
@@ -360,16 +410,140 @@ export function buildDefaultHighlights(
 }
 
 /**
+ * System / audit fields the app-shell filters out of auto-generated detail
+ * sections. Mirrored here so fieldGroups-derived sections (used by the
+ * synth-only consumers — Studio page preview, metadata-admin anchors)
+ * match the runtime detail page. Fields an author EXPLICITLY assigns to a
+ * group are kept — explicit listing wins, same as authored sections.
+ */
+const DERIVED_SECTION_SKIP_FIELDS = new Set<string>([
+  'created_at', 'created_by', 'updated_at', 'updated_by',
+  'organization_id', 'tenant_id', 'is_deleted', 'deleted_at',
+]);
+
+/**
+ * Derive detail sections from the object's declared `fieldGroups` plus each
+ * field's `group` membership — the same metadata the object designer writes
+ * and the runtime form (`@object-ui/plugin-form` `deriveFieldGroupSections`)
+ * already honours. Semantics mirror the form side:
+ *
+ *   - sections come back in declared-group order;
+ *   - declared groups no visible field references are dropped;
+ *   - fields without a (declared) group collect into a trailing untitled
+ *     section so they render flat rather than as a spurious card;
+ *   - `collapsible` / `collapsed` pass through (as DetailSection's
+ *     `collapsible` / `defaultCollapsed`).
+ *
+ * Returns `null` when grouping does not apply — no declared groups, no
+ * visible field references one, or the object opted out via
+ * `detail.useFieldGroups: false` — so callers fall back to their existing
+ * layout (flat or auto-split).
+ *
+ * Section fields are emitted as rich descriptors (`{ name, label, type,
+ * options }`) so DetailSection renders typed values without re-resolving
+ * the object definition.
+ */
+export function deriveFieldGroupDetailSections(
+  def: ObjectDefLike | undefined,
+): Array<Record<string, any>> | null {
+  if (!def) return null;
+  if (def.detail?.useFieldGroups === false) return null;
+  const declared = (Array.isArray(def.fieldGroups) ? def.fieldGroups : [])
+    .filter((g): g is NonNullable<typeof g> => !!g && typeof g === 'object')
+    .map((g) => ({
+      key: typeof g.key === 'string' ? g.key : '',
+      label: typeof g.label === 'string' ? g.label : undefined,
+      collapsible: typeof g.collapsible === 'boolean' ? g.collapsible : undefined,
+      collapsed: typeof g.collapsed === 'boolean' ? g.collapsed : undefined,
+    }))
+    .filter((g) => g.key);
+  if (declared.length === 0) return null;
+
+  const declaredKeys = new Set(declared.map((g) => g.key));
+  const fields = def.fields || {};
+  const toField = (name: string) => {
+    const f = fields[name] || {};
+    return {
+      name,
+      label: f.label || name,
+      type: f.type || 'text',
+      ...(f.options ? { options: f.options } : {}),
+      ...((f as any).reference_to || (f as any).reference
+        ? { reference_to: (f as any).reference_to || (f as any).reference }
+        : {}),
+      ...((f as any).reference_field ? { reference_field: (f as any).reference_field } : {}),
+      ...((f as any).currency ? { currency: (f as any).currency } : {}),
+    };
+  };
+
+  const buckets = new Map<string, string[]>();
+  for (const g of declared) buckets.set(g.key, []);
+  const ungrouped: string[] = [];
+  let anyGrouped = false;
+  for (const [name, f] of Object.entries(fields)) {
+    if (f?.hidden) continue;
+    const g = typeof f?.group === 'string' && declaredKeys.has(f.group) ? f.group : null;
+    if (g) {
+      buckets.get(g)!.push(name);
+      anyGrouped = true;
+    } else if (!DERIVED_SECTION_SKIP_FIELDS.has(name)) {
+      ungrouped.push(name);
+    }
+  }
+  // No visible field references a declared group → keep the flat layout.
+  if (!anyGrouped) return null;
+
+  const sections: Array<Record<string, any>> = [];
+  for (const g of declared) {
+    const names = buckets.get(g.key)!;
+    if (names.length === 0) continue;
+    sections.push({
+      name: g.key,
+      title: g.label ?? g.key,
+      ...(g.collapsible !== undefined ? { collapsible: g.collapsible } : {}),
+      ...(g.collapsed !== undefined ? { defaultCollapsed: g.collapsed } : {}),
+      fields: names.map(toField),
+    });
+  }
+  // Trailing untitled bucket for ungrouped fields. Omitting `name`/`title`
+  // keeps the section flat (record-details defaults showBorder to false
+  // for untitled sections) instead of surfacing an internal key as a
+  // header.
+  if (ungrouped.length > 0) {
+    sections.push({ fields: ungrouped.map(toField) });
+  }
+  return sections.length > 0 ? sections : null;
+}
+
+/**
+ * Resolve the sections for the Details tab body:
+ *   1) explicit `options.sections` from the caller (RecordDetailView folds
+ *      `detail.sections` / legacy `views.form.sections` in here);
+ *   2) else the object's spec-writable `detail.sections`;
+ *   3) else sections derived from `fieldGroups` (designer metadata);
+ *   4) else `undefined` — record:details falls back to its flat layout.
+ */
+export function resolveDetailSections(
+  def: ObjectDefLike | undefined,
+  sections?: BuildPageOptions['sections'],
+): BuildPageOptions['sections'] | undefined {
+  if (Array.isArray(sections) && sections.length > 0) return sections;
+  const declared = def?.detail?.sections;
+  if (Array.isArray(declared) && declared.length > 0) return declared;
+  return deriveFieldGroupDetailSections(def) ?? undefined;
+}
+
+/**
  * Sub-builder: the Details tab body — a single `record:details` node.
  */
 export function buildDefaultDetails(
-  _def: ObjectDefLike | undefined,
+  def: ObjectDefLike | undefined,
   sections?: BuildPageOptions['sections'],
   hideFields?: string[],
 ): any {
   return {
     type: 'record:details',
-    sections,
+    sections: resolveDetailSections(def, sections),
     ...(hideFields && hideFields.length > 0 ? { hideFields } : {}),
   };
 }


### PR DESCRIPTION
关联 #2148,同时收编 #2065(`detail.stageField: false` 关闭阶段条)。

## 问题一:字段分组在详情页不生效

对象上定义的 `fieldGroups[]` + `fields[].group`(设计器里的"字段分组")此前只有表单在用(plugin-form 的 `deriveFieldGroupSections`),默认详情页和 synth 详情页完全忽略,全部字段被自动拆成"主要字段 + 更多详情"两段。

**改动:**
- `plugin-detail` synth 新增导出 `deriveFieldGroupDetailSections(def)`:按 `fieldGroups` 声明顺序分桶 `fields[].group`,语义对齐 plugin-form——空的已声明分组丢弃、`collapsible`/`collapsed` 透传(`collapsed` 映射为 DetailSection 的 `defaultCollapsed`)、未分组字段进末尾无标题分区。未分组桶跳过审计/系统字段(`created_at`、`updated_by`、`tenant_id` 等,与 app-shell 的 AUDIT+HIDDEN 集合完全一致);**显式**归入某分组的审计字段保留(显式声明优先,与手写 sections 语义一致)。
- 新增导出 `resolveDetailSections(def, sections?)` 统一优先级,`buildDefaultDetails` 接入,所以所有 synth 消费方(默认详情页、Studio 预览、metadata-admin)自动获得分组分区。
- `RecordDetailView` 复用同一推导:命名分组标题走 `sectionLabel` i18n 约定(`{ns}.objects.{objectName}._sections.{key}.label`),未分组剩余字段仍保留 primary/"更多详情" 折叠拆分,不破坏现有"更多详情"按钮体验。

**分区来源优先级:** 显式 sections(`detail.sections` ?? `views.form.sections`)> `fieldGroups` 推导 > 自动两段式兜底。

## 问题二:详情提示写在 spec 不认的键上

console 此前从 `views.detail.highlightFields`、`views.form.sections`、顶层 `stageField` 读取提示,但 `@objectstack/spec` 的 `ObjectSchema.create()` 对这些键直接抛错、`safeParse` 静默剥离——即用户按文档写了也到不了运行时。spec 里顶层 `detail` 块是 passthrough(可写),所以:

- 所有详情提示优先读 `detail.*`:`detail.stageField`(string 指定 / `false` 关闭,#2065)、`detail.highlightFields`(支持 `string` 或 `{name}` 条目,畸形条目丢弃)、`detail.sections`、`detail.sectionGroups`、`detail.useFieldGroups: false`(关闭 fieldGroups 推导的逃生门)。
- 旧键(`views.*`、顶层 `stageField`/`highlightFields`)全部保留为回退,零破坏。

## ⚠️ 行为变化(release note)

已声明 `fieldGroups` 的对象,详情页会从自动两段式变为按分组渲染。逃生门:`detail: { useFieldGroups: false }`。

## 测试

- plugin-detail synth 新增 19 个测试(detail.* 提示优先级/回退、`deriveFieldGroupDetailSections` 各分支、`resolveDetailSections` 优先级、`buildDefaultPageSchema` 集成含 `detail.stageField: false` 去掉 record:path),全部通过;synth 定向套件 73/73。
- app-shell 全量:123 文件 / 955 用例全绿。
- `turbo type-check`(plugin-detail + app-shell)通过;`turbo build`(两条依赖链 29 个任务)通过。
- 本 worktree 有 7 个 plugin-detail 测试套件因 `components/dist` 解析失败——已用 `git stash` 在干净树上复现同样 7 个套件失败,属预置环境问题,与本次改动无关。

## 后续(不在本 PR)

- 两个抽屉(plugin-detail / plugin-dashboard 的 `RecordDetailDrawer`)的分组渲染,见 #2148。
- 上游 spec 可考虑把 `detail.highlightFields`/`detail.stageField`/`detail.sections` 收进强类型(#2148 待确认 Q7)。

Closes #2065