### PR TITLE
fix(app-shell): don't show recovery-password reminder on SSO-enforced envs

### DIFF
--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -184,7 +184,7 @@ function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) 
  */
 function RecoveryPasswordReminder({ t }: { t: (key: string, opts?: any) => string }) {
   const navigate = useNavigate();
-  const { hasLocalPassword } = useAuth();
+  const { hasLocalPassword, getAuthConfig } = useAuth();
   const [show, setShow] = useState(false);
   useEffect(() => {
     if (typeof localStorage !== 'undefined' && localStorage.getItem('os:recovery-pw-dismissed') === '1') return;
@@ -198,11 +198,22 @@ function RecoveryPasswordReminder({ t }: { t: (key: string, opts?: any) => strin
       return;
     }
     let cancelled = false;
-    Promise.resolve(hasLocalPassword?.())
-      .then((has) => { if (!cancelled && has === false) setShow(true); })
+    Promise.all([
+      Promise.resolve(hasLocalPassword?.()),
+      Promise.resolve(getAuthConfig?.()).catch(() => null),
+    ])
+      .then(([has, config]: [unknown, any]) => {
+        if (cancelled) return;
+        // Skip on SSO-enforced envs: password login is disabled there, so a
+        // recovery password can't be used — nudging for one is misleading and
+        // gives a false sense of security. Same signal LoginForm uses.
+        const passwordUnavailable =
+          config?.features?.ssoEnforced === true || config?.emailPassword?.enabled === false;
+        if (has === false && !passwordUnavailable) setShow(true);
+      })
       .catch(() => { /* unknown → don't nag */ });
     return () => { cancelled = true; };
-  }, [hasLocalPassword]);
+  }, [hasLocalPassword, getAuthConfig]);
   const dismiss = () => {
     try { localStorage.setItem('os:recovery-pw-dismissed', '1'); } catch { /* ignore */ }
     setShow(false);


### PR DESCRIPTION
On SSO-enforced envs password login is disabled (LoginForm hides the password field), so the recovery password can't be used — nudging for one is misleading + false security. Gate RecoveryPasswordReminder on password-login availability using the same getAuthConfig signal LoginForm uses (features.ssoEnforced || emailPassword.enabled===false). Follows #2183 (first-run gate).