### PR TITLE
feat(app-shell): show a platform preview badge in the top bar

### DIFF
--- a/.changeset/platform-preview-badge.md
+++ b/.changeset/platform-preview-badge.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/i18n': minor
+---
+
+Signal the platform's preview stage in the UI.
+
+The console top bar (`AppHeader`) now shows a small **Preview** chip next to the
+product wordmark on every surface (home / app / orgs), so users always know the
+whole platform is pre-GA. It's a new `PreviewBadge` component driven by a
+`branding.stage` field in runtime-config (`'preview' | 'beta' | 'ga'`, exposed
+via `getPlatformStage()`), which defaults to `'preview'` so the badge shows out
+of the box. Operators flip the stage to `'ga'` at launch (`OS_PRODUCT_STAGE` /
+`RuntimeConfigPlugin`) and the badge disappears with no code change; `'beta'`
+renders a "Beta" chip instead. Labels are localized under `topbar.stage.*`.

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -585,6 +585,33 @@ go down"):
   pattern in-editor (the repo `Lint` workflow is manual, so the test is the CI
   gate).
 
+## Platform preview badge
+
+While the whole platform is pre-GA, the top bar (`AppHeader`) shows a small
+**Preview** chip next to the product wordmark on every console surface (home /
+app / orgs). It's rendered by `PreviewBadge`, driven by the platform stage in
+runtime-config:
+
+```ts
+// packages/app-shell/src/runtime-config.ts
+branding.stage: 'preview' | 'beta' | 'ga'  // default: 'preview'
+```
+
+- `getPlatformStage()` reads it (defaults to `'preview'`, so the badge shows out
+  of the box on any runtime that hasn't sent a stage yet).
+- The server pushes it via `GET /api/v1/runtime/config` (`branding.stage`).
+  Operators set it with `OS_PRODUCT_STAGE` or `new RuntimeConfigPlugin({ stage })`.
+- At launch, set `stage: 'ga'` — `PreviewBadge` renders nothing and the chip
+  disappears with **no code change**. `'beta'` shows a "Beta" chip instead.
+
+```tsx
+import { PreviewBadge, getPlatformStage } from '@object-ui/app-shell';
+
+<PreviewBadge className="ml-2 hidden sm:inline-flex" />; // used inside AppHeader
+```
+
+Labels are localized under `topbar.stage.*` (`@object-ui/i18n`).
+
 ## Compatibility
 
 - **React:** 18.x or 19.x

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -79,9 +79,10 @@ export {
   ActivityFeed,
   LocaleSwitcher,
   ModeToggle,
+  PreviewBadge,
   AuthPageLayout,
 } from './layout';
-export type { ActivityItem } from './layout';
+export type { ActivityItem, PreviewBadgeProps } from './layout';
 
 // Top-level chrome (dialogs, providers, error boundaries)
 export {
@@ -111,10 +112,11 @@ export {
   getCloudBase,
   getProductName,
   getProductShortName,
+  getPlatformStage,
   isRuntimeConfigInitialised,
   resetRuntimeConfigForTesting,
 } from './runtime-config';
-export type { RuntimeConfig, RuntimeFeatures, RuntimeBranding } from './runtime-config';
+export type { RuntimeConfig, RuntimeFeatures, RuntimeBranding, PlatformStage } from './runtime-config';
 
 // Standard inner-SPA views
 export {

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -76,6 +76,7 @@ import { KEYBOARD_SHORTCUTS_PARAM, RECORD_TRAIL_PARAM, decodeRecordTrail, buildR
 import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
 import { getProductName } from '../runtime-config';
 import { LocalizedSidebarTrigger } from './LocalizedSidebarTrigger';
+import { PreviewBadge } from './PreviewBadge';
 
 function humanizeSlug(slug: string): string {
   return slug.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
@@ -680,6 +681,12 @@ export function AppHeader({
             {getProductName()}
           </span>
         )}
+
+        {/* Platform-stage chip — sits in the brand zone so it rides along on
+            every console surface (home / app / orgs) while the whole platform
+            is in preview. Desktop-only to spare the crowded mobile top bar;
+            renders nothing once runtime-config reports GA. */}
+        <PreviewBadge className="ml-2 hidden sm:inline-flex" />
 
         {/* Workspace (organization) switcher — the global "which org am I in /
             switch org" affordance. Renders just the org name for single-org

--- a/packages/app-shell/src/layout/PreviewBadge.test.tsx
+++ b/packages/app-shell/src/layout/PreviewBadge.test.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * PreviewBadge — the top-bar platform-stage chip.
+ *
+ * Shows "Preview"/"Beta" while the platform is pre-GA and disappears at GA.
+ * The stage comes from runtime-config, mocked here so each case is deterministic
+ * without a server round-trip. Text is matched case-insensitively so the
+ * assertions hold whether i18n resolves the key or falls back to its
+ * defaultValue.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../runtime-config', () => ({
+  getPlatformStage: vi.fn(() => 'preview'),
+}));
+
+import { PreviewBadge } from './PreviewBadge';
+import { getPlatformStage } from '../runtime-config';
+
+const stageMock = vi.mocked(getPlatformStage);
+
+describe('PreviewBadge', () => {
+  beforeEach(() => {
+    stageMock.mockReset();
+  });
+
+  it('renders a Preview chip while the platform is in preview', () => {
+    stageMock.mockReturnValue('preview');
+    render(<PreviewBadge />);
+    const badge = screen.getByTestId('platform-preview-badge');
+    expect(badge.textContent ?? '').toMatch(/preview/i);
+    expect(badge.textContent ?? '').not.toMatch(/beta/i);
+  });
+
+  it('renders a Beta chip while the platform is in beta', () => {
+    stageMock.mockReturnValue('beta');
+    render(<PreviewBadge />);
+    expect(screen.getByTestId('platform-preview-badge').textContent ?? '').toMatch(/beta/i);
+  });
+
+  it('renders nothing once the platform reaches GA', () => {
+    stageMock.mockReturnValue('ga');
+    const { container } = render(<PreviewBadge />);
+    expect(screen.queryByTestId('platform-preview-badge')).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('passes caller classes through (responsive visibility / spacing)', () => {
+    stageMock.mockReturnValue('preview');
+    render(<PreviewBadge className="ml-2 hidden sm:inline-flex" />);
+    const badge = screen.getByTestId('platform-preview-badge');
+    expect(badge.className).toContain('sm:inline-flex');
+    expect(badge.className).toContain('ml-2');
+  });
+});

--- a/packages/app-shell/src/layout/PreviewBadge.tsx
+++ b/packages/app-shell/src/layout/PreviewBadge.tsx
@@ -1,0 +1,57 @@
+/**
+ * PreviewBadge — a compact "Preview" / "Beta" chip shown next to the product
+ * wordmark in the top bar while the whole platform is pre-GA.
+ *
+ * The stage is server-pushed through runtime-config (`branding.stage`, default
+ * `'preview'`), so operators flip it to `'ga'` at launch — via
+ * `OS_PRODUCT_STAGE` / `RuntimeConfigPlugin` — and the badge disappears with no
+ * code change. Renders nothing at GA. See ../runtime-config.
+ *
+ * @module
+ */
+
+import { Badge, cn } from '@object-ui/components';
+import { useObjectTranslation } from '@object-ui/i18n';
+import { getPlatformStage } from '../runtime-config';
+
+export interface PreviewBadgeProps {
+  /** Extra classes — e.g. responsive visibility / spacing from the caller. */
+  className?: string;
+}
+
+/**
+ * Read the platform stage from runtime-config and render the matching chip.
+ * `getPlatformStage()` is a module singleton populated before first paint
+ * (main.tsx awaits `initRuntimeConfig`), so this reads it directly at render
+ * time — the same non-reactive pattern the wordmark uses via `getProductName()`.
+ */
+export function PreviewBadge({ className }: PreviewBadgeProps) {
+  const { t } = useObjectTranslation();
+  const stage = getPlatformStage();
+
+  // Nothing to advertise once the platform reaches general availability.
+  if (stage !== 'preview' && stage !== 'beta') return null;
+
+  const label =
+    stage === 'beta'
+      ? t('topbar.stage.beta', { defaultValue: 'Beta' })
+      : t('topbar.stage.preview', { defaultValue: 'Preview' });
+  const tooltip = t('topbar.stage.tooltip', {
+    defaultValue: 'This platform is in preview — features may change.',
+  });
+
+  return (
+    <Badge
+      variant="secondary"
+      title={tooltip}
+      aria-label={tooltip}
+      data-testid="platform-preview-badge"
+      className={cn(
+        'shrink-0 cursor-default select-none rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+        className,
+      )}
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/packages/app-shell/src/layout/index.ts
+++ b/packages/app-shell/src/layout/index.ts
@@ -8,6 +8,8 @@ export { ActivityFeed } from './ActivityFeed';
 export type { ActivityItem } from './ActivityFeed';
 export { LocaleSwitcher } from './LocaleSwitcher';
 export { ModeToggle } from './ModeToggle';
+export { PreviewBadge } from './PreviewBadge';
+export type { PreviewBadgeProps } from './PreviewBadge';
 export { AuthPageLayout } from './AuthPageLayout';
 export { PageHeader } from './PageHeader';
 export type { PageHeaderProps } from './PageHeader';

--- a/packages/app-shell/src/runtime-config.test.ts
+++ b/packages/app-shell/src/runtime-config.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { initRuntimeConfig, getRuntimeConfig, resetRuntimeConfigForTesting } from './runtime-config.js';
+import { initRuntimeConfig, getRuntimeConfig, getPlatformStage, resetRuntimeConfigForTesting } from './runtime-config.js';
 
 function mockConfig(features: Record<string, unknown>) {
     vi.stubGlobal('fetch', vi.fn(async () => ({
@@ -51,5 +51,44 @@ describe('runtime-config commercial features', () => {
         expect(getRuntimeConfig().features.sso).toBe(false);
         // sanity: existing flags still parse
         expect(getRuntimeConfig().features.aiStudio).toBe(true);
+    });
+});
+
+/**
+ * Platform stage drives the top-bar preview/beta badge. It must default to
+ * `'preview'` so the whole platform reads as preview before/without any server
+ * signal, only leave preview when the server sends a recognised stage, and
+ * never blank out on a malformed payload.
+ */
+function mockBranding(branding: Record<string, unknown>) {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ branding }),
+    })) as any);
+}
+
+describe('runtime-config platform stage', () => {
+    it('defaults to preview before init (badge shows out of the box)', () => {
+        resetRuntimeConfigForTesting();
+        expect(getPlatformStage()).toBe('preview');
+    });
+
+    it('honours an explicit stage from the server (e.g. GA hides the badge)', async () => {
+        mockBranding({ stage: 'ga' });
+        await initRuntimeConfig();
+        expect(getPlatformStage()).toBe('ga');
+    });
+
+    it('keeps the preview default when branding omits the stage', async () => {
+        mockBranding({ productName: 'Acme' });
+        await initRuntimeConfig();
+        expect(getRuntimeConfig().branding.productName).toBe('Acme');
+        expect(getPlatformStage()).toBe('preview');
+    });
+
+    it('ignores an unrecognised stage rather than blanking the badge', async () => {
+        mockBranding({ stage: 'nonsense' });
+        await initRuntimeConfig();
+        expect(getPlatformStage()).toBe('preview');
     });
 });

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -56,11 +56,22 @@ export interface RuntimeFeatures {
   sso?: boolean;
 }
 
+/**
+ * Product lifecycle stage. Surfaced as a small chip next to the product
+ * wordmark: `'preview'` → "Preview", `'beta'` → "Beta"; `'ga'` hides it.
+ * Defaults to `'preview'` while the whole platform is pre-GA — operators flip
+ * it to `'ga'` at launch (via `OS_PRODUCT_STAGE` / `RuntimeConfigPlugin`) with
+ * no code change.
+ */
+export type PlatformStage = 'preview' | 'beta' | 'ga';
+
 export interface RuntimeBranding {
   /** Product name shown in browser title, splash, account chrome. */
   productName: string;
   /** Short variant for PWA shortName / compact spots. */
   productShortName: string;
+  /** Product lifecycle stage — drives the top-bar preview/beta badge. */
+  stage?: PlatformStage;
 }
 
 export interface RuntimeConfig {
@@ -84,8 +95,17 @@ const defaults: RuntimeConfig = {
   defaultOrgId: null,
   defaultEnvironmentId: null,
   features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true, customDomain: false, sso: false },
-  branding: { productName: 'ObjectOS', productShortName: 'ObjectOS' },
+  // `stage: 'preview'` while the whole platform is pre-GA, so the badge shows
+  // out of the box on any runtime that hasn't sent an explicit stage yet.
+  branding: { productName: 'ObjectOS', productShortName: 'ObjectOS', stage: 'preview' },
 };
+
+/** Valid {@link PlatformStage} values, for validating server-pushed config. */
+const PLATFORM_STAGES: readonly PlatformStage[] = ['preview', 'beta', 'ga'];
+
+function isPlatformStage(value: unknown): value is PlatformStage {
+  return typeof value === 'string' && (PLATFORM_STAGES as readonly string[]).includes(value);
+}
 
 let current: RuntimeConfig = { ...defaults };
 let initialised = false;
@@ -153,6 +173,10 @@ export async function initRuntimeConfig(baseUrl: string = ''): Promise<void> {
             typeof body.branding.productShortName === 'string' && body.branding.productShortName.trim()
               ? body.branding.productShortName.trim()
               : current.branding.productShortName,
+          // Only a recognised stage overrides the default; anything else
+          // (missing, typo'd) preserves the current value so the badge never
+          // vanishes on a malformed payload.
+          stage: isPlatformStage(body.branding.stage) ? body.branding.stage : current.branding.stage,
         }
         : current.branding,
     });
@@ -181,6 +205,15 @@ export function getProductName(): string {
 
 export function getProductShortName(): string {
   return current.branding?.productShortName || getProductName();
+}
+
+/**
+ * Product lifecycle stage — drives the top-bar preview/beta badge. Defaults to
+ * `'preview'` until the server (or an operator override) says otherwise, so the
+ * whole platform reads as preview out of the box; set `'ga'` to hide the badge.
+ */
+export function getPlatformStage(): PlatformStage {
+  return current.branding?.stage ?? 'preview';
 }
 
 /** Whether `initRuntimeConfig()` has run at least once. */

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1700,6 +1700,12 @@ const en = {
       disconnected: 'Disconnected',
       error: 'Connection Error',
     },
+    // Platform lifecycle chip shown next to the product wordmark (PreviewBadge).
+    stage: {
+      preview: 'Preview',
+      beta: 'Beta',
+      tooltip: 'This platform is in preview — features may change.',
+    },
   },
   home: {
     title: 'Home',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1785,6 +1785,12 @@ const zh = {
       disconnected: '已断开连接',
       error: '连接错误',
     },
+    // 产品名旁的平台阶段徽章（PreviewBadge）。
+    stage: {
+      preview: '预览版',
+      beta: '测试版',
+      tooltip: '本平台处于预览版，功能可能调整。',
+    },
   },
   home: {
     title: '首页',


### PR DESCRIPTION
## What & why

The whole platform is still in **preview**, but nothing in the UI says so. This adds a small **Preview** chip next to the product wordmark in the console top bar, so users always know they're on a pre-GA build.

It lives in the shared `AppHeader`, so it rides along on every console surface — **home / app / orgs** — in a single, non-invasive edit (no layout-height impact).

[placement: `◧ ObjectOS  [Preview]  …  ⌘K  🔔  ?  ◉`]

## How it works

- New **`PreviewBadge`** component (`packages/app-shell/src/layout/PreviewBadge.tsx`) reads the platform stage and renders a chip; it renders **nothing** at GA.
- Stage is server-pushed through runtime-config: **`branding.stage: 'preview' | 'beta' | 'ga'`** (default **`'preview'`**), read via the new **`getPlatformStage()`**.
  - Default `'preview'` ⇒ the badge shows out of the box on any runtime that hasn't sent a stage yet.
  - Operators flip it to **`'ga'`** at launch (`OS_PRODUCT_STAGE` / `RuntimeConfigPlugin`) and the chip disappears **with no code change**; `'beta'` shows a "Beta" chip.
  - A malformed/unknown stage is ignored (preserves the current value) so the badge never vanishes on a bad payload.
- Labels are localized under **`topbar.stage.*`** (added to `en` + `zh`; other locales fall back to the English `defaultValue`). Nested under the existing `topbar` section to keep the locale top-level-key parity test green without touching all 10 packs.

## Coverage / scope

- Shown on the authenticated console chrome (home / app / orgs) via `AppHeader`; desktop-only (`hidden sm:inline-flex`) to spare the crowded mobile bar.
- Not added to the login/auth screens or the standalone `/studio` front-door header (separate one-off headers) — easy follow-up if we want it there too.

## Testing

- `PreviewBadge.test.tsx` — renders "Preview"/"Beta"/nothing per stage; passes caller classes through. ✅
- `runtime-config.test.ts` — stage defaults to `'preview'`, honours an explicit server stage, keeps the default when branding omits it, ignores an unknown stage. ✅
- i18n locale top-level-key parity test still green. ✅
- `@object-ui/app-shell` + `@object-ui/i18n` `type-check` clean; ESLint no new errors.

## Files

- `packages/app-shell/src/layout/PreviewBadge.tsx` (+ test) — the component
- `packages/app-shell/src/runtime-config.ts` (+ test) — `PlatformStage`, `branding.stage`, `getPlatformStage()`
- `packages/app-shell/src/layout/AppHeader.tsx` — render the badge in the brand zone
- `packages/app-shell/src/layout/index.ts`, `packages/app-shell/src/index.ts` — exports
- `packages/i18n/src/locales/{en,zh}.ts` — `topbar.stage.*`
- `packages/app-shell/README.md`, `.changeset/platform-preview-badge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELtom7e9LBB31MoTZHmSQj

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELtom7e9LBB31MoTZHmSQj)_