### PR TITLE
fix(components): dropdown-closing click no longer dismisses the whole modal/drawer

### DIFF
--- a/packages/components/src/__tests__/mobile-dialog-content.test.tsx
+++ b/packages/components/src/__tests__/mobile-dialog-content.test.tsx
@@ -13,8 +13,12 @@
  * leaving a genuine backdrop click (which still closes the dialog) untouched.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
-import { isInsidePopperLayer } from '../custom/mobile-dialog-content';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  isInsidePopperLayer,
+  usePopperAwareInteractOutside,
+} from '../custom/mobile-dialog-content';
 
 function mount(html: string): HTMLElement {
   const host = document.createElement('div');
@@ -51,5 +55,97 @@ describe('isInsidePopperLayer', () => {
   it('is null/undefined safe', () => {
     expect(isInsidePopperLayer(null)).toBe(false);
     expect(isInsidePopperLayer(undefined)).toBe(false);
+  });
+});
+
+/**
+ * usePopperAwareInteractOutside — the deferred-dismissal path (#2156).
+ *
+ * radix-dialog@1.1.17 defers its outside-pointerdown verdict to the `click`
+ * phase, but radix-select dismisses and unregisters on `pointerdown`. The one
+ * click that closes an open dropdown therefore ALSO reads as the dialog's own
+ * outside click and used to dismiss the whole modal. The hook snapshots
+ * "popper open?" on document pointerdown (capture) and swallows the
+ * pointer-initiated interact-outside that follows.
+ */
+describe('usePopperAwareInteractOutside', () => {
+  const pointerInteractOutside = (target: Element) =>
+    ({
+      detail: { originalEvent: { type: 'pointerdown', target } },
+      preventDefault: vi.fn(),
+    }) as any;
+
+  const dispatchPointerDown = () =>
+    document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+  it('swallows the interact-outside when a popper flyout was open at pointerdown', () => {
+    mount('<div data-radix-popper-content-wrapper><div role="listbox"></div></div>');
+    const inner = vi.fn();
+    const { result } = renderHook(() => usePopperAwareInteractOutside(inner));
+
+    dispatchPointerDown();
+    const event = pointerInteractOutside(document.body);
+    result.current(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it('lets a plain backdrop click through when no popper is open', () => {
+    const inner = vi.fn();
+    const { result } = renderHook(() => usePopperAwareInteractOutside(inner));
+
+    dispatchPointerDown();
+    const event = pointerInteractOutside(document.body);
+    result.current(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(inner).toHaveBeenCalledWith(event);
+  });
+
+  it('closes normally on the SECOND click after the dropdown-closing one', () => {
+    const host = mount('<div data-radix-popper-content-wrapper></div>');
+    const inner = vi.fn();
+    const { result } = renderHook(() => usePopperAwareInteractOutside(inner));
+
+    // First click: popper open → swallowed (it closes the dropdown).
+    dispatchPointerDown();
+    const first = pointerInteractOutside(document.body);
+    result.current(first);
+    expect(first.preventDefault).toHaveBeenCalled();
+
+    // Dropdown unmounts; second click must dismiss the dialog again.
+    host.remove();
+    dispatchPointerDown();
+    const second = pointerInteractOutside(document.body);
+    result.current(second);
+    expect(second.preventDefault).not.toHaveBeenCalled();
+    expect(inner).toHaveBeenCalledWith(second);
+  });
+
+  it('still guards a target INSIDE a (possibly detached) popper layer', () => {
+    const host = mount('<div data-radix-popper-content-wrapper><span id="in">x</span></div>');
+    const target = host.querySelector('#in')!;
+    const { result } = renderHook(() => usePopperAwareInteractOutside());
+
+    const event = pointerInteractOutside(target);
+    result.current(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('does not apply the popper flag to focus-driven interact-outside', () => {
+    mount('<div data-radix-popper-content-wrapper></div>');
+    const inner = vi.fn();
+    const { result } = renderHook(() => usePopperAwareInteractOutside(inner));
+
+    dispatchPointerDown();
+    const event = {
+      detail: { originalEvent: { type: 'focusin', target: document.body } },
+      preventDefault: vi.fn(),
+    } as any;
+    result.current(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(inner).toHaveBeenCalledWith(event);
   });
 });

--- a/packages/components/src/custom/mobile-dialog-content.tsx
+++ b/packages/components/src/custom/mobile-dialog-content.tsx
@@ -44,14 +44,47 @@ export function isInsidePopperLayer(target: Element | null | undefined): boolean
   return !!target?.closest?.(POPPER_LAYER_SELECTOR);
 }
 
-export const MobileDialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, onInteractOutside, ...props }, ref) => {
-  const handleInteractOutside = React.useCallback(
-    (event: Parameters<NonNullable<typeof onInteractOutside>>[0]) => {
-      const target = (event.detail?.originalEvent?.target ?? null) as Element | null;
+type InteractOutsideHandler = NonNullable<
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>['onInteractOutside']
+>;
+
+/**
+ * Popper-aware interact-outside guard for Radix Dialog/Sheet content.
+ *
+ * Covers a second dismissal path `isInsidePopperLayer` alone cannot: with a
+ * dropdown OPEN, one outside click must only close the dropdown — but
+ * radix-dialog@1.1.17 defers its outside-pointerdown verdict to the `click`
+ * phase (`deferPointerDownOutside`), while radix-select@2.3.1 dismisses and
+ * unregisters on `pointerdown`. By the deferred verdict the dialog has become
+ * the top layer, so it treats the dropdown-closing click as its own outside
+ * click and dismisses too (#2156).
+ *
+ * The guard snapshots "was a popper flyout open?" on every `pointerdown`
+ * (document capture phase — runs before Radix's bubble-phase dismissal
+ * unmounts the flyout) and swallows the pointer-initiated interact-outside
+ * that follows. Focus-driven interact-outside (Tab out) is untouched, as is a
+ * plain backdrop click with no flyout open.
+ */
+export function usePopperAwareInteractOutside(
+  onInteractOutside?: InteractOutsideHandler,
+): InteractOutsideHandler {
+  const popperOpenAtPointerDownRef = React.useRef(false);
+  React.useEffect(() => {
+    const snapshotPopperState = () => {
+      popperOpenAtPointerDownRef.current = !!document.querySelector(POPPER_LAYER_SELECTOR);
+    };
+    document.addEventListener('pointerdown', snapshotPopperState, true);
+    return () => document.removeEventListener('pointerdown', snapshotPopperState, true);
+  }, []);
+  return React.useCallback(
+    (event: Parameters<InteractOutsideHandler>[0]) => {
+      const originalEvent = event.detail?.originalEvent;
+      const target = (originalEvent?.target ?? null) as Element | null;
       if (isInsidePopperLayer(target)) {
+        event.preventDefault();
+        return;
+      }
+      if (originalEvent?.type === 'pointerdown' && popperOpenAtPointerDownRef.current) {
         event.preventDefault();
         return;
       }
@@ -59,6 +92,13 @@ export const MobileDialogContent = React.forwardRef<
     },
     [onInteractOutside],
   );
+}
+
+export const MobileDialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, onInteractOutside, ...props }, ref) => {
+  const handleInteractOutside = usePopperAwareInteractOutside(onInteractOutside);
   return (
   <DialogPortal>
     <DialogOverlay />

--- a/packages/components/src/custom/navigation-overlay.tsx
+++ b/packages/components/src/custom/navigation-overlay.tsx
@@ -65,6 +65,7 @@ import {
   ResizablePanel,
   ResizableHandle,
 } from '../ui/resizable';
+import { usePopperAwareInteractOutside } from './mobile-dialog-content';
 
 /** Navigation mode type — matches ViewNavigationConfig.mode */
 export type NavigationOverlayMode =
@@ -282,6 +283,9 @@ export const NavigationOverlay: React.FC<NavigationOverlayProps> = ({
   // Keep hooks above all conditional returns. Opening a record changes
   // selectedRecord from null to an object, but hook order must stay stable.
   const resize = useDrawerResize(mode === 'drawer' ? storageKey : undefined);
+  // Inline-edit dropdowns render in body-level poppers; without this guard the
+  // click that closes an open dropdown also dismisses the drawer/modal (#2156).
+  const handleInteractOutside = usePopperAwareInteractOutside();
 
   // Non-overlay modes don't render anything
   if (mode === 'page' || mode === 'new_window' || mode === 'none') {
@@ -320,6 +324,7 @@ export const NavigationOverlay: React.FC<NavigationOverlayProps> = ({
       <Sheet open={isOpen} onOpenChange={setIsOpen}>
         <SheetContent
           side="right"
+          onInteractOutside={handleInteractOutside}
           className={cn(
             // Mobile: full width (no inline cap, no max-w from base sheet).
             // sm+: honor the host-supplied width via `--ov-w` CSS var with a
@@ -405,6 +410,7 @@ export const NavigationOverlay: React.FC<NavigationOverlayProps> = ({
     return (
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogContent
+          onInteractOutside={handleInteractOutside}
           className={cn(
             'w-[calc(100vw-1rem)] max-w-none sm:max-w-[var(--ov-w,42rem)] max-h-[90vh] overflow-y-auto',
             className,


### PR DESCRIPTION
Closes #2156

## 问题

弹窗表单(新建/编辑)中打开下拉字段的选项列表后,不选择而点击其他位置,下拉和整个弹窗会被**同一次点击**一起关闭。

## 根因(实测事件时间线定位)

- `@radix-ui/react-dialog@1.1.17` modal content 传 `deferPointerDownOutside: true`,把 outside-pointerdown 判定推迟到 click 阶段;
- `@radix-ui/react-select@2.3.1` 在 pointerdown 当场 dismiss 并从共享 dismissable-layer 注册表注销;
- 同一次点击:pointerdown → Select 关闭并注销 → Dialog 重渲染后成为最高层 → click 阶段 Dialog 的延迟判定把这次点击当成自己的外部点击 → 弹窗关闭。

## 修复

新增 `usePopperAwareInteractOutside`(components/custom/mobile-dialog-content.tsx):

- document **捕获阶段**监听 pointerdown(先于 Radix 冒泡阶段卸载浮层),快照“按下瞬间是否有 popper 浮层打开”;
- 随后到来的 pointer 型 interact-outside 若命中该快照 → `preventDefault()`(这次点击的职责是关下拉);
- 保留既有 `isInsidePopperLayer` 目标判定;focus 型 interact-outside(Tab 移出)与常规遮罩点击不受影响;第二次点击仍正常关闭弹窗。

接线:`MobileDialogContent`(ModalForm 的新建/编辑弹窗)+ `NavigationOverlay` 的 drawer(Sheet)/modal(Dialog)模式(抽屉内联编辑下拉同病)。

## 验证

- 单测:`mobile-dialog-content.test.tsx` 9 个用例(含 5 个新增:浮层开→吞掉、无浮层→放行、第二次点击→正常关闭、目标在已卸载浮层内、focus 路径不受影响);
- 真实环境(console dev :5180 + hotcrm 后端 :4001,crm_lead 新建弹窗)复现→修复验证:修复前一次外部点击同时关掉下拉+弹窗;修复后第一次只关下拉、弹窗保留,第二次正常关弹窗;报告人手测确认正常;
- `tsc --noEmit` 通过,components 包构建通过。