### PR TITLE
fix(plugin-grid): keep row selection in sync when bulk-action dialog closes

### DIFF
--- a/.changeset/bulk-action-selection-desync.md
+++ b/.changeset/bulk-action-selection-desync.md
@@ -1,0 +1,25 @@
+---
+"@object-ui/plugin-grid": patch
+"@object-ui/components": patch
+"@object-ui/types": patch
+---
+
+fix(plugin-grid): keep the grid's row selection in sync when a bulk-action dialog closes
+
+Closing a bulk-action result dialog (e.g. 派工 / 下推) on **Done** cleared
+ObjectGrid's `selectedRows` — which drives the selection toolbar — but never
+touched the DataTable's internal checkbox state. Two visible problems:
+
+- **Desync on success.** The toolbar disappeared while every row stayed visibly
+  ticked, because the checkboxes are table-internal state the grid couldn't
+  reach.
+
+- **Lost selection on total failure.** When the run failed for *every* row
+  (0 succeeded — a precondition error, say), the toolbar still vanished,
+  stranding the user with no way to retry the exact rows they'd picked.
+
+The dialog-close handler now gates the reset on `result.succeeded > 0`: a total
+failure keeps both the selection *and* the toolbar (and skips the phantom
+refetch) so the user can fix the cause and retry. When it does reset, a new
+`selectionResetKey` prop on DataTable clears the internal checkbox selection in
+lockstep with the toolbar, so the two never drift apart.

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -258,6 +258,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     searchable = true,
     selectable = false,
     showSelectionCount = true,
+    selectionResetKey,
     sortable = true,
     exportable = false,
     rowActions = false,
@@ -400,6 +401,15 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   useEffect(() => {
     setColumns(initialColumns);
   }, [initialColumns]);
+
+  // Clear the internal checkbox selection when the host bumps selectionResetKey.
+  // Row selection is otherwise table-internal state a host can't reach; this lets
+  // e.g. a grid reset the checkboxes after a bulk action. On mount the selection
+  // is already empty, so the initial run is a no-op.
+  useEffect(() => {
+    if (selectionResetKey === undefined) return;
+    setSelectedRowIds(new Set());
+  }, [selectionResetKey]);
 
   // Filtering
   const filteredData = useMemo(() => {

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -44,6 +44,7 @@ import { resolveRowCrudAffordances } from './rowCrudAffordances';
 import { RowActionMenu, formatActionLabel } from './components/RowActionMenu';
 import { BulkActionBar } from './components/BulkActionBar';
 import { BulkActionDialog } from './components/BulkActionDialog';
+import type { BulkResult } from './hooks/useBulkExecutor';
 import type { BulkActionDef } from '@object-ui/types';
 
 // Clickable text cell that can safely contain other interactive content
@@ -269,6 +270,10 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const [rowHeightMode, setRowHeightMode] = useState<'compact' | 'short' | 'medium' | 'tall' | 'extra_tall'>(schema.rowHeight ?? 'compact');
   const [selectedRows, setSelectedRows] = useState<any[]>([]);
   const [selectAllMatching, setSelectAllMatching] = useState(false);
+  // Bumped to tell the underlying table to drop its internal checkbox selection.
+  // The table owns that state, so clearing our `selectedRows` alone would leave
+  // the checkboxes ticked (toolbar gone, rows still visibly selected).
+  const [selectionResetKey, setSelectionResetKey] = useState(0);
   const [totalMatching, setTotalMatching] = useState<number | undefined>(undefined);
   const [activeBulkDef, setActiveBulkDef] = useState<BulkActionDef | null>(null);
   const [activeBulkRows, setActiveBulkRows] = useState<any[]>([]);
@@ -1658,13 +1663,19 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       setActiveBulkRows(expanded);
     })();
   };
-  const handleBulkDialogClose = (result?: unknown) => {
+  const handleBulkDialogClose = (result?: BulkResult | null) => {
     setActiveBulkDef(null);
     setActiveBulkRows([]);
-    if (result) {
-      // Clear selection after a successful run so the toolbar resets.
+    // Only reset selection when the run actually changed something. A total
+    // failure (0 succeeded — e.g. a "推计划" precondition error) leaves the data
+    // untouched, so we keep the selection *and* the toolbar so the user can fix
+    // it and retry the same rows. Both selection sources must move together, or
+    // the checkboxes (table-internal) and the toolbar (our `selectedRows`) drift
+    // out of sync — ticked rows with no toolbar.
+    if (result && result.succeeded > 0) {
       setSelectedRows([]);
       setSelectAllMatching(false);
+      setSelectionResetKey(k => k + 1);
       // Trigger refresh via the same path used by single-record mutations.
       setRefreshKey(k => k + 1);
     }
@@ -1849,6 +1860,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       setSelectedRows(rows);
       onRowSelect?.(rows);
     },
+    selectionResetKey,
     onRowClick: navigation.handleClick,
     onCellChange: onCellChange,
     // Install a dataSource-backed default only when the consumer did NOT wire

--- a/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
@@ -225,3 +225,69 @@ describe('ObjectGrid — rich bulk action def (operation:update) refreshes the l
     );
   });
 });
+
+/**
+ * Selection desync (separate from #2159's refresh gap): closing the rich-def
+ * dialog on Done cleared ObjectGrid's `selectedRows` (which drives the toolbar)
+ * but never touched the DataTable's *internal* `selectedRowIds` (which drives
+ * the checkboxes). After a run the toolbar vanished yet every row stayed
+ * visibly ticked — and on a *total failure* the toolbar vanished too, stranding
+ * the user with no way to retry the rows they'd selected.
+ *
+ * The fix gates the reset on `result.succeeded > 0` and, when it does reset,
+ * bumps a `selectionResetKey` so the table drops its checkbox state in lockstep
+ * with the toolbar. These tests pin both halves: success clears checkboxes +
+ * toolbar together; total failure preserves both (and skips the refetch).
+ */
+describe('ObjectGrid — bulk dialog Done keeps selection in sync', () => {
+  const headerChecked = () =>
+    (document.querySelector('thead [role="checkbox"]') as HTMLElement)?.getAttribute('data-state');
+
+  it('clears the row checkboxes (not just the toolbar) after a successful run', async () => {
+    const ds = makeDataSource();
+    renderGridWithDefs(ds);
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+
+    fireEvent.click(document.querySelector('thead [role="checkbox"]') as HTMLElement);
+    // Header checkbox reflects "all selected" before the action runs.
+    await waitFor(() => expect(headerChecked()).toBe('checked'));
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_plan_bulk'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(ds.update).toHaveBeenCalledTimes(2));
+    fireEvent.click(await screen.findByRole('button', { name: 'Done' }));
+
+    // Both selection sources reset in lockstep: toolbar gone AND boxes cleared.
+    await waitFor(() =>
+      expect(screen.queryByTestId('bulk-actions-bar')).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(headerChecked()).toBe('unchecked'));
+  });
+
+  it('keeps selection + toolbar and skips the refetch when every row fails', async () => {
+    const ds = makeDataSource();
+    // Every per-row update rejects → succeeded: 0, failed: 2.
+    ds.update = vi.fn(async () => { throw new Error('precondition not met'); });
+
+    renderGridWithDefs(ds);
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    const findCallsBefore = ds.find.mock.calls.length;
+
+    fireEvent.click(document.querySelector('thead [role="checkbox"]') as HTMLElement);
+    await waitFor(() => expect(headerChecked()).toBe('checked'));
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_plan_bulk'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(ds.update).toHaveBeenCalledTimes(2));
+    fireEvent.click(await screen.findByRole('button', { name: 'Done' }));
+
+    // Nothing changed on the server, so: no refetch, and the user keeps the
+    // exact rows they picked (toolbar present, boxes still ticked) to retry.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(ds.find.mock.calls.length).toBe(findCallsBefore);
+    expect(screen.queryByTestId('bulk-actions-bar')).toBeInTheDocument();
+    expect(headerChecked()).toBe('checked');
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -444,6 +444,13 @@ export interface DataTableSchema extends BaseSchema {
    */
   onSelectionChange?: (selectedRows: any[]) => void;
   /**
+   * Bump this value to imperatively clear the table's internal row selection.
+   * The table clears its checkbox selection whenever the key changes to a new
+   * value. Lets a host (e.g. a grid clearing selection after a bulk action)
+   * reset the checkboxes, which are otherwise internal table state.
+   */
+  selectionResetKey?: string | number;
+  /**
    * Columns reorder handler
    */
   onColumnsReorder?: (columns: TableColumn[]) => void;


### PR DESCRIPTION
## 问题

在列表里勾选若干行、跑一个批量动作(派工 / 下推)后,点结果弹窗的 **Done**:

- **成功时脱同步**:批处理工具条消失了,但每行的勾选框仍然是选中的 —— 因为勾选状态是 DataTable 内部 state,ObjectGrid 只清了自己的 `selectedRows`(工具条数据源),没碰到勾选框。
- **全部失败时丢选择**:当所有行都失败(0 成功,比如前置条件不满足),工具条照样消失,用户失去了"用同一批行重试"的入口。

截图里的现象:点 Done 后批处理按钮消失、但选择没有被清空,两个选择来源(工具条 vs 勾选框)对不上。

## 改动

- `handleBulkDialogClose` 现在按 `result.succeeded > 0` 门控:**全部失败**时保留选择 + 工具条,并跳过那次无意义的刷新,用户可以修好原因后重试原来那批行。
- 需要清空时,新增 `selectionResetKey` prop 让 DataTable 与工具条**同步**丢掉内部勾选状态,两者不再漂移。

`refreshKey` 只是取数 effect 的依赖(不会重挂 DataTable),所以刷新本身不会清勾选框 —— `selectionResetKey` 是真正需要的。

## 影响的包

- `@object-ui/types` — `DataTableSchema.selectionResetKey?`
- `@object-ui/components` — DataTable 响应 `selectionResetKey` 清空内部勾选
- `@object-ui/plugin-grid` — ObjectGrid 按成功与否门控 reset,并推进 key

## 测试

`packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx` 新增 2 个用例(共 5 个通过):

- 成功后勾选框(不只工具条)被清空
- 全部失败时保留选择 + 工具条,且不触发 refetch

## 说明

改动经单元测试 + 构建验证(build 退出码 0;仅剩既有的 dts rootDir 噪声,与本次改动无关)。未做浏览器端手动验证 —— 复现该状态需要跑完整的多步批量动作失败流程,本地不易稳定重现。