### PR TITLE
feat(auth): phone number + password sign-in on the login page

### DIFF
--- a/.changeset/phone-password-login.md
+++ b/.changeset/phone-password-login.md
@@ -1,0 +1,26 @@
+---
+"@object-ui/auth": minor
+"@object-ui/console": patch
+---
+
+feat(auth): phone number + password sign-in on the login page
+
+The login page's password mode now accepts an **email OR a phone number** as the
+identifier and routes by shape — email → `/sign-in/email`, phone →
+`/sign-in/phone-number` (better-auth phoneNumber plugin, framework#2780). It
+coexists with the existing phone-OTP mode.
+
+- Gated on `features.phoneNumber` (phoneNumber plugin enabled). Unlike phone-OTP
+  it needs no SMS service, so it uses that coarser capability flag, not
+  `features.phoneNumberOtp`. When the flag is off the field stays email-only.
+- New `AuthClient.signInWithPhonePassword(phoneNumber, password)` wired through
+  `AuthContext` / `AuthProvider` / `useAuth`.
+- New `normalizePhoneIdentifier` / `looksLikePhoneIdentifier` helpers that mirror
+  the backend's `normalizePhoneNumber` exactly (strip `[\s\-().]`, validate
+  `^\+?[0-9]{6,15}$`, **no** forced E.164 / country code — the backend stores the
+  light-stripped form, so anything heavier would break the lookup).
+- SSO stays email-only (a phone-shaped identifier no longer attempts domain
+  routing).
+
+Only works for accounts that have both a phone number and a password set;
+phone-only accounts set a password on first OTP sign-in.

--- a/apps/console/src/pages/auth/LoginPage.tsx
+++ b/apps/console/src/pages/auth/LoginPage.tsx
@@ -274,6 +274,10 @@ function LoginFormCard({
       labels={{
         emailLabel: t('auth.login.emailLabel', { defaultValue: 'Email' }),
         emailPlaceholder: t('auth.login.emailPlaceholder', { defaultValue: 'name@example.com' }),
+        emailOrPhoneLabel: t('auth.login.emailOrPhoneLabel', { defaultValue: 'Email or phone number' }),
+        emailOrPhonePlaceholder: t('auth.login.emailOrPhonePlaceholder', {
+          defaultValue: 'name@example.com or +1 555 000 0000',
+        }),
         passwordLabel: t('auth.login.passwordLabel', { defaultValue: 'Password' }),
         passwordPlaceholder: t('auth.login.passwordPlaceholder', { defaultValue: 'Enter your password' }),
         forgotPasswordText: t('auth.login.forgotPasswordText', { defaultValue: 'Forgot password?' }),

--- a/packages/auth/src/AuthContext.ts
+++ b/packages/auth/src/AuthContext.ts
@@ -52,6 +52,8 @@ export interface AuthContextValue {
   sendPhoneOtp: (phoneNumber: string) => Promise<void>;
   /** framework#2780 — sign in by verifying a phone OTP. */
   signInWithPhoneOtp: (phoneNumber: string, code: string) => Promise<void>;
+  /** framework#2780 — sign in with phone number + password (no SMS required). */
+  signInWithPhonePassword: (phoneNumber: string, password: string) => Promise<void>;
   /** framework#2780 — request a password-reset OTP SMS for the phone number. */
   requestPhonePasswordReset: (phoneNumber: string) => Promise<void>;
   /** framework#2780 — reset the password with a phone OTP. */

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -316,6 +316,25 @@ export function AuthProvider({
     [client],
   );
 
+  const signInWithPhonePassword = useCallback(
+    async (phoneNumber: string, password: string) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await client.signInWithPhonePassword(phoneNumber, password);
+        setUser(result.user);
+        setSession(result.session);
+      } catch (err) {
+        const authError = err instanceof Error ? err : new Error(String(err));
+        setError(authError);
+        throw authError;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [client],
+  );
+
   const requestPhonePasswordReset = useCallback(
     async (phoneNumber: string) => {
       setError(null);
@@ -651,6 +670,7 @@ export function AuthProvider({
       resetPassword,
       sendPhoneOtp,
       signInWithPhoneOtp,
+      signInWithPhonePassword,
       requestPhonePasswordReset,
       resetPasswordWithPhoneOtp,
       changePassword,
@@ -686,7 +706,7 @@ export function AuthProvider({
     [
       user, session, isAuthenticated, isAuthEnabled, isLoading, error, isPreviewMode, previewMode,
       signIn, signUp, signOut, updateUser, forgotPassword, sendVerificationEmail, resetPassword, changePassword, setInitialPassword, hasLocalPassword, getAuthConfig, signInWithProvider,
-      sendPhoneOtp, signInWithPhoneOtp, requestPhonePasswordReset, resetPasswordWithPhoneOtp,
+      sendPhoneOtp, signInWithPhoneOtp, signInWithPhonePassword, requestPhonePasswordReset, resetPasswordWithPhoneOtp,
       remediationRequired, enrollTotp, verifyTotp,
       organizations, activeOrganization, activeMember, isOrganizationsLoading, switchOrganization, createOrganization, refreshOrganizations,
       updateOrganization, deleteOrganization, leaveOrganization,

--- a/packages/auth/src/LoginForm.tsx
+++ b/packages/auth/src/LoginForm.tsx
@@ -9,6 +9,7 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from './useAuth';
 import { SocialSignInButtons } from './SocialSignInButtons';
+import { looksLikePhoneIdentifier, normalizePhoneIdentifier } from './phone-identifier';
 import type { AuthLinkComponentProps } from './types';
 import {
   AUTH_FIELD_LABEL_CLASS,
@@ -25,6 +26,10 @@ import {
 export interface LoginFormLabels {
   emailLabel?: string;
   emailPlaceholder?: string;
+  /** Identifier label when phone+password is enabled (defaults to "Email or phone number"). */
+  emailOrPhoneLabel?: string;
+  /** Identifier placeholder when phone+password is enabled. */
+  emailOrPhonePlaceholder?: string;
   passwordLabel?: string;
   passwordPlaceholder?: string;
   forgotPasswordText?: string;
@@ -141,7 +146,7 @@ export function LoginForm({
   labels = {},
   errorMessages,
 }: LoginFormProps) {
-  const { signIn, isLoading, getAuthConfig, sendPhoneOtp, signInWithPhoneOtp } = useAuth();
+  const { signIn, isLoading, getAuthConfig, sendPhoneOtp, signInWithPhoneOtp, signInWithPhonePassword } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -150,6 +155,11 @@ export function LoginForm({
   // deliverable SMS service is wired — so the mode never renders as a dead
   // entry point whose code can never arrive.
   const [phoneOtpEnabled, setPhoneOtpEnabled] = useState(false);
+  // Phone + password sign-in (framework#2780). Offered when the server reports
+  // `features.phoneNumber` — the phoneNumber plugin is on. Unlike OTP this needs
+  // no SMS service, so it's gated on the coarser flag: the password-mode
+  // identifier field then accepts an email OR a phone number.
+  const [phonePasswordEnabled, setPhonePasswordEnabled] = useState(false);
   const [mode, setMode] = useState<'password' | 'phone-otp'>('password');
   const [phone, setPhone] = useState('');
   const [otpCode, setOtpCode] = useState('');
@@ -183,6 +193,7 @@ export function LoginForm({
         if (cancelled) return;
         setSsoEnabled(config?.features?.sso === true);
         setPhoneOtpEnabled(config?.features?.phoneNumberOtp === true);
+        setPhonePasswordEnabled(config?.features?.phoneNumber === true);
         setSsoEnforced(
           config?.features?.ssoEnforced === true ||
             config?.emailPassword?.enabled === false,
@@ -204,6 +215,8 @@ export function LoginForm({
   const l = {
     emailLabel: labels.emailLabel ?? 'Email',
     emailPlaceholder: labels.emailPlaceholder ?? 'name@example.com',
+    emailOrPhoneLabel: labels.emailOrPhoneLabel ?? 'Email or phone number',
+    emailOrPhonePlaceholder: labels.emailOrPhonePlaceholder ?? 'name@example.com or +1 555 000 0000',
     passwordLabel: labels.passwordLabel ?? 'Password',
     passwordPlaceholder: labels.passwordPlaceholder ?? 'Enter your password',
     forgotPasswordText: labels.forgotPasswordText ?? 'Forgot password?',
@@ -241,6 +254,11 @@ export function LoginForm({
     try {
       if (mode === 'phone-otp') {
         await signInWithPhoneOtp(phone.trim(), otpCode.trim());
+      } else if (phonePasswordEnabled && looksLikePhoneIdentifier(email)) {
+        // Unified identifier: a phone-shaped entry routes to phone+password.
+        // Normalize identically to the backend (strip formatting, no country
+        // code) or the phoneNumber lookup fails.
+        await signInWithPhonePassword(normalizePhoneIdentifier(email) ?? email.trim(), password);
       } else {
         await signIn(email, password);
       }
@@ -289,6 +307,11 @@ export function LoginForm({
    */
   const handleSso = async () => {
     setError(null);
+    // SSO routes by email domain — a phone-shaped identifier can't map to an IdP.
+    if (looksLikePhoneIdentifier(email)) {
+      setError('Enter your email address to sign in with SSO.');
+      return;
+    }
     try {
       const base = window.location.pathname.replace(/\/login(?:\/.*)?$/, '');
       const res = await fetch('/api/v1/auth/sign-in/sso', {
@@ -402,16 +425,19 @@ export function LoginForm({
 
           <div className="space-y-2">
             <label htmlFor="login-email" className={AUTH_FIELD_LABEL_CLASS}>
-              {l.emailLabel}
+              {phonePasswordEnabled ? l.emailOrPhoneLabel : l.emailLabel}
             </label>
             <input
               id="login-email"
-              type="email"
-              placeholder={l.emailPlaceholder}
+              // `text` (not `email`) when a phone number is also accepted, so the
+              // browser doesn't reject a phone-shaped value on native validation.
+              type={phonePasswordEnabled ? 'text' : 'email'}
+              inputMode={phonePasswordEnabled ? 'text' : 'email'}
+              placeholder={phonePasswordEnabled ? l.emailOrPhonePlaceholder : l.emailPlaceholder}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              autoComplete="email"
+              autoComplete="username"
               disabled={isLoading}
               className={AUTH_INPUT_CLASS}
             />

--- a/packages/auth/src/__tests__/LoginForm.test.tsx
+++ b/packages/auth/src/__tests__/LoginForm.test.tsx
@@ -129,7 +129,8 @@ describe('LoginForm — server-gated phone-OTP sign-in', () => {
 
   it('hides the phone-OTP link when the server does not report features.phoneNumberOtp', async () => {
     renderLogin(createMockClient({ features: { phoneNumber: true, phoneNumberOtp: false } }));
-    await screen.findByLabelText('Email');
+    // phoneNumber:true relabels the identifier field (phone+password enabled).
+    await screen.findByLabelText('Email or phone number');
     expect(screen.queryByRole('button', OTP_LINK)).toBeNull();
   });
 
@@ -193,5 +194,61 @@ describe('LoginForm — server-gated phone-OTP sign-in', () => {
     await screen.findByLabelText('Phone number');
     fireEvent.click(screen.getByRole('button', { name: 'Sign in with password instead' }));
     await screen.findByLabelText('Email');
+  });
+});
+
+// Phone + password (framework#2780): the password-mode identifier accepts an
+// email OR a phone number, gated on `features.phoneNumber` (plugin on — no SMS
+// needed). The form routes by identifier shape to /sign-in/email vs
+// /sign-in/phone-number.
+describe('LoginForm — phone + password sign-in (framework#2780)', () => {
+  it('keeps the "Email" label when features.phoneNumber is off', async () => {
+    renderLogin(createMockClient({ features: { phoneNumber: false } }));
+    await screen.findByLabelText('Email');
+    expect(screen.queryByLabelText('Email or phone number')).toBeNull();
+  });
+
+  it('relabels the identifier field when features.phoneNumber is on', async () => {
+    renderLogin(createMockClient({ features: { phoneNumber: true } }));
+    await screen.findByLabelText('Email or phone number');
+    expect(screen.queryByLabelText('Email')).toBeNull();
+  });
+
+  it('routes a phone-shaped identifier to signInWithPhonePassword (normalized like the backend)', async () => {
+    const signIn = vi.fn();
+    const signInWithPhonePassword = vi.fn().mockResolvedValue({
+      user: { id: 'u2' },
+      session: { token: 'pw-tok' },
+    });
+    renderLogin(createMockClient({ features: { phoneNumber: true } }, { signIn, signInWithPhonePassword }));
+
+    fireEvent.change(await screen.findByLabelText('Email or phone number'), {
+      target: { value: '+86 138-0013-8000' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'S3cret!' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    await waitFor(() =>
+      expect(signInWithPhonePassword).toHaveBeenCalledWith('+8613800138000', 'S3cret!'),
+    );
+    expect(signIn).not.toHaveBeenCalled();
+  });
+
+  it('routes an email identifier to signIn even when phone is enabled', async () => {
+    const signIn = vi.fn().mockResolvedValue({ user: { id: '1' }, session: { token: 't' } });
+    const signInWithPhonePassword = vi.fn();
+    renderLogin(createMockClient({ features: { phoneNumber: true } }, { signIn, signInWithPhonePassword }));
+
+    fireEvent.change(await screen.findByLabelText('Email or phone number'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'pw' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    // client.signIn takes a { email, password } credentials object.
+    await waitFor(() =>
+      expect(signIn).toHaveBeenCalledWith({ email: 'user@example.com', password: 'pw' }),
+    );
+    expect(signInWithPhonePassword).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth/src/__tests__/createAuthClient.test.ts
+++ b/packages/auth/src/__tests__/createAuthClient.test.ts
@@ -333,6 +333,33 @@ describe('createAuthClient — phone-number OTP (framework#2780)', () => {
     expect(TokenStorage.get()).toBeNull();
   });
 
+  it('signInWithPhonePassword POSTs /sign-in/phone-number, stores the token, returns user+session', async () => {
+    const { mockFn, calls } = createMockFetch({
+      '/sign-in/phone-number': {
+        body: { token: 'pw-session-token', user: { id: 'u2', phoneNumber: '+8613800000000' } },
+      },
+    });
+    const client = createAuthClient({ baseURL: 'http://localhost/api/auth', fetchFn: mockFn });
+    const result = await client.signInWithPhonePassword('+8613800000000', 'S3cret-pass!');
+    expect(result.session.token).toBe('pw-session-token');
+    expect(result.user.id).toBe('u2');
+    expect(TokenStorage.get()).toBe('pw-session-token');
+    const call = calls.find((c) => c.url.includes('/sign-in/phone-number'));
+    expect(call?.method).toBe('POST');
+    expect(JSON.parse(call!.body as string)).toEqual({ phoneNumber: '+8613800000000', password: 'S3cret-pass!' });
+  });
+
+  it('signInWithPhonePassword rejects invalid credentials and stores no token', async () => {
+    const { mockFn } = createMockFetch({
+      '/sign-in/phone-number': { status: 401, body: { message: 'Invalid phone number or password', code: 'INVALID_PHONE_NUMBER_OR_PASSWORD' } },
+    });
+    const client = createAuthClient({ baseURL: 'http://localhost/api/auth', fetchFn: mockFn });
+    await expect(client.signInWithPhonePassword('+8613800000000', 'wrong')).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(TokenStorage.get()).toBeNull();
+  });
+
   it('requestPhonePasswordReset + resetPasswordWithPhoneOtp POST the reset endpoints', async () => {
     const { mockFn, calls } = createMockFetch({
       '/phone-number/request-password-reset': { body: { status: true } },

--- a/packages/auth/src/__tests__/phone-identifier.test.ts
+++ b/packages/auth/src/__tests__/phone-identifier.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePhoneIdentifier, looksLikePhoneIdentifier } from '../phone-identifier';
+
+describe('normalizePhoneIdentifier', () => {
+  it('strips formatting and keeps a leading +', () => {
+    expect(normalizePhoneIdentifier('+1 (555) 000-0000')).toBe('+15550000000');
+    expect(normalizePhoneIdentifier('138 0013 8000')).toBe('13800138000');
+    expect(normalizePhoneIdentifier('  +86-138-0013-8000  ')).toBe('+8613800138000');
+  });
+
+  it('does NOT inject a country code or force E.164 (must match backend storage)', () => {
+    // A bare national number stays bare — the backend stores it as-is.
+    expect(normalizePhoneIdentifier('5550000')).toBe('5550000');
+  });
+
+  it('rejects non-phone input', () => {
+    expect(normalizePhoneIdentifier('name@example.com')).toBeNull();
+    expect(normalizePhoneIdentifier('12345')).toBeNull(); // too short (<6)
+    expect(normalizePhoneIdentifier('1234567890123456')).toBeNull(); // too long (>15)
+    expect(normalizePhoneIdentifier('+1-abc-def')).toBeNull();
+    expect(normalizePhoneIdentifier('')).toBeNull();
+  });
+});
+
+describe('looksLikePhoneIdentifier', () => {
+  it('treats anything with @ as email', () => {
+    expect(looksLikePhoneIdentifier('user@example.com')).toBe(false);
+    expect(looksLikePhoneIdentifier('+1555000@weird')).toBe(false);
+  });
+
+  it('detects phone-shaped identifiers', () => {
+    expect(looksLikePhoneIdentifier('+8613800138000')).toBe(true);
+    expect(looksLikePhoneIdentifier('(555) 000-0000')).toBe(true);
+    expect(looksLikePhoneIdentifier('13800138000')).toBe(true);
+  });
+
+  it('rejects plain emails and garbage', () => {
+    expect(looksLikePhoneIdentifier('name@example.com')).toBe(false);
+    expect(looksLikePhoneIdentifier('notaphone')).toBe(false);
+    expect(looksLikePhoneIdentifier('12345')).toBe(false);
+  });
+});

--- a/packages/auth/src/createAuthClient.ts
+++ b/packages/auth/src/createAuthClient.ts
@@ -423,6 +423,21 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
       return { user, session: { token } as AuthSession };
     },
 
+    async signInWithPhonePassword(phoneNumber: string, password: string) {
+      // Phone + password sign-in (better-auth `/sign-in/phone-number`). Needs
+      // no SMS service — gated server-side by `features.phoneNumber` (plugin
+      // on), NOT `features.phoneNumberOtp`. Response: `{ token, user }`, mirror
+      // of signInWithPhoneOtp.
+      const payload = await postPhoneNumberEndpoint('/sign-in/phone-number', { phoneNumber, password });
+      const token = typeof payload.token === 'string' ? payload.token : undefined;
+      const user = (payload.user ?? null) as AuthUser | null;
+      if (!token || !user) {
+        throw new Error('Invalid phone number or password.');
+      }
+      TokenStorage.set(token);
+      return { user, session: { token } as AuthSession };
+    },
+
     async requestPhonePasswordReset(phoneNumber: string) {
       // Always answers `{status:true}` (no account-existence oracle) — the
       // OTP only arrives when the number belongs to an account.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -33,6 +33,7 @@ export { SocialSignInButtons, type SocialSignInButtonsProps } from './SocialSign
 export { UserMenu, type UserMenuProps } from './UserMenu';
 export { PreviewBanner, type PreviewBannerProps } from './PreviewBanner';
 export { createAuthClient, TokenStorage } from './createAuthClient';
+export { normalizePhoneIdentifier, looksLikePhoneIdentifier } from './phone-identifier';
 export { createAuthenticatedFetch, ActiveOrganizationStorage, type AuthenticatedAdapterOptions } from './createAuthenticatedFetch';
 export { getUserInitials } from './types';
 

--- a/packages/auth/src/phone-identifier.ts
+++ b/packages/auth/src/phone-identifier.ts
@@ -1,0 +1,27 @@
+/**
+ * Identifier helpers shared by the login surfaces for phone sign-in
+ * (framework#2780).
+ *
+ * These MIRROR the backend's `normalizePhoneNumber`
+ * (`@objectstack/plugin-auth`): strip spaces / dashes / parens / dots, then
+ * validate `^\+?[0-9]{6,15}$`. They deliberately do NOT force E.164 or inject a
+ * country code — accounts are stored in exactly this light-stripped form, so
+ * anything heavier would fail the `phoneNumber` lookup at sign-in. Keep this in
+ * lock-step with the backend regex.
+ */
+
+/** Strip formatting and validate; returns the canonical string or `null`. */
+export function normalizePhoneIdentifier(raw: string): string | null {
+  const stripped = String(raw ?? '').replace(/[\s\-().]/g, '');
+  return /^\+?[0-9]{6,15}$/.test(stripped) ? stripped : null;
+}
+
+/**
+ * Whether an identifier should be treated as a phone number rather than an
+ * email. An `@` always means email; otherwise it is a phone only when it
+ * normalizes to a valid number.
+ */
+export function looksLikePhoneIdentifier(raw: string): boolean {
+  if (typeof raw !== 'string' || raw.includes('@')) return false;
+  return normalizePhoneIdentifier(raw) !== null;
+}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -196,6 +196,8 @@ export interface AuthClient {
   sendPhoneOtp: (phoneNumber: string) => Promise<void>;
   /** framework#2780 — verify a phone OTP; signs in the number's user. */
   signInWithPhoneOtp: (phoneNumber: string, code: string) => Promise<{ user: AuthUser; session: AuthSession }>;
+  /** framework#2780 — sign in with phone number + password (no SMS; gated by `features.phoneNumber`). */
+  signInWithPhonePassword: (phoneNumber: string, password: string) => Promise<{ user: AuthUser; session: AuthSession }>;
   /** framework#2780 — request a password-reset OTP SMS for the phone number. */
   requestPhonePasswordReset: (phoneNumber: string) => Promise<void>;
   /** framework#2780 — reset the password using a phone OTP. */

--- a/packages/auth/src/useAuth.ts
+++ b/packages/auth/src/useAuth.ts
@@ -45,6 +45,7 @@ export function useAuth(): AuthContextValue {
       resetPassword: async () => { throw new Error('useAuth must be used within an AuthProvider'); },
       sendPhoneOtp: async () => { throw new Error('useAuth must be used within an AuthProvider'); },
       signInWithPhoneOtp: async () => { throw new Error('useAuth must be used within an AuthProvider'); },
+      signInWithPhonePassword: async () => { throw new Error('useAuth must be used within an AuthProvider'); },
       requestPhonePasswordReset: async () => { throw new Error('useAuth must be used within an AuthProvider'); },
       resetPasswordWithPhoneOtp: async () => { throw new Error('useAuth must be used within an AuthProvider'); },
       changePassword: async () => { throw new Error('useAuth must be used within an AuthProvider'); },


### PR DESCRIPTION
Closes #2416.

## What

The Console login page's **password mode** now accepts an **email OR a phone number** as the identifier and routes by shape:
- email → `/sign-in/email`
- phone → `/sign-in/phone-number` (better-auth phoneNumber plugin, framework#2780)

It coexists with the existing **phone-OTP** mode. Chosen UX is the **unified identifier field** (Google/X/LinkedIn pattern), which is the smallest change and the dominant global convention.

## Why it was only a frontend gap

The backend already ships everything: `/sign-in/phone-number` is registered with the phoneNumber plugin, and `getPublicConfig().features.phoneNumber` already advertises "plugin enabled" (distinct from `features.phoneNumberOtp`, which also needs a deliverable SMS service). The frontend just never wired a phone+password path.

## Changes

- **Gating** — the identifier accepts a phone only when `features.phoneNumber === true`. Unlike OTP this needs **no SMS service**, so it uses that coarser flag. When off, the field stays email-only (`type="email"`, label "Email") — zero behavior change for deployments without the plugin.
- **`AuthClient.signInWithPhonePassword(phoneNumber, password)`** → `POST /sign-in/phone-number`, wired through `AuthContext` / `AuthProvider` / `useAuth` (mirrors `signInWithPhoneOtp`).
- **`normalizePhoneIdentifier` / `looksLikePhoneIdentifier`** helpers that mirror the backend's `normalizePhoneNumber` **exactly**: strip `[\s\-().]`, validate `^\+?[0-9]{6,15}$`, with **no** forced E.164 or country-code injection. This is deliberate — the backend stores the light-stripped form, so anything heavier would break the `phoneNumber` lookup at sign-in. (No `libphonenumber` dependency added.)
- **SSO stays email-only** — a phone-shaped identifier no longer attempts domain-based IdP routing.
- **Console `LoginPage`** passes i18n keys for the new "Email or phone number" label/placeholder.

## Tests

- `phone-identifier`: normalization + email/phone detection (incl. "no country-code injection" lock).
- `createAuthClient`: `signInWithPhonePassword` posts the right endpoint, stores the token, and the invalid-credential path stores no token.
- `LoginForm`: label gating on `features.phoneNumber`, and routing (phone → `signInWithPhonePassword` normalized; email → `signIn`).
- Full `@object-ui/auth` suite: **153 pass**; `tsc --noEmit` clean.

## Scope / notes

- Only works for accounts that have both a phone number **and** a password set. Phone-only (import) accounts set a password on first OTP sign-in, after which phone+password works.
- **Out of scope**: country-code selector / E.164 migration (backend stores non-E.164 — a separate coordinated change); phone+password self-registration (`signUpOnVerification` is deliberately off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NT4mx1fHXtkxery6MtLTsp)_