### PR TITLE
fix(app-shell): warn when userFilters on an object list view is suppressed

### DIFF
--- a/.changeset/warn-userfilters-views-mode.md
+++ b/.changeset/warn-userfilters-views-mode.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Warn when `userFilters` / `quickFilters` on an object list view are
+suppressed instead of dropping them silently (#2219).
+
+ADR-0053 correctly reserves those fields for page lists (InterfaceListPage
+"filters" mode) and suppresses them on the object default list, but until the
+phase-4 schema guardrail lands the author got zero signal — a valid schema
+and a toolbar with nothing where the filter controls should be. ObjectView
+now logs a one-shot warning per object/view naming the offending fields and
+where they belong.

--- a/packages/app-shell/src/utils/__tests__/warnSuppressedListNav.test.ts
+++ b/packages/app-shell/src/utils/__tests__/warnSuppressedListNav.test.ts
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0053 wrong-context authoring surfaced instead of silently dropped
+ * (#2219): `userFilters` / `quickFilters` on an object list view are
+ * suppressed by ObjectView — the author must get a console warning, once
+ * per object/view.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    warnSuppressedListNav,
+    resetSuppressedListNavWarnings,
+} from '../warnSuppressedListNav';
+
+const USER_FILTERS = { element: 'dropdown', fields: [{ field: 'status' }] };
+
+describe('warnSuppressedListNav (#2219)', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        resetSuppressedListNavWarnings();
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warn.mockRestore();
+    });
+
+    it('warns when the view def carries userFilters', () => {
+        const hit = warnSuppressedListNav('showcase_task', 'showcase_task.tabular',
+            { userFilters: USER_FILTERS }, {});
+        expect(hit).toBe(true);
+        expect(warn).toHaveBeenCalledTimes(1);
+        const msg = warn.mock.calls[0][0] as string;
+        expect(msg).toContain('showcase_task.tabular');
+        expect(msg).toContain('userFilters');
+        expect(msg).toContain('ADR-0053');
+    });
+
+    it('warns when only the base list schema carries quickFilters', () => {
+        const hit = warnSuppressedListNav('showcase_task', 'all',
+            {}, { quickFilters: [{ field: 'status' }] });
+        expect(hit).toBe(true);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0][0]).toContain('quickFilters');
+    });
+
+    it('warns only once per object/view across re-renders', () => {
+        warnSuppressedListNav('showcase_task', 'tabular', { userFilters: USER_FILTERS }, {});
+        warnSuppressedListNav('showcase_task', 'tabular', { userFilters: USER_FILTERS }, {});
+        expect(warn).toHaveBeenCalledTimes(1);
+        // A different view still gets its own warning.
+        warnSuppressedListNav('showcase_task', 'board', { userFilters: USER_FILTERS }, {});
+        expect(warn).toHaveBeenCalledTimes(2);
+    });
+
+    it('stays silent for a clean view', () => {
+        const hit = warnSuppressedListNav('showcase_task', 'grid', { filter: [] }, {});
+        expect(hit).toBe(false);
+        expect(warn).not.toHaveBeenCalled();
+    });
+});

--- a/packages/app-shell/src/utils/warnSuppressedListNav.ts
+++ b/packages/app-shell/src/utils/warnSuppressedListNav.ts
@@ -1,0 +1,51 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0053: on an object's default list ("views" mode) the ViewTabBar is the
+ * only navigation control — `userFilters` / `quickFilters` belong to page
+ * lists (InterfaceListPage, "filters" mode) and are suppressed by
+ * `ObjectView.renderListView`.
+ *
+ * The suppression is correct, but until the phase-4 guardrail (zod `refine`
+ * + `check` rule) lands, an author who puts `userFilters` on an object list
+ * view gets a valid schema and a page that renders nothing where they expect
+ * filter controls — zero signal at any layer (#2219). Surface the drop with
+ * a one-shot console warning per object/view.
+ *
+ * Returns whether the view carried a suppressed field (mainly for tests).
+ */
+const warned = new Set<string>();
+
+export function warnSuppressedListNav(
+    objectName: string,
+    viewId: string,
+    viewDef: Record<string, unknown> | null | undefined,
+    listSchema: Record<string, unknown> | null | undefined,
+): boolean {
+    const offending = (['userFilters', 'quickFilters'] as const).filter(
+        (k) => (viewDef?.[k] ?? listSchema?.[k]) != null,
+    );
+    if (offending.length === 0) return false;
+    const key = `${objectName}.${viewId}`;
+    if (!warned.has(key)) {
+        warned.add(key);
+        console.warn(
+            `[ObjectView] View "${viewId}" on object "${objectName}" defines ` +
+                `${offending.join(' and ')}, which are ignored on an object list view ` +
+                `(ADR-0053 "views" mode — the view switcher is the only nav control here). ` +
+                `Move them to a page list (InterfaceListPage "filters" mode).`,
+        );
+    }
+    return true;
+}
+
+/** Test-only: clear the one-shot warning memory. */
+export function resetSuppressedListNavWarnings(): void {
+    warned.clear();
+}

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -48,6 +48,7 @@ import { ManagedByBadge } from '../components/ManagedByBadge';
 import { RecordDetailView } from './RecordDetailView';
 import { resolveCrudAffordances } from '../utils/crudAffordances';
 import { resolveManagedByEmptyState } from '../utils/managedByEmptyState';
+import { warnSuppressedListNav } from '../utils/warnSuppressedListNav';
 import { useObjectActions } from '../hooks/useObjectActions';
 import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
@@ -1163,6 +1164,12 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 </Suspense>
             );
         }
+
+        // ADR-0053 wrong-context authoring: userFilters/quickFilters on an
+        // object list view are suppressed below — say so instead of letting
+        // the author stare at a toolbar with nothing where their filter
+        // controls should be (#2219).
+        warnSuppressedListNav(objectDef.name, viewDef.id || viewDef.name || '', viewDef as any, listSchema as any);
 
         const fullSchema: ListViewSchema = {
             ...listSchema,


### PR DESCRIPTION
Fixes #2219

## Problem

ADR-0053 (views mode vs filters mode) correctly suppresses `userFilters` / `quickFilters` on the object default list — `packages/app-shell/src/views/ObjectView.tsx` hardcodes them to `undefined` in `renderListView`. But the suppression is **completely silent**, and the ADR's phase-4 guardrail (zod `refine` + `check` rule rejecting the wrong-context field) never landed: `packages/types/src/zod/objectql.zod.ts` still accepts `userFilters` on any list view with no context check.

Net effect: an author (human or AI) who puts `userFilters` on an object list view gets a schema that validates, a build that passes, and a toolbar with nothing where the filter dropdowns should be — zero signal at any layer. Found while dogfooding `app-showcase` (`showcase_task.tabular` carries exactly this wrong-context block).

## Fix

New `warnSuppressedListNav()` util, called from `renderListView` right before the suppression: when the view def or base list schema actually carries `userFilters`/`quickFilters`, log a one-shot warning (per object/view) naming the offending fields, the ADR, and where the fields belong (InterfaceListPage "filters" mode). Same "never swallow silently" treatment as #2217/#2218.

The suppression itself is untouched; the phase-4 schema-level rejection can supersede this warning when it lands.

## Testing

- 4 new unit tests (view-def hit, base-schema hit, once-per-view dedupe, clean view stays silent) — all pass.
- `pnpm --filter @object-ui/app-shell... build` passes.
- Browser-verified (HMR console against the framework `app-showcase` backend): opening `showcase_task.tabular` — whose metadata carries a wrong-context `userFilters` block — now logs
  `[ObjectView] View "showcase_task.tabular" on object "showcase_task" defines userFilters, which are ignored on an object list view (ADR-0053 "views" mode …)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)