### PR TITLE
fix(access): field-level permission editor now lists an object's published fields

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.scope.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.scope.test.tsx
@@ -32,6 +32,9 @@ import { MemoryRouter } from 'react-router-dom';
 interface Server {
   set: Record<string, unknown>;
   packageObjects: Array<{ name: string; label?: string }>;
+  // Keyed by object name → the merged object definition returned by
+  // get('object', name). `fields` may be an array or a `{ [name]: def }` map.
+  objectFields: Record<string, { fields?: unknown } | undefined>;
   saved: Array<Record<string, unknown>>;
   savedOpts: Array<Record<string, unknown> | undefined>;
 }
@@ -54,7 +57,16 @@ function makeClient(server: Server) {
         void opts;
         return server.packageObjects.map((o) => ({ item: o }));
       }
+      // The field-level editor no longer lists the `field` type; it reads the
+      // merged object definition via get('object', name). A bare list('field')
+      // returning [] would reproduce the "no fields" bug this suite guards.
       return [];
+    },
+    get: async (type: string, name: string) => {
+      // Mirror `GET /api/v1/meta/object/<name>` — the merged definition whose
+      // `fields` reflect the published object (inline + standalone fields).
+      if (type === 'object') return server.objectFields[name] ?? null;
+      return null;
     },
     save: async (_type: string, _name: string, payload: Record<string, unknown>, opts?: Record<string, unknown>) => {
       server.saved.push(payload);
@@ -86,6 +98,22 @@ afterEach(cleanup);
 function freshServer(): Server {
   return {
     packageObjects: [{ name: 'a_account' }, { name: 'a_contact' }],
+    // a_account carries its fields inline on the published object definition
+    // (array form); a_contact uses the keyed-map form. Both must surface.
+    objectFields: {
+      a_account: {
+        fields: [
+          { name: 'name', label: 'Name' },
+          { name: 'industry', label: 'Industry' },
+        ],
+      },
+      a_contact: {
+        fields: {
+          email: { label: 'Email' },
+          phone: { label: 'Phone' },
+        },
+      },
+    },
     saved: [],
     savedOpts: [],
     set: {
@@ -161,5 +189,31 @@ describe('PermissionMatrixEditPage — package scope + slice merge (ADR-0086 P0)
       allowEdit: true,
       viewAllRecords: true,
     });
+  });
+
+  // Regression: expanding an object row for field-level read/write must list
+  // the object's published fields (read via get('object', name)) — not fall
+  // back to "no fields" because list('field') was empty.
+  it('lists an object\'s published fields when its row is expanded', async () => {
+    const server = freshServer();
+    clientImpl = makeClient(server);
+    renderMatrix();
+
+    // Expand a_account (fields provided as an array on the object def).
+    const accountToggle = await screen.findByRole('button', { name: /a_account/ });
+    fireEvent.click(accountToggle);
+
+    // Both inline fields surface with their labels — never "no fields".
+    await screen.findByLabelText('a_account.name readable');
+    expect(screen.getByLabelText('a_account.name editable')).toBeInTheDocument();
+    expect(screen.getByLabelText('a_account.industry readable')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No fields registered for this object.'),
+    ).not.toBeInTheDocument();
+
+    // Expand a_contact (fields provided as a keyed map) — same outcome.
+    fireEvent.click(screen.getByRole('button', { name: /a_contact/ }));
+    await screen.findByLabelText('a_contact.email readable');
+    expect(screen.getByLabelText('a_contact.phone editable')).toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -27,8 +27,11 @@
  * Wiring: registered from `builtinComponents.tsx` as
  *   registerMetadataResource({ type: 'permission', EditPage: PermissionMatrixEditPage })
  *
- * The component reads `/api/v1/meta/object` + `/api/v1/meta/field` to
- * enumerate available objects and their fields. Saves through the
+ * The component reads `/api/v1/meta/object` to enumerate available
+ * objects, and reads each object's merged definition (`GET
+ * /api/v1/meta/object/<name>`, whose `fields` reflect the published
+ * object — inline + standalone) to enumerate that object's fields for
+ * field-level permission editing. Saves through the
  * standard metadata save flow (overlay-aware, OCC, destructive-change
  * dialog already provided by the generic engine — we go through
  * client.save() directly).
@@ -219,14 +222,26 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
   async function ensureFields(objectName: string) {
     if (fieldsByObject[objectName]) return;
     try {
-      // Fields are stored as `${object}__${field}` keys under the
-      // `field` metadata type. We resolve by listing then filtering
-      // on the `object` attribute of the item.
-      const items = await client.list<any>('field');
-      const list: FieldSummary[] = ((items as any[]) ?? [])
-        .map((row) => row?.item ?? row)
-        .filter((f) => String(f?.object ?? '') === objectName)
-        .map((f) => ({ name: String(f?.name ?? ''), label: f?.label }))
+      // Read the authoritative, merged object definition (same source the
+      // object settings tab uses for its nameField dropdown). The `field`
+      // LIST endpoint only surfaces standalone/code-package field metadata
+      // and misses fields carried inline on a published object, which left
+      // this editor showing "no fields" for objects that clearly have them.
+      // `fields` may come back as an array or as a `{ [name]: def }` map.
+      const obj = (await client.get<any>('object', objectName)) as
+        | { fields?: Record<string, any> | Array<any> }
+        | null;
+      const raw = obj?.fields;
+      const list: FieldSummary[] = (
+        Array.isArray(raw)
+          ? raw.map((f: any) => ({ name: String(f?.name ?? ''), label: f?.label }))
+          : raw && typeof raw === 'object'
+            ? Object.entries(raw).map(([name, f]: [string, any]) => ({
+                name: String(f?.name ?? name),
+                label: f?.label,
+              }))
+            : []
+      )
         .filter((f) => !!f.name)
         .sort((a, b) => a.name.localeCompare(b.name));
       setFieldsByObject((prev) => ({ ...prev, [objectName]: list }));


### PR DESCRIPTION
## 问题

ObjectStack Studio 的 **Access 支柱**(权限矩阵 `PermissionMatrixEditor`)里,展开某对象行配置**字段级读写**时,即使该对象已发布且有字段,也显示 **"该对象未注册字段。"** —— 导致字段级权限只能走 REST `PUT /api/v1/meta/permission/<name>`,无法在 UI 里配置。

## 根因

字段级编辑器的 `ensureFields` 用 `client.list('field')` 枚举字段。该 LIST 端点**只返回 standalone / 代码包的 field 元数据**,拿不到已发布对象上**内联携带(inline)的字段**,于是对明明有字段的对象返回空列表 → 显示 "no fields"。

而对象设置 tab(nameField 下拉)能正确列出全部字段,因为它读的是 `client.get('object', name)` 返回的**合并后对象定义**(`GET /api/v1/meta/object/<name>` 的权威 `fields`)。两者数据源不一致。

## 修复

`packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx`

- `ensureFields` 改为读 `client.get('object', name)` 的合并定义 —— 与对象设置 tab 统一数据源。
- 同时兼容 `fields` 的两种形态:数组 `[{ name, label }]` 与键控 map `{ [name]: def }`。
- 更新文件头 doc 注释,说明字段来源。

## 测试

`PermissionMatrixEditor.scope.test.tsx` 新增回归用例:展开对象行后,断言其已发布字段(数组形态 + 键控 map 形态各一个对象)都能列出 readable/editable 勾选框,且不再出现 "No fields registered for this object."。

- `vitest run PermissionMatrixEditor.scope.test.tsx` → 2 passed
- `turbo run type-check --filter=@object-ui/app-shell` → 29/29 successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014TWMoRRb2y6R832sHpxhh3)_