### PR TITLE
fix(plugin-chatbot): peel Vercel tool-output envelope in isProposalResult (#787 finding B)

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -78,6 +78,7 @@ import {
   SourcesContent,
   Source,
 } from './elements/sources';
+import { parseResultEnvelope } from './mapMessages';
 
 export interface ChatMessage {
   id: string;
@@ -800,20 +801,19 @@ interface ToolSummaryGroup {
  * The tool RETURNED, but its result is a confirm-before-change PREVIEW — the
  * change was proposed, NOT applied. Detects the gate envelopes
  * (`changes_proposed` from granular edits, `blueprint_proposed` /
- * `awaiting_confirmation` from the build flow). Tolerates a JSON-string or
- * object result. #772: without this a proposed edit's activity chip read
- * "Completed" even though it was still waiting for the user to confirm.
+ * `awaiting_confirmation` from the build flow). #772: without this a proposed
+ * edit's activity chip read "Completed" even though it was still waiting for
+ * the user to confirm.
+ *
+ * Uses the shared `parseResultEnvelope` so it peels the Vercel AI SDK tool
+ * output shell `{ type:'text', value:'<json>' }` before reading `.status` —
+ * the real `tool.result` is that wrapped shell, not a bare object/string, so a
+ * hand-rolled `.status` check (which only saw the shell) always returned false
+ * and the collapsed header stayed "Completed" instead of "Awaiting Approval"
+ * (#787 finding B / #2362).
  */
 export function isProposalResult(result: unknown): boolean {
-  let obj: unknown = result;
-  if (typeof obj === 'string') {
-    try {
-      obj = JSON.parse(obj);
-    } catch {
-      return false;
-    }
-  }
-  const status = (obj as { status?: unknown } | null | undefined)?.status;
+  const status = parseResultEnvelope(result)?.status;
   return (
     status === 'changes_proposed' ||
     status === 'blueprint_proposed' ||

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -74,8 +74,13 @@ function extractReasoning(parts: AnyPart[]): string | undefined {
  * The Vercel SDK wraps tool outputs as `{ type: 'text', value: string }`, so we
  * peel one layer if present, then fall back to the raw value. Returns the first
  * candidate that parses to a plain object.
+ *
+ * Exported so `isProposalResult` (ChatbotEnhanced) shares the exact same
+ * envelope-peeling logic — otherwise a wrapped `{type:'text', value:'…'}`
+ * result slips past its `.status` check and the activity chip mis-reads a
+ * still-pending proposal as "Completed" (#787 finding B / #2362).
  */
-function parseResultEnvelope(result: unknown): Record<string, unknown> | undefined {
+export function parseResultEnvelope(result: unknown): Record<string, unknown> | undefined {
   const tryParse = (value: unknown): Record<string, unknown> | undefined => {
     if (value && typeof value === 'object') return value as Record<string, unknown>;
     if (typeof value !== 'string') return undefined;

--- a/packages/plugin-chatbot/src/tool-state.test.ts
+++ b/packages/plugin-chatbot/src/tool-state.test.ts
@@ -15,6 +15,23 @@ describe('isProposalResult', () => {
     expect(isProposalResult('{"status":"changes_proposed"}')).toBe(true);
   });
 
+  // #787 finding B / #2362: the REAL tool.result is the Vercel AI SDK tool
+  // output shell `{ type:'text', value:'<json>' }`, not a bare object/string.
+  // isProposalResult must peel that shell (via parseResultEnvelope) or the
+  // collapsed header reads "Completed" instead of "Awaiting Approval".
+  it('peels the Vercel {type,value} tool-output envelope', () => {
+    expect(
+      isProposalResult({ type: 'text', value: '{"status":"changes_proposed","changes":[]}' }),
+    ).toBe(true);
+    expect(
+      isProposalResult({ type: 'text', value: '{"status":"blueprint_proposed","blueprint":{}}' }),
+    ).toBe(true);
+    // A wrapped, genuinely-applied result stays "Completed".
+    expect(isProposalResult({ type: 'text', value: '{"status":"drafted","drafted":["x"]}' })).toBe(
+      false,
+    );
+  });
+
   it('is false for applied / other results and junk', () => {
     expect(isProposalResult({ status: 'drafted', drafted: ['x'] })).toBe(false);
     expect(isProposalResult({ ok: true })).toBe(false);
@@ -41,6 +58,17 @@ describe('getToolState — proposed preview reads as awaiting', () => {
         toolCallId: 't2',
         toolName: 'propose_blueprint',
         result: { status: 'blueprint_proposed', blueprint: {} },
+      }),
+    ).toBe('awaiting');
+  });
+
+  it('a returned changes_proposed WRAPPED in the Vercel {type,value} shell → awaiting', () => {
+    // The exact shape headerState/renderToolDetail receive at runtime (#787 B).
+    expect(
+      getToolState({
+        toolCallId: 't2b',
+        toolName: 'apply_edit',
+        result: { type: 'text', value: '{"status":"changes_proposed","changes":[{"verb":"add_field"}]}' },
       }),
     ).toBe('awaiting');
   });


### PR DESCRIPTION
## Problem (#787 finding B / #2362)

An iterate "add field" (or a blueprint propose) returns a **confirm-before-change preview** — the change is proposed, **not applied**. The confirm-card body renders correctly ("确认改动 / Confirm this change before it is applied"), but the collapsed activity header still reads **"Add field ✅ Completed"** / **"Propose blueprint ✅ Completed"** instead of **"Awaiting Approval"**.

## Root cause

`isProposalResult(result)` (ChatbotEnhanced.tsx) only understood a **bare object** or **bare JSON string** and read `.status` directly. But the real `tool.result` is the Vercel AI SDK tool-output shell `{ type: 'text', value: '<json>' }`. Reading `.status` on that outer shell yields `undefined`, so `isProposalResult` returned `false` and `getToolState` fell through to `'completed'` — leaving the header badge un-flipped.

By contrast, `mapMessages.ts`'s `detectProposedChanges` peels the shell via `parseResultEnvelope`, which is why the confirm-card **body** rendered while the **header** did not. The two code paths disagreed on the shape of `tool.result`.

## Fix

- Export `parseResultEnvelope` from `mapMessages.ts`.
- `isProposalResult` now delegates to it, so header and body share the **exact same** one-layer envelope peeling (`{type,value}` shell → inner `status`, plus JSON-string and bare-object tolerance).
- No runtime import cycle: `mapMessages` only imports **types** from `ChatbotEnhanced` (erased at build), so the new value import is one-directional at runtime.

## Tests

Extended `tool-state.test.ts`:
- `isProposalResult` peels the `{type:'text', value:'<json>'}` shell for `changes_proposed` / `blueprint_proposed`, and stays `false` for a wrapped `drafted` (applied) result.
- `getToolState` on a returned wrapped `changes_proposed` envelope → `awaiting`.

All 9 tests pass locally (`vitest run packages/plugin-chatbot/src/tool-state.test.ts`).

## Integration

cloud pins objectui at `be8332121c09bde00c224639aec6b19b1280e434`; a companion cloud PR bumps `.objectui-sha` so staging serves this build.


---
_Generated by [Claude Code](https://claude.ai/code/session_017T6rHV8f3cnWupaYUmvvPp)_