### PR TITLE
feat(plugin-gantt): api 数据源支持读取 + 全部回写

### DIFF
--- a/.changeset/gantt-api-data-source.md
+++ b/.changeset/gantt-api-data-source.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/plugin-gantt": patch
+---
+
+ObjectGantt now supports the `api` data source for **both read and write-back**.
+Previously `provider: 'api'` logged "API provider not yet implemented" and rendered
+nothing, and every write-back (reschedule, dependency edit, delete, drawer
+inline-edit) was hard-wired to the context ObjectQL `dataSource` + `objectName`,
+so the api provider's `write` config was never used.
+
+All reads and writes now flow through a single adapter resolved by
+`resolveDataSource(schema.data, dataSource)`: `object` → context DataSource
+(unchanged), `api` → `ApiDataSource` (executes the `read`/`write` HttpRequest
+config), `value` → in-memory `ValueDataSource`. A pure-api view needs no
+`objectName` and no context `dataSource` prop. Object-backed views are behavior-
+preserving. Lookup/master_detail quick-filter option domains still resolve from
+the context object backend (they degrade to distinct in-row values when absent).

--- a/packages/plugin-gantt/src/ObjectGantt.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.test.tsx
@@ -275,6 +275,63 @@ describe('ObjectGantt', () => {
     expect(del.mock.calls[0][1]).toBe('1');
   });
 
+  // --- API provider: read + write-back over HTTP (no object backend) --------
+  it('api provider: reads via fetch and persists a drag update via write config', async () => {
+    // A Response-like stub carrying JSON.
+    const jsonResponse = (payload: unknown) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: (k: string) => (k.toLowerCase() === 'content-type' ? 'application/json' : null) },
+      json: async () => payload,
+      text: async () => JSON.stringify(payload),
+    });
+    const fetchMock = vi.fn(async (_url: any, init?: any) => {
+      // GET → read config returns the task list; anything else → write ack.
+      if ((init?.method ?? 'GET') === 'GET') return jsonResponse({ data: mockData }) as any;
+      return jsonResponse({}) as any;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const schema: any = {
+        type: 'gantt',
+        gantt: { titleField: 'name', startDateField: 'start_date', endDateField: 'end_date' },
+        // Pure API view — no objectName, no context dataSource prop.
+        data: {
+          provider: 'api',
+          read: { url: 'https://api.test/tasks' },
+          write: { url: 'https://api.test/tasks', method: 'PATCH' },
+        },
+      };
+      // NOTE: no `dataSource` prop — proves the api provider stands alone.
+      render(<ObjectGantt schema={schema} />);
+
+      // Read: rows come from the GET on the read url.
+      await waitFor(() => expect(screen.getAllByTestId('gantt-task')).toHaveLength(2));
+      expect(fetchMock).toHaveBeenCalled();
+      expect(String(fetchMock.mock.calls[0][0])).toContain('https://api.test/tasks');
+
+      // Write-back: dragging task 1 issues a PATCH to the write url with the
+      // rescheduled dates in the body.
+      fetchMock.mockClear();
+      fireEvent.click(screen.getByTestId('gv-update-1'));
+
+      await waitFor(() => {
+        const patch = fetchMock.mock.calls.find((c) => (c[1] as any)?.method === 'PATCH');
+        expect(patch).toBeTruthy();
+      });
+      const patchCall = fetchMock.mock.calls.find((c) => (c[1] as any)?.method === 'PATCH')!;
+      expect(String(patchCall[0])).toContain('https://api.test/tasks/1');
+      expect(JSON.parse((patchCall[1] as any).body)).toMatchObject({
+        start_date: '2024-02-01T00:00:00.000Z',
+        end_date: '2024-02-05T00:00:00.000Z',
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   // --- Dependency edit writeback (依赖增删 + 类型选择) -----------------------
   const depData = [
     { id: '1', name: 'Task 1', start_date: '2024-01-01', end_date: '2024-01-05', deps: '' },

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -38,7 +38,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@object-ui/components';
-import { extractRecords, buildExpandFields, getRecordDisplayName } from '@object-ui/core';
+import { extractRecords, buildExpandFields, getRecordDisplayName, resolveDataSource } from '@object-ui/core';
 import {
   getSemanticColorName,
   getSemanticHex,
@@ -339,6 +339,25 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   const ganttConfig = getGanttConfig(schema);
   const hasInlineData = dataConfig?.provider === 'value';
 
+  // Resolve the ViewData config into a concrete DataSource adapter:
+  //   provider: 'object' → the context DataSource passed via props (unchanged)
+  //   provider: 'api'    → an ApiDataSource that executes the read/write HttpRequest config
+  //   provider: 'value'  → an in-memory ValueDataSource
+  // Every read AND write-back below goes through this single adapter, so the
+  // 'api' provider now supports reschedule / dependency / delete / inline-edit
+  // write-backs — not just object-backed views.
+  const effectiveDataSource = useMemo(
+    () => resolveDataSource(dataConfig, dataSource ?? null),
+    // dataConfig is already memoized by deep value above.
+    [dataConfig, dataSource],
+  );
+
+  // Unified resource name for find/update/delete. For 'object' it's the bound
+  // object; for 'api' the adapter ignores it (the URL carries the endpoint),
+  // so an empty string is fine there.
+  const resource =
+    dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName ?? '';
+
   // Fetch data based on provider
   useEffect(() => {
     const fetchData = async () => {
@@ -358,26 +377,21 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           return;
         }
 
-        if (!dataSource || typeof dataSource.find !== 'function') {
+        if (!effectiveDataSource || typeof effectiveDataSource.find !== 'function') {
           throw new Error('DataSource required for object/api providers');
         }
 
-        if (dataConfig?.provider === 'object') {
-          const objectName = dataConfig.object;
-          // Auto-inject $expand for lookup/master_detail fields
-          const expand = buildExpandFields(objectSchema?.fields);
-          const result = await dataSource.find(objectName, {
-            $filter: schema.filter,
-            $orderby: convertSortToQueryParams(schema.sort),
-            ...(expand.length > 0 ? { $expand: expand } : {}),
-          });
-          let items: any[] = extractRecords(result);
-          setData(items);
-        } else if (dataConfig?.provider === 'api') {
-          console.warn('API provider not yet implemented for ObjectGantt');
-          setData([]);
-        }
-        
+        // 'object' → context adapter, 'api' → ApiDataSource (both resolved above).
+        // Auto-inject $expand for lookup/master_detail fields when a schema is
+        // available; api adapters return an empty field map, so expand stays off.
+        const expand = buildExpandFields(objectSchema?.fields);
+        const result = await effectiveDataSource.find(resource, {
+          $filter: schema.filter,
+          $orderby: convertSortToQueryParams(schema.sort),
+          ...(expand.length > 0 ? { $expand: expand } : {}),
+        });
+        setData(extractRecords(result));
+
         setLoading(false);
       } catch (err) {
         setError(err as Error);
@@ -386,31 +400,26 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     };
 
     fetchData();
-  }, [dataConfig, dataSource, hasInlineData, schema.filter, schema.sort, objectSchema]);
+  }, [effectiveDataSource, resource, hasInlineData, dataConfig, schema.filter, schema.sort, objectSchema]);
 
   // Fetch object schema for field metadata
   useEffect(() => {
     const fetchObjectSchema = async () => {
       try {
-        if (!dataSource) return;
-        
-        const objectName = dataConfig?.provider === 'object' 
-          ? dataConfig.object 
-          : schema.objectName;
-          
-        if (!objectName) return;
-        
-        const schemaData = await dataSource.getObjectSchema(objectName);
+        if (!effectiveDataSource) return;
+        if (!resource) return;
+
+        const schemaData = await effectiveDataSource.getObjectSchema(resource);
         setObjectSchema(schemaData);
       } catch (err) {
         console.error('Failed to fetch object schema:', err);
       }
     };
 
-    if (!hasInlineData && dataSource) {
+    if (!hasInlineData && effectiveDataSource) {
       fetchObjectSchema();
     }
-  }, [schema.objectName, dataSource, hasInlineData, dataConfig]);
+  }, [resource, effectiveDataSource, hasInlineData, dataConfig]);
 
   // Transform data to gantt tasks
   const tasks = useMemo(() => {
@@ -858,9 +867,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   const handleTaskUpdateDefault = useCallback(
     async (task: GanttTask, changes: { start?: Date; end?: Date; title?: string; progress?: number }) => {
       if (!ganttConfig) return;
-      const objectName =
-        dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
-      if (!objectName || !dataSource || typeof dataSource.update !== 'function') return;
+      if (!effectiveDataSource || typeof effectiveDataSource.update !== 'function') return;
 
       const { startDateField, endDateField, titleField, progressField } = ganttConfig;
       const patch: Record<string, unknown> = {};
@@ -882,13 +889,13 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       );
 
       try {
-        await dataSource.update(objectName, String(recordId), patch);
+        await effectiveDataSource.update(resource, String(recordId), patch);
       } catch (err) {
         console.error('[ObjectGantt] Failed to persist task update:', err);
         setData(prevSnapshot); // revert
       }
     },
-    [ganttConfig, dataConfig, dataSource, schema.objectName, data],
+    [ganttConfig, effectiveDataSource, resource, data],
   );
 
   // Re-serialize a normalized dependency list back onto a record field,
@@ -915,9 +922,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     async (targetId: string | number, raw: unknown, nextDeps: GanttDependency[]) => {
       const depField = ganttConfig?.dependenciesField;
       if (!depField) return;
-      const objectName =
-        dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
-      if (!objectName || !dataSource || typeof dataSource.update !== 'function') return;
+      if (!effectiveDataSource || typeof effectiveDataSource.update !== 'function') return;
       const nextValue = serializeDependencies(raw, nextDeps);
       const prevSnapshot = data;
       setData((prev) =>
@@ -926,13 +931,13 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         ),
       );
       try {
-        await dataSource.update(objectName, String(targetId), { [depField]: nextValue });
+        await effectiveDataSource.update(resource, String(targetId), { [depField]: nextValue });
       } catch (err) {
         console.error('[ObjectGantt] Failed to persist dependency:', err);
         setData(prevSnapshot); // revert
       }
     },
-    [ganttConfig, dataConfig, dataSource, schema.objectName, data],
+    [ganttConfig, effectiveDataSource, resource, data],
   );
 
   // Persist a created/updated dependency (依赖增 + 类型选择): upsert the source
@@ -1004,9 +1009,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
 
   const confirmDelete = useCallback(async () => {
     if (!pendingDelete) return;
-    const objectName =
-      dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
-    if (!objectName || !dataSource?.delete) {
+    if (!effectiveDataSource?.delete) {
       setPendingDelete(null);
       return;
     }
@@ -1023,7 +1026,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       prev.filter((r) => String(r.id ?? r._id) !== String(recordId)),
     );
     try {
-      await dataSource.delete(objectName, String(recordId));
+      await effectiveDataSource.delete(resource, String(recordId));
       setPendingDelete(null);
     } catch (err) {
       console.error('[ObjectGantt] Failed to delete:', err);
@@ -1032,7 +1035,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     } finally {
       setDeleting(false);
     }
-  }, [pendingDelete, dataConfig, dataSource, schema.objectName, data]);
+  }, [pendingDelete, effectiveDataSource, resource, data]);
 
   if (loading) {
     return (
@@ -1127,7 +1130,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         )}
       </div>
       {navigation.isOverlay && navigation.isOpen && navigation.selectedRecord && (() => {
-        const objectName = dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
+        const objectName = resource;
         const rec = navigation.selectedRecord as Record<string, any>;
         const recordId = rec.id ?? rec._id;
         if (!objectName || recordId == null) return null;
@@ -1143,13 +1146,13 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
             record={rec}
             objectName={objectName}
             recordId={recordId}
-            dataSource={dataSource}
+            dataSource={effectiveDataSource ?? undefined}
             objectSchema={objectSchema as any}
             width={navigation.width as any}
             fullPageHref={deriveRecordPageHref(objectName, recordId) ?? undefined}
             onFieldSave={async (field, value) => {
-              if (!dataSource?.update) return;
-              await dataSource.update(objectName, String(recordId), { [field]: value });
+              if (!effectiveDataSource?.update) return;
+              await effectiveDataSource.update(resource, String(recordId), { [field]: value });
               setData((prev) => prev.map((r) =>
                 String(r.id ?? r._id) === String(recordId)
                   ? { ...r, [field]: value }
@@ -1157,8 +1160,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
               ));
             }}
             onDelete={async () => {
-              if (!dataSource?.delete) return;
-              await dataSource.delete(objectName, String(recordId));
+              if (!effectiveDataSource?.delete) return;
+              await effectiveDataSource.delete(resource, String(recordId));
               setData((prev) => prev.filter((r) =>
                 String(r.id ?? r._id) !== String(recordId),
               ));


### PR DESCRIPTION
## 问题

甘特图(`ObjectGantt`)的数据源此前只有 `object` / `value` 两条路真正可用。`provider: 'api'` 是空壳:

- **读**: 命中 api 分支只 `console.warn('API provider not yet implemented')` 并 `setData([])`,渲染空。
- **写**: 四类回写(拖拽改期 / 依赖增删 / 删除 / 抽屉内联编辑)全部硬绑到从 props 传入的上下文 ObjectQL `dataSource` + `objectName`,`ViewData` 的 api `write`(HttpRequest)配置**从没被读过**。

也就是"回写只能绑顶层对象,不能走接口"。

## 方案

仓库其实已有完整的适配器层(`ApiDataSource` / `ValueDataSource` / `resolveDataSource`),只是甘特图没接。本 PR 把 gantt 的读和**全部写回写**统一走 `resolveDataSource(schema.data, dataSource)` 解析出的单一适配器:

| provider | 解析结果 | 行为 |
|---|---|---|
| `object` | 上下文 DataSource | 不变 |
| `api` | `ApiDataSource` | 执行 read/write HttpRequest 配置 |
| `value` | 内存 `ValueDataSource` | 内联数据 |

要点:

- 纯 api 视图**无需 `objectName`、无需上下文 `dataSource` prop**(`ApiDataSource` 忽略 resource,URL 自带端点)。
- object 视图行为保持不变(`effectiveDataSource === 上下文 dataSource`)。
- 快筛的引用对象选项(lookup/master_detail)仍走上下文对象后端;api 场景无对象后端时降级为"已加载行的去重值"。
- api 无对象元数据:`getObjectSchema` 返回空字段 stub,`$expand` 自动关闭,字段格式化优雅降级。

## 改动点(均在 `ObjectGantt.tsx`)

- 新增 `effectiveDataSource` = `resolveDataSource(dataConfig, dataSource)` 与统一 `resource`。
- 读 effect:去掉 api warning + object 分支收敛为一条 `effectiveDataSource.find(resource, …)`。
- object schema effect:改用 `effectiveDataSource`。
- 四类回写:`handleTaskUpdateDefault` / `persistDependencies` / `confirmDelete` / 抽屉 `onFieldSave`+`onDelete` 全部改用 `effectiveDataSource` + `resource`,并放宽 `!objectName` 守卫(api 下不需要)。

## 测试

- 新增 `api provider: reads via fetch and persists a drag update via write config`:纯 api schema(无 objectName、无 dataSource prop),mock `fetch`,验证 GET 读取渲染 + 拖拽触发 PATCH 到 write url 且 body 携带改期日期。
- 全量 `pnpm vitest run` **233 passed**;`tsc --noEmit` 无错;`turbo build` 通过;无新增 eslint error(既有 1 处 `no-useless-assignment` 在 HEAD 上已存在)。

> 注:同款 api stub 也存在于 `plugin-calendar`,本 PR 按范围只改 gantt。