### PR TITLE
fix(console): non-ASCII workspace slug + full chart category labels

### DIFF
--- a/packages/app-shell/src/console/organizations/CreateWorkspaceDialog.tsx
+++ b/packages/app-shell/src/console/organizations/CreateWorkspaceDialog.tsx
@@ -25,15 +25,37 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { Loader2 } from 'lucide-react';
 import { provisionProductionEnvironment } from './provisionEnvironment';
 
-/** Convert a display name to a URL-friendly slug */
+/**
+ * Convert a display name to a URL-friendly slug.
+ *
+ * The ASCII pass strips everything outside [a-z0-9 _-]. For a name written
+ * entirely in a non-Latin script (中文 / 日本語 / 한국어 / العربية …) that pass
+ * yields the empty string — and an empty slug left the "Create workspace"
+ * button permanently disabled (`!slug.trim()`), dead-ending the FIRST step of
+ * onboarding for every non-Latin-name user. Rather than block them, fall back
+ * to a deterministic, non-empty slug they can still edit.
+ *
+ * Deterministic (not random) on purpose: a name-derived hash means the slug
+ * doesn't jitter on every keystroke while typing a CJK name, and re-typing the
+ * same name reproduces the same slug. Uniqueness across different names comes
+ * from the hash; the server still enforces global slug uniqueness on submit.
+ */
 function nameToSlug(name: string): string {
-  return name
+  const ascii = name
     .toLowerCase()
     .replace(/[^a-z0-9\s_-]/g, '')
     .replace(/[\s_]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
     .slice(0, 48);
+  if (ascii) return ascii;
+  // Empty name → empty slug (keep the button disabled; nothing to create yet).
+  const trimmed = name.trim();
+  if (!trimmed) return '';
+  // Non-empty name with no ASCII-sluggable chars → deterministic fallback.
+  let hash = 0;
+  for (const ch of trimmed) hash = (Math.imul(hash, 31) + ch.charCodeAt(0)) >>> 0;
+  return `workspace-${hash.toString(36).slice(0, 6)}`;
 }
 
 interface CreateWorkspaceDialogProps {

--- a/packages/plugin-charts/src/ChartImpl.tsx
+++ b/packages/plugin-charts/src/ChartImpl.tsx
@@ -91,7 +91,14 @@ export default function ChartImpl({
             tick={needAngle ? <AngledTick /> : { fill: 'hsl(var(--muted-foreground))', fontSize: 12, fontFamily: 'monospace' }}
             tickLine={false}
             axisLine={{ stroke: 'hsl(var(--border))' }}
-            interval={needAngle ? 0 : 'preserveStartEnd'}
+            // Always render every category tick. The old non-angled branch used
+            // `preserveStartEnd`, which keeps ONLY the first + last label — so a
+            // short 3–4 category chart lost its middle labels entirely (AI-built
+            // "count by status" dashboards showed 4 bars but only 2 axis labels,
+            // leaving the middle bars unlabelled). Non-angled means ≤4 short
+            // categories — horizontal space is ample — and the angled branch
+            // already prevents overlap on crowded axes, so `0` is safe for both.
+            interval={0}
             height={needAngle ? 56 : undefined}
             dy={needAngle ? undefined : 10}
           />


### PR DESCRIPTION
Two front-end defects found in a **real Chinese-user magic-flow walkthrough** (browser E2E on the local full stack), both blocking the Airtable-replacement target audience.

## 1. Non-ASCII workspace name → onboarding dead-end 🚫 (blocker)

`CreateWorkspaceDialog.nameToSlug()` strips everything outside `[a-z0-9 _-]`. A name written entirely in **中文 / 日本語 / 한국어** yields an **empty slug**, and the "Create workspace" button is `disabled={!slug.trim()}` → **permanently disabled**. A Chinese-named user literally cannot create their first workspace — they're stuck on step one of onboarding.

**Fix:** when the ASCII pass yields empty (and the name is non-empty), fall back to a deterministic `workspace-<hash>` slug the user can still edit. Empty name still yields empty slug (button stays correctly disabled). Deterministic (name-derived hash) so the slug doesn't jitter per keystroke while typing a CJK name.

**Verified end-to-end in the browser** (local stack, real registration): `李娜的客户管理` → slug `workspace-er6yfk`, button **enabled**, workspace **created**, landed in the console. Also: empty→disabled, `한국어`→`workspace-w3mf7`, `Acme 商贸`→`acme` (ASCII part wins).

## 2. Bar-chart X axis drops middle category labels 📊

The non-angled branch of `ChartImpl` used `interval='preserveStartEnd'`, which keeps **only the first + last tick**. A short 3–5 category chart — e.g. an AI-built "count by status" dashboard — renders all its bars but labels only the first and last; the middle bars have **no axis label**. First observed on a customer-management dashboard: 4 bars, only 2 labels.

**Fix:** `interval={0}` (render every tick). Non-angled means ≤4 short categories where horizontal space is ample, and the angled branch already prevents overlap on crowded axes, so `0` is safe for both. (`interval={0}` showing every category tick is recharts' documented behavior.)

## Verification notes

- **bug #1**: full browser E2E (screenshotted), plus a determinism table across zh/ja/ko/mixed/empty.
- **bug #2**: code + build verified (fix compiled into the console bundle, overlaid onto the env serve path, backend dashboard valid with a 5-category `order_status` dimension). Pixel-level confirmation of the 5 labels was blocked by an **unrelated** app-publish propagation issue (the AI-built app showed "not available yet" on its app route and wasn't listed in the launcher — filed separately), not by the chart fix.

## Consumer

Cloud pins objectui via `.objectui-sha`; a follow-up cloud PR will bump the pin once this merges.