### PR TITLE
fix(metadata-admin): authenticate console MetadataClient requests

### DIFF
--- a/.changeset/metadata-client-authenticated-fetch.md
+++ b/.changeset/metadata-client-authenticated-fetch.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(metadata-admin): authenticate console MetadataClient requests (Bearer token)
+
+Studio / metadata-admin surfaces issued `/api/v1/meta/*` requests (list types,
+`?package=…` reads, `_drafts`, the `/meta` root) that came back `401
+unauthenticated` in the token-based console, while the runtime data adapter's
+reads (`/meta/object|view|app`) succeeded — so the same page showed some
+metadata requests failing and others working.
+
+Root cause: `useMetadataClient` and `MetadataProvider`'s draft-preview client
+constructed `MetadataClient` without a `fetch`, so it fell back to the bare
+`globalThis.fetch` and sent no `Authorization` header. The console
+authenticates by a Bearer token in localStorage (`auth-session-token`) — there
+is no session cookie — so those requests were unauthenticated. A same-origin
+cookie deployment masks the bug, which is why it went unnoticed and regressed
+twice.
+
+Both sites (and every future console surface) now construct through a single
+`createConsoleMetadataClient` factory that bakes in `createAuthenticatedFetch`
+(Bearer token + `X-Tenant-ID` + `Accept-Language`), matching the runtime data
+adapter. This is additive for cookie deployments — `credentials` is untouched,
+so a same-origin session cookie still flows. A
+`metadata-client-auth.ratchet.test.ts` guard forbids a bare
+`new MetadataClient(` elsewhere in app-shell so authentication can't silently
+regress again.

--- a/packages/app-shell/src/metadata-client-auth.ratchet.test.ts
+++ b/packages/app-shell/src/metadata-client-auth.ratchet.test.ts
@@ -1,0 +1,83 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Ratchet — MetadataClient must be constructed through the authenticated
+ * console factory, never bare.
+ *
+ * The bug this guards: `MetadataClient` defaults its `fetch` to the bare
+ * `globalThis.fetch`, which sends no `Authorization` header. The console
+ * authenticates to `/api/v1/*` with a Bearer token in `localStorage`
+ * (`auth-session-token`) — there is no session cookie — so a client built on
+ * the raw global fetch is unauthenticated and every `/api/v1/meta/*` request
+ * comes back `401`. That regressed twice (`useMetadataClient` +
+ * `MetadataProvider`'s preview client) and stayed hidden because a same-origin
+ * cookie deployment masks it. The fix funnels construction through
+ * `createConsoleMetadataClient`, which bakes in `createAuthenticatedFetch`.
+ *
+ * If this fails: don't write `new MetadataClient(...)` in app-shell. Call
+ * `createConsoleMetadataClient(...)` from `views/metadata-admin/
+ * metadataClientFactory.ts` so the client carries the Bearer token. Do not
+ * allowlist — add the fetch at the one sanctioned construction point.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// packages/app-shell/src
+const srcRoot = here;
+
+/** The one file allowed to call `new MetadataClient(` in app-shell. */
+const FACTORY = 'views/metadata-admin/metadataClientFactory.ts';
+const BARE_CONSTRUCT = /\bnew\s+MetadataClient\s*\(/;
+
+function collectSourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const name = entry.name;
+      if (name === 'node_modules' || name === 'dist' || name === '.next') continue;
+      const full = path.join(dir, name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.tsx?$/.test(name) && !/\.(test|spec)\.tsx?$/.test(name)) {
+        out.push(full);
+      }
+    }
+  };
+  walk(srcRoot);
+  return out;
+}
+
+describe('MetadataClient authentication ratchet', () => {
+  it('scans a plausible number of app-shell source files (guards a broken scan path)', () => {
+    expect(collectSourceFiles().length).toBeGreaterThan(100);
+  });
+
+  it('constructs MetadataClient only through the authenticated console factory', () => {
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles()) {
+      const rel = path.relative(srcRoot, file).split(path.sep).join('/');
+      if (rel === FACTORY) continue;
+      const src = readFileSync(file, 'utf8');
+      src.split('\n').forEach((line, i) => {
+        if (BARE_CONSTRUCT.test(line)) offenders.push(`${rel}:${i + 1} :: ${line.trim()}`);
+      });
+    }
+    // If this fails: route construction through createConsoleMetadataClient so
+    // the Bearer token is attached. See metadataClientFactory.ts.
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the sanctioned factory authenticated (Bearer fetch wired in)', () => {
+    const factory = readFileSync(path.join(srcRoot, FACTORY), 'utf8');
+    // The factory must both construct the client and supply an authenticated
+    // fetch — if either disappears the ratchet above would pass vacuously.
+    expect(BARE_CONSTRUCT.test(factory)).toBe(true);
+    expect(factory).toMatch(/createAuthenticatedFetch/);
+    expect(factory).toMatch(/fetch:\s*consoleApiFetch/);
+  });
+});

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -6,10 +6,11 @@ import {
   useMemo,
   type ReactNode,
 } from 'react';
-import { MetadataClient, type ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { type ObjectStackAdapter } from '@object-ui/data-objectstack';
 import { resolveInlineMode } from '@object-ui/plugin-form';
 import { MetadataCtx, useMetadata, type MetadataContextValue, type MetadataState } from '@object-ui/react';
 import { usePreviewDrafts } from '../preview/PreviewModeContext';
+import { createConsoleMetadataClient } from '../views/metadata-admin/metadataClientFactory';
 import { subscribeCanvasInvalidate, subscribeMetadataRefresh } from '../assistant/assistantBus';
 
 export type { MetadataState, MetadataContextValue };
@@ -333,13 +334,13 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
   // reads come from the REST `?preview=draft` overlay (pending ADR-0033
   // drafts win over active) instead of the adapter SDK. The MetadataClient
   // is used because the SDK's meta API doesn't carry the preview flag; same
-  // endpoints, same cookie auth. Reads only — every write path is unchanged.
+  // endpoints, same authenticated fetch (Bearer token) as every other console
+  // client — see `createConsoleMetadataClient`. Reads only — every write path
+  // is unchanged.
   const previewDrafts = usePreviewDrafts();
   const previewClient = useMemo(() => {
     if (!previewDrafts) return null;
-    const baseUrl =
-      (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_SERVER_URL) || '';
-    return new MetadataClient({ baseUrl, previewDrafts: true });
+    return createConsoleMetadataClient({ previewDrafts: true });
   }, [previewDrafts]);
   const previewClientRef = useRef(previewClient);
   previewClientRef.current = previewClient;

--- a/packages/app-shell/src/views/metadata-admin/metadataClientFactory.ts
+++ b/packages/app-shell/src/views/metadata-admin/metadataClientFactory.ts
@@ -1,0 +1,82 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The single construction point for {@link MetadataClient} in the console.
+ *
+ * Authentication is a cross-cutting concern, but `MetadataClient` is a
+ * framework-agnostic HTTP client that defaults its `fetch` to the bare
+ * `globalThis.fetch` (no `Authorization` header). The console authenticates
+ * to `/api/v1/*` with a **Bearer token** kept in `localStorage`
+ * (`auth-session-token`) — there is no session cookie — so any client built on
+ * the raw global fetch is *unauthenticated* and every `/api/v1/meta/*` request
+ * comes back `401 unauthenticated`. That failure only surfaces in the
+ * token-based console (a same-origin cookie deployment masks it), which is why
+ * two construction sites silently regressed.
+ *
+ * Funnelling every console client through this factory bakes in the shared
+ * authenticated fetch (Bearer token + `X-Tenant-ID` + `Accept-Language`, via
+ * {@link createAuthenticatedFetch}) so a caller can no longer *forget* to
+ * authenticate. `metadata-client-auth.ratchet.test.ts` forbids a bare
+ * `new MetadataClient(` anywhere else in app-shell so this stays the one source
+ * of truth. This is additive for cookie deployments — `createAuthenticatedFetch`
+ * never touches `credentials`, so a same-origin session cookie still flows.
+ */
+
+import { MetadataClient } from '@object-ui/data-objectstack';
+import { createAuthenticatedFetch } from '@object-ui/auth';
+
+/**
+ * One authenticated fetch shared by every console metadata client.
+ * `createAuthenticatedFetch()` returns a stateless wrapper — it reads the
+ * Bearer token and active organization from storage *lazily on each call* — so
+ * a single shared instance is both correct (always current) and cheaper than
+ * re-allocating the closure per client.
+ */
+const consoleApiFetch = createAuthenticatedFetch();
+
+/**
+ * Resolve the metadata API base URL. `VITE_SERVER_URL` targets a split-origin
+ * backend (the `pnpm dev` setup: SPA on :5180, API on :3000); when unset it
+ * falls back to `''` (relative → current origin) for same-origin production,
+ * matching every other client in the app (see `apps/console/src/main.tsx`).
+ */
+export function resolveMetadataBaseUrl(): string {
+  return (
+    (typeof import.meta !== 'undefined' &&
+      (import.meta as { env?: Record<string, string | undefined> }).env
+        ?.VITE_SERVER_URL) ||
+    ''
+  );
+}
+
+export interface ConsoleMetadataClientOptions {
+  /**
+   * ADR-0037 Live Canvas — when true, reads overlay pending drafts on the
+   * active registry (`?preview=draft`). Writes are unaffected.
+   */
+  previewDrafts?: boolean;
+  /** Scope reads/writes to a tenant environment (`withEnvironment`). */
+  environmentId?: string;
+}
+
+/**
+ * Build an authenticated {@link MetadataClient} for the console. This is the
+ * only sanctioned way to construct one inside app-shell — see the module doc.
+ */
+export function createConsoleMetadataClient(
+  options: ConsoleMetadataClientOptions = {},
+): MetadataClient {
+  const { previewDrafts = false, environmentId } = options;
+  const client = new MetadataClient({
+    baseUrl: resolveMetadataBaseUrl(),
+    previewDrafts,
+    fetch: consoleApiFetch,
+  });
+  return environmentId ? client.withEnvironment(environmentId) : client;
+}

--- a/packages/app-shell/src/views/metadata-admin/useMetadata.ts
+++ b/packages/app-shell/src/views/metadata-admin/useMetadata.ts
@@ -16,8 +16,9 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { MetadataClient, type MetadataDiagnosticsSummary, type MetadataDiagnosticsEntry } from '@object-ui/data-objectstack';
+import { type MetadataClient, type MetadataDiagnosticsSummary, type MetadataDiagnosticsEntry } from '@object-ui/data-objectstack';
 import { usePreviewDrafts } from '../../preview/PreviewModeContext';
+import { createConsoleMetadataClient } from './metadataClientFactory';
 
 /**
  * A declarative **type-level** action surfaced on a metadata type by the
@@ -94,24 +95,20 @@ export interface RichMetadataTypeEntry {
 /**
  * Use a single MetadataClient for the whole admin engine.
  *
- * The base resolves to `VITE_SERVER_URL` so `/meta/*` writes reach the backend
- * even when the SPA and API are served from different origins (the split-origin
- * `pnpm dev` setup: SPA on :5180, backend on :3000). In same-origin production
- * `VITE_SERVER_URL` is unset → falls back to `''` (relative, current origin),
- * matching every other client in the app (see `apps/console/src/main.tsx`).
+ * Construction (base-URL resolution + the authenticated fetch that carries the
+ * Bearer token to `/api/v1/meta/*`) lives in `createConsoleMetadataClient` so
+ * every console surface shares one authenticated client — see
+ * `metadataClientFactory.ts`. The hook caches per `baseUrl + environmentId +
+ * previewDrafts` so `client.withEnvironment(...)` swaps without remounting.
  */
 export function useMetadataClient(environmentId?: string): MetadataClient {
   // ADR-0037: inside a draft-preview tree (?preview=draft), reads overlay
   // pending drafts on the active registry. Writes are unaffected.
   const previewDrafts = usePreviewDrafts();
-  return useMemo(() => {
-    const baseUrl =
-      (typeof import.meta !== 'undefined' &&
-        (import.meta as any).env?.VITE_SERVER_URL) ||
-      '';
-    const c = new MetadataClient({ baseUrl, previewDrafts });
-    return environmentId ? c.withEnvironment(environmentId) : c;
-  }, [environmentId, previewDrafts]);
+  return useMemo(
+    () => createConsoleMetadataClient({ previewDrafts, environmentId }),
+    [environmentId, previewDrafts],
+  );
 }
 
 /**


### PR DESCRIPTION
## Symptom

On `/_console/studio/<pkg>/data` some metadata requests 401 while others 200 in the **same logged-in browser**. Verified with the Chrome extension:

| request | cookie only | + Bearer token |
|---|---|---|
| `GET /api/v1/meta/object` | 401 | 200 |
| `GET /api/v1/meta/object?package=…` | 401 | 200 |
| `GET /api/v1/meta/app?package=…`, `/meta/_drafts`, `/meta` | 401 | 200 |

The deciding variable is **the `Authorization: Bearer` header**, not the URL or a permission — `document.cookie` has no session cookie (`authCookiesPresent: []`); the console authenticates purely by the `auth-session-token` Bearer token.

## Root cause

`MetadataClient` (`@object-ui/data-objectstack`) defaults `config.fetch ?? globalThis.fetch` — the bare global fetch sends no `Authorization` header. Two construction sites built it **without a `fetch`**:

- `views/metadata-admin/useMetadata.ts` — `useMetadataClient()` (backs ~30 Studio/metadata-admin surfaces)
- `providers/MetadataProvider.tsx` — the draft-preview client

The runtime adapter (`AdapterProvider.tsx`) builds with `createAuthenticatedFetch()`, so its `/meta/object|view|app` reads carried the token → 200; the Studio-authoring client did not → 401. A same-origin cookie deployment masked the bug, so it regressed twice. The `MetadataProvider` comment literally said "same cookie auth" — the mistaken assumption.

## Fix

Funnel every console `MetadataClient` through a single authenticated factory `createConsoleMetadataClient` (new `metadataClientFactory.ts`) that bakes in `createAuthenticatedFetch` (Bearer + `X-Tenant-ID` + `Accept-Language`) and dedupes the copied `baseUrl` resolution. Additive for cookie deployments — `credentials` is untouched. `withEnvironment`/`withPreviewDrafts` propagate the fetch, so fixing the construction points covers all downstream clients.

A `metadata-client-auth.ratchet.test.ts` guard forbids a bare `new MetadataClient(` elsewhere in app-shell so authentication can't silently regress.

## Verification

- HTTP-level proof (above): injecting the Bearer token flips all five 401 endpoints to 200 — exactly what the factory now does.
- `turbo run type-check --filter=@object-ui/app-shell` → 29/29 tasks pass.
- `data-objectstack` metadata-client tests: 20 passed (fetch injection + `withEnvironment` propagation intact).
- `MetadataProvider` merge/extract + the new ratchet: 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)