### PR TITLE
fix(grid): refresh list after a string bulk / row action succeeds (#2159)

### DIFF
--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1456,7 +1456,13 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
           canDelete={canDelete}
           onEdit={onEdit}
           onDelete={onDelete}
-          onAction={(action, r) => executeAction({ type: action, params: { record: r } })}
+          onAction={(action, r) => {
+            void executeAction({ type: action, params: { record: r } }).then(res => {
+              // A successful row action typically mutated this record; refresh
+              // so the grid reflects the server state (same rationale as bulk).
+              if (res?.success) setRefreshKey(k => k + 1);
+            });
+          }}
           onActionDef={(def, r) => {
             // Dispatch schema-driven row action through the runner. We forward
             // the full action def so type/target/recordIdParam/bodyShape/etc.
@@ -1469,7 +1475,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
               dispatch.actionParams = rawParams;
             }
             dispatch.params = { _rowRecord: r };
-            executeAction(dispatch);
+            void executeAction(dispatch).then(res => {
+              if (res?.success) setRefreshKey(k => k + 1);
+            });
           }}
         />
       ),
@@ -1591,7 +1599,17 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
         setSelectAllMatching(false);
         return;
       }
-      executeAction({ type: action, params: { records: expanded } });
+      // A string bulk action (e.g. 下推 / 派工) mutated the selected records,
+      // usually through a custom API that never touches dataSource.update — so
+      // nothing else signals the grid to refetch. On success, reset the
+      // selection toolbar and refresh so the list reflects the server state
+      // (mirrors the delete branch and handleBulkDialogClose).
+      const res = await executeAction({ type: action, params: { records: expanded } });
+      if (res?.success) {
+        setSelectedRows([]);
+        setSelectAllMatching(false);
+        setRefreshKey(k => k + 1);
+      }
     })();
   };
 

--- a/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression (#2159): after selecting rows and running a string bulk action
+ * (e.g. 下推 / 派工 declared via `batchActions`), the operation succeeded on the
+ * server but the list never refreshed — it stayed on stale data, and the
+ * selection toolbar was left in place.
+ *
+ * Root cause: `dispatchBulkAction`'s non-delete branch fired `executeAction`
+ * and stopped there — no `refreshKey` bump, no selection reset. Only the
+ * BulkActionDialog (rich def) and delete branches refreshed. This drives the
+ * full path (header checkbox → BulkActionBar → dispatchBulkAction →
+ * ActionRunner custom handler) against an in-memory fake server, so a passing
+ * test means the grid refetches after the action and a failing one pinpoints
+ * the missing refresh.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+const OBJECT = 'os_prod_plan';
+
+// A fake server backed by a mutable store, so a bulk action can mutate records
+// and a subsequent find() returns the new value — exactly like a real backend.
+function makeDataSource() {
+  const store: Record<string, any> = {
+    r1: { id: 'r1', name: 'Plan A', status: 'draft' },
+    r2: { id: 'r2', name: 'Plan B', status: 'draft' },
+  };
+  const find = vi.fn(async () => {
+    const data = Object.values(store).map((r) => ({ ...r }));
+    return { data, total: data.length, hasMore: false, pageSize: 50 };
+  });
+  // Per-row update primitive — the exact surface the rich-def executor
+  // (useBulkExecutor, operation:'update') mutates through, per record.
+  const update = vi.fn(async (_resource: string, id: string, patch: Record<string, any>) => {
+    if (store[id]) Object.assign(store[id], patch);
+    return { ...store[id] };
+  });
+  return {
+    store,
+    find,
+    update,
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text' },
+        status: { type: 'text' },
+      },
+    }),
+  } as any;
+}
+
+function renderGrid(dataSource: any, handlers: Record<string, any>) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    // String bulk action — the path 下推 / 派工 travels.
+    batchActions: ['approve'],
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'status', label: 'Status' },
+    ],
+    pagination: { pageSize: 50 },
+  };
+  return render(
+    <ActionProvider handlers={handlers}>
+      <ObjectGrid schema={schema} dataSource={dataSource} />
+    </ActionProvider>,
+  );
+}
+
+describe('ObjectGrid — string bulk action refreshes the list on success', () => {
+  it('refetches and clears the selection after a batchAction succeeds', async () => {
+    const ds = makeDataSource();
+    // A custom bulk action that mutates the "server" and reports success.
+    const approve = vi.fn(async () => {
+      Object.values(ds.store).forEach((r: any) => { r.status = 'approved'; });
+      return { success: true };
+    });
+    renderGrid(ds, { approve });
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    // Initial "draft" is on screen; no "approved" yet.
+    expect(screen.getAllByText('draft').length).toBeGreaterThan(0);
+    const findCallsBefore = ds.find.mock.calls.length;
+
+    // Select all rows on the page (header checkbox), then run the bulk action.
+    const headerCheckbox = document.querySelector('thead [role="checkbox"]') as HTMLElement;
+    expect(headerCheckbox).toBeTruthy();
+    fireEvent.click(headerCheckbox);
+
+    const approveBtn = await screen.findByTestId('bulk-action-approve');
+    fireEvent.click(approveBtn);
+
+    // The handler ran against the selected records.
+    await waitFor(() => expect(approve).toHaveBeenCalledTimes(1));
+
+    // The list refetched — the grid reflects the server state (draft → approved).
+    await waitFor(() =>
+      expect(ds.find.mock.calls.length).toBeGreaterThan(findCallsBefore),
+    );
+    await waitFor(() => expect(screen.getAllByText('approved').length).toBeGreaterThan(0));
+
+    // And the selection toolbar reset (no stuck "N selected" bar).
+    await waitFor(() =>
+      expect(screen.queryByTestId('bulk-actions-bar')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('does NOT refresh or clear selection when the bulk action fails', async () => {
+    const ds = makeDataSource();
+    // A failing action must leave the selection intact (so the user can retry)
+    // and must not trigger a phantom refresh.
+    const approve = vi.fn(async () => ({ success: false, error: 'nope' }));
+    renderGrid(ds, { approve });
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    const findCallsBefore = ds.find.mock.calls.length;
+
+    const headerCheckbox = document.querySelector('thead [role="checkbox"]') as HTMLElement;
+    fireEvent.click(headerCheckbox);
+    const approveBtn = await screen.findByTestId('bulk-action-approve');
+    fireEvent.click(approveBtn);
+
+    await waitFor(() => expect(approve).toHaveBeenCalledTimes(1));
+
+    // Give any (unwanted) refetch a chance to fire, then assert none did and the
+    // selection bar is still present.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(ds.find.mock.calls.length).toBe(findCallsBefore);
+    expect(screen.queryByTestId('bulk-actions-bar')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Rich `bulkActionDefs` path — the mechanism the os-tianshun-ehr 排班计划 grid
+ * actually uses for 下推 / 派工: `operation: 'update'`, `patch: { <trigger>: true }`,
+ * `batchSize: 1` (per-row so each record independently trips its Hooks). This
+ * travels bar → dispatchBulkActionDef → BulkActionDialog → useBulkExecutor
+ * (dataSource.update per row) → onClose(result) → handleBulkDialogClose. This
+ * refresh has existed since rich defs were introduced; the test guards it so the
+ * production path never silently regresses to the string-path bug (#2159).
+ */
+function renderGridWithDefs(dataSource: any) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    // Mirrors production: update + trigger patch, batchSize 1 → per-row execution.
+    bulkActionDefs: [
+      {
+        name: 'push_plan_bulk',
+        label: '下推',
+        operation: 'update',
+        patch: { status: 'pushed' },
+        batchSize: 1,
+        confirmText: '确认下推勾选的计划吗？',
+      },
+    ],
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'status', label: 'Status' },
+    ],
+    pagination: { pageSize: 50 },
+  };
+  return render(
+    <ActionProvider handlers={{}}>
+      <ObjectGrid schema={schema} dataSource={dataSource} />
+    </ActionProvider>,
+  );
+}
+
+describe('ObjectGrid — rich bulk action def (operation:update) refreshes the list', () => {
+  it('runs the def through the dialog, updates each row, and refetches on Done', async () => {
+    const ds = makeDataSource();
+    renderGridWithDefs(ds);
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    expect(screen.getAllByText('draft').length).toBeGreaterThan(0);
+    const findCallsBefore = ds.find.mock.calls.length;
+
+    // Select all rows, then open the rich-def dialog from the bar.
+    const headerCheckbox = document.querySelector('thead [role="checkbox"]') as HTMLElement;
+    expect(headerCheckbox).toBeTruthy();
+    fireEvent.click(headerCheckbox);
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_plan_bulk'));
+
+    // Confirm step (no params) → Run, then the executor mutates each row.
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(ds.update).toHaveBeenCalledTimes(2));
+
+    // Result step → Done closes the dialog with a truthy result → refresh.
+    fireEvent.click(await screen.findByRole('button', { name: 'Done' }));
+
+    // The list refetched and reflects the server state (draft → pushed).
+    await waitFor(() =>
+      expect(ds.find.mock.calls.length).toBeGreaterThan(findCallsBefore),
+    );
+    await waitFor(() => expect(screen.getAllByText('pushed').length).toBeGreaterThan(0));
+
+    // And the selection toolbar reset.
+    await waitFor(() =>
+      expect(screen.queryByTestId('bulk-actions-bar')).not.toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## Problem (#2159)

After selecting rows and running a bulk action, the grid could keep showing **stale data** once the server mutation completed, and the selection toolbar stayed stuck.

## Scope — which paths were actually broken

I traced every bulk/row path in `ObjectGrid`, and (by decompiling the shipped `@objectstack/console@11.5.0` bundle) confirmed the same in production:

| Path | Refreshed before? |
|------|-------------------|
| Rich `bulkActionDefs` dialog (`handleBulkDialogClose`) | ✅ already refreshed (since defs were introduced in `9e4657d1b`) |
| Bulk **delete** (`onBulkDelete`) | ✅ already reset selection |
| **String** bulk actions (`batchActions` / `bulkActions`, e.g. 下推 / 派工 when modeled as strings) | ❌ **no refresh** |
| **Row** action menu (`onAction` / `onActionDef`) | ❌ **no refresh** |

The string bulk path fired `executeAction({type, params:{records}})` and stopped — no `refreshKey` bump, no selection reset. The row actions did the same. `ObjectGrid` self-fetches on `refreshKey` and has no `onMutation` subscription, and custom bulk/row APIs bypass `dataSource.update`, so nothing else signaled a refetch.

> Note: the os-tianshun-ehr 排班计划 下推/派工 use the **rich `bulkActionDefs`** path, which already refreshes in 11.5.0 — so this PR does **not** by itself change that tenant's behavior. This is a defensive fix for the genuinely-unrefreshed string + row paths.

## Fix

On a **successful** action (`res?.success`), reset the selection and bump `refreshKey` so the list reflects server state — mirroring the delete + dialog branches. Failures leave the selection intact (so the user can retry) and trigger no phantom refetch.

## Tests

`bulkActionRefresh.test.tsx` drives the full paths against an in-memory fake server:
- string bulk action → asserts a refetch + selection reset on success
- string bulk action failure → asserts **no** refetch and selection preserved
- rich `bulkActionDefs` (operation:`update`, `batchSize:1`) through the dialog → asserts per-row `update` + refetch on Done (regression guard so the def path never silently regresses to the string-path bug)

All 3 pass on latest `main`.