### PR TITLE
fix(studio): attach a Properties panel to interface/view pages

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -1035,6 +1035,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.inspector.tabSource': 'Source',
   'engine.studio.inspector.emptyLine1': 'Click a block on the canvas,',
   'engine.studio.inspector.emptyLine2': 'and edit its properties right here.',
+  'engine.studio.inspector.noPageSchema': 'Page settings are unavailable — the page schema could not be loaded.',
   'engine.studio.inspector.sourcePageLine1': 'This page is {kind} source, not a block tree —',
   'engine.studio.inspector.sourcePageLine2': 'edit it in the Source tab; the canvas shows the live preview.',
   // Data pillar
@@ -2017,6 +2018,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.inspector.tabSource': '源码',
   'engine.studio.inspector.emptyLine1': '在画布里点选一个积木,',
   'engine.studio.inspector.emptyLine2': '它的属性会在这里直接编辑。',
+  'engine.studio.inspector.noPageSchema': '页面设置不可用——无法加载页面 schema。',
   'engine.studio.inspector.sourcePageLine1': '这个页面是 {kind} 源码,不是积木树 ——',
   'engine.studio.inspector.sourcePageLine2': '请在「源码」标签页里编辑,画布展示实时预览。',
   // Data pillar

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageDefaultInspector.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * PageDefaultInspector — the curated "home" panel for a Page, shown as the
+ * DEFAULT right panel (no block selection).
+ *
+ * An interface/list page (kanban / calendar / gallery / gantt board —
+ * `type: 'list'` + `interfaceConfig.source`) has NO block tree, so the block
+ * inspector (`PageBlockInspector`) never fires and the Interfaces-pillar panel
+ * used to sit permanently on the "click a block" empty state — the config was
+ * uneditable. This renders the spec-driven Page authoring form so the
+ * `interfaceConfig` (source / columns / appearance.allowedVisualizations /
+ * userActions / showRecordCount …) is editable from the panel, exactly as the
+ * classic metadata-admin editor already allowed.
+ *
+ * SPEC-DRIVEN (mirrors {@link ReportDefaultInspector}): fields come from the
+ * spec's canonical `pageForm` + Page JSONSchema fed into {@link SchemaForm};
+ * the form's type-conditional `visibleOn` sections surface the right fields per
+ * page type, and server-only fields are grafted via {@link mergeServerFields}
+ * so a newer server stays editable even when the bundled spec lags.
+ */
+
+import * as React from 'react';
+import { SchemaForm } from '../SchemaForm';
+import { getPageSchema, getPageForm, PAGE_FIELDS_OWNED_ELSEWHERE } from '../page-schema';
+import { mergeServerFields } from '../mergeServerFields';
+import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
+import { t } from '../i18n';
+
+export function PageDefaultInspector({
+  draft,
+  onPatch,
+  readOnly,
+  serverSchema,
+  locale,
+}: MetadataDefaultInspectorProps) {
+  const { schema, form } = React.useMemo(
+    () =>
+      mergeServerFields({
+        bundledSchema: getPageSchema(),
+        bundledForm: getPageForm(),
+        serverSchema,
+        excludeFields: PAGE_FIELDS_OWNED_ELSEWHERE,
+        sectionTitle: t('engine.inspector.moreFields', locale),
+      }),
+    [serverSchema, locale],
+  );
+
+  if (!schema) {
+    return (
+      <p className="px-1 py-2 text-xs text-muted-foreground">
+        {t('engine.studio.inspector.noPageSchema', locale)}
+      </p>
+    );
+  }
+
+  return (
+    <SchemaForm
+      schema={schema}
+      form={form}
+      value={draft}
+      hiddenFields={[...PAGE_FIELDS_OWNED_ELSEWHERE]}
+      readOnly={readOnly}
+      onChange={(next) => onPatch(next)}
+    />
+  );
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/index.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/index.ts
@@ -13,6 +13,7 @@ import { FlowInspector } from './FlowInspector';
 import { AppNavInspector } from './AppNavInspector';
 import { ViewInspector, ViewDefaultInspector } from './ViewInspector';
 import { PageBlockInspector } from './PageBlockInspector';
+import { PageDefaultInspector } from './PageDefaultInspector';
 import { ReportDefaultInspector } from './ReportDefaultInspector';
 import { ObjectFieldInspector } from './ObjectFieldInspector';
 import { ObjectDefaultInspector } from './ObjectDefaultInspector';
@@ -33,6 +34,11 @@ export function registerBuiltinInspectors(): void {
   registerMetadataInspector('view', ViewInspector);
   registerMetadataDefaultInspector('view', ViewDefaultInspector);
   registerMetadataInspector('page', PageBlockInspector);
+  // Interface/list pages (kanban/calendar/gallery/gantt — `type:'list'` +
+  // `interfaceConfig.source`) have no block tree, so the block inspector never
+  // fires. The default inspector renders the spec-driven page/interfaceConfig
+  // form so those pages are editable from the panel, not just the empty state.
+  registerMetadataDefaultInspector('page', PageDefaultInspector);
   // ADR-0021 single-form: a 9.0 report selects dataset measures/dimensions
   // by NAME (no per-column config document), so there is no scoped column
   // inspector — the default inspector owns the whole editing surface.

--- a/packages/app-shell/src/views/metadata-admin/page-schema.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/page-schema.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { getPageSchema, getPageForm, PAGE_FIELDS_OWNED_ELSEWHERE } from './page-schema';
+import { registerBuiltinInspectors } from './inspectors';
+import { getMetadataDefaultInspector } from './default-inspector-registry';
+import { PageDefaultInspector } from './inspectors/PageDefaultInspector';
+
+describe('page-schema (spec-derived Page authoring metadata)', () => {
+  it('derives a Page JSONSchema that carries interfaceConfig (interface/list pages)', () => {
+    const schema = getPageSchema();
+    expect(schema).toBeTruthy();
+    expect(schema!.properties && typeof schema!.properties).toBe('object');
+    // The whole point: an interface/list page's config must be describable, so
+    // its inspector can render source / visualizations / userActions etc.
+    expect(JSON.stringify(schema)).toContain('interfaceConfig');
+  });
+
+  it('exposes the canonical authoring form with canvas/identity fields pruned', () => {
+    const form = getPageForm();
+    // Spec ships a pageForm; if present, it must not re-declare the fields the
+    // canvas / identity own (they are edited on the canvas, not in this panel).
+    if (form) {
+      const declared = new Set<string>();
+      for (const s of form.sections ?? []) {
+        for (const f of s.fields ?? []) declared.add(typeof f === 'string' ? f : (f as any)?.field);
+      }
+      for (const owned of PAGE_FIELDS_OWNED_ELSEWHERE) {
+        expect(declared.has(owned)).toBe(false);
+      }
+    }
+  });
+});
+
+describe('page default inspector registration', () => {
+  it('registers PageDefaultInspector as the no-selection inspector for `page`', () => {
+    registerBuiltinInspectors();
+    expect(getMetadataDefaultInspector('page')).toBe(PageDefaultInspector);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/page-schema.ts
+++ b/packages/app-shell/src/views/metadata-admin/page-schema.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * page-schema.ts — the SINGLE source of truth for Page authoring metadata,
+ * sourced directly from `@objectstack/spec/ui` (the protocol) rather than
+ * hand-written field lists. Mirrors {@link ../report-schema} / view-schema.
+ *
+ * Why: the Page inspector must render the CORRECT config fields for every page
+ * type without hardcoding them. An interface/list page (kanban / calendar /
+ * gallery / gantt board — `type: 'list'` + `interfaceConfig.source`) has no
+ * block tree, so the block inspector never fires; the default panel needs a
+ * form for `interfaceConfig` (source / columns / appearance.
+ * allowedVisualizations / userActions / showRecordCount). The spec already
+ * describes all of this:
+ *
+ *   • `pageForm`   — the canonical authoring FormView: sections with
+ *                    type-conditional `visibleOn` predicates.
+ *   • `PageSchema` — the zod schema for the whole Page document.
+ *
+ * We convert the zod schema to JSONSchema once (memoised) via zod 4's native
+ * `z.toJSONSchema` and feed `{ form, schema }` straight into {@link SchemaForm}.
+ * Adding a new page type or config prop to the spec flows through automatically
+ * — zero code changes here.
+ */
+
+import { z } from 'zod';
+import { PageSchema, pageForm as specPageForm } from '@objectstack/spec/ui';
+import type { FormViewSpec } from './SchemaForm';
+
+type JsonSchema = Record<string, any>;
+
+const TO_JSON_OPTS = { io: 'input', unrepresentable: 'any' } as const;
+
+/**
+ * Fields the design canvas / identity own, pruned from the spec form and
+ * hidden on the SchemaForm so they are not (double-)rendered in the panel:
+ *   • `name`               — record identity (renamed elsewhere).
+ *   • `regions` / `children` — the block tree, edited on the canvas.
+ */
+export const PAGE_FIELDS_OWNED_ELSEWHERE = new Set(['name', 'regions', 'children']);
+
+let _pageSchema: JsonSchema | undefined;
+let _pageSchemaFailed = false;
+
+/** JSONSchema for the whole Page document (memoised, spec-derived). */
+export function getPageSchema(): JsonSchema | undefined {
+  if (_pageSchema || _pageSchemaFailed) return _pageSchema;
+  try {
+    _pageSchema = z.toJSONSchema(PageSchema, TO_JSON_OPTS) as JsonSchema;
+  } catch (err) {
+    _pageSchemaFailed = true;
+    if (typeof console !== 'undefined') {
+      console.warn('[page-schema] failed to derive Page JSONSchema from spec', err);
+    }
+  }
+  return _pageSchema;
+}
+
+let _pageForm: FormViewSpec | undefined;
+
+/**
+ * The canonical authoring FormView, with the canvas/identity-owned fields
+ * pruned from every section (so they are not double-rendered and no bare
+ * section header is left behind). Everything else — including the
+ * type-conditional `interfaceConfig` sections — flows through verbatim.
+ */
+export function getPageForm(): FormViewSpec | undefined {
+  if (_pageForm) return _pageForm;
+  if (!specPageForm || typeof specPageForm !== 'object') return undefined;
+  try {
+    const clone = JSON.parse(JSON.stringify(specPageForm)) as FormViewSpec;
+    for (const section of clone.sections ?? []) {
+      section.fields = (section.fields ?? []).filter((f: any) => {
+        const name = typeof f === 'string' ? f : f?.field;
+        return !PAGE_FIELDS_OWNED_ELSEWHERE.has(name);
+      });
+    }
+    clone.sections = (clone.sections ?? []).filter((s) => (s.fields ?? []).length > 0);
+    _pageForm = clone;
+  } catch (err) {
+    if (typeof console !== 'undefined') {
+      console.warn('[page-schema] failed to prune Page authoring form from spec', err);
+    }
+    _pageForm = specPageForm as FormViewSpec;
+  }
+  return _pageForm;
+}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -67,6 +67,7 @@ import {
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
 import { PermissionMatrixEditPage } from '../metadata-admin/PermissionMatrixEditor';
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
+import { getMetadataDefaultInspector } from '../metadata-admin/default-inspector-registry';
 import { useMetadataClient } from '../metadata-admin/useMetadata';
 import {
   DESIGNER_SEL_PARAM,
@@ -1128,6 +1129,11 @@ function InterfacesPillar({
 
   const Preview = getMetadataPreview(current?.type ?? '');
   const Inspector = getMetadataInspector(current?.type ?? '');
+  // The "home" (no-selection) inspector for the surface type — e.g. a page's
+  // interfaceConfig form. Interface/list pages (kanban/calendar boards) have no
+  // block tree, so `selection` never populates; without this the panel would
+  // sit permanently on the "click a block" empty state.
+  const DefaultInspector = getMetadataDefaultInspector(current?.type ?? '');
   // Object leaves render as a runtime records grid (preview = runtime); schema
   // editing is the Data pillar's job, so they are not draft-editable in this canvas.
   const isEditable = !!Preview && current?.type !== 'object';
@@ -1531,6 +1537,21 @@ function InterfacesPillar({
                 </div>
               </TabsContent>
             </Tabs>
+          ) : DefaultInspector && current && isEditable ? (
+            // No block selected → the surface's "home" inspector (e.g. a page's
+            // interfaceConfig form). Selecting a sub-element from it swaps in the
+            // scoped block inspector above via onSelectionChange.
+            <div className="min-h-0 flex-1 overflow-auto p-3">
+              <DefaultInspector
+                type={current.type}
+                name={current.name}
+                draft={draft}
+                onPatch={onPatch}
+                onSelectionChange={setSelection}
+                readOnly={false}
+                locale={locale}
+              />
+            </div>
           ) : (
             <div className="min-h-0 flex-1 overflow-auto p-3">
               <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">


### PR DESCRIPTION
## Problem

Opening a **view/interface page** in the Studio → Interfaces pillar (e.g. `…/studio/com.example.showcase/interfaces?surface=page:showcase_task_board` — a kanban board) left the right-hand **Properties panel unwired**: it sat permanently on the "click a block on the canvas" empty state, so the page's config couldn't be edited.

**Root cause.** `showcase_task_board` is a `type:'list'` page with `interfaceConfig.source` (kanban) and `regions: []` — it has **no block tree**, so the block inspector (`PageBlockInspector`) never fires. Two compounding gaps:
1. The Interfaces pillar only ever mounted the **selection** inspector (`getMetadataInspector`, gated on a block `selection`) — it never rendered the **default / no-selection** inspector (`getMetadataDefaultInspector`).
2. **`page` had no default inspector registered at all** (dashboard / view / report / object / dataset / action do).

The editing UI already existed for the classic metadata-admin editor (schema-driven `SchemaForm` + widgets); the new Studio just never surfaced it.

## Fix

- **`page-schema.ts`** — spec-derived Page JSONSchema + authoring form (`z.toJSONSchema(PageSchema)` + `pageForm` from `@objectstack/spec/ui`), mirroring `report-schema.ts`/`view-schema.ts`. Canvas/identity fields (`name`/`regions`/`children`) are pruned from the form and hidden.
- **`PageDefaultInspector`** — renders that spec form through the shared `SchemaForm` (reusing the registered widgets: visualizations multi-select, view-ref, user-filters), so `interfaceConfig` (source / columns / appearance.allowedVisualizations / userActions / showRecordCount …) is editable from the panel. Registered as the `page` default inspector.
- **Interfaces pillar** — render `getMetadataDefaultInspector(current.type)` when no block is selected (gated to editable, non-object surfaces). Bonus: view / dashboard / report also get their Properties panel here instead of the empty state.
- i18n (en + zh) + a spec/registration test.

## Verification

- `tsc --noEmit` on `@object-ui/app-shell`: **0 errors**; `eslint` on changed files: **0 errors**.
- New `page-schema.test.ts`: schema carries `interfaceConfig`, the form prunes canvas/identity fields, and `getMetadataDefaultInspector('page')` resolves to `PageDefaultInspector`.
- app-shell studio-design + metadata-admin suites: **591 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxVTSDSXrdnfqHNBkHB6yi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxVTSDSXrdnfqHNBkHB6yi)_