### PR TITLE
feat: cascading & role-gated select options via option.visibleWhen (#2284)

### DIFF
--- a/.changeset/cascading-select-visiblewhen.md
+++ b/.changeset/cascading-select-visiblewhen.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/types': minor
+'@object-ui/core': minor
+'@object-ui/components': minor
+'@object-ui/fields': minor
+---
+
+Cascading & role-gated `select` options (#2284).
+
+`select` options now accept a per-option `visibleWhen` CEL predicate — the option
+is offered only when it evaluates TRUE against the live record **plus
+`current_user`** (same engine/env as a field-level `visibleWhen`). Combined with a
+field-level `dependsOn`, this drives dependent selects (country → province → city)
+and role/context gating with no bespoke matrix — the same primitives dependent
+lookups (#2215) already use.
+
+- `@object-ui/core` exposes `resolveVisibleOptions` / `isOptionGroupGated` /
+  `resolveDependsOnFields` / `isValueStillOffered` (evaluator), reusing the
+  canonical `evalFieldPredicate`.
+- The form renderer narrows a dependent select's option list, gates the control
+  with a "Select {parent} first" hint while a `dependsOn` field is empty, and
+  clears a now-invalid value when the parent changes.
+- The standalone `SelectField` widget applies the same resolution via
+  `dependentValues` + the global predicate scope.
+
+Client-side hiding is UX, not authorization: gate authorization-sensitive option
+values on the server too. Aligns with `@objectstack/spec` `SelectOption.visibleWhen`.

--- a/content/docs/fields/select.mdx
+++ b/content/docs/fields/select.mdx
@@ -19,6 +19,73 @@ The Select Field component provides a dropdown for selecting one or more options
 
 <SchemaExample id="fields-select/multi-select" />
 
+## Cascading & Role-Gated Options
+
+An option can carry a `visibleWhen` CEL predicate — it is offered only when the
+predicate is TRUE. The predicate is evaluated against the **live record** plus
+**`current_user`**, the same engine and binding environment as a field-level
+`visibleWhen`. This single mechanism covers two needs:
+
+- **Cascading / dependent options** — narrow a child list by a parent field
+  (country → province → city).
+- **Role / context gating** — offer an option only to certain users.
+
+Declare the sibling field(s) a select reacts to with `dependsOn`. While any is
+empty the control is **gated** (a "Select country first" hint) instead of
+showing an unfiltered list; once the parent changes, the list re-evaluates and
+any now-invalid selection is **cleared automatically** (no stale "China +
+California" pair).
+
+### Cascading (country → province)
+
+<SchemaExample id="fields-select/cascading-options" />
+
+```json
+{
+  "type": "form",
+  "fields": [
+    { "name": "country", "label": "Country", "type": "select", "options": [
+      { "label": "China", "value": "cn" },
+      { "label": "United States", "value": "us" }
+    ]},
+    { "name": "province", "label": "Province", "type": "select", "dependsOn": "country", "options": [
+      { "label": "Zhejiang",   "value": "zj", "visibleWhen": "record.country == 'cn'" },
+      { "label": "Guangdong",  "value": "gd", "visibleWhen": "record.country == 'cn'" },
+      { "label": "California",  "value": "ca", "visibleWhen": "record.country == 'us'" },
+      { "label": "Texas",       "value": "tx", "visibleWhen": "record.country == 'us'" }
+    ]}
+  ]
+}
+```
+
+Chain a third level (`city`, `dependsOn: "province"`) the same way — the gate and
+cascade-clear propagate down the chain.
+
+### Role-gated option
+
+```json
+{ "name": "tier", "type": "select", "options": [
+  { "label": "Standard", "value": "standard" },
+  { "label": "Admin only", "value": "admin_only", "visibleWhen": "'admin' in current_user.roles" }
+]}
+```
+
+> **Security — hiding is UX, not authorization.** A `visibleWhen` on an option
+> only removes it from the dropdown on the client; a determined caller can still
+> submit the value. When an option is gated for **access-control** reasons the
+> **server must also reject** writes of that value (the rule-validator evaluates
+> the picked value's `visibleWhen`). Use option `visibleWhen` for convenience and
+> cascades freely; for real authorization, pair it with server-side enforcement.
+
+### When to use options vs. a lookup
+
+`visibleWhen` options are for **small, static dictionaries** (category →
+subcategory, a handful of provinces). When the data is large, changes over time,
+or is shared across forms (real country/province/city tables, org units, product
+catalogs), model each level as a **`lookup`** with `depends_on` instead — the
+candidate query is filtered server-side and paginated. See
+[Lookup Field](/docs/fields/lookup).
+
 ## Field Schema
 
 ```plaintext
@@ -33,9 +100,14 @@ interface SelectFieldSchema {
   readonly?: boolean;            // Read-only mode
   disabled?: boolean;            // Disabled state
   className?: string;            // Additional CSS classes
-  
+
   // Options
   options: SelectOption[];       // Available options
+
+  // Cascading: sibling field(s) whose value drives this option list. While any
+  // is empty the field is gated ("Select <parent> first"); it re-evaluates as
+  // they change. Same knob dependent lookups use.
+  dependsOn?: string | string[];
 }
 
 interface SelectOption {
@@ -43,6 +115,11 @@ interface SelectOption {
   value: string;                 // Option value
   color?: string;                // Badge color (gray, red, blue, etc.)
   disabled?: boolean;            // Disable specific option
+
+  // Per-option visibility predicate (CEL). The option is offered only when TRUE,
+  // evaluated against the live record + current_user (same engine/env as a
+  // field-level visibleWhen). Omit = always available.
+  visibleWhen?: string;
 }
 ```
 

--- a/examples/schema-catalog/src/index.ts
+++ b/examples/schema-catalog/src/index.ts
@@ -343,6 +343,7 @@ import fields_phone_required_phone from './schemas/fields-phone/required-phone.j
 import fields_rich_text_html_editor from './schemas/fields-rich-text/html-editor.json' with { type: 'json' };
 import fields_rich_text_markdown_editor from './schemas/fields-rich-text/markdown-editor.json' with { type: 'json' };
 import fields_select_basic_select from './schemas/fields-select/basic-select.json' with { type: 'json' };
+import fields_select_cascading_options from './schemas/fields-select/cascading-options.json' with { type: 'json' };
 import fields_select_colored_options from './schemas/fields-select/colored-options.json' with { type: 'json' };
 import fields_select_multi_select from './schemas/fields-select/multi-select.json' with { type: 'json' };
 import fields_summary_average_of_field_values from './schemas/fields-summary/average-of-field-values.json' with { type: 'json' };
@@ -3520,6 +3521,15 @@ const REGISTRY: Record<string, Example> = {
       category: 'fields-select',
     },
     schema: fields_select_basic_select,
+  },
+  'fields-select/cascading-options': {
+    id: 'fields-select/cascading-options',
+    meta: {
+      title: "Cascading Options",
+      description: "Dependent select — province options narrow to the chosen country via per-option visibleWhen + dependsOn",
+      category: 'fields-select',
+    },
+    schema: fields_select_cascading_options,
   },
   'fields-select/colored-options': {
     id: 'fields-select/colored-options',

--- a/examples/schema-catalog/src/schemas/fields-select/cascading-options.json
+++ b/examples/schema-catalog/src/schemas/fields-select/cascading-options.json
@@ -1,0 +1,30 @@
+{
+  "type": "form",
+  "showSubmit": false,
+  "showCancel": false,
+  "fields": [
+    {
+      "name": "country",
+      "label": "Country",
+      "type": "select",
+      "placeholder": "Select country...",
+      "options": [
+        { "label": "China", "value": "cn" },
+        { "label": "United States", "value": "us" }
+      ]
+    },
+    {
+      "name": "province",
+      "label": "Province / State",
+      "type": "select",
+      "placeholder": "Select province...",
+      "dependsOn": "country",
+      "options": [
+        { "label": "Zhejiang", "value": "zj", "visibleWhen": "record.country == 'cn'" },
+        { "label": "Guangdong", "value": "gd", "visibleWhen": "record.country == 'cn'" },
+        { "label": "California", "value": "ca", "visibleWhen": "record.country == 'us'" },
+        { "label": "Texas", "value": "tx", "visibleWhen": "record.country == 'us'" }
+      ]
+    }
+  ]
+}

--- a/packages/components/src/renderers/form/__tests__/form-cascading-select.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-cascading-select.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Cascading `select` options in the inline form renderer (#2284).
+ *
+ * The form renderer's builtin `case 'select'` must narrow a dependent field's
+ * options by each option's `visibleWhen` and gate the whole control (a "select
+ * the parent first" hint) while its `dependsOn` controlling field is empty —
+ * re-evaluating live as the user edits the parent. We drive the controlling
+ * field through a plain text `input` (Radix Select can't be driven by synthetic
+ * DOM events) and assert the gate transition on the dependent select.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+
+beforeAll(async () => {
+  await import('../../../renderers');
+}, 30000);
+
+function renderForm(fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields }} />,
+  );
+}
+
+const cascadeFields = [
+  { name: 'country', label: 'Country', type: 'input', defaultValue: '' },
+  {
+    name: 'province',
+    label: 'Province',
+    type: 'select',
+    dependsOn: 'country',
+    options: [
+      { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+      { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+    ],
+  },
+];
+
+describe('form renderer — cascading select (#2284)', () => {
+  it('gates the dependent select until the controlling field is set, then unlocks', async () => {
+    renderForm(cascadeFields);
+
+    // Country empty → province is gated with a parent-first hint (no combobox).
+    expect(screen.getByText(/select country first/i)).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+
+    // Pick a country → the gate lifts and the dependent select becomes usable.
+    fireEvent.change(screen.getByLabelText(/country/i), { target: { value: 'cn' } });
+    await waitFor(() => {
+      expect(screen.queryByText(/select country first/i)).not.toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate } from '@object-ui/core';
+import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveVisibleOptions, isOptionGroupGated, resolveDependsOnFields, isValueStillOffered } from '@object-ui/core';
 import type { FormSchema, FormField as FormFieldConfig, ValidationRule, FieldCondition, SelectOption } from '@object-ui/types';
 import { useForm } from 'react-hook-form';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from '../../ui/form';
@@ -28,7 +28,7 @@ import { AlertCircle, ChevronDown, ChevronRight, Loader2, Maximize2, Check, X } 
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from '../../ui/dialog';
 import { cn } from '../../lib/utils';
 import React from 'react';
-import { SchemaRendererContext } from '@object-ui/react';
+import { SchemaRendererContext, usePredicateScope } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
 
 /** Inline section header rendered as a virtual field inside a flat SchemaRenderer field list.
@@ -124,6 +124,8 @@ function stripRendererOnlyProps<T extends Record<string, any>>(props: T): T {
     mobile_fullscreen: _mobileFullscreen,
     fullscreen: _fullscreen,
     dependentValues: _dependentValues,
+    dependsOn: _dependsOn,
+    emptyHint: _emptyHint,
     ...domProps
   } = props;
 
@@ -144,6 +146,7 @@ function stripRegisteredFieldProps(type: string, props: RenderFieldProps): Rende
     mobile_fullscreen: _mobileFullscreen,
     fullscreen: _fullscreen,
     dependentValues,
+    emptyHint: _emptyHint,
     schema: _schema,
     ...fieldProps
   } = props;
@@ -327,6 +330,51 @@ ComponentRegistry.register('form',
     // widgets as a prop so they can dynamically load related records.
     const schemaCtx = React.useContext(SchemaRendererContext);
     const contextDataSource = schemaCtx?.dataSource ?? null;
+
+    // Global predicate scope (from the host shell's ExpressionProvider) — carries
+    // `current_user` etc. so per-option `visibleWhen` can gate on role/context in
+    // addition to sibling field values. Empty object when no provider is mounted.
+    const predicateScope = usePredicateScope();
+
+    // Field name → label, for the "select the parent first" gate hint (#2284).
+    const fieldLabelByName = React.useMemo(() => {
+      const m: Record<string, string> = {};
+      for (const f of fields as FormFieldConfig[]) if (f?.name) m[f.name] = (f as any).label || f.name;
+      return m;
+    }, [fields]);
+
+    // Cascade clear (#2284): when a select/radio's option list narrows — because a
+    // controlling field changed or a role/context predicate flipped — a previously
+    // chosen value may no longer be offered. Drop it so the form never submits a
+    // stale "china + california" pair. Mirrors the dependent-lookup gate but for
+    // static/predicate-driven option sets. Fail-open filtering keeps unrelated
+    // fields untouched (no visibleWhen / dependsOn → nothing recomputed).
+    React.useEffect(() => {
+      for (const f of fields as FormFieldConfig[]) {
+        const name = f?.name;
+        if (!name) continue;
+        const resolvedType = (f as any).widget || f.type;
+        if (resolvedType !== 'select' && resolvedType !== 'radio' && resolvedType !== 'multiselect') continue;
+        const opts = (f as any).options as SelectOption[] | undefined;
+        if (!opts || opts.length === 0) continue;
+        const dependsOn = (f as any).dependsOn;
+        const hasOptionPredicate = opts.some((o) => (o as any)?.visibleWhen != null);
+        if (!hasOptionPredicate && !dependsOn) continue;
+        const current = form.getValues(name);
+        if (current === undefined || current === null || current === '') continue;
+        // While gated (a dependency is empty) the whole list is withheld — clear
+        // any prior value so it can't linger past a parent reset.
+        const gated = isOptionGroupGated(dependsOn, ruleRecord);
+        const visible = gated ? [] : resolveVisibleOptions(opts, ruleRecord, predicateScope);
+        if (!isValueStillOffered(current, visible)) {
+          form.setValue(name, Array.isArray(current) ? [] : undefined, {
+            shouldValidate: false,
+            shouldDirty: true,
+          });
+        }
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [ruleRecord, predicateScope]);
 
     // React to defaultValues changes — but ONLY when the values actually
     // change, not on every new object identity. Callers often pass a freshly
@@ -629,6 +677,28 @@ ComponentRegistry.register('form',
                 // Resolve the component type: prefer widget override, fallback to field type
                 const resolvedType = widget || type;
 
+                // Cascading / role-gated option lists (#2284). For option fields,
+                // narrow the set by each option's `visibleWhen` (evaluated against
+                // the live record + `current_user`), and gate the whole control
+                // while a declared `dependsOn` parent is still empty — surfacing a
+                // "select the parent first" hint instead of an unfiltered list.
+                const isOptionField =
+                  resolvedType === 'select' || resolvedType === 'radio' || resolvedType === 'multiselect';
+                const rawOptions = (fieldProps as any).options as SelectOption[] | undefined;
+                const dependsOnFields = isOptionField
+                  ? resolveDependsOnFields((field as any).dependsOn)
+                  : [];
+                const optionGroupGated =
+                  dependsOnFields.length > 0 && isOptionGroupGated((field as any).dependsOn, ruleRecord);
+                const effectiveOptions = isOptionField
+                  ? optionGroupGated
+                    ? []
+                    : resolveVisibleOptions(rawOptions, ruleRecord, predicateScope)
+                  : rawOptions;
+                const gatedHint = optionGroupGated
+                  ? `Select ${dependsOnFields.map((fn) => fieldLabelByName[fn] || fn).join(' / ')} first`
+                  : undefined;
+
                 // colSpan classes for grid layout.
                 //
                 // When the container uses container-query-based grid classes
@@ -740,15 +810,19 @@ ComponentRegistry.register('form',
                             field: (field as any).field || field, 
                             ...formField,
                             inputType: fieldProps.inputType,
-                            options: fieldProps.options,
+                            options: isOptionField ? effectiveOptions : fieldProps.options,
                             placeholder: fieldProps.placeholder ?? (resolvedType === 'select' ? t('common.selectOption') : undefined),
                             // `disabled` means "not interactive, muted"; `readonly` means
                             // "shown plainly, not editable" — keep them distinct so widgets
                             // that implement a real readonly display (e.g. EmailField's
                             // mailto link) actually receive it instead of always collapsing
-                            // to the grayed-out disabled look.
-                            disabled: disabled || fieldDisabled || isSubmitting,
+                            // to the grayed-out disabled look. A dependency-gated option
+                            // list (#2284) is disabled until its controlling field is set.
+                            disabled: disabled || fieldDisabled || isSubmitting || optionGroupGated,
                             readonly,
+                            // Gate hint shown when a dependent option list is still
+                            // waiting on its controlling field (#2284).
+                            emptyHint: gatedHint,
                             dataSource: contextDataSource,
                             // Live form values for dependent (cascading) lookups
                             // (#2215): the widget's `dependsOn` gate + filters must
@@ -911,7 +985,7 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
     return <RegisteredComponent schema={fieldSchema} {...registeredProps} />;
   }
 
-  const { inputType, options = [], placeholder, readonly, ...fieldProps } = props;
+  const { inputType, options = [], placeholder, readonly, emptyHint, ...fieldProps } = props;
   const domFieldProps = stripRendererOnlyProps(fieldProps);
   // Text-like controls get a real readonly treatment (native `readOnly` +
   // a soft, non-"disabled" tint) instead of being grayed out. Toggle/choice
@@ -994,9 +1068,16 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
       // For select with react-hook-form, we need to handle the onChange
       const { value: selectValue, onChange: selectOnChange, disabled: selDisabled, ...selectProps } = domFieldProps;
 
-      // Safety check for options
+      // Safety check for options. When a dependent (cascading) select is still
+      // waiting on its controlling field the renderer passes a gate hint (#2284)
+      // — surface that instead of the generic "no options" so the user knows to
+      // pick the parent first rather than reading it as a broken widget.
       if (!options || options.length === 0) {
-        return <div className="text-sm text-muted-foreground">No options available</div>;
+        return (
+          <div className="text-sm text-muted-foreground">
+            {emptyHint || 'No options available'}
+          </div>
+        );
       }
 
       return (

--- a/packages/core/src/evaluator/__tests__/optionRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/optionRules.test.ts
@@ -1,0 +1,129 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Unit coverage for cascading / role-gated option resolution (#2284).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveDependsOnFields,
+  isOptionGroupGated,
+  resolveVisibleOptions,
+  isValueStillOffered,
+  type OptionLike,
+} from '../optionRules';
+
+const provinces: OptionLike[] = [
+  { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+  { label: 'Guangdong', value: 'gd', visibleWhen: "record.country == 'cn'" },
+  { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+  { label: 'Texas', value: 'tx', visibleWhen: "record.country == 'us'" },
+  { label: 'Other', value: 'other' }, // no predicate → always offered
+];
+
+describe('resolveDependsOnFields', () => {
+  it('normalizes bare string, array of strings, and {field,param}', () => {
+    expect(resolveDependsOnFields('country')).toEqual(['country']);
+    expect(resolveDependsOnFields(['country', 'region'])).toEqual(['country', 'region']);
+    expect(resolveDependsOnFields([{ field: 'country', param: 'country_id' }])).toEqual(['country']);
+    expect(resolveDependsOnFields(undefined)).toEqual([]);
+    expect(resolveDependsOnFields(null)).toEqual([]);
+  });
+});
+
+describe('isOptionGroupGated', () => {
+  it('is gated while a dependency is empty and unlocks once set', () => {
+    expect(isOptionGroupGated('country', {})).toBe(true);
+    expect(isOptionGroupGated('country', { country: '' })).toBe(true);
+    expect(isOptionGroupGated('country', { country: null })).toBe(true);
+    expect(isOptionGroupGated('country', { country: 'cn' })).toBe(false);
+  });
+
+  it('requires ALL dependencies to be present', () => {
+    expect(isOptionGroupGated(['country', 'region'], { country: 'cn' })).toBe(true);
+    expect(isOptionGroupGated(['country', 'region'], { country: 'cn', region: 'east' })).toBe(false);
+  });
+
+  it('is never gated when there are no dependencies', () => {
+    expect(isOptionGroupGated(undefined, {})).toBe(false);
+  });
+});
+
+describe('resolveVisibleOptions — cascade', () => {
+  it('narrows the list to the controlling value', () => {
+    const cn = resolveVisibleOptions(provinces, { country: 'cn' }).map((o) => o.value);
+    expect(cn).toEqual(['zj', 'gd', 'other']);
+
+    const us = resolveVisibleOptions(provinces, { country: 'us' }).map((o) => o.value);
+    expect(us).toEqual(['ca', 'tx', 'other']);
+  });
+
+  it('keeps only predicate-less options when the parent is present-but-null', () => {
+    // The form renderer seeds every declared field to `null` (see form.tsx
+    // ruleRecord), so an unset parent evaluates as `null == 'cn'` → false and the
+    // dependent options are hidden — leaving only the predicate-less 'other'.
+    const none = resolveVisibleOptions(provinces, { country: null }).map((o) => o.value);
+    expect(none).toEqual(['other']);
+  });
+
+  it('fails open (keeps the option) when the referenced field is entirely absent', () => {
+    // A *missing* key (not seeded to null) makes the CEL engine fault; per the
+    // fail-open convention a broken predicate keeps the option. In practice
+    // `dependsOn` gating withholds the whole list first, so this only surfaces for
+    // predicate options with no declared dependency.
+    const all = resolveVisibleOptions(provinces, {}).map((o) => o.value);
+    expect(all).toEqual(['zj', 'gd', 'ca', 'tx', 'other']);
+  });
+
+  it('returns [] for empty / missing option lists', () => {
+    expect(resolveVisibleOptions([], { country: 'cn' })).toEqual([]);
+    expect(resolveVisibleOptions(undefined, { country: 'cn' })).toEqual([]);
+  });
+});
+
+describe('resolveVisibleOptions — role / context gating via scope', () => {
+  const options: OptionLike[] = [
+    { label: 'Standard', value: 'standard' },
+    { label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.roles" },
+  ];
+
+  it('hides the admin option for a non-admin', () => {
+    const vals = resolveVisibleOptions(options, {}, { current_user: { roles: ['sales'] } }).map(
+      (o) => o.value,
+    );
+    expect(vals).toEqual(['standard']);
+  });
+
+  it('offers the admin option to an admin', () => {
+    const vals = resolveVisibleOptions(options, {}, { current_user: { roles: ['admin'] } }).map(
+      (o) => o.value,
+    );
+    expect(vals).toEqual(['standard', 'admin_only']);
+  });
+});
+
+describe('isValueStillOffered — cascade clear decision', () => {
+  const cnOptions = resolveVisibleOptions(provinces, { country: 'cn' });
+
+  it('treats empty values as always valid (nothing to clear)', () => {
+    expect(isValueStillOffered(undefined, cnOptions)).toBe(true);
+    expect(isValueStillOffered('', cnOptions)).toBe(true);
+    expect(isValueStillOffered([], cnOptions)).toBe(true);
+  });
+
+  it('flags a value dropped by a parent change', () => {
+    // 'ca' was valid under country=us but not under country=cn.
+    expect(isValueStillOffered('ca', cnOptions)).toBe(false);
+    expect(isValueStillOffered('zj', cnOptions)).toBe(true);
+  });
+
+  it('handles multi-select arrays element-wise', () => {
+    expect(isValueStillOffered(['zj', 'gd'], cnOptions)).toBe(true);
+    expect(isValueStillOffered(['zj', 'ca'], cnOptions)).toBe(false);
+  });
+});

--- a/packages/core/src/evaluator/index.ts
+++ b/packages/core/src/evaluator/index.ts
@@ -9,6 +9,7 @@
 export * from './ExpressionContext.js';
 export * from './ExpressionEvaluator.js';
 export * from './fieldRules.js';
+export * from './optionRules.js';
 export * from './ExpressionCache.js';
 export * from './FormulaFunctions.js';
 export * from './SafeExpressionParser.js';

--- a/packages/core/src/evaluator/optionRules.ts
+++ b/packages/core/src/evaluator/optionRules.ts
@@ -1,0 +1,114 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Client-side resolution of per-option visibility for `select` / `radio` /
+ * `multiselect` fields — cascading (dependent) options and role/context gating.
+ *
+ * An option carries an optional `visibleWhen` CEL predicate; the option is
+ * offered only when it evaluates TRUE against the live record + `current_user`
+ * (the SAME engine and binding environment as a field-level `visibleWhen`, via
+ * {@link evalFieldPredicate}). This expresses both:
+ *   - cascades — `record.country == 'cn'` (the dependent list narrows as the
+ *     controlling field changes), and
+ *   - role/context gating — `'admin' in current_user.roles`.
+ *
+ * A field declares which sibling fields its option list reacts to via
+ * `dependsOn` (aligns with `@objectstack/spec` Field.dependsOn — the same knob
+ * lookups use). While any dependency is empty the list is *gated*: we surface a
+ * "select the parent first" hint instead of an unfiltered set, mirroring the
+ * dependent-lookup UX (#2215).
+ *
+ * Evaluation is fail-open (a broken/absent predicate keeps the option) — the
+ * same safe default as field visibility. Client-side hiding is UX, not a
+ * security boundary: when an option is gated for access-control reasons the
+ * server must also reject writes of its value.
+ */
+import { evalFieldPredicate, type FieldRulePredicate } from './fieldRules.js';
+
+/**
+ * Minimal shape of a select/radio option this module reads. Deliberately has no
+ * index signature so richer option types (`SelectOption`, `SelectOptionMetadata`)
+ * remain structurally assignable — the helpers only read `value`/`visibleWhen`.
+ */
+export interface OptionLike {
+  label: string;
+  value: string;
+  /** Per-option visibility predicate (CEL). Omit = always available. */
+  visibleWhen?: FieldRulePredicate;
+}
+
+/** A field's `dependsOn` as authored: a bare name, or a list of names / `{field,param}`. */
+export type DependsOnInput =
+  | string
+  | Array<string | { field: string; param?: string }>
+  | undefined
+  | null;
+
+/**
+ * Normalize a field's `dependsOn` to the list of sibling field names it reacts
+ * to. The lookup-only `{field,param}` form contributes just its `field`.
+ */
+export function resolveDependsOnFields(dependsOn: DependsOnInput): string[] {
+  if (!dependsOn) return [];
+  const arr = Array.isArray(dependsOn) ? dependsOn : [dependsOn];
+  return arr
+    .map((d) => (typeof d === 'string' ? d : d && typeof d === 'object' ? d.field : null))
+    .filter((f): f is string => typeof f === 'string' && f.length > 0);
+}
+
+/** A value counts as "empty" (dependency unmet) when nullish, blank, or an empty array. */
+function isEmptyValue(v: unknown): boolean {
+  return v === undefined || v === null || v === '' || (Array.isArray(v) && v.length === 0);
+}
+
+/**
+ * True when at least one `dependsOn` field is empty in the record — the option
+ * list is gated and the widget should prompt for the parent rather than show an
+ * unfiltered set. Returns false when there are no dependencies.
+ */
+export function isOptionGroupGated(
+  dependsOn: DependsOnInput,
+  record: Record<string, unknown>,
+): boolean {
+  const fields = resolveDependsOnFields(dependsOn);
+  return fields.some((f) => isEmptyValue(record[f]));
+}
+
+/**
+ * Filter options by their per-option `visibleWhen` predicate, evaluated against
+ * the live `record` (+ optional `scope`, e.g. `{ current_user }`). Options with
+ * no predicate are always kept; a predicate that errors fails open (kept).
+ */
+export function resolveVisibleOptions<T extends OptionLike>(
+  options: readonly T[] | undefined | null,
+  record: Record<string, unknown>,
+  scope?: Record<string, unknown>,
+): T[] {
+  if (!options || options.length === 0) return [];
+  return options.filter((o) =>
+    o?.visibleWhen == null ? true : evalFieldPredicate(o.visibleWhen, record, true, undefined, scope),
+  );
+}
+
+/**
+ * Whether a scalar field value is still valid given the currently-visible
+ * options — used to decide a cascade clear (parent changed, child's old choice
+ * no longer offered). An empty value is always "valid" (nothing to clear).
+ */
+export function isValueStillOffered(
+  value: unknown,
+  visibleOptions: readonly OptionLike[],
+): boolean {
+  if (isEmptyValue(value)) return true;
+  if (Array.isArray(value)) {
+    // Multi-select: valid only when every selected value is still offered.
+    return value.every((v) => visibleOptions.some((o) => o.value === v));
+  }
+  return visibleOptions.some((o) => o.value === value);
+}

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -55,6 +55,17 @@ Supported types out of the box:
 - **Media**: `file`, `image`
 - **System**: `formula`, `summary`, `auto_number`
 
+### Cascading & role-gated select options
+
+`select` options support a per-option `visibleWhen` CEL predicate (offered only
+when TRUE, evaluated against the live record + `current_user`) and a field-level
+`dependsOn`. Together they drive dependent selects (country → province → city)
+and role-gated options with no bespoke matrix — the same primitives dependent
+lookups use. While a `dependsOn` parent is empty the control is gated; a parent
+change re-filters the list and clears a now-invalid value. Client-side hiding is
+UX only — gate authorization-sensitive values on the server too. See
+[`content/docs/fields/select.mdx`](../../content/docs/fields/select.mdx).
+
 <!-- release-metadata:v3.3.0 -->
 
 ## Compatibility

--- a/packages/fields/src/widgets/SelectField.cascade.test.tsx
+++ b/packages/fields/src/widgets/SelectField.cascade.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Cascading / role-gated `select` options (#2284).
+ *
+ * Exercises the observable, non-Radix behaviour of {@link SelectField}: the
+ * dependency gate (a "select the parent first" empty-state) and the cascade
+ * clear (a value dropped when the offered set no longer includes it). The
+ * per-option filtering itself is unit-tested in `@object-ui/core`
+ * (`optionRules.test.ts`); here we prove the widget wires `dependentValues` +
+ * predicate scope into that resolver.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { SelectField } from './SelectField';
+
+const provinceField = {
+  name: 'province',
+  type: 'select',
+  dependsOn: 'country',
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+  ],
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SelectField — dependency gating (#2284)', () => {
+  it('gates with a "select parent first" hint while the controlling field is empty', () => {
+    render(
+      <SelectField
+        value={undefined}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: {} } as any)}
+      />,
+    );
+    const gate = screen.getByTestId('select-empty-province');
+    expect(gate).toHaveTextContent(/select country first/i);
+    // Gated → no live combobox is offered.
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('unlocks the combobox once the controlling field is set', () => {
+    render(
+      <SelectField
+        value={undefined}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    expect(screen.queryByTestId('select-empty-province')).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+});
+
+describe('SelectField — cascade clear (#2284)', () => {
+  it('clears a value the parent change no longer offers', () => {
+    const onChange = vi.fn();
+    render(
+      <SelectField
+        value={'ca'}
+        onChange={onChange}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    // 'ca' is a US province — under country=cn it is not offered, so it is dropped.
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('keeps a value that is still offered', () => {
+    const onChange = vi.fn();
+    render(
+      <SelectField
+        value={'zj'}
+        onChange={onChange}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('SelectField — role / context gating (#2284)', () => {
+  const tierField = {
+    name: 'tier',
+    type: 'select',
+    options: [
+      { label: 'Standard', value: 'standard' },
+      { label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.roles" },
+    ],
+  } as any;
+
+  it('clears an admin-only value for a non-admin (offered set excludes it)', () => {
+    const onChange = vi.fn();
+    render(
+      <PredicateScopeProvider scope={{ current_user: { roles: ['sales'] } }}>
+        <SelectField
+          value={'admin_only'}
+          onChange={onChange}
+          field={tierField}
+          {...({ name: 'tier', dependentValues: {} } as any)}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('keeps an admin-only value for an admin', () => {
+    const onChange = vi.fn();
+    render(
+      <PredicateScopeProvider scope={{ current_user: { roles: ['admin'] } }}>
+        <SelectField
+          value={'admin_only'}
+          onChange={onChange}
+          field={tierField}
+          {...({ name: 'tier', dependentValues: {} } as any)}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import {
   Select,
   SelectContent,
@@ -7,17 +7,42 @@ import {
   SelectValue,
   EmptyValue,
 } from '@object-ui/components';
+import {
+  resolveVisibleOptions,
+  isOptionGroupGated,
+  resolveDependsOnFields,
+  isValueStillOffered,
+} from '@object-ui/core';
+import { SchemaRendererContext, usePredicateScope } from '@object-ui/react';
 import { SelectFieldMetadata } from '@object-ui/types';
 import { useFieldTranslation } from './useFieldTranslation';
 import { FieldWidgetProps } from './types';
 
 /**
- * SelectField - Dropdown selection widget with configurable options
- * Renders options from field metadata with support for placeholder and readonly display
+ * SelectField - Dropdown selection widget with configurable options.
+ *
+ * Supports cascading / role-gated options (#2284): each option may carry a
+ * `visibleWhen` CEL predicate, evaluated against the live form record +
+ * `current_user`, so the offered set narrows as a controlling field changes
+ * (`record.country == 'cn'`) or by role (`'admin' in current_user.roles`). A
+ * field declares which sibling fields drive its list via `dependsOn`; while any
+ * of those is empty the control is gated with a "select the parent first" hint,
+ * mirroring the dependent-lookup UX.
  */
-export function SelectField({ value, onChange, field, readonly, ...props }: FieldWidgetProps<string>) {
-  const config = (field || (props as any).schema) as SelectFieldMetadata;
-  const options = config?.options || [];
+export function SelectField({
+  value,
+  onChange,
+  field,
+  readonly,
+  schema,
+  dependentValues,
+  dependsOn: dependsOnProp,
+  emptyHint: _emptyHint,
+  dataSource: _dataSource,
+  ...props
+}: FieldWidgetProps<string>) {
+  const config = (field || schema) as SelectFieldMetadata;
+  const rawOptions = config?.options || [];
   const { t } = useFieldTranslation();
   // Stable hook for automation/e2e — react-hook-form + Radix Select cannot be
   // driven by synthetic DOM events, so e2e must target the trigger/options by a
@@ -25,32 +50,67 @@ export function SelectField({ value, onChange, field, readonly, ...props }: Fiel
   // react-hook-form field name spread in by the form renderer (FormField).
   const fieldName = (props as any).name || (config as any)?.name || props.id || '';
 
+  // Live form values for cascading options — injected by the form renderer as
+  // `dependentValues` (same channel dependent lookups use), falling back to the
+  // record on SchemaRendererContext. `current_user` etc. come from the global
+  // predicate scope so role/context predicates resolve too.
+  const ctx = useContext(SchemaRendererContext) as any;
+  const record = useMemo<Record<string, unknown>>(() => {
+    return (dependentValues ?? ctx?.formValues ?? ctx?.data ?? {}) as Record<string, unknown>;
+  }, [dependentValues, ctx?.formValues, ctx?.data]);
+  const predicateScope = usePredicateScope();
+
+  const dependsOn = (config as any)?.dependsOn ?? dependsOnProp;
+  const dependsOnFields = useMemo(() => resolveDependsOnFields(dependsOn), [dependsOn]);
+  const gated = useMemo(
+    () => dependsOnFields.length > 0 && isOptionGroupGated(dependsOn, record),
+    [dependsOnFields, dependsOn, record],
+  );
+
+  // Effective (offered) options after per-option `visibleWhen` filtering. Empty
+  // while gated so we never present an unfiltered set before the parent is set.
+  const options = useMemo(
+    () => (gated ? [] : resolveVisibleOptions(rawOptions, record, predicateScope)),
+    [gated, rawOptions, record, predicateScope],
+  );
+
+  // Cascade clear: once the offered set no longer includes the current value
+  // (parent changed / predicate flipped), drop it so no stale pair persists.
+  useEffect(() => {
+    if (readonly) return;
+    if (value === undefined || value === null || (value as unknown) === '') return;
+    if (!isValueStillOffered(value, options)) onChange?.(undefined as unknown as string);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options, gated]);
+
   if (readonly) {
-    const option = options.find((o) => o.value === value);
+    const option = rawOptions.find((o) => o.value === value);
     const display = option?.label || value;
     return display ? <span className="text-sm">{display}</span> : <EmptyValue />;
   }
 
   // A select with no options is unfillable — a silently-empty Radix dropdown
-  // reads as "broken widget" and hides the real cause (the field metadata has
-  // no `options`). Surface a legible empty state instead, without needing to
-  // open the popover. Mirrors the inline form renderer's behaviour
-  // (see plugin form `renderFieldComponent`'s `case 'select'`).
+  // reads as "broken widget" and hides the real cause. Surface a legible state:
+  // a dependency-gated list prompts for its controlling field; an unconfigured
+  // list says so. Mirrors the inline form renderer's behaviour.
   if (options.length === 0) {
+    const hint = gated
+      ? `Select ${dependsOnFields.join(' / ')} first`
+      : 'No options available';
     return (
       <div
         data-testid={fieldName ? `select-empty-${fieldName}` : undefined}
         className="flex h-9 w-full items-center rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
       >
-        No options available
+        {hint}
       </div>
     );
   }
 
   return (
-    <Select 
+    <Select
       {...props}
-      value={value} 
+      value={value}
       onValueChange={onChange}
       disabled={readonly || props.disabled}
     >

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -264,6 +264,16 @@ export interface SelectOptionMetadata {
   color?: string;
   icon?: string;
   disabled?: boolean;
+  /**
+   * Per-option visibility predicate (CEL). The option is offered only when TRUE,
+   * evaluated against the live record + `current_user` (same env as field-level
+   * `visibleWhen`). Omit = always available. Drives cascading/dependent options
+   * (`record.country == 'cn'`) and role/context gating
+   * (`'admin' in current_user.roles`). Aligns with @objectstack/spec
+   * SelectOption.visibleWhen. Client-side hiding is UX only — access-control
+   * gating must also be enforced server-side.
+   */
+  visibleWhen?: string | { dialect?: string; source: string };
 }
 
 /**

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -278,6 +278,19 @@ export interface SelectOption {
    * Option icon
    */
   icon?: string;
+  /**
+   * Per-option visibility predicate (CEL). The option is offered only when this
+   * evaluates TRUE against the live record + `current_user` (same engine/env as
+   * field-level {@link FormFieldConfig.visibleWhen}). Omit = always available.
+   * Expresses both cascading options (`record.country == 'cn'`) and role/context
+   * gating (`'admin' in current_user.roles`). Aligns with @objectstack/spec
+   * SelectOption.visibleWhen.
+   *
+   * Client-side hiding is UX, not authorization — access-control gating must also
+   * be enforced server-side (the rule-validator rejects writes of a value whose
+   * predicate is false).
+   */
+  visibleWhen?: string | { dialect?: string; source: string };
 }
 
 /**

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -235,6 +235,52 @@ paid_on:   Field.date({
   never locks a field. `visibleWhen` is client-only — never rely on it for
   security; use `readonlyWhen`/`requiredWhen` (or a validation rule) for guarantees.
 
+## Cascading & role-gated select options (`option.visibleWhen` + `dependsOn`)
+
+For dependent selects (country → province → city) and role-gated options, do
+**not** invent a `validFor` / `controllingField` matrix. Reuse the two primitives
+you already have — the mechanism is uniform with dependent lookups, so both
+humans and AI author it correctly by pattern-matching:
+
+- **`SelectOption.visibleWhen`** — a per-option CEL predicate; the option is
+  offered only when TRUE. Evaluated against the live `record` **plus
+  `current_user`** (same engine/env as a field-level `visibleWhen`).
+- **`field.dependsOn`** — declares the sibling field(s) the option list reacts
+  to. While any is empty the control is **gated** ("Select country first"); a
+  parent change re-evaluates the list and **auto-clears** a now-invalid value.
+
+```jsonc
+{ "type": "form", "fields": [
+  { "name": "country", "type": "select", "options": [
+    { "label": "China", "value": "cn" }, { "label": "United States", "value": "us" }
+  ]},
+  { "name": "province", "type": "select", "dependsOn": "country", "options": [
+    { "label": "Zhejiang",   "value": "zj", "visibleWhen": "record.country == 'cn'" },
+    { "label": "California", "value": "ca", "visibleWhen": "record.country == 'us'" }
+  ]},
+  // role gating — same predicate, references current_user instead of a sibling:
+  { "name": "tier", "type": "select", "options": [
+    { "label": "Standard",   "value": "standard" },
+    { "label": "Admin only", "value": "admin_only", "visibleWhen": "'admin' in current_user.roles" }
+  ]}
+]}
+```
+
+**Decision rule — options vs. lookup.** Use `option.visibleWhen` only for
+**small, static dictionaries** (a handful of provinces, category → subcategory).
+When the data is large, changes over time, or is shared across forms (real
+country/province/city tables, org units, product catalogs) model each level as a
+**`lookup`** with `depends_on` — the candidate query is filtered and paginated
+server-side. Wrong tool = a 4000-row `<select>`.
+
+**Security.** Option `visibleWhen` only hides the choice on the client; the value
+is still submittable. When an option is gated for **authorization**, the server
+must also reject writes of that value (the rule-validator evaluates the picked
+value's `visibleWhen`). Use it freely for cascades/UX; pair it with server
+enforcement for access control. Multi-field conditions (`record.country == 'cn'
+&& current_user.department == 'sales'`) work — just list every referenced sibling
+in `dependsOn`.
+
 ## Data binding with `bind`
 
 The `bind` field is NOT expression-evaluated. It's a path string resolved by `useDataScope()`:


### PR DESCRIPTION
Closes #2284.

## What & why

Frontend forms need **cascading / dependent selects** (country → province → city) and **role/context-gated options**. Rather than invent a Salesforce-style `validFor` / `controllingField` matrix, this reuses the two primitives the codebase already has — so the mechanism is uniform with dependent lookups (#2215) and both humans and AI author it correctly by pattern-matching:

- **`SelectOption.visibleWhen`** — a per-option CEL predicate; the option is offered only when TRUE, evaluated against the live `record` **plus `current_user`** (same engine/env as a field-level `visibleWhen`).
- **`field.dependsOn`** — declares the sibling field(s) the option list reacts to; while any is empty the control is **gated** ("Select country first"), and a parent change **auto-clears** a now-invalid value.

The two purposes — cascade (record fields) and role gating (`current_user`) — are the same predicate; `dependsOn` and `visibleWhen` stay orthogonal (an option can have `visibleWhen` with no `dependsOn`).

## Changes

- **`@object-ui/core`** — new evaluator helpers `resolveVisibleOptions` / `isOptionGroupGated` / `resolveDependsOnFields` / `isValueStillOffered`, built on the canonical `evalFieldPredicate` (`@objectstack/formula`).
- **`@object-ui/components`** — the form renderer narrows a dependent select's options, gates with a "Select {parent} first" hint, and clears a now-invalid value on parent change (new `usePredicateScope()` wiring for `current_user`).
- **`@object-ui/fields`** — `SelectField` applies the same resolution via `dependentValues` + the global predicate scope.
- **`@object-ui/types`** — mirror `SelectOption.visibleWhen` on `SelectOption` / `SelectOptionMetadata` (aligns with `@objectstack/spec`).
- **Docs / example / skill** — `content/docs/fields/select.mdx`, a `fields-select/cascading-options` schema-catalog demo, the `schema-expressions` skill guide, and the `@object-ui/fields` README.
- **Changeset** — minor across the four packages.

## Security

Client-side hiding is **UX, not authorization** — a `visibleWhen` only removes the choice from the dropdown; the value is still submittable. For authorization-gated options the server must also reject writes of that value (rule-validator evaluates the picked value's `visibleWhen`). Documented in the field docs and skill.

## Depends on spec

Requires `SelectOption.visibleWhen` in `@objectstack/spec` — see companion PR **objectstack-ai/framework#[spec]** (`claude/cascading-select-visiblewhen`). The objectui types mirror the spec, as with `dependsOn` / `visibleWhen`.

## Tests

- `@object-ui/core` `optionRules.test.ts` — cascade filtering, gating, role gating via scope, cascade-clear decision (13).
- `@object-ui/fields` `SelectField.cascade.test.tsx` — gate hint, unlock, cascade clear, role gating (6).
- `@object-ui/components` `form-cascading-select.test.tsx` — inline renderer gate transition end-to-end (1).
- Existing `standard-widgets` / form suites pass unchanged. `@object-ui/fields` closure builds (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aYFm77ddLp6tzuJjt9hK2

---
_Generated by [Claude Code](https://claude.ai/code/session_019aYFm77ddLp6tzuJjt9hK2)_