### PR TITLE
fix(plugin-form): strip computed fields from form submit payloads

### DIFF
--- a/packages/plugin-form/src/LineItemsPanel.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.tsx
@@ -66,6 +66,21 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
   const [dirty, setDirty] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Child object schema — used to strip computed / read-only columns from each
+  // row before persisting (parity with the parent form's sanitize). Rows are
+  // loaded from a full read, so an edit would otherwise round-trip formula /
+  // summary columns the server rejects as unknown fields.
+  const [childSchema, setChildSchema] = useState<{ fields?: Record<string, any> } | null>(null);
+  useEffect(() => {
+    const ds: any = dataSource;
+    if (!ds || typeof ds.getObjectSchema !== 'function') return;
+    let cancelled = false;
+    ds.getObjectSchema(schema.childObject)
+      .then((s: any) => { if (!cancelled) setChildSchema(s ?? null); })
+      .catch(() => { if (!cancelled) setChildSchema(null); });
+    return () => { cancelled = true; };
+  }, [dataSource, schema.childObject]);
+
   const load = useCallback(async () => {
     if (!dataSource || !parentId) {
       setLoading(false);
@@ -110,6 +125,8 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
         amountField: schema.amountField,
         // only roll up when we know the parent object to write the total onto
         totalField: parentObject ? schema.totalField : undefined,
+        // Strip computed / read-only columns from each child row payload.
+        childSchema,
       });
       await load();
     } catch (e: any) {
@@ -117,7 +134,7 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
     } finally {
       setSaving(false);
     }
-  }, [dataSource, parentId, rows, original, schema, parentObject, load]);
+  }, [dataSource, parentId, rows, original, schema, parentObject, load, childSchema]);
 
   const gridField = useMemo(
     () =>

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -361,6 +361,36 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
   const stateRef = useRef(state);
   stateRef.current = state;
 
+  // Cache of child object schemas (keyed by childObject), fetched once so the
+  // client-orchestrated and atomic-batch child writes can strip computed /
+  // read-only columns from each row — parity with the parent form's
+  // `sanitizeFormData`. Child rows are seeded from a full record read, so an
+  // edit would otherwise round-trip formula/summary columns the server rejects.
+  // A ref (not state) so a late-arriving schema never re-renders — and thus
+  // never resets — the header <ObjectForm> (see #1581). Reads happen at submit
+  // time, long after the fetch resolves.
+  const childSchemasRef = useRef<Record<string, { fields?: Record<string, any> }>>({});
+  useEffect(() => {
+    const ds: any = dataSource;
+    if (!ds || typeof ds.getObjectSchema !== 'function') return;
+    let cancelled = false;
+    const objects = Array.from(new Set(rawDetails.map((d) => d.childObject).filter(Boolean)));
+    (async () => {
+      const entries = await Promise.all(
+        objects.map(async (obj) => {
+          try { return [obj, await ds.getObjectSchema(obj)] as const; }
+          catch { return [obj, null] as const; }
+        }),
+      );
+      if (cancelled) return;
+      const next: Record<string, { fields?: Record<string, any> }> = {};
+      for (const [obj, sch] of entries) if (sch) next[obj] = sch;
+      childSchemasRef.current = next;
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataSource, schema.objectName, schema.details]);
+
   // Bumped after a successful CREATE to remount the parent <ObjectForm> (which
   // owns react-hook-form state) so its fields clear for the next entry.
   const [formKey, setFormKey] = useState(0);
@@ -505,6 +535,8 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
           original: isEdit ? original : undefined,
           amountField: d.amountField,
           totalField: d.totalField,
+          // Strip computed / read-only columns from each child row payload.
+          childSchema: childSchemasRef.current[d.childObject],
         });
         createdIds.push(...created);
       }
@@ -565,6 +597,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
               relationshipField: d.relationshipField!,
               rows: stateRef.current[i]?.rows ?? [],
               original: stateRef.current[i]?.original ?? [],
+              childSchema: childSchemasRef.current[d.childObject],
             })),
           )
         : buildMasterDetailBatch(
@@ -574,6 +607,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
               childObject: d.childObject,
               relationshipField: d.relationshipField!,
               rows: stateRef.current[i]?.rows ?? [],
+              childSchema: childSchemasRef.current[d.childObject],
             })),
           );
       const res = await ds.batchTransaction(ops);

--- a/packages/plugin-form/src/ObjectForm.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.test.tsx
@@ -225,6 +225,80 @@ describe('ObjectForm Integration', () => {
         expect(screen.queryByText('Contact Info')).toBeNull();
     });
 
+    it('strips computed and server-managed fields from the edit-mode update payload', async () => {
+        // Repro of the showcase_project "Unknown field 'budget_remaining'" bug:
+        // an edit form is seeded from a full record read that includes computed
+        // columns (formula/summary) the form never renders — they live in the
+        // form's `sections` allow-list nowhere, yet react-hook-form retains the
+        // seeded defaultValues and round-trips them on submit. The backend then
+        // rejects those non-writable fields. ObjectForm must sanitize them out.
+        const schema = {
+            name: 'test_project',
+            fields: {
+                name: { type: 'text', label: 'Name' },
+                budget: { type: 'currency', label: 'Budget', scale: 2 },
+                // Computed — server-managed, never writable.
+                budget_remaining: { type: 'formula', label: 'Budget Remaining' },
+                task_count: { type: 'summary', label: 'Tasks' },
+            },
+        };
+        const record = {
+            id: 'p1',
+            name: 'Website',
+            budget: 150000,
+            // Present in the read (and thus the form defaultValues) but NOT in
+            // any rendered section — the exact leak path.
+            budget_remaining: 90000,
+            task_count: 5,
+            created_at: '2020-01-01T00:00:00Z',
+        };
+        const ds: any = {
+            getObjectSchema: vi.fn().mockResolvedValue(schema),
+            findOne: vi.fn().mockResolvedValue(record),
+            update: vi.fn().mockResolvedValue({ ...record }),
+            create: vi.fn(),
+        };
+
+        const { container } = render(
+            <ObjectForm
+                schema={{
+                    type: 'object-form',
+                    objectName: 'test_project',
+                    mode: 'edit',
+                    recordId: 'p1',
+                    // Curated form view: only the writable fields are laid out.
+                    sections: [{ name: 'main', label: 'Main', fields: ['name', 'budget'] }],
+                } as any}
+                dataSource={ds}
+            />,
+        );
+
+        // Wait for the record read to seed the form.
+        const nameInput = await waitFor(() => {
+            const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+            if (!el || el.value !== 'Website') throw new Error('form not seeded yet');
+            return el;
+        });
+        fireEvent.change(nameInput, { target: { value: 'Website v2' } });
+
+        const form = container.querySelector('form') as HTMLFormElement;
+        fireEvent.submit(form);
+
+        await waitFor(() => {
+            expect(ds.update).toHaveBeenCalledTimes(1);
+        });
+        const [obj, id, payload] = ds.update.mock.calls[0];
+        expect(obj).toBe('test_project');
+        expect(id).toBe('p1');
+        // Edited writable field is sent...
+        expect(payload).toMatchObject({ name: 'Website v2', budget: 150000 });
+        // ...but the computed and server-managed keys are stripped.
+        expect(payload).not.toHaveProperty('budget_remaining');
+        expect(payload).not.toHaveProperty('task_count');
+        expect(payload).not.toHaveProperty('id');
+        expect(payload).not.toHaveProperty('created_at');
+    });
+
     it('renders as a master-detail form when schema.subforms is set', async () => {
         // A plain object form becomes master-detail by config (no bespoke page):
         // parent fields on top + an editable child grid + a single Save action.

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -35,6 +35,7 @@ import {
   inferColumns,
 } from './autoLayout';
 import { deriveFieldGroupSections } from './fieldGroups';
+import { sanitizeFormData } from './sanitize';
 
 export interface ObjectFormProps {
   /**
@@ -586,17 +587,25 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
       throw new Error('DataSource is required for form submission (inline mode not configured)');
     }
 
-    // Strip non-editable fields from the payload (FLS — never trust the
-    // client form state; if the user lacked edit access we MUST NOT
-    // include the field in the create/update request).
-    let payload = formData;
-    if (perms?.isLoaded && formData && typeof formData === 'object') {
-      payload = {} as Record<string, unknown>;
-      for (const k of Object.keys(formData)) {
+    // Strip server-managed and computed / read-only fields from the payload
+    // before persisting. react-hook-form retains state for unmounted/disabled
+    // fields (see ModalForm), so an edit form seeded from a full record read
+    // round-trips computed columns it never rendered — formula/summary/rollup
+    // values, flattened lookups, id/timestamps — which the server rejects as
+    // unknown or non-writable fields. Mirrors ModalForm/DrawerForm. For inline
+    // forms `objectSchema` is a field-less stub, so pass null to strip only the
+    // server-managed keys rather than dropping every (schema-less) value.
+    let payload = sanitizeFormData(formData, hasInlineFields ? null : objectSchema);
+    // FLS defence-in-depth: never trust the client to include a field the user
+    // lacked edit access to — drop any that fail the write check.
+    if (perms?.isLoaded && payload && typeof payload === 'object') {
+      const stripped: Record<string, unknown> = {};
+      for (const k of Object.keys(payload)) {
         if (perms.checkField(schema.objectName, k, 'write')) {
-          (payload as Record<string, unknown>)[k] = formData[k];
+          stripped[k] = (payload as Record<string, unknown>)[k];
         }
       }
+      payload = stripped;
     }
 
     try {
@@ -640,7 +649,7 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
       
       throw err;
     }
-  }, [schema, dataSource, hasInlineFields, perms]);
+  }, [schema, dataSource, hasInlineFields, perms, objectSchema]);
 
   // Handle form cancellation
   const handleCancel = useCallback(() => {

--- a/packages/plugin-form/src/masterDetailTx.test.ts
+++ b/packages/plugin-form/src/masterDetailTx.test.ts
@@ -207,3 +207,84 @@ describe('applyDetail — client-orchestrated child write', () => {
     expect(ds.update).not.toHaveBeenCalled();
   });
 });
+
+// A line-item child schema mirroring the real fixture pattern: `amount` is a
+// STORED currency column carrying an `expression` for live client recompute
+// (persisted as-is, MUST survive sanitize), while `line_total` (summary) and
+// `note_calc` (formula) are true computed types the server rejects on write.
+const LINE_SCHEMA = {
+  fields: {
+    product: { type: 'text' },
+    quantity: { type: 'number' },
+    unit_price: { type: 'currency' },
+    amount: { type: 'currency', expression: { dialect: 'cel', source: 'record.quantity * record.unit_price' } },
+    line_total: { type: 'summary' },
+    note_calc: { type: 'formula' },
+    invoice: { type: 'master_detail' },
+  },
+};
+
+describe('child payload sanitize (childSchema supplied)', () => {
+  const dirtyRow = (over: Record<string, any> = {}) => ({
+    product: 'Widget', quantity: 2, unit_price: 10, amount: 20,
+    line_total: 20, note_calc: 'x', ...over,
+  });
+
+  it('buildMasterDetailBatch strips computed/server-managed child fields, keeps stored amount + FK', () => {
+    const ops = buildMasterDetailBatch('invoice', { name: 'INV-1' }, [{
+      childObject: 'inv_line', relationshipField: 'invoice',
+      rows: [dirtyRow({ id: 'client-only' })],
+      childSchema: LINE_SCHEMA,
+    }]);
+    // formula/summary + client-only id dropped; stored amount kept; FK is $ref.
+    expect(ops[1].data).toEqual({
+      product: 'Widget', quantity: 2, unit_price: 10, amount: 20, invoice: { $ref: 0 },
+    });
+  });
+
+  it('buildMasterDetailEditBatch: update carries routing id but a sanitized data payload', () => {
+    const ops = buildMasterDetailEditBatch('invoice', 'inv1', { name: 'INV-1' }, [{
+      childObject: 'inv_line', relationshipField: 'invoice',
+      rows: [dirtyRow({ id: 'l1', amount: 25 }), dirtyRow({ product: 'New', amount: 5 })],
+      original: [{ id: 'l1', product: 'Widget', quantity: 1, unit_price: 10, amount: 10 }],
+      childSchema: LINE_SCHEMA,
+    }]);
+    // op[0] is the PARENT update — scope to the child object for the line ops.
+    const upd = ops.find((o) => o.object === 'inv_line' && o.action === 'update');
+    // Routed by id; data has the FK + stored fields, NOT id/line_total/note_calc.
+    expect(upd).toEqual({
+      object: 'inv_line', action: 'update', id: 'l1',
+      data: { product: 'Widget', quantity: 2, unit_price: 10, amount: 25, invoice: 'inv1' },
+    });
+    const cre = ops.find((o) => o.object === 'inv_line' && o.action === 'create');
+    expect(cre!.data).toEqual({ product: 'New', quantity: 2, unit_price: 10, amount: 5, invoice: 'inv1' });
+    expect(cre!.data).not.toHaveProperty('note_calc');
+  });
+
+  it('applyDetail sanitizes create and update child payloads', async () => {
+    const ds = mockDataSource();
+    await applyDetail(ds, 'invoice', 'inv1', {
+      childObject: 'inv_line', relationshipField: 'invoice',
+      original: [{ id: 'l1', product: 'Widget', quantity: 1, unit_price: 10, amount: 10 }],
+      rows: [dirtyRow({ id: 'l1', amount: 25 }), dirtyRow({ product: 'New', amount: 5 })],
+      childSchema: LINE_SCHEMA,
+    });
+    // Update: computed/id stripped, stored amount + FK kept.
+    expect(ds.update).toHaveBeenCalledWith('inv_line', 'l1', {
+      product: 'Widget', quantity: 2, unit_price: 10, amount: 25, invoice: 'inv1',
+    });
+    // Create (via bulk): computed dropped, amount kept.
+    expect(ds.bulk).toHaveBeenCalledWith('inv_line', 'create', [
+      { product: 'New', quantity: 2, unit_price: 10, amount: 5, invoice: 'inv1' },
+    ]);
+  });
+
+  it('leaves rows untouched when no childSchema is supplied (backward compatible)', () => {
+    const ops = buildMasterDetailBatch('invoice', { name: 'INV-1' }, [{
+      childObject: 'inv_line', relationshipField: 'invoice',
+      rows: [dirtyRow()],
+    }]);
+    // No schema → the computed columns pass through unchanged (prior behavior).
+    expect(ops[1].data).toMatchObject({ line_total: 20, note_calc: 'x' });
+  });
+});

--- a/packages/plugin-form/src/masterDetailTx.ts
+++ b/packages/plugin-form/src/masterDetailTx.ts
@@ -14,9 +14,29 @@
  */
 
 import type { DataSource } from '@object-ui/types';
+import { sanitizeFormData } from './sanitize';
 
 export const idOf = (rec: any): string | undefined =>
   rec == null ? undefined : (rec.id ?? rec._id ?? rec.recordId);
+
+/** Optional child object schema (`{ fields }`) used to strip non-writable
+ *  values from a child payload before persisting. */
+export type ChildSchema = { fields?: Record<string, any> } | null | undefined;
+
+/**
+ * Strip computed / read-only / server-managed / unknown fields from a child
+ * row's write payload — the same guard the parent form applies via
+ * `sanitizeFormData` (ObjectForm). Child rows are seeded from a full record
+ * read (`dataSource.find`), so an edit round-trips computed columns (formula /
+ * summary) the grid never let the user edit; the server rejects those as
+ * unknown/non-writable fields. Gated on a schema being supplied so existing
+ * callers that don't pass one keep their exact behavior (incl. sending `id`
+ * inside an update payload). A stored client-computed column
+ * (`type: currency` + `expression`, e.g. a line `amount`) is intentionally
+ * preserved — only true computed *types* / `readonly` / unknown keys are dropped.
+ */
+const toWritable = (data: Record<string, any>, childSchema: ChildSchema): Record<string, any> =>
+  childSchema ? sanitizeFormData(data, childSchema) : data;
 
 export interface RowDiff {
   toCreate: Record<string, any>[];
@@ -33,6 +53,9 @@ export interface BatchDetailInput {
   childObject: string;
   relationshipField: string;
   rows: Record<string, any>[];
+  /** When supplied, child write payloads are sanitized against it (drops
+   *  computed / read-only / unknown fields). Omit to persist rows as-is. */
+  childSchema?: ChildSchema;
 }
 
 /** Edit-mode detail input: current rows + the loaded snapshot to diff against. */
@@ -81,7 +104,9 @@ export function buildMasterDetailBatch(
   for (const d of details) {
     for (const row of d.rows) {
       if (isBlankRow(row, d.relationshipField)) continue; // skip the ghost/empty line
-      ops.push({ object: d.childObject, action: 'create', data: { ...row, [d.relationshipField]: { $ref: 0 } } });
+      // Sanitize business fields, then attach the FK (a schema field, so it
+      // survives sanitize anyway — attached explicitly for clarity/safety).
+      ops.push({ object: d.childObject, action: 'create', data: { ...toWritable(row, d.childSchema), [d.relationshipField]: { $ref: 0 } } });
     }
   }
   return ops;
@@ -108,10 +133,12 @@ export function buildMasterDetailEditBatch(
       if (isBlankRow(row, d.relationshipField)) continue; // skip the ghost/empty line
       // Strip any client-only id so the server generates one.
       const { id: _omit, _id: _omit2, recordId: _omit3, ...clean } = row as any;
-      ops.push({ object: d.childObject, action: 'create', data: clean });
+      ops.push({ object: d.childObject, action: 'create', data: toWritable(clean, d.childSchema) });
     }
     for (const row of toUpdate) {
-      ops.push({ object: d.childObject, action: 'update', id: idOf(row)!, data: row });
+      // Route by id; the id is carried separately so sanitize can drop it (and
+      // any computed columns) from the data payload without losing the target.
+      ops.push({ object: d.childObject, action: 'update', id: idOf(row)!, data: toWritable(row, d.childSchema) });
     }
     for (const id of toDelete) {
       ops.push({ object: d.childObject, action: 'delete', id });
@@ -181,6 +208,9 @@ export interface ApplyDetailOptions {
   amountField?: string;
   /** Parent field to receive the rolled-up sum. */
   totalField?: string;
+  /** When supplied, child write payloads are sanitized against it (drops
+   *  computed / read-only / unknown fields). Omit to persist rows as-is. */
+  childSchema?: ChildSchema;
 }
 
 export interface ApplyDetailResult {
@@ -208,15 +238,16 @@ export async function applyDetail(
 
   if (opts.original !== undefined) {
     const { toCreate, toUpdate, toDelete } = diffRows(opts.original, withFk);
-    const newRecords = await createMany(dataSource, opts.childObject, toCreate);
+    const newRecords = await createMany(dataSource, opts.childObject, toCreate.map((r) => toWritable(r, opts.childSchema)));
     for (const rec of newRecords) {
       const id = idOf(rec);
       if (id) created.push({ object: opts.childObject, id });
     }
-    await Promise.all(toUpdate.map((r) => dataSource.update(opts.childObject, idOf(r)!, r)));
+    // idOf(r) is read BEFORE sanitize so update routing survives dropping the id.
+    await Promise.all(toUpdate.map((r) => dataSource.update(opts.childObject, idOf(r)!, toWritable(r, opts.childSchema))));
     await Promise.all(toDelete.map((id) => dataSource.delete(opts.childObject, id)));
   } else {
-    const newRecords = await createMany(dataSource, opts.childObject, withFk);
+    const newRecords = await createMany(dataSource, opts.childObject, withFk.map((r) => toWritable(r, opts.childSchema)));
     for (const rec of newRecords) {
       const id = idOf(rec);
       if (id) created.push({ object: opts.childObject, id });

--- a/packages/plugin-form/src/sanitize.test.ts
+++ b/packages/plugin-form/src/sanitize.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeFormData } from './sanitize';
+
+describe('sanitizeFormData', () => {
+  it('drops server-managed keys regardless of schema', () => {
+    const out = sanitizeFormData({
+      id: 'r1',
+      _id: 'r1',
+      created_at: 'x',
+      updated_at: 'x',
+      createdAt: 'x',
+      updatedAt: 'x',
+      organization_id: 'o1',
+      organizationId: 'o1',
+      name: 'keep',
+    });
+    // No schema → only server-managed keys are stripped; business keys stay.
+    expect(out).toEqual({ name: 'keep' });
+  });
+
+  it('drops computed / read-only field types when a schema is provided', () => {
+    const schema = {
+      fields: {
+        name: { type: 'text' },
+        budget: { type: 'currency' },
+        // Computed field types — never writable, server rejects them.
+        budget_remaining: { type: 'formula' },
+        task_count: { type: 'summary' },
+        seq: { type: 'autonumber' },
+        // Flagged read-only / computed even though the base type is writable.
+        locked: { type: 'text', readonly: true },
+        derived: { type: 'text', computed: true },
+      },
+    };
+    const out = sanitizeFormData(
+      {
+        name: 'Website',
+        budget: 1000,
+        budget_remaining: 400,
+        task_count: 5,
+        seq: 42,
+        locked: 'no',
+        derived: 'no',
+      },
+      schema,
+    );
+    expect(out).toEqual({ name: 'Website', budget: 1000 });
+  });
+
+  it('drops keys absent from the schema (flattened/projected fields)', () => {
+    const schema = { fields: { name: { type: 'text' } } };
+    const out = sanitizeFormData({ name: 'keep', account__name: 'drop' }, schema);
+    expect(out).toEqual({ name: 'keep' });
+  });
+
+  it('keeps unknown business keys when schema is null (inline forms)', () => {
+    // Inline forms have no fetched object schema; passing null must NOT drop
+    // every key — only the server-managed ones.
+    const out = sanitizeFormData({ id: 'r1', anything: 1, custom: 'ok' }, null);
+    expect(out).toEqual({ anything: 1, custom: 'ok' });
+  });
+
+  it('returns non-object input unchanged', () => {
+    expect(sanitizeFormData(undefined as any)).toBeUndefined();
+    expect(sanitizeFormData(null as any)).toBeNull();
+  });
+});

--- a/packages/plugin-form/src/sanitize.ts
+++ b/packages/plugin-form/src/sanitize.ts
@@ -27,6 +27,7 @@ const SERVER_MANAGED_FIELDS = new Set([
  */
 const COMPUTED_FIELD_TYPES = new Set([
   'formula',
+  'summary',
   'rollup',
   'lookup_value',
   'auto_number',


### PR DESCRIPTION
## Problem

Editing a `showcase_project` record and saving failed with:

> `[ObjectStack] INVALID_FIELD: Unknown field 'budget_remaining' on object 'showcase_project'`

The showcase fixture was **already correct** — `budget_remaining` is a `Field.formula` and is excluded from the form view's sections. The bug was entirely in the console's submit path.

## Root cause

The page-route edit form (`/apps/:app/:object/record/:id/edit` → `RecordFormPage` → `ObjectForm`/`SimpleObjectForm`) seeds react-hook-form `defaultValues` from a full record read (`findOne`), which includes backend-computed columns (`budget_remaining`, and the `task_count`/`total_estimate` summaries). RHF (no `shouldUnregister`, `reset(defaultValues)`) **retains and round-trips unregistered default values on submit** — so computed columns the form never rendered leaked into `dataSource.update()`, and the backend rejected them.

`SimpleObjectForm.handleSubmit` only stripped by field-level **write permission** — unlike `ModalForm`/`DrawerForm` it never called `sanitizeFormData`.

## Changes

**Commit 1 — parent / page-route form (`e83537ee`)**
- `ObjectForm.tsx`: `handleSubmit` now calls `sanitizeFormData(payload, hasInlineFields ? null : objectSchema)` before the write-permission strip (mirrors ModalForm/DrawerForm). Inline forms pass `null` so only server-managed keys are dropped.
- `sanitize.ts`: added `'summary'` to `COMPUTED_FIELD_TYPES` — it was missing, so summary roll-ups (`task_count`/`total_estimate`) would be the *next* rejected field even on the already-sanitizing modal path. Aligns with the ImportWizard filter (`['formula','summary','autonumber']`).

**Commit 2 — master-detail child write path (`6cff60d8`)**
- Extends the same guard to `masterDetailTx.ts` (shared by `MasterDetailForm` **and** `LineItemsPanel`). `buildMasterDetailBatch`/`buildMasterDetailEditBatch`/`applyDetail` sanitize each child op's `data` when an optional `childSchema` is supplied — **gated**, so existing callers/tests are byte-identical. `idOf()` is read before sanitize so update routing survives id-stripping.
- `MasterDetailForm`/`LineItemsPanel` fetch + cache child schemas and pass them through (a `ref` in MasterDetailForm so a late fetch never resets the header form — #1581).
- **Canary preserved:** a *stored* client-computed column (`type: currency` + `expression`, e.g. a line `amount` the server persists as-is) is **not** stripped — sanitize only drops true computed *types* / `readonly` / `computed` / unknown keys. The opportunity/invoice line-item flows are unaffected. No current fixture triggers the child leak (examples use the stored-computed pattern); this half is defensive.

## Testing
- `sanitize.test.ts` (new): strip contract incl. `summary` + inline null-schema.
- `ObjectForm.test.tsx`: edit-mode payload test — **verified to fail without the fix** (`budget_remaining`/`id` leaked), passes with it.
- `masterDetailTx.test.ts`: child create/update sanitize, the `amount`-preservation canary, and a no-schema backward-compat assertion.
- Full `plugin-form` suite: **175 passing**. `vite build` green (`.d.ts` complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)