### PR TITLE
fix(plugin-grid): readable import preview — wider columns + friendlier validation errors

### DIFF
--- a/.changeset/import-preview-readability.md
+++ b/.changeset/import-preview-readability.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/plugin-grid": patch
+"@object-ui/i18n": patch
+---
+
+fix(plugin-grid): make the import wizard's preview step readable — wider columns + friendlier validation errors
+
+Two problems on the import wizard's 预览 (preview) step:
+
+- **Cramped preview table.** With many mapped columns crammed into the fixed
+  dialog width, each header collapsed to one character per line (`关联排班计划`
+  stacked vertically) and became unreadable. Columns now get a `min-width` and
+  headers no longer wrap, so the preview area scrolls horizontally instead of
+  crushing every column.
+
+- **Unreadable dry-run error messages.** A reference cell that couldn't resolve
+  rendered as `第 1 行: product: product: no os_tianshun_ehr_product matches "导管架"`
+  — the field named twice, an internal object api-name leaking through, all in
+  English. The server already tags each failure with a structured `code`, so we
+  now drive the message off that code (localized, with the offending value),
+  resolve the field's api-name to its label, and only fall back to the raw
+  server text — minus the duplicated prefix — for unrecognized codes. The same
+  row now reads `第 1 行: 产品：找不到匹配 "导管架" 的记录`.

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -257,6 +257,9 @@ const zh = {
       validateFailed: '{{ok}} 条有效，{{errors}} 条有错误。',
       errorCount: '{{count}} 个错误',
       errorRowPrefix: '第 {{row}} 行：',
+      // 服务端结构化导入错误的友好文案
+      referenceNotFound: '找不到匹配 "{{value}}" 的记录',
+      referenceAmbiguous: '"{{value}}" 匹配到多条记录，请使用唯一值或记录 ID',
       // 导入选项 / 写入模式
       options: '导入选项',
       writeMode: '当某行匹配到已有记录时',

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -16,6 +16,7 @@ import type {
   DataSource,
   ImportRequestOptions,
   ImportRecordsResult,
+  ImportRowResult,
   ImportWriteMode,
   CreateImportJobResult,
   ImportJobProgressInfo,
@@ -117,6 +118,9 @@ const IMPORT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'grid.import.validatePassed': 'All {{ok}} rows are valid.',
   'grid.import.validateFailed': '{{ok}} valid, {{errors}} with errors.',
   'grid.import.errorRowPrefix': 'Row {{row}}: ',
+  // Friendly, localized renderings of the server's structured import errors.
+  'grid.import.referenceNotFound': 'No matching record for "{{value}}"',
+  'grid.import.referenceAmbiguous': '"{{value}}" matches more than one record — use a unique value or the record id',
   // Import-job history
   'grid.import.history': 'History',
   'grid.import.historyBack': 'Back to import',
@@ -193,6 +197,7 @@ export const __testables = {
   get autoMapColumns() { return autoMapColumns; },
   get isUnsupportedImport() { return isUnsupportedImport; },
   get mappedReferenceFields() { return mappedReferenceFields; },
+  get formatDryRunError() { return formatDryRunError; },
   get isUnsupportedImportJob() { return isUnsupportedImportJob; },
   get jobResultToImportResult() { return jobResultToImportResult; },
   get buildFailedRowsCsv() { return buildFailedRowsCsv; },
@@ -309,6 +314,51 @@ function mappedReferenceFields(
 ): ImportWizardProps['fields'] {
   const mappedNames = new Set(Object.values(mapping));
   return fields.filter((f) => mappedNames.has(f.name) && REFERENCE_IMPORT_TYPES.has(f.type));
+}
+
+/** Pull the first double-quoted token out of a server error message — e.g.
+ *  `no os_..._product matches "导管架"` → `导管架`. A locale-agnostic fallback for
+ *  naming the offending value when it can't be read back from the row. */
+function extractQuotedValue(message?: string): string | undefined {
+  const m = message?.match(/"([^"]*)"/);
+  return m?.[1];
+}
+
+/**
+ * Turn one failed dry-run row into a friendly, localizable error line.
+ *
+ * The server keys each error by a field's api-name, bakes that same api-name
+ * into an English message (`product: no os_..._product matches "..."`), and
+ * tags it with a structured `code`. Rendered verbatim that reads as
+ * `产品: product: no os_..._product matches "..."` — the field twice, an
+ * internal object name, all in English. So we drive the message off `code`
+ * (localized, with the offending value), resolve the api-name to its human
+ * label, and only fall back to the raw server text — minus any duplicated
+ * `<api-name>:` prefix — for codes we don't recognize.
+ */
+function formatDryRunError(
+  r: Pick<ImportRowResult, 'field' | 'error' | 'code'>,
+  fieldLabelByName: Map<string, string>,
+  value: string | undefined,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): { fieldLabel?: string; message: string } {
+  const fieldLabel = r.field ? (fieldLabelByName.get(r.field) ?? r.field) : undefined;
+  // Prefer the value the row actually supplied; fall back to the token the
+  // server echoed into its message.
+  const shown = (value ?? '').trim() || extractQuotedValue(r.error) || '';
+  switch (r.code) {
+    case 'reference_not_found':
+      return { fieldLabel, message: t('grid.import.referenceNotFound', { value: shown }) };
+    case 'reference_ambiguous':
+      return { fieldLabel, message: t('grid.import.referenceAmbiguous', { value: shown }) };
+  }
+  let message = (r.error ?? r.code ?? '').trim();
+  // Drop a leading `<api-name>:` the server prepended, so it isn't shown on top
+  // of the label we render.
+  if (r.field && message.toLowerCase().startsWith(`${r.field.toLowerCase()}:`)) {
+    message = message.slice(r.field.length + 1).trimStart();
+  }
+  return { fieldLabel, message };
 }
 
 function validateValue(value: string, type: string): boolean {
@@ -933,7 +983,9 @@ const StepPreview: React.FC<{
         <TableHeader>
           <TableRow>
             <TableHead className="w-12">#</TableHead>
-            {mappedCols.map((col) => <TableHead key={col.csvIdx}>{col.field.label}</TableHead>)}
+            {mappedCols.map((col) => (
+              <TableHead key={col.csvIdx} className="min-w-[140px] whitespace-nowrap">{col.field.label}</TableHead>
+            ))}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -1286,6 +1338,28 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
   // job for a small import — the sync path never captures undo state.
   const [backgroundImport, setBackgroundImport] = useState(false);
   const label = objectLabel ?? objectName;
+
+  // Field api-name → human label, for friendlier dry-run error messages.
+  const fieldLabelByName = useMemo(
+    () => new Map(fields.map((f) => [f.name, f.label])),
+    [fields],
+  );
+  // Field api-name → its source CSV column (first mapped match wins), so a
+  // dry-run error can name the offending cell value without parsing the message.
+  const csvIdxByField = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const [idx, fieldName] of Object.entries(mapping)) {
+      if (!m.has(fieldName)) m.set(fieldName, Number(idx));
+    }
+    return m;
+  }, [mapping]);
+  const dryRunCellValue = useCallback((row1Based: number, field?: string): string | undefined => {
+    if (!field) return undefined;
+    const csvIdx = csvIdxByField.get(field);
+    if (csvIdx === undefined) return undefined;
+    const rIdx = row1Based - 1;
+    return corrections[rIdx]?.[csvIdx] ?? rows[rIdx]?.[csvIdx];
+  }, [csvIdxByField, corrections, rows]);
 
   // The background-import toggle only makes sense when the data source can
   // actually run jobs (create + poll + fetch results). Mirrors the guard in
@@ -1848,12 +1922,15 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
                         </p>
                         {dryRunResult.errors > 0 && (
                           <ul className="max-h-32 overflow-auto text-xs text-destructive">
-                            {dryRunResult.results.filter((r) => !r.ok).slice(0, 20).map((r, i) => (
-                              <li key={i}>
-                                {r.row > 0 ? t('grid.import.errorRowPrefix', { row: r.row }) : ''}
-                                {r.field ? `${r.field}: ` : ''}{r.error ?? r.code ?? ''}
-                              </li>
-                            ))}
+                            {dryRunResult.results.filter((r) => !r.ok).slice(0, 20).map((r, i) => {
+                              const { fieldLabel, message } = formatDryRunError(r, fieldLabelByName, dryRunCellValue(r.row, r.field), t);
+                              return (
+                                <li key={i}>
+                                  {r.row > 0 ? t('grid.import.errorRowPrefix', { row: r.row }) : ''}
+                                  {fieldLabel ? `${fieldLabel}: ` : ''}{message}
+                                </li>
+                              );
+                            })}
                           </ul>
                         )}
                       </div>

--- a/packages/plugin-grid/src/importDryRun.test.ts
+++ b/packages/plugin-grid/src/importDryRun.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { __testables } from './ImportWizard';
 
-const { assembleImportRequest } = __testables;
+const { assembleImportRequest, formatDryRunError } = __testables;
 
 const rows = [{ name: 'Acme' }, { name: 'Beta' }];
 const baseOpts = {
@@ -50,5 +50,60 @@ describe('assembleImportRequest', () => {
     expect(req.createMissingOptions).toBe(true);
     expect(req.runAutomations).toBe(true);
     expect(req.skipBlankMatchKey).toBe(true);
+  });
+});
+
+describe('formatDryRunError', () => {
+  const labels = new Map([['product', '产品']]);
+  // Echoes the server's structured English messages for reference failures.
+  const t = (key: string, vars?: Record<string, unknown>) =>
+    ({
+      'grid.import.referenceNotFound': `No matching record for "${vars?.value}"`,
+      'grid.import.referenceAmbiguous': `"${vars?.value}" matches more than one record`,
+    } as Record<string, string>)[key] ?? key;
+
+  it('resolves the field api-name to its label', () => {
+    const { fieldLabel } = formatDryRunError(
+      { field: 'product', code: 'reference_not_found', error: 'product: no os_x_product matches "导管架"' },
+      labels, '导管架', t,
+    );
+    expect(fieldLabel).toBe('产品');
+  });
+
+  it('renders reference_not_found from the code, not the raw English server text', () => {
+    const { message } = formatDryRunError(
+      { field: 'product', code: 'reference_not_found', error: 'product: no os_x_product matches "导管架"' },
+      labels, '导管架', t,
+    );
+    // No duplicated field name, no internal object api-name leaking through.
+    expect(message).toBe('No matching record for "导管架"');
+    expect(message).not.toContain('os_x_product');
+    expect(message).not.toContain('product:');
+  });
+
+  it('falls back to the quoted value when the cell value is unavailable', () => {
+    const { message } = formatDryRunError(
+      { field: 'product', code: 'reference_not_found', error: 'product: no os_x_product matches "导管架"' },
+      labels, undefined, t,
+    );
+    expect(message).toBe('No matching record for "导管架"');
+  });
+
+  it('maps reference_ambiguous through its own key', () => {
+    const { message } = formatDryRunError(
+      { field: 'product', code: 'reference_ambiguous', error: 'product: "导管架" matches more than one os_x_product' },
+      labels, '导管架', t,
+    );
+    expect(message).toBe('"导管架" matches more than one record');
+  });
+
+  it('strips a duplicated api-name prefix for codes it does not recognize', () => {
+    const { fieldLabel, message } = formatDryRunError(
+      { field: 'product', code: 'some_other_error', error: 'product: value is out of range' },
+      labels, 'x', t,
+    );
+    expect(fieldLabel).toBe('产品');
+    // The label carries the field; the message must not repeat "product:".
+    expect(message).toBe('value is out of range');
   });
 });


### PR DESCRIPTION
## 背景

导入向导「预览」步骤有两处影响可读性的问题(见截图):

1. **预览表格太挤** —— 映射了很多列时,所有列被压进固定的弹窗宽度里,中文表头被压成一列一个字(`关联排班计划` 竖着排),看不清。
2. **校验报错难读** —— 引用字段解析失败时显示成:
   > 第 1 行: **product: product:** no os_tianshun_ehr_product matches "导管架"

   字段名重复、内部对象 API 名(`os_tianshun_ehr_product`)泄露给用户、且全是英文。

## 改动

- **表格**:给映射列加 `min-w-[140px]` 且表头 `whitespace-nowrap`,列太多时预览区横向滚动,而不是把每列压扁。
- **报错文案**:服务端结果本就带结构化 `code`(`reference_not_found` / `reference_ambiguous`),客户端又有该行的单元格值。于是**按 `code` 本地化**渲染中文 + 用字段标签(而非 API 名),**完全不解析英文句子**(仅在拿不到单元格值时,从消息里抠出引号里的值兜底)。不认识的 `code` 才退回服务端原文,并去掉重复的 `字段名:` 前缀。

效果:

| | |
|---|---|
| 之前 | `第 1 行: product: product: no os_tianshun_ehr_product matches "导管架"` |
| 之后 | `第 1 行: 产品:找不到匹配 "导管架" 的记录` |

## 为什么不改 framework

那句英文产在 framework 的 `import-coerce.ts:316`,但它已经吐了结构化 `code`。据 `code` 在前端本地化更稳:不跨仓库、不受服务端 locale 限制、i18n 友好。framework 端唯一可选的改进是去掉消息里重复的 `${field}:` 前缀(重复根源),但客户端已兜住,非必需。

## 测试

- `formatDryRunError` 新增 5 个单测(标签解析、按 code 渲染、值兜底、ambiguous、未知 code 去前缀),`importDryRun.test.ts` 共 9 个用例全绿。
- `@object-ui/plugin-grid`、`@object-ui/i18n` 构建通过(exit 0,0 TS 错误)。
- ⚠️ **未做浏览器实测**:这屏要走完整「上传 → 映射 → 点校验数据 → 服务端返回引用错误」才触发,本地不好复现真实 dry-run 报错,故仅逻辑 + 单测层面验证。
