### PR TITLE
feat(home,studio): builder cover on Home + builder→app bridge

### DIFF
--- a/.changeset/home-cover-builder-bridge.md
+++ b/.changeset/home-cover-builder-bridge.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(home,studio): builder cover on Home + builder→app bridge
+
+Two entries that wire the application builder into the platform journey the
+Airtable way — Home is the cover, the app is the published front-end:
+
+- **Home builder cover** (admins/builders only): two guided cards above "Your
+  apps" — **Build an app** (start from scratch → `/studio`, pick/create a
+  writable package) and **Start with a template** (→ marketplace). End users
+  see their apps as before.
+- **打开应用 bridge** in the `/studio` top bar: when the package ships an app,
+  one click opens its published front-end (`/apps/<name>`) in a new tab —
+  the builder edits the 设计界面, the app is what end users see (Airtable's
+  Data ↔ published-Interfaces relationship, our draft→publish included).

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -28,7 +28,7 @@ import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
 import { appRouteSegment } from '../../utils';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
-import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText } from 'lucide-react';
+import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText, Hammer, LayoutTemplate } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
 import { resolveAiApiBase } from '../../hooks/useAiSurface';
@@ -342,6 +342,54 @@ export function HomePage() {
               t={t}
             />
           </div>
+
+          {/* Builder cover — guided creation entries (Airtable-style Home). The
+            * application builder's front door lives HERE, not in a separate
+            * builder app: build from scratch → /studio (pick/create a writable
+            * package), or start from a template via the marketplace. Shown to
+            * builders/admins only; end users just see their apps below. */}
+          {isAdmin && (
+            <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => navigate('/studio')}
+                className="flex items-start gap-3 rounded-xl border bg-card px-4 py-3.5 text-left transition-colors hover:border-primary/50 hover:bg-muted/40"
+              >
+                <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <Hammer className="h-4.5 w-4.5" />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-semibold">
+                    {t('home.build.title', { defaultValue: 'Build an app' })}
+                  </span>
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    {t('home.build.subtitle', {
+                      defaultValue: 'Start from scratch — design objects, forms, automations and interfaces.',
+                    })}
+                  </span>
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate('/apps/setup/system/marketplace')}
+                className="flex items-start gap-3 rounded-xl border bg-card px-4 py-3.5 text-left transition-colors hover:border-primary/50 hover:bg-muted/40"
+              >
+                <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <LayoutTemplate className="h-4.5 w-4.5" />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-semibold">
+                    {t('home.template.title', { defaultValue: 'Start with a template' })}
+                  </span>
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    {t('home.template.subtitle', {
+                      defaultValue: 'Install a template app from the marketplace and customize it.',
+                    })}
+                  </span>
+                </span>
+              </button>
+            </div>
+          )}
 
           {/* Your apps — compact, scalable launcher (favorites first) */}
           <HomeAppsStrip

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -44,6 +44,7 @@ import {
   Rocket,
   ChevronDown,
   Lock,
+  ExternalLink,
   type LucideIcon,
 } from 'lucide-react';
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
@@ -383,6 +384,30 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   const onDraftSaved = React.useCallback(() => setDraftNonce((n) => n + 1), []);
   const hasPending = (pendingCount ?? 0) > 0;
 
+  // Builder → running-app bridge (Airtable's Launch): the builder edits the
+  // package (设计界面), the app is its published front-end. If this package
+  // ships an app, offer 打开应用 — opened in a new tab so the builder context
+  // survives. (App → builder is the reverse bridge, tracked separately.)
+  const shellClient = useMetadataClient();
+  const [packageApp, setPackageApp] = React.useState<{ name: string; label: string } | null>(null);
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const apps = (await shellClient.list('app', { packageId })) as Array<Record<string, unknown>>;
+        const first = (apps || [])
+          .map((a) => ({ name: String(a.name ?? ''), label: String(a.label ?? a.name ?? '') }))
+          .filter((a) => a.name)[0];
+        if (!cancelled) setPackageApp(first ?? null);
+      } catch {
+        if (!cancelled) setPackageApp(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [shellClient, packageId, publishNonce]);
+
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
       {aiSlot ? <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside> : null}
@@ -411,6 +436,17 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
 
           {/* Package-level draft review + one atomic publish (replaces per-item 发布) */}
           <div className="ml-auto flex items-center gap-2">
+            {packageApp && (
+              <button
+                type="button"
+                onClick={() => window.open(`/apps/${encodeURIComponent(packageApp.name)}`, '_blank')}
+                title={`打开应用「${packageApp.label}」(发布后的前端界面)`}
+                className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                打开应用
+              </button>
+            )}
             <button
               type="button"
               onClick={() => setChangesOpen(true)}


### PR DESCRIPTION
Implements the settled journey model (Airtable reference): **Home is the cover, the app is the published front-end, /studio is the 设计界面**. The classic Studio app is intentionally NOT removed in this step (owner direction).

## What

- **Home builder cover** (admins only), above "Your apps": **Build an app** → `/studio` (pick/create a writable package) · **Start with a template** → marketplace. Airtable-style guided creation on the platform cover.
- **打开应用 bridge** in the `/studio` top bar (Airtable's Launch): when the package ships an app, one click opens its published front-end `/apps/<name>` in a new tab. Resolved via `client.list('app', {packageId})`, refreshed after each package publish. App→builder reverse bridge tracked separately (needs app↔package affordance in the running shell).

## Verified in-browser (fresh backend :3011, worktree vite)

- Home shows the two cards; "Build an app" lands on `/studio` ✓
- Opening com.example.showcase in the builder shows 「打开应用」, tooltip 「打开应用「Showcase」(发布后的前端界面)」, and the intercepted `window.open` target is **`/apps/showcase_app`** ✓
- End-user view unchanged (cards are admin-gated) ✓

`type-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)