### PR TITLE
fix(studio): stamp packageId on draft saves → true package-scoped publish

### DIFF
--- a/.changeset/studio-draft-packageid.md
+++ b/.changeset/studio-draft-packageid.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(studio): stamp packageId on pillar draft saves → true package-scoped publish
+
+Studio pillar draft-saves now pass the active `packageId`, so each draft row is
+stamped with its package binding (`sys_metadata.package_id`) instead of `null`.
+This makes the package-scoped surfaces reliable: the top-bar count + Changes review
+filter via `GET /meta/_drafts?packageId=`, and Publish promotes exactly this
+package's drafts via `POST /packages/:id/publish-drafts` (which matches
+`WHERE package_id = X`). Replaces the previous "publish all pending" fallback that
+was only needed because null-package drafts couldn't be package-filtered or picked
+up by publish-drafts.

--- a/packages/app-shell/src/preview/DraftChangesPanel.tsx
+++ b/packages/app-shell/src/preview/DraftChangesPanel.tsx
@@ -39,8 +39,9 @@ export interface DraftChangeEntry {
 }
 
 /** Pending drafts straight from the ADR-0033 `_drafts` endpoint. */
-async function listPendingDrafts(): Promise<DraftChangeEntry[]> {
-  const res = await fetch('/api/v1/meta/_drafts', {
+async function listPendingDrafts(packageId?: string | null): Promise<DraftChangeEntry[]> {
+  const qs = packageId ? `?packageId=${encodeURIComponent(packageId)}` : '';
+  const res = await fetch(`/api/v1/meta/_drafts${qs}`, {
     credentials: 'include',
     headers: { Accept: 'application/json' },
     cache: 'no-store',
@@ -85,9 +86,11 @@ async function publishedNamesOf(type: string): Promise<Set<string>> {
 export interface DraftChangesPanelProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** When set, list only pending drafts belonging to this package (Studio is package-scoped). */
+  packageId?: string | null;
 }
 
-export function DraftChangesPanel({ open, onOpenChange }: DraftChangesPanelProps) {
+export function DraftChangesPanel({ open, onOpenChange, packageId }: DraftChangesPanelProps) {
   const { t } = useObjectTranslation();
   const [entries, setEntries] = useState<DraftChangeEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -96,7 +99,7 @@ export function DraftChangesPanel({ open, onOpenChange }: DraftChangesPanelProps
     setEntries(null);
     setError(null);
     try {
-      const drafts = await listPendingDrafts();
+      const drafts = await listPendingDrafts(packageId);
       setEntries(drafts);
       // Classify new-vs-update per TYPE: one published-list read covers every
       // draft of that type. A type whose read fails stays unclassified
@@ -124,7 +127,7 @@ export function DraftChangesPanel({ open, onOpenChange }: DraftChangesPanelProps
     } catch (e) {
       setError((e as Error).message);
     }
-  }, []);
+  }, [packageId]);
 
   useEffect(() => {
     if (open) void load();

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -51,8 +51,7 @@ import { AppNavCanvas } from '../metadata-admin/previews/AppNavCanvas';
 import { readFields, writeFields, newField } from '../metadata-admin/previews/object-fields-io';
 import { ObjectFormDesigner } from './ObjectFormDesigner';
 import { DraftChangesPanel } from '../../preview/DraftChangesPanel';
-import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
-import { useObjectTranslation } from '@object-ui/i18n';
+import { toast } from 'sonner';
 
 const PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> = [
   { key: 'data', label: 'Data', Icon: Database },
@@ -140,24 +139,20 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   const packageId = params.packageId ?? 'com.example.showcase';
   const tab = params.tab ?? 'interfaces';
 
-  // Package-level publish (ADR-0033/0037): edits accumulate as per-item drafts;
-  // publishing is ONE governed pass over ALL pending drafts — the same path the
-  // Home banner / draft-preview bar use (usePublishAllDrafts → per-package
-  // publish-drafts with structure-before-seeds + L3 probes, and by-reference for
-  // orphan/null-package drafts). Reviewed as a whole in DraftChangesPanel; there
-  // is no per-item publish. (Drafts carry no reliable packageId — the flow overlay
-  // reports null — so we count/publish ALL pending, which in the single-package
-  // Studio is exactly this app's build.)
-  const { t } = useObjectTranslation();
-  const { publishAll, publishing } = usePublishAllDrafts(t);
+  // Package-level publish (ADR-0033/0037/0048): edits accumulate as per-item
+  // drafts STAMPED with this package (each save passes packageId → the draft row's
+  // sys_metadata.package_id). Publishing promotes exactly THIS package's drafts in
+  // one atomic pass (POST /packages/:id/publish-drafts), reviewed as a whole in
+  // DraftChangesPanel. There is no per-item publish.
   const [changesOpen, setChangesOpen] = React.useState(false);
   const [pendingCount, setPendingCount] = React.useState<number | null>(null);
+  const [publishing, setPublishing] = React.useState(false);
   const [publishNonce, setPublishNonce] = React.useState(0); // ↑ → pillars re-read the published baseline
   const [draftNonce, setDraftNonce] = React.useState(0); // ↑ → refresh the pending-draft count
 
   const refreshPending = React.useCallback(async () => {
     try {
-      const res = await fetch('/api/v1/meta/_drafts', {
+      const res = await fetch(`/api/v1/meta/_drafts?packageId=${encodeURIComponent(packageId)}`, {
         credentials: 'include',
         headers: { Accept: 'application/json' },
         cache: 'no-store',
@@ -169,20 +164,33 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
     } catch {
       setPendingCount(null);
     }
-  }, []);
+  }, [packageId]);
 
   React.useEffect(() => {
     void refreshPending();
   }, [refreshPending, publishNonce, draftNonce]);
 
   const doPublish = React.useCallback(async () => {
-    const r = await publishAll();
-    if (r.ok) {
+    setPublishing(true);
+    try {
+      const res = await fetch(`/api/v1/packages/${encodeURIComponent(packageId)}/publish-drafts`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: '{}',
+      });
+      const payload = (await res.json().catch(() => null)) as { success?: boolean; error?: { message?: string } } | null;
+      if (!res.ok || payload?.success === false) throw new Error(payload?.error?.message || `HTTP ${res.status}`);
+      toast.success('已发布本软件包的全部草稿(一次原子发布)');
       setChangesOpen(false);
       setPublishNonce((n) => n + 1);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPublishing(false);
     }
     await refreshPending();
-  }, [publishAll, refreshPending]);
+  }, [packageId, refreshPending]);
 
   const onDraftSaved = React.useCallback(() => setDraftNonce((n) => n + 1), []);
   const hasPending = (pendingCount ?? 0) > 0;
@@ -249,7 +257,7 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
         </div>
       </div>
 
-      <DraftChangesPanel open={changesOpen} onOpenChange={setChangesOpen} />
+      <DraftChangesPanel open={changesOpen} onOpenChange={setChangesOpen} packageId={packageId} />
     </div>
   );
 }
@@ -439,7 +447,7 @@ function InterfacesPillar({
     if (!current) return;
     setSaving('draft');
     try {
-      await client.save(current.type, current.name, draft, { mode: 'draft' });
+      await client.save(current.type, current.name, draft, { mode: 'draft', packageId });
       setHasDraft(true);
       onDraftSaved?.();
     } catch (e) {
@@ -458,7 +466,7 @@ function InterfacesPillar({
     if (!appName) return;
     setNavSaving('draft');
     try {
-      await client.save('app', appName, appDraft, { mode: 'draft' });
+      await client.save('app', appName, appDraft, { mode: 'draft', packageId });
       setNavHasDraft(true);
       setNavDirty(false);
       onDraftSaved?.();
@@ -845,7 +853,7 @@ function DataPillar({
     setSaving('draft');
     setError(null);
     try {
-      await client.save('object', current.name, objDraft, { mode: 'draft' });
+      await client.save('object', current.name, objDraft, { mode: 'draft', packageId });
       setHasDraft(true);
       setDirty(false);
       onDraftSaved?.();
@@ -876,7 +884,7 @@ function DataPillar({
       setSaving('draft');
       setError(null);
       try {
-        await client.save('object', current.name, body, { mode: 'draft' });
+        await client.save('object', current.name, body, { mode: 'draft', packageId });
         setHasDraft(true);
         setDirty(false);
         onDraftSaved?.();
@@ -1254,7 +1262,7 @@ function AutomationsPillar({
     setSaving('draft');
     setError(null);
     try {
-      await client.save('flow', current.name, draft, { mode: 'draft' });
+      await client.save('flow', current.name, draft, { mode: 'draft', packageId });
       setHasDraft(true);
       onDraftSaved?.();
     } catch (e) {


### PR DESCRIPTION
Follow-up to #2147. Answers the root cause behind that PR's "publish all pending" fallback.

## Root cause

The draft store (ADR-0048) keys overlay rows by `(org, type, name, package_id)`, and the save path stamps `package_id` from the request's `?package=<id>`. The **classic editor** passes it; the **pillar Studio** `doSave` did not — so pillar drafts landed with `package_id = null`. Then `POST /packages/:id/publish-drafts` (which matches `WHERE package_id = X`) silently skipped them, and `_drafts?packageId=` couldn't filter them.

## Fix

Pillar draft-saves now pass the active `packageId` (the pillar already has it) — one option added at all five save sites (`MetadataClient.save` already forwards it as `?package=`). With drafts stamped, the shell switches from the publish-all fallback to **true package scope**:

- count + Changes review → `GET /meta/_drafts?packageId=<id>` (server-filtered)
- Publish → `POST /packages/:id/publish-drafts` (promotes exactly this package's drafts, one pass)

## Verified in-browser (`/studio/com.example.showcase`, flow — object drafts are gated by `OS_METADATA_WRITABLE`)

Before the fix the flow draft reported `packageId: null` and `publish-drafts` left it (before=after=1). After:
- draft now carries `packageId` ✓
- `GET /meta/_drafts?packageId=com.example.showcase` returns it ✓
- `POST /packages/…/publish-drafts` → **after = 0** ✓
- UI: 保存草稿 → **变更 · 1** → 发布 → count 0.

`type-check`: 0 errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)