### PR TITLE
Active-org nav context, related-list action bridges, first-run wizard fixes (cloud ADR-0081)

### DIFF
--- a/apps/console/src/pages/auth/SetupPage.tsx
+++ b/apps/console/src/pages/auth/SetupPage.tsx
@@ -40,7 +40,6 @@ export function SetupPage() {
   const {
     user,
     signUp,
-    organizations,
     refreshOrganizations,
     updateOrganization,
     createOrganization,
@@ -83,10 +82,14 @@ export function SetupPage() {
   }, [bootstrapped, user, navigate]);
 
   useEffect(() => {
-    if (user) {
+    // Already-signed-in visitors bounce home — but NOT mid-submission: signUp
+    // flips `user` while handleSubmit is still renaming the bootstrap org, and
+    // navigating here killed that in-flight rename (the org silently kept the
+    // "Default Organization" name). handleSubmit owns the redirect on success.
+    if (user && !submitting) {
       window.location.assign('/');
     }
-  }, [user]);
+  }, [user, submitting]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -94,26 +97,43 @@ export function SetupPage() {
     try {
       await signUp(name, email, password);
 
-      // The Security plugin auto-creates a personal "<User>'s Workspace"
-      // on signup so multi-tenant RLS has something to hang on. Don't
-      // create a second org — rename the auto-created one to the user's
-      // chosen name (or create a fresh one if the plugin is disabled).
+      // The server bootstraps the owner's organization (plugin-auth's
+      // default-org bootstrap in single-org mode; org-scoping's in
+      // multi-org) — don't create a second org, RENAME the bootstrap one
+      // to the user's chosen name. Two subtleties:
+      //   - the bootstrap runs off a permission-grant middleware and may
+      //     land moments after signUp() resolves → poll briefly;
+      //   - the `organizations` state from useAuth() is a STALE CLOSURE
+      //     here (refresh just updated it, but this render can't see it) —
+      //     use the list refreshOrganizations() returns. Reading the state
+      //     was the bug that made this path silently fall through to
+      //     createOrganization(), which single-org mode FORBIDs.
       const trimmedName = orgName.trim();
       if (trimmedName) {
         try {
-          await refreshOrganizations();
-          const personal = organizations[0];
+          let personal: { id?: string } | undefined;
+          for (let attempt = 0; attempt < 4 && !personal?.id; attempt++) {
+            if (attempt > 0) await new Promise((r) => setTimeout(r, 500));
+            const orgs = await refreshOrganizations();
+            personal = orgs?.[0];
+          }
+          // CJK/emoji-only names slugify to '' — an empty slug fails the org
+          // update server-side and the whole rename used to be silently
+          // swallowed. The rename is about the DISPLAY name: keep the
+          // existing slug when there's nothing latin to derive, and mint a
+          // stable fallback only when creating from scratch.
+          const slug = slugify(trimmedName);
           let activeOrgId: string | undefined;
           if (personal?.id) {
             await updateOrganization(personal.id, {
               name: trimmedName,
-              slug: slugify(trimmedName),
+              ...(slug ? { slug } : {}),
             });
             activeOrgId = personal.id;
           } else {
             const created = await createOrganization({
               name: trimmedName,
-              slug: slugify(trimmedName),
+              slug: slug || `org-${Date.now().toString(36)}`,
             });
             activeOrgId = created?.id;
           }

--- a/packages/app-shell/src/chrome/CommandPalette.tsx
+++ b/packages/app-shell/src/chrome/CommandPalette.tsx
@@ -70,8 +70,11 @@ export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSour
   }, [open]);
 
   const baseUrl = `/apps/${appName || appRouteSegment(activeApp)}`;
-  const { user } = useAuth();
-  const templateContext = useMemo(() => ({ currentUserId: user?.id ?? null }), [user?.id]);
+  const { user, activeOrganization } = useAuth();
+  const templateContext = useMemo(
+    () => ({ currentUserId: user?.id ?? null, currentOrgId: activeOrganization?.id ?? null }),
+    [user?.id, activeOrganization?.id],
+  );
 
   const runCommand = useCallback((command: () => void) => {
     setOpen(false);

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -165,8 +165,17 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       const row = action?.params && !Array.isArray(action.params)
         ? (action.params as Record<string, any>)._rowRecord
         : undefined;
+      // Field-backed params resolve against the action's OWN object when the
+      // dispatch carries one (related-list row actions retarget a CHILD object
+      // — e.g. sys_member rows on an org record page); the page-level object
+      // is only the fallback. Without this, a child action's `field` lookup
+      // ran against the parent object, missed, and degraded to a bare text
+      // input (no select options, no field label).
+      const actionObject = typeof action?.objectName === 'string' && action.objectName
+        ? action.objectName
+        : undefined;
       const resolved = resolveActionParams(params as any, {
-        objectName: objectName || (objectDef as any)?.name || '',
+        objectName: actionObject || objectName || (objectDef as any)?.name || '',
         objects: objects || [],
         fieldLabel,
         fieldOptionLabel,
@@ -174,7 +183,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       });
       // Localize each param's label/placeholder/helpText via the
       // `_actions.<action>.params.<param>.<attr>` convention.
-      const objForI18n = objectName || (objectDef as any)?.name;
+      const objForI18n = actionObject || objectName || (objectDef as any)?.name;
       const localized = (resolved as any[]).map((p: any) => ({
         ...p,
         label: actionParamText(objForI18n, action?.name, p.name, 'label', p.label) ?? p.label,

--- a/packages/app-shell/src/layout/AppSidebar.tsx
+++ b/packages/app-shell/src/layout/AppSidebar.tsx
@@ -139,7 +139,7 @@ const getIcon = resolveIcon;
 
 export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: string, onAppChange: (name: string) => void }) {
   const { isMobile, setOpenMobile } = useSidebar();
-  const { user, signOut, isAuthEnabled } = useAuth();
+  const { user, signOut, isAuthEnabled, activeOrganization } = useAuth();
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const navigate = useNavigate();
   const location = useLocation();
@@ -389,7 +389,7 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
                       location.pathname,
                       location.search,
                       basePath,
-                      { currentUserId: user?.id ?? null, contextValues },
+                      { currentUserId: user?.id ?? null, currentOrgId: activeOrganization?.id ?? null, contextValues },
                     );
                     const sel = active ? `?sel=${encodeURIComponent(`nav:${active.id}`)}` : '';
                     navigate(`/apps/${seg}/metadata/app/${activeAppName}${sel}`);
@@ -499,7 +499,7 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
              resolveObjectLabel={(objectName, fallback) => resolveNavObjectLabel({ name: objectName, label: fallback })}
              resolveViewLabel={(objectName, viewName, fallback) => resolveNavViewLabel(objectName, viewName, fallback)}
              t={t}
-             templateContext={{ currentUserId: user?.id ?? null, contextValues }}
+             templateContext={{ currentUserId: user?.id ?? null, currentOrgId: activeOrganization?.id ?? null, contextValues }}
            />
 
            {/* Recent Items (elevated position for quick access) */}
@@ -686,7 +686,7 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
           return leaves.slice(0, 5).map((item: any) => {
           const NavIcon = getIcon(item.icon);
           const baseUrl = activeApp ? `/apps/${appRouteSegment(activeApp) ?? activeAppName}` : '';
-          const { href } = resolveHref(item, baseUrl, { currentUserId: user?.id ?? null });
+          const { href } = resolveHref(item, baseUrl, { currentUserId: user?.id ?? null, currentOrgId: activeOrganization?.id ?? null });
           return (
             <Link key={item.id} to={href} className="flex flex-col items-center gap-0.5 px-2 py-1.5 text-muted-foreground hover:text-foreground transition-colors min-w-[44px] min-h-[44px] justify-center">
               <NavIcon className="h-5 w-5" />

--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -150,7 +150,7 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
   const { t } = useObjectTranslation();
   const { objectLabel: resolveNavObjectLabel, dashboardLabel: resolveNavDashboardLabel, navGroupLabel: resolveNavGroupLabel, viewLabel: resolveNavViewLabel } = useObjectLabel();
   const { context, currentAppName } = useNavigationContext();
-  const { user } = useAuth();
+  const { user, activeOrganization } = useAuth();
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
 
   // Swipe-from-left-edge gesture to open sidebar on mobile
@@ -454,7 +454,7 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
              ) : undefined}
              resolveViewLabel={(objectName, viewName, fallback) => resolveNavViewLabel(objectName, viewName, fallback)}
              t={t}
-             templateContext={{ currentUserId: user?.id ?? null, contextValues }}
+             templateContext={{ currentUserId: user?.id ?? null, currentOrgId: activeOrganization?.id ?? null, contextValues }}
            />
 
            {/* Recent Items */}

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -117,7 +117,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   const objectName = objectNameOverride ?? params.objectName;
   const recordId = recordIdOverride ?? params.recordId;
   const { showDebug } = useMetadataInspector();
-  const { user } = useAuth();
+  const { user, activeOrganization } = useAuth();
   const navigate = useNavigate();
   // objectui#2257 — the active detail tab is URL-addressable (`?tab=`), so it
   // survives the page subtree remounting (refreshKey-style save refreshes;
@@ -362,15 +362,27 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
 
   const paramCollectionHandler = useCallback((params: ActionParamDef[], action?: any) => {
     return new Promise<Record<string, any> | null>((resolve) => {
+      // Related-list row actions retarget a CHILD object (e.g. sys_member rows
+      // on an org record page) and stash the clicked row under
+      // `params._rowRecord` — resolve field-backed params against the
+      // action's own object and pre-fill `defaultFromRow` from the row, with
+      // the page object only as fallback (mirrors useConsoleActionRuntime).
+      const actionObject = typeof action?.objectName === 'string' && action.objectName
+        ? action.objectName
+        : undefined;
+      const row = action?.params && !Array.isArray(action.params)
+        ? (action.params as Record<string, any>)._rowRecord
+        : undefined;
       const resolved = resolveActionParams(params as any, {
-        objectName: objectName || objectDef?.name || '',
+        objectName: actionObject || objectName || objectDef?.name || '',
         objects: objects || [],
         fieldLabel,
         fieldOptionLabel,
+        row,
       });
       // Localize param label/placeholder/helpText (see ObjectView for the
       // convention); falls back to the metadata literal.
-      const objForI18n = objectName || objectDef?.name;
+      const objForI18n = actionObject || objectName || objectDef?.name;
       const localized = (resolved as any[]).map((p: any) => ({
         ...p,
         label: actionParamText(objForI18n, action?.name, p.name, 'label', p.label) ?? p.label,
@@ -422,12 +434,81 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     }
   }, [navigate]);
 
-  // API action handler — maps logical action targets to dataSource operations
+  // Authenticated fetch for direct backend calls (absolute `type:'api'`
+  // targets below + the flow trigger). Declared before apiHandler.
+  const authFetch = useMemo(() => createAuthenticatedFetch(), []);
+
+  // API action handler — absolute HTTP targets go to the backend verbatim
+  // (the canonical `type:'api'` semantics); logical targets map to
+  // dataSource operations.
   const apiHandler = useCallback(async (action: ActionDef) => {
     try {
       const target = action.target || action.name;
+      const rowRecord = action.params && !Array.isArray(action.params)
+        ? ((action.params as Record<string, any>)._rowRecord as Record<string, any> | undefined)
+        : undefined;
       const params: Record<string, any> = { ...(action.params || {}) };
       delete params._rowRecord;
+
+      // Absolute HTTP target — mirror of useConsoleActionRuntime.apiHandler's
+      // canonical branch (fetch + recordIdParam/bodyExtra/bodyShape +
+      // active-org injection for better-auth endpoints). The legacy
+      // dataSource.update mapping below MUST NOT see these: routing a
+      // better-auth row action (remove_member / update_member_role) through
+      // it either silently no-opped (no collected params) or bypassed
+      // better-auth with a raw table write on a managed identity table.
+      const targetStr = typeof target === 'string' ? target : '';
+      if (targetStr.startsWith('/') || /^https?:\/\//i.test(targetStr)) {
+        const baseUrl = import.meta.env.VITE_SERVER_URL || '';
+        // Interpolate `{field}` tokens in the target URL from the row record.
+        let resolvedTarget = targetStr;
+        if (rowRecord && /\{[a-z_][a-z0-9_]*\}/i.test(resolvedTarget)) {
+          resolvedTarget = resolvedTarget.replace(/\{([a-z_][a-z0-9_]*)\}/gi, (_, k) => {
+            const v = rowRecord[k];
+            return v == null ? '' : encodeURIComponent(String(v));
+          });
+        }
+        const url = resolvedTarget.startsWith('http') ? resolvedTarget : `${baseUrl}${resolvedTarget}`;
+
+        const wrap = action.bodyShape && typeof action.bodyShape === 'object' && (action.bodyShape as any).wrap
+          ? (action.bodyShape as any).wrap
+          : undefined;
+        const body: Record<string, any> = wrap ? { [wrap]: params } : { ...params };
+
+        if (action.recordIdParam) {
+          const rowField = (action as any).recordIdField || 'id';
+          const rowValue = rowRecord?.[rowField] ?? (action as any).recordId
+            ?? (!action.objectName || action.objectName === objectName ? (pageRecord as any)?.[rowField] : undefined);
+          if (rowValue != null) body[action.recordIdParam] = rowValue;
+        }
+
+        // better-auth org endpoints resolve the session's active org; pass it
+        // explicitly so row actions stay correct mid-org-switch.
+        if (/\/api\/v1\/auth\//.test(resolvedTarget) && !body.organizationId && activeOrganization?.id) {
+          body.organizationId = activeOrganization.id;
+        }
+        if (action.bodyExtra && typeof action.bodyExtra === 'object') {
+          Object.assign(body, action.bodyExtra);
+        }
+
+        const method = (action.method || 'POST').toUpperCase();
+        const init: any = {
+          method,
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+        };
+        if (method !== 'GET' && method !== 'DELETE') init.body = JSON.stringify(body);
+        const res = await authFetch(url, init);
+        if (!res.ok) {
+          let errBody: any = null;
+          try { errBody = await res.json(); } catch { /* response body not JSON */ }
+          const detail = errBody?.error?.message || errBody?.error || errBody?.message || `HTTP ${res.status}`;
+          return { success: false, error: typeof detail === 'string' ? detail : `HTTP ${res.status}` };
+        }
+        const data = await res.json().catch(() => ({}));
+        if (action.refreshAfter === true) notifyRecordChanged();
+        return { success: true, data, reload: action.refreshAfter === true };
+      }
 
       // Merge `bodyExtra` constant fields into the update payload. Per the
       // ActionSchema contract these are "applied last; overrides user params",
@@ -496,14 +577,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     } catch (error) {
       return { success: false, error: (error as Error).message };
     }
-  }, [dataSource, objectName, pureRecordId, pageRecord]);
+  }, [dataSource, objectName, pureRecordId, pageRecord, authFetch, activeOrganization]);
 
   // Client-side modal transport: `type:'modal'` actions open here (Dialog /
   // Sheet / Drawer by `placement`) and render arbitrary SchemaNode content.
   const { modalHandler, modalElement } = useActionModal(dataSource);
-
-  // Authenticated fetch for direct backend calls (e.g. flow trigger).
-  const authFetch = useMemo(() => createAuthenticatedFetch(), []);
 
   // Flow action handler — POST to /api/v1/automation/{name}/trigger.
   // Triggered when an Action with `type: 'flow'` is invoked from a record-level

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -91,13 +91,18 @@ export interface RelatedRecordActionsBridgeProps {
 }
 
 /**
- * Derive the child object's row actions (metadata `actions` filtered to the
- * `list_item` location), localized and shaped for the related-list row menu.
+ * Derive the child object's actions for a related-list location
+ * (`list_item` → row menu, `list_toolbar` → header buttons), localized and
+ * shaped for the related-list bridge.
  */
-function deriveRowActions(childDef: any, actionLabel: ActionLabelFn): RelatedRowActionDef[] {
+function deriveActions(
+  childDef: any,
+  actionLabel: ActionLabelFn,
+  location: 'list_item' | 'list_toolbar',
+): RelatedRowActionDef[] {
   const actions = Array.isArray(childDef?.actions) ? childDef.actions : [];
   return actions
-    .filter((a: any) => Array.isArray(a?.locations) && a.locations.includes('list_item'))
+    .filter((a: any) => Array.isArray(a?.locations) && a.locations.includes(location))
     .map((a: any) => ({
       ...a,
       label: actionLabel(childDef.name, a.name, a.label || a.name),
@@ -221,11 +226,22 @@ export function RelatedRecordActionsBridge({
           };
         }
 
-        const rowActions = deriveRowActions(childDef, actionLabel);
+        const rowActions = deriveActions(childDef, actionLabel, 'list_item');
         if (rowActions.length > 0) {
           handlers.rowActions = rowActions;
           handlers.onRowAction = (action, record) =>
             runRowAction(objectName, record, action);
+        }
+
+        // List-level actions (e.g. sys_invitation's `invite_user`) render as
+        // header buttons — the related-list equivalent of the object list's
+        // toolbar. Executed through the same dispatch as row actions, just
+        // without a row record.
+        const toolbarActions = deriveActions(childDef, actionLabel, 'list_toolbar');
+        if (toolbarActions.length > 0) {
+          handlers.toolbarActions = toolbarActions;
+          handlers.onToolbarAction = (action) =>
+            runRowAction(objectName, undefined, action);
         }
 
         return handlers;

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -142,13 +142,24 @@ export function RelatedRecordActionsBridge({
   const runRowAction = useCallback(
     async (childObject: string, record: any, action: RelatedRowActionDef) => {
       const id = record?.id ?? record?._id;
-      const def = {
-        ...(action as unknown as ActionDef),
+      // Same dispatch shape as ObjectGrid.onActionDef: a metadata action's
+      // `params` is the ActionParam[] COLLECTION DEFINITION — surface it as
+      // `actionParams` (the runner's param-dialog input) and reserve `params`
+      // for the `_rowRecord` stash (apiHandler row-id injection +
+      // `defaultFromRow` prefill). Spreading the array into `params` used to
+      // produce `{0: {...}}`, which downstream consumers sent to the data API
+      // as a fields map → INVALID_FIELD: Unknown field '0'.
+      const { params: rawParams, ...rest } = action as unknown as ActionDef & { params?: unknown };
+      const def: any = {
+        ...rest,
         objectName: childObject,
         ...(id != null ? { recordId: String(id) } : {}),
-        params: { ...(action.params as Record<string, unknown> | undefined) },
-      } as ActionDef;
-      const res = await execute(def);
+        params: { _rowRecord: record },
+      };
+      if (Array.isArray(rawParams) && rawParams.length > 0) {
+        def.actionParams = rawParams;
+      }
+      const res = await execute(def as ActionDef);
       // Refresh open related lists for this child object after a successful
       // mutating action (the row menu handler is otherwise fire-and-forget).
       if (res?.success) notifyRelatedChanged(childObject);

--- a/packages/app-shell/src/views/SearchResultsPage.tsx
+++ b/packages/app-shell/src/views/SearchResultsPage.tsx
@@ -75,13 +75,13 @@ export function SearchResultsPage() {
   const apps = metadataApps || [];
   const activeApp = matchAppBySegment(apps, appName) || apps[0];
   const baseUrl = `/apps/${appName}`;
-  const { user } = useAuth();
+  const { user, activeOrganization } = useAuth();
 
   // Build searchable items from navigation
   const allItems = useMemo((): SearchResult[] => {
     if (!activeApp) return [];
     const navItems = flattenNavigation(activeApp.navigation || []);
-    const templateContext = { currentUserId: user?.id ?? null };
+    const templateContext = { currentUserId: user?.id ?? null, currentOrgId: activeOrganization?.id ?? null };
     return navItems.map((item: any) => {
       const { href } = resolveHref(item, baseUrl, templateContext);
 

--- a/packages/auth/src/AuthContext.ts
+++ b/packages/auth/src/AuthContext.ts
@@ -93,8 +93,12 @@ export interface AuthContextValue {
   switchOrganization: (orgId: string) => Promise<void>;
   /** Create a new organization */
   createOrganization: (data: { name: string; slug: string; logo?: string }) => Promise<AuthOrganization>;
-  /** Refresh the organizations list */
-  refreshOrganizations: () => Promise<void>;
+  /**
+   * Refresh the organizations list. Returns the freshly fetched list so
+   * callers that need it right away (e.g. the first-run wizard's rename
+   * step) don't read a stale `organizations` closure.
+   */
+  refreshOrganizations: () => Promise<AuthOrganization[] | undefined>;
   /** Update organization details (owner/admin) */
   updateOrganization: (orgId: string, data: Partial<Pick<AuthOrganization, 'name' | 'slug' | 'logo' | 'metadata'>>) => Promise<AuthOrganization>;
   /** Delete an organization (owner) */

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -351,20 +351,35 @@ export function AuthProvider({
     setIsOrganizationsLoading(true);
     try {
       const orgs = await client.listOrganizations();
-      if (isCancelled?.()) return;
+      if (isCancelled?.()) return orgs;
       setOrganizations(orgs);
       // If no active org is set but orgs exist, try to get active from server
       if (orgs.length > 0 && !activeOrganization) {
+        let active: AuthOrganization | null = null;
         try {
-          const active = await client.getActiveOrganization();
-          if (active && !isCancelled?.()) {
-            setActiveOrganization(active);
-            ActiveOrganizationStorage.set(active.id);
-          }
+          active = await client.getActiveOrganization();
         } catch {
           // No active org set — that's fine
+          active = null;
+        }
+        // Single-membership repair (ADR-0081): a session created before the
+        // server-side active-org stamp existed carries no active org even
+        // though the user belongs to exactly one — activate it so org-scoped
+        // UI ({current_org_id} nav links, org endpoints) works without a
+        // re-login. With multiple orgs the choice stays with the user.
+        if (!active && orgs.length === 1) {
+          try {
+            active = await client.setActiveOrganization(orgs[0].id);
+          } catch {
+            active = null;
+          }
+        }
+        if (active && !isCancelled?.()) {
+          setActiveOrganization(active);
+          ActiveOrganizationStorage.set(active.id);
         }
       }
+      return orgs;
     } catch (err) {
       // A route change / unmount racing the in-flight request is not a real
       // failure — only warn when this call is still the one that matters.

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -86,6 +86,14 @@ export interface RelatedListProps {
   rowActions?: RelatedRowActionDef[];
   /** Execute one of {@link rowActions} against the clicked row. */
   onRowAction?: (action: RelatedRowActionDef, row: any) => void | Promise<void>;
+  /**
+   * Child-object list actions (`locations: ['list_toolbar']`), already
+   * localized by the host. Rendered as header buttons next to Add/New —
+   * e.g. `invite_user` on an organization's Invitations list.
+   */
+  toolbarActions?: RelatedRowActionDef[];
+  /** Execute one of {@link toolbarActions} (no row context). */
+  onToolbarAction?: (action: RelatedRowActionDef) => void | Promise<void>;
   /** Maximum number of columns to auto-generate. Default 6. */
   maxColumns?: number;
   /** Page size for pagination (enables pagination when set) */
@@ -148,6 +156,8 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   onRowClick,
   rowActions,
   onRowAction,
+  toolbarActions,
+  onToolbarAction,
   add,
   maxColumns = 6,
   pageSize,
@@ -742,6 +752,24 @@ export const RelatedList: React.FC<RelatedListProps> = ({
             )}
           </div>
           <div className="flex items-center gap-1 shrink-0">
+            {/* Child-object list_toolbar actions (e.g. Invite User) — the
+                related-list equivalent of the object list's toolbar buttons.
+                Rendered before Add/New so the domain action leads. */}
+            {onToolbarAction && (toolbarActions ?? []).map((a) => {
+              const ActionIcon = a.icon ? resolveIconComponent(a.icon) : null;
+              return (
+                <Button
+                  key={a.name}
+                  variant={a.variant === 'primary' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={(e) => { e.stopPropagation(); void onToolbarAction(a); }}
+                  className="gap-1 h-9 sm:h-7 text-xs shadow-none"
+                >
+                  {ActionIcon && <ActionIcon className="h-3.5 w-3.5" />}
+                  {a.label || a.name}
+                </Button>
+              );
+            })}
             {add && (
               <Button
                 variant={isEmpty ? 'ghost' : 'outline'}

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -140,6 +140,8 @@ export const RecordRelatedListRenderer: React.FC<RecordRelatedListRendererProps>
         add={(schema as any).add}
         rowActions={handlers?.rowActions}
         onRowAction={handlers?.onRowAction}
+        toolbarActions={handlers?.toolbarActions}
+        onToolbarAction={handlers?.onToolbarAction}
         // Create a new child, pre-linked to this parent (增). Host omits when
         // create is denied by lifecycle/permissions, hiding the "New" button.
         onNew={handlers?.onCreate}

--- a/packages/react/src/context/RelatedRecordActionsContext.tsx
+++ b/packages/react/src/context/RelatedRecordActionsContext.tsx
@@ -70,6 +70,15 @@ export interface RelatedRecordHandlers {
   rowActions?: RelatedRowActionDef[];
   /** Execute one of {@link rowActions} against a specific child row. */
   onRowAction?: (action: RelatedRowActionDef, record: unknown) => void | Promise<void>;
+  /**
+   * Child object list-level actions (`locations: ['list_toolbar']`),
+   * localized — rendered as header buttons on the related list (e.g.
+   * `invite_user` on an organization's Invitations list). Same bridge
+   * contract as {@link rowActions}, minus the row context.
+   */
+  toolbarActions?: RelatedRowActionDef[];
+  /** Execute one of {@link toolbarActions} (no row context). */
+  onToolbarAction?: (action: RelatedRowActionDef) => void | Promise<void>;
 }
 
 /** Input to {@link RelatedRecordActionsValue.resolve}. */


### PR DESCRIPTION
Mechanism wiring for cloud ADR-0081 (in-shell org/member management) — no business logic, all metadata plumbing + real bug fixes:

- **`currentOrgId` in nav template context** (sidebars, command palette, search): `{current_org_id}` `recordId` tokens now resolve — the spec + NavigationRenderer already supported them; the shell never supplied the value.
- **AuthProvider**: `refreshOrganizations` returns the fetched list (callers read a stale state closure); a session with no active org and exactly ONE membership auto-activates it (repairs pre-existing sessions without re-login).
- **Related-list row actions on record pages were broken end-to-end** (pre-existing):
  - the bridge spread the `ActionParam[]` DEFINITION array into the params object (`{0:{…}}`) → sent to the data API as a fields map → `INVALID_FIELD: Unknown field '0'`; dispatch now mirrors ObjectGrid (`actionParams` + `params:{_rowRecord}`);
  - param dialogs resolve field-backed params against the action's OWN (child) object + prefill `defaultFromRow` from the clicked row;
  - `RecordDetailView.apiHandler` gains the canonical absolute-HTTP branch — previously every `type:'api'` action mapped to `dataSource.update`: `remove_member` silently no-opped as fake success, `update_member_role` bypassed better-auth with a raw managed-table write.
- **NEW: related lists bridge child `list_toolbar` actions** as header buttons (`invite_user` on an org's Invitations list) — same contract as row actions, no row context.
- **First-run wizard (SetupPage)**: fresh org list + short retry (stale closure always fell through to `createOrganization`, FORBIDden in single-org, error swallowed); keep the existing slug when the name slugifies to `''` (CJK names); don't auto-redirect mid-submission (the navigation killed the in-flight rename).

## Verification
react 5464 ✓ / app-shell 1135 ✓ / plugin-detail 170 ✓ / auth 130 ✓. Browser E2E against both a single-org framework stack and the full cloud stack (real signup → Team page → invite/accept/change-role/remove through better-auth).

Pairs with objectstack-ai/framework#2699 and objectstack-ai/cloud feat/console-team-page (cloud#738).

🤖 Generated with [Claude Code](https://claude.com/claude-code)