### PR TITLE
fix(studio): scope Access matrix by { packageId } + slice-merge on save (ADR-0086 P0)

### DIFF
--- a/.changeset/access-matrix-package-scope.md
+++ b/.changeset/access-matrix-package-scope.md
@@ -17,7 +17,9 @@ Opened inside a package, the matrix now:
   package's slice, leaving every row contributed by other packages
   byte-for-byte intact.
 
-Permission *sets* remain platform-level (the left rail still lists them all);
-only the object matrix and its Save are package-scoped. Behavior is unchanged
-when the editor is used outside a package (no `packageId`): full object list,
-whole-record save.
+The Access rail also hides environment-owned platform-default sets
+(`admin_full_access`, `member_default`, …) from a package's panel once the
+backend tags sets with a record-level `package_id` (framework ADR-0086 P1), with
+a mid-migration guard that shows all sets until that provenance axis is live so
+the rail never goes empty. Behavior is unchanged when the editor is used outside
+a package (no `packageId`): full object list, whole-record save.

--- a/.changeset/access-matrix-package-scope.md
+++ b/.changeset/access-matrix-package-scope.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(studio): scope the Access matrix by package + slice-merge on save (ADR-0086 P0)
+
+The Access pillar embedded the permission matrix at **environment scope**: it
+listed every object in the environment (the "84-object leak"), and Save
+overwrote the whole permission set — silently dropping authorization rows other
+packages had contributed.
+
+Opened inside a package, the matrix now:
+
+- lists **only the objects that package declares** (`list('object', { packageId })`),
+  so a package's Access panel no longer exposes unrelated objects; and
+- saves via **slice-merge** — it re-reads the record and writes back only this
+  package's slice, leaving every row contributed by other packages
+  byte-for-byte intact.
+
+Permission *sets* remain platform-level (the left rail still lists them all);
+only the object matrix and its Save are package-scoped. Behavior is unchanged
+when the editor is used outside a package (no `packageId`): full object list,
+whole-record save.

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -164,6 +164,23 @@ enable, or disable packages; direct `/metadata/package` links redirect there.
 The Studio sidebar also flattens the root Overview group so Home and package
 navigation sit directly under the package selector.
 
+### Access matrix (package-scoped)
+
+The Access pillar's permission matrix follows the active package (ADR-0086 P0).
+A Permission Set / Profile is a single record whose `objects` / `fields` maps
+accumulate authorization rows contributed by many packages, so the matrix:
+
+- lists **only the objects the active package declares** — the panel never
+  exposes the whole environment's objects; and
+- saves via **slice-merge** — it re-reads the record and writes back just this
+  package's slice, leaving rows contributed by other packages untouched.
+
+Permission *sets* stay platform-level (the left rail lists them all); only the
+object matrix and its Save are package-scoped. Rendering `PermissionMatrixEditPage`
+without a `packageId` keeps the environment-wide behavior (full object list,
+whole-record save). The scope/merge helpers (`scopePermissionSet`,
+`mergePermissionSlice`) live in `metadata-admin/permission-slice.ts`.
+
 ### Visual flow canvas
 
 The `flow` designer (`FlowPreview` → `FlowCanvas`) renders an automation as an

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -175,11 +175,15 @@ accumulate authorization rows contributed by many packages, so the matrix:
 - saves via **slice-merge** — it re-reads the record and writes back just this
   package's slice, leaving rows contributed by other packages untouched.
 
-Permission *sets* stay platform-level (the left rail lists them all); only the
-object matrix and its Save are package-scoped. Rendering `PermissionMatrixEditPage`
-without a `packageId` keeps the environment-wide behavior (full object list,
-whole-record save). The scope/merge helpers (`scopePermissionSet`,
-`mergePermissionSlice`) live in `metadata-admin/permission-slice.ts`.
+The left rail lists only permission sets this package owns — environment-owned
+platform defaults (`admin_full_access`, `member_default`, …) are hidden once the
+backend tags sets with a record-level `package_id` (framework ADR-0086 P1). A
+mid-migration guard keeps the rail populated until that provenance axis is live
+(if no set carries a `package_id` yet, all are shown). Rendering
+`PermissionMatrixEditPage` without a `packageId` keeps the environment-wide
+behavior (full object list, whole-record save). The scope/merge helpers
+(`scopePermissionSet`, `mergePermissionSlice`, `scopePermissionSetList`) live in
+`metadata-admin/permission-slice.ts`.
 
 ### Visual flow canvas
 

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.scope.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.scope.test.tsx
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0086 P0 — closed-loop integration test for the package-scoped Access
+ * matrix. Drives the REAL `PermissionMatrixEditPage` (load effect + doSave)
+ * against a fake metadata client that behaves like the server:
+ *
+ *   • `list('object', { packageId })` returns only the package's objects, and
+ *   • `layered()` reflects the last saved payload (so "reopen" reads it back).
+ *
+ * It proves both directions the issue asks for:
+ *   1. Opening package A's panel shows ONLY package A's objects (no
+ *      environment leak — package B's `b_order` never appears).
+ *   2. Editing + saving in package A writes back a merged payload in which
+ *      package B's row survives byte-for-byte.
+ *   3. Reopening still shows only package A's slice.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Server state shared with the mocked client ──────────────────────────────
+interface Server {
+  set: Record<string, unknown>;
+  packageObjects: Array<{ name: string; label?: string }>;
+  saved: Array<Record<string, unknown>>;
+}
+
+function makeClient(server: Server) {
+  return {
+    layered: async () => ({
+      effective: server.set,
+      code: null,
+      overlay: null,
+      overlayScope: null,
+    }),
+    list: async (type: string, opts?: { packageId?: string }) => {
+      if (type === 'object') {
+        // The server scopes to the package — the panel must not see anything
+        // outside `server.packageObjects` regardless of what the set contains.
+        void opts;
+        return server.packageObjects.map((o) => ({ item: o }));
+      }
+      return [];
+    },
+    save: async (_type: string, _name: string, payload: Record<string, unknown>) => {
+      server.saved.push(payload);
+      server.set = payload; // becomes the new effective (reopen reads this)
+      return payload;
+    },
+  } as any;
+}
+
+let clientImpl: any;
+
+vi.mock('./useMetadata', () => ({
+  useMetadataClient: () => clientImpl,
+  useMetadataTypes: () => ({
+    loading: false,
+    error: null,
+    entries: [{ type: 'permission', label: 'Permission', allowOrgOverride: true }],
+  }),
+}));
+
+// AssignedUsersSection makes its own adapter calls — irrelevant here.
+vi.mock('./AssignedUsersSection', () => ({ AssignedUsersSection: () => null }));
+
+import { PermissionMatrixEditPage } from './PermissionMatrixEditor';
+
+afterEach(cleanup);
+
+function freshServer(): Server {
+  return {
+    packageObjects: [{ name: 'a_account' }, { name: 'a_contact' }],
+    saved: [],
+    set: {
+      name: 'sales_perms',
+      label: 'Sales',
+      isProfile: false,
+      systemPermissions: ['api_enabled'],
+      objects: {
+        a_account: { allowRead: true, allowCreate: true },
+        a_contact: { allowRead: true },
+        // Package B's row — must never appear, must survive saves.
+        b_order: { allowRead: true, allowEdit: true, viewAllRecords: true },
+      },
+      fields: { 'b_order.total': { readable: true, editable: true } },
+    },
+  };
+}
+
+function renderMatrix() {
+  return render(
+    <MemoryRouter>
+      <PermissionMatrixEditPage type="permission" name="sales_perms" packageId="app.a" />
+    </MemoryRouter>,
+  );
+}
+
+describe('PermissionMatrixEditPage — package scope + slice merge (ADR-0086 P0)', () => {
+  it('lists only the package objects, then merges the slice on save', async () => {
+    const server = freshServer();
+    clientImpl = makeClient(server);
+    const view = renderMatrix();
+
+    // 1) Only package A's objects are listed — no 84-object leak.
+    await screen.findByText('a_account');
+    expect(screen.getByText('a_contact')).toBeInTheDocument();
+    expect(screen.queryByText('b_order')).not.toBeInTheDocument();
+
+    // 2) Edit package A: clear a_account's grants via its row "None" button.
+    const row = screen.getByText('a_account').closest('tr')!;
+    fireEvent.click(within(row).getByRole('button', { name: 'None' }));
+
+    // 3) Save.
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(server.saved).toHaveLength(1));
+
+    const saved = server.saved[0] as any;
+    // Package B's contributed rows are preserved byte-for-byte.
+    expect(saved.objects.b_order).toEqual({
+      allowRead: true,
+      allowEdit: true,
+      viewAllRecords: true,
+    });
+    expect(saved.fields['b_order.total']).toEqual({ readable: true, editable: true });
+    // Package A's edit landed; a_contact (untouched, in-scope) retained.
+    expect(saved.objects.a_account).toEqual({});
+    expect(saved.objects.a_contact).toEqual({ allowRead: true });
+    // Set-level identity/extras carried through from the fresh base.
+    expect(saved.systemPermissions).toEqual(['api_enabled']);
+
+    view.unmount();
+
+    // 4) Reopen against the same (now-saved) server: still scoped to A.
+    clientImpl = makeClient(server);
+    renderMatrix();
+    await screen.findByText('a_account');
+    expect(screen.queryByText('b_order')).not.toBeInTheDocument();
+    // The saved server state still carries package B's row.
+    expect((server.set as any).objects.b_order).toEqual({
+      allowRead: true,
+      allowEdit: true,
+      viewAllRecords: true,
+    });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -63,39 +63,17 @@ import { useMetadataClient, useMetadataTypes, type RichMetadataTypeEntry } from 
 import { resolveResourceConfig } from './registry';
 import { t as translate, detectLocale } from './i18n';
 import { AssignedUsersSection } from './AssignedUsersSection';
+import {
+  mergePermissionSlice,
+  scopePermissionSet,
+  type ObjectPerm,
+  type FieldPerm,
+  type PermissionSetDraft,
+} from './permission-slice';
 
 /* ────────────────────────────────────────────────────────────────── */
 /* Domain shapes                                                      */
 /* ────────────────────────────────────────────────────────────────── */
-
-interface ObjectPerm {
-  allowCreate?: boolean;
-  allowRead?: boolean;
-  allowEdit?: boolean;
-  allowDelete?: boolean;
-  allowTransfer?: boolean;
-  allowRestore?: boolean;
-  allowPurge?: boolean;
-  viewAllRecords?: boolean;
-  modifyAllRecords?: boolean;
-}
-
-interface FieldPerm {
-  readable?: boolean;
-  editable?: boolean;
-}
-
-interface PermissionSetDraft {
-  name: string;
-  label?: string;
-  isProfile?: boolean;
-  objects: Record<string, ObjectPerm>;
-  fields?: Record<string, FieldPerm>;
-  systemPermissions?: string[];
-  tabPermissions?: Record<string, 'visible' | 'hidden' | 'default_on' | 'default_off'>;
-  // Any extra keys are carried through untouched on save.
-  [extra: string]: unknown;
-}
 
 interface ObjectSummary {
   name: string;
@@ -126,13 +104,20 @@ function getObjectActions(
 export interface PermissionMatrixEditPageProps {
   type: string;
   name: string;
+  /**
+   * When set, the matrix is scoped to a single package (ADR-0086 P0): it lists
+   * only the objects that package declares, and Save merges just that slice
+   * back — other packages' contributed rows are left untouched. When omitted,
+   * the matrix operates at environment scope (all objects, whole-record save).
+   */
+  packageId?: string;
 }
 
 /* ────────────────────────────────────────────────────────────────── */
 /* Component                                                          */
 /* ────────────────────────────────────────────────────────────────── */
 
-export function PermissionMatrixEditPage({ type, name }: PermissionMatrixEditPageProps) {
+export function PermissionMatrixEditPage({ type, name, packageId }: PermissionMatrixEditPageProps) {
   const navigate = useNavigate();
   const client = useMetadataClient();
   const { entries } = useMetadataTypes(client);
@@ -168,17 +153,13 @@ export function PermissionMatrixEditPage({ type, name }: PermissionMatrixEditPag
       try {
         const [lay, objList] = await Promise.all([
           client.layered<PermissionSetDraft>(type, name).catch(() => null),
-          client.list<any>('object').catch(() => []),
+          // In package scope, list only the objects this package declares
+          // (ADR-0086 P0) — otherwise the whole environment leaks into the panel.
+          client.list<any>('object', packageId ? { packageId } : {}).catch(() => []),
         ]);
         if (cancelled) return;
         const effective: PermissionSetDraft = (lay?.effective ??
           lay?.code ?? { name, objects: {} }) as PermissionSetDraft;
-        setDraft({
-          ...effective,
-          name: String(effective?.name ?? name),
-          objects: effective?.objects ?? {},
-          fields: effective?.fields ?? {},
-        });
         const list: ObjectSummary[] = ((objList as any[]) ?? [])
           .map((row) => {
             const item = row?.item ?? row;
@@ -187,6 +168,21 @@ export function PermissionMatrixEditPage({ type, name }: PermissionMatrixEditPag
           .filter((o) => !!o.name)
           .sort((a, b) => a.name.localeCompare(b.name));
         setObjects(list);
+        const full: PermissionSetDraft = {
+          ...effective,
+          name: String(effective?.name ?? name),
+          objects: effective?.objects ?? {},
+          fields: effective?.fields ?? {},
+        };
+        // Package scope: only surface this package's slice for editing; rows
+        // contributed by other packages stay off-screen and are re-merged on
+        // Save from a fresh read (see doSave).
+        if (packageId) {
+          const sliced = scopePermissionSet(full, list.map((o) => o.name));
+          setDraft({ ...full, objects: sliced.objects, fields: sliced.fields });
+        } else {
+          setDraft(full);
+        }
       } catch (err: any) {
         setError(err?.message ?? String(err));
       } finally {
@@ -196,7 +192,7 @@ export function PermissionMatrixEditPage({ type, name }: PermissionMatrixEditPag
     return () => {
       cancelled = true;
     };
-  }, [client, type, name]);
+  }, [client, type, name, packageId]);
 
   /* ── Lazy-load fields when an object is expanded ─────────── */
   async function ensureFields(objectName: string) {
@@ -280,17 +276,39 @@ export function PermissionMatrixEditPage({ type, name }: PermissionMatrixEditPag
     });
   }
 
+  /**
+   * Re-narrow a freshly-read full permission set to this package's slice for
+   * display. No-op at environment scope (no `packageId`).
+   */
+  function toDisplayDraft(set: PermissionSetDraft): PermissionSetDraft {
+    if (!packageId) return set;
+    const sliced = scopePermissionSet(set, objects.map((o) => o.name));
+    return { ...set, objects: sliced.objects, fields: sliced.fields };
+  }
+
   /* ── Save ────────────────────────────────────────────────── */
   async function doSave(force: boolean, pending?: PermissionSetDraft) {
     const payload = pending ?? draft;
     setSaving(true);
     setError(null);
     try {
-      await client.save<PermissionSetDraft>(type, payload.name, payload, {
+      // Package scope: merge only this package's slice back onto a fresh read
+      // of the record so rows contributed by other packages survive byte-for-
+      // byte (ADR-0086 P0). Environment scope keeps the whole-record save.
+      let toSave = payload;
+      if (packageId) {
+        const scope = objects.map((o) => o.name);
+        const fresh = await client
+          .layered<PermissionSetDraft>(type, payload.name)
+          .catch(() => null);
+        const base = (fresh?.effective ?? payload) as PermissionSetDraft;
+        toSave = mergePermissionSlice(base, payload, scope);
+      }
+      await client.save<PermissionSetDraft>(type, payload.name, toSave, {
         force,
       });
       const lay = await client.layered<PermissionSetDraft>(type, payload.name);
-      setDraft((lay.effective ?? payload) as PermissionSetDraft);
+      setDraft(toDisplayDraft((lay.effective ?? toSave) as PermissionSetDraft));
       setDestructive(null);
     } catch (err: any) {
       if (err?.status === 409 && err?.code === 'destructive_change') {

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -989,8 +989,8 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.access.title': 'Permission matrix',
   'engine.studio.access.subtitle': 'Objects × CRUD · field-level R/W',
   'engine.studio.access.bannerTitle':
-    'Permissions are platform-level authorization; the matrix’s “Save” takes effect immediately — it doesn’t enter package drafts, so the top-bar “Publish” doesn’t apply here.',
-  'engine.studio.access.banner': 'Saved = live · not package drafts',
+    'This matrix lists only the objects this package declares, and “Save” merges just that slice — grants contributed by other packages are preserved. Permissions take effect immediately: they don’t enter package drafts, so the top-bar “Publish” doesn’t apply here.',
+  'engine.studio.access.banner': 'This package’s objects · saved = live',
   'engine.studio.access.heading': 'Permission sets / Profiles',
   'engine.studio.access.search': 'Search permissions…',
   'engine.studio.access.none': 'No permission sets yet — create one below',
@@ -1848,8 +1848,8 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.access.title': '权限矩阵',
   'engine.studio.access.subtitle': '对象 × CRUD · 字段级读写',
   'engine.studio.access.bannerTitle':
-    '权限是平台级授权配置,矩阵内的「Save」保存即生效;不进入软件包草稿,顶栏「发布」不涉及它。',
-  'engine.studio.access.banner': '保存即生效 · 不走包草稿',
+    '此矩阵仅列出本包声明的对象,「Save」只合并本包切片 —— 其他包贡献的授权原样保留。权限保存即生效:不进入软件包草稿,顶栏「发布」不涉及它。',
+  'engine.studio.access.banner': '仅本包对象 · 保存即生效',
   'engine.studio.access.heading': '权限集 / Profile',
   'engine.studio.access.search': '搜索权限…',
   'engine.studio.access.none': '还没有权限集 — 在下方新建一个',

--- a/packages/app-shell/src/views/metadata-admin/permission-slice.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/permission-slice.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0086 P0 — the Access matrix, when opened inside a package, must edit only
+ * that package's slice and, on Save, leave every other package's contributed
+ * rows byte-for-byte intact. These pin both halves of the contract:
+ *   • scoping (what the panel shows), and
+ *   • slice-merge (what Save writes back).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  fieldKeyObject,
+  mergePermissionSlice,
+  scopePermissionSet,
+  type PermissionSetDraft,
+} from './permission-slice';
+
+// A permission set two packages have contributed to. Package A owns
+// `a_account` / `a_contact`; package B owns `b_order`.
+const full: PermissionSetDraft = {
+  name: 'sales_perms',
+  label: 'Sales permissions',
+  isProfile: false,
+  systemPermissions: ['api_enabled'],
+  tabPermissions: { a_account: 'visible', b_order: 'default_on' },
+  objects: {
+    a_account: { allowRead: true, allowCreate: true },
+    a_contact: { allowRead: true },
+    b_order: { allowRead: true, allowEdit: true, viewAllRecords: true },
+  },
+  fields: {
+    'a_account.name': { readable: true, editable: true },
+    'a_contact.email': { readable: true, editable: false },
+    'b_order.total': { readable: true, editable: true },
+  },
+};
+
+const SCOPE_A = ['a_account', 'a_contact'];
+
+describe('fieldKeyObject', () => {
+  it('extracts the object name up to the first dot', () => {
+    expect(fieldKeyObject('a_account.name')).toBe('a_account');
+    expect(fieldKeyObject('lonely')).toBe('lonely');
+  });
+});
+
+describe('scopePermissionSet — panel shows only the package slice', () => {
+  it('keeps only in-scope object + field rows (no environment leak)', () => {
+    const sliced = scopePermissionSet(full, SCOPE_A);
+    expect(Object.keys(sliced.objects).sort()).toEqual(['a_account', 'a_contact']);
+    expect(Object.keys(sliced.fields).sort()).toEqual([
+      'a_account.name',
+      'a_contact.email',
+    ]);
+    // Package B's rows are absent from the panel.
+    expect(sliced.objects.b_order).toBeUndefined();
+    expect(sliced.fields['b_order.total']).toBeUndefined();
+  });
+
+  it('tolerates a missing fields map', () => {
+    const sliced = scopePermissionSet({ objects: { a_account: {} } }, SCOPE_A);
+    expect(sliced.fields).toEqual({});
+  });
+});
+
+describe('mergePermissionSlice — Save preserves other packages byte-for-byte', () => {
+  it("re-grants package A while package B's rows stay identical", () => {
+    // Panel loaded package A's slice, user edited it (grant edit on a_account,
+    // drop a_contact entirely).
+    const edited: PermissionSetDraft = {
+      ...scopePermissionSet(full, SCOPE_A),
+      name: full.name,
+      label: full.label,
+      isProfile: full.isProfile,
+    };
+    edited.objects.a_account = { allowRead: true, allowCreate: true, allowEdit: true };
+    delete edited.objects.a_contact;
+    delete edited.fields!['a_contact.email'];
+
+    const merged = mergePermissionSlice(full, edited, SCOPE_A);
+
+    // Package B's object + field rows are the SAME reference (untouched).
+    expect(merged.objects.b_order).toBe(full.objects.b_order);
+    expect(merged.fields!['b_order.total']).toBe(full.fields!['b_order.total']);
+
+    // Package A's edits landed.
+    expect(merged.objects.a_account.allowEdit).toBe(true);
+    expect(merged.objects.a_contact).toBeUndefined(); // removed grant gone
+    expect(merged.fields!['a_contact.email']).toBeUndefined();
+
+    // Set-level extras survive from base.
+    expect(merged.systemPermissions).toEqual(['api_enabled']);
+    expect(merged.tabPermissions).toEqual(full.tabPermissions);
+  });
+
+  it("editing package B does not disturb package A's slice", () => {
+    const scopeB = ['b_order'];
+    const editedB: PermissionSetDraft = {
+      ...scopePermissionSet(full, scopeB),
+      name: full.name,
+    };
+    editedB.objects.b_order = { allowRead: true }; // narrow B's grant
+
+    const merged = mergePermissionSlice(full, editedB, scopeB);
+
+    expect(merged.objects.a_account).toBe(full.objects.a_account);
+    expect(merged.objects.a_contact).toBe(full.objects.a_contact);
+    expect(merged.fields!['a_account.name']).toBe(full.fields!['a_account.name']);
+    expect(merged.objects.b_order).toEqual({ allowRead: true });
+  });
+
+  it('a fresh base (no other packages yet) round-trips the edited slice', () => {
+    const base: PermissionSetDraft = { name: 'sales_perms', objects: {}, fields: {} };
+    const edited: PermissionSetDraft = {
+      name: 'sales_perms',
+      objects: { a_account: { allowRead: true } },
+      fields: { 'a_account.name': { readable: true } },
+    };
+    const merged = mergePermissionSlice(base, edited, SCOPE_A);
+    expect(merged.objects).toEqual({ a_account: { allowRead: true } });
+    expect(merged.fields).toEqual({ 'a_account.name': { readable: true } });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/permission-slice.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/permission-slice.test.ts
@@ -13,6 +13,7 @@ import {
   fieldKeyObject,
   mergePermissionSlice,
   scopePermissionSet,
+  scopePermissionSetList,
   type PermissionSetDraft,
 } from './permission-slice';
 
@@ -42,6 +43,34 @@ describe('fieldKeyObject', () => {
   it('extracts the object name up to the first dot', () => {
     expect(fieldKeyObject('a_account.name')).toBe('a_account');
     expect(fieldKeyObject('lonely')).toBe('lonely');
+  });
+});
+
+describe('scopePermissionSetList — rail hides other packages / platform defaults', () => {
+  const rail = [
+    { name: 'showcase_contributor', label: 'Contributor', packageId: 'com.example.showcase' },
+    { name: 'admin_full_access', label: 'Admin', packageId: null }, // platform default
+    { name: 'member_default', label: 'Member' }, // platform default (no field)
+    { name: 'crm_sales', label: 'Sales', packageId: 'app.acme.crm' }, // other package
+  ];
+
+  it('keeps only this package once sets carry provenance (defaults hidden)', () => {
+    const scoped = scopePermissionSetList(rail, 'com.example.showcase');
+    expect(scoped.map((p) => p.name)).toEqual(['showcase_contributor']);
+  });
+
+  it('scopes to another package independently', () => {
+    expect(scopePermissionSetList(rail, 'app.acme.crm').map((p) => p.name)).toEqual([
+      'crm_sales',
+    ]);
+  });
+
+  it('mid-migration guard: shows everything when no set is tagged yet', () => {
+    const untagged = [
+      { name: 'a', label: 'A' },
+      { name: 'b', label: 'B', packageId: null },
+    ];
+    expect(scopePermissionSetList(untagged, 'com.example.showcase')).toBe(untagged);
   });
 });
 

--- a/packages/app-shell/src/views/metadata-admin/permission-slice.ts
+++ b/packages/app-shell/src/views/metadata-admin/permission-slice.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Package-scoped slice merge for the permission matrix (ADR-0086 P0).
+ *
+ * A Permission Set / Profile is a single metadata record whose `objects` and
+ * `fields` maps accumulate authorization rows contributed by many packages.
+ * When the Access matrix is opened inside a package context it must:
+ *
+ *   1. show only the objects that package declares (scope), and
+ *   2. on Save write back ONLY that slice — leaving every row contributed by
+ *      other packages byte-for-byte intact.
+ *
+ * Overwriting the whole record (the pre-P0 behavior) silently drops the rows
+ * other packages contributed. {@link mergePermissionSlice} rebuilds the record
+ * from a freshly-read base, keeping the set-level identity and every
+ * out-of-scope row, and overlaying only the in-scope rows the user edited.
+ */
+
+export interface ObjectPerm {
+  allowCreate?: boolean;
+  allowRead?: boolean;
+  allowEdit?: boolean;
+  allowDelete?: boolean;
+  allowTransfer?: boolean;
+  allowRestore?: boolean;
+  allowPurge?: boolean;
+  viewAllRecords?: boolean;
+  modifyAllRecords?: boolean;
+}
+
+export interface FieldPerm {
+  readable?: boolean;
+  editable?: boolean;
+}
+
+export interface PermissionSetDraft {
+  name: string;
+  label?: string;
+  isProfile?: boolean;
+  objects: Record<string, ObjectPerm>;
+  fields?: Record<string, FieldPerm>;
+  systemPermissions?: string[];
+  tabPermissions?: Record<string, 'visible' | 'hidden' | 'default_on' | 'default_off'>;
+  // Any extra keys are carried through untouched on save.
+  [extra: string]: unknown;
+}
+
+/**
+ * Object name embedded in a `${object}.${field}` field-permission key. Object
+ * and field names are field-name-safe (snake_case, no dots), so the object is
+ * everything up to the first dot.
+ */
+export function fieldKeyObject(key: string): string {
+  const dot = key.indexOf('.');
+  return dot === -1 ? key : key.slice(0, dot);
+}
+
+function asScopeSet(scope: Iterable<string>): Set<string> {
+  return scope instanceof Set ? scope : new Set(scope);
+}
+
+/**
+ * Narrow a permission set down to just the rows whose object is in `scope`.
+ * Used to drive the matrix display so a package panel lists only its own
+ * objects (and their field overrides), never the whole environment.
+ */
+export function scopePermissionSet(
+  set: Pick<PermissionSetDraft, 'objects' | 'fields'>,
+  scope: Iterable<string>,
+): { objects: Record<string, ObjectPerm>; fields: Record<string, FieldPerm> } {
+  const scopeSet = asScopeSet(scope);
+  const objects: Record<string, ObjectPerm> = {};
+  for (const [k, v] of Object.entries(set.objects ?? {})) {
+    if (scopeSet.has(k)) objects[k] = v;
+  }
+  const fields: Record<string, FieldPerm> = {};
+  for (const [k, v] of Object.entries(set.fields ?? {})) {
+    if (scopeSet.has(fieldKeyObject(k))) fields[k] = v;
+  }
+  return { objects, fields };
+}
+
+/**
+ * Merge the edited in-scope slice back onto a freshly-read full `base`.
+ *
+ * Out-of-scope rows (other packages' contributions) are copied verbatim from
+ * `base`; in-scope rows are taken entirely from `edited` (so removing a grant
+ * in the package panel deletes only that package's row). Set-level identity and
+ * any extra keys (systemPermissions, tabPermissions, …) come from `base`, with
+ * name / label / isProfile taking the user's edits.
+ */
+export function mergePermissionSlice(
+  base: PermissionSetDraft,
+  edited: PermissionSetDraft,
+  scope: Iterable<string>,
+): PermissionSetDraft {
+  const scopeSet = asScopeSet(scope);
+
+  const objects: Record<string, ObjectPerm> = {};
+  for (const [k, v] of Object.entries(base.objects ?? {})) {
+    if (!scopeSet.has(k)) objects[k] = v; // preserve other packages' rows
+  }
+  for (const [k, v] of Object.entries(edited.objects ?? {})) {
+    if (scopeSet.has(k)) objects[k] = v; // write this package's slice
+  }
+
+  const fields: Record<string, FieldPerm> = {};
+  for (const [k, v] of Object.entries(base.fields ?? {})) {
+    if (!scopeSet.has(fieldKeyObject(k))) fields[k] = v;
+  }
+  for (const [k, v] of Object.entries(edited.fields ?? {})) {
+    if (scopeSet.has(fieldKeyObject(k))) fields[k] = v;
+  }
+
+  return {
+    ...base,
+    name: edited.name,
+    label: edited.label,
+    isProfile: edited.isProfile,
+    objects,
+    fields,
+  };
+}

--- a/packages/app-shell/src/views/metadata-admin/permission-slice.ts
+++ b/packages/app-shell/src/views/metadata-admin/permission-slice.ts
@@ -61,6 +61,29 @@ function asScopeSet(scope: Iterable<string>): Set<string> {
 }
 
 /**
+ * Narrow the Access pillar's permission-set rail to the sets a package owns.
+ *
+ * Permission sets carry a record-level `package_id` provenance axis (framework
+ * ADR-0086 P1): sets a package declares are seeded owned by it, while
+ * environment-owned platform defaults (`admin_full_access`, `member_default`,
+ * …) have none. A package's Access panel must not list those platform defaults.
+ *
+ * Rollout guard: filter ONLY once the backend actually tags sets with a
+ * `packageId` (i.e. at least one row carries one). Until then — a backend that
+ * predates the P1 provenance seeding — no row is tagged and we show everything,
+ * so the rail never collapses to empty mid-migration. Tighten (drop the guard)
+ * once the provenance axis is guaranteed live.
+ */
+export function scopePermissionSetList<T extends { packageId?: string | null }>(
+  items: T[],
+  packageId: string,
+): T[] {
+  const anyTagged = items.some((p) => p.packageId != null);
+  if (!anyTagged) return items;
+  return items.filter((p) => p.packageId === packageId);
+}
+
+/**
  * Narrow a permission set down to just the rows whose object is in `scope`.
  * Used to drive the matrix display so a package panel lists only its own
  * objects (and their field overrides), never the whole environment.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -590,7 +590,7 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
           ) : tab === 'automations' ? (
             <AutomationsPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} />
           ) : tab === 'access' ? (
-            <AccessPillar />
+            <AccessPillar packageId={packageId} />
           ) : (
             <InterfacesPillar
               packageId={packageId}
@@ -2328,15 +2328,17 @@ function AutomationsPillar({
 /**
  * Access pillar — the permission workbench (builder-ui §7, ADR-0084's fourth
  * content pillar). Left rail: the environment's permission sets / profiles;
- * main: the existing Salesforce-style PermissionMatrixEditPage (objects ×
- * CRUD/VAMA + field-level R/W), embedded unchanged.
+ * main: the Salesforce-style PermissionMatrixEditPage (objects × CRUD/VAMA +
+ * field-level R/W).
  *
- * Semantics note (v1, deliberate): permissions are PLATFORM-level authorization
- * objects, not package content — the matrix's own Save writes the ACTIVE item
- * directly (no draft, no package binding), so the shell's 变更/发布 does not
- * apply here. The banner says so instead of pretending otherwise.
+ * Scope note (ADR-0086 P0): permission SETS are platform-level authorization
+ * objects (the left rail lists all of them), but the object MATRIX is scoped to
+ * the current package — it lists only the objects this package declares, and
+ * its Save merges just that slice back, leaving other packages' contributed
+ * rows untouched. The matrix still writes the ACTIVE item directly (no draft,
+ * no draft/publish flow), so the shell's 变更/发布 does not apply here.
  */
-function AccessPillar(): React.ReactElement {
+function AccessPillar({ packageId }: { packageId: string }): React.ReactElement {
   const client = useMetadataClient();
   const locale = useMetadataLocale();
   const [perms, setPerms] = React.useState<Array<{ name: string; label: string; isProfile?: boolean }>>([]);
@@ -2520,7 +2522,12 @@ function AccessPillar(): React.ReactElement {
             /* The existing Salesforce-style matrix page, embedded unchanged —
              * objects × CRUD/VAMA/lifecycle up top, per-object field-level R/W
              * below, its own Save + destructive-change guard included. */
-            <PermissionMatrixEditPage key={current} type="permission" name={current} />
+            <PermissionMatrixEditPage
+              key={current}
+              type="permission"
+              name={current}
+              packageId={packageId}
+            />
           ) : (
             <div className="py-16 text-center text-sm text-muted-foreground">
               {loaded && perms.length === 0 ? t('engine.studio.access.emptyMain', locale) : t('engine.studio.access.pick', locale)}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -51,6 +51,7 @@ import {
 } from 'lucide-react';
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
 import { PermissionMatrixEditPage } from '../metadata-admin/PermissionMatrixEditor';
+import { scopePermissionSetList } from '../metadata-admin/permission-slice';
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
 import { useMetadataClient } from '../metadata-admin/useMetadata';
 import { t, tFormat, useMetadataLocale } from '../metadata-admin/i18n';
@@ -2331,17 +2332,22 @@ function AutomationsPillar({
  * main: the Salesforce-style PermissionMatrixEditPage (objects × CRUD/VAMA +
  * field-level R/W).
  *
- * Scope note (ADR-0086 P0): permission SETS are platform-level authorization
- * objects (the left rail lists all of them), but the object MATRIX is scoped to
- * the current package — it lists only the objects this package declares, and
- * its Save merges just that slice back, leaving other packages' contributed
- * rows untouched. The matrix still writes the ACTIVE item directly (no draft,
- * no draft/publish flow), so the shell's 变更/发布 does not apply here.
+ * Scope note (ADR-0086 P0/P1): the pillar is scoped to the current package.
+ * The left rail lists only permission sets this package owns — environment-owned
+ * platform defaults (`admin_full_access`, `member_default`, …) are hidden once
+ * the backend tags sets with a record-level `package_id` (P1); see
+ * `scopePermissionSetList` for the mid-migration guard. The object MATRIX lists
+ * only the objects this package declares, and its Save merges just that slice
+ * back, leaving other packages' contributed rows untouched. The matrix still
+ * writes the ACTIVE item directly (no draft/publish flow), so the shell's
+ * 变更/发布 does not apply here.
  */
 function AccessPillar({ packageId }: { packageId: string }): React.ReactElement {
   const client = useMetadataClient();
   const locale = useMetadataLocale();
-  const [perms, setPerms] = React.useState<Array<{ name: string; label: string; isProfile?: boolean }>>([]);
+  const [perms, setPerms] = React.useState<
+    Array<{ name: string; label: string; isProfile?: boolean; packageId?: string | null }>
+  >([]);
   const [loaded, setLoaded] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [current, setCurrent] = React.useState<string | null>(null);
@@ -2361,16 +2367,23 @@ function AccessPillar({ packageId }: { packageId: string }): React.ReactElement 
           name: String(p.name ?? (p as Record<string, unknown>).id ?? ''),
           label: String(p.label ?? p.name ?? ''),
           isProfile: !!(p as Record<string, unknown>).isProfile,
+          // Record-level provenance (framework ADR-0086 P1); snake_case is the
+          // framework field, camelCase tolerated for either serialization.
+          packageId: ((p as Record<string, unknown>).package_id ??
+            (p as Record<string, unknown>).packageId) as string | undefined,
         }))
         .filter((p) => p.name);
-      setPerms(items);
-      setCurrent((c) => c ?? items[0]?.name ?? null);
+      // Hide environment-owned platform-default sets (no package_id) from this
+      // package's panel — see scopePermissionSetList for the mid-migration guard.
+      const scoped = scopePermissionSetList(items, packageId);
+      setPerms(scoped);
+      setCurrent((c) => c ?? scoped[0]?.name ?? null);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoaded(true);
     }
-  }, [client]);
+  }, [client, packageId]);
 
   React.useEffect(() => {
     void load();


### PR DESCRIPTION
Closes #2221.

## Problem

The Access pillar (#2196) embedded the permission matrix at **environment scope**, producing two real security/safety issues:

1. **"84-object leak"** — opening the Access panel in a package listed the permission matrix for **every object in the environment**, not just the ones the package declares. An admin editing package A could see (and mis-edit) authorization for objects belonging to other packages.
2. **Cross-package data loss** — Save **overwrote the whole permission set**, silently clobbering authorization rows other packages had contributed.

Per ADR-0086 (framework #2559) — this PR executes, it does not re-decide.

## What changed

Opened inside a package, `PermissionMatrixEditPage` now:

- **Scopes the object list by `{ packageId }`** — `list('object', { packageId })`, so the panel lists only the objects that package declares (the package's manifest-declared object set, discovered via the existing server-side `?package=` filter).
- **Slice-merges on Save** — it re-reads the record and writes back **only this package's slice** via `mergePermissionSlice`, leaving every row contributed by other packages **byte-for-byte** intact. The post-save refresh re-narrows to the slice too.

The Access **rail** also scopes to permission sets this package owns (`scopePermissionSetList`): environment-owned platform defaults (`admin_full_access`, `member_default`, …) are hidden once the backend tags sets with a record-level `package_id` (framework ADR-0086 P1, framework#2566). A **mid-migration guard** keeps the rail populated on backends that predate the P1 provenance seeding — if no set carries a `package_id` yet, all are shown, so the rail never collapses to empty. (Follows the coordination update on #2221.)

When `PermissionMatrixEditPage` is rendered without a `packageId` (e.g. the generic metadata-resource editor), behavior is unchanged: full object list, whole-record save.

The scope/merge logic is a pure, dependency-free helper — `packages/app-shell/src/views/metadata-admin/permission-slice.ts` (`scopePermissionSet`, `mergePermissionSlice`, `scopePermissionSetList`).

## Acceptance criteria

- [x] Opening package A's Access panel shows only package A's declared objects (no 84-object environment list).
- [x] After editing + saving package A's matrix, package B's prior authorization rows are preserved **byte-for-byte** (write-back regression test).
- [x] Closed loop open → edit → save → reopen, with a cross-package slice-retention check.
- [x] Platform-default permission sets (no `package_id`) are hidden from a package's rail once provenance is tagged.
- [x] `type-check` 0 errors; existing tests do not regress (516 app-shell tests green).

## Testing

- **`permission-slice.test.ts`** — unit tests for object scoping, slice-merge (other-package rows survive as the same reference, both directions), and rail scoping incl. the mid-migration guard.
- **`PermissionMatrixEditor.scope.test.tsx`** — component integration test that drives the **real** editor through load → edit (clear a package-A object) → save → reopen against a fake client that behaves like the server, asserting: only package A's objects render (`b_order` never appears), and the saved payload preserves package B's `objects`/`fields` rows verbatim.

> Note on the browser closed-loop: the live backend that provides `?package=` scoping and permission persistence lives in the `framework` repo, which is not present in this environment. The component integration test exercises the same load→edit→save→reopen path against a server-faithful fake client as the closest achievable substitute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWcZRYnJXN3YXFTbm3PLg5