### PR TITLE
fix(components): also toast form submit errors so they're visible past the fold

### DIFF
--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../ui/select';
 import { renderChildren } from '../../lib/utils';
 import { Alert, AlertDescription } from '../../ui/alert';
+import { toast } from '../../ui/sonner';
 import { AlertCircle, ChevronDown, ChevronRight, Loader2, Maximize2, Check, X } from 'lucide-react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from '../../ui/dialog';
 import { cn } from '../../lib/utils';
@@ -469,6 +470,9 @@ ComponentRegistry.register('form',
           // Check if submission returned an error
           if (result?.error) {
             setSubmitError(result.error);
+            // Also surface as a toast so the message is visible even when the
+            // in-form banner has scrolled out of view (long forms in modals/drawers).
+            toast.error(result.error);
             return;
           }
         }
@@ -488,7 +492,10 @@ ComponentRegistry.register('form',
             ? error 
             : 'An error occurred during submission';
         setSubmitError(errorMessage);
-        
+        // Also surface as a toast so the message is visible even when the
+        // in-form banner has scrolled out of view (long forms in modals/drawers).
+        toast.error(errorMessage);
+
         // Log errors for debugging (dev environment only)
         // process may not be defined in all environments
         if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'development') {


### PR DESCRIPTION
## 问题

新建/编辑记录时，服务端校验错误（如「设备编号「EQ-00001」已存在，不能重复」）以红色横幅渲染在**表单顶部**。当表单较长、在 Modal/Drawer 里滚动后，从底部点「创建」提交，横幅已滚出可视区，用户看不到任何反馈。

![scroll issue](https://user-images.githubusercontent.com/placeholder)

## 改动

在共用表单渲染器 `packages/components/src/renderers/form/form.tsx` 的**两条错误路径**里，`setSubmitError()` 的同时追加 `toast.error()`：

- 返回式错误 `result.error`
- 抛出式错误 `catch` 分支（Modal/Drawer 表单的 submit 错误都经此路径）

顶部横幅保持不变，只是额外多一个不受滚动位置影响的 toast。

## 为什么可行

- `ConsoleToaster` 已挂载在控制台右下角（`apps/console/src/App.tsx`），toast 无需额外接线即可弹出。
- `ModalForm` / `DrawerForm` 的 submit 错误都会抛出并由本渲染器捕获，改一处即可覆盖新建与编辑。

## 测试

- 类型检查：改动文件无新增类型错误（`../../ui/sonner` 正常解析）。
- 未做浏览器实测（需起 console + 后端并造重复记录）；改动小且局限于单一渲染器。