### PR TITLE
fix(grid): 批量编辑弹窗补齐多选/日期控件 + 确认展示与必填校验 (#2185)

### DIFF
--- a/packages/plugin-grid/src/__tests__/bulkActionDialogParams.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionDialogParams.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * BulkActionDialog param widgets (#2185): the bulk-edit dialog previously only
+ * rendered single-value controls, so a multi-value backend field (e.g. a
+ * multi-user `executors`) could not be set — the picker collapsed to one value
+ * and overwrote the array. These tests pin the multi-select path end-to-end
+ * (empty-array required-gating → pick many → array patch → label preview) plus
+ * the new date widget.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { BulkActionDialog } from '../components/BulkActionDialog';
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+  // Radix Popover/cmdk probe pointer capture APIs that jsdom lacks.
+  if (!(Element.prototype as any).hasPointerCapture) {
+    (Element.prototype as any).hasPointerCapture = () => false;
+  }
+  if (!(Element.prototype as any).setPointerCapture) {
+    (Element.prototype as any).setPointerCapture = () => {};
+  }
+});
+
+function makeDataSource() {
+  const update = vi.fn(async () => ({}));
+  const del = vi.fn(async () => ({}));
+  return { update, delete: del } as any;
+}
+
+describe('BulkActionDialog — multi-select param produces an array patch', () => {
+  it('gates required until a value is picked, sends an array, and previews labels', async () => {
+    const ds = makeDataSource();
+    const def: any = {
+      name: 'set_tags',
+      label: 'Set tags',
+      operation: 'update',
+      params: [
+        {
+          name: 'tags',
+          label: 'Tags',
+          type: 'select',
+          multiple: true,
+          required: true,
+          options: [
+            { label: 'Red', value: 'red' },
+            { label: 'Blue', value: 'blue' },
+          ],
+        },
+      ],
+    };
+    render(
+      <BulkActionDialog
+        def={def}
+        rows={[{ id: 'r1' }, { id: 'r2' }]}
+        resource="thing"
+        dataSource={ds}
+        open
+        onClose={() => {}}
+      />,
+    );
+
+    // Required multi-select with no selection → Next is disabled (empty array
+    // must count as "not filled").
+    const next = screen.getByRole('button', { name: 'Next' });
+    expect(next).toBeDisabled();
+
+    // Open the multi-select popover and pick both options.
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(await screen.findByText('Red'));
+    fireEvent.click(await screen.findByText('Blue'));
+
+    // Now valid → advance to confirm.
+    await waitFor(() => expect(next).toBeEnabled());
+    fireEvent.click(next);
+
+    // Confirm step shows the human labels (not the raw ids) for the array value.
+    const confirmRun = await screen.findByRole('button', { name: 'Run' });
+    expect(screen.getByText(/Red, Blue/)).toBeInTheDocument();
+
+    fireEvent.click(confirmRun);
+
+    // Per-row update fires with the multi-value array intact.
+    await waitFor(() => expect(ds.update).toHaveBeenCalledTimes(2));
+    expect(ds.update).toHaveBeenCalledWith('thing', 'r1', { tags: ['red', 'blue'] });
+    expect(ds.update).toHaveBeenCalledWith('thing', 'r2', { tags: ['red', 'blue'] });
+  });
+});
+
+describe('BulkActionDialog — date param renders a date picker', () => {
+  it('renders a native date input rather than a free-text box', () => {
+    const ds = makeDataSource();
+    const def: any = {
+      name: 'set_due',
+      label: 'Set due date',
+      operation: 'update',
+      params: [{ name: 'due', label: 'Due', type: 'date' }],
+    };
+    render(
+      <BulkActionDialog
+        def={def}
+        rows={[{ id: 'r1' }]}
+        resource="thing"
+        dataSource={ds}
+        open
+        onClose={() => {}}
+      />,
+    );
+    // Radix Dialog portals its content to document.body, not the render root.
+    const dateInput = document.querySelector('input[type="date"]');
+    expect(dateInput).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -8,7 +8,14 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  Badge,
   Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -17,6 +24,9 @@ import {
   DialogTitle,
   Input,
   Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Progress,
   ScrollArea,
   Select,
@@ -27,7 +37,7 @@ import {
   Switch,
   Textarea,
 } from '@object-ui/components';
-import { AlertTriangle, CheckCircle2, Loader2, XCircle } from 'lucide-react';
+import { AlertTriangle, Check, CheckCircle2, ChevronsUpDown, Loader2, XCircle } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
 import type { BulkActionDef, BulkActionParam } from '@object-ui/types';
 import { useBulkExecutor, type BulkExecutorOptions, type BulkResult } from '../hooks/useBulkExecutor';
@@ -120,9 +130,13 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
         try {
           const res = await dataSource.find!(p.object as string, { $top: 200 });
           const items = Array.isArray(res) ? res : (res?.data ?? []);
+          const labelField = typeof p.labelField === 'string' ? p.labelField : undefined;
           next[p.name] = items.map(r => ({
             value: String(r.id ?? r._id ?? ''),
-            label: String(r.name ?? r.full_name ?? r.email ?? r.id ?? '(unnamed)'),
+            label: String(
+              (labelField ? r[labelField] : undefined)
+              ?? r.name ?? r.full_name ?? r.email ?? r.id ?? '(unnamed)',
+            ),
           })).filter(o => o.value);
         } catch {
           next[p.name] = [];
@@ -141,10 +155,25 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
       if (p.required) {
         const v = values[p.name];
         if (v === undefined || v === null || v === '') return false;
+        if (Array.isArray(v) && v.length === 0) return false;
       }
     }
     return true;
   }, [params, values]);
+
+  // Resolve a param value into a human-readable string for the confirm step:
+  // maps select/lookup ids back to their labels, joins multi-value arrays, and
+  // renders booleans/empties sensibly (a raw `String(v)` would show ids and
+  // `[object Object]`).
+  const describeValue = useCallback((param: BulkActionParam | undefined, v: unknown): string => {
+    if (v === null || v === undefined || v === '' || (Array.isArray(v) && v.length === 0)) return '—';
+    if (typeof v === 'boolean') return v ? t('grid.yes', { defaultValue: 'Yes' }) : t('grid.no', { defaultValue: 'No' });
+    const optSource: LookupOption[] = param?.type === 'lookup'
+      ? (lookupCache[param.name] ?? [])
+      : (param?.options ?? []).map(o => ({ value: String(o.value), label: String(o.label) }));
+    const labelOf = (x: unknown) => optSource.find(o => o.value === String(x))?.label ?? String(x);
+    return Array.isArray(v) ? v.map(labelOf).join(', ') : labelOf(v);
+  }, [t, lookupCache]);
 
   const maxRecords = def?.maxRecords ?? Infinity;
   const overLimit = rows.length > maxRecords;
@@ -273,11 +302,14 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
             </ScrollArea>
             {Object.keys(values).length > 0 && (
               <div className="rounded border bg-muted/30 p-2 text-xs space-y-0.5">
-                {Object.entries(values).map(([k, v]) => (
-                  <div key={k}>
-                    <span className="text-muted-foreground">{k}:</span> {formatValue(v, t)}
-                  </div>
-                ))}
+                {Object.entries(values).map(([k, v]) => {
+                  const p = params.find(x => x.name === k);
+                  return (
+                    <div key={k}>
+                      <span className="text-muted-foreground">{p?.label ?? k}:</span> {describeValue(p, v)}
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>
@@ -402,12 +434,6 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   );
 };
 
-function formatValue(v: unknown, t: (key: string, options?: Record<string, unknown>) => string): string {
-  if (v === null || v === undefined || v === '') return '—';
-  if (typeof v === 'boolean') return v ? t('grid.yes', { defaultValue: 'Yes' }) : t('grid.no', { defaultValue: 'No' });
-  return String(v);
-}
-
 interface ParamFieldProps {
   param: BulkActionParam;
   value: unknown;
@@ -447,15 +473,23 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, value, onChange, lookupO
       );
       break;
     case 'select': {
-      const options = param.options ?? [];
-      control = (
+      const options = (param.options ?? []).map(o => ({ value: String(o.value), label: o.label }));
+      control = param.multiple ? (
+        <MultiSelectControl
+          id={id}
+          options={options}
+          value={value}
+          onChange={onChange}
+          placeholder={param.placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' })}
+        />
+      ) : (
         <Select value={value !== undefined && value !== null ? String(value) : ''} onValueChange={onChange}>
           <SelectTrigger id={id}>
             <SelectValue placeholder={param.placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' })} />
           </SelectTrigger>
           <SelectContent>
             {options.map(o => (
-              <SelectItem key={String(o.value)} value={String(o.value)}>{o.label}</SelectItem>
+              <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
             ))}
           </SelectContent>
         </Select>
@@ -464,10 +498,21 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, value, onChange, lookupO
     }
     case 'lookup': {
       const opts = lookupOptions ?? [];
-      control = (
+      const loadingPlaceholder = opts.length === 0
+        ? t('grid.bulk.loading', { defaultValue: 'Loading…' })
+        : (param.placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' }));
+      control = param.multiple ? (
+        <MultiSelectControl
+          id={id}
+          options={opts}
+          value={value}
+          onChange={onChange}
+          placeholder={loadingPlaceholder}
+        />
+      ) : (
         <Select value={(value as string) ?? ''} onValueChange={onChange}>
           <SelectTrigger id={id}>
-            <SelectValue placeholder={opts.length === 0 ? t('grid.bulk.loading', { defaultValue: 'Loading…' }) : (param.placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' }))} />
+            <SelectValue placeholder={loadingPlaceholder} />
           </SelectTrigger>
           <SelectContent>
             {opts.map(o => (
@@ -478,6 +523,28 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, value, onChange, lookupO
       );
       break;
     }
+    case 'date':
+      control = (
+        <Input
+          id={id}
+          type="date"
+          value={(value as string) ?? ''}
+          onChange={e => onChange(e.target.value === '' ? undefined : e.target.value)}
+          placeholder={param.placeholder}
+        />
+      );
+      break;
+    case 'datetime':
+      control = (
+        <Input
+          id={id}
+          type="datetime-local"
+          value={(value as string) ?? ''}
+          onChange={e => onChange(e.target.value === '' ? undefined : e.target.value)}
+          placeholder={param.placeholder}
+        />
+      );
+      break;
     case 'number':
       control = (
         <Input
@@ -509,5 +576,75 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, value, onChange, lookupO
       {control}
       {param.help && <p className="text-[11px] text-muted-foreground">{param.help}</p>}
     </div>
+  );
+};
+
+interface MultiSelectControlProps {
+  id: string;
+  options: LookupOption[];
+  value: unknown;
+  onChange: (v: string[]) => void;
+  placeholder?: string;
+}
+
+/**
+ * Popover + Command multi-select used for `multiple` select/lookup params. The
+ * value is a string array (written straight into the patch to match a
+ * multi-value backend field). Search filters the already-loaded option set.
+ */
+const MultiSelectControl: React.FC<MultiSelectControlProps> = ({ id, options, value, onChange, placeholder }) => {
+  const { t } = useObjectTranslation();
+  const [open, setOpen] = useState(false);
+  const selected = Array.isArray(value) ? (value as unknown[]).map(String) : [];
+  const labelOf = (v: string) => options.find(o => o.value === v)?.label ?? v;
+  const toggle = (v: string) => {
+    const next = selected.includes(v) ? selected.filter(x => x !== v) : [...selected, v];
+    onChange(next);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between h-auto min-h-9 font-normal"
+        >
+          <span className="flex flex-wrap gap-1 items-center text-left">
+            {selected.length === 0 && (
+              <span className="text-muted-foreground">
+                {placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' })}
+              </span>
+            )}
+            {selected.map(v => (
+              <Badge key={v} variant="secondary" className="font-normal">{labelOf(v)}</Badge>
+            ))}
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+        <Command>
+          <CommandInput placeholder={t('grid.bulk.searchPlaceholder', { defaultValue: 'Search…' })} />
+          <CommandList>
+            <CommandEmpty>{t('grid.bulk.noOptions', { defaultValue: 'No options.' })}</CommandEmpty>
+            <CommandGroup>
+              {options.map(o => {
+                const checked = selected.includes(o.value);
+                return (
+                  <CommandItem key={o.value} value={o.label} onSelect={() => toggle(o.value)}>
+                    <Check className={`mr-2 h-4 w-4 ${checked ? 'opacity-100' : 'opacity-0'}`} />
+                    {o.label}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 };

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -277,6 +277,18 @@ export interface BulkActionParam {
   options?: Array<{ label: string; value: string | number | boolean }>;
   /** For lookup widgets — the related object name (e.g. 'user'). */
   object?: string;
+  /**
+   * For `select` / `lookup` widgets — allow picking multiple values. The param
+   * value becomes a string array and is written to the patch as-is (matching a
+   * multi-value backend field, e.g. a multi-user `executors`). Defaults to
+   * single-select.
+   */
+  multiple?: boolean;
+  /**
+   * For `lookup` widgets — the related-object field used as the option label
+   * (defaults to name/full_name/email/id in that order).
+   */
+  labelField?: string;
   /** Placeholder text. */
   placeholder?: string;
   /**


### PR DESCRIPTION
Closes #2185

## 背景

grid/list 批量操作弹窗(`BulkActionDialog`)的参数控件(`ParamField`)是个 MVP,只实现了 6 种单值控件。真实场景下会踩到:

- **多选人员/关联字段无法批量设置**:如"执行责任人 executors"(多选,数组),弹窗只能选 1 个,且写回会把数组**覆盖成单值**。
- `date` / `datetime`:类型声明了,但 switch 无分支 → 退化成**纯文本框**,只能手打字符串。
- 数组/多值在确认页显示成 `a,b` 或 `[object Object]`。
- 空数组 `[]` 能通过必填校验。

数据链路层本就 OK:`useBulkExecutor.buildPatch` 直接 spread params,数组值 `{ executors: [id1,id2] }` 天然能写进 patch。缺口纯在 UI 控件层。

## 改动(向后兼容 — 不设 `multiple` 时行为完全不变)

- `BulkActionParam` 新增 `multiple?: boolean` 与 `labelField?: string`。
- `select` / `lookup` 支持**多选**:`multiple` 时渲染 Popover + Command 多选控件(带本地搜索、Badge 展示已选),值为字符串数组;`buildPatch` 无需改动。
- 补 `date` / `datetime` 控件(原生日期选择器),替代退化文本框。
- 确认页用选项 label 解析并 join 数组值(不再是裸 id / `[object Object]`),并显示 param.label。
- `paramsValid`:空数组视为未填,多选必填能拦住。
- lookup 选项 label 可经 `labelField` 配置(此前写死 name/full_name/email/id)。
- 移除已被替代的 `formatValue` 辅助函数。

## 后续(单独 issue,本 PR 不含)

- lookup 的 **200 条硬上限 + 远程搜索 + 分页**:需要服务端 search API、防抖、分页,是独立工程。本 PR 仅在多选控件内提供**已加载集合内的本地搜索**,不改 200 上限。

## 用法示例

```ts
bulkActionDefs: [
  {
    name: 'set_executors',
    label: '批量设置执行责任人',
    operation: 'update',
    params: [
      { name: 'executors', label: '执行责任人', type: 'lookup',
        object: 'users', multiple: true, required: true },
    ],
  },
]
```

## 验证

- 新增 `bulkActionDialogParams.test.tsx`:多选 select 端到端(必填空数组拦截 → 选多项 → 确认页显示 label → Run 断言 patch 为数组 `{ tags: ['red','blue'] }`)+ date 控件渲染。
- `@object-ui/plugin-grid` 全量测试:**22 files / 171 passed**。
- 影响面仅 `packages/plugin-grid`(`BulkActionDialog.tsx`)+ `packages/types`(`BulkActionParam`)。
