### PR TITLE
fix(plugin-grid): 批量弹窗里关掉下拉/选人组件时不再连带关掉整个弹窗 (#2185)

### DIFF
--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Badge,
   Button,
@@ -103,6 +103,28 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   const [retrying, setRetrying] = useState<string | null>(null);
   const [undoing, setUndoing] = useState(false);
   const [undoneAt, setUndoneAt] = useState<number | null>(null);
+
+  // #2185 — keep the dialog open when the user dismisses a nested Radix popper
+  // (the Status <Select> dropdown or a ComboBox <Popover>) by clicking away from
+  // it. Radix leaves the dialog overlay at pointer-events:auto while marking the
+  // dialog body pointer-events:none, so that click lands on the backdrop and
+  // Radix's DismissableLayer would tear the whole dialog down. We can't detect
+  // the open popper inside the dialog's onInteractOutside handler — by the time
+  // it runs, Radix has already unmounted the popper (verified: popper is present
+  // at capture-phase pointerdown but gone by bubble). So we snapshot "was a
+  // popper open?" on the capture-phase pointerdown and let the guards below read
+  // that snapshot instead of the (already stale) live DOM.
+  const popperOpenAtPointerDown = useRef(false);
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = () => {
+      popperOpenAtPointerDown.current = !!document.querySelector(
+        '[data-radix-popper-content-wrapper] [data-state="open"]',
+      );
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [open]);
 
   // Reset internal state whenever the dialog re-opens for a different action.
   useEffect(() => {
@@ -242,7 +264,21 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(result); }}>
-      <DialogContent className="max-w-md">
+      <DialogContent
+        className="max-w-md"
+        // If the outside interaction that reached the dialog was really the user
+        // dismissing an open nested popper (see popperOpenAtPointerDown above),
+        // swallow it: the popper's own DismissableLayer already closed the
+        // dropdown, so the first click away just dismisses it and the dialog
+        // stays put. A genuine backdrop click (no popper open) still closes the
+        // dialog normally. (#2185)
+        onPointerDownOutside={(e) => {
+          if (popperOpenAtPointerDown.current) e.preventDefault();
+        }}
+        onInteractOutside={(e) => {
+          if (popperOpenAtPointerDown.current) e.preventDefault();
+        }}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             {step === 'running' && <Loader2 className="h-4 w-4 animate-spin" />}


### PR DESCRIPTION
## 问题

批量编辑弹窗(`BulkActionDialog`)里,打开 Status 单选下拉(Radix `<Select>`)或可搜索的 lookup 选人组件(ComboBox `<Popover>`)后,**不点选项、点弹窗内别处空白**,会把**整个批量弹窗**一起关掉——用户只是想收起下拉,却丢了整个弹窗。#2186(#2185)引入这些控件后暴露出来。

## 根因(实测确认)

下拉/popover 打开时,Radix 把弹窗主体标成 `pointer-events:none`,却把遮罩层保留为 `pointer-events:auto`。于是点在“视觉上还在的弹窗”上,点击穿透到背后的遮罩 → Radix 的 DismissableLayer 认为是“点了弹窗外面” → 拆掉整个 Dialog。

无法在 Dialog 的 `onInteractOutside` 里直接检测“下拉是否开着”:加 capture/bubble 双探针验证——**同一次 pointerdown,capture 阶段 popper 还在,到 bubble 阶段 Radix 已经把它卸载了**,所以处理器里读实时 DOM 永远读到“没有 popper”。

## 修法

在 **capture 阶段的 pointerdown** 打一个快照(当时有没有 popper 开着),`onPointerDownOutside`/`onInteractOutside` 读这个快照而不是过时的实时 DOM:

- 第一次点别处 → 只收起下拉/popover,**弹窗保留** ✓
- 之后再点遮罩(此时没 popper 开着)→ 弹窗照常关闭,原有行为不变 ✓

## 验证(真实浏览器,CDP 级点击)

- 单选 `<Select>`(Reschedule 的 Status):点别处 → `dialogStillOpen: true`、下拉关闭 ✓
- 可搜索 ComboBox `<Popover>`(Assign Team 的选人):点别处 → 弹窗保留、popover 关闭 ✓
- 纯遮罩点击(无 popper 开着)回归:弹窗正常关闭 ✓
- 单元测试 `bulkActionDialogParams.test.tsx` 3/3 通过

注:此交互依赖 Radix 的 portal + `pointer-events` + DismissableLayer 时序,jsdom 复现不了,未加独立单测——改为真实浏览器验证 + 代码内详注原因。
