### PR TITLE
fix(plugin-detail): fix React #300 crash on master-detail drill-in (hoist DetailSection early return below hooks)

### DIFF
--- a/.changeset/detail-section-hooks-order.md
+++ b/.changeset/detail-section-hooks-order.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+Fix a React #300 crash when drilling from a master record into a related child record.
+
+`DetailSection` placed its all-empty `return null` guard *before* the virtual-scroll `useEffect`, so a section that rendered all-empty on one pass (effect skipped) and populated on the next (effect runs) changed its hook count between renders of the same reconciled fiber — React threw error #300 ("rendered more hooks than during the previous render"). This reliably tripped on the master-detail drill-in (e.g. Account → Project), showing an error boundary and bouncing the user away on refresh. The all-empty guard now runs after every hook, making the hook count invariant.

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -179,9 +179,6 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     ? section.fields.filter((field) => !isEmptyValue(field))
     : section.fields;
 
-  // Hide entire section when all fields are empty AND user did not request to show them.
-  if (visibleFields.length === 0 && emptyCount === section.fields.length) return null;
-
   // Apply auto-layout: infer columns and auto-span wide fields
   const { fields: layoutFields, columns: rawColumns } = applyDetailAutoLayout(
     visibleFields,
@@ -449,6 +446,18 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [vsEnabled, layoutFields.length, vsBatchSize]);
+
+  // Hide entire section when all fields are empty AND the user has not asked to
+  // reveal them. This early return MUST come AFTER every hook above (including
+  // the virtual-scroll useEffect) — never before. When a section is all-empty
+  // on one render (early return, N hooks) but has data on the next render (the
+  // useEffect runs, N+1 hooks) of the SAME reconciled fiber, the hook count
+  // changes between renders and React throws error #300 ("rendered more hooks
+  // than during the previous render"). This is the master-detail drill-in
+  // crash: navigating account → project reuses this DetailSection fiber, and
+  // its sections flip from empty to populated. Keeping the guard below all
+  // hooks makes the hook count invariant.
+  if (visibleFields.length === 0 && emptyCount === section.fields.length) return null;
 
   const renderedFields = visibleCount !== undefined
     ? layoutFields.slice(0, visibleCount)


### PR DESCRIPTION
## Problem

Drilling from a master record's related sub-table into a child record crashed with a minified **React error #300** (\"rendered more hooks than during the previous render\"). The record detail page showed the orange error boundary, and refreshing bounced the user away.

Repro (showcase): **Accounts list → open Northwind detail → Projects tab → click a project row** → the child project detail page crashes.

## Root cause

`DetailSection` had its all-empty early return placed **before** a hook:

```tsx
// BEFORE
if (visibleFields.length === 0 && emptyCount === section.fields.length) return null; // ← early return
...
React.useEffect(() => { /* virtual-scroll batching */ }, [vsEnabled, layoutFields.length, vsBatchSize]); // ← hook AFTER the return
```

When the **same reconciled fiber** rendered all-empty on one pass (early return → effect skipped → N hooks) and populated on the next (no early return → effect runs → N+1 hooks), the hook count changed between renders — the classic Rules-of-Hooks violation React reports as #300.

The master-detail drill-in reuses the `RecordDetailView` / `DetailSection` fiber (only `objectName`/`recordId` change via the router), and the sections flip from empty to populated, so it trips reliably.

## Fix

Move the all-empty guard to run **after every hook** (including the `useEffect`), so the hook count is invariant to field/data/`visibleCount`. Render output is unchanged.

## Verification (showcase console)

- ✅ Accounts → Northwind detail → Projects tab → **Website Relaunch** drill-in now renders (客户/状态/健康度/预算/负责人/已花费/日期 all show), **no crash, zero console errors**.
- ✅ Back-nav via breadcrumb (project → account) works, no crash.
- ✅ Inline edit + field validation (\"Tax ID must look like…\") + save round-trip all work.

Fixes the master-detail browse/edit/return flow reported as broken.