### PR TITLE
fix(components): page:header record title honours nameField via unified ADR-0079 resolver

### DIFF
--- a/.changeset/page-header-namefield.md
+++ b/.changeset/page-header-namefield.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/components": patch
+"@object-ui/app-shell": patch
+"@object-ui/plugin-detail": patch
+---
+
+fix(components): page:header record title honours `nameField` via the unified ADR-0079 resolver
+
+The default console record detail page renders the synthesized `page:header`
+(`buildDefaultPageSchema`, renderViaSchema default-on), whose record-chip title
+chain probed `objSchema.primaryField` (not a spec property — always undefined),
+`titleFormat`, then hardcoded `name`/`full_name`/`title`/`subject`/
+`display_name`/`label` record keys. It never consulted the object's declared
+`nameField`/`displayNameField`, so an object titled by e.g. `subject` rendered
+`<ObjectLabel> <id-prefix>` as its H1 instead of the record's real name.
+
+`PageHeaderRenderer` now resolves through `getRecordDisplayName(objSchema, data,
+{ deriveFromRecordKeys: false })` after the author overrides and before the
+legacy probes — mirroring `DetailView.resolveDisplayTitle` so both headers
+agree. `RecordDetailView`'s `primaryField` derivation and
+`buildDefaultPageSchema`'s highlight-strip dedup also honour
+`nameField`/`displayNameField`.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1233,8 +1233,13 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       return { type: 'detail-view' } as DetailViewSchema;
     }
 
-    // Auto-detect primary field: prefer objectDef metadata, then 'name' or 'title' heuristic
+    // Auto-detect primary field: prefer objectDef metadata — `primaryField`
+    // (objectui-local override), then the spec-canonical `nameField` and its
+    // deprecated `displayNameField` alias (ADR-0079) — then the 'name'/'title'
+    // heuristic.
     const primaryField = objectDef.primaryField
+      || (objectDef as any).nameField
+      || (objectDef as any).displayNameField
       || Object.keys(objectDef.fields || {}).find(
         (key) => key === 'name' || key === 'title'
       );

--- a/packages/components/src/__tests__/page-header-title.test.tsx
+++ b/packages/components/src/__tests__/page-header-title.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for PageHeaderRenderer record-chip title resolution.
+ *
+ * The default console record page renders `page:header` (synthesized by
+ * `buildDefaultPageSchema`), so this renderer IS the record detail H1.
+ * It must honour the object's declared `nameField` / `displayNameField`
+ * via the unified ADR-0079 resolver — an object whose title lives in e.g.
+ * `subject` must not fall back to `${objectLabel} ${id}`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider, RecordContextProvider } from '@object-ui/react';
+
+function PageHeader({ schema }: { schema: any }) {
+  const Component = ComponentRegistry.get('page:header');
+  if (!Component) throw new Error('page:header not registered');
+  return <Component schema={schema} />;
+}
+
+function renderHeader(opts: { record: any; objectSchema: any; schema?: any }) {
+  return render(
+    <ActionProvider>
+      <RecordContextProvider
+        objectName={opts.objectSchema?.name ?? 'task'}
+        recordId={opts.record?.id ?? null}
+        data={opts.record}
+        objectSchema={opts.objectSchema}
+      >
+        <PageHeader schema={opts.schema ?? { type: 'page:header' }} />
+      </RecordContextProvider>
+    </ActionProvider>
+  );
+}
+
+describe('PageHeaderRenderer — record title resolution', () => {
+  it('resolves the declared nameField (no literal name/title field)', () => {
+    renderHeader({
+      objectSchema: {
+        name: 'task',
+        label: 'Task',
+        nameField: 'subject',
+        fields: { subject: { type: 'text', label: 'Subject' } },
+      },
+      record: { id: 'rec-12345678', subject: 'Fix the widget' },
+    });
+    expect(screen.getByText('Fix the widget')).toBeTruthy();
+  });
+
+  it('nameField wins over a record-level `name` value', () => {
+    renderHeader({
+      objectSchema: {
+        name: 'contract',
+        label: 'Contract',
+        nameField: 'contract_no',
+        fields: {
+          name: { type: 'text', label: 'Name' },
+          contract_no: { type: 'text', label: 'Contract No' },
+        },
+      },
+      record: { id: 'rec-1', name: 'internal-name', contract_no: 'HT-2026-001' },
+    });
+    expect(screen.getByText('HT-2026-001')).toBeTruthy();
+  });
+
+  it('honours the deprecated displayNameField alias', () => {
+    renderHeader({
+      objectSchema: {
+        name: 'activity',
+        label: 'Activity',
+        displayNameField: 'activity_name',
+        fields: { activity_name: { type: 'text', label: 'Activity Name' } },
+      },
+      record: { id: 'rec-2', activity_name: 'Kickoff call' },
+    });
+    expect(screen.getByText('Kickoff call')).toBeTruthy();
+  });
+
+  it('titleFormat still outranks nameField (legacy header behaviour)', () => {
+    renderHeader({
+      objectSchema: {
+        name: 'contact',
+        label: 'Contact',
+        nameField: 'nickname',
+        titleFormat: '{first_name} {last_name}',
+        fields: {
+          nickname: { type: 'text' },
+          first_name: { type: 'text' },
+          last_name: { type: 'text' },
+        },
+      },
+      record: { id: 'rec-3', nickname: 'Ada', first_name: 'Ada', last_name: 'Lovelace' },
+    });
+    expect(screen.getByText('Ada Lovelace')).toBeTruthy();
+  });
+
+  it('falls back to `${objectLabel} ${id}` when the record is truly unnamed', () => {
+    renderHeader({
+      objectSchema: {
+        name: 'audit_log',
+        label: 'Audit Log',
+        fields: { acted_at: { type: 'datetime' } },
+      },
+      record: { id: 'abcdefgh-rest-of-id', acted_at: '2026-07-04' },
+    });
+    expect(screen.getByText(/Audit Log abcdefgh/)).toBeTruthy();
+  });
+});

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { ComponentRegistry, ExpressionEvaluator } from '@object-ui/core';
+import { ComponentRegistry, ExpressionEvaluator, getRecordDisplayName } from '@object-ui/core';
 import { useRecordContext, useAction, usePredicateScope } from '@object-ui/react';
 import { renderChildren, cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
@@ -942,6 +942,9 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   //   2. Author hasn't opted out via `recordChrome: false`.
   // When both pass, we resolve the chip title from (in order):
   //   - explicit `schema.title` (interpolated against data),
+  //   - `objectSchema.primaryField` / `titleFormat` (author overrides),
+  //   - the unified ADR-0079 resolver (`nameField` → `displayNameField` →
+  //     type-aware derivation) — same precedence as DetailView's own header,
   //   - common display fields on the record (`name`, `title`, `display_name`),
   //   - `${objectLabel} ${id}` as a last-resort.
   const hasRecord = !!(ctx?.data && (ctx as any)?.objectSchema);
@@ -967,10 +970,25 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     const interpolatedTitleFormat = titleFormatStr
       ? cleanupTitleSeparators(interpolate(titleFormatStr, data, objSchema, fieldOptionLabel, rawObjectName).trim())
       : '';
+    // Unified resolver (ADR-0079): honours the object's declared
+    // `nameField`/`displayNameField` and falls back to type-aware field
+    // derivation. `deriveFromRecordKeys: false` keeps bare record-key
+    // guesses from outranking the legacy probes below; the resolver's
+    // `Record #<id>` floor is detected and skipped so the richer
+    // `${objectLabel} ${id}` fallback still wins for truly unnamed records.
+    const recordId = data?.id ?? data?._id;
+    const unifiedTitle = (() => {
+      const resolved = getRecordDisplayName(objSchema, data, { deriveFromRecordKeys: false });
+      const isFloor =
+        resolved === 'Untitled' ||
+        (recordId !== null && recordId !== undefined && resolved === `Record #${recordId}`);
+      return isFloor ? '' : resolved;
+    })();
     const resolvedTitle =
       explicitTitle ||
       (primaryField && data?.[primaryField]) ||
       (interpolatedTitleFormat && !interpolatedTitleFormat.includes('{') ? interpolatedTitleFormat : '') ||
+      unifiedTitle ||
       data?.name ||
       data?.full_name ||
       data?.title ||

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -290,8 +290,11 @@ export function deriveHighlightFields(
   // The record's display/primary field is already shown as the page H1 —
   // surfacing it again in the highlight strip duplicates content and
   // wastes a slot (e.g. Task pages would show 主题 twice). Skip the
-  // common candidates and whatever the def declares as `primaryField`.
+  // common candidates and whatever the def declares as `primaryField`,
+  // `nameField`, or the deprecated `displayNameField` alias (ADR-0079).
   if (def.primaryField) skip.add(def.primaryField);
+  if ((def as any).nameField) skip.add((def as any).nameField);
+  if ((def as any).displayNameField) skip.add((def as any).displayNameField);
   for (const candidate of ['name', 'full_name', 'title', 'subject', 'display_name']) {
     if (candidate in (def.fields || {})) skip.add(candidate);
   }


### PR DESCRIPTION
Fixes #2232

## Problem

The console default record detail page renders the synthesized `page:header` (`buildDefaultPageSchema`, renderViaSchema default-on). Its record-chip title chain was:

`explicitTitle → objSchema.primaryField → titleFormat → data.name/full_name/title/subject/display_name/label → objectLabel+id`

`primaryField` is not a spec ObjectSchema property (the canonical pointer is `nameField`, ADR-0079/0085), so it is always undefined for stack-defined objects — and the chain never consulted `nameField`/`displayNameField` nor the unified resolver. An object declaring `nameField: 'subject'` (no literal `name`/`title` field, no `titleFormat`) rendered its H1 as `<ObjectLabel> <id-prefix>`; with a `name` field present, `name` always outranked the declared field. Meanwhile the framework serves `nameField` correctly and `@object-ui/core#getRecordDisplayName` already treats it as top priority — the header just never called it. (Record-page-header sibling of objectstack-ai/framework#1295.)

## Fix

- **`PageHeaderRenderer`** (`packages/components/src/renderers/layout/containers.tsx`): resolve through `getRecordDisplayName(objSchema, data, { deriveFromRecordKeys: false })` after the author overrides (`primaryField`/`titleFormat`) and before the legacy record-key probes, detecting & skipping the resolver's `Record #<id>` floor — mirroring `DetailView.resolveDisplayTitle` so the two headers agree.
- **`RecordDetailView`** (`packages/app-shell`): `primaryField` derivation now prefers `nameField`/`displayNameField` over the literal `'name'`/`'title'` field probe.
- **`buildDefaultPageSchema`** (`packages/plugin-detail`): highlight-strip dedup also skips the `nameField`/`displayNameField` field so the H1 value isn't duplicated in the highlight strip.

## Tests

- New `packages/components/src/__tests__/page-header-title.test.tsx`: nameField resolution (no name-ish field), nameField winning over a record-level `name` value, deprecated `displayNameField` alias, `titleFormat` back-compat precedence, and the `${objectLabel} ${id}` fallback for truly unnamed records — 5 passed.
- `plugin-detail` full suite: 152 passed. `components` full suite: 5182 passed, 1 pre-existing TZ-sensitive failure in `packages/core` `FormulaFunctions` DATEFORMAT (unrelated — this PR doesn't touch core).
- `type-check` clean for `components`, `app-shell`, `plugin-detail`.