### PR TITLE
fix(components): don't guess US$ for a currency metric with no currency

### DIFF
--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -287,11 +287,12 @@ function formatValue(
 ): string {
   if (value == null || Number.isNaN(value)) return '—';
   let opts = FORMAT_OPTS[format ?? 'number'] ?? FORMAT_OPTS.number;
-  // A `currency`-format metric resolves its ISO code from the tenant default
-  // (localization.currency, ADR-0053) instead of a baked-in USD; falls back to
-  // USD only when no tenant currency is configured.
+  // A `currency`-format metric resolves its ISO code from the field/tenant
+  // default (localization.currency, ADR-0053). When no currency is known,
+  // render a plain number rather than guessing USD — a baked-in `$` silently
+  // mis-displays non-USD orgs (e.g. RMB amounts shown as US$).
   if (format === 'currency') {
-    opts = { ...FORMAT_OPTS.currency, currency: currency || 'USD' };
+    opts = currency ? { ...FORMAT_OPTS.currency, currency } : FORMAT_OPTS.number;
   }
   const body = new Intl.NumberFormat(locale, opts).format(value);
   return `${prefix ?? ''}${body}${suffix ?? ''}`;


### PR DESCRIPTION
## Problem

没有指定货币类型时，`element:number` 仍然显示 `US$`。

The dashboard `element:number` renderer, when given `format: 'currency'`, fell back to a hard-coded `'USD'` whenever neither a field currency nor a tenant default currency was resolved. So a currency metric in an org that hasn't configured a currency rendered amounts as `US$1,234`, mis-displaying non-USD orgs (e.g. RMB amounts shown as US\$).

## Fix

Render a plain number when no currency is known — matching the codebase-wide convention already followed by `CurrencyCellRenderer`, grid summaries, `CurrencyField`, and `formatCurrency` in `packages/fields`:

```js
opts = currency ? { ...FORMAT_OPTS.currency, currency } : FORMAT_OPTS.number;
```

`MetricWidget.tsx` was reviewed and left unchanged — it only enters the currency branch when a currency is explicitly given (via prop or a `$`/`¥`/`€`/`£` symbol), so it never shows `US$` for an unspecified currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)