### PR TITLE
fix(app-shell): fast-fail Studio source editors to textarea when Monaco CDN is blocked; repair plugin-view test

### DIFF
--- a/.changeset/studio-source-editor-cdn-fastfail.md
+++ b/.changeset/studio-source-editor-cdn-fastfail.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Studio source-code editors fall back to the textarea instantly when Monaco can't load (offline / air-gapped / CSP).
+
+The metadata designer's code surfaces — the JSON **Source** tab (`JsonSourceEditor`) and the `kind:'html'`/`kind:'react'` page editor (`SourcePageEditor`) — lazy-load Monaco from a public CDN (jsdelivr). On installs that block it (the console is meant to embed in any ObjectStack server, many shipping a strict CSP), the loader script fails and the panel sat on Monaco's own "Loading…" for a hard-coded 4 seconds before the textarea fallback engaged. A new shared `useMonacoFallback` hook now watches `loader.init()` and flips to the textarea the moment the CDN load rejects (~immediately), keeping the previous `.view-line` DOM-poll as a backstop for the "resolved but painted nothing" case. On working networks Monaco still loads normally. This also makes the Studio Interfaces pillar's "edit it directly in the code panel on the left" hint (added in #2285) actually point at a populated editor instead of a stuck spinner.

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.fallback.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.fallback.test.tsx
@@ -8,7 +8,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
-vi.mock('@monaco-editor/react', () => ({ default: () => null }));
+// Monaco "loads" (loader.init resolves) but renders nothing, so the DOM-poll
+// backstop — not the loader fast-fail path — is what must engage here.
+vi.mock('@monaco-editor/react', () => ({
+  default: () => null,
+  loader: { init: () => Promise.resolve({}) },
+}));
 
 import { JsonSourceEditor } from './JsonSourceEditor';
 

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
@@ -23,6 +23,7 @@ import React from 'react';
 import { Skeleton } from '@object-ui/components';
 import * as jsonc from 'jsonc-parser';
 import { detectLocale, t } from './i18n';
+import { useMonacoFallback } from './useMonacoFallback';
 
 // Lazy: Monaco's React wrapper itself pulls in the editor core
 // (~3MB), so we keep it out of the initial app-shell chunk.
@@ -88,19 +89,11 @@ export function JsonSourceEditor({
   // Monaco's core is fetched lazily and, by default, from a public CDN, and it
   // also spins up web workers. When any of that is blocked — offline /
   // air-gapped / CSP-restricted installs — the editor mounts an empty shell
-  // with no error and the Source tab looks blank. Detect "nothing actually
-  // painted" via the rendered `.view-line` rows and fall back to a plain
-  // textarea so the source is always readable and editable.
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const [monacoUnavailable, setMonacoUnavailable] = React.useState(false);
-  React.useEffect(() => {
-    if (monacoUnavailable) return;
-    const id = setTimeout(() => {
-      const el = containerRef.current;
-      if (!el || !el.querySelector('.view-line')) setMonacoUnavailable(true);
-    }, fallbackDelayMs);
-    return () => clearTimeout(id);
-  }, [monacoUnavailable, fallbackDelayMs]);
+  // with no error and the Source tab looks blank. `useMonacoFallback` fast-fails
+  // to a plain textarea the moment the CDN loader rejects, and also backstops
+  // the "resolved but painted nothing" case via a `.view-line` DOM poll, so the
+  // source is always readable and editable.
+  const [monacoUnavailable, containerRef] = useMonacoFallback(fallbackDelayMs);
 
   // Match against the dark class our app-shell toggles on <html>; pick
   // a Monaco theme that doesn't fight the rest of the chrome.

--- a/packages/app-shell/src/views/metadata-admin/previews/SourcePageEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/SourcePageEditor.tsx
@@ -21,6 +21,7 @@ import * as React from 'react';
 import { Skeleton } from '@object-ui/components';
 import { SchemaRenderer } from '@object-ui/react';
 import { PreviewShell, PreviewErrorBoundary } from './PreviewShell';
+import { useMonacoFallback } from '../useMonacoFallback';
 
 const LazyMonaco = React.lazy(async () => {
   const mod = await import('@monaco-editor/react');
@@ -41,7 +42,6 @@ export function SourcePageEditor({ draft, onPatch, readOnly, fallbackDelayMs = 4
 
   const [text, setText] = React.useState(source);
   const lastCommittedRef = React.useRef(source);
-  const containerRef = React.useRef<HTMLDivElement | null>(null);
 
   // Sync from upstream (Reset / inspector edits) without clobbering keystrokes.
   React.useEffect(() => {
@@ -51,16 +51,10 @@ export function SourcePageEditor({ draft, onPatch, readOnly, fallbackDelayMs = 4
     }
   }, [source]);
 
-  // Monaco-unavailable fallback (headless / CSP) → plain textarea.
-  const [monacoUnavailable, setMonacoUnavailable] = React.useState(false);
-  React.useEffect(() => {
-    if (monacoUnavailable) return;
-    const id = setTimeout(() => {
-      const el = containerRef.current;
-      if (!el || !el.querySelector('.view-line')) setMonacoUnavailable(true);
-    }, fallbackDelayMs);
-    return () => clearTimeout(id);
-  }, [monacoUnavailable, fallbackDelayMs]);
+  // Monaco-unavailable fallback (headless / CSP / air-gapped) → plain textarea.
+  // Fast-fails the moment the CDN loader rejects instead of waiting the full
+  // grace period; see useMonacoFallback.
+  const [monacoUnavailable, containerRef] = useMonacoFallback(fallbackDelayMs);
 
   const [theme, setTheme] = React.useState<'vs-dark' | 'light'>(() =>
     typeof document !== 'undefined' && document.documentElement.classList.contains('dark') ? 'vs-dark' : 'light',

--- a/packages/app-shell/src/views/metadata-admin/useMonacoFallback.fastfail.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/useMonacoFallback.fastfail.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * When Monaco's CDN loader script fails outright (offline / air-gapped / CSP —
+ * the console embeds in servers that ship a strict CSP), `loader.init()`
+ * rejects. The editor must fall back to the textarea IMMEDIATELY rather than
+ * making the user wait out the DOM-poll grace period. We prove the fast path by
+ * setting a very long `fallbackDelayMs`: if the textarea appears, it can only be
+ * because the rejected `loader.init()` tripped it, not the poll.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@monaco-editor/react', () => ({
+  default: () => null,
+  // Simulate the CDN loader script failing to load.
+  loader: { init: () => Promise.reject(new Error('CDN blocked')) },
+}));
+
+import { JsonSourceEditor } from './JsonSourceEditor';
+
+describe('useMonacoFallback — fast-fail on CDN/loader rejection', () => {
+  it('shows the textarea immediately when loader.init() rejects, without waiting out fallbackDelayMs', async () => {
+    const draft = { name: 'work_order', fields: { title: { type: 'text' } } };
+    // Long grace period: only the fast path can satisfy this within the timeout.
+    render(<JsonSourceEditor value={draft} onChange={() => {}} fallbackDelayMs={60_000} />);
+
+    const ta = (await screen.findByLabelText(
+      'JSON source',
+      {},
+      { timeout: 2000 },
+    )) as HTMLTextAreaElement;
+
+    expect(ta.value).toContain('work_order');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/useMonacoFallback.ts
+++ b/packages/app-shell/src/views/metadata-admin/useMonacoFallback.ts
@@ -1,0 +1,73 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * useMonacoFallback — decide between the Monaco editor and a plain-textarea
+ * fallback for the metadata designer's code surfaces (JSON source tab,
+ * html/react page source).
+ *
+ * Monaco's core is fetched lazily from a public CDN (jsdelivr) and spins up
+ * web workers. On offline / air-gapped / CSP-restricted installs — and the
+ * console is explicitly meant to embed in ANY ObjectStack server, many of
+ * which ship a strict CSP — that fetch fails. We detect it two ways:
+ *
+ *  - **Fast path:** `loader.init()` rejects the moment the CDN loader script
+ *    fails to load, so we flip to the textarea immediately instead of making
+ *    the user stare at Monaco's own "Loading…" for the full grace period
+ *    (previously a hard-coded 4s of dead air on every CSP-blocked install).
+ *  - **Backstop:** some failures still resolve the loader but paint nothing
+ *    (e.g. blocked workers). A one-shot DOM poll after `fallbackDelayMs`
+ *    checks for a rendered `.view-line` row and falls back if the editor
+ *    mounted empty.
+ *
+ * `loader.init()` is an idempotent singleton, so calling it from multiple
+ * editors (and alongside `<Editor>`'s own internal init) is safe — every
+ * caller observes the same resolution.
+ *
+ * Returns `[unavailable, containerRef]`; attach `containerRef` to the element
+ * that wraps the Monaco instance so the backstop can inspect it.
+ */
+
+import * as React from 'react';
+import { loader } from '@monaco-editor/react';
+
+export function useMonacoFallback(
+  fallbackDelayMs = 4000,
+): readonly [boolean, React.RefObject<HTMLDivElement | null>] {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const [unavailable, setUnavailable] = React.useState(false);
+
+  // Fast fail: the CDN loader script errored (offline / CSP). Optional-chained
+  // so a test that mocks '@monaco-editor/react' without a `loader` export
+  // simply skips the fast path and relies on the DOM-poll backstop.
+  React.useEffect(() => {
+    if (unavailable) return;
+    let cancelled = false;
+    const init = loader?.init?.();
+    if (init && typeof init.catch === 'function') {
+      init.catch(() => {
+        if (!cancelled) setUnavailable(true);
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [unavailable]);
+
+  // Backstop: Monaco resolved but painted nothing (blocked workers, etc.).
+  React.useEffect(() => {
+    if (unavailable) return;
+    const id = setTimeout(() => {
+      const el = containerRef.current;
+      if (!el || !el.querySelector('.view-line')) setUnavailable(true);
+    }, fallbackDelayMs);
+    return () => clearTimeout(id);
+  }, [unavailable, fallbackDelayMs]);
+
+  return [unavailable, containerRef] as const;
+}

--- a/packages/plugin-view/src/__tests__/ObjectView.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.test.tsx
@@ -21,6 +21,12 @@ vi.mock('@object-ui/react', () => {
       </div>
     ),
     SchemaRendererContext: React.createContext(null),
+    // Data-invalidation bus (objectui#2269). `@object-ui/components` — a real,
+    // unmocked transitive dep pulled in here — imports these at module-eval
+    // time, so the mock must expose them or vitest's strict mock throws
+    // ("No 'subscribeDataChanges' export is defined") before any test runs.
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
   };
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #2285, closing out its **Bonus** items and the pre-existing broken test flagged in #2291's test plan. Each finding was re-triaged live (objectstack backend + console dev server) before fixing.

### 1. Studio "Command Center" bonus bugs → actually a Monaco-CDN loading bug

The audit flagged "Weekly Throughput stuck on *Loading…*" and "KPI cards clipped" on the `showcase_command_center_jsx` page. Live triage showed **the real runtime renders that page perfectly** (full-width cards, bars painted) — both symptoms only appear in the **Studio Interfaces preview**, and the "Loading…" is **not** the page content:

- The left panel of the `kind:'html'`/`'react'` page editor (`SourcePageEditor`) is a **Monaco code editor**, lazy-loaded from `cdn.jsdelivr.net`. Under CSP / air-gapped / offline installs — and the console is explicitly meant to embed in any ObjectStack server, many shipping a strict CSP — the loader script fails. The panel then sat on Monaco's own "Loading…" for a **hard-coded 4 seconds** before the `.view-line` DOM-poll fell back to a textarea.
- The KPI "clipping" is just the narrow side-by-side preview pane (renders full-width in the real app) — cosmetic, not fixed.

**Fix:** a shared `useMonacoFallback` hook watches `loader.init()` and flips to the textarea the *instant* the CDN load rejects (measured ~330 ms vs the old 4000 ms), keeping the DOM-poll as a backstop for the "resolved but painted nothing" (blocked-workers) case. Applied to both `SourcePageEditor` and `JsonSourceEditor` (identical pattern). On working networks Monaco loads normally. This also makes the #2285 "edit it directly in the code panel on the left" hint point at a populated editor instead of a stuck spinner.

### 2. Repair `plugin-view` `ObjectView.test.tsx`

The suite errored before any test ran: its hand-rolled `@object-ui/react` mock was missing the data-invalidation bus exports (`subscribeDataChanges` / `notifyDataChanged`) that `@object-ui/components` — a real, unmocked transitive dep — now imports at module-eval time (#2269), so vitest's strict mock threw. Added the two bus stubs to the mock. Test-only; no runtime change. Suite: **58 tests pass** (was 0 / import error).

### 3. Re-verified Studio mobile responsive on a fresh writable package

Created an empty writable package and walked the pillars at 390 px: the Objects rail collapses behind a hamburger toggle, the drawer opens as an overlay (content dimmed) with the object-creation form reachable, the pillar tabs scroll horizontally (Access reachable), and content is full-width. The #2285 responsive fix holds in a real edit state, not just the read-only showcase. **No code change needed.**

## Test plan

- [x] `useMonacoFallback` fast-fail: new test asserts the textarea appears with `fallbackDelayMs=60000` (only the loader-reject fast path can satisfy that)
- [x] `JsonSourceEditor.fallback.test.tsx` still green (DOM-poll backstop path; mock updated to resolve `loader.init`)
- [x] `plugin-view` full suite: 58 tests pass (was import-error / 0)
- [x] `eslint` on touched files: 0 new errors (pre-existing `any` warnings + a pre-existing `require()` error in the test's mock factory, untouched, unchanged)
- [x] `tsc` clean on the touched app-shell files
- [x] Live-verified in a dev stack: source editor now shows the code in ~330 ms under the sandbox's blocked CDN; mobile drawer/tabs verified on a fresh package
- [x] Changeset added (`app-shell` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LAwMrrYJn1fLV9eh7U179

---
_Generated by [Claude Code](https://claude.ai/code/session_017LAwMrrYJn1fLV9eh7U179)_