### PR TITLE
fix(plugin-detail): 修复点击相关列表子表 name 字段导致 record:details 崩溃 (React #310)

### DIFF
--- a/packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression tests for the `record:details` renderer's rules-of-hooks
+ * contract. The renderer calls a fixed set of hooks (record context,
+ * permissions, field labels, highlight names, inline-edit state + save
+ * callbacks) and must call ALL of them on EVERY render — before any
+ * conditional return.
+ *
+ * The bug these tests lock out: the designer placeholder (`!ctx`) and the
+ * permission-denied notice used to `return` *between* hooks. When a
+ * related-list row click flipped the bound record / permission state under a
+ * mounted `record:details`, the re-render ran fewer hooks than the previous
+ * one and React threw error #310 ("Rendered fewer hooks than expected"),
+ * crashing the whole detail block. A transition between any two of these
+ * branches must NOT throw.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+const stub = {
+  recordCtx: undefined as any,
+  can: true,
+};
+
+// Each stubbed hook consumes exactly ONE real React hook slot (via useRef) so
+// the component's hook-count invariant is genuinely exercised: `useRecordContext`
+// really calls `useContext` before the `!ctx` early return in production, and
+// that leading real-hook is what makes a fewer-hooks re-render throw #310. A
+// plain `() => value` stub would call no real hook, silently masking the bug.
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
+  return {
+    useRecordContext: () => (React.useRef(0), stub.recordCtx),
+    useHighlightFieldNames: () => (React.useRef(0), [] as string[]),
+    useSafeFieldLabel: () => (React.useRef(0), {
+      sectionLabel: (_obj: string, _name: string, fallback: string) => fallback,
+    }),
+  };
+});
+
+vi.mock('@object-ui/permissions', async () => {
+  const React = await import('react');
+  return {
+    usePermissions: () => (React.useRef(0), { can: () => stub.can }),
+    useFieldPermissions: (_objectName: string) => (React.useRef(0), {
+      readableFields: (names: string[]) => names,
+    }),
+  };
+});
+
+// Keep the test focused on the renderer's own hook ordering — stub the heavy
+// children so we don't drag in the full DetailView / dialog trees.
+vi.mock('../../DetailView', () => ({
+  DetailView: (props: any) => <div data-testid="detail-view" data-object={props?.schema?.objectName} />,
+}));
+vi.mock('../../ConcurrentUpdateDialog', () => ({
+  ConcurrentUpdateDialog: () => null,
+  isConcurrentUpdateError: () => false,
+}));
+
+import { RecordDetailsRenderer } from '../record-details';
+
+const BOUND_CTX = {
+  objectName: 'mtc_lead',
+  recordId: 'rec_1',
+  data: { id: 'rec_1', name: 'Acme' },
+  dataSource: { update: async () => ({}) },
+  refresh: async () => {},
+  objectSchema: { primaryField: 'name' },
+};
+
+beforeEach(() => {
+  stub.recordCtx = BOUND_CTX;
+  stub.can = true;
+  cleanup();
+});
+
+describe('RecordDetailsRenderer — rules of hooks', () => {
+  it('renders the bound record then survives the record UNBINDING (ctx → null)', () => {
+    const { rerender, queryByTestId } = render(
+      <RecordDetailsRenderer schema={{ fields: ['name'] }} />,
+    );
+    expect(queryByTestId('detail-view')).not.toBeNull();
+
+    // A related-list row click can unbind the context mid-flight. Pre-fix this
+    // re-render dropped from ~11 hooks to 1 → React #310.
+    stub.recordCtx = undefined;
+    expect(() => rerender(<RecordDetailsRenderer schema={{ fields: ['name'] }} />)).not.toThrow();
+    expect(queryByTestId('detail-view')).toBeNull();
+  });
+
+  it('survives a permission flip (allowed → denied) between renders', () => {
+    const schema = { fields: ['name'], requiredPermissions: ['read'] };
+    const { rerender, queryByTestId } = render(<RecordDetailsRenderer schema={schema} />);
+    expect(queryByTestId('detail-view')).not.toBeNull();
+
+    // Permissions (re)load and now deny — the permission-denied branch used to
+    // return before several hooks, changing the hook count → React #310.
+    stub.can = false;
+    expect(() => rerender(<RecordDetailsRenderer schema={schema} />)).not.toThrow();
+    expect(queryByTestId('detail-view')).toBeNull();
+  });
+
+  it('survives re-binding back to a record (null → ctx) without a hook mismatch', () => {
+    stub.recordCtx = undefined;
+    const { rerender, queryByTestId } = render(
+      <RecordDetailsRenderer schema={{ fields: ['name'] }} />,
+    );
+    expect(queryByTestId('detail-view')).toBeNull();
+
+    stub.recordCtx = BOUND_CTX;
+    expect(() => rerender(<RecordDetailsRenderer schema={{ fields: ['name'] }} />)).not.toThrow();
+    expect(queryByTestId('detail-view')).not.toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -44,8 +44,173 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   className,
   ...props
 }) => {
+  // ── Hooks (unconditional — before ANY early return) ──────────────────────
+  // Rules of hooks: every hook below MUST run on every render, whether or not
+  // a record is bound and whether or not the viewer has permission. Returning
+  // early *between* hooks — the designer placeholder (`!ctx`) or the
+  // permission-denied notice — changes the hook count between renders and
+  // throws React error #310 ("Rendered fewer hooks than expected"). That is
+  // precisely the crash a related-list row click produced: `onRowClick` flips
+  // the bound record / permission state, `ctx` (or `perms.can(...)`) toggles,
+  // and the previously-mounted `record:details` re-renders with fewer hooks.
+  // Keep all hooks here; move all conditional returns below them.
   const ctx = useRecordContext();
   const { designer } = splitDesigner(props);
+
+  const objectName = ctx?.objectName || '';
+  const perms = usePermissions();
+  const { readableFields } = useFieldPermissions(objectName);
+  const { sectionLabel } = useSafeFieldLabel();
+
+  // Phase N.4b: field names registered live by a mounted `record:highlights`
+  // instance via HighlightFieldsContext (used to dedupe them out of the grid).
+  const liveHighlightNames = useHighlightFieldNames();
+
+  /**
+   * Optimistic Concurrency Control state for inline edits: a `409
+   * CONCURRENT_UPDATE` opens a resolution dialog instead of silently retrying
+   * or overwriting.
+   */
+  const [conflict, setConflict] = React.useState<ConcurrentUpdateConflict | null>(null);
+  const [conflictBusy, setConflictBusy] = React.useState(false);
+
+  const fieldLabelFor = React.useCallback(
+    (name: string): string | undefined => {
+      const all: any[] = [
+        ...(Array.isArray(schema.fields) ? (schema.fields as any[]) : []),
+        ...((Array.isArray(schema.sections) ? (schema.sections as any[]) : [])
+          .flatMap((s: any) => (Array.isArray(s?.fields) ? s.fields : []))),
+      ];
+      for (const f of all) {
+        const fname = typeof f === 'string' ? f : (f?.name || f?.field);
+        if (fname === name) {
+          const label = typeof f === 'object' ? (f?.label as string | undefined) : undefined;
+          return label;
+        }
+      }
+      return undefined;
+    },
+    [schema.fields, schema.sections]
+  );
+
+  /**
+   * Persist a single inline-edited field through the bound DataSource and
+   * trigger a context refresh so the new value re-hydrates from the server
+   * after save. Without this wiring the DetailView only updated its own
+   * local `data` state — the change would visibly stick until the user
+   * reloaded the page, then silently revert because nothing was sent to
+   * the backend.
+   *
+   * Passes the record's `updated_at` as `ifMatch` so the server can reject the
+   * write with `409 CONCURRENT_UPDATE` when a concurrent writer has bumped the
+   * row; on conflict we open a resolution dialog.
+   */
+  const handleInlineFieldSave = React.useCallback(
+    async (field: string, value: any) => {
+      const ds: any = ctx?.dataSource;
+      const recordId = ctx?.recordId;
+      const objName = ctx?.objectName;
+      if (!ds || !recordId || !objName) return;
+      const ifMatch =
+        typeof (ctx?.data as any)?.updated_at === 'string'
+          ? ((ctx?.data as any).updated_at as string)
+          : undefined;
+      const opts = ifMatch ? { ifMatch } : undefined;
+      try {
+        if (typeof ds.update === 'function') {
+          await ds.update(objName, recordId, { [field]: value }, opts);
+        } else if (typeof ds.updateOne === 'function') {
+          await ds.updateOne(objName, recordId, { [field]: value }, opts);
+        } else if (typeof ds.patch === 'function') {
+          await ds.patch(objName, recordId, { [field]: value }, opts);
+        } else {
+          console.warn('[record:details] DataSource exposes no update/updateOne/patch method; cannot persist inline edit');
+          return;
+        }
+        if (typeof ctx?.refresh === 'function') {
+          await ctx.refresh();
+        }
+      } catch (err) {
+        if (isConcurrentUpdateError(err)) {
+          const current = err.currentRecord ?? null;
+          setConflict({
+            field,
+            label: fieldLabelFor(field),
+            pendingValue: value,
+            currentValue: current ? (current as Record<string, unknown>)[field] : undefined,
+            currentVersion: err.currentVersion,
+            currentRecord: current,
+          });
+          // Re-throw so DetailView rolls back its optimistic local state.
+          // The dialog drives the eventual resolution (reload / overwrite).
+          throw err;
+        }
+        console.error('[record:details] Inline-edit save failed', err);
+        // Re-throw so DetailView can roll back the optimistic local state and
+        // surface the failure to the user. Without this the value would
+        // appear to stick until the next reload, masking backend rejections
+        // (e.g. RECORD_LOCKED while an approval is in progress).
+        throw err;
+      }
+    },
+    [ctx?.dataSource, ctx?.recordId, ctx?.objectName, ctx?.data, ctx?.refresh, fieldLabelFor]
+  );
+
+  const closeConflict = React.useCallback(() => {
+    setConflict(null);
+    setConflictBusy(false);
+  }, []);
+
+  const handleConflictReload = React.useCallback(async () => {
+    setConflictBusy(true);
+    try {
+      if (typeof ctx?.refresh === 'function') {
+        await ctx.refresh();
+      }
+    } finally {
+      closeConflict();
+    }
+  }, [ctx?.refresh, closeConflict]);
+
+  const handleConflictOverwrite = React.useCallback(async () => {
+    if (!conflict) {
+      closeConflict();
+      return;
+    }
+    const ds: any = ctx?.dataSource;
+    const recordId = ctx?.recordId;
+    const objName = ctx?.objectName;
+    if (!ds || !recordId || !objName) {
+      closeConflict();
+      return;
+    }
+    setConflictBusy(true);
+    try {
+      // Re-key the write against the latest known server version. The
+      // server's `currentVersion` from the 409 is now the freshest
+      // token we hold, so passing it through still uses OCC — it just
+      // means "I've seen this newer version, apply my change on top".
+      const opts = conflict.currentVersion
+        ? { ifMatch: conflict.currentVersion }
+        : undefined;
+      if (typeof ds.update === 'function') {
+        await ds.update(objName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
+      } else if (typeof ds.updateOne === 'function') {
+        await ds.updateOne(objName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
+      } else if (typeof ds.patch === 'function') {
+        await ds.patch(objName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
+      }
+      if (typeof ctx?.refresh === 'function') {
+        await ctx.refresh();
+      }
+    } catch (err) {
+      console.error('[record:details] Overwrite-on-conflict failed', err);
+    } finally {
+      closeConflict();
+    }
+  }, [conflict, ctx?.dataSource, ctx?.recordId, ctx?.objectName, ctx?.refresh, closeConflict]);
+
+  // ── Conditional returns (safe now — all hooks above have run) ────────────
 
   // Studio designer / palette: render an empty shell when no record bound.
   if (!ctx) {
@@ -62,14 +227,6 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
     );
   }
 
-  const layout: 'vertical' | 'horizontal' =
-    schema.layout === 'inline' || schema.layout === 'compact' ? 'horizontal' : 'vertical';
-
-  const objectName = ctx.objectName || '';
-  const perms = usePermissions();
-  const { readableFields } = useFieldPermissions(objectName);
-  const { sectionLabel } = useSafeFieldLabel();
-
   const required: string[] = Array.isArray((schema as any).requiredPermissions)
     ? (schema as any).requiredPermissions
     : [];
@@ -85,6 +242,9 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
       );
     }
   }
+
+  const layout: 'vertical' | 'horizontal' =
+    schema.layout === 'inline' || schema.layout === 'compact' ? 'horizontal' : 'vertical';
 
   const enforceFLS = (schema as any).enforceFieldSecurity === true;
   const redact: string[] = Array.isArray((schema as any).redactFields)
@@ -122,12 +282,10 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   // Phase N.4: dedupe with the highlight strip — when authors include a
   // field in `record:highlights` we drop it from the details grid so it
   // isn't shown twice. The synth pipeline passes the highlight list via
-  // `hideFields`; authors can also set it directly on the schema.
-  // Phase N.4b: also merge in any field names registered live by a
-  // mounted `record:highlights` instance via HighlightFieldsContext.
-  // Covers hand-authored Lightning pages that don't go through the
-  // synth dedup path.
-  const liveHighlightNames = useHighlightFieldNames();
+  // `hideFields`; authors can also set it directly on the schema. We also
+  // merge in any field names registered live via HighlightFieldsContext
+  // (see `liveHighlightNames` above) to cover hand-authored Lightning pages
+  // that don't go through the synth dedup path.
   const hideFieldNames = new Set<string>(
     (Array.isArray((schema as any).hideFields) ? (schema as any).hideFields : [])
       .map((n: any) => (typeof n === 'string' ? n : fieldName(n)))
@@ -202,146 +360,6 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   // (`RecordDetailView` non-assignedPage branch) where every field is
   // click-to-edit. Authors can opt out with `inlineEdit: false`.
   const inlineEditDefault = schema.inlineEdit ?? true;
-
-  /**
-   * Persist a single inline-edited field through the bound DataSource and
-   * trigger a context refresh so the new value re-hydrates from the server
-   * after save. Without this wiring the DetailView only updated its own
-   * local `data` state — the change would visibly stick until the user
-   * reloaded the page, then silently revert because nothing was sent to
-   * the backend.
-   *
-   * Optimistic Concurrency Control: pass the record's `updated_at` as
-   * `ifMatch` so the server can reject the write with `409 CONCURRENT_UPDATE`
-   * when a concurrent writer has bumped the row. On conflict we open a
-   * resolution dialog instead of silently retrying or silently overwriting.
-   */
-  const [conflict, setConflict] = React.useState<ConcurrentUpdateConflict | null>(null);
-  const [conflictBusy, setConflictBusy] = React.useState(false);
-
-  const fieldLabelFor = React.useCallback(
-    (fieldName: string): string | undefined => {
-      const all: any[] = [
-        ...(Array.isArray(schema.fields) ? (schema.fields as any[]) : []),
-        ...((Array.isArray(schema.sections) ? (schema.sections as any[]) : [])
-          .flatMap((s: any) => (Array.isArray(s?.fields) ? s.fields : []))),
-      ];
-      for (const f of all) {
-        const name = typeof f === 'string' ? f : (f?.name || f?.field);
-        if (name === fieldName) {
-          const label = typeof f === 'object' ? (f?.label as string | undefined) : undefined;
-          return label;
-        }
-      }
-      return undefined;
-    },
-    [schema.fields, schema.sections]
-  );
-
-  const handleInlineFieldSave = React.useCallback(
-    async (field: string, value: any) => {
-      const ds: any = ctx.dataSource;
-      const recordId = ctx.recordId;
-      const objectName = ctx.objectName;
-      if (!ds || !recordId || !objectName) return;
-      const ifMatch =
-        typeof (ctx.data as any)?.updated_at === 'string'
-          ? ((ctx.data as any).updated_at as string)
-          : undefined;
-      const opts = ifMatch ? { ifMatch } : undefined;
-      try {
-        if (typeof ds.update === 'function') {
-          await ds.update(objectName, recordId, { [field]: value }, opts);
-        } else if (typeof ds.updateOne === 'function') {
-          await ds.updateOne(objectName, recordId, { [field]: value }, opts);
-        } else if (typeof ds.patch === 'function') {
-          await ds.patch(objectName, recordId, { [field]: value }, opts);
-        } else {
-          console.warn('[record:details] DataSource exposes no update/updateOne/patch method; cannot persist inline edit');
-          return;
-        }
-        if (typeof ctx.refresh === 'function') {
-          await ctx.refresh();
-        }
-      } catch (err) {
-        if (isConcurrentUpdateError(err)) {
-          const current = err.currentRecord ?? null;
-          setConflict({
-            field,
-            label: fieldLabelFor(field),
-            pendingValue: value,
-            currentValue: current ? (current as Record<string, unknown>)[field] : undefined,
-            currentVersion: err.currentVersion,
-            currentRecord: current,
-          });
-          // Re-throw so DetailView rolls back its optimistic local state.
-          // The dialog drives the eventual resolution (reload / overwrite).
-          throw err;
-        }
-        console.error('[record:details] Inline-edit save failed', err);
-        // Re-throw so DetailView can roll back the optimistic local state and
-        // surface the failure to the user. Without this the value would
-        // appear to stick until the next reload, masking backend rejections
-        // (e.g. RECORD_LOCKED while an approval is in progress).
-        throw err;
-      }
-    },
-    [ctx.dataSource, ctx.recordId, ctx.objectName, ctx.data, ctx.refresh, fieldLabelFor]
-  );
-
-  const closeConflict = React.useCallback(() => {
-    setConflict(null);
-    setConflictBusy(false);
-  }, []);
-
-  const handleConflictReload = React.useCallback(async () => {
-    setConflictBusy(true);
-    try {
-      if (typeof ctx.refresh === 'function') {
-        await ctx.refresh();
-      }
-    } finally {
-      closeConflict();
-    }
-  }, [ctx.refresh, closeConflict]);
-
-  const handleConflictOverwrite = React.useCallback(async () => {
-    if (!conflict) {
-      closeConflict();
-      return;
-    }
-    const ds: any = ctx.dataSource;
-    const recordId = ctx.recordId;
-    const objectName = ctx.objectName;
-    if (!ds || !recordId || !objectName) {
-      closeConflict();
-      return;
-    }
-    setConflictBusy(true);
-    try {
-      // Re-key the write against the latest known server version. The
-      // server's `currentVersion` from the 409 is now the freshest
-      // token we hold, so passing it through still uses OCC — it just
-      // means "I've seen this newer version, apply my change on top".
-      const opts = conflict.currentVersion
-        ? { ifMatch: conflict.currentVersion }
-        : undefined;
-      if (typeof ds.update === 'function') {
-        await ds.update(objectName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
-      } else if (typeof ds.updateOne === 'function') {
-        await ds.updateOne(objectName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
-      } else if (typeof ds.patch === 'function') {
-        await ds.patch(objectName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
-      }
-      if (typeof ctx.refresh === 'function') {
-        await ctx.refresh();
-      }
-    } catch (err) {
-      console.error('[record:details] Overwrite-on-conflict failed', err);
-    } finally {
-      closeConflict();
-    }
-  }, [conflict, ctx.dataSource, ctx.recordId, ctx.objectName, ctx.refresh, closeConflict]);
 
   const synthesized: any = {
     type: 'detail-view',


### PR DESCRIPTION
## 问题

记录详情页点击「相关」下子表的 **name** 字段时,整块详情崩溃:

> Component "record:details" failed to render — Minified React error #310

## 根因

`RecordDetailsRenderer` 违反了 React 的 rules of hooks:先调用 `useRecordContext()`,然后在 `!ctx`(设计器占位)和权限拒绝两个提前 `return` **之后**才调用其余约 10 个 hook(`usePermissions`、`useFieldPermissions`、`useSafeFieldLabel`、`useHighlightFieldNames`、两个 `useState`、五个 `useCallback`)。

点子表 name 字段 → 触发子表 data-table 的 `onRowClick` → 翻转仍挂载的 `record:details` 下的 RecordContext / 权限状态 → 该次重渲染走了不同的提前 `return` 分支、执行的 hook 数量比上次少 → React 抛出 #310("Rendered fewer hooks than expected"),整个详情块崩溃。

## 修复

把所有 hook 上提到组件顶部无条件执行,再把条件 `return` 与非 hook 的计算全部下移。回调体和依赖数组改用 `ctx?.` 可选链(定义时 ctx 可能为 null)。**纯顺序调整,无行为改动。**

## 测试

新增回归测试 `record-details.test.tsx`,覆盖 row-click 触发的三种状态切换:解绑(`ctx → null`)、权限翻转(允许 → 拒绝)、重新绑定(`null → ctx`)。每个被 mock 的 hook 都消费一个真实 React hook 槽位(`React.useRef(0)`),确保 hook-count 不变式被真正触发——已确认该测试对修复前代码会 fail、对修复后会 pass。

- plugin-detail 全套:**159/159 通过**