### PR TITLE
fix(plugin-detail): don't inline-edit object-readonly or system/audit fields (#2402 hardening)

### DIFF
--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -31,6 +31,7 @@ import { applyDetailAutoLayout } from './autoLayout';
 import { useDetailTranslation } from './useDetailTranslation';
 import { useSafeFieldLabel } from '@object-ui/react';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
+import { NON_EDITABLE_SYSTEM_FIELDS } from './systemFields';
 
 /**
  * Compute responsive col-span classes so that col-span never exceeds the
@@ -247,7 +248,15 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     // carries the object-lifecycle + permission gate.
     const inlineEditType = enrichedField.type || field.type;
     const isComputedField = TEXTUAL_REF_FALLBACK_TYPES.has(inlineEditType as string);
-    const fieldEditable = !field.readonly && !isComputedField;
+    // Honor the OBJECT metadata's read-only flag too — the enrichment above
+    // intentionally doesn't copy `readonly` into enrichedField, so read it
+    // straight off objectDefField (covers formula / non-updateable fields the
+    // framework flags `readonly:true` even when the view schema doesn't). And
+    // never offer inline edit on immutable audit/identity fields by name
+    // (created_at / id / …), in case a schema surfaces one as a section row.
+    const isReadonly = field.readonly === true || objectDefField?.readonly === true;
+    const isSystemField = NON_EDITABLE_SYSTEM_FIELDS.has(field.name);
+    const fieldEditable = !isReadonly && !isComputedField && !isSystemField;
     const canInlineEditField = fieldEditable && !!onEnterInlineEdit;
 
     const displayValue = (() => {

--- a/packages/plugin-detail/src/__tests__/DetailSection.doubleClickEdit.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.doubleClickEdit.test.tsx
@@ -124,3 +124,63 @@ describe('DetailSection double-click inline-edit affordance', () => {
     expect(screen.getByDisplayValue('Hello')).toHaveFocus();
   });
 });
+
+/**
+ * #2402 hardening — inline edit must also respect the OBJECT metadata's
+ * `readonly` flag (the view-schema field may not carry it) and immutable
+ * system/audit fields by name (created_at / id / …), not just view-schema
+ * `readonly` + computed types.
+ */
+describe('DetailSection inline-edit — object-readonly & system-field gate', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+  });
+
+  const section: DetailViewSection = {
+    fields: [
+      { name: 'title', label: 'Title' },
+      { name: 'ext_id', label: 'External ID' }, // readonly in OBJECT schema only
+      { name: 'created_at', label: 'Created' },  // immutable system field by name
+    ],
+  } as DetailViewSection;
+
+  // View-schema fields carry NO `readonly`; the object metadata marks ext_id.
+  const objectSchema = {
+    fields: {
+      title: { type: 'text' },
+      ext_id: { type: 'text', readonly: true },
+      created_at: { type: 'text' }, // gated by NAME, type is irrelevant here
+    },
+  };
+
+  const data = { title: 'Hello', ext_id: 'EXT-9', created_at: 'CR-1' };
+
+  it('does not offer inline edit for a field the OBJECT schema marks readonly', () => {
+    const onEnter = vi.fn();
+    render(
+      <DetailSection section={section} data={data} objectSchema={objectSchema} onEnterInlineEdit={onEnter} />,
+    );
+    fireEvent.doubleClick(screen.getByText('EXT-9'));
+    expect(onEnter).not.toHaveBeenCalled();
+    // …but a normal field still enters edit.
+    fireEvent.doubleClick(screen.getByText('Hello'));
+    expect(onEnter).toHaveBeenCalledWith('title');
+  });
+
+  it('never inline-edits an immutable system field, nor turns object-readonly into an input', () => {
+    const onEnter = vi.fn();
+    const { rerender } = render(
+      <DetailSection section={section} data={data} objectSchema={objectSchema} onEnterInlineEdit={onEnter} />,
+    );
+    fireEvent.doubleClick(screen.getByText('CR-1')); // system field (created_at)
+    expect(onEnter).not.toHaveBeenCalled();
+
+    // Even in global inline-edit mode, both stay read-only; only title is an input.
+    rerender(
+      <DetailSection section={section} data={data} objectSchema={objectSchema} isEditing onEnterInlineEdit={onEnter} />,
+    );
+    expect(screen.getByDisplayValue('Hello')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('EXT-9')).toBeNull();
+    expect(screen.queryByDisplayValue('CR-1')).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/systemFields.ts
+++ b/packages/plugin-detail/src/systemFields.ts
@@ -1,0 +1,29 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * System / audit field names that are **never user-editable** — the framework's
+ * `applySystemFields` owns them (created_x, updated_x, modified_x) plus record
+ * identity and soft-delete bookkeeping. Used by the inline-edit gate so a
+ * double-click / pencil is never offered on them, even when a detail schema
+ * happens to surface one and doesn't flag it `readonly`.
+ *
+ * Intentionally NARROWER than the display-oriented system-field sets in
+ * `deriveLookupColumns.ts` / `RecordDetailDrawer.tsx`: it deliberately EXCLUDES
+ * `owner_id` / `organization_id` / `tenant_id` / `company_id` / `space`, which
+ * are legitimately editable in some contexts (e.g. reassigning the owner). This
+ * set is only the immutable, framework-managed bookkeeping fields.
+ */
+export const NON_EDITABLE_SYSTEM_FIELDS = new Set<string>([
+  'id', '_id', '__v',
+  'created', 'created_at', 'createdAt', 'created_by',
+  'modified', 'modified_by',
+  'updated_at', 'updatedAt', 'updated_by',
+  'deleted_at', 'is_deleted', 'deleted',
+  'instance_state',
+]);


### PR DESCRIPTION
Hardening of #2402 (double-click / pencil inline edit).

## Gap

The inline-edit affordance gated `fieldEditable` on only the **view schema's** `readonly` + computed types (`formula`/`summary`/`rollup`/`auto_number`). It missed:
- **Object-metadata `readonly`** — `DetailSection`'s field enrichment intentionally doesn't copy `readonly` from `objectSchema.fields[name]` into the enriched field, so a field the *object* schema marks read-only (but the view field doesn't) was treated as editable.
- **Immutable system/audit fields by name** — e.g. a `created_at` / `id` surfaced as a section row could be double-clicked into an editor.

## Fix

- `DetailSection`: `fieldEditable = !isReadonly && !isComputedField && !isSystemField`, where `isReadonly` now also reads `objectDefField.readonly`, and `isSystemField` checks a new `NON_EDITABLE_SYSTEM_FIELDS` set.
- New `packages/plugin-detail/src/systemFields.ts` — the immutable field-name set. **Deliberately narrower** than the display-oriented system-field sets in `deriveLookupColumns.ts` / `RecordDetailDrawer.tsx`: it EXCLUDES `owner_id` / `organization_id` / `tenant_id`, which are legitimately editable (e.g. reassigning owner). Only truly framework-managed bookkeeping (created_x, updated_x, modified_x, id, soft-delete, instance_state).
- Applies to both the pencil/double-click affordance and the input gate, so it also holds in global inline-edit mode.

## Verification

- New unit tests (`DetailSection.doubleClickEdit.test.tsx`): object-schema-readonly field + system field are not inline-editable; a normal field still enters edit. **9/9 pass** (incl. #2402's existing cases).
- `plugin-detail` (vite) build ✓.
- No browser step: the showcase detail surfaces no system/readonly section field to demonstrate; the gate is unit-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)