### PR TITLE
fix(app-shell): automation canvas opens at 100% centered, Variables collapsed

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -420,14 +420,21 @@ export function FlowCanvas({
     });
   }, [size.height, size.width]);
 
-  // Auto-fit once on mount so opening a flow shows the whole diagram
-  // centered and appropriately zoomed instead of always starting at a fixed
-  // 100%/pan-{0,0} view — that default left most small (2-4 node) flows
-  // stranded in a corner of a mostly-empty canvas. Deliberately mount-only
-  // (not re-run on every `size` change): re-fitting on every node add/drag
-  // would yank the viewport out from under an actively editing user.
+  // Center the diagram at 100% on mount so opening a flow shows a familiar 1:1
+  // scale with the diagram centered — rather than an auto-fit that zoomed small
+  // (2-4 node) flows up to 160%. Centering (not pan-{0,0}) keeps the diagram
+  // from being stranded in a corner. Authors can still zoom / fit-to-view from
+  // the toolbar. Deliberately mount-only (not re-run on every `size` change):
+  // re-centering on every node add/drag would yank the viewport out from under
+  // an actively editing user.
   React.useEffect(() => {
-    fitToView();
+    const vp = viewportRef.current;
+    if (!vp) return;
+    setZoom(1);
+    setPan({
+      x: (vp.clientWidth - size.width) / 2,
+      y: Math.max(16, (vp.clientHeight - size.height) / 2),
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -84,7 +84,9 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
   const selectedEdgeId = selection && selection.kind === 'edge' ? selection.id : null;
 
   const [showDebug, setShowDebug] = React.useState(false);
-  const [showVars, setShowVars] = React.useState(true);
+  // Variables panel is opt-in: opening a flow should show the full-width canvas,
+  // not a mostly-empty side panel (most flows declare no variables).
+  const [showVars, setShowVars] = React.useState(false);
   const [showRuns, setShowRuns] = React.useState(false);
   const [showProblems, setShowProblems] = React.useState(false);
   const [runHL, setRunHL] = React.useState<{

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -2682,11 +2682,6 @@ function AutomationsPillar({
               </pre>
             )}
           </div>
-          {isEditable && (
-            <p className="mt-2 flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
-              <MousePointer2 className="h-3 w-3" /> {t('engine.studio.auto.editHint', locale)}
-            </p>
-          )}
         </main>
 
         <aside className="w-72 shrink-0 overflow-auto border-l">


### PR DESCRIPTION
## What & why

Three small UX defaults for the Studio automation (flow) designer, from maintainer feedback on the automations canvas:

1. **Open at 100%, centered.** The canvas auto-fit on mount, which zoomed small (2–4 node) flows all the way up to **160%**. It now opens at a familiar **1:1 (100%)** scale with the diagram centered. Fit-to-view is unchanged and still available from the toolbar button.
2. **Variables panel collapsed by default.** The right-hand Variables panel opened by default even when a flow declares no variables (a mostly-empty panel next to the canvas). It's now **opt-in** — the canvas gets full width on open, and the Variables toggle still reveals it.
3. **Drop the redundant footer hint.** Removed the `Click a node → configure on the right · then "Save draft" → "Publish"` line under the automations canvas.

## Changes

- `FlowCanvas.tsx` — mount effect centers the diagram at 100% zoom instead of calling `fitToView()`.
- `FlowPreview.tsx` — `showVars` now defaults to `false`.
- `StudioDesignSurface.tsx` — removed the automations `editHint` footer paragraph.

## Verification

- `turbo run type-check --filter=@object-ui/app-shell` (+ its deps) — 29/29 tasks pass.
- `vitest run FlowCanvas.test.tsx studio-locale.i18n.test.tsx` — 9/9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRpnAQoDZa6wENVwgPLsh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRpnAQoDZa6wENVwgPLsh4)_