### PR TITLE
fix(studio): lookup target picker shows the package's own draft objects

### DIFF
--- a/.changeset/lookup-picker-draft-objects.md
+++ b/.changeset/lookup-picker-draft-objects.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(studio): lookup target picker can see the package's own draft objects
+
+When designing a set of related objects in one authoring pass, the field
+inspector's lookup "related object" picker only listed **published** objects
+(`list('object')`), so sibling objects still in draft — the ones you're most
+likely to point a new lookup at — were invisible and had to be typed as a raw
+API name, blind. The picker now also merges unpublished object drafts
+(`listDrafts({ type: 'object' })`, labelled "(草稿)"), so a lookup can target a
+sibling object before the package's first publish.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -1034,18 +1034,32 @@ function useObjectOptions(): Array<{ value: string; label: string }> {
 
   React.useEffect(() => {
     let cancelled = false;
-    client
-      .list<{ name?: string; label?: string }>('object')
-      .then((items) => {
+    Promise.all([
+      client.list<{ name?: string; label?: string }>('object'),
+      // Draft objects are not yet published, so `list('object')` can't see
+      // them. Include them so a lookup can target a SIBLING object being
+      // designed in the same authoring pass (before the package's first
+      // publish) instead of forcing the author to type an API name blind.
+      client.listDrafts({ type: 'object' }).catch(() => [] as Array<{ name?: string }>),
+    ])
+      .then(([published, drafts]) => {
         if (cancelled) return;
-        const mapped = items
-          .filter((i) => typeof i?.name === 'string' && i.name)
-          .map((i) => ({
-            value: i.name as string,
-            label: i.label ? `${i.label} (${i.name})` : (i.name as string),
-          }))
-          .sort((a, b) => a.value.localeCompare(b.value));
-        setOpts(mapped);
+        const byName = new Map<string, { value: string; label: string }>();
+        for (const i of published ?? []) {
+          if (typeof i?.name === 'string' && i.name && !byName.has(i.name)) {
+            byName.set(i.name, {
+              value: i.name,
+              label: i.label ? `${i.label} (${i.name})` : i.name,
+            });
+          }
+        }
+        for (const d of drafts ?? []) {
+          const name = (d as { name?: string }).name;
+          if (typeof name === 'string' && name && !byName.has(name)) {
+            byName.set(name, { value: name, label: `${name} (草稿)` });
+          }
+        }
+        setOpts([...byName.values()].sort((a, b) => a.value.localeCompare(b.value)));
       })
       .catch(() => {
         // Empty list — picker falls back to free-text. No banner needed.


### PR DESCRIPTION
## What
The field inspector's lookup **related-object** picker listed only *published* objects (`list('object')`), so a sibling object still in draft — the natural target when wiring a new relational model in a single authoring pass — was invisible and had to be typed as a raw API name blind.

Now the picker also merges unpublished object drafts (`listDrafts({ type: 'object' })`, labelled `(草稿)`), so a lookup can target a draft sibling before the package's first publish.

## Why
Found dogfooding a new package end-to-end: building `application → candidate / job` while all three were still drafts, the picker showed only `showcase_*` / `sys_*` objects, not the objects being designed. This is the Data-pillar twin of the nav object-picker fix in #2198.

## Verification
- Created a draft object `interview` (面试), added a lookup field, and confirmed `interview` appears in the target datalist alongside the published `job` / `candidate` / `application` (89 options total).
- `@object-ui/app-shell` type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)