### PR TITLE
feat(fields): default relation pickers to inline "create related record"

### DIFF
--- a/packages/app-shell/src/console/ConsoleShell.tsx
+++ b/packages/app-shell/src/console/ConsoleShell.tsx
@@ -14,7 +14,8 @@ import { Suspense, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { AuthGuard, useAuth } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
-import { SchemaRendererProvider } from '@object-ui/react';
+import { SchemaRendererProvider, ActionProvider } from '@object-ui/react';
+import { useActionModal } from '../hooks/useActionModal';
 import { createObjectStackUserStateAdapter } from '@object-ui/data-objectstack';
 import { AdapterProvider, useAdapter } from '../providers/AdapterProvider';
 import { MetadataProvider, useMetadata } from '../providers/MetadataProvider';
@@ -35,6 +36,26 @@ export function LoadingFallback() {
     <div className="h-screen flex items-center justify-center text-sm text-muted-foreground">
       Loading…
     </div>
+  );
+}
+
+/**
+ * Provide a MODAL handler at the console ROOT — the same level the global
+ * SchemaRendererProvider (dataSource) sits — so it reaches EVERY field widget,
+ * including a relation field inside a create/edit form that renders in a Radix
+ * Dialog portal (which sits above the lower per-view ActionProviders). This is
+ * what lets a lookup's inline "create the referenced record" open that object's
+ * OWN create form and select the result. Only ADDS the modal capability where
+ * none existed; richer per-view ActionProviders still override it where they
+ * apply. Must render inside MetadataProvider (useActionModal reads useMetadata).
+ */
+function GlobalCreateModalProvider({ dataSource, children }: { dataSource: unknown; children: ReactNode }) {
+  const { modalHandler, modalElement } = useActionModal(dataSource);
+  return (
+    <ActionProvider onModal={modalHandler}>
+      {children}
+      {modalElement}
+    </ActionProvider>
   );
 }
 
@@ -125,7 +146,9 @@ function ConnectedShellInner({ children }: { children: ReactNode }) {
     <SchemaRendererProvider dataSource={adapter}>
       <MetadataProvider key={language} adapter={adapter}>
         <UserStateBridge />
-        {children}
+        <GlobalCreateModalProvider dataSource={adapter}>
+          {children}
+        </GlobalCreateModalProvider>
       </MetadataProvider>
     </SchemaRendererProvider>
   );

--- a/packages/fields/src/complex-widgets.test.tsx
+++ b/packages/fields/src/complex-widgets.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LookupField } from './widgets/LookupField';
+import { ActionProvider } from '@object-ui/react';
 import { FieldEditWidget } from './FieldEditWidget';
 import { MasterDetailField } from './widgets/MasterDetailField';
 import { GridField } from './widgets/GridField';
@@ -342,6 +343,85 @@ describe('Complex & Relationship Widgets', () => {
             await waitFor(() => {
                 expect(onChange).toHaveBeenCalledWith('new-1');
             });
+        });
+
+        it('defaults inline-create ON for a user-facing relation (no allow_create needed)', async () => {
+            // dynamicField.reference_to === 'customers' (user-facing) with NO
+            // allow_create flag → the capability is ON by default (standard).
+            mockDataSource.find.mockResolvedValue({ data: [], total: 0 });
+            mockDataSource.create.mockResolvedValue({ id: 'new-2', name: 'Zeta' });
+            const onChange = vi.fn();
+
+            render(<LookupField {...dynamicProps} onChange={onChange} />);
+            await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Select/i })); });
+            const input = await screen.findByRole('combobox');
+            await act(async () => { fireEvent.change(input, { target: { value: 'Zeta' } }); });
+
+            expect(await screen.findByText('Create new "Zeta"')).toBeInTheDocument();
+            // No ActionProvider in scope → the create falls back to a direct
+            // dataSource.create (the modal-open path is exercised in the E2E).
+            await act(async () => { fireEvent.click(screen.getByText('Create new "Zeta"')); });
+            await waitFor(() => { expect(mockDataSource.create).toHaveBeenCalledWith('customers', { name: 'Zeta' }); });
+        });
+
+        it('does NOT default inline-create for a system / user-directory reference', async () => {
+            // A picker into the platform user directory must not offer "+ create"
+            // (those rows are org members, not inline-created from a field).
+            mockDataSource.find.mockResolvedValue({ data: [], total: 0 });
+            const field = { ...dynamicField, reference_to: 'sys_user' } as any;
+
+            render(<LookupField {...dynamicProps} field={field} />);
+            await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Select/i })); });
+            const input = await screen.findByRole('combobox');
+            await act(async () => { fireEvent.change(input, { target: { value: 'Somebody' } }); });
+
+            await waitFor(() => { expect(screen.getByText('No options found')).toBeInTheDocument(); });
+            expect(screen.queryByText(/Create new/)).not.toBeInTheDocument();
+        });
+
+        it('honors an explicit allow_create:false opt-out on a user-facing relation', async () => {
+            mockDataSource.find.mockResolvedValue({ data: [], total: 0 });
+            const field = { ...dynamicField, allow_create: false } as any;
+
+            render(<LookupField {...dynamicProps} field={field} />);
+            await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Select/i })); });
+            const input = await screen.findByRole('combobox');
+            await act(async () => { fireEvent.change(input, { target: { value: 'Nope' } }); });
+
+            await waitFor(() => { expect(screen.getByText('No options found')).toBeInTheDocument(); });
+            expect(screen.queryByText(/Create new/)).not.toBeInTheDocument();
+        });
+
+        it('under an ActionProvider, "+ create" opens the referenced object\'s create form (not a one-field create) and selects the result', async () => {
+            // The standard behaviour (founder ask): rather than blindly creating a
+            // record from the typed text, open the referenced object's OWN create
+            // form so the user fills every required field, then select what they
+            // made. Routed through the ActionProvider modal handler — the console
+            // wires one globally (ConsoleShell.GlobalCreateModalProvider).
+            mockDataSource.find.mockResolvedValue({ data: [], total: 0 });
+            mockDataSource.create.mockClear();
+            const onChange = vi.fn();
+            // Stand-in for the console's global create-modal host: resolves with
+            // the record the user created in the opened form.
+            const onModal = vi.fn(async (_schema: any) => ({ success: true, reload: true, data: { id: 'bk-1', name: 'Deep Sea Mechanics' } }));
+
+            render(
+                <ActionProvider onModal={onModal}>
+                    <LookupField {...dynamicProps} onChange={onChange} />
+                </ActionProvider>
+            );
+            await act(async () => { fireEvent.click(screen.getByRole('button', { name: /Select/i })); });
+            const input = await screen.findByRole('combobox');
+            await act(async () => { fireEvent.change(input, { target: { value: 'Deep Sea Mechanics' } }); });
+            await act(async () => { fireEvent.click(await screen.findByText('Create new "Deep Sea Mechanics"')); });
+
+            // It opened the referenced object's CREATE FORM (modal), addressed by
+            // object name + create mode — NOT a silent one-field dataSource.create.
+            await waitFor(() => { expect(onModal).toHaveBeenCalled(); });
+            expect(onModal.mock.calls[0][0]).toMatchObject({ objectName: 'customers', mode: 'create' });
+            expect(mockDataSource.create).not.toHaveBeenCalled();
+            // The record the user created in the form is selected back into the field.
+            await waitFor(() => { expect(onChange).toHaveBeenCalledWith('bk-1'); });
         });
 
         it('shows a recently-used section on empty focus', async () => {

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -21,7 +21,7 @@ import { getRecordDisplayName } from '@object-ui/core';
 import { getRecentLookupIds, pushRecentLookupId } from './recentLookups';
 import { getPersonInitials } from './personDisplay';
 import { getCellRendererResolver } from './_cell-renderer-bridge';
-import { SchemaRendererContext as ImportedSchemaRendererContext } from '@object-ui/react';
+import { SchemaRendererContext as ImportedSchemaRendererContext, useAction, useHasActionProvider } from '@object-ui/react';
 import { useFieldTranslation } from './useFieldTranslation';
 
 export interface LookupOption {
@@ -39,6 +39,22 @@ const LOOKUP_PAGE_SIZE = 50;
  * Using a static import to be compatible with Next.js Turbopack SSR.
  */
 const SchemaRendererContext: React.Context<any> = ImportedSchemaRendererContext;
+
+/**
+ * A relation whose picker should offer inline "create the referenced record" by
+ * default. Inline quick-create is a STANDARD capability so a freshly-built app
+ * isn't a dead end (an empty required picker → you can create the FIRST related
+ * record right here). Platform/system objects are excluded: the user directory
+ * (`sys_user` and its bare `user`/`users` aliases) and everything under the
+ * `sys_`/`cloud_`/`ai_` namespaces are pre-populated plumbing you must not create
+ * from a field picker. A user-authored business entity (customer, pet, book, …)
+ * never matches, so it gets the capability.
+ */
+const SYSTEM_REFERENCE_RX = /^(sys_|cloud_|ai_)/;
+const USER_DIRECTORY_REFS = new Set(['user', 'users']);
+function isUserFacingReference(reference: string | undefined): boolean {
+  return !!reference && !SYSTEM_REFERENCE_RX.test(reference) && !USER_DIRECTORY_REFS.has(reference);
+}
 
 /**
  * Render a record title from a `titleFormat` template (e.g. `{full_name}` or
@@ -212,9 +228,15 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   const idField = fieldMeta?.id_field || 'id';
   // ObjectStack convention uses `reference`; types define `reference_to` — support both
   const referenceTo: string | undefined = fieldMeta?.reference_to || fieldMeta?.reference;
-  // Opt-in inline quick-create: when set, an empty/zero-result picker offers to
-  // create a record from the typed text via dataSource.create.
-  const allowCreate: boolean = !!(fieldMeta?.allow_create ?? fieldMeta?.allowCreate);
+  // Inline quick-create — a STANDARD capability, default ON for user-facing
+  // relations: an empty/zero-result picker offers to create the referenced
+  // record (opening its create form; see handleCreateNew) so the first related
+  // record can be made right here. An explicit `allowCreate` (either casing)
+  // wins — set it `false` to opt a field out; system/user-directory references
+  // are excluded from the default (isUserFacingReference).
+  const explicitAllowCreate = fieldMeta?.allow_create ?? fieldMeta?.allowCreate;
+  const allowCreate: boolean =
+    explicitAllowCreate != null ? !!explicitAllowCreate : isUserFacingReference(referenceTo);
 
   // Enterprise Record Picker configuration
   const lookupColumns: Array<string | LookupColumnDef> | undefined = fieldMeta?.lookup_columns ?? fieldMeta?.lookupColumns;
@@ -637,14 +659,47 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   useEffect(() => { setActiveIndex(-1); }, [visibleOptions.length]);
 
   const [creating, setCreating] = useState(false);
-  const canCreate = !!onCreateNew || (allowCreate && hasDataSource);
+  // Open the referenced object's create form through the ActionProvider's modal
+  // handler (when a form host wired one). Safe outside a provider — useAction
+  // returns a local runner and useHasActionProvider is false.
+  const { execute } = useAction();
+  const hasActionProvider = useHasActionProvider();
+  const canCreate = !!onCreateNew || (allowCreate && (hasActionProvider || hasDataSource));
   const handleCreateNew = useCallback(
     async (q: string) => {
       const label = (q || '').trim();
       if (onCreateNew) { onCreateNew(label); setIsOpen(false); return; }
-      if (!allowCreate || !dataSource || !referenceTo || !label) return;
-      setCreating(true);
+      if (!allowCreate || !referenceTo) return;
       setCreateError(null);
+
+      // Preferred path — open the referenced object's FULL create form so the
+      // user fills every required field themselves, then select the record they
+      // created. This is the standard "create related record" behaviour: it
+      // works for ANY object (not only ones whose sole required field is the
+      // title) and turns an empty required picker from a dead end into a way to
+      // author the first related record.
+      if (hasActionProvider) {
+        setIsOpen(false); // hand off to the modal
+        const result: any = await execute({
+          type: 'modal',
+          modal: { objectName: referenceTo, mode: 'create' },
+        } as any);
+        if (result?.success && result.data) {
+          const opt = recordToOption(result.data, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema);
+          setPickerResolvedRecords((prev) => [opt, ...prev.filter((o) => o.value !== opt.value)]);
+          handleSelect(opt);
+          return;
+        }
+        // `success` + an echoed `modal` schema means no modal handler was wired
+        // in this tree → fall through to the legacy inline create. Anything else
+        // (cancel / no data) means the user backed out → stop.
+        if (!(result?.success && result.modal)) return;
+      }
+
+      // Fallback (no modal handler in scope): the legacy one-field inline create
+      // from the typed text. Best-effort; surfaces any validation error inline.
+      if (!dataSource || !label) return;
+      setCreating(true);
       try {
         const created = await (dataSource as any).create(referenceTo, { [displayField]: label });
         const opt = recordToOption(created, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema);
@@ -656,7 +711,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
         setCreating(false);
       }
     },
-    [onCreateNew, allowCreate, dataSource, referenceTo, displayField, idField, effectiveDescriptionField, refTitleFormat, handleSelect],
+    [onCreateNew, allowCreate, referenceTo, hasActionProvider, execute, dataSource, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema, handleSelect],
   );
 
   // Compact one-line preview of an option's extra (non-display) columns —


### PR DESCRIPTION
## Why
A freshly-built app is a **dead end** at its first record: a Create form with a REQUIRED relation (an appointment's Customer*/Pet*, a loan's Book*/Member*) opens an **empty** picker — with zero records to select, a brand-new user is stuck. Inline "create the referenced record" already existed in `LookupField` but was **opt-in (off)**, and its create path blindly wrote the typed text to a field named `name`, so it failed validation for any object whose title field isn't literally `name` (AI-built objects name theirs `book_name`, `customer_name`, …).

## What
Make inline create a **standard capability** of the relation picker (a platform/objectui behavior, not an AI-authoring one — every app gets it regardless of how its schema was authored):

- **`LookupField`** — default `allowCreate` **ON** for user-facing relations. References to platform/system objects (`sys_`/`cloud_`/`ai_` + the `user`/`users` directory) are excluded (they're pre-populated and must not be inline-created from a picker); an explicit `allowCreate:false` still opts a field out. Choosing **"+ create &lt;text&gt;"** now opens the referenced object's **OWN create form** (via the `ActionProvider` modal handler) and selects the record you create — so you fill every required field, instead of the old one-field create that failed validation. Falls back to the legacy inline create when no modal host is in scope.
- **`ConsoleShell`** — provide the modal handler at the console **root** (`GlobalCreateModalProvider`) so it reaches every field widget, including a relation field inside a create/edit form rendered in a Radix Dialog portal (which sits above the lower per-view `ActionProvider`s).

## Tests
`packages/fields/src/complex-widgets.test.tsx` — added coverage for: default-ON for a user-facing relation (no `allow_create` needed), the system/user-directory exclusion, and the explicit `allow_create:false` opt-out. Full `@object-ui/fields` suite green.

> Note: the create-form modal layout (compactLayout) is being finalized separately; this PR ships the picker capability + the root modal host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)