### PR TITLE
fix(app-shell): don't show recovery-password reminder on a user's first landing

### DIFF
--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -188,6 +188,15 @@ function RecoveryPasswordReminder({ t }: { t: (key: string, opts?: any) => strin
   const [show, setShow] = useState(false);
   useEffect(() => {
     if (typeof localStorage !== 'undefined' && localStorage.getItem('os:recovery-pw-dismissed') === '1') return;
+    // Don't nag on the very first landing: let a brand-new SSO user reach
+    // their magic moment (build their first app) before asking them to set a
+    // recovery password. Record the first home visit; show the reminder only
+    // from the next one on. (The component already intends 'not before the
+    // first session'; previously the code still fired on the very first screen.)
+    if (typeof localStorage !== 'undefined' && localStorage.getItem('os:recovery-pw-first-seen') !== '1') {
+      try { localStorage.setItem('os:recovery-pw-first-seen', '1'); } catch { /* ignore */ }
+      return;
+    }
     let cancelled = false;
     Promise.resolve(hasLocalPassword?.())
       .then((has) => { if (!cancelled && has === false) setShow(true); })


### PR DESCRIPTION
RecoveryPasswordReminder fired on the env home on a brand-new SSO user's very first screen (before they've built anything) — premature friction on the first-run magic moment. The component already intends 'not before the first session' but the code didn't honor it. Gate on a first-visit localStorage marker: record the first home landing, show the reminder only from the next visit on. Still dismissible; preserves SSO-fallback resilience for default (password-allowed) envs. Follow-up: also gate off SSO-enforced envs where the password can't be used.