### PR TITLE
fix(form): de-emphasize field labels so fieldGroups hierarchy reads

### DIFF
--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -705,7 +705,7 @@ ComponentRegistry.register('form',
                         data-field={name}
                       >
                         {label && (
-                          <FormLabel className="text-xs sm:text-sm">
+                          <FormLabel className="text-xs font-normal text-muted-foreground">
                             {label}
                             {required && (
                               <span className="text-destructive ml-1" aria-label="required">


### PR DESCRIPTION
## 问题

创建/编辑表单里,字段 label 全部加粗、字号偏大(`text-sm` / `font-medium` 500 / 近黑),和分组的 section 头(SectionDivider)字重一致。结果 grouped 表单看着平铺、看不出字段属于哪个分组 —— 见天顺 `mtc_lead`「新建线索」表单反馈。

根因:字段 label 继承了全局 `labelVariants` 的 `font-medium`([label.tsx:17](../blob/main/packages/components/src/ui/label.tsx#L17)),与组头没有视觉层级差。

## 改动

`packages/components/src/renderers/form/form.tsx` 里表单字段 label 一行:

```diff
- <FormLabel className="text-xs sm:text-sm">
+ <FormLabel className="text-xs font-normal text-muted-foreground">
```

只覆盖表单渲染器的字段 label,**不动全局 `Label` variant**,避免波及按钮/其他控件的 label。

## 效果(实测 computed style,取自真实 `mtc_lead` 表单)

| | 字段 label 改前 | 字段 label 改后 | 组头(未动) |
|---|---|---|---|
| 字号 | 14px | 12px | 14px |
| 字重 | 500 | 400 | 600 |
| 颜色 | 近黑 | 灰 rgb(100,116,139) | 近黑 rgb(2,8,23) |

组头保持深色加粗 + 下边框,字段 label 变小变灰,拉开明显的两级层级。

## 验证

在 objectui worktree 起 vite dev console,proxy 到真实天顺后端(`com.titanwind.mtc` / `mtc_lead`),打开「新建线索」grouped 表单确认层级清晰、computed style 与上表一致。