### PR TITLE
docs(guide): document related-list 'primary' tab default in slotted-pages (framework #2579)

### DIFF
--- a/content/docs/guide/slotted-pages.md
+++ b/content/docs/guide/slotted-pages.md
@@ -66,8 +66,13 @@ export const AccountDetailPage: Page = {
 ```
 
 Result: the account record page renders with your custom header, and
-the synthesizer fills in the highlights, tabs (Details / Related /
-History), and discussion regions as if you'd authored nothing else.
+the synthesizer fills in the highlights, tabs, and discussion regions as
+if you'd authored nothing else. The default tab strip is **Details** → one
+tab per related list flagged `relatedList: 'primary'` on its relationship → a
+shared **Related** tab for the rest → **History**; so promoting a child table to
+its own tab is a one-word change on the relationship, not a page-authoring task.
+`relatedLayout: 'tabs' | 'stack'` remains an app-level override (force
+all-own-tabs / all-stacked).
 
 ## Composing default + custom
 


### PR DESCRIPTION
## What

Doc follow-up to #2235 (framework issue objectstack-ai/framework#2579) — documents the new default related-list tab layout in the slotted-pages guide.

- **`content/docs/guide/slotted-pages.md`** — the synthesized detail page's default tab strip is now **Details → one tab per `relatedList: 'primary'` child → a shared "Related" tab for the rest → History** (the guide previously listed only "Details / Related / History"). Clarifies that promoting a child table to its own tab is a one-word change on the relationship (no custom page needed), and that `relatedLayout: 'tabs' | 'stack'` is an app-level override.

Refs objectstack-ai/framework#2579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
