### PR TITLE
fix(studio): surface spec-validation failures on the field at save/publish

### DIFF
--- a/.changeset/studio-inline-validation-errors.md
+++ b/.changeset/studio-inline-validation-errors.md
@@ -1,0 +1,32 @@
+---
+"@object-ui/data-objectstack": patch
+"@object-ui/app-shell": patch
+---
+
+fix(studio): surface spec-validation failures on the field at save/publish
+
+When a Studio metadata draft failed spec validation, the designer got a single
+opaque banner (and, on a partial publish, a false "published!" toast) — the
+server was already returning field-anchored issues, but the client threw them
+away. Two problems, both fixed:
+
+- **`parseError` (data-objectstack)** read `String(body.error)`, which yields
+  `"[object Object]"` for the dispatcher's object-shaped error, and ignored the
+  validation `issues`. It now reads the message from either shape (string or
+  `{ message }`) and exposes `MetadataError.issues`, accepting all live server
+  shapes — top-level `body.issues` (REST server) and `error.details.issues`
+  (HTTP dispatcher).
+
+- **Studio save/publish (app-shell)** now render those issues **field-anchored**.
+  A new `formatMetadataError` helper turns a caught error into one line per
+  offending field (`• fields.amount.type — Invalid option: …`); the save banners
+  render it with `whitespace-pre-line`. `doPublish` no longer claims success when
+  the response carries `data.failed[]` — it lists which drafts failed and why
+  (the server returns 200 with the failures buried, so the UI used to swallow
+  them). `formatPublishFailures` formats those per-draft.
+
+Verified end-to-end against a live backend: an invalid object draft returns 422
+with field-anchored issues, and the Studio banner shows
+`• fields.amount.type — Invalid option: expected one of "text"|…` instead of a
+generic message. Unit-tested: `parseError` on the dispatcher shape, and the
+`formatMetadataError` / `formatPublishFailures` helpers.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -53,6 +53,7 @@ import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/pr
 import { PermissionMatrixEditPage } from '../metadata-admin/PermissionMatrixEditor';
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
 import { useMetadataClient } from '../metadata-admin/useMetadata';
+import { formatMetadataError, formatPublishFailures, type PublishFailure } from './metadataError';
 import { t, tFormat, useMetadataLocale } from '../metadata-admin/i18n';
 import { AppNavCanvas } from '../metadata-admin/previews/AppNavCanvas';
 import {
@@ -192,7 +193,7 @@ function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string })
       setIdTouched(false);
       navigate(`/studio/${encodeURIComponent(id)}/data`);
     } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e));
+      setErr(formatMetadataError(e));
     } finally {
       setBusy(false);
     }
@@ -377,13 +378,30 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
         headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
         body: '{}',
       });
-      const payload = (await res.json().catch(() => null)) as { success?: boolean; error?: { message?: string } } | null;
-      if (!res.ok || payload?.success === false) throw new Error(payload?.error?.message || `HTTP ${res.status}`);
-      toast.success(t('engine.studio.publishedAll', locale));
-      setChangesOpen(false);
+      const payload = (await res.json().catch(() => null)) as {
+        success?: boolean;
+        error?: { message?: string; details?: { issues?: unknown } };
+        data?: { failed?: PublishFailure[] };
+      } | null;
+      if (!res.ok || payload?.success === false) {
+        // Hard failure (e.g. package not found) — carry the field-anchored issues.
+        throw Object.assign(new Error(payload?.error?.message || `HTTP ${res.status}`), {
+          issues: payload?.error?.details?.issues,
+        });
+      }
+      const failed = payload?.data?.failed ?? [];
+      if (failed.length > 0) {
+        // Partial publish: some drafts did NOT go live. The server returns 200
+        // with them buried in `failed[]`, so the UI used to claim success and
+        // swallow the reason — surface which drafts failed and why instead.
+        toast.error(formatPublishFailures(failed));
+      } else {
+        toast.success(t('engine.studio.publishedAll', locale));
+        setChangesOpen(false);
+      }
       setPublishNonce((n) => n + 1);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(formatMetadataError(e));
     } finally {
       setPublishing(false);
     }
@@ -429,7 +447,7 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
       setAppNameTouched(false);
       setDraftNonce((n) => n + 1);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(formatMetadataError(e));
     } finally {
       setAppBusy(false);
     }
@@ -911,7 +929,7 @@ function InterfacesPillar({
         setCurrent((cur) => cur ?? firstLeaf);
       } catch (e) {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : String(e));
+          setError(formatMetadataError(e));
           setAppStatus('missing');
         }
       }
@@ -952,7 +970,7 @@ function InterfacesPillar({
         setDraft(body ? { ...baseline, ...body } : baseline);
         setHasDraft(!!body);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(formatMetadataError(e));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -974,7 +992,7 @@ function InterfacesPillar({
       setHasDraft(true);
       onDraftSaved?.();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatMetadataError(e));
     } finally {
       setSaving(false);
     }
@@ -1006,7 +1024,7 @@ function InterfacesPillar({
       setNavDirty(false);
       onDraftSaved?.();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatMetadataError(e));
     } finally {
       setNavSaving(false);
     }
@@ -1145,7 +1163,7 @@ function InterfacesPillar({
             )}
           </div>
           {error && (
-            <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive whitespace-pre-line">
               {error}
             </div>
           )}
@@ -1401,7 +1419,7 @@ function DataPillar({
         // the first thing to do here is make an object, so put the inputs up.
         if (items.length === 0) setCreating(true);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(formatMetadataError(e));
       } finally {
         if (!cancelled) setObjectsLoaded(true);
       }
@@ -1440,7 +1458,7 @@ function DataPillar({
         setHasDraft(!!draftBody);
         setHasBaseline(!!(lay.effective ?? lay.code));
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(formatMetadataError(e));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -1500,7 +1518,7 @@ function DataPillar({
       setNameTouched(false);
       onDraftSaved?.();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatMetadataError(e));
     } finally {
       setCreateBusy(false);
     }
@@ -1516,7 +1534,7 @@ function DataPillar({
       setDirty(false);
       onDraftSaved?.();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatMetadataError(e));
     } finally {
       setSaving(false);
     }
@@ -1548,7 +1566,7 @@ function DataPillar({
         onDraftSaved?.();
         setGridVer((v) => v + 1); // remount so the grid reflects the new (draft) order
       } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
+        setError(formatMetadataError(e));
       } finally {
         setSaving(false);
       }
@@ -1768,7 +1786,7 @@ function DataPillar({
                 )}
               </div>
               {error && (
-                <div className="mb-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-1.5 text-[11px] text-destructive">
+                <div className="mb-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-1.5 text-[11px] text-destructive whitespace-pre-line">
                   {error}
                 </div>
               )}
@@ -2049,7 +2067,7 @@ function AutomationsPillar({
         setFlows(items);
         setCurrent((c) => c ?? items[0] ?? null);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(formatMetadataError(e));
       } finally {
         if (!cancelled) setListed(true);
       }
@@ -2089,7 +2107,7 @@ function AutomationsPillar({
       onDraftSaved?.();
       toast.success(tFormat('engine.studio.auto.savedDraft', locale, { label }));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatMetadataError(e));
     } finally {
       setCreateBusy(false);
     }
@@ -2114,7 +2132,7 @@ function AutomationsPillar({
         setDraft(draftBody ? { ...baseline, ...draftBody } : baseline);
         setHasDraft(!!draftBody);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(formatMetadataError(e));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -2137,7 +2155,7 @@ function AutomationsPillar({
       setHasDraft(true);
       onDraftSaved?.();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatMetadataError(e));
     } finally {
       setSaving(false);
     }
@@ -2247,7 +2265,7 @@ function AutomationsPillar({
             {current && <span className="text-[11px] text-muted-foreground">flow · {current.name}</span>}
           </div>
           {error && (
-            <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive whitespace-pre-line">
               {error}
             </div>
           )}
@@ -2402,7 +2420,7 @@ function AccessPillar({
       setPerms(scoped);
       setCurrent((c) => c ?? scoped[0]?.name ?? null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(formatMetadataError(e));
     } finally {
       setLoaded(true);
     }
@@ -2432,7 +2450,7 @@ function AccessPillar({
       await load();
       setCurrent(name);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(formatMetadataError(e));
     } finally {
       setBusy(false);
     }

--- a/packages/app-shell/src/views/studio-design/metadataError.test.ts
+++ b/packages/app-shell/src/views/studio-design/metadataError.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { extractIssues, formatMetadataError, formatPublishFailures } from './metadataError';
+
+describe('formatMetadataError', () => {
+  it('lists field-anchored issues, one per line, when the error carries them', () => {
+    const err = Object.assign(new Error('[invalid_metadata] object/bad failed spec validation: ...'), {
+      issues: [
+        { path: 'fields.amount.type', message: 'Required' },
+        { path: 'label', message: 'Required' },
+      ],
+    });
+    expect(formatMetadataError(err)).toBe(
+      '• fields.amount.type — Required\n• label — Required',
+    );
+  });
+
+  it('labels a root-level issue (empty path) as (root)', () => {
+    const err = Object.assign(new Error('bad'), { issues: [{ path: '', message: 'Must have a name' }] });
+    expect(formatMetadataError(err)).toBe('• (root) — Must have a name');
+  });
+
+  it('falls back to the plain message when there are no issues', () => {
+    expect(formatMetadataError(new Error('Save failed: network'))).toBe('Save failed: network');
+  });
+
+  it('stringifies a non-Error throw', () => {
+    expect(formatMetadataError('boom')).toBe('boom');
+  });
+});
+
+describe('extractIssues', () => {
+  it('returns the issues array, or empty for none / non-arrays', () => {
+    expect(extractIssues({ issues: [{ path: 'a', message: 'b' }] })).toHaveLength(1);
+    expect(extractIssues(new Error('x'))).toEqual([]);
+    expect(extractIssues({ issues: 'nope' })).toEqual([]);
+    expect(extractIssues(null)).toEqual([]);
+  });
+});
+
+describe('formatPublishFailures', () => {
+  it('heads each failed draft and indents its field-anchored issues', () => {
+    const out = formatPublishFailures([
+      {
+        type: 'object',
+        name: 'invoice',
+        error: 'failed spec validation',
+        issues: [{ path: 'fields.total.type', message: 'Required' }],
+      },
+      { type: 'flow', name: 'notify', error: 'start node missing' },
+    ]);
+    expect(out).toBe(
+      'object/invoice: failed spec validation\n  • fields.total.type — Required\n' +
+        'flow/notify: start node missing',
+    );
+  });
+});

--- a/packages/app-shell/src/views/studio-design/metadataError.ts
+++ b/packages/app-shell/src/views/studio-design/metadataError.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Turn a metadata save/publish failure into a FIELD-ANCHORED message. The
+// framework validates a draft against its spec and returns structured issues
+// (`error.details.issues: [{ path, message }]`, surfaced on `MetadataError.issues`
+// by the client); a publish carries per-draft failures in `data.failed[]`. These
+// helpers render "which field, and why" instead of a single opaque banner line —
+// the point of surfacing validation at the save/publish moment.
+
+import type { MetadataValidationIssue } from '@object-ui/data-objectstack';
+
+/** Pull structured validation issues off a caught error (empty if none). */
+export function extractIssues(e: unknown): MetadataValidationIssue[] {
+  const issues = (e as { issues?: unknown } | null | undefined)?.issues;
+  return Array.isArray(issues) ? (issues as MetadataValidationIssue[]) : [];
+}
+
+/** One issue → a single field-anchored line: `• fields.amount.type — Required`. */
+function issueLine(i: MetadataValidationIssue): string {
+  return `• ${i.path && i.path.length > 0 ? i.path : '(root)'} — ${i.message}`;
+}
+
+/**
+ * Format a caught save/publish error for a banner/toast. When the error carries
+ * spec-validation issues, list them (one field per line) so the user sees the
+ * offending fields; otherwise fall back to the plain message. Rendered with
+ * `whitespace-pre-line` so the lines show as a list.
+ */
+export function formatMetadataError(e: unknown): string {
+  const issues = extractIssues(e);
+  if (issues.length > 0) return issues.map(issueLine).join('\n');
+  const err = e as { message?: string } | null | undefined;
+  return err?.message ?? String(e);
+}
+
+/** A single failed draft from a publish response's `data.failed[]`. */
+export interface PublishFailure {
+  type: string;
+  name: string;
+  error: string;
+  issues?: MetadataValidationIssue[];
+}
+
+/**
+ * Format the `failed[]` from a partial publish (the server returns 200 with the
+ * drafts that DIDN'T go live). Each failed draft gets a heading and, when the
+ * failure was a validation error, its field-anchored issues indented below.
+ */
+export function formatPublishFailures(failed: PublishFailure[]): string {
+  return failed
+    .map((f) => {
+      const head = `${f.type}/${f.name}: ${f.error}`;
+      const issues = Array.isArray(f.issues) ? f.issues : [];
+      return [head, ...issues.map((i) => `  ${issueLine(i)}`)].join('\n');
+    })
+    .join('\n');
+}

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -2636,6 +2636,7 @@ export type {
   MetadataDeleteOptions,
   MetadataHistoryOptions,
   MetadataError,
+  MetadataValidationIssue,
   MetadataLayered,
   MetadataReference,
   MetadataDiagnostics,

--- a/packages/data-objectstack/src/metadata-client.test.ts
+++ b/packages/data-objectstack/src/metadata-client.test.ts
@@ -122,6 +122,36 @@ describe('MetadataClient', () => {
     });
   });
 
+  it('extracts message, code + field-anchored issues from the dispatcher error shape', async () => {
+    // The dispatcher sends `error` as an OBJECT { message, code, details:{ code, issues } }.
+    // Reading `.message` (not String(object) → "[object Object]") and surfacing
+    // `details.issues` is what lets the Studio point at the offending field.
+    const c = new MetadataClient({
+      baseUrl: 'http://localhost:3000',
+      fetch: mockFetch(async () =>
+        new Response(
+          JSON.stringify({
+            success: false,
+            error: {
+              message: '[invalid_metadata] object/bad failed spec validation: label: Required',
+              code: 422,
+              details: {
+                code: 'invalid_metadata',
+                issues: [{ path: 'label', message: 'Required', code: 'invalid_type' }],
+              },
+            },
+          }),
+          { status: 422, headers: { 'content-type': 'application/json' } },
+        )),
+    });
+    await expect(c.save('object', 'bad', {})).rejects.toMatchObject({
+      status: 422,
+      code: 'invalid_metadata',
+      message: '[invalid_metadata] object/bad failed spec validation: label: Required',
+      issues: [{ path: 'label', message: 'Required', code: 'invalid_type' }],
+    });
+  });
+
   it('listDrafts requests /meta/_drafts with packageId + type and parses {drafts}', async () => {
     const seen: string[] = [];
     const c = new MetadataClient({

--- a/packages/data-objectstack/src/metadata-client.ts
+++ b/packages/data-objectstack/src/metadata-client.ts
@@ -278,10 +278,20 @@ export interface MetadataHistoryOptions {
   limit?: number;
 }
 
+/** A single field-anchored spec-validation issue (server `error.details.issues`). */
+export interface MetadataValidationIssue {
+  /** Dot-path to the offending field, e.g. `fields.amount.type` (`''` = root). */
+  path: string;
+  message: string;
+  code?: string;
+}
+
 export interface MetadataError extends Error {
   status: number;
   code?: string;
   body?: unknown;
+  /** Structured spec-validation issues, when the failure was a validation error. */
+  issues?: MetadataValidationIssue[];
 }
 
 const META_PREFIX = '/meta';
@@ -310,16 +320,36 @@ async function parseError(res: Response): Promise<MetadataError> {
   } catch {
     body = await res.text().catch(() => undefined);
   }
+  const bodyObj = body && typeof body === 'object' ? (body as Record<string, any>) : undefined;
+  // The dispatcher error shape is `{ success:false, error:{ message, code,
+  // details:{ code, issues } } }` — `error` is an OBJECT. Older/other surfaces
+  // send `error` as a plain string or a top-level `message`. Accept all three
+  // (reading `.message` off the object case, not `String(object)` which yields
+  // "[object Object]").
+  const errNode = bodyObj?.error;
   const message =
-    (body && typeof body === 'object' && 'error' in (body as Record<string, unknown>)
-      ? String((body as Record<string, unknown>).error)
-      : undefined) ?? `Metadata request failed: ${res.status} ${res.statusText}`;
-  const err = new Error(message) as MetadataError;
+    (errNode && typeof errNode === 'object' ? errNode.message : errNode) ??
+    bodyObj?.message ??
+    `Metadata request failed: ${res.status} ${res.statusText}`;
+  const err = new Error(String(message)) as MetadataError;
   err.status = res.status;
   err.body = body;
-  if (body && typeof body === 'object' && 'code' in (body as Record<string, unknown>)) {
-    err.code = String((body as Record<string, unknown>).code);
-  }
+  // Field-anchored spec-validation issues. Two live server shapes carry them:
+  // the REST server puts them at top-level `body.issues` (with `error` a string),
+  // the HTTP dispatcher nests them under `error.details.issues` (with `error` an
+  // object). Accept both (plus a defensive `error.issues`) so the caller can
+  // point at the offending field regardless of which transport served the error.
+  const details = errNode && typeof errNode === 'object' ? errNode.details : undefined;
+  const issues =
+    details?.issues ??
+    (errNode && typeof errNode === 'object' ? errNode.issues : undefined) ??
+    bodyObj?.issues;
+  if (Array.isArray(issues)) err.issues = issues as MetadataValidationIssue[];
+  const code =
+    details?.code ??
+    (errNode && typeof errNode === 'object' ? errNode.code : undefined) ??
+    bodyObj?.code;
+  if (code != null) err.code = String(code);
   return err;
 }
 


### PR DESCRIPTION
## Why (UX eval #4 — validation up-front + inline errors)

When a Studio metadata draft failed spec validation, the designer got a single **opaque banner** — and on a *partial* publish, a false **"published!"** toast. The server was already computing field-anchored issues (and, on the REST path, already returning them as `body.issues`), but the client threw them away. This is the #1 "silent failure" UX theme: you save, something's wrong, and the UI won't tell you *which field* or *why*.

Companion to framework #2589 (which carries `issues` through the HTTP-dispatcher error path); this PR is the client half and also handles the REST server's existing `body.issues` shape.

## What

**`parseError` (`data-objectstack`)**
- Read `String(body.error)` → `"[object Object]"` for the dispatcher's object-shaped error. Now reads `.message` from either shape (string *or* `{ message }`).
- Ignored the validation issues. Now exposes `MetadataError.issues`, accepting **all live server shapes**: top-level `body.issues` (REST server) and `error.details.issues` (HTTP dispatcher).

**Studio save/publish (`app-shell`)**
- New `formatMetadataError(e)` turns a caught error into **one line per offending field** — `• fields.amount.type — Invalid option: …`; the three pillar save banners render it with `whitespace-pre-line`.
- `doPublish` no longer claims success when the response carries `data.failed[]` (the server returns **200** with the failures buried, so the UI used to swallow them). It lists which drafts failed and why; `formatPublishFailures` formats those per-draft.

## Verification

**Unit** — `parseError` on the dispatcher error shape (message + code + `issues`, no more `[object Object]`); `formatMetadataError` (issues → field lines, empty path → `(root)`, no issues → plain message) and `formatPublishFailures`. `@object-ui/data-objectstack` (20) + studio-design (11) suites green; app-shell type-check clean (29/29).

**Live browser** — console proxied to a real backend. An invalid object draft (`{ fields: { amount: { type: 'not_a_type' } } }`) returns **422**, the client extracts the issues from the real response, and the banner text resolves to:

```
• fields.amount.type — Invalid option: expected one of "text"|"textarea"|… |"user"
```

— pointing at the exact field, where the old code showed a generic line (or `[object Object]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)