### PR TITLE
feat(detail): generic record Attachments panel gated on enable.files (framework#2727)

### DIFF
--- a/.changeset/record-attachments-panel.md
+++ b/.changeset/record-attachments-panel.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/app-shell': minor
+---
+
+feat(detail): generic record Attachments panel gated on `enable.files: true` (framework#2727)
+
+New `RecordAttachmentsPanel` — Salesforce "Notes & Attachments" parity for
+any object that opts in via `enable: { files: true }`:
+
+- Upload via the canonical presigned three-step storage flow
+  (`createObjectStackUploadAdapter`; blob → `sys_file`), then a
+  `sys_attachment` join row targeting `(parent_object, parent_id)`.
+- List (name/size/mime), stable download links
+  (`/api/v1/storage/files/:fileId` 302-redirect endpoint), delete.
+- Rendered by RecordDetailView in both the page-schema and legacy branches.
+  Opt-in: objects without the flag see no panel, and the server
+  independently rejects attachment rows targeting them
+  (403 FILES_DISABLED).

--- a/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
+++ b/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
@@ -1,0 +1,242 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from 'react';
+import { cn, Button } from '@object-ui/components';
+import { Paperclip, Upload, Trash2, Download, Loader2 } from 'lucide-react';
+import { createObjectStackUploadAdapter } from '@object-ui/providers';
+import { useObjectTranslation } from '@object-ui/react';
+
+/**
+ * RecordAttachmentsPanel — generic record Attachments surface (#2727,
+ * Salesforce "Notes & Attachments" parity).
+ *
+ * Rendered by RecordDetailView ONLY when the object declares
+ * `enable: { files: true }` (opt-in; the server rejects sys_attachment
+ * rows targeting any other object with 403 FILES_DISABLED, so this panel
+ * and the enforcement seam always agree).
+ *
+ * Storage model: one `sys_file` row per uploaded blob (three-step
+ * presigned upload via @object-ui/providers' ObjectStack adapter), one
+ * `sys_attachment` join row linking it to `(parent_object, parent_id)`.
+ * Downloads go through the stable `/storage/files/:fileId` endpoint,
+ * which 302-redirects to a freshly signed URL on every request.
+ */
+
+interface AttachmentRow {
+  id: string;
+  file_id: string;
+  file_name?: string | null;
+  mime_type?: string | null;
+  size?: number | null;
+  created_at?: string | null;
+  uploaded_by?: string | null;
+}
+
+export interface RecordAttachmentsPanelProps {
+  objectName: string;
+  recordId: string;
+  /** ObjectUI DataSource (sys_attachment CRUD goes through the generic data path). */
+  dataSource: any;
+  /** Current user id, stamped on `uploaded_by`. */
+  currentUserId?: string | null;
+  className?: string;
+}
+
+function formatSize(bytes?: number | null): string {
+  if (bytes == null || !Number.isFinite(bytes)) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
+  objectName,
+  recordId,
+  dataSource,
+  currentUserId,
+  className,
+}) => {
+  const { t } = useObjectTranslation();
+  const [rows, setRows] = React.useState<AttachmentRow[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [uploading, setUploading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  // Same base-URL convention as RecordDetailView's raw API fetches: the
+  // Vite dev console proxies same-origin `/api` unless VITE_SERVER_URL
+  // points elsewhere.
+  const baseUrl = (import.meta as any).env?.VITE_SERVER_URL || '';
+  const adapter = React.useMemo(
+    () => createObjectStackUploadAdapter({ baseUrl, scope: 'attachments' }),
+    [baseUrl],
+  );
+
+  const refresh = React.useCallback(async () => {
+    if (!dataSource || !objectName || !recordId) return;
+    setLoading(true);
+    try {
+      const res: any = await dataSource.find('sys_attachment', {
+        $filter: { parent_object: objectName, parent_id: recordId },
+        $orderby: { created_at: 'desc' },
+        $top: 100,
+      });
+      const items: AttachmentRow[] = Array.isArray(res) ? res : res?.data ?? [];
+      setRows(items);
+    } catch {
+      // A 404 (table not provisioned on older stacks) is tolerated silently;
+      // the panel just stays empty.
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [dataSource, objectName, recordId]);
+
+  React.useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleFiles = React.useCallback(
+    async (files: FileList | null) => {
+      if (!files || files.length === 0 || !dataSource) return;
+      setUploading(true);
+      setError(null);
+      try {
+        for (const file of Array.from(files)) {
+          // 1) blob → sys_file via the canonical presigned three-step flow
+          const uploaded = await adapter.upload(file);
+          const fileId = (uploaded.meta as any)?.fileId as string | undefined;
+          if (!fileId) throw new Error('Upload did not return a fileId');
+          // 2) join row → sys_attachment (server enforces enable.files)
+          await dataSource.create('sys_attachment', {
+            parent_object: objectName,
+            parent_id: recordId,
+            file_id: fileId,
+            file_name: uploaded.name ?? file.name,
+            mime_type: uploaded.mimeType ?? file.type,
+            size: uploaded.size ?? file.size,
+            ...(currentUserId ? { uploaded_by: currentUserId } : {}),
+          });
+        }
+        await refresh();
+      } catch (err: any) {
+        setError(String(err?.message ?? err));
+      } finally {
+        setUploading(false);
+        if (inputRef.current) inputRef.current.value = '';
+      }
+    },
+    [adapter, dataSource, objectName, recordId, currentUserId, refresh],
+  );
+
+  const handleDelete = React.useCallback(
+    async (row: AttachmentRow) => {
+      if (!dataSource) return;
+      setError(null);
+      try {
+        await dataSource.delete('sys_attachment', row.id);
+        setRows((prev) => prev.filter((r) => r.id !== row.id));
+      } catch (err: any) {
+        setError(String(err?.message ?? err));
+      }
+    },
+    [dataSource],
+  );
+
+  return (
+    <div className={cn('rounded-lg border bg-card', className)} data-testid="record-attachments-panel">
+      <div className="flex items-center justify-between px-4 py-3 border-b">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Paperclip className="h-4 w-4 text-muted-foreground" />
+          <span>{t('detail.attachments', { defaultValue: 'Attachments' })}</span>
+          {rows.length > 0 && (
+            <span className="text-xs text-muted-foreground">({rows.length})</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            ref={inputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(e) => void handleFiles(e.target.files)}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={uploading}
+            onClick={() => inputRef.current?.click()}
+          >
+            {uploading ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <Upload className="h-4 w-4 mr-1" />
+            )}
+            {t('detail.uploadAttachment', { defaultValue: 'Upload' })}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-4 py-2 text-xs text-destructive border-b" role="alert">
+          {error}
+        </div>
+      )}
+
+      {loading && rows.length === 0 ? (
+        <div className="px-4 py-6 text-sm text-muted-foreground flex items-center gap-2">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {t('detail.loadingAttachments', { defaultValue: 'Loading attachments…' })}
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="px-4 py-6 text-sm text-muted-foreground">
+          {t('detail.noAttachments', { defaultValue: 'No attachments yet. Upload a file to get started.' })}
+        </div>
+      ) : (
+        <ul className="divide-y">
+          {rows.map((row) => (
+            <li key={row.id} className="flex items-center gap-3 px-4 py-2.5">
+              <Paperclip className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm">{row.file_name || row.file_id}</div>
+                <div className="text-xs text-muted-foreground">
+                  {[formatSize(row.size), row.mime_type || undefined]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </div>
+              </div>
+              <a
+                href={`${baseUrl}/api/v1/storage/files/${encodeURIComponent(row.file_id)}`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex"
+                aria-label={t('detail.downloadAttachment', { defaultValue: 'Download' })}
+              >
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Download className="h-4 w-4" />
+                </Button>
+              </a>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                aria-label={t('detail.deleteAttachment', { defaultValue: 'Delete attachment' })}
+                onClick={() => void handleDelete(row)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default RecordAttachmentsPanel;

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -34,6 +34,7 @@ import { useRecordBreadcrumbTitle } from '../context/NavigationContext';
 import type { DetailViewSchema, FeedItem, HighlightField } from '@object-ui/types';
 import type { ActionDef, ActionParamDef } from '@object-ui/core';
 import { useRecordApprovals } from '../hooks/useRecordApprovals';
+import { RecordAttachmentsPanel } from './RecordAttachmentsPanel';
 import { getRecordDisplayName } from '../utils';
 import { useFavorites } from '../hooks/useFavorites';
 import { useActionModal } from '../hooks/useActionModal';
@@ -924,6 +925,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // empty anyway — skipping keeps the network quiet).
   const feedsEnabled = objectDef?.enable?.feeds !== false;
   const activitiesEnabled = objectDef?.enable?.activities !== false;
+  // `enable.files` (#2727) is opt-IN (spec default `false`): the generic
+  // Attachments panel is a new surface, so it only renders when the object
+  // explicitly declares it. The server enforces the same gate on
+  // sys_attachment creation (403 FILES_DISABLED).
+  const filesEnabled = objectDef?.enable?.files === true;
 
   useEffect(() => {
     if (!dataSource || !pureRecordId || !objectDef || !historyEnabled) {
@@ -2012,6 +2018,19 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                 >
                   <SchemaRenderer schema={withPageTabsUrlSync(renderedPage, { defaultTab: activeTabParam, onTabChange: handleTabChange }) as any} />
                 </RelatedRecordActionsBridge>
+                {/* Generic Attachments panel (#2727) — opt-in via
+                    `enable.files: true`; the server rejects attachments
+                    targeting any other object (403 FILES_DISABLED). */}
+                {filesEnabled && pureRecordId && (
+                  <div className="mt-6">
+                    <RecordAttachmentsPanel
+                      objectName={objectName!}
+                      recordId={pureRecordId}
+                      dataSource={dataSource}
+                      currentUserId={currentUser?.id}
+                    />
+                  </div>
+                )}
                 {/* Auto-append RecordChatterPanel only when the page
                     schema doesn't already place a `record:discussion` /
                     `record:chatter` component. Hard opt-out via
@@ -2138,23 +2157,36 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
               }}
               discussionSlot={
                 // `enable.feeds: false` (#2707) suppresses the discussion
-                // panel — same opt-out gate as the page-schema branch above.
-                feedsEnabled ? (
-                  <RecordChatterPanel
-                    config={{
-                      position: 'bottom',
-                      collapsible: false,
-                      feed: {
-                        enableReactions: true,
-                        enableThreading: true,
-                        showCommentInput: true,
-                      },
-                    }}
-                    items={feedItems}
-                    onAddComment={handleAddComment}
-                    onAddReply={handleAddReply}
-                    onToggleReaction={handleToggleReaction}
-                  />
+                // panel; `enable.files: true` (#2727) adds the Attachments
+                // panel — same gates as the page-schema branch above.
+                feedsEnabled || filesEnabled ? (
+                  <div className="space-y-4">
+                    {filesEnabled && pureRecordId && (
+                      <RecordAttachmentsPanel
+                        objectName={objectName!}
+                        recordId={pureRecordId}
+                        dataSource={dataSource}
+                        currentUserId={currentUser?.id}
+                      />
+                    )}
+                    {feedsEnabled && (
+                      <RecordChatterPanel
+                        config={{
+                          position: 'bottom',
+                          collapsible: false,
+                          feed: {
+                            enableReactions: true,
+                            enableThreading: true,
+                            showCommentInput: true,
+                          },
+                        }}
+                        items={feedItems}
+                        onAddComment={handleAddComment}
+                        onAddReply={handleAddReply}
+                        onToggleReaction={handleToggleReaction}
+                      />
+                    )}
+                  </div>
                 ) : undefined
               }
             />


### PR DESCRIPTION
## 概述

framework#2727 的 objectui 半边:新 `RecordAttachmentsPanel`,给通过 `enable: { files: true }` **显式 opt-in** 的对象提供 Salesforce "Notes & Attachments" 级的记录附件面板:

- **上传**:走 canonical 三步 presigned 流(`createObjectStackUploadAdapter`,blob → `sys_file`),然后写 `sys_attachment` join 行(`parent_object`/`parent_id`)。
- **列表/下载/删除**:文件名+大小+MIME;下载走稳定端点 `/api/v1/storage/files/:fileId`(302 到新签名 URL);删除走通用 data 路径。
- RecordDetailView 两个渲染分支(page-schema + legacy `discussionSlot`)都接入;**opt-in**:没设 flag 的对象不渲染面板,服务端也独立拒绝指向它们的附件行(403 `FILES_DISABLED`,framework 侧)。

## 验证

- `turbo build --filter=@object-ui/app-shell`(tsc)✓;app-shell 测试 151 文件/1164 用例 ✓
- **浏览器实测**(console dev :5199 → fresh showcase 后端):`files:true` 探针对象=面板渲染、列出 API 上传的附件、下载返回原始字节;无 flag 对象=记录页正常但无面板
- 顺带坑:console 的 auth 客户端直连 `VITE_SERVER_URL`(默认 :3000)而非 Vite 代理——dev 验证两者都要指到同一后端

配套:objectstack-ai/framework PR(feat/2727-generic-attachments,FILES_DISABLED 闸门 + ledger files→live)。合并顺序:framework 先(闸门先在,面板后到=安全;反序则面板先到、无闸门=可写但无强制,窗口小但没必要)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)