### PR TITLE
feat(detail): honor enable.feeds / enable.activities opt-out gates (framework#2707)

### DIFF
--- a/.changeset/enable-feeds-activities-gates.md
+++ b/.changeset/enable-feeds-activities-gates.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/app-shell': minor
+---
+
+feat(detail): honor object `enable.feeds` / `enable.activities` opt-out gates (framework#2707)
+
+RecordDetailView rendered the discussion panel and merged the sys_activity
+timeline unconditionally; the object capability flags gating them were dead.
+Both are now honored with opt-OUT semantics (spec default flips to `true`,
+so absent block/flag = unchanged behavior; only an explicit `false`
+disables):
+
+- `feeds: false` hides the record discussion panel (both the page-schema
+  auto-append and the legacy DetailView `discussionSlot`) and skips the
+  sys_comment fetch. The server independently rejects new comments for such
+  objects (403 FEEDS_DISABLED).
+- `activities: false` skips the sys_activity fetch/merge — the server stops
+  mirroring CRUD for such objects, so this also keeps the network quiet.
+
+Also fixes the long-wrong comment claiming plugin-audit's writers were
+gated by `enable.activities` opt-in (they were unconditional; the new
+contract is opt-out). The History tab gate (`enable.trackHistory === true`)
+is unchanged.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -914,6 +914,17 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     return objects.some((o: any) => o.name === 'sys_audit_log');
   }, [objectDef, objects]);
 
+  // ── Capability gates: enable.feeds / enable.activities (#2707) ─────
+  // Both are opt-OUT capabilities (spec default `true`): absent enable
+  // block/flag = on; only an explicit `false` disables. `feeds:false`
+  // hides the discussion panel and skips the sys_comment fetch (the
+  // server also rejects new comments with 403 FEEDS_DISABLED);
+  // `activities:false` skips the sys_activity timeline fetch/merge (the
+  // server stops mirroring CRUD for such objects, so the fetch would be
+  // empty anyway — skipping keeps the network quiet).
+  const feedsEnabled = objectDef?.enable?.feeds !== false;
+  const activitiesEnabled = objectDef?.enable?.activities !== false;
+
   useEffect(() => {
     if (!dataSource || !pureRecordId || !objectDef || !historyEnabled) {
       setHistoryEntries(null);
@@ -1109,7 +1120,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       }));
     };
 
-    dataSource.find('sys_comment', { $filter: { thread_id: threadId }, $orderby: { created_at: 'asc' } })
+    if (feedsEnabled) dataSource.find('sys_comment', { $filter: { thread_id: threadId }, $orderby: { created_at: 'asc' } })
       .then((res: any) => {
         if (!res?.data?.length) return;
         const mapped: FeedItem[] = res.data.map((c: any) => ({
@@ -1137,9 +1148,10 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
 
     // M10.11: Fetch sys_activity rows for this record and merge into the
     // timeline. plugin-audit's writers populate sys_activity on every
-    // create/update/delete of objects that opt-in via enable.activities,
-    // so this surface — once wired here — gives us a Salesforce-style
-    // "what happened on this record" feed without any per-app glue.
+    // create/update/delete unless the object opts OUT via an explicit
+    // `enable.activities: false` (#2707 — opt-out contract, spec default
+    // true), so this surface gives us a Salesforce-style "what happened
+    // on this record" feed without any per-app glue.
     //
     // We map sys_activity.type to FeedItemType so the existing icon /
     // colour map in RecordActivityTimeline keeps working:
@@ -1166,7 +1178,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       login:     undefined,
       logout:    undefined,
     };
-    dataSource.find('sys_activity', {
+    if (activitiesEnabled) dataSource.find('sys_activity', {
       $filter: { object_name: objectName, record_id: pureRecordId },
       $orderby: { timestamp: 'asc' },
       $top: 200,
@@ -1214,7 +1226,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         });
       })
       .catch(() => {});
-  }, [dataSource, objectName, pureRecordId, currentUser]);
+  }, [dataSource, objectName, pureRecordId, currentUser, feedsEnabled, activitiesEnabled]);
 
   /**
    * Note: comment-mention → notification fan-out lives on the server
@@ -1766,7 +1778,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     // into `regions[]` so `buildDefaultPageSchema` output and
     // full-Lightning authored pages are both detected.
     const hasDiscussion = hasExplicitDiscussion(effectivePage as any);
-    const showAutoDiscussion = !disableDiscussion && !hasDiscussion;
+    // `enable.feeds: false` (#2707) suppresses the discussion panel outright —
+    // same opt-out contract the server enforces on sys_comment creation.
+    const showAutoDiscussion = !disableDiscussion && !hasDiscussion && feedsEnabled;
     // Slice 2 — when we're synthesizing (no author assignedPage), rebuild
     // the schema with the actual detailSchema.sections + highlight fields
     // so record:details renders the same field layout the legacy
@@ -2123,21 +2137,25 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                 onEdit({ id: pureRecordId });
               }}
               discussionSlot={
-                <RecordChatterPanel
-                  config={{
-                    position: 'bottom',
-                    collapsible: false,
-                    feed: {
-                      enableReactions: true,
-                      enableThreading: true,
-                      showCommentInput: true,
-                    },
-                  }}
-                  items={feedItems}
-                  onAddComment={handleAddComment}
-                  onAddReply={handleAddReply}
-                  onToggleReaction={handleToggleReaction}
-                />
+                // `enable.feeds: false` (#2707) suppresses the discussion
+                // panel — same opt-out gate as the page-schema branch above.
+                feedsEnabled ? (
+                  <RecordChatterPanel
+                    config={{
+                      position: 'bottom',
+                      collapsible: false,
+                      feed: {
+                        enableReactions: true,
+                        enableThreading: true,
+                        showCommentInput: true,
+                      },
+                    }}
+                    items={feedItems}
+                    onAddComment={handleAddComment}
+                    onAddReply={handleAddReply}
+                    onToggleReaction={handleToggleReaction}
+                  />
+                ) : undefined
               }
             />
             {modalElement}


### PR DESCRIPTION
## 概述

framework#2707 处置的 objectui 半边:RecordDetailView 此前**无条件**渲染讨论面板并合并 sys_activity timeline——对象能力 flag `enable.feeds`/`enable.activities` 在渲染层是 dead 的。本 PR 让两者按 **opt-out** 契约生效(配套 framework PR 把 spec 默认值翻成 `true`,所以缺省行为完全不变,只有显式 `false` 才关):

- `feeds: false` → 隐藏讨论面板(page-schema 自动追加 + legacy `discussionSlot` 两处),并跳过 sys_comment 拉取;服务端同时 fail-closed(403 `FEEDS_DISABLED`,framework 侧)。
- `activities: false` → 跳过 sys_activity 拉取/合并(服务端已停止镜像该对象,拉了也是空——顺带省一次请求)。

另修正 1140 行错误注释(声称 writer 由 `enable.activities` **opt-in** 门控——实际此前无条件写;新契约是 opt-out)。History 标签页闸门(`enable.trackHistory === true`)保持不变。

## 验证

- `turbo build --filter=@object-ui/app-shell`(tsc)✓
- `turbo test --filter=@object-ui/app-shell` ✓
- 配套 framework 分支端到端冒烟:探针对象(两 flag 显式 false)0 条 activity 镜像、评论 403;默认对象行为不变(activity 镜像 + 评论 201)。

配套:objectstack-ai/framework PR(feat/2707-enable-capability-gates 分支,含 spec 默认翻转 + writer/hook 闸门 + ledger 修正)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)