### PR TITLE
chore(agents): harden worktree-first guard + add CLAUDE.md

### DIFF
--- a/.claude/hooks/guard-main-checkout.sh
+++ b/.claude/hooks/guard-main-checkout.sh
@@ -1,50 +1,64 @@
 #!/usr/bin/env bash
-# guard-main-checkout.sh — PreToolUse guard enforcing worktree-first discipline.
-# Blocks Edit / Write / NotebookEdit while the session's checkout is on the repo's
-# default branch (main).
+# guard-main-checkout.sh — PreToolUse guard enforcing AGENTS.md worktree-first rule.
+# Blocks Edit / Write / NotebookEdit unless the file being edited lives in a dedicated
+# git WORKTREE — not the shared primary checkout.
 #
-# Why: this repo is worked on by multiple agents in parallel. The shared default
-# checkout has its HEAD switched and the tree reset *under you* by other agents,
-# silently clobbering uncommitted edits. Dedicated per-task worktrees are
-# physically isolated, so edits there are safe. This guard turns the documented
-# discipline into a hard stop for the one place it actually fails — editing on the
-# shared default branch.
+# Why: this repo (and its sibling repos) are edited by MULTIPLE agents at once. The
+# shared primary checkout has its HEAD switched and its tree reset *under you*, silently
+# clobbering uncommitted work. A feature branch on the shared checkout is NOT enough —
+# it still gets switched under you. Only a dedicated per-task worktree is isolated.
 #
-# Deliberate exception (a human quick-fix that still lands via PR, never task work
-# committed straight to the default branch): export OS_ALLOW_MAIN_EDITS=1.
+# Hardened over the original guard (holes agents fell through):
+#   1. Checks "am I in a linked worktree?" — not merely "branch != default". A feature
+#      branch on the shared checkout no longer passes.
+#   2. Checks the EDITED FILE's repo — not just $CLAUDE_PROJECT_DIR — so sibling repos
+#      edited from this session are guarded too.
+#   3. Resolves the file's nearest EXISTING ancestor dir, so creating a new file in a
+#      new directory can't fail-open past the guard.
+#
+# Deliberate exception (a human quick-fix that still lands via PR): OS_ALLOW_MAIN_EDITS=1.
 
 set -uo pipefail
 
-# Escape hatch.
 [ "${OS_ALLOW_MAIN_EDITS:-}" = "1" ] && exit 0
 
-dir="${CLAUDE_PROJECT_DIR:-$PWD}"
-
-# Not a git repo (or git unavailable) → nothing to guard, allow.
-branch="$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
-
-# Repo default branch (origin/HEAD), e.g. "main"; fall back to "main".
-default="$(git -C "$dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)"
-default="${default#origin/}"
-[ -n "$default" ] || default="main"
-
-if [ "$branch" = "$default" ]; then
-  root="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$dir")"
-  name="$(basename "$root")"
-  cat >&2 <<EOF
-⛔ Blocked: editing files while on the shared '$default' checkout (root=$root).
-
-This repo is worked on by multiple agents in parallel — the shared '$default' tree
-gets its HEAD switched and reset under you, silently clobbering uncommitted edits.
-
-Per AGENTS.md (worktree-first), create a dedicated worktree and edit from there:
-
-  git worktree add ../$name-<task> -b <branch> $default
-  cd ../$name-<task> && pnpm install
-
-Deliberate exception (not task work): re-run with OS_ALLOW_MAIN_EDITS=1.
-EOF
-  exit 2
+input="$(cat 2>/dev/null || true)"
+file=""
+if command -v jq >/dev/null 2>&1; then
+  file="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+fi
+if [ -z "$file" ]; then
+  file="$(printf '%s' "$input" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/^.*"\([^"]*\)"$/\1/' || true)"
 fi
 
-exit 0
+# Judge the checkout at the file's nearest existing ancestor dir (handles new files in
+# not-yet-created directories). Fall back to the project dir when no file path is given.
+if [ -n "$file" ]; then d="$(dirname "$file")"; else d="${CLAUDE_PROJECT_DIR:-$PWD}"; fi
+while [ -n "$d" ] && [ "$d" != "/" ] && [ ! -d "$d" ]; do d="$(dirname "$d")"; done
+[ -d "$d" ] || d="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+gitdir="$(git -C "$d" rev-parse --git-dir 2>/dev/null)" || exit 0
+
+case "$gitdir" in
+  */worktrees/*) exit 0 ;;
+esac
+
+root="$(git -C "$d" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$d")"
+branch="$(git -C "$d" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '?')"
+name="$(basename "$root")"
+cat >&2 <<EOF
+⛔ Blocked: editing on the shared PRIMARY checkout, not a worktree.
+   repo: $root  (branch: $branch)
+
+This repo is edited by multiple agents at once — the shared checkout gets its HEAD
+switched and tree reset under you, silently clobbering uncommitted work. A feature
+branch on the shared checkout is NOT enough; you must be in a dedicated worktree:
+
+  git worktree add ../${name}-<task> -b <branch> main
+  cd ../${name}-<task> && pnpm install    # then re-run your edits there
+
+This guard checks the edited file's OWN repo, so sibling repos are covered too.
+
+Deliberate non-task exception: re-run with OS_ALLOW_MAIN_EDITS=1.
+EOF
+exit 2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ export const SchemaRenderer = ({ schema }: { schema: UIComponent }) => {
 本仓库有**多个 agent 并行**修改 —— 分支会被切换、共享文件会在你工作时被改动(正常现象,不是 bug):
 
 - **只改你任务需要的文件**;别去"修"无关的 diff、回退或别人的在途编辑,也别管整棵工作树。
-- **必须一个任务一个 git worktree**(`git worktree add ../objectui-<task> -b <branch> main`,新树里跑 `pnpm install`)做物理隔离 —— 这是强制而非「首选」。共享的 `main` checkout **不是**可用退路:HEAD 会被别的 agent 切换、你刚写的文件会在操作中途被 reset 掉。一个 **PreToolUse 钩子**(`.claude/hooks/guard-main-checkout.sh`)**强制**此规则:HEAD 在 `main` 上时拦截 `Edit`/`Write`/`NotebookEdit`(确属非任务的临时改动用 `OS_ALLOW_MAIN_EDITS=1` 放行)。即便在自己的 worktree 里,下面这些防御性条款仍然适用。
+- **必须一个任务一个 git worktree**(`git worktree add ../objectui-<task> -b <branch> main`,新树里跑 `pnpm install`)做物理隔离 —— 这是强制而非「首选」。共享的 `main` checkout **不是**可用退路:HEAD 会被别的 agent 切换、你刚写的文件会在操作中途被 reset 掉。一个 **PreToolUse 钩子**(`.claude/hooks/guard-main-checkout.sh`)**强制**此规则:除非被编辑文件位于专属 **worktree** 否则拦截 `Edit`/`Write`/`NotebookEdit`——在共享 checkout 上开 feature 分支**也不行**(仍会被切走),且按**被编辑文件所属的仓库**判断(sibling 仓 `framework`/`cloud` 一并守住)(确属非任务的临时改动用 `OS_ALLOW_MAIN_EDITS=1` 放行)。即便在自己的 worktree 里,下面这些防御性条款仍然适用。
 - **一个任务一个 feature 分支 + 一个 PR**;**绝不**把任务改动直接提交到 `main`。
 - **绝不 `git push --force`/`--force-with-lease`,绝不推 `main`**(会覆盖并行 agent 的工作;`main` 共享,一律走 PR)。
 - **每次 commit/push 前先确认当前分支**(`git rev-parse --abbrev-ref HEAD`);HEAD 可能被别的 agent 切走 —— 不是你的分支就停下重新 checkout。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+**[AGENTS.md](./AGENTS.md) is the source of truth for working in this repo — read it.**
+Its rules are binding. Don't rely on this file alone; the one rule that must never be
+missed is inlined here because missing it corrupts other agents' work.
+
+## ⛔ Worktree-first — before your FIRST file edit
+
+This repo — **and every sibling repo you touch (`framework`, `cloud`)** — is edited by
+**multiple agents at once**. The shared primary checkout has its HEAD switched and its
+tree reset *under you*, silently clobbering uncommitted work. **A feature branch on the
+shared checkout is NOT enough** — it still gets switched under you. You MUST be in a
+**dedicated per-task worktree**:
+
+```
+git worktree add ../<repo>-<task> -b <branch> main && cd ../<repo>-<task> && pnpm install
+```
+
+Make all edits there, **one worktree per repo** a task spans. A PreToolUse hook
+(`.claude/hooks/guard-main-checkout.sh`) enforces this — it blocks `Edit`/`Write`/
+`NotebookEdit` unless the edited file is in a linked worktree, and it checks the edited
+file's own repo (so sibling repos are covered). Non-task exception: `OS_ALLOW_MAIN_EDITS=1`.
+
+See **AGENTS.md** for the full playbook.


### PR DESCRIPTION
Mirrors framework#2517 to objectui. The guard had two holes agents fell through — and the multi-agent collision that motivated this happened on **objectui's** hook:

1. It checked `branch != default`, so a feature branch on the **shared** checkout passed while still being switched/reset under you. Now it checks **"is the edited file in a linked worktree"** (branch-agnostic).
2. It only inspected `$CLAUDE_PROJECT_DIR`, so editing a **sibling repo** (framework/cloud) on its shared checkout from a session was unguarded. Now it parses the edited file's path and checks **that repo's** checkout.

Also adds **CLAUDE.md** (auto-loaded, unlike AGENTS.md) inlining the worktree-first rule + pointing to AGENTS.md, and updates AGENTS.md's hook line.

Hook unit tests (5/5): primary→block, worktree→allow, cross-repo primary→block, non-repo→allow, `OS_ALLOW_MAIN_EDITS=1`→allow. Authored from a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)