### PR TITLE
fix(fields): 内嵌子表行操作(删除/复制)常显,不再靠 hover

### DIFF
--- a/.changeset/subform-row-actions-always-visible.md
+++ b/.changeset/subform-row-actions-always-visible.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/fields': patch
+---
+
+Show inline line-item (master-detail subform) row actions always, not on hover.
+In grid mode the per-row remove (🗑) and duplicate buttons were `opacity-0`
+until the row was hovered (`group-hover`), so they read as "delete not
+supported" and were unreachable on touch / coarse-pointer devices with no hover.
+They now render at full opacity (kept muted via `text-muted-foreground`); the
+action column width was already reserved, so there is no layout shift. Existing
+`allow_delete: false` / `readonly` / `disabled` / `min_rows` gating is unchanged.

--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -185,6 +185,20 @@ describe('GridField / LineItemsField — editable line items', () => {
     expect(onChange).toHaveBeenCalledWith([{ description: 'B', amount: 2 }]);
   });
 
+  it('row action buttons are always visible in grid mode (not hover-revealed)', () => {
+    render(
+      <GridField
+        value={[{ description: 'A', amount: 1 }]}
+        onChange={() => {}}
+        field={field}
+      />,
+    );
+    // Grid-mode rows previously gated these behind opacity-0/group-hover, so they
+    // were invisible until hover and unreachable on touch — they must always show.
+    expect(screen.getByLabelText('Remove row').className).not.toContain('opacity-0');
+    expect(screen.getByTestId('line-items-duplicate-0').className).not.toContain('opacity-0');
+  });
+
   it('readonly mode shows values and a summed total footer', () => {
     render(
       <GridField

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -857,10 +857,11 @@ export function GridField({
                               type="button"
                               variant="ghost"
                               size="icon"
-                              className={cn(
-                                'h-8 w-8 text-muted-foreground hover:text-foreground',
-                                !isList && 'opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',
-                              )}
+                              // Always visible (not hover-revealed): row actions must be
+                              // discoverable and reachable on touch/coarse-pointer devices,
+                              // which have no hover. The action column width is reserved
+                              // regardless, so this adds no layout shift.
+                              className="h-8 w-8 text-muted-foreground hover:text-foreground"
                               aria-label="Duplicate row"
                               title="Duplicate line"
                               data-testid={`line-items-duplicate-${rowIdx}`}
@@ -875,10 +876,8 @@ export function GridField({
                               type="button"
                               variant="ghost"
                               size="icon"
-                              className={cn(
-                                'h-8 w-8 text-muted-foreground hover:text-destructive',
-                                !isList && 'opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',
-                              )}
+                              // Always visible — see the duplicate button above.
+                              className="h-8 w-8 text-muted-foreground hover:text-destructive"
                               aria-label="Remove row"
                               data-testid={`line-items-remove-${rowIdx}`}
                               onClick={() => removeRow(rowIdx)}


### PR DESCRIPTION
Closes #2194

## 问题

主从表单内嵌子表格(line-items,grid 模式)每行的 🗑 删除、复制按钮默认 `opacity-0`,只有鼠标悬停到该行才浮现。导致:

1. **不好发现**——用户普遍以为「子表不支持删除行」;
2. **触屏/平板无 hover**——按钮基本点不到,等于删不了行。

## 改动

`packages/fields/src/widgets/GridField.tsx`:去掉删除、复制按钮在 grid 模式下的 `opacity-0 ... group-hover:opacity-100` 门控,改为常显。图标仍用 `text-muted-foreground` 弱化,操作列宽度本就预留,**无布局跳动**。

拖拽排序手柄(reorder grip)不在本次范围,维持悬停显示。`allow_delete: false` / `readonly` / `disabled` / 到 `min_rows` 下限禁用等既有门控不变。

## 测试

- 新增用例:grid 模式下删除/复制按钮的 className 不含 `opacity-0`(防回归)。
- `GridField.test.tsx` **26 项全过**;`@object-ui/fields` type-check 通过。