### PR TITLE
feat(app-shell): app → Studio reverse bridge in the top bar (ADR-0080)

### DIFF
--- a/.changeset/app-studio-reverse-bridge.md
+++ b/.changeset/app-studio-reverse-bridge.md
@@ -1,0 +1,6 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/i18n': minor
+---
+
+Add the app → Studio reverse bridge (ADR-0080): workspace admins see a "Design in Studio" entry in the app top bar that deep-links to the running app's owning package on the Studio design surface (`/studio/:packageId/data`). Hidden for non-admins and for apps with no owning package; package writability stays server-side (read-only packages open as browse-only).

--- a/content/docs/guide/console.md
+++ b/content/docs/guide/console.md
@@ -29,6 +29,7 @@ The console opens at **http://localhost:5175** with MSW (Mock Service Worker) pr
 | **Branding** | Per-app colors, favicons, and logos via `AppShell` branding. |
 | **Command Palette** | `⌘+K` opens a searchable command bar for quick navigation. |
 | **Studio Package Scope** | Studio home, metadata counts, quick-create links, and diagnostics follow the selected package. |
+| **Design in Studio** | Workspace admins get a top-bar entry inside a running app that opens its owning package on the Studio design surface (`/studio/:packageId/data`). |
 | **App Creation Wizard** | 4-step wizard (Basic Info → Objects → Navigation → Branding) to create or edit apps. |
 | **Error Boundary** | Graceful error handling with a retry button. |
 

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -152,6 +152,15 @@ for each metadata type. Every type has a pure-renderer **preview** that doubles
 as its **designer** when given `editing` + `onPatch` props — no backend round
 trip is required to edit a draft.
 
+### App → Studio reverse bridge
+
+Inside a running app, workspace admins get a "Design in Studio" entry in the
+top bar (`AppHeader`) that deep-links to the app's owning package on the Studio
+design surface (`/studio/:packageId/data`). It is the reverse of the builder's
+"Open app" bridge (ADR-0080): the entry only renders for admins and only when
+the app has an owning package (`_packageId`), and package writability stays a
+server-side concern — a read-only package opens in Studio as browse-only.
+
 ### Studio package scope
 
 Studio treats the selected package as the authoring scope. The package selector

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -47,6 +47,7 @@ import {
   BookOpen,
   ExternalLink,
   Keyboard,
+  Hammer,
 } from 'lucide-react';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -63,9 +64,9 @@ import type { ConnectionState } from '@object-ui/data-objectstack';
 import { useAdapter } from '../providers/AdapterProvider';
 import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import type { BreadcrumbItem as BreadcrumbItemType } from '@object-ui/types';
-import { useAuth, getUserInitials } from '@object-ui/auth';
+import { useAuth, getUserInitials, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useMetadata } from '../providers/MetadataProvider';
-import { resolveI18nLabel, preferLocal, matchAppBySegment, appRouteSegment } from '../utils';
+import { resolveI18nLabel, preferLocal, matchAppBySegment, appRouteSegment, appStudioDesignPath } from '../utils';
 import { getIcon } from '../utils/getIcon';
 import { useMobileViewSwitcher } from './MobileViewSwitcherContext';
 import { useNavigationContext } from '../context/NavigationContext';
@@ -143,6 +144,9 @@ export function AppHeader({
   // no AI (Community Edition) so it can't dead-end on a chat with no agent.
   // Same signal as the FAB and the `/ai` route guard.
   const { enabled: aiEnabled } = useAiSurfaceEnabled();
+  // Design entry points mutate shared package metadata, so the app → Studio
+  // bridge below is admin-only (mirrors the runtime view/page editors).
+  const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const { t } = useObjectTranslation();
   const { objectLabel, dashboardLabel, pageLabel, reportLabel, viewLabel, appLabel } = useObjectLabel();
   const { apps: metadataApps, dashboards: metadataDashboards, pages: metadataPages, reports: metadataReports } = useMetadata();
@@ -551,6 +555,11 @@ export function AppHeader({
     ? (helpDocs ?? []).filter((d) => d._packageId === currentAppPackageId)
     : [];
 
+  // App → Studio reverse bridge (ADR-0080): admins jump from the running app
+  // to its owning package's design surface. Null when there is nothing to
+  // open (non-admin, or no owning package).
+  const studioDesignPath = isApp ? appStudioDesignPath(currentApp, isWorkspaceAdmin) : null;
+
   const objectSiblings = appObjects.map((o: any) => ({
     label: objectLabel(o),
     href: `${baseHref}/${o.name}`,
@@ -848,6 +857,26 @@ export function AppHeader({
             onMarkAllRead={markAllRead}
             onMarkRead={markNotificationRead}
           />
+
+          {/* Design in Studio — the app → builder reverse bridge (ADR-0080).
+              Admins jump from the running app to its owning package's design
+              surface (/studio/:packageId/data); hidden for everyone else and
+              for apps with no owning package. */}
+          {studioDesignPath && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              asChild
+              data-testid="app-design-in-studio-button"
+              aria-label={t('topbar.designInStudio', { defaultValue: 'Design in Studio' })}
+              title={t('topbar.designInStudio', { defaultValue: 'Design in Studio' })}
+            >
+              <Link to={studioDesignPath}>
+                <Hammer className="h-4 w-4" />
+              </Link>
+            </Button>
+          )}
 
           {/* AI Assistant — only when the runtime serves AI (hidden on
               Community Edition so it can't dead-end on an agent-less chat). */}

--- a/packages/app-shell/src/utils/__tests__/appRoute.test.ts
+++ b/packages/app-shell/src/utils/__tests__/appRoute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { appRouteSegment, matchAppBySegment } from '../appRoute';
+import { appRouteSegment, matchAppBySegment, appStudioDesignPath } from '../appRoute';
 
 /**
  * ADR-0048 (option A) — package-id route segment.
@@ -36,5 +36,32 @@ describe('matchAppBySegment', () => {
   it('returns undefined for missing inputs', () => {
     expect(matchAppBySegment(apps, undefined)).toBeUndefined();
     expect(matchAppBySegment(null, 'com.acme.crm')).toBeUndefined();
+  });
+});
+
+/**
+ * ADR-0080 — app → Studio reverse bridge.
+ */
+describe('appStudioDesignPath', () => {
+  const crm = { name: 'crm', _packageId: 'com.acme.crm' };
+
+  it('resolves an admin viewing a packaged app to its design surface', () => {
+    expect(appStudioDesignPath(crm, true)).toBe('/studio/com.acme.crm/data');
+  });
+  it('URL-encodes the package id', () => {
+    expect(appStudioDesignPath({ _packageId: 'com.acme/crm' }, true)).toBe(
+      '/studio/com.acme%2Fcrm/data',
+    );
+  });
+  it('returns null for non-admins', () => {
+    expect(appStudioDesignPath(crm, false)).toBeNull();
+  });
+  it('returns null for apps with no owning package (runtime/DB apps)', () => {
+    expect(appStudioDesignPath({ name: 'crm' }, true)).toBeNull();
+    expect(appStudioDesignPath(undefined, true)).toBeNull();
+    expect(appStudioDesignPath(null, true)).toBeNull();
+  });
+  it('returns null for the DB-authored sys_metadata pseudo-package', () => {
+    expect(appStudioDesignPath({ name: 'crm', _packageId: 'sys_metadata' }, true)).toBeNull();
   });
 });

--- a/packages/app-shell/src/utils/appRoute.ts
+++ b/packages/app-shell/src/utils/appRoute.ts
@@ -28,3 +28,27 @@ export function matchAppBySegment<T extends AppLike>(
   if (!apps || seg == null) return undefined;
   return apps.find((a) => a?._packageId === seg) ?? apps.find((a) => a?.name === seg);
 }
+
+/**
+ * App → Studio reverse bridge (ADR-0080). Resolves a running app to its owning
+ * package's design surface (`/studio/:packageId/data`), or `null` when there is
+ * nothing to open:
+ * - the viewer is not a workspace admin (designing mutates shared package
+ *   metadata, so the entry point is admin-only — mirrors the runtime editors);
+ * - the app has no owning package (runtime/DB apps), or its container is the
+ *   DB-authored `sys_metadata` pseudo-package, which is not a package the
+ *   Studio design surface can open.
+ *
+ * Writability of the target package is NOT checked here — the ADR-0070 D4 gate
+ * stays the server-side authority, and the Studio surface itself renders
+ * read-only packages as browse-only.
+ */
+export function appStudioDesignPath(
+  app: AppLike | null | undefined,
+  isWorkspaceAdmin: boolean,
+): string | null {
+  if (!isWorkspaceAdmin) return null;
+  const packageId = app?._packageId;
+  if (typeof packageId !== 'string' || !packageId || packageId === 'sys_metadata') return null;
+  return `/studio/${encodeURIComponent(packageId)}/data`;
+}

--- a/packages/app-shell/src/utils/index.ts
+++ b/packages/app-shell/src/utils/index.ts
@@ -32,7 +32,7 @@ export { deriveRelatedLists } from './deriveRelatedLists';
 export type { DerivedRelatedList } from './deriveRelatedLists';
 
 export { preferLocal } from './preferLocal';
-export { appRouteSegment, matchAppBySegment } from './appRoute';
+export { appRouteSegment, matchAppBySegment, appStudioDesignPath } from './appRoute';
 
 /**
  * Resolves an I18nLabel to a plain string.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1263,6 +1263,7 @@ const ar = {
   },
   topbar: {
     aiAssistant: "مساعد الذكاء الاصطناعي",
+    designInStudio: "التصميم في Studio",
   },
   home: {
     title: "الرئيسية",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1263,6 +1263,7 @@ const de = {
   },
   topbar: {
     aiAssistant: "KI-Assistent",
+    designInStudio: "Im Studio gestalten",
   },
   home: {
     title: "Startseite",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1672,6 +1672,7 @@ const en = {
   },
   topbar: {
     aiAssistant: 'AI Assistant',
+    designInStudio: 'Design in Studio',
     openAssistant: 'Open {{name}} assistant',
     offline: 'Offline',
     usersOnline: 'Users currently online',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1263,6 +1263,7 @@ const es = {
   },
   topbar: {
     aiAssistant: "Asistente de IA",
+    designInStudio: "Diseñar en Studio",
   },
   home: {
     title: "Inicio",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1263,6 +1263,7 @@ const fr = {
   },
   topbar: {
     aiAssistant: "Assistant IA",
+    designInStudio: "Concevoir dans Studio",
   },
   home: {
     title: "Accueil",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1263,6 +1263,7 @@ const ja = {
   },
   topbar: {
     aiAssistant: "AI アシスタント",
+    designInStudio: "Studio でデザイン",
   },
   home: {
     title: "ホーム",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1263,6 +1263,7 @@ const ko = {
   },
   topbar: {
     aiAssistant: "AI 어시스턴트",
+    designInStudio: "Studio에서 디자인",
   },
   home: {
     title: "홈",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1263,6 +1263,7 @@ const pt = {
   },
   topbar: {
     aiAssistant: "Assistente de IA",
+    designInStudio: "Projetar no Studio",
   },
   home: {
     title: "Início",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1263,6 +1263,7 @@ const ru = {
   },
   topbar: {
     aiAssistant: "ИИ-ассистент",
+    designInStudio: "Дизайн в Studio",
   },
   home: {
     title: "Главная",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1757,6 +1757,7 @@ const zh = {
   },
   topbar: {
     aiAssistant: 'AI 助手',
+    designInStudio: '在 Studio 中设计',
     openAssistant: '打开{{name}}助手',
     offline: '离线',
     usersOnline: '当前在线用户',


### PR DESCRIPTION
## Summary

`StudioDesignSurface` already ships the builder → running-app bridge (the 「打开应用」 button), with the reverse direction explicitly noted as tracked separately:

> `// survives. (App → builder is the reverse bridge, tracked separately.)`

This PR adds that reverse bridge: inside a running app (e.g. `/_console/apps/com.example.showcase/page/showcase_start_here`), **workspace admins** now see a **"Design in Studio"** hammer icon in the top bar that deep-links to the app's owning package on the Studio design surface — `/studio/:packageId/data`.

## Behavior

- Rendered only in the `app` header variant, gated by `useIsWorkspaceAdmin()` (same gate as the runtime page/view editors' edit affordances).
- Resolves the target from the current app's `_packageId`; hidden when the app has no owning package (runtime/DB apps) or when the container is the DB-authored `sys_metadata` pseudo-package.
- Package **writability is not checked client-side** — the ADR-0070 D4 gate stays the server-side authority, and Studio renders read-only packages as browse-only.

## Changes

- `packages/app-shell/src/utils/appRoute.ts` — new pure `appStudioDesignPath(app, isWorkspaceAdmin)` resolver (+ barrel export) so the gating logic is unit-testable.
- `packages/app-shell/src/utils/__tests__/appRoute.test.ts` — tests: admin + packaged app → path, URL-encoding, non-admin / packageless / `sys_metadata` → `null`.
- `packages/app-shell/src/layout/AppHeader.tsx` — the top-bar entry (`data-testid="app-design-in-studio-button"`), placed next to the AI assistant button.
- `packages/i18n/src/locales/*.ts` — `topbar.designInStudio` added to all 10 built-in language packs.
- Docs: `packages/app-shell/README.md` (new "App → Studio reverse bridge" section) and `content/docs/guide/console.md` feature table.
- Changeset: minor bump for `@object-ui/app-shell` and `@object-ui/i18n`.

## Testing

- `vitest run packages/app-shell/src/utils/__tests__/appRoute.test.ts packages/i18n/src/__tests__/i18n.test.ts` — 54 passed (includes the locale key-parity checks).
- `vitest run packages/app-shell/src/layout packages/app-shell/src/console` — 18 files / 82 tests passed.
- `turbo run build --filter=@object-ui/app-shell` — 29 packages built clean (tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHEJnxwzMvBUHbYyizAsrY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHEJnxwzMvBUHbYyizAsrY)_