### PR TITLE
fix(previews): portal flow node palette + add-widget picker to escape overflow-hidden

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/AddWidgetPicker.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AddWidgetPicker.tsx
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 import { Plus, Search } from 'lucide-react';
+import { Popover, PopoverTrigger, PopoverContent } from '@object-ui/components';
 import {
   WIDGETS_BY_CATEGORY,
   WIDGET_CATEGORY_LABEL,
@@ -24,28 +25,7 @@ export interface AddWidgetPickerProps {
 export function AddWidgetPicker({ onAdd, label = 'Add widget' }: AddWidgetPickerProps) {
   const [open, setOpen] = React.useState(false);
   const [q, setQ] = React.useState('');
-  const popoverRef = React.useRef<HTMLDivElement | null>(null);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
-
-  React.useEffect(() => {
-    if (!open) {
-      setQ('');
-      return;
-    }
-    const onDoc = (e: MouseEvent) => {
-      if (!popoverRef.current?.contains(e.target as Node)) setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
-    };
-    document.addEventListener('mousedown', onDoc);
-    document.addEventListener('keydown', onKey);
-    queueMicrotask(() => inputRef.current?.focus());
-    return () => {
-      document.removeEventListener('mousedown', onDoc);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
 
   const filtered = React.useMemo(() => {
     const ql = q.trim().toLowerCase();
@@ -60,64 +40,81 @@ export function AddWidgetPicker({ onAdd, label = 'Add widget' }: AddWidgetPicker
       .filter((g) => g.types.length);
   }, [q]);
 
+  // Radix Popover (portaled to <body>) — the dashboard PreviewShell root is
+  // `overflow-hidden`, so an `absolute` panel used to be clipped against the
+  // shell box (especially when short). Portaling escapes that clip; Radix also
+  // handles outside-click + Escape, replacing the manual document listeners.
   return (
-    <div ref={popoverRef} className="relative">
-      <button
-        type="button"
-        className="inline-flex items-center gap-1 rounded border border-dashed px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/30 hover:text-foreground"
-        onClick={() => setOpen((v) => !v)}
+    <Popover
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) setQ('');
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded border border-dashed px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/30 hover:text-foreground"
+        >
+          <Plus className="h-3 w-3" />
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={4}
+        className="w-72 p-0"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }}
       >
-        <Plus className="h-3 w-3" />
-        {label}
-      </button>
-      {open && (
-        <div className="absolute right-0 top-full z-40 mt-1 w-72 rounded-md border bg-popover shadow-md">
-          <div className="flex items-center gap-2 border-b px-2 py-1.5">
-            <Search className="h-3.5 w-3.5 text-muted-foreground" />
-            <input
-              ref={inputRef}
-              type="text"
-              value={q}
-              onChange={(e) => setQ(e.target.value)}
-              placeholder="Search widgets…"
-              className="w-full bg-transparent text-xs outline-none placeholder:text-muted-foreground"
-            />
-          </div>
-          <div className="max-h-72 overflow-auto py-1">
-            {filtered.length === 0 ? (
-              <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                No matches.
-              </div>
-            ) : (
-              filtered.map((group) => (
-                <div key={group.category}>
-                  <div className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground">
-                    {WIDGET_CATEGORY_LABEL[group.category]}
-                  </div>
-                  {group.types.map((t) => {
-                    const Icon = (WIDGET_TYPE_META[t.id]?.icon ?? UnknownWidgetIcon);
-                    return (
-                      <button
-                        key={t.id}
-                        type="button"
-                        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent"
-                        onClick={() => {
-                          onAdd(t.id);
-                          setOpen(false);
-                        }}
-                      >
-                        <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                        <span className="font-medium truncate">{t.label}</span>
-                        <code className="ml-auto text-[10px] text-muted-foreground">{t.id}</code>
-                      </button>
-                    );
-                  })}
-                </div>
-              ))
-            )}
-          </div>
+        <div className="flex items-center gap-2 border-b px-2 py-1.5">
+          <Search className="h-3.5 w-3.5 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search widgets…"
+            className="w-full bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+          />
         </div>
-      )}
-    </div>
+        <div className="max-h-72 overflow-auto py-1">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+              No matches.
+            </div>
+          ) : (
+            filtered.map((group) => (
+              <div key={group.category}>
+                <div className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                  {WIDGET_CATEGORY_LABEL[group.category]}
+                </div>
+                {group.types.map((t) => {
+                  const Icon = (WIDGET_TYPE_META[t.id]?.icon ?? UnknownWidgetIcon);
+                  return (
+                    <button
+                      key={t.id}
+                      type="button"
+                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent"
+                      onClick={() => {
+                        onAdd(t.id);
+                        setOpen(false);
+                      }}
+                    >
+                      <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                      <span className="font-medium truncate">{t.label}</span>
+                      <code className="ml-auto text-[10px] text-muted-foreground">{t.id}</code>
+                    </button>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -514,24 +514,21 @@ export function FlowCanvas({
       {/* Toolbar */}
       <div className="absolute right-2 top-2 z-30 flex items-center gap-1.5">
         {editable && (
-          <div className="relative">
+          <NodePalette
+            locale={locale}
+            items={paletteItems}
+            open={paletteOpen}
+            onOpenChange={setPaletteOpen}
+            onPick={(type) => addNode(type, { from: selectedId ?? undefined })}
+          >
             <button
               type="button"
-              onClick={() => setPaletteOpen((v) => !v)}
               className="inline-flex items-center gap-1.5 rounded-lg border bg-background/90 px-2.5 py-1.5 text-xs font-medium shadow-sm backdrop-blur-sm transition-colors hover:border-primary/50 hover:bg-accent hover:text-foreground"
             >
               <Plus className="h-3.5 w-3.5" />
               {tr('engine.inspector.add.node', locale)}
             </button>
-            {paletteOpen && (
-              <NodePalette
-                locale={locale}
-                items={paletteItems}
-                onClose={() => setPaletteOpen(false)}
-                onPick={(type) => addNode(type, { from: selectedId ?? undefined })}
-              />
-            )}
-          </div>
+          </NodePalette>
         )}
         <div className="flex items-center rounded-lg border bg-background/90 shadow-sm backdrop-blur-sm">
           <button

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -35,7 +35,7 @@ import {
   Zap,
   type LucideIcon,
 } from 'lucide-react';
-import { cn } from '@object-ui/components';
+import { cn, Popover, PopoverTrigger, PopoverContent } from '@object-ui/components';
 import { NODE_W, NODE_H, type Point } from './flow-canvas-layout';
 
 export function nodeIcon(type: string): LucideIcon {
@@ -555,11 +555,14 @@ export interface NodePaletteProps {
   /** Node types to offer. Defaults to the hardcoded {@link NODE_PALETTE}. */
   items?: PaletteItem[];
   onPick: (type: string) => void;
-  onClose: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The trigger button — rendered as the Popover anchor. */
+  children: React.ReactNode;
 }
 
 /** Compact popover listing the node types an author can add, grouped by category. */
-export function NodePalette({ items = NODE_PALETTE, onPick, onClose }: NodePaletteProps) {
+export function NodePalette({ items = NODE_PALETTE, onPick, open, onOpenChange, children }: NodePaletteProps) {
   // Bucket items by category (falling back to the type's inferred category, so
   // engine-only / plugin nodes still land in a sensible section), then render
   // sections in the canonical order. Empty sections are skipped.
@@ -596,10 +599,17 @@ export function NodePalette({ items = NODE_PALETTE, onPick, onClose }: NodePalet
     );
   };
 
+  // Radix Popover (portaled to <body>) — the flow canvas root is
+  // `overflow-hidden` (pan/zoom), so an `absolute` panel used to be clipped at
+  // the canvas edge instead of overlaying it. Portaling escapes that clip.
   return (
-    <>
-      <div className="fixed inset-0 z-20" onClick={onClose} aria-hidden />
-      <div className="absolute right-0 top-full z-30 mt-1.5 max-h-[66vh] w-60 overflow-y-auto rounded-xl border bg-popover/95 p-1.5 shadow-xl shadow-foreground/[0.08] ring-1 ring-black/[0.03] backdrop-blur-md">
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        className="max-h-[66vh] w-60 overflow-y-auto rounded-xl border bg-popover/95 p-1.5 shadow-xl shadow-foreground/[0.08] ring-1 ring-black/[0.03] backdrop-blur-md"
+      >
         {grouped.map(([category, list], gi) => (
           <div key={category} className={cn(gi > 0 && 'mt-1 border-t border-border/60 pt-1')}>
             <div className="px-2 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
@@ -608,7 +618,7 @@ export function NodePalette({ items = NODE_PALETTE, onPick, onClose }: NodePalet
             {list.map(renderItem)}
           </div>
         ))}
-      </div>
-    </>
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
A sweep for the same overflow-clip class of bug fixed on the Studio package switcher (#2297). A classifier walked every custom trigger-anchored dropdown in `app-shell` views; two are genuinely clipped by an `overflow-hidden` ancestor (the rest open upward or have no clipping ancestor and are fine).

## Fixes

- **`NodePalette`** (flow canvas add-node menu) — drops up to `66vh`, but the flow canvas root is `overflow-hidden` (pan/zoom), so it was clipped at the canvas bottom edge. Converted to a Radix **`Popover`** (portals to `<body>`); `FlowCanvas` now passes the toolbar button as the Popover trigger, replacing the ad-hoc `absolute` panel + `fixed inset-0` backdrop.
- **`AddWidgetPicker`** (dashboard preview) — anchored in `PreviewShell`'s 32px header, whose root is `overflow-hidden`; the ~288px picker was clipped against the shell box (worst when the shell is short). Converted to a Radix **`Popover`** and dropped the hand-rolled `document` mousedown/Escape listeners (Radix handles outside-click + Escape); the search input is focused via `onOpenAutoFocus`.

Behaviour preserved in both (list contents, search, pick-to-add, close semantics).

## Not changed (verified safe)

- `RichTextCommentInput` @mention dropdown and `ReactionPicker` open **upward** with no clipping ancestor.
- Chatbot prompt overlay is a full-width bar within its container's bounds.
- `plugin-grid` `InlineEditing` renders a one-line validation **error label** (not a menu) — low impact and awkward to portal; left as-is.
- Remaining `absolute` panels in `StudioDesignSurface` are full-screen backdrops / mobile drawers, not anchored dropdowns.

## Verification

- `tsc --noEmit` on `@object-ui/app-shell`: **0 errors**; `eslint` on changed files: **0 errors**.
- app-shell previews suite: **198 tests pass** (incl. `FlowCanvas.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxVTSDSXrdnfqHNBkHB6yi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxVTSDSXrdnfqHNBkHB6yi)_