### PR TITLE
feat(app-shell,plugin-grid): 身份导入——ImportWizard 复用接入 sys_user 批量导入（framework#2782）

### DIFF
--- a/.changeset/identity-import-wizard.md
+++ b/.changeset/identity-import-wizard.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/plugin-grid": minor
+"@object-ui/app-shell": minor
+"@object-ui/auth": patch
+"@object-ui/i18n": patch
+---
+
+feat: identity import — the stock ImportWizard now drives sys_user bulk import (framework#2782)
+
+The Users list gets an Import entry for platform admins (gated on
+`features.admin` from `/api/v1/auth/config` plus workspace-admin), wired to
+the dedicated `POST /api/v1/auth/admin/import-users` pipeline instead of the
+generic data import (which would bypass better-auth hashing and produce
+accounts that can never sign in).
+
+- **plugin-grid**: two generic, backend-agnostic ImportWizard slots —
+  `extraOptionsContent` (host-injected options on the preview step) and
+  `renderResultExtra` (host-rendered content on the result step).
+- **app-shell**: identity import dataSource adapter — splits files into the
+  endpoint's ≤500-row batches (idempotent upsert makes re-runs safe), injects
+  the selected password policy, renumbers per-batch results onto the whole
+  file, and enriches rows with their sign-in identity. Password policy panel
+  (`none` default / `invite` / `temporary`) and a one-shot temporary-password
+  reveal with CSV download (client memory only — nothing is persisted).
+  Async-job/undo surfaces are hidden for identity import by design.
+- **auth**: `AuthPublicConfig.features.admin` typing.
+- **i18n**: en/zh strings for the identity import panels.

--- a/packages/app-shell/src/views/IdentityImportPanels.tsx
+++ b/packages/app-shell/src/views/IdentityImportPanels.tsx
@@ -1,0 +1,137 @@
+// Identity import UI panels — framework#2782.
+//
+// Injected into the stock ImportWizard through its generic slots
+// (`extraOptionsContent` / `renderResultExtra`); the wizard itself stays
+// backend-agnostic. See identityImport.ts for the matching dataSource wrapper.
+
+import React, { useMemo } from 'react';
+import {
+  Button,
+  Label,
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@object-ui/components';
+import { Download, KeyRound, ShieldAlert } from 'lucide-react';
+import type { ImportRecordsResult } from '@object-ui/types';
+import { useSafeTranslate } from '@object-ui/i18n';
+import {
+  buildTemporaryPasswordCsv,
+  collectTemporaryPasswords,
+  type IdentityPasswordPolicy,
+} from './identityImport';
+
+const POLICY_FALLBACKS: Record<IdentityPasswordPolicy, { label: string; hint: string }> = {
+  none: {
+    label: 'No password (recommended)',
+    hint: 'Users first sign in with a phone OTP, magic link, or password-reset link, then set their own password.',
+  },
+  invite: {
+    label: 'Send invitations',
+    hint: 'Each created user gets a set-your-password email (or an invitation SMS for phone-only rows). Requires a configured email/SMS service.',
+  },
+  temporary: {
+    label: 'Temporary passwords',
+    hint: 'For deployments without email/SMS: each created user gets a one-time password, shown ONCE on the result screen. First sign-in forces a change.',
+  },
+};
+
+export function IdentityImportOptions({
+  policy,
+  onPolicyChange,
+}: {
+  policy: IdentityPasswordPolicy;
+  onPolicyChange: (p: IdentityPasswordPolicy) => void;
+}) {
+  const t = useSafeTranslate();
+  return (
+    <div className="mb-2 flex flex-col gap-2 rounded-md border border-border p-3" data-testid="identity-import-options">
+      <div className="flex items-center gap-2">
+        <KeyRound className="h-4 w-4 text-muted-foreground" />
+        <Label className="text-xs font-medium">
+          {t('console.identityImport.policyTitle', 'Sign-in setup for imported users')}
+        </Label>
+      </div>
+      <Select value={policy} onValueChange={(v) => onPolicyChange(v as IdentityPasswordPolicy)}>
+        <SelectTrigger className="h-8 w-full sm:w-80" data-testid="identity-import-policy">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {(Object.keys(POLICY_FALLBACKS) as IdentityPasswordPolicy[]).map((p) => (
+            <SelectItem key={p} value={p}>
+              {t(`console.identityImport.policy.${p}`, POLICY_FALLBACKS[p].label)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">
+        {t(`console.identityImport.policyHint.${policy}`, POLICY_FALLBACKS[policy].hint)}
+      </p>
+    </div>
+  );
+}
+
+/** One-shot reveal of the temporary passwords a `temporary`-policy import
+ *  returned. They exist only in this component's props (server keeps no
+ *  copy); closing the dialog discards them permanently. */
+export function IdentityImportResultExtra({ serverResult }: { serverResult?: ImportRecordsResult }) {
+  const t = useSafeTranslate();
+  const entries = useMemo(() => collectTemporaryPasswords(serverResult), [serverResult]);
+  if (entries.length === 0) return null;
+
+  const handleDownload = () => {
+    const csv = buildTemporaryPasswordCsv(entries);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'temporary-passwords.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="mt-2 flex w-full flex-col gap-2 rounded-md border border-amber-500/50 bg-amber-500/5 p-3" data-testid="identity-import-passwords">
+      <div className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+        <ShieldAlert className="h-4 w-4 shrink-0" />
+        <p className="text-xs font-medium">
+          {t(
+            'console.identityImport.passwordsNote',
+            'Temporary passwords — shown once, never stored. Save them now; each user must change theirs at first sign-in.',
+          )}
+        </p>
+      </div>
+      <div className="max-h-40 overflow-auto rounded border bg-background p-2 font-mono text-xs">
+        {entries.slice(0, 50).map((e) => (
+          <p key={e.row} data-testid={`identity-import-password-row-${e.row}`}>
+            {e.identity}: {e.temporaryPassword}
+          </p>
+        ))}
+        {entries.length > 50 && (
+          <p className="text-muted-foreground">
+            {t('console.identityImport.passwordsMore', 'More entries omitted — use the download.')}
+          </p>
+        )}
+      </div>
+      <div>
+        <Button variant="outline" size="sm" onClick={handleDownload} data-testid="identity-import-passwords-download">
+          <Download className="mr-1 h-4 w-4" />
+          {t('console.identityImport.passwordsDownload', 'Download CSV')} ({entries.length})
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** Curated importable columns for sys_user. The generic writable-field filter
+ *  would drop `phone_number` (readonly for CRUD — identity writes go through
+ *  better-auth), so identity import declares its own target set. */
+export function identityImportFields(
+  objectFields: Record<string, any> | undefined,
+): Array<{ name: string; label: string; type: string; required?: boolean }> {
+  const label = (name: string, fallback: string) => objectFields?.[name]?.label || fallback;
+  return [
+    { name: 'email', label: label('email', 'Email'), type: 'text' },
+    { name: 'phone_number', label: label('phone_number', 'Phone Number'), type: 'text' },
+    { name: 'name', label: label('name', 'Name'), type: 'text' },
+    { name: 'role', label: label('role', 'Platform Role'), type: 'text' },
+  ];
+}

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -49,6 +49,9 @@ import type { MobileViewSwitcherItem } from '../layout/MobileViewSwitcherContext
 import { ManagedByBadge } from '../components/ManagedByBadge';
 import { RecordDetailView } from './RecordDetailView';
 import { resolveCrudAffordances } from '../utils/crudAffordances';
+import { createIdentityImportDataSource, IDENTITY_IMPORT_OBJECT, type IdentityPasswordPolicy } from './identityImport';
+import { IdentityImportOptions, IdentityImportResultExtra, identityImportFields } from './IdentityImportPanels';
+import { useExpressionContext } from '../providers/ExpressionProvider';
 import { resolveManagedByEmptyState } from '../utils/managedByEmptyState';
 import { resolveViewId } from '../utils/resolveViewId';
 import { warnSuppressedListNav } from '../utils/warnSuppressedListNav';
@@ -374,6 +377,31 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
 
     // Import wizard open/close state — toolbar entry triggers it.
     const [showImport, setShowImport] = useState(false);
+
+    // ─── Identity import (framework#2782) ────────────────────────────────
+    // sys_user's generic import affordance stays FALSE (a data-layer insert
+    // would bypass better-auth's hashing and never create a credential), but
+    // platform admins get the same wizard wired to the dedicated
+    // /api/v1/auth/admin/import-users pipeline. Gated on the deployment's
+    // admin surface (features.admin from /api/v1/auth/config) plus the
+    // caller being a workspace admin (the server re-checks, ADR-0068).
+    const { features } = useExpressionContext();
+    const isIdentityImport = objectDef.name === IDENTITY_IMPORT_OBJECT;
+    const identityImportEnabled = isIdentityImport && features?.admin === true && isAdmin;
+    const [identityPasswordPolicy, setIdentityPasswordPolicy] = useState<IdentityPasswordPolicy>('none');
+    const identityPolicyRef = useRef<IdentityPasswordPolicy>('none');
+    identityPolicyRef.current = identityPasswordPolicy;
+    const identityDataSource = useMemo(
+      () => (identityImportEnabled
+        ? createIdentityImportDataSource({
+            base: dataSource,
+            authFetch: actionRuntime.authFetch,
+            baseUrl: import.meta.env.VITE_SERVER_URL || '',
+            getPasswordPolicy: () => identityPolicyRef.current,
+          })
+        : undefined),
+      [identityImportEnabled, dataSource, actionRuntime.authFetch],
+    );
 
     // ─── User-defined views (metadata overlay) ──────────────────────────
     // Saved views created via the ViewConfigPanel ("Add View") live in the
@@ -1610,7 +1638,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                         are inherently a desk/laptop workflow; the button
                         was eating header space on mobile next to the
                         primary "+" action. */}
-                    {affordances.import && can(objectDef.name, 'create') && (
+                    {(identityImportEnabled || (affordances.import && can(objectDef.name, 'create'))) && (
                     <Button
                         size="sm"
                         variant="outline"
@@ -1686,7 +1714,13 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                    onOpenChange={setShowImport}
                    objectName={objectDef.name}
                    objectLabel={objectLabel(objectDef)}
-                   fields={Object.entries(objectDef.fields || {})
+                   fields={identityImportEnabled
+                     // Identity import has a curated target set — the generic
+                     // writable-field filter below would drop phone_number
+                     // (readonly for CRUD; identity writes go through
+                     // better-auth, framework#2782).
+                     ? identityImportFields(objectDef.fields)
+                     : Object.entries(objectDef.fields || {})
                      // Only writable fields are importable targets. Computed
                      // types (formula/summary/autonumber) and fields flagged
                      // readonly / write:false are server-rejected, so we omit
@@ -1705,7 +1739,18 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                        // Enum options seed the downloadable template's example row.
                        ...(def?.options ? { options: def.options } : {}),
                      }))}
-                   dataSource={dataSource}
+                   dataSource={identityDataSource ?? dataSource}
+                   {...(identityImportEnabled ? {
+                     extraOptionsContent: (
+                       <IdentityImportOptions
+                         policy={identityPasswordPolicy}
+                         onPolicyChange={setIdentityPasswordPolicy}
+                       />
+                     ),
+                     renderResultExtra: (res: any) => (
+                       <IdentityImportResultExtra serverResult={res?.serverResult} />
+                     ),
+                   } : {})}
                    onComplete={(result) => {
                      setRefreshKey(k => k + 1);
                      const ok = result.importedRows;

--- a/packages/app-shell/src/views/__tests__/identityImport.test.ts
+++ b/packages/app-shell/src/views/__tests__/identityImport.test.ts
@@ -1,0 +1,181 @@
+// framework#2782 — identity import adapter unit tests (pure logic, no DOM).
+import { describe, it, expect, vi } from 'vitest';
+import {
+  splitIntoBatches,
+  resolveIdentityWriteOptions,
+  mergeIdentityBatchResults,
+  createIdentityImportDataSource,
+  collectTemporaryPasswords,
+  buildTemporaryPasswordCsv,
+  IDENTITY_IMPORT_BATCH_SIZE,
+} from '../identityImport';
+import type { ImportRecordsResult } from '@object-ui/types';
+
+const okResponse = (rows: Array<Record<string, unknown>>, overrides: Record<string, unknown> = {}) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({
+    success: true,
+    data: {
+      summary: { total: rows.length, created: rows.length, updated: 0, skipped: 0, errors: 0, dryRun: false },
+      rows: rows.map((_, i) => ({ row: i + 1, ok: true, action: 'created', id: `u-${i}` })),
+      ...overrides,
+    },
+  }),
+});
+
+describe('splitIntoBatches', () => {
+  it('splits at the endpoint cap and keeps order', () => {
+    const rows = Array.from({ length: 1201 }, (_, i) => i);
+    const batches = splitIntoBatches(rows);
+    expect(batches.map((b) => b.length)).toEqual([500, 500, 201]);
+    expect(batches[1][0]).toBe(500);
+    expect(IDENTITY_IMPORT_BATCH_SIZE).toBe(500);
+  });
+
+  it('handles fewer rows than one batch', () => {
+    expect(splitIntoBatches([1, 2, 3]).length).toBe(1);
+  });
+});
+
+describe('resolveIdentityWriteOptions', () => {
+  it('maps insert and upsert-by-email/phone', () => {
+    expect(resolveIdentityWriteOptions({})).toEqual({ mode: 'insert' });
+    expect(resolveIdentityWriteOptions({ writeMode: 'upsert', matchFields: ['email'] }))
+      .toEqual({ mode: 'upsert', matchBy: 'email' });
+    expect(resolveIdentityWriteOptions({ writeMode: 'upsert', matchFields: ['phone_number'] }))
+      .toEqual({ mode: 'upsert', matchBy: 'phone' });
+  });
+
+  it('rejects update mode and unsupported match fields before any batch is sent', () => {
+    expect(() => resolveIdentityWriteOptions({ writeMode: 'update', matchFields: ['email'] })).toThrow(/insert and upsert/);
+    expect(() => resolveIdentityWriteOptions({ writeMode: 'upsert', matchFields: ['name'] })).toThrow(/email.*phone_number/);
+  });
+});
+
+describe('mergeIdentityBatchResults', () => {
+  it('renumbers batch-local rows onto the whole file and enriches identity', () => {
+    const batch1 = [{ email: 'a@x.co' }, { email: 'b@x.co' }];
+    const batch2 = [{ phone_number: '+8613800000000' }];
+    const merged = mergeIdentityBatchResults(
+      [
+        {
+          summary: { total: 2, created: 2, updated: 0, skipped: 0, errors: 0, dryRun: false },
+          rows: [
+            { row: 1, ok: true, action: 'created', id: 'u1' },
+            { row: 2, ok: true, action: 'created', id: 'u2', temporaryPassword: 'Pw-Two!234567890' },
+          ],
+        },
+        {
+          summary: { total: 1, created: 0, updated: 0, skipped: 0, errors: 1, dryRun: false },
+          rows: [{ row: 1, ok: false, action: 'failed', code: 'INVALID_PHONE', error: 'bad phone' }],
+        },
+      ],
+      [batch1, batch2],
+      { dryRun: false, writeMode: 'insert' },
+    );
+    expect(merged.total).toBe(3);
+    expect(merged.created).toBe(2);
+    expect(merged.errors).toBe(1);
+    expect(merged.ok).toBe(2);
+    expect(merged.results.map((r) => r.row)).toEqual([1, 2, 3]);
+    const withPw = merged.results[1] as any;
+    expect(withPw.temporaryPassword).toBe('Pw-Two!234567890');
+    expect(withPw.identity).toBe('b@x.co');
+    const failed = merged.results[2] as any;
+    expect(failed.code).toBe('INVALID_PHONE');
+    expect(failed.identity).toBe('+8613800000000');
+  });
+});
+
+describe('createIdentityImportDataSource', () => {
+  const makeAdapter = (fetchImpl: ReturnType<typeof vi.fn>, policy: 'none' | 'invite' | 'temporary' = 'none') =>
+    createIdentityImportDataSource({
+      base: { find: 'passthrough-marker', createImportJob: () => {}, undoImportJob: () => {} },
+      authFetch: fetchImpl as any,
+      baseUrl: 'http://srv',
+      getPasswordPolicy: () => policy,
+    }) as any;
+
+  it('POSTs batches to the identity endpoint with the selected policy', async () => {
+    const rows = Array.from({ length: 501 }, (_, i) => ({ email: `u${i}@x.co` }));
+    const fetchImpl = vi.fn(async (_url: string, init: any) => {
+      const body = JSON.parse(init.body);
+      return okResponse(body.rows) as any;
+    });
+    const ds = makeAdapter(fetchImpl, 'temporary');
+    const res: ImportRecordsResult = await ds.importRecords('sys_user', { format: 'json', rows });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2); // 500 + 1
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe('http://srv/api/v1/auth/admin/import-users');
+    const body = JSON.parse(init.body);
+    expect(body.passwordPolicy).toBe('temporary');
+    expect(body.mode).toBe('insert');
+    expect(body.rows.length).toBe(500);
+    expect(res.total).toBe(501);
+    expect(res.results.length).toBe(501);
+    expect(res.results[500].row).toBe(501); // renumbered across batches
+  });
+
+  it('passes dryRun and upsert options through', async () => {
+    const fetchImpl = vi.fn(async (_url: string, init: any) => okResponse(JSON.parse(init.body).rows) as any);
+    const ds = makeAdapter(fetchImpl);
+    await ds.importRecords('sys_user', {
+      format: 'json',
+      rows: [{ email: 'a@x.co' }],
+      dryRun: true,
+      writeMode: 'upsert',
+      matchFields: ['email'],
+    });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.dryRun).toBe(true);
+    expect(body.mode).toBe('upsert');
+    expect(body.matchBy).toBe('email');
+  });
+
+  it('aborts remaining batches on a request-level failure and surfaces the server message', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      json: async () => ({ success: false, error: { code: 'EMAIL_SERVICE_REQUIRED', message: 'needs email service' } }),
+    }) as any);
+    const ds = makeAdapter(fetchImpl, 'invite');
+    const rows = Array.from({ length: 1000 }, (_, i) => ({ email: `u${i}@x.co` }));
+    await expect(ds.importRecords('sys_user', { format: 'json', rows })).rejects.toThrow('needs email service');
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // no second batch
+  });
+
+  it('hides the async-job and undo surfaces the wizard feature-detects', () => {
+    const ds = makeAdapter(vi.fn());
+    expect(ds.createImportJob).toBeUndefined();
+    expect(ds.undoImportJob).toBeUndefined();
+    expect(ds.cancelImportJob).toBeUndefined();
+    expect(ds.find).toBe('passthrough-marker'); // reads pass through
+  });
+});
+
+describe('temporary password reveal helpers', () => {
+  const result = {
+    object: 'sys_user', dryRun: false, writeMode: 'insert',
+    total: 2, ok: 2, errors: 0, created: 2, updated: 0, skipped: 0,
+    results: [
+      { row: 1, ok: true, action: 'created', identity: 'a@x.co', temporaryPassword: 'Aa1!aaaaaaaaaaaa' },
+      { row: 2, ok: true, action: 'created' },
+    ],
+  } as unknown as ImportRecordsResult;
+
+  it('collects only rows that carry a password', () => {
+    const entries = collectTemporaryPasswords(result);
+    expect(entries).toEqual([{ row: 1, identity: 'a@x.co', temporaryPassword: 'Aa1!aaaaaaaaaaaa' }]);
+    expect(collectTemporaryPasswords(undefined)).toEqual([]);
+  });
+
+  it('builds a CSV with escaping', () => {
+    const csv = buildTemporaryPasswordCsv([
+      { row: 1, identity: 'a@x.co', temporaryPassword: 'p,w"1' },
+    ]);
+    expect(csv.split('\n')[0]).toBe('row,identity,temporary_password');
+    expect(csv).toContain('"p,w""1"');
+  });
+});

--- a/packages/app-shell/src/views/identityImport.ts
+++ b/packages/app-shell/src/views/identityImport.ts
@@ -1,0 +1,254 @@
+// Identity import adapter — framework#2782.
+//
+// `sys_user` cannot go through the generic `/api/v1/data/sys_user/import`
+// route: a plain data-layer insert bypasses better-auth's password hashing and
+// never creates the credential account, so imported "users" could never sign
+// in. The server exposes a dedicated, platform-admin-gated endpoint instead
+// (`POST /api/v1/auth/admin/import-users`) whose payload is deliberately
+// byte-compatible with the generic import request.
+//
+// This module wraps the regular dataSource so the stock ImportWizard drives
+// that endpoint unchanged: `importRecords` is overridden to (1) split rows
+// into ≤500-row batches — the endpoint's hard cap, because password-related
+// work is CPU-bound server-side — and (2) inject the admin's chosen password
+// policy. The endpoint is idempotent on upsert (matched by email/phone), so
+// re-running a failed batch is safe.
+//
+// Password policies (framework#2820): `none` (default — identity only, users
+// first sign in via phone OTP / magic link / reset link and set a password
+// afterwards), `invite` (adds a set-your-password email / invitation SMS per
+// created row), `temporary` (per-row one-time passwords returned ONLY in the
+// response — the result step must surface them immediately; they are never
+// persisted anywhere, client or server).
+
+import type { ImportRecordsResult, ImportRequestOptions, ImportRowResult } from '@object-ui/types';
+
+export const IDENTITY_IMPORT_OBJECT = 'sys_user';
+
+/** Server-side hard cap on rows per identity import request. */
+export const IDENTITY_IMPORT_BATCH_SIZE = 500;
+
+export type IdentityPasswordPolicy = 'none' | 'invite' | 'temporary';
+
+/** Row results from the identity endpoint may carry a one-time password. */
+export type IdentityImportRowResult = ImportRowResult & {
+  temporaryPassword?: string;
+  /** The row's sign-in identity (email or phone), enriched from the source
+   *  rows by the adapter so the one-time-password reveal is usable. */
+  identity?: string;
+};
+
+interface IdentityImportResponse {
+  success: boolean;
+  error?: { code?: string; message?: string };
+  data?: {
+    summary: {
+      total: number;
+      created: number;
+      updated: number;
+      skipped: number;
+      errors: number;
+      dryRun: boolean;
+    };
+    rows: Array<{
+      row: number;
+      ok: boolean;
+      action?: 'created' | 'updated' | 'skipped' | 'failed';
+      id?: string;
+      field?: string;
+      code?: string;
+      error?: string;
+      temporaryPassword?: string;
+    }>;
+  };
+}
+
+/** Split rows into endpoint-sized batches (pure; exported for tests). */
+export function splitIntoBatches<T>(rows: T[], size = IDENTITY_IMPORT_BATCH_SIZE): T[][] {
+  const batches: T[][] = [];
+  for (let i = 0; i < rows.length; i += size) batches.push(rows.slice(i, i + size));
+  return batches;
+}
+
+/**
+ * Map the wizard's generic write options onto the identity endpoint's
+ * `mode` / `matchBy`. Throws early (before any batch is sent) on options the
+ * identity pipeline doesn't support, so the wizard surfaces one clear error
+ * instead of a half-imported file.
+ */
+export function resolveIdentityWriteOptions(request: ImportRequestOptions): {
+  mode: 'insert' | 'upsert';
+  matchBy?: 'email' | 'phone';
+} {
+  const writeMode = request.writeMode ?? 'insert';
+  if (writeMode === 'update') {
+    throw new Error('Identity import supports the insert and upsert write modes only.');
+  }
+  if (writeMode === 'insert') return { mode: 'insert' };
+  const match = (request.matchFields ?? [])[0];
+  if (match === 'email') return { mode: 'upsert', matchBy: 'email' };
+  if (match === 'phone_number') return { mode: 'upsert', matchBy: 'phone' };
+  throw new Error('Identity import matches existing users by "email" or "phone_number" only.');
+}
+
+/**
+ * Merge per-batch endpoint responses into one wizard-shaped
+ * {@link ImportRecordsResult}, renumbering each batch's 1-based rows onto the
+ * whole file (pure; exported for tests).
+ */
+export function mergeIdentityBatchResults(
+  responses: Array<NonNullable<IdentityImportResponse['data']>>,
+  batches: Array<Array<Record<string, unknown>>>,
+  meta: { dryRun: boolean; writeMode: 'insert' | 'upsert' },
+): ImportRecordsResult {
+  let total = 0, created = 0, updated = 0, skipped = 0, errors = 0;
+  const results: IdentityImportRowResult[] = [];
+  let offset = 0;
+  for (let b = 0; b < responses.length; b++) {
+    const { summary, rows } = responses[b];
+    const sourceRows = batches[b] ?? [];
+    total += summary.total;
+    created += summary.created;
+    updated += summary.updated;
+    skipped += summary.skipped;
+    errors += summary.errors;
+    for (const r of rows) {
+      if (!r) continue;
+      // Enrich with the row's sign-in identity so the one-time-password
+      // reveal (and its CSV) pairs each password with a recognizable account.
+      const source = sourceRows[r.row - 1] as { email?: unknown; phone_number?: unknown; phoneNumber?: unknown; phone?: unknown } | undefined;
+      const identity = [source?.email, source?.phone_number, source?.phoneNumber, source?.phone]
+        .find((v): v is string => typeof v === 'string' && v.trim().length > 0);
+      results.push({
+        row: offset + r.row,
+        ok: r.ok,
+        action: r.action,
+        ...(r.id ? { id: r.id } : {}),
+        ...(r.field ? { field: r.field } : {}),
+        ...(r.code ? { code: r.code } : {}),
+        ...(r.error ? { error: r.error } : {}),
+        ...(r.temporaryPassword ? { temporaryPassword: r.temporaryPassword } : {}),
+        ...(identity ? { identity: identity.trim() } : {}),
+      });
+    }
+    offset += sourceRows.length || summary.total;
+  }
+  return {
+    object: IDENTITY_IMPORT_OBJECT,
+    dryRun: meta.dryRun,
+    writeMode: meta.writeMode,
+    total,
+    ok: total - errors,
+    errors,
+    created,
+    updated,
+    skipped,
+    results,
+  };
+}
+
+export interface IdentityImportDataSourceOptions {
+  /** The regular dataSource — reads (and everything else) pass through. */
+  base: unknown;
+  /** Authenticated fetch (Bearer + tenant headers), e.g. createAuthenticatedFetch(). */
+  authFetch: (url: string, init?: RequestInit) => Promise<Response>;
+  /** Server origin (VITE_SERVER_URL); '' for same-origin. */
+  baseUrl: string;
+  /** Read the admin's currently selected password policy at send time. */
+  getPasswordPolicy: () => IdentityPasswordPolicy;
+}
+
+/**
+ * Wrap a dataSource so the ImportWizard writes through the identity endpoint.
+ *
+ * Also *removes* the async-job and undo surfaces: identity import is
+ * synchronous-only server-side (batching happens here instead) and undo would
+ * mean bulk-deleting users — the wizard feature-detects these methods, so
+ * clearing them cleanly hides the corresponding UI.
+ */
+export function createIdentityImportDataSource(opts: IdentityImportDataSourceOptions): unknown {
+  const { base, authFetch, baseUrl, getPasswordPolicy } = opts;
+
+  const importRecords = async (
+    _objectName: string,
+    request: ImportRequestOptions,
+  ): Promise<ImportRecordsResult> => {
+    const { mode, matchBy } = resolveIdentityWriteOptions(request);
+    const passwordPolicy = getPasswordPolicy();
+    const rows = Array.isArray(request.rows) ? request.rows : [];
+    if (rows.length === 0) {
+      throw new Error('Identity import needs mapped rows (rows[]) — file uploads are parsed client-side.');
+    }
+
+    const batches = splitIntoBatches(rows);
+    const responses: Array<NonNullable<IdentityImportResponse['data']>> = [];
+    for (const batch of batches) {
+      const res = await authFetch(`${baseUrl}/api/v1/auth/admin/import-users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          format: 'json',
+          rows: batch,
+          mode,
+          ...(matchBy ? { matchBy } : {}),
+          passwordPolicy,
+          ...(request.dryRun ? { dryRun: true } : {}),
+          ...(request.mappingName ? { mappingName: request.mappingName } : {}),
+          ...(request.trimWhitespace !== undefined ? { trimWhitespace: request.trimWhitespace } : {}),
+          ...(request.nullValues ? { nullValues: request.nullValues } : {}),
+        }),
+      });
+      const body = (await res.json().catch(() => null)) as IdentityImportResponse | null;
+      if (!res.ok || !body?.success || !body.data) {
+        const message = body?.error?.message ?? `Identity import failed with status ${res.status}`;
+        // Abort the remaining batches: the request-level failure (bad policy,
+        // missing email service, …) would repeat identically for every batch.
+        throw new Error(message);
+      }
+      responses.push(body.data);
+    }
+
+    return mergeIdentityBatchResults(
+      responses,
+      batches as Array<Array<Record<string, unknown>>>,
+      { dryRun: request.dryRun === true, writeMode: mode },
+    );
+  };
+
+  // Spread first, then null the surfaces identity import must not offer —
+  // a plain spread would copy the generic job/undo methods along.
+  return {
+    ...(base as Record<string, unknown>),
+    importRecords,
+    createImportJob: undefined,
+    getImportJobProgress: undefined,
+    getImportJobResults: undefined,
+    listImportJobs: undefined,
+    cancelImportJob: undefined,
+    undoImportJob: undefined,
+  };
+}
+
+/** Rows that carry a one-time password, for the result-step reveal. */
+export function collectTemporaryPasswords(
+  result: ImportRecordsResult | undefined,
+): Array<{ row: number; identity: string; temporaryPassword: string }> {
+  if (!result?.results) return [];
+  const out: Array<{ row: number; identity: string; temporaryPassword: string }> = [];
+  for (const r of result.results as IdentityImportRowResult[]) {
+    if (r?.temporaryPassword) {
+      out.push({ row: r.row, identity: r.identity ?? `#${r.row}`, temporaryPassword: r.temporaryPassword });
+    }
+  }
+  return out;
+}
+
+/** CSV for the one-time-password handout (client memory only — never persisted). */
+export function buildTemporaryPasswordCsv(
+  entries: Array<{ row: number; identity: string; temporaryPassword: string }>,
+): string {
+  const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+  const lines = ['row,identity,temporary_password'];
+  for (const e of entries) lines.push(`${e.row},${esc(e.identity)},${esc(e.temporaryPassword)}`);
+  return lines.join('\n');
+}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -156,6 +156,13 @@ export interface AuthPublicConfig {
      * entry point whose code can never arrive.
      */
     phoneNumberOtp?: boolean;
+    /**
+     * better-auth admin plugin mounted server-side (`auth.plugins.admin`;
+     * SCIM forces it on). Gates the admin user-management surfaces — the
+     * sys_user create/set-password actions and the identity import wizard
+     * entry (framework#2766 / #2782).
+     */
+    admin?: boolean;
   };
 }
 

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1283,6 +1283,22 @@ const en = {
       noAccessTitle: 'Access denied',
       noAccess: 'You do not have permission to view this data.',
     },
+    identityImport: {
+      policyTitle: 'Sign-in setup for imported users',
+      policy: {
+        none: 'No password (recommended)',
+        invite: 'Send invitations',
+        temporary: 'Temporary passwords',
+      },
+      policyHint: {
+        none: 'Users first sign in with a phone OTP, magic link, or password-reset link, then set their own password.',
+        invite: 'Each created user gets a set-your-password email (or an invitation SMS for phone-only rows). Requires a configured email/SMS service.',
+        temporary: 'For deployments without email/SMS: each created user gets a one-time password, shown ONCE on the result screen. First sign-in forces a change.',
+      },
+      passwordsNote: 'Temporary passwords — shown once, never stored. Save them now; each user must change theirs at first sign-in.',
+      passwordsMore: 'More entries omitted — use the download.',
+      passwordsDownload: 'Download CSV',
+    },
     objectView: {
       objectNotFound: 'Object Not Found',
       objectNotFoundDescription: 'The object "{{objectName}}" does not exist in the current configuration.',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1356,6 +1356,22 @@ const zh = {
       noAccessTitle: '无访问权限',
       noAccess: '您没有权限查看此数据。',
     },
+    identityImport: {
+      policyTitle: '导入用户的登录方式',
+      policy: {
+        none: '不设密码（推荐）',
+        invite: '发送邀请',
+        temporary: '临时密码',
+      },
+      policyHint: {
+        none: '用户通过手机验证码、魔法链接或重置链接首次登录，之后自行设置密码。',
+        invite: '为每个新建用户发送"设置密码"邮件（仅手机号的行发送邀请短信）。需要已配置邮件/短信服务。',
+        temporary: '适用于未配置邮件/短信的部署：为每个新建用户生成一次性密码，仅在结果页显示一次，首次登录强制修改。',
+      },
+      passwordsNote: '临时密码——仅显示一次，不会被保存。请立即保存；用户首次登录时必须修改。',
+      passwordsMore: '更多条目已省略——请使用下载。',
+      passwordsDownload: '下载 CSV',
+    },
     objectView: {
       systemViewReadonly: '系统视图由代码定义，只读。',
       expandToPage: '以完整页面打开',

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -274,6 +274,16 @@ export interface ImportWizardProps {
    *  "my real data is in it" without re-picking the file. Ignored on reopen
    *  once consumed. */
   initialFile?: File;
+  /** Extra content rendered above the write-options panel on the preview step.
+   *  Hosts inject domain-specific import options here (e.g. the identity
+   *  import's password policy — framework#2782); any state it collects flows
+   *  back through the host's own `dataSource` wrapper, so the wizard stays
+   *  backend-agnostic. */
+  extraOptionsContent?: React.ReactNode;
+  /** Render extra content at the top of the result step — e.g. one-time
+   *  credentials a domain-specific import endpoint returned in
+   *  `result.serverResult` (framework#2782). */
+  renderResultExtra?: (result: ImportResult) => React.ReactNode;
 }
 
 export interface ImportResult {
@@ -1432,7 +1442,7 @@ const ImportHistoryPanel: React.FC<{
 // Main wizard component
 export const ImportWizard: React.FC<ImportWizardProps> = ({
   objectName, objectLabel, fields, dataSource, onComplete, onCancel, open, onOpenChange, onErrorMode = 'skip',
-  templateStorageKey, templateStorage, savedMappings, initialFile,
+  templateStorageKey, templateStorage, savedMappings, initialFile, extraOptionsContent, renderResultExtra,
 }) => {
   const { t } = useImportTranslation();
   const [step, setStep] = useState<WizardStep>('upload');
@@ -2071,6 +2081,9 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
             )}
             {step === 'preview' && (
               <>
+                {extraOptionsContent && (
+                  <div data-testid="import-extra-options">{extraOptionsContent}</div>
+                )}
                 {/* Write-mode/match options are owned by the artifact when a
                     named mapping is active; hide the manual panel. */}
                 {!activeMapping && (
@@ -2206,6 +2219,9 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
               )}
               {result.skippedRows > 0 && <Badge variant="destructive">{t('grid.import.skippedCount', { count: result.skippedRows })}</Badge>}
             </div>
+            {renderResultExtra && (
+              <div className="w-full" data-testid="import-result-extra">{renderResultExtra(result)}</div>
+            )}
             {result.errors.length > 0 && (
               <>
                 <div className="max-h-32 w-full overflow-auto rounded border p-2 text-xs">


### PR DESCRIPTION
Implements framework#2782: the Users list (sys_user) gains an **Import** toolbar entry for platform admins, driving the existing generic ImportWizard against the dedicated identity endpoint — no new wizard UI was built.

## Why not the generic import route

sys_user's generic import affordance stays **false** by design: a data-layer insert bypasses better-auth's password hashing and never creates the credential account, so imported "users" could never sign in. The server ships a dedicated, platform-admin-gated `POST /api/v1/auth/admin/import-users` (framework#2771/#2820) whose payload is deliberately byte-compatible with the generic import request — which is what makes this adapter thin.

## Changes

**plugin-grid（保持后端无关）**
- Two generic ImportWizard slots: `extraOptionsContent` (rendered on the preview step) and `renderResultExtra` (result step). No identity logic in the wizard.

**app-shell（身份逻辑全部在此）**
- `identityImport.ts` — dataSource adapter: overrides `importRecords` to split files into **≤500-row batches** (the endpoint's hard cap; upsert matches by email/phone and is idempotent, so re-running a failed batch is safe — this replaces the server-side async job per framework#2781's closure), injects the selected `passwordPolicy`, renumbers per-batch rows onto the whole file, and enriches result rows with their sign-in identity. Async-job/undo surfaces are removed so the wizard's feature detection hides that UI (identity import is sync-only; undo would bulk-delete users).
- `IdentityImportPanels.tsx` — password-policy select (**`none` default** / `invite` / `temporary`, matching framework#2820) and the one-shot temporary-password reveal + CSV download. Passwords exist only in component props / client memory; closing the dialog discards them.
- `ObjectView.tsx` — entry gated on `features.admin` (from `/api/v1/auth/config`) **and** workspace admin (server re-checks per ADR-0068); curated importable-field set for sys_user (`email` / `phone_number` / `name` / `role` — the generic writable filter would drop the CRUD-readonly `phone_number`).

**auth / i18n**
- `AuthPublicConfig.features.admin` typing; en/zh strings (other locales fall back to English via `useSafeTranslate`).

## Testing

- New `identityImport.test.ts`: 11 cases — batch splitting at 500, write-option mapping (insert/upsert-by-email/phone; `update` mode and non-identity match fields rejected before any batch is sent), cross-batch row renumbering + identity enrichment, policy/dryRun passthrough, request-level failure aborts remaining batches, job/undo surface hiding, temporary-password collection + CSV escaping.
- Touched packages all green: plugin-grid 194, app-shell 1189 (32 turbo tasks); `tsc` builds clean.

Server counterpart: framework#2771 / #2820 / #2797. Closes framework#2782 (objectui side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r6eiJzivw1CkwTDSGho1o

---
_Generated by [Claude Code](https://claude.ai/code/session_016r6eiJzivw1CkwTDSGho1o)_