### PR TITLE
fix(console-ai): preserve ?package= across the /ai URL mirror (ADR-0057 P1 hardening)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -790,8 +790,15 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     // until the hook re-resolves under the new one. Mirroring it would write
     // it onto the new agent's URL and resume the wrong chat.
     if (conversationScope !== chatScope) return;
-    navigate(`/ai/${activeAgentRoute}/${conversationId}`, { replace: true });
-  }, [segmentIsAgent, urlConversationId, conversationId, conversationScope, chatScope, activeAgentRoute, navigate]);
+    // Preserve the `?package=` binding (ADR-0070 "Edit with AI") across the
+    // mirror. Without it the rewrite to `/ai/:agent/:conversationId` drops the
+    // query, so `editPackageId` goes undefined and the conversation scope falls
+    // back from `app:${package}:${product}` to the product alone (ADR-0057) —
+    // which would then let a bare `/ai/build` visit resume this package-scoped
+    // thread. The consumed `agent`/`new` params stay stripped as before.
+    const pkgQuery = editPackageId ? `?package=${encodeURIComponent(editPackageId)}` : '';
+    navigate(`/ai/${activeAgentRoute}/${conversationId}${pkgQuery}`, { replace: true });
+  }, [segmentIsAgent, urlConversationId, conversationId, conversationScope, chatScope, activeAgentRoute, editPackageId, navigate]);
 
   const titledRef = useRef<Set<string>>(new Set());
 


### PR DESCRIPTION
## What & why

Follow-up hardening to ADR-0057 **P1** (merged in #2414), surfaced by **live browser testing** against the real cloud AI stack.

The live run showed the full-page build surface caching its conversation under **both** `app:acme.demo:build` (the intended ADR-0057 key) **and** a bare `build` key. Root cause: `AiChatPage`'s URL-mirror effect rewrites `/ai/build?package=X` → `/ai/build/:conversationId` **without the query string**, so `editPackageId` goes `undefined` on the next render and the conversation scope falls back from `app:${package}:${product}` to the product alone.

- The **shared-thread acceptance still held** (the Studio copilot and the full-page focus view both resolve `app:X:build` at creation), which is why unit tests passed.
- But the fallback also cached the package-scoped conversation under the bare `build` key — so a later plain `/ai/build` visit could resume a package-specific thread (a small leak), and the ADR-0070 "Edit with AI" package binding dropped from the URL.

## Fix

Re-append `?package=` when mirroring, so the app scope (and the package context) persists across the rewrite. The consumed `agent`/`new` params stay stripped exactly as before.

```diff
-    navigate(`/ai/${activeAgentRoute}/${conversationId}`, { replace: true });
+    const pkgQuery = editPackageId ? `?package=${encodeURIComponent(editPackageId)}` : '';
+    navigate(`/ai/${activeAgentRoute}/${conversationId}${pkgQuery}`, { replace: true });
```

## Verification

- `pnpm --filter @object-ui/app-shell` console-ai + hooks tests: **49 passed** (incl. `chatScope.test.ts`, which already covers the `app:${package}:${product}` key formation).
- `turbo type-check` clean; ESLint on the changed file: 0 errors.
- The behavior itself was found by the live browser run described above (built console against the seeded cloud stack); a full AiChatPage render+router test for the mirror would need a new harness the suite doesn't currently have (existing tests cover pure helpers), so it's intentionally not added for this one-line fix.

Pure bug fix — no changeset (per repo convention).

Refs: ADR `docs/adr/0057-console-ai-chat-one-conversation-docked.md` · P1+P2 #2414 · work order #2412.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJKsT9dvjxgVSPYid8EtTQ)_