### PR TITLE
feat(studio): builder landing + studio:builder entry — join the login journey

### DIFF
--- a/.changeset/studio-entry-journey.md
+++ b/.changeset/studio-entry-journey.md
@@ -1,0 +1,19 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(studio): builder landing + `studio:builder` entry — the builder joins the login journey
+
+The pillar application builder was a URL-only surface (zero links anywhere pointed at
+`/studio/...`). Now it has a front door wired into the platform journey:
+
+- **BuilderLanding** — pick or create a writable base package (writable bases lead,
+  read-only code packages listed for browsing), then jump into the full-screen pillar
+  builder. Served standalone at bare **`/studio`** (bookmarkable) and embeddable via
+  the **`studio:builder`** component ref, which the framework's Studio app references
+  from its new 「App Builder」 nav entry — so the journey is: login → Home → Studio →
+  App Builder → package → build.
+- `/studio/:packageId` now lands on **`data`** (the pillar order's first surface)
+  instead of `interfaces`.
+- Package-list parsing/creation is extracted to `packages-io` and shared by the
+  landing and the top-bar package switcher.

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -37,6 +37,7 @@ import {
   DefaultSettingsPage,
   DefaultAiChatPage,
   StudioDesignSurface,
+  BuilderLanding,
 } from '@object-ui/app-shell';
 
 import { AppContent } from './AppContent';
@@ -178,10 +179,17 @@ export function App() {
               * REST API and renders a read-only view.
               */}
             <Route path="/s/:token" element={<SharedRecordPage />} />
-            {/* Dev-only (ADR-0080 slice-1): Studio WYSIWYG design surface
-              * harness. Public + backend-free so it renders from a fixture.
-              * Purely additive — touches no existing surface. Not product nav. */}
-            <Route path="/studio/:packageId" element={<Navigate to="interfaces" replace />} />
+            {/* Application builder (ADR-0080/0084). `/studio` is the front door
+              * (pick/create a writable package); a package lands on its Data
+              * pillar. Also reachable from the Studio app's 「应用构建」 nav. */}
+            <Route path="/studio" element={
+              <ProtectedRoute>
+                <div className="min-h-screen bg-background text-foreground">
+                  <BuilderLanding />
+                </div>
+              </ProtectedRoute>
+            } />
+            <Route path="/studio/:packageId" element={<Navigate to="data" replace />} />
             <Route path="/studio/:packageId/:tab" element={
               <ProtectedRoute>
                 <StudioDesignSurface />

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -148,6 +148,9 @@ import './components/schema/registerObjectDetailWidgets';
 // Register `developer:*` component refs.
 import './registerDeveloperComponents';
 
+// Register `studio:*` component refs (the application-builder entry).
+import './registerStudioComponents';
+
 // Register `account:*` component refs (My Profile, etc.).
 import './registerAccountComponents';
 

--- a/apps/console/src/registerStudioComponents.tsx
+++ b/apps/console/src/registerStudioComponents.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Studio builder component registration.
+ *
+ * Binds the `studio:builder` registry key (referenced from the framework's
+ * Studio app navigation — the 「应用构建」 entry) to the builder landing page,
+ * so the application builder is reachable from the moment a user logs in:
+ * Home → Studio app → 应用构建 → pick/create a writable package → the
+ * full-screen pillar builder at `/studio/:packageId/:tab`.
+ *
+ * URL shape resolved by `ComponentNavView`:
+ *   studio:builder → /apps/<app>/component/studio/builder
+ *
+ * The standalone `/studio` route renders the same landing full-screen.
+ */
+
+import { lazy, Suspense } from 'react';
+import { registerAppComponent } from '@object-ui/app-shell';
+
+const BuilderLandingLazy = lazy(() =>
+  import('@object-ui/app-shell').then((m) => ({ default: m.BuilderLanding })),
+);
+
+registerAppComponent({
+  ref: 'studio:builder',
+  label: '应用构建',
+  source: '@objectstack/console',
+  component: (props: any) => (
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">加载应用构建器…</div>}>
+      <BuilderLandingLazy {...props} />
+    </Suspense>
+  ),
+});

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -262,6 +262,9 @@ export {
   StudioDesignSurface,
   type StudioDesignSurfaceProps,
 } from './views/studio-design/StudioDesignSurface';
+// The builder's front door: pick/create a writable package → pillar builder.
+// Standalone at `/studio` and embedded via the `studio:builder` component ref.
+export { BuilderLanding } from './views/studio-design/BuilderLanding';
 
 // AI assistant bus — connects the metadata designers to the global chat.
 export {

--- a/packages/app-shell/src/views/studio-design/BuilderLanding.tsx
+++ b/packages/app-shell/src/views/studio-design/BuilderLanding.tsx
@@ -1,0 +1,202 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * BuilderLanding — the application builder's front door.
+ *
+ * The journey from login: Home → Studio app → 「应用构建」 (this page, embedded
+ * in the app chrome via the `studio:builder` component ref) → pick or create a
+ * writable base package → the full-screen pillar builder
+ * (`/studio/:packageId/:tab`). Also served standalone at bare `/studio` so the
+ * builder is bookmarkable.
+ *
+ * Writable bases (where authoring happens) lead; read-only code packages are
+ * listed secondary for browsing. Writability is the shared display heuristic
+ * from packages-io — the ADR-0070 D4 gate stays the server-side authority.
+ */
+
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Boxes, Hammer, Lock, Plus, Loader2 } from 'lucide-react';
+import { toFieldNameLoose } from '../metadata-admin/previews/object-fields-io';
+import { fetchPackages, createBasePackage, PACKAGE_ID_RE, type PkgEntry } from './packages-io';
+
+export function BuilderLanding(): React.ReactElement {
+  const navigate = useNavigate();
+  const [pkgs, setPkgs] = React.useState<PkgEntry[] | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [creating, setCreating] = React.useState(false);
+  const [newName, setNewName] = React.useState('');
+  const [newId, setNewId] = React.useState('');
+  const [idTouched, setIdTouched] = React.useState(false);
+  const [busy, setBusy] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    fetchPackages()
+      .then((list) => {
+        if (!cancelled) setPkgs(list);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const open = (id: string) => navigate(`/studio/${encodeURIComponent(id)}/data`);
+
+  const doCreate = async () => {
+    const name = newName.trim();
+    const id = newId.trim();
+    if (!name || !PACKAGE_ID_RE.test(id)) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await createBasePackage(id, name);
+      open(id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const writable = pkgs?.filter((p) => p.writable) ?? [];
+  const readonly = pkgs?.filter((p) => !p.writable) ?? [];
+
+  return (
+    <div className="mx-auto w-full max-w-3xl p-6">
+      <div className="mb-1 flex items-center gap-2">
+        <Hammer className="h-5 w-5 text-primary" />
+        <h1 className="text-lg font-semibold">应用构建</h1>
+      </div>
+      <p className="mb-5 text-xs leading-5 text-muted-foreground">
+        在一个<b>可写软件包</b>里设计对象、表单、自动化与界面;编辑存为草稿,整包一次发布。
+        源码加载的软件包为只读(仅可浏览)。
+      </p>
+
+      {error && (
+        <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-1.5 text-[11px] text-destructive">
+          {error}
+        </div>
+      )}
+
+      <h2 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        我的软件包(可写)
+      </h2>
+      <div className="mb-6 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {pkgs === null && <p className="text-[11px] text-muted-foreground">加载中…</p>}
+        {pkgs !== null && writable.length === 0 && (
+          <p className="text-[11px] text-muted-foreground">还没有可写软件包 — 从右侧新建一个开始。</p>
+        )}
+        {writable.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => open(p.id)}
+            className="flex items-center gap-2.5 rounded-lg border bg-background px-3 py-2.5 text-left hover:border-primary/50 hover:bg-muted/40"
+          >
+            <Boxes className="h-4 w-4 shrink-0 text-primary" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-[13px] font-medium">{p.name}</span>
+              <span className="block truncate font-mono text-[10px] text-muted-foreground">{p.id}</span>
+            </span>
+            <span className="rounded bg-emerald-400/15 px-1.5 py-0.5 text-[10px] text-emerald-600 dark:text-emerald-300">
+              可写
+            </span>
+          </button>
+        ))}
+
+        {/* new-package card */}
+        {creating ? (
+          <div className="flex flex-col gap-1.5 rounded-lg border border-dashed bg-muted/20 px-3 py-2.5">
+            <input
+              autoFocus
+              value={newName}
+              onChange={(e) => {
+                setNewName(e.target.value);
+                if (!idTouched) {
+                  const slug = toFieldNameLoose(e.target.value).replace(/_/g, '-');
+                  setNewId(slug ? `com.example.${slug}` : '');
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void doCreate();
+                if (e.key === 'Escape') setCreating(false);
+              }}
+              placeholder="名称(如:维修中心)"
+              className="h-7 w-full rounded-md border bg-background px-2 text-[11px] outline-none focus:ring-1 focus:ring-primary"
+            />
+            <input
+              value={newId}
+              onChange={(e) => {
+                setIdTouched(true);
+                setNewId(e.target.value.toLowerCase().replace(/[^a-z0-9_.-]/g, ''));
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void doCreate();
+                if (e.key === 'Escape') setCreating(false);
+              }}
+              placeholder="包 ID(如:com.example.repairs)"
+              className="h-7 w-full rounded-md border bg-background px-2 font-mono text-[11px] outline-none focus:ring-1 focus:ring-primary"
+            />
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => void doCreate()}
+                disabled={busy || !newName.trim() || !PACKAGE_ID_RE.test(newId.trim())}
+                className="inline-flex flex-1 items-center justify-center gap-1 rounded-md bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
+              >
+                {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />}
+                创建并开始构建
+              </button>
+              <button
+                type="button"
+                onClick={() => setCreating(false)}
+                className="rounded-md border px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted"
+              >
+                取消
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="flex items-center justify-center gap-1.5 rounded-lg border border-dashed px-3 py-2.5 text-xs text-muted-foreground hover:border-primary/50 hover:text-foreground"
+          >
+            <Plus className="h-4 w-4" /> 新建软件包
+          </button>
+        )}
+      </div>
+
+      {readonly.length > 0 && (
+        <>
+          <h2 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            已安装(只读 · 可浏览)
+          </h2>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {readonly.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => open(p.id)}
+                className="flex items-center gap-2.5 rounded-lg border bg-muted/20 px-3 py-2.5 text-left hover:bg-muted/40"
+              >
+                <Boxes className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[13px]">{p.name}</span>
+                  <span className="block truncate font-mono text-[10px] text-muted-foreground">{p.id}</span>
+                </span>
+                <span className="inline-flex items-center gap-0.5 rounded bg-amber-400/15 px-1.5 py-0.5 text-[10px] text-amber-600 dark:text-amber-300">
+                  <Lock className="h-2.5 w-2.5" /> 只读
+                </span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -58,6 +58,7 @@ import {
   toFieldNameLoose,
 } from '../metadata-admin/previews/object-fields-io';
 import { ObjectFormDesigner } from './ObjectFormDesigner';
+import { fetchPackages, createBasePackage, PACKAGE_ID_RE, type PkgEntry } from './packages-io';
 import { DraftChangesPanel } from '../../preview/DraftChangesPanel';
 import { toast } from 'sonner';
 
@@ -137,33 +138,6 @@ function extractDraftBody(resp: unknown): Record<string, unknown> | null {
   return Object.keys(body as object).length > 0 ? (body as Record<string, unknown>) : null;
 }
 
-/** A package as the switcher needs it. Writability is a display heuristic —
- * kernel packages (scope system/cloud) are hidden, `scope: 'project'` marks a
- * read-only code package (authoring is refused by the ADR-0070 D4 gate), and a
- * scope-less entry is a database base package (writable). The gate stays the
- * authority; this only sets expectations up front. */
-interface PkgEntry {
-  id: string;
-  name: string;
-  writable: boolean;
-}
-
-function parsePackages(payload: unknown): PkgEntry[] {
-  const root = (payload as { data?: unknown })?.data ?? payload;
-  const raw = Array.isArray(root) ? root : ((root as { packages?: unknown[] })?.packages ?? []);
-  const out: PkgEntry[] = [];
-  for (const p of raw as Array<Record<string, unknown>>) {
-    if (!p || typeof p !== 'object') continue;
-    const m = (p.manifest ?? {}) as Record<string, unknown>;
-    const id = String(m.id ?? p.id ?? '');
-    if (!id) continue;
-    const scope = typeof m.scope === 'string' ? m.scope : '';
-    if (scope === 'system' || scope === 'cloud') continue; // kernel — not app packages
-    out.push({ id, name: String(m.name ?? id), writable: scope !== 'project' });
-  }
-  return out;
-}
-
 /** Top-bar package switcher: list app packages (可写 base vs 只读 code), switch by
  * navigation, and create a new writable base inline (POST /packages {id,name}). */
 function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string }): React.ReactElement {
@@ -179,20 +153,13 @@ function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string })
 
   React.useEffect(() => {
     let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch('/api/v1/packages', {
-          credentials: 'include',
-          headers: { Accept: 'application/json' },
-          cache: 'no-store',
-        });
-        if (!res.ok) return;
-        const parsed = parsePackages(await res.json());
+    fetchPackages()
+      .then((parsed) => {
         if (!cancelled) setPkgs(parsed);
-      } catch {
+      })
+      .catch(() => {
         /* leave null — switcher still works for navigation-free display */
-      }
-    })();
+      });
     return () => {
       cancelled = true;
     };
@@ -203,18 +170,11 @@ function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string })
   const doCreate = React.useCallback(async () => {
     const name = newName.trim();
     const id = newId.trim();
-    if (!name || !/^[a-z][a-z0-9_.-]*(\.[a-z0-9_-]+)+$/.test(id)) return;
+    if (!name || !PACKAGE_ID_RE.test(id)) return;
     setBusy(true);
     setErr(null);
     try {
-      const res = await fetch('/api/v1/packages', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify({ id, name }),
-      });
-      const payload = (await res.json().catch(() => null)) as { success?: boolean; error?: { message?: string } } | null;
-      if (!res.ok || payload?.success === false) throw new Error(payload?.error?.message || `HTTP ${res.status}`);
+      await createBasePackage(id, name);
       toast.success(`软件包 ${name} 已创建(可写)`);
       setOpen(false);
       setCreating(false);
@@ -325,7 +285,7 @@ function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string })
                     <button
                       type="button"
                       onClick={() => void doCreate()}
-                      disabled={busy || !newName.trim() || !/^[a-z][a-z0-9_.-]*(\.[a-z0-9_-]+)+$/.test(newId.trim())}
+                      disabled={busy || !newName.trim() || !PACKAGE_ID_RE.test(newId.trim())}
                       className="inline-flex flex-1 items-center justify-center gap-1 rounded-md bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
                     >
                       {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />}

--- a/packages/app-shell/src/views/studio-design/packages-io.ts
+++ b/packages/app-shell/src/views/studio-design/packages-io.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Package-list helpers shared by the Studio package switcher and the builder
+ * landing page.
+ *
+ * Writability is a DISPLAY heuristic — kernel packages (scope system/cloud)
+ * are hidden, `scope: 'project'` marks a read-only code package (authoring is
+ * refused server-side by the ADR-0070 D4 gate), and a scope-less entry is a
+ * database base package (writable). The gate stays the authority; this only
+ * sets expectations up front.
+ */
+
+export interface PkgEntry {
+  id: string;
+  name: string;
+  writable: boolean;
+}
+
+export function parsePackages(payload: unknown): PkgEntry[] {
+  const root = (payload as { data?: unknown })?.data ?? payload;
+  const raw = Array.isArray(root) ? root : ((root as { packages?: unknown[] })?.packages ?? []);
+  const out: PkgEntry[] = [];
+  for (const p of raw as Array<Record<string, unknown>>) {
+    if (!p || typeof p !== 'object') continue;
+    const m = (p.manifest ?? {}) as Record<string, unknown>;
+    const id = String(m.id ?? p.id ?? '');
+    if (!id) continue;
+    const scope = typeof m.scope === 'string' ? m.scope : '';
+    if (scope === 'system' || scope === 'cloud') continue; // kernel — not app packages
+    out.push({ id, name: String(m.name ?? id), writable: scope !== 'project' });
+  }
+  return out;
+}
+
+export async function fetchPackages(): Promise<PkgEntry[]> {
+  const res = await fetch('/api/v1/packages', {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return parsePackages(await res.json());
+}
+
+/** Create a writable base package (POST /packages {id, name}). */
+export async function createBasePackage(id: string, name: string): Promise<void> {
+  const res = await fetch('/api/v1/packages', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ id, name }),
+  });
+  const payload = (await res.json().catch(() => null)) as
+    | { success?: boolean; error?: { message?: string } }
+    | null;
+  if (!res.ok || payload?.success === false) {
+    throw new Error(payload?.error?.message || `HTTP ${res.status}`);
+  }
+}
+
+export const PACKAGE_ID_RE = /^[a-z][a-z0-9_.-]*(\.[a-z0-9_-]+)+$/;


### PR DESCRIPTION
The pillar application builder was a **URL-only surface** — zero inbound links anywhere. This wires it into the platform journey, from the moment a user logs in (companion: framework PR adding the Studio app's **App Builder** nav entry).

## The journey (now)

**Login → Home → Studio app → 「App Builder」 → pick/create a writable package → full-screen pillar builder** — plus bare **`/studio`** as a bookmarkable front door.

## What

- **BuilderLanding**: writable bases lead (「创建并开始构建」 inline form → `POST /packages`), read-only code packages listed for browsing (🔒只读). Served standalone at `/studio` and embedded via the **`studio:builder`** component ref (registered console-side like `developer:*`).
- `/studio/:packageId` default tab: `interfaces` → **`data`** (matches the pillar order; builders land on the data workbench).
- Extracted `packages-io` (parse/fetch/create + writability heuristic) — shared by the landing and the top-bar package switcher (net dedupe of the switcher's inline copies).

## Browser-verified from login (fresh backend, worktree build of framework nav)

- Studio sidebar shows **App Builder** (Overview, first entry) ✓
- Landing renders **inside the classic Studio chrome**: empty 可写 list + 新建 card + showcase 🔒只读 ✓
- Creating **客服中心 / com.example.support** jumps straight into `/studio/com.example.support/data` (writable, no 只读 badge) ✓
- Bare `/studio` is auth-guarded (redirects to login with `?redirect=/studio`) ✓

`type-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)