### PR TITLE
fix(plugin-form): 子表格按字段类型渲染,手写 subform columns 不再全变文本框

### DIFF
--- a/.changeset/subform-hydrate-column-types.md
+++ b/.changeset/subform-hydrate-column-types.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+Hydrate widget types on hand-authored master-detail subform columns. A view can
+list a child grid's columns as bare `{ field, label }` (the common authoring
+form); previously such untyped columns were passed straight to the grid, so a
+`select` / `lookup` / `date` / `number` field silently rendered as a plain text
+cell. `MasterDetailForm` (and `deriveDetail`) now resolve each untyped column's
+`type` (plus `options` / `reference` / computed `expr`) from the child object's
+schema via the new `hydrateColumns` helper — a picklist becomes a dropdown, a
+lookup a record picker, a date a date input — while preserving the author's
+exact column set, order and labels. Columns that already declare a `type` are
+left untouched (the author's explicit choice still wins).

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -30,7 +30,7 @@ import { LineItemsField, type GridColumn } from '@object-ui/fields';
 import { Button, Card, CardContent, CardHeader, CardTitle, cn, toast } from '@object-ui/components';
 import { ObjectForm } from './ObjectForm';
 import { applyDetail, idOf, buildMasterDetailBatch, buildMasterDetailEditBatch, sumRows } from './masterDetailTx';
-import { deriveDetail, type InlineMode } from './deriveMasterDetail';
+import { deriveDetail, hydrateColumns, type InlineMode } from './deriveMasterDetail';
 
 export interface MasterDetailDetailConfig {
   /** Child object name, e.g. 'expense_line'. */
@@ -300,8 +300,12 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
 
   // A detail can be configured with just `{ childObject }` — the relationship
   // FK and grid columns are then derived from the child object's metadata
-  // (DataSource.getObjectSchema). Resolve those before rendering the grid.
-  const needsDerive = rawDetails.some((d) => !d.relationshipField || !d.columns?.length);
+  // (DataSource.getObjectSchema). We also resolve when columns are hand-authored
+  // as bare `{ field, label }` (no `type`): those need their widget type
+  // hydrated from the child schema, else every cell falls back to a text input.
+  const needsDerive = rawDetails.some(
+    (d) => !d.relationshipField || !d.columns?.length || d.columns.some((c) => !c.type),
+  );
   const [resolvedDetails, setResolvedDetails] = useState<MasterDetailDetailConfig[] | null>(
     needsDerive ? null : rawDetails,
   );
@@ -314,9 +318,17 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
     (async () => {
       const out = await Promise.all(
         rawDetails.map(async (d) => {
-          if (d.relationshipField && d.columns?.length) return d;
+          const columnsTyped = d.columns?.length ? d.columns.every((c) => !!c.type) : false;
+          // Fully configured (FK + every column typed) — nothing to resolve.
+          if (d.relationshipField && columnsTyped) return d;
           try {
             const childSchema = await dataSource.getObjectSchema(d.childObject);
+            // Author gave the FK + an explicit column set but left some columns
+            // untyped — hydrate just their widget types from the schema, keeping
+            // their exact column set / order / labels (don't re-derive columns).
+            if (d.relationshipField && d.columns?.length) {
+              return { ...d, columns: hydrateColumns(d.columns, childSchema) };
+            }
             const derived = deriveDetail(d.childObject, childSchema, schema.objectName, {
               relationshipField: d.relationshipField,
               columns: d.columns,

--- a/packages/plugin-form/src/deriveMasterDetail.test.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findRelationshipField, deriveColumns, deriveDetail, deriveFormFields, resolveInlineMode, fieldTypeToColumnType } from './deriveMasterDetail';
+import { findRelationshipField, deriveColumns, deriveDetail, deriveFormFields, resolveInlineMode, fieldTypeToColumnType, hydrateColumns } from './deriveMasterDetail';
 
 const taskSchema = {
   name: 'showcase_task',
@@ -193,6 +193,70 @@ describe('deriveFormFields (per-row expand form)', () => {
     expect(Array.isArray(d.formFields)).toBe(true);
     expect(d.formFields).toContain('title');
     expect(d.formFields).not.toContain('project');
+  });
+});
+
+describe('hydrateColumns (fill types on bare author columns)', () => {
+  it('infers each bare {field,label} column\'s widget type from the child schema', () => {
+    const cols = hydrateColumns(
+      [
+        { field: 'title', label: 'Title' },
+        { field: 'status', label: 'Status' },
+        { field: 'estimate_hours', label: 'Est' },
+        { field: 'budget', label: 'Budget' },
+        { field: 'due_date', label: 'Due' },
+        { field: 'assignee', label: 'Owner' },
+      ] as any,
+      taskSchema,
+    );
+    const byName = Object.fromEntries(cols.map((c) => [c.field, c]));
+    expect(byName.title.type).toBe('text');
+    expect(byName.status).toMatchObject({ type: 'select', options: [{ label: 'To Do', value: 'todo' }, { label: 'Done', value: 'done' }] });
+    expect(byName.estimate_hours.type).toBe('number');
+    expect(byName.budget.type).toBe('currency');
+    expect(byName.due_date.type).toBe('date');
+    expect(byName.assignee).toMatchObject({ type: 'lookup', reference: 'user', displayField: 'name' });
+  });
+
+  it('preserves the author\'s column set, order and labels', () => {
+    const cols = hydrateColumns(
+      [{ field: 'due_date', label: '合同时间' }, { field: 'status', label: 'Status' }] as any,
+      taskSchema,
+    );
+    expect(cols.map((c) => c.field)).toEqual(['due_date', 'status']); // order kept, no extra columns
+    expect(cols[0].label).toBe('合同时间'); // author label kept, not schema's "Due Date"
+  });
+
+  it('never overrides an explicit type the author already set', () => {
+    const cols = hydrateColumns(
+      [{ field: 'status', label: 'Status', type: 'text' }] as any,
+      taskSchema,
+    );
+    expect(cols[0].type).toBe('text'); // author wins — not upgraded to select
+    expect(cols[0].options).toBeUndefined();
+  });
+
+  it('leaves a column untouched when its field is absent from the schema', () => {
+    const cols = hydrateColumns([{ field: 'ghost', label: 'Ghost' }] as any, taskSchema);
+    expect(cols[0].type).toBeUndefined(); // unknown field → grid falls back to text
+  });
+
+  it('is a no-op without a schema or columns', () => {
+    expect(hydrateColumns([{ field: 'x' }] as any, undefined)).toEqual([{ field: 'x' }]);
+    expect(hydrateColumns(undefined, taskSchema)).toEqual([]);
+  });
+});
+
+describe('deriveDetail hydrates explicit-but-untyped override columns', () => {
+  it('fills widget types on bare author columns instead of passing them through raw', () => {
+    const d = deriveDetail('showcase_task', taskSchema, 'showcase_project', {
+      relationshipField: 'project',
+      columns: [{ field: 'status', label: 'Status' }, { field: 'due_date', label: 'Due' }] as any,
+    });
+    const byName = Object.fromEntries(d.columns.map((c) => [c.field, c]));
+    expect(byName.status.type).toBe('select');
+    expect(byName.due_date.type).toBe('date');
+    expect(d.columns.map((c) => c.field)).toEqual(['status', 'due_date']); // author set kept
   });
 });
 

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -208,6 +208,53 @@ export function deriveColumns(
   return curateColumns(cols, maxColumns);
 }
 
+/**
+ * Fill in missing widget metadata on author-supplied grid columns from the
+ * child object's field definitions. A view often lists columns as bare
+ * `{ field, label }` (the common, ergonomic authoring form) — without a `type`
+ * those cells fall back to a plain text `<Input>`, so a lookup, date, number or
+ * picklist field silently renders as free text. This resolves each such
+ * column's `type` (plus `options` / `reference` / computed `expr`) from the
+ * schema, exactly as {@link deriveColumns} would, while preserving the author's
+ * column set, order and labels. A column that already declares a `type` is left
+ * untouched — the author's explicit choice always wins.
+ */
+export function hydrateColumns(
+  columns: GridColumn[] | undefined,
+  childSchema: ObjectSchemaLike | undefined,
+): GridColumn[] {
+  const cols = columns ?? [];
+  const fields = childSchema?.fields;
+  if (!cols.length || !fields || typeof fields !== 'object') return cols;
+  return cols.map((col) => {
+    if (col.type) return col; // explicit type — respect the author's choice
+    const d = (fields as any)[col.field];
+    if (!d) return col; // unknown field — leave as-is (grid falls back to text)
+    const type = fieldTypeToColumnType(d?.type);
+    const next: GridColumn = { ...col, type };
+    if (next.label == null) next.label = d?.label || col.field;
+    if (next.required == null) next.required = !!d?.required;
+    const options = optionsFor(d);
+    if (type === 'select' && options && !next.options) next.options = options;
+    if (type === 'lookup') {
+      if (next.reference == null) next.reference = d?.reference;
+      if (next.displayField == null) next.displayField = d?.display_field || d?.reference_field;
+    }
+    if (next.readonlyWhen == null && d?.readonlyWhen) next.readonlyWhen = d.readonlyWhen;
+    if (next.requiredWhen == null && (d?.requiredWhen ?? d?.conditionalRequired)) {
+      next.requiredWhen = d.requiredWhen ?? d.conditionalRequired;
+    }
+    const expr = typeof d?.expression === 'string' ? d.expression : d?.expression?.source;
+    if (!next.computed && expr && typeof expr === 'string') {
+      next.computed = true;
+      next.expr = expr;
+      next.required = false; // computed → never user-entered, so never required
+      if (typeof d?.scale === 'number') next.scale = d.scale;
+    }
+    return next;
+  });
+}
+
 /** Computed / non-input field types — excluded from the row form (read-only,
  *  server-derived). Unlike grid columns we DO keep rich inputs (textarea,
  *  richtext, file, image, json…) since the row form has room for them. */
@@ -327,7 +374,9 @@ export function deriveDetail(
       `Set relationshipField explicitly.`,
     );
   }
-  const columns = override.columns?.length ? override.columns : deriveColumns(childSchema, { relationshipField });
+  const columns = override.columns?.length
+    ? hydrateColumns(override.columns, childSchema)
+    : deriveColumns(childSchema, { relationshipField });
   const amountField = override.amountField || pickAmountField(columns);
   const formFields = deriveFormFields(childSchema, { relationshipField });
   // Resolve mode from the explicit override, else the relationship field's


### PR DESCRIPTION
Closes #2188

## 问题

主从表单内嵌子表格里,`select` / `lookup` / `date` / `number` 字段全渲染成文本框——只要视图用了最省事的 `{ field, label }` 列写法(不带 `type`)。子对象 schema 类型正确也没用(如 `mtc_lead` / `mtc_lead_product`)。

## 根因

- `MasterDetailForm`:`if (d.relationshipField && d.columns?.length) return d;` 只要有列就跳过 `deriveDetail()`,没检查每列是否带 `type`。
- `deriveDetail`:`override.columns` 存在就原样透传,不补 `type`。
- 于是 `type=undefined` 的列进 `GridField`,兜底成 text。

## 改动

`@object-ui/plugin-form`,3 处:

1. **新增 `hydrateColumns()`**(`deriveMasterDetail.ts`):对「缺 `type`」的作者列,从子对象 schema 补 `type` + `options`/`reference`/`displayField`/计算列 `expr`,逻辑与 `deriveColumns` 一致。**已写 `type` 的列不动**(作者优先);列集合/顺序/标签全保留;未知字段跳过。
2. **`deriveDetail`** 透传列时先 hydrate。
3. **`MasterDetailForm`**:`needsDerive` 增加「有列但缺 type」判定;解析时对「FK+列齐、但列缺 type」只补类型、不重新推导列。

## 测试

- `deriveMasterDetail.test.ts`:新增 6 项(类型推断 / 保留列序+标签 / 显式 type 不被覆盖 / 未知字段跳过 / 无 schema 或无列的 no-op / deriveDetail 透传列 hydrate),**共 31 项全过**。
- `@object-ui/plugin-form` type-check 通过。

> 注:该包的 `.tsx` 集成测试因本地另一 worktree 的 `tsbuildinfo` 污染导致 dist 解析失败而无法加载(报错路径指向 `objectui-dedupe-action-toast`),属既有环境问题、与本改动无关;0 断言失败。CI 全新构建不受影响。

## 影响

消费方(如 tianshun-mtc 的 `mtc_lead`)**无需改对象/视图**,子表格即按字段类型渲染下拉/引用选择器/日期选择器/数字输入。已写 `type` 的列行为不变,向后兼容。