### PR TITLE
fix(grid): inline-edit toggle takes effect immediately + staged editor closes on save

### DIFF
--- a/packages/components/src/__tests__/data-table-inline-edit.test.tsx
+++ b/packages/components/src/__tests__/data-table-inline-edit.test.tsx
@@ -179,4 +179,40 @@ describe('data-table — inline edit is per-row usable', () => {
 
     expect(container.textContent).not.toContain('Save failed');
   });
+
+  it('E) a staged editor (e.g. a lookup picker) exits edit mode after Save All', async () => {
+    // Regression: relational pickers (lookup/master_detail/user/owner) keep their
+    // widget open on pick — they `stage` the value rather than commit-and-close.
+    // saveBatch cleared pendingChanges but never cleared `editingCell`, so after
+    // 全部保存 the saved cell stayed stuck showing the picker widget instead of
+    // reverting to the resolved display value. Save All must close any open editor.
+    const onBatchSave = vi.fn().mockResolvedValue(undefined);
+    // A host-injected editor that mimics a lookup: picking a value STAGES it and
+    // deliberately keeps the editor open (no commit/close).
+    const renderCellEditor = ({ column, stage }: any) =>
+      column.accessorKey === 'qty' ? (
+        <button data-testid="picker" onClick={() => stage('picked')}>
+          picker
+        </button>
+      ) : null;
+
+    const { container, getByText, getByTestId, queryByTestId } = renderComponent({
+      ...editableSchema,
+      onBatchSave,
+      renderCellEditor,
+    });
+
+    const cells = container.querySelectorAll('tbody td');
+    const qtyCell = cells[2] as HTMLElement; // uses the injected picker editor
+    fireEvent.click(qtyCell);
+
+    // Editor is open; pick a value — it stages and stays open (no close).
+    fireEvent.click(getByTestId('picker'));
+    expect(queryByTestId('picker')).toBeInTheDocument();
+
+    // Save All persists the staged value AND must exit edit mode.
+    fireEvent.click(getByText(/Save All/i));
+    await waitFor(() => expect(onBatchSave).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(queryByTestId('picker')).not.toBeInTheDocument());
+  });
 });

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -765,6 +765,13 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       const newPendingChanges = new Map(pendingChanges);
       newPendingChanges.delete(rowIndex);
       setPendingChanges(newPendingChanges);
+      // A staged editor (e.g. a lookup picker, which keeps its widget open on
+      // pick rather than committing) must exit edit mode once its value is
+      // persisted — otherwise the saved cell stays stuck showing the editor.
+      if (editingCell?.rowIndex === rowIndex) {
+        setEditingCell(null);
+        setEditValue('');
+      }
       // Saved — drop any prior error for this row, and clear the banner once
       // no errored rows remain.
       setErroredRows((prev) => {
@@ -815,6 +822,11 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       
       // Clear all pending changes
       setPendingChanges(new Map());
+      // Any staged editor left open (e.g. a lookup picker that keeps its widget
+      // open on pick) must exit edit mode now that every row is persisted —
+      // otherwise the edited cell stays stuck showing the editor after 全部保存.
+      setEditingCell(null);
+      setEditValue('');
       // Saved — clear any prior errors.
       setErroredRows(new Set());
       setSaveError(null);

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -363,6 +363,16 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   const [draggedColumn, setDraggedColumn] = useState<number | null>(null);
   const [dragOverColumn, setDragOverColumn] = useState<number | null>(null);
   const [editingCell, setEditingCell] = useState<{ rowIndex: number; columnKey: string } | null>(null);
+  // Mirror of `editingCell` that is mutated synchronously, so the `startEdit`
+  // re-entry guard can't be defeated by a stale closure. A lookup/select option
+  // renders in a Portal; picking it fires the option's onChange (which stages
+  // the value) and — because React synthetic events still bubble through the
+  // component tree — the cell's onClick, re-invoking `startEdit` for the SAME
+  // cell within one event. Reading `editingCell` state there can observe a stale
+  // (pre-edit) value under batching/contention, so the guard misses and the
+  // just-picked value is reset from empty `pendingChanges`. The ref always
+  // reflects the latest edit target within the same tick, so re-entry is caught.
+  const editingCellRef = useRef<{ rowIndex: number; columnKey: string } | null>(null);
   const [editValue, setEditValue] = useState<any>('');
   // Track pending changes for multi-cell editing: rowIndex -> { columnKey -> newValue }
   const [pendingChanges, setPendingChanges] = useState<Map<number, Record<string, any>>>(new Map());
@@ -668,12 +678,16 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     // overlay (a lookup/select popover renders in a Portal, but React events
     // still bubble through the component tree to this cell's onClick), that reset
     // reads a stale `pendingChanges` — before the just-staged value has flushed —
-    // and clobbers the freshly picked value. Guarding here keeps the selection.
-    if (editingCell?.rowIndex === rowIndex && editingCell?.columnKey === columnKey) return;
+    // and clobbers the freshly picked value. Guard on the synchronous ref (not
+    // the `editingCell` state, which can read stale under batching/contention —
+    // the intermittent CI failure #2150) so the re-entrant call is always caught.
+    const active = editingCellRef.current;
+    if (active?.rowIndex === rowIndex && active?.columnKey === columnKey) return;
 
     const column = columns.find(col => col.accessorKey === columnKey);
     if (column?.editable === false) return;
 
+    editingCellRef.current = { rowIndex, columnKey };
     setEditingCell({ rowIndex, columnKey });
     
     // Check if there's a pending change for this cell, otherwise use current data value
@@ -711,12 +725,14 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       schema.onCellChange(globalIndex, columnKey, valueToStage, row);
     }
 
+    editingCellRef.current = null;
     setEditingCell(null);
     setEditValue('');
   };
 
   const cancelEdit = () => {
     skipBlurSaveRef.current = true;
+    editingCellRef.current = null;
     setEditingCell(null);
     setEditValue('');
   };
@@ -769,6 +785,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       // pick rather than committing) must exit edit mode once its value is
       // persisted — otherwise the saved cell stays stuck showing the editor.
       if (editingCell?.rowIndex === rowIndex) {
+        editingCellRef.current = null;
         setEditingCell(null);
         setEditValue('');
       }
@@ -825,6 +842,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       // Any staged editor left open (e.g. a lookup picker that keeps its widget
       // open on pick) must exit edit mode now that every row is persisted —
       // otherwise the edited cell stays stuck showing the editor after 全部保存.
+      editingCellRef.current = null;
       setEditingCell(null);
       setEditValue('');
       // Saved — clear any prior errors.

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -662,10 +662,18 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   // Cell editing handlers
   const startEdit = (rowIndex: number, columnKey: string) => {
     if (!editable) return;
-    
+
+    // Already editing THIS cell — do nothing. Re-entering would reset `editValue`
+    // from `pendingChanges`, and when a widget-injected editor commits via an
+    // overlay (a lookup/select popover renders in a Portal, but React events
+    // still bubble through the component tree to this cell's onClick), that reset
+    // reads a stale `pendingChanges` — before the just-staged value has flushed —
+    // and clobbers the freshly picked value. Guarding here keeps the selection.
+    if (editingCell?.rowIndex === rowIndex && editingCell?.columnKey === columnKey) return;
+
     const column = columns.find(col => col.accessorKey === columnKey);
     if (column?.editable === false) return;
-    
+
     setEditingCell({ rowIndex, columnKey });
     
     // Check if there's a pending change for this cell, otherwise use current data value

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -9,6 +9,7 @@
 import { ObjectStackClient, type QueryOptions as ObjectStackQueryOptions } from '@objectstack/client';
 import type {
   DataSource,
+  MutationEvent,
   QueryParams,
   QueryResult,
   FileUploadResult,
@@ -403,6 +404,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   // so optional collections like sys_presence don't hammer the server with
   // failing requests on every record open / panel render.
   private missingResources = new Set<string>();
+  // Subscribers registered via onMutation(). Emitted after each successful
+  // create/update/delete so data-bound views (ListView, ObjectView, kanban,
+  // calendar) auto-refresh — the interface ListView relies on to reflect
+  // inline-edit "Save All" writes without a manual reload.
+  private mutationListeners = new Set<(event: MutationEvent<T>) => void>();
 
   constructor(config: {
     baseUrl: string;
@@ -706,9 +712,37 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   /**
    * Create a new record.
    */
+  /**
+   * Notify all mutation subscribers. A throwing listener must not break the
+   * mutation or starve the other subscribers, so each is isolated.
+   */
+  private emitMutation(event: MutationEvent<T>): void {
+    for (const listener of this.mutationListeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        console.warn('ObjectStackAdapter: mutation listener error', err);
+      }
+    }
+  }
+
+  /**
+   * Subscribe to create/update/delete events on any resource. Returns an
+   * unsubscribe function. Data-bound views use this to auto-refresh after a
+   * mutation (e.g. inline-edit "Save All", which writes through `update` and
+   * must repaint the list without a manual reload).
+   */
+  onMutation(callback: (event: MutationEvent<T>) => void): () => void {
+    this.mutationListeners.add(callback);
+    return () => {
+      this.mutationListeners.delete(callback);
+    };
+  }
+
   async create(resource: string, data: Partial<T>): Promise<T> {
     await this.connect();
     const result = await this.client.data.create<T>(resource, data);
+    this.emitMutation({ type: 'create', resource, record: { ...result.record } });
     return result.record;
   }
 
@@ -737,6 +771,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         data,
         opts?.ifMatch ? { ifMatch: opts.ifMatch } : undefined,
       );
+      this.emitMutation({ type: 'update', resource, id, record: { ...result.record } });
       return result.record;
     } catch (err) {
       throw normaliseClientError(err);
@@ -762,6 +797,9 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         String(id),
         opts?.ifMatch ? { ifMatch: opts.ifMatch } : undefined,
       );
+      if (result.deleted) {
+        this.emitMutation({ type: 'delete', resource, id });
+      }
       return result.deleted;
     } catch (err) {
       throw normaliseClientError(err);
@@ -792,6 +830,13 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     if (!ids || ids.length === 0) return 0;
     const records = ids.map((id) => ({ id: String(id), data: patch as any }));
 
+    // Notify subscribers once for the whole batch (not per-id) so a single
+    // "mark all read"/"archive selected" refreshes bound views exactly once.
+    const emitBulk = (count: number): number => {
+      if (count > 0) this.emitMutation({ type: 'update', resource });
+      return count;
+    };
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const updateMany = (this.client.data as any).updateMany;
     if (typeof updateMany === 'function') {
@@ -800,10 +845,10 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         // The server returns BatchUpdateResponse { succeeded, failed, ... };
         // fall back to ids.length on adapters that return a bare array.
         if (res && typeof res === 'object' && typeof (res as any).succeeded === 'number') {
-          return (res as any).succeeded as number;
+          return emitBulk((res as any).succeeded as number);
         }
-        if (Array.isArray(res)) return (res as any[]).length;
-        return ids.length;
+        if (Array.isArray(res)) return emitBulk((res as any[]).length);
+        return emitBulk(ids.length);
       } catch (err) {
         throw normaliseClientError(err);
       }
@@ -819,7 +864,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         // continueOnError semantics — swallow per-row errors
       }
     }
-    return succeeded;
+    return emitBulk(succeeded);
   }
 
   /**
@@ -837,17 +882,23 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     if (!ids || ids.length === 0) return 0;
     const strIds = ids.map((id) => String(id));
 
+    // Notify subscribers once for the whole batch (see bulkUpdate).
+    const emitBulk = (count: number): number => {
+      if (count > 0) this.emitMutation({ type: 'delete', resource });
+      return count;
+    };
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const deleteMany = (this.client.data as any).deleteMany;
     if (typeof deleteMany === 'function') {
       try {
         const res = await deleteMany(resource, strIds, { continueOnError: true });
         if (res && typeof res === 'object' && typeof (res as any).succeeded === 'number') {
-          return (res as any).succeeded as number;
+          return emitBulk((res as any).succeeded as number);
         }
-        if (Array.isArray(res)) return (res as any[]).length;
+        if (Array.isArray(res)) return emitBulk((res as any[]).length);
         // deleteMany historically returns void on success — assume all hit.
-        return strIds.length;
+        return emitBulk(strIds.length);
       } catch (err) {
         throw normaliseClientError(err);
       }
@@ -863,7 +914,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         // continueOnError semantics — swallow per-row errors
       }
     }
-    return succeeded;
+    return emitBulk(succeeded);
   }
 
   /**

--- a/packages/data-objectstack/src/onMutation.test.ts
+++ b/packages/data-objectstack/src/onMutation.test.ts
@@ -1,0 +1,125 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: ObjectStackAdapter must implement `onMutation` and emit an event
+ * after every successful create/update/delete (and bulk variant).
+ *
+ * Real-world symptom (framework app-showcase): inline-edit a grid cell, click
+ * "全部保存" (Save All) — the write persisted but the list did NOT auto-refresh.
+ * ListView auto-refreshes by subscribing to `dataSource.onMutation`; the
+ * ObjectStack adapter never implemented it, so the per-row `update` writes
+ * issued by ObjectGrid's default batch-save were silent and the grid kept
+ * showing stale rows until a manual reload.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackAdapter } from './index';
+import type { MutationEvent } from '@object-ui/types';
+
+function makeDS(stub: Record<string, any>) {
+  const ds: any = new ObjectStackAdapter({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () => {
+      const body = { success: true, data: { capabilities: {}, routes: {} } };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  });
+  ds.connected = true;
+  ds.connectionState = 'connected';
+  ds.client = { data: stub };
+  return ds;
+}
+
+describe('ObjectStackAdapter.onMutation', () => {
+  it('emits an update event after a successful update (the inline-edit save path)', async () => {
+    const update = vi
+      .fn()
+      .mockResolvedValue({ record: { id: 'r1', account: 'acc-1' } });
+    const ds = makeDS({ update });
+
+    const events: MutationEvent[] = [];
+    const unsub = ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.update('showcase_project', 'r1', { account: 'acc-1' });
+
+    expect(events).toEqual([
+      { type: 'update', resource: 'showcase_project', id: 'r1', record: { id: 'r1', account: 'acc-1' } },
+    ]);
+
+    // Unsubscribe stops delivery.
+    unsub();
+    await ds.update('showcase_project', 'r1', { account: 'acc-2' });
+    expect(events).toHaveLength(1);
+  });
+
+  it('emits a create event with the new record', async () => {
+    const create = vi.fn().mockResolvedValue({ record: { id: 'new', name: 'X' } });
+    const ds = makeDS({ create });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.create('showcase_project', { name: 'X' });
+
+    expect(events).toEqual([
+      { type: 'create', resource: 'showcase_project', record: { id: 'new', name: 'X' } },
+    ]);
+  });
+
+  it('emits a delete event only when the server confirms deletion', async () => {
+    const del = vi
+      .fn()
+      .mockResolvedValueOnce({ deleted: true })
+      .mockResolvedValueOnce({ deleted: false });
+    const ds = makeDS({ delete: del });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.delete('showcase_project', 'r1');
+    await ds.delete('showcase_project', 'r2');
+
+    expect(events).toEqual([
+      { type: 'delete', resource: 'showcase_project', id: 'r1' },
+    ]);
+  });
+
+  it('emits a single bulk event per bulkUpdate call (not per id)', async () => {
+    const updateMany = vi.fn().mockResolvedValue({ succeeded: 3, failed: 0, results: [] });
+    const ds = makeDS({ updateMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.bulkUpdate('showcase_project', ['a', 'b', 'c'], { archived: true });
+
+    expect(events).toEqual([{ type: 'update', resource: 'showcase_project' }]);
+  });
+
+  it('does not emit when a bulk operation affected zero rows', async () => {
+    const updateMany = vi.fn().mockResolvedValue({ succeeded: 0, failed: 0, results: [] });
+    const ds = makeDS({ updateMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.bulkUpdate('showcase_project', ['a'], { archived: true });
+
+    expect(events).toEqual([]);
+  });
+
+  it('isolates a throwing listener so the mutation still resolves and others fire', async () => {
+    const update = vi.fn().mockResolvedValue({ record: { id: 'r1' } });
+    const ds = makeDS({ update });
+    const good = vi.fn();
+    ds.onMutation(() => { throw new Error('boom'); });
+    ds.onMutation(good);
+
+    await expect(ds.update('showcase_project', 'r1', { x: 1 })).resolves.toBeTruthy();
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fields/src/__tests__/lookupCellReferenceKey.test.tsx
+++ b/packages/fields/src/__tests__/lookupCellReferenceKey.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Regression: LookupCellRenderer must resolve a bare foreign-key id to a
+ * display name when the field metadata carries the ObjectStack `reference`
+ * key (as produced by `Field.lookup('...')` in @objectstack/spec) — not only
+ * the objectui `reference_to` alias.
+ *
+ * Real-world symptom (framework app-showcase): inline-edit a lookup cell, pick
+ * a record, click another row → the cell showed a muted "—" forever because
+ * the just-picked opaque id could not be resolved. Every other reader in the
+ * codebase (LookupField, UserField, DetailSection, RelatedList, …) already
+ * accepts `reference_to || reference`; this read cell used to read only
+ * `reference_to`.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { LookupCellRenderer } from '../index';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+// A ULID-style id: `isLikelyOpaqueId` returns true for it, so the OLD code
+// (which failed to resolve) would fall back to the muted "—" placeholder.
+const OPAQUE_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+
+function makeDataSource() {
+  const findOne = vi.fn(async (object: string, id: string) => {
+    if (object === 'showcase_account' && id === OPAQUE_ID) {
+      return { id, name: 'Globex' };
+    }
+    return null;
+  });
+  return { findOne, find: vi.fn() } as any;
+}
+
+describe('LookupCellRenderer — reference key resolution', () => {
+  it('resolves an opaque id to a name via the `reference` key (not just reference_to)', async () => {
+    const ds = makeDataSource();
+    render(
+      <SchemaRendererProvider dataSource={ds}>
+        <LookupCellRenderer
+          value={OPAQUE_ID}
+          // ObjectStack convention: the lookup target lives under `reference`.
+          field={{ type: 'lookup', reference: 'showcase_account' } as any}
+        />
+      </SchemaRendererProvider>,
+    );
+
+    // The related record's display name must appear…
+    await waitFor(() => {
+      expect(screen.getByText('Globex')).toBeInTheDocument();
+    });
+    // …and the muted placeholder must NOT be what the user sees.
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+    expect(ds.findOne).toHaveBeenCalledWith('showcase_account', OPAQUE_ID);
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1163,7 +1163,14 @@ export function ImageCellRenderer({ value }: CellRendererProps): React.ReactElem
  *    Falls back to a muted placeholder while pending and on failure.
  */
 export function LookupCellRenderer({ value, field }: CellRendererProps): React.ReactElement {
-  const referenceTo = (field as { reference_to?: string }).reference_to;
+  // ObjectStack object metadata uses `reference` for the lookup target while the
+  // objectui types call it `reference_to`. Every other reader (LookupField,
+  // UserField, DetailSection, RelatedList, …) accepts both; this read cell must
+  // too, or a picked/opaque id never resolves to a name and the cell shows the
+  // muted "—" placeholder forever (e.g. after inline-editing a lookup).
+  const referenceTo =
+    (field as { reference_to?: string }).reference_to ||
+    (field as { reference?: string }).reference;
 
   // Pick the FIRST primitive id we see (for arrays, only the first one is auto-resolved
   // to keep the cell cheap; multi-value lookups should generally be expanded server-side).

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -605,6 +605,18 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
 
   const handleSelect = useCallback(
     (option: LookupOption) => {
+      // Cache the picked option so its label resolves synchronously and durably,
+      // independent of the popover's `fetchedOptions` (which the editor may have
+      // remounted away, or which a slow/contended re-render hasn't surfaced yet —
+      // the intermittent CI failure where a just-picked lookup showed no label,
+      // #2150). `selectedOptions` consults `pickerResolvedRecords` in `findOption`.
+      if (option && option.value != null) {
+        setPickerResolvedRecords((prev) => {
+          const map = new Map(prev.map((o) => [o.value, o]));
+          map.set(option.value, option);
+          return Array.from(map.values());
+        });
+      }
       if (multiple) {
         // Normalise any expanded-reference objects to bare ids so toggling
         // compares like-for-like and always persists ids (never mixed shapes).

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1491,7 +1491,13 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
           canDelete={canDelete}
           onEdit={onEdit}
           onDelete={onDelete}
-          onAction={(action, r) => executeAction({ type: action, params: { record: r } })}
+          onAction={(action, r) => {
+            void executeAction({ type: action, params: { record: r } }).then(res => {
+              // A successful row action typically mutated this record; refresh
+              // so the grid reflects the server state (same rationale as bulk).
+              if (res?.success) setRefreshKey(k => k + 1);
+            });
+          }}
           onActionDef={(def, r) => {
             // Dispatch schema-driven row action through the runner. We forward
             // the full action def so type/target/recordIdParam/bodyShape/etc.
@@ -1504,7 +1510,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
               dispatch.actionParams = rawParams;
             }
             dispatch.params = { _rowRecord: r };
-            executeAction(dispatch);
+            void executeAction(dispatch).then(res => {
+              if (res?.success) setRefreshKey(k => k + 1);
+            });
           }}
         />
       ),
@@ -1626,7 +1634,17 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
         setSelectAllMatching(false);
         return;
       }
-      executeAction({ type: action, params: { records: expanded } });
+      // A string bulk action (e.g. 下推 / 派工) mutated the selected records,
+      // usually through a custom API that never touches dataSource.update — so
+      // nothing else signals the grid to refetch. On success, reset the
+      // selection toolbar and refresh so the list reflects the server state
+      // (mirrors the delete branch and handleBulkDialogClose).
+      const res = await executeAction({ type: action, params: { records: expanded } });
+      if (res?.success) {
+        setSelectedRows([]);
+        setSelectAllMatching(false);
+        setRefreshKey(k => k + 1);
+      }
     })();
   };
 

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -196,6 +196,32 @@ function getDataConfig(schema: ObjectGridSchema): ViewData | null {
 }
 
 /**
+ * Relational field metadata that a lookup / master_detail / user cell needs to
+ * (a) resolve a bare foreign-key id to a display name (LookupCellRenderer →
+ * `field.reference_to`) and (b) drive the inline picker's query (LookupField
+ * reads reference_to/reference, display_field, id_field, description_field,
+ * lookup_filters). These are dropped if we only copy the scalar-display props
+ * (label/currency/precision/…), which is why an inline-edited lookup showed the
+ * raw id after moving to another row. Copy them from the object-schema field
+ * definition onto the built `fieldMeta` for every column-building path.
+ */
+const RELATIONAL_META_KEYS = [
+  'reference_to', 'reference', 'reference_to_field',
+  'display_field', 'id_field', 'description_field',
+  'lookup_filters', 'lookupFilters', 'titleFormat',
+] as const;
+
+function applyRelationalMeta(
+  fieldMeta: Record<string, any>,
+  fieldDef: Record<string, any> | undefined | null,
+): void {
+  if (!fieldDef) return;
+  for (const key of RELATIONAL_META_KEYS) {
+    if (fieldDef[key] !== undefined) fieldMeta[key] = fieldDef[key];
+  }
+}
+
+/**
  * Helper to normalize columns configuration
  * Handles both string[] and ListColumn[] formats
  */
@@ -898,6 +924,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
                 if (objectDefField.format) fieldMeta.format = objectDefField.format;
                 if (objectDefField.options) fieldMeta.options = translateOptions(schema.objectName, col.field, objectDefField.options);
               }
+              // Preserve relational metadata (reference_to, display_field, …) so
+              // lookup cells resolve ids to names and the inline picker can query.
+              applyRelationalMeta(fieldMeta, objectDefField as any);
               // Auto-generate options from data for inferred select without existing options
               if (inferredType === 'select' && !fieldMeta.options) {
                 const uniqueValues = Array.from(new Set(data.map(row => row[col.field]).filter(Boolean)));
@@ -1056,6 +1085,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
             if (fieldDef.format) fieldMeta.format = fieldDef.format;
             if (fieldDef.options) fieldMeta.options = translateOptions(schema.objectName, fieldName, fieldDef.options);
           }
+          // Preserve relational metadata (reference_to, display_field, …) so
+          // lookup cells resolve ids to names and the inline picker can query.
+          applyRelationalMeta(fieldMeta, fieldDef as any);
           // Auto-generate select options from data when no options defined
           if (resolvedType === 'select' && !fieldMeta.options) {
             const uniqueValues = Array.from(new Set(data.map(row => row[fieldName]).filter(Boolean)));
@@ -1131,6 +1163,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
             if (fieldDef.format) fieldMeta.format = fieldDef.format;
             if (fieldDef.options) fieldMeta.options = translateOptions(schema.objectName, fieldName, fieldDef.options);
           }
+          // Preserve relational metadata (reference_to, display_field, …) so
+          // lookup cells resolve ids to names and the inline picker can query.
+          applyRelationalMeta(fieldMeta, fieldDef as any);
           // Auto-generate select options from data when no options defined
           if (resolvedType === 'select' && !fieldMeta.options) {
             const uniqueValues = Array.from(new Set(data.map(row => row[fieldName]).filter(Boolean)));

--- a/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression (#2159): after selecting rows and running a string bulk action
+ * (e.g. 下推 / 派工 declared via `batchActions`), the operation succeeded on the
+ * server but the list never refreshed — it stayed on stale data, and the
+ * selection toolbar was left in place.
+ *
+ * Root cause: `dispatchBulkAction`'s non-delete branch fired `executeAction`
+ * and stopped there — no `refreshKey` bump, no selection reset. Only the
+ * BulkActionDialog (rich def) and delete branches refreshed. This drives the
+ * full path (header checkbox → BulkActionBar → dispatchBulkAction →
+ * ActionRunner custom handler) against an in-memory fake server, so a passing
+ * test means the grid refetches after the action and a failing one pinpoints
+ * the missing refresh.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+const OBJECT = 'os_prod_plan';
+
+// A fake server backed by a mutable store, so a bulk action can mutate records
+// and a subsequent find() returns the new value — exactly like a real backend.
+function makeDataSource() {
+  const store: Record<string, any> = {
+    r1: { id: 'r1', name: 'Plan A', status: 'draft' },
+    r2: { id: 'r2', name: 'Plan B', status: 'draft' },
+  };
+  const find = vi.fn(async () => {
+    const data = Object.values(store).map((r) => ({ ...r }));
+    return { data, total: data.length, hasMore: false, pageSize: 50 };
+  });
+  return {
+    store,
+    find,
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text' },
+        status: { type: 'text' },
+      },
+    }),
+  } as any;
+}
+
+function renderGrid(dataSource: any, handlers: Record<string, any>) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    // String bulk action — the path 下推 / 派工 travels.
+    batchActions: ['approve'],
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'status', label: 'Status' },
+    ],
+    pagination: { pageSize: 50 },
+  };
+  return render(
+    <ActionProvider handlers={handlers}>
+      <ObjectGrid schema={schema} dataSource={dataSource} />
+    </ActionProvider>,
+  );
+}
+
+describe('ObjectGrid — string bulk action refreshes the list on success', () => {
+  it('refetches and clears the selection after a batchAction succeeds', async () => {
+    const ds = makeDataSource();
+    // A custom bulk action that mutates the "server" and reports success.
+    const approve = vi.fn(async () => {
+      Object.values(ds.store).forEach((r: any) => { r.status = 'approved'; });
+      return { success: true };
+    });
+    renderGrid(ds, { approve });
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    // Initial "draft" is on screen; no "approved" yet.
+    expect(screen.getAllByText('draft').length).toBeGreaterThan(0);
+    const findCallsBefore = ds.find.mock.calls.length;
+
+    // Select all rows on the page (header checkbox), then run the bulk action.
+    const headerCheckbox = document.querySelector('thead [role="checkbox"]') as HTMLElement;
+    expect(headerCheckbox).toBeTruthy();
+    fireEvent.click(headerCheckbox);
+
+    const approveBtn = await screen.findByTestId('bulk-action-approve');
+    fireEvent.click(approveBtn);
+
+    // The handler ran against the selected records.
+    await waitFor(() => expect(approve).toHaveBeenCalledTimes(1));
+
+    // The list refetched — the grid reflects the server state (draft → approved).
+    await waitFor(() =>
+      expect(ds.find.mock.calls.length).toBeGreaterThan(findCallsBefore),
+    );
+    await waitFor(() => expect(screen.getAllByText('approved').length).toBeGreaterThan(0));
+
+    // And the selection toolbar reset (no stuck "N selected" bar).
+    await waitFor(() =>
+      expect(screen.queryByTestId('bulk-actions-bar')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('does NOT refresh or clear selection when the bulk action fails', async () => {
+    const ds = makeDataSource();
+    // A failing action must leave the selection intact (so the user can retry)
+    // and must not trigger a phantom refresh.
+    const approve = vi.fn(async () => ({ success: false, error: 'nope' }));
+    renderGrid(ds, { approve });
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    const findCallsBefore = ds.find.mock.calls.length;
+
+    const headerCheckbox = document.querySelector('thead [role="checkbox"]') as HTMLElement;
+    fireEvent.click(headerCheckbox);
+    const approveBtn = await screen.findByTestId('bulk-action-approve');
+    fireEvent.click(approveBtn);
+
+    await waitFor(() => expect(approve).toHaveBeenCalledTimes(1));
+
+    // Give any (unwanted) refetch a chance to fire, then assert none did and the
+    // selection bar is still present.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(ds.find.mock.calls.length).toBe(findCallsBefore);
+    expect(screen.queryByTestId('bulk-actions-bar')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
@@ -50,9 +50,16 @@ function makeDataSource() {
     const data = Object.values(store).map((r) => ({ ...r }));
     return { data, total: data.length, hasMore: false, pageSize: 50 };
   });
+  // Per-row update primitive — the exact surface the rich-def executor
+  // (useBulkExecutor, operation:'update') mutates through, per record.
+  const update = vi.fn(async (_resource: string, id: string, patch: Record<string, any>) => {
+    if (store[id]) Object.assign(store[id], patch);
+    return { ...store[id] };
+  });
   return {
     store,
     find,
+    update,
     getObjectSchema: async (name: string) => ({
       name,
       fields: {
@@ -143,5 +150,78 @@ describe('ObjectGrid — string bulk action refreshes the list on success', () =
     await new Promise((r) => setTimeout(r, 50));
     expect(ds.find.mock.calls.length).toBe(findCallsBefore);
     expect(screen.queryByTestId('bulk-actions-bar')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Rich `bulkActionDefs` path — the mechanism the os-tianshun-ehr 排班计划 grid
+ * actually uses for 下推 / 派工: `operation: 'update'`, `patch: { <trigger>: true }`,
+ * `batchSize: 1` (per-row so each record independently trips its Hooks). This
+ * travels bar → dispatchBulkActionDef → BulkActionDialog → useBulkExecutor
+ * (dataSource.update per row) → onClose(result) → handleBulkDialogClose. This
+ * refresh has existed since rich defs were introduced; the test guards it so the
+ * production path never silently regresses to the string-path bug (#2159).
+ */
+function renderGridWithDefs(dataSource: any) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    // Mirrors production: update + trigger patch, batchSize 1 → per-row execution.
+    bulkActionDefs: [
+      {
+        name: 'push_plan_bulk',
+        label: '下推',
+        operation: 'update',
+        patch: { status: 'pushed' },
+        batchSize: 1,
+        confirmText: '确认下推勾选的计划吗？',
+      },
+    ],
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'status', label: 'Status' },
+    ],
+    pagination: { pageSize: 50 },
+  };
+  return render(
+    <ActionProvider handlers={{}}>
+      <ObjectGrid schema={schema} dataSource={dataSource} />
+    </ActionProvider>,
+  );
+}
+
+describe('ObjectGrid — rich bulk action def (operation:update) refreshes the list', () => {
+  it('runs the def through the dialog, updates each row, and refetches on Done', async () => {
+    const ds = makeDataSource();
+    renderGridWithDefs(ds);
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    expect(screen.getAllByText('draft').length).toBeGreaterThan(0);
+    const findCallsBefore = ds.find.mock.calls.length;
+
+    // Select all rows, then open the rich-def dialog from the bar.
+    const headerCheckbox = document.querySelector('thead [role="checkbox"]') as HTMLElement;
+    expect(headerCheckbox).toBeTruthy();
+    fireEvent.click(headerCheckbox);
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_plan_bulk'));
+
+    // Confirm step (no params) → Run, then the executor mutates each row.
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(ds.update).toHaveBeenCalledTimes(2));
+
+    // Result step → Done closes the dialog with a truthy result → refresh.
+    fireEvent.click(await screen.findByRole('button', { name: 'Done' }));
+
+    // The list refetched and reflects the server state (draft → pushed).
+    await waitFor(() =>
+      expect(ds.find.mock.calls.length).toBeGreaterThan(findCallsBefore),
+    );
+    await waitFor(() => expect(screen.getAllByText('pushed').length).toBeGreaterThan(0));
+
+    // And the selection toolbar reset.
+    await waitFor(() =>
+      expect(screen.queryByTestId('bulk-actions-bar')).not.toBeInTheDocument(),
+    );
   });
 });

--- a/packages/plugin-grid/src/__tests__/inlineEditLookupRepro.test.tsx
+++ b/packages/plugin-grid/src/__tests__/inlineEditLookupRepro.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Repro: inline-edit a LOOKUP cell, pick a value, then click ANOTHER row.
+ * Reported bug: the just-picked value is lost when moving to another row.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+  if (!(Element.prototype as any).hasPointerCapture) {
+    (Element.prototype as any).hasPointerCapture = () => false;
+  }
+  if (!(Element.prototype as any).setPointerCapture) {
+    (Element.prototype as any).setPointerCapture = () => {};
+  }
+  if (!(Element.prototype as any).releasePointerCapture) {
+    (Element.prototype as any).releasePointerCapture = () => {};
+  }
+});
+
+const OBJECT = 'os_prod_report';
+
+function makeDataSource() {
+  const store: Record<string, any> = {
+    r1: { id: 'r1', name: '塔筒 T1' },
+    r2: { id: 'r2', name: '塔筒 T2' },
+  };
+  const users: Record<string, any> = {
+    u1: { id: 'u1', name: 'Dev Admin' },
+    u2: { id: 'u2', name: '班组长-测' },
+  };
+  const find = vi.fn(async (object: string) => {
+    if (object === 'users') {
+      const data = Object.values(users).map((r) => ({ ...r }));
+      return { data, total: data.length, hasMore: false, pageSize: 50 };
+    }
+    const data = Object.values(store).map((r) => ({ ...r }));
+    return { data, total: data.length, hasMore: false, pageSize: 50 };
+  });
+  const findOne = vi.fn(async (object: string, id: string) => {
+    if (object === 'users') return users[id] ? { ...users[id] } : null;
+    return store[id] ? { ...store[id] } : null;
+  });
+  const update = vi.fn(async (_o: string, id: string, changes: Record<string, any>) => {
+    store[id] = { ...store[id], ...changes };
+    return { ...store[id] };
+  });
+  return {
+    store,
+    find,
+    findOne,
+    update,
+    getObjectSchema: async (name: string) => {
+      if (name === 'users') {
+        return { name, fields: { id: { type: 'text' }, name: { type: 'text' } } };
+      }
+      return {
+        name,
+        fields: {
+          id: { type: 'text' },
+          name: { type: 'text' },
+          manager: { type: 'lookup', label: '管理责任人', reference_to: 'users' },
+        },
+      };
+    },
+  } as any;
+}
+
+function renderGrid(dataSource: any) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    editable: true,
+    singleClickEdit: true,
+    columns: [
+      { field: 'name', label: '作业对象', editable: false },
+      { field: 'manager', label: '管理责任人', type: 'lookup' },
+    ],
+    pagination: { pageSize: 50 },
+  };
+  return render(
+    <ActionProvider>
+      <SchemaRendererProvider dataSource={dataSource}>
+        <ObjectGrid schema={schema} dataSource={dataSource} />
+      </SchemaRendererProvider>
+    </ActionProvider>,
+  );
+}
+
+describe('ObjectGrid — lookup inline edit survives clicking another row', () => {
+  it('keeps the picked lookup value after clicking another row', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('塔筒 T1')).toBeInTheDocument());
+
+    const rows = () => Array.from(container.querySelectorAll('tbody tr')) as HTMLElement[];
+    const managerCellOf = (row: HTMLElement) => {
+      const tds = Array.from(row.querySelectorAll('td'));
+      // columns: [rownum] name, manager  -> manager is the last data col
+      return tds[tds.length - 1] as HTMLElement;
+    };
+
+    // Enter edit mode on row1's manager cell.
+    fireEvent.click(managerCellOf(rows()[0]));
+
+    // The lookup trigger button should appear inside the cell; open the popover.
+    const trigger = await waitFor(() => {
+      const btn = managerCellOf(rows()[0]).querySelector('button');
+      expect(btn).toBeTruthy();
+      return btn as HTMLButtonElement;
+    });
+    fireEvent.click(trigger);
+
+    // Pick "Dev Admin" from the popover options (fetched from `users`).
+    const option = await waitFor(() => {
+      const el = screen.getByText('Dev Admin');
+      expect(el).toBeInTheDocument();
+      return el;
+    });
+    fireEvent.click(option);
+
+    // The staged value shows in row1's manager cell.
+    await waitFor(() => {
+      expect(within(managerCellOf(rows()[0])).getByText('Dev Admin')).toBeInTheDocument();
+    });
+
+    // Now click ANOTHER row's manager cell.
+    fireEvent.click(managerCellOf(rows()[1]));
+
+    // BUG: row1's picked value must still be present.
+    await waitFor(() => {
+      expect(within(managerCellOf(rows()[0])).queryByText('Dev Admin')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -499,17 +499,22 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   }), []);
 
   // --- P2: Auto-subscribe to DataSource mutation events ---
-  // When an external refreshTrigger is provided, rely on that instead of
-  // subscribing to dataSource mutations to avoid double refreshes.
+  // Refetch whenever the bound object is mutated through the DataSource. This
+  // is the ONLY refresh signal for inline-edit "Save All": ObjectGrid persists
+  // those edits by calling dataSource.update() directly, with no form-success
+  // handler to bump an external refreshTrigger — so subscribing even when
+  // `refreshTrigger` is provided is required, not redundant. Form/delete flows
+  // also bump refreshTrigger; the extra refetch that produces is harmless
+  // because find() coalesces concurrent identical reads into one round-trip.
   React.useEffect(() => {
-    if (!dataSource?.onMutation || !schema.objectName || schema.refreshTrigger) return;
+    if (!dataSource?.onMutation || !schema.objectName) return;
     const unsub = dataSource.onMutation((event: any) => {
       if (event.resource === schema.objectName) {
         setRefreshKey(k => k + 1);
       }
     });
     return unsub;
-  }, [dataSource, schema.objectName, schema.refreshTrigger]);
+  }, [dataSource, schema.objectName]);
 
   // Dynamic page size state (wired from pageSizeOptions selector)
   const [dynamicPageSize, setDynamicPageSize] = React.useState<number | undefined>(undefined);
@@ -1471,7 +1476,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         };
       }
     }
-  }, [currentView, schema, currentSort, effectiveFields, groupingConfig, rowColorConfig, navigation.handleClick, density.mode, galleryCardSize]);
+  }, [currentView, schema, currentSort, effectiveFields, groupingConfig, rowColorConfig, navigation.handleClick, density.mode, galleryCardSize, inlineEdit]);
 
   const hasFilters = currentFilters.conditions && currentFilters.conditions.length > 0;
 

--- a/packages/plugin-list/src/__tests__/ListView.mutationRefresh.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.mutationRefresh.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: ListView must refetch on `dataSource.onMutation` events EVEN when
+ * an external `refreshTrigger` is provided.
+ *
+ * Real-world symptom (framework app-showcase): inline-edit a grid cell, click
+ * "全部保存" (Save All) — the write persisted but the list did not auto-refresh.
+ * ObjectView drives the grid with `refreshTrigger`, which is bumped by
+ * form-success / delete handlers but NOT by inline-edit saves (ObjectGrid
+ * writes those straight through `dataSource.update`). The only signal for that
+ * path is `onMutation`; ListView used to skip subscribing whenever a
+ * refreshTrigger was present, so inline edits never repainted.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ListView } from '../ListView';
+import type { ListViewSchema } from '@object-ui/types';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: (() => {
+      let store: Record<string, string> = {};
+      return {
+        getItem: (k: string) => store[k] ?? null,
+        setItem: (k: string, v: string) => { store[k] = v; },
+        clear: () => { store = {}; },
+        removeItem: (k: string) => { delete store[k]; },
+      };
+    })(),
+    configurable: true,
+  });
+});
+
+function makeDataSource() {
+  let listeners: Array<(e: any) => void> = [];
+  const find = vi.fn().mockResolvedValue({ data: [], total: 0 });
+  return {
+    find,
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    onMutation: (cb: (e: any) => void) => {
+      listeners.push(cb);
+      return () => { listeners = listeners.filter((l) => l !== cb); };
+    },
+    // test helper to fire an event
+    __emit: (e: any) => listeners.forEach((l) => l(e)),
+  } as any;
+}
+
+describe('ListView — refetch on onMutation with an external refreshTrigger', () => {
+  it('refetches when the bound object is mutated even though refreshTrigger is set', async () => {
+    const ds = makeDataSource();
+    const schema: ListViewSchema = {
+      type: 'list-view',
+      objectName: 'showcase_project',
+      // ObjectView always passes this for grid-driven views; it used to disable
+      // the onMutation subscription.
+      refreshTrigger: 0,
+      fields: ['name'],
+    } as any;
+
+    render(
+      <SchemaRendererProvider dataSource={ds}>
+        <ListView schema={schema} dataSource={ds} />
+      </SchemaRendererProvider>,
+    );
+
+    // Initial fetch(es) settle.
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    const callsBefore = ds.find.mock.calls.length;
+
+    // Simulate an inline-edit save landing on the SAME object.
+    ds.__emit({ type: 'update', resource: 'showcase_project', id: 'r1' });
+
+    await waitFor(() => {
+      expect(ds.find.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+
+  it('ignores mutations on a different object', async () => {
+    const ds = makeDataSource();
+    const schema: ListViewSchema = {
+      type: 'list-view',
+      objectName: 'showcase_project',
+      refreshTrigger: 0,
+      fields: ['name'],
+    } as any;
+
+    render(
+      <SchemaRendererProvider dataSource={ds}>
+        <ListView schema={schema} dataSource={ds} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    const callsBefore = ds.find.mock.calls.length;
+
+    ds.__emit({ type: 'update', resource: 'some_other_object', id: 'x' });
+
+    // Give any (unwanted) refetch a chance to fire, then assert none did.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(ds.find.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -2365,3 +2365,65 @@ describe('ListView — viewType normalization (AI-authored views)', () => {
     expect(screen.queryByText(/Unknown component type/i)).not.toBeInTheDocument();
   });
 });
+
+describe('ListView — inline-edit toggle drives grid editability', () => {
+  // Regression: clicking 行内编辑 flipped the toggle's own highlight but the grid
+  // did NOT enter edit mode. The grid schema is built in a useMemo that embeds
+  // `editable: inlineEdit`, but `inlineEdit` was missing from the memo's deps —
+  // so the emitted `editable` stayed stale until some *other* dep changed (a data
+  // refetch), lagging the toggle by one interaction. The spy grid below records
+  // the `editable` prop it is rendered with on each toggle.
+  let prevObjectGrid: ReturnType<typeof ComponentRegistry.get>;
+  let editableCalls: Array<boolean | undefined>;
+
+  beforeAll(() => {
+    prevObjectGrid = ComponentRegistry.get('object-grid');
+    ComponentRegistry.register('object-grid', (props: any) => {
+      editableCalls.push(props.editable);
+      return <div data-testid="grid-editable">{String(!!props.editable)}</div>;
+    });
+  });
+  afterAll(() => {
+    if (prevObjectGrid) {
+      ComponentRegistry.register('object-grid', prevObjectGrid);
+    } else {
+      ComponentRegistry.unregister('object-grid');
+    }
+  });
+  beforeEach(() => {
+    editableCalls = [];
+  });
+
+  it('toggling 行内编辑 immediately propagates editable to the grid (no one-toggle lag)', async () => {
+    mockDataSource.find.mockResolvedValue([
+      { id: '1', name: 'Alice', email: 'alice@test.com' },
+    ]);
+    const onInlineEditChange = vi.fn();
+    const schema: ListViewSchema = {
+      type: 'list-view',
+      objectName: 'contacts',
+      viewType: 'grid',
+      fields: ['name', 'email'],
+    };
+
+    renderWithProvider(
+      <ListView schema={schema} dataSource={mockDataSource} onInlineEditChange={onInlineEditChange} />,
+    );
+
+    // Starts non-editable (wait for the initial data fetch to paint the grid).
+    expect(await screen.findByTestId('grid-editable')).toHaveTextContent('false');
+
+    // One click on the toggle must make the grid editable on the SAME interaction.
+    fireEvent.click(screen.getByTestId('toolbar-inline-edit-toggle'));
+
+    expect(onInlineEditChange).toHaveBeenCalledWith(true);
+    expect(screen.getByTestId('grid-editable')).toHaveTextContent('true');
+    // The last schema the grid received must carry editable:true.
+    expect(editableCalls.at(-1)).toBe(true);
+
+    // Toggling back off must return to non-editable, again on the same click.
+    fireEvent.click(screen.getByTestId('toolbar-inline-edit-toggle'));
+    expect(screen.getByTestId('grid-editable')).toHaveTextContent('false');
+    expect(editableCalls.at(-1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 问题

在 showcase(`showcase_project` 的 Projects 表格,`account` lookup 列)实测发现两个行内编辑的 bug:

### Bug A — 点了「行内编辑」列表不进编辑模式
切换「行内编辑」后需要再点一次才真正生效。`ListView` 里生成 grid schema 的 `useMemo`(设置 `editable: inlineEdit`)漏了 `inlineEdit` 依赖,导致切换那一下用的是旧值,慢一拍。

**修复**:把 `inlineEdit` 加入依赖数组,切换同一次交互即生效。

### Bug B — 编辑 lookup 后点「全部保存」,单元格卡在搜索框
行内编辑一个 lookup 单元格并点「全部保存」后,格子仍卡着显示 picker 组件,而不是解析后的展示值。关系型编辑器(lookup/master_detail/user/owner)会 `stage` 值并**故意保持编辑器打开**;而 `saveRow`/`saveBatch` 只清了 `pendingChanges`,从没清 `editingCell`,所以保存后的格子一直没退回展示态。

**修复**:行/批保存后关闭任何仍打开的编辑器。

### 附带
- `ListView` 即使有外部 `refreshTrigger` 也订阅 `dataSource.onMutation` 刷新(行内编辑保存走 `dataSource.update`,只通过 `onMutation` 发信号)。
- lookup 单元格正确推导 reference key。

## 验证
- 两个 bug 均在 framework showcase 实测修复通过(单击切换即进编辑;保存后编辑器关闭、显示解析值 `Globex`)。
- 回归测试:`data-table-inline-edit`(E)、`ListView` toggle / `ListView.mutationRefresh`、`onMutation`、`lookupCellReferenceKey`。
- 每个修复都验证过「去掉修复即失败」。typecheck 干净,相关测试套件全绿。