### PR TITLE
fix(app-shell): give freshly-created records a back link to their origin

### DIFF
--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -447,7 +447,28 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
       surface: deriveRecordSurface(currentObjectDef),
       recordId: saved?.id ?? saved?._id,
     });
-    if (target.kind !== 'none') navigate(target.url, { replace: true });
+    if (target.kind === 'none') return;
+    if (target.kind === 'detail-page') {
+      // The new record's detail is a fresh route carrying no `?from=` trail,
+      // so on its own it renders NO back affordance — a dead-end. Thread the
+      // create's originating route as a history-state `from`, mirroring
+      // ObjectView's list-row navigation (which is why clicking a row DOES
+      // yield a back link). The origin is a list/view route, not a record, so
+      // it rides history state rather than the record-only `?from=` trail.
+      const originSp = new URLSearchParams(window.location.search);
+      originSp.delete(RECORD_FORM_PARAM);
+      originSp.delete(RECORD_FORM_OBJECT_PARAM);
+      originSp.delete(RECORD_FORM_LINK_PARAM);
+      const originQs = originSp.toString();
+      const originPath = `${location.pathname}${originQs ? `?${originQs}` : ''}`;
+      const originLabel = objectLabel(currentObjectDef as any);
+      navigate(target.url, {
+        replace: true,
+        state: originLabel ? { from: { pathname: originPath, label: originLabel } } : undefined,
+      });
+      return;
+    }
+    navigate(target.url, { replace: true });
   }, [handleCrudSuccess, isChildFormTask, formObjectDef, editingRecord, currentObjectDef, appName, activeApp?.name, location.pathname, navigate, closeRecordForm, objectLabel, t]);
 
   // Track recent items on route change.


### PR DESCRIPTION
## Problem

After creating a record, the new record's detail page had **no back button** — a dead-end.

**Root cause:** `handleRecordFormSuccess` (AppContent) navigated to the new record's detail route with `navigate(url, { replace: true })`, passing no origin. `RecordDetailView`'s back affordance only renders when `originFrom` resolves from `state.from` or the `?from=` trail — neither was set. (A code comment even claimed a "← all records" affordance existed; it does not.) By contrast, clicking a **list row** goes through `ObjectView` which *does* pass `state.from`, which is why row-click details have a back link but freshly-created ones did not.

## Fix

Thread the create's originating route as history-state `from`, mirroring `ObjectView`'s list-row navigation. The origin is a list/view route (not a record), so it rides history state rather than the record-only `?from=` trail. Only applies to the `detail-page` create target; the `detail-drawer` case already keeps the list intact underneath.

## Verification (browser, worktree source → :3000 backend)

- **Before:** new task detail top showed only "Record path" + highlights, no back link.
- **After:** top shows `← 任务` linking to `/apps/com.example.showcase/showcase_task`; clicking returns to the Tasks list. ✅
- `@object-ui/app-shell` type-check passes (29/29); `recordFormNavigation` unit tests pass (37/37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)