### PR TITLE
fix(access): effective-holders list for permission sets + explain user-picker discoverability

### DIFF
--- a/.changeset/access-effective-holders.md
+++ b/.changeset/access-effective-holders.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Access pillar: the 已分配用户 section now lists EFFECTIVE holders — direct
+grants ∪ holders of every position bound to the set — with per-row
+attribution badges (直授 / 经岗位 X). Position-held rows are not removable
+here (remove on the position's assignments); an `everyone`-anchor binding
+renders as a note ("every signed-in member holds this set") instead of
+enumerating the tenant (objectui#2382 — the direct-grants-only list told
+admins "0 users" for any normally-administered set). The explain panel's
+user field gains a chevron so "pick another user" is discoverable
+(objectui#2381 — the picker existed but read as static text).

--- a/packages/app-shell/src/views/metadata-admin/AccessExplainPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/AccessExplainPanel.tsx
@@ -34,6 +34,7 @@ import { createAuthenticatedFetch } from '@object-ui/auth';
 import {
   AlertTriangle,
   CheckCircle2,
+  ChevronsUpDown,
   HelpCircle,
   Loader2,
   ShieldQuestion,
@@ -182,9 +183,13 @@ export function AccessExplainPanel({ open, onOpenChange, defaultObject }: Access
                 className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md border bg-background px-2 text-left text-xs hover:bg-muted/60"
               >
                 <UserIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <span className="truncate">
+                <span className="min-w-0 flex-1 truncate">
                   {user ? user.label : t('engine.studio.access.explain.self', locale)}
                 </span>
+                {/* objectui#2381 — the picker was here all along but the button
+                    read as static text; the chevron makes "pick another user"
+                    discoverable. */}
+                <ChevronsUpDown className="h-3 w-3 shrink-0 text-muted-foreground/70" />
               </button>
               {user && (
                 <Button

--- a/packages/app-shell/src/views/metadata-admin/AssignedUsersSection.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/AssignedUsersSection.test.tsx
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the MIT license.
+//
+// objectui#2382 — the 已分配用户 section must count EFFECTIVE holders:
+// direct grants ∪ holders of every position bound to the set. A
+// direct-grants-only list told the admin "0 users" for any
+// normally-administered set (positions are THE distribution channel in
+// ADR-0090), right before they edit or delete it.
+
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AssignedUsersSection } from './AssignedUsersSection';
+
+vi.mock('@object-ui/react', () => ({
+  useAdapter: () => mockAdapter,
+}));
+vi.mock('@object-ui/fields', () => ({
+  RecordPickerDialog: () => null,
+}));
+
+const data: Record<string, any[]> = {
+  sys_permission_set: [{ id: 'ps_1', name: 'showcase_contributor' }],
+  sys_user_permission_set: [{ id: 'grant_1', permission_set_id: 'ps_1', user_id: 'u_direct' }],
+  sys_position_permission_set: [
+    { id: 'bind_1', position_id: 'pos_contrib', permission_set_id: 'ps_1' },
+    { id: 'bind_2', position_id: 'pos_everyone', permission_set_id: 'ps_1' },
+  ],
+  sys_position: [
+    { id: 'pos_contrib', name: 'contributor', label: 'Contributor' },
+    { id: 'pos_everyone', name: 'everyone', label: 'Everyone' },
+  ],
+  sys_user_position: [
+    { id: 'up_1', user_id: 'u_held', position: 'contributor' },
+    // The direct grantee ALSO holds the position — must merge into one row.
+    { id: 'up_2', user_id: 'u_direct', position: 'contributor' },
+  ],
+  sys_user: [
+    { id: 'u_direct', name: 'Direct Dana', email: 'dana@example.com' },
+    { id: 'u_held', name: 'Held Henry', email: 'henry@example.com' },
+  ],
+};
+
+const mockAdapter = {
+  find: vi.fn(async (object: string, query: any) => {
+    const rows = data[object] ?? [];
+    const filter = query?.$filter ?? {};
+    return rows.filter((r) =>
+      Object.entries(filter).every(([k, v]: [string, any]) => {
+        if (v && typeof v === 'object' && Array.isArray(v.$in)) return v.$in.includes(r[k]);
+        return r[k] === v;
+      }),
+    );
+  }),
+  create: vi.fn(),
+  delete: vi.fn(),
+};
+
+describe('AssignedUsersSection — effective holders (objectui#2382)', () => {
+  it('lists direct grantees AND position-held users, with via badges', async () => {
+    render(<AssignedUsersSection permissionSetName="showcase_contributor" />);
+
+    await waitFor(() => expect(screen.getByText('Direct Dana')).toBeTruthy());
+    // Position-held user appears even with no direct grant.
+    expect(screen.getByText('Held Henry')).toBeTruthy();
+    // Count = deduped users (u_direct merged), not junction rows.
+    expect(screen.getByText('2')).toBeTruthy();
+    // Attribution badges.
+    expect(screen.getAllByText('direct').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('via position contributor').length).toBeGreaterThan(0);
+  });
+
+  it('surfaces the everyone-anchor binding as a note instead of enumerating members', async () => {
+    render(<AssignedUsersSection permissionSetName="showcase_contributor" />);
+    await waitFor(() =>
+      expect(screen.getByText(/every signed-in member holds this set/i)).toBeTruthy(),
+    );
+  });
+
+  it('keeps the remove affordance only on direct grants', async () => {
+    render(<AssignedUsersSection permissionSetName="showcase_contributor" />);
+    await waitFor(() => expect(screen.getByText('Held Henry')).toBeTruthy());
+    // One removable (direct grant) row → exactly one Remove button.
+    expect(screen.getAllByLabelText('Remove')).toHaveLength(1);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/AssignedUsersSection.tsx
+++ b/packages/app-shell/src/views/metadata-admin/AssignedUsersSection.tsx
@@ -33,10 +33,13 @@ export interface AssignedUsersSectionProps {
 }
 
 interface AssignedRow {
-  grantId: string;
+  /** Junction row id for DIRECT grants; position-held rows are not removable here. */
+  grantId: string | null;
   userId: string;
   name: string;
   email: string;
+  /** How the user holds the set: a direct grant, or via one or more positions. */
+  via: Array<{ kind: 'direct' } | { kind: 'position'; position: string }>;
 }
 
 /** Minimal locale-aware copy (zh vs everything-else) — keeps the surface in the user's language. */
@@ -56,6 +59,10 @@ function useCopy() {
               'AI 席位已用完(' + n + '/' + n + ')。请先移除一个用户,或在许可证中提升席位上限,再分配新用户。',
             addFailed: '分配失败,请重试。',
             countOf: (n: number) => n + ' 人',
+            direct: '直授',
+            viaPosition: (p: string) => '经岗位 ' + p,
+            everyoneNote: '已绑定到 everyone 锚点 — 所有登录成员都持有此权限集。',
+            positionHeldHint: '经岗位持有 — 在岗位的指派中移除。',
           }
         : {
             title: 'Assigned Users',
@@ -68,6 +75,10 @@ function useCopy() {
               'All ' + n + ' AI seat(s) are in use. Remove a user or raise the license cap before assigning another.',
             addFailed: 'Failed to assign. Please try again.',
             countOf: (n: number) => String(n),
+            direct: 'direct',
+            viaPosition: (p: string) => 'via position ' + p,
+            everyoneNote: 'Bound to the everyone anchor — every signed-in member holds this set.',
+            positionHeldHint: 'Held via a position — remove it on the position’s assignments.',
           },
     [zh],
   );
@@ -85,6 +96,7 @@ export function AssignedUsersSection({ permissionSetName }: AssignedUsersSection
 
   const [setId, setSetId] = React.useState<string | null>(null);
   const [rows, setRows] = React.useState<AssignedRow[]>([]);
+  const [everyoneBound, setEveryoneBound] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const [busy, setBusy] = React.useState(false);
@@ -100,31 +112,81 @@ export function AssignedUsersSection({ permissionSetName }: AssignedUsersSection
       setSetId(id);
       if (!id) {
         setRows([]);
+        setEveryoneBound(false);
         return;
       }
+
+      // Effective holders = direct grants ∪ holders of every position bound to
+      // the set (objectui#2382). In the ADR-0090 model positions are THE
+      // distribution channel — a direct-grants-only list told the admin
+      // "0 users" for any normally-administered set.
       const grants = asArray(
         await adapter.find('sys_user_permission_set', { $filter: { permission_set_id: id }, $top: 500 }),
       );
-      const userIds = [...new Set(grants.map((g: any) => g.user_id).filter(Boolean).map(String))];
+
+      let positionNames: string[] = [];
+      let boundEveryone = false;
+      try {
+        const bindings = asArray(
+          await adapter.find('sys_position_permission_set', { $filter: { permission_set_id: id }, $top: 200 }),
+        );
+        const positionIds = [...new Set(bindings.map((b: any) => b.position_id).filter(Boolean).map(String))];
+        if (positionIds.length) {
+          const positions = asArray(
+            await adapter.find('sys_position', { $filter: { id: { $in: positionIds } }, $top: 200 }),
+          );
+          const names = positions.map((p: any) => String(p.name ?? '')).filter(Boolean);
+          // The audience anchors are implicit memberships — `everyone` is every
+          // signed-in member; enumerating them as rows would be noise. Surface
+          // a note instead and expand only the explicit positions.
+          boundEveryone = names.includes('everyone');
+          positionNames = names.filter((n) => n !== 'everyone' && n !== 'guest');
+        }
+      } catch {
+        /* position expansion is additive — direct grants still render */
+      }
+
+      const assignments = positionNames.length
+        ? asArray(
+            await adapter.find('sys_user_position', { $filter: { position: { $in: positionNames } }, $top: 1000 }),
+          )
+        : [];
+
+      const viaByUser = new Map<string, AssignedRow['via']>();
+      const grantIdByUser = new Map<string, string>();
+      for (const g of grants) {
+        if (!g?.user_id) continue;
+        const uid = String(g.user_id);
+        grantIdByUser.set(uid, String(g.id));
+        viaByUser.set(uid, [...(viaByUser.get(uid) ?? []), { kind: 'direct' as const }]);
+      }
+      for (const a of assignments) {
+        if (!a?.user_id || !a?.position) continue;
+        const uid = String(a.user_id);
+        viaByUser.set(uid, [...(viaByUser.get(uid) ?? []), { kind: 'position' as const, position: String(a.position) }]);
+      }
+
+      const userIds = [...viaByUser.keys()];
       const users = userIds.length
-        ? asArray(await adapter.find('sys_user', { $filter: { id: { $in: userIds } }, $top: 500 }))
+        ? asArray(await adapter.find('sys_user', { $filter: { id: { $in: userIds } }, $top: 1000 }))
         : [];
       const byId = new Map(users.map((u: any) => [String(u.id), u]));
       setRows(
-        grants
-          .filter((g: any) => g.user_id)
-          .map((g: any) => {
-            const u = byId.get(String(g.user_id));
-            return {
-              grantId: String(g.id),
-              userId: String(g.user_id),
-              name: u ? personLabel(u) : String(g.user_id),
-              email: u?.email ?? '',
-            };
-          }),
+        userIds.map((uid) => {
+          const u = byId.get(uid);
+          return {
+            grantId: grantIdByUser.get(uid) ?? null,
+            userId: uid,
+            name: u ? personLabel(u) : uid,
+            email: u?.email ?? '',
+            via: viaByUser.get(uid) ?? [],
+          };
+        }),
       );
+      setEveryoneBound(boundEveryone);
     } catch {
       setRows([]);
+      setEveryoneBound(false);
     } finally {
       setLoading(false);
     }
@@ -213,36 +275,59 @@ export function AssignedUsersSection({ permissionSetName }: AssignedUsersSection
         </div>
       )}
 
+      {everyoneBound && (
+        <div className="mb-3 flex items-start gap-2 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          <Users className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span>{c.everyoneNote}</span>
+        </div>
+      )}
+
       {loading ? (
         <div className="flex items-center gap-2 text-xs text-muted-foreground py-3">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
           {c.loading}
         </div>
       ) : rows.length === 0 ? (
-        <div className="text-xs text-muted-foreground italic py-3">{c.empty}</div>
+        !everyoneBound && <div className="text-xs text-muted-foreground italic py-3">{c.empty}</div>
       ) : (
         <ul className="divide-y rounded-md border">
           {rows.map((r) => (
-            <li key={r.grantId} className="flex items-center gap-3 px-3 py-2">
+            <li key={r.userId} className="flex items-center gap-3 px-3 py-2">
               <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-medium shrink-0">
                 {(r.name || '?').slice(0, 1).toUpperCase()}
               </div>
               <div className="min-w-0 flex-1">
-                <div className="text-sm truncate">{r.name}</div>
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <span className="text-sm truncate">{r.name}</span>
+                  {r.via.map((v, i) => (
+                    <span
+                      key={i}
+                      className="shrink-0 rounded border bg-muted/40 px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground"
+                    >
+                      {v.kind === 'direct' ? c.direct : c.viaPosition(v.position)}
+                    </span>
+                  ))}
+                </div>
                 {r.email && r.email !== r.name && (
                   <div className="text-xs text-muted-foreground truncate">{r.email}</div>
                 )}
               </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => void removeUser(r.grantId)}
-                aria-label={c.remove}
-                title={c.remove}
-                className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
-              >
-                <X className="h-4 w-4" />
-              </Button>
+              {r.grantId ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void removeUser(r.grantId!)}
+                  aria-label={c.remove}
+                  title={c.remove}
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              ) : (
+                <span className="shrink-0 text-[10px] text-muted-foreground/70" title={c.positionHeldHint}>
+                  —
+                </span>
+              )}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Closes #2382. Closes #2381. Both filed while dogfooding the Access pillar as a business admin against a live showcase boot.

## #2382 — 已分配用户 now shows EFFECTIVE holders

The section listed `sys_user_permission_set` rows only — in the ADR-0090 model positions are THE distribution channel, so any normally-administered set showed **0 人** exactly where an admin decides whether to edit or delete it. Now:

- holders = direct grants ∪ holders of every bound position (`sys_position_permission_set` → `sys_position` → `sys_user_position`), deduped per user;
- per-row attribution badges: 直授 / 经岗位 X (a user holding both shows both);
- position-held rows have no remove button (removal lives on the position's assignments — hint on hover);
- an `everyone`-anchor binding renders as a note ("every signed-in member holds this set") instead of enumerating the tenant;
- position expansion is additive and fail-soft — direct grants still render if any lookup errors.

## #2381 — explain user picker was there; now it's discoverable

The picker existed all along (RecordPickerDialog over `sys_user`) but the trigger rendered as static text 「我(当前调用者)」 — reported as missing by our own dogfood. A `ChevronsUpDown` affordance fixes the discoverability; no behavior change.

## Verification

- 3 new tests (`AssignedUsersSection.test.tsx`: merged holders + count, everyone note, remove-only-on-direct); app-shell suite **153 files / 1181 tests green**.
- Live browser (Vite console :5180 → fresh framework backend): the set bound to `contributor` with one position-held user renders 「已分配用户 1 人 · Held Henry · 经岗位 contributor · —」; explain panel: picking Held Henry returns HIS decision (principal card shows `contributor`/`everyone` + `showcase_member_default`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)