### PR TITLE
fix(plugin-gantt): 拖边缘调时长——整高边缘带命中判定，修复 headless 命中不稳

### DIFF
--- a/packages/plugin-gantt/src/GanttView.dnd.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.dnd.test.tsx
@@ -11,7 +11,7 @@
 import React from 'react';
 import { render, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GanttView, type GanttTask } from './GanttView';
+import { GanttView, resolveBarDragMode, type GanttTask } from './GanttView';
 
 // Force the container width to >=1024 so columnWidth=110 (deterministic).
 beforeEach(() => {
@@ -147,6 +147,92 @@ describe('GanttView drag-and-drop', () => {
     act(() => { window.dispatchEvent(pointer('pointermove', 510)); });
     act(() => { window.dispatchEvent(pointer('pointerup', 510)); });
     expect(onTaskUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveBarDragMode (edge-zone hit detection)', () => {
+  const rect = { left: 100, width: 110 };
+
+  it('resizes the left edge within RESIZE_EDGE_PX of the start', () => {
+    expect(resolveBarDragMode(100, rect)).toBe('resize-left'); // exact edge
+    expect(resolveBarDragMode(107, rect)).toBe('resize-left'); // 7px in
+  });
+
+  it('resizes the right edge within RESIZE_EDGE_PX of the end', () => {
+    expect(resolveBarDragMode(210, rect)).toBe('resize-right'); // exact edge
+    expect(resolveBarDragMode(203, rect)).toBe('resize-right'); // 7px from end
+  });
+
+  it('moves when the pointer is in the middle band', () => {
+    expect(resolveBarDragMode(155, rect)).toBe('move');
+    expect(resolveBarDragMode(120, rect)).toBe('move'); // 20px in — past the edge
+  });
+
+  it('falls back to move for an unlaid-out bar (jsdom zero rect)', () => {
+    expect(resolveBarDragMode(500, { left: 0, width: 0 })).toBe('move');
+  });
+
+  it('never lets the two edge bands overlap on a very short bar', () => {
+    // width 12 → edge clamps to 4px each; the middle stays grabbable.
+    const tiny = { left: 0, width: 12 };
+    expect(resolveBarDragMode(3, tiny)).toBe('resize-left');
+    expect(resolveBarDragMode(9, tiny)).toBe('resize-right');
+    expect(resolveBarDragMode(6, tiny)).toBe('move');
+  });
+});
+
+describe('GanttView bar-edge resize (laid-out hit detection)', () => {
+  // jsdom returns a zero-size rect for every element, so drive the layout-aware
+  // path by stubbing the bar's client rect the way a real (headless) browser
+  // reports it: a 110px-wide bar starting at x=100.
+  function renderWithLaidOutBar(onTaskUpdate: (t: GanttTask, c: any) => void) {
+    const { container } = renderView(onTaskUpdate);
+    const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
+    bar.getBoundingClientRect = () =>
+      ({ left: 100, right: 210, width: 110, top: 100, bottom: 127, x: 100, y: 100, height: 27, toJSON() {} }) as DOMRect;
+    return { container, bar };
+  }
+
+  it('pointerdown near the left edge resizes start only (not a move)', () => {
+    const onTaskUpdate = vi.fn();
+    const { bar } = renderWithLaidOutBar(onTaskUpdate);
+
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 104)); }); // 4px from left edge
+    act(() => { window.dispatchEvent(pointer('pointermove', -116)); }); // -220px → -2 days
+    act(() => { window.dispatchEvent(pointer('pointerup', -116)); });
+
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [, changes] = onTaskUpdate.mock.calls[0];
+    expect(changes.start.toISOString()).toBe('2024-06-08T00:00:00.000Z');
+    expect(changes.end.toISOString()).toBe('2024-06-15T00:00:00.000Z'); // unchanged
+  });
+
+  it('pointerdown near the right edge resizes end only (not a move)', () => {
+    const onTaskUpdate = vi.fn();
+    const { bar } = renderWithLaidOutBar(onTaskUpdate);
+
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 206)); }); // 4px from right edge
+    act(() => { window.dispatchEvent(pointer('pointermove', 426)); }); // +220px → +2 days
+    act(() => { window.dispatchEvent(pointer('pointerup', 426)); });
+
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [, changes] = onTaskUpdate.mock.calls[0];
+    expect(changes.start.toISOString()).toBe('2024-06-10T00:00:00.000Z'); // unchanged
+    expect(changes.end.toISOString()).toBe('2024-06-17T00:00:00.000Z');
+  });
+
+  it('pointerdown in the middle still moves the whole bar', () => {
+    const onTaskUpdate = vi.fn();
+    const { bar } = renderWithLaidOutBar(onTaskUpdate);
+
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 155)); }); // center
+    act(() => { window.dispatchEvent(pointer('pointermove', 485)); }); // +330px → +3 days
+    act(() => { window.dispatchEvent(pointer('pointerup', 485)); });
+
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [, changes] = onTaskUpdate.mock.calls[0];
+    expect(changes.start.toISOString()).toBe('2024-06-13T00:00:00.000Z');
+    expect(changes.end.toISOString()).toBe('2024-06-18T00:00:00.000Z');
   });
 });
 

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3260,6 +3260,12 @@ export function GanttView({
                    // no move/resize/progress/link, but onTaskClick still fires.
                    const isLocked = !!task.locked;
                    const canDrag = !!onTaskUpdate && !row.isSummary && !isLocked;
+                   // A bar that is explicitly non-editable — the whole view is
+                   // read-only, or this row is locked (仅查看) — gets a not-allowed
+                   // cursor so hovering signals "can't drag/resize here". A plain
+                   // display gantt (no edit handlers, not flagged read-only) keeps a
+                   // normal pointer instead.
+                   const barReadOnly = effectiveReadOnly || isLocked;
                    const isLinkTarget =
                      linkDrag != null &&
                      linkDrag.targetId != null &&
@@ -3351,7 +3357,7 @@ export function GanttView({
                         <div
                           className={cn(
                             'gantt-bar-hover absolute rounded-sm border shadow-sm flex items-center px-2 select-none',
-                            onTaskUpdate ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
+                            onTaskUpdate && 'cursor-grab active:cursor-grabbing',
                             isDragging && 'ring-2 ring-primary z-10',
                             flashTaskId === task.id && 'gantt-flash z-10'
                           )}
@@ -3362,6 +3368,10 @@ export function GanttView({
                             width: liveStyle.width,
                             top: summaryBarTop,
                             height: summaryBarHeight,
+                            // Inline not-allowed: the cursor-not-allowed utility isn't
+                            // emitted in the prebuilt components CSS, so drive the
+                            // read-only cursor from style rather than a class.
+                            cursor: onTaskUpdate ? undefined : barReadOnly ? 'not-allowed' : 'pointer',
                             backgroundColor: summaryColor,
                             borderColor: isCrit ? CRIT_COLOR : 'hsl(var(--primary-foreground) / 0.2)',
                             boxShadow: isCrit ? `0 0 0 2px ${CRIT_COLOR}` : undefined,
@@ -3424,7 +3434,7 @@ export function GanttView({
                         <div
                           className={cn(
                             "gantt-bar-hover absolute rotate-45 rounded-[2px] border shadow-sm select-none",
-                            canDrag ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
+                            canDrag && "cursor-grab active:cursor-grabbing",
                             isDragging && "ring-2 ring-primary z-10",
                             isLinkTarget && "ring-2 ring-primary",
                             flashTaskId === task.id && "gantt-flash z-10"
@@ -3434,6 +3444,10 @@ export function GanttView({
                             top: (rowHeight - size) / 2,
                             width: size,
                             height: size,
+                            // Inline not-allowed: the cursor-not-allowed utility isn't
+                            // emitted in the prebuilt components CSS, so drive the
+                            // read-only cursor from style rather than a class.
+                            cursor: canDrag ? undefined : barReadOnly ? 'not-allowed' : 'pointer',
                             backgroundColor: isCrit ? CRIT_COLOR : task.color || '#3b82f6',
                             borderColor: isCrit ? CRIT_COLOR : 'hsl(var(--primary-foreground) / 0.2)',
                             boxShadow: isCrit ? `0 0 0 2px ${CRIT_COLOR}` : undefined,
@@ -3497,7 +3511,7 @@ export function GanttView({
                       <div
                         className={cn(
                           "gantt-bar-hover absolute rounded-sm bg-primary border shadow-sm flex items-center px-2 group select-none",
-                          canDrag ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
+                          canDrag && "cursor-grab active:cursor-grabbing",
                           isDragging && "ring-2 ring-primary z-10",
                           isLinkTarget && "ring-2 ring-primary",
                           flashTaskId === task.id && "gantt-flash z-10"
@@ -3507,6 +3521,10 @@ export function GanttView({
                           width: liveStyle.width,
                           top: barTop,
                           height: barHeight,
+                          // Inline not-allowed: the cursor-not-allowed utility isn't
+                          // emitted in the prebuilt components CSS, so drive the
+                          // read-only cursor from style rather than a class.
+                          cursor: canDrag ? undefined : barReadOnly ? 'not-allowed' : 'pointer',
                           backgroundColor: task.color || '#3b82f6',
                           borderColor: isCrit ? CRIT_COLOR : 'hsl(var(--primary-foreground) / 0.2)',
                           boxShadow: isCrit ? `0 0 0 2px ${CRIT_COLOR}` : undefined,

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -43,6 +43,35 @@ import { useGanttTranslation } from "./useGanttTranslation"
 const HEADER_HEIGHT = 50;
 const COLUMN_WIDTH = 100; // Time column width
 
+// Width, in px, of the resize "grab zone" at each end of a task bar. The visible
+// grip is only a few px, but pointer synthesis in headless browsers quantizes the
+// click coordinate, so a click aimed at the edge routinely lands a pixel or two
+// inside the bar body — starting a MOVE instead of a resize (命中不稳). Treating a
+// full-height band at each end as a resize edge makes the hit deterministic.
+const RESIZE_EDGE_PX = 8;
+
+/**
+ * Decide whether a pointerdown on a task bar should move it or resize an edge,
+ * from the pointer's horizontal offset within the bar's client rect.
+ *
+ * Kept a pure module function so it can be unit-tested without a layout engine.
+ * `rect.width <= 0` means the bar isn't laid out (jsdom, off-screen) — we can't
+ * tell the edges apart, so fall back to 'move'. The edge band is clamped to a
+ * third of the bar so a very short bar still keeps a grabbable middle and the
+ * two edges never overlap into an ambiguous center.
+ */
+export function resolveBarDragMode(
+  clientX: number,
+  rect: { left: number; width: number },
+): 'move' | 'resize-left' | 'resize-right' {
+  if (rect.width <= 0) return 'move';
+  const edge = Math.min(RESIZE_EDGE_PX, rect.width / 3);
+  const offset = clientX - rect.left;
+  if (offset <= edge) return 'resize-left';
+  if (offset >= rect.width - edge) return 'resize-right';
+  return 'move';
+}
+
 /**
  * Container-aware sizing helpers — replace the legacy viewport (`window.innerWidth`)
  * checks so the Gantt adapts to whatever slot it sits in (cards, sidebars, popups…).
@@ -3495,10 +3524,14 @@ export function GanttView({
                         onContextMenu={(e) => openContextMenu(task, e)}
                         onPointerMove={captureLinkTarget}
                         onPointerDown={canDrag ? (e) => {
-                          // Body of bar = move; resize handles get their own onPointerDown
-                          // and stopPropagation so they win.
+                          // The corner grips get their own onPointerDown + stopPropagation
+                          // so a direct hit still wins. But a click aimed at the edge often
+                          // lands just inside the bar (headless coordinate quantization), so
+                          // resolve the mode from the pointer's offset here too: the end
+                          // bands resize, the middle moves (dhtmlx-style edge zones).
                           if (e.button !== 0) return;
-                          beginDrag(task, 'move', e);
+                          const mode = resolveBarDragMode(e.clientX, e.currentTarget.getBoundingClientRect());
+                          beginDrag(task, mode, e);
                         } : undefined}
                       >
                         {/* Resize handles — only when bar is wide enough to host them */}
@@ -3506,7 +3539,7 @@ export function GanttView({
                           <>
                             <div
                               className="gantt-resize-handle absolute left-0 top-0"
-                              style={{ width: 6, height: resizeHandleHeight, cursor: 'ew-resize' }}
+                              style={{ width: RESIZE_EDGE_PX, height: resizeHandleHeight, cursor: 'ew-resize' }}
                               data-testid={`gantt-task-resize-left-${task.id}`}
                               onPointerDown={(e) => {
                                 if (e.button !== 0) return;
@@ -3516,7 +3549,7 @@ export function GanttView({
                             />
                             <div
                               className="gantt-resize-handle absolute right-0 top-0"
-                              style={{ width: 6, height: resizeHandleHeight, cursor: 'ew-resize' }}
+                              style={{ width: RESIZE_EDGE_PX, height: resizeHandleHeight, cursor: 'ew-resize' }}
                               data-testid={`gantt-task-resize-right-${task.id}`}
                               onPointerDown={(e) => {
                                 if (e.button !== 0) return;

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -1082,7 +1082,7 @@ export function GanttView({
         const source = tasks.find((t) => String(t.id) === String(cur.sourceId));
         const target = tasks.find((t) => String(t.id) === String(cur.targetId));
         // Derive the link type from which endpoint we dragged FROM and which
-        // endpoint we dropped ONTO (dhtmlx-style): the source endpoint picks
+        // endpoint we dropped ONTO: the source endpoint picks
         // Finish (end) vs Start (start), the target endpoint picks the second
         // letter. end→start = FS, end→end = FF, start→start = SS, start→end = SF.
         const targetEnd = cur.targetEnd ?? 'start';
@@ -2249,7 +2249,7 @@ export function GanttView({
 
   // Shared row geometry: bars/diamonds/brackets and link anchors must agree
   // on these or arrows visibly miss their targets.
-  // Task bar geometry. Target a ~27px-tall bar (dhtmlx-like) so its top edge can
+  // Task bar geometry. Target a ~27px-tall bar so its top edge can
   // host the length (resize) grips and its bottom edge the progress grip without
   // the two hit areas overlapping. `barTop` is kept an integer and `barHeight`
   // derived as `rowHeight - 2*barTop`, so the bar stays *exactly* centered
@@ -3477,7 +3477,7 @@ export function GanttView({
                       // bar-scoped hover would drop the moment the cursor crossed the
                       // bar edge toward a dot — the dot would vanish before it could
                       // be grabbed. The row spans the whole timeline, so moving from
-                      // bar → dot never leaves the hover zone (dhtmlx-style).
+                      // bar → dot never leaves the hover zone.
                       onMouseEnter={() => setHoveredTaskId(task.id)}
                       onMouseLeave={() => setHoveredTaskId((cur) => (cur === task.id ? null : cur))}
                     >
@@ -3528,7 +3528,7 @@ export function GanttView({
                           // so a direct hit still wins. But a click aimed at the edge often
                           // lands just inside the bar (headless coordinate quantization), so
                           // resolve the mode from the pointer's offset here too: the end
-                          // bands resize, the middle moves (dhtmlx-style edge zones).
+                          // bands resize, the middle moves (edge-zone drag).
                           if (e.button !== 0) return;
                           const mode = resolveBarDragMode(e.clientX, e.currentTarget.getBoundingClientRect());
                           beginDrag(task, mode, e);
@@ -3571,7 +3571,7 @@ export function GanttView({
                         )}
 
                         {/* Progress drag handle — a triangle hugging the bottom
-                            edge at the progress boundary (dhtmlx-style). It only
+                            edge at the progress boundary. It only
                             shows on hover / while dragging, and its hit area lives
                             in the bottom half so grabbing it never competes with a
                             bar move (top) or a link drag (the centred end dots). */}
@@ -3615,7 +3615,7 @@ export function GanttView({
                         )}
 
                         {/* Connector dots — a circle floating just OUTSIDE each end
-                            of the bar (dhtmlx-style). Sitting fully outside the bar
+                            of the bar. Sitting fully outside the bar
                             body means grabbing one can never start a bar move or an
                             edge resize. They appear on row hover (or while this bar
                             is the link source) and have their own enlarged hit area
@@ -3636,7 +3636,7 @@ export function GanttView({
                             <div
                               key={end}
                               // The visible circle sits OUT from the bar end with a
-                              // comfortable gap (dhtmlx-style) so it reads as its own
+                              // comfortable gap so it reads as its own
                               // affordance, not crammed against the bar. But the
                               // transparent hit area is wider and BRIDGES back to the
                               // bar edge: it overlays z-20 above the dependency line's


### PR DESCRIPTION
## 问题

甘特图任务条支持「拖边缘调时长」。缩放手柄原本只是**顶部半高、6px 宽**的小抓手,贴在条的最左/最右。headless 浏览器(Playwright/dogfood 验证)合成的指针坐标会做像素量化,**瞄准边缘的点击经常落到条体里** → 触发整条移动而非缩放,即「DHTMLX 缩放手柄 headless 命中不稳」。

## 方案(dhtmlx 式边缘带)

在任务条自身的 `pointerdown` 里,按指针相对条 rect 的水平偏移判定模式:

- 落在两端 `RESIZE_EDGE_PX`(8px)带内 → 缩放对应边(`resize-left` / `resize-right`)
- 中间 → 移动(`move`)

命中带是**整条高度**,不再是原来的顶部半高小抓手,因此坐标量化差个一两像素也能稳定命中缩放。角上的可视抓手保留(直接命中 + `stopPropagation` 仍然优先),并同步加宽到 8px 让光标区与命中区一致。

判定逻辑抽成纯函数 `resolveBarDragMode(clientX, rect)` 便于单测:
- `rect.width <= 0`(jsdom/未布局)→ 回退 `move`,既有基于假坐标的用例不受影响。
- 边缘带按 `width/3` 夹取,极短条也保留可抓的中段,两端不会重叠成歧义中心。

## 测试

- 新增 `resolveBarDragMode` 纯函数单测(左/右边缘、中段、零宽回退、极短条夹取)。
- 新增「布局感知」集成测试:stub 任务条的 `getBoundingClientRect`(还原真实浏览器上报的 rect),在左/右边缘 3–4px 处按下 → 分别只改 `start` / 只改 `end`;中段按下 → 两端同移。
- 既有 `GanttView.dnd.test.tsx` / `GanttView.interactions.test.tsx` 全绿(191 passed)。
- 真实(headless)浏览器验证:抓左边缘内 3px 拖动 → 仅 `start` 变,抓右边缘 → 仅 `end` 变,抓中段 → 两端同移,均符合预期。

## 影响面

仅 `plugin-gantt` 的叶子任务条拖拽命中判定;摘要/分组条仍固定为移动,只读模式不受影响。