### PR TITLE
docs(skills): add app-composition decision guide (nav vs views vs pages)

### DIFF
--- a/content/docs/guide/designing-app-navigation.md
+++ b/content/docs/guide/designing-app-navigation.md
@@ -1,0 +1,96 @@
+---
+title: "Designing App Navigation"
+description: "How to choose between object navigation, named views, custom pages, and dashboards when composing an app"
+---
+
+# Designing App Navigation
+
+When you compose an app, the same requirement can often be expressed three
+ways: a plain object menu entry, an object entry pinned to a named view, or a
+custom page that embeds views. They are **not** interchangeable — this guide
+gives you the decision rules. (The canonical, agent-facing version lives in
+`skills/objectui/guides/app-composition.md`; keep the two in sync.)
+
+## The Three Ways to Reach a List
+
+Say your app has a `project` object:
+
+| You write | User lands on | You get for free |
+|---|---|---|
+| `{ "type": "object", "objectName": "project" }` | `/apps/my_app/project` — the object's **default view** | The full object shell: view switcher, object actions, a create button, record detail routing, search and recent-items integration |
+| `{ "type": "object", "objectName": "project", "viewName": "project.by_status" }` | `/apps/my_app/project/view/project.by_status` | The same shell, with the entry **anchored** to a named view — users can still switch |
+| `{ "type": "page", "pageName": "project_overview" }` | `/apps/my_app/page/project_overview` | Nothing but your page schema. View switching, actions, and record links must be assembled by hand |
+
+The key asymmetry: a page can imitate the other two, but it **loses the object
+shell** — and every future improvement to that shell (new actions, better view
+switching, permission trimming) will skip your page.
+
+## The Rule of Least Power
+
+Use the least powerful construct that expresses the requirement:
+
+1. **Default: one plain `object` entry per core business object.**
+   No `viewName`. The default view is defined by view metadata, so the
+   navigation layer stays decoupled from presentation.
+
+2. **Add `viewName` when the menu item is a named slice.**
+   If the label is a *perspective* — "By Status", "Due This Week",
+   "My Tasks" — create a named view (convention: `<object>.<key>`, e.g.
+   `project.by_status`) and anchor the entry to it. `viewName` sets the
+   entry point; it does not lock the user in.
+
+3. **Create a page only for composition a single object view cannot express.**
+   Multiple objects side by side or in tabs, KPI cards mixed with lists,
+   onboarding or static content, parameterized pages. A page that wraps a
+   single object's single view is an anti-pattern.
+
+4. **Use `dashboard` for metric/chart aggregation and `report` for tabular
+   analysis** — don't rebuild them as pages of chart blocks.
+
+5. **One entry per target.** Don't offer the same object through both a plain
+   entry and a page that wraps its default view. If one object needs several
+   menu entries, make all of them named-view entries — mixing styles breaks
+   active-state highlighting in the sidebar.
+
+As a rule of thumb, in a typical business app about 80% of navigation entries
+should be `object` entries (with or without `viewName`); pages are for the
+home screen, onboarding, and cross-object workbenches.
+
+## Write Spec-Shaped Items
+
+Navigation is a discriminated union on `type`. Each type has its own target
+field — there is no generic `path` and no `kind`:
+
+```json
+{
+  "navigation": [
+    { "id": "nav_projects", "type": "object", "objectName": "project", "label": "Projects" },
+    { "id": "nav_by_status", "type": "object", "objectName": "project", "viewName": "project.by_status", "label": "By Status" },
+    { "id": "nav_kpis", "type": "dashboard", "dashboardName": "company_kpis", "label": "KPIs" },
+    { "id": "nav_workbench", "type": "page", "pageName": "cross_object_workbench", "label": "Workbench" },
+    { "id": "nav_docs", "type": "url", "url": "https://docs.example.com", "target": "_blank", "label": "Docs" }
+  ]
+}
+```
+
+Requirements:
+
+- `id` (snake_case), `type`, and `label` are mandatory on every item.
+- The target field must match the type: `objectName`, `pageName`,
+  `dashboardName`, `reportName`, or `url`. Keys like `path` or `kind` are
+  ignored at runtime and rejected at save.
+- Put items under the `navigation` key. `menu` is deprecated legacy and only
+  kept for backward compatibility.
+
+Object entries also support record deep-links — `recordId` (with template
+variables like `{current_user_id}`) opens a specific record, which is how
+"My Profile"-style entries are built.
+
+## Quick Checklist
+
+Before publishing an app, scan the navigation for:
+
+- Pages that merely wrap a single object view → replace with an object entry.
+- Items carrying `path`/`kind` → rewrite as typed items.
+- The same object reachable twice (plain entry + wrapper page) → keep one.
+- View names not following `<object>.<key>`, ids not snake_case → rename.

--- a/content/docs/guide/meta.json
+++ b/content/docs/guide/meta.json
@@ -18,6 +18,7 @@
     "plugins",
     "plugin-development",
     "building-crud-app",
+    "designing-app-navigation",
     "public-forms",
     "record-edit-modes",
     "slotted-pages",

--- a/skills/objectui/SKILL.md
+++ b/skills/objectui/SKILL.md
@@ -109,6 +109,7 @@ See `rules/no-touch-zones.md` for the full list and rationale.
 
 ### Guides
 
+- **App composition — choosing object nav vs views vs pages vs dashboards** → [`guides/app-composition.md`](./guides/app-composition.md)
 - **Page building & schema design** → [`guides/page-builder.md`](./guides/page-builder.md)
 - **Custom plugin development** → [`guides/plugin-development.md`](./guides/plugin-development.md)
 - **Expression syntax & debugging** → [`guides/schema-expressions.md`](./guides/schema-expressions.md)

--- a/skills/objectui/evals/app-composition.json
+++ b/skills/objectui/evals/app-composition.json
@@ -1,0 +1,57 @@
+{
+  "skill_name": "objectui",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Generate the app schema navigation for a project-management app with objects `project` and `task`. Requirements: a Projects menu, a Tasks menu, a 'Tasks by Status' board entry, and a company KPI overview. Use ObjectUI / @objectstack/spec metadata.",
+      "expected_output": "Emits a `navigation` array of typed items: bare object entries for project and task, an object entry with viewName pointing at a named view like `task.by_status`, and a dashboard entry for the KPI overview. No `path`/`kind` keys, snake_case ids, no page wrapping a single view.",
+      "files": [],
+      "assertions": {
+        "must_contain": [
+          "navigation",
+          "\"type\": \"object\"",
+          "objectName",
+          "viewName",
+          "dashboard"
+        ],
+        "must_not_contain": [
+          "\"path\":",
+          "\"kind\":"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "prompt": "In our app I want a menu item 'My Open Tickets' that shows the ticket object filtered to the current user's open tickets. Should I build a custom page for it? Generate the metadata.",
+      "expected_output": "Recommends a named view (e.g. `ticket.my_open`) plus an object nav entry with viewName instead of a custom page, explains that a page wrapping a single object view is an anti-pattern losing the ObjectView shell, and emits the spec-shaped nav item.",
+      "files": [],
+      "assertions": {
+        "must_contain": [
+          "viewName",
+          "\"type\": \"object\"",
+          "view"
+        ],
+        "must_not_contain": [
+          "\"type\": \"page\"",
+          "\"path\":"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "prompt": "Our generated app has a nav entry {\"label\": \"Projects\", \"path\": \"/projects\", \"kind\": \"object\"} but clicking it does nothing. Fix the metadata.",
+      "expected_output": "Diagnoses that `path`/`kind` are off-spec keys ignored by resolveHref, and rewrites the item as a discriminated-union member with type 'object', objectName, a snake_case id, and a label — removing path and kind entirely.",
+      "files": [],
+      "assertions": {
+        "must_contain": [
+          "\"type\": \"object\"",
+          "objectName",
+          "id"
+        ],
+        "must_not_contain": [
+          "\"path\": \"/projects\""
+        ]
+      }
+    }
+  ]
+}

--- a/skills/objectui/guides/app-composition.md
+++ b/skills/objectui/guides/app-composition.md
@@ -1,0 +1,129 @@
+---
+name: objectui-app-composition
+description: Choose the right metadata construct when composing an app — object navigation vs named views vs custom pages vs dashboards. Use this skill whenever generating or reviewing app navigation, deciding between a view / page / dashboard / report for a requirement, or authoring `navigation` items in an app schema. This is the canonical decision guide for AI app generation and for human authors in the metadata studio.
+---
+
+# App Composition: Choosing the Right Metadata
+
+This guide answers **"which construct do I reach for?"** — not "how do I build it."
+It is the single source of truth for app-composition decisions. AI generators,
+inspector UIs, and human docs must all follow the same rules; do not fork or
+paraphrase the decision tables elsewhere — link here instead.
+
+## The Least-Power Principle
+
+Every requirement should be expressed with the **least powerful construct that
+can express it**. The hierarchy, from least to most powerful:
+
+```
+object nav (default view)
+  → object nav + viewName (named slice)
+    → dashboard / report (aggregation)
+      → page (free-form SDUI composition)
+```
+
+A more powerful construct can always imitate a weaker one — a page can embed a
+single object view — but doing so **discards the built-in chrome** the weaker
+construct provides for free, and every future improvement to that chrome will
+skip your app. Powerful constructs are escape hatches, not defaults.
+
+## What Each Navigation Target Buys You
+
+The nav contract is a discriminated union on `type` (see `NavigationItemSchema`
+in `@object-ui/types`; aligned with `@objectstack/spec`). Runtime resolution is
+`resolveHref` in `packages/layout/src/NavigationRenderer.tsx` — the single
+source of truth for nav → URL mapping.
+
+| Nav item | Route | What the runtime provides |
+|---|---|---|
+| `{type:'object', objectName}` | `/:objectName` | Full `ObjectView` shell: default view, **view switcher**, object actions, create button, `record/:id` detail routing, search & recents integration, permission trimming |
+| `{type:'object', objectName, viewName}` | `/:objectName/view/:viewId` | Same shell, entry **anchored to a named view** (user can still switch) |
+| `{type:'object', objectName, recordId}` | `/:objectName/record/:id` | Direct record deep-link; supports template vars like `{current_user_id}` ("My Profile") |
+| `{type:'dashboard', dashboardName}` | `/dashboard/:name` | Dashboard renderer (widgets, KPIs, charts) |
+| `{type:'report', reportName}` | `/report/:name` | Report renderer |
+| `{type:'page', pageName}` | `/page/:name` | **Bare SDUI rendering only.** No object shell — view switching, actions, and record routing must be hand-assembled in the page schema |
+| `{type:'url', url}` | external | External link (`target` controls tab) |
+| `{type:'group', children}` | — | Grouping only; no target |
+
+## Decision Rules (in priority order)
+
+1. **Default: one bare `object` entry per core business object.**
+   "Tasks", "Projects" → `{type:'object', objectName}`. No `viewName`. The
+   default view comes from view metadata; the nav layer stays decoupled.
+   Least metadata, most user freedom.
+
+2. **Add `viewName` only when the menu item is a *named slice* of an object.**
+   Test: the label is a *perspective*, not the object's name — "By Status",
+   "Due This Week", "My Tasks". Create a named view (naming convention:
+   `<object>.<key>`, e.g. `showcase_project.by_status`) and point the nav
+   entry at it. `viewName` is an **entry anchor**, not a lock — users can
+   still switch views once inside. That is a feature.
+
+3. **Reach for a `page` only for cross-object or free-form composition.**
+   Qualifying cases (any one suffices): multiple objects' views side by side
+   or in tabs, KPI cards mixed with lists, static/onboarding content,
+   parameterized pages driven by `params`.
+   **A page that wraps a single object's single view is an anti-pattern** —
+   it is a degraded copy of rules 1–2 that loses the object shell and adds a
+   second metadata document to maintain.
+
+4. **Pure metric/chart aggregation → `dashboard`, tabular analysis → `report`.**
+   Do not simulate either with a page of hand-placed chart blocks.
+
+5. **One entry per target (dedup constraint).**
+   A navigation tree must not contain both a bare `object` entry and a page
+   that merely wraps that object's default view. If one object needs several
+   menu entries, make **all of them** named-view entries (rule 2) — mixing a
+   bare entry with slice entries breaks active-state highlighting, and
+   `resolveHref` cannot dedup entries for you.
+
+6. **Generation order follows the hierarchy.**
+   objects → named views (extracted from the "perspectives" in the
+   requirement) → nav (rules 1–2) → only what remains inexpressible becomes a
+   page/dashboard. **Page count is an inverse quality signal**: in a typical
+   business app, ~80% of nav entries should be `object` (± `viewName`); pages
+   are for home/onboarding/cross-object workbenches.
+
+## The One-Sentence Rule (for generation prompts)
+
+> Prefer the object's default view over a pinned `viewName`; prefer a named
+> view over a page; use a page only for composition a single object view
+> cannot express. Every target appears exactly once.
+
+Generation prompts should embed only this sentence plus a link to this guide —
+never an inline copy of the tables above.
+
+## Contract Reminders (spec-strict)
+
+- Nav items are a **discriminated union on `type`**. There is no `path` and no
+  `kind` — those keys are ignored by `resolveHref` and rejected/stripped at
+  save. Emit the typed target field for the chosen type (`objectName`,
+  `pageName`, `dashboardName`, `reportName`, `url`, `componentRef`).
+- Every nav item needs a snake_case `id` and a `label` (both required by
+  `NavigationItemSchema`).
+- The `navigation` key is the spec'd root for app nav. `menu` is deprecated
+  legacy (`MenuItem[]`, auto-migrated at runtime via
+  `menuItemToNavigationItem`); never generate it.
+
+## Anti-Pattern Checklist
+
+Reject (or fix) generated apps that contain any of:
+
+- [ ] A page whose schema is a single object view wrapper.
+- [ ] Nav items carrying `path` or `kind` keys.
+- [ ] The same object reachable via both a bare object entry and a
+      default-view page.
+- [ ] Dashboards rebuilt as pages of chart blocks.
+- [ ] Nav written under `nav` / `tabs` / `items` / `menu` instead of
+      `navigation`.
+- [ ] View names not following `<object>.<key>`, or nav `id`s not snake_case.
+
+## Related
+
+- Navigation item schema: `packages/types/src/zod/app.zod.ts`
+  (`NavigationItemSchema`), `packages/types/src/app.ts` (`NavigationItem`)
+- Runtime resolution: `packages/layout/src/NavigationRenderer.tsx`
+  (`resolveHref`)
+- Console routes: `packages/app-shell/src/console/AppContent.tsx`
+- Human-facing version: `content/docs/guide/designing-app-navigation.md`
+  (derived from this guide — update both together)


### PR DESCRIPTION
## Why

App composition currently has three ways to express "show the user a list": a bare `object` nav entry (default view + full ObjectView shell), an `object` entry pinned to a named view (`/view/<object>.<key>`), and a custom `page` that embeds views. Nothing in the repo documents **which one to choose**, so AI generators and human authors fork their own conventions — including the off-spec `path`/`kind` shape tracked in #2245.

The existing content system has two layers (`skills/objectui/` for agents, `content/docs/guide/` for humans) and both only answer "how to build X", never "which construct to reach for". This PR adds that missing decision layer, with one authoritative source and one derived human version.

## What

- **`skills/objectui/guides/app-composition.md`** (new, canonical): the least-power principle (`object` → `+viewName` → `dashboard`/`report` → `page`), a per-target capability table grounded in `resolveHref` (`packages/layout/src/NavigationRenderer.tsx`) and the console routes, six priority-ordered decision rules (incl. the one-entry-per-target dedup constraint), a one-sentence rule intended for embedding in AI generation prompts, spec-contract reminders (discriminated union on `type`, no `path`/`kind`, snake_case `id`, `navigation` root key), and an anti-pattern checklist. Registered in `SKILL.md`'s guides index.
- **`skills/objectui/evals/app-composition.json`** (new): three evals following the existing eval format — generate spec-shaped nav for a two-object app, prefer a named view over a wrapper page, repair an off-spec `path`/`kind` item.
- **`content/docs/guide/designing-app-navigation.md`** (new): human-facing version for app builders, derived from the canonical guide (cross-referenced both ways); registered in `content/docs/guide/meta.json` after *Building a CRUD App*.

## Relation to #2245

Companion doc for the AppNavInspector rework: the inspector's `type` + typed-target picker design, AI app generation, and the docs site now cite a single decision source instead of three diverging rule sets. No code changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m3GX7EMKNPDZuee152EKK

---
_Generated by [Claude Code](https://claude.ai/code/session_018m3GX7EMKNPDZuee152EKK)_