### PR TITLE
fix(detail): reach 4-column density and stop JSON values overflowing (#2578)

### DIFF
--- a/.changeset/detail-view-multi-column.md
+++ b/.changeset/detail-view-multi-column.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/plugin-detail': minor
+'@object-ui/fields': patch
+---
+
+Align the DetailView column density with the entry form (objectui#2578 "多列显示").
+
+- **Detail views now reach up to 4 columns, matching the form.** `inferDetailColumns` was hard-capped at 2 columns and the section column count was derived per-section, so a field-heavy record displayed 2 columns in detail but 4 in the edit form. It now uses the same density scale as the form's `inferColumns` (1 → 2 → 3 → 4 by field count) and `deriveFieldGroupDetailSections` derives the count from the object's *total* field count and stamps it uniformly on every section — so view and edit read at the same width. The responsive grid classes and `getResponsiveSpanClass` ladder were extended through the 3- and 4-column breakpoints, and the effective column count is clamped to the number of visible fields so a lone field never sits at 1/N width.
+- **Long JSON values no longer spill into the neighbouring column.** `JsonCellRenderer` (used by `address`/`json`/`object`/`composite`/`record` fields) applied `truncate` to a bare inline `<span>`, where `overflow:hidden`/`text-overflow:ellipsis` never clip (there is no width box) and the accompanying `white-space:nowrap` also defeated the cell's `break-words`; a long name-keyed map or address JSON therefore overflowed into the adjacent GPS/color cell once the grid narrowed to multi-column. The renderer is now a `block max-w-full` element so `truncate` clamps to the cell width (full value still on hover), and the detail cell wrappers carry `min-w-0` so unbreakable values wrap instead of setting the track's min width.

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1450,7 +1450,13 @@ export function JsonCellRenderer({ value }: CellRendererProps): React.ReactEleme
   } else {
     text = String(value);
   }
-  return <span className="font-mono text-xs text-gray-600 truncate" title={text}>{text}</span>;
+  // inline-block + max-w-full so `truncate` (overflow-hidden/ellipsis/nowrap)
+  // actually clamps to the cell width. On a bare inline <span> truncate never
+  // clips — there is no width box — and its `white-space:nowrap` also defeats
+  // the parent cell's `break-words`, so a long name-keyed map / address JSON
+  // spills into the neighbouring column (objectui#2578). The title keeps the
+  // full value on hover.
+  return <span className="block max-w-full font-mono text-xs text-gray-600 truncate" title={text}>{text}</span>;
 }
 
 /**

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -37,7 +37,11 @@ import { useSafeFieldLabel } from '@object-ui/react';
  *
  * For columns=1: no span class (always single column)
  * For columns=2: md:col-span-{min(span,2)}
- * For columns>=3: md:col-span-{min(span,2)} lg:col-span-{min(span,3)}
+ * For columns=3: md:col-span-{min(span,2)} lg:col-span-{min(span,3)}
+ * For columns>=4: …lg:col-span-{min(span,3)} xl:col-span-{min(span,4)}
+ *
+ * Mirrors the grid's breakpoint ladder (md→2, lg→3, xl→4) so a wide field
+ * never spans more cells than exist at any breakpoint (objectui#2578).
  */
 export function getResponsiveSpanClass(span: number | undefined, columns: number): string {
   if (!span || span <= 1 || columns <= 1) return '';
@@ -46,9 +50,16 @@ export function getResponsiveSpanClass(span: number | undefined, columns: number
     return span >= 2 ? 'md:col-span-2' : '';
   }
 
-  // columns >= 3: grid-cols-1 md:grid-cols-2 lg:grid-cols-3
+  if (columns === 3) {
+    if (span === 2) return 'md:col-span-2';
+    if (span >= 3) return 'md:col-span-2 lg:col-span-3';
+    return '';
+  }
+
+  // columns >= 4: grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4
   if (span === 2) return 'md:col-span-2';
-  if (span >= 3) return 'md:col-span-2 lg:col-span-3';
+  if (span === 3) return 'md:col-span-2 lg:col-span-3';
+  if (span >= 4) return 'md:col-span-2 lg:col-span-3 xl:col-span-4';
 
   return '';
 }
@@ -172,10 +183,14 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
   if (visibleFields.length === 0 && emptyCount === section.fields.length) return null;
 
   // Apply auto-layout: infer columns and auto-span wide fields
-  const { fields: layoutFields, columns: effectiveColumns } = applyDetailAutoLayout(
+  const { fields: layoutFields, columns: rawColumns } = applyDetailAutoLayout(
     visibleFields,
     section.columns
   );
+  // Never render more columns than there are visible fields — the object-wide
+  // column count (objectui#2578) can exceed a section's visible count when
+  // empty fields are hidden; a lone field shouldn't sit at 1/N width.
+  const effectiveColumns = Math.min(rawColumns, Math.max(1, visibleFields.length));
 
   const renderField = (field: DetailViewField) => {
     const value = data?.[field.name] ?? field.value;
@@ -265,8 +280,12 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     }
 
     // Default field rendering with copy button and touch-friendly targets
+    // min-w-0: a grid item defaults to min-width:auto, so a long unbreakable
+    // value (raw JSON, a GPS pair, a URL) sets the track's min width and
+    // overflows into the neighbouring cell — visible once columns narrow
+    // (objectui#2578). Allowing the item to shrink lets the value wrap.
     return (
-      <div key={field.name} className={cn("space-y-1.5 group", spanClass)}>
+      <div key={field.name} className={cn("space-y-1.5 group min-w-0", spanClass)}>
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
           {fieldLabel(objectName || '', field.name, field.label || field.name)}
         </div>
@@ -374,7 +393,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
           role={canCopy ? "button" : undefined}
           tabIndex={canCopy ? 0 : undefined}
         >
-          <div className="text-sm flex-1 break-words py-1">
+          <div className="text-sm flex-1 min-w-0 break-words py-1">
             {displayValue}
           </div>
           {canCopy && (
@@ -450,7 +469,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
             effectiveColumns === 1 ? "grid-cols-1" :
             effectiveColumns === 2 ? "grid-cols-1 md:grid-cols-2" :
             effectiveColumns === 3 ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" :
-            "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
+            "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
           )}
         >
           {renderedFields.map(renderField)}

--- a/packages/plugin-detail/src/__tests__/detailColumns.test.ts
+++ b/packages/plugin-detail/src/__tests__/detailColumns.test.ts
@@ -1,0 +1,83 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#2578 "多列显示" — the DETAIL view must reach the same column
+ * density as the entry FORM. Before this, `inferDetailColumns` hard-capped at
+ * 2 and the section column count was derived per-section, so a field-heavy
+ * record showed 2 columns in detail but 4 in the form. These tests pin the
+ * aligned behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { inferDetailColumns } from '../autoLayout';
+import { getResponsiveSpanClass } from '../DetailSection';
+import { deriveFieldGroupDetailSections } from '../synth/buildDefaultPageSchema';
+
+describe('inferDetailColumns — density scale aligned with the form (#2578)', () => {
+  it('scales 1 → 2 → 3 → 4 by field count (no longer capped at 2)', () => {
+    expect(inferDetailColumns(1)).toBe(1);
+    expect(inferDetailColumns(3)).toBe(1);
+    expect(inferDetailColumns(4)).toBe(2);
+    expect(inferDetailColumns(8)).toBe(2);
+    expect(inferDetailColumns(9)).toBe(3);
+    expect(inferDetailColumns(15)).toBe(3);
+    expect(inferDetailColumns(16)).toBe(4);
+    expect(inferDetailColumns(57)).toBe(4);
+  });
+
+  it('clamps to a single column on a narrow container', () => {
+    expect(inferDetailColumns(20, 480)).toBe(1);
+    expect(inferDetailColumns(20, 800)).toBe(4);
+  });
+});
+
+describe('getResponsiveSpanClass — spans track the breakpoint ladder up to 4', () => {
+  it('never spans more cells than exist at each breakpoint', () => {
+    expect(getResponsiveSpanClass(1, 4)).toBe('');
+    expect(getResponsiveSpanClass(2, 4)).toBe('md:col-span-2');
+    expect(getResponsiveSpanClass(3, 4)).toBe('md:col-span-2 lg:col-span-3');
+    expect(getResponsiveSpanClass(4, 4)).toBe('md:col-span-2 lg:col-span-3 xl:col-span-4');
+  });
+
+  it('caps at the 3-column ladder for 3-column sections', () => {
+    expect(getResponsiveSpanClass(4, 3)).toBe('md:col-span-2 lg:col-span-3');
+    expect(getResponsiveSpanClass(2, 3)).toBe('md:col-span-2');
+  });
+});
+
+describe('deriveFieldGroupDetailSections — one object-wide column count on every section (#2578)', () => {
+  const heavyDef = {
+    name: 'lead',
+    fieldGroups: [
+      { key: 'basic', label: 'Basic' },
+      { key: 'plan', label: 'Plan' },
+    ],
+    fields: Object.fromEntries(
+      // 3 in basic, 15 in plan → 18 total → 4 columns
+      [
+        ...Array.from({ length: 3 }, (_, i) => [`b${i}`, { type: 'text', group: 'basic' }]),
+        ...Array.from({ length: 15 }, (_, i) => [`p${i}`, { type: 'text', group: 'plan' }]),
+      ],
+    ),
+  };
+
+  it('stamps columns derived from the TOTAL field count on every section (matches the form)', () => {
+    const sections = deriveFieldGroupDetailSections(heavyDef as any);
+    expect(sections).not.toBeNull();
+    // 18 total fields → 4 columns, applied uniformly — the 3-field Basic group
+    // and the 15-field Plan group both get 4 (not per-section 2 / 3).
+    for (const s of sections!) {
+      expect(s.columns).toBe(4);
+    }
+  });
+
+  it('returns null for an object without fieldGroups', () => {
+    expect(deriveFieldGroupDetailSections({ name: 'x', fields: {} } as any)).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/autoLayout.ts
+++ b/packages/plugin-detail/src/autoLayout.ts
@@ -15,13 +15,16 @@
  *
  * Priority: User configuration > Auto-layout inference
  *
- * Column rules for detail views (wider thresholds than forms):
- * - 0-3 fields  → 1 column
- * - 4+ fields   → 2 columns
+ * Column rules mirror the entry form's `inferColumns` so a record reads at the
+ * same width in view and edit (objectui#2578 "多列显示"):
+ * - 0-3 fields   → 1 column
+ * - 4-8 fields   → 2 columns
+ * - 9-15 fields  → 3 columns
+ * - 16+ fields   → 4 columns
  *
- * Note: 3 columns was previously emitted for 11+ fields but produced
- * very sparse rows on typical desktop widths (~30% cell fill rate).
- * Capped at 2 for a denser, more legible grid.
+ * This is the UPPER BOUND; the grid's responsive breakpoints clamp it to the
+ * real container width at render, so a heavy record does not render 4 sparse
+ * columns on a narrow viewport.
  */
 
 import type { DetailViewField } from '@object-ui/types';
@@ -51,18 +54,27 @@ export function isWideFieldType(type: string): boolean {
  * Infer optimal number of columns for a detail section based on field count.
  * When containerWidth is provided, limits columns for narrower viewports.
  *
- * Rules (field-count based):
- * - 0-3 fields → 1 column
- * - 4+ fields  → 2 columns
+ * Rules (field-count based, aligned with the form):
+ * - 0-3 fields   → 1 column
+ * - 4-8 fields   → 2 columns
+ * - 9-15 fields  → 3 columns
+ * - 16+ fields   → 4 columns
  *
  * Responsive capping (when containerWidth is supplied):
  * - containerWidth < 640px → max 1 column
- * - containerWidth >= 640px → no cap (max is already 2)
  */
 export function inferDetailColumns(fieldCount: number, containerWidth?: number): number {
+  // Density scale — the UPPER BOUND, identical to the entry form's
+  // `inferColumns` (plugin-form) so a record reads at the same width in view
+  // and edit (objectui#2578 "多列显示"). The detail path previously
+  // hard-capped at 2, which is why field-heavy records showed 2 columns in
+  // detail but 4 in the form. The grid's breakpoints clamp this to the real
+  // width at render.
   let cols: number;
   if (fieldCount <= 3) cols = 1;
-  else cols = 2;
+  else if (fieldCount <= 8) cols = 2;
+  else if (fieldCount <= 15) cols = 3;
+  else cols = 4;
 
   // Apply responsive capping when container width is known
   if (containerWidth !== undefined) {

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -24,6 +24,7 @@
  */
 
 import { deriveFieldGroupLayout } from '@objectstack/spec/data';
+import { inferDetailColumns } from '../autoLayout';
 
 /** Minimal shape of an object definition we read here. We deliberately
  *  duck-type so this helper has zero hard dependency on a specific
@@ -451,6 +452,16 @@ export function deriveFieldGroupDetailSections(
     };
   };
 
+  // Column count is derived ONCE from the object's TOTAL detail-field count and
+  // applied to every section — mirroring the entry form (plugin-form's
+  // `derivedSections` uses `inferColumns(totalFieldCount)` uniformly), so a
+  // record reads at the same width in view and edit (objectui#2578). Without
+  // this each section re-inferred from its OWN field count, so a 15-field group
+  // showed 3 columns in detail while the form showed 4. The grid's CSS
+  // breakpoints still clamp to the real rendered width.
+  const totalFields = derived.reduce((n, s) => n + s.fields.length, 0);
+  const columns = inferDetailColumns(totalFields);
+
   // Untitled trailing bucket: omitting `name`/`title` keeps the section flat
   // (record-details defaults showBorder to false for untitled sections)
   // instead of surfacing an internal key as a header.
@@ -458,6 +469,7 @@ export function deriveFieldGroupDetailSections(
     ...(s.key !== undefined ? { name: s.key, title: s.label ?? s.key } : {}),
     ...(s.collapse !== 'none' ? { collapsible: true } : {}),
     ...(s.collapse === 'collapsed' ? { defaultCollapsed: true } : {}),
+    columns,
     fields: s.fields.map(toField),
   }));
 }


### PR DESCRIPTION
## Summary

Follow-up to #2578 ("多列显示"). The detail view was under-delivering the multi-column layout: a field-heavy record rendered **2 columns in the detail view but 4 columns in the edit form**, and long JSON values spilled into the neighbouring column. This aligns the detail path with the form and fixes the overflow.

### The two divergences (fixed)

1. **Column density was hard-capped at 2 and derived per-section.**
   - `inferDetailColumns` capped at 2; it now uses the form's density scale — `1 → 2 → 3 → 4` by field count (identical to `plugin-form`'s `inferColumns`).
   - `deriveFieldGroupDetailSections` now derives the count from the object's **total** detail-field count and stamps it uniformly on every section — matching the form, where `derivedSections` uses `inferColumns(totalFieldCount)`. Previously each section re-inferred from its own field count, so a 15-field group showed 3 columns in detail while the form showed 4.
   - Responsive grid classes and the `getResponsiveSpanClass` span ladder are extended through the 3- and 4-column breakpoints (`md`→2, `lg`→3, `xl`→4).
   - The effective column count is clamped to the visible-field count so a lone field (after empty fields are hidden) never sits at 1/N width.

2. **Long JSON values overflowed into the next column.**
   - `JsonCellRenderer` (used by `address` / `json` / `object` / `composite` / `record`) applied `truncate` to a bare inline `<span>`, where `overflow:hidden`/`ellipsis` never clip (no width box) and `white-space:nowrap` also defeats the cell's `break-words`. It is now a `block max-w-full` element so `truncate` clamps to the cell width (full value still shown on hover via `title`).
   - The detail cell wrappers carry `min-w-0` so an unbreakable value can shrink and wrap instead of setting the grid track's min width.

## Testing

- New unit suite `plugin-detail/src/__tests__/detailColumns.test.ts` pins the aligned behaviour (density scale, mobile clamp, the 3-/4-column span ladder, and total-derived uniform section columns).
- `plugin-detail` + `fields` unit tests: **318 passing**.
- `type-check` clean for both packages.
- Browser-verified on `showcase_field_zoo`: the detail view now renders **4 columns** (was 2), matching the edit form, and every JSON value truncates cleanly within its column with no overlap into the GPS/color neighbours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zKcAtbtxuF9SXYgSzjk9v

---
_Generated by [Claude Code](https://claude.ai/code/session_019zKcAtbtxuF9SXYgSzjk9v)_