### PR TITLE
feat(components,app-shell): honour Action.order in record-header; prioritize Approve/Reject

### DIFF
--- a/.changeset/record-header-action-order.md
+++ b/.changeset/record-header-action-order.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/types': minor
+'@object-ui/components': minor
+'@object-ui/app-shell': minor
+---
+
+Record-header actions honour `Action.order`, so approval decisions no longer get buried in the `⋯` overflow menu (objectui#2339 / framework#2670).
+
+The `action:bar` renderer now stable-sorts its actions by an explicit **`order`** field (lower = higher / more prominent, default `0`) before the inline/overflow split. The sort is stable and treats unset `order` as `0`, so action groups where nobody sets `order` keep their exact registration order — existing toolbars are unaffected. `order` is added to `ActionSchema` in `@object-ui/types`, mirroring `Action.order` in `@objectstack/spec`.
+
+`RecordDetailView` now assigns the injected **Approve / Reject** decision buttons a strongly-negative `order` (and gives Approve the highlighted `primary` variant), so on a pending-approval record the approver's decision takes the primary-button slot and app `record_header` actions follow it — instead of the app having to hide its own actions to surface the decision.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1418,13 +1418,21 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           type: 'text',
           multiline: true,
         };
+        // A pending approval is THE decision the approver came to make, so the
+        // decision buttons must outrank app `record_header` actions rather than
+        // being appended after them (and buried in overflow). A strongly
+        // negative `order` floats them into the primary slot; the action:bar
+        // stable-sorts by `order`, so app actions keep their relative order
+        // just after the decision. Approve gets the highlighted `primary`
+        // variant; Reject stays `destructive`. (#2670 / objectui#2339)
         base.push({
           name: 'approve_request',
           type: 'approval',
           target: 'approve_request',
           label: t('approvals.approve', { defaultValue: 'Approve' }),
           icon: 'check',
-          variant: 'default',
+          variant: 'primary',
+          order: -100,
           locations: ['record_header'],
           refreshAfter: true,
           collectParams: [commentParam],
@@ -1437,6 +1445,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           label: t('approvals.reject', { defaultValue: 'Reject' }),
           icon: 'x',
           variant: 'destructive',
+          order: -99,
           locations: ['record_header'],
           refreshAfter: true,
           confirmText: t('approvals.rejectConfirm', {

--- a/packages/components/src/__tests__/action-bar.test.tsx
+++ b/packages/components/src/__tests__/action-bar.test.tsx
@@ -167,6 +167,71 @@ describe('ActionBar (action:bar)', () => {
     });
   });
 
+  describe('order (#2670)', () => {
+    const inlineButtonsSelector =
+      ':scope > button:not([aria-haspopup]), :scope > [role="button"]:not([aria-haspopup])';
+
+    it('orders inline actions by `order` (lower = earlier / primary slot)', () => {
+      const { container } = renderComponent({
+        type: 'action:bar',
+        location: 'record_header',
+        maxVisible: 5,
+        actions: [
+          // Registration order puts the app action first; `order` must reorder.
+          { name: 'close_deal', label: 'Close', type: 'script', locations: ['record_header'] },
+          { name: 'print', label: 'Print', type: 'script', locations: ['record_header'], order: 5 },
+          { name: 'approve', label: 'Approve', type: 'script', locations: ['record_header'], order: -10 },
+        ],
+      });
+      const toolbar = container.querySelector('[role="toolbar"]');
+      const inlineText = Array.from(toolbar!.querySelectorAll(inlineButtonsSelector))
+        .map(b => b.textContent)
+        .join('|');
+      // approve (-10) → close_deal (unset = 0) → print (5)
+      expect(inlineText.indexOf('Approve')).toBeLessThan(inlineText.indexOf('Close'));
+      expect(inlineText.indexOf('Close')).toBeLessThan(inlineText.indexOf('Print'));
+    });
+
+    it('promotes a low-`order` action into the primary slot even when registered last', () => {
+      const { container } = renderComponent({
+        type: 'action:bar',
+        location: 'record_header',
+        maxVisible: 1,
+        actions: [
+          { name: 'app_action', label: 'App Action', type: 'script', locations: ['record_header'] },
+          { name: 'approve', label: 'Approve', type: 'script', locations: ['record_header'], order: -100 },
+        ],
+      });
+      const toolbar = container.querySelector('[role="toolbar"]');
+      // 1 inline primary button + 1 overflow menu trigger
+      expect(toolbar!.children.length).toBe(2);
+      const inlineText = Array.from(toolbar!.querySelectorAll(inlineButtonsSelector))
+        .map(b => b.textContent)
+        .join(' ');
+      expect(inlineText).toContain('Approve');
+      expect(inlineText).not.toContain('App Action');
+    });
+
+    it('is stable — actions without `order` keep their registration order', () => {
+      const { container } = renderComponent({
+        type: 'action:bar',
+        location: 'record_header',
+        maxVisible: 5,
+        actions: [
+          { name: 'a', label: 'Alpha', type: 'script', locations: ['record_header'] },
+          { name: 'b', label: 'Bravo', type: 'script', locations: ['record_header'] },
+          { name: 'c', label: 'Charlie', type: 'script', locations: ['record_header'] },
+        ],
+      });
+      const toolbar = container.querySelector('[role="toolbar"]');
+      const inlineText = Array.from(toolbar!.querySelectorAll(inlineButtonsSelector))
+        .map(b => b.textContent)
+        .join('|');
+      expect(inlineText.indexOf('Alpha')).toBeLessThan(inlineText.indexOf('Bravo'));
+      expect(inlineText.indexOf('Bravo')).toBeLessThan(inlineText.indexOf('Charlie'));
+    });
+  });
+
   describe('systemActions', () => {
     it('renders a single overflow menu when only systemActions are provided', () => {
       const { container } = renderComponent({

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -128,12 +128,23 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
           );
       // Deduplicate by action name — keep first occurrence
       const seen = new Set<string>();
-      return located.filter(a => {
+      const deduped = located.filter(a => {
         if (!a.name) return true;
         if (seen.has(a.name)) return false;
         seen.add(a.name);
         return true;
       });
+      // Order by explicit `order` (lower = earlier / more prominent) before the
+      // inline/overflow split. Stable: actions that leave `order` unset (treated
+      // as 0) keep their incoming order, so this only moves actions that opt in.
+      // This is what lets an injected Approve/Reject with a negative `order`
+      // float into the primary-button slot instead of the "More" overflow menu
+      // (#2670 / objectui#2339), and lets authors order their own record_header
+      // actions declaratively via `Action.order`.
+      if (deduped.some(a => a.order !== undefined)) {
+        return [...deduped].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+      }
+      return deduped;
     }, [schema.actions, schema.location]);
 
     // System actions: always go into the overflow menu, deduped by name,

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -154,7 +154,16 @@ export interface ActionSchema {
   
   /** Visual component type (defaults to 'action:button') */
   component?: ActionComponent;
-  
+
+  /**
+   * Sort order within a location group (lower = higher / more prominent;
+   * defaults to 0). The action:bar stable-sorts actions by `order` before the
+   * inline/overflow split, so in `record_header` a lower `order` promotes an
+   * action into the primary-button slot and a higher `order` pushes it toward
+   * the "More" (⋯) overflow menu. Mirrors `Action.order` in `@objectstack/spec`.
+   */
+  order?: number;
+
   // === Behavior ===
   
   /** Action execution type */


### PR DESCRIPTION
Frontend companion to **framework#2670** / **framework#2682**. Closes **#2339**.

## Problem

The record header renders the first visible `record_header` action as the primary button and pushes the rest into the `⋯` overflow menu. The `action:bar` inline/overflow split was purely **array-position** based, and `RecordDetailView` **appended** the injected Approve/Reject decision buttons after all app actions. So on a pending-approval record, the approver's decision (the whole point of the screen) was buried in the overflow menu behind app actions like "申请关闭商机".

## Changes

- **`action:bar` sorts by `order`** (`packages/components/src/renderers/action/action-bar.tsx`) — the renderer now stable-sorts its actions by an explicit `order` field (lower = higher / more prominent, default `0`) **before** the inline/overflow split. Stable + unset-as-`0` means any group where nobody sets `order` keeps its exact registration order, so existing toolbars are unaffected.
- **`ActionSchema.order`** (`packages/types/src/ui-action.ts`) — new optional field mirroring `Action.order` in `@objectstack/spec`.
- **Injected Approve / Reject prioritized** (`packages/app-shell/src/views/RecordDetailView.tsx`) — the pending-approval decision buttons now carry a strongly-negative `order` (`approve_request: -100`, `reject_request: -99`), and Approve gets the highlighted `primary` variant. Result: the decision takes the primary-button slot and app `record_header` actions follow it — instead of the app having to hide its own actions to make room.

## Ordering rule

Within `record_header`, actions order by `order` ascending (unset = `0`), then original registration order (stable). The first visible action becomes the primary button; the rest overflow.

## Verification

- `pnpm --filter @object-ui/components exec vitest run src/__tests__/action-bar.test.tsx` — **21 passed** (incl. 3 new: order sort, primary-slot promotion when registered last, stability).
- `pnpm --filter @object-ui/types type-check`, `@object-ui/components type-check`, `@object-ui/app-shell type-check` — all clean.

## After merge

Bump `.objectui-sha` in framework so the console build picks up this renderer (framework#2682 documents this follow-up).

Refs framework#2670, framework#2682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H4wb2JGo68NggKiTh5Dag

---
_Generated by [Claude Code](https://claude.ai/code/session_018H4wb2JGo68NggKiTh5Dag)_