### PR TITLE
feat(app-shell): book audience gates by permission set — mirror the spec's { permissionSet } shape (ADR-0090)

### DIFF
--- a/.changeset/book-audience-permission-set.md
+++ b/.changeset/book-audience-permission-set.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Book audience mirrors the spec's permission-set gate (ADR-0090).
+
+`@objectstack/spec` renamed the gated arm of `BookAudience` from
+`{ profile: string }` to `{ permissionSet: string }` — ADR-0090 D2 removed
+the Profile concept, and D9 makes the gate a capability reference (a
+permission-set name the reader must hold, e.g. `crm_admin`). Updated the
+three mirrors: the metadata-admin default JSON schema (`book.audience`
+`oneOf`), the `BookPreview` audience chip, and the book list-column
+renderer. One-step rename, no alias, matching the spec's launch-window
+discipline.

--- a/packages/app-shell/src/services/builtinComponents.tsx
+++ b/packages/app-shell/src/services/builtinComponents.tsx
@@ -188,8 +188,8 @@ registerMetadataResource({
       render: (v) =>
         v == null
           ? 'org'
-          : typeof v === 'object' && v && 'profile' in (v as Record<string, unknown>)
-            ? `profile: ${(v as { profile: string }).profile}`
+          : typeof v === 'object' && v && 'permissionSet' in (v as Record<string, unknown>)
+            ? `permission set: ${(v as { permissionSet: string }).permissionSet}`
             : String(v),
     },
     {

--- a/packages/app-shell/src/views/metadata-admin/default-schemas.ts
+++ b/packages/app-shell/src/views/metadata-admin/default-schemas.ts
@@ -260,12 +260,18 @@ const SCHEMAS: Record<string, Record<string, unknown>> = {
       },
       audience: {
         title: 'Audience',
-        description: "Access audience. 'org' (default) inherits the package grant; 'public' is anonymously readable; { profile } gates by role.",
-        // Union of the two scalar literals and the { profile } object — kept lax
-        // so the role-gated object form round-trips untouched through the form.
+        description:
+          "Access audience. 'org' (default) inherits the package grant; 'public' is anonymously readable; { permissionSet } gates by a permission set the reader must hold (ADR-0090).",
+        // Union of the two scalar literals and the { permissionSet } object — kept lax
+        // so the permission-set-gated object form round-trips untouched through the form.
         oneOf: [
           { type: 'string', enum: ['org', 'public'] },
-          { type: 'object', title: 'Role-gated', properties: { profile: { type: 'string', title: 'Profile' } }, required: ['profile'] },
+          {
+            type: 'object',
+            title: 'Permission-set gated',
+            properties: { permissionSet: { type: 'string', title: 'Permission set' } },
+            required: ['permissionSet'],
+          },
         ],
       },
       groups: {

--- a/packages/app-shell/src/views/metadata-admin/previews/BookPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/BookPreview.tsx
@@ -35,7 +35,7 @@ import {
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewErrorBoundary, PreviewEmptyState } from './PreviewShell';
 
-type Audience = 'org' | 'public' | { profile: string } | undefined;
+type Audience = 'org' | 'public' | { permissionSet: string } | undefined;
 type Include = string | { tag: string } | undefined;
 
 interface PageNode {
@@ -116,8 +116,8 @@ function audienceChip(audience: Audience): { icon: React.ReactNode; label: strin
   if (audience === 'public') {
     return { icon: <Globe className="h-3 w-3" />, label: 'Public', tone: 'text-emerald-700 bg-emerald-50 border-emerald-200' };
   }
-  if (audience && typeof audience === 'object' && typeof audience.profile === 'string') {
-    return { icon: <Lock className="h-3 w-3" />, label: `Profile: ${audience.profile}`, tone: 'text-amber-800 bg-amber-50 border-amber-200' };
+  if (audience && typeof audience === 'object' && typeof audience.permissionSet === 'string') {
+    return { icon: <Lock className="h-3 w-3" />, label: `Permission set: ${audience.permissionSet}`, tone: 'text-amber-800 bg-amber-50 border-amber-200' };
   }
   // 'org' (default) or absent — inherits the package grant.
   return { icon: <Building2 className="h-3 w-3" />, label: 'Org', tone: 'text-muted-foreground bg-muted/40 border-muted' };


### PR DESCRIPTION
# Summary

Companion to objectstack-ai/framework#2732, which retires `BookAudience`'s `{ profile: string }` arm — the Profile concept was removed by ADR-0090 D2, and per D9 the gate becomes a **capability reference**: `{ permissionSet: string }`, e.g. `{ permissionSet: 'crm_admin' }` (packages own permission sets but never positions, so a permission-set gate keeps ADR-0086 provenance/uninstall semantics intact). Launch-window one-step rename, no alias.

## Changes

Three UI mirrors of the shape updated in `@object-ui/app-shell`:

- `views/metadata-admin/default-schemas.ts` — the `book.audience` JSON-schema `oneOf` object arm is now `{ permissionSet }`; the form title "Role-gated" (itself a violation of the ADR-0090 D3 word ban in UI copy) becomes "Permission-set gated".
- `views/metadata-admin/previews/BookPreview.tsx` — the audience chip type and renderer read `permissionSet` and label it "Permission set: …".
- `services/builtinComponents.tsx` — the book list's Audience column renders `permission set: …`.

Plus a `minor` changeset for `@object-ui/app-shell`.

## Not in this PR (flagged for follow-up)

`default-schemas.ts` still carries two other pre-ADR-0090 leftovers: a `role` metadata-type schema (with `parentRole` hierarchy — positions are flat per D3) and a `profile` type schema (with `isProfile`, removed by D2). These mirror the framework's `metadata-form-registry.ts`, which still maps `profile: permissionForm`, so removing them cleanly needs a coordinated registry change rather than a drive-by edit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ph4jEAfWDh6taMbZweWhom

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph4jEAfWDh6taMbZweWhom)_