### PR TITLE
docs(skills): add filters-slice eval to app-composition (#2251 follow-up)

### DIFF
--- a/skills/objectui/evals/app-composition.json
+++ b/skills/objectui/evals/app-composition.json
@@ -52,6 +52,24 @@
           "\"path\": \"/projects\""
         ]
       }
+    },
+    {
+      "id": 4,
+      "prompt": "On our sales dashboard, the 'Overdue Deals' KPI card should drill through to the underlying opportunity records (status open, past due). Also give me a shareable link for 'opportunities assigned to me'. Generate the nav/link metadata — we don't want to maintain extra saved views for these.",
+      "expected_output": "Uses the parameterized bare data surface instead of authoring views: emits object nav items / links with filters (serialized to /:objectName/data?filter[...]), uses {current_user_id} for the assigned-to-me link, and does not create new view or page metadata for these one-off slices.",
+      "files": [],
+      "assertions": {
+        "must_contain": [
+          "filters",
+          "/data",
+          "{current_user_id}",
+          "\"type\": \"object\""
+        ],
+        "must_not_contain": [
+          "\"type\": \"page\"",
+          "viewName"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Tiny follow-up to #2255 (and companion to framework#2626): adds the missing positive-path eval to `skills/objectui/evals/app-composition.json`.

## Why

The existing three evals cover generating spec-shaped nav, preferring a named view over a wrapper page, and repairing off-spec `path`/`kind` items — but nothing guards the new rule 3: **one-off / parameterized slices should use `filters` (the `/data` bare surface) instead of authoring views**. Without a regression eval, generation can quietly drift back to "create a view for every condition".

## What

One new eval (`id: 4`): a dashboard KPI drill-through plus an "assigned to me" shareable link must be expressed as object nav items with `filters` (including `{current_user_id}` templating, serialized to `/data?filter[...]`), and must NOT mint new view or page metadata.

This completes the AI-discovery chain for the `/data` route: spec `.describe()` (framework#2626) → skill decision rules (#2255) → one-sentence prompt rule (#2255) → **eval regression guard (this PR)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m3GX7EMKNPDZuee152EKK

---
_Generated by [Claude Code](https://claude.ai/code/session_018m3GX7EMKNPDZuee152EKK)_