### PR TITLE
fix(plugin-form): managed 对象按 userActions.edit 逐字段 readonly 渲染，取消一刀切禁用（ADR-0092 D4）

### DIFF
--- a/.changeset/sys-user-edit-form-readonly.md
+++ b/.changeset/sys-user-edit-form-readonly.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/plugin-form": patch
+---
+
+fix(plugin-form): honor `userActions.edit` on managed objects instead of blanket-disabling every field (ADR-0092 D4)
+
+`ObjectForm` disabled every field on any non-`platform` lifecycle bucket
+(config / system / append-only / better-auth) — a defensive default from when
+those objects had no generic edit affordance at all. Now that an object can
+OPEN per-record editing via `userActions.{edit,create}` (framework ADR-0092 D4
+— e.g. `sys_user` exposing its `name`/`image` profile fields), the blanket
+lock lifts for the current mode when its affordance is `true`, and each
+field's own `readonly` flag decides. Managed buckets still default the
+affordance off, so an object that doesn't opt in is unchanged. The server-side
+identity write guard remains the real boundary; this is UX only.

--- a/packages/plugin-form/src/ObjectForm.managedEdit.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.managedEdit.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ObjectForm } from './ObjectForm';
+import { registerAllFields } from '@object-ui/fields';
+import React from 'react';
+
+registerAllFields();
+
+/**
+ * ADR-0092 D4 — managed-object edit affordance gating.
+ *
+ * Non-`platform` lifecycle buckets (config / system / append-only /
+ * better-auth) blanket-disable every form field by default. When an object
+ * OPENS per-record editing for the mode via `userActions.{edit,create}`, the
+ * blanket lock lifts and each field's own `readonly` flag decides — so a
+ * `managedBy:'better-auth'` object like sys_user can expose `name`/`image`
+ * while keeping `email`/`role` read-only. The server-side write guard is the
+ * real boundary; this is UX only.
+ */
+describe('ObjectForm — managed-object edit affordance (ADR-0092 D4)', () => {
+  const sysUserFields = {
+    name: { type: 'text', label: 'Name', readonly: false },
+    image: { type: 'url', label: 'Profile Image', readonly: false },
+    email: { type: 'email', label: 'Email', readonly: true },
+    role: { type: 'text', label: 'Role', readonly: true },
+  };
+
+  const record = { id: 'u1', name: 'Dev Admin', email: 'a@b.c', role: 'user', image: '' };
+  const dsFor = (schema: any): any => ({
+    getObjectSchema: vi.fn().mockResolvedValue(schema),
+    findOne: vi.fn().mockResolvedValue(record),
+    getRecord: vi.fn().mockResolvedValue(record),
+    createRecord: vi.fn(),
+    updateRecord: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    query: vi.fn(),
+  });
+
+  const renderEdit = (schema: any) =>
+    render(
+      <ObjectForm
+        schema={{ type: 'object-form', objectName: schema.name, mode: 'edit', recordId: 'u1' } as any}
+        dataSource={dsFor(schema)}
+      />,
+    );
+
+  async function inputByName(container: HTMLElement, name: string): Promise<HTMLInputElement> {
+    return waitFor(() => {
+      const el = container.querySelector(`input[name="${name}"]`) as HTMLInputElement | null;
+      if (!el) throw new Error(`${name} input not yet rendered`);
+      return el;
+    });
+  }
+
+  it('better-auth object WITH userActions.edit: editable (readonly:false) field becomes an enabled input', async () => {
+    const schema = { name: 'sys_user', managedBy: 'better-auth', userActions: { edit: true }, fields: sysUserFields };
+    const { container } = renderEdit(schema);
+
+    // The profile field the affordance opens (readonly:false) is now editable —
+    // the blanket managed-object lock no longer applies. (readonly:true fields
+    // like email/role are excluded from the edit form by the existing
+    // readonly-field mechanism, so they can never be edited here either.)
+    const name = await inputByName(container, 'name');
+    expect(name.disabled).toBe(false);
+    // No readonly field leaks in as an enabled input.
+    expect(container.querySelector('input[name="email"]:not([disabled])')).toBeNull();
+    expect(container.querySelector('input[name="role"]:not([disabled])')).toBeNull();
+  });
+
+  it('better-auth object WITHOUT userActions.edit: blanket lock disables the field (backward compat)', async () => {
+    const schema = { name: 'sys_session', managedBy: 'better-auth', fields: sysUserFields };
+    const { container } = renderEdit(schema);
+
+    const name = await inputByName(container, 'name');
+    expect(name.disabled).toBe(true); // no affordance override → blanket lock applies even to readonly:false
+  });
+
+  it('platform object: fields editable regardless (unchanged behavior)', async () => {
+    const schema = { name: 'crm_lead', managedBy: 'platform', fields: { name: { type: 'text', label: 'Name' } } };
+    const { container } = renderEdit(schema);
+    const name = await inputByName(container, 'name');
+    expect(name.disabled).toBe(false);
+  });
+});

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -438,7 +438,26 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     if (!objectSchema) return;
 
     const generatedFields: FormField[] = [];
-    
+
+    // Managed-object blanket lock (ADR-0092 D4). Non-`platform` lifecycle
+    // buckets (config / system / append-only / better-auth) historically had
+    // no generic edit affordance, so every field was disabled as a defensive
+    // default. An object can now OPEN per-record editing for the current mode
+    // via `userActions.{edit,create}` (e.g. sys_user opens `edit` for its
+    // profile fields); when it does, we drop the blanket lock and honor each
+    // field's own `readonly` flag instead. Mirrors the server's
+    // resolveCrudAffordances contract — managed buckets default the affordance
+    // off, so only an explicit `=== true` override unlocks. The server-side
+    // write guard remains the real boundary; this is UX only.
+    const managed = !!objectSchema?.managedBy && objectSchema.managedBy !== 'platform';
+    const modeAffordanceOpen =
+      schema.mode === 'edit'
+        ? (objectSchema as any)?.userActions?.edit === true
+        : schema.mode === 'create'
+          ? (objectSchema as any)?.userActions?.create === true
+          : false;
+    const managedBlanketLock = managed && !modeAffordanceOpen;
+
     // Determine which fields to include
     const fieldsToShow = schema.fields || Object.keys(objectSchema.fields || {});
     
@@ -472,7 +491,7 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
           label: fieldLabel(schema.objectName, name, field.label || fieldName),
           type: mapFieldTypeToFormType(field.type),
           required: field.required || false,
-          disabled: schema.readOnly || schema.mode === 'view' || field.readonly || (objectSchema?.managedBy && objectSchema.managedBy !== 'platform'),
+          disabled: schema.readOnly || schema.mode === 'view' || field.readonly || managedBlanketLock,
           placeholder: field.placeholder,
           description: field.help || field.description,
           validation: buildValidationRules(field),


### PR DESCRIPTION
## 概要

ADR-0092 D4 的 objectui 配套。`ObjectForm`（`packages/plugin-form/src/ObjectForm.tsx:475`）此前对任何非 `platform` 生命周期桶（config/system/append-only/better-auth）的**所有**表单字段一刀切 `disabled` —— 这是这些对象过去没有通用编辑 affordance 时的防御默认。

framework 侧（ADR-0092 D4 / #2817）已让 `sys_user` 通过 `userActions:{edit:true}` 开放档案字段编辑,并对非档案字段逐字段标 `readonly`。但 vendored console 的一刀切禁用把本应可编辑的 `name`/`image` 也锁死 → Edit 按钮"可见但不可用"（framework #2833）。

## 改动

`ObjectForm` 字段生成时：当对象在当前 mode 的 affordance 为 `true`（`userActions.edit`/`userActions.create` 显式开启）时,取消一刀切锁,改由每个字段自己的 `readonly` 决定：

```
const managed = !!managedBy && managedBy !== 'platform';
const modeAffordanceOpen = mode==='edit' ? userActions?.edit===true
                         : mode==='create' ? userActions?.create===true : false;
const managedBlanketLock = managed && !modeAffordanceOpen;
// disabled: schema.readOnly || mode==='view' || field.readonly || managedBlanketLock
```

- `sys_user`（better-auth + edit:true）：`name`/`image`（readonly:false）→ 可编辑；readonly 字段仍被既有机制排除在编辑表单外,永不可编。
- 未开 affordance 的 managed 对象（如 sys_session）：一刀切锁**保持**,向后兼容。
- platform 对象：不受影响。

服务端身份写守卫（framework #2828）才是真正边界,本改动仅 UX。

## 测试

新增 `ObjectForm.managedEdit.test.tsx`（3 例,全过）：better-auth+edit → name 可编辑且无 readonly 字段泄漏为可编辑 input；better-auth 无 edit → 一刀切禁用;platform → 可编辑。plugin-form 全套 196 通过;`pnpm --filter @object-ui/plugin-form build` 通过。

## 联动 / 相关

- framework 侧 `pnpm objectui:refresh` 更新 pin SHA + vendored bundle 后,framework #2817（PR #2832）的 affordance 才真正可用。
- 修复 framework #2833 描述的问题 · ADR-0092 D4 · framework #2817 / #2828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGAN5VvvBi4YRGwpNT6e21

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGAN5VvvBi4YRGwpNT6e21)_