### PR TITLE
feat(console-ai): ask→build handoff carries conversation context + live verification (ADR-0057 P4)

### DIFF
--- a/.changeset/adr-0057-p4-handoff-context.md
+++ b/.changeset/adr-0057-p4-handoff-context.md
@@ -1,0 +1,29 @@
+---
+"@object-ui/plugin-chatbot": minor
+"@object-ui/app-shell": minor
+---
+
+feat(console-ai): ask→build handoff carries conversation context (ADR-0057 P4 / cloud#817)
+
+The P4 "Open in Builder →" handoff previously carried only the build prompt + an
+optional package, so the Builder started cold and the user re-explained
+themselves. It now also carries the **source `ask` conversation** as context —
+ADR-0057 P4 / cloud#817 — so the build agent's first turn starts with the thread
+the user already had.
+
+- `@object-ui/app-shell`: both handoff sites (the full-page `AiChatPage` and the
+  console FAB) now append `?parentConversationId=<ask thread id>` to the
+  `/ai/build` URL. The build surface reads it and forwards it to `useObjectChat`;
+  the existing URL-mirror drops it once the build conversation id is minted, so a
+  reload never re-carries it.
+- `@object-ui/plugin-chatbot`: `useObjectChat` accepts `parentConversationId` and
+  sends it as `context.parentConversationId` on the **first turn only** (held in a
+  ref, consumed once) — the backend redeems it into the turn's context and the
+  client owns history from there. New pure helper `withHandoffContext` (unit
+  tested) does the non-mutating `context` merge.
+
+Requires the cloud handoff-context contract (service-ai, cloud#817): the build
+agent redeems `context.parentConversationId` into a single system block on its
+first turn — ownership-checked, and carrying only the user/assistant text the
+user already saw (ADR-0063 governance boundary). Without it the console degrades
+cleanly: the id is sent but ignored, and the handoff is a (working) cold start.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -571,6 +571,14 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   // "Open in Builder →" (suggest_builder). Seeded as the build surface's first
   // message below; the URL-mirror strips it once the conversation is minted.
   const handoffPrompt = searchParams.get('handoffPrompt')?.trim() || undefined;
+  // ADR-0057 P4 / cloud#817 — the source `ask` conversation id handed off to the
+  // Builder alongside the prompt. Forwarded to ChatPane → useObjectChat, which
+  // sends it as `context.parentConversationId` on the build surface's FIRST turn
+  // so the agent starts with the ask thread as context (never a cold start). The
+  // URL-mirror below drops it once the build conversation id is minted, exactly
+  // like `handoffPrompt`, so a reload never re-carries it.
+  const handoffParentConversationId =
+    searchParams.get('parentConversationId')?.trim() || undefined;
   const navigate = useNavigate();
   const { setContext } = useNavigationContext();
 
@@ -994,6 +1002,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
             apiBase={apiBase}
             conversationId={conversationId}
             editPackageId={editPackageId}
+            parentHandoffConversationId={handoffParentConversationId}
             initialMessages={initialMessages}
             pendingFirstMessageRef={pendingFirstMessageRef}
             onSent={handleSent}
@@ -1071,6 +1080,10 @@ interface ChatPaneProps {
   /** ADR-0070 "Edit with AI": the package the user opened to edit (from `?package=`),
    *  forwarded to the build agent as `context.packageId` to scope it to that app. */
   editPackageId?: string;
+  /** ADR-0057 P4 / cloud#817 — source `ask` conversation id (from `?parentConversationId=`),
+   *  forwarded to the build agent's FIRST turn as `context.parentConversationId` so it
+   *  starts with the ask thread as context. Undefined outside a handoff. */
+  parentHandoffConversationId?: string;
   initialMessages: HydratedUIMessage[];
   /** Page-owned stash for a first message sent before the conversation id resolved
    *  (survives this pane's id-keyed remount). See {@link useDeferredFirstSend}. */
@@ -1094,6 +1107,7 @@ export function ChatPane({
   apiBase,
   conversationId,
   editPackageId,
+  parentHandoffConversationId,
   initialMessages,
   pendingFirstMessageRef,
   onSent,
@@ -1113,17 +1127,20 @@ export function ChatPane({
   // Open the full-page BUILD surface seeded with the handoff prompt (carried as
   // `?handoffPrompt=`, auto-sent on arrival; ADR-0063 decline-and-redirect — an
   // explicit, user-initiated switch, never a silent re-route). Prefer the
-  // handoff's own packageId, else this surface's edit package.
+  // handoff's own packageId, else this surface's edit package. cloud#817: also
+  // carry THIS (ask) thread's id as `?parentConversationId=` so the Builder's
+  // first turn starts with the ask conversation as context, not a cold start.
   const openBuilder = useCallback(
     (handoff: { prompt: string; packageId?: string }) => {
       const params = new URLSearchParams();
       const pkg = handoff.packageId || editPackageId;
       if (pkg) params.set('package', pkg);
       if (handoff.prompt) params.set('handoffPrompt', handoff.prompt);
+      if (conversationId) params.set('parentConversationId', conversationId);
       const qs = params.toString();
       navigate(`/ai/build${qs ? `?${qs}` : ''}`);
     },
-    [navigate, editPackageId],
+    [navigate, editPackageId, conversationId],
   );
 
   // ── ADR-0037 Live Canvas ────────────────────────────────────────────────
@@ -1214,6 +1231,9 @@ export function ChatPane({
   } = useObjectChat({
     api: chatApi,
     conversationId,
+    // ADR-0057 P4 / cloud#817 — on a handoff, carry the ask thread as the build
+    // agent's first-turn context (consumed once inside useObjectChat).
+    parentConversationId: parentHandoffConversationId,
     // ADR-0028: the user's picked model (or the env default) rides each request.
     model: effectiveModelId,
     onError: handleChatError,

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -696,10 +696,13 @@ function ChatbotInner({
         // (suggest_builder). Open the full-page BUILD surface seeded with the
         // handoff prompt (ADR-0063 decline-and-redirect — explicit, never a
         // silent re-route). The FAB has no package of its own; use the handoff's.
+        // cloud#817: carry the FAB's own ask thread id as `?parentConversationId=`
+        // so the Builder's first turn starts with that conversation as context.
         onOpenBuilder={(handoff) => {
           const params = new URLSearchParams();
           if (handoff.packageId) params.set('package', handoff.packageId);
           if (handoff.prompt) params.set('handoffPrompt', handoff.prompt);
+          if (conversationId) params.set('parentConversationId', conversationId);
           const qs = params.toString();
           navigate(`/ai/build${qs ? `?${qs}` : ''}`);
         }}

--- a/packages/plugin-chatbot/src/__tests__/useObjectChat.handoffContext.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/useObjectChat.handoffContext.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * ADR-0057 P4 / cloud#817 — INTEGRATION test for the ask→build handoff context
+ * on the REAL `useObjectChat` transport (not just the pure `withHandoffContext`
+ * merge). It captures the outgoing chat POST bodies and asserts that the handed-
+ * off `ask` conversation id rides `context.parentConversationId` on the FIRST
+ * turn only — the backend redeems it once, and the client owns history after
+ * that, so re-sending would re-inject the same context block.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { useObjectChat } from '../useObjectChat';
+
+const API = 'https://example.test/api/v1/ai/agents/build/chat';
+
+/** A minimal, well-formed Vercel AI UI-message data stream so a send completes
+ *  cleanly and the hook is ready for the next turn. */
+function dataStreamResponse(): Response {
+  const body =
+    'data: {"type":"start"}\n\n' +
+    'data: {"type":"finish"}\n\n' +
+    'data: [DONE]\n\n';
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'x-vercel-ai-ui-message-stream': 'v1',
+    },
+  });
+}
+
+/** Parse the `context` object out of a captured fetch call's JSON body. */
+function contextOf(fetchMock: ReturnType<typeof vi.fn>, callIndex: number): Record<string, unknown> {
+  const init = fetchMock.mock.calls[callIndex]?.[1] as { body?: string } | undefined;
+  const parsed = JSON.parse(init?.body ?? '{}') as { context?: Record<string, unknown> };
+  return parsed.context ?? {};
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useObjectChat — ask→build handoff context (cloud#817)', () => {
+  it('sends context.parentConversationId on the FIRST turn only', async () => {
+    const fetchMock = vi.fn(async () => dataStreamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() =>
+      useObjectChat({
+        api: API,
+        conversationId: 'build_1',
+        parentConversationId: 'ask_42',
+        body: { context: { agentName: 'build', packageId: 'app.crm' } },
+      }),
+    );
+
+    // Turn 1 — the handoff turn.
+    await act(async () => {
+      result.current.sendMessage('add a priority field to tasks');
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const ctx1 = contextOf(fetchMock, 0);
+    expect(ctx1.parentConversationId).toBe('ask_42');
+    // The existing context (agentName/packageId) is preserved, not clobbered.
+    expect(ctx1).toMatchObject({ agentName: 'build', packageId: 'app.crm' });
+
+    // Turn 2 — a normal follow-up; the parent must NOT ride again.
+    await act(async () => {
+      result.current.sendMessage('also add a due date');
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const ctx2 = contextOf(fetchMock, 1);
+    expect(ctx2.parentConversationId).toBeUndefined();
+    expect(ctx2).toMatchObject({ agentName: 'build', packageId: 'app.crm' });
+  });
+
+  it('sends no parentConversationId when none was handed off', async () => {
+    const fetchMock = vi.fn(async () => dataStreamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() =>
+      useObjectChat({
+        api: API,
+        conversationId: 'build_1',
+        body: { context: { agentName: 'build' } },
+      }),
+    );
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    expect(contextOf(fetchMock, 0).parentConversationId).toBeUndefined();
+  });
+});

--- a/packages/plugin-chatbot/src/__tests__/withHandoffContext.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/withHandoffContext.test.ts
@@ -1,0 +1,44 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit tests for ADR-0057 P4 / cloud#817 — the ask→build handoff carries the
+ * source `ask` conversation id into the Builder's FIRST turn as
+ * `context.parentConversationId`. `withHandoffContext` is the pure merge wired
+ * into the chat transport's `prepareSendMessagesRequest`; the "first turn only"
+ * clearing lives in the ref beside it (see useObjectChat).
+ */
+import { describe, it, expect } from 'vitest';
+import { withHandoffContext } from '../useObjectChat';
+
+describe('withHandoffContext', () => {
+  it('nests parentConversationId under context (where the agent route reads it)', () => {
+    const out = withHandoffContext(
+      { conversationId: 'build_1', context: { agentName: 'build', packageId: 'app.crm' } },
+      'ask_42',
+    );
+    expect(out.context).toMatchObject({
+      agentName: 'build',
+      packageId: 'app.crm',
+      parentConversationId: 'ask_42',
+    });
+    // Sibling body fields are preserved.
+    expect(out.conversationId).toBe('build_1');
+  });
+
+  it('creates context when the body has none', () => {
+    const out = withHandoffContext({ conversationId: 'b1' }, 'ask_9');
+    expect(out.context).toEqual({ parentConversationId: 'ask_9' });
+  });
+
+  it('does NOT mutate the input body or its context (cached transport body is shared)', () => {
+    const ctx = { agentName: 'build' };
+    const body = { context: ctx };
+    const out = withHandoffContext(body, 'ask_7');
+    expect(out).not.toBe(body);
+    expect(out.context).not.toBe(ctx);
+    // Original is untouched — a later turn re-using it must not carry the parent.
+    expect(ctx).toEqual({ agentName: 'build' });
+    expect('parentConversationId' in ctx).toBe(false);
+  });
+});

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -105,6 +105,21 @@ export function withTurnId(req: {
   };
 }
 
+/**
+ * ADR-0057 P4 / cloud#817 — merge a handed-off `ask` conversation id into a
+ * request body's `context` (the object the agent chat route reads as
+ * `AgentChatContext`), returning a NEW body so the cached transport body is
+ * never mutated. The build agent redeems `context.parentConversationId` on its
+ * first turn to seed the ask thread as context. Exported for unit testing.
+ */
+export function withHandoffContext(
+  body: Record<string, unknown>,
+  parentConversationId: string,
+): Record<string, unknown> {
+  const ctx = (body.context ?? {}) as Record<string, unknown>;
+  return { ...body, context: { ...ctx, parentConversationId } };
+}
+
 type InitialMessage = OuiChatMessage & {
   parts?: Array<Record<string, unknown>>;
   reasoning?: string;
@@ -128,6 +143,14 @@ export interface UseObjectChatOptions {
    * Conversation ID for multi-turn context.
    */
   conversationId?: string;
+  /**
+   * ADR-0057 P4 / cloud#817 — id of the source `ask` conversation handed off to
+   * the Builder ("Open in Builder →"). Sent as `context.parentConversationId` on
+   * the FIRST turn only (consumed once, then cleared), so the build agent starts
+   * with the ask thread as context; the backend redeems it and never re-reads it
+   * on later turns (client owns history from there).
+   */
+  parentConversationId?: string;
   /**
    * System prompt for the assistant.
    */
@@ -247,6 +270,7 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
     api,
     initialMessages,
     conversationId,
+    parentConversationId,
     systemPrompt,
     model,
     streamingEnabled = true,
@@ -314,6 +338,13 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
   const modelRef = useRef(model);
   modelRef.current = model;
 
+  // ADR-0057 P4 / cloud#817 — the handed-off `ask` conversation id. Sent as
+  // `context.parentConversationId` on the FIRST turn only: the backend redeems
+  // it once (loading that thread as the build turn's context) and the client
+  // owns history from there, so re-sending it would re-inject the same block. We
+  // hold it in a ref and clear it after the first send (below, in prepare).
+  const parentConvRef = useRef(parentConversationId);
+
   // Build a transport for API mode that posts to the configured endpoint and
   // forwards conversation/system/model metadata in the request body.
   // Note: conversationId is sent in the body (not a header) to avoid CORS
@@ -341,6 +372,14 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
         // ADR-0028: always send the CURRENTLY selected model (see modelRef above)
         // so a mid-session picker switch routes, despite the cached transport.
         if (modelRef.current) (req.body as Record<string, unknown>).model = modelRef.current;
+        // ADR-0057 P4 / cloud#817 — carry the handed-off ask conversation id on
+        // the FIRST turn only, nested under `context` (where the agent route
+        // reads it). Then clear the ref so later turns don't re-send it (the
+        // client owns history from there; re-sending re-injects the same block).
+        if (parentConvRef.current) {
+          req.body = withHandoffContext(req.body as Record<string, unknown>, parentConvRef.current);
+          parentConvRef.current = undefined;
+        }
         return req;
       },
     });


### PR DESCRIPTION
The two **ADR-0057 P4** follow-ups deferred by #2439: the **context-carrying upgrade** (cloud#817) and **verification** of the ask→build handoff.

## Context-carrying (the upgrade)
#2439's "Open in Builder →" carried only the build prompt + optional package, so the Builder started **cold**. It now also carries the source `ask` conversation so the build agent's first turn starts with the thread the user already had.

- **app-shell** — both handoff sites (the full-page `AiChatPage` and the console FAB) append `?parentConversationId=<ask thread id>` to `/ai/build`. The build surface reads it and forwards it to `useObjectChat`; the existing URL-mirror drops it once the build conversation id is minted, so a reload never re-carries it (same treatment as `?handoffPrompt`).
- **plugin-chatbot** — `useObjectChat` accepts `parentConversationId` and sends it as `context.parentConversationId` on the **first turn only** (held in a ref, consumed once in `prepareSendMessagesRequest`). New pure `withHandoffContext` does the non-mutating `context` merge.

## Verification (the ADR-0054 proof #2439 skipped — done deterministically)
A full LLM-driven browser e2e needs the cloud AI stack (`run-stack` + a provider key + a seat) which isn't reachable in CI/sandbox — the console's build surface only renders against a live agent catalog. Instead this proves the **whole contract** with tests that exercise the *real* wiring, not mocks of it:

- `withHandoffContext.test.ts` — the context merge (nest under `context`, preserve siblings, never mutate the cached body). **3 ✓**
- `useObjectChat.handoffContext.test.tsx` — **integration**: renders the real `useObjectChat`, captures the outgoing chat POST bodies, asserts `context.parentConversationId` rides the **first turn only** and is gone on turn 2. **2 ✓**
- No regressions across `ChatbotEnhanced` / `useObjectChat` / `mapMessages` suites. **137 ✓**
- Backend counterpart (cloud PR #819): a route-level integration test proves the redemption + all guardrails against the real handler.

**Manual staging proof** (for when the cloud AI stack is up): ask the `ask` agent a build-shaped question → it declines with the "Open in Builder →" card → click it → on `/ai/build`, the first chat POST body carries `context.parentConversationId` (the ask thread) and a reload does not re-send it.

## Dependency
Consumes the cloud handoff-context contract: **objectstack-ai/cloud#819 (cloud#817)** — merge that first. Without it the console degrades cleanly: the id is sent but ignored, a working cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)