### PR TITLE
feat(fields): inline combobox for search-first user fields

### DIFF
--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -726,6 +726,36 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   const compact = !!(props as any).compact;
   const singleSelectedLabel = selectedOptions[0]?.label || selectedOptions[0]?.[displayField];
 
+  // Shared field trigger — the anchor for either the inline PeoplePicker
+  // (search fields) or the classic quick-select popover. No onClick: the Radix
+  // trigger it is slotted into (PopoverTrigger / SheetTrigger) owns open/close.
+  const triggerButton = (
+    <Button
+      variant="outline"
+      className={cn(
+        'min-w-0 flex-1 justify-start text-left font-normal',
+        compact && 'h-8 rounded-none border-0 bg-transparent px-2 shadow-none focus-visible:ring-1 focus-visible:ring-ring/60',
+      )}
+      type="button"
+      disabled={dependenciesMissing || (props as any).disabled}
+      data-testid={dependenciesMissing ? 'lookup-trigger-gated' : (((props as any).name || lookupField?.name) ? `lookup-trigger-${(props as any).name || lookupField.name}` : 'lookup-trigger')}
+      title={dependenciesMissing
+        ? t('lookup.selectFirst', { fields: dependsOn.map(d => d.field).join(', ') })
+        : undefined}
+    >
+      <Search className={cn('size-4 shrink-0 text-muted-foreground', compact ? 'mr-1.5' : 'mr-2')} />
+      <span className={cn('truncate', compact && selectedOptions.length === 0 && 'text-muted-foreground')}>
+        {dependenciesMissing
+          ? t('lookup.selectFirst', { fields: dependsOn.map(d => d.field).join(', ') })
+          : compact && !multiple && selectedOptions.length > 0
+            ? singleSelectedLabel
+            : selectedOptions.length === 0
+              ? lookupField?.placeholder || t('common.select')
+              : multiple ? t('table.selected', { count: selectedOptions.length }) : t('common.select')}
+      </span>
+    </Button>
+  );
+
   return (
     <div className={compact ? '' : 'space-y-2'}>
       {/* Selected values display (full mode only — compact shows it in-trigger) */}
@@ -778,46 +808,38 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
         </div>
       )}
 
-      {/* Level 1: Quick-select Popover (inline typeahead) */}
+      {/* Field control: search-first inline combobox (anchored dropdown / mobile
+          sheet), else the classic quick-select popover. */}
+      {pickerVariant === 'search' && hasDataSource && dataSource && referenceTo ? (
+        <PeoplePicker
+          inline
+          trigger={triggerButton}
+          open={isPickerOpen}
+          onOpenChange={setIsPickerOpen}
+          title={lookupField?.label || t('common.select')}
+          multiple={multiple}
+          dataSource={dataSource}
+          objectName={referenceTo}
+          displayField={displayField}
+          idField={idField}
+          subtitleFields={subtitleFields}
+          avatarField={avatarField}
+          pageSize={lookupPageSize}
+          value={value}
+          onSelect={onChange}
+          onSelectRecords={handlePickerSelectRecords}
+          lookupFilters={lookupFilters}
+        />
+      ) : (
       <div className="flex items-center gap-1.5">
       <Popover
-        open={pickerVariant === 'search' ? false : isOpen}
+        open={isOpen}
         onOpenChange={(o) => {
-          // Search-first fields open the PeoplePicker instead of this popover.
-          if (pickerVariant === 'search') return;
           if (!dependenciesMissing) setIsOpen(o);
         }}
       >
         <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            className={cn(
-              'min-w-0 flex-1 justify-start text-left font-normal',
-              compact && 'h-8 rounded-none border-0 bg-transparent px-2 shadow-none focus-visible:ring-1 focus-visible:ring-ring/60',
-            )}
-            type="button"
-            onClick={pickerVariant === 'search' ? () => { if (!dependenciesMissing) setIsPickerOpen(true); } : undefined}
-            aria-haspopup={pickerVariant === 'search' ? 'dialog' : 'listbox'}
-            aria-expanded={pickerVariant === 'search' ? undefined : isOpen}
-            aria-controls={listboxId}
-            disabled={dependenciesMissing || (props as any).disabled}
-            data-testid={dependenciesMissing ? 'lookup-trigger-gated' : (((props as any).name || lookupField?.name) ? `lookup-trigger-${(props as any).name || lookupField.name}` : 'lookup-trigger')}
-            title={dependenciesMissing
-              ? t('lookup.selectFirst', { fields: dependsOn.map(d => d.field).join(', ') })
-              : undefined}
-          >
-            <Search className={cn('size-4 shrink-0 text-muted-foreground', compact ? 'mr-1.5' : 'mr-2')} />
-            <span className={cn('truncate', compact && selectedOptions.length === 0 && 'text-muted-foreground')}>
-            {dependenciesMissing
-              ? t('lookup.selectFirst', { fields: dependsOn.map(d => d.field).join(', ') })
-              : compact && !multiple && selectedOptions.length > 0
-                ? singleSelectedLabel
-                : selectedOptions.length === 0
-                  ? lookupField?.placeholder || t('common.select')
-                  : multiple ? t('table.selected', { count: selectedOptions.length }) : t('common.select')
-            }
-            </span>
-          </Button>
+          {triggerButton}
         </PopoverTrigger>
         <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
           {/* Search input */}
@@ -1002,48 +1024,29 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
         </Button>
       )}
       </div>
+      )}
 
-      {/* Level 2: Full picker — search-first PeoplePicker or classic table dialog */}
-      {hasDataSource && dataSource && referenceTo && (
-        pickerVariant === 'search' ? (
-          <PeoplePicker
-            open={isPickerOpen}
-            onOpenChange={setIsPickerOpen}
-            title={lookupField?.label || t('common.select')}
-            multiple={multiple}
-            dataSource={dataSource}
-            objectName={referenceTo}
-            displayField={displayField}
-            idField={idField}
-            subtitleFields={subtitleFields}
-            avatarField={avatarField}
-            pageSize={lookupPageSize}
-            value={value}
-            onSelect={onChange}
-            onSelectRecords={handlePickerSelectRecords}
-            lookupFilters={lookupFilters}
-          />
-        ) : (
-          <RecordPickerDialog
-            open={isPickerOpen}
-            onOpenChange={setIsPickerOpen}
-            title={lookupField?.label || t('common.select')}
-            multiple={multiple}
-            dataSource={dataSource}
-            objectName={referenceTo}
-            columns={pickerColumns}
-            displayField={displayField}
-            titleFormat={refTitleFormat}
-            idField={idField}
-            pageSize={lookupPageSize}
-            value={value}
-            onSelect={onChange}
-            onSelectRecords={handlePickerSelectRecords}
-            lookupFilters={lookupFilters}
-            cellRenderer={getCellRendererResolver()}
-            filterColumns={filterColumns}
-          />
-        )
+      {/* Level 2: classic table picker — search fields use the inline combobox above. */}
+      {hasDataSource && dataSource && referenceTo && pickerVariant !== 'search' && (
+        <RecordPickerDialog
+          open={isPickerOpen}
+          onOpenChange={setIsPickerOpen}
+          title={lookupField?.label || t('common.select')}
+          multiple={multiple}
+          dataSource={dataSource}
+          objectName={referenceTo}
+          columns={pickerColumns}
+          displayField={displayField}
+          titleFormat={refTitleFormat}
+          idField={idField}
+          pageSize={lookupPageSize}
+          value={value}
+          onSelect={onChange}
+          onSelectRecords={handlePickerSelectRecords}
+          lookupFilters={lookupFilters}
+          cellRenderer={getCellRendererResolver()}
+          filterColumns={filterColumns}
+        />
       )}
     </div>
   );

--- a/packages/fields/src/widgets/PeoplePicker.test.tsx
+++ b/packages/fields/src/widgets/PeoplePicker.test.tsx
@@ -268,4 +268,67 @@ describe('PeoplePicker', () => {
     await waitFor(() => expect(screen.getAllByTestId('selection-chip')).toHaveLength(1));
     expect(screen.getByTestId('selection-tray').textContent).toContain('Amy Lin');
   });
+
+  it('inline: renders an anchored popover, not a modal dialog', async () => {
+    const ds = makeDataSource();
+    render(
+      <PeoplePicker
+        {...baseProps}
+        inline
+        trigger={<button data-testid="inline-trigger">open</button>}
+        dataSource={ds}
+        onOpenChange={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('people-picker-inline')).toBeTruthy());
+    expect(screen.queryByTestId('people-picker-dialog')).toBeNull();
+    expect(screen.getByTestId('inline-trigger')).toBeTruthy();
+  });
+
+  it('inline multi: toggling a row commits live, with no confirm button', async () => {
+    const ds = makeDataSource();
+    const onSelect = vi.fn();
+    render(
+      <PeoplePicker
+        {...baseProps}
+        inline
+        multiple
+        value={[]}
+        dataSource={ds}
+        trigger={<button data-testid="inline-trigger" />}
+        onOpenChange={vi.fn()}
+        onSelect={onSelect}
+        onSelectRecords={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Amy Lin')).toBeTruthy());
+    // Inline has no staging tray / confirm — selection lives in the field chips.
+    expect(screen.queryByText('Confirm')).toBeNull();
+    fireEvent.click(screen.getByText('Amy Lin'));
+    expect(onSelect).toHaveBeenLastCalledWith(['u1']);
+    fireEvent.click(screen.getByText('Bob Wu'));
+    expect(onSelect).toHaveBeenLastCalledWith(['u1', 'u2']);
+  });
+
+  it('inline single: clicking a row commits and closes', async () => {
+    const ds = makeDataSource();
+    const onSelect = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <PeoplePicker
+        {...baseProps}
+        inline
+        dataSource={ds}
+        trigger={<button data-testid="inline-trigger" />}
+        onOpenChange={onOpenChange}
+        onSelect={onSelect}
+        onSelectRecords={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Amy Lin')).toBeTruthy());
+    fireEvent.click(screen.getByText('Amy Lin'));
+    expect(onSelect).toHaveBeenCalledWith('u1');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
 });

--- a/packages/fields/src/widgets/PeoplePicker.tsx
+++ b/packages/fields/src/widgets/PeoplePicker.tsx
@@ -15,11 +15,15 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   ScrollArea,
   Sheet,
   SheetContent,
   SheetHeader,
   SheetTitle,
+  SheetTrigger,
   Skeleton,
   useIsMobile,
 } from '@object-ui/components';
@@ -79,6 +83,17 @@ export interface PeoplePickerProps {
   value?: any;
   onSelect: (value: any) => void;
   onSelectRecords?: (records: any[]) => void;
+
+  /**
+   * Render as an inline combobox anchored to {@link trigger} — a Popover
+   * dropdown on desktop, a bottom Sheet on mobile — instead of a centered
+   * modal Dialog. In inline mode multi-select commits live on each toggle
+   * (the caller's field chips are the selection), so there's no staging tray
+   * or confirm button.
+   */
+  inline?: boolean;
+  /** The element the inline dropdown/sheet anchors to (the field trigger). */
+  trigger?: React.ReactNode;
 }
 
 const DEFAULT_PAGE_SIZE = 25;
@@ -102,6 +117,8 @@ export function PeoplePicker({
   value,
   onSelect,
   onSelectRecords,
+  inline = false,
+  trigger,
 }: PeoplePickerProps) {
   const { t } = useFieldTranslation();
   const isMobile = useIsMobile();
@@ -215,6 +232,15 @@ export function PeoplePicker({
     [multiple, objectName, onSelect, onSelectRecords, onOpenChange],
   );
 
+  // Inline mode has no confirm step — push the value out on every change.
+  const commitLive = useCallback(
+    (records: any[]) => {
+      onSelect(records.map(r => getPersonId(r, idField)));
+      onSelectRecords?.(records);
+    },
+    [onSelect, onSelectRecords, idField],
+  );
+
   const handleRowSelect = useCallback(
     (record: any) => {
       const id = getPersonId(record, idField);
@@ -222,22 +248,30 @@ export function PeoplePicker({
         commit([id], [record]);
         return;
       }
-      setSelectedRecords(prev => {
-        const key = String(id);
-        return prev.some(r => String(getPersonId(r, idField)) === key)
-          ? prev.filter(r => String(getPersonId(r, idField)) !== key)
-          : [...prev, record];
-      });
+      const key = String(id);
+      const exists = selectedRecords.some(r => String(getPersonId(r, idField)) === key);
+      const next = exists
+        ? selectedRecords.filter(r => String(getPersonId(r, idField)) !== key)
+        : [...selectedRecords, record];
+      setSelectedRecords(next);
+      // Inline: commit live (chips live in the field), stay open for more.
+      // Modal: stage in the tray until Confirm.
+      if (inline) {
+        if (!exists) pushRecentLookupId(objectName, id);
+        commitLive(next);
+      }
     },
-    [multiple, idField, commit],
+    [multiple, idField, commit, selectedRecords, inline, objectName, commitLive],
   );
 
   const handleRemove = useCallback(
     (id: any) => {
       const key = String(id);
-      setSelectedRecords(prev => prev.filter(r => String(getPersonId(r, idField)) !== key));
+      const next = selectedRecords.filter(r => String(getPersonId(r, idField)) !== key);
+      setSelectedRecords(next);
+      if (inline) commitLive(next);
     },
-    [idField],
+    [idField, selectedRecords, inline, commitLive],
   );
 
   const handleConfirm = useCallback(() => {
@@ -413,8 +447,9 @@ export function PeoplePicker({
         </div>
       </ScrollArea>
 
-      {/* Multi-select tray + confirm */}
-      {multiple && (
+      {/* Multi-select tray + confirm — modal only; inline commits live and
+          shows the selection as chips in the caller's field. */}
+      {multiple && !inline && (
         <>
           <SelectionTray
             records={selectedRecords}
@@ -439,6 +474,40 @@ export function PeoplePicker({
       )}
     </>
   );
+
+  // Inline combobox: anchored Popover on desktop, bottom Sheet (opened from the
+  // same trigger) on mobile. The trigger is the caller's field control.
+  if (inline) {
+    if (isMobile) {
+      return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+          <SheetTrigger asChild>{trigger}</SheetTrigger>
+          <SheetContent
+            side="bottom"
+            className="flex h-[85vh] flex-col gap-3"
+            data-testid="people-picker-sheet"
+          >
+            <SheetHeader className="text-left">
+              <SheetTitle>{titleText}</SheetTitle>
+            </SheetHeader>
+            {body}
+          </SheetContent>
+        </Sheet>
+      );
+    }
+    return (
+      <Popover open={open} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="flex max-h-[min(28rem,60vh)] w-[var(--radix-popover-trigger-width)] min-w-72 flex-col gap-3 p-3"
+          data-testid="people-picker-inline"
+        >
+          {body}
+        </PopoverContent>
+      </Popover>
+    );
+  }
 
   if (isMobile) {
     return (


### PR DESCRIPTION
Make the search-first user picker a true inline combobox (follow-up to #2144): clicking a user/owner field opens an anchored Popover dropdown below it on desktop (bottom Sheet on mobile), and multi-select commits live on each toggle — the field avatar chips are the selection, no staging tray or confirm. All gated on picker:'search' (classic lookups unchanged). PeoplePicker gains inline+trigger props; LookupField search variant renders <PeoplePicker inline trigger={field}>. Verified: 293 fields tests (3 new inline: anchored-popover-not-dialog, live-commit multi, single commit+close), vite build type-clean, and browser-verified (dropdown anchors below the field, value updates live to a new chip with no confirm button). Desktop = anchored dropdown, mobile = bottom sheet; replaces the modal Dialog #2144 shipped for search fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)