### PR TITLE
fix(app-shell): stop double-toasting failed script/modal action errors

### DIFF
--- a/.changeset/dedupe-script-action-error-toast.md
+++ b/.changeset/dedupe-script-action-error-toast.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(app-shell): stop double-toasting failed script/modal action errors
+
+`serverActionHandler` toasted the action error itself **and** returned
+`{ success: false, error }`, which `ActionRunner.handlePostExecution` also
+surfaces as a toast — so a failed script action (e.g. a validation throw)
+showed two identical red toasts.
+
+`apiHandler` and `flowHandler` already only return the error and let the
+runner own the toast; `serverActionHandler` now does the same, so a failed
+action toasts exactly once.

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -44,12 +44,26 @@ vi.mock('../../views/ActionParamDialog', () => ({ ActionParamDialog: () => null 
 vi.mock('../../views/ActionResultDialog', () => ({ ActionResultDialog: () => null }));
 vi.mock('../../views/FlowRunner', () => ({ FlowRunner: () => null }));
 
+// Spy on the toast library so we can assert the handlers DON'T toast errors
+// themselves (the ActionRunner's post-execution hook owns the error toast —
+// toasting here too double-fires it).
+vi.mock('sonner', () => {
+  const fn: any = vi.fn();
+  fn.error = vi.fn();
+  fn.success = vi.fn();
+  return { toast: fn };
+});
+
+import { toast } from 'sonner';
 import { useConsoleActionRuntime, ConsoleActionRuntimeProvider } from '../useConsoleActionRuntime';
 import { useAction, usePageVariables, PageVariablesProvider, PageVariableActionBridge } from '@object-ui/react';
 
 beforeEach(() => {
   authFetchSpy.mockReset();
   navigateSpy.mockReset();
+  (toast as any).mockClear?.();
+  (toast as any).error.mockClear();
+  (toast as any).success.mockClear();
 });
 
 describe('useConsoleActionRuntime — authenticated handlers', () => {
@@ -168,6 +182,29 @@ describe('useConsoleActionRuntime — authenticated handlers', () => {
 
     expect(String(authFetchSpy.mock.calls[0][0])).toContain('/api/v1/actions/global/provision');
     expect(res).toMatchObject({ success: true });
+  });
+
+  it('serverActionHandler returns a failed action error WITHOUT toasting it (the ActionRunner owns the error toast — no double toast)', async () => {
+    // A script action that throws (e.g. lead_apply_convert validation) returns
+    // { success:false, error } from the server. The handler must NOT toast it —
+    // ActionRunner.handlePostExecution does, and toasting here too showed the
+    // error twice (the reported bug).
+    authFetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: false, error: '线索信息不完整，提交转商机申请前请补全：终端客户' }),
+    });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'mtc_lead' }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.serverActionHandler({ type: 'script', name: 'lead_apply_convert' } as any);
+    });
+
+    expect(res).toEqual({ success: false, error: '线索信息不完整，提交转商机申请前请补全：终端客户' });
+    expect((toast as any).error).not.toHaveBeenCalled();
   });
 
   it('exposes ActionProvider props with the api/flow/script/modal handlers wired', () => {

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -510,7 +510,9 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       if (!res.ok || (json && json.success === false)) {
         const errMsg = json?.error || `Action "${targetName}" failed (HTTP ${res.status})`;
         if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
-        toast.error(errMsg);
+        // Don't toast here — the ActionRunner's post-execution hook surfaces
+        // `error` as a toast (see apiHandler/flowHandler, which likewise only
+        // return). Toasting here too double-fires the error (two identical toasts).
         return { success: false, error: errMsg };
       }
       const shouldRefresh = action.refreshAfter !== false;
@@ -544,7 +546,8 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     } catch (error) {
       if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
       const msg = (error as Error).message;
-      toast.error(msg);
+      // The ActionRunner's post-execution hook toasts `error`; returning it here
+      // (without a local toast.error) avoids the double toast.
       return { success: false, error: msg };
     } finally {
       serverActionInFlight.current.delete(inflightKey);


### PR DESCRIPTION
## 问题

某项目动作 `lead_apply_convert` 校验失败时,同一条错误 toast **弹出两遍**(两个完全相同的红色 toast 叠着)。

## 根因

`useConsoleActionRuntime` 里的 `serverActionHandler`(`type: 'script'` / `modal` 动作)对失败**弹了一次** `toast.error(...)`,同时又 `return { success: false, error }`;而 `ActionRunner.handlePostExecution` 会**再**把 `error` 弹成一次 toast → 双弹。

对照:同文件的 `apiHandler` / `flowHandler` 都**只** `return { success:false, error }`、由 runner 统一弹,所以它们只弹一次。唯独 `serverActionHandler` 多弹了。

## 改动

删掉 `serverActionHandler` 里两处多余的 `toast.error(...)`(失败响应分支 + catch 分支),与 `apiHandler` / `flowHandler` 对齐 —— 错误 toast 统一交给 `ActionRunner.handlePostExecution`,失败动作只弹一次。

`toast` import 仍被其他地方使用(弹窗拦截提示、`toastHandler`),无未用 import。

## 测试

- `useConsoleActionRuntime.test.tsx` 全绿(19/19),新增回归用例:失败的 script 动作返回 `{success:false, error}` 但**不**自行 `toast.error`。
- `@object-ui/app-shell` `tsc --noEmit` 0 error。

> 配套修复:错误消息里前缀那段英文调试包装(`action '…' threw: Error:`)由 framework 侧处理:objectstack-ai/framework#2534。两者独立,各自可单独合入。