### PR TITLE
Fix grouped-form section styling: unify Card/divider look, split readonly from disabled

### DIFF
--- a/.changeset/grouped-form-sections-visual-fix.md
+++ b/.changeset/grouped-form-sections-visual-fix.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/types': minor
+'@object-ui/components': minor
+'@object-ui/plugin-form': minor
+---
+
+Fix form section grouping inconsistencies found in a UX review of grouped forms:
+
+- **Unified section visual language.** `FormSection`'s Card-wrapped path (used by Modal/Split/Tabbed/Wizard forms) previously rendered as a nearly-invisible white-on-white card (same `bg-card` as the page background, distinguished only by a barely-visible shadow) with a duplicated, inconsistent header (different title size, and a collapse chevron positioned differently) versus the flat `SectionDivider` path used by simple/drawer forms. Both now share the same header treatment (`text-sm font-semibold`, inline-left chevron, bottom border), and the Card path gets a soft `bg-muted/40` tint so grouped sections are visually distinguishable without relying on shadow alone.
+- **`readonly` no longer renders as `disabled`.** A field marked `readonly` (statically or via `readonlyWhen`) was being folded into the `disabled` prop before reaching field widgets, so widgets with a dedicated readonly display (e.g. `EmailField`'s mailto link, `TextField`'s plain-text view) never received it — every readonly field just looked permanently disabled. `readonly` is now forwarded as its own prop; generic `input`/`textarea` fields get a distinct readonly style (`bg-muted/40`, no `cursor-not-allowed`) instead of the disabled look.
+- **Section `className`/`gridClassName` now flow through JSON schemas.** `ObjectFormSection` and the per-form-variant section configs (`ModalFormSectionConfig`, `SplitFormSectionConfig`, `FormSectionConfig`, `DrawerFormSectionConfig`) accept `className` (and `gridClassName` where applicable), wired through `ObjectForm`'s form-type dispatch into `FormSection`/`SectionDivider` — closing a gap where section wrappers couldn't be customized from schema despite `FormSection` itself already supporting it.

--- a/examples/byo-backend-console/src/App.tsx
+++ b/examples/byo-backend-console/src/App.tsx
@@ -21,6 +21,7 @@ function App() {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/form/:objectName" element={<ObjectFormPage />} />
+              <Route path="/form-modal/:objectName" element={<ObjectFormModalPage />} />
               <Route path="/:objectName" element={<ObjectPage />} />
             </Routes>
           </AppShell>
@@ -59,6 +60,12 @@ function Sidebar() {
           className="block rounded px-3 py-2 text-sm hover:bg-accent"
         >
           Contact Form (grouped)
+        </Link>
+        <Link
+          to="/form-modal/contact"
+          className="block rounded px-3 py-2 text-sm hover:bg-accent"
+        >
+          Contact Form (modal, grouped)
         </Link>
       </div>
 
@@ -167,6 +174,35 @@ function ObjectFormPage() {
         dataSource={mockDataSource}
       />
     </div>
+  );
+}
+
+/**
+ * Modal ObjectForm with explicit `sections` — exercises the Card-wrapped
+ * `FormSection` path (formType: 'modal'/'split'/'tabbed'/'wizard' all share
+ * it), as opposed to `ObjectFormPage` above which renders the flat
+ * divider-only path used by the default `formType: 'simple'` + `fieldGroups`.
+ */
+function ObjectFormModalPage() {
+  const { objectName } = useParams<{ objectName: string }>();
+
+  return (
+    <ObjectForm
+      schema={{
+        type: 'object-form',
+        objectName: objectName || '',
+        mode: 'create',
+        formType: 'modal',
+        title: `New ${objectName}`,
+        description: 'Card-wrapped section layout (formType: modal).',
+        open: true,
+        sections: [
+          { name: 'identity', label: 'Identity', fields: ['name'] },
+          { name: 'contact_info', label: 'Contact Info', fields: ['email', 'phone', 'notes'] },
+        ],
+      }}
+      dataSource={mockDataSource}
+    />
   );
 }
 

--- a/packages/components/src/__tests__/form-renderers.test.tsx
+++ b/packages/components/src/__tests__/form-renderers.test.tsx
@@ -388,4 +388,28 @@ describe('Form Renderers - Display Issue Detection', () => {
       expect(screen.getByTestId('field:email')).toBeInTheDocument();
     });
   });
+
+  describe('Form field readonly vs disabled (regression)', () => {
+    it('a field marked `readonly` renders read-only, not disabled', () => {
+      renderComponent({
+        type: 'form',
+        fields: [{ name: 'notes', label: 'Notes', type: 'input', readonly: true }],
+      } as any);
+
+      const input = screen.getByTestId('field:notes').querySelector('input');
+      expect(input?.hasAttribute('readonly')).toBe(true);
+      expect(input?.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('a field marked `disabled` still renders disabled, not merely read-only', () => {
+      renderComponent({
+        type: 'form',
+        fields: [{ name: 'notes', label: 'Notes', type: 'input', disabled: true }],
+      } as any);
+
+      const input = screen.getByTestId('field:notes').querySelector('input');
+      expect(input?.hasAttribute('disabled')).toBe(true);
+      expect(input?.hasAttribute('readonly')).toBe(false);
+    });
+  });
 });

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -33,18 +33,20 @@ import { createSafeTranslation } from '@object-ui/i18n';
 
 /** Inline section header rendered as a virtual field inside a flat SchemaRenderer field list.
  *  Collapsibility is controlled externally (collapsed state lives in DrawerForm). */
-function SectionDivider({ label, collapsible, collapsed, onToggle }: {
+function SectionDivider({ label, collapsible, collapsed, onToggle, className }: {
   label?: string;
   collapsible?: boolean;
   collapsed?: boolean;
   onToggle?: () => void;
+  className?: string;
 }) {
   if (!label) return null;
   return (
     <div
       className={cn(
         'col-span-full pt-4 pb-1 border-b border-border',
-        collapsible && 'cursor-pointer select-none'
+        collapsible && 'cursor-pointer select-none',
+        className
       )}
       onClick={collapsible ? onToggle : undefined}
       role={collapsible ? 'button' : undefined}
@@ -605,6 +607,7 @@ ComponentRegistry.register('form',
                       collapsible={fp.collapsible}
                       collapsed={fp.collapsed}
                       onToggle={fp.onToggle}
+                      className={fp.className}
                     />
                   );
                 }
@@ -739,7 +742,13 @@ ComponentRegistry.register('form',
                             inputType: fieldProps.inputType,
                             options: fieldProps.options,
                             placeholder: fieldProps.placeholder ?? (resolvedType === 'select' ? t('common.selectOption') : undefined),
-                            disabled: disabled || fieldDisabled || readonly || isSubmitting,
+                            // `disabled` means "not interactive, muted"; `readonly` means
+                            // "shown plainly, not editable" — keep them distinct so widgets
+                            // that implement a real readonly display (e.g. EmailField's
+                            // mailto link) actually receive it instead of always collapsing
+                            // to the grayed-out disabled look.
+                            disabled: disabled || fieldDisabled || isSubmitting,
+                            readonly,
                             dataSource: contextDataSource,
                             // Live form values for dependent (cascading) lookups
                             // (#2215): the widget's `dependsOn` gate + filters must
@@ -881,6 +890,7 @@ interface RenderFieldProps {
   value?: any;
   onChange?: (value: any) => void;
   disabled?: boolean;
+  readonly?: boolean;
   [key: string]: any;
 }
 
@@ -901,8 +911,13 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
     return <RegisteredComponent schema={fieldSchema} {...registeredProps} />;
   }
 
-  const { inputType, options = [], placeholder, ...fieldProps } = props;
+  const { inputType, options = [], placeholder, readonly, ...fieldProps } = props;
   const domFieldProps = stripRendererOnlyProps(fieldProps);
+  // Text-like controls get a real readonly treatment (native `readOnly` +
+  // a soft, non-"disabled" tint) instead of being grayed out. Toggle/choice
+  // controls (checkbox/switch/select) have no meaningful "look but don't
+  // touch" state of their own, so for those `readonly` falls back to disabled.
+  const readonlyInputClass = readonly && 'bg-muted/40 cursor-default focus-visible:ring-0';
 
   switch (type) {
     case 'input':
@@ -911,8 +926,17 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
          const { value, ...fileProps } = domFieldProps;
          return <Input type="file" placeholder={placeholder} className="min-h-[44px] sm:min-h-0" {...fileProps} />;
       }
-      return <Input type={inputType || 'text'} placeholder={placeholder} className="min-h-[44px] sm:min-h-0" {...domFieldProps} value={domFieldProps.value ?? ''} />;
-      
+      return (
+        <Input
+          type={inputType || 'text'}
+          placeholder={placeholder}
+          className={cn('min-h-[44px] sm:min-h-0', readonlyInputClass)}
+          {...domFieldProps}
+          readOnly={readonly}
+          value={domFieldProps.value ?? ''}
+        />
+      );
+
     case 'textarea': {
       const { mobile_fullscreen, fullscreen, label } = fieldProps as any;
       const { label: _label, ...rest } = stripRendererOnlyProps(fieldProps);
@@ -927,16 +951,25 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
           />
         );
       }
-      return <Textarea placeholder={placeholder} className="min-h-[44px] sm:min-h-0" {...rest} value={rest.value ?? ''} />;
+      return (
+        <Textarea
+          placeholder={placeholder}
+          className={cn('min-h-[44px] sm:min-h-0', readonlyInputClass)}
+          {...rest}
+          readOnly={readonly}
+          value={rest.value ?? ''}
+        />
+      );
     }
-    
+
     case 'checkbox': {
       // For checkbox, we need to handle the value differently
-      const { value, onChange, ...checkboxProps } = domFieldProps;
+      const { value, onChange, disabled: cbDisabled, ...checkboxProps } = domFieldProps;
       return (
-        <Checkbox 
+        <Checkbox
           checked={value}
           onCheckedChange={onChange}
+          disabled={cbDisabled || readonly}
           className="min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
           {...checkboxProps}
         />
@@ -945,28 +978,29 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
 
     case 'switch': {
       // For switch, we need to handle the value differently (same as checkbox)
-      const { value, onChange, ...switchProps } = domFieldProps;
+      const { value, onChange, disabled: swDisabled, ...switchProps } = domFieldProps;
       return (
-        <Switch 
+        <Switch
           checked={value}
           onCheckedChange={onChange}
+          disabled={swDisabled || readonly}
           className="min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0"
           {...switchProps}
         />
       );
     }
-    
+
     case 'select': {
       // For select with react-hook-form, we need to handle the onChange
-      const { value: selectValue, onChange: selectOnChange, ...selectProps } = domFieldProps;
-      
+      const { value: selectValue, onChange: selectOnChange, disabled: selDisabled, ...selectProps } = domFieldProps;
+
       // Safety check for options
       if (!options || options.length === 0) {
         return <div className="text-sm text-muted-foreground">No options available</div>;
       }
-      
+
       return (
-        <Select value={selectValue} onValueChange={selectOnChange} {...selectProps}>
+        <Select value={selectValue} onValueChange={selectOnChange} disabled={selDisabled || readonly} {...selectProps}>
           <SelectTrigger className="min-h-[44px] sm:min-h-0">
             <SelectValue placeholder={placeholder || 'Select an option'} />
           </SelectTrigger>
@@ -980,8 +1014,16 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
         </Select>
       );
     }
-    
+
     default:
-      return <Input type={inputType || 'text'} placeholder={placeholder} {...domFieldProps} />;
+      return (
+        <Input
+          type={inputType || 'text'}
+          placeholder={placeholder}
+          className={cn(readonlyInputClass)}
+          {...domFieldProps}
+          readOnly={readonly}
+        />
+      );
   }
 }

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -74,6 +74,8 @@ export interface DrawerFormSectionConfig {
   fields: (string | FormField)[];
   collapsible?: boolean;
   collapsed?: boolean;
+  /** Custom CSS class for the section's divider header. */
+  className?: string;
 }
 
 export interface DrawerFormSchema {
@@ -451,6 +453,7 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
           onToggle: section.collapsible
             ? () => setCollapsedSections(prev => ({ ...prev, [sectionKey]: !isCollapsed }))
             : undefined,
+          className: (section as any).className,
         } as any);
 
         const sectionFields = buildSectionFields(section);

--- a/packages/plugin-form/src/FormSection.tsx
+++ b/packages/plugin-form/src/FormSection.tsx
@@ -16,7 +16,7 @@
 import React, { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@object-ui/components';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@object-ui/components';
+import { Card, CardContent, CardHeader } from '@object-ui/components';
 
 export interface FormSectionProps {
   /**
@@ -138,7 +138,7 @@ export const FormSection: React.FC<FormSectionProps> = ({
       )}
       <div className="flex-1">
         {label && (
-          <h3 className="text-base font-semibold text-foreground">
+          <h3 className="text-sm font-semibold text-foreground">
             {label}
           </h3>
         )}
@@ -159,25 +159,9 @@ export const FormSection: React.FC<FormSectionProps> = ({
 
   if (wrapInCard) {
     return (
-      <Card className={cn('form-section', className)}>
-        {headerNode && (
-          <CardHeader className="pb-3">
-            {label && <CardTitle className="text-base">{label}</CardTitle>}
-            {description && <CardDescription>{description}</CardDescription>}
-            {collapsible && (
-              <button
-                type="button"
-                className="absolute right-4 top-4 text-muted-foreground"
-                onClick={handleToggle}
-                aria-expanded={!isCollapsed}
-                aria-label={isCollapsed ? 'Expand section' : 'Collapse section'}
-              >
-                {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              </button>
-            )}
-          </CardHeader>
-        )}
-        {contentNode && <CardContent>{contentNode}</CardContent>}
+      <Card className={cn('form-section bg-muted/40 shadow-none', className)}>
+        {headerNode && <CardHeader className="border-b border-border pb-3">{headerNode}</CardHeader>}
+        {contentNode && <CardContent className="pt-4">{contentNode}</CardContent>}
       </Card>
     );
   }

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -76,6 +76,10 @@ export interface ModalFormSectionConfig {
   description?: string;
   columns?: 1 | 2 | 3 | 4;
   fields: (string | FormField)[];
+  /** Custom CSS class for the section's Card wrapper. */
+  className?: string;
+  /** Custom CSS class for the section's field grid. */
+  gridClassName?: string;
 }
 
 export interface ModalFormSchema {
@@ -555,7 +559,12 @@ export const ModalForm: React.FC<ModalFormProps> = ({
             </TabsList>
             {sections.map((section, index) => (
               <TabsContent key={sectionKey(section, index)} value={sectionKey(section, index)}>
-                <FormSection description={section.description} columns={1}>
+                <FormSection
+                  description={section.description}
+                  columns={1}
+                  className={section.className}
+                  gridClassName={section.gridClassName}
+                >
                   {renderBody(section)}
                 </FormSection>
               </TabsContent>
@@ -572,6 +581,8 @@ export const ModalForm: React.FC<ModalFormProps> = ({
               label={sectionTitle(section)}
               description={section.description}
               columns={1}
+              className={section.className}
+              gridClassName={section.gridClassName}
             >
               {renderBody(section)}
             </FormSection>

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -160,6 +160,8 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
             description: s.description,
             columns: s.columns,
             fields: s.fields,
+            className: (s as any).className,
+            gridClassName: (s as any).gridClassName,
           })),
           defaultTab: schema.defaultTab,
           tabPosition: schema.tabPosition,
@@ -182,6 +184,8 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
             description: s.description,
             columns: s.columns,
             fields: s.fields,
+            className: (s as any).className,
+            gridClassName: (s as any).gridClassName,
           })),
           allowSkip: schema.allowSkip,
           showStepIndicator: schema.showStepIndicator,
@@ -207,6 +211,8 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
             description: s.description,
             columns: s.columns,
             fields: s.fields,
+            className: (s as any).className,
+            gridClassName: (s as any).gridClassName,
           })),
           splitDirection: schema.splitDirection,
           splitSize: schema.splitSize,
@@ -235,6 +241,7 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
             fields: s.fields,
             collapsible: (s as any).collapsible,
             collapsed: (s as any).collapsed,
+            className: (s as any).className,
           })),
           open: schema.open,
           onOpenChange: schema.onOpenChange,
@@ -262,6 +269,8 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
             description: s.description,
             columns: s.columns,
             fields: s.fields,
+            className: (s as any).className,
+            gridClassName: (s as any).gridClassName,
           })),
           open: schema.open,
           onOpenChange: schema.onOpenChange,
@@ -852,6 +861,7 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
           onToggle: section.collapsible
             ? () => setCollapsedSections(prev => ({ ...prev, [sectionKey]: !isCollapsed }))
             : undefined,
+          className: (section as any).className,
         } as FormField);
       }
 

--- a/packages/plugin-form/src/SplitForm.tsx
+++ b/packages/plugin-form/src/SplitForm.tsx
@@ -33,6 +33,10 @@ export interface SplitFormSectionConfig {
   description?: string;
   columns?: 1 | 2 | 3 | 4;
   fields: (string | FormField)[];
+  /** Custom CSS class for the section's Card wrapper. */
+  className?: string;
+  /** Custom CSS class for the section's field grid. */
+  gridClassName?: string;
 }
 
 export interface SplitFormSchema {
@@ -230,13 +234,15 @@ export const SplitForm: React.FC<SplitFormProps> = ({
   };
 
   const renderSections = (sections: SplitFormSectionConfig[], showButtons: boolean) => (
-    <div className="space-y-4 p-4">
+    <div className="space-y-6 p-4">
       {sections.map((section, index) => (
         <FormSection
           key={section.name || section.label || index}
           label={section.label}
           description={section.description}
           columns={1}
+          className={section.className}
+          gridClassName={section.gridClassName}
         >
           <SchemaRenderer
             schema={{

--- a/packages/plugin-form/src/TabbedForm.tsx
+++ b/packages/plugin-form/src/TabbedForm.tsx
@@ -47,6 +47,16 @@ export interface FormSectionConfig {
    * Field names or configurations in this section
    */
   fields: (string | FormField)[];
+
+  /**
+   * Custom CSS class for the section's Card wrapper.
+   */
+  className?: string;
+
+  /**
+   * Custom CSS class for the section's field grid.
+   */
+  gridClassName?: string;
 }
 
 export interface TabbedFormSchema {
@@ -347,6 +357,8 @@ export const TabbedForm: React.FC<TabbedFormProps> = ({
               <FormSection
                 description={section.description}
                 columns={1}
+                className={section.className}
+                gridClassName={section.gridClassName}
               >
                 {/* Render fields for this section. Multi-column is applied to
                     the field container inside the form (sectionFormLayout), not

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -516,6 +516,8 @@ export const WizardForm: React.FC<WizardFormProps> = ({
             label={currentSection.label}
             description={currentSection.description}
             columns={1}
+            className={currentSection.className}
+            gridClassName={currentSection.gridClassName}
           >
             {currentSectionFields.length > 0 ? (
               <SchemaRenderer

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -781,6 +781,18 @@ export interface ObjectFormSection {
    * Field names or inline field configurations for this section
    */
   fields: (string | FormField)[];
+
+  /**
+   * Custom CSS class for the section's wrapper (Card, when the form variant
+   * renders sections as cards; the divider header, for the flat/simple path).
+   */
+  className?: string;
+
+  /**
+   * Custom CSS class for the section's field grid. Only used by form variants
+   * that render sections as Card chrome (Modal/Split/Tabbed/Wizard).
+   */
+  gridClassName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up implementation of a UX review of grouped forms (screenshot showed a "Create Project" modal where section cards were nearly invisible and some fields looked confusingly disabled). Root-caused to three issues in the shared form-rendering layer:

- **Two disconnected section-grouping visual languages.** `FormSection` (used by Modal/Split/Tabbed/Wizard forms) wrapped groups in a `Card` with `bg-card` — identical to the page background in both light and dark themes — so cards were only distinguishable by a barely-visible `shadow-sm`. Its collapsible-header markup also duplicated (and diverged from) the plain `SectionDivider` used by simple/drawer forms (different title size, chevron on the opposite side). Both now share one header treatment (`text-sm font-semibold`, inline-left chevron, bottom border), and the Card gets a `bg-muted/40` tint so grouping reads without relying on shadow.
- **`readonly` was collapsing into `disabled`.** `form.tsx` folded a field's `readonly` state into its `disabled` prop before handing off to the field widget, so widgets with a real readonly display (`EmailField`'s mailto link, `TextField`'s plain-text/empty view) never received `readonly=true` — every readonly field just rendered as a grayed-out disabled input. `readonly` is now forwarded as its own prop; generic `input`/`textarea` fields get a distinct readonly style instead of the disabled look.
- **Section `className`/`gridClassName` weren't schema-overridable.** `FormSection` already accepted `className`/`gridClassName` props, but none of the section config shapes that feed it (`ObjectFormSection`, `ModalFormSectionConfig`, `SplitFormSectionConfig`, `FormSectionConfig`, `DrawerFormSectionConfig`) exposed them, and `ObjectForm`'s form-type dispatch explicitly whitelisted fields when mapping sections to each variant (so even adding the field to the type wouldn't have reached the renderer). Wired end-to-end.

## Changes

- `packages/plugin-form/src/FormSection.tsx` — shared header markup for Card and flat paths, `bg-muted/40` tint, dropped the barely-visible shadow.
- `packages/components/src/renderers/form/form.tsx` — split `disabled`/`readonly`, gave `input`/`textarea` a distinct readonly style, `SectionDivider` accepts `className`.
- `packages/plugin-form/src/{ModalForm,SplitForm,TabbedForm,DrawerForm,WizardForm,ObjectForm}.tsx` — `className`/`gridClassName` on section configs, wired through the form-type dispatch.
- `packages/types/src/objectql.ts` — `className`/`gridClassName` on `ObjectFormSection` (follows the existing precedent of other schema-level `className` escape hatches already in this file).
- `examples/byo-backend-console` — added a `formType: 'modal'` route demonstrating the Card path (previously only the flat/divider path had a live example).
- Two new regression tests asserting a `readonly` field renders `readOnly` without `disabled`, and vice versa.

## Test plan

- [x] `pnpm build` — 44/44 packages successful
- [x] `@object-ui/plugin-form` test suite — 191/191 passing
- [x] `@object-ui/components` test suite — 22/22 files, 236/236 tests passing (run individually; the full-suite invocation hits an unrelated worker-pool contention issue in this sandbox)
- [x] `tsc --noEmit` on `@object-ui/types` and `@object-ui/components` — clean
- [x] `eslint` on all changed files — 0 errors (pre-existing warnings only)
- [x] Manual browser verification via `examples/byo-backend-console` (no `../framework` backend available in this environment): confirmed the Card path is now visibly distinct against a white background, confirmed a `readonly` field renders via the widget's readonly display instead of a disabled input


---
_Generated by [Claude Code](https://claude.ai/code/session_014qManeBJuBLAM7jRynSMmK)_