### PR TITLE
feat(detail): make default related lists support CRUD, open-detail and child actions

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -26,6 +26,7 @@ import { ActionConfirmDialog, type ConfirmDialogState } from './ActionConfirmDia
 import { ActionParamDialog, type ParamDialogState } from './ActionParamDialog';
 import { ActionResultDialog, type ResultDialogState } from './ActionResultDialog';
 import { FlowRunner, type ScreenFlowState } from './FlowRunner';
+import { RelatedRecordActionsBridge } from './RelatedRecordActionsBridge';
 import { resolveActionParams } from '../utils/resolveActionParams';
 import { useRecordBreadcrumbTitle } from '../context/NavigationContext';
 import type { DetailViewSchema, FeedItem, HighlightField } from '@object-ui/types';
@@ -402,28 +403,37 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         case 'opportunity_mark_lost':
           await dataSource.update(objectName!, pureRecordId!, { stage: 'closed_lost', loss_reason: params.loss_reason });
           break;
-        default:
-          // Generic: update record with collected params
-          if (Object.keys(params).length > 0) {
+        default: {
+          // Generic: update record with collected params. Related-list row
+          // actions retarget a CHILD record via explicit `objectName`/`recordId`;
+          // otherwise the update falls back to this page's record.
+          const targetObject = action.objectName ?? objectName;
+          const targetId = (action as any).recordId ?? pureRecordId;
+          const isThisRecord =
+            targetObject === objectName && String(targetId) === String(pureRecordId);
+          if (Object.keys(params).length > 0 && targetObject && targetId != null) {
             // Undoable single-record update: capture the changed fields' prior
             // values from the loaded record so the success toast can offer Undo.
-            if (action.undoable && pageRecord && objectName && pureRecordId) {
+            // Only this page's record has its prior values loaded, so child-row
+            // updates skip undo capture.
+            if (action.undoable && isThisRecord && pageRecord) {
               const undoData: Record<string, unknown> = {};
               for (const k of Object.keys(params)) undoData[k] = (pageRecord as any)[k] ?? null;
               undo = {
-                id: `undo-${objectName}-${pureRecordId}-${Date.now()}`,
+                id: `undo-${targetObject}-${targetId}-${Date.now()}`,
                 type: 'update',
-                objectName,
-                recordId: String(pureRecordId),
+                objectName: targetObject,
+                recordId: String(targetId),
                 timestamp: Date.now(),
-                description: action.label || `Undo ${objectName}`,
+                description: action.label || `Undo ${targetObject}`,
                 undoData,
                 redoData: { ...params },
               };
             }
-            await dataSource.update(objectName!, pureRecordId!, params);
+            await dataSource.update(targetObject, String(targetId), params);
           }
           break;
+        }
       }
 
       const shouldRefresh = action.refreshAfter === true;
@@ -465,8 +475,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            recordId: pureRecordId,
-            objectName,
+            // Related-list row actions retarget the flow at a CHILD record via
+            // an explicit `recordId` / `objectName`; fall back to this page's
+            // record when the action carries none (header/more actions).
+            recordId: (action as any).recordId ?? pureRecordId,
+            objectName: action.objectName ?? objectName,
             params: action.params ?? {},
           }),
         },
@@ -588,7 +601,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ recordId: pureRecordId, params }),
+          // Related-list row actions retarget a CHILD record via explicit
+          // `recordId`; header/more actions carry none and use this page's id.
+          body: JSON.stringify({ recordId: (action as any).recordId ?? pureRecordId, params }),
         },
       );
       const json = await res.json().catch(() => null);
@@ -1801,7 +1816,14 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                     <span>{originFrom.label}</span>
                   </Link>
                 )}
-                <SchemaRenderer schema={renderedPage as any} />
+                <RelatedRecordActionsBridge
+                  appName={appName}
+                  objects={objects}
+                  dataSource={dataSource}
+                  actionLabel={actionLabel}
+                >
+                  <SchemaRenderer schema={renderedPage as any} />
+                </RelatedRecordActionsBridge>
                 {/* Auto-append RecordChatterPanel only when the page
                     schema doesn't already place a `record:discussion` /
                     `record:chatter` component. Hard opt-out via

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -1,0 +1,163 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RelatedRecordActionsBridge — supplies the console's object-aware CRUD +
+ * action handlers to the `record:related_list` renderers on a detail page.
+ *
+ * The renderer (in `@object-ui/plugin-detail`) knows the child object, the FK
+ * back to the parent, and the parent id — but not the SPA routes, the
+ * create/edit form pages, or the per-object lifecycle affordances. This bridge
+ * (mounted inside the page's `ActionProvider`) closes that gap:
+ *
+ *   - 查看详情 → navigate to the child record's detail route
+ *   - 增        → navigate to the child's `/new` page, pre-linking the parent
+ *                 via `?<relationshipField>=<parentId>` (the convention
+ *                 RecordFormPage already reads as create-mode initial values)
+ *   - 改        → navigate to the child record's `/edit` page
+ *   - 删        → `dataSource.delete(child, id)` (RelatedList shows the confirm
+ *                 dialog and refreshes afterwards)
+ *   - 子对象 action → the child object's `list_item` actions, executed against
+ *                 the clicked row through the page's shared ActionRunner
+ *
+ * Each affordance is gated by {@link resolveCrudAffordances} so system /
+ * append-only children never show New / Edit / Delete. When this bridge is
+ * absent (e.g. the Studio designer) the related list stays read-only.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  RelatedRecordActionsProvider,
+  useAction,
+  type RelatedRecordActionsValue,
+  type RelatedRecordHandlers,
+  type RelatedRowActionDef,
+} from '@object-ui/react';
+import type { ActionDef } from '@object-ui/core';
+import { resolveCrudAffordances } from '../utils/crudAffordances';
+
+/** Notify open related lists for `objectName` to refetch (see RelatedList). */
+export function notifyRelatedChanged(objectName: string): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('objectui:related-changed', { detail: { objectName } }),
+  );
+}
+
+/** i18n label resolver signature (matches `useObjectLabel().actionLabel`). */
+type ActionLabelFn = (objectName: string | undefined, actionName: string, fallback: string) => string;
+
+export interface RelatedRecordActionsBridgeProps {
+  /** Current app segment used to build `/apps/:appName/...` routes. */
+  appName?: string;
+  /** All object definitions (to resolve the child object + its actions). */
+  objects: any[];
+  /** Data source for delete + action dispatch. */
+  dataSource: any;
+  /** Localizes a child action's label (falls back to the raw label). */
+  actionLabel: ActionLabelFn;
+  children: React.ReactNode;
+}
+
+/**
+ * Derive the child object's row actions (metadata `actions` filtered to the
+ * `list_item` location), localized and shaped for the related-list row menu.
+ */
+function deriveRowActions(childDef: any, actionLabel: ActionLabelFn): RelatedRowActionDef[] {
+  const actions = Array.isArray(childDef?.actions) ? childDef.actions : [];
+  return actions
+    .filter((a: any) => Array.isArray(a?.locations) && a.locations.includes('list_item'))
+    .map((a: any) => ({
+      ...a,
+      label: actionLabel(childDef.name, a.name, a.label || a.name),
+    }));
+}
+
+export function RelatedRecordActionsBridge({
+  appName,
+  objects,
+  dataSource,
+  actionLabel,
+  children,
+}: RelatedRecordActionsBridgeProps) {
+  const navigate = useNavigate();
+  const { execute } = useAction();
+  const base = appName ? `/apps/${appName}` : '';
+
+  // Execute a child object's row action against the clicked record. Reuses the
+  // page's ActionRunner (confirm dialog, toast, param collection are handled by
+  // it) but retargets it at the CHILD object + row via the action's
+  // `objectName` / `recordId`, which the record-detail action handlers honor.
+  const runRowAction = useCallback(
+    async (childObject: string, record: any, action: RelatedRowActionDef) => {
+      const id = record?.id ?? record?._id;
+      const def = {
+        ...(action as unknown as ActionDef),
+        objectName: childObject,
+        ...(id != null ? { recordId: String(id) } : {}),
+        params: { ...(action.params as Record<string, unknown> | undefined) },
+      } as ActionDef;
+      const res = await execute(def);
+      // Refresh open related lists for this child object after a successful
+      // mutating action (the row menu handler is otherwise fire-and-forget).
+      if (res?.success) notifyRelatedChanged(childObject);
+    },
+    [execute],
+  );
+
+  const value = useMemo<RelatedRecordActionsValue>(
+    () => ({
+      resolve: ({ objectName, relationshipField, parentId }) => {
+        const childDef = objects.find((o: any) => o?.name === objectName);
+        if (!childDef || !base) return {} as RelatedRecordHandlers;
+        const aff = resolveCrudAffordances(childDef);
+        const detailUrl = (id: string | number) =>
+          `${base}/${objectName}/record/${encodeURIComponent(String(id))}`;
+
+        const handlers: RelatedRecordHandlers = {
+          // Viewing a child record is always allowed when the list is visible.
+          onView: (id) => navigate(detailUrl(id)),
+        };
+
+        if (aff.create) {
+          handlers.onCreate = () => {
+            const canLink =
+              relationshipField && parentId != null && parentId !== '';
+            const qs = canLink
+              ? `?${encodeURIComponent(relationshipField as string)}=${encodeURIComponent(String(parentId))}`
+              : '';
+            navigate(`${base}/${objectName}/new${qs}`);
+          };
+        }
+        if (aff.edit) {
+          handlers.onEdit = (id) => navigate(`${detailUrl(id)}/edit`);
+        }
+        if (aff.delete) {
+          handlers.onDelete = async (id) => {
+            await dataSource?.delete?.(objectName, String(id));
+          };
+        }
+
+        const rowActions = deriveRowActions(childDef, actionLabel);
+        if (rowActions.length > 0) {
+          handlers.rowActions = rowActions;
+          handlers.onRowAction = (action, record) =>
+            runRowAction(objectName, record, action);
+        }
+
+        return handlers;
+      },
+    }),
+    [objects, base, navigate, dataSource, actionLabel, runRowAction],
+  );
+
+  return (
+    <RelatedRecordActionsProvider value={value}>{children}</RelatedRecordActionsProvider>
+  );
+}

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -9,6 +9,7 @@
 // Enterprise-level DataTable Component (Airtable-like)
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { cn } from '../../lib/utils';
+import { resolveIcon } from '../action/resolve-icon';
 import { useGridFieldAuthoring } from '../../context/gridFieldAuthoring';
 import { ComponentRegistry } from '@object-ui/core';
 import type { DataTableSchema } from '@object-ui/types';
@@ -1500,7 +1501,15 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                 </Button>
                               </>
                             ) : (
-                              (schema.onRowEdit || schema.onRowDelete) && (
+                              (() => {
+                                const customActions =
+                                  Array.isArray(schema.rowActionDefs) && schema.onRowActionDef
+                                    ? schema.rowActionDefs
+                                    : [];
+                                if (!schema.onRowEdit && !schema.onRowDelete && customActions.length === 0) {
+                                  return null;
+                                }
+                                return (
                                 <DropdownMenu>
                                   <DropdownMenuTrigger asChild>
                                     <Button
@@ -1520,7 +1529,26 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                         {t('table.edit')}
                                       </DropdownMenuItem>
                                     )}
-                                    {schema.onRowEdit && schema.onRowDelete && <DropdownMenuSeparator />}
+                                    {/* Child-object custom actions (e.g. a related
+                                        list surfacing the child's `list_item`
+                                        actions). Dispatched with the clicked row. */}
+                                    {customActions.length > 0 && schema.onRowEdit && <DropdownMenuSeparator />}
+                                    {customActions.map((action) => {
+                                      const ActionIcon = resolveIcon(action.icon);
+                                      return (
+                                        <DropdownMenuItem
+                                          key={action.name}
+                                          onClick={() => { void schema.onRowActionDef?.(action, row); }}
+                                          className={cn(
+                                            action.variant === 'danger' && 'text-destructive focus:text-destructive',
+                                          )}
+                                        >
+                                          {ActionIcon && <ActionIcon className="mr-2 h-4 w-4" />}
+                                          {action.label || action.name}
+                                        </DropdownMenuItem>
+                                      );
+                                    })}
+                                    {schema.onRowDelete && (schema.onRowEdit || customActions.length > 0) && <DropdownMenuSeparator />}
                                     {schema.onRowDelete && (
                                       <DropdownMenuItem
                                         onClick={() => schema.onRowDelete?.(row)}
@@ -1532,7 +1560,8 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                     )}
                                   </DropdownMenuContent>
                                 </DropdownMenu>
-                              )
+                                );
+                              })()
                             )}
                           </div>
                         </TableCell>

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -26,7 +26,7 @@ import {
   cn,
   useIsMobile,
 } from '@object-ui/components';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, type RelatedRowActionDef } from '@object-ui/react';
 import {
   Plus,
   ExternalLink,
@@ -79,6 +79,13 @@ export interface RelatedListProps {
   };
   /** Callback when a row is clicked (opens record detail) */
   onRowClick?: (row: any) => void;
+  /**
+   * Child-object row actions (`locations: ['list_item']`), already localized
+   * by the host. Rendered in each row's overflow menu alongside Edit/Delete.
+   */
+  rowActions?: RelatedRowActionDef[];
+  /** Execute one of {@link rowActions} against the clicked row. */
+  onRowAction?: (action: RelatedRowActionDef, row: any) => void | Promise<void>;
   /** Maximum number of columns to auto-generate. Default 6. */
   maxColumns?: number;
   /** Page size for pagination (enables pagination when set) */
@@ -139,6 +146,8 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   onRowEdit,
   onRowDelete,
   onRowClick,
+  rowActions,
+  onRowAction,
   add,
   maxColumns = 6,
   pageSize,
@@ -249,6 +258,21 @@ export const RelatedList: React.FC<RelatedListProps> = ({
       }
     }
   }, [api, dataProvided, dataSource, referenceField, parentId, refreshNonce]);
+
+  // Refetch when a mutation elsewhere signals this related object changed —
+  // e.g. a child row action executed through the host retargets `api` and
+  // dispatches `objectui:related-changed`. Only meaningful on the auto-fetch
+  // path (parent-provided data is refreshed by the parent).
+  React.useEffect(() => {
+    if (!api || dataProvided) return;
+    const onChanged = (ev: Event) => {
+      const detail = (ev as CustomEvent).detail || {};
+      if (detail.objectName && detail.objectName !== api) return;
+      setRefreshNonce((n) => n + 1);
+    };
+    window.addEventListener('objectui:related-changed', onChanged as EventListener);
+    return () => window.removeEventListener('objectui:related-changed', onChanged as EventListener);
+  }, [api, dataProvided]);
 
   // Resolve lookup-field display labels by batch-fetching referenced records.
   // For each lookup/master_detail column whose data is a primitive ID, gather
@@ -594,7 +618,8 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     return pruned.slice(0, Math.max(1, maxColumns));
   }, [columns, objectSchema, objectName, api, resolveFieldLabel, referenceField, relatedData, maxColumns, lookupLabels, perms]);
 
-  const hasRowActions = !!onRowEdit || !!onRowDelete;
+  const hasCustomRowActions = Array.isArray(rowActions) && rowActions.length > 0;
+  const hasRowActions = !!onRowEdit || !!onRowDelete || hasCustomRowActions;
   const isMobile = useIsMobile();
 
   const viewSchema = React.useMemo(() => {
@@ -641,6 +666,10 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           onRowEdit,
           onRowDelete: onRowDelete ? handleDeleteRow : undefined,
           onRowClick,
+          // Child-object row actions (locations:['list_item']) rendered in the
+          // same overflow menu, dispatched with the clicked row as target.
+          rowActionDefs: hasCustomRowActions ? rowActions : undefined,
+          onRowActionDef: hasCustomRowActions ? onRowAction : undefined,
         };
       case 'list':
         return {
@@ -650,7 +679,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
       default:
         return { type: 'div', children: 'No view configured' };
     }
-  }, [type, paginatedData, effectiveColumns, schema, effectivePageSize, hasRowActions, onRowEdit, onRowDelete, handleDeleteRow, onRowClick, isMobile, api]);
+  }, [type, paginatedData, effectiveColumns, schema, effectivePageSize, hasRowActions, hasCustomRowActions, rowActions, onRowAction, onRowEdit, onRowDelete, handleDeleteRow, onRowClick, isMobile, api]);
 
   const headerClassName = collapsible ? 'cursor-pointer select-none' : undefined;
   const handleHeaderClick = collapsible ? () => setCollapsed((c) => !c) : undefined;

--- a/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.hostactions.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.hostactions.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Coverage for the detail-page related list becoming interactive: the
+ * `record:related_list` renderer must wire the host-provided CRUD + action
+ * handlers (view / create / edit / delete / row actions) onto `RelatedList`,
+ * scoped to the child object + parent relationship. With no host provider it
+ * stays read-only (only the legacy `add`-based remove survives).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import {
+  RecordContextProvider,
+  RelatedRecordActionsProvider,
+  type RelatedRecordActionsValue,
+} from '@object-ui/react';
+import { RecordRelatedListRenderer } from '../renderers/record-related-list';
+
+// Capture the props the renderer passes to RelatedList.
+const h = vi.hoisted(() => ({ captured: null as any }));
+vi.mock('../RelatedList', () => ({
+  RelatedList: (props: any) => {
+    h.captured = props;
+    return null;
+  },
+}));
+
+const ds = { find: vi.fn(async () => []), delete: vi.fn(async () => undefined) };
+
+function renderWith(value: RelatedRecordActionsValue | null) {
+  return render(
+    <RecordContextProvider objectName="account" recordId="ACC-1" dataSource={ds as any}>
+      {value ? (
+        <RelatedRecordActionsProvider value={value}>
+          <RecordRelatedListRenderer schema={{ objectName: 'contact', relationshipField: 'account_id' }} />
+        </RelatedRecordActionsProvider>
+      ) : (
+        <RecordRelatedListRenderer schema={{ objectName: 'contact', relationshipField: 'account_id' }} />
+      )}
+    </RecordContextProvider>,
+  );
+}
+
+beforeEach(() => {
+  h.captured = null;
+  ds.delete.mockClear();
+});
+
+describe('RecordRelatedListRenderer — host CRUD + action wiring', () => {
+  it('wires view / create / edit / delete from the host, scoped to child + parent', () => {
+    const onView = vi.fn();
+    const onCreate = vi.fn();
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const resolve = vi.fn(() => ({ onView, onCreate, onEdit, onDelete }));
+
+    renderWith({ resolve });
+
+    // resolve() is called with the child object + relationship + parent id.
+    expect(resolve).toHaveBeenCalledWith({
+      objectName: 'contact',
+      relationshipField: 'account_id',
+      parentId: 'ACC-1',
+    });
+
+    const p = h.captured;
+    expect(typeof p.onNew).toBe('function');
+    expect(typeof p.onRowClick).toBe('function');
+    expect(typeof p.onRowEdit).toBe('function');
+    expect(typeof p.onRowDelete).toBe('function');
+
+    // Row click opens the child detail; edit/delete target the row's id.
+    p.onRowClick({ id: 'c1', name: 'Alice' });
+    expect(onView).toHaveBeenCalledWith('c1', { id: 'c1', name: 'Alice' });
+
+    p.onNew();
+    expect(onCreate).toHaveBeenCalledTimes(1);
+
+    p.onRowEdit({ _id: 'c2' });
+    expect(onEdit).toHaveBeenCalledWith('c2', { _id: 'c2' });
+
+    p.onRowDelete({ id: 'c3' });
+    expect(onDelete).toHaveBeenCalledWith('c3', { id: 'c3' });
+  });
+
+  it('passes the child object row actions through to RelatedList', () => {
+    const onRowAction = vi.fn();
+    const rowActions = [{ name: 'send_welcome', label: 'Send Welcome' }];
+    renderWith({ resolve: () => ({ rowActions, onRowAction }) });
+
+    expect(h.captured.rowActions).toEqual(rowActions);
+    expect(h.captured.onRowAction).toBe(onRowAction);
+  });
+
+  it('omits an affordance the host does not grant (e.g. create denied)', () => {
+    // Host grants only view (append-only child): no New / Edit button.
+    renderWith({ resolve: () => ({ onView: vi.fn() }) });
+    expect(h.captured.onNew).toBeUndefined();
+    expect(h.captured.onRowEdit).toBeUndefined();
+    expect(typeof h.captured.onRowClick).toBe('function');
+  });
+
+  it('stays read-only with no host provider (only add-based remove wiring applies)', () => {
+    renderWith(null);
+    expect(h.captured.onNew).toBeUndefined();
+    expect(h.captured.onRowClick).toBeUndefined();
+    expect(h.captured.onRowEdit).toBeUndefined();
+    // No `add` config + no host → delete stays unwired.
+    expect(h.captured.onRowDelete).toBeUndefined();
+  });
+});

--- a/packages/plugin-detail/src/__tests__/RelatedList.rowactions.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.rowactions.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Coverage for surfacing a child object's own row actions in a detail-page
+ * related list: RelatedList must thread `rowActions` / `onRowAction` into the
+ * data-table schema (as `rowActionDefs` / `onRowActionDef`) and enable the
+ * row-actions column, so the actions appear in each row's overflow menu.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { RelatedList } from '../RelatedList';
+
+// Capture the schema RelatedList hands to SchemaRenderer.
+const h = vi.hoisted(() => ({ schema: null as any }));
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    SchemaRenderer: (props: any) => {
+      h.schema = props.schema;
+      return null;
+    },
+  };
+});
+
+beforeEach(() => {
+  h.schema = null;
+});
+
+describe('RelatedList — child object row actions', () => {
+  it('threads rowActions into the data-table as rowActionDefs + enables the actions column', () => {
+    const onRowAction = vi.fn();
+    const rowActions = [
+      { name: 'send_welcome', label: 'Send Welcome', icon: 'mail' },
+      { name: 'deactivate', label: 'Deactivate', variant: 'danger' as const },
+    ];
+    render(
+      <RelatedList
+        title="Contacts"
+        type="table"
+        api="contact"
+        objectName="contact"
+        data={[{ id: 'c1', name: 'Alice' }]}
+        columns={[{ accessorKey: 'name', header: 'Name' }]}
+        rowActions={rowActions}
+        onRowAction={onRowAction}
+      />,
+    );
+
+    expect(h.schema).toBeTruthy();
+    expect(h.schema.type).toBe('data-table');
+    // Row-actions column is enabled purely by the presence of custom actions.
+    expect(h.schema.rowActions).toBe(true);
+    expect(h.schema.rowActionDefs).toEqual(rowActions);
+    expect(h.schema.onRowActionDef).toBe(onRowAction);
+  });
+
+  it('does not enable row actions when none are supplied', () => {
+    render(
+      <RelatedList
+        title="Contacts"
+        type="table"
+        api="contact"
+        objectName="contact"
+        data={[{ id: 'c1', name: 'Alice' }]}
+        columns={[{ accessorKey: 'name', header: 'Name' }]}
+      />,
+    );
+
+    expect(h.schema.type).toBe('data-table');
+    expect(h.schema.rowActions).toBe(false);
+    expect(h.schema.rowActionDefs).toBeUndefined();
+    expect(h.schema.onRowActionDef).toBeUndefined();
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -12,7 +12,7 @@
  */
 
 import React from 'react';
-import { useRecordContext, useSafeFieldLabel } from '@object-ui/react';
+import { useRecordContext, useSafeFieldLabel, useRelatedRecordActions } from '@object-ui/react';
 import { useFieldPermissions, usePermissions } from '@object-ui/permissions';
 import { humanizeLabel } from '@object-ui/fields';
 import type { RecordRelatedListComponentProps } from '@object-ui/types';
@@ -24,6 +24,9 @@ const colName = (entry: any): string | null => {
   if (entry && typeof entry === 'object') return entry.field || entry.name || entry.key || null;
   return null;
 };
+
+/** Extract a record's primary key, tolerating the `id` / `_id` split. */
+const rowId = (row: any): string | number | null => row?.id ?? row?._id ?? null;
 
 const splitDesigner = (props: Record<string, any>) => {
   const { 'data-obj-id': id, 'data-obj-type': type, style, ...rest } = props || {};
@@ -72,6 +75,23 @@ export const RecordRelatedListRenderer: React.FC<RecordRelatedListRendererProps>
   const perms = usePermissions();
   const { readableFields } = useFieldPermissions(objectName);
 
+  // Host-provided CRUD + action handlers for this child object. Absent when no
+  // host wired the provider (Studio designer, standalone embed) — the related
+  // list then stays read-only. The host decides, per child object, which of
+  // create / edit / delete / view it exposes (lifecycle affordances + FLS), so
+  // we simply wire whatever comes back. `resolve` is passed the relationship so
+  // a newly-created child is pre-linked to the current parent.
+  const relatedActions = useRelatedRecordActions();
+  const handlers = React.useMemo(
+    () =>
+      relatedActions?.resolve({
+        objectName,
+        relationshipField: schema.relationshipField,
+        parentId: (ctx?.recordId ?? null) as string | number | null,
+      }) ?? null,
+    [relatedActions, objectName, schema.relationshipField, ctx?.recordId],
+  );
+
   const required: string[] = Array.isArray((schema as any).requiredPermissions)
     ? (schema as any).requiredPermissions
     : [];
@@ -118,17 +138,46 @@ export const RecordRelatedListRenderer: React.FC<RecordRelatedListRendererProps>
         pageSize={schema.limit}
         dataSource={ctx?.dataSource as any}
         add={(schema as any).add}
-        onRowDelete={
-          // Generic remove for link/junction rows: delete the related row itself.
-          // RelatedList refreshes after this resolves. Only wired when an `add`
-          // config is present (i.e. this is a managed assignment list), so plain
-          // read-only related lists keep their existing behavior.
-          (schema as any).add && ctx?.dataSource
-            ? async (row: any) => {
-                const id = row?.id ?? row?._id;
-                if (id != null) await (ctx!.dataSource as any).delete?.(objectName, String(id));
+        rowActions={handlers?.rowActions}
+        onRowAction={handlers?.onRowAction}
+        // Create a new child, pre-linked to this parent (增). Host omits when
+        // create is denied by lifecycle/permissions, hiding the "New" button.
+        onNew={handlers?.onCreate}
+        // Open the child record's detail page on row click (查看记录详情).
+        onRowClick={
+          handlers?.onView
+            ? (row: any) => {
+                const id = rowId(row);
+                if (id != null) handlers.onView!(id, row);
               }
             : undefined
+        }
+        // Open the child record's edit form (改).
+        onRowEdit={
+          handlers?.onEdit
+            ? (row: any) => {
+                const id = rowId(row);
+                if (id != null) handlers.onEdit!(id, row);
+              }
+            : undefined
+        }
+        onRowDelete={
+          // Delete the child record (删). Prefer the host handler (gated by
+          // lifecycle affordance + permissions); fall back to the generic
+          // link/junction remove when an `add` config is present so managed
+          // assignment lists keep working without a host provider. RelatedList
+          // shows the confirm dialog and refreshes after this resolves.
+          handlers?.onDelete
+            ? (row: any) => {
+                const id = rowId(row);
+                if (id != null) return handlers.onDelete!(id, row);
+              }
+            : (schema as any).add && ctx?.dataSource
+              ? async (row: any) => {
+                  const id = row?.id ?? row?._id;
+                  if (id != null) await (ctx!.dataSource as any).delete?.(objectName, String(id));
+                }
+              : undefined
         }
       />
     </div>

--- a/packages/react/src/context/RelatedRecordActionsContext.tsx
+++ b/packages/react/src/context/RelatedRecordActionsContext.tsx
@@ -1,0 +1,112 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RelatedRecordActionsContext — host-provided CRUD + action handlers for the
+ * child collections ("related lists") rendered on a record DETAIL page.
+ *
+ * The `record:related_list` renderer (in `@object-ui/plugin-detail`) knows the
+ * child object name, the FK back to the parent, and the parent id — but it
+ * lives in a low-level package with no access to the console's SPA router, the
+ * create/edit form routes, or the per-object CRUD affordances / permissions.
+ * Those all live in the app shell.
+ *
+ * So the host (e.g. `RecordDetailView`) provides this context; the renderer
+ * calls {@link RelatedRecordActionsValue.resolve} for its child object and
+ * wires whatever handlers come back onto the `RelatedList` (New / Edit / Delete
+ * / row-click-to-open, plus the child object's own row actions). A handler that
+ * is OMITTED means the capability is unavailable (permission or lifecycle
+ * affordance denied, or no host routing) — the related list simply hides that
+ * affordance. When no provider is present at all (e.g. the Studio designer, or
+ * a standalone embedded renderer) the related list stays read-only, which is
+ * the correct graceful fallback.
+ */
+
+import React, { createContext, useContext } from 'react';
+
+/** A child-object action surfaced in a related list's row menu. */
+export interface RelatedRowActionDef {
+  /** Stable action name (matches the object's action metadata). */
+  name: string;
+  /** Display label (already localized by the host). */
+  label?: string;
+  /** Lucide icon name (kebab-case). */
+  icon?: string;
+  /** Visual emphasis for the menu item. */
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost' | 'link';
+  /** Confirmation prompt shown before the action runs. */
+  confirmText?: string;
+  /** Any remaining action metadata (target, params, …) is preserved. */
+  [k: string]: unknown;
+}
+
+/**
+ * CRUD + action handlers for a single related list's child object, resolved by
+ * the host for a specific child object + parent relationship. Every handler is
+ * optional: an omitted handler hides its affordance in the list.
+ */
+export interface RelatedRecordHandlers {
+  /** Open the child record's detail page (查看详情). */
+  onView?: (recordId: string | number, record?: unknown) => void;
+  /**
+   * Open a create form for a new child record. The host pre-links it to the
+   * parent (via the relationship field + parent id passed to `resolve`), so no
+   * argument is needed here (增).
+   */
+  onCreate?: () => void;
+  /** Open an edit form for an existing child record (改). */
+  onEdit?: (recordId: string | number, record?: unknown) => void;
+  /**
+   * Delete a child record (删). Returns a promise so the list can refresh once
+   * the deletion resolves.
+   */
+  onDelete?: (recordId: string | number, record?: unknown) => void | Promise<void>;
+  /** Child object row-level actions (`locations: ['list_item']`), localized. */
+  rowActions?: RelatedRowActionDef[];
+  /** Execute one of {@link rowActions} against a specific child row. */
+  onRowAction?: (action: RelatedRowActionDef, record: unknown) => void | Promise<void>;
+}
+
+/** Input to {@link RelatedRecordActionsValue.resolve}. */
+export interface ResolveRelatedRecordActionsInput {
+  /** Child object machine name (the related list's `api`). */
+  objectName: string;
+  /** FK field on the child pointing back at the parent record. */
+  relationshipField?: string;
+  /** Primary-key value of the parent record (used to pre-link new children). */
+  parentId?: string | number | null;
+}
+
+export interface RelatedRecordActionsValue {
+  /**
+   * Resolve the CRUD + action handlers for a child object. Implementations
+   * should be stable (memoized) so consumers can safely depend on the returned
+   * identity.
+   */
+  resolve: (input: ResolveRelatedRecordActionsInput) => RelatedRecordHandlers;
+}
+
+const RelatedRecordActionsContext = createContext<RelatedRecordActionsValue | null>(null);
+
+export const RelatedRecordActionsProvider: React.FC<{
+  value: RelatedRecordActionsValue;
+  children: React.ReactNode;
+}> = ({ value, children }) => (
+  <RelatedRecordActionsContext.Provider value={value}>
+    {children}
+  </RelatedRecordActionsContext.Provider>
+);
+
+/**
+ * Consume the host-provided related-record actions. Returns `null` when no
+ * host wired the provider (embedded / designer contexts) — callers must treat
+ * that as "read-only related list".
+ */
+export function useRelatedRecordActions(): RelatedRecordActionsValue | null {
+  return useContext(RelatedRecordActionsContext);
+}

--- a/packages/react/src/context/index.ts
+++ b/packages/react/src/context/index.ts
@@ -8,3 +8,4 @@ export * from './AppShellContext';
 export * from './RecordContext';
 export * from './DiscussionContext';
 export * from './DrillNavigationContext';
+export * from './RelatedRecordActionsContext';

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -298,6 +298,28 @@ export interface TableSchema extends BaseSchema {
 }
 
 /**
+ * A single extra per-row action rendered in the data-table's row overflow
+ * menu (after Edit/Delete). Used to surface an object's own row actions in
+ * embedded tables — e.g. a detail page's related list showing the child
+ * object's `list_item` actions. The host pre-localizes `label`/`confirmText`
+ * and executes the action via {@link DataTableSchema.onRowActionDef}.
+ */
+export interface DataTableRowAction {
+  /** Stable action name. */
+  name: string;
+  /** Display label (already localized). */
+  label?: string;
+  /** Lucide icon name (kebab-case). */
+  icon?: string;
+  /** `'danger'` renders the item in the destructive color. */
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost' | 'link';
+  /** Confirmation prompt shown before the action runs. */
+  confirmText?: string;
+  /** Remaining action metadata is preserved for the host executor. */
+  [k: string]: unknown;
+}
+
+/**
  * Enterprise data table with advanced features
  */
 export interface DataTableSchema extends BaseSchema {
@@ -439,6 +461,18 @@ export interface DataTableSchema extends BaseSchema {
    * Row delete handler
    */
   onRowDelete?: (row: any) => void;
+  /**
+   * Extra per-row action definitions rendered in the row overflow menu, after
+   * Edit/Delete. Each is dispatched via {@link onRowActionDef} with the clicked
+   * row. Surfaces an object's own row actions in embedded tables (e.g. a detail
+   * page's related list). Requires {@link rowActions} to be enabled.
+   */
+  rowActionDefs?: DataTableRowAction[];
+  /**
+   * Handler invoked when one of {@link rowActionDefs} is chosen from the row
+   * overflow menu.
+   */
+  onRowActionDef?: (action: DataTableRowAction, row: any) => void | Promise<void>;
   /**
    * Selection change handler
    */


### PR DESCRIPTION
## What

On the schema-driven record **detail page**, child collections render via `record:related_list` → `RelatedList`, but the renderer only wired a delete handler (and only for `add`/junction lists). Related lists were effectively **read-only**: no New, no Edit, no open-detail, and no way to run the child object's own actions.

This wires the full set — 增删改查 + 查看记录详情 + 子对象 action — through a small, host-provided context, with graceful read-only fallback when no host is present (Studio designer / embeds).

## How

- **`RelatedRecordActionsContext`** (`@object-ui/react`, new): the host resolves, per child object, the permitted `{ onView, onCreate, onEdit, onDelete, rowActions, onRowAction }`. Absent provider ⇒ read-only.
- **`RecordRelatedListRenderer`** (`plugin-detail`): consumes it and wires `RelatedList`'s `onNew` / `onRowClick` / `onRowEdit` / `onRowDelete` + child row actions; keeps the legacy `add`/junction remove as a fallback.
- **`RelatedRecordActionsBridge`** (`app-shell`, new; mounted inside the detail page's `ActionProvider`): object-agnostic handlers — navigate to the child's detail / new / edit routes (create pre-links the parent via `?<relationshipField>=<parentId>`), delete via `dataSource`, and run the child object's `list_item` actions against the clicked row through the page `ActionRunner`. Each affordance is gated by `resolveCrudAffordances`.
- **`data-table`** gains optional `rowActionDefs` / `onRowActionDef`; `RelatedList` threads child actions into the row overflow menu and refetches on an `objectui:related-changed` event after a row action mutates.
- Record-detail action handlers honor an explicit child `objectName` / `recordId` so row actions target the child row, not the master record.

## Verification

- `tsc` / `vite build` gate passes for types, react, components, plugin-detail, app-shell.
- Unit tests: renderer CRUD/action wiring + `RelatedList` → `data-table` threading. 164 plugin-detail + data-table tests pass, no regressions.
- **Live** (console against a real backend, showcase app): on an account detail page's Projects related list — New → child `/new?account=<id>` with the parent pre-filled (增), row menu Edit → child edit page (改), row click → child detail (查), row menu Delete → confirm dialog → row removed + list refreshes (删).

🤖 Generated with [Claude Code](https://claude.com/claude-code)