### PR TITLE
fix(ai-chat): proposed-preview reads as awaiting; AiChatPage follows conversation language (cloud#772)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -80,6 +80,7 @@ import { useReconcileOnError } from '../../hooks/useReconcileOnError';
 import { ConversationsSidebar } from './ConversationsSidebar';
 import { LiveCanvas } from './LiveCanvas';
 import { BuildDebugDrawer } from './BuildDebugDrawer';
+import { isConversationZh } from './conversationLanguage';
 
 const DEFAULT_AI_PATH = '/api/v1/ai';
 
@@ -1185,6 +1186,25 @@ export function ChatPane({
     );
   }, [conversationId, messages]);
 
+  // #772 — the confirm-card SEND messages must match the CONVERSATION's
+  // language, not the console UI locale: a Chinese thread under an English UI
+  // was sending "Looks good — build it as proposed." into its own chat. The
+  // gate (service-ai-studio) accepts both languages, so this is a cosmetic —
+  // but jarring — mismatch. Override the sent strings to Chinese when the
+  // conversation is Chinese; button LABELS stay on the UI locale.
+  const convZh = useMemo(
+    () => isConversationZh(messages as ChatMessage[]) || isConversationZh(initialMessages),
+    [messages, initialMessages],
+  );
+  const planApproveMessage = convZh
+    ? '确认，开始搭建。'
+    : t('console.ai.planApproveMessage', { defaultValue: 'Looks good — build it as proposed.' });
+  const planApproveDefaultsMessage = convZh
+    ? '确认搭建，未决问题按你的合理假设和默认处理。'
+    : t('console.ai.planApproveDefaultsMessage', {
+        defaultValue: 'Build it with your best assumptions; use sensible defaults for the open questions.',
+      });
+
   // ADR-0037: refresh the live preview when a turn finishes while the canvas is
   // open. The per-artifact `onDraftArtifacts` signal covers a build streaming in,
   // but an incremental edit (add a field, rename) can land without growing the
@@ -1507,12 +1527,8 @@ export function ChatPane({
         planReadyLabel={t('console.ai.planReady', {
           defaultValue: 'The plan is ready. Build it now, or tell me what to adjust.',
         })}
-        planApproveMessage={t('console.ai.planApproveMessage', {
-          defaultValue: 'Looks good — build it as proposed.',
-        })}
-        planApproveDefaultsMessage={t('console.ai.planApproveDefaultsMessage', {
-          defaultValue: 'Build it with your best assumptions; use sensible defaults for the open questions.',
-        })}
+        planApproveMessage={planApproveMessage}
+        planApproveDefaultsMessage={planApproveDefaultsMessage}
         planAnswerMessage={(question, option) =>
           t('console.ai.planAnswerMessage', {
             question,

--- a/packages/app-shell/src/console/ai/conversationLanguage.ts
+++ b/packages/app-shell/src/console/ai/conversationLanguage.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the UNLICENSED license.
+//
+// The language an AI CONVERSATION is being held in — distinct from the console
+// UI locale. A user chatting in Chinese under an English console must get
+// Chinese canned messages, progress labels and confirm-card send text, not
+// have English spliced into their thread (cloud#772). The conversation's own
+// language wins; the UI locale is the fallback until a thread establishes one.
+
+/** A message shape both the floating panel and the full-page chat can supply. */
+interface LangProbeMessage {
+  role?: string;
+  content?: unknown;
+  parts?: unknown;
+}
+
+/** Pull plain user text from either a bare-string `content` or `parts[]`. */
+function userText(m: LangProbeMessage): string {
+  if (typeof m.content === 'string') return m.content;
+  const parts = m.parts;
+  if (Array.isArray(parts)) {
+    return parts
+      .map((p) =>
+        p && typeof p === 'object' && (p as { type?: string }).type === 'text'
+          ? String((p as { text?: unknown }).text ?? '')
+          : '',
+      )
+      .join(' ');
+  }
+  return '';
+}
+
+/**
+ * The conversation's language from its latest user message, or `undefined`
+ * when it can't tell (no user turn yet / non-CJK text). CJK unified ideographs
+ * → Chinese; anything else defers to the caller's UI-locale fallback.
+ */
+export function detectConversationLanguage(
+  msgs: ReadonlyArray<LangProbeMessage> | undefined,
+): string | undefined {
+  if (!Array.isArray(msgs)) return undefined;
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const m = msgs[i];
+    if (!m || m.role !== 'user') continue;
+    const text = userText(m);
+    if (!text.trim()) continue;
+    return /[一-鿿]/.test(text) ? 'zh-CN' : undefined;
+  }
+  return undefined;
+}
+
+/** True when the conversation is being held in Chinese. */
+export function isConversationZh(
+  msgs: ReadonlyArray<LangProbeMessage> | undefined,
+): boolean {
+  return (detectConversationLanguage(msgs) ?? '').toLowerCase().startsWith('zh');
+}

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -52,6 +52,7 @@ import { fetchPendingDraftCount } from '../preview/draftStatus';
 import { getRuntimeConfig } from '../runtime-config';
 import { cloudPricingDeepLink } from '../console/marketplace/marketplaceApi';
 import { shouldShowAgentPicker } from './agentPicker';
+import { detectConversationLanguage } from '../console/ai/conversationLanguage';
 
 /**
  * Display names for the two built-in platform agents (ADR-0063: `ask` / `build`,
@@ -342,43 +343,6 @@ function buildEditorSuggestions(
   return zh
     ? [`为「${subject}」补充字段`, `为「${subject}」建议校验规则`, '添加一个状态选项字段']
     : [`Add fields to ${subject}`, `Suggest validations for ${subject}`, 'Add a status picklist field'];
-}
-
-/**
- * The language the CONVERSATION is being held in, from its latest user
- * message — `undefined` when it can't tell (no user turn yet / non-CJK).
- *
- * Why this exists (#772): the chat surface's locale used to follow only the
- * console UI language, so a user chatting in Chinese under an English UI got
- * English canned messages ("Looks good — build it as proposed."), English
- * progress labels and English starter chips spliced into their Chinese
- * thread. The conversation's own language must win; the UI locale is the
- * fallback for a thread that hasn't started.
- */
-function detectConversationLanguage(
-  msgs: ReadonlyArray<{ role?: string; content?: unknown; parts?: unknown }> | undefined,
-): string | undefined {
-  if (!Array.isArray(msgs)) return undefined;
-  for (let i = msgs.length - 1; i >= 0; i--) {
-    const m = msgs[i];
-    if (!m || m.role !== 'user') continue;
-    let text = '';
-    if (typeof m.content === 'string') text = m.content;
-    const parts = (m as { parts?: unknown }).parts;
-    if (!text && Array.isArray(parts)) {
-      text = parts
-        .map((p) =>
-          p && typeof p === 'object' && (p as { type?: string }).type === 'text'
-            ? String((p as { text?: unknown }).text ?? '')
-            : '',
-        )
-        .join(' ');
-    }
-    if (!text.trim()) continue;
-    // CJK unified ideographs → the thread is in Chinese.
-    return /[一-鿿]/.test(text) ? 'zh-CN' : undefined;
-  }
-  return undefined;
 }
 
 /** Segments after `:appName` that are route prefixes, not object names. */

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -796,7 +796,32 @@ interface ToolSummaryGroup {
   errorText?: string;
 }
 
-function getToolState(tool: ChatToolInvocation): ToolSummaryState {
+/**
+ * The tool RETURNED, but its result is a confirm-before-change PREVIEW — the
+ * change was proposed, NOT applied. Detects the gate envelopes
+ * (`changes_proposed` from granular edits, `blueprint_proposed` /
+ * `awaiting_confirmation` from the build flow). Tolerates a JSON-string or
+ * object result. #772: without this a proposed edit's activity chip read
+ * "Completed" even though it was still waiting for the user to confirm.
+ */
+export function isProposalResult(result: unknown): boolean {
+  let obj: unknown = result;
+  if (typeof obj === 'string') {
+    try {
+      obj = JSON.parse(obj);
+    } catch {
+      return false;
+    }
+  }
+  const status = (obj as { status?: unknown } | null | undefined)?.status;
+  return (
+    status === 'changes_proposed' ||
+    status === 'blueprint_proposed' ||
+    status === 'awaiting_confirmation'
+  );
+}
+
+export function getToolState(tool: ChatToolInvocation): ToolSummaryState {
   const state =
     tool.state ??
     (tool.errorText
@@ -812,7 +837,9 @@ function getToolState(tool: ChatToolInvocation): ToolSummaryState {
     return 'awaiting';
   }
   if (state === 'output-available') {
-    return 'completed';
+    // A returned-but-not-applied confirm preview is AWAITING the user, not done
+    // (#772): the change only commits when they approve on the next turn.
+    return isProposalResult(tool.result) ? 'awaiting' : 'completed';
   }
   return 'running';
 }

--- a/packages/plugin-chatbot/src/tool-state.test.ts
+++ b/packages/plugin-chatbot/src/tool-state.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #772 — a granular metadata edit that RETURNED a confirm-before-change
+// preview (status:'changes_proposed') must read as AWAITING the user, not
+// "Completed": the change only commits when they approve on the next turn.
+
+import { describe, it, expect } from 'vitest';
+import { getToolState, isProposalResult } from './ChatbotEnhanced';
+
+describe('isProposalResult', () => {
+  it('detects the confirm-gate preview envelopes (object or JSON string)', () => {
+    expect(isProposalResult({ status: 'changes_proposed', changes: [] })).toBe(true);
+    expect(isProposalResult({ status: 'blueprint_proposed', blueprint: {} })).toBe(true);
+    expect(isProposalResult({ status: 'awaiting_confirmation' })).toBe(true);
+    expect(isProposalResult('{"status":"changes_proposed"}')).toBe(true);
+  });
+
+  it('is false for applied / other results and junk', () => {
+    expect(isProposalResult({ status: 'drafted', drafted: ['x'] })).toBe(false);
+    expect(isProposalResult({ ok: true })).toBe(false);
+    expect(isProposalResult('not json')).toBe(false);
+    expect(isProposalResult(undefined)).toBe(false);
+    expect(isProposalResult(null)).toBe(false);
+  });
+});
+
+describe('getToolState — proposed preview reads as awaiting', () => {
+  it('a returned changes_proposed tool → awaiting (not completed)', () => {
+    expect(
+      getToolState({
+        toolCallId: 't1',
+        toolName: 'apply_edit',
+        result: { status: 'changes_proposed', changes: [{ verb: 'add_field' }] },
+      }),
+    ).toBe('awaiting');
+  });
+
+  it('a returned blueprint_proposed tool → awaiting', () => {
+    expect(
+      getToolState({
+        toolCallId: 't2',
+        toolName: 'propose_blueprint',
+        result: { status: 'blueprint_proposed', blueprint: {} },
+      }),
+    ).toBe('awaiting');
+  });
+
+  it('a genuinely applied (drafted) tool → completed', () => {
+    expect(
+      getToolState({
+        toolCallId: 't3',
+        toolName: 'apply_blueprint',
+        result: { status: 'drafted', drafted: ['customer'] },
+      }),
+    ).toBe('completed');
+  });
+
+  it('an errored tool → failed; a running one → running', () => {
+    expect(getToolState({ toolCallId: 't4', toolName: 'x', errorText: 'boom' })).toBe('failed');
+    expect(getToolState({ toolCallId: 't5', toolName: 'x' })).toBe('running');
+  });
+
+  it('an explicit approval-requested state → awaiting', () => {
+    expect(
+      getToolState({ toolCallId: 't6', toolName: 'x', state: 'approval-requested', result: undefined }),
+    ).toBe('awaiting');
+  });
+});


### PR DESCRIPTION
## Summary

2026-07-09 魔法流程验收剩余的两个信任修复(objectstack-ai/cloud#772):

1. **确认卡状态词**:granular 变更工具返回 confirm 预览(`changes_proposed` / `blueprint_proposed` / `awaiting_confirmation`)时,活动 chip 仍显示 "Completed"——实际什么都没应用,是在**等用户确认**。`getToolState()` 现在把 proposal envelope 判为 `awaiting`,chip 显示 "Awaiting approval",直到用户下一轮确认。
2. **AiChatPage 会话语言**:全页 /ai 路由的确认卡 canned 消息("Looks good — build it as proposed.")跟 UI locale——中文会话在英文 UI 下被塞英文。现在跟**会话语言**(共享 `detectConversationLanguage` util,从 ConsoleFloatingChatbot 提出,两个 surface 共用一份实现)。

## 测试
- 新增 7 个 getToolState/isProposalResult 用例
- app-shell + plugin-chatbot 全量 1264 ✓
- 英文会话与已应用工具行为不变

配对 cloud 侧 objectstack-ai/cloud#782(重复文本)。

Refs objectstack-ai/cloud#772

🤖 Generated with [Claude Code](https://claude.com/claude-code)