### PR TITLE
feat(plugin-gantt): 连线校验——锁定/分组落点拒绝、成环检测、onBeforeDependencyCreate 钩子(#2436 第 1、2 项)

### DIFF
--- a/.changeset/gantt-dependency-guards.md
+++ b/.changeset/gantt-dependency-guards.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/plugin-gantt": patch
+---
+
+拖拽连线增加内建校验与宿主否决钩子(#2436 第 1、2 项)。落点为锁定行
+(`locked`)或分组行(`type: 'group'`)时,悬停不再高亮、松手不再创建;
+成环依赖(直接回边、跨层级传递回边)基于**全量任务集**检测并拒绝——不受
+折叠子树导致可见连线缺边的影响。新增 `onBeforeDependencyCreate(source,
+target, type)` 钩子,在内建校验通过后调用,返回 `false` 可否决本次连线
+(即 DHTMLX `onBeforeLinkAdd` / Syncfusion `actionBegin` 惯例)。
+`wouldCreateDependencyCycle` 从 `scheduling` 导出并单测覆盖。

--- a/packages/plugin-gantt/src/GanttView.interactions.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.interactions.test.tsx
@@ -240,6 +240,83 @@ describe('GanttView drag-to-create dependency', () => {
   });
 });
 
+describe('GanttView dependency creation guards', () => {
+  function dragLink(container: HTMLElement, fromDot: string, toBar: string) {
+    const dot = container.querySelector(`[data-testid="${fromDot}"]`) as HTMLElement;
+    expect(dot).toBeTruthy();
+    fireEvent.pointerDown(dot, { button: 0, clientX: 600, clientY: 20 });
+    act(() => { window.dispatchEvent(pointer('pointermove', 700, 60)); });
+    const bar = container.querySelector(`[data-testid="${toBar}"]`) as HTMLElement;
+    expect(bar).toBeTruthy();
+    fireEvent.pointerMove(bar, { clientX: 980, clientY: 60 });
+    act(() => { window.dispatchEvent(pointer('pointerup', 980, 60)); });
+  }
+
+  it('rejects dropping onto a locked row', () => {
+    const onDependencyCreate = vi.fn();
+    const lockedB = makeTask('b', '2024-06-17T00:00:00.000Z', '2024-06-21T00:00:00.000Z', { locked: true });
+    const { container } = renderView([A(), lockedB], { onDependencyCreate });
+
+    dragLink(container, 'gantt-link-dot-end-a', 'gantt-task-bar-b');
+    expect(onDependencyCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a link that would close a dependency cycle', () => {
+    // a already depends on b (edge b→a); dragging a→b would close the loop.
+    const onDependencyCreate = vi.fn();
+    const a = makeTask('a', '2024-06-03T00:00:00.000Z', '2024-06-13T00:00:00.000Z', { dependencies: ['b'] });
+    const { container } = renderView([a, B()], { onDependencyCreate });
+
+    dragLink(container, 'gantt-link-dot-end-a', 'gantt-task-bar-b');
+    expect(onDependencyCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a transitive cycle even when the middle of the chain is collapsed', () => {
+    // Chain a→c→d where c lives inside collapsed group p. The rendered links
+    // derive from visible rows only, so the a→c and c→d edges vanish from the
+    // view — the guard must still block dragging d→a using the full task set.
+    const onDependencyCreate = vi.fn();
+    const a = makeTask('a', '2024-06-03T00:00:00.000Z', '2024-06-06T00:00:00.000Z');
+    const p = makeTask('p', '2024-06-07T00:00:00.000Z', '2024-06-12T00:00:00.000Z');
+    const c = makeTask('c', '2024-06-08T00:00:00.000Z', '2024-06-11T00:00:00.000Z', { parent: 'p', dependencies: ['a'] });
+    const dTask = makeTask('d', '2024-06-13T00:00:00.000Z', '2024-06-15T00:00:00.000Z', { dependencies: ['c'] });
+    const { container } = renderView([a, p, c, dTask], { onDependencyCreate });
+
+    // Collapse p (rows: a, p, c, d → two ArrowDowns select p).
+    const body = container.querySelector('[data-testid="gantt-body"]') as HTMLElement;
+    fireEvent.keyDown(body, { key: 'ArrowDown' });
+    fireEvent.keyDown(body, { key: 'ArrowDown' });
+    fireEvent.keyDown(body, { key: 'ArrowLeft' });
+    expect(container.querySelector('[data-testid="gantt-task-bar-c"]')).toBeFalsy();
+
+    dragLink(container, 'gantt-link-dot-end-d', 'gantt-task-bar-a');
+    expect(onDependencyCreate).not.toHaveBeenCalled();
+  });
+
+  it('onBeforeDependencyCreate can veto the link', () => {
+    const onDependencyCreate = vi.fn();
+    const onBeforeDependencyCreate = vi.fn().mockReturnValue(false);
+    const { container } = renderView([A(), B()], { onDependencyCreate, onBeforeDependencyCreate });
+
+    dragLink(container, 'gantt-link-dot-end-a', 'gantt-task-bar-b');
+    expect(onBeforeDependencyCreate).toHaveBeenCalledTimes(1);
+    const [source, target, type] = onBeforeDependencyCreate.mock.calls[0];
+    expect(source.id).toBe('a');
+    expect(target.id).toBe('b');
+    expect(type).toBe('fs');
+    expect(onDependencyCreate).not.toHaveBeenCalled();
+  });
+
+  it('onBeforeDependencyCreate returning true lets the link through', () => {
+    const onDependencyCreate = vi.fn();
+    const onBeforeDependencyCreate = vi.fn().mockReturnValue(true);
+    const { container } = renderView([A(), B()], { onDependencyCreate, onBeforeDependencyCreate });
+
+    dragLink(container, 'gantt-link-dot-end-a', 'gantt-task-bar-b');
+    expect(onDependencyCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('GanttView row drag-to-reorder', () => {
   function makeDataTransfer() {
     const store: Record<string, string> = {};

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -36,7 +36,7 @@ import {
   Separator,
   useResizeObserver,
 } from "@object-ui/components"
-import { computeCriticalPath, computeProjectReschedule, type WorkingCalendar, type RescheduleChange } from "./scheduling"
+import { computeCriticalPath, computeProjectReschedule, wouldCreateDependencyCycle, type WorkingCalendar, type RescheduleChange } from "./scheduling"
 import { shiftDayStart, type NormShiftSegments } from "./shifts"
 import { useGanttTranslation } from "./useGanttTranslation"
 
@@ -258,6 +258,13 @@ export interface GanttViewProps {
    * another bar to create a dependency (target depends on source).
    */
   onDependencyCreate?: (source: GanttTask, target: GanttTask, type: GanttLinkType) => void
+  /**
+   * Veto hook for drag-created dependencies (the onBeforeLinkAdd pattern).
+   * Runs after the built-in guards — locked/group drop targets and
+   * cycle-closing links are always rejected first — so hosts only see
+   * structurally valid candidates. Return false to cancel the link.
+   */
+  onBeforeDependencyCreate?: (source: GanttTask, target: GanttTask, type: GanttLinkType) => boolean
   /**
    * Enables dependency removal: right-clicking a dependency link opens a menu
    * with "移除依赖" and a type switch. Called with the source/target tasks of the
@@ -500,6 +507,7 @@ export function GanttView({
   onTaskDelete: onTaskDeleteProp,
   onViewChange,
   onDependencyCreate: onDependencyCreateProp,
+  onBeforeDependencyCreate,
   onDependencyDelete: onDependencyDeleteProp,
   onTaskReorder: onTaskReorderProp,
   className,
@@ -1055,6 +1063,34 @@ export function GanttView({
   // Dragging the connector dot on a bar draws a dashed rubber band; releasing
   // over another bar fires onDependencyCreate(source, target, 'fs'). The
   // hovered target is tracked by bar-level pointermove (no pointer capture).
+
+  // Dependency edges over the FULL task set — the visible-rows `links` memo
+  // below drops edges inside collapsed subtrees, which must still count for
+  // cycle detection.
+  const dependencyEdges = React.useMemo(() => {
+    const out: Array<[string, string]> = [];
+    for (const t of tasks) {
+      for (const dep of t.dependencies ?? []) {
+        const depId = typeof dep === 'object' && dep !== null ? dep.id : dep;
+        if (depId == null || depId === '') continue;
+        out.push([String(depId), String(t.id)]);
+      }
+    }
+    return out;
+  }, [tasks]);
+
+  // Built-in drop-target policy, applied both when a bar registers itself as
+  // the hover target (no candidate highlight) and again on release (pointer
+  // ordering isn't trusted): locked rows (仅查看) and group headers can't
+  // receive a dependency, and a link that would close a cycle is rejected.
+  const canReceiveLink = React.useCallback(
+    (sourceId: string | number, target: GanttTask) =>
+      String(target.id) !== String(sourceId) &&
+      !target.locked &&
+      target.type !== 'group' &&
+      !wouldCreateDependencyCycle(dependencyEdges, sourceId, target.id),
+    [dependencyEdges],
+  );
   const contentRef = React.useRef<HTMLDivElement>(null);
   const [linkDrag, setLinkDrag] = React.useState<{
     sourceId: string | number;
@@ -1078,7 +1114,7 @@ export function GanttView({
     };
     const onUp = () => {
       const cur = linkDragRef.current;
-      if (cur && cur.targetId != null && String(cur.targetId) !== String(cur.sourceId) && onDependencyCreate) {
+      if (cur && cur.targetId != null && onDependencyCreate) {
         const source = tasks.find((t) => String(t.id) === String(cur.sourceId));
         const target = tasks.find((t) => String(t.id) === String(cur.targetId));
         // Derive the link type from which endpoint we dragged FROM and which
@@ -1087,7 +1123,13 @@ export function GanttView({
         // letter. end→start = FS, end→end = FF, start→start = SS, start→end = SF.
         const targetEnd = cur.targetEnd ?? 'start';
         const type: GanttLinkType = `${cur.sourceEnd === 'end' ? 'f' : 's'}${targetEnd === 'end' ? 'f' : 's'}` as GanttLinkType;
-        if (source && target) onDependencyCreate(source, target, type);
+        if (
+          source && target &&
+          canReceiveLink(cur.sourceId, target) &&
+          (onBeforeDependencyCreate?.(source, target, type) ?? true)
+        ) {
+          onDependencyCreate(source, target, type);
+        }
       }
       suppressNextClickRef.current = true;
       window.setTimeout(() => { suppressNextClickRef.current = false; }, 0);
@@ -1101,7 +1143,7 @@ export function GanttView({
       window.removeEventListener('pointerup', onUp);
       window.removeEventListener('pointercancel', onUp);
     };
-  }, [linkDrag, tasks, onDependencyCreate]);
+  }, [linkDrag, tasks, onDependencyCreate, onBeforeDependencyCreate, canReceiveLink]);
 
   // --- Context menu ---------------------------------------------------------
   const [ctxMenu, setCtxMenu] = React.useState<{ x: number; y: number; taskId: string | number } | null>(null);
@@ -3283,7 +3325,7 @@ export function GanttView({
                      const half: 'start' | 'end' =
                        r.width > 0 && e.clientX - r.left > r.width / 2 ? 'end' : 'start';
                      setLinkDrag((prev) =>
-                       prev && String(prev.sourceId) !== String(task.id)
+                       prev && canReceiveLink(prev.sourceId, task)
                          ? { ...prev, targetId: task.id, targetEnd: half }
                          : prev
                      );

--- a/packages/plugin-gantt/src/scheduling.test.ts
+++ b/packages/plugin-gantt/src/scheduling.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   computeCriticalPath,
   computeProjectReschedule,
+  wouldCreateDependencyCycle,
   type SchedulableTask,
   type WorkingCalendar,
 } from './scheduling';
@@ -211,5 +212,33 @@ describe('working calendar', () => {
     ];
     expect([...computeCriticalPath(tasks).criticalIds].sort()).toEqual(['A', 'B', 'D']);
     expect([...computeCriticalPath(tasks, weekdaysOnly).criticalIds].sort()).toEqual(['A', 'C', 'D']);
+  });
+});
+
+describe('wouldCreateDependencyCycle', () => {
+  // Edges are [predecessor, dependent]: a→b means b depends on a.
+  const chain: Array<[string, string]> = [['a', 'b'], ['b', 'c']];
+
+  it('rejects a direct back-edge (b→a when a→b exists)', () => {
+    expect(wouldCreateDependencyCycle([['a', 'b']], 'b', 'a')).toBe(true);
+  });
+
+  it('rejects a transitive back-edge (c→a across a→b→c)', () => {
+    expect(wouldCreateDependencyCycle(chain, 'c', 'a')).toBe(true);
+  });
+
+  it('rejects self-links', () => {
+    expect(wouldCreateDependencyCycle([], 'a', 'a')).toBe(true);
+  });
+
+  it('allows forward and diamond edges', () => {
+    expect(wouldCreateDependencyCycle(chain, 'a', 'c')).toBe(false); // shortcut, no cycle
+    expect(wouldCreateDependencyCycle(chain, 'c', 'd')).toBe(false); // extend chain
+    // Diamond: a→b, a→c; closing b→c is fine.
+    expect(wouldCreateDependencyCycle([['a', 'b'], ['a', 'c']], 'b', 'c')).toBe(false);
+  });
+
+  it('coerces mixed id types via String()', () => {
+    expect(wouldCreateDependencyCycle([['1', '2']], 2, 1)).toBe(true);
   });
 });

--- a/packages/plugin-gantt/src/scheduling.ts
+++ b/packages/plugin-gantt/src/scheduling.ts
@@ -398,3 +398,47 @@ export function computeProjectReschedule(tasks: SchedulableTask[], cal?: Working
   }
   return changes;
 }
+
+// ---------------------------------------------------------------------------
+// Dependency-cycle guard (creation-time)
+// ---------------------------------------------------------------------------
+
+/**
+ * Would adding the dependency edge `sourceId → targetId` (predecessor →
+ * dependent) close a cycle? `edges` is the EXISTING graph as
+ * [predecessorId, dependentId] pairs — build it from the full task set, not
+ * from visible rows, so links hidden inside collapsed subtrees still count.
+ *
+ * The new edge cycles iff `sourceId` is already reachable from `targetId`
+ * (a path target ⇝ source exists). The toposort above only *skips* cyclic
+ * chains during scheduling; this guard is what keeps them from being created
+ * in the first place.
+ */
+export function wouldCreateDependencyCycle(
+  edges: Array<[string, string]>,
+  sourceId: string | number,
+  targetId: string | number,
+): boolean {
+  const src = String(sourceId);
+  const tgt = String(targetId);
+  if (src === tgt) return true;
+  const adj = new Map<string, string[]>();
+  for (const [from, to] of edges) {
+    const list = adj.get(from);
+    if (list) list.push(to);
+    else adj.set(from, [to]);
+  }
+  const seen = new Set<string>([tgt]);
+  const stack = [tgt];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    for (const next of adj.get(cur) ?? []) {
+      if (next === src) return true;
+      if (!seen.has(next)) {
+        seen.add(next);
+        stack.push(next);
+      }
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
关联 #2436(第 1、2 项,首刀)。

## 问题

1. **连线落点不拒绝锁定行/分组行**:拖连线松手时只排除自连,落到 `locked` 行(如派工单)或 `type:'group'` 合成行(项目/产品分组)照样触发 `onDependencyCreate`,写库会落到不该写的对象上。
2. **无成环检测**:a→b 已存在时再拖 b→a(或跨层级传递回边)直接创建,后续 `computeCriticalPath` / `computeProjectReschedule` 遇环整体 bail,甘特图排程功能静默失效。

## 方案

按商业甘特(DHTMLX `onBeforeLinkAdd` / Syncfusion `actionBegin` cancel)的惯例,把校验收敛到一个否决点:

- 新增 `canReceiveLink(sourceId, target)`,统一守卫**悬停高亮**与**松手创建**两处:自连、`locked`、`type:'group'`、成环一律拒绝。悬停即不高亮,用户拖的过程中就能看出落点非法。
- 成环检测 `wouldCreateDependencyCycle(edges, source, target)`(`scheduling.ts` 导出):从 target 沿依赖方向 DFS,可达 source 即成环。**边集取自全量 `tasks`**,不是可见行的 links memo——折叠子树会把中段边从视图里抹掉,但环仍然是环。
- 新增宿主钩子 `onBeforeDependencyCreate(source, target, type)`:内建校验通过后才调用,返回 `false` 否决。宿主(如排班计划页)可以再叠业务规则(如跨项目禁连)。

## 测试

- `scheduling.test.ts`:直接回边、传递回边、自连、菱形/顺向放行、混合 id 类型(`String()` 归一)。
- `GanttView.interactions.test.tsx`(复用既有连线拖拽 choreography):锁定落点拒绝;成环拒绝;**折叠中段子树后传递环仍拒绝**;钩子返回 false 否决(并断言入参)、返回 true 放行。
- 全套 `pnpm --filter @object-ui/plugin-gantt test`:19 文件 242 用例全绿;`tsc --noEmit` 干净;eslint 仅存量告警(`set-state-in-effect` 在 base commit 上同样报)。

## 非目标

按 #2436:断网监听、并发保护(OCC)、framework 改动均不做。后续项(树感知筛选、预警描边、抽屉锁定、写后回读、刷新按钮)分 PR 提交。