### PR TITLE
fix(fields): stop inline "create related" flashing / dismissing the parent form

### DIFF
--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -679,7 +679,20 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
       // title) and turns an empty required picker from a dead end into a way to
       // author the first related record.
       if (hasActionProvider) {
-        setIsOpen(false); // hand off to the modal
+        setIsOpen(false); // close the picker popover first
+        // Defer opening the create dialog until the popover has fully closed and
+        // returned focus to the field trigger. Two nested-modal bugs come from
+        // opening it in the same tick as the triggering click:
+        //  1) the just-mounted Dialog treats this click's release (and the
+        //     popover's own dismiss) as an outside-interaction and flashes shut
+        //     on the FIRST click (works on the second);
+        //  2) with the popover already gone, the "+ create" button that Radix
+        //     would return focus to is unmounted, so when the nested modal later
+        //     closes focus leaks to <body> and dismisses the PARENT form's dialog
+        //     too ("Cancel closes both").
+        // A macrotask runs after Radix's focus-return layout effects, so focus is
+        // safely back on the still-mounted field trigger before the Dialog opens.
+        await new Promise((r) => setTimeout(r, 0));
         const result: any = await execute({
           type: 'modal',
           modal: { objectName: referenceTo, mode: 'create' },


### PR DESCRIPTION
Follow-up to #2192. Two nested-modal bugs surfaced by live testing (a lookup's **"+ create"** opening the referenced object's create form from inside a create/edit form):

1. **First click flashed** the create dialog open then shut (worked on the 2nd click). Mounted in the same tick as the triggering click and the picker popover's dismiss, the dialog treated that click's release as an outside interaction and closed itself.
2. **Cancelling the nested dialog also closed the PARENT form's dialog.** With the picker popover already gone, the "+ create" button Radix returns focus to was unmounted → focus leaked to `<body>` and dismissed the parent dialog too.

**Fix:** after closing the picker popover, defer opening the create dialog to the next macrotask — which runs after Radix's focus-return layout effects, so focus is back on the still-mounted field trigger before the dialog opens. Only the ActionProvider (open-a-real-modal) path changes; the no-provider inline-create fallback is untouched.

`@object-ui/fields` suite green (41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)