### PR TITLE
feat(app-shell): keep a clickable path back when drilling into a related record

### DIFF
--- a/.changeset/record-drill-in-breadcrumb-trail.md
+++ b/.changeset/record-drill-in-breadcrumb-trail.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Keep a clickable path back when drilling from a record into a related child record (objectui "点击子表标题跳转后如何返回").
+
+Clicking a related sub-table row opens the child record's detail page, but that page dropped all trace of where you came from: its breadcrumb only led to the child object's *list* (never the parent record), and the record body's built-in Back button is suppressed on the schema-rendered surface. From a related-list drill-in the only way back was the browser Back button.
+
+- **New reserved `?from=` URL param carries the ancestor trail.** When you open a related record (both the synth `RelatedRecordActionsBridge.onView` path and the legacy `RecordDetailView` `onRowClick` path), the parent record is appended to a compact, refresh- and share-safe trail encoded in the URL. Nested drill-ins accumulate (`Account → Invoice → Invoice Line`); depth is capped at 8 and titles truncated so the URL can't grow unbounded, and a trailing self-reference is deduped. Codec (`encodeRecordTrail`/`decodeRecordTrail`/`appendRecordTrail`/`buildRecordTrailHref`) is total — a malformed value yields no ancestor crumbs rather than throwing.
+- **The top-bar breadcrumb renders the trail as clickable segments.** A record route with a `?from=` trail now shows `Account → #parent → Invoice → #child`, each ancestor an `object-list → record` pair that links back, with mid-path crumbs preserving the ancestors above them.
+- **The record body shows an inline "← back to parent" link** derived from the trail's nearest ancestor, so the immediate-parent affordance survives refresh and shared links (previously it relied on in-session history state that nothing populated for this flow).

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -72,7 +72,7 @@ import { useMobileViewSwitcher } from './MobileViewSwitcherContext';
 import { useNavigationContext } from '../context/NavigationContext';
 import { useCommandPalette } from '../context/CommandPaletteProvider';
 import { useUrlOverlay } from '../hooks/useUrlOverlay';
-import { KEYBOARD_SHORTCUTS_PARAM } from '../urlParams';
+import { KEYBOARD_SHORTCUTS_PARAM, RECORD_TRAIL_PARAM, decodeRecordTrail, buildRecordTrailHref } from '../urlParams';
 import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
 import { getProductName } from '../runtime-config';
 import { LocalizedSidebarTrigger } from './LocalizedSidebarTrigger';
@@ -600,6 +600,26 @@ export function AppHeader({
     } else if (routeType) {
       const currentObject = safeObjects.find((o: any) => o.name === routeType);
       if (currentObject) {
+        // Ancestor trail (record → related-record drill-in, `?from=`). Prepend
+        // an object-list + record segment per ancestor so the path reads
+        // `Account → #parent → Invoice → #child`, each crumb a link back. The
+        // ancestor record crumb carries its OWN ancestors so mid-path clicks
+        // preserve everything above them.
+        if (pathParts[3] === 'record' && pathParts[4]) {
+          const trail = decodeRecordTrail(new URLSearchParams(location.search).get(RECORD_TRAIL_PARAM));
+          trail.forEach((entry, k) => {
+            const ancObj = safeObjects.find((o: any) => o.name === entry.o);
+            extraSegments.push({
+              label: ancObj ? objectLabel(ancObj) : humanizeSlug(entry.o),
+              href: `${baseHref}/${entry.o}`,
+            });
+            const ancShortId = entry.i.length > 12 ? `${entry.i.slice(0, 8)}…` : entry.i;
+            extraSegments.push({
+              label: entry.t || `#${ancShortId}`,
+              href: buildRecordTrailHref(baseHref, entry, trail.slice(0, k)),
+            });
+          });
+        }
         extraSegments.push({
           label: objectLabel(currentObject),
           href: `${baseHref}/${routeType}`,

--- a/packages/app-shell/src/urlParams.test.ts
+++ b/packages/app-shell/src/urlParams.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Record breadcrumb trail (`?from=`) codec — the drill-in path that lets a
+ * child record page (account → invoice → invoice-line) render a clickable path
+ * back up. The encode/decode/append helpers must be total: a malformed or
+ * hostile `from` value can never throw or break the page, and the trail must
+ * stay bounded so deep nesting can't grow the URL without limit.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  RECORD_TRAIL_PARAM,
+  RESERVED_URL_PARAMS,
+  decodeRecordTrail,
+  encodeRecordTrail,
+  appendRecordTrail,
+  buildRecordTrailHref,
+  type RecordTrailEntry,
+} from './urlParams.js';
+
+describe('record trail codec', () => {
+  it('reserves the `from` param', () => {
+    expect(RECORD_TRAIL_PARAM).toBe('from');
+    expect(RESERVED_URL_PARAMS).toContain('from');
+  });
+
+  it('round-trips a trail through encode → decode', () => {
+    const trail: RecordTrailEntry[] = [
+      { o: 'showcase_account', i: 'acct1', t: 'Acme Corp' },
+      { o: 'showcase_invoice', i: 'inv1', t: 'INV-001' },
+    ];
+    expect(decodeRecordTrail(encodeRecordTrail(trail))).toEqual(trail);
+  });
+
+  it('returns [] for missing / malformed / hostile input (never throws)', () => {
+    expect(decodeRecordTrail(null)).toEqual([]);
+    expect(decodeRecordTrail(undefined)).toEqual([]);
+    expect(decodeRecordTrail('')).toEqual([]);
+    expect(decodeRecordTrail('not json')).toEqual([]);
+    expect(decodeRecordTrail('{"not":"array"}')).toEqual([]);
+    // Entries missing required keys are dropped, not fatal.
+    expect(decodeRecordTrail('[{"o":"x"},{"i":"y"},42,null]')).toEqual([]);
+  });
+
+  it('appends the current record and dedupes a trailing self-reference', () => {
+    const first = appendRecordTrail(null, { o: 'showcase_account', i: 'acct1', t: 'Acme' });
+    expect(decodeRecordTrail(first)).toEqual([{ o: 'showcase_account', i: 'acct1', t: 'Acme' }]);
+
+    const second = appendRecordTrail(first, { o: 'showcase_invoice', i: 'inv1', t: 'INV-001' });
+    expect(decodeRecordTrail(second)).toEqual([
+      { o: 'showcase_account', i: 'acct1', t: 'Acme' },
+      { o: 'showcase_invoice', i: 'inv1', t: 'INV-001' },
+    ]);
+
+    // Re-entering the same record must not stack a duplicate crumb.
+    const dupe = appendRecordTrail(second, { o: 'showcase_invoice', i: 'inv1', t: 'INV-001' });
+    expect(decodeRecordTrail(dupe)).toEqual(decodeRecordTrail(second));
+  });
+
+  it('caps trail depth so deep nesting cannot grow the URL unbounded', () => {
+    let raw: string | null = null;
+    for (let n = 0; n < 20; n++) {
+      raw = appendRecordTrail(raw, { o: 'obj', i: `id${n}`, t: `T${n}` });
+    }
+    const trail = decodeRecordTrail(raw);
+    expect(trail.length).toBe(8);
+    // Keeps the MOST RECENT ancestors (nearest to the current record).
+    expect(trail[trail.length - 1]).toEqual({ o: 'obj', i: 'id19', t: 'T19' });
+  });
+
+  it('truncates over-long titles', () => {
+    const long = 'x'.repeat(200);
+    const [entry] = decodeRecordTrail(appendRecordTrail(null, { o: 'obj', i: 'id', t: long }));
+    expect(entry.t!.length).toBe(48);
+  });
+
+  it('builds a record href, carrying preceding ancestors into its own ?from=', () => {
+    const trail: RecordTrailEntry[] = [
+      { o: 'showcase_account', i: 'acct1', t: 'Acme' },
+      { o: 'showcase_invoice', i: 'inv1', t: 'INV-001' },
+    ];
+    // Outermost ancestor: no ancestors before it → clean URL, no ?from=.
+    expect(buildRecordTrailHref('/apps/demo', trail[0], [])).toBe(
+      '/apps/demo/showcase_account/record/acct1',
+    );
+    // Second ancestor: carries the account before it.
+    const href = buildRecordTrailHref('/apps/demo', trail[1], trail.slice(0, 1));
+    expect(href.startsWith('/apps/demo/showcase_invoice/record/inv1?from=')).toBe(true);
+    const carried = decodeRecordTrail(new URLSearchParams(href.split('?')[1]).get('from'));
+    expect(carried).toEqual([trail[0]]);
+  });
+});

--- a/packages/app-shell/src/urlParams.ts
+++ b/packages/app-shell/src/urlParams.ts
@@ -38,6 +38,9 @@
  * |             | objectui#2257). Never stacks history.          |              |
  * | `palette`   | Command palette overlay (alias `cmdk`).        | replace      |
  * | `shortcuts` | Keyboard-shortcuts dialog overlay.             | replace      |
+ * | `from`      | Ancestor breadcrumb trail for a record route,  | push (with   |
+ * |             | so drilling record→related-record keeps a      | the drill-in) |
+ * |             | clickable path back (`Account → #p → Invoice`).|              |
  *
  * Push-vs-replace rule of thumb: an overlay the user OPENED (form, drawer)
  * pushes one entry so browser Back closes it; passive state that tracks an
@@ -71,6 +74,19 @@ export const COMMAND_PALETTE_PARAM = 'palette';
 export const KEYBOARD_SHORTCUTS_PARAM = 'shortcuts';
 
 /**
+ * Ancestor breadcrumb trail for a record route (`?from=<encoded trail>`).
+ * When you drill from one record into a related child record (e.g. an
+ * account → one of its invoices), the child URL carries the ancestors that
+ * led here so the top-bar breadcrumb can render them as clickable segments
+ * (`Account → #parent → Invoice → #child`) and the record body can show an
+ * inline "← back to parent" link. Refresh- and share-safe (URL, not history
+ * state). Value is a JSON array of {@link RecordTrailEntry}; use
+ * {@link encodeRecordTrail} / {@link decodeRecordTrail} / {@link appendRecordTrail}
+ * rather than reading it raw.
+ */
+export const RECORD_TRAIL_PARAM = 'from';
+
+/**
  * All reserved params, for collision checks (e.g. a lint or a dev-time
  * assertion that a page-scoped param doesn't shadow the console contract).
  */
@@ -82,4 +98,98 @@ export const RESERVED_URL_PARAMS: readonly string[] = [
   RECORD_DETAIL_TAB_PARAM,
   COMMAND_PALETTE_PARAM,
   KEYBOARD_SHORTCUTS_PARAM,
+  RECORD_TRAIL_PARAM,
 ];
+
+/**
+ * One ancestor in a record breadcrumb trail (see {@link RECORD_TRAIL_PARAM}).
+ * Kept intentionally terse — this rides in the URL, so short keys keep it
+ * compact: `o` = object name, `i` = record id, `t` = display title (optional;
+ * falls back to a shortened id when absent).
+ */
+export interface RecordTrailEntry {
+  /** Object (table) name of the ancestor record. */
+  o: string;
+  /** Primary-key id of the ancestor record. */
+  i: string;
+  /** Human-readable title, truncated. Optional — id is the fallback. */
+  t?: string;
+}
+
+/** Cap trail depth so deeply-nested drill-ins can't grow the URL unbounded. */
+const MAX_TRAIL_DEPTH = 8;
+/** Cap per-entry title length so one long name can't bloat the URL. */
+const MAX_TRAIL_TITLE = 48;
+
+/**
+ * Parse the raw `?from=` value into a validated trail (outermost ancestor
+ * first). Returns `[]` for missing/malformed input — a broken trail must
+ * never throw or break the page; it just yields no ancestor breadcrumbs.
+ */
+export function decodeRecordTrail(raw: string | null | undefined): RecordTrailEntry[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (e): e is RecordTrailEntry =>
+          !!e && typeof e.o === 'string' && e.o.length > 0 && typeof e.i === 'string' && e.i.length > 0,
+      )
+      .slice(-MAX_TRAIL_DEPTH)
+      .map((e) => ({
+        o: e.o,
+        i: e.i,
+        ...(typeof e.t === 'string' && e.t.trim() ? { t: e.t.trim().slice(0, MAX_TRAIL_TITLE) } : {}),
+      }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Serialize a trail into the string stored under `?from=`. Callers pass the
+ * result to `URLSearchParams.set`, which handles percent-encoding.
+ */
+export function encodeRecordTrail(trail: RecordTrailEntry[]): string {
+  return JSON.stringify(trail.slice(-MAX_TRAIL_DEPTH));
+}
+
+/**
+ * Append the current record to an existing raw trail, producing the value to
+ * store under `?from=` when navigating into a child record. Dedupes a trailing
+ * self-reference (re-entering the same record shouldn't stack duplicate
+ * crumbs) and caps depth.
+ */
+export function appendRecordTrail(
+  rawCurrent: string | null | undefined,
+  entry: RecordTrailEntry,
+): string {
+  const trail = decodeRecordTrail(rawCurrent);
+  const last = trail[trail.length - 1];
+  if (!last || last.o !== entry.o || last.i !== entry.i) {
+    trail.push({
+      o: entry.o,
+      i: entry.i,
+      ...(entry.t && entry.t.trim() ? { t: entry.t.trim().slice(0, MAX_TRAIL_TITLE) } : {}),
+    });
+  }
+  return encodeRecordTrail(trail);
+}
+
+/**
+ * Build the `/apps/:app/:object/record/:id` href for one ancestor in a trail,
+ * carrying the ancestors that precede it so clicking that breadcrumb lands on
+ * the ancestor record with ITS own trail intact.
+ */
+export function buildRecordTrailHref(
+  baseAppUrl: string,
+  entry: RecordTrailEntry,
+  ancestorsBefore: RecordTrailEntry[],
+): string {
+  const url = `${baseAppUrl}/${entry.o}/record/${encodeURIComponent(entry.i)}`;
+  if (ancestorsBefore.length === 0) return url;
+  const sp = new URLSearchParams();
+  sp.set(RECORD_TRAIL_PARAM, encodeRecordTrail(ancestorsBefore));
+  return `${url}?${sp.toString()}`;
+}

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -28,7 +28,7 @@ import { ActionResultDialog, type ResultDialogState } from './ActionResultDialog
 import { FlowRunner, type ScreenFlowState } from './FlowRunner';
 import { RelatedRecordActionsBridge } from './RelatedRecordActionsBridge';
 import { withPageTabsUrlSync } from '../utils/pageTabsUrlSync';
-import { RECORD_DETAIL_TAB_PARAM } from '../urlParams';
+import { RECORD_DETAIL_TAB_PARAM, RECORD_TRAIL_PARAM, appendRecordTrail, decodeRecordTrail, buildRecordTrailHref } from '../urlParams';
 import { resolveActionParams } from '../utils/resolveActionParams';
 import { useRecordBreadcrumbTitle } from '../context/NavigationContext';
 import type { DetailViewSchema, FeedItem, HighlightField } from '@object-ui/types';
@@ -133,7 +133,24 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     setTabSearchParams(sp, { replace: true });
   }, [setTabSearchParams]);
   const location = useLocation();
-  const originFrom = (location.state as any)?.from as { pathname?: string; label?: string } | undefined;
+  // Inline "← back to parent" link shown above the record body. Prefers an
+  // explicit history-state `from` (legacy, in-session only), then falls back
+  // to the last ancestor in the `?from=` URL trail — which, unlike history
+  // state, survives refresh and shared links. This is the immediate-parent
+  // affordance; the full clickable path lives in the top-bar breadcrumb.
+  const originFromState = (location.state as any)?.from as { pathname?: string; label?: string } | undefined;
+  const originFrom = useMemo<{ pathname?: string; label?: string } | undefined>(() => {
+    if (originFromState?.pathname && originFromState?.label) return originFromState;
+    const trail = decodeRecordTrail(new URLSearchParams(location.search).get(RECORD_TRAIL_PARAM));
+    const parent = trail[trail.length - 1];
+    if (!parent) return undefined;
+    const baseAppUrl = appName ? `/apps/${appName}` : '';
+    const shortId = parent.i.length > 12 ? `${parent.i.slice(0, 8)}…` : parent.i;
+    return {
+      pathname: buildRecordTrailHref(baseAppUrl, parent, trail.slice(0, -1)),
+      label: parent.t || `#${shortId}`,
+    };
+  }, [originFromState, location.search, appName]);
   const { t } = useObjectTranslation();
   const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, actionParamOptionLabel, actionDescription, fieldLabel, fieldOptionLabel } = useObjectLabel();
   const { isFavorite, toggleFavorite, refreshLabel: refreshFavoriteLabel } = useFavorites();
@@ -1484,7 +1501,22 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       const buildRecordUrl = (row: any) => {
         const rid = row?.id || row?._id;
         if (!rid) return null;
-        return `${baseAppUrl}/${childObject}/record/${encodeURIComponent(String(rid))}`;
+        const url = `${baseAppUrl}/${childObject}/record/${encodeURIComponent(String(rid))}`;
+        // Thread this (the parent) record into the child's `?from=` trail so
+        // the breadcrumb + back link can path back up. Mirrors the synth-path
+        // bridge; both must stay in sync.
+        if (objectName && pureRecordId) {
+          const rawFrom = new URLSearchParams(window.location.search).get(RECORD_TRAIL_PARAM);
+          const trail = appendRecordTrail(rawFrom, {
+            o: objectName,
+            i: pureRecordId,
+            ...(recordTitle ? { t: recordTitle } : {}),
+          });
+          const sp = new URLSearchParams();
+          sp.set(RECORD_TRAIL_PARAM, trail);
+          return `${url}?${sp.toString()}`;
+        }
+        return url;
       };
 
       const onNew = baseAppUrl
@@ -1873,6 +1905,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                   objects={objects}
                   dataSource={dataSource}
                   actionLabel={actionLabel}
+                  parentObjectName={objectName}
+                  parentRecordId={pureRecordId ?? undefined}
+                  parentTitle={recordTitle}
                 >
                   <SchemaRenderer schema={withPageTabsUrlSync(renderedPage, { defaultTab: activeTabParam, onTabChange: handleTabChange }) as any} />
                 </RelatedRecordActionsBridge>

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -50,7 +50,7 @@ import {
 } from '@object-ui/react';
 import type { ActionDef } from '@object-ui/core';
 import { resolveCrudAffordances } from '../utils/crudAffordances';
-import { RECORD_FORM_PARAM, RECORD_FORM_OBJECT_PARAM, RECORD_FORM_LINK_PARAM } from '../urlParams';
+import { RECORD_FORM_PARAM, RECORD_FORM_OBJECT_PARAM, RECORD_FORM_LINK_PARAM, RECORD_TRAIL_PARAM, appendRecordTrail } from '../urlParams';
 
 /**
  * Notify open related lists for `objectName` to refetch.
@@ -78,6 +78,15 @@ export interface RelatedRecordActionsBridgeProps {
   dataSource: any;
   /** Localizes a child action's label (falls back to the raw label). */
   actionLabel: ActionLabelFn;
+  /**
+   * The record this bridge is mounted under — the PARENT of any related row a
+   * user drills into. Threaded into the child record's `?from=` trail so the
+   * breadcrumb can offer a path back (`Account → #parent → Invoice → #child`).
+   * Omit when there is no parent context (e.g. a standalone list).
+   */
+  parentObjectName?: string;
+  parentRecordId?: string;
+  parentTitle?: string;
   children: React.ReactNode;
 }
 
@@ -100,6 +109,9 @@ export function RelatedRecordActionsBridge({
   objects,
   dataSource,
   actionLabel,
+  parentObjectName,
+  parentRecordId,
+  parentTitle,
   children,
 }: RelatedRecordActionsBridgeProps) {
   const navigate = useNavigate();
@@ -150,8 +162,26 @@ export function RelatedRecordActionsBridge({
         const childDef = objects.find((o: any) => o?.name === objectName);
         if (!childDef || !base) return {} as RelatedRecordHandlers;
         const aff = resolveCrudAffordances(childDef);
-        const detailUrl = (id: string | number) =>
-          `${base}/${objectName}/record/${encodeURIComponent(String(id))}`;
+        const detailUrl = (id: string | number) => {
+          const url = `${base}/${objectName}/record/${encodeURIComponent(String(id))}`;
+          // Carry the parent record into the child's `?from=` trail so the
+          // breadcrumb (and the record body's back link) can path back up.
+          // Read the current trail off the live URL — this bridge outlives a
+          // single search-params snapshot, so a fresh read avoids a stale
+          // closure and keeps nested drill-ins accumulating correctly.
+          if (parentObjectName && parentRecordId) {
+            const rawFrom = new URLSearchParams(window.location.search).get(RECORD_TRAIL_PARAM);
+            const trail = appendRecordTrail(rawFrom, {
+              o: parentObjectName,
+              i: parentRecordId,
+              ...(parentTitle ? { t: parentTitle } : {}),
+            });
+            const sp = new URLSearchParams();
+            sp.set(RECORD_TRAIL_PARAM, trail);
+            return `${url}?${sp.toString()}`;
+          }
+          return url;
+        };
 
         const handlers: RelatedRecordHandlers = {
           // Viewing a child record is always allowed when the list is visible.
@@ -190,7 +220,7 @@ export function RelatedRecordActionsBridge({
         return handlers;
       },
     }),
-    [objects, base, navigate, dataSource, actionLabel, runRowAction, openChildForm],
+    [objects, base, navigate, dataSource, actionLabel, runRowAction, openChildForm, parentObjectName, parentRecordId, parentTitle],
   );
 
   return (


### PR DESCRIPTION
## Problem

Clicking a related sub-table row (e.g. an invoice under an account) opens the child record's detail page — but that page dropped all trace of where you came from:

- The top-bar **breadcrumb** only led to the child object's *list* (`App → Invoice → #child`), never back to the parent record.
- The record body's built-in **Back button is suppressed** on the default schema-rendered surface (`record:details` sets `showBack: false`, delegating chrome to the surrounding page header).
- The existing inline back-link read `location.state.from`, which **nothing populated** for this flow (and wouldn't survive a refresh anyway).

Net effect: from a related-list drill-in, the only way back was the browser Back button. (Reported in Chinese: “点击子表的标题，直接跳转到子表记录的记录详情页了，如何返回呢？”)

## Change

Carry the ancestor trail in a new **reserved `?from=` URL param** (refresh- and share-safe, unlike history state) as records drill into related records:

- **`urlParams.ts`** — new `RECORD_TRAIL_PARAM` plus a total codec: `encodeRecordTrail` / `decodeRecordTrail` / `appendRecordTrail` / `buildRecordTrailHref`. A malformed or hostile value yields no ancestor crumbs rather than throwing. Depth capped at 8, titles truncated to 48 chars so the URL can't grow unbounded; a trailing self-reference is deduped.
- **`RelatedRecordActionsBridge.tsx`** (synth path) and **`RecordDetailView.tsx`** (legacy `onRowClick` path) — append the current record to the trail when navigating into a related record. Both read the live URL so **nested drill-ins accumulate** (`Account → Invoice → Invoice Line`).
- **`AppHeader.tsx`** — the breadcrumb renders the trail as clickable `Account → #parent → Invoice → #child` segments, each ancestor an `object-list → record` pair; mid-path crumbs preserve the ancestors above them.
- **`RecordDetailView.tsx`** — the inline “← back to parent” link now derives from the trail's nearest ancestor, so the immediate-parent affordance survives refresh and shared links.

## Behavior

| Where you are | Breadcrumb |
|---|---|
| Account record | `App → Account → #account` |
| → drill into an Invoice | `App → Account → #account → Invoice → #invoice` |
| → drill into an Invoice Line | `App → Account → #account → Invoice → #invoice → Invoice Line → #line` |

Every segment links back to that level (records carry their own sub-trail).

## Testing

- New `urlParams.test.ts` — 7 tests covering round-trip, malformed/hostile input, append + self-dedupe, depth cap (keeps most-recent 8), title truncation, and ancestor-href sub-trail carry. All pass.
- `turbo run type-check --filter=@object-ui/app-shell` — green.
- eslint on the changed files introduces no new errors (only pre-existing `no-explicit-any` warnings consistent with the surrounding files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1WQZwQUoUMTWqw2kcNv3f

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1WQZwQUoUMTWqw2kcNv3f)_