### PR TITLE
fix(app-shell): stop double-firing action error/success toasts in RecordDetailView & delete handler

### DIFF
--- a/.changeset/dedupe-recorddetail-delete-toast.md
+++ b/.changeset/dedupe-recorddetail-delete-toast.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Stop double-firing action toasts on record-detail script actions and the delete handler.
+
+`ActionRunner.handlePostExecution` already surfaces a result's `error` as a toast
+(and a success toast unless `silent`). Two handlers ALSO toasted themselves while
+returning `{success:false, error}` (or a non-`silent` success), so on a runner
+seeded with `onToast` the same message fired twice:
+
+- **`RecordDetailView` `serverActionHandler`** (script actions): the HTTP/inner-fail
+  branch and the catch branch each called `toast.error` before returning the error.
+  #2177 fixed the twin in `useConsoleActionRuntime` (interface pages) but not this
+  copy, so record-detail script-action failures (e.g. a `RECORD_LOCKED` from an
+  approval-locked record) still showed the error twice for everyone on the published
+  console bundle. Both branches now return the error and let the runner toast it once.
+
+- **`useObjectActions` `delete` handler** (ObjectView list/detail deletes): kept its
+  richer localized toast (label + description, or the bulk succeeded/failed summary)
+  and now returns WITHOUT `error` on failure so the runner doesn't re-toast it, and
+  marks successful deletes `silent` so the runner doesn't append a second generic
+  "Action completed successfully" toast.
+
+Adds `useObjectActions.test.tsx` asserting exactly one toast on delete
+success / failure / partial-bulk-failure.

--- a/packages/app-shell/src/hooks/__tests__/useObjectActions.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useObjectActions.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression coverage for the delete handler's error feedback (double-toast fix).
+ *
+ * useObjectActions runs its handlers on an ActionRunner seeded with `onToast`
+ * (ObjectView passes its console toastHandler). The delete handler surfaces
+ * failures with its own contextual `toast.error` (label + description, or the
+ * bulk succeeded/failed summary). It must therefore return WITHOUT an `error`
+ * key — otherwise ActionRunner.handlePostExecution toasts the error a SECOND
+ * time and the user sees the same delete failure twice.
+ *
+ * These tests wire `onToast` to the same sonner sink the handler uses (exactly
+ * as ObjectView's real toastHandler does) and assert the user sees ONE toast.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateSpy,
+  useParams: () => ({ appName: 'crm' }),
+}));
+
+vi.mock('@object-ui/i18n', () => ({
+  useObjectTranslation: () => ({
+    // Echo the interpolated defaultValue so assertions read naturally; fall
+    // back to the key when a test doesn't provide one.
+    t: (key: string, opts?: Record<string, any>) => (opts?.defaultValue ?? key),
+  }),
+}));
+
+// Spy on the toast sink. Both the handler's direct call AND the runner's
+// onToast bridge funnel here in the real app, so the call count is exactly
+// what the user sees.
+vi.mock('sonner', () => {
+  const fn: any = vi.fn();
+  fn.error = vi.fn();
+  fn.success = vi.fn();
+  return { toast: fn };
+});
+
+import { toast } from 'sonner';
+import { useObjectActions } from '../useObjectActions';
+
+// Mirror ObjectView's real toastHandler: route the runner's post-execution
+// toast into the same sonner sink the handler uses directly.
+const onToast = (message: string, options?: { type?: string }) => {
+  if (options?.type === 'error') (toast as any).error(message);
+  else (toast as any).success(message);
+};
+
+const onConfirm = async () => true;
+
+beforeEach(() => {
+  navigateSpy.mockReset();
+  (toast as any).mockClear?.();
+  (toast as any).error.mockClear();
+  (toast as any).success.mockClear();
+});
+
+function setup(dataSource: any) {
+  return renderHook(() =>
+    useObjectActions({
+      objectName: 'mtc_lead',
+      objectLabel: '线索',
+      dataSource,
+      onConfirm,
+      onToast,
+    }),
+  );
+}
+
+describe('useObjectActions — delete handler toast de-duplication', () => {
+  it('a failed single delete surfaces EXACTLY ONE error toast (not two)', async () => {
+    const dataSource = {
+      delete: vi.fn().mockRejectedValue(
+        new Error('RECORD_LOCKED: record is locked while an approval is in progress'),
+      ),
+    };
+    const { result } = setup(dataSource);
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.deleteRecord('lead-1');
+    });
+
+    // The handler owns the (richer) failure toast; the runner must stay quiet.
+    expect((toast as any).error).toHaveBeenCalledTimes(1);
+    // And it's the contextual "deleteFailed" toast (with the error as its
+    // description), not the runner's bare error string — i18n is stubbed here,
+    // so the key stands in for the interpolated label.
+    expect((toast as any).error).toHaveBeenCalledWith(
+      'objectActions.deleteFailed',
+      expect.objectContaining({ description: expect.stringContaining('RECORD_LOCKED') }),
+    );
+    // Returning without `error` is exactly what suppresses the runner's toast.
+    expect(res).toEqual({ success: false });
+  });
+
+  it('a successful delete surfaces one success toast and no error toast', async () => {
+    const dataSource = { delete: vi.fn().mockResolvedValue(undefined) };
+    const { result } = setup(dataSource);
+
+    await act(async () => {
+      await result.current.deleteRecord('lead-1');
+    });
+
+    expect((toast as any).success).toHaveBeenCalledTimes(1);
+    expect((toast as any).error).not.toHaveBeenCalled();
+  });
+
+  it('a partial bulk delete surfaces EXACTLY ONE error toast carrying the summary', async () => {
+    // One id succeeds, one rejects → "1 deleted, 1 failed" summary toast only.
+    const dataSource = {
+      delete: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('boom')),
+    };
+    const { result } = setup(dataSource);
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.execute({
+        type: 'delete',
+        params: { records: [{ id: 'a' }, { id: 'b' }] },
+      } as any);
+    });
+
+    expect((toast as any).error).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ success: false });
+  });
+});

--- a/packages/app-shell/src/hooks/useObjectActions.ts
+++ b/packages/app-shell/src/hooks/useObjectActions.ts
@@ -106,7 +106,10 @@ export function useObjectActions({
               defaultValue: `Deleted ${succeeded} ${objectLabel || objectName} records`,
             }),
           );
-          return { success: true, reload: true };
+          // `silent`: the handler already toasted the localized summary above;
+          // without this the runner's post-execution hook adds a second, generic
+          // "Action completed successfully" toast (double success toast).
+          return { success: true, reload: true, silent: true };
         }
         toast.error(
           t('objectActions.bulkDeletePartial', {
@@ -115,7 +118,11 @@ export function useObjectActions({
             defaultValue: `${succeeded} deleted, ${failed} failed`,
           }),
         );
-        return { success: false, error: `${failed} failed` };
+        // The toast above is the authoritative feedback (it carries the
+        // succeeded/failed summary the runner can't reconstruct). Return
+        // WITHOUT `error` so the ActionRunner post-execution hook — this runner
+        // has a toastHandler (onToast) — doesn't fire a second, duplicate toast.
+        return { success: false };
       }
 
       const recordId =
@@ -129,12 +136,17 @@ export function useObjectActions({
         await dataSource.delete(objectName, recordId);
         onRefresh?.();
         toast.success(t('objectActions.deleteSuccess', { label: objectLabel || objectName }));
-        return { success: true, reload: true };
+        // `silent`: handler owns the localized success toast above — suppress the
+        // runner's generic duplicate (see the bulk branch).
+        return { success: true, reload: true, silent: true };
       } catch (err: any) {
         toast.error(t('objectActions.deleteFailed', { label: objectLabel || objectName }), {
           description: err.message,
         });
-        return { success: false, error: err.message };
+        // Keep the richer toast above (label + error description) and return
+        // WITHOUT `error` so the ActionRunner post-execution hook doesn't toast
+        // the raw message a second time. See the bulk branch for the rationale.
+        return { success: false };
       }
     });
 

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -618,9 +618,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       if (!res.ok || (json && json.success === false) || innerFailed) {
         const errMsg = (innerFailed && inner.error) || json?.error || `Action "${targetName}" failed (HTTP ${res.status})`;
         if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
-        // Surface the failure — this custom new-tab path bypasses
-        // ActionRunner's toast-on-error, so otherwise the user gets no feedback.
-        toast.error(errMsg);
+        // Don't toast here. This handler always runs through the ActionRunner
+        // (registered as the `script` handler on the ActionProvider below, which
+        // wires `onToast`), whose post-execution hook surfaces the returned
+        // `error` as one toast. Toasting again double-fired the message
+        // (e.g. RECORD_LOCKED appeared twice). Mirrors useConsoleActionRuntime.
         return { success: false, error: errMsg };
       }
       const shouldRefresh = action.refreshAfter !== false;
@@ -663,7 +665,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     } catch (error) {
       if (preOpenedTab) { try { preOpenedTab.close(); } catch { /* ignore */ } }
       const msg = (error as Error).message;
-      toast.error(msg);
+      // Don't toast here — the ActionRunner post-execution hook toasts the
+      // returned `error` once (see the failure branch above).
       return { success: false, error: msg };
     } finally {
       serverActionInFlight.current.delete(inflightKey);


### PR DESCRIPTION
Closes #2252

## 问题

Console 记录详情页点一个会失败的 **script 动作**(如「分配线索」触发后端 `RECORD_LOCKED`)时,同一条错误 toast **弹两次**。后端只抛一次,是纯 UI 重复。排查中一并发现 **删除动作** 同类重复:失败弹两条、成功也弹两条。

## 根因

`ActionRunner.handlePostExecution` 已负责把结果 `error` 弹成 toast(成功则按 `showOnSuccess` 弹)。若某 handler **自己又调 `toast.*`** 且 **返回 `{success:false, error}`(成功时未标 `silent`)**,而 runner 又设了 `onToast`,就会被弹第二遍。

- **`RecordDetailView.serverActionHandler`(script)**:失败分支与 catch 分支各自 `toast.error` 后又返回 error。#2177 只修了孪生副本 `useConsoleActionRuntime`(interface page),记录详情页这份没修 → 仍双弹。也解释了「两天前修过还在」「同事没 clone objectui 也复现」(都吃同一份已发布的 `@objectstack/console`)。
- **`useObjectActions.delete`**(ObjectView 装配 `onToast`):失败自弹+返回 error → 双弹;成功自弹+未标 `silent` → runner 追加通用「Action completed successfully」;批量部分失败同理。

## 改动

- `RecordDetailView.tsx`:两个失败分支去掉自 `toast.error`,返回 error 交给 runner 弹一次(对齐 #2177)。
- `useObjectActions.ts`:保留更友好的本地化文案(label+description / 批量汇总),失败返回不带 `error`、成功标 `silent:true`,避免 runner 重复。

## 测试

**① 单元测试** — 新增 `useObjectActions.test.tsx`,把 `onToast` 接到与真实 ObjectView 相同的 sonner sink,断言用户实际所见:
- 删除失败 → error **恰好 1 次**(修前 2 次)
- 删除成功 → success **恰好 1 次**(此条修前报 `got 2 times`,揪出了成功路径的第 3 处双弹)
- 批量部分失败 → error **恰好 1 次**且带汇总

`3 新增 + 83 相关回归(含 #2177 的用例)全绿`。

**② 产物级证据** — 从本分支构建 console,grep 打包后的 `RecordDetailView` chunk,对照当初坐实 bug 的同一签名:

| bundle | 自弹签名 `.error(X),{success:!1,error:X}` |
|---|---|
| 旧发布版 `@objectstack/console@12.1.0` | **2 处** |
| 本 PR 构建 | **0 处** |

发货代码里两处自弹已消失。