### PR TITLE
fix(plugin-list): 筛选记录面板忽略空值条件 (#2364)

### DIFF
--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -127,14 +127,25 @@ export function normalizeFilters(filters: any[]): any[] {
     .filter(f => Array.isArray(f) && f.length > 0);
 }
 
-function convertFilterGroupToAST(group: FilterGroup): any[] {
+export function convertFilterGroupToAST(group: FilterGroup): any[] {
   if (!group || !group.conditions || group.conditions.length === 0) return [];
 
-  const conditions = group.conditions.map(c => {
-    if (c.operator === 'isEmpty') return [c.field, '=', null];
-    if (c.operator === 'isNotEmpty') return [c.field, '!=', null];
-    return [c.field, mapOperator(c.operator), c.value];
-  });
+  const conditions = group.conditions
+    .filter(c => {
+      // isEmpty/isNotEmpty carry no value input — always keep them.
+      if (c.operator === 'isEmpty' || c.operator === 'isNotEmpty') return true;
+      // Skip incomplete rows (no value entered yet). Emitting `[field, op, '']`
+      // would be a silently-wrong filter (matches only empty) rather than
+      // "no filter", excluding all rows. Matches groupToCondition in
+      // datasetFilterCondition.ts (#1964).
+      const v = c.value;
+      return !(v == null || v === '' || (Array.isArray(v) && v.length === 0));
+    })
+    .map(c => {
+      if (c.operator === 'isEmpty') return [c.field, '=', null];
+      if (c.operator === 'isNotEmpty') return [c.field, '!=', null];
+      return [c.field, mapOperator(c.operator), c.value];
+    });
 
   // Normalize in/not-in conditions for backend compatibility
   const normalized = normalizeFilters(conditions);

--- a/packages/plugin-list/src/__tests__/convertFilterGroupToAST.test.ts
+++ b/packages/plugin-list/src/__tests__/convertFilterGroupToAST.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { convertFilterGroupToAST } from '../ListView';
+import type { FilterGroup } from '@object-ui/components';
+
+describe('convertFilterGroupToAST', () => {
+  it('skips incomplete rows with an empty value (no filter, not `field = ""`)', () => {
+    const group: FilterGroup = {
+      logic: 'and',
+      conditions: [{ field: 'project_type', operator: 'equals', value: '' }],
+    } as FilterGroup;
+    // Empty value → no condition emitted, so all rows show.
+    expect(convertFilterGroupToAST(group)).toEqual([]);
+  });
+
+  it.each([undefined, null, '', []])('skips value %p', (value) => {
+    const group: FilterGroup = {
+      logic: 'and',
+      conditions: [{ field: 'x', operator: 'equals', value }],
+    } as unknown as FilterGroup;
+    expect(convertFilterGroupToAST(group)).toEqual([]);
+  });
+
+  it('keeps rows with a real value', () => {
+    const group: FilterGroup = {
+      logic: 'and',
+      conditions: [{ field: 'x', operator: 'equals', value: 'foo' }],
+    } as FilterGroup;
+    expect(convertFilterGroupToAST(group)).toEqual(['x', '=', 'foo']);
+  });
+
+  it('keeps isEmpty/isNotEmpty operators even though they carry no value', () => {
+    const group: FilterGroup = {
+      logic: 'and',
+      conditions: [{ field: 'x', operator: 'isEmpty', value: '' }],
+    } as FilterGroup;
+    expect(convertFilterGroupToAST(group)).toEqual(['x', '=', null]);
+  });
+
+  it('drops only the incomplete row in a mixed group', () => {
+    const group: FilterGroup = {
+      logic: 'and',
+      conditions: [
+        { field: 'a', operator: 'equals', value: 'foo' },
+        { field: 'b', operator: 'equals', value: '' },
+      ],
+    } as FilterGroup;
+    // Single surviving condition unwraps to the bare triplet.
+    expect(convertFilterGroupToAST(group)).toEqual(['a', '=', 'foo']);
+  });
+});


### PR DESCRIPTION
## 问题

列表视图的「筛选记录」弹窗中,添加一条筛选(如「项目类型 等于 [选择值]」)但**不选任何值**时,该空条件仍被下发到后端,变成 `字段 = ''`,匹配不到任何记录,**列表数据全部消失**。

## 根因

一个列表页有三个独立的「条件 → 查询 AST」代码路径,互不共享:

| 筛选入口 | 空值跳过 | 状态 |
|---|---|---|
| 顶部快捷筛选(`UserFilters.emitFilters`) | 一直有 `.filter(v.length > 0)` | ✅ |
| 数据集/报表(`datasetFilterCondition.groupToCondition`) | #1964 已加 | ✅ |
| **列表「筛选记录」弹窗**(`ListView.convertFilterGroupToAST`) | **从未有过** | ❌ |

`convertFilterGroupToAST` 直接把 `{operator:'equals', value:''}` 映射成 `[field, '=', '']`,`normalizeFilters` 只丢弃长度为 0 的数组,该三元组存活并下发。这不是回归——该面板(2026-02-04 加入)从来没有这层保护,此前也无任何单测拦截。

## 改动

- `convertFilterGroupToAST`:跳过 `value` 为 `null`/`undefined`/`''`/`[]` 的未完成条件(`isEmpty`/`isNotEmpty` 本身不带值,保留),与另外两条路径对齐。
- 导出 `convertFilterGroupToAST` 并新增 `convertFilterGroupToAST.test.ts`(8 项),覆盖此前零测试的列表路径。

## 验证

- 新单测 8 项通过;现有 `UserFilters.test.tsx` 5 项通过。
- Showcase 端到端视觉测试:在 Projects 列表「筛选记录」加一条空值条件(`Organization 等于 [空]`),数据保持 5 条不变;数据请求确认无 `$filter` 下发。

Closes #2364