### PR TITLE
Fix objectui-side follow-ups from Showcase E2E audit (framework#2620)

### DIFF
--- a/apps/console/.env.production
+++ b/apps/console/.env.production
@@ -10,9 +10,12 @@ VITE_USE_MOCK_SERVER=false
 # Sentry error tracking
 # DSN is a public ingest key (write-only) — safe to commit. When set,
 # @sentry/react is loaded lazily from a dedicated chunk (vendor-sentry,
-# ~97 KB brotli). Self-hosters can unset VITE_SENTRY_DSN to disable
-# observability entirely; the chunk is then never fetched.
+# ~97 KB brotli). Self-hosters/forks have two ways to disable observability
+# entirely (the chunk is then never fetched): unset VITE_SENTRY_DSN below, or
+# keep it and set VITE_SENTRY_ENABLED=false (handy if you'd rather not edit
+# this file at all when forking).
 VITE_SENTRY_DSN=https://1373a588ceb9da150b11e64bf85f583d@o4510356161757184.ingest.us.sentry.io/4511439670673408
+# VITE_SENTRY_ENABLED=false
 VITE_SENTRY_ENVIRONMENT=production
 VITE_SENTRY_SEND_DEFAULT_PII=true
 # VITE_SENTRY_RELEASE=  # injected by CI as VERCEL_GIT_COMMIT_SHA when available

--- a/packages/app-shell/src/observability/sentry.ts
+++ b/packages/app-shell/src/observability/sentry.ts
@@ -11,6 +11,11 @@
  *
  * Env vars consumed (all optional):
  *  - `VITE_SENTRY_DSN`         — DSN; absent disables the integration entirely
+ *  - `VITE_SENTRY_ENABLED`     — set to `"false"` to force-disable reporting
+ *    even when a DSN is configured (e.g. a fork that keeps the upstream DSN
+ *    in `.env.production` but doesn't want to report to it). Default: enabled
+ *    whenever a DSN is present — this is an *additional* off switch, not a
+ *    change to that default.
  *  - `VITE_SENTRY_ENVIRONMENT` — defaults to `MODE` (production/development)
  *  - `VITE_SENTRY_RELEASE`     — defaults to `VITE_APP_VERSION` or `unknown`
  *  - `VITE_SENTRY_TRACES_SAMPLE_RATE` — defaults to `0.1`
@@ -43,7 +48,7 @@ export function initSentry(): Promise<boolean> {
   initPromise = (async () => {
     const env = (import.meta as any).env ?? {};
     const dsn = env.VITE_SENTRY_DSN as string | undefined;
-    if (!dsn) return false;
+    if (!dsn || env.VITE_SENTRY_ENABLED === 'false') return false;
 
     try {
       const Sentry = (await import('@sentry/react')) as SentryModule;

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -346,17 +346,18 @@ export function AuthProvider({
 
   // --- Organization methods ---
 
-  const refreshOrganizations = useCallback(async () => {
+  const refreshOrganizations = useCallback(async (isCancelled?: () => boolean) => {
     if (!enabled || isPreviewMode) return;
     setIsOrganizationsLoading(true);
     try {
       const orgs = await client.listOrganizations();
+      if (isCancelled?.()) return;
       setOrganizations(orgs);
       // If no active org is set but orgs exist, try to get active from server
       if (orgs.length > 0 && !activeOrganization) {
         try {
           const active = await client.getActiveOrganization();
-          if (active) {
+          if (active && !isCancelled?.()) {
             setActiveOrganization(active);
             ActiveOrganizationStorage.set(active.id);
           }
@@ -365,9 +366,15 @@ export function AuthProvider({
         }
       }
     } catch (err) {
-      console.warn('[AuthProvider] Failed to load organizations:', err);
+      // A route change / unmount racing the in-flight request is not a real
+      // failure — only warn when this call is still the one that matters.
+      if (!isCancelled?.()) {
+        console.warn('[AuthProvider] Failed to load organizations:', err);
+      }
     } finally {
-      setIsOrganizationsLoading(false);
+      if (!isCancelled?.()) {
+        setIsOrganizationsLoading(false);
+      }
     }
   }, [client, enabled, isPreviewMode, activeOrganization]);
 
@@ -404,9 +411,10 @@ export function AuthProvider({
 
   // Load organizations once user is authenticated
   useEffect(() => {
-    if (user && enabled && !isPreviewMode) {
-      refreshOrganizations();
-    }
+    if (!(user && enabled && !isPreviewMode)) return;
+    let cancelled = false;
+    refreshOrganizations(() => cancelled);
+    return () => { cancelled = true; };
   }, [user, enabled, isPreviewMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const switchOrganization = useCallback(

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -113,7 +113,9 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
       ...rest
     } = props;
 
-    const isVisible = useCondition(toPredicateInput(schema.visible));
+    // Fails CLOSED on a throwing predicate — mirrors ActionEngine's
+    // getActionsForLocation contract (see action-button.tsx for rationale).
+    const isVisible = useCondition(toPredicateInput(schema.visible), undefined, { throwOnError: true });
     const isMobile = useIsMobile();
 
     // Filter business actions by location and deduplicate by name

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -52,7 +52,10 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
     const recordData = data != null && typeof data === 'object' ? data as Record<string, any> : {};
 
     // Evaluate visibility and disabled conditions with record data context.
-    const isVisible = useCondition(toPredicateInput(schema.visible), recordData);
+    // `visible` fails CLOSED on a throwing predicate (mirrors ActionEngine's
+    // getActionsForLocation) — a precondition that can't be evaluated should
+    // hide the action, not silently show one whose guard is broken.
+    const isVisible = useCondition(toPredicateInput(schema.visible), recordData, { throwOnError: true });
     // Spec field is `disabled` (boolean | CEL predicate — disabled when TRUE).
     // It previously had zero consumers (the renderer only read a non-spec
     // `enabled`), so a spec-authored `disabled` guard did nothing (#1885,

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -64,7 +64,9 @@ const ActionMenuItem: React.FC<{
   action: ActionSchema;
   onExecute: (action: ActionSchema) => Promise<void>;
 }> = ({ action, onExecute }) => {
-  const isVisible = useCondition(toPredicateInput(action.visible));
+  // Fails CLOSED on a throwing predicate — mirrors ActionEngine's
+  // getActionsForLocation contract (see action-button.tsx for rationale).
+  const isVisible = useCondition(toPredicateInput(action.visible), undefined, { throwOnError: true });
   const isEnabled = useCondition(toPredicateInput(action.enabled));
 
   const iconElement = useMemo(() => {
@@ -108,7 +110,9 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
     const [loading, setLoading] = useState(false);
     const moreActionsLabel = useMoreActionsLabel();
 
-    const isVisible = useCondition(toPredicateInput(schema.visible));
+    // Fails CLOSED on a throwing predicate — mirrors ActionEngine's
+    // getActionsForLocation contract (see action-button.tsx for rationale).
+    const isVisible = useCondition(toPredicateInput(schema.visible), undefined, { throwOnError: true });
 
     const TriggerIcon = resolveIcon(schema.icon) || MoreHorizontal;
     const variant = schema.variant || 'ghost';

--- a/packages/components/src/renderers/form/calendar.tsx
+++ b/packages/components/src/renderers/form/calendar.tsx
@@ -21,6 +21,10 @@ ComponentRegistry.register('calendar',
   ),
   {
     namespace: 'ui',
+    // `calendar` collides with the plugin-calendar full CRUD calendar VIEW,
+    // which owns the bare `type: 'calendar'` schema keyword; this date-picker
+    // primitive is reached via `ui:calendar` only.
+    skipFallback: true,
     label: 'Calendar',
     inputs: [
       { name: 'mode', type: 'enum', enum: ['default', 'single', 'multiple', 'range'], defaultValue: 'single', label: 'Mode' },

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -674,7 +674,14 @@ export class ActionRunner {
     }
 
     try {
-      const result = this.evaluator.evaluate(`\${${script}}`);
+      let result = this.evaluator.evaluate(`\${${script}}`);
+      // The expression itself is synchronous, but a formula function it calls
+      // may kick off an async write and return a Promise. Await it so the
+      // caller's success/failure — and the post-execution toast — reflects
+      // whether that write actually completed, not just that we called it.
+      if (result != null && typeof (result as any).then === 'function') {
+        result = await result;
+      }
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: `Script execution failed: ${(error as Error).message}` };

--- a/packages/core/src/actions/__tests__/ActionRunner.scriptAwait.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.scriptAwait.test.ts
@@ -1,0 +1,60 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ActionRunner — generic `script` action must await a Promise-returning
+ * formula function before reporting success, so the success toast reflects
+ * the underlying write actually completing rather than firing as soon as the
+ * (synchronous) expression evaluation returned a still-pending Promise.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ActionRunner, type ActionDef } from '../ActionRunner';
+
+describe('ActionRunner - script action awaits a Promise-returning formula', () => {
+  let runner: ActionRunner;
+  let toast: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    runner = new ActionRunner({});
+    toast = vi.fn();
+    runner.setToastHandler(toast);
+  });
+
+  it('resolves `data` to the awaited value, not a pending Promise, and toasts only after it settles', async () => {
+    let resolveWrite: (v: string) => void;
+    const write = new Promise<string>((resolve) => { resolveWrite = resolve; });
+    // Formula names are registered case-insensitively (stored upper-cased),
+    // so the expression must call it by that same upper-cased name.
+    runner.getEvaluator().registerFunction('doWrite', () => write);
+
+    const action: ActionDef = { type: 'script', execute: 'DOWRITE()' };
+    const pending = runner.execute(action);
+
+    // The write hasn't resolved yet — no toast should have fired.
+    await Promise.resolve();
+    expect(toast).not.toHaveBeenCalled();
+
+    resolveWrite!('saved');
+    const result = await pending;
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBe('saved'); // the resolved value, not the Promise itself
+    expect(toast).toHaveBeenCalledWith('Action completed successfully', expect.objectContaining({ type: 'success' }));
+  });
+
+  it('surfaces a rejected write as success:false instead of a false-positive success toast', async () => {
+    runner.getEvaluator().registerFunction('doFailingWrite', () => Promise.reject(new Error('write failed')));
+    const action: ActionDef = { type: 'script', execute: 'DOFAILINGWRITE()' };
+
+    const result = await runner.execute(action);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/write failed/);
+    expect(toast).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ type: 'success' }));
+  });
+});

--- a/packages/core/src/evaluator/ExpressionEvaluator.ts
+++ b/packages/core/src/evaluator/ExpressionEvaluator.ts
@@ -238,9 +238,14 @@ export class ExpressionEvaluator {
     }
     try {
       return Boolean(this.evaluateExpression(trimmed, { sanitize: options.sanitize !== false }));
-    } catch {
+    } catch (error) {
       // Unparseable predicate — preserve the historical "default to
-      // visible/enabled" behaviour rather than hiding/blocking on a typo.
+      // visible/enabled" behaviour rather than hiding/blocking on a typo,
+      // UNLESS the caller opted into fail-closed semantics (mirrors the
+      // `${...}` template path above, which already honors this).
+      if (options.throwOnError) {
+        throw error;
+      }
       return true;
     }
   }

--- a/packages/core/src/styling/scoped-styles.test.ts
+++ b/packages/core/src/styling/scoped-styles.test.ts
@@ -20,8 +20,8 @@ describe('scoped-styles compiler (ADR-0065)', () => {
       large: { padding: '24px', display: 'flex' },
       small: { padding: '12px' },
     });
-    expect(css).toContain('.os-s-card { padding: 24px; display: flex; }');
-    expect(css).toContain('@media (max-width: 640px) { .os-s-card { padding: 12px; } }');
+    expect(css).toContain('.os-s-card { padding: 24px !important; display: flex !important; }');
+    expect(css).toContain('@media (max-width: 640px) { .os-s-card { padding: 12px !important; } }');
     // No declaration ever sits outside a `.selector { … }` block.
     expect(css).not.toMatch(/(^|\n)\s*padding:/);
   });
@@ -33,7 +33,7 @@ describe('scoped-styles compiler (ADR-0065)', () => {
       small: { gap: '8px' },
       xsmall: { gap: '4px' },
     });
-    expect(css.split('\n')[0]).toBe('.x { gap: 16px; }');
+    expect(css.split('\n')[0]).toBe('.x { gap: 16px !important; }');
     expect(css).toContain(`@media (max-width: ${STYLE_BREAKPOINTS.medium}px)`);
     expect(css).toContain(`@media (max-width: ${STYLE_BREAKPOINTS.small}px)`);
     expect(css).toContain(`@media (max-width: ${STYLE_BREAKPOINTS.xsmall}px)`);
@@ -49,10 +49,10 @@ describe('scoped-styles compiler (ADR-0065)', () => {
         gridTemplateColumns: 'repeat(3, 1fr)',
       },
     });
-    expect(css).toContain('font-size: 44px;');
-    expect(css).toContain('color: #1a2b3c;');
-    expect(css).toContain('padding: var(--space-6);');
-    expect(css).toContain('grid-template-columns: repeat(3, 1fr);'); // camel→kebab, value intact
+    expect(css).toContain('font-size: 44px !important;');
+    expect(css).toContain('color: #1a2b3c !important;');
+    expect(css).toContain('padding: var(--space-6) !important;');
+    expect(css).toContain('grid-template-columns: repeat(3, 1fr) !important;'); // camel→kebab, value intact
   });
 
   it('emits nothing for empty / absent styles', () => {
@@ -64,6 +64,17 @@ describe('scoped-styles compiler (ADR-0065)', () => {
     expect(scopeClassFor('plan_solo')).toBe('os-s-plan_solo');
     expect(scopeClassFor(':r0:')).toBe('os-s--r0-'); // React useId() shape
     expect(scopeClassFor('a.b c')).toBe('os-s-a-b-c');
+  });
+
+  it('emits `!important` so a scoped display always beats a same-specificity utility class (regression: flex/grid layout conflict)', () => {
+    // A `type: 'flex'` node also carrying `responsiveStyles: { display: 'grid', ... }`
+    // lands `.flex` (from the Flex renderer) and `.os-s-<id>` (this compiler's
+    // output) on the same element — both single-class selectors, equal
+    // specificity. Without `!important` the winner depends on stylesheet
+    // injection order (flips between dev HMR and prod builds); with it, the
+    // scoped per-node override always wins deterministically.
+    const css = compileScopedStyles('.os-s-x', { large: { display: 'grid' } });
+    expect(css).toBe('.os-s-x { display: grid !important; }');
   });
 
   it('hasResponsiveStyles detects real style payloads', () => {

--- a/packages/core/src/styling/scoped-styles.ts
+++ b/packages/core/src/styling/scoped-styles.ts
@@ -42,11 +42,19 @@ const camelToKebab = (k: string): string =>
 
 /** Style-map → `prop: value;` declarations. Values pass through **verbatim** —
  * that is the whole point: arbitrary values (`13px`, `#1a2b3c`) and design
- * tokens (`var(--space-6)`) work with zero build step. */
+ * tokens (`var(--space-6)`) work with zero build step.
+ *
+ * `!important` on every declaration is deliberate: this scoped rule and a
+ * component's own base utility class (e.g. `flex`/`grid` from the layout
+ * renderer) both land on the same element with equal (single-class)
+ * specificity, so without it the winner depends on stylesheet injection
+ * order — which flips between dev (HMR-injected Tailwind CSS) and prod
+ * (head `<link>` precedes body). An explicit per-node style is always the
+ * more specific author intent and must win deterministically. */
 const declarations = (m: StyleMap): string =>
   Object.entries(m)
     .filter(([, v]) => v != null && v !== '')
-    .map(([k, v]) => `${camelToKebab(k)}: ${typeof v === 'number' ? String(v) : v};`)
+    .map(([k, v]) => `${camelToKebab(k)}: ${typeof v === 'number' ? String(v) : v} !important;`)
     .join(' ');
 
 /** True when a node actually carries responsive styles worth compiling. */

--- a/packages/fields/src/__tests__/DateCellRenderer.test.tsx
+++ b/packages/fields/src/__tests__/DateCellRenderer.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DateCellRenderer, formatRelativeDate } from '../index';
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+}
+
+describe('formatRelativeDate', () => {
+  it('renders "Overdue Nd" only when dueLike is set', () => {
+    expect(formatRelativeDate(daysAgo(3), { dueLike: true })).toBe('Overdue 3d');
+  });
+
+  it('renders neutral "Nd ago" for a past date that is not due-like', () => {
+    expect(formatRelativeDate(daysAgo(3))).toBe('3d ago');
+    expect(formatRelativeDate(daysAgo(3), { dueLike: false })).toBe('3d ago');
+  });
+});
+
+describe('DateCellRenderer', () => {
+  it('does not label a past start_date as "Overdue" (regression: field-role-agnostic formatter)', () => {
+    render(<DateCellRenderer value={daysAgo(6)} field={{ type: 'date', name: 'start_date' } as any} />);
+    expect(screen.getByText('6d ago')).toBeInTheDocument();
+    expect(screen.queryByText(/Overdue/)).not.toBeInTheDocument();
+  });
+
+  it('labels a past due_date as "Overdue Nd" and colors it red', () => {
+    render(<DateCellRenderer value={daysAgo(6)} field={{ type: 'date', name: 'due_date' } as any} />);
+    const el = screen.getByText('Overdue 6d');
+    expect(el).toBeInTheDocument();
+    expect(el.className).toMatch(/text-red-600/);
+  });
+
+  it('respects an explicit dueLike:true override regardless of field name', () => {
+    render(<DateCellRenderer value={daysAgo(2)} field={{ type: 'date', name: 'end_date', dueLike: true } as any} />);
+    expect(screen.getByText('Overdue 2d')).toBeInTheDocument();
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -362,8 +362,12 @@ export function humanizeLabel(value: string): string {
 
 /**
  * Format date as relative time (e.g., "2 days ago", "Today", "Overdue 3d")
+ *
+ * `dueLike` gates the "Overdue" wording — a past `start_date`/`created_at`
+ * isn't overdue, only a past due/deadline-semantic field is. Non-due-like
+ * past dates render as "Nd ago" instead.
  */
-export function formatRelativeDate(value: string | Date | number): string {
+export function formatRelativeDate(value: string | Date | number, options?: { dueLike?: boolean }): string {
   if (value === null || value === undefined || value === '') return '—';
   const date = value instanceof Date ? value : new Date(value as any);
   if (!(date instanceof Date) || isNaN(date.getTime())) return '—';
@@ -379,7 +383,7 @@ export function formatRelativeDate(value: string | Date | number): string {
   if (diffDays === -1) return 'Yesterday';
   if (diffDays < -1) {
     const absDays = Math.abs(diffDays);
-    if (absDays <= 7) return `Overdue ${absDays}d`;
+    if (absDays <= 7) return options?.dueLike ? `Overdue ${absDays}d` : `${absDays}d ago`;
     return formatDate(date);
   }
   if (diffDays > 1 && diffDays <= 7) return `In ${diffDays} days`;
@@ -389,7 +393,7 @@ export function formatRelativeDate(value: string | Date | number): string {
 /**
  * Format date value
  */
-export function formatDate(value: string | Date | number, style?: string): string {
+export function formatDate(value: string | Date | number, style?: string, options?: { dueLike?: boolean }): string {
   if (value === null || value === undefined || value === '') return '—';
   const date = value instanceof Date ? value : new Date(value as any);
   if (!(date instanceof Date) || isNaN(date.getTime())) return '—';
@@ -403,7 +407,7 @@ export function formatDate(value: string | Date | number, style?: string): strin
   }
 
   if (style === 'relative') {
-    return formatRelativeDate(date);
+    return formatRelativeDate(date, options);
   }
   
   // Default format: locale-aware human-readable. Drop the year when it
@@ -597,19 +601,20 @@ export function DateCellRenderer({ value, field }: CellRendererProps): React.Rea
   const safe = coerceToSafeValue(value);
   const dateField = field as any;
   const style = dateField.format || 'relative';
-  const formatted = formatDate(safe as string | Date, style);
 
-  // Determine if date is overdue (in the past) — but only color it red when the
-  // field is *semantically* a due/deadline. A plain "start_date" or "created_at"
-  // in the past should not render in red.
-  const date = safe != null ? new Date(safe as string | number) : null;
-  const isValidDate = date !== null && !isNaN(date.getTime());
-  const startOfToday = new Date();
-  startOfToday.setHours(0, 0, 0, 0);
+  // A date is only *semantically* a due/deadline when the field says so — a
+  // plain "start_date" or "created_at" in the past is neither overdue text
+  // nor red, even though it renders in the same relative-time style.
   const fieldName = String(dateField?.name || dateField?.accessorKey || dateField?.key || '').toLowerCase();
   const dueLike =
     dateField?.dueLike === true ||
     /(^|_)(due|deadline|expires?|expiry|expiration|expected_close|target_close|sla|return_by|renewal|next_action)(_|$)/.test(fieldName);
+  const formatted = formatDate(safe as string | Date, style, { dueLike });
+
+  const date = safe != null ? new Date(safe as string | number) : null;
+  const isValidDate = date !== null && !isNaN(date.getTime());
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
   const isOverdue = dueLike && isValidDate && date! < startOfToday;
   const isoString = isValidDate ? date!.toISOString() : String(safe);
 
@@ -2037,6 +2042,12 @@ const FIELD_TYPES_SKIP_FALLBACK = new Set([
   'slider',
   // Display renderer owned by `plugin-markdown:markdown`.
   'markdown',
+  // No other package owns the bare `time`/`address` key, but `registerField`
+  // wraps each call in a fresh `React.lazy(...)`, so re-registration (HMR,
+  // re-import) fails the registry's identity check every time and logs the
+  // same "bare-name fallback overwritten" warning at every boot regardless.
+  'time',
+  'address',
 ]);
 
 export function registerField(fieldType: string): void {
@@ -2093,7 +2104,10 @@ export function registerFields() {
   ComponentRegistry.register('select', createFieldRenderer(SelectField), { namespace: 'field', skipFallback: true });
   ComponentRegistry.register('date', createFieldRenderer(DateField), { namespace: 'field' });
   ComponentRegistry.register('datetime', createFieldRenderer(DateTimeField), { namespace: 'field' });
-  ComponentRegistry.register('time', createFieldRenderer(TimeField), { namespace: 'field' });
+  // Namespaced-only: no other renderer legitimately owns the bare 'time' key,
+  // but the fallback still triggered noisy "bare-name overwritten" warnings on
+  // every re-registration (e.g. hot reload / re-init in a shared registry).
+  ComponentRegistry.register('time', createFieldRenderer(TimeField), { namespace: 'field', skipFallback: true });
   
   // Contact fields - wrapped for documentation compatibility
   // `email` collides with the `ui:email` input variant; namespaced-only so the
@@ -2151,7 +2165,8 @@ export function registerFields() {
   ComponentRegistry.register('code', createFieldRenderer(CodeField), { namespace: 'field' });
   // `avatar` collides with the display avatar widget; namespaced-only.
   ComponentRegistry.register('avatar', createFieldRenderer(AvatarField), { namespace: 'field', skipFallback: true });
-  ComponentRegistry.register('address', createFieldRenderer(AddressField), { namespace: 'field' });
+  // Namespaced-only — see the 'time' registration above for rationale.
+  ComponentRegistry.register('address', createFieldRenderer(AddressField), { namespace: 'field', skipFallback: true });
   ComponentRegistry.register('geolocation', createFieldRenderer(GeolocationField), { namespace: 'field' });
   ComponentRegistry.register('signature', createFieldRenderer(SignatureField), { namespace: 'field' });
   ComponentRegistry.register('qrcode', createFieldRenderer(QRCodeField), { namespace: 'field' });

--- a/packages/layout/src/NavigationRenderer.tsx
+++ b/packages/layout/src/NavigationRenderer.tsx
@@ -260,10 +260,13 @@ export function resolveLabel(
 /**
  * Resolve a navigation item label, applying:
  * 1. i18n translation for I18nLabel objects (when `t` is provided)
- * 2. Convention-based i18n for object-type items with plain string labels
- *    (when `resolveObjectLabel` is provided)
- * 3. Convention-based i18n for dashboard-type items with plain string labels
- *    (when `resolveDashboardLabel` is provided)
+ * 2. Convention-based i18n for object-type items whose plain string label was
+ *    never customized (still equal to the bare object/dashboard/item name),
+ *    so standard nav entries still localize automatically
+ *    (when `resolveObjectLabel`/`resolveDashboardLabel`/etc. is provided)
+ * 3. Otherwise, the schema-authored explicit label always wins — an app
+ *    author who wrote a custom label (e.g. a plural 'Projects') must never
+ *    have it silently overridden by an `objects.<name>.label` translation.
  */
 function resolveNavItemLabel(
   item: NavigationItem,
@@ -278,28 +281,37 @@ function resolveNavItemLabel(
   // Only apply convention-based resolution for items with plain string labels.
   // I18nLabel objects (with explicit key/defaultValue) already have their own translation keys.
   if (typeof item.label !== 'string') return base;
+  // An explicit label that differs from the bare target name was authored on
+  // purpose (e.g. a custom plural 'Projects') — never let convention-based
+  // i18n resolution override it.
+  const isCustomized = (target: string | undefined) =>
+    !!target && base.trim().toLowerCase() !== target.trim().toLowerCase();
   if (item.type === 'object' && item.objectName) {
     // View-scoped item — prefer view-specific label so a Kanban / Calendar /
     // custom view in the sidebar doesn't collapse to the parent object's
     // label (which would visually duplicate the object's list entry).
     // Convention: `{ns}.objects.{objectName}._views.{viewName}.label`.
     if (item.viewName) {
+      if (isCustomized(item.viewName)) return base;
       if (viewResolver) return viewResolver(item.objectName, item.viewName, base);
       // No view resolver: respect the schema-provided explicit label rather
       // than overriding with the parent object's i18n label.
       return base;
     }
+    if (isCustomized(item.objectName)) return base;
     if (resolver) return resolver(item.objectName, base);
   }
-  if (dashboardResolver && item.type === 'dashboard' && (item as any).dashboardName) {
-    return dashboardResolver((item as any).dashboardName, base);
+  if (item.type === 'dashboard' && (item as any).dashboardName) {
+    if (isCustomized((item as any).dashboardName)) return base;
+    if (dashboardResolver) return dashboardResolver((item as any).dashboardName, base);
   }
-  if (groupResolver && item.type === 'group' && item.id) {
-    return groupResolver(item.id, base);
+  if (item.type === 'group' && item.id) {
+    if (isCustomized(item.id)) return base;
+    if (groupResolver) return groupResolver(item.id, base);
   }
   // Fallback for non-object/non-dashboard/non-group items (url, page, report,
   // custom) with a stable id — translate via the per-app navigation namespace.
-  if (itemResolver && item.id) {
+  if (itemResolver && item.id && !isCustomized(item.id)) {
     return itemResolver(item.id, base);
   }
   return base;

--- a/packages/plugin-charts/src/AdvancedChartImpl.axisLabels.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.axisLabels.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression: the X-axis tick formatter rendered the raw category value
+ * verbatim even when the caller supplied a resolved display label for it via
+ * `config[value].label` — the same lookup already used for series names and
+ * pie/donut legend entries, just missing for the axis.
+ */
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+const DATA = [
+  { status: 'active', count: 5 },
+  { status: 'archived', count: 2 },
+];
+
+describe('AdvancedChartImpl — axis tick label resolution', () => {
+  it('renders the resolved config label instead of the raw enum value', () => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={DATA}
+        xAxisKey="status"
+        series={[{ dataKey: 'count', label: 'Count' }]}
+        config={{
+          count: { label: 'Count' },
+          active: { label: '合作中' },
+          archived: { label: 'Archived' },
+        }}
+      />,
+    );
+    expect(container.textContent).toContain('合作中');
+    expect(container.textContent).toContain('Archived');
+    expect(container.textContent).not.toContain('active');
+    expect(container.textContent).not.toContain('archived');
+  });
+
+  it('falls back to the raw value when no config label is set (no regression)', () => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={DATA}
+        xAxisKey="status"
+        series={[{ dataKey: 'count', label: 'Count' }]}
+      />,
+    );
+    expect(container.textContent).toMatch(/active/);
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -240,6 +240,13 @@ export default function AdvancedChartImpl({
   // Falls back to the raw value when not parseable as a date.
   const formatTick = React.useCallback((value: any): string => {
     if (value == null || value === '') return '';
+    // A resolved display label for this exact category value — the same
+    // `config[key]?.label` convention already used for series names (below)
+    // and pie/donut legend entries. Wins over the raw value so an
+    // analytics-response-shaped `config` (value → { label }) reaches the
+    // axis too, not just series/legend text.
+    const resolved = config?.[String(value)]?.label;
+    if (resolved != null) return String(resolved);
     const str = typeof value === 'string' ? value : String(value);
     // Detect ISO 8601 date / datetime strings (YYYY-MM-DD or with time component)
     const isoLike = /^\d{4}-\d{2}-\d{2}/.test(str);
@@ -264,7 +271,7 @@ export default function AdvancedChartImpl({
     }
     if (isMobile && str.length > 8) return str.slice(0, 8) + '…';
     return str;
-  }, [data, xAxisKey, isMobile]);
+  }, [data, xAxisKey, isMobile, config]);
 
   // Memoize whether any X-axis label is long enough to warrant angle rotation
   const hasLongLabels = React.useMemo(

--- a/packages/plugin-charts/src/index.tsx
+++ b/packages/plugin-charts/src/index.tsx
@@ -51,11 +51,15 @@ ComponentRegistry.register(
     },
   }
 );
-// Alias for generic view
+// Alias for generic view. `chart` collides with the raw data
+// `plugin-charts:chart` (ChartRenderer) registered below, which owns the bare
+// `type: 'chart'` schema keyword; this object/aggregate-query variant is
+// reached via `view:chart` only.
 ComponentRegistry.register('chart', ObjectChart, {
   namespace: 'view',
   category: 'view',
   label: 'Chart',
+  skipFallback: true,
   inputs: [
     { name: 'objectName', type: 'string', label: 'Object Name', required: true },
     { name: 'type', type: 'string', label: 'Chart Type' },

--- a/packages/plugin-chatbot/src/useAgents.ts
+++ b/packages/plugin-chatbot/src/useAgents.ts
@@ -112,6 +112,56 @@ function normalize(raw: RawAgent[]): AgentDescriptor[] {
 }
 
 /**
+ * Module-level cache + in-flight dedup keyed by `apiBase`, so remounting a
+ * chat surface on every navigation doesn't re-hit `GET /agents` — the catalog
+ * rarely changes within a session. `refetch()` bypasses both.
+ */
+const AGENTS_CACHE_TTL_MS = 30_000;
+const agentsCache = new Map<string, { data: AgentDescriptor[]; timestamp: number }>();
+const agentsInFlight = new Map<string, Promise<AgentDescriptor[]>>();
+
+function fetchAgentsCached(
+  apiBase: string,
+  headers: Record<string, string> | undefined,
+  force: boolean,
+): Promise<AgentDescriptor[]> {
+  if (force) {
+    agentsCache.delete(apiBase);
+  } else {
+    const cached = agentsCache.get(apiBase);
+    if (cached && Date.now() - cached.timestamp < AGENTS_CACHE_TTL_MS) {
+      return Promise.resolve(cached.data);
+    }
+  }
+
+  const inFlight = agentsInFlight.get(apiBase);
+  if (inFlight && !force) return inFlight;
+
+  const url = `${apiBase.replace(/\/$/, '')}/agents`;
+  const promise = fetch(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json', ...(headers ?? {}) },
+    credentials: 'include',
+  })
+    .then(async (res) => {
+      if (!res.ok) throw new Error(`Failed to load agents (${res.status})`);
+      const payload = (await res.json()) as { agents?: RawAgent[] } | RawAgent[];
+      const list = Array.isArray(payload) ? payload : payload?.agents ?? [];
+      return normalize(list);
+    })
+    .then((normalized) => {
+      agentsCache.set(apiBase, { data: normalized, timestamp: Date.now() });
+      return normalized;
+    })
+    .finally(() => {
+      agentsInFlight.delete(apiBase);
+    });
+
+  agentsInFlight.set(apiBase, promise);
+  return promise;
+}
+
+/**
  * Fetches the active agent catalog from the backend.
  *
  * @example
@@ -133,31 +183,17 @@ export function useAgents(options: UseAgentsOptions = {}): UseAgentsReturn {
   useEffect(() => {
     if (!enabled || !apiBase) return;
 
-    const controller = new AbortController();
     let cancelled = false;
-
     setIsLoading(true);
     setError(undefined);
 
-    const url = `${apiBase.replace(/\/$/, '')}/agents`;
-    fetch(url, {
-      method: 'GET',
-      headers: { Accept: 'application/json', ...(headersRef.current ?? {}) },
-      credentials: 'include',
-      signal: controller.signal,
-    })
-      .then(async (res) => {
-        if (!res.ok) throw new Error(`Failed to load agents (${res.status})`);
-        return res.json() as Promise<{ agents?: RawAgent[] } | RawAgent[]>;
-      })
-      .then((payload) => {
+    fetchAgentsCached(apiBase, headersRef.current, reloadToken > 0)
+      .then((normalized) => {
         if (cancelled) return;
-        const list = Array.isArray(payload) ? payload : payload?.agents ?? [];
-        const normalized = normalize(list);
         setAgents(normalized.length > 0 ? normalized : fallback);
       })
       .catch((err: Error) => {
-        if (cancelled || err.name === 'AbortError') return;
+        if (cancelled) return;
         setError(err);
         setAgents(fallback);
       })
@@ -165,10 +201,7 @@ export function useAgents(options: UseAgentsOptions = {}): UseAgentsReturn {
         if (!cancelled) setIsLoading(false);
       });
 
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
+    return () => { cancelled = true; };
     // `fallback` is intentionally excluded — callers usually pass a fresh array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiBase, enabled, reloadToken]);

--- a/packages/plugin-designer/src/AppCreationWizard.tsx
+++ b/packages/plugin-designer/src/AppCreationWizard.tsx
@@ -109,7 +109,9 @@ function generateNavFromObjects(objects: ObjectSelection[]): NavigationItem[] {
     .map((o) => ({
       id: o.name,
       type: 'object' as const,
-      label: o.label,
+      // Nav entries open a list view — prefer the object's plural label
+      // ('Projects') over its singular label ('Project') when available.
+      label: o.pluralLabel || o.label,
       icon: o.icon,
       objectName: o.name,
     }));

--- a/packages/plugin-designer/src/pages/CreateAppPage.tsx
+++ b/packages/plugin-designer/src/pages/CreateAppPage.tsx
@@ -28,6 +28,7 @@ export function CreateAppPage() {
   const availableObjects: ObjectSelection[] = (objects || []).map((obj: any) => ({
     name: obj.name,
     label: obj.label || obj.name,
+    pluralLabel: obj.pluralLabel,
     icon: obj.icon,
     selected: false,
   }));

--- a/packages/plugin-designer/src/pages/EditAppPage.tsx
+++ b/packages/plugin-designer/src/pages/EditAppPage.tsx
@@ -31,6 +31,7 @@ export function EditAppPage() {
   const availableObjects: ObjectSelection[] = (objects || []).map((obj: any) => ({
     name: obj.name,
     label: obj.label || obj.name,
+    pluralLabel: obj.pluralLabel,
     icon: obj.icon,
     selected: appToEdit?.navigation?.some(
       (nav: any) => nav.type === 'object' && nav.objectName === obj.name,

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -205,6 +205,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
       const refTarget = objectDefField.reference_to || objectDefField.reference;
       if (refTarget && !enrichedField.reference_to) enrichedField.reference_to = refTarget;
       if (objectDefField.reference_field && !enrichedField.reference_field) enrichedField.reference_field = objectDefField.reference_field;
+      if ((objectDefField as any).dueLike !== undefined && enrichedField.dueLike === undefined) enrichedField.dueLike = (objectDefField as any).dueLike;
     }
     if (objectName && Array.isArray(enrichedField.options) && enrichedField.options.length > 0) {
       enrichedField.options = translateOptions(objectName, field.name, enrichedField.options as any);

--- a/packages/plugin-form/src/ObjectForm.submitBehavior.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.submitBehavior.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Declarative `submitBehavior` handling for metadata-only (non-wizard) forms —
+ * mirrors WizardForm.successBehavior.test.tsx for the flat ObjectForm path.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+const { toastSuccess } = vi.hoisted(() => ({ toastSuccess: vi.fn() }));
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, toast: { ...actual.toast, success: toastSuccess, error: vi.fn() } };
+});
+
+import { ObjectForm } from './ObjectForm';
+import { registerAllFields } from '@object-ui/fields';
+
+registerAllFields();
+
+const objectSchema = {
+  name: 'o',
+  fields: { name: { type: 'text', label: 'Name' } },
+};
+const makeDS = () => ({
+  getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+  create: vi.fn(async (_o: string, d: any) => ({ id: 'r1', ...d })),
+  update: vi.fn(),
+  findOne: vi.fn(),
+});
+const waitInput = (c: HTMLElement, name: string) =>
+  waitFor(() => {
+    const el = c.querySelector(`input[name="${name}"]`) as HTMLInputElement | null;
+    if (!el) throw new Error(`${name} not ready`);
+    return el;
+  });
+
+describe('ObjectForm — submitBehavior', () => {
+  beforeEach(() => toastSuccess.mockClear());
+
+  it('redirect: same-origin-guarded navigate, no toast', async () => {
+    const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+    const ds = makeDS();
+    const { container } = render(
+      <ObjectForm
+        schema={{
+          type: 'object-form', objectName: 'o', mode: 'create',
+          submitBehavior: { kind: 'redirect', url: '/apps/x/done' },
+        } as any}
+        dataSource={ds as any}
+      />,
+    );
+    fireEvent.change(await waitInput(container, 'name'), { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/apps/x/done'));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    assign.mockRestore();
+  });
+
+  it('thank-you: toasts the custom message', async () => {
+    const ds = makeDS();
+    const { container } = render(
+      <ObjectForm
+        schema={{
+          type: 'object-form', objectName: 'o', mode: 'create',
+          submitBehavior: { kind: 'thank-you', message: 'All set!' },
+        } as any}
+        dataSource={ds as any}
+      />,
+    );
+    fireEvent.change(await waitInput(container, 'name'), { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('All set!'));
+  });
+
+  it('continue: resets the form for another entry', async () => {
+    const ds = makeDS();
+    const { container } = render(
+      <ObjectForm
+        schema={{
+          type: 'object-form', objectName: 'o', mode: 'create',
+          submitBehavior: { kind: 'continue' },
+        } as any}
+        dataSource={ds as any}
+      />,
+    );
+    fireEvent.change(await waitInput(container, 'name'), { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+      if (!el) throw new Error('form gone');
+      expect(el.value).toBe('');
+    });
+  });
+});

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -18,7 +18,7 @@ import type { ObjectFormSchema, FormField, FormSchema, DataSource } from '@objec
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { mapFieldTypeToFormType, buildValidationRules, formatFileSize } from '@object-ui/fields';
 import { useIsMobile, toast } from '@object-ui/components';
-import { resolveSuccessNavigate } from './successBehavior';
+import { resolveSuccessNavigate, isSameOriginUrl } from './successBehavior';
 import { usePermissions } from '@object-ui/permissions';
 import { TabbedForm } from './TabbedForm';
 import { WizardForm } from './WizardForm';
@@ -629,6 +629,28 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
       // already toasts) so we never double-confirm.
       if (schema.onSuccess) {
         await schema.onSuccess(result);
+      } else if (!schema.submitHandler && schema.submitBehavior) {
+        const behavior = schema.submitBehavior;
+        switch (behavior.kind) {
+          case 'redirect':
+            if (isSameOriginUrl(behavior.url)) {
+              setTimeout(() => window.location.assign(behavior.url), behavior.delayMs ?? 0);
+            }
+            break;
+          case 'continue':
+            // Reset is driven declaratively by `resetOnSubmit` below (mirrors
+            // `resetOnSuccess`) — nothing imperative to do here.
+            break;
+          case 'next-record':
+          case 'thank-you':
+          default:
+            toast.success(
+              behavior.kind === 'thank-you' && behavior.message
+                ? behavior.message
+                : schema.successMessage || (schema.mode === 'create' ? 'Created' : 'Saved'),
+            );
+            break;
+        }
       } else if (!schema.submitHandler) {
         const nav = resolveSuccessNavigate(schema.navigateOnSuccess, result);
         if (nav) {
@@ -930,7 +952,9 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     cancelLabel: schema.cancelText,
     showSubmit: schema.showSubmit !== false && schema.mode !== 'view',
     showCancel: schema.showCancel !== false,
-    resetOnSubmit: schema.showReset || (schema.resetOnSuccess && schema.mode === 'create'),
+    resetOnSubmit: schema.showReset
+      || schema.submitBehavior?.kind === 'continue'
+      || (!schema.submitBehavior && schema.resetOnSuccess && schema.mode === 'create'),
     defaultValues: finalDefaultValues,
     onSubmit: handleSubmit,
     onCancel: handleCancel,

--- a/packages/plugin-form/src/WizardForm.successBehavior.test.tsx
+++ b/packages/plugin-form/src/WizardForm.successBehavior.test.tsx
@@ -56,6 +56,57 @@ describe('WizardForm — navigateOnSuccess', () => {
   });
 });
 
+describe('WizardForm — submitBehavior', () => {
+  beforeEach(() => toastSuccess.mockClear());
+
+  it('redirect: same-origin-guarded navigate, no navigateOnSuccess/successMessage fallback', async () => {
+    const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+    const ds = makeDS();
+    const schema = {
+      type: 'object-form', formType: 'wizard', objectName: 'o', mode: 'create',
+      submitBehavior: { kind: 'redirect', url: '/apps/x/done' },
+      sections: [{ label: 'A', fields: ['name'] }],
+    };
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+    fireEvent.change(await waitInput(container, 'name'), { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/apps/x/done'));
+    expect(toastSuccess).not.toHaveBeenCalled();
+    assign.mockRestore();
+  });
+
+  it('thank-you: toasts the custom message', async () => {
+    const ds = makeDS();
+    const schema = {
+      type: 'object-form', formType: 'wizard', objectName: 'o', mode: 'create',
+      submitBehavior: { kind: 'thank-you', message: 'All set!' },
+      sections: [{ label: 'A', fields: ['name'] }],
+    };
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+    fireEvent.change(await waitInput(container, 'name'), { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('All set!'));
+  });
+
+  it('continue: returns to a cleared step 1 after create (like resetOnSuccess)', async () => {
+    const ds = makeDS();
+    const schema = {
+      type: 'object-form', formType: 'wizard', objectName: 'o', mode: 'create',
+      submitBehavior: { kind: 'continue' },
+      sections: [{ label: 'A', fields: ['name'] }],
+    };
+    const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
+    fireEvent.change(await waitInput(container, 'name'), { target: { value: 'Alpha' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+      if (!el) throw new Error('not back to step 1');
+      expect(el.value).toBe('');
+    });
+  });
+});
+
 describe('WizardForm — resetOnSuccess', () => {
   beforeEach(() => toastSuccess.mockClear());
   it('returns to a cleared step 1 after create and toasts', async () => {

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -21,7 +21,7 @@ import { FormSection } from './FormSection';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
 import { sectionFormLayout } from './autoLayout';
-import { resolveSuccessNavigate } from './successBehavior';
+import { resolveSuccessNavigate, isSameOriginUrl, type SubmitBehavior } from './successBehavior';
 import type { FormSectionConfig } from './TabbedForm';
 
 export interface WizardFormSchema {
@@ -80,17 +80,27 @@ export interface WizardFormSchema {
   /**
    * Declarative success toast text shown when no `onSuccess` handler is given
    * (metadata pages cannot pass a function). Falls back to 'Created'/'Saved'.
+   * Ignored when `submitBehavior` is set.
    */
   successMessage?: string;
 
   /** Navigate here after a successful create/update (declarative; metadata
    * pages can't pass onSuccess). Supports `{id}`/`{recordId}` interpolation
-   * from the saved record. Same-origin-guarded. Takes precedence over the toast. */
+   * from the saved record. Same-origin-guarded. Takes precedence over the toast.
+   * Ignored when `submitBehavior` is set. */
   navigateOnSuccess?: string;
 
   /** Reset the wizard (back to step 1, cleared) after a successful create so the
-   * user can enter another. Ignored when `navigateOnSuccess` is set. */
+   * user can enter another. Ignored when `navigateOnSuccess` or `submitBehavior`
+   * is set. */
   resetOnSuccess?: boolean;
+
+  /**
+   * Declarative post-submit behavior aligned with `@objectstack/spec`'s
+   * `FormView.submitBehavior`. When present, takes precedence over
+   * `successMessage` / `navigateOnSuccess` / `resetOnSuccess`.
+   */
+  submitBehavior?: SubmitBehavior;
   
   /**
    * Show cancel button
@@ -297,8 +307,34 @@ export const WizardForm: React.FC<WizardFormProps> = ({
         
         if (schema.onSuccess) {
           await schema.onSuccess(result);
+        } else if (schema.submitBehavior) {
+          const behavior = schema.submitBehavior;
+          switch (behavior.kind) {
+            case 'redirect': {
+              if (isSameOriginUrl(behavior.url)) {
+                setTimeout(() => window.location.assign(behavior.url), behavior.delayMs ?? 0);
+              }
+              break;
+            }
+            case 'continue':
+              // Back to a fresh step 1 for the next entry.
+              setFormData({});
+              setCompletedSteps(new Set());
+              setCurrentStep(0);
+              setResetNonce((n) => n + 1);
+              break;
+            case 'next-record':
+            case 'thank-you':
+            default:
+              toast.success(
+                behavior.kind === 'thank-you' && behavior.message
+                  ? behavior.message
+                  : schema.successMessage || (schema.mode === 'create' ? 'Created' : 'Saved'),
+              );
+              break;
+          }
         } else {
-          // Declarative success behaviors for metadata-only wizards.
+          // Legacy declarative success behaviors for metadata-only wizards.
           const nav = resolveSuccessNavigate(schema.navigateOnSuccess, result);
           if (nav) {
             // Landing on the saved record is the confirmation — no toast needed.

--- a/packages/plugin-form/src/successBehavior.ts
+++ b/packages/plugin-form/src/successBehavior.ts
@@ -13,8 +13,10 @@
  * → here), so the same-origin check is inlined.
  */
 
+export type { SubmitBehavior } from '@object-ui/types';
+
 /** Same-origin guard for declarative navigation (relative or absolute URLs). */
-function isSameOriginUrl(rawUrl: string): boolean {
+export function isSameOriginUrl(rawUrl: string): boolean {
   try {
     if (typeof window === 'undefined') return false;
     const url = new URL(rawUrl, window.location.href);

--- a/packages/plugin-map/src/ObjectMap.styleFallback.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.styleFallback.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression: a failed MapLibre style/tile load used to render a blank map
+ * with no indication anything went wrong. `onError` now surfaces a banner,
+ * and a schema-configured `style` overrides the public demo default.
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectMap } from './ObjectMap';
+
+let capturedProps: any = null;
+
+vi.mock('react-map-gl/maplibre', () => ({
+  default: (props: any) => {
+    capturedProps = props;
+    return (
+      <div aria-label="Map">
+        <button
+          type="button"
+          data-testid="simulate-map-error"
+          onClick={() => props.onError?.({ error: new Error('Failed to fetch') })}
+        />
+        {props.children}
+      </div>
+    );
+  },
+  Map: ({ children }: any) => <div aria-label="Map">{children}</div>,
+  NavigationControl: () => <div data-testid="nav-control" />,
+  Marker: ({ children }: any) => <div data-testid="map-marker">{children}</div>,
+  Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
+}));
+
+const mockData = [{ id: '1', name: 'Loc 1', latitude: 40, longitude: -74 }];
+
+describe('ObjectMap — style/load-failure fallback', () => {
+  it('uses the configured style over the public demo default', async () => {
+    const schema: any = {
+      type: 'map',
+      style: 'https://tiles.example.com/style.json',
+      map: { latitudeField: 'latitude', longitudeField: 'longitude', titleField: 'name' },
+      data: { provider: 'value', items: mockData },
+    };
+    render(<ObjectMap schema={schema} />);
+    await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+    expect(capturedProps.mapStyle).toBe('https://tiles.example.com/style.json');
+  });
+
+  it('falls back to the public demo style when none is configured', async () => {
+    const schema: any = {
+      type: 'map',
+      map: { latitudeField: 'latitude', longitudeField: 'longitude', titleField: 'name' },
+      data: { provider: 'value', items: mockData },
+    };
+    render(<ObjectMap schema={schema} />);
+    await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+    expect(capturedProps.mapStyle).toBe('https://demotiles.maplibre.org/style.json');
+  });
+
+  it('shows a degraded-state banner when the style/tiles fail to load', async () => {
+    const schema: any = {
+      type: 'map',
+      map: { latitudeField: 'latitude', longitudeField: 'longitude', titleField: 'name' },
+      data: { provider: 'value', items: mockData },
+    };
+    render(<ObjectMap schema={schema} />);
+    await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+    expect(screen.queryByRole('alert')).toBeNull();
+    fireEvent.click(screen.getByTestId('simulate-map-error'));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Map failed to load/);
+  });
+});

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -39,7 +39,16 @@ const MapConfigSchema = z.object({
   descriptionField: z.string().optional(),
   zoom: z.number().optional(),
   center: z.tuple([z.number(), z.number()]).optional(),
+  style: z.string().optional(),
 });
+
+/**
+ * Public MapLibre demo style — free, unauthenticated, but not intended for
+ * production traffic (rate-limited, no uptime guarantee). Used only when no
+ * `style` is configured; a load failure surfaces the banner below rather
+ * than failing silently.
+ */
+const DEFAULT_MAP_STYLE = 'https://demotiles.maplibre.org/style.json';
 
 export interface ObjectMapProps {
   schema: ObjectGridSchema;
@@ -70,6 +79,8 @@ interface MapConfig {
   zoom?: number;
   /** Center coordinates [lat, lng] */
   center?: [number, number];
+  /** MapLibre style URL/spec (overrides the public demo default) */
+  style?: string;
 }
 
 /**
@@ -128,6 +139,12 @@ function convertSortToQueryParams(sort: string | any[] | undefined): Record<stri
  * Helper to get map configuration from schema
  */
 function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
+  // A custom style may be set alongside any of the shapes below — read it
+  // once so every return path can carry it through.
+  const style: string | undefined =
+    (schema as any).style || (schema as any).mapStyle
+    || (schema.filter as any)?.map?.style || (schema as any).map?.style;
+
   // 1. Check top-level properties (ObjectMapSchema style)
   if (schema.locationField || schema.latitudeField) {
       return {
@@ -137,7 +154,8 @@ function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
           titleField: schema.titleField || 'name',
           descriptionField: schema.descriptionField,
           zoom: schema.zoom,
-          center: schema.center
+          center: schema.center,
+          style,
       };
   }
 
@@ -146,7 +164,7 @@ function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
   if (schema.filter && typeof schema.filter === 'object' && 'map' in schema.filter) {
     config = (schema.filter as any).map as MapConfig;
   }
-  
+
   // For backward compatibility, check if schema has map config at root
   else if ((schema as any).map) {
     config = (schema as any).map as MapConfig;
@@ -157,9 +175,9 @@ function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
      if (!result.success) {
        console.warn(`[ObjectMap] Invalid map configuration:`, result.error.format());
      }
-     return config;
+     return { ...config, style: config.style || style };
   }
-  
+
   // Default configuration
   return {
     latitudeField: 'latitude',
@@ -169,6 +187,7 @@ function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
     descriptionField: 'description',
     zoom: 10,
     center: [0, 0],
+    style,
   };
 }
 
@@ -309,6 +328,13 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
   const [userLocation, setUserLocation] = useState<{ lng: number; lat: number } | null>(null);
   const [geoError, setGeoError] = useState<string | null>(null);
   const [geoBusy, setGeoBusy] = useState(false);
+  // Style/tile load failures (bad network, unreachable style server) don't
+  // throw from react-map-gl — they emit an `error` event. Without this, a
+  // failed load renders a blank map with no indication anything went wrong.
+  const [mapStyleError, setMapStyleError] = useState<string | null>(null);
+  const handleMapError = useCallback((e: { error?: Error & { status?: number } }) => {
+    setMapStyleError(e?.error?.message || 'Failed to load the map style/tiles.');
+  }, []);
   const requestUserLocation = useCallback(() => {
     if (typeof navigator === 'undefined' || !navigator.geolocation) {
       setGeoError('Geolocation is not available in this browser.');
@@ -569,12 +595,22 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
             ref={(r) => { mapRef.current = r as any; }}
             initialViewState={initialViewState}
             style={{ width: '100%', height: '100%' }}
-            mapStyle="https://demotiles.maplibre.org/style.json"
+            mapStyle={mapConfig.style || DEFAULT_MAP_STYLE}
             touchZoomRotate={true}
             dragRotate={true}
             touchPitch={true}
             onZoom={(e) => setCurrentZoom(Math.round(e.viewState.zoom))}
+            onError={handleMapError}
          >
+            {mapStyleError && (
+              <div
+                role="alert"
+                className="absolute inset-x-0 top-0 z-20 p-2 text-sm text-center text-amber-900 bg-amber-50 border-b border-amber-200"
+              >
+                Map failed to load ({mapStyleError}). Markers below are still listed in the search box;{' '}
+                {mapConfig.style ? 'check the configured map style URL.' : 'configure a custom map style for production use.'}
+              </div>
+            )}
             <NavigationControl position="top-right" showCompass={true} showZoom={true} />
 
             {/* Geolocation button — explicit user-initiated location request */}

--- a/packages/react/src/hooks/__tests__/useExpression.test.ts
+++ b/packages/react/src/hooks/__tests__/useExpression.test.ts
@@ -83,4 +83,32 @@ describe('useCondition', () => {
 
     expect(result.current).toBe(true);
   });
+
+  describe('{ throwOnError: true } — fail-closed opt-in (mirrors ActionEngine)', () => {
+    // A bare reference to an undeclared identifier — not merely a property
+    // access on an existing object — genuinely throws a ReferenceError from
+    // the compiled expression, the same shape of failure ActionEngine's own
+    // fail-closed regression test uses (a predicate referencing missing context).
+    const THROWING = '${nonexistentIdentifier.field}';
+
+    it('defaults to fail-OPEN (true) on a throwing predicate when not requested', () => {
+      const { result } = renderHook(() => useCondition(THROWING, { data: {} }));
+      expect(result.current).toBe(true);
+    });
+
+    it('fails CLOSED (false) on a throwing predicate when requested', () => {
+      const { result } = renderHook(() =>
+        useCondition(THROWING, { data: {} }, { throwOnError: true }),
+      );
+      expect(result.current).toBe(false);
+    });
+
+    it('still evaluates normally (no change) when the predicate does not throw', () => {
+      const context = { data: { status: 'active' } };
+      const { result } = renderHook(() =>
+        useCondition('${data.status === "active"}', context, { throwOnError: true }),
+      );
+      expect(result.current).toBe(true);
+    });
+  });
 });

--- a/packages/react/src/hooks/useExpression.ts
+++ b/packages/react/src/hooks/useExpression.ts
@@ -115,15 +115,27 @@ export function useExpression(
  */
 export function useCondition(
   condition: string | boolean | undefined,
-  context: Record<string, any> = {}
+  context: Record<string, any> = {},
+  options?: { throwOnError?: boolean }
 ): boolean {
   const scope = usePredicateScope();
   // We evaluate directly without caching the evaluator to avoid issues with context changes
   return useMemo(
     () => {
       const evaluator = new ExpressionEvaluator({ ...scope, ...context });
+      if (options?.throwOnError) {
+        // Fail-closed: a predicate that can't be evaluated hides/disables
+        // rather than defaulting to visible — mirrors ActionEngine's
+        // getActionsForLocation contract, opted into by callers gating a
+        // real action rather than passive display content.
+        try {
+          return evaluator.evaluateCondition(condition, { throwOnError: true });
+        } catch {
+          return false;
+        }
+      }
       return evaluator.evaluateCondition(condition);
     },
-    [condition, context, scope]
+    [condition, context, scope, options?.throwOnError]
   );
 }

--- a/packages/react/src/spec-bridge/bridges/form-view.ts
+++ b/packages/react/src/spec-bridge/bridges/form-view.ts
@@ -40,6 +40,7 @@ interface FormViewSpec {
   defaultSort?: any;
   sharing?: any;
   aria?: { ariaLabel?: string; ariaDescribedBy?: string; role?: string };
+  submitBehavior?: any;
 }
 
 function mapField(field: FormField): Record<string, any> {
@@ -100,6 +101,7 @@ export const bridgeFormView: BridgeFn<FormViewSpec> = (
   if (formType) node.formType = formType;
   if (spec.groups) node.groups = spec.groups;
   if (spec.defaultSort) node.defaultSort = spec.defaultSort;
+  if (spec.submitBehavior) node.submitBehavior = spec.submitBehavior;
 
   // P1.6 — i18n & ARIA
   if (spec.sharing) node.sharing = spec.sharing;

--- a/packages/types/src/app.ts
+++ b/packages/types/src/app.ts
@@ -456,8 +456,11 @@ export interface ObjectSelection {
   /** Object name (snake_case) */
   name: string;
 
-  /** Display label */
+  /** Display label (singular) */
   label: string;
+
+  /** Plural display label — preferred for list-style nav entries (falls back to `label`) */
+  pluralLabel?: string;
 
   /** Icon name (Lucide) */
   icon?: string;

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -228,6 +228,13 @@ export interface DateFieldMetadata extends BaseFieldMetadata {
   format?: string;
   min_date?: string | Date;
   max_date?: string | Date;
+  /**
+   * Marks this field as due/deadline-semantic (vs. a plain start/end/created
+   * date). Gates the relative-time "Overdue Nd" wording and red styling —
+   * without it, a past date renders as neutral "Nd ago" text. Auto-detected
+   * from common due/deadline field-name conventions when omitted.
+   */
+  dueLike?: boolean;
 }
 
 /**

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -796,6 +796,18 @@ export interface ObjectFormSection {
  * - `drawer`  – Slide-out form panel (reserved)
  * - `modal`   – Dialog-based form (reserved)
  */
+
+/**
+ * Declarative post-submit behavior — aligned with `@objectstack/spec`'s
+ * `FormView.submitBehavior`. Lets metadata-only forms (which can't pass an
+ * `onSuccess` function) declare what happens after a successful create/update.
+ */
+export type SubmitBehavior =
+  | { kind: 'thank-you'; title?: string; message?: string }
+  | { kind: 'redirect'; url: string; delayMs?: number }
+  | { kind: 'continue' }
+  | { kind: 'next-record' };
+
 export interface ObjectFormSchema extends BaseSchema {
   type: 'object-form';
   
@@ -963,10 +975,17 @@ export interface ObjectFormSchema extends BaseSchema {
 
   /**
    * Reset the form after a successful create so the user can enter another.
-   * Ignored when `navigateOnSuccess` is set.
+   * Ignored when `navigateOnSuccess` or `submitBehavior` is set.
    */
   resetOnSuccess?: boolean;
-  
+
+  /**
+   * Declarative post-submit behavior aligned with `@objectstack/spec`'s
+   * `FormView.submitBehavior`. When present, takes precedence over
+   * `successMessage` / `navigateOnSuccess` / `resetOnSuccess`.
+   */
+  submitBehavior?: SubmitBehavior;
+
   /**
    * Show cancel button
    * @default true
@@ -2033,6 +2052,13 @@ export interface ObjectMapSchema extends BaseSchema {
   locationField?: string;
   /** Field for marker title */
   titleField?: string;
+  /**
+   * MapLibre style URL/spec. Overrides the default demo style
+   * (`https://demotiles.maplibre.org/style.json`), which is a public demo
+   * server unsuited for production use. Named `mapStyle` (not `style`) to
+   * avoid colliding with `BaseSchema.style` (inline CSS properties).
+   */
+  mapStyle?: string;
 }
 
 /**

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -175,6 +175,12 @@ export const ObjectFormSchema = BaseSchema.extend({
   successMessage: z.string().optional().describe('Success toast text after create/update when no onSuccess handler is given'),
   navigateOnSuccess: z.string().optional().describe('Navigate here after success ({id}/{recordId} interpolated, same-origin-guarded); precedes the toast'),
   resetOnSuccess: z.boolean().optional().describe('Reset the form after a successful create for another entry'),
+  submitBehavior: z.union([
+    z.object({ kind: z.literal('thank-you'), title: z.string().optional(), message: z.string().optional() }),
+    z.object({ kind: z.literal('redirect'), url: z.string(), delayMs: z.number().optional() }),
+    z.object({ kind: z.literal('continue') }),
+    z.object({ kind: z.literal('next-record') }),
+  ]).optional().describe('Declarative post-submit behavior; takes precedence over successMessage/navigateOnSuccess/resetOnSuccess'),
   showCancel: z.boolean().optional().describe('Show cancel button'),
   cancelText: z.string().optional().describe('Cancel button text'),
   showReset: z.boolean().optional().describe('Show reset button'),
@@ -386,6 +392,7 @@ export const ObjectMapSchema = BaseSchema.extend({
   objectName: z.string().describe('ObjectQL object name'),
   locationField: z.string().optional().describe('Location field'),
   titleField: z.string().optional().describe('Title field'),
+  mapStyle: z.string().optional().describe('MapLibre style URL/spec (overrides the public demo default)'),
 });
 
 /**

--- a/packages/types/src/zod/views.zod.ts
+++ b/packages/types/src/zod/views.zod.ts
@@ -49,6 +49,9 @@ export const DetailViewFieldSchema = z.object({
   reference_to: z.string().optional().describe('Referenced object name for lookup/master_detail fields'),
   reference_field: z.string().optional().describe('Display field on the referenced object'),
   currency: z.string().optional().describe('Currency code for currency fields (e.g. USD, EUR)'),
+  dueLike: z.boolean().optional().describe(
+    'Marks a date/datetime field as due/deadline-semantic, gating the relative "Overdue Nd" wording (vs. neutral "Nd ago" for start/end/created dates)',
+  ),
 });
 
 /**


### PR DESCRIPTION
## Summary

Resolves the objectui-side items tracked in `objectstack-ai/framework#2620` (follow-ups from the Showcase full-chain UX test in framework#2616). Each item was independently investigated in this repo's source before being fixed.

- **A1 — UnifiedSidebar label priority**: an explicit nav item `label` (e.g. `'Projects'`) was always overridden by an `objects.<name>.label` i18n translation. `resolveNavItemLabel` now only applies convention-based i18n when the label wasn't customized (still equal to the bare object/dashboard/view/item name); a customized label always wins. Object-nav auto-generation (`AppCreationWizard.generateNavFromObjects`, `CreateAppPage`/`EditAppPage`) now prefers the object's `pluralLabel` over its singular `label`.
- **A3 — ActionEngine visibility/toast consistency**: `action-button`/`action-bar`/`action-menu`'s `visible` predicate now supports fail-closed evaluation via a new `useCondition(..., { throwOnError: true })` opt-in, mirroring `ActionEngine.getActionsForLocation`'s existing fail-closed contract (a broken predicate hides the action instead of leaking it). `ActionRunner`'s generic `script` action now awaits a Promise-returning formula function before reporting success, so the success toast reflects the write's actual outcome instead of firing as soon as the (synchronous) expression call returned a still-pending promise.
- **B1 — Wizard `submitBehavior`**: `WizardForm`/`ObjectForm` now implement the spec's declarative `submitBehavior` (`thank-you` / `redirect` / `continue` / `next-record`), which the spec-bridge (`bridges/form-view.ts`) previously dropped before it ever reached the renderer.
- **B2 — Date formatter field-role awareness**: the relative-date formatter's "Overdue Nd" wording (and red styling) is now gated on a `dueLike` field flag/heuristic — a past `start_date`/`created_at` renders as neutral "Nd ago" instead of "Overdue".
- **C2 — Work Map style/fallback**: `ObjectMap` now accepts a configurable `mapStyle` (schema `mapStyle` field), and shows a banner when the MapLibre style/tiles fail to load instead of rendering a silent blank map.
- **C3 — Sentry kill switch**: added `VITE_SENTRY_ENABLED=false` as an explicit, discoverable opt-out even when a DSN is configured (dev already defaults off; this is an additional safety valve for forks/self-hosters).
- **D — SDUI flex/grid + chart labels**: scoped per-node `responsiveStyles` now compile with `!important`, so they deterministically beat a same-specificity layout utility class (e.g. `type: 'flex'` + `responsiveStyles: { display: 'grid' }}`) regardless of stylesheet injection order. Chart axis ticks now honor a resolved `config[value].label`, matching the lookup already used for series names and pie/donut legend entries.
- **E — misc warnings/perf**: fixed noisy boot-time "bare-name fallback overwritten" warnings (`field:time`/`field:address`, `ui:calendar` vs `view:calendar`, `view:chart` vs `plugin-charts:chart`). `AuthProvider`'s organization refresh no longer warns on an unmount/route-change race. `useAgents` now caches the agent catalog per `apiBase` instead of refetching on every navigation.

## Test plan
- [x] Added/updated unit tests for every fix (see new `*.test.ts(x)` files and updated existing suites)
- [x] Full monorepo `vitest run`: 5263 passed, 24 skipped, 0 failed
- [x] Full monorepo `pnpm build` (turbo, 44/44 tasks) and `tsc --noEmit` across touched packages: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0113dfdy2CMFwQ4TJmQWjkdf)_