### PR TITLE
feat(ai-chat): spreadsheet attachments reach the agent — local parse + structured brief (cloud#797 WS3)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1229,11 +1229,60 @@ export function ChatPane({
 
   // The real send, shared by a normal submit and by the deferred-first-message
   // replay below (resetSuppression → send → onSent, in that order).
+  //
+  // Spreadsheet attachments (cloud#797 WS3): historically every attachment was
+  // silently dropped between the composer and the transport. Excel/CSV files
+  // are now parsed CLIENT-side (plugin-grid's importParsers; the bytes never
+  // leave the page) and the agent is briefed with a compact structured block —
+  // headers + first sample rows + row count — appended to the user's text. The
+  // agent's solution-design skill takes it from there (match an object, offer
+  // missing fields, point at the object list's Import action). Non-spreadsheet
+  // attachments stay out of scope and are disclosed rather than dropped.
   const doSend = useCallback(
     (content: string, files?: File[]) => {
       resetSuppression();
-      sendMessage(content, files);
-      onSent(content);
+      const sheets = (files ?? []).filter((f) => /\.(xlsx|xlsm|csv|tsv|txt)$/i.test(f.name));
+      if (!sheets.length) {
+        if (files?.length) {
+          // Honest disclosure beats a silent drop — the agent cannot read these.
+          sendMessage(
+            `${content}\n\n(用户上传了 ${files.length} 个附件:${files
+              .map((f) => f.name)
+              .join('、')} — 当前仅支持读取表格类附件(Excel/CSV),这些文件的内容我没有读取。)`,
+          );
+          onSent(content);
+          return;
+        }
+        sendMessage(content);
+        onSent(content);
+        return;
+      }
+      void (async () => {
+        const cap = (s: string) => (s.length > 40 ? `${s.slice(0, 40)}…` : s);
+        const line = (r: string[]) =>
+          r.slice(0, 12).map((c) => cap(String(c ?? '')).replace(/\s+/g, ' ')).join(' | ');
+        let merged = content;
+        for (const f of sheets.slice(0, 2)) {
+          try {
+            const { parseSpreadsheetFile } = await import('@object-ui/plugin-grid');
+            const rows = await parseSpreadsheetFile(f);
+            const headers = rows[0] ?? [];
+            const samples = rows.slice(1, 4);
+            merged += [
+              `\n\n[附件表格 ${f.name} — ${Math.max(0, rows.length - 1)} 数据行 × ${headers.length} 列(控制台已在本地解析,文件本体未上传)]`,
+              `表头: ${line(headers)}`,
+              ...samples.map((r, i) => `样例${i + 1}: ${line(r)}`),
+            ].join('\n');
+          } catch (err) {
+            merged += `\n\n[附件表格 ${f.name}] 解析失败(${err instanceof Error ? err.message : 'unknown'})— 请引导用户改用对象列表的 Import 上传该文件。`;
+          }
+        }
+        if (sheets.length > 2) merged += `\n\n(另有 ${sheets.length - 2} 个表格附件未读取 — 一次最多读取 2 个。)`;
+        const nonSheets = (files ?? []).length - sheets.length;
+        if (nonSheets > 0) merged += `\n\n(另有 ${nonSheets} 个非表格附件,内容未读取。)`;
+        sendMessage(merged);
+        onSent(merged);
+      })();
     },
     [resetSuppression, sendMessage, onSent],
   );

--- a/packages/plugin-chatbot/src/elements/prompt-input.tsx
+++ b/packages/plugin-chatbot/src/elements/prompt-input.tsx
@@ -80,8 +80,18 @@ import {
 // Provider Context & Types
 // ============================================================================
 
+/**
+ * An attached file: the AI-SDK `FileUIPart` shape plus a client-side id and —
+ * for same-page consumers such as the spreadsheet-import flow (cloud#797 WS3)
+ * — the ORIGINAL `File` object. Historically only the objectURL survived
+ * `add()`, so downstream `.file` readers (ChatbotEnhanced.handleSubmit) always
+ * came up empty and every attachment was silently dropped. The `File` never
+ * leaves the page: only url/mediaType/filename are ever put on the transport.
+ */
+export type PromptInputFileItem = FileUIPart & { id: string; file?: File };
+
 export type AttachmentsContext = {
-  files: (FileUIPart & { id: string })[];
+  files: PromptInputFileItem[];
   add: (files: File[] | FileList) => void;
   remove: (id: string) => void;
   clear: () => void;
@@ -157,7 +167,7 @@ export function PromptInputProvider({
 
   // ----- attachments state (global when wrapped)
   const [attachmentFiles, setAttachmentFiles] = useState<
-    (FileUIPart & { id: string })[]
+    PromptInputFileItem[]
   >([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const openRef = useRef<() => void>(() => {});
@@ -176,6 +186,9 @@ export function PromptInputProvider({
           url: URL.createObjectURL(file),
           mediaType: file.type,
           filename: file.name,
+          // Keep the original File for same-page consumers (spreadsheet
+          // import). Never serialized — the transport uses url/mediaType only.
+          file,
         }))
       )
     );
@@ -283,7 +296,7 @@ export const usePromptInputAttachments = () => {
 };
 
 export type PromptInputAttachmentProps = HTMLAttributes<HTMLDivElement> & {
-  data: FileUIPart & { id: string };
+  data: PromptInputFileItem;
   className?: string;
 };
 
@@ -382,7 +395,7 @@ export type PromptInputAttachmentsProps = Omit<
   HTMLAttributes<HTMLDivElement>,
   "children"
 > & {
-  children: (attachment: FileUIPart & { id: string }) => ReactNode;
+  children: (attachment: PromptInputFileItem) => ReactNode;
 };
 
 export function PromptInputAttachments({
@@ -485,7 +498,7 @@ export const PromptInput = ({
   const formRef = useRef<HTMLFormElement | null>(null);
 
   // ----- Local attachments (only used when no provider)
-  const [items, setItems] = useState<(FileUIPart & { id: string })[]>([]);
+  const [items, setItems] = useState<PromptInputFileItem[]>([]);
   const files = usingProvider ? controller.attachments.files : items;
 
   // Keep a ref to files for cleanup on unmount (avoids stale closure)
@@ -553,7 +566,7 @@ export const PromptInput = ({
             message: "Too many files. Some were not added.",
           });
         }
-        const next: (FileUIPart & { id: string })[] = [];
+        const next: PromptInputFileItem[] = [];
         for (const file of capped) {
           next.push({
             id: nanoid(),
@@ -561,6 +574,9 @@ export const PromptInput = ({
             url: URL.createObjectURL(file),
             mediaType: file.type,
             filename: file.name,
+            // Keep the original File for same-page consumers (spreadsheet
+            // import) — mirrors the provider-mode add() above.
+            file,
           });
         }
         return prev.concat(next);

--- a/packages/plugin-grid/src/index.tsx
+++ b/packages/plugin-grid/src/index.tsx
@@ -14,6 +14,11 @@ import { VirtualGrid } from './VirtualGrid';
 import { ImportWizard } from './ImportWizard';
 
 export { ObjectGrid, VirtualGrid, ImportWizard };
+// Spreadsheet parsers (pure functions; ExcelJS lazy-loads inside) — exported
+// for the chat-native attachment flow (cloud#797 WS3): the AI build panel
+// parses an attached Excel/CSV client-side and briefs the agent with the
+// headers + sample rows instead of dropping the file.
+export { parseSpreadsheetFile, parseClipboardTable, inferColumnType } from './importParsers';
 export { InlineEditing } from './InlineEditing';
 export { useRowColor } from './useRowColor';
 export { useGroupedData } from './useGroupedData';


### PR DESCRIPTION
cloud#797 WS3(聊天原生表格附件)objectui 侧。

**修两处静默丢弃**:prompt-input 在 add() 就丢掉原始 File(只剩 objectURL),ChatbotEnhanced 的 `.file` 读取恒空 —— 回形针/拖拽 UI 一直连着一个黑洞。现在附件项保留原始 File(`PromptInputFileItem = FileUIPart & {id, file}`),**字节不出页面**(transport 仍只拿 url/mediaType)。

**AiChatPage.doSend**:Excel/CSV 附件本地解析(plugin-grid importParsers,ExcelJS 懒加载),给 agent 发结构化简报 `[附件表格 名称 — N 数据行 × M 列] + 表头 + 3 样例行`(上限 2 表/12 列/40 字符);agent 据此对齐字段并指路对象列表的 Import(cloud 侧 skill 配套 PR)。非表格附件如实披露"未读取"而非静默丢弃;解析失败降级为诚实提示。

plugin-grid barrel 导出纯解析函数供跨插件复用。测试:chatbot 192/192、grid 194/194、app-shell 1178/1178;拓扑构建绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)