### PR TITLE
fix(components,fields): 日期/时间字段点框内任意处即可打开选择器 (#2335)

### DIFF
--- a/packages/components/src/renderers/form/__tests__/form-date-picker-click.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-date-picker-click.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Click-anywhere-to-open for native date/time inputs.
+ *
+ * Native `<input type="date|datetime-local|time">` only open their picker when
+ * the user clicks the tiny calendar/clock icon. The form renderer wires an
+ * onClick that calls `showPicker()` so clicking anywhere in the box opens the
+ * picker — matching how the other field widgets behave. Plain inputs must not
+ * trigger a picker.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+
+beforeAll(async () => {
+  await import('../../../renderers');
+}, 30000);
+
+function renderForm(fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields }} />,
+  );
+}
+
+describe('form renderer — native date/time picker opens on click', () => {
+  it('calls showPicker() when a datetime-local field is clicked anywhere', () => {
+    const showPicker = vi.fn();
+    // jsdom does not implement showPicker; install a spy on the prototype.
+    (HTMLInputElement.prototype as any).showPicker = showPicker;
+
+    renderForm([
+      { name: 'endAt', label: 'End', type: 'input', inputType: 'datetime-local' },
+    ]);
+
+    fireEvent.click(screen.getByLabelText(/end/i));
+    expect(showPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call showPicker() for a plain text field', () => {
+    const showPicker = vi.fn();
+    (HTMLInputElement.prototype as any).showPicker = showPicker;
+
+    renderForm([{ name: 'title', label: 'Title', type: 'input' }]);
+
+    fireEvent.click(screen.getByLabelText(/title/i));
+    expect(showPicker).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -1025,6 +1025,24 @@ interface RenderFieldProps {
   [key: string]: any;
 }
 
+// Native date/time inputs only open their picker when the user clicks the tiny
+// calendar/clock icon. For these types we open the picker on any click inside the
+// box so they behave like the other field widgets (click-anywhere-to-edit).
+const NATIVE_PICKER_INPUT_TYPES = new Set(['date', 'datetime-local', 'time', 'month', 'week']);
+
+function openNativePickerOnClick(inputType: string | undefined) {
+  if (!inputType || !NATIVE_PICKER_INPUT_TYPES.has(inputType)) return undefined;
+  return (e: React.MouseEvent<HTMLInputElement>) => {
+    const el = e.currentTarget;
+    if (el.disabled || el.readOnly) return;
+    try {
+      (el as HTMLInputElement & { showPicker?: () => void }).showPicker?.();
+    } catch {
+      // Browsers throw when the picker can't be shown; the native icon still works.
+    }
+  };
+}
+
 function renderFieldComponent(type: string, props: RenderFieldProps) {
   // 1. Try to resolve specialized field widget from registry first.
   //    Form fields should always prefer the `field:<type>` namespace when
@@ -1063,6 +1081,10 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
           placeholder={placeholder}
           className={cn('min-h-[44px] sm:min-h-0', readonlyInputClass)}
           {...domFieldProps}
+          onClick={(e) => {
+            openNativePickerOnClick(inputType)?.(e);
+            domFieldProps.onClick?.(e);
+          }}
           readOnly={readonly}
           value={domFieldProps.value ?? ''}
         />
@@ -1160,6 +1182,10 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
           placeholder={placeholder}
           className={cn(readonlyInputClass)}
           {...domFieldProps}
+          onClick={(e) => {
+            openNativePickerOnClick(inputType)?.(e);
+            domFieldProps.onClick?.(e);
+          }}
           readOnly={readonly}
         />
       );

--- a/packages/fields/src/widgets/DateField.tsx
+++ b/packages/fields/src/widgets/DateField.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
 import { FieldWidgetProps } from './types';
+import { openNativePicker } from './openNativePicker';
 
 /**
  * DateField - Date picker input widget
@@ -20,6 +21,10 @@ export function DateField({ value, onChange, field, readonly, ...props }: FieldW
       type="date"
       value={value || ''}
       onChange={(e) => onChange(e.target.value)}
+      onClick={(e) => {
+        openNativePicker(e.currentTarget);
+        domProps.onClick?.(e);
+      }}
       disabled={readonly || domProps.disabled}
     />
   );

--- a/packages/fields/src/widgets/DateTimeField.tsx
+++ b/packages/fields/src/widgets/DateTimeField.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
 import { FieldWidgetProps } from './types';
+import { openNativePicker } from './openNativePicker';
 
 /**
  * DateTimeField - Combined date and time picker widget
@@ -26,6 +27,10 @@ export function DateTimeField({ value, onChange, field, readonly, ...props }: Fi
       type="datetime-local"
       value={value || ''}
       onChange={(e) => onChange(e.target.value)}
+      onClick={(e) => {
+        openNativePicker(e.currentTarget);
+        domProps.onClick?.(e);
+      }}
       disabled={readonly || domProps.disabled}
     />
   );

--- a/packages/fields/src/widgets/TimeField.tsx
+++ b/packages/fields/src/widgets/TimeField.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
 import { FieldWidgetProps } from './types';
+import { openNativePicker } from './openNativePicker';
 
 /**
  * TimeField - Time picker input widget
@@ -20,6 +21,10 @@ export function TimeField({ value, onChange, field, readonly, ...props }: FieldW
       type="time"
       value={value || ''}
       onChange={(e) => onChange(e.target.value)}
+      onClick={(e) => {
+        openNativePicker(e.currentTarget);
+        domProps.onClick?.(e);
+      }}
       disabled={readonly || domProps.disabled}
     />
   );

--- a/packages/fields/src/widgets/openNativePicker.ts
+++ b/packages/fields/src/widgets/openNativePicker.ts
@@ -1,0 +1,18 @@
+/**
+ * Open the browser's native picker (date / datetime-local / time) for an input.
+ *
+ * Native date/time inputs only open their picker when the user clicks the small
+ * calendar/clock icon. Calling `showPicker()` on click makes the whole field
+ * behave like other widgets — clicking anywhere in the box opens the picker.
+ *
+ * `showPicker()` can throw (unsupported browser, not user-activated, or the input
+ * is disabled/hidden), so failures are swallowed and the native fallback stands.
+ */
+export function openNativePicker(input: HTMLInputElement): void {
+  if (input.disabled || input.readOnly) return;
+  try {
+    (input as HTMLInputElement & { showPicker?: () => void }).showPicker?.();
+  } catch {
+    // Ignore — browsers throw when the picker can't be shown; the icon still works.
+  }
+}


### PR DESCRIPTION
Closes #2335

## 问题

日期/日期时间/时间字段是原生 `<input type="date|datetime-local|time">`,浏览器默认只有点右侧那个小日历/时钟图标才弹出选择器,点框内其它区域无反应,与其它字段"点框即编辑"的交互不一致。

## 改动

点击框内任意位置即调用原生 `showPicker()` 打开选择器。覆盖两条渲染路径:

- **表单弹窗**:`packages/components` 表单渲染器的 `FieldControl`(`input` 与 `default` 分支)
- **列表行内联编辑**:`packages/fields` 的 `FieldEditWidget → DateField / DateTimeField / TimeField`,抽出共享辅助 `openNativePicker.ts`

约束:
- 仅对 `date` / `datetime-local` / `time` / `month` / `week` 生效,普通文本框不受影响
- `disabled` / `readonly` 不触发
- 老浏览器 `showPicker()` 抛错时 try/catch 兜底,静默回退到"点图标"的原生行为,无回归
- 与已有 `onClick` 组合调用,不覆盖

## 验证

- ✅ 新增回归测试 `form-date-picker-click.test.tsx`,走真实 registry 渲染路径:点击 datetime 字段触发 `showPicker()`、普通文本字段不触发;`packages/components` 表单测试全绿
- ✅ 真实 console(dev server 连本地后端)实测:表单弹窗与列表行内联编辑两条路径,点击输入框文本区(非图标)均成功弹出原生选择器