### PR TITLE
feat(console-ai): unify AI chat — one conversation key + one surface→agent resolver (ADR-0057 P1+P2)

### DIFF
--- a/.changeset/console-chat-conversation-key.md
+++ b/.changeset/console-chat-conversation-key.md
@@ -1,0 +1,30 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(console-ai): key AI chat conversations on `(user, app, product)`, not on surface (ADR-0057 P1)
+
+The console rendered AI chat through parallel shells that **forked the
+conversation**: the Studio design copilot scoped its thread as
+`studio:${packageId}:${agent}` while the full-page `/ai/build` focus view scoped
+on the agent alone — so opening the *same app* in both showed an empty "Build
+with AI" copilot beside an active full-page build thread (indistinguishable from
+data loss).
+
+Per ADR-0057 (**surface = view · conversation = model · product = binding
+axis**), conversations are now keyed on `(user, app, product)`:
+
+- New pure, unit-tested `chatConversationScope({ appId, product })` +
+  `chatProductOfAgent(name)` helper (`hooks/chatScope.ts`) is the single place
+  the scope key is formed. `product` is the ADR-0063 axis (`ask` | `build`),
+  derived from the resolved agent — never a per-surface choice.
+- `StudioAiCopilot` and the full-page `AiChatPage` both resolve
+  `app:${packageId}:${product}` for a package-scoped surface (the Studio copilot
+  editing package X and the `/ai/build?package=X` "Edit with AI" focus view now
+  resume ONE shared thread). The legacy `studio:` surface prefix is dropped.
+- A generic `/ai/:agent` visit with no `?package=` degrades to the product alone
+  (`build` / `ask`) — unchanged behaviour for that surface.
+
+Enablement stays on the single access-filtered agent-catalog gate
+(`useAiSurfaceEnabled`, ADR-0068) — a seat-less user's empty catalog hides the
+whole AI surface. No layout change.

--- a/.changeset/console-surface-agent-resolver.md
+++ b/.changeset/console-surface-agent-resolver.md
@@ -1,0 +1,30 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(console-ai): one declarative surface→agent resolver (ADR-0057 P2)
+
+The console re-implemented the ADR-0063 surface→agent chain in ~5 places, each
+spelled slightly differently — and `ConsoleLayout` carried an AI-Studio-off
+downgrade special case that existed nowhere else. This collapses them into one
+pure, unit-tested resolver so ADR-0063 (exactly two products `ask`/`build`,
+bound by surface — no roster, no per-turn classifier) becomes a **structural**
+guarantee.
+
+- New `hooks/surfaceAgent.ts`: `resolveSurfaceAgent(surface, { agents,
+  appDefaultAgent, aiStudioEnabled })` + `SURFACE_DEFAULT`. `app.defaultAgent` is
+  **bounded** to ask/build (alias-aware) — a withdrawn tenant custom agent is
+  rejected, not passed through, so no roster is representable (ADR-0057 open
+  question #4). The AI-Studio-off `build → ask` downgrade is folded in ONCE.
+- `StudioAiCopilot` (studio-build → build) and the console FAB (`default` → ask)
+  resolve through it. The FAB keeps #771's "prefer build when the catalog unlocks
+  it and nothing pinned a product" by passing that as its default PRODUCT input —
+  so the resolver still owns bounding + the downgrade, which now also applies to
+  the #771 preference (closing the leak where an authoring-disabled deployment
+  could still open build).
+- `ConsoleLayout`'s bespoke `!aiStudioEnabled && isBuildAgent(...)` downgrade is
+  deleted; it passes the raw `app.defaultAgent` and the resolver downgrades.
+
+Ships a unit table proving the ADR-0063 rows: Studio→build, other→ask,
+AI-Studio-off downgrade, `app.defaultAgent` bounded (valid override wins, roster
+rejected), alias-aware catalog resolution, empty catalog → inert (ADR-0025).

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -152,6 +152,21 @@ for each metadata type. Every type has a pure-renderer **preview** that doubles
 as its **designer** when given `editing` + `onPatch` props — no backend round
 trip is required to edit a draft.
 
+### AI chat conversation key (ADR-0057)
+
+The console's AI chat surfaces are **views over one conversation model**, not
+separate chats. A conversation is keyed on `(user, app, product)` — never on the
+surface — by the pure `chatConversationScope({ appId, product })` helper
+(`src/hooks/chatScope.ts`). `product` is the ADR-0063 binding axis (`ask` |
+`build`), derived from the resolved agent via `chatProductOfAgent(name)`, never a
+per-surface choice. A package-scoped surface resolves `app:${packageId}:${product}`,
+so the Studio design copilot editing package `X` and the full-page focus view
+`/ai/build?package=X` (the "Edit with AI" entry) **resume the same thread**
+instead of forking; a generic `/ai/:agent` visit with no package degrades to the
+product alone (`build` / `ask`). Enablement is the single access-filtered
+agent-catalog gate (`useAiSurfaceEnabled`, ADR-0068): a seat-less user's empty
+catalog hides the whole AI surface.
+
 ### App → Studio reverse bridge
 
 Inside a running app, workspace admins get a "Design in Studio" entry in the

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -79,6 +79,7 @@ import {
   type HydratedUIMessagePart,
 } from '../../hooks/useChatConversation';
 import { useReconcileOnError } from '../../hooks/useReconcileOnError';
+import { chatConversationScope, chatProductOfAgent } from '../../hooks/chatScope';
 import { ConversationsSidebar } from './ConversationsSidebar';
 import { LiveCanvas } from './LiveCanvas';
 import { BuildDebugDrawer } from './BuildDebugDrawer';
@@ -638,14 +639,24 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`
     : undefined;
 
+  // ADR-0057: key the conversation on `(user, app, product)`, not on surface.
+  // When this full-page surface was deep-linked to edit a package
+  // (`/ai/build?package=X`, the ADR-0070 "Edit with AI" entry), it shares the
+  // Studio copilot's `app:X:build` thread instead of forking a separate one; a
+  // generic `/ai/:agent` visit (no `?package=`) degrades to the product alone,
+  // unchanged from before. `undefined` while the agent is still resolving.
+  const chatScope = activeAgent
+    ? chatConversationScope({ appId: editPackageId, product: chatProductOfAgent(activeAgent) })
+    : undefined;
+
   const { conversationId, conversationScope, initialMessages } = useChatConversation({
     // Gate resolution on the agent being known: resolving while `activeAgent`
     // is still undefined (catalog loading) would bind a SCOPELESS conversation
     // that the per-(user,scope) guard then sticks with — so the agent surface
     // would resume some other agent's last chat. Waiting one tick keys the
-    // conversation to the right agent from the first resolve.
+    // conversation to the right scope from the first resolve.
     userId: activeAgent ? userId : undefined,
-    scope: activeAgent,
+    scope: chatScope,
     apiBase,
     activeId: urlConversationId ?? legacyConversationId,
     forceNew: forceNewConversation,
@@ -774,13 +785,13 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   useEffect(() => {
     if (!segmentIsAgent || urlConversationId || !conversationId || !activeAgentRoute) return;
     if (staleNewTargetRef.current && staleNewTargetRef.current.id === conversationId) return;
-    // Don't mirror a conversation that belongs to the PREVIOUS agent: right
-    // after a launcher switch, `conversationId` still holds the old agent's id
-    // until the hook re-resolves under the new scope. Mirroring it would write
+    // Don't mirror a conversation that belongs to the PREVIOUS scope: right
+    // after a launcher switch, `conversationId` still holds the old scope's id
+    // until the hook re-resolves under the new one. Mirroring it would write
     // it onto the new agent's URL and resume the wrong chat.
-    if (conversationScope !== activeAgent) return;
+    if (conversationScope !== chatScope) return;
     navigate(`/ai/${activeAgentRoute}/${conversationId}`, { replace: true });
-  }, [segmentIsAgent, urlConversationId, conversationId, conversationScope, activeAgent, activeAgentRoute, navigate]);
+  }, [segmentIsAgent, urlConversationId, conversationId, conversationScope, chatScope, activeAgentRoute, navigate]);
 
   const titledRef = useRef<Set<string>>(new Set());
 

--- a/packages/app-shell/src/hooks/__tests__/chatScope.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/chatScope.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import {
+  chatConversationScope,
+  chatProductOfAgent,
+  type ChatProduct,
+} from '../chatScope';
+
+describe('chatProductOfAgent (ADR-0063 binding axis)', () => {
+  it('maps the authoring agent (and its legacy alias) to `build`', () => {
+    expect(chatProductOfAgent('build')).toBe('build');
+    expect(chatProductOfAgent('metadata_assistant')).toBe('build');
+  });
+
+  it('maps the data agent (and its legacy alias) to `ask`', () => {
+    expect(chatProductOfAgent('ask')).toBe('ask');
+    expect(chatProductOfAgent('data_chat')).toBe('ask');
+  });
+
+  it('treats an unknown/custom agent as `ask` (never a third product)', () => {
+    expect(chatProductOfAgent('support_bot')).toBe('ask');
+  });
+
+  it('treats an unresolved (undefined) agent as `ask`', () => {
+    expect(chatProductOfAgent(undefined)).toBe('ask');
+  });
+});
+
+describe('chatConversationScope (ADR-0057 `(app, product)` key)', () => {
+  it('keys on app + product when an app id is known', () => {
+    expect(chatConversationScope({ appId: 'app.acme.crm', product: 'build' })).toBe(
+      'app:app.acme.crm:build',
+    );
+    expect(chatConversationScope({ appId: 'app.acme.crm', product: 'ask' })).toBe(
+      'app:app.acme.crm:ask',
+    );
+  });
+
+  it('degrades to the product alone when no app id is known', () => {
+    expect(chatConversationScope({ product: 'build' })).toBe('build');
+    expect(chatConversationScope({ product: 'ask' })).toBe('ask');
+    expect(chatConversationScope({ appId: undefined, product: 'ask' })).toBe('ask');
+  });
+
+  it('separates threads per app and per product', () => {
+    const keys = new Set([
+      chatConversationScope({ appId: 'app.a', product: 'build' }),
+      chatConversationScope({ appId: 'app.a', product: 'ask' }),
+      chatConversationScope({ appId: 'app.b', product: 'build' }),
+    ]);
+    expect(keys.size).toBe(3);
+  });
+
+  it('UNIFIES the Studio copilot and the full-page focus view for one app+product', () => {
+    // The forked-conversation bug this ADR fixes: the Studio design copilot
+    // (packageId = X, build) and the full-page `/ai/build?package=X` focus view
+    // (editPackageId = X, build) must resolve to the SAME conversation key.
+    const packageId = 'app.acme.crm';
+    const product: ChatProduct = chatProductOfAgent('build');
+    const studioScope = chatConversationScope({ appId: packageId, product });
+    const focusScope = chatConversationScope({ appId: packageId, product });
+    expect(studioScope).toBe(focusScope);
+    expect(studioScope).toBe('app:app.acme.crm:build');
+  });
+
+  it('no longer carries the legacy `studio:` surface prefix', () => {
+    const scope = chatConversationScope({ appId: 'app.acme.crm', product: 'build' });
+    expect(scope.startsWith('studio:')).toBe(false);
+  });
+});

--- a/packages/app-shell/src/hooks/__tests__/surfaceAgent.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/surfaceAgent.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import type { AgentDescriptor } from '@object-ui/plugin-chatbot';
+import { resolveSurfaceAgent, SURFACE_DEFAULT } from '../surfaceAgent';
+
+const agent = (name: string): AgentDescriptor => ({ name, label: name });
+
+/** A modern catalog serving both products under their friendly names. */
+const BOTH = [agent('build'), agent('ask')];
+/** A legacy catalog serving the pre-rename ids only (alias resolution path). */
+const LEGACY = [agent('metadata_assistant'), agent('data_chat')];
+/** An ask-only catalog (a pure end-user deployment / no authoring seat). */
+const ASK_ONLY = [agent('ask')];
+
+describe('resolveSurfaceAgent — the ADR-0063 table', () => {
+  it('Studio authoring surface → build', () => {
+    expect(resolveSurfaceAgent('studio-build', { agents: BOTH })).toBe('build');
+  });
+
+  it('every other surface → ask', () => {
+    expect(resolveSurfaceAgent('default', { agents: BOTH })).toBe('ask');
+  });
+
+  it('AI-Studio-off downgrades a build want to ask (the folded-in ConsoleLayout case)', () => {
+    expect(
+      resolveSurfaceAgent('studio-build', { agents: BOTH, aiStudioEnabled: false }),
+    ).toBe('ask');
+    // …and an app that asked for build is downgraded too.
+    expect(
+      resolveSurfaceAgent('default', {
+        agents: BOTH,
+        appDefaultAgent: 'build',
+        aiStudioEnabled: false,
+      }),
+    ).toBe('ask');
+  });
+
+  describe('app.defaultAgent is bounded to ask/build (no roster representable)', () => {
+    it('a valid build override wins on a default surface', () => {
+      expect(resolveSurfaceAgent('default', { agents: BOTH, appDefaultAgent: 'build' })).toBe(
+        'build',
+      );
+    });
+
+    it('a valid ask override wins on the Studio surface', () => {
+      expect(
+        resolveSurfaceAgent('studio-build', { agents: BOTH, appDefaultAgent: 'ask' }),
+      ).toBe('ask');
+    });
+
+    it('the legacy alias of a product is accepted as an override', () => {
+      expect(
+        resolveSurfaceAgent('default', { agents: LEGACY, appDefaultAgent: 'metadata_assistant' }),
+      ).toBe('metadata_assistant');
+    });
+
+    it('REJECTS a non-product agent (withdrawn tenant custom) → surface default applies', () => {
+      // A roster entry must NOT be honoured even if the catalog somehow serves it.
+      const withRoster = [...BOTH, agent('weather_bot')];
+      expect(
+        resolveSurfaceAgent('default', { agents: withRoster, appDefaultAgent: 'weather_bot' }),
+      ).toBe('ask');
+      expect(
+        resolveSurfaceAgent('studio-build', { agents: withRoster, appDefaultAgent: 'weather_bot' }),
+      ).toBe('build');
+    });
+  });
+
+  describe('catalog resolution (alias-aware + fallback)', () => {
+    it('resolves the wanted product through its legacy alias', () => {
+      expect(resolveSurfaceAgent('studio-build', { agents: LEGACY })).toBe('metadata_assistant');
+      expect(resolveSurfaceAgent('default', { agents: LEGACY })).toBe('data_chat');
+    });
+
+    it('falls back to the platform default when the wanted product is not served', () => {
+      // Studio wants build, but only ask is served → platform default (ask).
+      expect(resolveSurfaceAgent('studio-build', { agents: ASK_ONLY })).toBe('ask');
+    });
+
+    it('returns undefined on an empty catalog (ADR-0025 OSS: inert surface)', () => {
+      expect(resolveSurfaceAgent('studio-build', { agents: [] })).toBeUndefined();
+      expect(resolveSurfaceAgent('default', { agents: [] })).toBeUndefined();
+    });
+  });
+
+  it('SURFACE_DEFAULT encodes exactly the two products', () => {
+    expect(SURFACE_DEFAULT).toEqual({ 'studio-build': 'build', default: 'ask' });
+  });
+});

--- a/packages/app-shell/src/hooks/chatScope.ts
+++ b/packages/app-shell/src/hooks/chatScope.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * chatScope — the console AI-chat conversation key (ADR-0057).
+ *
+ * ADR-0057 principle: **surface = view · conversation = model · product
+ * (`ask` / `build`) = the binding axis.** Conversations are keyed on
+ * **`(user, app, product)` — NOT on surface.** Two surfaces that resolve the
+ * SAME `(appId, product)` therefore resume ONE shared thread instead of forking:
+ *
+ *   - the full-page focus view `/ai/build?package=X` (the ADR-0070 "Edit with
+ *     AI" deep-link — `editPackageId = X`), and
+ *   - the Studio design copilot editing package `X` (`packageId = X`),
+ *
+ * both produce `app:X:build`, so opening one after the other resumes the same
+ * design conversation rather than showing an empty copilot beside an active
+ * full-page thread (the forked-conversation bug this ADR fixes). The `(user)`
+ * dimension is applied by {@link useChatConversation}'s per-user cache key; this
+ * helper owns the `(app, product)` half.
+ *
+ * `product` is the ADR-0063 binding axis (`ask` | `build`) — derived from the
+ * resolved agent, **never** a per-surface choice. There is no roster and no
+ * per-turn classifier: an agent is either the authoring (`build`) agent or it is
+ * `ask`.
+ *
+ * When no app id is known — a generic `/ai/:agent` visit with no `?package=`,
+ * or the ambient console FAB — the key degrades to the product alone
+ * (`build` / `ask`), preserving today's per-product thread for that surface.
+ *
+ * Kept as a pure, dependency-light module (only the agent-kind predicate from
+ * `@object-ui/plugin-chatbot`) so every shell resolves the key the SAME way and
+ * it can be unit-tested without the chat component graph.
+ *
+ * @module
+ */
+
+import { isBuildAgent } from '@object-ui/plugin-chatbot';
+
+/** The ADR-0063 binding axis: exactly two products, bound by surface. */
+export type ChatProduct = 'ask' | 'build';
+
+/**
+ * Map a resolved agent name to its product (the ADR-0063 axis). The authoring
+ * agent (`build`, alias-aware via {@link isBuildAgent}) is `build`; everything
+ * else — including a still-unresolved (`undefined`) agent — is `ask`.
+ */
+export function chatProductOfAgent(agentName: string | undefined): ChatProduct {
+  return agentName && isBuildAgent(agentName) ? 'build' : 'ask';
+}
+
+export interface ChatScopeInput {
+  /**
+   * The app / package the conversation is bound to (Studio `packageId` or the
+   * full-page `?package=` `editPackageId` — the same package id space). Omit for
+   * a surface with no app identity (generic `/ai/:agent`, the ambient FAB).
+   */
+  appId?: string;
+  /** The ADR-0063 product this surface binds — the resolved agent's axis. */
+  product: ChatProduct;
+}
+
+/**
+ * The conversation scope key for {@link useChatConversation}. Encodes
+ * `(app, product)`; the hook layers `(user)` on top. Surfaces sharing an
+ * `(appId, product)` share a thread; app-less surfaces key on product alone.
+ */
+export function chatConversationScope({ appId, product }: ChatScopeInput): string {
+  return appId ? `app:${appId}:${product}` : product;
+}

--- a/packages/app-shell/src/hooks/surfaceAgent.ts
+++ b/packages/app-shell/src/hooks/surfaceAgent.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * surfaceAgent — the one declarative surface→agent resolver (ADR-0057 P2).
+ *
+ * ADR-0063 fixes the agent model: **exactly two products (`ask` / `build`),
+ * bound by SURFACE — no roster, no per-turn classifier.** Before this module the
+ * console re-implemented that resolution chain in ~5 places, each spelled
+ * slightly differently (and `ConsoleLayout` carried a downgrade special case
+ * that existed nowhere else). This is the single place the rule lives, so
+ * ADR-0063 is a **structural** guarantee: there is no seam to add a roster or a
+ * classifier into.
+ *
+ * The rule, in one function:
+ *
+ *   1. `app.defaultAgent` may override the surface default, but it is **bounded**
+ *      to the two products (ask/build, alias-aware). Anything else — a withdrawn
+ *      tenant custom agent — is **rejected** (not silently passed through), so a
+ *      roster cannot be smuggled in via app metadata (ADR-0057 open question #4).
+ *   2. Otherwise the surface decides: the Studio authoring surface wants `build`;
+ *      every other surface wants `ask`.
+ *   3. With AI Studio disabled the build agent is unreachable, so a `build` want
+ *      degrades to `ask` (the former `ConsoleLayout` special case, folded in ONCE).
+ *   4. The chosen product is resolved against the LIVE catalog (alias-aware); if
+ *      it isn't served, fall back to the catalog's platform default.
+ *
+ * Kept pure (no React) so every call site resolves identically and the ADR-0063
+ * table is unit-tested without the chat component graph.
+ *
+ * @module
+ */
+
+import {
+  isBuildAgent,
+  isBuiltinAgentName,
+  resolveAgentParam,
+  resolveDefaultAgentName,
+  type AgentDescriptor,
+} from '@object-ui/plugin-chatbot';
+
+/**
+ * The surfaces that resolve an agent. `studio-build` is the ADR-0080 Studio
+ * authoring surface (the only one that wants `build` by default); every other
+ * surface — the console FAB, the full-page `/ai` fallback, a runtime app — is
+ * `default` and wants `ask`. Deliberately NOT a per-shell enum: the axis is the
+ * product, not the view.
+ */
+export type ChatSurface = 'studio-build' | 'default';
+
+/** The ADR-0063 product a surface wants before catalog resolution. */
+export const SURFACE_DEFAULT: Record<ChatSurface, 'ask' | 'build'> = {
+  'studio-build': 'build',
+  default: 'ask',
+};
+
+export interface ResolveSurfaceAgentInput {
+  /** The live agent catalog (`useAgents`) — the single source of truth. */
+  agents: AgentDescriptor[];
+  /**
+   * `app.defaultAgent` from app metadata. Bounded to ask/build (alias-aware);
+   * any other value is rejected so no roster is representable.
+   */
+  appDefaultAgent?: string;
+  /**
+   * Whether AI Studio (authoring) is enabled for this deployment. When off, a
+   * `build` want degrades to `ask`. Defaults to true.
+   */
+  aiStudioEnabled?: boolean;
+}
+
+/**
+ * Resolve the concrete agent NAME a surface should bind, per ADR-0063. Returns
+ * `undefined` only when the catalog is empty (no agent to talk to → the AI
+ * surface is inert; ADR-0025 OSS degradation).
+ */
+export function resolveSurfaceAgent(
+  surface: ChatSurface,
+  { agents, appDefaultAgent, aiStudioEnabled = true }: ResolveSurfaceAgentInput,
+): string | undefined {
+  const catalog = agents.map((a) => a.name);
+  // (1) app.defaultAgent bounded to the two products — reject anything else.
+  const bounded = isBuiltinAgentName(appDefaultAgent) ? appDefaultAgent : undefined;
+  // (2) surface default when no valid override.
+  const want = bounded ?? SURFACE_DEFAULT[surface] ?? SURFACE_DEFAULT.default;
+  // (3) the ConsoleLayout downgrade, folded in ONCE.
+  const eff = !aiStudioEnabled && isBuildAgent(want) ? 'ask' : want;
+  // (4) resolve against the live catalog (alias-aware); else platform default.
+  return resolveAgentParam(eff, catalog) ?? resolveDefaultAgentName(agents);
+}

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -18,7 +18,6 @@ import {
   useAgents,
   useAiModels,
   useHitlInChat,
-  resolveDefaultAgentName,
   uiMessagesToChatMessages,
   publishHealthFromResponse,
   agentRouteName,
@@ -50,6 +49,7 @@ import {
 import { useAssistant, requestAssistantReview, emitCanvasInvalidate, emitMetadataRefresh, type AssistantEditorContext } from '../assistant/assistantBus';
 import { fetchPendingDraftCount } from '../preview/draftStatus';
 import { getRuntimeConfig } from '../runtime-config';
+import { resolveSurfaceAgent } from '../hooks/surfaceAgent';
 import { cloudPricingDeepLink } from '../console/marketplace/marketplaceApi';
 import { shouldShowAgentPicker } from './agentPicker';
 import { detectConversationLanguage } from '../console/ai/conversationLanguage';
@@ -905,17 +905,23 @@ export default function ConsoleFloatingChatbot({
   const [activeAgent, setActiveAgent] = React.useState<string | undefined>(undefined);
   React.useEffect(() => {
     if (!activeAgent && agents.length > 0) {
-      // Resolution: app.defaultAgent → env default → BUILD (when offered) →
-      // catalog fallback. #771: the catalog only serves `build` to users who
-      // can build, and the build surface is the one that RESUMES its
-      // conversation — landing them on the ask tab hid their in-progress
-      // build thread behind a tab switch ("my build chat disappeared"), and
-      // buried the primary capability. Users bound to ask-only see no change.
-      const preferred =
-        defaultAgentProp ??
-        envDefaultAgent ??
-        (agents.some((a) => agentRouteName(a.name) === 'build') ? 'build' : undefined);
-      const resolved = resolveDefaultAgentName(agents, preferred);
+      // ADR-0057 P2: resolve through the ONE `resolveSurfaceAgent` resolver. The
+      // FAB is the `default` (ask) surface. #771: the catalog only serves `build`
+      // to users who can build, and the build surface is the one that RESUMES its
+      // conversation — landing a builder on the ask tab hid their in-progress
+      // build thread behind a tab switch. So we PREFER build when the catalog
+      // unlocks it and neither the app nor env pinned a product — expressed as
+      // the surface's default PRODUCT input, so the resolver still owns the
+      // ask/build bounding AND the AI-Studio-off downgrade (which now applies to
+      // this preference too, closing the leak where an authoring-disabled
+      // deployment still opened build). Users bound to ask-only see no change.
+      const buildUnlocked = agents.some((a) => agentRouteName(a.name) === 'build');
+      const resolved = resolveSurfaceAgent('default', {
+        agents,
+        appDefaultAgent:
+          defaultAgentProp ?? envDefaultAgent ?? (buildUnlocked ? 'build' : undefined),
+        aiStudioEnabled: getRuntimeConfig().features.aiStudio !== false,
+      });
       if (resolved) setActiveAgent(resolved);
     }
   }, [agents, activeAgent, defaultAgentProp, envDefaultAgent]);

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -10,7 +10,6 @@
 
 import React, { useEffect } from 'react';
 import { AppShell } from '@object-ui/layout';
-import { isBuildAgent } from '@object-ui/plugin-chatbot';
 
 // Lightweight FAB stub — the heavy chat chunk graph (plugin-chatbot,
 // shiki, streamdown, mermaid, @ai-sdk, ~20MB) only downloads on first
@@ -26,7 +25,7 @@ import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
 import { useNavigationContext } from '../context/NavigationContext';
 import { CommandPaletteProvider } from '../context/CommandPaletteProvider';
 import { resolveI18nLabel } from '../utils';
-import { getProductName, getRuntimeConfig } from '../runtime-config';
+import { getProductName } from '../runtime-config';
 import type { ConnectionState } from '@object-ui/data-objectstack';
 
 /** Minimal object shape used by the chatbot context */
@@ -72,18 +71,11 @@ export function ConsoleLayout({
   // top-bar AI link): show the chatbot only when the server actually serves AI,
   // or when an explicit `VITE_AI_BASE_URL` opt-in points at an external server.
   const { enabled: showChatbot } = useAiSurfaceEnabled();
-  // AI Studio (AI-driven metadata authoring / "online development") can be
-  // turned off per deployment. When off, suppress the metadata-authoring
-  // assistant so the chatbot falls back to the generic data assistant — the
-  // generic data-chat experience stays available.
-  const aiStudioEnabled = getRuntimeConfig().features.aiStudio !== false;
-  // Alias-aware: the build/authoring agent is `build` (new) or
-  // `metadata_assistant` (legacy). When AI Studio is off, drop it so the FAB
-  // falls back to the generic data assistant.
-  const effectiveDefaultAgent =
-    !aiStudioEnabled && isBuildAgent(activeApp?.defaultAgent)
-      ? undefined
-      : activeApp?.defaultAgent;
+  // ADR-0057 P2: the AI-Studio-off downgrade (a `build` default falls back to
+  // `ask` when authoring is deployment-disabled) is no longer spelled here — it
+  // is folded into the ONE `resolveSurfaceAgent` resolver, which the FAB applies
+  // to the raw `app.defaultAgent` below. This was the special case that existed
+  // nowhere else; it now lives in exactly one place.
   const { setContext, setCurrentAppName } = useNavigationContext();
 
   // Set navigation context to 'app' when this layout mounts
@@ -147,7 +139,7 @@ export function ConsoleLayout({
         <ConsoleChatbotFab
           appLabel={appLabel}
           appName={activeAppName}
-          defaultAgent={effectiveDefaultAgent}
+          defaultAgent={activeApp?.defaultAgent}
           objects={objects}
           userId={userId}
         />

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -4,9 +4,10 @@ import React from 'react';
 import { useAuth } from '@object-ui/auth';
 import { Button } from '@object-ui/components';
 import { Sparkles, PanelLeftClose } from 'lucide-react';
-import { useAgents, resolveDefaultAgentName, isBuildAgent } from '@object-ui/plugin-chatbot';
+import { useAgents } from '@object-ui/plugin-chatbot';
 import { useChatConversation } from '../../hooks/useChatConversation';
 import { chatConversationScope, chatProductOfAgent } from '../../hooks/chatScope';
+import { resolveSurfaceAgent } from '../../hooks/surfaceAgent';
 import { ChatPane, resolveApiBase, type PendingFirstMessage } from '../../console/ai/AiChatPage';
 
 export interface StudioAiCopilotProps {
@@ -39,12 +40,13 @@ export function StudioAiCopilot({ packageId, locale }: StudioAiCopilotProps): Re
 
   const { agents, isLoading: agentsLoading, error: agentsError } = useAgents({ apiBase });
 
-  // Prefer the build agent (metadata authoring); fall back to the platform default.
-  const activeAgent = React.useMemo(() => {
-    if (agents.length === 0) return undefined;
-    const build = agents.find((a) => isBuildAgent(a.name));
-    return build?.name ?? resolveDefaultAgentName(agents, undefined);
-  }, [agents]);
+  // ADR-0057 P2: the Studio authoring surface resolves through the ONE
+  // declarative resolver (`studio-build` → build, else platform default), not a
+  // local `isBuildAgent` pick. Same result, single source of truth.
+  const activeAgent = React.useMemo(
+    () => resolveSurfaceAgent('studio-build', { agents }),
+    [agents],
+  );
 
   const chatApi = activeAgent
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -6,6 +6,7 @@ import { Button } from '@object-ui/components';
 import { Sparkles, PanelLeftClose } from 'lucide-react';
 import { useAgents, resolveDefaultAgentName, isBuildAgent } from '@object-ui/plugin-chatbot';
 import { useChatConversation } from '../../hooks/useChatConversation';
+import { chatConversationScope, chatProductOfAgent } from '../../hooks/chatScope';
 import { ChatPane, resolveApiBase, type PendingFirstMessage } from '../../console/ai/AiChatPage';
 
 export interface StudioAiCopilotProps {
@@ -49,11 +50,15 @@ export function StudioAiCopilot({ packageId, locale }: StudioAiCopilotProps): Re
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`
     : undefined;
 
-  // One durable conversation per (user, package, agent) — reopening Studio on the
-  // same app resumes the same design chat.
+  // One durable conversation per (user, app, product) — ADR-0057. Keyed on the
+  // PACKAGE and PRODUCT, not on this surface, so reopening the same app's design
+  // chat in the full-page `/ai/build?package=…` focus view resumes THIS thread
+  // (no `studio:` fork). See {@link chatConversationScope}.
   const { conversationId, initialMessages } = useChatConversation({
     userId: activeAgent ? userId : undefined,
-    scope: activeAgent ? `studio:${packageId}:${activeAgent}` : undefined,
+    scope: activeAgent
+      ? chatConversationScope({ appId: packageId, product: chatProductOfAgent(activeAgent) })
+      : undefined,
     apiBase,
     activeId: undefined,
     forceNew: false,


### PR DESCRIPTION
Lands the two sign-off-free phases of **ADR-0057 — Console AI chat unification** (work order #2412, epic #2409). Both are reversible; the two founder-decision phases (P3 dock / P4 handoff) are follow-ups.

---

## P1 — key conversations on `(user, app, product)`, not surface

The console forked the AI conversation across shells: the Studio copilot scoped `studio:${packageId}:${agent}` while the full-page `/ai/build` focus view scoped on the agent alone — the same app showed an empty "Build with AI" copilot beside an active full-page build thread (looks like data loss).

- **New `hooks/chatScope.ts`** (pure, unit-tested): `chatConversationScope({ appId, product })` + `chatProductOfAgent(name)` — the single place the scope key is formed. `product` is the ADR-0063 axis (`ask`|`build`), derived from the resolved agent, never per-surface.
- `StudioAiCopilot` and full-page `AiChatPage` both resolve `app:${packageId}:${product}`, so the Studio copilot editing package X and `/ai/build?package=X` ("Edit with AI", ADR-0070) resume **one shared thread**. Legacy `studio:` prefix dropped. Generic `/ai/:agent` (no `?package=`) degrades to the product alone — unchanged.
- AiChatPage's URL-mirror guard now compares the resolved scope against the new value.
- Gate already consolidated on `useAiSurfaceEnabled` (ADR-0068); no change needed.

## P2 — one declarative surface→agent resolver

~5 divergent re-implementations of the ADR-0063 chain (and a `ConsoleLayout` downgrade special case that existed nowhere else) collapse into one pure resolver, making ADR-0063 a **structural** guarantee.

- **New `hooks/surfaceAgent.ts`**: `resolveSurfaceAgent(surface, { agents, appDefaultAgent, aiStudioEnabled })` + `SURFACE_DEFAULT`. `app.defaultAgent` is **bounded** to ask/build (alias-aware) — a withdrawn tenant custom agent is rejected, so no roster is representable (open question #4). The AI-Studio-off `build→ask` downgrade is folded in **once**.
- `StudioAiCopilot` (studio-build→build) and the console FAB (default→ask) resolve through it. The FAB preserves #771's "prefer build when the catalog unlocks it and nothing pinned a product" by passing that as its default *product* input — the resolver still owns bounding + the downgrade, which now **also** applies to the #771 preference (closing the leak where an authoring-disabled deployment could still open build).
- `ConsoleLayout`'s bespoke downgrade is deleted; it passes the raw `app.defaultAgent`.

## Invariants held
- **ADR-0063**: exactly two products, bound by surface; no roster / no per-turn classifier representable.
- **ADR-0025 (OSS)**: empty catalog → whole surface inert (`resolveSurfaceAgent` returns `undefined`; `useAiSurfaceEnabled` hides everything).
- No cloud backend change.

## Verification
- **New unit tables**: `chatScope.test.ts` (shared-thread key invariant + product derivation incl. legacy aliases) and `surfaceAgent.test.ts` (the ADR-0063 rows: Studio→build, other→ask, AI-Studio-off downgrade, `app.defaultAgent` bounded + roster rejected, alias-aware resolution, empty catalog→inert).
- `pnpm --filter @object-ui/app-shell`: **267** hooks/layout/studio/console tests green (incl. the two new tables).
- `turbo type-check` clean; `turbo build --filter=@object-ui/console` clean (full-graph integration).
- **Real-browser boot** (Chromium): app loads with **0 uncaught JS errors / 0 non-network console errors**.

> ⚠️ **Browser proof limit (ADR-0054):** interactive AI-chat verification (the two surfaces sharing one live thread) needs the cloud `service-ai` stack + `AI_GATEWAY_API_KEY` + a real login (httpOnly session) — none available in the CI/sandbox. The behaviour is pinned by the unit invariants above; a maintainer login is needed for the screenshot proof.

## Follow-ups
- **P3** — docked rail; per founder decision this keeps Studio's current layout (**properties right / chat left**), so the disruptive 3-pane reflow is dropped.
- **P4** — ask→build handoff via an explicit **"Open in Builder →"** (founder decision).
- Both P3/P4 need the live AI stack for their ADR-0054 browser proof.

Refs: ADR `docs/adr/0057-console-ai-chat-one-conversation-docked.md` (#2411) · work order #2412 · epic #2409.