### PR TITLE
fix(app-shell): Studio "Open app" button 404s under a /_console mount

### DIFF
--- a/packages/app-shell/src/console/organizations/__tests__/resolveHomeUrl.test.ts
+++ b/packages/app-shell/src/console/organizations/__tests__/resolveHomeUrl.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, expect, it } from 'vitest';
-import { resolveHomeUrl, resolveRootUrl } from '../resolveHomeUrl';
+import { resolveHomeUrl, resolveRootUrl, resolveConsoleUrl } from '../resolveHomeUrl';
 
 describe('resolveHomeUrl', () => {
   it('builds an absolute /_console/home URL when base href points at the console mount', () => {
@@ -44,6 +44,29 @@ describe('resolveRootUrl', () => {
   it('resolves to the mount dir from a deeper route (drops the route segment)', () => {
     expect(resolveRootUrl('https://host.example/_console/organizations')).toBe(
       'https://host.example/_console/',
+    );
+  });
+});
+
+describe('resolveConsoleUrl', () => {
+  it('keeps the /_console mount prefix for a raw route path (the 404 this fixes)', () => {
+    // `window.open('/apps/my_app')` resolves against the document origin and
+    // drops the `/_console/` mount, 404ing on hosts that serve the console
+    // under a sub-path (studio-design's "Open app" button — objectui#404).
+    expect(resolveConsoleUrl('apps/my_app', 'https://host.example/_console/')).toBe(
+      'https://host.example/_console/apps/my_app',
+    );
+  });
+
+  it('accepts a leading slash on the path without dropping the mount', () => {
+    expect(resolveConsoleUrl('/apps/my_app', 'https://host.example/_console/')).toBe(
+      'https://host.example/_console/apps/my_app',
+    );
+  });
+
+  it('resolves against the document root when the console mounts at /', () => {
+    expect(resolveConsoleUrl('apps/my_app', 'https://host.example/')).toBe(
+      'https://host.example/apps/my_app',
     );
   });
 });

--- a/packages/app-shell/src/console/organizations/resolveHomeUrl.ts
+++ b/packages/app-shell/src/console/organizations/resolveHomeUrl.ts
@@ -44,3 +44,17 @@ export function resolveRootUrl(baseURI?: string): string {
   }
   return consoleRoot().toString();
 }
+
+/**
+ * Resolve an arbitrary router-relative path (e.g. `apps/my_app`) against the
+ * console's deployment mount, for full-page navigations (`window.open`,
+ * `window.location.assign`, a plain `<a href>`) that fall outside React
+ * Router and so never see its `basename`. A raw absolute path like
+ * `/apps/my_app` resolves against the document origin, not the SPA mount —
+ * dropping the `/_console/` prefix and 404ing when the host serves the
+ * console under a sub-path. See {@link resolveHomeUrl} above for the
+ * mount-resolution history this reuses.
+ */
+export function resolveConsoleUrl(path: string, baseURI?: string): string {
+  return new URL(path.replace(/^\//, ''), resolveRootUrl(baseURI)).toString();
+}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -78,6 +78,7 @@ import { ObjectSettingsPanel } from './ObjectSettingsPanel';
 import { fetchPackages, createBasePackage, PACKAGE_ID_RE, type PkgEntry } from './packages-io';
 import { PackageIdInput, PackageIdSuggestionHint } from './PackageIdInput';
 import { DraftChangesPanel } from '../../preview/DraftChangesPanel';
+import { resolveConsoleUrl } from '../../console/organizations/resolveHomeUrl';
 import { toast } from 'sonner';
 
 const PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> = [
@@ -568,7 +569,7 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
             {packageApp ? (
               <button
                 type="button"
-                onClick={() => window.open(`/apps/${encodeURIComponent(packageApp.name)}`, '_blank')}
+                onClick={() => window.open(resolveConsoleUrl(`apps/${encodeURIComponent(packageApp.name)}`), '_blank')}
                 title={tFormat('engine.studio.app.openTitle', locale, { label: packageApp.label })}
                 className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
               >


### PR DESCRIPTION
## Summary

- After building/deploying the console under a `/_console` mount (the framework CLI's normal setup), clicking **"Open app"** in the top-right of the Studio design surface (`StudioDesignSurface.tsx`) 404'd.
- Root cause: the button opened its target with a raw absolute path — `window.open(\`/apps/${name}\`, '_blank')`. `window.open` is a native browser API that resolves a root-relative path against the *document origin*, not against React Router's `basename` — so it drops the `/_console/` mount prefix entirely and the server has nothing registered at bare `/apps/...`.
- This exact class of bug (full-page navigation bypassing the SPA's basename) was already identified and fixed once before in this codebase for the login/redirect flow (see `resolveHomeUrl.ts`'s history comments). I generalized that fix into a reusable `resolveConsoleUrl(path)` helper and routed the "Open app" button through it, so the URL is always resolved against the actual `<base href>` mount.

## Changes

- `packages/app-shell/src/console/organizations/resolveHomeUrl.ts`: add `resolveConsoleUrl(path, baseURI?)`, built on the existing `resolveRootUrl` mount-resolution logic.
- `packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx`: use `resolveConsoleUrl` for the "Open app" button's target instead of a raw absolute path.
- `packages/app-shell/src/console/organizations/__tests__/resolveHomeUrl.test.ts`: unit tests covering the mount-prefix-preserving behavior (including the regression case that was 404ing).

This is a bug fix, so no changeset is included per repo convention.

## Test plan

- [x] `vitest run` for `resolveHomeUrl.test.ts` — new `resolveConsoleUrl` tests pass
- [x] `vitest run src/views/studio-design` — existing Studio tests still pass
- [x] Full `@object-ui/app-shell` test suite (`vitest run`): 141 files / 1091 tests pass
- [x] `eslint` on touched files — 0 errors (pre-existing warnings only, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_017LAwMrrYJn1fLV9eh7U179)_