### PR TITLE
fix(components): honor row action visible/disabled CEL in data-table row menu

### DIFF
--- a/.changeset/data-table-row-action-visible-cel.md
+++ b/.changeset/data-table-row-action-visible-cel.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/components': patch
+---
+
+Data-table row menu: honor each custom row action's `visible` (and `disabled`) predicate.
+
+The data-table's inline row overflow menu — used by a record detail page's related list — rendered every custom row action unconditionally, ignoring the action's `visible` CEL. ObjectGrid's row menu already evaluates `visible` per row (`RowActionMenuItem`), so the two row-menu paths disagreed: on an organization's Members tab, `sys_member`'s `transfer_ownership` action (`visible: "record.role != 'owner' && …"`) showed on the owner's own row.
+
+Each custom action now renders through a hook-safe `DataTableRowActionItem` that mirrors `RowActionMenuItem`, evaluating `visible`/`disabled` with `useCondition`/`toPredicateInput` against the same per-row context (`{ ...row, record: row }`); `features`/`user` resolve from the ambient `ExpressionProvider` scope, so gating matches the grid. Rendering-layer only — the action definitions are unchanged.

--- a/packages/components/src/renderers/complex/__tests__/data-table-row-action-visible.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-row-action-visible.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: the data-table's inline row overflow menu must honor a custom
+ * row action's `visible` (and `disabled`) CEL predicate, per-row — the same
+ * way ObjectGrid's `RowActionMenuItem` already does.
+ *
+ * Bug context: a `sys_organization` detail page's Members tab renders member
+ * rows through a related list, which feeds the child object's `list_item`
+ * actions into the data-table as `rowActionDefs`. `sys_member`'s
+ * `transfer_ownership` action declares
+ *   `visible: "record.role != 'owner' && features.organization != false"`,
+ * yet the data-table used to render every custom action unconditionally, so
+ * "Transfer Ownership" showed on the owner's own row. This exercises the
+ * `DataTableRowActionItem` subcomponent that now evaluates the predicate.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { DataTableRowActionItem } from '../data-table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '../../../ui/dropdown-menu';
+
+// The real `sys_member` action definition — the one reported in the bug.
+const TRANSFER_OWNERSHIP = {
+  name: 'transfer_ownership',
+  label: 'Transfer Ownership',
+  visible: "record.role != 'owner' && features.organization != false",
+};
+
+/**
+ * Render a single `DataTableRowActionItem` inside a controlled-open dropdown
+ * menu so the portal content mounts deterministically (Radix triggers open on
+ * `pointerdown`, which is flaky to synthesize in happy-dom). The
+ * `PredicateScopeProvider` supplies the ambient `features` scope the app-shell
+ * feeds in production, so `features.organization` resolves.
+ */
+function renderRowActionItem(action: any, row: any) {
+  return render(
+    <PredicateScopeProvider scope={{ features: { organization: true } }}>
+      <DropdownMenu open modal={false}>
+        <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DataTableRowActionItem action={action} row={row} onActionDef={() => {}} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </PredicateScopeProvider>,
+  );
+}
+
+describe('data-table row action — visible / disabled CEL evaluation', () => {
+  it('hides an action whose `visible` predicate is false for the row (owner)', () => {
+    renderRowActionItem(TRANSFER_OWNERSHIP, { id: '1', role: 'owner', name: 'Olga' });
+    expect(screen.queryByTestId('row-action-transfer_ownership')).toBeNull();
+    expect(screen.queryByText('Transfer Ownership')).toBeNull();
+  });
+
+  it('shows an action whose `visible` predicate is true for the row (member)', () => {
+    renderRowActionItem(TRANSFER_OWNERSHIP, { id: '2', role: 'member', name: 'Mel' });
+    expect(screen.getByTestId('row-action-transfer_ownership')).toBeInTheDocument();
+    expect(screen.getByText('Transfer Ownership')).toBeInTheDocument();
+  });
+
+  it('supports the `record.` scope for the visible predicate', () => {
+    // Same predicate, referenced via the bare-field scope should behave the
+    // same as `record.` — assert the bare-field convention also resolves.
+    const bareField = { name: 'transfer_ownership', label: 'Transfer Ownership', visible: "role != 'owner'" };
+    renderRowActionItem(bareField, { id: '1', role: 'owner' });
+    expect(screen.queryByTestId('row-action-transfer_ownership')).toBeNull();
+  });
+
+  it('renders an action with no `visible` predicate unconditionally', () => {
+    renderRowActionItem({ name: 'view_profile', label: 'View Profile' }, { id: '1', role: 'owner' });
+    expect(screen.getByTestId('row-action-view_profile')).toBeInTheDocument();
+    expect(screen.getByText('View Profile')).toBeInTheDocument();
+  });
+
+  it('evaluates a `disabled` CEL predicate against the row (disabled on owner)', () => {
+    renderRowActionItem(
+      { name: 'edit_member', label: 'Edit', disabled: "record.role == 'owner'" },
+      { id: '1', role: 'owner' },
+    );
+    const item = screen.getByTestId('row-action-edit_member');
+    expect(item).toBeInTheDocument();
+    expect(item).toHaveAttribute('data-disabled');
+  });
+
+  it('leaves the action enabled when its `disabled` CEL is false (member)', () => {
+    renderRowActionItem(
+      { name: 'edit_member', label: 'Edit', disabled: "record.role == 'owner'" },
+      { id: '2', role: 'member' },
+    );
+    const item = screen.getByTestId('row-action-edit_member');
+    expect(item).toBeInTheDocument();
+    expect(item).not.toHaveAttribute('data-disabled');
+  });
+
+  it('supports a boolean `disabled` flag', () => {
+    renderRowActionItem(
+      { name: 'locked_action', label: 'Locked', disabled: true },
+      { id: '1', role: 'member' },
+    );
+    expect(screen.getByTestId('row-action-locked_action')).toHaveAttribute('data-disabled');
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -13,7 +13,7 @@ import { resolveIcon } from '../action/resolve-icon';
 import { useGridFieldAuthoring } from '../../context/gridFieldAuthoring';
 import { ComponentRegistry } from '@object-ui/core';
 import type { DataTableSchema } from '@object-ui/types';
-import { useObjectTranslation } from '@object-ui/react';
+import { useObjectTranslation, useCondition, toPredicateInput } from '@object-ui/react';
 import { 
   Table, 
   TableHeader, 
@@ -207,6 +207,71 @@ function extractSaveErrorMessage(error: unknown): string {
   }
   return typeof error === 'string' && error.trim() ? error.trim() : 'Unknown error';
 }
+
+/**
+ * The element type of `DataTableSchema.rowActionDefs`. Derived via indexed
+ * access rather than imported by name: `@object-ui/types` defines
+ * `DataTableRowAction` but doesn't re-export it from its public entry, so it's
+ * only reachable structurally through `DataTableSchema`.
+ */
+type RowActionDef = NonNullable<DataTableSchema['rowActionDefs']>[number];
+
+/**
+ * One schema-driven custom row action in the data-table's inline row overflow
+ * menu. Extracted into its own component so the action's `visible` (and
+ * `disabled`) CEL predicate can be evaluated with a hook (`useCondition`)
+ * without violating the rules-of-hooks inside a `.map()`.
+ *
+ * Mirrors `RowActionMenuItem` on the ObjectGrid path so BOTH row-menu
+ * renderers honor `visible`/`disabled` identically. Previously this path
+ * (used by a detail page's related list) rendered every custom action
+ * unconditionally, so e.g. a member row's "Transfer Ownership"
+ * (`visible: "record.role != 'owner' && …"`) showed on the owner's own row.
+ *
+ * Bare field references (`role`) resolve against the row record and `record.`
+ * references (`record.role`) against the same, while `features`/`user` come
+ * from the ambient ExpressionProvider scope — so gating stays consistent with
+ * the grid's own row menu.
+ *
+ * Exported for unit tests — NOT part of the package's public API: the
+ * `@object-ui/components` barrel only side-effect-imports this module (to run
+ * its `ComponentRegistry.register`), so this named export is reachable solely
+ * via the deep module path the colocated test uses.
+ */
+export const DataTableRowActionItem: React.FC<{
+  action: RowActionDef;
+  row: any;
+  onActionDef?: (action: RowActionDef, row: any) => void | Promise<void>;
+}> = ({ action, row, onActionDef }) => {
+  const predicateCtx = { ...(row && typeof row === 'object' ? row : {}), record: row };
+  const visiblePred = action.visible;
+  const isVisible = useCondition(toPredicateInput(visiblePred), predicateCtx);
+  // `disabled` may be a boolean or a CEL predicate evaluated against the row
+  // (e.g. grey out an action once a record reaches a terminal state).
+  const disabledPred = toPredicateInput(action.disabled);
+  const evalDisabled = useCondition(
+    typeof disabledPred === 'string' ? disabledPred : undefined,
+    predicateCtx,
+  );
+  const isDisabled = typeof disabledPred === 'string' ? evalDisabled : disabledPred === true;
+  if (visiblePred && !isVisible) return null;
+  const ActionIcon = resolveIcon(action.icon);
+  return (
+    <DropdownMenuItem
+      disabled={isDisabled}
+      onClick={() => { if (!isDisabled) void onActionDef?.(action, row); }}
+      data-testid={`row-action-${action.name}`}
+      className={cn(
+        action.variant === 'danger' && 'text-destructive focus:text-destructive',
+      )}
+    >
+      {/* Dynamic icon resolution from Lucide, not component creation during render */}
+      {/* eslint-disable-next-line react-hooks/static-components */}
+      {ActionIcon && <ActionIcon className="mr-2 h-4 w-4" />}
+      {action.label || action.name}
+    </DropdownMenuItem>
+  );
+};
 
 /**
  * Enterprise-level data table component with Airtable-like features.
@@ -1533,21 +1598,14 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                         list surfacing the child's `list_item`
                                         actions). Dispatched with the clicked row. */}
                                     {customActions.length > 0 && schema.onRowEdit && <DropdownMenuSeparator />}
-                                    {customActions.map((action) => {
-                                      const ActionIcon = resolveIcon(action.icon);
-                                      return (
-                                        <DropdownMenuItem
-                                          key={action.name}
-                                          onClick={() => { void schema.onRowActionDef?.(action, row); }}
-                                          className={cn(
-                                            action.variant === 'danger' && 'text-destructive focus:text-destructive',
-                                          )}
-                                        >
-                                          {ActionIcon && <ActionIcon className="mr-2 h-4 w-4" />}
-                                          {action.label || action.name}
-                                        </DropdownMenuItem>
-                                      );
-                                    })}
+                                    {customActions.map((action) => (
+                                      <DataTableRowActionItem
+                                        key={action.name}
+                                        action={action}
+                                        row={row}
+                                        onActionDef={schema.onRowActionDef}
+                                      />
+                                    ))}
                                     {schema.onRowDelete && (schema.onRowEdit || customActions.length > 0) && <DropdownMenuSeparator />}
                                     {schema.onRowDelete && (
                                       <DropdownMenuItem


### PR DESCRIPTION
## Summary

The data-table's inline row overflow menu — used by a record detail page's **related list** — rendered every custom row action unconditionally, ignoring each action's `visible` predicate. ObjectGrid's own row menu already evaluates `visible` per row (via `RowActionMenuItem`), so the two row-menu paths disagreed.

Concretely: on a `sys_organization` detail page's **Members** tab, `sys_member`'s `transfer_ownership` action — `visible: "record.role != 'owner' && features.organization != false"` — showed on the **owner's own row**, where it should be hidden.

## Root cause

Two row-menu render paths exist; only one evaluated `visible`:

- **ObjectView → ObjectGrid → `RowActionMenu`** (`plugin-grid`): `RowActionMenuItem` evaluates `visible`/`disabled` per row via `useCondition(toPredicateInput(...))`. ✅ correct.
- **RelatedList (`plugin-detail`) → data-table** (`components`): the inline row menu's `customActions.map(...)` rendered each `DropdownMenuItem` directly, evaluating nothing. ❌ the bug.

RelatedList feeds the child object's `list_item` actions into the data-table as `schema.rowActionDefs` (`visible` is preserved end-to-end — `RelatedRecordActionsBridge`'s `deriveActions` spreads the whole action def), but the data-table never looked at it.

## Fix

Extract each custom action into a hook-safe `DataTableRowActionItem` that mirrors `RowActionMenuItem`:

- Evaluate `visible` (and `disabled`) with `useCondition` / `toPredicateInput` (already a dependency of `@object-ui/components`).
- Same per-row predicate context — `{ ...row, record: row }` — so bare-field (`role`) and `record.` (`record.role`) conventions both resolve, and `features`/`user` come from the ambient `ExpressionProvider` scope, identical to the grid.
- `return null` when hidden; honor a boolean-or-CEL `disabled`.

The child-component extraction is required by the rules-of-hooks (can't call `useCondition` inside a `.map()` callback) — the same reason `plugin-grid` has `RowActionMenuItem`. A direct import of `RowActionMenu` would create a `plugin-grid → components` dependency cycle, so the small `useCondition` pattern is duplicated (a few lines) rather than imported.

## Scope / non-goals

- **Rendering-layer only.** The `transfer_ownership` action definition is already correct — the bug was purely that the data-table render path didn't evaluate it. No action defs, no `better-auth`/permission logic touched. (The server already rejects an unauthorized transfer, so this was a display bug, not a security hole.)
- ObjectGrid / `RowActionMenu` are **unchanged** (already correct).

## Testing

- New colocated unit test `data-table-row-action-visible.test.tsx` (7 cases): owner row **hides** Transfer Ownership, member row **shows** it, bare-field scope, no-`visible` renders unconditionally, `disabled` CEL true/false, boolean `disabled`.
- Existing data-table suites stay green — row-click, inline-edit, manual-pagination, registration metadata (22 tests).
- `tsc --noEmit` clean; ESLint clean on the changed files.
- Browser E2E (Cloud → Team → org record Members tab) should be run in the full stack; it is not runnable in this CI container.

Adds a `patch` changeset for `@object-ui/components`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011wxYurB3RKgRyCP9nZJ7co)_