### PR TITLE
fix(app-shell): block record-scoped toolbar actions with zero rows selected

### DIFF
--- a/.changeset/toolbar-zero-selection-block.md
+++ b/.changeset/toolbar-zero-selection-block.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/components": patch
+---
+
+Block record-scoped toolbar actions launched with zero rows selected (#2210).
+
+A flow/script action that also mounts on list rows (`locations` includes
+`list_item`) has no record to run on when triggered from the list toolbar with
+nothing selected — pre-fix the wizard opened anyway, collected input, and died
+at its first record-bound node ("Update requires an ID or options.multi=true").
+The console runtime now blocks up front with "select a row first", mirroring
+the existing multi-selection guard. Pure object-level toolbar actions
+(`locations: ['list_toolbar']` only) keep triggering without a record.
+
+The action renderers (button/icon/menu/group) now forward the `locations`
+declaration to the ActionRunner — previously it was dropped by their
+allow-list payloads, so the runtime could not tell the two shapes apart.

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -265,6 +265,50 @@ describe('flowHandler — list_toolbar selection fallback', () => {
     expect(authFetchSpy).not.toHaveBeenCalled();
   });
 
+  it('blocks a record-scoped flow (locations include list_item) launched with zero rows selected (#2210)', async () => {
+    // BulkReassignAction shape: mounts on rows AND the toolbar. From the
+    // toolbar with nothing selected there is no record to run on — pre-fix
+    // the wizard opened anyway and died at the first record-bound node
+    // ("Update requires an ID or options.multi=true").
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [] }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.flowHandler(
+        {
+          type: 'flow', name: 'showcase_bulk_reassign', target: 'showcase_reassign_wizard',
+          locations: ['list_item', 'list_toolbar'],
+        } as any,
+        { selectedRecords: [] } as any,
+      );
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/select a row/i);
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('still triggers an object-level toolbar flow (no record locations) with zero rows selected', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'inv' }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.flowHandler(
+        { type: 'flow', name: 'monthly_close', target: 'monthly_close', locations: ['list_toolbar'] } as any,
+        { selectedRecords: [] } as any,
+      );
+    });
+
+    expect(res).toMatchObject({ success: true });
+    const body = JSON.parse(authFetchSpy.mock.calls[0][1].body);
+    expect(body.recordId ?? null).toBeNull();
+  });
+
   it('an explicit _rowRecord (list_item invocation) still wins over the selection', async () => {
     authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
     const { result } = renderHook(() =>
@@ -368,6 +412,42 @@ describe('serverActionHandler — list_toolbar selection fallback', () => {
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/single record/i);
     expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks a record-scoped script action launched with zero rows selected (#2210)', async () => {
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'inv' }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.serverActionHandler(
+        { type: 'script', name: 'archive', locations: ['list_item', 'list_toolbar'] } as any,
+        { selectedRecords: [] } as any,
+      );
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/select a row/i);
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('still calls an object-level toolbar script action with zero rows selected', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'inv' }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.serverActionHandler(
+        { type: 'script', name: 'export_all', locations: ['list_toolbar'] } as any,
+        { selectedRecords: [] } as any,
+      );
+    });
+
+    expect(res).toMatchObject({ success: true });
+    expect(String(authFetchSpy.mock.calls[0][0])).toContain('/api/v1/actions/inv/export_all');
   });
 });
 

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -50,6 +50,22 @@ import { resolvePageVarTokens } from '../utils/resolvePageVarTokens';
 
 const FALLBACK_USER = { id: 'current-user', name: 'Demo User', isPlatformAdmin: false };
 
+/**
+ * An action that also mounts on list rows (`list_item`) or record pages is
+ * designed to run against a single record. When such an action is launched
+ * from the list toolbar with nothing selected, there is no record context to
+ * resolve — block up front instead of triggering a run that fails at its
+ * first record-bound step (#2210: "Update requires an ID"). Actions declaring
+ * only object-level locations (e.g. `['list_toolbar']`) are left alone: they
+ * legitimately run without a record.
+ */
+function isRecordScoped(action: ActionDef): boolean {
+  const locations = (action as { locations?: unknown }).locations;
+  if (!Array.isArray(locations)) return false;
+  return locations.some((l) =>
+    l === 'list_item' || l === 'record_header' || l === 'record_more' || l === 'record_section');
+}
+
 export interface ConsoleActionRuntimeOptions {
   /** Adapter for generic CRUD / execute calls. */
   dataSource: any;
@@ -369,12 +385,18 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       // context as `selectedRecords`. Flows take a single `recordId` input
       // variable, so a multi-row selection is ambiguous: block with a message
       // instead of triggering a run that fails at its first record-bound node.
+      // Zero selection is blocked too when the action is record-scoped (it
+      // also mounts on list rows) — otherwise the wizard opens, collects
+      // input, and dies at its first record-bound node ("Update requires an
+      // ID"). Pure object-level toolbar flows keep triggering with no record.
       if (recordId == null) {
         const selected = Array.isArray(context?.selectedRecords) ? context!.selectedRecords : [];
         if (selected.length === 1) {
           recordId = selected[0]?.id;
         } else if (selected.length > 1) {
           return { success: false, error: 'This flow runs on a single record — select exactly one row.' };
+        } else if (isRecordScoped(action)) {
+          return { success: false, error: 'This flow runs on a single record — select a row first.' };
         }
       }
       if (recordId != null && params.recordId == null) params.recordId = recordId;
@@ -430,7 +452,8 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     // Same list_toolbar fallback as flowHandler: no `_rowRecord` means the
     // action came from the toolbar — resolve the recordId from the grid's
     // checkbox selection (published as `selectedRecords`). Multi-select is
-    // ambiguous for a single-record action, so block with a message.
+    // ambiguous for a single-record action, so block with a message; so is
+    // zero selection when the action is record-scoped (see isRecordScoped).
     if (resolvedRecordId == null) {
       const selected = Array.isArray(context?.selectedRecords) ? context!.selectedRecords : [];
       if (selected.length === 1) {
@@ -438,6 +461,8 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       } else if (selected.length > 1) {
         // The runner's post-execution hook surfaces `error` as a toast.
         return { success: false, error: 'This action runs on a single record — select exactly one row.' };
+      } else if (isRecordScoped(action)) {
+        return { success: false, error: 'This action runs on a single record — select a row first.' };
       }
     }
 

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -106,6 +106,10 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
           // handler never builds the undo operation.
           undoable: (schema as any).undoable,
           recordIdField: (schema as any).recordIdField,
+          // Forward the placement declaration — the console runtime uses it to
+          // tell record-scoped actions (also mounted on rows) from pure
+          // object-level toolbar actions when no row is selected (#2210).
+          locations: (schema as any).locations,
           toast: schema.toast,
           // One-shot reveal dialog for actions whose response is shown
           // exactly once (2FA setup, OAuth client_secret, regenerated

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -142,6 +142,8 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
           successMessage: action.successMessage,
           errorMessage: action.errorMessage,
           refreshAfter: action.refreshAfter,
+          // Placement declaration — see action-button.tsx (#2210).
+          locations: action.locations,
           toast: action.toast,
         });
       },

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -66,6 +66,8 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
           successMessage: schema.successMessage,
           errorMessage: schema.errorMessage,
           refreshAfter: schema.refreshAfter,
+          // Placement declaration — see action-button.tsx (#2210).
+          locations: (schema as any).locations,
           toast: schema.toast,
           ...localContext,
         });

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -136,6 +136,8 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
             successMessage: action.successMessage,
             errorMessage: action.errorMessage,
             refreshAfter: action.refreshAfter,
+            // Placement declaration — see action-button.tsx (#2210).
+            locations: action.locations,
             toast: action.toast,
             // See action-button.tsx — overflow-menu actions need the
             // resultDialog spec forwarded too or the one-shot reveal is lost.


### PR DESCRIPTION
Fixes #2210 — P0-27 of the showcase console dogfood audit.

## Problem

A flow/script action that also mounts on list rows (`locations` includes `list_item`, e.g. the showcase `BulkReassignAction`) has no record context when launched from the list toolbar with **nothing selected**. The run triggered anyway: the screen-flow wizard opened, collected user input, and died at its first record-bound node:

```
Node 'apply' failed: update_record(showcase_task) failed: Update requires an ID or options.multi=true
```

## Fix (two halves — both required)

1. **`useConsoleActionRuntime`** — `flowHandler` and `serverActionHandler` now block zero-selection launches of record-scoped actions with an actionable error ("This flow/action runs on a single record — select a row first."), mirroring the existing multi-selection guard. `isRecordScoped()` = the action declares a row/record location (`list_item`, `record_header`, `record_more`, `record_section`). Pure object-level toolbar actions (`locations: ['list_toolbar']` only) keep triggering with no record — unchanged.

2. **Action renderers (`action-button` / `action-icon` / `action-menu` / `action-group`)** — forward the `locations` declaration in their `execute()` payloads. They build allow-list payloads that silently dropped `locations`, so the runtime had no way to tell the two shapes apart. Caught live: the handler fix alone passed unit tests but did not change browser behavior.

## Verified

- Unit: 4 new cases (flow + script × block/pass-through); `useConsoleActionRuntime.test.tsx` 23/23; full app-shell suite 973/973; `action-bar` 18/18; full workspace build 44/44.
- Live (HMR console against the showcase server):
  - 0 rows selected + toolbar "Reassign…" → single red toast "select a row first", **no wizard, no flow run** (pre-fix: wizard opened then crashed at `apply`);
  - 1 row selected + toolbar → wizard → submit → single green "Done", record updated (API-verified);
  - row-menu (`list_item`) launch → wizard → submit → single green "Done" — unchanged.

Sibling symptom P0-35 (double toast on row-level launch) was verified already fixed on current main during the same session — no change needed.