### PR TITLE
fix(ai-chat): allow spreadsheet attachments in composer accept list (cloud#797 WS3)

### DIFF
--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -1118,7 +1118,11 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       maxHeight = '500px',
       enableMarkdown: _enableMarkdown = true,
       enableFileUpload = false,
-      acceptedFileTypes = 'image/*,.pdf,.doc,.docx,.txt',
+      // Spreadsheets included (cloud#797 WS3): the AI build panel parses
+      // .xlsx/.xlsm/.csv/.tsv attachments locally and briefs the agent — an
+      // accept list without them made that whole flow unreachable from the UI
+      // (the composer's type filter rejected the file before anything ran).
+      acceptedFileTypes = 'image/*,.pdf,.doc,.docx,.txt,.csv,.tsv,.xlsx,.xlsm',
       maxFileSize = 10 * 1024 * 1024,
       suggestions,
       labels,


### PR DESCRIPTION
#2386 让 AI build 面板本地解析 .xlsx/.csv 附件并简报给 agent,但 composer 默认 `acceptedFileTypes = 'image/*,.pdf,.doc,.docx,.txt'` —— 类型过滤在解析之前就把表格拒了(活体确认:把 CSV 塞进 input 不出 chip)。补上 `.csv/.tsv/.xlsx/.xlsm`,整条 WS3 流程才从 UI 够得着。chatbot 192/192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)