### PR TITLE
fix(plugin-chatbot): make empty-state intro & suggestion chips wrap in narrow containers

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -14,7 +14,7 @@
  *  - tool-call visualisation (Tool* family)
  *  - reasoning / chain-of-thought collapsible (Reasoning*)
  *  - inline citations / sources panel (Sources*)
- *  - suggestion chips on empty state (Suggestion / Suggestions)
+ *  - suggestion chips on empty state (Suggestion; wrapped in a flex-wrap row)
  *  - streaming markdown via streamdown (used by Message internals)
  */
 import * as React from 'react';
@@ -59,7 +59,7 @@ import {
   PromptInputActionAddAttachments,
   type PromptInputMessage,
 } from './elements/prompt-input';
-import { Suggestion, Suggestions } from './elements/suggestion';
+import { Suggestion } from './elements/suggestion';
 import {
   Tool,
   ToolHeader,
@@ -2206,23 +2206,23 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     <Bot className="size-4" />
                   )}
                 </div>
-                <div className="space-y-1">
-                  <h3 className="text-sm font-medium text-foreground/90">{L.emptyTitle}</h3>
-                  <p className="text-sm text-muted-foreground">
+                <div className="w-full max-w-full space-y-1">
+                  <h3 className="text-sm font-medium text-foreground/90 break-words">{L.emptyTitle}</h3>
+                  <p className="text-sm text-muted-foreground break-words">
                     {L.emptyDescription}
                   </p>
                 </div>
                 {suggestions && suggestions.length > 0 ? (
-                  <Suggestions className="justify-center gap-2">
+                  <div className="flex w-full max-w-full flex-wrap justify-center gap-2">
                     {suggestions.map((s) => (
                       <Suggestion
                         key={s}
-                        className="h-8 border-border/60 bg-background/80 px-3 text-xs font-medium text-foreground/90 shadow-none hover:bg-muted/60"
+                        className="h-auto min-h-8 min-w-0 max-w-full whitespace-normal break-words rounded-full border-border/60 bg-background/80 px-3 py-1 text-left text-xs font-medium text-foreground/90 shadow-none hover:bg-muted/60"
                         suggestion={s}
                         onClick={handleSuggestionClick}
                       />
                     ))}
-                  </Suggestions>
+                  </div>
                 ) : null}
               </ConversationEmptyState>
             ) : (


### PR DESCRIPTION
## Problem

`ChatbotEnhanced`'s pre-first-message empty state — the "Build with AI" title, description, and suggested-prompt chips (e.g. _"Build a sales CRM — customers, contacts, and a deal pipeline…"_) — overflowed and was **clipped on the right** when the chat rendered in a narrow (~384px) container.

This shows up in the new Studio AI copilot (`StudioAiCopilot.tsx`, #2306), which embeds `ChatPane` in a `w-96` (384px) `overflow-hidden` aside. `ChatPane` → `ChatbotEnhanced` (from `@object-ui/plugin-chatbot`). The empty-state assumed a wide, full-page container. The same empty state is also used by the floating chat FAB (`ConsoleFloatingChatbot`).

## Root cause

The suggestion chips were rendered with the vendored `Suggestions` component (from `ai-elements`), which forces a horizontal, non-wrapping scroll row (`w-max`, `flex-nowrap`, `whitespace-nowrap`), with fixed-height single-line chips (`h-8` + Button's base `whitespace-nowrap`). In a narrow `overflow-hidden` parent the chips exceeded the width and were clipped instead of wrapping.

## Fix

Fixed at the correct layer — inside `@object-ui/plugin-chatbot` (no override in `StudioAiCopilot`):

- Replaced the horizontal-scroll `Suggestions` wrapper with a plain `flex flex-wrap justify-center` row (`w-full max-w-full`).
- Let each chip shrink and wrap: `min-w-0`, `max-w-full`, `whitespace-normal`, `break-words`, `h-auto min-h-8`, `py-1`, dropping the fixed single-line height.
- Added `break-words` + `w-full max-w-full` to the title/description block.

Per the vendored file's guidance, the `Suggestions` element itself is untouched — the wrapping layout lives in the consumer (`ChatbotEnhanced`).

## Verification

Rendered the empty state (with the real Build-agent title/description and suggestion strings) inside a 384px `overflow-hidden` aside, faithfully reproducing the involved Tailwind utilities:

- **Narrow (384px, Studio copilot / FAB):** before — only the first chip visible, clipped mid-word; after — all 5 chips fully visible, each wrapping its text, contained within the aside.
- **Wide (672px, `max-w-2xl` full-page `/ai/build`):** chips sit on their own centered pill rows, fully visible; layout still looks right.

## Affected files

- `packages/plugin-chatbot/src/ChatbotEnhanced.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvbR2rZVoi4q7e8smaWNfX)_