### PR TITLE
fix(plugin-detail): polish the detail-header highlight strip (#2249)

### DIFF
--- a/packages/plugin-detail/src/HeaderHighlight.tsx
+++ b/packages/plugin-detail/src/HeaderHighlight.tsx
@@ -52,7 +52,7 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
       )}
       aria-label="Record highlights"
     >
-      <div className={cn('flex flex-wrap gap-x-8 gap-y-3')}>
+      <div className={cn('flex flex-wrap gap-y-4')}>
         {visibleFields.map((field) => {
           const value = data[field.name];
           // Enrich field metadata from objectSchema
@@ -88,8 +88,16 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
           // and look mangled when truncated mid-domain
           // (`zhuangjianguo@gmail.co` swallowing the `…m`). Let those
           // columns grow wider so the address fits on one line. Same
-          // treatment for textarea fields that authors may opt into.
-          const isWide = resolvedType === 'email' || resolvedType === 'url' || resolvedType === 'textarea';
+          // treatment for textarea fields and reference/lookup values —
+          // related-record names (`国家电投江苏海上风电有限公司`) are long
+          // and losing the tail hides the very thing the field identifies.
+          const isWide =
+            resolvedType === 'email' ||
+            resolvedType === 'url' ||
+            resolvedType === 'textarea' ||
+            resolvedType === 'reference' ||
+            resolvedType === 'lookup' ||
+            resolvedType === 'master_detail';
           // BooleanCellRenderer paints a tiny disabled checkbox which
           // reads as "empty input" in the header context. Pills with
           // ✓ / ✗ icons match how every modern enterprise UI
@@ -100,11 +108,18 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
             <div
               key={field.name}
               className={cn(
-                'flex flex-col gap-1 min-w-[8rem] basis-[10rem]',
-                isWide ? 'max-w-[24rem] basis-[16rem]' : 'max-w-[16rem]',
+                // Vertical divider + even padding makes each field read as
+                // its own column (Salesforce Highlights Panel). The first
+                // column drops the rule/left-pad so the row stays flush-left.
+                'flex flex-col gap-1 min-w-[7rem] px-5 border-l border-border/60 first:border-l-0 first:pl-0',
+                // Keep exactly one basis/max-w pair — emitting both
+                // basis-[9rem] and basis-[16rem] lets Tailwind's CSS order
+                // (not source order) pick the winner, so wide columns would
+                // silently collapse to the narrow width and truncate.
+                isWide ? 'basis-[16rem] max-w-[24rem]' : 'basis-[9rem] max-w-[16rem]',
               )}
             >
-              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              <span className="text-xs font-medium text-muted-foreground">
                 {fieldLabel(objectName || '', field.name, field.label)}
               </span>
               {isBoolean ? (
@@ -121,11 +136,14 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
                 )
               ) : (
                 <span
+                  title={typeof value === 'string' ? value : undefined}
                   className={cn(
-                    'block min-w-0 truncate',
-                    isKpi
-                      ? 'text-xl md:text-2xl font-semibold leading-tight tabular-nums tracking-tight'
-                      : 'text-sm font-semibold',
+                    // Uniform value size keeps every field on the same
+                    // baseline — a lone text-2xl KPI towering over text-sm
+                    // neighbours read as unbalanced. Numbers keep
+                    // tabular-nums so columns still align digit-for-digit.
+                    'block min-w-0 truncate text-sm font-semibold',
+                    isKpi && 'tabular-nums tracking-tight',
                   )}
                 >
                   <CellRenderer value={value} field={enrichedField as any} />


### PR DESCRIPTION
Closes #2249

## 背景

对象详情页顶部的高亮字段条(`HeaderHighlight`)显示效果不够理想:金额 KPI 一枝独大导致基线不齐、中文标签被英文式 `uppercase`/宽字距拉散、关联客户等长引用被拦腰截断、列间缺乏边界。详见 #2249。

## 改动(`packages/plugin-detail/src/HeaderHighlight.tsx`)

参考 Salesforce Highlights Panel / Stripe 明细头范式,纯样式调整:

- **统一值字号** — 取消 KPI 的 `text-xl md:text-2xl`,所有值 `text-sm font-semibold`,数字保留 `tabular-nums`,整排基线对齐。
- **矫正中文标签** — 去掉 `uppercase tracking-wide`。
- **成列分隔** — 每列 `border-l px-5`,首列 `first:border-l-0 first:pl-0`。
- **放宽引用字段 + 悬停全称** — reference/lookup/master_detail 纳入 `isWide`,值加 `title`。
- **修 basis 隐患** — 列容器 `basis`/`max-w` 改为互斥输出,避免两个 `flex-basis` 让 Tailwind CSS 顺序决定胜负、wide 列塌回窄宽度。

不改取字段与数据渲染逻辑。

## 验证

真机详情页需 console + 带数据后端(本 worktree 无),用组件改动后**实际输出的 DOM + 相同 Tailwind 类**搭自包含页面(真实 Tailwind 编译 + 主题变量)截图核对:

- 前:金额 24px 独大、中文标签松散、关联客户截断为「国家电投江苏…」、无列分隔。
- 后:所有值统一字号基线对齐、竖线成列、标签正常、金额 `tabular-nums`、关联客户完整显示「国家电投江苏海上风电有限公司」。

改动文件类型检查无新增报错(仅 worktree 依赖未构建 dist 导致的 `Cannot find module @object-ui/*` 通病)。