### PR TITLE
feat: consume dynamic runtime branding across the console frontend

### DIFF
--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -8,13 +8,41 @@
       - For stricter CSP, serve headers via your web server (see docs/deployment.md) and use
         nonces or hashes instead of 'unsafe-inline'.
     -->
-    <link rel="icon" type="image/svg+xml" href="./favicon.svg" id="favicon" />
+    <link rel="icon" type="image/png" href="" id="favicon" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <link rel="manifest" href="./manifest.json" />
-    <title>ObjectOS</title>
+    <title></title>
+    <script>
+      // Pre-React branding — fetch runtime config as early as possible so the
+      // browser title and favicon reflect the operator's branding BEFORE React
+      // mounts. Falls back gracefully on any error (non-blocking).
+      (async function applyEarlyBranding() {
+        try {
+          const base = (window.__CONSOLE_SERVER_URL || '').replace(/\/+$/, '');
+          const res = await fetch(base + '/api/v1/runtime/config', {
+            credentials: 'include',
+            headers: { Accept: 'application/json' },
+          });
+          if (!res.ok) return;
+          const body = await res.json();
+          if (body?.branding) {
+            if (body.branding.productName) {
+              document.title = body.branding.productName;
+            }
+            if (body.branding.faviconUrl) {
+              var link = document.getElementById('favicon');
+              if (link) {
+                link.href = body.branding.faviconUrl;
+                link.type = body.branding.faviconUrl.endsWith('.svg') ? 'image/svg+xml' : 'image/png';
+              }
+            }
+          }
+        } catch (_) { /* non-blocking */ }
+      })();
+    </script>
     <script>
       window.process = window.process || { env: { NODE_ENV: 'development' }, version: '', platform: 'browser' };
     </script>

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -12,7 +12,7 @@
  * with extra `<Route>` children.
  */
 
-import { type ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation, Link } from 'react-router-dom';
 import { AuthProvider, AuthGuard, useAuth } from '@object-ui/auth';
 import { DevMasterDetail } from './dev/DevMasterDetail';
@@ -38,6 +38,8 @@ import {
   DefaultAiChatPage,
   StudioDesignSurface,
   BuilderLanding,
+  getProductName,
+  getFaviconUrl,
 } from '@object-ui/app-shell';
 
 import { AppContent } from './AppContent';
@@ -132,12 +134,30 @@ function HomeRoute() {
   );
 }
 
+/** Syncs document title + favicon with runtime branding on every route change. */
+function BrandingSync() {
+  const location = useLocation();
+  useEffect(() => {
+    document.title = getProductName();
+    const faviconUrl = getFaviconUrl();
+    if (faviconUrl) {
+      const link = document.getElementById('favicon') as HTMLLinkElement | null;
+      if (link) {
+        link.href = faviconUrl;
+        link.type = faviconUrl.endsWith('.svg') ? 'image/svg+xml' : 'image/png';
+      }
+    }
+  }, [location]);
+  return null;
+}
+
 export function App() {
   return (
     <AuthProvider authUrl={AUTH_URL}>
       <ConsoleToaster position="bottom-right" />
       <MetadataHmrReloader />
       <BrowserRouter basename={BASENAME}>
+        <BrandingSync />
         <ConsoleShell>
           <Routes>
             {/*
@@ -193,7 +213,7 @@ export function App() {
                       title="返回主页"
                       className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-0.5 text-[13px] font-semibold hover:bg-muted"
                     >
-                      ObjectOS
+                      {getProductName()}
                     </Link>
                   </header>
                   <div className="min-h-0 flex-1 overflow-auto">

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -9,10 +9,10 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import { App } from './App';
 import { I18nProvider } from '@object-ui/i18n';
-import { MobileProvider } from '@object-ui/mobile';
+import { MobileProvider, generatePWAManifest } from '@object-ui/mobile';
 import { ComponentRegistry } from '@object-ui/core';
 import { registerPlaceholders } from '@object-ui/components';
-import { initSentry, initRuntimeConfig, getProductName, getProductShortName } from '@object-ui/app-shell';
+import { initSentry, initRuntimeConfig, getProductName, getProductShortName, getFaviconUrl, getPwaDescription, getPwaThemeColor } from '@object-ui/app-shell';
 import { loadLanguage } from './loadLanguage';
 import { preflightAuth } from './lib/auth-preflight';
 
@@ -176,6 +176,46 @@ Promise.all([
   initRuntimeConfig(SERVER_BASE),
   preflightAuth(AUTH_URL),
 ]).finally(() => {
+  // Apply runtime branding before React mounts — avoids a flash of the
+  // static defaults for operators who configure OS_PRODUCT_NAME etc.
+  document.title = getProductName();
+
+  // Inject dynamic favicon if the operator configured one.
+  const faviconUrl = getFaviconUrl();
+  if (faviconUrl) {
+    const link = document.getElementById('favicon') as HTMLLinkElement | null;
+    if (link) {
+      link.href = faviconUrl;
+      // Update type attr when switching from svg to png
+      link.type = faviconUrl.endsWith('.svg') ? 'image/svg+xml' : 'image/png';
+    }
+  }
+
+  // Generate a dynamic PWA manifest from runtime branding and inject it.
+  // Blob URL replaces the static /manifest.json so PWA install prompts use
+  // the branded name, short name, description, theme color, and favicon.
+  const manifestJson = generatePWAManifest({
+    enabled: true,
+    name: getProductName(),
+    shortName: getProductShortName(),
+    description: getPwaDescription(),
+    themeColor: getPwaThemeColor(),
+    backgroundColor: '#ffffff',
+    display: 'standalone',
+    startUrl: './',
+    scope: './',
+    orientation: 'any',
+    icons: [{ src: faviconUrl || './favicon.svg', sizes: 'any', type: 'image/svg+xml', purpose: 'any' }],
+  });
+  const blob = new Blob([JSON.stringify(manifestJson)], { type: 'application/json' });
+  const manifestUrl = URL.createObjectURL(blob);
+  const existingManifest = document.querySelector<HTMLLinkElement>('link[rel="manifest"]');
+  if (existingManifest) existingManifest.remove();
+  const manifestLink = document.createElement('link');
+  manifestLink.rel = 'manifest';
+  manifestLink.href = manifestUrl;
+  document.head.appendChild(manifestLink);
+
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <MobileProvider pwa={{ enabled: true, name: getProductName(), shortName: getProductShortName() }}>

--- a/apps/console/src/pages/auth/AuthLayout.tsx
+++ b/apps/console/src/pages/auth/AuthLayout.tsx
@@ -28,7 +28,7 @@
 import { useEffect, type ReactNode } from 'react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { cn } from '@object-ui/components';
-import { getProductName } from '@object-ui/app-shell';
+import { getProductName, getLogoUrl } from '@object-ui/app-shell';
 
 export interface AuthLayoutProps {
   children: ReactNode;
@@ -65,24 +65,29 @@ function currentHost(): string | null {
  */
 function BrandMark() {
   const productName = getProductName();
+  const logoUrl = getLogoUrl();
   return (
     <div className="flex items-center justify-center gap-2.5 select-none">
-      <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-indigo-600 text-white shadow-sm shadow-indigo-500/30">
-        <svg
-          viewBox="0 0 24 24"
-          width="18"
-          height="18"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M12 2 2 7l10 5 10-5-10-5Z" />
-          <path d="m2 17 10 5 10-5" />
-          <path d="m2 12 10 5 10-5" />
-        </svg>
+      <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-indigo-600 text-white shadow-sm shadow-indigo-500/30 overflow-hidden">
+        {logoUrl ? (
+          <img src={logoUrl} alt={productName} className="h-full w-full object-contain" />
+        ) : (
+          <svg
+            viewBox="0 0 24 24"
+            width="18"
+            height="18"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 2 2 7l10 5 10-5-10-5Z" />
+            <path d="m2 17 10 5 10-5" />
+            <path d="m2 12 10 5 10-5" />
+          </svg>
+        )}
       </span>
       <span className="text-lg font-semibold tracking-tight text-foreground">{productName}</span>
     </div>

--- a/apps/console/src/pages/auth/DeviceAuthPage.tsx
+++ b/apps/console/src/pages/auth/DeviceAuthPage.tsx
@@ -9,10 +9,11 @@
 
 import { useState } from 'react';
 import { Navigate, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
-import { CheckCircle2, GalleryVerticalEnd } from 'lucide-react';
+import { CheckCircle2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
+import { getProductName, getLogoUrl } from '@object-ui/app-shell';
 import {
   Button,
   Card,
@@ -29,10 +30,14 @@ function PageShell({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-svh w-full flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
       <div className="flex w-full max-w-sm flex-col gap-6">
         <a href="#" className="flex items-center gap-2 self-center font-medium">
-          <div className="flex size-6 items-center justify-center rounded-md bg-primary text-primary-foreground">
-            <GalleryVerticalEnd className="size-4" />
+          <div className="flex size-6 items-center justify-center rounded-md bg-primary text-primary-foreground overflow-hidden">
+            {getLogoUrl() ? (
+              <img src={getLogoUrl()} alt={getProductName()} className="h-full w-full object-contain" />
+            ) : (
+              <CheckCircle2 className="size-4" />
+            )}
           </div>
-          ObjectStack
+          {getProductName()}
         </a>
         <div className="flex flex-col gap-6">{children}</div>
       </div>
@@ -237,7 +242,7 @@ export function DeviceAuthPage() {
               </p>
               <p className="font-medium">{runtimeName}</p>
               {runtimeVersion ? (
-                <p className="text-xs text-muted-foreground">objectos {runtimeVersion}</p>
+                <p className="text-xs text-muted-foreground">{getProductName().toLowerCase()} {runtimeVersion}</p>
               ) : null}
             </div>
           ) : null}

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import type { Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import fs from 'fs';
 import { viteCryptoStub } from '../../scripts/vite-crypto-stub';
 import { compression } from 'vite-plugin-compression2';
 import { visualizer } from 'rollup-plugin-visualizer';
@@ -32,6 +33,46 @@ function preloadCriticalChunks(): Plugin {
       }
       if (preloadTags.length === 0) return html;
       return html.replace('</head>', `    ${preloadTags.join('\n    ')}\n  </head>`);
+    },
+  };
+}
+
+/**
+ * Dev-only Vite plugin: serves runtime branding assets at /runtime/assets/*.
+ *
+ * When the console dev server runs standalone (port 5180), the backend does
+ * not proxy /runtime requests.  This plugin looks for assets in the host
+ * project's `runtime/assets/` directory (four levels up from apps/console)
+ * so URLs like /runtime/assets/logo.png resolve.
+ *
+ * Non-blocking — silently skips when the directory doesn't exist.
+ */
+function serveRuntimeAssets(): Plugin {
+  const ASSETS_DIR = path.resolve(__dirname, '../../../../runtime/assets');
+  const MIME: Record<string, string> = {
+    '.png': 'image/png', '.svg': 'image/svg+xml', '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg', '.ico': 'image/x-icon', '.webp': 'image/webp',
+  };
+
+  return {
+    name: 'serve-runtime-assets',
+    apply: 'serve', // dev-only — prod builds include assets in the bundle
+    configureServer(server) {
+      if (!fs.existsSync(ASSETS_DIR)) return;
+      server.middlewares.use('/runtime/assets', (req, res, next) => {
+        const filename = (req.url || '').replace(/^\/+/, '').replace(/[?#].*$/, '');
+        if (!filename) { next(); return; }
+        const filePath = path.join(ASSETS_DIR, filename);
+        if (!filePath.startsWith(ASSETS_DIR)) { next(); return; } // path traversal guard
+        try {
+          const content = fs.readFileSync(filePath);
+          res.setHeader('Content-Type', MIME[path.extname(filePath).toLowerCase()] || 'application/octet-stream');
+          res.statusCode = 200;
+          res.end(content);
+        } catch {
+          next();
+        }
+      });
     },
   };
 }
@@ -132,6 +173,10 @@ export default defineConfig({
     react(),
     // Inject <link rel="modulepreload"> for critical chunks
     preloadCriticalChunks(),
+    // Dev-only plugin: serve runtime assets (product logo/favicon) from the
+    // host project's runtime/assets directory so branding URLs configured
+    // via OS_LOGO_URL / OS_FAVICON_URL resolve without a fragile symlink.
+    serveRuntimeAssets(),
     // Gzip/Brotli compression & bundle visualizer are skipped on Vercel/CI to
     // reduce memory usage — Vercel's CDN compresses assets automatically.
     ...(!isCI ? [

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -72,7 +72,7 @@ test.describe('Console App – Smoke', () => {
 
   test('should have correct page title', async ({ page }) => {
     await page.goto(`${CONSOLE_BASE}/`);
-    await expect(page).toHaveTitle(/ObjectStack|ObjectUI|ObjectOS|Console/i);
+    await expect(page).toHaveTitle(/.+/);
   });
 
   test('should show the app shell or loading screen', async ({ page }) => {

--- a/packages/app-shell/src/chrome/LoadingScreen.tsx
+++ b/packages/app-shell/src/chrome/LoadingScreen.tsx
@@ -2,7 +2,7 @@
 import { Spinner, Button } from '@object-ui/components';
 import { Database, CheckCircle2, Loader2, AlertCircle, RefreshCw } from 'lucide-react';
 import { useState, useEffect, useMemo } from 'react';
-import { getProductName } from '../runtime-config';
+import { getProductName, getLogoUrl } from '../runtime-config';
 import { en as enLocale, zh as zhLocale } from '@object-ui/i18n';
 
 interface LoadingScreenProps {
@@ -58,7 +58,11 @@ export function LoadingScreen({ message, error, onRetry, retrying }: LoadingScre
         <div className="relative">
           <div className="absolute inset-0 bg-primary/20 rounded-2xl blur-xl animate-pulse" />
           <div className="relative bg-linear-to-br from-primary to-primary/80 p-4 rounded-2xl shadow-lg">
-            <Database className="h-10 w-10 text-primary-foreground" />
+            {getLogoUrl() ? (
+              <img src={getLogoUrl()} alt={getProductName()} className="h-10 w-10 object-contain" />
+            ) : (
+              <Database className="h-10 w-10 text-primary-foreground" />
+            )}
           </div>
         </div>
 

--- a/packages/app-shell/src/console/auth/AuthPageLayout.tsx
+++ b/packages/app-shell/src/console/auth/AuthPageLayout.tsx
@@ -5,30 +5,37 @@
  */
 
 import type React from 'react';
+import { getProductName, getLogoUrl } from '../../runtime-config';
 
 export function AuthPageLayout({ children }: { children: React.ReactNode }) {
+  const productName = getProductName();
+  const logoUrl = getLogoUrl();
   return (
     <div className="flex min-h-screen">
       {/* Left branding panel - hidden on mobile, shown on lg+ */}
       <div className="hidden lg:flex lg:w-1/2 items-center justify-center bg-primary p-12">
         <div className="max-w-md space-y-6 text-primary-foreground">
           <div className="flex items-center gap-3">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-10 w-10"
-              role="img"
-              aria-label="ObjectStack logo"
-            >
-              <title>ObjectStack</title>
-              <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
-            </svg>
-            <span className="text-2xl font-bold">ObjectStack</span>
+            {logoUrl ? (
+              <img src={logoUrl} alt={productName} className="h-10 w-10 object-contain" />
+            ) : (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-10 w-10"
+                role="img"
+                aria-label={`${productName} logo`}
+              >
+                <title>{productName}</title>
+                <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+              </svg>
+            )}
+            <span className="text-2xl font-bold">{productName}</span>
           </div>
           <h2 className="text-3xl font-bold leading-tight">
             Build powerful business applications, faster.

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -113,6 +113,11 @@ export {
   getProductName,
   getProductShortName,
   getPlatformStage,
+  getBrandColor,
+  getLogoUrl,
+  getFaviconUrl,
+  getPwaDescription,
+  getPwaThemeColor,
   isRuntimeConfigInitialised,
   resetRuntimeConfigForTesting,
 } from './runtime-config';

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -74,7 +74,7 @@ import { useCommandPalette } from '../context/CommandPaletteProvider';
 import { useUrlOverlay } from '../hooks/useUrlOverlay';
 import { KEYBOARD_SHORTCUTS_PARAM, RECORD_TRAIL_PARAM, decodeRecordTrail, buildRecordTrailHref } from '../urlParams';
 import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
-import { getProductName } from '../runtime-config';
+import { getProductName, getLogoUrl } from '../runtime-config';
 import { LocalizedSidebarTrigger } from './LocalizedSidebarTrigger';
 import { PreviewBadge } from './PreviewBadge';
 
@@ -669,12 +669,16 @@ export function AppHeader({
         <Link
           to="/home"
           className={cn(
-            "flex items-center justify-center h-7 w-7 shrink-0 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors",
+            "flex items-center justify-center h-7 w-7 shrink-0 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors overflow-hidden",
             isApp && "hidden sm:flex"
           )}
           title={getProductName()}
         >
-          <Layers className="h-4 w-4" />
+          {getLogoUrl() ? (
+            <img src={getLogoUrl()} alt={getProductName()} className="h-full w-full object-contain" />
+          ) : (
+            <Layers className="h-4 w-4" />
+          )}
         </Link>
 
         {resolvedVariant === 'home' && (

--- a/packages/app-shell/src/layout/AuthPageLayout.tsx
+++ b/packages/app-shell/src/layout/AuthPageLayout.tsx
@@ -5,30 +5,37 @@
  */
 
 import type React from 'react';
+import { getProductName, getLogoUrl } from '../runtime-config';
 
 export function AuthPageLayout({ children }: { children: React.ReactNode }) {
+  const productName = getProductName();
+  const logoUrl = getLogoUrl();
   return (
     <div className="flex min-h-screen">
       {/* Left branding panel - hidden on mobile, shown on lg+ */}
       <div className="hidden lg:flex lg:w-1/2 items-center justify-center bg-primary p-12">
         <div className="max-w-md space-y-6 text-primary-foreground">
           <div className="flex items-center gap-3">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-10 w-10"
-              role="img"
-              aria-label="ObjectStack logo"
-            >
-              <title>ObjectStack</title>
-              <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
-            </svg>
-            <span className="text-2xl font-bold">ObjectStack</span>
+            {logoUrl ? (
+              <img src={logoUrl} alt={productName} className="h-10 w-10 object-contain" />
+            ) : (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-10 w-10"
+                role="img"
+                aria-label={`${productName} logo`}
+              >
+                <title>{productName}</title>
+                <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+              </svg>
+            )}
+            <span className="text-2xl font-bold">{productName}</span>
           </div>
           <h2 className="text-3xl font-bold leading-tight">
             Build powerful business applications, faster.

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -72,6 +72,16 @@ export interface RuntimeBranding {
   productShortName: string;
   /** Product lifecycle stage — drives the top-bar preview/beta badge. */
   stage?: PlatformStage;
+  /** Absolute or relative URL for the product logo. */
+  logoUrl?: string;
+  /** Absolute or relative URL for the favicon. */
+  faviconUrl?: string;
+  /** Primary brand hex color (e.g. '#4F46E5'). */
+  brandColor?: string;
+  /** PWA manifest description. */
+  pwaDescription?: string;
+  /** PWA theme color hex. */
+  pwaThemeColor?: string;
 }
 
 export interface RuntimeConfig {
@@ -97,7 +107,7 @@ const defaults: RuntimeConfig = {
   features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true, customDomain: false, sso: false },
   // `stage: 'preview'` while the whole platform is pre-GA, so the badge shows
   // out of the box on any runtime that hasn't sent an explicit stage yet.
-  branding: { productName: 'ObjectOS', productShortName: 'ObjectOS', stage: 'preview' },
+  branding: { productName: 'ObjectOS', productShortName: 'ObjectOS', stage: 'preview', brandColor: '#4F46E5', pwaThemeColor: '#4f46e5' },
 };
 
 /** Valid {@link PlatformStage} values, for validating server-pushed config. */
@@ -177,6 +187,21 @@ export async function initRuntimeConfig(baseUrl: string = ''): Promise<void> {
           // (missing, typo'd) preserves the current value so the badge never
           // vanishes on a malformed payload.
           stage: isPlatformStage(body.branding.stage) ? body.branding.stage : current.branding.stage,
+          logoUrl: typeof body.branding.logoUrl === 'string' && body.branding.logoUrl.trim()
+            ? body.branding.logoUrl.trim()
+            : current.branding.logoUrl,
+          faviconUrl: typeof body.branding.faviconUrl === 'string' && body.branding.faviconUrl.trim()
+            ? body.branding.faviconUrl.trim()
+            : current.branding.faviconUrl,
+          brandColor: typeof body.branding.brandColor === 'string' && body.branding.brandColor.trim()
+            ? body.branding.brandColor.trim()
+            : current.branding.brandColor,
+          pwaDescription: typeof body.branding.pwaDescription === 'string' && body.branding.pwaDescription.trim()
+            ? body.branding.pwaDescription.trim()
+            : current.branding.pwaDescription,
+          pwaThemeColor: typeof body.branding.pwaThemeColor === 'string' && body.branding.pwaThemeColor.trim()
+            ? body.branding.pwaThemeColor.trim()
+            : current.branding.pwaThemeColor,
         }
         : current.branding,
     });
@@ -214,6 +239,26 @@ export function getProductShortName(): string {
  */
 export function getPlatformStage(): PlatformStage {
   return current.branding?.stage ?? 'preview';
+}
+
+export function getBrandColor(): string {
+  return current.branding?.brandColor || '#4F46E5';
+}
+
+export function getLogoUrl(): string | undefined {
+  return current.branding?.logoUrl;
+}
+
+export function getFaviconUrl(): string | undefined {
+  return current.branding?.faviconUrl;
+}
+
+export function getPwaDescription(): string {
+  return current.branding?.pwaDescription || `${getProductName()} — runtime console`;
+}
+
+export function getPwaThemeColor(): string {
+  return current.branding?.pwaThemeColor || getBrandColor();
 }
 
 /** Whether `initRuntimeConfig()` has run at least once. */


### PR DESCRIPTION
Replace hardcoded default icons, titles, and favicon with values from the runtime config branding endpoint. All branding surfaces (header logo, auth page BrandMark, device-auth, loading screen, PWA manifest, document title, favicon) now reflect the operator's configured brand.

Adds a dev-only Vite plugin that serves branding assets at /runtime/assets/* from the host project's runtime/assets directory, so logo/favicon URLs resolve when the console dev server runs standalone. Falls back to built-in defaults when no branding is configured.