### PR TITLE
fix(studio): scope Access rail server-side by package (ADR-0086 P1 follow-up)

### DIFF
--- a/.changeset/access-rail-server-scope.md
+++ b/.changeset/access-rail-server-scope.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(studio): scope the Access rail server-side by package (ADR-0086 P1)
+
+The Access pillar's permission-set rail filtered client-side on a `package_id`
+field read from `client.list('permission')` rows. But the metadata list endpoint
+does not echo the record-level provenance columns — every row comes back with
+`package_id` unset — so the filter's "any set tagged?" guard never fired and the
+rail showed **all** sets, including environment-owned platform defaults
+(`admin_full_access`, `member_default`, …), in a package's Access panel.
+
+The rail now scopes server-side via `client.list('permission', { packageId })`:
+the metadata API filters `permission` by the `package_id` provenance seeded in
+framework ADR-0086 P1, returning only the sets this package owns. Verified
+against a live showcase backend — the panel lists exactly `showcase_contributor`
+and `showcase_member_default`, and the four platform defaults are excluded.
+
+Removes the now-unused `scopePermissionSetList` client-side helper. Object-matrix
+scoping and Save slice-merge (ADR-0086 P0) are unchanged.

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -175,14 +175,16 @@ accumulate authorization rows contributed by many packages, so the matrix:
 - saves via **slice-merge** — it re-reads the record and writes back just this
   package's slice, leaving rows contributed by other packages untouched.
 
-The left rail lists only permission sets this package owns — environment-owned
-platform defaults (`admin_full_access`, `member_default`, …) are hidden once the
-backend tags sets with a record-level `package_id` (framework ADR-0086 P1). A
-mid-migration guard keeps the rail populated until that provenance axis is live
-(if no set carries a `package_id` yet, all are shown). Rendering
+The left rail lists only permission sets this package owns — the metadata API
+filters `permission` by the record-level `package_id` provenance server-side
+(framework ADR-0086 P1), via `client.list('permission', { packageId })`, so
+environment-owned platform defaults (`admin_full_access`, `member_default`, …)
+are excluded by the backend. (The `?package=` list rows don't echo the
+provenance columns, so a client-side filter can't do this.) Save writes a
+package draft and publishes with the whole package (ADR-0086 P2). Rendering
 `PermissionMatrixEditPage` without a `packageId` keeps the environment-wide
 behavior (full object list, whole-record save). The scope/merge helpers
-(`scopePermissionSet`, `mergePermissionSlice`, `scopePermissionSetList`) live in
+(`scopePermissionSet`, `mergePermissionSlice`) live in
 `metadata-admin/permission-slice.ts`.
 
 ### Visual flow canvas

--- a/packages/app-shell/src/console/organizations/__tests__/CreateWorkspaceDialog.test.tsx
+++ b/packages/app-shell/src/console/organizations/__tests__/CreateWorkspaceDialog.test.tsx
@@ -75,7 +75,8 @@ describe('CreateWorkspaceDialog', () => {
       expect(createOrganization).toHaveBeenCalledWith({ name: 'Acme Inc', slug: 'acme-inc' }),
     );
     await waitFor(() =>
-      expect(provisionMock).toHaveBeenCalledWith({ organizationId: 'org-123' }),
+      // The workspace name is passed through as the production env displayName (#2228).
+      expect(provisionMock).toHaveBeenCalledWith({ organizationId: 'org-123', displayName: 'Acme Inc' }),
     );
     await waitFor(() =>
       expect(onCreated).toHaveBeenCalledWith(expect.objectContaining({ id: 'org-123' })),

--- a/packages/app-shell/src/views/metadata-admin/permission-slice.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/permission-slice.test.ts
@@ -13,7 +13,6 @@ import {
   fieldKeyObject,
   mergePermissionSlice,
   scopePermissionSet,
-  scopePermissionSetList,
   type PermissionSetDraft,
 } from './permission-slice';
 
@@ -43,34 +42,6 @@ describe('fieldKeyObject', () => {
   it('extracts the object name up to the first dot', () => {
     expect(fieldKeyObject('a_account.name')).toBe('a_account');
     expect(fieldKeyObject('lonely')).toBe('lonely');
-  });
-});
-
-describe('scopePermissionSetList — rail hides other packages / platform defaults', () => {
-  const rail = [
-    { name: 'showcase_contributor', label: 'Contributor', packageId: 'com.example.showcase' },
-    { name: 'admin_full_access', label: 'Admin', packageId: null }, // platform default
-    { name: 'member_default', label: 'Member' }, // platform default (no field)
-    { name: 'crm_sales', label: 'Sales', packageId: 'app.acme.crm' }, // other package
-  ];
-
-  it('keeps only this package once sets carry provenance (defaults hidden)', () => {
-    const scoped = scopePermissionSetList(rail, 'com.example.showcase');
-    expect(scoped.map((p) => p.name)).toEqual(['showcase_contributor']);
-  });
-
-  it('scopes to another package independently', () => {
-    expect(scopePermissionSetList(rail, 'app.acme.crm').map((p) => p.name)).toEqual([
-      'crm_sales',
-    ]);
-  });
-
-  it('mid-migration guard: shows everything when no set is tagged yet', () => {
-    const untagged = [
-      { name: 'a', label: 'A' },
-      { name: 'b', label: 'B', packageId: null },
-    ];
-    expect(scopePermissionSetList(untagged, 'com.example.showcase')).toBe(untagged);
   });
 });
 

--- a/packages/app-shell/src/views/metadata-admin/permission-slice.ts
+++ b/packages/app-shell/src/views/metadata-admin/permission-slice.ts
@@ -61,29 +61,6 @@ function asScopeSet(scope: Iterable<string>): Set<string> {
 }
 
 /**
- * Narrow the Access pillar's permission-set rail to the sets a package owns.
- *
- * Permission sets carry a record-level `package_id` provenance axis (framework
- * ADR-0086 P1): sets a package declares are seeded owned by it, while
- * environment-owned platform defaults (`admin_full_access`, `member_default`,
- * …) have none. A package's Access panel must not list those platform defaults.
- *
- * Rollout guard: filter ONLY once the backend actually tags sets with a
- * `packageId` (i.e. at least one row carries one). Until then — a backend that
- * predates the P1 provenance seeding — no row is tagged and we show everything,
- * so the rail never collapses to empty mid-migration. Tighten (drop the guard)
- * once the provenance axis is guaranteed live.
- */
-export function scopePermissionSetList<T extends { packageId?: string | null }>(
-  items: T[],
-  packageId: string,
-): T[] {
-  const anyTagged = items.some((p) => p.packageId != null);
-  if (!anyTagged) return items;
-  return items.filter((p) => p.packageId === packageId);
-}
-
-/**
  * Narrow a permission set down to just the rows whose object is in `scope`.
  * Used to drive the matrix display so a package panel lists only its own
  * objects (and their field overrides), never the whole environment.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -51,7 +51,6 @@ import {
 } from 'lucide-react';
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
 import { PermissionMatrixEditPage } from '../metadata-admin/PermissionMatrixEditor';
-import { scopePermissionSetList } from '../metadata-admin/permission-slice';
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
 import { useMetadataClient } from '../metadata-admin/useMetadata';
 import { t, tFormat, useMetadataLocale } from '../metadata-admin/i18n';
@@ -2332,15 +2331,14 @@ function AutomationsPillar({
  * main: the Salesforce-style PermissionMatrixEditPage (objects × CRUD/VAMA +
  * field-level R/W).
  *
- * Scope note (ADR-0086 P0/P1): the pillar is scoped to the current package.
- * The left rail lists only permission sets this package owns — environment-owned
- * platform defaults (`admin_full_access`, `member_default`, …) are hidden once
- * the backend tags sets with a record-level `package_id` (P1); see
- * `scopePermissionSetList` for the mid-migration guard. The object MATRIX lists
- * only the objects this package declares, and its Save merges just that slice
- * back, leaving other packages' contributed rows untouched. The matrix still
- * writes the ACTIVE item directly (no draft/publish flow), so the shell's
- * 变更/发布 does not apply here.
+ * Scope note (ADR-0086 P0/P1/P2): the pillar is scoped to the current package.
+ * The left rail lists only permission sets this package owns — the metadata API
+ * filters `permission` by the record-level `package_id` provenance server-side
+ * (P1), so environment-owned platform defaults (`admin_full_access`,
+ * `member_default`, …) are excluded by the backend. The object MATRIX lists only
+ * the objects this package declares, and Save merges just that slice back,
+ * leaving other packages' contributed rows untouched (P0). Save writes a package
+ * DRAFT and publishes with the whole package via the top-bar Publish (P2, D6).
  */
 function AccessPillar({
   packageId,
@@ -2354,7 +2352,7 @@ function AccessPillar({
   const client = useMetadataClient();
   const locale = useMetadataLocale();
   const [perms, setPerms] = React.useState<
-    Array<{ name: string; label: string; isProfile?: boolean; packageId?: string | null }>
+    Array<{ name: string; label: string; isProfile?: boolean }>
   >([]);
   const [loaded, setLoaded] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -2369,15 +2367,23 @@ function AccessPillar({
 
   const load = React.useCallback(async () => {
     try {
+      // Scope the rail to this package server-side (ADR-0086 P1): the metadata
+      // API filters `permission` by the record-level `package_id` provenance, so
+      // it returns only the sets this package owns — environment-owned platform
+      // defaults (`admin_full_access`, `member_default`, …) are excluded by the
+      // backend, not the client. (The `?package=` list rows don't echo the
+      // provenance columns, so a client-side filter can't do this.)
+      //
       // ADR-0086 P2 (D6): a package permission set is draft/published metadata,
       // so the rail shows published ∪ pending-draft sets — a set created (or
-      // renamed) as a draft but not yet published must still appear here, just
-      // like the Data/Interfaces pillars merge their drafts.
+      // renamed) as a draft but not yet published must still appear, just like
+      // the Data/Interfaces pillars merge their drafts. Draft headers are
+      // already package-scoped by `listDrafts({ packageId })`.
       const [list, drafts] = await Promise.all([
-        client.list('permission') as Promise<Array<Record<string, unknown>>>,
+        client.list('permission', { packageId }) as Promise<Array<Record<string, unknown>>>,
         client.listDrafts({ packageId, type: 'permission' }).catch(() => []),
       ]);
-      const byName = new Map<string, { name: string; label: string; isProfile?: boolean; packageId?: string | null }>();
+      const byName = new Map<string, { name: string; label: string; isProfile?: boolean }>();
       for (const p of list || []) {
         const name = String(p.name ?? (p as Record<string, unknown>).id ?? '');
         if (!name) continue;
@@ -2385,22 +2391,14 @@ function AccessPillar({
           name,
           label: String(p.label ?? p.name ?? ''),
           isProfile: !!(p as Record<string, unknown>).isProfile,
-          // Record-level provenance (framework ADR-0086 P1); snake_case is the
-          // framework field, camelCase tolerated for either serialization.
-          packageId: ((p as Record<string, unknown>).package_id ??
-            (p as Record<string, unknown>).packageId) as string | undefined,
         });
       }
-      // Draft-only sets (no published row yet) are stamped with this package,
-      // so add them without needing scope-list's mid-migration guard.
-      for (const d of (drafts as Array<{ name?: string; packageId?: string | null }>) || []) {
+      for (const d of (drafts as Array<{ name?: string }>) || []) {
         const name = String(d?.name ?? '');
         if (!name || byName.has(name)) continue;
-        byName.set(name, { name, label: name, packageId: d?.packageId ?? packageId });
+        byName.set(name, { name, label: name });
       }
-      // Hide environment-owned platform-default sets (no package_id) from this
-      // package's panel — see scopePermissionSetList for the mid-migration guard.
-      const scoped = scopePermissionSetList([...byName.values()], packageId);
+      const scoped = [...byName.values()];
       setPerms(scoped);
       setCurrent((c) => c ?? scoped[0]?.name ?? null);
     } catch (e) {


### PR DESCRIPTION
Follow-up to #2222 (P0) / #2225 (P2), addressing #2223 item 1. Found by live end-to-end verification against a real backend now that framework ADR-0086 P1 (framework#2566) is merged.

## The bug (silent, security-relevant)

The Access pillar's permission-set **rail** filtered **client-side** on a `package_id` read from `client.list('permission')` rows, hiding environment-owned platform defaults from a package's panel. But the metadata list endpoint **does not echo the record-level provenance columns** — every row comes back with `package_id` unset. So the "is any set tagged?" guard never fired and the rail fell back to showing **all** sets, including `admin_full_access` / `member_default`, inside a package's Access panel. This defeated acceptance item 3 of the #2221 coordination note ("platform defaults must not appear in a package's Access panel").

## Fix

Scope the rail **server-side**: `client.list('permission', { packageId })`. The metadata API filters `permission` by the `package_id` provenance seeded in framework ADR-0086 P1, returning only the sets this package owns — the same mechanism the Data/Interfaces pillars already use for objects (`list('object', { packageId })`). The published ∪ package-scoped-drafts merge (P2) is unchanged; the now-unused `scopePermissionSetList` client helper is removed.

## Live verification (objectstack dev --fresh showcase backend on :4010)

Ran the real framework showcase backend (with P1 + P2 merged) and the objectui console dev proxying to it, and checked the exact calls the UI makes:

| call | before | after |
|---|---|---|
| rail: `meta/permission` (unscoped) | 6 sets (incl. 4 platform defaults) | — |
| rail: `meta/permission?package=com.example.showcase` | — | **2 sets** (`showcase_contributor`, `showcase_member_default`) |
| matrix: `meta/object` (unscoped) | 84 objects | — |
| matrix: `meta/object?package=com.example.showcase` | — | **20 objects** (all `showcase_*`) |

Provenance confirmed on the data rows (`sys_permission_set`): `showcase_*` → `managed_by=package, package_id=com.example.showcase`; the four platform defaults → null (environment-owned). The 84→20 object scoping is the P0 behavior from #2222, re-confirmed live.

## Tests

- `permission-slice.test.ts` — updated (drops the removed helper's cases); `scopePermissionSet` / `mergePermissionSlice` still pinned.
- `PermissionMatrixEditor.scope.test.tsx` — unchanged, still green (object scope + slice-merge + P2 draft-save mode).
- `type-check` 0 errors.

## Follow-ups (tracked in #2223)

- Item 2 (live browser closed-loop) — this PR does the live **API/stack** verification end-to-end; a rendered browser pass is still nice-to-have (the chrome-devtools MCP couldn't find a Chrome binary in this env).
- Item 3 (new-set package ownership) — already delivered by #2225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWcZRYnJXN3YXFTbm3PLg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWcZRYnJXN3YXFTbm3PLg5)_