### PR TITLE
fix(components): stop a nested dialog's close from dismissing the parent dialog

### DIFF
--- a/packages/components/src/custom/mobile-dialog-content.tsx
+++ b/packages/components/src/custom/mobile-dialog-content.tsx
@@ -70,8 +70,17 @@ export function usePopperAwareInteractOutside(
 ): InteractOutsideHandler {
   const popperOpenAtPointerDownRef = React.useRef(false);
   React.useEffect(() => {
-    const snapshotPopperState = () => {
-      popperOpenAtPointerDownRef.current = !!document.querySelector(POPPER_LAYER_SELECTOR);
+    const snapshotPopperState = (e: PointerEvent) => {
+      const t = e.target as Element | null;
+      // Same deferred-verdict race, second source: a NESTED dialog (a create /
+      // edit form opened from a lookup field's inline "+ create") also portals
+      // to <body>. Closing it — e.g. its Cancel button — reads to THIS dialog as
+      // its own outside click and dismisses it too. Snapshot on the capture
+      // phase whether the pointerdown landed on a popper OR inside another open
+      // dialog, before Radix's bubble-phase dismissal can unmount it.
+      popperOpenAtPointerDownRef.current =
+        !!document.querySelector(POPPER_LAYER_SELECTOR) ||
+        !!t?.closest?.('[role="dialog"]');
     };
     document.addEventListener('pointerdown', snapshotPopperState, true);
     return () => document.removeEventListener('pointerdown', snapshotPopperState, true);
@@ -80,7 +89,9 @@ export function usePopperAwareInteractOutside(
     (event: Parameters<InteractOutsideHandler>[0]) => {
       const originalEvent = event.detail?.originalEvent;
       const target = (originalEvent?.target ?? null) as Element | null;
-      if (isInsidePopperLayer(target)) {
+      // Inside this dialog's own dropdown flyout, or inside a nested dialog
+      // stacked above it — either way, not a backdrop click, so keep this open.
+      if (isInsidePopperLayer(target) || target?.closest?.('[role="dialog"]')) {
         event.preventDefault();
         return;
       }


### PR DESCRIPTION
## Bug
Opening a create/edit form from **inside another form** — e.g. a lookup field's inline **"+ create"** (the first-related-record unblock, objectui#2192) — and then **Cancelling / closing** the nested form also **dismissed the parent form's dialog**. So a user creating a borrow record, who inline-creates the referenced book and cancels (or even completes) it, lost the whole borrow-record form.

(#2201 fixed the *open-time* half — the nested form flashing shut on first click. This is the *close-time* half.)

## Root cause — the same race `MobileDialogContent` already guards for poppers (#2156)
The nested create form portals its own Radix `Dialog` to `<body>`. `radix-dialog` defers its outside-pointerdown verdict to the `click` phase; by then the nested dialog has unmounted, so the parent — now the top dismissable layer — treats the closing click as *its own* outside click and dismisses too. This is exactly the deferred-verdict race the existing `usePopperAwareInteractOutside` snapshots for Select/Popover flyouts.

## Fix
Extend that capture-phase guard to also cover nested **dialogs**: snapshot on `pointerdown` whether the target sits inside another open `[role="dialog"]` (not just a popper flyout), and swallow the interact-outside that follows. One selector added to the snapshot + the immediate check. No API change; every dialog built on `MobileDialogContent` benefits.

## Verified (live, local stack)
- Empty book picker → **"+ create"** opens the book's full create form (stable, first click).
- **Cancel** the nested form → parent 借阅记录 form **stays open**. ✅
- **Create** the book → nested closes, parent **stays open**, and the new book is **selected** into the lookup. ✅

`@object-ui/components` `mobile-dialog-content` tests green (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)