### PR TITLE
fix: honor action visible/enabled CEL in three more action renderers

### DIFF
--- a/.changeset/action-visible-cel-followups.md
+++ b/.changeset/action-visible-cel-followups.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/components': patch
+'@object-ui/plugin-detail': patch
+'@object-ui/plugin-grid': patch
+---
+
+Honor action `visible` (and `enabled`) predicates in three more action renderers.
+
+Following the data-table row-action fix, three sibling renderers still rendered schema-defined actions without evaluating their `visible` CEL predicate:
+
+- **`action:group` dropdown mode** (`@object-ui/components`) — dropdown items ignored `visible`/`enabled`, while the group's inline mode already honored them.
+- **Related-list `list_toolbar` header actions** (`@object-ui/plugin-detail`) — e.g. an organization's "Invite User" button ignored `visible`, even though the sibling row actions (fed by the same `deriveActions` bridge) already honored it via the data-table's `DataTableRowActionItem`.
+- **Grid bulk-action bar** (`@object-ui/plugin-grid`) — `bulkActionDefs.visible` was ignored entirely; the button is now hidden when the predicate is false (the `BulkActionDef.visible` doc comment is corrected from "disables" to "hides" to match).
+
+Each now evaluates `visible` (and, where applicable, `enabled`) via a hook-safe per-item component that mirrors `RowActionMenuItem` / `DataTableRowActionItem`, resolving `features`/`user` from the ambient `ExpressionProvider` scope. Rendering-layer only — no action definitions changed.

--- a/packages/components/src/renderers/action/__tests__/action-group-dropdown-visible.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-group-dropdown-visible.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: an `action:group` in `display: 'dropdown'` mode must honor each
+ * action's `visible` (and `enabled`) CEL predicate — the same way the group's
+ * inline mode (`InlineActionButton`) already does. Previously the dropdown
+ * branch mapped `schema.actions` straight to `DropdownMenuItem`s, so an action
+ * whose `visible` said to hide it showed anyway.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { DropdownActionItem } from '../action-group';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '../../../ui';
+
+// Render a single dropdown action item inside a controlled-open menu so the
+// portal content mounts deterministically (Radix triggers open on pointerdown,
+// which is flaky to synthesize in happy-dom). `visible`/`enabled` resolve
+// against the ambient ExpressionProvider scope, matching `InlineActionButton`.
+function renderItem(action: any, scope: Record<string, any> = {}) {
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <DropdownMenu open modal={false}>
+        <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownActionItem action={action} index={0} onSelect={() => {}} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </PredicateScopeProvider>,
+  );
+}
+
+describe('action:group dropdown item — visible / enabled CEL', () => {
+  it('hides an action whose `visible` predicate is false', () => {
+    renderItem(
+      { name: 'archive', label: 'Archive', visible: 'features.canArchive == true' },
+      { features: { canArchive: false } },
+    );
+    expect(screen.queryByText('Archive')).toBeNull();
+  });
+
+  it('shows an action whose `visible` predicate is true', () => {
+    renderItem(
+      { name: 'archive', label: 'Archive', visible: 'features.canArchive == true' },
+      { features: { canArchive: true } },
+    );
+    expect(screen.getByText('Archive')).toBeInTheDocument();
+  });
+
+  it('renders an action with no `visible` predicate', () => {
+    renderItem({ name: 'view', label: 'View' });
+    expect(screen.getByText('View')).toBeInTheDocument();
+  });
+
+  it('disables (but still renders) an action whose `enabled` CEL is false', () => {
+    renderItem(
+      { name: 'run', label: 'Run', enabled: 'features.ready == true' },
+      { features: { ready: false } },
+    );
+    const item = screen.getByText('Run').closest('[role="menuitem"]');
+    expect(item).toBeTruthy();
+    expect(item).toHaveAttribute('data-disabled');
+  });
+});

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -105,6 +105,53 @@ const InlineActionButton: React.FC<{
 
 InlineActionButton.displayName = 'InlineActionButton';
 
+/**
+ * One action inside an `action:group`'s dropdown (overflow) menu. Extracted
+ * into its own component so the action's `visible`/`enabled` CEL predicate can
+ * be evaluated with a hook (`useCondition`) without violating the
+ * rules-of-hooks inside a `.map()`. Mirrors `InlineActionButton` (the
+ * inline-mode leaf) so BOTH display modes honor `visible`/`enabled`
+ * identically — previously the dropdown branch rendered every action
+ * unconditionally, so an action with `visible: "record.role != 'owner'"`
+ * showed even when its predicate was false.
+ */
+export const DropdownActionItem: React.FC<{
+  action: ActionSchema;
+  index: number;
+  onSelect: (action: ActionSchema) => void | Promise<void>;
+}> = ({ action, index, onSelect }) => {
+  const isVisible = useCondition(toPredicateInput(action.visible));
+  const isEnabled = useCondition(toPredicateInput(action.enabled));
+  if (action.visible && !isVisible) return null;
+  const Icon = resolveIcon(action.icon);
+  const isDisabled = action.enabled ? !isEnabled : false;
+  const showSeparator = action.tags?.includes('separator-before') && index > 0;
+  return (
+    <>
+      {showSeparator && <DropdownMenuSeparator />}
+      <DropdownMenuItem
+        disabled={isDisabled}
+        onSelect={async (e) => {
+          e.preventDefault();
+          if (isDisabled) return;
+          await onSelect(action);
+        }}
+        className={cn(
+          (action.variant as string) === 'destructive' && 'text-destructive focus:text-destructive',
+          action.className,
+        )}
+      >
+        {/* Dynamic icon resolution from Lucide, not component creation during render */}
+        {/* eslint-disable-next-line react-hooks/static-components */}
+        {Icon && <Icon className="mr-2 h-4 w-4" />}
+        <span>{action.label || action.name}</span>
+      </DropdownMenuItem>
+    </>
+  );
+};
+
+DropdownActionItem.displayName = 'DropdownActionItem';
+
 const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSchema; [key: string]: any }>(
   ({ schema, className, ...props }, ref) => {
     const {
@@ -150,6 +197,20 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
       [execute],
     );
 
+    // Dropdown items share the trigger's loading spinner, so wrap execution to
+    // toggle `dropdownLoading` (inline items manage their own local loading).
+    const handleDropdownSelect = useCallback(
+      async (action: ActionSchema) => {
+        setDropdownLoading(true);
+        try {
+          await handleExecute(action);
+        } finally {
+          setDropdownLoading(false);
+        }
+      },
+      [handleExecute],
+    );
+
     if (schema.visible && !isVisible) return null;
     if (actions.length === 0) return null;
 
@@ -177,33 +238,14 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
           </DropdownMenuTrigger>
 
           <DropdownMenuContent align="end">
-            {actions.map((action, index) => {
-              const Icon = resolveIcon(action.icon);
-              const showSeparator = action.tags?.includes('separator-before') && index > 0;
-              return (
-                <React.Fragment key={action.name || index}>
-                  {showSeparator && <DropdownMenuSeparator />}
-                  <DropdownMenuItem
-                    onSelect={async (e) => {
-                      e.preventDefault();
-                      setDropdownLoading(true);
-                      try {
-                        await handleExecute(action);
-                      } finally {
-                        setDropdownLoading(false);
-                      }
-                    }}
-                    className={cn(
-                      action.variant === 'destructive' && 'text-destructive focus:text-destructive',
-                      action.className,
-                    )}
-                  >
-                    {Icon && <Icon className="mr-2 h-4 w-4" />}
-                    <span>{action.label || action.name}</span>
-                  </DropdownMenuItem>
-                </React.Fragment>
-              );
-            })}
+            {actions.map((action, index) => (
+              <DropdownActionItem
+                key={action.name || index}
+                action={action}
+                index={index}
+                onSelect={handleDropdownSelect}
+              />
+            ))}
           </DropdownMenuContent>
         </DropdownMenu>
       );

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -26,7 +26,7 @@ import {
   cn,
   useIsMobile,
 } from '@object-ui/components';
-import { SchemaRenderer, type RelatedRowActionDef } from '@object-ui/react';
+import { SchemaRenderer, useCondition, toPredicateInput, type RelatedRowActionDef } from '@object-ui/react';
 import {
   Plus,
   ExternalLink,
@@ -138,6 +138,45 @@ function resolveIconComponent(name: string | undefined): LucideIcon {
     .join('');
   return ((lucideIcons as Record<string, LucideIcon>)[pascal]) || Inbox;
 }
+
+/**
+ * One `list_toolbar` action button on a related-list header (e.g. "Invite
+ * User" on an organization's Invitations list). Extracted into its own
+ * component so the action's `visible` CEL predicate can be evaluated with a
+ * hook (`useCondition`) without violating the rules-of-hooks inside a `.map()`.
+ *
+ * The SAME bridge (`RelatedRecordActionsBridge.deriveActions`) feeds both a
+ * child object's row actions (`list_item`) and these header toolbar actions
+ * (`list_toolbar`), spreading each action's `visible` predicate through
+ * untouched. The row path already honors `visible` (via the data-table's
+ * `DataTableRowActionItem`); this brings the toolbar path to parity so e.g.
+ * `invite_user` (`visible: "features.organization != false"`) hides when its
+ * predicate is false. `features`/`user` resolve from the ambient
+ * ExpressionProvider scope.
+ */
+export const RelatedToolbarButton: React.FC<{
+  action: RelatedRowActionDef;
+  onToolbarAction: (action: RelatedRowActionDef) => void | Promise<void>;
+}> = ({ action, onToolbarAction }) => {
+  const visiblePred = action.visible;
+  const isVisible = useCondition(toPredicateInput(visiblePred));
+  if (visiblePred && !isVisible) return null;
+  const ActionIcon = action.icon ? resolveIconComponent(action.icon) : null;
+  return (
+    <Button
+      variant={action.variant === 'primary' ? 'default' : 'outline'}
+      size="sm"
+      onClick={(e) => { e.stopPropagation(); void onToolbarAction(action); }}
+      className="gap-1 h-9 sm:h-7 text-xs shadow-none"
+      data-testid={`related-toolbar-action-${action.name}`}
+    >
+      {/* Dynamic icon resolution from Lucide, not component creation during render */}
+      {/* eslint-disable-next-line react-hooks/static-components */}
+      {ActionIcon && <ActionIcon className="h-3.5 w-3.5" />}
+      {action.label || action.name}
+    </Button>
+  );
+};
 
 export const RelatedList: React.FC<RelatedListProps> = ({
   title,
@@ -755,21 +794,13 @@ export const RelatedList: React.FC<RelatedListProps> = ({
             {/* Child-object list_toolbar actions (e.g. Invite User) — the
                 related-list equivalent of the object list's toolbar buttons.
                 Rendered before Add/New so the domain action leads. */}
-            {onToolbarAction && (toolbarActions ?? []).map((a) => {
-              const ActionIcon = a.icon ? resolveIconComponent(a.icon) : null;
-              return (
-                <Button
-                  key={a.name}
-                  variant={a.variant === 'primary' ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={(e) => { e.stopPropagation(); void onToolbarAction(a); }}
-                  className="gap-1 h-9 sm:h-7 text-xs shadow-none"
-                >
-                  {ActionIcon && <ActionIcon className="h-3.5 w-3.5" />}
-                  {a.label || a.name}
-                </Button>
-              );
-            })}
+            {onToolbarAction && (toolbarActions ?? []).map((a) => (
+              <RelatedToolbarButton
+                key={a.name}
+                action={a}
+                onToolbarAction={onToolbarAction}
+              />
+            ))}
             {add && (
               <Button
                 variant={isEmpty ? 'ghost' : 'outline'}

--- a/packages/plugin-detail/src/__tests__/related-toolbar-visible.test.tsx
+++ b/packages/plugin-detail/src/__tests__/related-toolbar-visible.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: a related list's `list_toolbar` header actions must honor each
+ * action's `visible` CEL predicate. The same bridge (`deriveActions`) feeds
+ * both the row actions (`list_item`, honored via the data-table's
+ * `DataTableRowActionItem`) and these header buttons (`list_toolbar`); the
+ * toolbar path used to render every action unconditionally, so e.g.
+ * `invite_user` (`visible: "features.organization != false"`) showed even when
+ * the org feature was disabled.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { RelatedToolbarButton } from '../RelatedList';
+
+function renderButton(action: any, scope: Record<string, any> = {}) {
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <RelatedToolbarButton action={action} onToolbarAction={() => {}} />
+    </PredicateScopeProvider>,
+  );
+}
+
+describe('RelatedList list_toolbar button — visible CEL', () => {
+  it('hides a toolbar action whose `visible` predicate is false', () => {
+    renderButton(
+      { name: 'invite_user', label: 'Invite User', visible: 'features.organization != false' },
+      { features: { organization: false } },
+    );
+    expect(screen.queryByTestId('related-toolbar-action-invite_user')).toBeNull();
+    expect(screen.queryByText('Invite User')).toBeNull();
+  });
+
+  it('shows a toolbar action whose `visible` predicate is true', () => {
+    renderButton(
+      { name: 'invite_user', label: 'Invite User', visible: 'features.organization != false' },
+      { features: { organization: true } },
+    );
+    expect(screen.getByTestId('related-toolbar-action-invite_user')).toBeInTheDocument();
+    expect(screen.getByText('Invite User')).toBeInTheDocument();
+  });
+
+  it('renders a toolbar action with no `visible` predicate', () => {
+    renderButton({ name: 'export', label: 'Export' });
+    expect(screen.getByTestId('related-toolbar-action-export')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-grid/src/__tests__/bulk-action-visible.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulk-action-visible.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: the selection bulk-action bar must honor each `BulkActionDef`'s
+ * `visible` predicate (a permission / feature gate). It used to render every
+ * `bulkActionDefs` entry unconditionally, ignoring `visible` entirely.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { BulkActionBar } from '../components/BulkActionBar';
+
+function renderBar(actionDefs: any[], scope: Record<string, any> = {}) {
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <BulkActionBar
+        selectedRows={[{ id: '1' }]}
+        actions={[]}
+        actionDefs={actionDefs}
+        onActionDef={() => {}}
+      />
+    </PredicateScopeProvider>,
+  );
+}
+
+describe('BulkActionBar — bulk action visible CEL', () => {
+  it('hides a bulk action whose `visible` predicate is false', () => {
+    renderBar(
+      [{ name: 'bulk_delete', label: 'Delete', visible: 'features.canBulkDelete == true' }],
+      { features: { canBulkDelete: false } },
+    );
+    expect(screen.queryByTestId('bulk-action-bulk_delete')).toBeNull();
+    // The bar itself still renders (the selection count / Clear affordance).
+    expect(screen.getByTestId('bulk-actions-bar')).toBeInTheDocument();
+  });
+
+  it('shows a bulk action whose `visible` predicate is true', () => {
+    renderBar(
+      [{ name: 'bulk_delete', label: 'Delete', visible: 'features.canBulkDelete == true' }],
+      { features: { canBulkDelete: true } },
+    );
+    expect(screen.getByTestId('bulk-action-bulk_delete')).toBeInTheDocument();
+  });
+
+  it('renders a bulk action with no `visible` predicate', () => {
+    renderBar([{ name: 'bulk_tag', label: 'Tag' }]);
+    expect(screen.getByTestId('bulk-action-bulk_tag')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-grid/src/components/BulkActionBar.tsx
+++ b/packages/plugin-grid/src/components/BulkActionBar.tsx
@@ -10,9 +10,47 @@ import React from 'react';
 import { Button } from '@object-ui/components';
 import { Trash2, CheckSquare, X } from 'lucide-react';
 import { LazyIcon, toKebabIconName } from '@object-ui/components';
-import { useObjectTranslation } from '@object-ui/react';
+import { useObjectTranslation, useCondition, toPredicateInput } from '@object-ui/react';
 import type { BulkActionDef } from '@object-ui/types';
 import { formatActionLabel } from './RowActionMenu';
+
+/**
+ * One rich bulk-action button. Extracted into its own component so the def's
+ * `visible` CEL predicate can be evaluated with a hook (`useCondition`)
+ * without violating the rules-of-hooks inside a `.map()` — previously
+ * `bulkActionDefs` rendered unconditionally, ignoring `visible` entirely.
+ *
+ * `visible` is a permission / feature gate evaluated against the ambient
+ * ExpressionProvider scope (`features`/`user`); when it evaluates false the
+ * button is hidden, matching how the row (`RowActionMenuItem` /
+ * `DataTableRowActionItem`) and related-list toolbar renderers treat `visible`.
+ */
+const BulkActionButton: React.FC<{
+  def: BulkActionDef;
+  selectedRows: any[];
+  onActionDef?: (def: BulkActionDef, selectedRows: any[]) => void;
+}> = ({ def, selectedRows, onActionDef }) => {
+  const isVisible = useCondition(toPredicateInput(def.visible));
+  if (def.visible && !isVisible) return null;
+  const isDestructive = def.variant === 'danger' || def.operation === 'delete';
+  const iconName = def.icon ? toKebabIconName(def.icon) : null;
+  return (
+    <Button
+      variant={isDestructive ? 'destructive' : 'outline'}
+      size="sm"
+      className="h-7 px-2.5 text-xs gap-1.5"
+      onClick={() => onActionDef?.(def, selectedRows)}
+      data-testid={`bulk-action-${def.name}`}
+    >
+      {iconName ? (
+        <LazyIcon name={iconName} className="h-3 w-3" />
+      ) : isDestructive ? (
+        <Trash2 className="h-3 w-3" />
+      ) : null}
+      {def.label ?? formatActionLabel(def.name)}
+    </Button>
+  );
+};
 
 export interface BulkActionBarProps {
   /** Array of selected row records */
@@ -136,27 +174,14 @@ export const BulkActionBar: React.FC<BulkActionBarProps> = ({
         </span>
       </span>
       <div className="flex items-center gap-1.5 ml-3">
-        {hasDefs && actionDefs!.map(def => {
-          const isDestructive = def.variant === 'danger' || def.operation === 'delete';
-          const iconName = def.icon ? toKebabIconName(def.icon) : null;
-          return (
-            <Button
-              key={def.name}
-              variant={isDestructive ? 'destructive' : 'outline'}
-              size="sm"
-              className="h-7 px-2.5 text-xs gap-1.5"
-              onClick={() => onActionDef?.(def, selectedRows)}
-              data-testid={`bulk-action-${def.name}`}
-            >
-              {iconName ? (
-                <LazyIcon name={iconName} className="h-3 w-3" />
-              ) : isDestructive ? (
-                <Trash2 className="h-3 w-3" />
-              ) : null}
-              {def.label ?? formatActionLabel(def.name)}
-            </Button>
-          );
-        })}
+        {hasDefs && actionDefs!.map(def => (
+          <BulkActionButton
+            key={def.name}
+            def={def}
+            selectedRows={selectedRows}
+            onActionDef={onActionDef}
+          />
+        ))}
         {!hasDefs && hasLegacy && actions.map(action => {
           const actionStr = String(action).toLowerCase();
           const isDestructive = actionStr.includes('delete') || actionStr.includes('remove') || actionStr.includes('destroy');

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -342,7 +342,7 @@ export interface BulkActionDef {
   confirmText?: string;
   /** Custom Confirm button label (default: "Run"). */
   confirmLabel?: string;
-  /** Permission check expression — disables the button when it returns falsy. */
+  /** Permission / feature gate expression — hides the button when it evaluates falsy. */
   visible?: string;
   /** Max records the action will operate on; selection above this is blocked. */
   maxRecords?: number;


### PR DESCRIPTION
Follow-up to #2373 (data-table row-action `visible` fix). A sweep of every action-rendering path in `@object-ui/components` and the `plugin-*` packages surfaced three more renderers that rendered schema-defined actions **without** evaluating each action's `visible` CEL predicate — the same class of bug.

## Fixes

| Renderer | Package | Was |
|----------|---------|-----|
| **`action:group` dropdown mode** | `@object-ui/components` | Dropdown items mapped straight to `DropdownMenuItem` — ignored `visible`/`enabled`, while the group's **inline** mode (`InlineActionButton`) honored both. |
| **Related-list `list_toolbar` header actions** | `@object-ui/plugin-detail` | Header buttons (e.g. an org's **Invite User**) rendered raw — ignored `visible`, even though the sibling **row** actions (fed by the *same* `deriveActions` bridge) already honor it via the data-table's `DataTableRowActionItem`. |
| **Grid bulk-action bar** | `@object-ui/plugin-grid` | `bulkActionDefs.visible` was ignored entirely (neither hidden nor disabled). |

Each action is now rendered through a **hook-safe per-item component** that evaluates `visible` (and `enabled`, where the sibling inline path does) with `useCondition` / `toPredicateInput`, returning `null` when hidden — mirroring `RowActionMenuItem` / `DataTableRowActionItem`. Predicates resolve `features` / `user` from the ambient `ExpressionProvider` scope, consistent with the existing correct paths.

## Notes / decisions

- **Bulk-action semantics.** `BulkActionDef.visible` was *documented* as "disables the button", but the field is named `visible` and no renderer implemented either behavior. Resolved as **hide** (consistent with every other action renderer) and corrected the type doc comment accordingly.
- **Scope.** Rendering-layer only — no action definitions, permission logic, or the (already-correct) `RowActionMenu` path touched. The `react-hooks/static-components` disable directives on the new dynamic-icon renders match the repo's existing convention (`statistic.tsx`, `DataTableRowActionItem`).
- The audit cleared everything else in both packages (honors `visible` per-item, pre-filters via `getActionsForLocation`, delegates to `action:bar`/`action:button` leaves, or carries no `visible` field).

## Testing

- New colocated unit tests, **10 cases** total: `action-group-dropdown-visible` (4), `related-toolbar-visible` (3), `bulk-action-visible` (3) — each covering hidden / shown / no-predicate (and enabled→disabled for the dropdown).
- `tsc --noEmit` clean on all three packages (pre-existing `rootDir` / unrelated errors aside); ESLint introduces no new errors.
- Adds a `patch` changeset for the three packages.

---
_Generated by [Claude Code](https://claude.ai/code/session_011wxYurB3RKgRyCP9nZJ7co)_