### PR TITLE
test(studio): extend create-conformance gate to the inline pillar creators

### DIFF
--- a/.changeset/studio-inline-skeleton-gate.md
+++ b/.changeset/studio-inline-skeleton-gate.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/app-shell": patch
+---
+
+test(studio): extend the create-conformance gate to the inline pillar creators
+
+`createConformance.test.ts` guards that every authorable type's default
+create-form output passes spec validation — catching the recurring "the designer
+emits a minimal shape the spec rejects, so create→save 422s" dead-end family. But
+it read only the metadata-admin registry, so the Studio's **inline** "New X"
+creators (Data → object, Automations → flow, Interfaces → app, Access →
+permission) — which build their skeletons directly in `StudioDesignSurface.tsx`,
+bypassing the registry — were **uncovered**. A future edit to one of those shapes
+could turn its "New" button into a silent dead-end with nothing to catch it.
+
+Extracted the four inline skeletons into pure, exported builders
+(`studio-design/skeletons.ts`) consumed by BOTH the pillars and a new gate block,
+so the test can't drift from what the "New" button actually emits. No behavior
+change — the builders return the byte-identical skeletons. The gate now covers all
+create paths (registry + inline); the four inline skeletons validate clean.

--- a/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from 'vitest';
 import { registerBuiltinAnchors } from './anchors';
 import { listMetadataResources, type MetadataResourceConfig } from './registry';
 import { validateMetadataDraft, hasClientValidator } from './clientValidation';
+import { buildObjectSkeleton, buildFlowSkeleton, buildAppSkeleton, buildPermissionSkeleton } from '../studio-design/skeletons';
 
 registerBuiltinAnchors();
 
@@ -103,6 +104,30 @@ describe('create-roundtrip conformance: default create output passes spec valida
       expect(
         issues,
         `${cfg.type} create output rejected by spec: ${JSON.stringify(issues)}\noutput=${JSON.stringify(output)}`,
+      ).toHaveLength(0);
+    });
+  }
+});
+
+// The Studio pillars (Data/Automations/Interfaces/Access) build their "New X"
+// skeletons INLINE, bypassing the registry the guard above reads — so they need
+// their own coverage, from the SAME source the pillars consume (`skeletons.ts`),
+// so this can never drift from what the "New" button actually emits. Guards the
+// same dead-end family (a minimal shape the spec rejects → create→save 422s).
+describe('Studio inline creators: skeletons pass spec validation', () => {
+  const STUDIO_SKELETONS: Array<{ type: string; skeleton: Record<string, unknown> }> = [
+    { type: 'object', skeleton: buildObjectSkeleton('conf_obj', 'Conformance Object', 'Name') },
+    { type: 'flow', skeleton: buildFlowSkeleton('conf_flow', 'Conformance Flow', 'Start', 'End') },
+    { type: 'app', skeleton: buildAppSkeleton('conf_app', 'Conformance App') },
+    { type: 'permission', skeleton: buildPermissionSkeleton('conf_perm', 'Conformance Permission') },
+  ];
+
+  for (const { type, skeleton } of STUDIO_SKELETONS) {
+    it(`${type}: Studio inline "New" skeleton is spec-valid`, async () => {
+      const { issues } = await validateMetadataDraft(type, skeleton);
+      expect(
+        issues,
+        `${type} inline skeleton rejected by spec: ${JSON.stringify(issues)}\nskeleton=${JSON.stringify(skeleton)}`,
       ).toHaveLength(0);
     });
   }

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -54,6 +54,7 @@ import { PermissionMatrixEditPage } from '../metadata-admin/PermissionMatrixEdit
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
 import { useMetadataClient } from '../metadata-admin/useMetadata';
 import { formatMetadataError, formatPublishFailures, type PublishFailure } from './metadataError';
+import { buildObjectSkeleton, buildFlowSkeleton, buildAppSkeleton, buildPermissionSkeleton } from './skeletons';
 import { t, tFormat, useMetadataLocale } from '../metadata-admin/i18n';
 import { AppNavCanvas } from '../metadata-admin/previews/AppNavCanvas';
 import {
@@ -436,7 +437,7 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
       await shellClient.save(
         'app',
         name,
-        { name, label, active: true, navigation: [] },
+        buildAppSkeleton(name, label),
         { mode: 'draft', packageId },
       );
       toast.success(tFormat('engine.studio.app.savedDraft', locale, { label }));
@@ -1501,11 +1502,7 @@ function DataPillar({
     setCreateBusy(true);
     setError(null);
     try {
-      const body: Record<string, unknown> = {
-        name,
-        label,
-        fields: { name: { type: 'text', label: t('engine.studio.data.nameFieldLabel', locale) } },
-      };
+      const body = buildObjectSkeleton(name, label, t('engine.studio.data.nameFieldLabel', locale));
       await client.save('object', name, body, { mode: 'draft', packageId });
       const surface: Surface = { type: 'object', name, label };
       setObjects((prev) => [...prev, surface]);
@@ -2143,16 +2140,12 @@ function AutomationsPillar({
     try {
       // Minimal valid, autolaunched skeleton: start → end. The designer fills in
       // the trigger + nodes; publishing it is a separate, user-initiated step.
-      const skeleton = {
+      const skeleton = buildFlowSkeleton(
         name,
         label,
-        type: 'autolaunched',
-        nodes: [
-          { id: 'start', type: 'start', label: t('engine.studio.auto.nodeStart', locale) },
-          { id: 'end', type: 'end', label: t('engine.studio.auto.nodeEnd', locale) },
-        ],
-        edges: [{ id: 'e1', source: 'start', target: 'end' }],
-      };
+        t('engine.studio.auto.nodeStart', locale),
+        t('engine.studio.auto.nodeEnd', locale),
+      );
       await client.save('flow', name, skeleton, { mode: 'draft', packageId });
       const item: Surface = { type: 'flow', name, label };
       setFlows((fs) => [...fs.filter((f) => f.name !== name), item]);
@@ -2538,7 +2531,7 @@ function AccessPillar({
     try {
       // Package door → create as a DRAFT stamped with this package (D6/D7),
       // published atomically with the rest of the package.
-      await client.save('permission', name, { name, label, objects: {}, fields: {} }, { mode: 'draft', packageId });
+      await client.save('permission', name, buildPermissionSkeleton(name, label), { mode: 'draft', packageId });
       toast.success(tFormat('engine.studio.access.created', locale, { label }));
       setCreating(false);
       setNewLabel('');

--- a/packages/app-shell/src/views/studio-design/skeletons.ts
+++ b/packages/app-shell/src/views/studio-design/skeletons.ts
@@ -1,0 +1,48 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Minimal-valid draft skeletons for the Studio's INLINE "New X" creators
+// (Data → object, Automations → flow, Interfaces → app, Access → permission).
+//
+// These bypass the metadata-admin registry, so `createConformance.test.ts`'s
+// registry-driven gate does NOT cover them — a future edit to one of these
+// shapes could make its "New" button a silent dead-end (create→save 422s). They
+// live here, pure and exported, so BOTH the pillars and the conformance gate
+// consume the SAME source: the test can't drift from what the designer emits.
+//
+// Label strings are parameters (the pillars pass localized `t(...)` values); the
+// gate passes any placeholder — the labels don't affect spec validity.
+
+export function buildObjectSkeleton(name: string, label: string, nameFieldLabel: string): Record<string, unknown> {
+  return {
+    name,
+    label,
+    fields: { name: { type: 'text', label: nameFieldLabel } },
+  };
+}
+
+export function buildFlowSkeleton(name: string, label: string, startLabel: string, endLabel: string): Record<string, unknown> {
+  return {
+    name,
+    label,
+    type: 'autolaunched',
+    nodes: [
+      { id: 'start', type: 'start', label: startLabel },
+      { id: 'end', type: 'end', label: endLabel },
+    ],
+    edges: [{ id: 'e1', source: 'start', target: 'end' }],
+  };
+}
+
+export function buildAppSkeleton(name: string, label: string): Record<string, unknown> {
+  return { name, label, active: true, navigation: [] };
+}
+
+export function buildPermissionSkeleton(name: string, label: string): Record<string, unknown> {
+  return { name, label, objects: {}, fields: {} };
+}


### PR DESCRIPTION
## Why (UX eval #3 — create-flow consistency gate)

`createConformance.test.ts` guards that every authorable type's default create-form output passes spec validation — catching the recurring **"the designer emits a minimal shape the spec rejects, so create→save 422s"** dead-end family (dashboard `layout`, report anchors, action missing `body`, …).

But it read only the **metadata-admin registry**. The Studio's **inline** "New X" creators — Data → `object`, Automations → `flow`, Interfaces → `app`, Access → `permission` — build their skeletons **directly in `StudioDesignSurface.tsx`, bypassing the registry**, so they were **uncovered**. A future edit to one of those shapes could turn its "New" button into a silent dead-end with nothing to catch it. (The known `action`/etc. dead-ends are already fixed and gated; this closes the last uncovered create path.)

## What

Extracted the four inline skeletons into pure, exported builders (`studio-design/skeletons.ts`) consumed by **both** the pillars and a new gate block in `createConformance.test.ts` — so the test **can't drift** from what the "New" button actually emits.

**No behavior change** — the builders return byte-identical skeletons (`object`: 1 text field; `flow`: start→end autolaunched; `app`: empty nav; `permission`: empty matrix). The gate now covers **all** create paths (registry + inline).

## Verification

`createConformance` suite **15 green** (11 registry + 4 new inline: object/flow/app/permission each spec-valid). app-shell type-check clean (29/29). Behavior-preserving refactor, so no runtime change to the create flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
