### PR TITLE
fix(plugin-gantt): 加高条高、进度/长度拖拽分层、点击条不再弹详情 (#2352)

### DIFF
--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -2220,8 +2220,16 @@ export function GanttView({
 
   // Shared row geometry: bars/diamonds/brackets and link anchors must agree
   // on these or arrows visibly miss their targets.
-  const barTop = Math.round(rowHeight * 0.2); // task bar inset from the row top
+  // Task bar geometry. Target a ~27px-tall bar (dhtmlx-like) so its top edge can
+  // host the length (resize) grips and its bottom edge the progress grip without
+  // the two hit areas overlapping. `barTop` is kept an integer and `barHeight`
+  // derived as `rowHeight - 2*barTop`, so the bar stays *exactly* centered
+  // (link anchors assume rowHeight/2) with no sub-pixel drift.
+  const barTop = Math.max(2, Math.round(rowHeight / 2) - 14); // bar inset from the row top
   const barHeight = rowHeight - barTop * 2;
+  // Split the bar vertically: top band drives length (resize), bottom band drives
+  // progress — so the two grips never compete for the same pixels.
+  const resizeHandleHeight = Math.round(barHeight / 2);
   const milestoneSize = Math.max(Math.round(rowHeight * 0.4), 12);
   // The diamond is a square rotated 45° around its center at the task date;
   // its horizontal tips sit half a diagonal out from that center.
@@ -3341,7 +3349,11 @@ export function GanttView({
                           }}
                           onClick={() => {
                             if (suppressNextClickRef.current) return;
-                            onTaskClick?.(task);
+                            // Clicking the bar only selects it — opening the detail
+                            // drawer is reserved for the task-name column, the
+                            // context menu, and keyboard Enter, so a mis-tap while
+                            // aiming to drag never pops the side panel (易误触).
+                            setSelectedTaskId(task.id);
                           }}
                           onContextMenu={(e) => openContextMenu(task, e)}
                         >
@@ -3403,7 +3415,11 @@ export function GanttView({
                           onMouseLeave={() => setHoveredTaskId((cur) => (cur === task.id ? null : cur))}
                           onClick={() => {
                             if (suppressNextClickRef.current) return;
-                            onTaskClick?.(task);
+                            // Clicking the bar only selects it — opening the detail
+                            // drawer is reserved for the task-name column, the
+                            // context menu, and keyboard Enter, so a mis-tap while
+                            // aiming to drag never pops the side panel (易误触).
+                            setSelectedTaskId(task.id);
                           }}
                           onContextMenu={(e) => openContextMenu(task, e)}
                           onPointerMove={captureLinkTarget}
@@ -3470,7 +3486,11 @@ export function GanttView({
                         data-testid={`gantt-task-bar-${task.id}`}
                         onClick={() => {
                           if (suppressNextClickRef.current) return;
-                          onTaskClick?.(task);
+                          // Clicking the bar only selects it — opening the detail
+                          // drawer is reserved for the task-name column, the
+                          // context menu, and keyboard Enter, so a mis-tap while
+                          // aiming to drag never pops the side panel (易误触).
+                          setSelectedTaskId(task.id);
                         }}
                         onContextMenu={(e) => openContextMenu(task, e)}
                         onPointerMove={captureLinkTarget}
@@ -3485,8 +3505,8 @@ export function GanttView({
                         {canDrag && liveStyle.width >= 14 && (
                           <>
                             <div
-                              className="gantt-resize-handle absolute left-0 top-0 bottom-0"
-                              style={{ width: 6, cursor: 'ew-resize' }}
+                              className="gantt-resize-handle absolute left-0 top-0"
+                              style={{ width: 6, height: resizeHandleHeight, cursor: 'ew-resize' }}
                               data-testid={`gantt-task-resize-left-${task.id}`}
                               onPointerDown={(e) => {
                                 if (e.button !== 0) return;
@@ -3495,8 +3515,8 @@ export function GanttView({
                               onClick={(e) => e.stopPropagation()}
                             />
                             <div
-                              className="gantt-resize-handle absolute right-0 top-0 bottom-0"
-                              style={{ width: 6, cursor: 'ew-resize' }}
+                              className="gantt-resize-handle absolute right-0 top-0"
+                              style={{ width: 6, height: resizeHandleHeight, cursor: 'ew-resize' }}
                               data-testid={`gantt-task-resize-right-${task.id}`}
                               onPointerDown={(e) => {
                                 if (e.button !== 0) return;


### PR DESCRIPTION
Closes #2352

## 改动(参考 dhtmlx gantt)

均在 `packages/plugin-gantt/src/GanttView.tsx`:

1. **条加高到 ~27px**:实测 28px(取偶数,保持 `barHeight = rowHeight − 2·barTop` 的精确居中不变量,避免依赖箭头出现半像素错位)。40px 行由 24 → 28px。
2. **拖长度与拖进度分层**:
   - 左右两端的宽度(resize)手柄改为只占**上半段**(`top:0, height≈14`)。
   - 进度手柄仍在**下半段**。
   - 上 ~14px 拖长度、下 ~14px 拖进度,进度到 0%/100% 落在条端时也不再与 resize 手柄抢同一块像素。
3. **点击条不再弹右侧详情**:任务/汇总/里程碑三种条的单击改为**仅选中**,不再触发 `onTaskClick`。详情入口保留:左侧任务名列点击、右键菜单「查看详情」、键盘 Enter。

## 验证

- Showcase(`gantt-demo` @ :5199)实测:
  - 条几何 `barH=28`;resize 手柄 `top≈1,h=14`(上段),进度手柄 `top=14,h=13`(下段)——无重叠。
  - 点条:未触发 `onTaskClick`、无 Drawer。
  - 点左侧任务名:仍触发 `onTaskClick` 并高亮选中。
- `pnpm --filter @object-ui/plugin-gantt test`:**183 个可运行用例全部通过**(含 resize/拖拽、进度、树居中、只读、分组)。
- `type-check`:`GanttView.tsx` 无类型错误。

> 说明:仓库里另有 2 个 `ObjectGantt.*` 集成测试文件在本 worktree 报红,原因是未构建的 `@object-ui/permissions` 依赖链(stash 掉本改动后同样报红),与本 PR 无关。