### PR TITLE
fix(plugin-form): dedupe master-detail create toast + localize Cancel

### DIFF
--- a/.changeset/masterdetail-dedupe-toast-cancel-i18n.md
+++ b/.changeset/masterdetail-dedupe-toast-cancel-i18n.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+Fix master-detail record create: stop double success toast + localize the Cancel button.
+
+Objects with inline subforms (master-detail, e.g. a Lead with product line items)
+render `MasterDetailForm` inside `ModalForm`/`DrawerForm` instead of the plain
+footer, which exposed two mismatches with the host contract:
+
+- **Double success toast.** Flat `ObjectForm` delegates confirmation to the host
+  when an `onSuccess` is supplied (skips its own default toast), but
+  `MasterDetailForm.handleSaved` ALWAYS toasted `Created`/`Saved` AND ran
+  `onSuccess`. In the console the host's `onSuccess` chains into the `crud_success`
+  handler, which toasts a localized message — so create fired both `Created` and
+  e.g. `线索创建成功`. `handleSaved` now only toasts as a fallback when no host
+  `onSuccess` is provided, matching the `ObjectForm` contract; saves without a host
+  handler stay non-silent.
+
+- **Hardcoded English `Cancel`.** The master-detail action bar wrote `Cancel` as a
+  literal and accepted no `cancelText`, so the button stayed English while the
+  submit button was localized (`submitText` was already forwarded).
+  `MasterDetailForm` now takes `cancelText`, and `ModalForm`/`DrawerForm`/`ObjectForm`
+  forward the host's localized label down the subforms branch.
+
+Adds regression tests: create with a host `onSuccess` fires no built-in toast (no
+double-confirm), and the Cancel button renders the host-supplied `cancelText`.

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -503,6 +503,7 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
         fields: schema.fields as any,
         sections: schema.sections as any,
         submitText: schema.submitText,
+        cancelText: cancelLabel,
         details: subforms as any,
         onSuccess: async (rec: any) => { await schema.onSuccess?.(rec); schema.onOpenChange?.(false); },
         onError: schema.onError,

--- a/packages/plugin-form/src/MasterDetailForm.test.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.test.tsx
@@ -35,7 +35,50 @@ describe('MasterDetailForm — submit feedback (never silent)', () => {
     toastError.mockClear();
   });
 
-  it('atomic path: shows a success toast + clears the form on create', async () => {
+  it('atomic path: built-in toast (no host onSuccess) + clears the form on create', async () => {
+    const batchTransaction = vi.fn().mockResolvedValue({ results: [{ id: 'po1' }] });
+    const ds = makeDataSource({ batchTransaction });
+
+    const { container } = render(
+      <MasterDetailForm
+        schema={{
+          objectName: 'po',
+          mode: 'create',
+          fields: ['ref'],
+          details: [
+            { childObject: 'po_line', relationshipField: 'po', columns: [{ key: 'qty', label: 'Qty', type: 'number' } as any] },
+          ],
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+    const input = await waitFor(() => {
+      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+      if (!el) throw new Error('parent form not ready');
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'PO-1' } });
+
+    // Drive the bottom action bar's Create button.
+    const createBtn = screen.getByRole('button', { name: /create/i });
+    fireEvent.click(createBtn);
+
+    await waitFor(() => expect(batchTransaction).toHaveBeenCalledTimes(1));
+    // No host onSuccess → the built-in toast is the fallback so the save is never silent.
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    // Parent form remounted (cleared) for the next entry.
+    await waitFor(() => {
+      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+      expect(el && el.value).toBeFalsy();
+    });
+  });
+
+  it('defers confirmation to a host onSuccess (no built-in toast → no double-confirm)', async () => {
+    // When the host owns feedback (e.g. the console toasts a localized message
+    // via its crud-success handler), MasterDetailForm must NOT also toast — the
+    // same contract flat ObjectForm follows. Regression guard for the double
+    // "Created" + "线索创建成功" toast on record create.
     const batchTransaction = vi.fn().mockResolvedValue({ results: [{ id: 'po1' }] });
     const onSuccess = vi.fn();
     const ds = makeDataSource({ batchTransaction });
@@ -61,19 +104,12 @@ describe('MasterDetailForm — submit feedback (never silent)', () => {
       return el;
     });
     fireEvent.change(input, { target: { value: 'PO-1' } });
-
-    // Drive the bottom action bar's Create button.
-    const createBtn = screen.getByRole('button', { name: /create/i });
-    fireEvent.click(createBtn);
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
 
     await waitFor(() => expect(batchTransaction).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(toastSuccess).toHaveBeenCalled()); // <- never silent
     await waitFor(() => expect(onSuccess).toHaveBeenCalled());
-    // Parent form remounted (cleared) for the next entry.
-    await waitFor(() => {
-      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
-      expect(el && el.value).toBeFalsy();
-    });
+    // Host owns confirmation — no built-in toast fires.
+    expect(toastSuccess).not.toHaveBeenCalled();
   });
 
   it('shows an error toast when the atomic write fails (rollback)', async () => {
@@ -206,5 +242,17 @@ describe('MasterDetailForm — showSubmit gate (Studio screen preview)', () => {
     });
     expect(screen.queryByTestId('md-form-submit')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /create|save/i })).not.toBeInTheDocument();
+  });
+
+  it('uses the host-supplied cancelText (i18n is the host\'s job)', async () => {
+    // The plugin is locale-agnostic — the console passes a localized label down.
+    render(
+      <MasterDetailForm
+        schema={{ ...base, cancelText: '取消', onCancel: vi.fn() }}
+        dataSource={makeDataSource()}
+      />,
+    );
+    const cancelBtn = await waitFor(() => screen.getByTestId('md-form-cancel'));
+    expect(cancelBtn).toHaveTextContent('取消');
   });
 });

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -79,6 +79,9 @@ export interface MasterDetailFormSchema {
   formType?: 'simple' | 'tabbed';
   title?: string;
   submitText?: string;
+  /** Label for the Cancel button in the action bar. i18n is the host's job
+   *  (this plugin is locale-agnostic); defaults to English 'Cancel'. */
+  cancelText?: string;
   /** Hide the bottom Save/Cancel action bar — e.g. a non-persisting design
    *  preview. Defaults to shown (the form owns the only Save in this layout). */
   showSubmit?: boolean;
@@ -490,14 +493,21 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
 
   /**
    * Built-in feedback so a save is NEVER silent (a silent success looks broken
-   * and invites duplicate submits). Shows a toast, and on CREATE clears the
-   * form for the next entry by resetting the line items + remounting the parent
-   * form. A page-supplied `onSuccess` still runs afterwards (e.g. to navigate).
+   * and invites duplicate submits). On CREATE also clears the form for the next
+   * entry by resetting the line items + remounting the parent form.
+   *
+   * The success toast is only our fallback: when the host supplies `onSuccess`
+   * it owns confirmation (e.g. the console toasts a localized message via its
+   * crud-success handler), so we stay quiet to avoid double-confirming — the
+   * same contract flat `ObjectForm` follows. Without a host `onSuccess` we keep
+   * the built-in toast so the save is never silent.
    */
   const handleSaved = useCallback(
     async (parent: any) => {
       releaseSave();
-      toast.success(isEdit ? (schema.title ? `${schema.title} saved` : 'Saved') : 'Created');
+      if (!schema.onSuccess) {
+        toast.success(isEdit ? (schema.title ? `${schema.title} saved` : 'Saved') : 'Created');
+      }
       if (!isEdit) {
         setState(details.map(() => ({ rows: [], original: [] })));
         setFormKey((k) => k + 1);
@@ -753,7 +763,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
         <div className="flex items-center justify-end gap-2 border-t border-border pt-4">
           {schema.onCancel && (
             <Button type="button" variant="outline" onClick={schema.onCancel} disabled={saving} data-testid="md-form-cancel">
-              Cancel
+              {schema.cancelText ?? 'Cancel'}
             </Button>
           )}
           <Button type="button" onClick={handleSave} disabled={saving || (needsDerive && !resolvedDetails)} data-testid="md-form-submit">

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -688,6 +688,7 @@ export const ModalForm: React.FC<ModalFormProps> = ({
                 initialValues: schema.initialValues,
                 initialData: schema.initialData,
                 submitText: submitLabel,
+                cancelText: cancelLabel,
                 details: subforms as any,
                 onSuccess: async (rec: any) => { await schema.onSuccess?.(rec); schema.onOpenChange?.(false); },
                 onError: schema.onError,

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -133,6 +133,7 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
           fields: schema.fields as any,
           title: schema.title,
           submitText: schema.submitText,
+          cancelText: schema.cancelText,
           // Forward the host's submit-visibility so a non-persisting preview
           // can hide the master-detail Save bar (it owns the only Save here).
           showSubmit: (schema as any).showSubmit,


### PR DESCRIPTION
Closes #2278

## 问题
带明细子表(master-detail / subforms)的对象在**新建记录**弹窗里:
1. 保存后弹**两条**成功 toast——写死英文 `Created` + 本地化 `线索创建成功`;
2. 底部操作栏**取消按钮显示英文 `Cancel`**(提交按钮却是本地化的「创建」)。

普通(无明细)对象走 `ModalForm` 页脚,不复现;只有 master-detail 走 `MasterDetailForm` 自带操作栏才暴露。

## 根因
`MasterDetailForm` 这套自带 UI 与 host 约定没对齐:
- flat `ObjectForm` 契约是「有 `onSuccess` 就不自弹,交给 host」;而 `MasterDetailForm.handleSaved` **既自弹 `Created` 又调 `onSuccess`**,host 的 `onSuccess` → `crud_success` handler 又弹本地化一条 → 撞车。
- 取消按钮文案**写死英文**,组件不接受 `cancelText`,host 也没传下去。

## 改动
- `MasterDetailForm.handleSaved`:内置成功 toast 加 `if (!schema.onSuccess)` 兜底——host 负责提示时不再重复;无 host 场景保留 toast,不静默。
- `MasterDetailForm` schema 增加 `cancelText`,操作栏用 `{schema.cancelText ?? 'Cancel'}`;`ModalForm`/`DrawerForm`/`ObjectForm` 的 subforms 分支透传本地化取消文案(console 本就传 `t('common.cancel')`)。
- 更新/新增回归测试:有 `onSuccess` → 不双弹;无 → 兜底自弹 + 清表;`cancelText` 本地化渲染。

## 验证
- `pnpm --filter @object-ui/plugin-form test` → **191 passed**
- `turbo run type-check --filter=@object-ui/plugin-form` → **11/11 通过**

浏览器验证:该改动需完整 console + master-detail 对象 + 后端(重型环境),属纯逻辑/文案层且已被上述回归测试精确覆盖,故以单测为验证依据。

## 遗留
同操作栏的 `Saving…`(提交中短暂显示)仍硬编码英文,可后续一并本地化。