### PR TITLE
feat(components,plugin-detail,app-shell): URL-driven record detail tabs — `?tab=` survives remounts (#2257)

### DIFF
--- a/.changeset/detail-tab-url-sync.md
+++ b/.changeset/detail-tab-url-sync.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/components': minor
+'@object-ui/plugin-detail': minor
+'@object-ui/app-shell': minor
+'@object-ui/types': patch
+---
+
+Record detail tabs are URL-addressable (`?tab=`) and survive subtree remounts (objectui#2257, ADR-0054 C3).
+
+- `buildDefaultTabs` emits STABLE semantic tab values (`details` / `related:<child>` / `related` / `activity` / `history`) instead of leaving the renderer to synthesize index-derived ones.
+- `PageTabsRenderer` honors `item.value`, a host-provided `schema.defaultTab` (validated against actual tabs) and `schema.onTabChange`; index fallback kept for authored schemas without values.
+- app-shell `RecordDetailView` restores the active tab from `?tab=` and writes it back with `replace` (tab switches never stack history), via the pure `withPageTabsUrlSync` page-tree injector (never mutates authored/memoized page schemas). Legacy `DetailView.autoTabs` wired to the same contract (`defaultTab`/`onTabChange`).
+- Fixes the tab strip resetting to Details after save-refresh remounts (`refreshKey`-style) and dev-StrictMode URL churn; enables `?tab=` deep links; invalid values fall back to Details.

--- a/packages/app-shell/src/utils/__tests__/pageTabsUrlSync.test.ts
+++ b/packages/app-shell/src/utils/__tests__/pageTabsUrlSync.test.ts
@@ -1,0 +1,72 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { withPageTabsUrlSync } from '../pageTabsUrlSync';
+
+const onTabChange = () => {};
+
+describe('withPageTabsUrlSync (objectui#2257)', () => {
+  const page = {
+    type: 'page',
+    regions: [
+      {
+        name: 'main',
+        components: [
+          { type: 'page:header' },
+          { type: 'page:tabs', items: [{ label: 'Details', value: 'details', children: [] }] },
+        ],
+      },
+      {
+        name: 'aside',
+        components: [{ type: 'record:reference_rail' }],
+      },
+    ],
+  };
+
+  it('injects defaultTab + onTabChange into every page:tabs node', () => {
+    const out: any = withPageTabsUrlSync(page, { defaultTab: 'related', onTabChange });
+    const tabs = out.regions[0].components[1];
+    expect(tabs.defaultTab).toBe('related');
+    expect(tabs.onTabChange).toBe(onTabChange);
+  });
+
+  it('never mutates the input tree (authored pages may be shared/memoized)', () => {
+    const before = JSON.stringify(page);
+    withPageTabsUrlSync(page, { defaultTab: 'related', onTabChange });
+    expect(JSON.stringify(page)).toBe(before);
+  });
+
+  it('clones only the path to the tabs node; untouched branches keep identity', () => {
+    const out: any = withPageTabsUrlSync(page, { defaultTab: 'x', onTabChange });
+    expect(out).not.toBe(page);
+    expect(out.regions[0].components[0]).toBe(page.regions[0].components[0]); // sibling node
+    expect(out.regions[1]).toBe(page.regions[1]); // untouched region
+  });
+
+  it('reaches page:tabs nested under children containers', () => {
+    const nested = {
+      type: 'page',
+      children: [{ type: 'page:card', children: [{ type: 'page:tabs', items: [] }] }],
+    };
+    const out: any = withPageTabsUrlSync(nested, { defaultTab: 't', onTabChange });
+    expect(out.children[0].children[0].defaultTab).toBe('t');
+  });
+
+  it('returns the input unchanged when there is no page:tabs node', () => {
+    const noTabs = { type: 'page', regions: [{ components: [{ type: 'page:header' }] }] };
+    expect(withPageTabsUrlSync(noTabs, { defaultTab: 'x', onTabChange })).toBe(noTabs);
+  });
+
+  it('omitting defaultTab still wires onTabChange (first tab stays default)', () => {
+    const out: any = withPageTabsUrlSync(page, { onTabChange });
+    const tabs = out.regions[0].components[1];
+    expect(tabs.defaultTab).toBeUndefined();
+    expect(tabs.onTabChange).toBe(onTabChange);
+  });
+});

--- a/packages/app-shell/src/utils/pageTabsUrlSync.ts
+++ b/packages/app-shell/src/utils/pageTabsUrlSync.ts
@@ -1,0 +1,71 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * pageTabsUrlSync — make a record page's `page:tabs` node URL-aware
+ * (objectui#2257, ADR-0054 C3 "URL-addressable state").
+ *
+ * The active detail tab is user state that must SURVIVE the page subtree
+ * remounting — which happens for real on every `refreshKey`-style save
+ * refresh (and, in dev StrictMode, on any URL search change). An
+ * uncontrolled Radix `defaultValue` loses it; the URL keeps it.
+ *
+ * This helper walks a page schema tree and returns a NEW tree in which every
+ * `page:tabs` node carries the host-provided `defaultTab` (the value read
+ * from `?tab=`) and `onTabChange` (writes `?tab=` back, with `replace`). It
+ * never mutates the input — authored/assigned page schemas may be shared or
+ * memoized objects.
+ *
+ * Only container keys are traversed (`regions` / `components` / `children`);
+ * `page:tabs`' own `items` are its content, not a container to recurse into.
+ */
+
+export interface PageTabsUrlSyncInject {
+  /** Initial active tab (from `?tab=`); ignored by the renderer if it names no tab. */
+  defaultTab?: string;
+  /** Called by the renderer on every tab switch (host writes `?tab=`). */
+  onTabChange?: (value: string) => void;
+}
+
+const CONTAINER_KEYS = ['regions', 'components', 'children'] as const;
+
+export function withPageTabsUrlSync<T>(node: T, inject: PageTabsUrlSyncInject): T {
+  if (Array.isArray(node)) {
+    let outArr: unknown[] | null = null;
+    (node as unknown[]).forEach((n, i) => {
+      const next = withPageTabsUrlSync(n, inject);
+      if (next !== n) {
+        outArr = outArr ?? (node as unknown[]).slice();
+        outArr[i] = next;
+      }
+    });
+    return (outArr ?? node) as unknown as T;
+  }
+  if (!node || typeof node !== 'object') return node;
+
+  const rec = node as Record<string, unknown>;
+  let out: Record<string, unknown> | null = null;
+
+  if (rec.type === 'page:tabs') {
+    out = { ...rec };
+    if (inject.defaultTab !== undefined) out.defaultTab = inject.defaultTab;
+    if (inject.onTabChange) out.onTabChange = inject.onTabChange;
+  }
+
+  for (const key of CONTAINER_KEYS) {
+    const child = (out ?? rec)[key];
+    if (child === undefined || child === null) continue;
+    const next = withPageTabsUrlSync(child, inject);
+    if (next !== child) {
+      out = out ?? { ...rec };
+      out[key] = next;
+    }
+  }
+
+  return (out ?? node) as T;
+}

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, useSearchParams, Link } from 'react-router-dom';
 import { DetailView, RecordChatterPanel, buildDefaultPageSchema, deriveFieldGroupDetailSections, extractMentions } from '@object-ui/plugin-detail';
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
 import { useAuth, createAuthenticatedFetch } from '@object-ui/auth';
@@ -27,6 +27,7 @@ import { ActionParamDialog, type ParamDialogState } from './ActionParamDialog';
 import { ActionResultDialog, type ResultDialogState } from './ActionResultDialog';
 import { FlowRunner, type ScreenFlowState } from './FlowRunner';
 import { RelatedRecordActionsBridge } from './RelatedRecordActionsBridge';
+import { withPageTabsUrlSync } from '../utils/pageTabsUrlSync';
 import { resolveActionParams } from '../utils/resolveActionParams';
 import { useRecordBreadcrumbTitle } from '../context/NavigationContext';
 import type { DetailViewSchema, FeedItem, HighlightField } from '@object-ui/types';
@@ -105,6 +106,7 @@ function isSecondaryField(fieldName: string, fieldDef: any): boolean {
 }
 
 export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverride, recordIdOverride, embedded }: RecordDetailViewProps) {
+
   const params = useParams<{
     appName?: string;
     objectName?: string;
@@ -116,6 +118,19 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   const { showDebug } = useMetadataInspector();
   const { user } = useAuth();
   const navigate = useNavigate();
+  // objectui#2257 — the active detail tab is URL-addressable (`?tab=`), so it
+  // survives the page subtree remounting (refreshKey-style save refreshes;
+  // dev-StrictMode URL churn). Written with `replace` — switching tabs must
+  // not stack history entries (Back would page through tabs and fight the
+  // overlay contract where Back closes `?form=…`).
+  const [tabSearchParams, setTabSearchParams] = useSearchParams();
+  const activeTabParam = tabSearchParams.get('tab') ?? undefined;
+  const handleTabChange = useCallback((value: string) => {
+    const sp = new URLSearchParams(window.location.search);
+    if (sp.get('tab') === value) return;
+    sp.set('tab', value);
+    setTabSearchParams(sp, { replace: true });
+  }, [setTabSearchParams]);
   const location = useLocation();
   const originFrom = (location.state as any)?.from as { pathname?: string; label?: string } | undefined;
   const { t } = useObjectTranslation();
@@ -1540,6 +1555,10 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       primaryField,
       sections,
       autoTabs: true,
+      // objectui#2257 — URL-driven active tab (same `?tab=` contract as the
+      // schema path's page:tabs node).
+      defaultTab: activeTabParam,
+      onTabChange: handleTabChange,
       autoDiscoverRelated: true,
       ...(historyEnabled && {
         history: {
@@ -1558,7 +1577,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       }),
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [objectDef?.name, pureRecordId, childRelatedData, actionRefreshKey, appName, navigate, dataSource, t, objectLabel, objects, historyEnabled, historyEntries, historyLoading, approvals.available, approvals.canDecide, approvals.pendingRequest, approvals.latestRequest, embedded]);
+  }, [objectDef?.name, pureRecordId, childRelatedData, actionRefreshKey, appName, navigate, dataSource, t, objectLabel, objects, historyEnabled, historyEntries, historyLoading, approvals.available, approvals.canDecide, approvals.pendingRequest, approvals.latestRequest, embedded, activeTabParam, handleTabChange]);
 
   if (isLoading) {
     return <SkeletonDetail />;
@@ -1839,7 +1858,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                   dataSource={dataSource}
                   actionLabel={actionLabel}
                 >
-                  <SchemaRenderer schema={renderedPage as any} />
+                  <SchemaRenderer schema={withPageTabsUrlSync(renderedPage, { defaultTab: activeTabParam, onTabChange: handleTabChange }) as any} />
                 </RelatedRecordActionsBridge>
                 {/* Auto-append RecordChatterPanel only when the page
                     schema doesn't already place a `record:discussion` /

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -244,6 +244,13 @@ const interpolate = (
 
 interface PageTabsItem {
   label: any;
+  /**
+   * Stable, semantic tab identity (e.g. `details`, `related:<childObject>`) —
+   * used as the Radix value and as the URL token for `?tab=` sync
+   * (objectui#2257). Falls back to an index-derived value when absent, which
+   * is NOT stable across item-list changes; synthesized pages always set it.
+   */
+  value?: string;
   icon?: string;
   /**
    * Optional badge value rendered after the label (e.g. related-list count).
@@ -383,11 +390,14 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     return seenAny ? sum : undefined;
   };
 
-  // PageTabsProps doesn't carry a value, synthesize one from the index so
-  // Radix Tabs (which requires stable values) is happy.
+  // Prefer an item's own STABLE `value` (semantic keys like `details` /
+  // `related:<child>`, emitted by buildDefaultTabs — objectui#2257); fall back
+  // to the index-derived value for authored schemas that don't declare one.
+  // Stable values are what make the active tab URL-addressable: an index
+  // value would silently point at a different tab when the item list changes.
   const itemsWithValue = items.map((it, idx) => ({
     ...it,
-    value: `tab-${idx}`,
+    value: typeof (it as any).value === 'string' && (it as any).value !== '' ? (it as any).value : `tab-${idx}`,
     // pickLocalized first (honours `{ en, zh }` / `{ default }`); translateLabel
     // then maps any plain-English well-known token (Details/Related/…) to the locale.
     labelStr: translateLabel(pickLocalized(it.label, language)),
@@ -397,7 +407,17 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       : computeCount(idx),
   }));
 
-  const defaultValue = itemsWithValue[0]?.value;
+  // Host-provided initial tab (e.g. app-shell restoring `?tab=` — the active
+  // tab is state that must SURVIVE this component remounting, so it cannot
+  // live only in Radix's internal uncontrolled state). Honored only when it
+  // names an actual tab; otherwise the first tab wins as before.
+  const requestedDefault: string | undefined = (schema as any)?.defaultTab;
+  const defaultValue =
+    (requestedDefault && itemsWithValue.some((it) => it.value === requestedDefault)
+      ? requestedDefault
+      : undefined) ?? itemsWithValue[0]?.value;
+  // Host callback on tab switch (app-shell writes `?tab=` with replace).
+  const onTabChange: ((value: string) => void) | undefined = (schema as any)?.onTabChange;
 
   const listClass = cn(
     isVertical && 'flex-col h-auto items-stretch p-1',
@@ -424,6 +444,7 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   return (
     <Tabs
       defaultValue={defaultValue}
+      onValueChange={onTabChange}
       orientation={isVertical ? 'vertical' : 'horizontal'}
       className={cn(className, isVertical && 'flex gap-4 w-full')}
       {...designer}

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -1193,6 +1193,21 @@ export const DetailView: React.FC<DetailViewProps> = ({
         const hasActivity = !!schema.activities && schema.activities.length > 0;
         const hasDiscussion = !!discussionSlot;
         const hasHistory = !!schema.history;
+        // objectui#2257 — the host may supply the initial tab (restored from
+        // `?tab=`) and a change callback (writes it back). Honored only when
+        // the requested value names a tab that actually renders; the active
+        // tab must survive this component remounting, so it cannot live only
+        // in Radix's uncontrolled state.
+        const tabValues = [
+          'details',
+          ...(hasRelated ? ['related'] : []),
+          ...(hasActivity ? ['activity'] : []),
+          ...(hasDiscussion ? ['discussion'] : []),
+          ...(hasHistory ? ['history'] : []),
+        ];
+        const requestedTab = (schema as any).defaultTab as string | undefined;
+        const initialTab = requestedTab && tabValues.includes(requestedTab) ? requestedTab : 'details';
+        const onTabChange = (schema as any).onTabChange as ((value: string) => void) | undefined;
         const detailsContent = (
           <div className="space-y-3 sm:space-y-4">
             {/* Section Groups */}
@@ -1254,7 +1269,7 @@ export const DetailView: React.FC<DetailViewProps> = ({
         }
 
         return (
-          <Tabs defaultValue="details" className="w-full">
+          <Tabs defaultValue={initialTab} onValueChange={onTabChange} className="w-full">
             <TabsList className="w-full justify-start border-b rounded-none bg-transparent p-0">
               <TabsTrigger
                 value="details"

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -930,3 +930,35 @@ describe('buildDefaultPageSchema integration (#2148)', () => {
     expect(types).not.toContain('record:path');
   });
 });
+
+describe('buildDefaultTabs — stable tab values (objectui#2257)', () => {
+  const relA = { title: 'Invoices', objectName: 'invoice', relationshipField: 'account', isPrimary: true };
+  const relB = { title: 'Notes', objectName: 'note', relationshipField: 'account' };
+
+  it('emits semantic values: details / related:<child> (primary) / related (rest) / activity / history', () => {
+    const tabs = buildDefaultTabs(undefined, {
+      related: [relA, relB],
+      showActivity: true,
+      history: { entries: [], loading: false },
+    });
+    expect(tabs.items.map((i: any) => i.value)).toEqual([
+      'details', 'related:invoice', 'related', 'activity', 'history',
+    ]);
+  });
+
+  it('relatedLayout tabs → every child gets related:<child>; stack → one related', () => {
+    const asTabs = buildDefaultTabs(undefined, { related: [relA, relB], relatedLayout: 'tabs' });
+    expect(asTabs.items.map((i: any) => i.value)).toEqual(['details', 'related:invoice', 'related:note']);
+    const stacked = buildDefaultTabs(undefined, { related: [relA, relB], relatedLayout: 'stack' });
+    expect(stacked.items.map((i: any) => i.value)).toEqual(['details', 'related']);
+  });
+
+  it('values stay stable when the related list shrinks (URL tokens must not shift)', () => {
+    const both = buildDefaultTabs(undefined, { related: [relA, relB] });
+    const onlyB = buildDefaultTabs(undefined, { related: [relB] });
+    // 'related' names the same (stacked) tab in both trees — an index value
+    // would have pointed at 'related:invoice' before and 'related' after.
+    expect(both.items.some((i: any) => i.value === 'related')).toBe(true);
+    expect(onlyB.items.some((i: any) => i.value === 'related')).toBe(true);
+  });
+});

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -509,8 +509,12 @@ export function buildDefaultTabs(
   const statusField = options.statusField ?? detectStatusField(def);
   const highlightFields =
     options.highlightFields ?? deriveHighlightFields(def, statusField);
+  // Every tab carries a STABLE, semantic `value` (objectui#2257): the active
+  // tab is URL-addressable (`?tab=<value>`, ADR-0054 C3), so values must
+  // survive related lists being added/removed — an index-derived value
+  // (`tab-2`) would silently point at a different tab after a schema change.
   const items: any[] = [
-    { label: 'Details', children: [buildDefaultDetails(def, options.sections, highlightFields)] },
+    { label: 'Details', value: 'details', children: [buildDefaultDetails(def, options.sections, highlightFields)] },
   ];
   if (
     !options.hideRelatedTab &&
@@ -528,6 +532,7 @@ export function buildDefaultTabs(
     });
     const asOwnTab = (rel: NonNullable<BuildPageOptions['related']>[number]) => ({
       label: rel.title || rel.objectName,
+      value: `related:${rel.objectName}`,
       ...(rel.icon ? { icon: rel.icon } : {}),
       children: [relatedNode(rel)],
     });
@@ -536,7 +541,7 @@ export function buildDefaultTabs(
       for (const rel of options.related) items.push(asOwnTab(rel));
     } else if (options.relatedLayout === 'stack') {
       // App-level override: all related lists share one stacked `Related` tab.
-      items.push({ label: 'Related', children: options.related.map(relatedNode) });
+      items.push({ label: 'Related', value: 'related', children: options.related.map(relatedNode) });
     } else {
       // DEFAULT (rule Z, ADR-0085 prominence): `isPrimary` lists become their
       // own tab; the rest collapse into one `Related` tab. Owned-before-lookup
@@ -547,16 +552,17 @@ export function buildDefaultTabs(
       const rest = options.related.filter((r) => !r.isPrimary);
       for (const rel of primary) items.push(asOwnTab(rel));
       if (rest.length > 0) {
-        items.push({ label: 'Related', children: rest.map(relatedNode) });
+        items.push({ label: 'Related', value: 'related', children: rest.map(relatedNode) });
       }
     }
   }
   if (options.showActivity) {
-    items.push({ label: 'Activity', children: [{ type: 'record:activity' }] });
+    items.push({ label: 'Activity', value: 'activity', children: [{ type: 'record:activity' }] });
   }
   if (options.history) {
     items.push({
       label: 'History',
+      value: 'history',
       children: [
         {
           type: 'record:history',

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -621,6 +621,15 @@ export interface DetailViewSchema extends BaseSchema {
    */
   autoTabs?: boolean;
   /**
+   * Initial active tab for `autoTabs` (`details` | `related` | `activity` |
+   * `discussion` | `history`) — typically restored from the host's `?tab=`
+   * URL param (objectui#2257). Ignored when it names a tab that doesn't
+   * render.
+   */
+  defaultTab?: string;
+  /** Called on every tab switch; the host persists it (e.g. writes `?tab=`). */
+  onTabChange?: (value: string) => void;
+  /**
    * Section groups — groups of sections rendered under a collapsible header.
    */
   sectionGroups?: SectionGroup[];


### PR DESCRIPTION
## 概述

修复 #2257:详情页 tab 条被子树重挂载重置回 Details。按 ADR-0054 C3 把 active tab 变成 **URL 可寻址状态**(`?tab=<value>`),同时补齐 framework#2604 验收中缺的最后一项(子表保存后父详情 **tab 保留**)。

## 根因(浏览器实测 + StrictMode A/B 对照,结论已更新到 #2257)

active tab 只活在**非受控** Radix state 里(`PageTabsRenderer` 的 `defaultValue` + legacy `DetailView` autoTabs),任何子树重挂载即清零。触发面分两类:

- **生产真实**:`key={refreshKey}` / `key={actionRefreshKey}` 的"保存/action 后整树重建"模式;
- **仅 dev(StrictMode)**:任何 URL search 变化都会重挂载 `RecordDetailView` —— 同一操作序列在 StrictMode OFF 下**零重挂载**、tab 保留(mount 探针 A/B 实证),故 `?recordId=`/`?form=` 引发的 tab 丢失是 dev 伪影,生产不受影响。

两类触发 URL 化后**全部免疫**——状态不在组件里,重挂载无所谓。

## 变更

- **plugin-detail `buildDefaultTabs`**:tab item 携带**稳定语义 value**(`details` / `related:<child>`(primary 独占 tab)/ `related` / `activity` / `history`)——索引合成值不能当 URL token(related list 增减时会漂移指向别的 tab)。
- **components `PageTabsRenderer`**:优先用 `item.value`(无则回退索引值,兼容 authored schema);接受宿主 `schema.defaultTab`(仅当命中真实 tab 才生效)+ `schema.onTabChange`。components 包保持 router 无感——只暴露口子。
- **app-shell `RecordDetailView`**:从 `?tab=` 恢复、`onTabChange` 用 **`replace`** 写回(切 tab 决不压 history——Back 必须继续承担"关 `?form=` overlay"的语义,不能在 tab 间倒带);经纯函数 `withPageTabsUrlSync` 注入 page 树(clone-on-write,**决不改动** authored/memoized 的页面 schema,含 6 个单测)。
- **legacy `DetailView` autoTabs** 同一契约接线(value 校验后才采用)。
- **types**:`DetailViewSchema.defaultTab/onTabChange`、`PageTabsItem.value` 声明。

## 验证

浏览器端到端(showcase,**StrictMode 开启**的最坏情况):

- ✅ 切到 Related → URL 变 `?tab=related`
- ✅ 打开子表 overlay → Esc → **tab 仍是 Related**(此前必回 Details)
- ✅ 子表新建保存 → **tab 保留 + 子表刷出新记录**(framework#2604 验收缺口补齐)
- ✅ `?tab=related` 深链直达;`?tab=nope` 回退 Details

单测 +9(稳定 value × 布局变体 × 注入器身份/不可变);3 包全量 **1365 通过**;turbo type-check 32/32。changeset 已附(fixed group minor)。

Closes #2257 · Refs framework#2604 · ADR-0054

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zKcAtbtxuF9SXYgSzjk9v

---
_Generated by [Claude Code](https://claude.ai/code/session_019zKcAtbtxuF9SXYgSzjk9v)_