### PR TITLE
fix(form): evaluate view-level FormField.visibleOn with the canonical CEL engine

### DIFF
--- a/.changeset/lazy-mirrors-brake.md
+++ b/.changeset/lazy-mirrors-brake.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/components': patch
+'@object-ui/plugin-form': patch
+'@object-ui/app-shell': patch
+'@object-ui/types': patch
+---
+
+Fix view-level `FormField.visibleOn` (CEL) never taking effect (#2212).
+
+The spec ships `visibleOn` as an Expression object `{ dialect: 'cel', source }`
+(what the `P` template emits) or a bare string, but the whole chain dropped it:
+
+- `sectionFields.ts` / `ObjectForm.tsx` only accepted the bare-string shape and
+  attached a dead `visible()` closure no renderer ever called — the Expression
+  object shape was silently discarded.
+- The form renderer destructured `visibleOn` out of the field config and never
+  evaluated it.
+- `RecordFormPage` dropped a `simple` form view's `sections` entirely, so
+  page-mode create/edit fell back to the raw schema (every field, no authored
+  selection/grouping) while the modal path honored the same view.
+- `ObjectForm`'s grouped-sections path matched section fields by name only,
+  dropping per-field `visibleOn` overrides.
+
+`visibleOn` now flows through normalization verbatim (both wire shapes) and is
+evaluated reactively by the form renderer with the canonical expression engine
+(`evalFieldPredicate` — same engine, record scope, and fail-open semantics as
+field-level `visibleWhen`; both predicates must allow a field for it to show).
+Sectioned/flat normalization also copies field-level `visibleWhen` /
+`readonlyWhen` / `requiredWhen` rules it previously lost.

--- a/packages/app-shell/src/views/RecordFormPage.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.tsx
@@ -233,19 +233,24 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
   const formDef: any = (objectDef as any).form ?? (objectDef as any).formViews?.default ?? {};
   const pageFormType: 'simple' | 'tabbed' | 'wizard' | 'split' =
     ['tabbed', 'wizard', 'split'].includes(formDef.type) ? formDef.type : 'simple';
-  const formLayoutProps =
-    pageFormType !== 'simple' && Array.isArray(formDef.sections)
-      ? {
-          sections: formDef.sections,
-          defaultTab: formDef.defaultTab,
-          tabPosition: formDef.tabPosition,
-          allowSkip: formDef.allowSkip,
-          showStepIndicator: formDef.showStepIndicator,
-          splitDirection: formDef.splitDirection,
-          splitSize: formDef.splitSize,
-          splitResizable: formDef.splitResizable,
-        }
-      : {};
+  // Curated `sections` are wired through for EVERY layout family — a `simple`
+  // form view's sections still carry the authored field selection, order,
+  // grouping and per-field `visibleOn` predicates (#2212). Dropping them for
+  // `simple` made the page-mode form fall back to the raw schema (every field,
+  // no conditional visibility) while the New/Edit modal honored the same view
+  // via resolveFormViewLayout.
+  const formLayoutProps = Array.isArray(formDef.sections) && formDef.sections.length > 0
+    ? {
+        sections: formDef.sections,
+        defaultTab: formDef.defaultTab,
+        tabPosition: formDef.tabPosition,
+        allowSkip: formDef.allowSkip,
+        showStepIndicator: formDef.showStepIndicator,
+        splitDirection: formDef.splitDirection,
+        splitSize: formDef.splitSize,
+        splitResizable: formDef.splitResizable,
+      }
+    : {};
 
   return (
     <ExpressionProvider user={expressionUser} app={{ name: appName }} data={{}} features={features}>

--- a/packages/components/src/renderers/form/__tests__/form-visibleon.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-visibleon.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * View-level FormField.visibleOn (#2212).
+ *
+ * A form-view field may declare a CEL `visibleOn` predicate — the wire shape
+ * is either a bare string or the spec Expression object `{ dialect, source }`
+ * (what the `P` template emits). The form renderer must evaluate it against
+ * the live record with the canonical engine, exactly like the field-level
+ * `visibleWhen` rules. Pre-fix the predicate was destructured out of the
+ * field config and dropped, so conditional fields always rendered.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+
+beforeAll(async () => {
+  await import('../../../renderers');
+}, 30000);
+
+function renderForm(fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        showSubmit: false,
+        showCancel: false,
+        fields,
+      }}
+    />,
+  );
+}
+
+describe('form renderer — view-level FormField.visibleOn (#2212)', () => {
+  it('hides a field whose `{ dialect, source }` visibleOn is FALSE and shows it when it turns TRUE', async () => {
+    renderForm([
+      { name: 'priority', label: 'Priority', type: 'input', defaultValue: 'low' },
+      {
+        name: 'notes',
+        label: 'Notes',
+        type: 'input',
+        visibleOn: { dialect: 'cel', source: "record.priority == 'urgent'" },
+      },
+    ]);
+
+    // priority = 'low' → notes hidden
+    expect(screen.getByLabelText(/priority/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/notes/i)).not.toBeInTheDocument();
+
+    // flip the controlling field → notes appears reactively
+    fireEvent.change(screen.getByLabelText(/priority/i), { target: { value: 'urgent' } });
+    await waitFor(() => {
+      expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
+    });
+
+    // and back → hidden again
+    fireEvent.change(screen.getByLabelText(/priority/i), { target: { value: 'low' } });
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/notes/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('accepts the bare-string wire shape', () => {
+    renderForm([
+      { name: 'priority', label: 'Priority', type: 'input', defaultValue: 'low' },
+      {
+        name: 'notes',
+        label: 'Notes',
+        type: 'input',
+        visibleOn: "record.priority == 'urgent'",
+      },
+    ]);
+    expect(screen.queryByLabelText(/notes/i)).not.toBeInTheDocument();
+  });
+
+  it('fails open on a broken predicate (field stays visible)', () => {
+    renderForm([
+      { name: 'priority', label: 'Priority', type: 'input', defaultValue: 'low' },
+      {
+        name: 'notes',
+        label: 'Notes',
+        type: 'input',
+        visibleOn: { dialect: 'cel', source: 'this is not (valid CEL' },
+      },
+    ]);
+    expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
+  });
+
+  it('combines with field-level visibleWhen (both must allow the field)', () => {
+    renderForm([
+      { name: 'priority', label: 'Priority', type: 'input', defaultValue: 'urgent' },
+      { name: 'status', label: 'Status', type: 'input', defaultValue: 'closed' },
+      {
+        name: 'notes',
+        label: 'Notes',
+        type: 'input',
+        visibleOn: { dialect: 'cel', source: "record.priority == 'urgent'" },
+        visibleWhen: "record.status == 'open'",
+      },
+    ]);
+    // visibleOn passes but visibleWhen fails → hidden
+    expect(screen.queryByLabelText(/notes/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ComponentRegistry, resolveFieldRuleState } from '@object-ui/core';
+import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate } from '@object-ui/core';
 import type { FormSchema, FormField as FormFieldConfig, ValidationRule, FieldCondition, SelectOption } from '@object-ui/types';
 import { useForm } from 'react-hook-form';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from '../../ui/form';
@@ -308,10 +308,15 @@ ComponentRegistry.register('form',
           ruleRecord,
           { required: !!f.required, readonly: (f as any).readonly === true },
         );
+        // View-level FormField.visibleOn hides the field the same way a
+        // field-level visibleWhen does (#2212) — fold it into the verdict.
+        const viewVisible =
+          (f as any).visibleOn == null ||
+          evalFieldPredicate((f as any).visibleOn, ruleRecord, true);
         // A hidden field shows no errors at all; an un-required field clears
         // only its *required* error (keep legitimate format/min/etc. errors).
         const errType = (errs[name] as { type?: string } | undefined)?.type;
-        if (!st.visible || (!st.required && errType === 'required')) form.clearErrors(name);
+        if (!st.visible || !viewVisible || (!st.required && errType === 'required')) form.clearErrors(name);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [ruleRecord]);
@@ -577,6 +582,15 @@ ComponentRegistry.register('form',
                   { required: staticRequired, readonly: staticReadonly === true },
                 );
                 if (!ruleState.visible) return null;
+
+                // View-level conditional visibility — spec FormField.visibleOn,
+                // authored on the form view (not the object field). Same
+                // canonical CEL engine and record scope as visibleWhen; both
+                // the bare-string and `{ dialect, source }` wire shapes are
+                // accepted, and a broken predicate fails open (#2212).
+                if (visibleOn != null && !evalFieldPredicate(visibleOn, ruleRecord, true)) {
+                  return null;
+                }
                 const required = ruleState.required;
                 const readonly = ruleState.readonly;
 

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -369,6 +369,11 @@ export const ModalForm: React.FC<ModalFormProps> = ({
         field: field,
         options: field.options,
         multiple: field.multiple,
+        // Field-level conditional rules (ADR-0036) — resolved reactively by
+        // the form renderer via the canonical engine (#2212).
+        visibleWhen: (field as any).visibleWhen,
+        readonlyWhen: (field as any).readonlyWhen,
+        requiredWhen: (field as any).requiredWhen ?? (field as any).conditionalRequired,
         // Field-group membership (Field.group → object.fieldGroups[].key) —
         // read by deriveFieldGroupSections for the fieldGroups fallback.
         group: (field as any).group,

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -16,7 +16,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { ObjectFormSchema, FormField, FormSchema, DataSource } from '@object-ui/types';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
-import { mapFieldTypeToFormType, buildValidationRules, evaluateCondition, formatFileSize } from '@object-ui/fields';
+import { mapFieldTypeToFormType, buildValidationRules, formatFileSize } from '@object-ui/fields';
 import { useIsMobile, toast } from '@object-ui/components';
 import { resolveSuccessNavigate } from './successBehavior';
 import { usePermissions } from '@object-ui/permissions';
@@ -402,22 +402,13 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     }
   }, [schema.objectName, schema.recordId, schema.mode, schema.initialValues, schema.initialData, dataSource, objectSchema, hasInlineFields]);
 
-  // Normalize a single FormField: if it carries a string `visibleOn`
-  // (spec FormFieldSchema CEL expression — see packages/spec FormFieldSchema),
-  // convert it to a reactive `visible(formData)` predicate so plugin-form
-  // variants honor live field-level visibility. Mirrors the schema-derived
-  // `field.visible_on` branch below.
-  const normalizeVisibility = useCallback((f: any): any => {
-    if (!f || typeof f.visible === 'function') return f;
-    const expr = f.visibleOn;
-    if (typeof expr === 'string' && expr.trim()) {
-      return {
-        ...f,
-        visible: (formData: any) => evaluateCondition(expr, formData),
-      };
-    }
-    return f;
-  }, []);
+  // FormField `visibleOn` (spec FormFieldSchema CEL expression) is consumed
+  // directly by the form renderer via the canonical engine — it accepts both
+  // the bare-string and `{ dialect, source }` wire shapes (#2212). Fields are
+  // passed through verbatim; the previous normalization attached a
+  // `visible(formData)` closure backed by the legacy `evaluateCondition`
+  // matcher, which is not a CEL evaluator and was never called downstream.
+  const normalizeVisibility = useCallback((f: any): any => f, []);
 
   // Generate form fields from object schema or inline fields
   useEffect(() => {
@@ -547,11 +538,11 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
           formField.disabled = true;
         }
 
-        // Add conditional visibility based on field dependencies
+        // Conditional visibility (legacy snake_case `visible_on`) — carry it
+        // as `visibleOn` so the form renderer evaluates it with the canonical
+        // CEL engine; the old `visible()` closure was never called (#2212).
         if (field.visible_on) {
-          formField.visible = (formData: any) => {
-            return evaluateCondition(field.visible_on, formData);
-          };
+          (formField as any).visibleOn = field.visible_on;
         }
 
         generatedFields.push(formField);
@@ -751,8 +742,20 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     const sourceFields = fieldGroupSections ? groupableFields : formFields;
     const groupedFields: FormField[] = [];
     effectiveSections.forEach((section, index) => {
-      const sectionFieldNames = section.fields.map(f => typeof f === 'string' ? f : ((f as any).field ?? f.name));
-      const sectionFields = applyFieldPerms(sourceFields.filter(f => sectionFieldNames.includes(f.name)));
+      // Section field defs may carry a per-field `visibleOn` predicate (spec
+      // FormFieldSchema, #2212). The filter below matches by name only, so the
+      // predicate must be merged onto the resolved field or it is silently
+      // dropped — the form renderer evaluates it with the canonical engine.
+      const sectionDefByName = new Map<string, any>(
+        section.fields.map(f => [typeof f === 'string' ? f : ((f as any).field ?? f.name), f]),
+      );
+      const sectionFieldNames = Array.from(sectionDefByName.keys());
+      const sectionFields = applyFieldPerms(sourceFields.filter(f => sectionFieldNames.includes(f.name)))
+        .map(f => {
+          const def = sectionDefByName.get(f.name);
+          const visibleOn = def && typeof def === 'object' ? (def as any).visibleOn : undefined;
+          return visibleOn != null ? ({ ...f, visibleOn } as FormField) : f;
+        });
       if (sectionFields.length === 0) return;
 
       const sectionKey = section.name || section.label || String(index);

--- a/packages/plugin-form/src/sectionFields.test.ts
+++ b/packages/plugin-form/src/sectionFields.test.ts
@@ -66,6 +66,55 @@ describe('normalizeSectionField', () => {
     const f = normalizeSectionField({ field: 'ghost', required: true }, ctx);
     expect(f.name).toBe('ghost'); // never undefined → no `.split` crash
   });
+
+  // View-level conditional visibility (#2212): the spec `P`-template ships
+  // `visibleOn` as an Expression object `{ dialect: 'cel', source }`. It must
+  // survive normalization verbatim so the form renderer can evaluate it with
+  // the canonical engine — the old code only accepted a bare string, and even
+  // then attached a dead `visible()` closure instead.
+  it('carries a `{ dialect, source }` visibleOn expression through (spec shape, #2212)', () => {
+    const expr = { dialect: 'cel', source: "record.priority == 'urgent'" };
+    const f = normalizeSectionField({ field: 'name', visibleOn: expr }, ctx);
+    expect((f as any).visibleOn).toEqual(expr);
+    expect((f as any).visible).toBeUndefined(); // no dead closure
+  });
+
+  it('carries a bare-string visibleOn through (#2212)', () => {
+    const f = normalizeSectionField(
+      { field: 'name', visibleOn: "record.priority == 'urgent'" },
+      ctx,
+    );
+    expect((f as any).visibleOn).toBe("record.priority == 'urgent'");
+  });
+
+  it('carries visibleOn on a runtime FormField object too (#2212)', () => {
+    const expr = { dialect: 'cel', source: 'record.flag == true' };
+    const f = normalizeSectionField({ name: 'custom', type: 'text', visibleOn: expr } as any, ctx);
+    expect((f as any).visibleOn).toEqual(expr);
+  });
+
+  it('copies field-level conditional rules from the object schema (#2212)', () => {
+    const rulesSchema = {
+      ...objectSchema,
+      fields: {
+        ...objectSchema.fields,
+        paid_on: {
+          type: 'date',
+          label: 'Paid on',
+          visibleWhen: "record.status == 'paid'",
+          requiredWhen: "record.status == 'paid'",
+          readonlyWhen: 'record.locked == true',
+        },
+      },
+    };
+    const rulesCtx = { ...ctx, objectSchema: rulesSchema };
+    for (const def of ['paid_on', { field: 'paid_on' }]) {
+      const f = normalizeSectionField(def as any, rulesCtx);
+      expect((f as any).visibleWhen).toBe("record.status == 'paid'");
+      expect((f as any).requiredWhen).toBe("record.status == 'paid'");
+      expect((f as any).readonlyWhen).toBe('record.locked == true');
+    }
+  });
 });
 
 describe('buildSectionFields', () => {

--- a/packages/plugin-form/src/sectionFields.ts
+++ b/packages/plugin-form/src/sectionFields.ts
@@ -26,7 +26,7 @@
  */
 
 import type { FormField } from '@object-ui/types';
-import { mapFieldTypeToFormType, buildValidationRules, evaluateCondition } from '@object-ui/fields';
+import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
 
 export interface SectionFieldsContext {
   /** Resolved object schema (`{ fields: { [name]: fieldDef } }`) or null. */
@@ -41,13 +41,23 @@ export interface SectionFieldsContext {
   fieldLabel: (objectName: string, fieldName: string, fallback?: string) => string;
 }
 
-/** Attach a reactive `visible(formData)` predicate from a CEL `visibleOn` string. */
+/**
+ * Carry a `visibleOn` predicate through to the runtime FormField so the form
+ * renderer evaluates it with the canonical CEL engine (`evalFieldPredicate`,
+ * same record scope as `visibleWhen`). Accepts both wire shapes — a bare CEL
+ * string and the spec Expression object `{ dialect, source }` (#2212).
+ *
+ * The previous implementation attached a `visible(formData)` closure backed
+ * by `evaluateCondition`, which is a legacy `{field, operator, value}`
+ * matcher, not a CEL evaluator — and nothing in the form render chain ever
+ * called the closure, so `visibleOn` silently did nothing.
+ */
 function attachVisibility(formField: FormField, expr: any): FormField {
-  if (typeof expr === 'string' && expr.trim()) {
-    return {
-      ...formField,
-      visible: (formData: any) => evaluateCondition(expr, formData),
-    } as FormField;
+  const isExpression =
+    (typeof expr === 'string' && expr.trim()) ||
+    (expr != null && typeof expr === 'object' && typeof expr.source === 'string' && expr.source.trim());
+  if (isExpression) {
+    return { ...formField, visibleOn: expr } as FormField;
   }
   return formField;
 }
@@ -70,6 +80,13 @@ function fromObjectSchema(fieldName: string, ctx: SectionFieldsContext): FormFie
     field,
     options: field.options,
     multiple: field.multiple,
+    // Field-level conditional rules (ADR-0036) — the form renderer resolves
+    // them via `resolveFieldRuleState`; without this copy a sectioned form
+    // silently dropped rules that the flat (schema-order) form honors.
+    visibleWhen: field.visibleWhen,
+    readonlyWhen: field.readonlyWhen,
+    requiredWhen: field.requiredWhen,
+    conditionalRequired: field.conditionalRequired,
   } as FormField;
 }
 

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -833,12 +833,15 @@ export interface FormField {
    */
   dependsOn?: string;
   /**
-   * Visibility condition expression.
-   * Aligns with @objectstack/spec FormField.visibleOn.
-   * When evaluated to false, the field is hidden.
-   * @example "${data.role === 'admin'}"
+   * Visibility condition expression (view-level, from the form view's
+   * FormField). Aligns with @objectstack/spec FormField.visibleOn — the wire
+   * shape is either a bare CEL string or the spec Expression object
+   * `{ dialect, source }`. Evaluated against the live record via the
+   * canonical `@objectstack/formula` engine (same as `visibleWhen`); a broken
+   * predicate fails open (field stays visible).
+   * @example "record.priority == 'urgent'"
    */
-  visibleOn?: string;
+  visibleOn?: string | { dialect?: string; source: string };
   /**
    * Whether the field is hidden.
    * Aligns with @objectstack/spec FormField.hidden.


### PR DESCRIPTION
Fixes #2212 — view-level `FormField.visibleOn` (CEL) never took effect anywhere in the form chain, while field-level `visibleWhen` worked.

## Root causes (all confirmed by source scan, file:line in #2212)

1. **Expression-object wire shape discarded** — the server ships `visibleOn` as `{ dialect: 'cel', source }` (what the spec `P` template emits). `sectionFields.ts` `attachVisibility` and `ObjectForm.tsx` `normalizeVisibility` only accepted `typeof expr === 'string'`, so the object shape was silently dropped.
2. **Dead closure, wrong engine** — even for strings, the old code attached a `visible()` closure built on `evaluateCondition`, which is not a CEL evaluator (it only understands `{field, operator, value}` legacy objects and defaults unknown input to `true`) — and no renderer ever called that closure anyway. The form renderer destructured `visibleOn` out of the field config and dropped it.
3. **Page mode lost sections entirely** — `RecordFormPage` only forwarded `sections` for `tabbed/wizard/split`, so a `simple` form view's authored field selection, grouping, and `visibleOn` predicates were all discarded in page-mode create/edit, while the New/Edit modal honored the same view via `resolveFormViewLayout`.
4. **Grouped-sections path dropped per-field overrides** — `ObjectForm`'s simple-sections branch matched section fields by name only, losing the section field def's `visibleOn`.

## Fix

- `visibleOn` flows through normalization verbatim (both wire shapes) and the form renderer evaluates it **reactively** with `evalFieldPredicate` — the same canonical engine, record scope, and fail-open semantics as field-level `visibleWhen` (ADR-0036). When both `visibleOn` and `visibleWhen` are present, both must allow the field.
- `RecordFormPage` now forwards curated `sections` for every layout family, aligned with the modal path.
- Sectioned (`fromObjectSchema`) and `ModalForm` flat normalization now also copy field-level `visibleWhen`/`readonlyWhen`/`requiredWhen` rules they previously lost.

## Tests

- New `form-visibleon.test.tsx` (4): object shape hides/shows reactively, bare-string shape, broken-CEL fail-open, `visibleOn` × `visibleWhen` combination.
- `sectionFields.test.ts` +5: both wire shapes survive normalization (no dead closure), runtime FormField shape, field-level rule copying.
- Suites: plugin-form 165/165, app-shell 969/969, components (5131 pass; the single DATEFORMAT failure is a pre-existing timezone flake also failing on unmodified main).

## Browser verification (examples/app-showcase, `showcase_task.notes` with `visibleOn: record.priority == 'urgent'`)

- Page-mode edit: `priority = Low` → 备注 hidden; switching to `Urgent` shows it live; back to `Low` hides it again. Sections (Task group header, authored 7-field selection) now render in page mode.
- New-record modal: 备注 hidden by default, appears when priority is set to `Urgent`.

Co-Authored-By: Claude <noreply@anthropic.com>