### PR TITLE
feat(app-shell): embed the build-agent copilot in Studio's aiSlot (ADR-0080 slice-1)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -233,7 +233,7 @@ function agentEmptyState(
   };
 }
 
-function resolveApiBase(explicit?: string): string {
+export function resolveApiBase(explicit?: string): string {
   if (explicit) return explicit.replace(/\/$/, '');
   const env = (import.meta as any).env ?? {};
   const fromEnv = env.VITE_AI_BASE_URL as string | undefined;
@@ -1046,7 +1046,7 @@ interface ChatPaneProps {
   onCanvasOpenChange?: (open: boolean) => void;
 }
 
-function ChatPane({
+export function ChatPane({
   agents,
   agentsLoading,
   agentsError,

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import React from 'react';
+import { useAuth } from '@object-ui/auth';
+import { Button } from '@object-ui/components';
+import { Sparkles, PanelLeftClose } from 'lucide-react';
+import { useAgents, resolveDefaultAgentName, isBuildAgent } from '@object-ui/plugin-chatbot';
+import { useChatConversation } from '../../hooks/useChatConversation';
+import { ChatPane, resolveApiBase, type PendingFirstMessage } from '../../console/ai/AiChatPage';
+
+export interface StudioAiCopilotProps {
+  /** The package the Studio surface is editing — scopes the build agent to it. */
+  packageId: string;
+  /** UI locale (from the Studio surface) for the panel chrome. */
+  locale?: string;
+}
+
+/**
+ * The Studio design surface's left AI copilot (ADR-0080 `aiSlot`). It embeds the
+ * SAME build-agent chat as the full-page `/ai/build` surface (ChatPane), but
+ * scoped to the package the user is designing (`editPackageId`), so "add a field
+ * / add a view / add an automation" acts on THIS app without leaving the design
+ * surface — the iterate copilot ADR-0080 calls for.
+ *
+ * Open-core: the chat UI ships in OSS app-shell but is INERT without a served
+ * agent. We gate on the live agent catalog (`useAgents`) — an env that serves a
+ * `build` agent (the cloud AI Studio) lights the copilot up; a community env
+ * with no agent renders nothing, leaving the plain three-zone surface. Same
+ * "cloud fills it" contract as the floating chat FAB, with no injected prop
+ * threaded through the console.
+ */
+export function StudioAiCopilot({ packageId, locale }: StudioAiCopilotProps): React.ReactElement | null {
+  const zh = (locale ?? '').toLowerCase().startsWith('zh');
+  const { user } = useAuth();
+  const userId = user?.id;
+  const apiBase = React.useMemo(() => resolveApiBase(), []);
+  const [collapsed, setCollapsed] = React.useState(false);
+
+  const { agents, isLoading: agentsLoading, error: agentsError } = useAgents({ apiBase });
+
+  // Prefer the build agent (metadata authoring); fall back to the platform default.
+  const activeAgent = React.useMemo(() => {
+    if (agents.length === 0) return undefined;
+    const build = agents.find((a) => isBuildAgent(a.name));
+    return build?.name ?? resolveDefaultAgentName(agents, undefined);
+  }, [agents]);
+
+  const chatApi = activeAgent
+    ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`
+    : undefined;
+
+  // One durable conversation per (user, package, agent) — reopening Studio on the
+  // same app resumes the same design chat.
+  const { conversationId, initialMessages } = useChatConversation({
+    userId: activeAgent ? userId : undefined,
+    scope: activeAgent ? `studio:${packageId}:${activeAgent}` : undefined,
+    apiBase,
+    activeId: undefined,
+    forceNew: false,
+  });
+
+  const pendingFirstMessageRef = React.useRef<PendingFirstMessage | null>(null);
+
+  // No agent served (community edition / misconfigured) → no copilot, plain surface.
+  if (!agentsLoading && agents.length === 0) return null;
+
+  if (collapsed) {
+    return (
+      <aside className="flex w-10 shrink-0 flex-col items-center gap-2 border-r bg-muted/40 py-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setCollapsed(false)}
+          title={zh ? '展开 AI 副驾' : 'Expand AI copilot'}
+          aria-label={zh ? '展开 AI 副驾' : 'Expand AI copilot'}
+        >
+          <Sparkles className="h-4 w-4" />
+        </Button>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="flex w-96 shrink-0 flex-col overflow-hidden border-r bg-muted/30">
+      <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Sparkles className="h-4 w-4 text-primary" />
+          {zh ? 'AI 副驾' : 'AI copilot'}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setCollapsed(true)}
+          title={zh ? '收起' : 'Collapse'}
+          aria-label={zh ? '收起 AI 副驾' : 'Collapse AI copilot'}
+        >
+          <PanelLeftClose className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1">
+        <ChatPane
+          key={`${chatApi ?? 'local'}:${conversationId ?? 'pending'}`}
+          agents={agents}
+          agentsLoading={agentsLoading}
+          agentsError={agentsError}
+          activeAgent={activeAgent}
+          chatApi={chatApi}
+          apiBase={apiBase}
+          conversationId={conversationId}
+          editPackageId={packageId}
+          initialMessages={initialMessages}
+          pendingFirstMessageRef={pendingFirstMessageRef}
+          onSent={() => {}}
+          onShare={() => {}}
+          showDebug={false}
+        />
+      </div>
+    </aside>
+  );
+}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { SchemaRenderer, useAdapter, SchemaRendererProvider } from '@object-ui/react';
+import { StudioAiCopilot } from './StudioAiCopilot';
 import {
   GridFieldAuthoringProvider,
   cn,
@@ -532,7 +533,15 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
 
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
-      {aiSlot ? <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside> : null}
+      {/* Left AI copilot (ADR-0080). An explicit `aiSlot` overrides; otherwise the
+        * built-in Studio copilot self-gates on the live agent catalog — it embeds
+        * the build-agent chat scoped to THIS package, or renders nothing when no
+        * agent is served (community edition). */}
+      {aiSlot ? (
+        <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside>
+      ) : (
+        <StudioAiCopilot packageId={packageId} locale={locale} />
+      )}
 
       <div className="flex min-w-0 flex-1 flex-col">
         {/* `overflow-x-auto` — none of Package/pillars/Publish shrink (all


### PR DESCRIPTION
The new WYSIWYG Studio (`StudioDesignSurface`) shipped its `aiSlot` unfilled — the magic-flow build agent lived only on the separate `/ai/build` page. This fills the slot so the magic flow becomes a first-class copilot *inside* Studio.

## What
- **`StudioAiCopilot`** — embeds the SAME `ChatPane` build chat, scoped to the package being designed (`editPackageId`), so 'add a field / add a view / add an automation' acts on THIS app without leaving the design surface (the iterate copilot ADR-0080 calls for). Collapsible `w-96` left aside; per-(user, package) conversation.
- Export `ChatPane` + `resolveApiBase` from `AiChatPage` (the embeddable chat body).
- `StudioDesignSurface` defaults its `aiSlot` to `<StudioAiCopilot>`; the prop stays an override.

## Open-core
The copilot self-gates on the live agent catalog (`useAgents`): an env that serves a `build` agent (cloud AI Studio) lights it up; a community env with no agent renders nothing — same 'cloud fills it' contract as the floating chat FAB, with **no injected prop threaded through the console**.

## Validation
- `tsc` app-shell clean (deps built first); `eslint` 0 errors; console build green.
- Rig (cloud env runtime with a served build agent): copilot renders in `/studio/:pkg` — build intro, 构建/提问 tabs, '向 构建 提问...' input, collapse control — all scoped to the package; verified via DOM eval (screenshot daemon wedged on the streaming chat DOM).

Pairs with cloud#750 (gap A: single-table builds now yield an openable app). Gap B (build-completion deep-link into Studio) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)