### PR TITLE
fix(studio): show a failed flow run's reason in the Runs panel (string errors)

### DIFF
--- a/.changeset/flow-runs-string-error.md
+++ b/.changeset/flow-runs-string-error.md
@@ -1,0 +1,19 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(studio): show a failed flow run's reason in the Runs panel (string errors)
+
+The Studio flow **Runs** panel (`FlowRunsPanel`) rendered a run-level error as
+`run.error?.message`, but the automation engine sends `ExecutionLog.error` as a
+plain **string** — so `.message` was always `undefined` and the failure reason,
+the single most useful thing about a failed run, was silently dropped. This grew
+important now that runs are durable (framework #2581): a failed run persists with
+its reason, but the panel showed only a red "Failed" badge and no "why".
+
+The panel now normalizes an error through a small `errorText()` helper that
+accepts **either** a string (the run-level shape) **or** a `{ code, message }`
+object (the step-level shape), and uses it for both the run summary and each
+step row. Verified with a jsdom render test (a failed run's string reason reaches
+the DOM) and live in the browser against a real failed run (`showcase_resilient_sync`):
+the reason now displays where it previously showed nothing.

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.render.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.render.test.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Render regression for the run-observability UI (framework #2581 + this fix):
+// the automation engine sends a run-level `error` as a plain STRING
+// (`ExecutionLog.error`). The panel previously read `.message` off it and so
+// dropped the failure reason — the single most useful thing about a failed run.
+// This asserts a failed run's string reason actually reaches the DOM.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FlowRunsPanel } from './FlowRunsPanel';
+
+const FAILED_RUN = {
+  id: 'run_run_dfc987a9',
+  status: 'failed',
+  startedAt: '2026-07-04T13:51:13.000Z',
+  durationMs: 12,
+  trigger: { type: '' },
+  steps: [], // durable history rows carry no step detail
+  // The engine's run-level error IS a string (not { message }).
+  error: "Node 'guarded_push' failed: catch region failed — Access denied",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('FlowRunsPanel (render)', () => {
+  it('shows a failed run and its string failure reason', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ success: true, data: { runs: [FAILED_RUN] } }), { status: 200 })),
+    );
+
+    render(<FlowRunsPanel flowName="showcase_resilient_sync" />);
+
+    // Status renders collapsed…
+    expect(await screen.findByText('Failed')).toBeTruthy();
+
+    // …expand the run to reveal the reason. The run row is the button carrying
+    // aria-expanded (the Refresh control does not), so it is unambiguous.
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+
+    // The string reason must now be in the DOM (pre-fix it was silently dropped).
+    expect(await screen.findByText(/catch region failed/)).toBeTruthy();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fetchFlowRuns } from './FlowRunsPanel';
+import { fetchFlowRuns, errorText } from './FlowRunsPanel';
 
 const RUN = {
   id: 'run-1',
@@ -52,5 +52,26 @@ describe('fetchFlowRuns', () => {
   it('returns null when the payload has no runs array', async () => {
     mockFetch(() => new Response(JSON.stringify({ data: {} }), { status: 200 }));
     expect(await fetchFlowRuns('empty')).toBeNull();
+  });
+});
+
+describe('errorText', () => {
+  it('reads a plain-string error (the engine run-level shape)', () => {
+    // Regression: the engine sends `ExecutionLog.error` as a string; the panel
+    // previously read `.message` off it and dropped the failure reason.
+    expect(errorText("Node 'guarded_push' failed: catch region failed")).toBe(
+      "Node 'guarded_push' failed: catch region failed",
+    );
+  });
+
+  it('reads a { message } object error (the step-level shape)', () => {
+    expect(errorText({ code: 'E_BOOM', message: 'kaboom' })).toBe('kaboom');
+  });
+
+  it('is empty for no error / empty string / message-less object', () => {
+    expect(errorText(undefined)).toBeUndefined();
+    expect(errorText(null)).toBeUndefined();
+    expect(errorText('')).toBeUndefined();
+    expect(errorText({ code: 'E' })).toBeUndefined();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
@@ -17,13 +17,18 @@ import { AlertCircle, CheckCircle2, ChevronDown, ChevronRight, Clock, Loader2, P
 import { cn } from '@object-ui/components';
 import { apiBase } from './useFlowNodePalette';
 
+/** An error on a run/step. The engine sends the run-level `error` as a plain
+ *  string (`ExecutionLog.error`) while a step-level error is a `{code,message}`
+ *  object — the panel accepts either shape. */
+type RunError = string | { code?: string; message?: string };
+
 /** Step entry of a run log (spec `ExecutionStepLogSchema`, fields we render). */
 interface RunStep {
   nodeId: string;
   nodeType?: string;
   status: 'success' | 'failure' | 'skipped' | string;
   durationMs?: number;
-  error?: { code?: string; message?: string };
+  error?: RunError;
 }
 
 /** Run log entry (spec `ExecutionLogSchema`, fields we render). */
@@ -35,7 +40,20 @@ export interface FlowRun {
   durationMs?: number;
   trigger?: { type?: string; userId?: string; object?: string };
   steps?: RunStep[];
-  error?: { message?: string };
+  error?: RunError;
+}
+
+/**
+ * Normalize a run/step error to its human-readable message. The engine emits a
+ * run-level `error` as a plain string but a step-level error as `{code,message}`
+ * — reading `.message` off the string case silently dropped the run failure
+ * reason (the whole point of the Runs panel for a failed run), so accept both.
+ */
+export function errorText(e: RunError | undefined | null): string | undefined {
+  if (!e) return undefined;
+  if (typeof e === 'string') return e || undefined;
+  const m = e.message;
+  return typeof m === 'string' && m ? m : undefined;
 }
 
 type LoadState = 'loading' | 'ready' | 'unavailable';
@@ -88,6 +106,7 @@ function StepRow({ step }: { step: RunStep }) {
       : step.status === 'failure'
         ? 'text-rose-600 dark:text-rose-400'
         : 'text-muted-foreground';
+  const stepErr = errorText(step.error);
   return (
     <li className="flex items-baseline gap-1.5 py-0.5">
       <span className={cn('shrink-0 text-[9px] font-semibold uppercase', cls)}>{step.status}</span>
@@ -96,9 +115,9 @@ function StepRow({ step }: { step: RunStep }) {
       {fmtDuration(step.durationMs) && (
         <span className="ml-auto shrink-0 text-[9px] text-muted-foreground">{fmtDuration(step.durationMs)}</span>
       )}
-      {step.error?.message && (
-        <span className="min-w-0 truncate text-[9px] text-rose-600" title={step.error.message}>
-          {step.error.message}
+      {stepErr && (
+        <span className="min-w-0 truncate text-[9px] text-rose-600" title={stepErr}>
+          {stepErr}
         </span>
       )}
     </li>
@@ -110,6 +129,7 @@ function RunRow({ run }: { run: FlowRun }) {
   const meta = statusMeta(run.status);
   const Icon = meta.icon;
   const steps = Array.isArray(run.steps) ? run.steps : [];
+  const runErr = errorText(run.error);
   return (
     <li className="rounded border bg-background">
       <button
@@ -138,8 +158,8 @@ function RunRow({ run }: { run: FlowRun }) {
             run {run.id}
             {run.trigger?.type && ` · trigger ${run.trigger.type}`}
           </div>
-          {run.error?.message && (
-            <div className="pb-1 text-[10px] text-rose-600">{run.error.message}</div>
+          {runErr && (
+            <div className="pb-1 text-[10px] text-rose-600">{runErr}</div>
           )}
           {steps.length === 0 ? (
             <div className="text-[10px] italic text-muted-foreground">No step log recorded.</div>


### PR DESCRIPTION
## Why

The Studio flow **Runs** panel (`FlowRunsPanel`, shown in the flow inspector) rendered a run-level error as `run.error?.message`. But the automation engine sends `ExecutionLog.error` as a plain **string** — so `.message` was always `undefined` and the failure reason, the single most useful thing about a failed run, was **silently dropped** (only a red "Failed" badge showed, no "why").

This became important now that runs are durable (framework #2581): a failed run persists with its reason, and the Runs panel is where an author looks to find it.

## What

Normalize an error through a small exported `errorText()` helper that accepts **either** shape:
- a **string** — the run-level `ExecutionLog.error`;
- a **`{ code, message }`** object — the step-level error.

Used for both the run summary and each step row, so run-level reasons now render (step-level ones are unchanged).

```
-  {run.error?.message && (<div ...>{run.error.message}</div>)}
+  {runErr && (<div ...>{runErr}</div>)}   // runErr = errorText(run.error)
```

## Verification

- **`errorText` unit test** — string → the string; `{message}` → the message; empty/undefined/message-less → undefined.
- **jsdom render test** — mounts `FlowRunsPanel` with a failed run whose `error` is a string, expands the row, asserts the reason reaches the DOM.
- **Live browser** — against a real failed run (`showcase_resilient_sync`) on a #2581 backend, through the console's auth + `/api` proxy: the endpoint returns `error` as a string, `errorText()` renders `"Node 'guarded_push' failed: try_catch… catch region failed…"`, where the pre-fix code showed **nothing**.

Type-check green (`turbo run type-check --filter=@object-ui/app-shell`, 29/29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)