### PR TITLE
test(app-shell,plugin-detail): CI regression guards for refresh-in-place (#2269)

### DIFF
--- a/packages/app-shell/src/no-refresh-key-remount.ratchet.test.ts
+++ b/packages/app-shell/src/no-refresh-key-remount.ratchet.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#2269 ratchet (AGENTS.md Commandment #8 — "refresh data, don't
+ * rebuild UI"). CI enforcement, same shape as the ADR-0054 ratchet: this test
+ * runs in the gating `pnpm test` job and fails if the refetch-by-remount
+ * anti-pattern reappears.
+ *
+ * The bug this guards: a record surface used `key={refreshKey}` /
+ * `key={actionRefreshKey}` to force a REMOUNT on save/action so its data
+ * refetched — which also destroyed the active tab, scroll position, collapsed
+ * sections, and in-progress inline edits, and triggered a full refetch storm.
+ * The fix (objectui#2269) routes writes through the data-invalidation bus so
+ * consumers refetch IN PLACE. This ratchet keeps the anti-pattern from
+ * silently returning.
+ *
+ * If this fails: don't add a `key={…Refresh…}` remount. Invalidate the data
+ * (`notifyDataChanged` from `@object-ui/react`) and let readers refetch via
+ * `useDataInvalidation`. See objectui#2269 / DetailView / RecordDetailView.
+ *
+ * SCOPE — the RECORD-DETAIL data surfaces #2269 fixed. It is deliberately not
+ * repo-wide: an explicit user "Refresh this page" affordance
+ * (`PageView.onRefresh` → `InterfaceListPage key={refreshKey}`) and the Studio
+ * dev preview harness (`sdui-workbench-preview.tsx`) legitimately remount to
+ * reset, and are a different concern from "a SAVE silently rebuilt the record
+ * page under the user". Guarding the fixed surfaces exactly, with no
+ * allowlist-of-shame, is the honest lock; AGENTS.md Commandment #8 + review
+ * cover brand-new surfaces.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// packages/app-shell/src  ->  repo root
+const repoRoot = path.resolve(here, '../../..');
+
+/**
+ * Banned: a React `key=` bound to any "*refresh*" / "*reload*" expression —
+ * the tell-tale of "bump a key to remount so data refetches". Case-insensitive
+ * on the identifier; tolerant of whitespace inside the JSX brace.
+ */
+const REFRESH_KEY_REMOUNT = /\bkey=\{\s*[^}]*(?:refresh|reload)[^}]*\}/i;
+
+/**
+ * The record-detail data surfaces #2269 fixed. Path fragments (POSIX) — a
+ * file is in scope if its repo-relative path contains any of these.
+ */
+const IN_SCOPE = [
+  'packages/plugin-detail/src/',
+  'packages/app-shell/src/views/RecordDetailView',
+  'packages/app-shell/src/views/RelatedRecordActionsBridge',
+  'packages/app-shell/src/console/AppContent',
+];
+
+function collectSourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const name = entry.name;
+      if (name === 'node_modules' || name === 'dist' || name.startsWith('.wt-') || name === '.next') {
+        continue;
+      }
+      const full = path.join(dir, name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.tsx$/.test(name) && !/\.(test|spec)\.tsx$/.test(name)) {
+        const rel = path.relative(repoRoot, full).split(path.sep).join('/');
+        if (IN_SCOPE.some((frag) => rel.includes(frag))) out.push(full);
+      }
+    }
+  };
+  for (const group of ['packages', 'apps']) {
+    const groupDir = path.join(repoRoot, group);
+    let pkgs: string[] = [];
+    try {
+      pkgs = readdirSync(groupDir);
+    } catch {
+      continue;
+    }
+    for (const pkg of pkgs) {
+      const srcDir = path.join(groupDir, pkg, 'src');
+      try {
+        if (statSync(srcDir).isDirectory()) walk(srcDir);
+      } catch {
+        /* package has no src/ */
+      }
+    }
+  }
+  return out;
+}
+
+describe('objectui#2269 — no refetch-by-remount ratchet', () => {
+  it('finds the in-scope record-detail surfaces (guards against a broken scan path)', () => {
+    // plugin-detail alone has dozens of source files; if this drops the
+    // scope globs have gone stale and the ratchet would silently pass.
+    expect(collectSourceFiles().length).toBeGreaterThan(20);
+  });
+
+  it('has zero `key={…refresh/reload…}` remount sites in the record-detail surfaces', () => {
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles()) {
+      const src = readFileSync(file, 'utf8');
+      for (const line of src.split('\n')) {
+        if (REFRESH_KEY_REMOUNT.test(line)) {
+          offenders.push(`${path.relative(repoRoot, file)} :: ${line.trim()}`);
+        }
+      }
+    }
+    // If this fails: you re-introduced "bump a key to remount so data
+    // refetches". Invalidate the data instead (notifyDataChanged +
+    // useDataInvalidation, objectui#2269). Do not allowlist.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/plugin-detail/src/__tests__/DetailView.invalidation.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailView.invalidation.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression guard for objectui#2269 (AGENTS.md Commandment #8: "refresh
+ * data, don't rebuild UI").
+ *
+ * DetailView self-fetches its record. After a write, the host used to bump a
+ * `key=` to REMOUNT it — which re-ran the fetch but also nuked scroll /
+ * collapsed sections / in-progress inline edits. The fix: DetailView
+ * subscribes to the data-invalidation bus and REFETCHES IN PLACE. This test
+ * pins that contract so a future change can't silently regress to
+ * remount-on-save:
+ *   - a matching `notifyDataChanged` re-runs findOne and renders fresh data,
+ *   - the component instance is NOT remounted (a persistent mount marker
+ *     survives),
+ *   - a non-matching change does nothing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import * as React from 'react';
+import { DetailView } from '../DetailView';
+import { notifyDataChanged } from '@object-ui/react';
+import type { DetailViewSchema } from '@object-ui/types';
+
+const OBJECT_SCHEMA = {
+  name: 'contact',
+  fields: { name: { type: 'text', label: 'Name' } },
+};
+
+function makeDataSource(nameByCall: string[]) {
+  let call = 0;
+  const findOne = vi.fn(async () => ({ id: 'C-1', name: nameByCall[Math.min(call++, nameByCall.length - 1)] }));
+  return {
+    getObjectSchema: vi.fn(async () => OBJECT_SCHEMA),
+    findOne,
+  } as any;
+}
+
+const schema: DetailViewSchema = {
+  type: 'detail-view',
+  objectName: 'contact',
+  resourceId: 'C-1',
+  fields: [{ name: 'name', label: 'Name' }],
+};
+
+/**
+ * A mount marker that persists in module scope so we can tell "refetched in
+ * place" (marker stable) from "remounted" (marker id changes). Rendered as a
+ * sibling so it shares DetailView's mount lifecycle under the same parent.
+ */
+let markerMounts = 0;
+function MountMarker() {
+  React.useEffect(() => { markerMounts += 1; }, []);
+  return null;
+}
+
+describe('DetailView — refetch in place on data invalidation (objectui#2269)', () => {
+  beforeEach(() => { markerMounts = 0; });
+
+  it('re-runs findOne and renders fresh data when its record is invalidated, without remounting', async () => {
+    const ds = makeDataSource(['Ada', 'Ada Lovelace']);
+    render(
+      <>
+        <MountMarker />
+        <DetailView schema={schema} dataSource={ds} />
+      </>,
+    );
+
+    await waitFor(() => expect(screen.getAllByText('Ada').length).toBeGreaterThan(0));
+    expect(ds.findOne).toHaveBeenCalledTimes(1);
+    expect(markerMounts).toBe(1);
+
+    // A write to this record lands on the bus (what a save/action does now).
+    await act(async () => { notifyDataChanged({ objectName: 'contact', recordId: 'C-1' }); });
+
+    await waitFor(() => expect(screen.getAllByText('Ada Lovelace').length).toBeGreaterThan(0));
+    expect(ds.findOne).toHaveBeenCalledTimes(2); // refetched
+    expect(markerMounts).toBe(1); // NOT remounted — the whole point
+  });
+
+  it('ignores changes to other records / objects', async () => {
+    const ds = makeDataSource(['Ada', 'SHOULD_NOT_APPEAR']);
+    render(<DetailView schema={schema} dataSource={ds} />);
+    await waitFor(() => expect(screen.getAllByText('Ada').length).toBeGreaterThan(0));
+
+    await act(async () => {
+      notifyDataChanged({ objectName: 'contact', recordId: 'OTHER' });
+      notifyDataChanged({ objectName: 'invoice' });
+    });
+
+    // No refetch — the fetch stays at its first call.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(ds.findOne).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('SHOULD_NOT_APPEAR')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概述

给 #2604 / #2257 / #2269 这条治理线**装 CI 回归绊线**。此前这些成果只被 scratchpad 里的一次性浏览器脚本验证过——距离静默回归只差一个 `key={refreshKey}`。本 PR 把两条护栏落进已是**合并门禁**的 `Test`(vitest)job,把 AGENTS.md 戒律 #8 从"建议"变成"门禁"。

> 说明:仓库的 `Build & E2E` 跑的是**无后端 mock 构建**(`e2e/live/**` 真实栈被 CI 排除,`view-workflows` 全 `.skip`),无法可靠跑"保存→重取"的真实写入流程。所以护栏落在确定、零 flake 的 `Test` job 做**行为级 + 源码级**验证,而非 e2e——这是基于仓库实际基建的诚实取舍。

## 两条护栏

**① 行为级(plugin-detail `DetailView.invalidation`)** —— 证明机制真的接通:
- mock dataSource → 渲染 → 匹配的 `notifyDataChanged` 触发 `findOne` **重跑、新数据渲染**;
- 同时一个兄弟 `MountMarker` 的挂载计数**保持 1**——即"原地重取、未重挂载"(#2269 的核心不变式);
- 非匹配的失效**不触发**重取。

**② 源码级 ratchet(app-shell `no-refresh-key-remount.ratchet`)** —— 照仓库既有 `adr0054-ratchet` 的模子,扫描 #2269 修复的记录详情面(`plugin-detail/**`、`RecordDetailView`、`RelatedRecordActionsBridge`、`AppContent`),若 `key={…refresh/reload…}` 重挂载复活即 **fail**。
- **精确锚定、非全仓**:用户显式的"刷新整页"(`PageView.onRefresh`)和 Studio dev 预览工具(`sdui-workbench-preview`)本就该重挂载,属不同关切,故不在范围——无 allowlist-of-shame;新面由戒律 #8 + code review 覆盖。
- **负向验证过**:注入 `key={actionRefreshKey}` 到 `RecordDetailView` → ratchet 立即 fail;还乡 → 绿。

## 验证

- ①②本地全绿;注入/还乡负向验证通过;
- 触及包(plugin-detail + app-shell)全量 **1164 通过**。

测试-only,无需 changeset(`Changeset Fixed Group Check` 只校验 fixed-group 配置完整性)。

Refs #2269 · #2257 · #2604 · ADR-0054(ratchet 先例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zKcAtbtxuF9SXYgSzjk9v

---
_Generated by [Claude Code](https://claude.ai/code/session_019zKcAtbtxuF9SXYgSzjk9v)_