### PR TITLE
refactor(plugin-view,app-shell): source record-surface derivation from @objectstack/spec/data (#2269 debt)

### DIFF
--- a/.changeset/consolidate-record-surface-mirror.md
+++ b/.changeset/consolidate-record-surface-mirror.md
@@ -1,0 +1,8 @@
+---
+'@object-ui/plugin-view': patch
+'@object-ui/app-shell': patch
+---
+
+Consolidate the record-surface mirror onto `@objectstack/spec/data` (objectui#2269 debt paydown).
+
+`plugin-view/src/recordSurface.ts` re-exports `deriveRecordSurface` / `deriveRecordFlowSurface` / `countAuthorableFields` / `RECORD_SURFACE_PAGE_THRESHOLD` + types from `@objectstack/spec/data` instead of carrying a hand-kept copy — the local mirror only existed because objectui pinned a spec (`^11.7`) predating those exports, and the pin is now `^12.2`. The objectui-local overlay-size helpers (`deriveOverlaySize` / `overlayWidthFor` / `OverlaySize`, a renderer width concern the protocol doesn't own) stay local but reuse spec's `countAuthorableFields`. `RecordSurface` widens to spec's `'page' | 'modal' | 'drawer'` (the heuristic still only emits page/drawer); `resolvePostCreateTarget`'s `surface` param accepts the wider type and treats `'modal'` like a drawer. Behavior is unchanged (mirror unit tests pass verbatim against the re-exported functions); console production build resolves the subpath import.

--- a/packages/app-shell/src/utils/recordFormNavigation.ts
+++ b/packages/app-shell/src/utils/recordFormNavigation.ts
@@ -185,8 +185,13 @@ export function resolvePostCreateTarget(opts: {
   pathname: string;
   /** Current location search (query string, with or without leading `?`). */
   search?: string;
-  /** The record's derived VIEW surface (`deriveRecordSurface(objectDef)`). */
-  surface: 'page' | 'drawer';
+  /**
+   * The record's derived VIEW surface (`deriveRecordSurface(objectDef)`).
+   * `deriveRecordSurface` only ever emits `'page'` / `'drawer'`; `'modal'` is
+   * accepted (spec widened `RecordSurface` to include it) and treated like a
+   * drawer — this helper only branches page-vs-not-page.
+   */
+  surface: 'page' | 'drawer' | 'modal';
   /** Saved record id (`result.id ?? result._id`). */
   recordId: unknown;
 }): PostCreateTarget {

--- a/packages/plugin-view/package.json
+++ b/packages/plugin-view/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@objectstack/spec": "^12.2.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@object-ui/components": "workspace:*",

--- a/packages/plugin-view/src/recordSurface.ts
+++ b/packages/plugin-view/src/recordSurface.ts
@@ -7,61 +7,36 @@
  */
 
 /**
- * Local mirror of `@objectstack/spec` `deriveRecordSurface` (framework #2578).
+ * Record-surface derivation — now sourced from `@objectstack/spec/data`
+ * (framework #2578 / #2604). The local mirror this file used to carry existed
+ * only because objectui pinned a spec that predated the export; with the spec
+ * bump to `^12.2.0` the real derivation is available, so we re-export it and
+ * delete the copy (restoring the single-source guarantee the mirror stood in
+ * for).
  *
- * A record's default surface — full `page` vs a `drawer`/`modal` overlay — is
- * DERIVED from how heavy the record is (visible, non-system field count), not
- * authored: per ADR-0085 §2 a `recordSurface` object key would fail the
- * admission test (field count is machine-inferable). Field-heavy objects open
- * create/edit/detail as a full page; light ones as a drawer. Mobile always
- * pages (overlays are cramped on phones). An explicit `schema.layout` or
- * per-view navigation config still wins — this is only the default.
- *
- * Kept local because objectui pins `@objectstack/spec@^11.7.0`, which predates
- * the export. Consolidate to
- * `import { deriveRecordSurface } from '@objectstack/spec/data'` when objectui
- * adopts spec >= 11.10 (framework #2578). The field set + threshold below mirror
- * the spec helper exactly so the two agree.
+ * Only the OVERLAY-SIZE helpers below (`deriveOverlaySize` / `overlayWidthFor`
+ * / `OverlaySize`) stay objectui-local: they map a field count to a
+ * viewport-clamped CSS width, which is a renderer concern the protocol does
+ * not (and should not) own. They reuse spec's `countAuthorableFields` so the
+ * field set stays in lockstep with `deriveRecordSurface`.
  */
 
-/** Audit/system fields excluded from the "how heavy is this record" count. */
-const RECORD_SURFACE_SYSTEM_FIELDS: ReadonlySet<string> = new Set([
-  'created_at', 'created_by', 'updated_at', 'updated_by',
-  'organization_id', 'tenant_id', 'is_deleted', 'deleted_at',
-]);
+export {
+  deriveRecordSurface,
+  deriveRecordFlowSurface,
+  countAuthorableFields,
+  RECORD_SURFACE_PAGE_THRESHOLD,
+} from '@objectstack/spec/data';
+export type {
+  RecordSurface,
+  RecordSurfaceOptions,
+  RecordSurfaceViewport,
+  RecordFlow,
+  RecordFlowContainer,
+  RecordFlowSurface,
+} from '@objectstack/spec/data';
 
-/** At/above this many authorable fields, a record opens as a full page. */
-export const RECORD_SURFACE_PAGE_THRESHOLD = 12;
-
-export type RecordSurface = 'page' | 'drawer';
-
-export interface RecordSurfaceOptions {
-  viewport?: 'mobile' | 'desktop';
-  pageThreshold?: number;
-}
-
-/** Count visible, non-system fields on an object schema. */
-function countAuthorableFields(objectSchema: unknown): number {
-  const fields = (objectSchema as { fields?: unknown } | null)?.fields;
-  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) return 0;
-  let n = 0;
-  for (const [name, f] of Object.entries(fields as Record<string, { hidden?: boolean } | undefined>)) {
-    if (f?.hidden === true) continue;
-    if (RECORD_SURFACE_SYSTEM_FIELDS.has(name)) continue;
-    n++;
-  }
-  return n;
-}
-
-/**
- * Derive the default record surface for an object schema. Field-heavy → `page`,
- * otherwise `drawer`; mobile always `page`.
- */
-export function deriveRecordSurface(objectSchema: unknown, opts: RecordSurfaceOptions = {}): RecordSurface {
-  if (opts.viewport === 'mobile') return 'page';
-  const threshold = opts.pageThreshold ?? RECORD_SURFACE_PAGE_THRESHOLD;
-  return countAuthorableFields(objectSchema) >= threshold ? 'page' : 'drawer';
-}
+import { countAuthorableFields } from '@objectstack/spec/data';
 
 /**
  * Overlay size bucket for a drawer/modal (mirrors spec `NavigationConfig.size`
@@ -93,57 +68,4 @@ export function deriveOverlaySize(objectSchema: unknown): OverlaySize {
 export function overlayWidthFor(size: 'auto' | OverlaySize | undefined, objectSchema: unknown): string {
   const bucket = (!size || size === 'auto') ? deriveOverlaySize(objectSchema) : size;
   return `min(92vw, ${OVERLAY_SIZE_PX[bucket]}px)`;
-}
-
-/**
- * Local mirror of `@objectstack/spec` `deriveRecordFlowSurface` (framework
- * #2604 — same consolidation TODO as `deriveRecordSurface` above: swap to the
- * `@objectstack/spec/data` import when the pinned spec ships it).
- *
- * The record flow being opened. `view` shows state; the other four perform a
- * task (create/change a record). For `child-*` flows — a subtable / related-
- * list child created or edited from its PARENT's detail — pass the CHILD
- * object's schema: the overlay sizes to the record being edited, while the
- * return target is always the parent (#2604 D3).
- */
-export type RecordFlow = 'view' | 'create' | 'edit' | 'child-create' | 'child-edit';
-
-/** How the surface is mounted: a navigated route, or an overlay over the origin. */
-export type RecordFlowContainer = 'route' | 'overlay';
-
-export interface RecordFlowSurface {
-  /**
-   * `'route'` only ever for flow `'view'` (a record is shareable state).
-   * Every task flow is an `'overlay'`: close returns to the origin with its
-   * context (scroll / filters / tab) intact — the #2604 return-flow invariant.
-   */
-  container: RecordFlowContainer;
-  /** Includes `'modal'`, which the base heuristic never emits — task flows do. */
-  surface: 'page' | 'modal' | 'drawer';
-  /** Maps onto `modalSize` / `navigation.size`; routes ignore it. */
-  size: 'auto' | 'full';
-}
-
-/**
- * Derive the DEFAULT surface for a record FLOW (#2604). The two axes are
- * independent: how BIG comes from {@link deriveRecordSurface} (unchanged);
- * whether it ROUTES comes from what the flow *is* — viewing a record is
- * state → route-capable; making/changing one is a task → always an overlay,
- * with the derived `'page'` mapped to a FULL-SCREEN MODAL (same big canvas,
- * overlay return semantics). A DEFAULT only: explicit `navigation.mode`/`size`,
- * `FormView.type`/`modalSize`, or an assigned page win.
- */
-export function deriveRecordFlowSurface(
-  objectSchema: unknown,
-  flow: RecordFlow,
-  opts: RecordSurfaceOptions = {},
-): RecordFlowSurface {
-  const surface = deriveRecordSurface(objectSchema, opts);
-  if (flow === 'view') {
-    return { container: surface === 'page' ? 'route' : 'overlay', surface, size: 'auto' };
-  }
-  // Task flows (create / edit / child-*): never a route. Field-heavy (or
-  // mobile, where the base derivation says 'page') → full-screen modal.
-  if (surface === 'page') return { container: 'overlay', surface: 'modal', size: 'full' };
-  return { container: 'overlay', surface, size: 'auto' };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2420,6 +2420,9 @@ importers:
       '@object-ui/types':
         specifier: workspace:*
         version: link:../types
+      '@objectstack/spec':
+        specifier: ^12.2.0
+        version: 12.2.0(ai@7.0.4(zod@4.4.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
## 概述

还清 #2269 挂账 #1:`@objectstack/spec` 已随 #2287 升到 `^12.2.0` 并同步到本仓,`plugin-view` 里 `deriveRecordSurface`/`deriveRecordFlowSurface` 的本地镜像可以按其自身 TODO 换回真实 import 了 —— 恢复镜像本来要替代的"单一来源"保证。

## 变更

- **`plugin-view/src/recordSurface.ts`**:改为从 `@objectstack/spec/data` **re-export** `deriveRecordSurface` / `deriveRecordFlowSurface` / `countAuthorableFields` / `RECORD_SURFACE_PAGE_THRESHOLD` + 全部类型,删掉手抄副本(−106 行)。objectui **本地**的 overlay 尺寸助手(`deriveOverlaySize` / `overlayWidthFor` / `OverlaySize` —— 把字段数映射成 viewport-clamped CSS 宽度,是渲染器关切、协议不该拥有)保留,但改用 spec 的 `countAuthorableFields`,与派生保持同源。
- **`plugin-view/package.json`**:补上 `@objectstack/spec ^12.2.0` 依赖(此前只通过镜像注释间接引用)。
- **类型加宽**:spec 的 `RecordSurface` = `'page' | 'modal' | 'drawer'`(启发式仍只发 page/drawer);`resolvePostCreateTarget` 的 `surface` 参数接受加宽类型,把 `'modal'` 当 drawer 处理(该 helper 只分 page-vs-非 page)。

## 验证

- ✅ 镜像单测 **10/10 逐字通过**(等于在验证 re-export 的 spec 函数行为与原实现一致);
- ✅ plugin-view + app-shell 全量 **1069 通过**;type-check **29/29**;
- ✅ **console 生产 vite 构建成功** —— 关键的新风险(`@objectstack/spec/data` 子路径能否在 bundle 里解析)已排除。

纯重构 + 依赖对齐,行为不变。

Refs #2269 · #2287 · framework#2578 · framework#2604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zKcAtbtxuF9SXYgSzjk9v

---
_Generated by [Claude Code](https://claude.ai/code/session_019zKcAtbtxuF9SXYgSzjk9v)_