### PR TITLE
feat(fields,plugin-form,plugin-detail): Setup system_permissions → capability multi-select (ADR-0056 P2)

### DIFF
--- a/.changeset/perm-setup-capability-picker.md
+++ b/.changeset/perm-setup-capability-picker.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/fields": patch
+"@object-ui/data-objectstack": patch
+"@object-ui/plugin-detail": patch
+"@object-ui/plugin-form": patch
+"@object-ui/components": patch
+---
+
+Setup permission sets: `system_permissions` is now a structured capability
+multi-select instead of a raw JSON textarea (ADR-0056 P2, epic #2398).
+
+A new `CapabilityMultiSelectField` (`field:capability-multiselect`) renders the
+live `sys_capability` registry as scope-grouped, labelled chips with the
+capability description on hover, and round-trips the value **byte-equivalent** to
+the `sys_permission_set.system_permissions` storage (a JSON-string array of
+capability names — parsed on load, `JSON.stringify(names)` on save). Unknown /
+legacy names are preserved. The widget is stamped onto the field via a single
+choke point (`ObjectStackAdapter.getObjectSchema`), so both the record form
+(ObjectForm) and the detail-page inline edit (DetailView / DetailSection) show
+the picker; the field's storage type is unchanged. First step toward retiring
+Setup's permission JSON textareas in favor of structured Studio editors.

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -121,7 +121,7 @@ const computeDirty = (
 };
 
 const BUILTIN_FIELD_TYPES = new Set(['input', 'textarea', 'checkbox', 'switch', 'select']);
-const DATA_SOURCE_FIELD_TYPES = new Set(['lookup', 'master_detail', 'tree']);
+const DATA_SOURCE_FIELD_TYPES = new Set(['lookup', 'master_detail', 'tree', 'capability-multiselect']);
 
 function stripRendererOnlyProps<T extends Record<string, any>>(props: T): T {
   const {

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1608,7 +1608,13 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       const schema = await this.metadataCache.get(objectName, () =>
         this.fetchObjectSchemaFresh(objectName),
       );
-      
+
+      // ADR-0056 P2 (epic #2398): stamp structured-widget hints onto specific
+      // platform fields. This is the single choke point both the record form
+      // (ObjectForm) and the detail view (DetailView/DetailSection) read the
+      // schema through, so one pass here reaches every edit surface.
+      this.applyFieldWidgetOverrides(objectName, schema);
+
       return schema;
     } catch (error: unknown) {
       // Check if it's a 404 error
@@ -1623,6 +1629,35 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       }
       
       throw createErrorFromResponse(errorObj, `getObjectSchema(${objectName})`);
+    }
+  }
+
+  /**
+   * ADR-0056 P2 (epic #2398) — stamp structured-widget hints onto platform
+   * fields whose framework type is a storage primitive (e.g. `textarea`) but
+   * whose authoring UX should be a structured editor. Only the render `widget`
+   * is added; the field's `type` (the storage contract) is untouched. Applied
+   * idempotently to the cached schema so form + detail both honor it. Widget
+   * components are registered as `field:<widget>` in `@object-ui/fields`.
+   */
+  private applyFieldWidgetOverrides(objectName: string, schema: unknown): void {
+    const OVERRIDES: Record<string, Record<string, string>> = {
+      // system_permissions stores a JSON-string array of capability names —
+      // edit it as a capability multi-select, never a raw JSON textarea.
+      sys_permission_set: { system_permissions: 'capability-multiselect' },
+    };
+    const overrides = OVERRIDES[objectName];
+    const fields =
+      schema && typeof schema === 'object' ? (schema as { fields?: unknown }).fields : null;
+    if (!overrides || !fields) return;
+    for (const [fname, widget] of Object.entries(overrides)) {
+      if (Array.isArray(fields)) {
+        const f = fields.find((x: any) => x?.name === fname);
+        if (f && !f.widget) f.widget = widget;
+      } else {
+        const f = (fields as Record<string, any>)[fname];
+        if (f && !f.widget) f.widget = widget;
+      }
     }
   }
 

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -179,6 +179,7 @@ import { CurrencyField } from './widgets/CurrencyField';
 import { TextAreaField } from './widgets/TextAreaField';
 import { RichTextField } from './widgets/RichTextField';
 import { LookupField } from './widgets/LookupField';
+import { CapabilityMultiSelectField } from './widgets/CapabilityMultiSelectField';
 import { DateTimeField } from './widgets/DateTimeField';
 import { TimeField } from './widgets/TimeField';
 import { PercentField } from './widgets/PercentField';
@@ -2152,6 +2153,12 @@ export function registerFields() {
   // display widget remains the default for { type: 'html', content }.
   ComponentRegistry.register('html', createFieldRenderer(RichTextField), { namespace: 'field', skipFallback: true });
   ComponentRegistry.register('lookup', createFieldRenderer(LookupField), { namespace: 'field' });
+  // Capability multi-select (ADR-0056 P2) — reached only via the field
+  // `widget: 'capability-multiselect'` hint (see MetadataProvider), never a bare
+  // field type. Registered WITHOUT createFieldRenderer: it is a fully-controlled
+  // widget (value/onChange from RHF), so the wrapper's extra label + local value
+  // buffer would only duplicate the form's FormLabel and desync the value.
+  ComponentRegistry.register('capability-multiselect', CapabilityMultiSelectField, { namespace: 'field', skipFallback: true });
   // master_detail = child-side FK lookup (single value, typically required). See
   // fieldWidgetMap above for rationale.
   ComponentRegistry.register('master_detail', createFieldRenderer(LookupField), { namespace: 'field' });
@@ -2212,6 +2219,7 @@ export * from './widgets/PasswordField';
 export * from './widgets/TextAreaField';
 export * from './widgets/RichTextField';
 export * from './widgets/LookupField';
+export * from './widgets/CapabilityMultiSelectField';
 export * from './widgets/RecordPickerDialog';
 export * from './widgets/FileField';
 export * from './widgets/ImageField';

--- a/packages/fields/src/widgets/CapabilityMultiSelectField.test.tsx
+++ b/packages/fields/src/widgets/CapabilityMultiSelectField.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * CapabilityMultiSelectField (ADR-0056 P2, epic #2398).
+ *
+ * Proves the two properties P2 depends on:
+ *  1. the stored value parses tolerantly into a capability-name list, and
+ *  2. every edit emits a JSON-**string** array of names — byte-equivalent to
+ *     the `sys_permission_set.system_permissions` textarea storage, so the
+ *     round-trip through the picker never changes the on-disk shape.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CapabilityMultiSelectField, parseCapabilityNames } from './CapabilityMultiSelectField';
+
+describe('parseCapabilityNames', () => {
+  it('parses the canonical JSON-string array', () => {
+    expect(parseCapabilityNames('["setup.access","studio.access"]')).toEqual([
+      'setup.access',
+      'studio.access',
+    ]);
+  });
+
+  it('treats empty / null / undefined as no selection', () => {
+    expect(parseCapabilityNames('')).toEqual([]);
+    expect(parseCapabilityNames('   ')).toEqual([]);
+    expect(parseCapabilityNames(null)).toEqual([]);
+    expect(parseCapabilityNames(undefined)).toEqual([]);
+    expect(parseCapabilityNames('[]')).toEqual([]);
+  });
+
+  it('tolerates an already-parsed array', () => {
+    expect(parseCapabilityNames(['a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('falls back to comma-splitting a non-JSON legacy string', () => {
+    expect(parseCapabilityNames('setup.access, studio.access')).toEqual([
+      'setup.access',
+      'studio.access',
+    ]);
+  });
+});
+
+const CAPS = [
+  { name: 'manage_users', label: 'Manage Users', description: 'Manage users', scope: 'platform', active: true },
+  { name: 'studio.access', label: 'Studio Access', description: 'Enter Studio', scope: 'platform', active: true },
+  { name: 'manage_org_users', label: 'Manage Org Users', description: 'Org members', scope: 'org', active: true },
+];
+
+function mockDataSource(rows = CAPS) {
+  return { find: vi.fn().mockResolvedValue({ data: rows }) } as any;
+}
+
+describe('CapabilityMultiSelectField', () => {
+  it('renders capabilities grouped by scope with human labels', async () => {
+    render(
+      <CapabilityMultiSelectField
+        value={'["studio.access"]'}
+        onChange={vi.fn()}
+        field={{ name: 'system_permissions' } as any}
+        dataSource={mockDataSource()}
+      />,
+    );
+    // group headers
+    expect(await screen.findByText('Platform')).toBeInTheDocument();
+    expect(screen.getByText('Organization')).toBeInTheDocument();
+    // labels, not raw names
+    expect(screen.getByRole('button', { name: 'Studio Access' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Manage Users' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('emits a JSON-string array when a capability is toggled on', async () => {
+    const onChange = vi.fn();
+    render(
+      <CapabilityMultiSelectField
+        value={'["studio.access"]'}
+        onChange={onChange}
+        field={{ name: 'system_permissions' } as any}
+        dataSource={mockDataSource()}
+      />,
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Manage Users' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const emitted = onChange.mock.calls[0][0];
+    // The emitted value must be a JSON *string* (not a raw array), byte-equal
+    // to the textarea storage contract.
+    expect(typeof emitted).toBe('string');
+    expect(JSON.parse(emitted)).toEqual(['studio.access', 'manage_users']);
+  });
+
+  it('removes a capability (and keeps emitting a JSON string) when toggled off', async () => {
+    const onChange = vi.fn();
+    render(
+      <CapabilityMultiSelectField
+        value={'["studio.access","manage_users"]'}
+        onChange={onChange}
+        field={{ name: 'system_permissions' } as any}
+        dataSource={mockDataSource()}
+      />,
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Studio Access' }));
+    const emitted = onChange.mock.calls[0][0];
+    expect(typeof emitted).toBe('string');
+    expect(JSON.parse(emitted)).toEqual(['manage_users']);
+  });
+
+  it('preserves an unknown/legacy selected name not in the registry', async () => {
+    render(
+      <CapabilityMultiSelectField
+        value={'["studio.access","legacy.custom"]'}
+        onChange={vi.fn()}
+        field={{ name: 'system_permissions' } as any}
+        dataSource={mockDataSource()}
+      />,
+    );
+    // The unknown name still renders as a (selected) chip so it is not dropped.
+    const legacy = await screen.findByRole('button', { name: 'legacy.custom' });
+    expect(legacy).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('renders selected labels as read-only badges when readonly', async () => {
+    render(
+      <CapabilityMultiSelectField
+        value={'["studio.access"]'}
+        onChange={vi.fn()}
+        field={{ name: 'system_permissions' } as any}
+        dataSource={mockDataSource()}
+        readonly
+      />,
+    );
+    // No toggle buttons in readonly mode.
+    expect(await screen.findByText('Studio Access')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Manage Users' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/fields/src/widgets/CapabilityMultiSelectField.tsx
+++ b/packages/fields/src/widgets/CapabilityMultiSelectField.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { Badge, EmptyValue, cn } from '@object-ui/components';
+import { SchemaRendererContext } from '@object-ui/react';
+import type { DataSource, QueryParams } from '@object-ui/types';
+import { FieldWidgetProps } from './types';
+
+/**
+ * CapabilityMultiSelectField — structured picker for a permission set's
+ * `system_permissions` (ADR-0056 / epic #2398, phase P2).
+ *
+ * `sys_permission_set.system_permissions` is framework-declared as a
+ * `Field.textarea` that stores a **JSON-serialized array of capability names**
+ * (e.g. `["setup.access","studio.access"]`; `security-plugin.ts` writes
+ * `JSON.stringify(...)` and reads `parseJson(...)`). Editing that as raw JSON is
+ * the anti-pattern ADR-0056 removes. This widget renders the same value as a
+ * multi-select over the live `sys_capability` registry — grouped by scope,
+ * labelled, with the capability description on hover — while round-tripping the
+ * stored value **byte-for-byte** as a JSON string of names.
+ *
+ * Reached via the field `widget: 'capability-multiselect'` hint (stamped onto
+ * the object metadata in MetadataProvider), registered in the field registry as
+ * `field:capability-multiselect`.
+ */
+
+interface Capability {
+  name: string;
+  label?: string;
+  description?: string;
+  scope?: string;
+  active?: boolean;
+}
+
+/**
+ * Parse the stored value into the selected capability-name list. The canonical
+ * storage is a JSON-string array; we also tolerate an already-parsed array (in
+ * case a caller hands us the parsed value) and a bare comma-separated string
+ * (legacy/hand-authored) so no selection is silently dropped.
+ */
+export function parseCapabilityNames(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((v) => String(v)).filter(Boolean);
+  if (typeof value === 'string') {
+    const s = value.trim();
+    if (!s) return [];
+    try {
+      const parsed = JSON.parse(s);
+      if (Array.isArray(parsed)) return parsed.map((v) => String(v)).filter(Boolean);
+      // A JSON scalar (unexpected) — treat as a single name.
+      return [String(parsed)].filter(Boolean);
+    } catch {
+      // Not JSON — fall back to comma-splitting so legacy values survive.
+      return s.split(',').map((x) => x.trim()).filter(Boolean);
+    }
+  }
+  return [];
+}
+
+/** Scope → group header. Order is intentional (platform powers first). */
+const SCOPE_ORDER = ['platform', 'org', 'other'] as const;
+const SCOPE_LABEL: Record<string, string> = {
+  platform: 'Platform',
+  org: 'Organization',
+  other: 'Other',
+};
+
+export function CapabilityMultiSelectField({
+  value,
+  onChange,
+  readonly,
+  className,
+  ...props
+}: FieldWidgetProps<string | string[]>) {
+  const ctx = React.useContext(SchemaRendererContext);
+  const dataSource: DataSource | null =
+    (props as any).dataSource ?? (ctx as any)?.dataSource ?? null;
+  const disabled = (props as any).disabled as boolean | undefined;
+
+  const [caps, setCaps] = React.useState<Capability[] | null>(null);
+
+  const selected = React.useMemo(() => parseCapabilityNames(value), [value]);
+
+  // Load the live capability registry (active only). Mirrors LookupField's
+  // context-dataSource access — createFieldRenderer does not forward the
+  // dataSource prop, so the SchemaRenderer context is the reliable source.
+  React.useEffect(() => {
+    if (!dataSource || typeof (dataSource as any).find !== 'function') return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await dataSource.find('sys_capability', {
+          $filter: { active: true },
+          $top: 500,
+        } as QueryParams);
+        const rows: Capability[] =
+          (res as any)?.data ?? (res as any)?.records ?? (Array.isArray(res) ? res : []);
+        if (!cancelled) setCaps(Array.isArray(rows) ? rows : []);
+      } catch {
+        if (!cancelled) setCaps([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dataSource]);
+
+  // Emit as a JSON string so the value round-trips byte-equivalent to the
+  // `system_permissions` textarea's `JSON.stringify(string[])` storage.
+  const emit = React.useCallback(
+    (names: string[]) => onChange(JSON.stringify(names) as any),
+    [onChange],
+  );
+
+  // Union of the fetched registry and any *selected* names not present in it
+  // (unknown / legacy / package-owned-inactive), so no current grant is hidden
+  // or dropped. Unknown names land in the "other" group.
+  const byName = React.useMemo(() => {
+    const map = new Map<string, Capability>();
+    for (const c of caps ?? []) if (c?.name) map.set(c.name, c);
+    for (const n of selected) if (!map.has(n)) map.set(n, { name: n, label: n, scope: 'other' });
+    return map;
+  }, [caps, selected]);
+
+  const labelFor = (name: string) => byName.get(name)?.label || name;
+
+  // Group options by scope for the editable grid. Computed BEFORE the readonly
+  // early-return so the hook order stays stable regardless of `readonly`.
+  const groups = React.useMemo(() => {
+    const buckets = new Map<string, Capability[]>();
+    for (const c of byName.values()) {
+      const key = (SCOPE_ORDER as readonly string[]).includes(c.scope as string)
+        ? (c.scope as string)
+        : 'other';
+      const list = buckets.get(key) ?? [];
+      list.push(c);
+      buckets.set(key, list);
+    }
+    return SCOPE_ORDER.filter((s) => buckets.has(s)).map((s) => ({
+      scope: s,
+      label: SCOPE_LABEL[s] ?? s,
+      items: (buckets.get(s) ?? []).sort((a, b) =>
+        (a.label || a.name).localeCompare(b.label || b.name),
+      ),
+    }));
+  }, [byName]);
+
+  if (readonly) {
+    if (selected.length === 0) return <EmptyValue />;
+    return (
+      <div className="flex flex-wrap gap-1">
+        {selected.map((name) => (
+          <Badge key={name} variant="outline" title={byName.get(name)?.description}>
+            {labelFor(name)}
+          </Badge>
+        ))}
+      </div>
+    );
+  }
+
+  const toggle = (name: string) => {
+    const next = selected.includes(name)
+      ? selected.filter((x) => x !== name)
+      : [...selected, name];
+    emit(next);
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      {caps === null && groups.length === 0 && (
+        <span className="text-sm text-muted-foreground">Loading capabilities…</span>
+      )}
+      {groups.map((group) => (
+        <div key={group.scope} className="flex flex-col gap-1.5">
+          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {group.label}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {group.items.map((cap) => {
+              const active = selected.includes(cap.name);
+              return (
+                <button
+                  type="button"
+                  key={cap.name}
+                  onClick={() => toggle(cap.name)}
+                  disabled={disabled}
+                  aria-pressed={active}
+                  title={cap.description || undefined}
+                  className={cn(
+                    'rounded-full border px-3 py-1 text-sm transition-colors disabled:opacity-50',
+                    active
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-input bg-background text-foreground hover:bg-accent',
+                  )}
+                >
+                  {cap.label || cap.name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default CapabilityMultiSelectField;

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -25,7 +25,7 @@ import {
 } from '@object-ui/components';
 import { ChevronDown, ChevronRight, Copy, Check, Eye, EyeOff } from 'lucide-react';
 import { SchemaRenderer } from '@object-ui/react';
-import { getCellRenderer, resolveCellRendererType, SelectField, BooleanField, LookupField, UserField, coerceToSafeValue } from '@object-ui/fields';
+import { getCellRenderer, resolveCellRendererType, SelectField, BooleanField, LookupField, UserField, CapabilityMultiSelectField, coerceToSafeValue } from '@object-ui/fields';
 import type { DetailViewSection as DetailViewSectionType, DetailViewField, FieldMetadata } from '@object-ui/types';
 import { applyDetailAutoLayout } from './autoLayout';
 import { useDetailTranslation } from './useDetailTranslation';
@@ -214,6 +214,10 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
       if (objectDefField.precision !== undefined && enrichedField.precision === undefined) enrichedField.precision = objectDefField.precision;
       if ((objectDefField as any).scale !== undefined && (enrichedField as any).scale === undefined) (enrichedField as any).scale = (objectDefField as any).scale;
       if (objectDefField.format && !enrichedField.format) enrichedField.format = objectDefField.format;
+      // Per-field widget override (ADR-0056 P2) — carry it from the object
+      // metadata so the inline-edit widget branch (and read cell) can honor a
+      // structured editor even when the synthesized section field didn't include it.
+      if ((objectDefField as any).widget && !enrichedField.widget) enrichedField.widget = (objectDefField as any).widget;
       const refTarget = objectDefField.reference_to || objectDefField.reference;
       if (refTarget && !enrichedField.reference_to) enrichedField.reference_to = refTarget;
       if (objectDefField.reference_field && !enrichedField.reference_field) enrichedField.reference_field = objectDefField.reference_field;
@@ -290,6 +294,21 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
           <div className="min-h-[44px] sm:min-h-0">
             {(() => {
               const editType = enrichedField.type || field.type;
+              // Per-field widget override (ADR-0056 P2) — honor a `widget` hint
+              // before the type switch so a structured editor (e.g. the
+              // capability multi-select on sys_permission_set.system_permissions)
+              // replaces the raw type in inline edit too, matching the form path.
+              const editWidget = (enrichedField as any).widget || (field as any).widget;
+              if (editWidget === 'capability-multiselect') {
+                return (
+                  <CapabilityMultiSelectField
+                    value={value}
+                    onChange={(v: any) => onFieldChange?.(field.name, v)}
+                    field={enrichedField as any}
+                    dataSource={dataSource}
+                  />
+                );
+              }
               // Picklist → real Select widget so users see localized
               // option labels and can't free-type invalid values.
               if (editType === 'select' && Array.isArray(enrichedField.options) && enrichedField.options.length > 0) {

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -507,6 +507,12 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
           group: field.group,
           // Important: Pass the original field metadata so widgets can access properties like precision, currency, etc.
           field: field,
+          // A per-field widget override (e.g. capability-multiselect stamped onto
+          // sys_permission_set.system_permissions by MetadataProvider, ADR-0056
+          // P2). `form.tsx` resolves `widget || type`, so this makes the
+          // auto-generated (no-form-view) form honor the override just like the
+          // authored-section path already does (sectionFields.ts).
+          widget: (field as any).widget,
         };
 
         // Add field-specific properties


### PR DESCRIPTION
## What

`sys_permission_set.system_permissions` in the **Setup** app is now a structured **capability multi-select** instead of a raw JSON textarea.

**ADR-0056 P2** (#2399) — first step of the epic #2398 (consolidate permission-set editing into Studio).

## How

- **New widget** `CapabilityMultiSelectField` → registered `field:capability-multiselect` (`@object-ui/fields`). Renders the live `sys_capability` registry (active only) as chips grouped by `scope` (Platform / Organization), labelled, with the capability `description` on hover.
- **Byte-equivalent round-trip**: the field stores a JSON-string array of capability names (`security-plugin.ts` writes `JSON.stringify`, reads `parseJson`). The widget parses on load and emits `JSON.stringify(names)` on change — the on-disk shape never changes. Unknown/legacy names are preserved.
- **Single injection point**: the `widget` hint is stamped onto the field in `ObjectStackAdapter.getObjectSchema` — the one method both the record form (ObjectForm) and the detail inline-edit (DetailView/DetailSection) read the schema through. The field's `type` (storage contract) is untouched. `ObjectForm` auto-gen now carries `field.widget`; `DetailSection` enriches + honors `widget` in its inline-edit switch.

## Verified

- **Unit** — `CapabilityMultiSelectField.test.tsx`, 9/9: parse tolerance (JSON string / array / empty / comma-legacy), scope grouping, JSON-**string** emit on toggle on & off, legacy-name preservation, readonly badges.
- **Browser (live backend)** — opened `admin_full_access`: `system_permissions` renders as the grouped picker (5 Platform chips selected + an Organization group). Toggled a capability and **saved through the UI**; confirmed the record persisted `["…","manage_org_users"]` as a JSON string (byte-equal shape), then restored the original. `row_level_security` / `tab_permissions` correctly remain JSON (they are P3/P4).
- Console `tsc` clean for the touched files.

## Not in scope

`admin_scope` / `row_level_security` / `tab_permissions` structured editors are **P3/P4** (tracked in #2398).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
