### PR TITLE
feat(app-shell): add /:objectName/data parameterized bare data surface (#2251)

### DIFF
--- a/content/docs/guide/console-architecture.md
+++ b/content/docs/guide/console-architecture.md
@@ -54,6 +54,7 @@ The console uses React Router DOM v7 with a simple flat route structure:
 | `/apps/:appName` | Home redirect | Redirects to the first object in navigation |
 | `/apps/:appName/:objectName` | `ObjectView` | Object list with view switcher |
 | `/apps/:appName/:objectName/view/:viewId` | `ObjectView` | Specific view for an object |
+| `/apps/:appName/:objectName/data` | `ObjectDataPage` | Bare data surface — URL `filter[<field>]=<value>` conditions, not bound to any saved view (ADR-0055) |
 | `/apps/:appName/:objectName/record/:recordId` | `RecordDetailView` | Single-record detail |
 | `/apps/:appName/create-app` | `CreateAppPage` | App creation wizard (4-step) |
 | `/apps/:appName/edit-app/:editAppName` | `EditAppPage` | Edit existing app configuration |

--- a/content/docs/guide/designing-app-navigation.md
+++ b/content/docs/guide/designing-app-navigation.md
@@ -19,6 +19,7 @@ Say your app has a `project` object:
 |---|---|---|
 | `{ "type": "object", "objectName": "project" }` | `/apps/my_app/project` — the object's **default view** | The full object shell: view switcher, object actions, a create button, record detail routing, search and recent-items integration |
 | `{ "type": "object", "objectName": "project", "viewName": "project.by_status" }` | `/apps/my_app/project/view/project.by_status` | The same shell, with the entry **anchored** to a named view — users can still switch |
+| `{ "type": "object", "objectName": "project", "filters": { "status": "open" } }` | `/apps/my_app/project/data?filter[status]=open` — the **bare data surface** | URL-defined conditions over everything permissions allow, bound to **no saved view**. Conditions show as removable chips; the full filter/sort/group toolbar is available; "Save as view" turns the slice into a named view |
 | `{ "type": "page", "pageName": "project_overview" }` | `/apps/my_app/page/project_overview` | Nothing but your page schema. View switching, actions, and record links must be assembled by hand |
 
 The key asymmetry: a page can imitate the other two, but it **loses the object
@@ -39,15 +40,23 @@ Use the least powerful construct that expresses the requirement:
    `project.by_status`) and anchor the entry to it. `viewName` sets the
    entry point; it does not lock the user in.
 
-3. **Create a page only for composition a single object view cannot express.**
+3. **Use `filters` for one-off or parameterized slices.**
+   A dashboard drill-through, a shared link, "records assigned to me" — put
+   the condition in the URL (`filters: { "owner_id": "{current_user_id}" }`)
+   and let it land on the bare data surface instead of authoring a view.
+   Promote the slice to a named view only when it's curated and reused.
+   Note the surface is not a security feature: it shows exactly what
+   row-level permissions already allow.
+
+4. **Create a page only for composition a single object view cannot express.**
    Multiple objects side by side or in tabs, KPI cards mixed with lists,
    onboarding or static content, parameterized pages. A page that wraps a
    single object's single view is an anti-pattern.
 
-4. **Use `dashboard` for metric/chart aggregation and `report` for tabular
+5. **Use `dashboard` for metric/chart aggregation and `report` for tabular
    analysis** — don't rebuild them as pages of chart blocks.
 
-5. **One entry per target.** Don't offer the same object through both a plain
+6. **One entry per target.** Don't offer the same object through both a plain
    entry and a page that wraps its default view. If one object needs several
    menu entries, make all of them named-view entries — mixing styles breaks
    active-state highlighting in the sidebar.
@@ -66,6 +75,7 @@ field — there is no generic `path` and no `kind`:
   "navigation": [
     { "id": "nav_projects", "type": "object", "objectName": "project", "label": "Projects" },
     { "id": "nav_by_status", "type": "object", "objectName": "project", "viewName": "project.by_status", "label": "By Status" },
+    { "id": "nav_my_open", "type": "object", "objectName": "project", "filters": { "owner_id": "{current_user_id}", "status": "open" }, "label": "My Open Projects" },
     { "id": "nav_kpis", "type": "dashboard", "dashboardName": "company_kpis", "label": "KPIs" },
     { "id": "nav_workbench", "type": "page", "pageName": "cross_object_workbench", "label": "Workbench" },
     { "id": "nav_docs", "type": "url", "url": "https://docs.example.com", "target": "_blank", "label": "Docs" }

--- a/docs/adr/0053-list-view-navigation-modes.md
+++ b/docs/adr/0053-list-view-navigation-modes.md
@@ -4,6 +4,7 @@
 **Author**: ObjectUI plugin-view / plugin-list / app-shell team
 **Consumers**: `@object-ui/types`, `@object-ui/plugin-view`, `@object-ui/plugin-list`, `@object-ui/app-shell` (Studio), `@object-ui/cli` (`check`), every app with an object list page or a list-in-a-page interface
 **Supersedes**: the list-tab placement of **ADR-0047** (per-view `tabs` on the object data-mode list)
+**Amended by**: **ADR-0055** (adds a third context — the `/:objectName/data` parameterized bare surface, filters mode anchored to the URL itself)
 
 ---
 

--- a/docs/adr/0055-parameterized-bare-data-surface.md
+++ b/docs/adr/0055-parameterized-bare-data-surface.md
@@ -1,0 +1,87 @@
+# ADR-0055: Parameterized bare data surface — the third list context
+
+**Status**: Accepted (2026-07-05)
+**Author**: ObjectUI app-shell team
+**Consumers**: `@object-ui/app-shell` (`ObjectDataPage`, console routes), `@object-ui/layout` (`resolveHref`), `@object-ui/types` (`NavigationItem.filters`)
+**Amends**: **ADR-0053** (adds a third context to its two-mode table)
+**Tracking**: objectstack-ai/objectui#2251
+
+---
+
+## TL;DR
+
+ADR-0053 gave a list surface exactly one navigation mode decided by context:
+**views** mode on the object route, **filters** mode inside a page. Neither
+context can express "show me this object's data filtered by conditions in the
+URL, bound to no saved view" — the object route always anchors to a view
+(URL `filter[...]` conditions stack **on top of** the default view's own
+filter and can never escape it), and a page requires authoring a page.
+
+**Decision:** add a third, URL-addressed context — purely additive, existing
+routes untouched:
+
+| Context | Route | Mode | Single control | Anchor |
+| --- | --- | --- | --- | --- |
+| Object default list (`ObjectView`) | `/:objectName` (+ `/view/:viewId`) | **views** | `ViewTabBar` | saved view |
+| List in a page (`InterfaceListPage`) | `/page/:pageName` | **filters** | `userFilters` | page config |
+| **Bare data surface (`ObjectDataPage`)** | `/:objectName/data` | **filters** | `userFilters` (auto-derived) + URL chips | **the URL itself** |
+
+`data` joins `new` / `view` / `record` as a reserved route segment.
+
+## The surface's contract
+
+1. **The URL is the view.** `filter[<field>]=<value>` params (equality) apply
+   over everything row-level security permits; no saved-view filter is baked
+   in. Conditions render as visible, removable chips — deliberately unlike
+   Odoo's invisible action `domain`, whose opacity is its most-complained
+   trait.
+2. **No saved-view chrome, no write-back.** The saved-view tab bar is absent;
+   nothing on this surface persists to any view. "Save as view" is the one
+   exit: it materializes the current conditions as a new view and navigates
+   to `/view/:viewId`.
+3. **Presentation is orthogonal to data scope.** The visualization switcher
+   (grid/kanban/calendar/gallery, bindings auto-derived from the object) is
+   ListView-internal, so switching presentation never rewrites the URL —
+   filter state survives by construction (Odoo view-mode semantics).
+4. **The filter bar is auto-derived.** ADR-0053 puts `userFilters` on views
+   and pages; this surface has neither, so the bar derives from the object's
+   enum-ish fields, and selections persist via ADR-0047 `uf_*` params.
+5. **Nav entries target it declaratively.** `NavigationItem.filters`
+   (`Record<string, string>`, `{current_user_id}`/`{current_org_id}`
+   templates) serializes through `resolveHref` to `/data?filter[...]`.
+   Precedence within `type:'object'`: `recordId` → `filters` → `viewName`.
+   Composition rule: URL filters for one-off / parameterized slices; a slice
+   graduates to a named view only when curated and reused (see the
+   app-composition guide).
+
+## Security model
+
+A view was never a security boundary, and neither is this surface. It shows
+**what row-level permissions allow, nothing more**:
+
+- the route gates on object `read` permission (explicit 403, never an empty
+  list);
+- auto-derived columns, filter-bar fields, and URL predicates are trimmed to
+  readable fields client-side — as UX honesty only;
+- the **server** is the enforcement point: it must inject the row-level
+  permission filter and drop predicates on unreadable fields (filter-oracle
+  probing), independent of anything the client sends.
+
+## Rejected alternatives
+
+- **Re-anchor the bare object route** (`/:objectName` = bare surface): breaks
+  every existing menu, bookmark, and `resolveHref` output. Rejected for a
+  reserved segment that is purely additive.
+- **A reserved view id** (`_all` in the views-mode tab bar): in-band
+  signalling, collides with user view ids, and inherits views-mode chrome the
+  surface must suppress.
+- **Making URL filters a picker on the default view**: conditions still stack
+  on the view's own filter — the "can never escape the default view" problem
+  this ADR exists to solve.
+
+## Follow-ups
+
+- `@objectstack/spec` sync for `NavigationItem.filters` (framework repo).
+- Server-side predicate trimming + row filter injection (framework repo).
+- Rich operator syntax (`filter[<field>][gte]=…`) — additive; the equality
+  shorthand stays.

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -48,6 +48,7 @@ const ReportView = lazy(() => import('../views/ReportView').then(m => ({ default
 const SearchResultsPage = lazy(() => import('../views/SearchResultsPage').then(m => ({ default: m.SearchResultsPage })));
 const RecordFormPage = lazy(() => import('../views/RecordFormPage').then(m => ({ default: m.RecordFormPage })));
 const ComponentNavView = lazy(() => import('../views/ComponentNavView').then(m => ({ default: m.ComponentNavView })));
+const ObjectDataPage = lazy(() => import('../views/ObjectDataPage').then(m => ({ default: m.ObjectDataPage })));
 
 // Metadata admin — mounted under /apps/:app/metadata. Lives at the top
 // level so URLs read like a normal nested resource (RFC-style) instead of
@@ -559,6 +560,13 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
                 } />
                 <Route path=":objectName/view/:viewId" element={
                   <ObjectView dataSource={dataSource} objects={allObjects} onEdit={handleEdit} externalRefreshKey={refreshKey} />
+                } />
+                {/* #2251: parameterized bare data surface — URL `filter[...]`
+                    conditions over everything row-level security permits, NOT
+                    anchored to any saved view. `data` is a reserved segment
+                    alongside `new` / `view` / `record`. */}
+                <Route path=":objectName/data" element={
+                  <ObjectDataPage dataSource={dataSource} objects={allObjects} />
                 } />
                 <Route path=":objectName/record/:recordId" element={
                   <RecordDetailView key={refreshKey} dataSource={dataSource} objects={allObjects} onEdit={handleEdit} />

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -561,7 +561,7 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
                 <Route path=":objectName/view/:viewId" element={
                   <ObjectView dataSource={dataSource} objects={allObjects} onEdit={handleEdit} externalRefreshKey={refreshKey} />
                 } />
-                {/* #2251: parameterized bare data surface — URL `filter[...]`
+                {/* ADR-0055: parameterized bare data surface — URL `filter[...]`
                     conditions over everything row-level security permits, NOT
                     anchored to any saved view. `data` is a reserved segment
                     alongside `new` / `view` / `record`. */}

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -78,7 +78,7 @@ const SYSTEM_FIELDS = new Set([
   'deleted_at', 'deletedAt', 'created_by', 'createdBy',
   'updated_by', 'updatedBy', '_version', '_rev',
 ]);
-function defaultColumnsFromObject(objectDef: any): string[] {
+export function defaultColumnsFromObject(objectDef: any): string[] {
   const curated = objectDef?.highlightFields;
   if (Array.isArray(curated) && curated.length > 0) {
     return curated.filter((n: string) => objectDef.fields?.[n]);

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -1,0 +1,413 @@
+/**
+ * Object Data Page — the parameterized bare data surface (#2251).
+ *
+ * Route: `/apps/:appName/:objectName/data` (± `filter[<field>]=<value>` and
+ * `uf_<field>` search params).
+ *
+ * Where ObjectView anchors to a saved list view (default or `/view/:viewId`),
+ * this surface is deliberately UNANCHORED — "the URL is the view":
+ *
+ *   • no saved-view filter is baked in: URL `filter[...]` conditions apply on
+ *     top of everything the user is allowed to see (row-level security is the
+ *     server-enforced baseline, never a view);
+ *   • URL conditions render as visible, removable chips (unlike Odoo's
+ *     invisible action domain);
+ *   • no saved-view tab bar — switching to a saved view is an explicit
+ *     navigation to `/view/:viewId` ("Save as view" is the exit);
+ *   • nothing here writes back to any saved view;
+ *   • the visualization switcher (grid/kanban/...) is ListView-internal, so
+ *     switching presentation never touches the URL — filter state survives;
+ *   • the common filter bar (ADR-0047 `userFilters` + `uf_*` persistence) is
+ *     auto-derived from the object's enum-ish fields, since there is no view
+ *     to author it on (ADR-0053 puts userFilters on views/pages).
+ *
+ * Field-level security: auto-derived columns, the filter bar, and URL filter
+ * predicates are all trimmed to readable fields client-side; the server is
+ * the enforcement point (it must drop predicates on unreadable fields).
+ */
+
+import * as React from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { ListView } from '@object-ui/plugin-list';
+import { useNavigationOverlay } from '@object-ui/react';
+import {
+  Button,
+  Empty,
+  EmptyTitle,
+  EmptyDescription,
+  NavigationOverlay,
+} from '@object-ui/components';
+import { Database, Lock, Plus, Save, X } from 'lucide-react';
+import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
+import { usePermissions, useFieldPermissions } from '@object-ui/permissions';
+import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
+import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState';
+import {
+  defaultColumnsFromObject,
+  defaultKanbanFromObject,
+  defaultCalendarFromObject,
+  defaultGalleryFromObject,
+} from './InterfaceListPage';
+import { RecordDetailView } from './RecordDetailView';
+import { PageHeader } from '../layout/PageHeader';
+import { getIcon } from '../utils/getIcon';
+import { useMetadataClient } from './metadata-admin/useMetadata';
+import { createRuntimeMetadata } from './runtime-metadata-persistence';
+import { CreateViewDialog } from './CreateViewDialog';
+
+/** Filter triple shape shared with view metadata: [field, operator, value]. */
+type FilterTriple = [string, string, unknown];
+
+/** Parse `filter[<field>]=<value>` search params into equality triples. */
+function parseUrlFilterTriples(searchParams: URLSearchParams): FilterTriple[] {
+  const out: FilterTriple[] = [];
+  searchParams.forEach((value, key) => {
+    const m = /^filter\[(.+)\]$/.exec(key);
+    if (m && m[1] && value !== '') out.push([m[1], '=', value]);
+  });
+  return out;
+}
+
+/** Field types the auto-derived user-filter bar offers as dropdowns. */
+const USER_FILTER_TYPES = new Set(['select', 'multiselect', 'radio', 'enum', 'boolean']);
+const MAX_USER_FILTERS = 4;
+
+export function ObjectDataPage({ dataSource, objects }: any) {
+  const { appName, objectName } = useParams();
+  const { t } = useObjectTranslation();
+  const { objectLabel, fieldLabel } = useObjectLabel();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { can } = usePermissions();
+  const { canRead } = useFieldPermissions(objectName ?? '');
+  const { user } = useAuth();
+  const isAdmin = useIsWorkspaceAdmin();
+  const metadataClient = useMetadataClient();
+  const [showCreateViewDialog, setShowCreateViewDialog] = React.useState(false);
+
+  const objectDef = React.useMemo(
+    () => (objects || []).find((o: any) => o.name === objectName),
+    [objects, objectName],
+  );
+
+  // ADR-0047 filter persistence — same wiring as InterfaceListPage: restore
+  // `uf_*` once at mount, mirror selection changes back (replace, no history
+  // spam).
+  const [initialUfSelections] = React.useState<Record<string, string[]> | undefined>(
+    () => parseUserFilterParams(new URLSearchParams(window.location.search)),
+  );
+  const handleUserFilterSelectionsChange = React.useCallback(
+    (selections: Record<string, Array<string | number | boolean>>) => {
+      setSearchParams((prev) => applyUserFilterParams(prev, selections), { replace: true });
+    },
+    [setSearchParams],
+  );
+
+  // URL filter triples, trimmed to readable fields. Predicates on unreadable
+  // fields are dropped here for UX honesty; the SERVER is the actual
+  // enforcement point against filter-oracle probing.
+  const filterParamsKey = Array.from(searchParams.entries())
+    .filter(([k]) => k.startsWith('filter['))
+    .map(([k, v]) => `${k}=${v}`)
+    .join('&');
+  const urlFilters = React.useMemo(() => {
+    const all = parseUrlFilterTriples(new URLSearchParams(filterParamsKey));
+    const readable = all.filter(([field]) => canRead(field));
+    if (readable.length < all.length) {
+      const dropped = all.filter(([field]) => !canRead(field)).map(([field]) => field);
+      console.warn(
+        `[ObjectDataPage] Dropped URL filter(s) on unreadable field(s): ${dropped.join(', ')}`,
+      );
+    }
+    // Template variables mirror nav `recordId` substitution so shared links
+    // can carry `{current_user_id}`.
+    return readable.map(([field, op, value]) =>
+      value === '{current_user_id}' ? [field, op, user?.id ?? value] : [field, op, value],
+    ) as FilterTriple[];
+  }, [filterParamsKey, canRead, user?.id]);
+
+  const removeUrlFilter = React.useCallback(
+    (field: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete(`filter[${field}]`);
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
+  // Auto-derived columns + filter bar, both trimmed by field-level security.
+  const columns = React.useMemo(
+    () => defaultColumnsFromObject(objectDef).filter((f: string) => canRead(f)),
+    [objectDef, canRead],
+  );
+  const userFilters = React.useMemo(() => {
+    const fields = objectDef?.fields;
+    if (!fields || typeof fields !== 'object') return undefined;
+    const picks = Object.entries(fields)
+      .filter(([name, f]: [string, any]) =>
+        f && !f.hidden && USER_FILTER_TYPES.has(f.type) && canRead(name))
+      .slice(0, MAX_USER_FILTERS)
+      .map(([name]) => ({ field: name }));
+    return picks.length > 0 ? { element: 'dropdown' as const, fields: picks } : undefined;
+  }, [objectDef, canRead]);
+
+  // Record open behavior — URL-driven drawer, same convention as ObjectView
+  // and InterfaceListPage (`?recordId=…` is shareable and refresh-safe).
+  const recordUrl = React.useCallback(
+    (id: string | number) =>
+      `/apps/${appName}/${objectName}/record/${encodeURIComponent(String(id))}`,
+    [appName, objectName],
+  );
+  const navOverlay = useNavigationOverlay({
+    navigation: { mode: 'drawer' },
+    objectName: objectName ?? '',
+    onNavigate: (id) => navigate(recordUrl(id)),
+  });
+  const drawerRecordId = searchParams.get('recordId');
+  const handleRecordClick = React.useCallback(
+    (record: any, event?: any) => {
+      const id = record?.id ?? record?._id;
+      const isMod = !!(event && (event.metaKey || event.ctrlKey || event.button === 1));
+      if (isMod && id != null) { window.open(recordUrl(id), '_blank'); return; }
+      if (id != null) {
+        setSearchParams((prev) => { const n = new URLSearchParams(prev); n.set('recordId', String(id)); return n; });
+      }
+    },
+    [recordUrl, setSearchParams],
+  );
+  const closeRecordDrawer = React.useCallback(() => {
+    setSearchParams((prev) => { const n = new URLSearchParams(prev); n.delete('recordId'); return n; });
+  }, [setSearchParams]);
+  React.useEffect(() => {
+    if (drawerRecordId && !navOverlay.isOpen) navOverlay.open({ id: drawerRecordId });
+    else if (!drawerRecordId && navOverlay.isOpen) navOverlay.close();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [drawerRecordId]);
+
+  // Visualization whitelist: grid always; others only when a field binding
+  // resolves from the object. The switcher is ListView-internal, so switching
+  // presentation never rewrites the URL — filter params survive by
+  // construction (#2251 acceptance).
+  const kanban = React.useMemo(() => defaultKanbanFromObject(objectDef), [objectDef]);
+  const calendar = React.useMemo(() => defaultCalendarFromObject(objectDef), [objectDef]);
+  const gallery = React.useMemo(() => defaultGalleryFromObject(objectDef), [objectDef]);
+  const allowedVisualizations = React.useMemo(() => {
+    const allowed = ['grid'];
+    if (kanban) allowed.push('kanban');
+    if (calendar) allowed.push('calendar');
+    if (gallery) allowed.push('gallery');
+    return allowed;
+  }, [kanban, calendar, gallery]);
+
+  const schema = React.useMemo(() => {
+    if (!objectDef) return undefined;
+    return {
+      type: 'list-view' as const,
+      objectName: objectDef.name,
+      viewType: 'grid' as const,
+      fields: columns,
+      ...(urlFilters.length ? { filters: urlFilters } : {}),
+      kanban,
+      calendar,
+      gallery,
+      userFilters,
+      appearance: { allowedVisualizations },
+      showViewSwitcher: allowedVisualizations.length > 1,
+      // Full list capability — this surface trades the saved-view anchor for
+      // the complete toolbar, NOT for a reduced one.
+      showSearch: true,
+      showSort: true,
+      showFilters: true,
+      showGroup: true,
+      showHideFields: true,
+      showDensity: true,
+      showRecordCount: true,
+      // Deliberately NO onSortChange/onFilterChange persistence hooks: this
+      // surface never writes back to any saved view (#2251).
+    };
+  }, [objectDef, columns, urlFilters, kanban, calendar, gallery, userFilters, allowedVisualizations]);
+
+  // "Save as view" — the one exit into the workspace: materialize the current
+  // URL conditions as a new saved view, then navigate to it.
+  const handleSaveAsView = React.useCallback(
+    async (config: Record<string, any> & { type: string; label: string }) => {
+      try {
+        const spec: Record<string, any> = {
+          ...config,
+          columns: Array.isArray(config.columns) && config.columns.length > 0 ? config.columns : columns,
+          ...(urlFilters.length ? { filter: urlFilters } : {}),
+        };
+        const draftName = String(config?.name ?? config?.id ?? '');
+        const createdId = await createRuntimeMetadata('view', draftName, spec, { metadataClient });
+        if (createdId) navigate(`../view/${createdId}`, { relative: 'path' });
+      } catch (err) {
+        console.error('[ObjectDataPage] Failed to save view:', err);
+      }
+    },
+    [columns, urlFilters, metadataClient, navigate],
+  );
+
+  if (!objectDef) {
+    return (
+      <div className="h-full flex items-center justify-center p-8">
+        <Empty>
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <Database className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <EmptyTitle>{t('console.objectView.objectNotFound')}</EmptyTitle>
+          <EmptyDescription>
+            {t('console.objectView.objectNotFoundDescription', { objectName })}
+          </EmptyDescription>
+        </Empty>
+      </div>
+    );
+  }
+
+  // Route gate — no read permission renders an explicit denial, never an
+  // empty list (#2251 security model). The server-enforced row filter is the
+  // real boundary; this is the honest UI for "you can't be here".
+  if (!can(objectDef.name, 'read')) {
+    return (
+      <div className="h-full flex items-center justify-center p-8" data-testid="object-data-403">
+        <Empty>
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <Lock className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <EmptyTitle>{t('console.objectData.noAccessTitle', { defaultValue: 'Access denied' })}</EmptyTitle>
+          <EmptyDescription>
+            {t('console.objectData.noAccess', {
+              defaultValue: 'You do not have permission to view this data.',
+            })}
+          </EmptyDescription>
+        </Empty>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-background min-w-0 overflow-hidden" data-testid="object-data-page">
+      <div className="hidden sm:block">
+        <PageHeader
+          title={
+            <span className="inline-flex items-center gap-2">
+              <span className="truncate">{objectLabel(objectDef)}</span>
+              <span className="rounded border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                {t('console.objectData.badge', { defaultValue: 'Data' })}
+              </span>
+            </span>
+          }
+          description={t('console.objectData.description', {
+            defaultValue: 'URL-defined data slice — not bound to any saved view.',
+          })}
+          icon={React.createElement(getIcon((objectDef as any)?.icon), { className: 'h-4 w-4' })}
+          actions={
+            <>
+              {can(objectDef.name, 'create') && (
+                <Button
+                  size="sm"
+                  onClick={() => navigate('../new', { relative: 'path' })}
+                  className="shadow-none gap-1.5 h-8 sm:h-9"
+                  data-testid="object-data-new-button"
+                >
+                  <Plus className="h-4 w-4" />
+                  <span className="hidden sm:inline">{t('console.objectView.new')}</span>
+                </Button>
+              )}
+              {isAdmin && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowCreateViewDialog(true)}
+                  className="shadow-none gap-1.5 h-8 sm:h-9"
+                  data-testid="object-data-save-as-view"
+                >
+                  <Save className="h-4 w-4" />
+                  <span className="hidden sm:inline">
+                    {t('console.objectData.saveAsView', { defaultValue: 'Save as view' })}
+                  </span>
+                </Button>
+              )}
+            </>
+          }
+        />
+      </div>
+
+      {/* URL filter chips — visible + individually removable (unlike Odoo's
+          invisible action domain). Removal rewrites the URL, which is the
+          single source of truth for this surface. */}
+      {urlFilters.length > 0 && (
+        <div
+          className="flex flex-wrap items-center gap-1.5 border-b px-3 sm:px-4 py-2 shrink-0"
+          data-testid="object-data-filter-chips"
+        >
+          <span className="text-xs text-muted-foreground">
+            {t('console.objectData.filteredBy', { defaultValue: 'Filtered by' })}
+          </span>
+          {urlFilters.map(([field, , value]) => (
+            <span
+              key={field}
+              className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs"
+            >
+              <span className="font-medium">{fieldLabel(objectDef.name, field, field)}</span>
+              <span className="text-muted-foreground">= {String(value)}</span>
+              <button
+                type="button"
+                onClick={() => removeUrlFilter(field)}
+                className="ml-0.5 rounded-full hover:bg-muted p-0.5"
+                aria-label={t('console.objectData.removeFilter', {
+                  defaultValue: 'Remove filter {{field}}',
+                  field,
+                })}
+                data-testid={`object-data-remove-filter-${field}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 overflow-auto">
+        {schema && (
+          <ListView
+            schema={schema as any}
+            dataSource={dataSource}
+            userFilterSelections={initialUfSelections}
+            onUserFilterSelectionsChange={handleUserFilterSelectionsChange}
+            onRowClick={handleRecordClick}
+          />
+        )}
+      </div>
+
+      {navOverlay.isOverlay && (
+        <NavigationOverlay
+          {...navOverlay}
+          setIsOpen={(open: boolean) => { if (!open) closeRecordDrawer(); }}
+          title={objectLabel(objectDef)}
+        >
+          {(record: any) => (
+            <RecordDetailView
+              objectNameOverride={objectDef.name}
+              recordIdOverride={String(record?.id ?? record?._id ?? drawerRecordId ?? '')}
+              embedded
+              dataSource={dataSource}
+              objects={objects}
+              onEdit={() => {}}
+            />
+          )}
+        </NavigationOverlay>
+      )}
+
+      {isAdmin && (
+        <CreateViewDialog
+          open={showCreateViewDialog}
+          onOpenChange={setShowCreateViewDialog}
+          onCreate={handleSaveAsView}
+          objectDef={objectDef}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -1,5 +1,5 @@
 /**
- * Object Data Page — the parameterized bare data surface (#2251).
+ * Object Data Page — the parameterized bare data surface (ADR-0055, #2251).
  *
  * Route: `/apps/:appName/:objectName/data` (± `filter[<field>]=<value>` and
  * `uf_<field>` search params).

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1267,6 +1267,15 @@ const en = {
       dark: 'Dark',
       system: 'System',
     },
+    objectData: {
+      badge: 'Data',
+      description: 'URL-defined data slice — not bound to any saved view.',
+      filteredBy: 'Filtered by',
+      removeFilter: 'Remove filter {{field}}',
+      saveAsView: 'Save as view',
+      noAccessTitle: 'Access denied',
+      noAccess: 'You do not have permission to view this data.',
+    },
     objectView: {
       objectNotFound: 'Object Not Found',
       objectNotFoundDescription: 'The object "{{objectName}}" does not exist in the current configuration.',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1340,6 +1340,15 @@ const zh = {
       dark: '深色',
       system: '系统',
     },
+    objectData: {
+      badge: '数据',
+      description: '由 URL 定义的数据切面——不绑定任何已保存视图。',
+      filteredBy: '筛选条件',
+      removeFilter: '移除筛选 {{field}}',
+      saveAsView: '另存为视图',
+      noAccessTitle: '无访问权限',
+      noAccess: '您没有权限查看此数据。',
+    },
     objectView: {
       systemViewReadonly: '系统视图由代码定义，只读。',
       expandToPage: '以完整页面打开',

--- a/packages/layout/src/NavigationRenderer.tsx
+++ b/packages/layout/src/NavigationRenderer.tsx
@@ -398,6 +398,23 @@ export function resolveHref(
         // pre-render). Fall through to the list view so the link is
         // still well-formed rather than a dead `#`.
       }
+      // `filters` (#2251) targets the parameterized bare data surface
+      // (`/:objectName/data`) instead of a saved view: each entry becomes a
+      // `filter[<field>]=<value>` search param. Values pass through the same
+      // template substitution as `recordId`; entries whose template can't be
+      // resolved are dropped so the link stays well-formed. Precedence:
+      // recordId → filters → viewName.
+      const navFilters = (item as any).filters as Record<string, string> | undefined;
+      if (navFilters && typeof navFilters === 'object' && !Array.isArray(navFilters)) {
+        const usp = new URLSearchParams();
+        for (const [field, raw] of Object.entries(navFilters)) {
+          if (raw === undefined || raw === null || field === '') continue;
+          const resolved = applyNavTemplate(String(raw), templateContext);
+          if (resolved !== null) usp.set(`filter[${field}]`, resolved);
+        }
+        const qs = usp.toString();
+        return { href: qs ? `${objectPath}/data?${qs}` : `${objectPath}/data`, external: false };
+      }
       return { href: item.viewName ? `${objectPath}/view/${item.viewName}` : objectPath, external: false };
     }
     case 'dashboard':

--- a/packages/layout/src/__tests__/resolveHref.test.ts
+++ b/packages/layout/src/__tests__/resolveHref.test.ts
@@ -1,0 +1,124 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * resolveHref — nav item → URL mapping, focused on the `type: 'object'`
+ * target precedence (recordId → filters → viewName) and the #2251
+ * parameterized bare data surface (`/:objectName/data?filter[...]=`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { NavigationItem } from '@object-ui/types';
+import { resolveHref } from '../NavigationRenderer';
+
+const BASE = '/apps/crm';
+
+function objectItem(extra: Partial<NavigationItem> = {}): NavigationItem {
+  return { id: 'nav_task', type: 'object', label: 'Tasks', objectName: 'task', ...extra };
+}
+
+/** Parse the href's query string back into entries for order-free asserts. */
+function queryOf(href: string): URLSearchParams {
+  const i = href.indexOf('?');
+  return new URLSearchParams(i >= 0 ? href.slice(i + 1) : '');
+}
+
+describe('resolveHref — object targets', () => {
+  it('bare object item → object route (workspace, default view)', () => {
+    const { href, external } = resolveHref(objectItem(), BASE);
+    expect(href).toBe(`${BASE}/task`);
+    expect(external).toBe(false);
+  });
+
+  it('viewName → explicit view route', () => {
+    const { href } = resolveHref(objectItem({ viewName: 'task.by_status' }), BASE);
+    expect(href).toBe(`${BASE}/task/view/task.by_status`);
+  });
+
+  it('filters → /data with filter[<field>]=<value> params', () => {
+    const { href, external } = resolveHref(
+      objectItem({ filters: { status: 'open', priority: 'high' } }),
+      BASE,
+    );
+    expect(href.startsWith(`${BASE}/task/data?`)).toBe(true);
+    expect(external).toBe(false);
+    const q = queryOf(href);
+    expect(q.get('filter[status]')).toBe('open');
+    expect(q.get('filter[priority]')).toBe('high');
+  });
+
+  it('empty filters object → bare /data surface with no params', () => {
+    const { href } = resolveHref(objectItem({ filters: {} }), BASE);
+    expect(href).toBe(`${BASE}/task/data`);
+  });
+
+  it('filters win over viewName (precedence: recordId → filters → viewName)', () => {
+    const { href } = resolveHref(
+      objectItem({ filters: { status: 'open' }, viewName: 'task.by_status' }),
+      BASE,
+    );
+    expect(href.startsWith(`${BASE}/task/data?`)).toBe(true);
+  });
+
+  it('recordId wins over filters', () => {
+    const { href } = resolveHref(
+      objectItem({ recordId: 'rec_1', filters: { status: 'open' } }),
+      BASE,
+    );
+    expect(href).toBe(`${BASE}/task/record/rec_1`);
+  });
+
+  it('substitutes template variables in filter values', () => {
+    const { href } = resolveHref(
+      objectItem({ filters: { owner_id: '{current_user_id}' } }),
+      BASE,
+      { currentUserId: 'u_42' },
+    );
+    expect(queryOf(href).get('filter[owner_id]')).toBe('u_42');
+  });
+
+  it('drops filter entries whose template cannot be resolved', () => {
+    const { href } = resolveHref(
+      objectItem({ filters: { owner_id: '{current_user_id}', status: 'open' } }),
+      BASE,
+      {},
+    );
+    const q = queryOf(href);
+    expect(q.get('filter[owner_id]')).toBeNull();
+    expect(q.get('filter[status]')).toBe('open');
+    expect(href.startsWith(`${BASE}/task/data?`)).toBe(true);
+  });
+
+  it('unresolved recordId falls through to filters, not the list view', () => {
+    const { href } = resolveHref(
+      objectItem({ recordId: '{current_user_id}', filters: { status: 'open' } }),
+      BASE,
+      {},
+    );
+    expect(href.startsWith(`${BASE}/task/data?`)).toBe(true);
+  });
+});
+
+describe('resolveHref — non-object targets unchanged', () => {
+  it('dashboard', () => {
+    const item: NavigationItem = { id: 'n1', type: 'dashboard', label: 'KPIs', dashboardName: 'kpis' };
+    expect(resolveHref(item, BASE).href).toBe(`${BASE}/dashboard/kpis`);
+  });
+
+  it('page', () => {
+    const item: NavigationItem = { id: 'n2', type: 'page', label: 'Home', pageName: 'home' };
+    expect(resolveHref(item, BASE).href).toBe(`${BASE}/page/home`);
+  });
+
+  it('url is external when target=_blank', () => {
+    const item: NavigationItem = { id: 'n3', type: 'url', label: 'Docs', url: 'https://example.com', target: '_blank' };
+    const { href, external } = resolveHref(item, BASE);
+    expect(href).toBe('https://example.com');
+    expect(external).toBe(true);
+  });
+});

--- a/packages/types/src/app.ts
+++ b/packages/types/src/app.ts
@@ -90,6 +90,22 @@ export interface NavigationItem {
    */
   recordMode?: 'view' | 'edit';
 
+  /**
+   * URL filter conditions (for type: 'object') — the entry targets the
+   * parameterized bare data surface `/:objectName/data` with each entry
+   * serialized as a `filter[<field>]=<value>` search param (equality),
+   * instead of anchoring to a saved view. Use for one-off / parameterized
+   * slices ("My open tickets" without authoring a view); slices worth
+   * curating belong in a named view via `viewName`.
+   *
+   * Values support the same template variables as `recordId`
+   * (`{current_user_id}`, `{current_org_id}`); entries whose template can't
+   * be resolved are dropped from the URL.
+   *
+   * Precedence within `type: 'object'`: `recordId` → `filters` → `viewName`.
+   */
+  filters?: Record<string, string>;
+
   /** Target dashboard name (for type: 'dashboard') */
   dashboardName?: string;
 

--- a/packages/types/src/zod/app.zod.ts
+++ b/packages/types/src/zod/app.zod.ts
@@ -44,6 +44,7 @@ export const NavigationItemSchema: z.ZodType<any> = z.lazy(() => z.object({
   viewName: z.string().optional().describe('Target view name (type: object) — named list view e.g. calendar, pipeline'),
   recordId: z.string().optional().describe('Target record id (type: object) — opens a single record. Supports template variables {current_user_id}, {current_org_id}.'),
   recordMode: z.enum(['view', 'edit']).optional().describe('Record opening mode when recordId is set (default: view)'),
+  filters: z.record(z.string(), z.string()).optional().describe('URL filter conditions (type: object) — targets the /:objectName/data bare surface via filter[<field>]=<value> params instead of a saved view. Values support {current_user_id}/{current_org_id}. Precedence: recordId → filters → viewName.'),
   dashboardName: z.string().optional().describe('Target dashboard name (type: dashboard)'),
   pageName: z.string().optional().describe('Target page name (type: page)'),
   reportName: z.string().optional().describe('Target report name (type: report)'),

--- a/skills/objectui/guides/app-composition.md
+++ b/skills/objectui/guides/app-composition.md
@@ -139,5 +139,7 @@ Reject (or fix) generated apps that contain any of:
 - Runtime resolution: `packages/layout/src/NavigationRenderer.tsx`
   (`resolveHref`)
 - Console routes: `packages/app-shell/src/console/AppContent.tsx`
+- Bare data surface decision record: `docs/adr/0055-parameterized-bare-data-surface.md`
+  (amends ADR-0053's context table)
 - Human-facing version: `content/docs/guide/designing-app-navigation.md`
   (derived from this guide — update both together)

--- a/skills/objectui/guides/app-composition.md
+++ b/skills/objectui/guides/app-composition.md
@@ -39,6 +39,7 @@ source of truth for nav → URL mapping.
 | `{type:'object', objectName}` | `/:objectName` | Full `ObjectView` shell: default view, **view switcher**, object actions, create button, `record/:id` detail routing, search & recents integration, permission trimming |
 | `{type:'object', objectName, viewName}` | `/:objectName/view/:viewId` | Same shell, entry **anchored to a named view** (user can still switch) |
 | `{type:'object', objectName, recordId}` | `/:objectName/record/:id` | Direct record deep-link; supports template vars like `{current_user_id}` ("My Profile") |
+| `{type:'object', objectName, filters}` | `/:objectName/data?filter[k]=v` | **Parameterized bare data surface** (#2251): URL conditions over everything row-level security permits, NOT anchored to any saved view. No saved-view tab bar; conditions render as removable chips; full filter/sort/group toolbar; "Save as view" is the exit into the workspace |
 | `{type:'dashboard', dashboardName}` | `/dashboard/:name` | Dashboard renderer (widgets, KPIs, charts) |
 | `{type:'report', reportName}` | `/report/:name` | Report renderer |
 | `{type:'page', pageName}` | `/page/:name` | **Bare SDUI rendering only.** No object shell — view switching, actions, and record routing must be hand-assembled in the page schema |
@@ -59,36 +60,46 @@ source of truth for nav → URL mapping.
    entry at it. `viewName` is an **entry anchor**, not a lock — users can
    still switch views once inside. That is a feature.
 
-3. **Reach for a `page` only for cross-object or free-form composition.**
+3. **Use `filters` (the `/data` surface) for one-off / parameterized slices.**
+   When a condition-driven entry is transient, user-specific, or generated —
+   a dashboard drill-through, an AI-produced link, a shared "open tickets
+   assigned to me" URL — put the condition in the URL via `filters` instead
+   of authoring a view. A slice graduates to a named view (rule 2) only when
+   it is curated and reused. Values support `{current_user_id}` /
+   `{current_org_id}` templates. The `/data` surface is never a security
+   boundary: it shows what row-level permissions allow, nothing more.
+
+4. **Reach for a `page` only for cross-object or free-form composition.**
    Qualifying cases (any one suffices): multiple objects' views side by side
    or in tabs, KPI cards mixed with lists, static/onboarding content,
    parameterized pages driven by `params`.
    **A page that wraps a single object's single view is an anti-pattern** —
-   it is a degraded copy of rules 1–2 that loses the object shell and adds a
+   it is a degraded copy of rules 1–3 that loses the object shell and adds a
    second metadata document to maintain.
 
-4. **Pure metric/chart aggregation → `dashboard`, tabular analysis → `report`.**
+5. **Pure metric/chart aggregation → `dashboard`, tabular analysis → `report`.**
    Do not simulate either with a page of hand-placed chart blocks.
 
-5. **One entry per target (dedup constraint).**
+6. **One entry per target (dedup constraint).**
    A navigation tree must not contain both a bare `object` entry and a page
    that merely wraps that object's default view. If one object needs several
    menu entries, make **all of them** named-view entries (rule 2) — mixing a
    bare entry with slice entries breaks active-state highlighting, and
    `resolveHref` cannot dedup entries for you.
 
-6. **Generation order follows the hierarchy.**
+7. **Generation order follows the hierarchy.**
    objects → named views (extracted from the "perspectives" in the
-   requirement) → nav (rules 1–2) → only what remains inexpressible becomes a
+   requirement) → nav (rules 1–3) → only what remains inexpressible becomes a
    page/dashboard. **Page count is an inverse quality signal**: in a typical
-   business app, ~80% of nav entries should be `object` (± `viewName`); pages
-   are for home/onboarding/cross-object workbenches.
+   business app, ~80% of nav entries should be `object` (± `viewName` /
+   `filters`); pages are for home/onboarding/cross-object workbenches.
 
 ## The One-Sentence Rule (for generation prompts)
 
-> Prefer the object's default view over a pinned `viewName`; prefer a named
-> view over a page; use a page only for composition a single object view
-> cannot express. Every target appears exactly once.
+> Prefer the object's default view over a pinned `viewName`; prefer URL
+> `filters` (the `/data` surface) over authoring a view for one-off slices;
+> prefer a named view over a page; use a page only for composition a single
+> object view cannot express. Every target appears exactly once.
 
 Generation prompts should embed only this sentence plus a link to this guide —
 never an inline copy of the tables above.
@@ -99,6 +110,9 @@ never an inline copy of the tables above.
   `kind` — those keys are ignored by `resolveHref` and rejected/stripped at
   save. Emit the typed target field for the chosen type (`objectName`,
   `pageName`, `dashboardName`, `reportName`, `url`, `componentRef`).
+- Object-item target precedence: `recordId` → `filters` → `viewName`
+  (`filters` is a `Record<string, string>`; equality semantics, serialized as
+  `filter[<field>]=<value>` on the `/data` route).
 - Every nav item needs a snake_case `id` and a `label` (both required by
   `NavigationItemSchema`).
 - The `navigation` key is the spec'd root for app nav. `menu` is deprecated


### PR DESCRIPTION
Implements the objectui half of #2251 — the three-route model, purely additive:

| Route | Saved-view tabs | Semantics | Status |
|---|---|---|---|
| `/:objectName` | ✅ | Workspace: default view + view switching | **untouched** |
| `/:objectName/view/:viewId` | ✅ | Workspace, anchored to a named view | untouched |
| `/:objectName/data` ± `filter[...]`/`uf_*` | ❌ | **Parameterized bare data surface** (new) | added |

## What

- **`ObjectDataPage`** (new, modeled on `InterfaceListPage` / ADR-0047 filters mode rather than carved out of the 1.9k-line `ObjectView` — zero regression surface on existing routes):
  - URL `filter[<field>]=<value>` conditions apply over everything row-level security permits — **no saved-view filter is baked in**; conditions render as visible, **removable chips** (deliberately unlike Odoo's invisible action domain)
  - no saved-view tab bar; **"Save as view"** (admin) materializes the current conditions via `CreateViewDialog` + `createRuntimeMetadata` and navigates to the new `/view/:viewId` — the one exit into the workspace
  - **no write-back**: the surface passes no persistence hooks to ListView
  - full toolbar (search / advanced filters / sort / group / hide fields / density) + auto-derived `userFilters` bar (ADR-0047 `uf_*` URL persistence, same wiring as `InterfaceListPage`)
  - visualization switcher (grid/kanban/calendar/gallery, bindings auto-derived) is ListView-internal, so **switching presentation never rewrites the URL — filter state survives** (#2251 acceptance)
  - **read-permission route gate** (403 empty state, `data-testid="object-data-403"`); auto-derived columns, filter-bar fields, and URL predicates are trimmed to readable fields via `useFieldPermissions` — client-side trims are UX only, the server remains the enforcement point
  - record drawer via `?recordId` (shareable, refresh-safe — same convention as ObjectView)
- **Nav contract**: `NavigationItem.filters?: Record<string, string>` (types + zod, mirrors `recordId` docs); `resolveHref` serializes object items with `filters` to `/data?filter[...]` with `{current_user_id}`/`{current_org_id}` template substitution and precedence `recordId → filters → viewName`. Items without `filters` produce byte-identical output.
- **Route**: `:objectName/data` registered in `AppContent.tsx` (lazy, `data` joins `new`/`view`/`record` as reserved segments).
- **i18n**: `console.objectData.*` (en, zh; other locales fall back to `defaultValue`).
- **Docs**: both app-composition guides (skill + docs site) gain the rule — URL `filters` for one-off/parameterized slices, named views for curated ones; one-sentence generation rule updated.

## Verification

- `pnpm turbo run build` for types/layout/app-shell (+ deps): 29/29 pass (tsc typecheck included)
- Tests: layout/types/i18n **303 passed**, app-shell **955 passed**, apps/console **80 passed**; new `resolveHref.test.ts` covers 12 cases (bare/viewName/filters/empty-filters/precedence/template substitution/dropped unresolved entries/non-object targets)
- ESLint on all touched files: 0 errors (the two pre-existing `NavigationRenderer` `static-components` errors reproduce without this diff — verified via stash)
- Browser smoke (Playwright + bundled Chromium against `vite dev`): app boots with the new lazy chunk registered, zero page errors. Driving the `/data` route with real data isn't possible in this environment (console requires an ObjectStack backend + auth — the same constraint that keeps the repo's deeper e2e specs `.skip`ped), so runtime acceptance on seeded data still needs a manual pass.

## Out of scope (tracked in #2251)

- `@objectstack/spec` sync for `filters` (framework repo) — local `@object-ui/types` mirrors it here, flagged for spec alignment before publish
- Server-side enforcement: dropping predicates on unreadable fields at the API layer
- Rich operator syntax (`filter[field][gte]=...`)

Closes nothing on its own; primary implementation PR for #2251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m3GX7EMKNPDZuee152EKK

---
_Generated by [Claude Code](https://claude.ai/code/session_018m3GX7EMKNPDZuee152EKK)_