### PR TITLE
fix(console): unwrap ExpandedViewItem envelope in FormPage internal loader

### DIFF
--- a/.changeset/formpage-unwrap-expanded-view.md
+++ b/.changeset/formpage-unwrap-expanded-view.md
@@ -1,0 +1,8 @@
+---
+"@object-ui/console": patch
+---
+
+FormPage: unwrap the ExpandedViewItem envelope from `/meta/view/:name` — the form
+spec lives under `config`, so internal forms rendered zero fields with a bare
+Submit that falsely succeeded. Non-form views reaching the forms route now throw
+an actionable error instead of the same empty-form false positive.

--- a/apps/console/src/components/FormPage.test.ts
+++ b/apps/console/src/components/FormPage.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeColumns,
   normalizeOptions,
   readPrefill,
+  resolveInternalForm,
 } from './FormPage';
 
 describe('normalizeColumns', () => {
@@ -178,5 +179,82 @@ describe('readPrefill', () => {
   it('treats empty-string values as a real prefill', () => {
     const out = readPrefill(fields, new URLSearchParams('prefill_company='));
     expect(out.company).toBe('');
+  });
+});
+
+/**
+ * objectui#2208 — the server's `/meta/view/:name` returns the flattened
+ * ExpandedViewItem envelope `{ name, object, viewKind, label, config }`;
+ * the form spec lives under `config`. Pre-fix the loader read sections off
+ * the envelope itself → every internal form rendered zero fields + a bare
+ * Submit that "succeeded". List views reaching the forms route (the
+ * framework#2554 collision fallout) rendered the same false positive
+ * instead of an actionable error.
+ */
+describe('resolveInternalForm', () => {
+  const envelope = {
+    name: 'showcase_task.tabbed',
+    object: 'showcase_task',
+    viewKind: 'form',
+    label: 'Tabbed',
+    scope: 'package',
+    config: {
+      type: 'tabbed',
+      data: { provider: 'object', object: 'showcase_task' },
+      sections: [{ name: 'overview', label: 'Overview', fields: ['title', 'status'] }],
+    },
+  };
+
+  it('unwraps the ExpandedViewItem envelope: form spec comes from config', () => {
+    const out = resolveInternalForm('showcase_task.tabbed', envelope);
+    expect(out.form.type).toBe('tabbed');
+    expect(out.form.sections).toHaveLength(1);
+    expect(out.label).toBe('Tabbed');
+    expect(out.object).toBe('showcase_task');
+  });
+
+  it('accepts the { item: envelope } wrapper', () => {
+    const out = resolveInternalForm('showcase_task.tabbed', { item: envelope });
+    expect(out.form.sections).toHaveLength(1);
+    expect(out.object).toBe('showcase_task');
+  });
+
+  it('falls back to the envelope name when neither envelope nor config carry a label', () => {
+    const { label: _l, ...noLabel } = envelope;
+    const out = resolveInternalForm('showcase_task.tabbed', noLabel);
+    expect(out.label).toBe('showcase_task.tabbed');
+  });
+
+  it('throws an actionable error for a non-form view instead of rendering an empty form', () => {
+    const listView = {
+      name: 'showcase_task.default',
+      object: 'showcase_task',
+      viewKind: 'list',
+      label: 'All Tasks',
+      config: { type: 'grid', data: { provider: 'object', object: 'showcase_task' }, columns: ['title'] },
+    };
+    expect(() => resolveInternalForm('showcase_task.default', listView)).toThrow(/list view, not a form view/);
+  });
+
+  it('still accepts a bare legacy form spec (no envelope)', () => {
+    const bare = {
+      type: 'simple',
+      label: 'Quick Edit',
+      data: { provider: 'object', object: 'task' },
+      sections: [{ label: 'Main', fields: ['title'] }],
+    };
+    const out = resolveInternalForm('task.quick', bare);
+    expect(out.form).toBe(bare as any);
+    expect(out.label).toBe('Quick Edit');
+    // object resolved from the spec's data binding
+    expect(out.object).toBe('task');
+  });
+
+  it('accepts the legacy { item: { spec } } wrapper', () => {
+    const out = resolveInternalForm('task.quick', {
+      item: { spec: { type: 'simple', object: 'task', sections: [] } },
+    });
+    expect(out.object).toBe('task');
+    expect(out.form.type).toBe('simple');
   });
 });

--- a/apps/console/src/components/FormPage.test.ts
+++ b/apps/console/src/components/FormPage.test.ts
@@ -236,6 +236,35 @@ describe('resolveInternalForm', () => {
     expect(() => resolveInternalForm('showcase_task.default', listView)).toThrow(/list view, not a form view/);
   });
 
+  it('throws for a flattened runtime-overlay list row that lost its viewKind (framework#2555 fallout)', () => {
+    // A personalization PUT persisted the raw config at the top level; the
+    // pre-heal server returns it with name/object/label but NO viewKind and
+    // NO config envelope. It must not pass for a legacy bare form spec.
+    const pollutedOverlay = {
+      name: 'showcase_task.default',
+      object: 'showcase_task',
+      label: 'All Tasks',
+      type: 'grid',
+      data: { provider: 'object', object: 'showcase_task' },
+      columns: [{ field: 'title' }],
+      sort: [{ id: '29200fa8-c416-471e-9ca3-913f9308ad89', field: 'estimate_hours', order: 'desc' }],
+    };
+    expect(() => resolveInternalForm('showcase_task.default', pollutedOverlay)).toThrow(/grid view, not a form view/);
+  });
+
+  it('throws for a flattened list body whose viewKind sits at the top level (healed overlay row)', () => {
+    const healedOverlay = {
+      name: 'showcase_task.default',
+      object: 'showcase_task',
+      viewKind: 'list',
+      label: 'All Tasks',
+      type: 'grid',
+      data: { provider: 'object', object: 'showcase_task' },
+      columns: [{ field: 'title' }],
+    };
+    expect(() => resolveInternalForm('showcase_task.default', healedOverlay)).toThrow(/list view, not a form view/);
+  });
+
   it('still accepts a bare legacy form spec (no envelope)', () => {
     const bare = {
       type: 'simple',

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -225,6 +225,46 @@ async function loadPublicForm(slug: string): Promise<LoadedForm> {
 }
 
 /**
+ * Unwrap a `/meta/view/:name` response into the FormViewSpec the renderer
+ * consumes. Since the ADR-0017 registrar the server returns the flattened
+ * ExpandedViewItem envelope — `{ name, object, viewKind, label, config:
+ * { type, sections, … } }` — with the actual form spec nested under
+ * `config`. Pre-fix, this loader read `sections`/`label` off the envelope
+ * itself and rendered every internal form as zero fields plus a bare
+ * Submit that "succeeded" (objectui#2208). Older servers / seeded rows may
+ * still serve `{ item: { spec } }` or the bare spec, so all shapes are
+ * accepted.
+ *
+ * Also rejects non-form views loudly: a list-view name reaching this route
+ * (e.g. an action target hit by the framework#2554 key collision) used to
+ * render as that same empty-form false positive.
+ */
+export function resolveInternalForm(
+  name: string,
+  viewBody: unknown,
+): { label: string; object?: string; form: FormViewSpec } {
+  const body = viewBody as Record<string, any> | null;
+  const item = body?.item ?? body;
+  const spec = item?.spec ?? item;
+  const isEnvelope =
+    spec && typeof spec === 'object'
+    && spec.config && typeof spec.config === 'object'
+    && ('viewKind' in spec || 'object' in spec);
+  const viewKind: string | undefined = isEnvelope ? spec.viewKind : undefined;
+  if (viewKind && viewKind !== 'form') {
+    throw new Error(
+      `View "${name}" is a ${viewKind} view, not a form view — check the action or link that targets it.`,
+    );
+  }
+  const form: FormViewSpec = isEnvelope ? spec.config : spec;
+  return {
+    label: (isEnvelope ? spec.label : undefined) ?? form?.label ?? name,
+    object: (isEnvelope ? spec.object : undefined) ?? (form as any)?.data?.object ?? spec?.object,
+    form,
+  };
+}
+
+/**
  * Internal mode: pull the FormView metadata directly + the target object's
  * schema. We use the same `/meta` REST surface the rest of the console
  * already speaks, so anything the user has READ on works automatically.
@@ -235,10 +275,7 @@ async function loadInternalForm(name: string): Promise<LoadedForm> {
     throw new Error(`Form metadata not found: view/${name}`);
   }
   const viewBody = await viewRes.json();
-  // /meta/:type/:name returns either { item: {...} } or the raw spec
-  const item = viewBody?.item ?? viewBody;
-  const spec = item?.spec ?? item;
-  const objectName: string | undefined = spec?.object;
+  const { label, object: objectName, form } = resolveInternalForm(name, viewBody);
   if (!objectName) {
     throw new Error(`FormView "${name}" is missing an "object" target`);
   }
@@ -261,9 +298,9 @@ async function loadInternalForm(name: string): Promise<LoadedForm> {
     // Schema fallback is non-fatal — the renderer copes with text inputs.
   }
   return {
-    label: spec?.label ?? name,
+    label,
     object: objectName,
-    form: spec,
+    form,
     objectSchema,
   };
 }

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -44,6 +44,9 @@ interface ObjectFieldDef {
   helpText?: string;
 }
 
+/** Visualization types the form renderer understands (FormViewSpec.type). */
+const FORM_SPEC_TYPES = new Set(['simple', 'tabbed', 'wizard', 'split', 'drawer', 'modal']);
+
 interface FormViewSpec {
   type?: 'simple' | 'tabbed' | 'wizard' | 'split' | 'drawer' | 'modal';
   label?: string;
@@ -250,13 +253,26 @@ export function resolveInternalForm(
     spec && typeof spec === 'object'
     && spec.config && typeof spec.config === 'object'
     && ('viewKind' in spec || 'object' in spec);
-  const viewKind: string | undefined = isEnvelope ? spec.viewKind : undefined;
+  // viewKind may sit on the envelope OR on a flattened list-view body
+  // (runtime personalization overlays are persisted with the config at the
+  // top level), so read it wherever it is.
+  const viewKind: string | undefined =
+    spec && typeof spec === 'object' ? spec.viewKind : undefined;
   if (viewKind && viewKind !== 'form') {
     throw new Error(
       `View "${name}" is a ${viewKind} view, not a form view — check the action or link that targets it.`,
     );
   }
   const form: FormViewSpec = isEnvelope ? spec.config : spec;
+  // A flattened list config carries no viewKind at all but declares a grid/
+  // kanban/… visualization type no form renderer understands — same false
+  // positive, same loud failure.
+  if (!viewKind && form && typeof form === 'object' && typeof form.type === 'string'
+    && !FORM_SPEC_TYPES.has(form.type)) {
+    throw new Error(
+      `View "${name}" is a ${form.type} view, not a form view — check the action or link that targets it.`,
+    );
+  }
   return {
     label: (isEnvelope ? spec.label : undefined) ?? form?.label ?? name,
     object: (isEnvelope ? spec.object : undefined) ?? (form as any)?.data?.object ?? spec?.object,


### PR DESCRIPTION
Closes #2208

## 问题(HMR console 5181 + framework 3777 实测)

内部表单路由 `/forms/<view>` 全部渲染成**零字段 + 裸 Submit**,且点击 Submit 会发空 `POST /data/<object>` 并误报成功。

根因:`GET /meta/view/<name>` 返回的是展平 ExpandedViewItem 信封 —— `{ name, object, viewKind, label, config: { type, data, sections } }`,真正的表单 spec 在 `config` 里;但 `loadInternalForm` 读的是 `item?.spec ?? item` 顶层的 `sections`/`label`(信封上没有)→ `buildSections` 得到空数组。label 同理显示裸视图名。

另外无 `viewKind` 校验:list 视图进这条路由照样渲染空表单(framework#2554 key 冲突把 action target 解析到 list 视图时的表现)。

## 修复

- 提取纯函数 `resolveInternalForm(name, viewBody)`:
  - 依次解包 `{ item }` 包装、ExpandedViewItem 信封(`config` 才是 FormViewSpec)、legacy `{ item: { spec } }` / 裸 spec 三种形状;
  - label 回退链:信封 label → config.label → 视图名;
  - object 解析:信封顶层 `object` → `config.data.object` → spec.object(裸 legacy spec 以前拿不到 object 直接报错,现在从 data 绑定解析);
  - `viewKind` 存在且非 `'form'` 时抛出可操作的错误("View X is a list view, not a form view — check the action or link that targets it"),不再空表单假成功。
- `loadInternalForm` 改用该函数,其余(objectSchema 拉取、提交)不变。

## 测试

- [FormPage.test.ts](apps/console/src/components/FormPage.test.ts) 新增 6 个 `resolveInternalForm` 用例(payload 取自 live server 实测响应):信封解包、`{item}` 包装、label 回退、list 视图报错、裸 legacy spec、`{item:{spec}}` 包装。
- `@object-ui/console` 套件:5129 pass;唯一失败是 `packages/core` 的 DATEFORMAT 时区敏感测试,干净 main 上同样失败(本地非 UTC 时区所致),与本 PR 无关。
- `pnpm --filter "@object-ui/console..." build` 全绿(含 tsc)。

Co-Authored-By: Claude <noreply@anthropic.com>