### PR TITLE
feat(ai-chat): Excel to App real-data import — attached sheet rows into a built object (cloud#797)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -18,6 +18,8 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { toast } from 'sonner';
+import { useAdapter } from '../../providers/AdapterProvider';
+import { ExcelImportBar } from './ExcelImportBar';
 import {
   Select,
   SelectContent,
@@ -1078,6 +1080,11 @@ export function ChatPane({
   // whole-app build doesn't trigger an invalidation storm.
   const [canvasApp, setCanvasApp] = useState<{ name: string; segment?: string; materialized: boolean } | null>(null);
   const [canvasRefreshKey, setCanvasRefreshKey] = useState(0);
+  // cloud#797 Excel→App: the attached spreadsheet the user can load real rows
+  // from (into a built object) via ExcelImportBar. Set when a sheet is sent,
+  // cleared on import/dismiss. `dataSource` drives the wizard's schema + import.
+  const dataSource = useAdapter();
+  const [pendingSheet, setPendingSheet] = useState<File | null>(null);
   const canvasTimerRef = useRef<number | null>(null);
   useEffect(() => () => {
     if (canvasTimerRef.current) window.clearTimeout(canvasTimerRef.current);
@@ -1257,6 +1264,10 @@ export function ChatPane({
         onSent(content);
         return;
       }
+      // Retain the first sheet so ExcelImportBar can load its REAL rows into a
+      // built object (cloud#797) — the agent got a brief; the user gets an
+      // import affordance without re-picking the file.
+      setPendingSheet(sheets[0]);
       void (async () => {
         const cap = (s: string) => (s.length > 40 ? `${s.slice(0, 40)}…` : s);
         const line = (r: string[]) =>
@@ -1405,6 +1416,21 @@ export function ChatPane({
 
   return (
     <div ref={split.containerRef} className="relative flex min-h-0 flex-1 px-0">
+      {/* Excel→App (cloud#797): float the real-data import affordance above the
+          chat when a spreadsheet was attached. Absolute so it doesn't disturb
+          the chat/canvas flex layout; the ImportWizard it opens is a modal. */}
+      {pendingSheet && dataSource ? (
+        <div className="pointer-events-none absolute top-2 left-0 right-0 z-20 flex justify-center px-4">
+          <div className="pointer-events-auto w-full max-w-3xl">
+            <ExcelImportBar
+              file={pendingSheet}
+              dataSource={dataSource}
+              defaultObjectName={canvasApp?.name}
+              onDone={() => setPendingSheet(null)}
+            />
+          </div>
+        </div>
+      ) : null}
       <div
         data-chat-column
         className={

--- a/packages/app-shell/src/console/ai/ExcelImportBar.tsx
+++ b/packages/app-shell/src/console/ai/ExcelImportBar.tsx
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ExcelImportBar — the "my real data is in it" half of the Excel→App wedge
+ * (cloud#797). When a user attaches a spreadsheet in the AI build panel, the
+ * agent parses a brief and builds the schema; this bar then lets them load the
+ * SAME file's real rows into a built object in two clicks — no re-picking the
+ * file, no hunting for the Import button in a list view.
+ *
+ * It's a thin host: pick a target object → hand the attached File straight to
+ * the existing ImportWizard with `initialFile`, which owns parsing, column
+ * mapping, dry-run and the real server-side import. So the magic-flow trial
+ * goes from "one sentence → app with demo data" to "app with MY data" — the
+ * retention hinge for a spreadsheet refugee.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Button, Badge } from '@object-ui/components';
+import { createAuthenticatedFetch } from '@object-ui/auth';
+import { toast } from 'sonner';
+import { ImportWizard } from '@object-ui/plugin-grid';
+
+type I18n = { en: string; zh: string };
+
+interface WizardField {
+  name: string;
+  label: string;
+  type: string;
+  required?: boolean;
+  options?: Array<{ label?: string; value?: string | number } | string>;
+}
+
+interface ExcelImportBarProps {
+  /** The attached spreadsheet, retained by the composer (objectui#2386). */
+  file: File;
+  /** The console data adapter (has getObjectSchema + import routes). */
+  dataSource: any;
+  /** Pre-select this object (e.g. the one just built this session). */
+  defaultObjectName?: string;
+  /** Called when the user dismisses the bar or an import completes. */
+  onDone: () => void;
+}
+
+function pick(label: I18n): string {
+  const lang =
+    (typeof document !== 'undefined' && document.documentElement.getAttribute('lang')) || 'en';
+  return lang.toLowerCase().startsWith('zh') ? label.zh : label.en;
+}
+
+const SKIP_OBJECT_PREFIXES = ['sys_', 'ai_', 'cloud_'];
+const NON_WRITABLE_TYPES = ['formula', 'summary', 'autonumber'];
+
+/** Normalize a getObjectSchema result's fields → the ImportWizard field shape. */
+function normalizeFields(schema: any): WizardField[] {
+  const raw = schema?.fields ?? schema?.data?.fields ?? schema?.item?.fields ?? {};
+  const entries: Array<[string, any]> = Array.isArray(raw)
+    ? raw.map((f: any) => [f?.name, f])
+    : Object.entries(raw);
+  return entries
+    .map(([name, def]) => ({
+      name: (def?.name ?? name) as string,
+      label: (def?.label ?? def?.name ?? name) as string,
+      type: (def?.type ?? 'text') as string,
+      required: !!def?.required,
+      options: def?.options,
+    }))
+    .filter((f) => f.name && !NON_WRITABLE_TYPES.includes(f.type));
+}
+
+export function ExcelImportBar({ file, dataSource, defaultObjectName, onDone }: ExcelImportBarProps) {
+  const authFetch = useMemo(() => createAuthenticatedFetch(), []);
+  const [objects, setObjects] = useState<Array<{ name: string; label: string }> | null>(null);
+  const [selected, setSelected] = useState<string>(defaultObjectName ?? '');
+  const [loadingFields, setLoadingFields] = useState(false);
+  const [fields, setFields] = useState<WizardField[] | null>(null);
+  const [open, setOpen] = useState(false);
+
+  // List the env's user objects so the user can target the import. Uses the
+  // uncached meta list endpoint; filters platform/system objects.
+  useEffect(() => {
+    let cancelled = false;
+    const apiBase = ((import.meta as any).env?.VITE_SERVER_URL || '').replace(/\/+$/, '');
+    (async () => {
+      try {
+        const res = await authFetch(`${apiBase}/api/v1/meta/object`, { method: 'GET', credentials: 'include' });
+        if (!res.ok) throw new Error(String(res.status));
+        const json = await res.json().catch(() => null);
+        const items = json?.data?.items ?? json?.items ?? json?.data ?? (Array.isArray(json) ? json : []);
+        const objs = (Array.isArray(items) ? items : [])
+          .map((o: any) => ({ name: o?.name as string, label: (o?.label as string) || (o?.name as string) }))
+          .filter((o: { name: string }) => o.name && !SKIP_OBJECT_PREFIXES.some((p) => o.name.startsWith(p)));
+        if (cancelled) return;
+        setObjects(objs);
+        if (!selected && objs.length) {
+          const preferred = defaultObjectName && objs.find((o: { name: string }) => o.name === defaultObjectName);
+          setSelected(preferred ? defaultObjectName! : objs[0].name);
+        }
+      } catch {
+        if (!cancelled) setObjects([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [authFetch, defaultObjectName]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function openWizard() {
+    if (!selected) return;
+    setLoadingFields(true);
+    try {
+      const schema = await dataSource.getObjectSchema(selected);
+      const f = normalizeFields(schema);
+      if (!f.length) {
+        toast.error(pick({ en: 'That object has no importable fields.', zh: '该对象没有可导入的字段。' }));
+        return;
+      }
+      setFields(f);
+      setOpen(true);
+    } catch {
+      toast.error(pick({ en: 'Could not read the object schema.', zh: '无法读取对象结构。' }));
+    } finally {
+      setLoadingFields(false);
+    }
+  }
+
+  const selectedLabel = objects?.find((o) => o.name === selected)?.label ?? selected;
+
+  if (open && fields) {
+    return (
+      <ImportWizard
+        open={open}
+        onOpenChange={(v) => { setOpen(v); if (!v) onDone(); }}
+        objectName={selected}
+        objectLabel={selectedLabel}
+        fields={fields}
+        dataSource={dataSource}
+        initialFile={file}
+        onComplete={(result) => {
+          toast.success(
+            pick({
+              en: `Imported ${result.importedRows} row(s) into ${selectedLabel}.`,
+              zh: `已把 ${result.importedRows} 行真实数据导入「${selectedLabel}」。`,
+            }),
+          );
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm" data-excel-import-bar>
+      <Badge variant="secondary">CSV / Excel</Badge>
+      <span className="text-muted-foreground">
+        {pick({ en: 'Import the real rows from', zh: '把真实数据导入自' })}
+      </span>
+      <code className="font-medium">{file.name}</code>
+      <span className="text-muted-foreground">{pick({ en: 'into', zh: '到' })}</span>
+      <select
+        className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+        value={selected}
+        onChange={(e) => setSelected(e.target.value)}
+        disabled={!objects || objects.length === 0}
+      >
+        {(objects ?? []).map((o) => (
+          <option key={o.name} value={o.name}>{o.label}</option>
+        ))}
+      </select>
+      <Button size="sm" onClick={openWizard} disabled={!selected || loadingFields}>
+        {loadingFields ? pick({ en: 'Opening…', zh: '打开中…' }) : pick({ en: 'Import', zh: '导入' })}
+      </Button>
+      <Button size="sm" variant="ghost" onClick={onDone}>
+        {pick({ en: 'Dismiss', zh: '忽略' })}
+      </Button>
+    </div>
+  );
+}

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -267,6 +267,13 @@ export interface ImportWizardProps {
    *  When omitted, the wizard fetches them via `dataSource.listImportMappings`
    *  (feature-detected). Pass explicitly to override / for tests. */
   savedMappings?: SavedMapping[];
+  /** Pre-loaded spreadsheet (cloud#797 Excel→App): when the wizard opens with
+   *  this set, it parses the File in memory and jumps straight to the mapping
+   *  step, skipping the upload UI. Used by the AI build panel to hand off an
+   *  already-attached Excel/CSV so the user goes from "one sentence → app" to
+   *  "my real data is in it" without re-picking the file. Ignored on reopen
+   *  once consumed. */
+  initialFile?: File;
 }
 
 export interface ImportResult {
@@ -1425,7 +1432,7 @@ const ImportHistoryPanel: React.FC<{
 // Main wizard component
 export const ImportWizard: React.FC<ImportWizardProps> = ({
   objectName, objectLabel, fields, dataSource, onComplete, onCancel, open, onOpenChange, onErrorMode = 'skip',
-  templateStorageKey, templateStorage, savedMappings,
+  templateStorageKey, templateStorage, savedMappings, initialFile,
 }) => {
   const { t } = useImportTranslation();
   const [step, setStep] = useState<WizardStep>('upload');
@@ -1614,6 +1621,31 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
   const handleFileLoaded = useCallback((h: string[], r: string[][]) => {
     setHeaders(h); setRows(r); setMapping(autoMapColumns(h, fields, r)); setCorrections({}); setStep('mapping');
   }, [fields]);
+
+  // cloud#797 Excel→App: when opened with a pre-loaded file (from the AI build
+  // panel's attachment), parse it once and jump straight to mapping — no
+  // re-picking the file the user already attached. Consumed once per File
+  // identity so reopening or a re-render doesn't re-parse or fight the user if
+  // they navigate back to upload.
+  const consumedInitialFileRef = React.useRef<File | null>(null);
+  useEffect(() => {
+    if (!open || !initialFile) return;
+    if (consumedInitialFileRef.current === initialFile) return;
+    consumedInitialFileRef.current = initialFile;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const parsed = await parseSpreadsheetFile(initialFile);
+        if (cancelled) return;
+        if (parsed.length < 2) return; // needs a header + at least one row
+        handleFileLoaded(parsed[0], parsed.slice(1));
+      } catch {
+        // Parse failed — leave the wizard on the upload step so the user can
+        // retry / pick a different file; the upload UI shows its own errors.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [open, initialFile, handleFileLoaded]);
 
   // Per-column type guesses, sampled from the loaded rows — drives mapping hints.
   const inferredTypes = useMemo<InferredType[]>(


### PR DESCRIPTION
补齐「表格楔子」的后半段。AI build 面板已能把附的 Excel/CSV 解析成简报让 agent 建 schema(WS3);这个 PR 补上另一半——**把同一份文件的真实行数据两步导进已建对象**,让试用从"一句话 → 带 demo 数据的 App"变成"带我自己数据的 App"(表格难民的留存铰链)。

- **plugin-grid ImportWizard**:新增 `initialFile` prop —— 传入已在内存的 File 时,内存解析、直接跳到列映射,跳过上传步(按 File 身份只消费一次)。
- **app-shell ExcelImportBar**:轻宿主,附了表格就出现 —— 选目标对象(env 用户对象,默认=本会话刚建的 app)→ 把 File 交给 ImportWizard 做映射/dry-run/真·服务端导入。字段来自 `dataSource.getObjectSchema`;文件本体不经过 agent/LLM。
- **AiChatPage**:发送时保留附的表格,`useAdapter` 作 dataSource,导入 bar 绝对定位浮在聊天上方(打开的向导是 modal,不扰乱布局)。

plugin-grid 194/194,app-shell 1178/1178;拓扑构建干净。依赖 objectui#2386。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
