### PR TITLE
Detail view: Edit as primary CTA; enter inline edit by double-clicking a field (#2401)

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1815,24 +1815,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       const affordances = resolveCrudAffordances(objectDef as any);
       const items: ActionDef[] = [];
       if (affordances.edit) {
-        // Inline-edit toggle. Surfaced ABOVE `sys_edit` so the
-        // overflow menu lists field-level editing first — Lightning /
-        // HubSpot put inline edit ("Edit details") above the modal /
-        // form-page edit because in-page editing is the higher-frequency
-        // interaction. Communicates with DetailView via a window event
-        // so we don't need to lift inline-edit state out of the plugin.
-        items.push({
-          name: 'sys_inline_edit',
-          label: t('detail.editFieldsInline', { defaultValue: 'Edit fields' }),
-          type: 'script',
-          locations: ['record_header'],
-          variant: 'outline',
-          onClick: () => {
-            window.dispatchEvent(new CustomEvent('objectui:record:inline-edit-toggle', {
-              detail: { recordId: pureRecordId, objectName },
-            }));
-          },
-        } as any);
+        // Single primary Edit CTA → opens the full record form. Inline editing
+        // is no longer a standalone header button; it is entered by
+        // double-clicking a field (or its hover pencil) in the record body,
+        // with the object-editability gate applied at the field-render source
+        // (record-details.tsx). See #2401.
         items.push({
           name: 'sys_edit',
           label: t('detail.edit', { defaultValue: 'Edit' }),

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -491,6 +491,7 @@ const en = {
     saveChanges: 'Save changes',
     saving: 'Saving…',
     editFieldsInline: 'Edit fields',
+    editInlineHint: 'Double-click to edit',
     lockedByApproval: 'Locked for approval',
     lockedTooltip: 'This record has a pending approval request; editing is locked',
     cancelApproval: 'Recall approval',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -571,6 +571,7 @@ const zh = {
     saveChanges: '保存更改',
     saving: '保存中…',
     editFieldsInline: '编辑字段',
+    editInlineHint: '双击编辑',
     lockedByApproval: '审批中已锁定',
     lockedTooltip: '该记录有待审批的请求，编辑已被锁定',
     cancelApproval: '撤回审批',

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -23,7 +23,7 @@ import {
   TooltipTrigger,
   useIsMobile,
 } from '@object-ui/components';
-import { ChevronDown, ChevronRight, Copy, Check, Eye, EyeOff } from 'lucide-react';
+import { ChevronDown, ChevronRight, Copy, Check, Eye, EyeOff, Pencil } from 'lucide-react';
 import { SchemaRenderer } from '@object-ui/react';
 import { getCellRenderer, resolveCellRendererType, SelectField, BooleanField, LookupField, UserField, coerceToSafeValue } from '@object-ui/fields';
 import type { DetailViewSection as DetailViewSectionType, DetailViewField, FieldMetadata } from '@object-ui/types';
@@ -108,6 +108,15 @@ export interface DetailSectionProps {
   isEditing?: boolean;
   /** Callback when a field value changes during inline editing */
   onFieldChange?: (field: string, value: any) => void;
+  /**
+   * Enter inline-edit mode focused on a specific field — wired to the per-field
+   * double-click / hover-pencil affordances. Supplied ONLY when the record is
+   * inline-editable (object lifecycle + permission gated upstream), so its
+   * presence is what surfaces those affordances.
+   */
+  onEnterInlineEdit?: (fieldName: string) => void;
+  /** Field to auto-focus when inline edit is entered from a field. */
+  autoFocusField?: string | null;
   /** DataSource used by reference (lookup/master_detail/user) widgets during inline editing */
   dataSource?: any;
   /** Virtual scrolling configuration for sections with many fields */
@@ -122,6 +131,8 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
   objectName,
   isEditing = false,
   onFieldChange,
+  onEnterInlineEdit,
+  autoFocusField,
   dataSource,
   virtualScroll,
 }) => {
@@ -223,6 +234,17 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
       enrichedField.options = translateOptions(objectName, field.name, enrichedField.options as any);
     }
 
+    // Inline-edit eligibility for THIS field. Mirrors the input-branch gate so
+    // the pencil / double-click affordance appears iff the field can actually
+    // become an input: computed types (formula/summary/rollup/auto_number) and
+    // fields explicitly flagged `readonly` are never editable. `onEnterInlineEdit`
+    // is only threaded when the record itself is inline-editable, so its presence
+    // carries the object-lifecycle + permission gate.
+    const inlineEditType = enrichedField.type || field.type;
+    const isComputedField = TEXTUAL_REF_FALLBACK_TYPES.has(inlineEditType as string);
+    const fieldEditable = !field.readonly && !isComputedField;
+    const canInlineEditField = fieldEditable && !!onEnterInlineEdit;
+
     const displayValue = (() => {
       const isEmpty = value === null || value === undefined || value === '';
       if (isEmpty) {
@@ -248,6 +270,10 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
       return String(value);
     })();
     const canCopy = value !== null && value !== undefined && value !== '';
+    // An editable field surfaces the pencil (edit) affordance instead of the
+    // copy affordance, and reserves single-click for text selection — so
+    // click-to-copy only applies to non-editable fields.
+    const copyInteractive = canCopy && !canInlineEditField;
     const isCopied = copiedField === field.name;
     const fieldLabelText = fieldLabel(objectName || '', field.name, field.label || field.name);
 
@@ -255,7 +281,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     // hairline-separated rows inside the section card. The native-feeling
     // settings/detail form for the mobile target. Editing falls back to the
     // stacked layout below so inputs have room.
-    if (isMobile && !(isEditing && !field.readonly)) {
+    if (isMobile && !(isEditing && fieldEditable)) {
       return (
         <div
           key={field.name}
@@ -286,7 +312,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
           {fieldLabel(objectName || '', field.name, field.label || field.name)}
         </div>
-        {isEditing && !field.readonly ? (
+        {isEditing && fieldEditable ? (
           <div className="min-h-[44px] sm:min-h-0">
             {(() => {
               const editType = enrichedField.type || field.type;
@@ -357,6 +383,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
               return (
                 <input
                   type={inputType}
+                  autoFocus={autoFocusField === field.name}
                   className="w-full px-2 py-1.5 text-sm border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
                   value={inputValue}
                   onChange={(e) => {
@@ -378,22 +405,50 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
         <div
           className={cn(
             "flex items-start justify-between gap-2 min-h-[44px] sm:min-h-0 rounded-md",
-            canCopy && "cursor-pointer active:bg-muted/60 transition-colors"
+            copyInteractive && "cursor-pointer active:bg-muted/60 transition-colors",
+            // Editable fields hint interactivity on hover and enter edit on
+            // double-click (Salesforce/Airtable pattern). The negative margin
+            // keeps the hover highlight flush with the label above.
+            canInlineEditField && "cursor-pointer hover:bg-muted/40 transition-colors -mx-1.5 px-1.5"
           )}
-          onClick={canCopy ? () => handleCopyField(field.name, value) : undefined}
-          onKeyDown={canCopy ? (e: React.KeyboardEvent) => {
+          onClick={copyInteractive ? () => handleCopyField(field.name, value) : undefined}
+          onDoubleClick={canInlineEditField ? () => onEnterInlineEdit?.(field.name) : undefined}
+          onKeyDown={copyInteractive ? (e: React.KeyboardEvent) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
               handleCopyField(field.name, value);
             }
           } : undefined}
-          role={canCopy ? "button" : undefined}
-          tabIndex={canCopy ? 0 : undefined}
+          role={copyInteractive ? "button" : undefined}
+          tabIndex={copyInteractive ? 0 : undefined}
+          title={canInlineEditField ? t('detail.editInlineHint') : undefined}
         >
           <div className="text-sm flex-1 min-w-0 break-words py-1">
             {displayValue}
           </div>
-          {canCopy && (
+          {canInlineEditField ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                    aria-label={t('detail.editInlineHint')}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onEnterInlineEdit?.(field.name);
+                    }}
+                  >
+                    <Pencil className="h-3 w-3" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t('detail.editInlineHint')}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : canCopy ? (
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -418,7 +473,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-          )}
+          ) : null}
         </div>
         )}
       </div>

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -183,6 +183,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
   const [editedValues, setEditedValues] = React.useState<Record<string, any>>({});
   const [isSaving, setIsSaving] = React.useState(false);
   const [saveError, setSaveError] = React.useState<string | null>(null);
+  // Field to auto-focus when inline edit is entered by double-clicking a field.
+  const [autoFocusField, setAutoFocusField] = React.useState<string | null>(null);
   const [objectSchema, setObjectSchema] = React.useState<any>(null);
   const [idCopied, setIdCopied] = React.useState(false);
   const [reloadTick, setReloadTick] = React.useState(0);
@@ -551,6 +553,7 @@ export const DetailView: React.FC<DetailViewProps> = ({
           }
           setEditedValues({});
           setIsInlineEditing(false);
+          setAutoFocusField(null);
         } catch (err: any) {
           // Roll back optimistic update and stay in edit mode so the user
           // can correct the input or cancel.
@@ -580,10 +583,21 @@ export const DetailView: React.FC<DetailViewProps> = ({
     setEditedValues({});
     setIsInlineEditing(false);
     setSaveError(null);
+    setAutoFocusField(null);
   }, []);
 
   const handleInlineFieldChange = React.useCallback((field: string, value: any) => {
     setEditedValues(prev => ({ ...prev, [field]: value }));
+  }, []);
+
+  // Enter whole-record inline edit focused on a single field. Wired to the
+  // per-field double-click / hover-pencil affordances in DetailSection.
+  // Mirrors Salesforce: editing any field flips the record into inline edit
+  // with a single Save/Cancel bar, rather than a standalone "Edit fields" toggle.
+  const handleEnterInlineEditField = React.useCallback((fieldName: string) => {
+    setAutoFocusField(fieldName);
+    setIsInlineEditing(true);
+    setSaveError(null);
   }, []);
 
   // Keyboard shortcuts for prev/next record navigation (← / →)
@@ -677,16 +691,9 @@ export const DetailView: React.FC<DetailViewProps> = ({
         onClick: handleEdit,
       });
     }
-    if (inlineEdit) {
-      items.push({
-        name: 'sys_toggle_inline_edit_mobile',
-        label: isInlineEditing ? t('detail.save') : t('detail.editInline'),
-        icon: 'edit',
-        type: 'script',
-        className: 'sm:hidden',
-        onClick: handleInlineEditToggle,
-      });
-    }
+    // No mobile inline-edit toggle: on touch (no hover / double-click) the
+    // primary Edit CTA — which opens the full form — is the single edit path,
+    // so we don't reintroduce a competing "Edit fields" entry in the overflow.
 
     // Universal record-level utilities (desktop + mobile).
     // Duplicate / Export / View History are intentionally omitted until
@@ -711,11 +718,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
     t,
     schema.showEdit,
     schema.showDelete,
-    inlineEdit,
-    isInlineEditing,
     handleShare,
     handleEdit,
-    handleInlineEditToggle,
     handleDelete,
   ]);
 
@@ -1011,27 +1015,26 @@ export const DetailView: React.FC<DetailViewProps> = ({
               </div>
             )}
 
-            {/* Inline Edit Toggle — desktop-only chrome.
-                Mobile fallback lives inside the unified action:bar overflow
-                menu as a `systemActions` entry with `sm:hidden`. */}
-            {inlineEdit && (
+            {/* Inline-edit Save / Cancel bar — rendered only WHILE editing.
+                There is no idle "Edit fields" toggle: inline edit is entered by
+                double-clicking a field (or its hover pencil). The primary Edit
+                CTA below opens the full record form. */}
+            {inlineEdit && isInlineEditing && (
               <>
-                {isInlineEditing && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleInlineEditCancel}
-                        className="gap-2 hidden sm:inline-flex"
-                      >
-                        <X className="h-4 w-4" />
-                        <span className="hidden sm:inline">{t('detail.cancel')}</span>
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>{t('detail.cancelEdit')}</TooltipContent>
-                  </Tooltip>
-                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleInlineEditCancel}
+                      className="gap-2 hidden sm:inline-flex"
+                    >
+                      <X className="h-4 w-4" />
+                      <span className="hidden sm:inline">{t('detail.cancel')}</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('detail.cancelEdit')}</TooltipContent>
+                </Tooltip>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -1230,6 +1233,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
                   objectName={schema.objectName}
                   isEditing={isInlineEditing}
                   onFieldChange={handleInlineFieldChange}
+                  onEnterInlineEdit={inlineEdit ? handleEnterInlineEditField : undefined}
+                  autoFocusField={autoFocusField}
                   dataSource={dataSource}
                 />
               ))
@@ -1244,6 +1249,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
                   objectName={schema.objectName}
                   isEditing={isInlineEditing}
                   onFieldChange={handleInlineFieldChange}
+                  onEnterInlineEdit={inlineEdit ? handleEnterInlineEditField : undefined}
+                  autoFocusField={autoFocusField}
                   dataSource={dataSource}
                 />
               ))
@@ -1259,6 +1266,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
                 objectName={schema.objectName}
                 isEditing={isInlineEditing}
                 onFieldChange={handleInlineFieldChange}
+                onEnterInlineEdit={inlineEdit ? handleEnterInlineEditField : undefined}
+                autoFocusField={autoFocusField}
                 dataSource={dataSource}
               />
             )}
@@ -1408,6 +1417,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
                   objectName={schema.objectName}
                   isEditing={isInlineEditing}
                   onFieldChange={handleInlineFieldChange}
+                  onEnterInlineEdit={inlineEdit ? handleEnterInlineEditField : undefined}
+                  autoFocusField={autoFocusField}
                   dataSource={dataSource}
                 />
               ))}
@@ -1426,6 +1437,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
                   objectName={schema.objectName}
                   isEditing={isInlineEditing}
                   onFieldChange={handleInlineFieldChange}
+                  onEnterInlineEdit={inlineEdit ? handleEnterInlineEditField : undefined}
+                  autoFocusField={autoFocusField}
                   dataSource={dataSource}
                 />
               ))}
@@ -1444,6 +1457,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
               objectName={schema.objectName}
               isEditing={isInlineEditing}
               onFieldChange={handleInlineFieldChange}
+              onEnterInlineEdit={inlineEdit ? handleEnterInlineEditField : undefined}
+              autoFocusField={autoFocusField}
               dataSource={dataSource}
             />
           )}

--- a/packages/plugin-detail/src/SectionGroup.tsx
+++ b/packages/plugin-detail/src/SectionGroup.tsx
@@ -26,6 +26,10 @@ export interface SectionGroupProps {
   objectName?: string;
   isEditing?: boolean;
   onFieldChange?: (field: string, value: any) => void;
+  /** Enter inline-edit mode focused on a field (double-click / hover pencil). */
+  onEnterInlineEdit?: (fieldName: string) => void;
+  /** Field to auto-focus when inline edit is entered from a field. */
+  autoFocusField?: string | null;
   /** DataSource used by reference widgets during inline editing */
   dataSource?: any;
 }
@@ -38,6 +42,8 @@ export const SectionGroup: React.FC<SectionGroupProps> = ({
   objectName,
   isEditing = false,
   onFieldChange,
+  onEnterInlineEdit,
+  autoFocusField,
   dataSource,
 }) => {
   const collapsible = group.collapsible ?? true;
@@ -54,6 +60,8 @@ export const SectionGroup: React.FC<SectionGroupProps> = ({
           objectName={objectName}
           isEditing={isEditing}
           onFieldChange={onFieldChange}
+          onEnterInlineEdit={onEnterInlineEdit}
+          autoFocusField={autoFocusField}
           dataSource={dataSource}
         />
       ))}

--- a/packages/plugin-detail/src/__tests__/DetailSection.doubleClickEdit.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.doubleClickEdit.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DetailSection } from '../DetailSection';
+import type { DetailViewSection } from '@object-ui/types';
+
+/**
+ * #2401 — inline editing is entered by double-clicking a field (or its hover
+ * pencil), replacing the standalone "Edit fields" toggle. The affordance must:
+ *   - fire `onEnterInlineEdit(fieldName)` on double-click of an EDITABLE field,
+ *   - be inert on computed (formula/summary/rollup/auto_number) and `readonly`
+ *     fields,
+ *   - be gated by the presence of `onEnterInlineEdit` (the parent supplies it
+ *     only when the record is inline-editable — object lifecycle + permission),
+ *   - never turn a computed / read-only field into an input, even in global
+ *     inline-edit mode.
+ *
+ * Assertions are behavioural (not tied to the localized tooltip text) so they
+ * hold whether or not an I18nProvider is mounted in the test env.
+ */
+describe('DetailSection double-click inline-edit affordance', () => {
+  // useIsMobile() keys off window.innerWidth (< 768 == mobile). Pin a desktop
+  // width so the read-mode desktop row (which carries the affordance) renders.
+  beforeAll(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+  });
+
+  const objectSchema = {
+    fields: {
+      title: { type: 'text' },
+      budget: { type: 'currency' },
+      score: { type: 'formula' },       // computed → never editable
+      code: { type: 'auto_number' },    // computed → never editable
+    },
+  };
+
+  const section: DetailViewSection = {
+    fields: [
+      { name: 'title', label: 'Title' },
+      { name: 'score', label: 'Score' },
+      { name: 'code', label: 'Code' },
+      { name: 'locked', label: 'Locked', readonly: true },
+    ],
+  } as DetailViewSection;
+
+  const data = { title: 'Hello', score: 42, code: 'A-001', locked: 'x' };
+
+  it('enters inline edit on double-click of an editable field', () => {
+    const onEnter = vi.fn();
+    render(
+      <DetailSection
+        section={section}
+        data={data}
+        objectSchema={objectSchema}
+        onEnterInlineEdit={onEnter}
+      />,
+    );
+    fireEvent.doubleClick(screen.getByText('Hello'));
+    expect(onEnter).toHaveBeenCalledWith('title');
+  });
+
+  it('is inert on computed (formula / auto_number) and readonly fields', () => {
+    const onEnter = vi.fn();
+    render(
+      <DetailSection
+        section={section}
+        data={data}
+        objectSchema={objectSchema}
+        onEnterInlineEdit={onEnter}
+      />,
+    );
+    fireEvent.doubleClick(screen.getByText('42'));      // formula
+    fireEvent.doubleClick(screen.getByText('A-001'));   // auto_number
+    fireEvent.doubleClick(screen.getByText('x'));       // readonly
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  it('offers no inline-edit entry when onEnterInlineEdit is absent', () => {
+    render(
+      <DetailSection section={section} data={data} objectSchema={objectSchema} />,
+    );
+    // Double-click is a no-op and the field stays in read mode (no input).
+    fireEvent.doubleClick(screen.getByText('Hello'));
+    expect(screen.queryByDisplayValue('Hello')).toBeNull();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('keeps computed and readonly fields read-only even in global inline-edit mode', () => {
+    render(
+      <DetailSection
+        section={section}
+        data={data}
+        objectSchema={objectSchema}
+        isEditing
+        onEnterInlineEdit={vi.fn()}
+      />,
+    );
+    // Editable field → input …
+    expect(screen.getByDisplayValue('Hello')).toBeInTheDocument();
+    // … computed (formula 42, auto_number A-001) and readonly (x) → NOT inputs.
+    expect(screen.queryByDisplayValue('42')).toBeNull();
+    expect(screen.queryByDisplayValue('A-001')).toBeNull();
+    expect(screen.queryByDisplayValue('x')).toBeNull();
+  });
+
+  it('auto-focuses the field named by autoFocusField in edit mode', () => {
+    render(
+      <DetailSection
+        section={section}
+        data={data}
+        objectSchema={objectSchema}
+        isEditing
+        autoFocusField="title"
+        onEnterInlineEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByDisplayValue('Hello')).toHaveFocus();
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -356,10 +356,21 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
       })
     : schema.sections;
 
-  // Inline-edit by default. Matches the default record detail experience
-  // (`RecordDetailView` non-assignedPage branch) where every field is
-  // click-to-edit. Authors can opt out with `inlineEdit: false`.
-  const inlineEditDefault = schema.inlineEdit ?? true;
+  // Inline-edit by default, but gated by the object's lifecycle: system /
+  // append-only / better-auth objects are not user-editable, so the per-field
+  // double-click / pencil affordances must not be offered on them. This mirrors
+  // resolveCrudAffordances (app-shell/utils/crudAffordances.ts) — duplicated
+  // here because plugin-detail cannot depend on app-shell; keep the two in
+  // lockstep. Previously this gate was carried only by the `sys_inline_edit`
+  // header button (removed in #2401); now that double-click is the entry point
+  // the object-editability check has to live at the field-render source.
+  // Authors can still force-disable with `inlineEdit: false`.
+  const NON_EDITABLE_BUCKETS = new Set(['system', 'append-only', 'better-auth']);
+  const managedBy = objSchema?.managedBy as string | undefined;
+  const userEditOverride = (objSchema?.userActions as { edit?: boolean } | undefined)?.edit;
+  const objectInlineEditable =
+    userEditOverride ?? !(managedBy != null && NON_EDITABLE_BUCKETS.has(managedBy));
+  const inlineEditDefault = (schema.inlineEdit ?? true) && objectInlineEditable;
 
   const synthesized: any = {
     type: 'detail-view',

--- a/packages/plugin-detail/src/useDetailTranslation.ts
+++ b/packages/plugin-detail/src/useDetailTranslation.ts
@@ -64,6 +64,7 @@ export const DETAIL_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'detail.save': 'Save',
   'detail.saveChanges': 'Save changes',
   'detail.editFieldsInline': 'Edit fields inline',
+  'detail.editInlineHint': 'Double-click to edit',
   'detail.cancel': 'Cancel',
   'detail.cancelEdit': 'Discard changes',
   'detail.openInNewTab': 'Open in new tab',


### PR DESCRIPTION
Closes #2401.

## What & why

The record header exposed **two competing edit entry points** — a prominent `Edit fields` (the inline-edit toggle) and a buried `Edit` (full form) — an inconsistent, confusing hierarchy (worse in the `page:header` synth path, where the overflow logic pushed the primary `Edit` into the `…` menu). This collapses them into one clear model (Salesforce-style):

- **`Edit` is the single primary CTA** in the header (opens the full form). Share/Delete live in the `…` overflow.
- **Inline editing moves onto the field**: hovering a field reveals a **pencil**, and **double-clicking** it (or the pencil) flips the record into inline edit — focused on that field — with the existing Save/Cancel bar. No more standalone `Edit fields` toggle.

Single-click stays for text-selection/copy (these are read-oriented display fields with selectable emails/links), so **double-click + hover-pencil** is the right trigger.

## Changes

| Area | Change |
|---|---|
| `RecordDetailView` | Drop the `sys_inline_edit` header action → `sys_edit` becomes the primary button; overflow keeps Share/Delete. |
| `DetailView` | Remove the idle standalone toggle + the mobile inline-edit entry; Save/Cancel renders only while editing; add `handleEnterInlineEditField` + `autoFocusField`; thread `onEnterInlineEdit` to every section. |
| `DetailSection` | Hover pencil + double-click to enter edit; gate the affordance **and** the input on field editability; auto-focus the entered field. |
| `record-details` | Gate inline-editability by object lifecycle (`managedBy` / `userActions`) — the gate the removed `sys_inline_edit` button used to carry. |
| `i18n` | `detail.editInlineHint` (en/zh) + `DETAIL_DEFAULT_TRANSLATIONS` fallback. |

## Guardrails preserved

- **Computed** (`formula` / `summary` / `rollup` / `auto_number`) and **`readonly`** fields expose no pencil and never become inputs — even in global inline-edit mode.
- **Object-lifecycle gate**: double-click is not offered on `system` / `append-only` / `better-auth` objects (honors `userActions.edit`).
- **Approval-locked** records and the **OCC / partial-update** save path are untouched (`{ [field]: value }` stays the de-facto sanitizer — no full-record writes).
- **Mobile** (no hover/double-click) falls back to the primary Edit button.

## Verification

- `plugin-detail` (vite) build ✓, `app-shell` (tsc) build ✓, `i18n` (tsc) build ✓.
- **New unit tests** (`DetailSection.doubleClickEdit.test.tsx`, 5 cases) + existing DetailView/record-details suites: **129 passing**.
- Dev-server HMR clean.
- ⏳ Visual browser pass on the showcase `Project` record pending (dev-server login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)