### PR TITLE
feat(console): pass workspace name as production env displayName (IA PR-5)

### DIFF
--- a/packages/app-shell/src/console/organizations/CreateWorkspaceDialog.tsx
+++ b/packages/app-shell/src/console/organizations/CreateWorkspaceDialog.tsx
@@ -142,7 +142,12 @@ export function CreateWorkspaceDialog({
         // resolves this to `alreadyProvisioned`; a genuine failure falls through
         // to the onboarding gate (lazy provision on first navigation).
         try {
-          await provisionProductionEnvironment({ organizationId: org.id });
+          // PR-5 (naming collapse): name the production environment after the
+          // workspace, so the user sees one consistent name instead of a
+          // workspace "Bloom Studio" whose environment is a generic "Production".
+          // The control plane inherits this displayName verbatim; auto-provision
+          // races that skip this call fall back to the org name server-side.
+          await provisionProductionEnvironment({ organizationId: org.id, displayName: name.trim() });
         } catch (provisionErr) {
           console.warn(
             '[CreateWorkspace] eager env provision failed; onboarding gate will provision lazily',


### PR DESCRIPTION
Companion to cloud [#739](https://github.com/objectstack-ai/cloud/pull/739) (IA PR-5 naming collapse).

`CreateWorkspaceDialog` now passes the **workspace name** to `provisionProductionEnvironment` as `displayName`, so the born-with-env production environment inherits the workspace name instead of the generic `"Production"` default.

Before: `provisionProductionEnvironment({ organizationId })` → the control plane's per-request path had no name to inherit → fell back to `"Production"`. A workspace "李娜的客户管理" ended up with an unrelated environment "Production".

After: `provisionProductionEnvironment({ organizationId, displayName: name.trim() })` → env inherits the workspace name.

Pairs with cloud `environment-lifecycle` (`envDisplayName = displayName`) and `auto-default-environment-plugin` (org-name fallback). 6-line change, one file.

⚠️ End-to-end verified in a clean env via the cloud-side follow-up card — local dev-stack build/overlay caching kept serving stale console dist so the local walkthrough couldn't confirm it (see #739 for detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)