### PR TITLE
fix(build): exclude node_modules from turbo tsbuildinfo outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "build/**", "**/*.tsbuildinfo"],
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "build/**",
+        "**/*.tsbuildinfo",
+        "!**/node_modules/**"
+      ],
       "env": ["NODE_ENV", "VITE_BASE_PATH", "OBJECTSTACK_CLIENT_DIST"]
     },
     "test": {


### PR DESCRIPTION
## Problem

`pnpm build` fails at `@object-ui/runner`:

```
Rolldown failed to resolve import "@object-ui/i18n" from ".../packages/react/src/index.ts".
```

The pnpm workspace symlinks under `packages/*/node_modules/@object-ui/*` had degraded from proper symlinks into **empty real directories** containing only `tsconfig.tsbuildinfo` (each with an `.ignored_*` twin). With no `package.json`/`dist`, rolldown can't resolve `@object-ui/i18n` (and `@object-ui/data-objectstack`, etc.), and the runner's Vite build — which aliases `@object-ui/react` to source — dies on the first unresolved re-export.

## Root cause

The build `outputs` glob `**/*.tsbuildinfo`, added in #1767 to cache composite `tsc` build info, also matches `tsconfig.tsbuildinfo` files reachable **through** the pnpm workspace symlinks — e.g. `packages/react/node_modules/@object-ui/core/node_modules/@object-ui/types/tsconfig.tsbuildinfo`. Turbo caches those paths and, on cache **restore**, recreates them as real directories, clobbering the symlinks. The corruption compounds build-over-build (cache artifacts even captured `.ignored_core` from a prior round).

Verified directly from the local turbo cache artifacts — they were packed full of deeply-nested `node_modules/@object-ui/**/tsconfig.tsbuildinfo` entries.

## Fix

Add `!**/node_modules/**` to the build `outputs` so turbo never captures or restores anything under `node_modules`, while still caching the package-root `tsconfig.tsbuildinfo` that #1767 relies on.

## Validation

Cold build in a fresh worktree (healthy symlinks) with the fix:

- **44/44** build tasks succeeded
- All `@object-ui/*` workspace symlinks intact after the build (no clobbering)
- **0** `.ignored_*` directories created
- **0** `node_modules/**tsbuildinfo` entries across all 44 new cache artifacts (only package-root `tsconfig.tsbuildinfo` is captured, e.g. `packages/auth/tsconfig.tsbuildinfo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)