### PR TITLE
fix(app-shell): resolve short view names in /view/<name> routes

### DIFF
--- a/.changeset/nav-viewname-short-route.md
+++ b/.changeset/nav-viewname-short-route.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Resolve short view names in `/view/<name>` routes instead of silently falling
+back to the default view (#2217).
+
+Nav items emit their `viewName` verbatim — usually the short form
+(`tabular`) — while canonical view ids are fully qualified
+(`showcase_task.tabular`), so nav-generated view links always rendered the
+default view with no hint anything was wrong. `ObjectView` now resolves the
+requested name in both directions (short → `<object>.<name>`, and qualified →
+bare key for legacy embedded listViews), and logs a warning listing the known
+view ids when nothing matches instead of swallowing the miss.

--- a/packages/app-shell/src/utils/__tests__/resolveViewId.test.ts
+++ b/packages/app-shell/src/utils/__tests__/resolveViewId.test.ts
@@ -1,0 +1,54 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * View-name resolution for `/view/<name>` routes (#2217).
+ *
+ * Nav items emit `viewName` verbatim (usually the short form) while
+ * canonical view ids are fully qualified — pre-fix a short-name route
+ * silently fell back to the default view.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveViewId } from '../resolveViewId';
+
+const QUALIFIED = ['showcase_task.grid', 'showcase_task.tabular', 'showcase_task.kanban'];
+const LEGACY = ['all', 'mine'];
+
+describe('resolveViewId (#2217)', () => {
+    it('returns an exact match as-is', () => {
+        expect(resolveViewId('showcase_task.tabular', QUALIFIED, 'showcase_task'))
+            .toBe('showcase_task.tabular');
+        expect(resolveViewId('all', LEGACY, 'showcase_task')).toBe('all');
+    });
+
+    it('qualifies a short name against fully-qualified ids (nav-generated links)', () => {
+        expect(resolveViewId('tabular', QUALIFIED, 'showcase_task'))
+            .toBe('showcase_task.tabular');
+    });
+
+    it('strips the object prefix against legacy bare ids', () => {
+        expect(resolveViewId('showcase_task.all', LEGACY, 'showcase_task')).toBe('all');
+    });
+
+    it('returns undefined when nothing matches (caller warns, then falls back)', () => {
+        expect(resolveViewId('nope', QUALIFIED, 'showcase_task')).toBeUndefined();
+        expect(resolveViewId('other_object.tabular', QUALIFIED, 'showcase_task')).toBeUndefined();
+    });
+
+    it('returns undefined for empty input', () => {
+        expect(resolveViewId(undefined, QUALIFIED, 'showcase_task')).toBeUndefined();
+        expect(resolveViewId(null, QUALIFIED, 'showcase_task')).toBeUndefined();
+        expect(resolveViewId('', QUALIFIED, 'showcase_task')).toBeUndefined();
+    });
+
+    it('does not double-qualify a name that already contains a dot', () => {
+        // `a.b` must not become `obj.a.b`
+        expect(resolveViewId('a.b', ['obj.a.b'], 'obj')).toBeUndefined();
+    });
+});

--- a/packages/app-shell/src/utils/resolveViewId.ts
+++ b/packages/app-shell/src/utils/resolveViewId.ts
@@ -1,0 +1,40 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Resolve a URL-requested view name against the object's actual view ids.
+ *
+ * Canonical view ids are fully qualified (`<object>.<viewKind>`, see
+ * MetadataProvider), but nav items emit their `viewName` verbatim — usually
+ * the short form — and legacy embedded listViews carry bare keys (including
+ * the `'all'` fallback view). Accept both directions (#2217):
+ *
+ * 1. exact id match;
+ * 2. short name (no `.`) → retry as `<objectName>.<name>`;
+ * 3. qualified name → retry with the `<objectName>.` prefix stripped.
+ *
+ * Returns the matching view id, or `undefined` when nothing matches — the
+ * caller decides how to fall back (and should warn rather than swallow it).
+ */
+export function resolveViewId(
+    requested: string | undefined | null,
+    viewIds: readonly string[],
+    objectName: string,
+): string | undefined {
+    if (!requested) return undefined;
+    const has = (id: string) => viewIds.includes(id);
+    if (has(requested)) return requested;
+    const prefix = `${objectName}.`;
+    if (!requested.includes('.') && has(prefix + requested)) {
+        return prefix + requested;
+    }
+    if (requested.startsWith(prefix) && has(requested.slice(prefix.length))) {
+        return requested.slice(prefix.length);
+    }
+    return undefined;
+}

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -48,6 +48,7 @@ import { ManagedByBadge } from '../components/ManagedByBadge';
 import { RecordDetailView } from './RecordDetailView';
 import { resolveCrudAffordances } from '../utils/crudAffordances';
 import { resolveManagedByEmptyState } from '../utils/managedByEmptyState';
+import { resolveViewId } from '../utils/resolveViewId';
 import { useObjectActions } from '../hooks/useObjectActions';
 import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
@@ -657,7 +658,25 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         const def = views.find((v: any) => v.isDefault);
         return def?.id;
     }, [views]);
-    const activeViewId = viewId || searchParams.get('view') || defaultViewId || views[0]?.id;
+    // Canonical view ids are fully qualified (`<object>.<viewKind>`, see
+    // MetadataProvider), but nav items emit `viewName` verbatim — usually
+    // the short form — and legacy embedded listViews carry bare keys (incl.
+    // the `'all'` fallback). Resolve the URL-requested name in both
+    // directions, and never swallow a miss silently (#2217).
+    const requestedViewId = viewId || searchParams.get('view') || undefined;
+    const resolvedViewId = useMemo(
+        () => resolveViewId(requestedViewId, views.map((v: any) => v.id), objectDef.name),
+        [requestedViewId, views, objectDef.name],
+    );
+    useEffect(() => {
+        if (requestedViewId && !resolvedViewId) {
+            console.warn(
+                `[ObjectView] Requested view "${requestedViewId}" not found on object "${objectDef.name}"; ` +
+                `falling back to the default view. Known views: ${views.map((v: any) => v.id).join(', ')}`,
+            );
+        }
+    }, [requestedViewId, resolvedViewId, objectDef.name, views]);
+    const activeViewId = resolvedViewId || defaultViewId || views[0]?.id;
     const baseView = views.find((v: any) => v.id === activeViewId) || views[0];
     const activeView = viewDraft && viewDraft.id === baseView?.id
         ? { ...baseView, ...viewDraft }


### PR DESCRIPTION
Fixes #2217

## Problem

A nav item with `viewName: 'tabular'` produces the route `/view/tabular`, but canonical view ids are fully qualified (`showcase_task.tabular`), so `ObjectView`'s exact-id lookup missed and `|| views[0]` **silently** rendered the default view. Every nav-generated view link was broken, with zero signal.

- Generators emit the short name verbatim: `packages/layout/src/NavigationRenderer.tsx` (object nav href) and `packages/layout/src/AppSchemaRenderer.tsx` (mobile bottom nav).
- Resolver did exact match + silent fallback: `packages/app-shell/src/views/ObjectView.tsx`.

## Fix

New `resolveViewId()` util resolves the URL-requested name (route param or `?view=`) in both directions:

1. exact id match;
2. short name (no `.`) → `<objectName>.<name>` — covers nav-generated links;
3. qualified name → bare key with the `<objectName>.` prefix stripped — covers legacy embedded listViews (incl. the `'all'` fallback view).

When nothing matches, a `console.warn` lists the known view ids before falling back — no more silent swallowing. The generators are intentionally left untouched: they can't see the target object's view list, so the resolver is the only place that can pick the right form for both id schemes.

## Testing

- 6 new unit tests for `resolveViewId` (exact / qualify / strip / miss / empty / no double-qualify) — all pass.
- `pnpm --filter @object-ui/app-shell... build` passes.
- Browser-verified against the framework `app-showcase` backend (HMR console):
  - `/view/tabular` (nav short name) now renders the **Task List (tabular)** view — pre-fix it rendered the default grid;
  - `/view/showcase_task.tabular` still works;
  - `/view/nonexistent_view` falls back to the default view and warns with the full known-view list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)