### PR TITLE
fix(ai-chat): confirm-card header reads Awaiting Approval, not Completed (cloud#772)

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -1601,6 +1601,15 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       // its title so a long blueprint/build call has a visible countdown, not a
       // static "Running" (issue #432).
       const isRunning = state === 'input-streaming' || state === 'input-available';
+      // #772 — the HEADER badge state. A tool that RETURNED a confirm-before-
+      // change PREVIEW (changes_proposed / blueprint_proposed) reads as
+      // "Awaiting Approval", not "Completed": nothing was applied, it's waiting
+      // for the user. Only the header badge is remapped — the local `state`
+      // (which gates payload display / HITL) is untouched.
+      const headerState =
+        state === 'output-available' && isProposalResult(tool.result)
+          ? ('approval-requested' as typeof state)
+          : state;
       const titleNode = (
         <span className="inline-flex min-w-0 items-center gap-2">
           <span>{friendlyTitle || tool.toolName}</span>
@@ -1640,7 +1649,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             isUnstructuredBuildProposal(tool)
           }
         >
-          <ToolHeader type={partType} state={state} title={titleNode} />
+          <ToolHeader type={partType} state={headerState} title={titleNode} />
           <ToolContent>
             {showPayload && tool.args !== undefined ? (
               <ToolInput input={tool.args} />


### PR DESCRIPTION
接 #2355:getToolState 修的是紧凑活动 chip;展开确认卡折叠头仍把原始 state（output-available）传给 ToolHeader，故未应用的 granular 编辑显示 Completed。此处仅头徽章在 proposal 预览时重映射为 approval-requested（Awaiting Approval），不动本地 state。/ai/build 迭代实测。Refs objectstack-ai/cloud#772