### PR TITLE
feat(app-shell): deep-link pages and reports from the "Design in Studio" bridge

### DIFF
--- a/.changeset/studio-bridge-page-report-surfaces.md
+++ b/.changeset/studio-bridge-page-report-surfaces.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/app-shell': minor
+---
+
+The top bar's "Design in Studio" bridge now deep-links pages and reports, not just dashboards.
+
+Previously only a **dashboard** route deep-linked to its design page in Studio's Interfaces pillar; a **page** or **report** route fell back to the package's generic Data tab, dropping the admin far from the surface they were viewing. The route-type → surface-type mapping now covers all three interface types (`dashboard` / `page` / `report`) via the new `appStudioRoutePath` helper, so e.g. viewing `/apps/:pkg/page/showcase_crm_workbench` and clicking the hammer opens `/studio/:packageId/interfaces?surface=page:showcase_crm_workbench`. Object routes and the app root still open the Data tab.

--- a/content/docs/guide/console.md
+++ b/content/docs/guide/console.md
@@ -29,7 +29,7 @@ The console opens at **http://localhost:5175** with MSW (Mock Service Worker) pr
 | **Branding** | Per-app colors, favicons, and logos via `AppShell` branding. |
 | **Command Palette** | `⌘+K` opens a searchable command bar for quick navigation. |
 | **Studio Package Scope** | Studio home, metadata counts, quick-create links, and diagnostics follow the selected package. |
-| **Design in Studio** | Workspace admins get a top-bar entry inside a running app that opens its owning package on the Studio design surface. On a dashboard route it deep-links straight to that dashboard's design page in the Interfaces pillar (`/studio/:packageId/interfaces?surface=dashboard:<name>`); elsewhere it opens the package's Data tab (`/studio/:packageId/data`). Dashboards are authored here — there is no in-page edit panel. |
+| **Design in Studio** | Workspace admins get a top-bar entry inside a running app that opens its owning package on the Studio design surface. On an interface route — a dashboard, page, or report — it deep-links straight to that surface's design page in the Interfaces pillar (`/studio/:packageId/interfaces?surface=<type>:<name>`, e.g. `surface=page:showcase_crm_workbench`); elsewhere (objects, the app root) it opens the package's Data tab (`/studio/:packageId/data`). These interfaces are authored in Studio — there is no in-page edit panel. |
 | **App Creation Wizard** | 4-step wizard (Basic Info → Objects → Navigation → Branding) to create or edit apps. |
 | **Error Boundary** | Graceful error handling with a retry button. |
 

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -156,10 +156,15 @@ trip is required to edit a draft.
 
 Inside a running app, workspace admins get a "Design in Studio" entry in the
 top bar (`AppHeader`) that deep-links to the app's owning package on the Studio
-design surface (`/studio/:packageId/data`). It is the reverse of the builder's
-"Open app" bridge (ADR-0080): the entry only renders for admins and only when
-the app has an owning package (`_packageId`), and package writability stays a
-server-side concern — a read-only package opens in Studio as browse-only.
+design surface. When the current route names a specific interface — a
+dashboard, page, or report — it opens straight to that surface in the Interfaces
+pillar (`/studio/:packageId/interfaces?surface=<type>:<name>`); on object routes
+and the app root it opens the package's Data tab (`/studio/:packageId/data`).
+The route-type → surface-type decision lives in `appStudioRoutePath`. It is the
+reverse of the builder's "Open app" bridge (ADR-0080): the entry only renders
+for admins and only when the app has an owning package (`_packageId`), and
+package writability stays a server-side concern — a read-only package opens in
+Studio as browse-only.
 
 ### Studio package scope
 

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -66,7 +66,7 @@ import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import type { BreadcrumbItem as BreadcrumbItemType } from '@object-ui/types';
 import { useAuth, getUserInitials, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useMetadata } from '../providers/MetadataProvider';
-import { resolveI18nLabel, preferLocal, matchAppBySegment, appRouteSegment, appStudioDesignPath, appStudioSurfacePath } from '../utils';
+import { resolveI18nLabel, preferLocal, matchAppBySegment, appRouteSegment, appStudioRoutePath } from '../utils';
 import { getIcon } from '../utils/getIcon';
 import { useMobileViewSwitcher } from './MobileViewSwitcherContext';
 import { useNavigationContext } from '../context/NavigationContext';
@@ -558,15 +558,16 @@ export function AppHeader({
     : [];
 
   // App → Studio reverse bridge (ADR-0080): admins jump from the running app
-  // to its owning package's design surface. Null when there is nothing to
-  // open (non-admin, or no owning package). When the current route is a
-  // specific interface (e.g. a dashboard), deep-link straight to THAT surface
+  // to its owning package's design surface. Null when there is nothing to open
+  // (non-admin, or no owning package). When the current route names a specific
+  // interface (a dashboard, page, or report), deep-link straight to THAT surface
   // in the Interfaces pillar instead of the package's generic Data tab — the
-  // dashboard's design page replaces the retired in-page inline editor.
+  // surface's design page replaces the retired in-page inline editor. The route
+  // type doubles as the surface type and `pathParts[3]` is the surface name
+  // (absent on the interface list routes, which fall back to the Data tab); the
+  // mapping lives in `appStudioRoutePath`.
   const studioDesignPath = isApp
-    ? (routeType === 'dashboard' && pathParts[3]
-        ? appStudioSurfacePath(currentApp, isWorkspaceAdmin, { type: 'dashboard', name: pathParts[3] })
-        : appStudioDesignPath(currentApp, isWorkspaceAdmin))
+    ? appStudioRoutePath(currentApp, isWorkspaceAdmin, { type: routeType, name: pathParts[3] })
     : null;
 
   const objectSiblings = appObjects.map((o: any) => ({

--- a/packages/app-shell/src/utils/__tests__/appRoute.test.ts
+++ b/packages/app-shell/src/utils/__tests__/appRoute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { appRouteSegment, matchAppBySegment, appStudioDesignPath, appStudioSurfacePath } from '../appRoute';
+import { appRouteSegment, matchAppBySegment, appStudioDesignPath, appStudioSurfacePath, appStudioRoutePath } from '../appRoute';
 
 /**
  * ADR-0048 (option A) — package-id route segment.
@@ -93,5 +93,54 @@ describe('appStudioSurfacePath', () => {
   it('returns null for apps with no owning package or the sys_metadata pseudo-package', () => {
     expect(appStudioSurfacePath({ name: 'crm' }, true, { type: 'dashboard', name: 'd' })).toBeNull();
     expect(appStudioSurfacePath({ _packageId: 'sys_metadata' }, true, { type: 'dashboard', name: 'd' })).toBeNull();
+  });
+});
+
+/**
+ * App → Studio route bridge — maps a running-app route to its Studio target:
+ * an interface surface (dashboard / page / report) deep-links into the
+ * Interfaces pillar; everything else opens the package's Data tab.
+ */
+describe('appStudioRoutePath', () => {
+  const crm = { name: 'crm', _packageId: 'com.acme.crm' };
+
+  it('deep-links a dashboard route to its Interfaces surface', () => {
+    expect(appStudioRoutePath(crm, true, { type: 'dashboard', name: 'executive_dashboard' })).toBe(
+      '/studio/com.acme.crm/interfaces?surface=dashboard:executive_dashboard',
+    );
+  });
+
+  it('deep-links a page route to its Interfaces surface (the fix — was the Data tab)', () => {
+    expect(appStudioRoutePath(crm, true, { type: 'page', name: 'showcase_crm_workbench' })).toBe(
+      '/studio/com.acme.crm/interfaces?surface=page:showcase_crm_workbench',
+    );
+  });
+
+  it('deep-links a report route to its Interfaces surface', () => {
+    expect(appStudioRoutePath(crm, true, { type: 'report', name: 'pipeline_report' })).toBe(
+      '/studio/com.acme.crm/interfaces?surface=report:pipeline_report',
+    );
+  });
+
+  it('falls back to the Data tab for object routes and the plain app root', () => {
+    // An object route (routeType is the object name) is a Data-pillar surface.
+    expect(appStudioRoutePath(crm, true, { type: 'account', name: undefined })).toBe('/studio/com.acme.crm/data');
+    // No route type at all (bare /apps/:pkg) → Data tab.
+    expect(appStudioRoutePath(crm, true, { type: undefined, name: undefined })).toBe('/studio/com.acme.crm/data');
+  });
+
+  it('falls back to the Data tab for an interface list route (no surface name)', () => {
+    // e.g. /apps/:pkg/page with no specific page selected.
+    expect(appStudioRoutePath(crm, true, { type: 'page', name: undefined })).toBe('/studio/com.acme.crm/data');
+  });
+
+  it('returns null for non-admins (bridge hidden), for both surface and Data targets', () => {
+    expect(appStudioRoutePath(crm, false, { type: 'page', name: 'showcase_crm_workbench' })).toBeNull();
+    expect(appStudioRoutePath(crm, false, { type: 'account', name: undefined })).toBeNull();
+  });
+
+  it('returns null when the app has no owning package (runtime/DB apps)', () => {
+    expect(appStudioRoutePath({ name: 'crm' }, true, { type: 'page', name: 'p' })).toBeNull();
+    expect(appStudioRoutePath({ _packageId: 'sys_metadata' }, true, { type: 'page', name: 'p' })).toBeNull();
   });
 });

--- a/packages/app-shell/src/utils/appRoute.ts
+++ b/packages/app-shell/src/utils/appRoute.ts
@@ -80,6 +80,38 @@ export function appStudioSurfacePath(
   return `/studio/${encodeURIComponent(packageId)}/interfaces?surface=${value}`;
 }
 
+/**
+ * Route types that correspond to a designable **interface** surface in Studio's
+ * Interfaces pillar. The console route type (`/apps/:pkg/<type>/<name>`) doubles
+ * as the Studio surface type — the keywords match `resolveSurface` in
+ * `StudioDesignSurface` (`dashboard` / `page` / `report`). Object/view routes
+ * are deliberately excluded: they belong to the Data pillar, not Interfaces.
+ */
+const INTERFACE_SURFACE_ROUTE_TYPES = new Set(['dashboard', 'page', 'report']);
+
+/**
+ * App → Studio bridge target for a running-app route (ADR-0080). When the route
+ * names a specific interface (a dashboard, page, or report — see
+ * {@link INTERFACE_SURFACE_ROUTE_TYPES}), deep-link straight to THAT surface in
+ * the Interfaces pillar via {@link appStudioSurfacePath}; otherwise fall back to
+ * the package's generic Data tab via {@link appStudioDesignPath}. Returns null
+ * when the bridge should not render (non-admin / no owning package). Centralizes
+ * the route-type → surface-type mapping so `AppHeader` stays declarative and the
+ * decision is unit-tested here.
+ */
+export function appStudioRoutePath(
+  app: AppLike | null | undefined,
+  isWorkspaceAdmin: boolean,
+  route: { type?: string | null; name?: string | null } | null | undefined,
+): string | null {
+  const type = route?.type;
+  const name = route?.name;
+  if (type && name && INTERFACE_SURFACE_ROUTE_TYPES.has(type)) {
+    return appStudioSurfacePath(app, isWorkspaceAdmin, { type, name });
+  }
+  return appStudioDesignPath(app, isWorkspaceAdmin);
+}
+
 /** Shared guard: the owning package id usable by the Studio design surface. */
 function studioPackageId(app: AppLike | null | undefined): string | null {
   const packageId = app?._packageId;

--- a/packages/app-shell/src/utils/index.ts
+++ b/packages/app-shell/src/utils/index.ts
@@ -32,7 +32,7 @@ export { deriveRelatedLists } from './deriveRelatedLists';
 export type { DerivedRelatedList } from './deriveRelatedLists';
 
 export { preferLocal } from './preferLocal';
-export { appRouteSegment, matchAppBySegment, appStudioDesignPath, appStudioSurfacePath } from './appRoute';
+export { appRouteSegment, matchAppBySegment, appStudioDesignPath, appStudioSurfacePath, appStudioRoutePath } from './appRoute';
 
 /**
  * Resolves an I18nLabel to a plain string.


### PR DESCRIPTION
## Problem

Clicking the top-bar hammer (**Design in Studio**, ADR-0080) while viewing a **page** dropped the admin on the package's generic **Data** tab (`/studio/:pkg/data`) instead of that page's design surface. Only **dashboard** routes deep-linked to the specific surface in the **Interfaces** pillar — pages and reports were left out.

Reported case: `…/apps/com.example.showcase/page/showcase_crm_workbench` → hammer should open the page's interface design menu, but went to the Data tab.

## Fix

Map all three interface route types (`dashboard` / `page` / `report`) to their Studio surface, via a new `appStudioRoutePath` helper that centralizes the route-type → surface-type decision so `AppHeader` stays declarative:

| Route | Before | After |
|---|---|---|
| `…/dashboard/<name>` | `interfaces?surface=dashboard:<name>` | `interfaces?surface=dashboard:<name>` (unchanged) |
| `…/page/<name>` | `…/data` ❌ | `interfaces?surface=page:<name>` ✅ |
| `…/report/<name>` | `…/data` ❌ | `interfaces?surface=report:<name>` ✅ |
| object route / app root | `…/data` | `…/data` (unchanged) |

The Studio side already supported `page`/`report` surfaces (`parseSurfaceParam` + `resolveSurface` in `StudioDesignSurface`); only the `AppHeader` mapping was dashboard-only. Admin-only + owning-package guards are unchanged.

## Verification

- **Unit tests** — `appRoute.test.ts` gains an `appStudioRoutePath` block covering dashboard/page/report deep-links, object/app-root/list-route fallbacks to Data, and the non-admin / no-package null cases (24 passing).
- **Browser (live showcase backend)** — signed in as workspace admin, opened `/apps/com.example.showcase/page/showcase_crm_workbench`, clicked the hammer, and landed on `/studio/com.example.showcase/interfaces?surface=page:showcase_crm_workbench` with the **Interfaces** pillar active and the **CRM Workbench** page surface selected (live preview + source inspector).

## Docs

- `content/docs/guide/console.md` — "Design in Studio" row generalized to dashboard/page/report.
- `packages/app-shell/README.md` — reverse-bridge section updated to describe the surface deep-link and `appStudioRoutePath`.

Changeset: `@object-ui/app-shell` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCgWvDBWWTiodYJ472xHba

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCgWvDBWWTiodYJ472xHba)_