### PR TITLE
feat(studio): duplicate-base (复制) on writable packages in the builder landing

### DIFF
--- a/.changeset/duplicate-to-writable.md
+++ b/.changeset/duplicate-to-writable.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(studio): 复制 (duplicate base) on writable packages in the builder landing
+
+Writable base cards on the builder landing gain **复制** — a name/id inline form
+that calls `POST /packages/:id/duplicate` (ADR-0070 D4: re-namespaced clone with
+rewritten references) and drops the user straight into the copy's builder — the
+Airtable "duplicate base" gesture. Read-only code packages stay browse-only:
+duplication copies `sys_metadata` rows, which code packages don't have; their
+customization path is template/marketplace install.

--- a/packages/app-shell/src/views/studio-design/BuilderLanding.tsx
+++ b/packages/app-shell/src/views/studio-design/BuilderLanding.tsx
@@ -16,9 +16,10 @@
 
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Boxes, Hammer, Lock, Plus, Loader2 } from 'lucide-react';
+import { Boxes, Hammer, Lock, Plus, Loader2, Copy } from 'lucide-react';
+import { toast } from 'sonner';
 import { toFieldNameLoose } from '../metadata-admin/previews/object-fields-io';
-import { fetchPackages, createBasePackage, PACKAGE_ID_RE, type PkgEntry } from './packages-io';
+import { fetchPackages, createBasePackage, duplicatePackage, PACKAGE_ID_RE, type PkgEntry } from './packages-io';
 
 export function BuilderLanding(): React.ReactElement {
   const navigate = useNavigate();
@@ -65,6 +66,40 @@ export function BuilderLanding(): React.ReactElement {
   const writable = pkgs?.filter((p) => p.writable) ?? [];
   const readonly = pkgs?.filter((p) => !p.writable) ?? [];
 
+  // 复制为可写副本 (ADR-0070 D4): a read-only code package is a STARTING POINT,
+  // not a dead end — duplicate re-namespaces it into a new writable base and
+  // drops the user straight into its builder. This is also the real substance
+  // behind Home's "Start with a template".
+  const [dupFor, setDupFor] = React.useState<string | null>(null);
+  const [dupName, setDupName] = React.useState('');
+  const [dupId, setDupId] = React.useState('');
+  const [dupBusy, setDupBusy] = React.useState(false);
+  const [dupErr, setDupErr] = React.useState<string | null>(null);
+
+  const startDup = (p: PkgEntry) => {
+    setDupFor(p.id);
+    setDupName(`${p.name} 副本`);
+    setDupId(`${p.id}-copy`);
+    setDupErr(null);
+  };
+  const doDup = async () => {
+    if (!dupFor) return;
+    const id = dupId.trim();
+    const name = dupName.trim();
+    if (!PACKAGE_ID_RE.test(id) || !name) return;
+    setDupBusy(true);
+    setDupErr(null);
+    try {
+      await duplicatePackage(dupFor, id, name);
+      toast.success(`已复制为可写软件包「${name}」`);
+      open(id);
+    } catch (e) {
+      setDupErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDupBusy(false);
+    }
+  };
+
   return (
     <div className="mx-auto w-full max-w-3xl p-6">
       <div className="mb-1 flex items-center gap-2">
@@ -91,21 +126,78 @@ export function BuilderLanding(): React.ReactElement {
           <p className="text-[11px] text-muted-foreground">还没有可写软件包 — 从右侧新建一个开始。</p>
         )}
         {writable.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            onClick={() => open(p.id)}
-            className="flex items-center gap-2.5 rounded-lg border bg-background px-3 py-2.5 text-left hover:border-primary/50 hover:bg-muted/40"
-          >
-            <Boxes className="h-4 w-4 shrink-0 text-primary" />
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-[13px] font-medium">{p.name}</span>
-              <span className="block truncate font-mono text-[10px] text-muted-foreground">{p.id}</span>
-            </span>
-            <span className="rounded bg-emerald-400/15 px-1.5 py-0.5 text-[10px] text-emerald-600 dark:text-emerald-300">
-              可写
-            </span>
-          </button>
+          <div key={p.id} className="rounded-lg border bg-background">
+            <div className="flex items-center gap-2.5 px-3 py-2.5">
+              <button
+                type="button"
+                onClick={() => open(p.id)}
+                className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+              >
+                <Boxes className="h-4 w-4 shrink-0 text-primary" />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[13px] font-medium">{p.name}</span>
+                  <span className="block truncate font-mono text-[10px] text-muted-foreground">{p.id}</span>
+                </span>
+              </button>
+              <span className="rounded bg-emerald-400/15 px-1.5 py-0.5 text-[10px] text-emerald-600 dark:text-emerald-300">
+                可写
+              </span>
+              {/* ADR-0070 D4 — duplicate base 只对可写 base 有意义:它复制的是
+                * sys_metadata 里的行;code 包的定制走模板/市场安装,不在这里。 */}
+              <button
+                type="button"
+                onClick={() => (dupFor === p.id ? setDupFor(null) : startDup(p))}
+                title="复制这个软件包为新的可写副本(Airtable 的 duplicate base)"
+                className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <Copy className="h-3 w-3" /> 复制
+              </button>
+            </div>
+            {dupFor === p.id && (
+              <div className="flex flex-col gap-1.5 border-t px-3 py-2.5">
+                <input
+                  autoFocus
+                  value={dupName}
+                  onChange={(e) => setDupName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') void doDup();
+                    if (e.key === 'Escape') setDupFor(null);
+                  }}
+                  placeholder="副本名称"
+                  className="h-7 w-full rounded-md border bg-background px-2 text-[11px] outline-none focus:ring-1 focus:ring-primary"
+                />
+                <input
+                  value={dupId}
+                  onChange={(e) => setDupId(e.target.value.toLowerCase().replace(/[^a-z0-9_.-]/g, ''))}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') void doDup();
+                    if (e.key === 'Escape') setDupFor(null);
+                  }}
+                  placeholder="副本包 ID"
+                  className="h-7 w-full rounded-md border bg-background px-2 font-mono text-[11px] outline-none focus:ring-1 focus:ring-primary"
+                />
+                {dupErr && <p className="text-[10px] text-destructive">{dupErr}</p>}
+                <div className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => void doDup()}
+                    disabled={dupBusy || !dupName.trim() || !PACKAGE_ID_RE.test(dupId.trim())}
+                    className="inline-flex flex-1 items-center justify-center gap-1 rounded-md bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
+                  >
+                    {dupBusy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Copy className="h-3 w-3" />}
+                    复制并进入构建器
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDupFor(null)}
+                    className="rounded-md border px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted"
+                  >
+                    取消
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
         ))}
 
         {/* new-package card */}

--- a/packages/app-shell/src/views/studio-design/packages-io.ts
+++ b/packages/app-shell/src/views/studio-design/packages-io.ts
@@ -59,4 +59,25 @@ export async function createBasePackage(id: string, name: string): Promise<void>
   }
 }
 
+/**
+ * Duplicate a package into a NEW writable base (ADR-0070 D4 — the Airtable
+ * "duplicate base" gesture; POST /packages/:id/duplicate). This is how a
+ * read-only code package becomes a customizable starting point: objects are
+ * re-namespaced and intra-package references rewritten server-side.
+ */
+export async function duplicatePackage(sourceId: string, targetId: string, targetName?: string): Promise<void> {
+  const res = await fetch(`/api/v1/packages/${encodeURIComponent(sourceId)}/duplicate`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ targetPackageId: targetId, ...(targetName ? { targetName } : {}) }),
+  });
+  const payload = (await res.json().catch(() => null)) as
+    | { success?: boolean; error?: { message?: string } }
+    | null;
+  if (!res.ok || payload?.success === false) {
+    throw new Error(payload?.error?.message || `HTTP ${res.status}`);
+  }
+}
+
 export const PACKAGE_ID_RE = /^[a-z][a-z0-9_.-]*(\.[a-z0-9_-]+)+$/;


### PR DESCRIPTION
Roadmap ② — the Airtable **duplicate base** gesture in the builder landing.

## What

- Writable base cards gain **复制**: an inline name/id form (defaults `<名称> 副本` / `<id>-copy`) → `POST /packages/:id/duplicate` (ADR-0070 D4: re-namespaced clone, references rewritten) → navigates straight into the copy's builder.
- Read-only code packages stay **browse-only** — duplication copies `sys_metadata` rows, which code packages don't have; their customization path is template/marketplace install. (First draft had the button on read-only cards; live probing showed `copied: 0` and the semantics corrected to D4's actual contract.)
- `packages-io.ts` gains the shared `duplicatePackage()` helper.

## Depends on framework#2540

Browser-probing found the server side was doubly broken; fixed there:
- `dispatcher-plugin` never **mounted** `/packages/:id/duplicate` (nor adopt-orphans / commits / rollback / discard-drafts) — hono 404 on every serve stack despite working handler code.
- `duplicatePackage` copied the source manifest **verbatim incl. `scope`**, branding copies read-only; now scope-less.

## Browser-verified (fresh stack)

订单中心 (published `order_ticket`) → **复制** → `/studio/com.example.orders-copy/data`: object in the rail ✓ no 只读 badge ✓ manifest scope-less ✓ durable `sys_packages` row ✓ `GET /data/order_ticket` 200 ✓ toast 已复制 ✓. `type-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)