### PR TITLE
feat(studio): 包 Access 门改走草稿/发布(ADR-0086 P2 · D6/D7)

### DIFF
--- a/.changeset/adr-0086-p2-package-access-door.md
+++ b/.changeset/adr-0086-p2-package-access-door.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(studio): package Access door is draft/published, not live (ADR-0086 P2 · D6/D7)
+
+The package **Access** pillar edited permission sets **live** — it wrote the
+active record directly, unlike the Data and Interfaces pillars which stage a
+draft and publish with the rest of the package. That contradicted ADR-0086 D6
+("a package's own access is metadata → draft/publish") and left the two doors
+sharing one live write path.
+
+Now the **package door** (`/studio/:packageId/access`) writes **drafts**:
+
+- The permission editor's Save (`PermissionMatrixEditPage`, package scope) and
+  the "new set" creator both call `client.save(..., { mode: 'draft', packageId })`
+  — the framework stamps the draft with the package, and the top-bar **Publish**
+  promotes it atomically (materialized into `sys_permission_set` by the framework
+  side, ADR-0086 P2 块1). The **environment-admin** door (no `packageId`) is
+  unchanged: it stays **live** (config), per D7.
+- Reads are draft-aware: the editor loads any pending draft over the published
+  baseline, and the pillar rail merges published ∪ draft sets — so a set created
+  or edited as a draft stays visible before publish (matching Data/Interfaces).
+  Saving bumps the surface's pending-changes counter; a publish reloads the
+  published baseline.
+- The pillar banner no longer claims "saved = live" (it said Publish didn't apply
+  here) — it now states edits save as package drafts and go live on Publish.

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.scope.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.scope.test.tsx
@@ -33,6 +33,7 @@ interface Server {
   set: Record<string, unknown>;
   packageObjects: Array<{ name: string; label?: string }>;
   saved: Array<Record<string, unknown>>;
+  savedOpts: Array<Record<string, unknown> | undefined>;
 }
 
 function makeClient(server: Server) {
@@ -43,6 +44,9 @@ function makeClient(server: Server) {
       overlay: null,
       overlayScope: null,
     }),
+    // ADR-0086 P2: the package door reads any pending draft first. This fixture
+    // models the published baseline only (no pending draft) → null.
+    getDraft: async () => null,
     list: async (type: string, opts?: { packageId?: string }) => {
       if (type === 'object') {
         // The server scopes to the package — the panel must not see anything
@@ -52,8 +56,9 @@ function makeClient(server: Server) {
       }
       return [];
     },
-    save: async (_type: string, _name: string, payload: Record<string, unknown>) => {
+    save: async (_type: string, _name: string, payload: Record<string, unknown>, opts?: Record<string, unknown>) => {
       server.saved.push(payload);
+      server.savedOpts.push(opts);
       server.set = payload; // becomes the new effective (reopen reads this)
       return payload;
     },
@@ -82,6 +87,7 @@ function freshServer(): Server {
   return {
     packageObjects: [{ name: 'a_account' }, { name: 'a_contact' }],
     saved: [],
+    savedOpts: [],
     set: {
       name: 'sales_perms',
       label: 'Sales',
@@ -138,6 +144,9 @@ describe('PermissionMatrixEditPage — package scope + slice merge (ADR-0086 P0)
     expect(saved.objects.a_contact).toEqual({ allowRead: true });
     // Set-level identity/extras carried through from the fresh base.
     expect(saved.systemPermissions).toEqual(['api_enabled']);
+    // ADR-0086 P2 (D6): the package door writes a DRAFT stamped with the
+    // package — not a live record — so the package Publish promotes it.
+    expect(server.savedOpts[0]).toMatchObject({ mode: 'draft', packageId: 'app.a' });
 
     view.unmount();
 

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -111,13 +111,23 @@ export interface PermissionMatrixEditPageProps {
    * the matrix operates at environment scope (all objects, whole-record save).
    */
   packageId?: string;
+  /**
+   * ADR-0086 P2 (D6/D7 — the package door). When editing under a `packageId`,
+   * a permission set is package **metadata**: Save writes a **draft** (not a
+   * live record), published atomically with the rest of the package. `onDraftSaved`
+   * notifies the surface so its pending-changes counter refreshes; `publishNonce`
+   * bumps on publish so the editor re-reads the now-published baseline (its draft
+   * is gone). Both are no-ops at environment scope, where Save stays live (D7).
+   */
+  onDraftSaved?: () => void;
+  publishNonce?: number;
 }
 
 /* ────────────────────────────────────────────────────────────────── */
 /* Component                                                          */
 /* ────────────────────────────────────────────────────────────────── */
 
-export function PermissionMatrixEditPage({ type, name, packageId }: PermissionMatrixEditPageProps) {
+export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, publishNonce }: PermissionMatrixEditPageProps) {
   const navigate = useNavigate();
   const client = useMetadataClient();
   const { entries } = useMetadataTypes(client);
@@ -151,14 +161,25 @@ export function PermissionMatrixEditPage({ type, name, packageId }: PermissionMa
     setLoading(true);
     (async () => {
       try {
-        const [lay, objList] = await Promise.all([
+        const [lay, objList, pendingDraft] = await Promise.all([
           client.layered<PermissionSetDraft>(type, name).catch(() => null),
           // In package scope, list only the objects this package declares
           // (ADR-0086 P0) — otherwise the whole environment leaks into the panel.
           client.list<any>('object', packageId ? { packageId } : {}).catch(() => []),
+          // ADR-0086 P2 (D6): under the package door a set is draft/published
+          // metadata, so surface the PENDING draft if one exists — otherwise a
+          // just-saved-not-yet-published edit would appear lost on reopen. Draft
+          // reads return the `{ type, name, item }` envelope; `null` = no draft.
+          packageId
+            ? client.getDraft<{ item?: PermissionSetDraft } | PermissionSetDraft>(type, name, { packageId }).catch(() => null)
+            : Promise.resolve(null),
         ]);
         if (cancelled) return;
-        const effective: PermissionSetDraft = (lay?.effective ??
+        const draftBody = pendingDraft
+          ? (((pendingDraft as any).item ?? pendingDraft) as PermissionSetDraft)
+          : null;
+        // Draft wins over the published baseline for display (D6).
+        const effective: PermissionSetDraft = (draftBody ?? lay?.effective ??
           lay?.code ?? { name, objects: {} }) as PermissionSetDraft;
         const list: ObjectSummary[] = ((objList as any[]) ?? [])
           .map((row) => {
@@ -192,7 +213,7 @@ export function PermissionMatrixEditPage({ type, name, packageId }: PermissionMa
     return () => {
       cancelled = true;
     };
-  }, [client, type, name, packageId]);
+  }, [client, type, name, packageId, publishNonce]);
 
   /* ── Lazy-load fields when an object is expanded ─────────── */
   async function ensureFields(objectName: string) {
@@ -304,11 +325,23 @@ export function PermissionMatrixEditPage({ type, name, packageId }: PermissionMa
         const base = (fresh?.effective ?? payload) as PermissionSetDraft;
         toSave = mergePermissionSlice(base, payload, scope);
       }
+      // ADR-0086 P2 (D6/D7). Package door → the set is metadata: write a DRAFT
+      // (stamped with `packageId`) that the package's atomic Publish promotes,
+      // exactly like the Data/Interfaces pillars — NOT a live record write.
+      // Environment door (no packageId) stays live (config).
       await client.save<PermissionSetDraft>(type, payload.name, toSave, {
         force,
+        ...(packageId ? { mode: 'draft' as const, packageId } : {}),
       });
-      const lay = await client.layered<PermissionSetDraft>(type, payload.name);
-      setDraft(toDisplayDraft((lay.effective ?? toSave) as PermissionSetDraft));
+      if (packageId) {
+        // The draft is now the pending truth for display; the published baseline
+        // hasn't moved. Show what we just staged and let the surface count it.
+        setDraft(toDisplayDraft(toSave));
+        onDraftSaved?.();
+      } else {
+        const lay = await client.layered<PermissionSetDraft>(type, payload.name);
+        setDraft(toDisplayDraft((lay.effective ?? toSave) as PermissionSetDraft));
+      }
       setDestructive(null);
     } catch (err: any) {
       if (err?.status === 409 && err?.code === 'destructive_change') {

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -989,8 +989,8 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.access.title': 'Permission matrix',
   'engine.studio.access.subtitle': 'Objects × CRUD · field-level R/W',
   'engine.studio.access.bannerTitle':
-    'This matrix lists only the objects this package declares, and “Save” merges just that slice — grants contributed by other packages are preserved. Permissions take effect immediately: they don’t enter package drafts, so the top-bar “Publish” doesn’t apply here.',
-  'engine.studio.access.banner': 'This package’s objects · saved = live',
+    'This matrix lists only the objects this package declares, and “Save” merges just that slice — grants contributed by other packages are preserved. Edits are saved as package drafts and go live when you Publish the package (top bar), exactly like Data and Interfaces.',
+  'engine.studio.access.banner': 'This package’s objects · saved as draft',
   'engine.studio.access.heading': 'Permission sets / Profiles',
   'engine.studio.access.search': 'Search permissions…',
   'engine.studio.access.none': 'No permission sets yet — create one below',
@@ -1848,8 +1848,8 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.access.title': '权限矩阵',
   'engine.studio.access.subtitle': '对象 × CRUD · 字段级读写',
   'engine.studio.access.bannerTitle':
-    '此矩阵仅列出本包声明的对象,「Save」只合并本包切片 —— 其他包贡献的授权原样保留。权限保存即生效:不进入软件包草稿,顶栏「发布」不涉及它。',
-  'engine.studio.access.banner': '仅本包对象 · 保存即生效',
+    '此矩阵仅列出本包声明的对象,「Save」只合并本包切片 —— 其他包贡献的授权原样保留。编辑保存为软件包草稿,点击顶栏「发布」后随整个包一起生效(与数据、界面一致)。',
+  'engine.studio.access.banner': '仅本包对象 · 保存为草稿',
   'engine.studio.access.heading': '权限集 / Profile',
   'engine.studio.access.search': '搜索权限…',
   'engine.studio.access.none': '还没有权限集 — 在下方新建一个',

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -591,7 +591,7 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
           ) : tab === 'automations' ? (
             <AutomationsPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} />
           ) : tab === 'access' ? (
-            <AccessPillar packageId={packageId} />
+            <AccessPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} />
           ) : (
             <InterfacesPillar
               packageId={packageId}
@@ -2342,7 +2342,15 @@ function AutomationsPillar({
  * writes the ACTIVE item directly (no draft/publish flow), so the shell's
  * 变更/发布 does not apply here.
  */
-function AccessPillar({ packageId }: { packageId: string }): React.ReactElement {
+function AccessPillar({
+  packageId,
+  publishNonce,
+  onDraftSaved,
+}: {
+  packageId: string;
+  publishNonce?: number;
+  onDraftSaved?: () => void;
+}): React.ReactElement {
   const client = useMetadataClient();
   const locale = useMetadataLocale();
   const [perms, setPerms] = React.useState<
@@ -2361,21 +2369,38 @@ function AccessPillar({ packageId }: { packageId: string }): React.ReactElement 
 
   const load = React.useCallback(async () => {
     try {
-      const list = (await client.list('permission')) as Array<Record<string, unknown>>;
-      const items = (list || [])
-        .map((p) => ({
-          name: String(p.name ?? (p as Record<string, unknown>).id ?? ''),
+      // ADR-0086 P2 (D6): a package permission set is draft/published metadata,
+      // so the rail shows published ∪ pending-draft sets — a set created (or
+      // renamed) as a draft but not yet published must still appear here, just
+      // like the Data/Interfaces pillars merge their drafts.
+      const [list, drafts] = await Promise.all([
+        client.list('permission') as Promise<Array<Record<string, unknown>>>,
+        client.listDrafts({ packageId, type: 'permission' }).catch(() => []),
+      ]);
+      const byName = new Map<string, { name: string; label: string; isProfile?: boolean; packageId?: string | null }>();
+      for (const p of list || []) {
+        const name = String(p.name ?? (p as Record<string, unknown>).id ?? '');
+        if (!name) continue;
+        byName.set(name, {
+          name,
           label: String(p.label ?? p.name ?? ''),
           isProfile: !!(p as Record<string, unknown>).isProfile,
           // Record-level provenance (framework ADR-0086 P1); snake_case is the
           // framework field, camelCase tolerated for either serialization.
           packageId: ((p as Record<string, unknown>).package_id ??
             (p as Record<string, unknown>).packageId) as string | undefined,
-        }))
-        .filter((p) => p.name);
+        });
+      }
+      // Draft-only sets (no published row yet) are stamped with this package,
+      // so add them without needing scope-list's mid-migration guard.
+      for (const d of (drafts as Array<{ name?: string; packageId?: string | null }>) || []) {
+        const name = String(d?.name ?? '');
+        if (!name || byName.has(name)) continue;
+        byName.set(name, { name, label: name, packageId: d?.packageId ?? packageId });
+      }
       // Hide environment-owned platform-default sets (no package_id) from this
       // package's panel — see scopePermissionSetList for the mid-migration guard.
-      const scoped = scopePermissionSetList(items, packageId);
+      const scoped = scopePermissionSetList([...byName.values()], packageId);
       setPerms(scoped);
       setCurrent((c) => c ?? scoped[0]?.name ?? null);
     } catch (e) {
@@ -2387,7 +2412,9 @@ function AccessPillar({ packageId }: { packageId: string }): React.ReactElement 
 
   React.useEffect(() => {
     void load();
-  }, [load]);
+    // Re-read after a package publish so drafts that went live collapse into
+    // the published rail (ADR-0086 P2).
+  }, [load, publishNonce]);
 
   const doCreate = React.useCallback(async () => {
     const label = newLabel.trim();
@@ -2395,12 +2422,15 @@ function AccessPillar({ packageId }: { packageId: string }): React.ReactElement 
     if (!label || !name || name === 'field') return;
     setBusy(true);
     try {
-      await client.save('permission', name, { name, label, objects: {}, fields: {} });
+      // Package door → create as a DRAFT stamped with this package (D6/D7),
+      // published atomically with the rest of the package.
+      await client.save('permission', name, { name, label, objects: {}, fields: {} }, { mode: 'draft', packageId });
       toast.success(tFormat('engine.studio.access.created', locale, { label }));
       setCreating(false);
       setNewLabel('');
       setNewName('');
       setNameTouched(false);
+      onDraftSaved?.();
       await load();
       setCurrent(name);
     } catch (e) {
@@ -2408,7 +2438,7 @@ function AccessPillar({ packageId }: { packageId: string }): React.ReactElement 
     } finally {
       setBusy(false);
     }
-  }, [client, newLabel, newName, load]);
+  }, [client, newLabel, newName, load, packageId, onDraftSaved, locale]);
 
   const filtered = perms.filter(
     (p) =>
@@ -2540,6 +2570,8 @@ function AccessPillar({ packageId }: { packageId: string }): React.ReactElement 
               type="permission"
               name={current}
               packageId={packageId}
+              publishNonce={publishNonce}
+              onDraftSaved={onDraftSaved}
             />
           ) : (
             <div className="py-16 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## 概述

ADR-0086 P2「两道门分离」的 **objectui 半边**。框架半边(块1 发布物化 + 块2 数据层写门)在 framework#2573;本 PR 把 studio **包 Access 门**从"实时写活动记录"改成"写草稿、随包发布"——与 Data/Interfaces 门一致(D6/D7)。

**问题(D6 违背)**:包 Access 门(`/studio/:packageId/access`)编辑权限集时直接 `client.save(...)` 写活动记录(live),banner 甚至明写"保存即生效 · 顶栏发布不涉及它"。而同一 studio 里 Data/Interfaces 门都是 `{mode:'draft'}` 草稿 + 顶栏 Publish 原子发布。两道门共用了同一条 live 写路径。

## 变更

**包门 → 写草稿:**
- `PermissionMatrixEditPage.doSave`(有 `packageId` 分支)+ `AccessPillar` 新建集 creator,改为 `client.save(..., { mode:'draft', packageId })`。框架给草稿盖上包归属,顶栏 **Publish** 随整个包原子发布(框架侧物化进 `sys_permission_set`)。
- **env-admin 门**(无 `packageId`)**保持 live**(config),符合 D7——两道门各写各的。

**草稿感知读:**
- 编辑器加载时先读 pending draft(`getDraft`),草稿覆盖已发布基线显示——否则"存了没发布"的编辑重开会像丢了。
- 侧栏合并 已发布 ∪ 草稿 权限集(`listDrafts`),所以草稿态/仅草稿的集在发布前也可见(与 Data/Interfaces 一致)。
- 保存 bump 顶栏 pending 计数;发布后 `publishNonce` 触发重载,草稿收敛回已发布基线。(`onDraftSaved`/`publishNonce` 从 surface 线到 `AccessPillar` + 编辑器。)

**banner 修正:** 不再声称"保存即生效 / 发布不涉及"——改为"保存为软件包草稿,发布后随整个包生效"(EN + ZH 双语)。

## 验证

- `PermissionMatrixEditor.scope.test.tsx`:新增断言——包门保存携带 `{ mode:'draft', packageId }`,且其他包切片仍逐字保留(ADR-0086 P0 切片合并不回退)。1 passed。
- app-shell **tsc --noEmit 0 error**;改动文件 lint 0 error(仅既有 warning 模式)。
- 全 workspace build 绿。

## 端到端(配合 framework#2573)

包门编辑 → Save 写草稿 + pending 计数 +1 → 顶栏 Publish → `POST /packages/:id/publish-drafts` → 框架发布 permission 草稿 → 块1 物化进 `sys_permission_set`(`managed_by:'package'`) → `publishNonce` 重载 → 草稿收敛。块2 写门确保 env-admin 不能绕过直接改包行。

## 关联

- framework#2573(P2 框架半边:块1 发布物化 + 块2 写门)
- ADR-0086 D6(包门=draft/publish metadata)· D7(两道门,各写各的)
- 前序:ADR-0086 P0(objectui#2222,Access 矩阵按包 scope + 切片合并)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014y5kiH3aPLWtRRRGcVrXcT

---
_Generated by [Claude Code](https://claude.ai/code/session_014y5kiH3aPLWtRRRGcVrXcT)_