### PR TITLE
fix(fields): unlock dependent lookups on parent selection and enforce the cascade on every picker

### DIFF
--- a/.changeset/cascading-lookup-dependson.md
+++ b/.changeset/cascading-lookup-dependson.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/components': patch
+'@object-ui/fields': patch
+---
+
+Fix dependent (cascading) lookups: unlock on parent selection and enforce the
+cascade filter on every candidate surface (#2215).
+
+Two breaks made `depends_on` unusable end to end:
+
+- **The gate never unlocked in create mode.** `LookupField` resolved dependent
+  values from `ctx.formValues` — a member `SchemaRendererContext` never had —
+  and nothing injected the `dependentValues` prop, so with a fresh record
+  (`ctx.data = {}`) the child lookup stayed disabled no matter what the user
+  picked in the parent field. The form renderer now injects its live form
+  values (the same reactive snapshot that drives field rules) as
+  `dependentValues` for data-source fields.
+- **The Level-2 table picker bypassed the cascade.** The `depends_on` chain
+  only reached the quick-select popover filter; `RecordPickerDialog` (and the
+  search-first `PeoplePicker`) received just `lookup_filters`, listing the full
+  unfiltered record set. Both pickers now take a `baseFilter` — a hard
+  `$filter` constraint merged after `lookupFilters` and user filter-bar input,
+  so it can never be widened back out — and `LookupField` passes the dependent
+  chain there, shares the same filter with the popover query, and disables the
+  browse-all button while dependencies are missing.

--- a/packages/components/src/renderers/form/__tests__/form-dependent-values.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-dependent-values.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Live `dependentValues` injection for data-source fields (#2215).
+ *
+ * Dependent (cascading) lookups resolve their `depends_on` gate and filters
+ * from the `dependentValues` prop. The form renderer must inject the LIVE
+ * form values there — pre-fix nothing injected the prop and the widget's
+ * context fallback read `ctx.formValues`, a member `SchemaRendererContext`
+ * never had, so in create mode a dependent lookup stayed gated forever no
+ * matter what the user picked in the parent field.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+
+// Probe widget standing in for a lookup field: surfaces the received
+// `dependentValues` so the test can assert on the injection.
+function DependentValuesProbe(props: any) {
+  return <div data-testid="dep-probe">{JSON.stringify(props.dependentValues ?? null)}</div>;
+}
+
+beforeAll(async () => {
+  await import('../../../renderers');
+  // Override the protocol placeholder for `field:lookup` with the probe
+  // (the fields package owns the real widget; components tests never load it).
+  ComponentRegistry.register('field:lookup', DependentValuesProbe, { namespace: 'test' });
+}, 30000);
+
+function renderForm(fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        showSubmit: false,
+        showCancel: false,
+        fields,
+      }}
+    />,
+  );
+}
+
+describe('form renderer — dependentValues injection for data-source fields (#2215)', () => {
+  it('feeds live form values to a lookup field as the user edits the parent', async () => {
+    renderForm([
+      { name: 'account', label: 'Account', type: 'input', defaultValue: '' },
+      { name: 'contact', label: 'Contact', type: 'lookup' },
+    ]);
+
+    const probe = screen.getByTestId('dep-probe');
+    // Initial snapshot carries the (empty) parent value — not undefined.
+    expect(JSON.parse(probe.textContent!)).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText(/account/i), { target: { value: 'a1' } });
+    await waitFor(() => {
+      expect(JSON.parse(screen.getByTestId('dep-probe').textContent!)).toMatchObject({
+        account: 'a1',
+      });
+    });
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -727,6 +727,12 @@ ComponentRegistry.register('form',
                             placeholder: fieldProps.placeholder ?? (resolvedType === 'select' ? t('common.selectOption') : undefined),
                             disabled: disabled || fieldDisabled || readonly || isSubmitting,
                             dataSource: contextDataSource,
+                            // Live form values for dependent (cascading) lookups
+                            // (#2215): the widget's `dependsOn` gate + filters must
+                            // re-scope as the user picks the parent field in THIS
+                            // form, not read a stale record snapshot. Forwarded to
+                            // data-source widgets only (see stripRegisteredFieldProps).
+                            dependentValues: ruleRecord,
                           })}
                         </FormControl>
                         {description && (

--- a/packages/fields/src/widgets/LookupField.dependsOn.test.tsx
+++ b/packages/fields/src/widgets/LookupField.dependsOn.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Dependent (cascading) lookups — #2215.
+ *
+ * A lookup with `depends_on` must:
+ *  1. gate every candidate surface while a dependency is empty,
+ *  2. unlock as soon as the dependent values arrive (the form renderer
+ *     injects live form values via the `dependentValues` prop), and
+ *  3. scope EVERY candidate query — quick-select popover, Level-2 table
+ *     picker and PeoplePicker — with the dependent-lookup chain as a hard
+ *     `$filter` no user filter input can override.
+ *
+ * Pre-fix, `dependentValues` was never injected by the form renderer (the
+ * context fallback read a member that does not exist), so create-mode
+ * cascades stayed gated forever; and the table picker only received
+ * `lookupFilters`, listing the full unfiltered record set.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LookupField } from './LookupField';
+import { RecordPickerDialog } from './RecordPickerDialog';
+import { PeoplePicker } from './PeoplePicker';
+
+const contacts = [
+  { id: 'c1', name: 'Nora Field', account: 'a1' },
+  { id: 'c2', name: 'Oscar Grant', account: 'a2' },
+];
+
+function makeDataSource() {
+  const find = vi.fn(async (_obj: string, params: any) => {
+    const account = params?.$filter?.account ?? params?.$filter?.account_id;
+    const data = account ? contacts.filter(c => c.account === account) : contacts;
+    return { data, total: data.length };
+  });
+  return { find } as any;
+}
+
+beforeEach(() => {
+  // jsdom has no matchMedia; PeoplePicker's useIsMobile needs it.
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as any;
+  try {
+    localStorage.clear();
+  } catch {
+    /* jsdom */
+  }
+});
+
+describe('LookupField — depends_on gating and cascade filter (#2215)', () => {
+  const dependentField = {
+    name: 'contact',
+    label: 'Contact',
+    reference_to: 'contacts',
+    reference_field: 'name',
+    depends_on: ['account'],
+  } as any;
+
+  it('gates the trigger while the dependency is empty', () => {
+    render(
+      <LookupField
+        field={dependentField}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={makeDataSource()}
+        {...({ dependentValues: { account: null } } as any)}
+      />,
+    );
+
+    const trigger = screen.getByTestId('lookup-trigger-gated');
+    expect(trigger).toBeDisabled();
+    expect(trigger).toHaveTextContent(/select account first/i);
+  });
+
+  it('unlocks when dependentValues carry the parent value and scopes the popover query', async () => {
+    const ds = makeDataSource();
+    render(
+      <LookupField
+        field={dependentField}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={ds}
+        {...({ dependentValues: { account: 'a1' } } as any)}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: /select/i });
+    expect(trigger).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith(
+        'contacts',
+        expect.objectContaining({ $filter: expect.objectContaining({ account: 'a1' }) }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Nora Field')).toBeInTheDocument();
+      expect(screen.queryByText('Oscar Grant')).not.toBeInTheDocument();
+    });
+  });
+
+  it('maps the explicit { field, param } shape onto the remote filter field', async () => {
+    const ds = makeDataSource();
+    const explicitField = {
+      ...dependentField,
+      depends_on: [{ field: 'account', param: 'account_id' }],
+    };
+    render(
+      <LookupField
+        field={explicitField}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={ds}
+        {...({ dependentValues: { account: 'a1' } } as any)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith(
+        'contacts',
+        expect.objectContaining({ $filter: expect.objectContaining({ account_id: 'a1' }) }),
+      );
+    });
+  });
+});
+
+describe('RecordPickerDialog — baseFilter is a hard constraint (#2215)', () => {
+  it('applies baseFilter over the lookupFilters base on the same field', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="contacts"
+        onSelect={vi.fn()}
+        lookupFilters={[{ field: 'account', operator: 'eq', value: 'stale' }]}
+        baseFilter={{ account: 'a1' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalled();
+    });
+    const lastParams = ds.find.mock.calls[ds.find.mock.calls.length - 1][1];
+    expect(lastParams.$filter).toMatchObject({ account: 'a1' });
+  });
+
+  it('cannot be widened back out by filter-bar input on the same field', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="contacts"
+        onSelect={vi.fn()}
+        lookupFilters={[{ field: 'account', operator: 'eq', value: 'stale' }]}
+        baseFilter={{ account: 'a1' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalled();
+    });
+
+    // Open the filter bar (auto-derived from lookupFilters) and try to
+    // override the cascaded field by hand.
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    const panel = await screen.findByTestId('record-picker-filter-panel');
+    const input = panel.querySelector('input')!;
+    fireEvent.change(input, { target: { value: 'a2' } });
+
+    // The hard constraint wins: no query may ever go out with the user's
+    // widened value.
+    await waitFor(() => {
+      for (const call of ds.find.mock.calls) {
+        expect(call[1]?.$filter?.account).toBe('a1');
+      }
+    });
+  });
+});
+
+describe('PeoplePicker — baseFilter scopes the candidate query (#2215)', () => {
+  it('merges baseFilter after lookupFilters so the cascade wins', async () => {
+    const ds = makeDataSource();
+    render(
+      <PeoplePicker
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="contacts"
+        onSelect={vi.fn()}
+        lookupFilters={[{ field: 'account', operator: 'eq', value: 'stale' }]}
+        baseFilter={{ account: 'a1' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalled();
+    });
+    const lastParams = ds.find.mock.calls[ds.find.mock.calls.length - 1][1];
+    expect(lastParams.$filter).toMatchObject({ account: 'a1' });
+  });
+});

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -368,22 +368,31 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   // State for the full Record Picker dialog (Level 2)
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
-  // Determine which options to display
-  // Quick-select popover fetch — the shared record-query kernel (same one the
-  // Record Picker dialog and PeoplePicker use). Filter = dependent-lookup chain
-  // + base lookupFilters, so the popover matches the full picker.
-  const popoverFilter = useMemo<Record<string, any> | undefined>(() => {
+  // Dependent-lookup chain as a hard QueryParams.$filter record. Shared by
+  // EVERY candidate surface — quick-select popover, Level-2 table picker and
+  // the search-first PeoplePicker — so no picker can bypass the cascade
+  // (#2215: the table picker used to list the full unfiltered set).
+  const dependentFilter = useMemo<Record<string, any> | undefined>(() => {
     const f: Record<string, any> = {};
     for (const { field, param } of dependsOn) {
       const v = resolvedDependentValues[field];
       if (v === undefined || v === null || v === '') continue;
       f[param] = typeof v === 'number' ? v : String(v);
     }
-    if (lookupFilters && lookupFilters.length > 0) {
-      Object.assign(f, lookupFiltersToRecord(lookupFilters));
-    }
     return Object.keys(f).length > 0 ? f : undefined;
-  }, [dependsOn, resolvedDependentValues, lookupFilters]);
+  }, [dependsOn, resolvedDependentValues]);
+
+  // Determine which options to display
+  // Quick-select popover fetch — the shared record-query kernel (same one the
+  // Record Picker dialog and PeoplePicker use). Filter = dependent-lookup chain
+  // + base lookupFilters, so the popover matches the full picker.
+  const popoverFilter = useMemo<Record<string, any> | undefined>(() => {
+    const f: Record<string, any> = {
+      ...(lookupFilters && lookupFilters.length > 0 ? lookupFiltersToRecord(lookupFilters) : {}),
+      ...(dependentFilter ?? {}),
+    };
+    return Object.keys(f).length > 0 ? f : undefined;
+  }, [dependentFilter, lookupFilters]);
 
   const popoverQuery = useRecordQuery({
     dataSource,
@@ -909,6 +918,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
           onSelect={onChange}
           onSelectRecords={handlePickerSelectRecords}
           lookupFilters={lookupFilters}
+          baseFilter={dependentFilter}
         />
       ) : (
       <div className="flex items-center gap-1.5">
@@ -1095,9 +1105,14 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
           size="icon"
           className="shrink-0"
           type="button"
+          // Gated exactly like the main trigger (#2215) — pre-fix this button
+          // opened the full unscoped table while the dependency was missing.
+          disabled={dependenciesMissing || (props as any).disabled}
           onClick={() => setIsPickerOpen(true)}
           aria-label={t('lookup.browseAll')}
-          title={t('lookup.browseAll')}
+          title={dependenciesMissing
+            ? t('lookup.selectFirst', { fields: dependsOn.map(d => d.field).join(', ') })
+            : t('lookup.browseAll')}
           data-testid="browse-all-records"
         >
           <TableProperties className="size-4" />
@@ -1124,6 +1139,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
           onSelect={onChange}
           onSelectRecords={handlePickerSelectRecords}
           lookupFilters={lookupFilters}
+          baseFilter={dependentFilter}
           cellRenderer={getCellRendererResolver()}
           filterColumns={filterColumns}
         />

--- a/packages/fields/src/widgets/PeoplePicker.tsx
+++ b/packages/fields/src/widgets/PeoplePicker.tsx
@@ -78,6 +78,12 @@ export interface PeoplePickerProps {
   pageSize?: number;
   /** Base candidate filters (e.g. exclude banned users). */
   lookupFilters?: LookupFilterDef[];
+  /**
+   * Hard filter constraints in QueryParams.$filter record form — the
+   * dependent (cascading) lookup chain (#2215). Always ANDed into the
+   * candidate query; spread after `lookupFilters` so it wins on conflicts.
+   */
+  baseFilter?: Record<string, any>;
 
   /** Current selection (id, or id[] when `multiple`). */
   value?: any;
@@ -114,6 +120,7 @@ export function PeoplePicker({
   searchFields,
   pageSize = DEFAULT_PAGE_SIZE,
   lookupFilters,
+  baseFilter: baseFilterProp,
   value,
   onSelect,
   onSelectRecords,
@@ -123,10 +130,13 @@ export function PeoplePicker({
   const { t } = useFieldTranslation();
   const isMobile = useIsMobile();
 
-  const baseFilter = useMemo<Record<string, any> | undefined>(
-    () => (lookupFilters?.length ? lookupFiltersToRecord(lookupFilters) : undefined),
-    [lookupFilters],
-  );
+  const baseFilter = useMemo<Record<string, any> | undefined>(() => {
+    const combined = {
+      ...(lookupFilters?.length ? lookupFiltersToRecord(lookupFilters) : {}),
+      ...(baseFilterProp ?? {}),
+    };
+    return Object.keys(combined).length > 0 ? combined : undefined;
+  }, [lookupFilters, baseFilterProp]);
 
   // Auto-expand relation subtitles (e.g. `primary_business_unit_id.name` needs
   // `$expand: ['primary_business_unit_id']`) unless the caller passed `expand`.

--- a/packages/fields/src/widgets/RecordPickerDialog.tsx
+++ b/packages/fields/src/widgets/RecordPickerDialog.tsx
@@ -262,6 +262,15 @@ export interface RecordPickerDialogProps {
   lookupFilters?: LookupFilterDef[];
 
   /**
+   * Hard filter constraints applied to every query, in QueryParams.$filter
+   * record form. Unlike `lookupFilters`, entries here never surface in the
+   * filter bar and cannot be overridden by user filter input — used for the
+   * dependent (cascading) lookup chain, where the parent field's value MUST
+   * scope the candidate set (#2215).
+   */
+  baseFilter?: Record<string, any>;
+
+  /**
    * Cell renderer resolver function.
    * When provided, columns with a `type` property will be rendered using the
    * resolved cell renderer (e.g. badges for select, formatted currency, etc.).
@@ -333,6 +342,7 @@ export function RecordPickerDialog({
   onSelect,
   onSelectRecords,
   lookupFilters,
+  baseFilter,
   cellRenderer,
   filterColumns,
   renderFilterBar,
@@ -415,17 +425,19 @@ export function RecordPickerDialog({
     return undefined;
   }, [filterColumns, lookupFilters]);
 
-  // Merge base lookup_filters with user filter bar values
+  // Merge base lookup_filters with user filter bar values. The hard
+  // `baseFilter` constraint (dependent-lookup chain, #2215) is spread LAST so
+  // user filter-bar input can never widen it back out.
   const mergedFilter = useMemo<Record<string, any> | undefined>(() => {
-    const baseFilter = lookupFilters?.length
+    const lookupBase = lookupFilters?.length
       ? lookupFiltersToRecord(lookupFilters)
       : {};
     const userFilter = effectiveFilterColumns?.length
       ? filterValuesToRecord(filterValues, effectiveFilterColumns)
       : {};
-    const combined = { ...baseFilter, ...userFilter };
+    const combined = { ...lookupBase, ...userFilter, ...(baseFilter ?? {}) };
     return Object.keys(combined).length > 0 ? combined : undefined;
-  }, [lookupFilters, effectiveFilterColumns, filterValues]);
+  }, [lookupFilters, effectiveFilterColumns, filterValues, baseFilter]);
 
   // Shared query kernel: builds params, fetches, and owns records/loading/error/
   // total plus the page/search/sort controls. Selection state stays local (above).


### PR DESCRIPTION
Fixes #2215.

## The two breaks

**1. The `depends_on` gate never unlocked in create mode.**
`LookupField` resolved dependent values as `dependentValues ?? ctx.formValues ?? ctx.data`, but `SchemaRendererContext` has no `formValues` member (dead fallback) and nothing ever injected the `dependentValues` prop. With a fresh record (`ctx.data = {}`) the child lookup stayed disabled forever, no matter what the user picked in the parent field.

**2. The Level-2 table picker bypassed the cascade.**
The `depends_on` chain only reached the quick-select popover's filter. `RecordPickerDialog` (and the search-first `PeoplePicker`) received just `lookup_filters`, so "Browse all records" listed the full unfiltered set (121 contacts across 13 pages in the showcase repro).

## The fix

- **`form.tsx`** injects the live form values (the same reactive `ruleRecord` snapshot that drives field rules) as `dependentValues`, forwarded to data-source field types only (`stripRegisteredFieldProps` already scoped that).
- **`RecordPickerDialog` / `PeoplePicker`** gain a `baseFilter` prop — a hard `$filter` constraint merged **after** `lookupFilters` and user filter-bar input, so filter-bar edits on the same field can never widen it back out.
- **`LookupField`** derives one `dependentFilter` from the `depends_on` chain and shares it across all three candidate surfaces (popover query, table picker, PeoplePicker), and disables the browse-all button while dependencies are missing (same gate + hint as the trigger).

## Verification

- 7 new unit tests: gating/unlock + popover `$filter` scoping (shorthand and `{field, param}` shapes), `baseFilter` wins over `lookupFilters` and over filter-bar input on the same field, `PeoplePicker` merge order, and live `dependentValues` injection by the form renderer.
- Browser repro on the app-showcase invoice form (`contact depends_on account`): contact unlocks after picking Northwind; popover and table picker both list only Northwind's 2 contacts (previously 121/13 pages); browse-all disabled while gated with the "select account first" hint.
- `pnpm --filter @object-ui/fields --filter @object-ui/components build` clean; full test suite run — only pre-existing failure is the known `DATEFORMAT` timezone flake in core (fails on main too, TZ-dependent).

Co-Authored-By: Claude <noreply@anthropic.com>