### PR TITLE
fix(studio): label the Form sub-modes' data source — draft vs published

### DIFF
--- a/.changeset/studio-preview-published-note.md
+++ b/.changeset/studio-preview-published-note.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(studio): say what the Form preview shows — published definition, not the draft
+
+The Data pillar's Form view has two sub-modes: **布局** (the WYSIWYG layout designer,
+rendered from the draft) and **预览** (the live runtime ObjectForm). The preview
+renders the **published** definition on purpose — a draft with structural changes has
+no physical columns yet (DDL lands at publish), so a draft-with-data preview would
+break — but the UI never said so: after arranging a draft in 布局, switching to 预览
+silently showed the old shape, reading as "my changes are lost".
+
+Now the sub-mode captions state their source (布局 = 草稿 · 含未发布改动 / 预览 =
+已发布定义), and when unpublished changes exist the preview shows an amber note:
+confirm the draft in 布局, or publish (top bar) first to see the published effect.
+Publishing stays a deliberate user action — nothing auto-publishes.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -978,7 +978,12 @@ function DataPillar({
                   </button>
                 </div>
                 <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
-                  <Eye className="h-3 w-3" /> {viewMode === 'grid' ? '运行态列表 · 同一渲染器' : '运行态表单 · 同一渲染器'}
+                  <Eye className="h-3 w-3" />{' '}
+                  {viewMode === 'grid'
+                    ? '运行态列表 · 同一渲染器'
+                    : formMode === 'layout'
+                      ? '表单设计 · 草稿'
+                      : '运行态表单 · 已发布定义'}
                 </span>
                 <button
                   type="button"
@@ -1072,8 +1077,17 @@ function DataPillar({
                   </button>
                 </div>
                 <span className="text-[11px] text-muted-foreground">
-                  {formMode === 'layout' ? '布局设计器 · 分组与排序' : '运行态表单 · 同一渲染器'}
+                  {formMode === 'layout' ? '布局设计器 · 草稿(含未发布改动)' : '运行态表单 · 已发布定义'}
                 </span>
+                {/* Preview renders the PUBLISHED definition on purpose: a draft with
+                  * structural changes has no physical columns yet (DDL lands at
+                  * publish), so a draft-with-data preview would break. Publishing is
+                  * a deliberate user action — say so instead of silently lying. */}
+                {formMode === 'preview' && (dirty || hasDraft) && (
+                  <span className="inline-flex items-center gap-1 rounded bg-amber-400/15 px-2 py-0.5 text-[11px] text-amber-600 dark:text-amber-300">
+                    有未发布改动 — 此预览为发布前(已发布)的效果;草稿确认用「布局」,看发布后效果请先点顶栏「发布」
+                  </span>
+                )}
               </div>
               {formMode === 'layout' ? (
                 <ObjectFormDesigner


### PR DESCRIPTION
Implements the settled draft/preview semantics for the Data pillar's Form view (companion doc: framework#2523).

**预览 renders the published definition on purpose** — a draft with structural changes has no physical columns until publish, so a data-bound draft preview would break. But the UI never said so: after arranging a draft in 布局, switching to 预览 silently showed the old shape, reading as "my changes are lost".

- Captions now state each sub-mode's source: **布局 = 草稿(含未发布改动)** / **预览 = 已发布定义**; the view-level badge follows the sub-mode (设计态 vs 运行态).
- With unpublished changes (dirty or saved draft), 预览 shows an amber note: 「有未发布改动 — 此预览为发布前(已发布)的效果;草稿确认用「布局」,看发布后效果请先点顶栏「发布」」. **Publishing stays a deliberate user action** — nothing auto-publishes.
- No rendering-logic changes; text + one conditional only.

**Verified in-browser** (worktree vite :5181 → fresh showcase backend :3005): 布局/预览 captions ✓ · clean state shows no hint ✓ · after adding a section (dirty) the amber hint appears in 预览 and the form correctly still shows the published shape ✓ · badge follows sub-mode ✓. `type-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)