### PR TITLE
test(app-shell): stub listDrafts in ObjectFieldInspector tests (fix main CI)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.test.tsx
@@ -3,9 +3,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 
-// The inspector loads the object list for the lookup picker; stub it.
+// The inspector loads the object list (published + drafts) for the lookup
+// picker; stub both surfaces.
 vi.mock('../useMetadata', () => ({
-  useMetadataClient: () => ({ list: vi.fn().mockResolvedValue([]) }),
+  useMetadataClient: () => ({
+    list: vi.fn().mockResolvedValue([]),
+    listDrafts: vi.fn().mockResolvedValue([]),
+  }),
 }));
 
 // Lookup picker config reads the referenced object's fields; stub the catalog.


### PR DESCRIPTION
## Problem

`main` CI has been red since run [28682411708](https://github.com/objectstack-ai/objectui/actions/runs/28682411708) (every push after #2199): all **16 tests** in `packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.test.tsx` fail with

```
TypeError: client.listDrafts is not a function
  at ObjectFieldInspector.tsx:1043
```

#2199 taught the inspector's `useObjectOptions` to also call `client.listDrafts({type:'object'})` (so a lookup can target sibling draft objects), but the test file's `useMetadataClient` mock only stubbed `list` — the component now throws in its mount effect on every render.

## Fix

Stub `listDrafts` alongside `list` in the mock. Test-only change, no changeset needed.

## Testing

`vitest run …/ObjectFieldInspector.test.tsx` → **16/16 pass** (was 16/16 fail on `origin/main` 638bbd90f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)