### PR TITLE
fix(app-shell): 设计按钮深链到对应对象的设计页

### DIFF
--- a/packages/app-shell/src/utils/__tests__/appRoute.test.ts
+++ b/packages/app-shell/src/utils/__tests__/appRoute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { appRouteSegment, matchAppBySegment, appStudioDesignPath, appStudioSurfacePath, appStudioRoutePath } from '../appRoute';
+import { appRouteSegment, matchAppBySegment, appStudioDesignPath, appStudioSurfacePath, appStudioObjectPath, appStudioRoutePath } from '../appRoute';
 
 /**
  * ADR-0048 (option A) — package-id route segment.
@@ -97,9 +97,39 @@ describe('appStudioSurfacePath', () => {
 });
 
 /**
+ * App → Studio object deep-link (Data pillar).
+ */
+describe('appStudioObjectPath', () => {
+  const crm = { name: 'crm', _packageId: 'com.acme.crm' };
+
+  it('deep-links to the object surface in the Data pillar', () => {
+    expect(appStudioObjectPath(crm, true, 'showcase_task')).toBe(
+      '/studio/com.acme.crm/data?surface=object:showcase_task',
+    );
+  });
+  it('URL-encodes the package id and the object name', () => {
+    expect(appStudioObjectPath({ _packageId: 'com.acme/crm' }, true, 'my object')).toBe(
+      '/studio/com.acme%2Fcrm/data?surface=object:my%20object',
+    );
+  });
+  it('returns null for non-admins', () => {
+    expect(appStudioObjectPath(crm, false, 'account')).toBeNull();
+  });
+  it('returns null when the object name is missing', () => {
+    expect(appStudioObjectPath(crm, true, undefined)).toBeNull();
+    expect(appStudioObjectPath(crm, true, '')).toBeNull();
+  });
+  it('returns null for apps with no owning package or the sys_metadata pseudo-package', () => {
+    expect(appStudioObjectPath({ name: 'crm' }, true, 'account')).toBeNull();
+    expect(appStudioObjectPath({ _packageId: 'sys_metadata' }, true, 'account')).toBeNull();
+  });
+});
+
+/**
  * App → Studio route bridge — maps a running-app route to its Studio target:
  * an interface surface (dashboard / page / report) deep-links into the
- * Interfaces pillar; everything else opens the package's Data tab.
+ * Interfaces pillar; an object record page deep-links that object in the Data
+ * pillar; everything else opens the package's Data tab.
  */
 describe('appStudioRoutePath', () => {
   const crm = { name: 'crm', _packageId: 'com.acme.crm' };
@@ -122,11 +152,22 @@ describe('appStudioRoutePath', () => {
     );
   });
 
-  it('falls back to the Data tab for object routes and the plain app root', () => {
-    // An object route (routeType is the object name) is a Data-pillar surface.
-    expect(appStudioRoutePath(crm, true, { type: 'account', name: undefined })).toBe('/studio/com.acme.crm/data');
+  it('deep-links an object route (routeType is the object name) to its Data-pillar surface', () => {
+    // The fix: an object records page now opens THAT object, not the generic Data tab.
+    expect(appStudioRoutePath(crm, true, { type: 'showcase_task', name: undefined })).toBe(
+      '/studio/com.acme.crm/data?surface=object:showcase_task',
+    );
+    // A record-detail route (name='record') still keys off the object route type.
+    expect(appStudioRoutePath(crm, true, { type: 'account', name: 'record' })).toBe(
+      '/studio/com.acme.crm/data?surface=object:account',
+    );
+  });
+
+  it('falls back to the plain Data tab for the app root and the system area', () => {
     // No route type at all (bare /apps/:pkg) → Data tab.
     expect(appStudioRoutePath(crm, true, { type: undefined, name: undefined })).toBe('/studio/com.acme.crm/data');
+    // The system settings area is not an object.
+    expect(appStudioRoutePath(crm, true, { type: 'system', name: 'members' })).toBe('/studio/com.acme.crm/data');
   });
 
   it('falls back to the Data tab for an interface list route (no surface name)', () => {

--- a/packages/app-shell/src/utils/appRoute.ts
+++ b/packages/app-shell/src/utils/appRoute.ts
@@ -81,23 +81,60 @@ export function appStudioSurfacePath(
 }
 
 /**
+ * Deep-link from a running app straight to a specific **object's** design
+ * surface in Studio's Data pillar — e.g. viewing the `account` records page
+ * opens `/studio/:packageId/data?surface=object:account`, which the Data
+ * pillar's `?surface=` restore honors (see `DataPillar` in
+ * `StudioDesignSurface`). Same admin/package guards as
+ * {@link appStudioDesignPath}; returns null when the object name is missing so
+ * the caller can fall back to the plain Data tab.
+ *
+ * The `surface` param value is `object:<name>` — the same `type:name` shape the
+ * Interfaces pillar uses; only the name is percent-encoded (`object` is a fixed
+ * keyword).
+ */
+export function appStudioObjectPath(
+  app: AppLike | null | undefined,
+  isWorkspaceAdmin: boolean,
+  objectName: string | null | undefined,
+): string | null {
+  if (!isWorkspaceAdmin) return null;
+  const packageId = studioPackageId(app);
+  if (!packageId) return null;
+  if (!objectName) return null;
+  const value = `object:${encodeURIComponent(objectName)}`;
+  return `/studio/${encodeURIComponent(packageId)}/data?surface=${value}`;
+}
+
+/**
  * Route types that correspond to a designable **interface** surface in Studio's
  * Interfaces pillar. The console route type (`/apps/:pkg/<type>/<name>`) doubles
  * as the Studio surface type — the keywords match `resolveSurface` in
- * `StudioDesignSurface` (`dashboard` / `page` / `report`). Object/view routes
- * are deliberately excluded: they belong to the Data pillar, not Interfaces.
+ * `StudioDesignSurface` (`dashboard` / `page` / `report`).
  */
 const INTERFACE_SURFACE_ROUTE_TYPES = new Set(['dashboard', 'page', 'report']);
+
+/**
+ * Console `/apps/:pkg/<type>` route types that are NOT object records — the
+ * interface surfaces (handled above) plus the `system` settings area. Any other
+ * route type IS the object name (see `AppHeader`'s breadcrumb switch: the
+ * `else if (routeType)` branch treats it as an object), so it deep-links the
+ * Data pillar to that object.
+ */
+const NON_OBJECT_ROUTE_TYPES = new Set([...INTERFACE_SURFACE_ROUTE_TYPES, 'system']);
 
 /**
  * App → Studio bridge target for a running-app route (ADR-0080). When the route
  * names a specific interface (a dashboard, page, or report — see
  * {@link INTERFACE_SURFACE_ROUTE_TYPES}), deep-link straight to THAT surface in
- * the Interfaces pillar via {@link appStudioSurfacePath}; otherwise fall back to
- * the package's generic Data tab via {@link appStudioDesignPath}. Returns null
- * when the bridge should not render (non-admin / no owning package). Centralizes
- * the route-type → surface-type mapping so `AppHeader` stays declarative and the
- * decision is unit-tested here.
+ * the Interfaces pillar via {@link appStudioSurfacePath}. When it names an
+ * object record page (the route type IS the object name), deep-link that object
+ * in the Data pillar via {@link appStudioObjectPath}. Otherwise (bare app root,
+ * a `system` route, or an interface list route with no surface name) fall back
+ * to the package's generic Data tab via {@link appStudioDesignPath}. Returns
+ * null when the bridge should not render (non-admin / no owning package).
+ * Centralizes the route-type → surface-type mapping so `AppHeader` stays
+ * declarative and the decision is unit-tested here.
  */
 export function appStudioRoutePath(
   app: AppLike | null | undefined,
@@ -108,6 +145,9 @@ export function appStudioRoutePath(
   const name = route?.name;
   if (type && name && INTERFACE_SURFACE_ROUTE_TYPES.has(type)) {
     return appStudioSurfacePath(app, isWorkspaceAdmin, { type, name });
+  }
+  if (type && !NON_OBJECT_ROUTE_TYPES.has(type)) {
+    return appStudioObjectPath(app, isWorkspaceAdmin, type);
   }
   return appStudioDesignPath(app, isWorkspaceAdmin);
 }

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -1693,6 +1693,13 @@ function DataPillar({
   // the header's Menu button.
   const isMobile = useIsMobile();
   const [railOpen, setRailOpen] = React.useState(false);
+  // Object deep-link: capture the `?surface=object:<name>` target once, at
+  // mount. The app→Studio bridge (ADR-0080) opens a running object's records
+  // page straight to THAT object here (see `appStudioObjectPath`); without this
+  // the rail always snapped to the first object. Captured in a ref so later
+  // in-pillar selections don't re-trigger the restore.
+  const [searchParams] = useSearchParams();
+  const initialObjectRef = React.useRef(parseSurfaceParam(searchParams.get(DESIGNER_SURFACE_PARAM)));
   const [objects, setObjects] = React.useState<Surface[]>([]);
   const [objectsLoaded, setObjectsLoaded] = React.useState(false);
   const [current, setCurrent] = React.useState<Surface | null>(null);
@@ -1752,7 +1759,11 @@ function DataPillar({
           }
         }
         setObjects(items);
-        setCurrent((c) => c ?? items[0] ?? null);
+        // Honor a `?surface=object:<name>` deep-link when it names an object we
+        // actually have; otherwise open the first object as before.
+        const wanted = initialObjectRef.current;
+        const deepLinked = wanted?.type === 'object' ? items.find((o) => o.name === wanted.name) : undefined;
+        setCurrent((c) => c ?? deepLinked ?? items[0] ?? null);
         // First-run: an empty writable package opens the creator right away —
         // the first thing to do here is make an object, so put the inputs up.
         if (items.length === 0 && !readOnly) setCreating(true);


### PR DESCRIPTION
## 问题

对象记录页右上角的 **设计（Design in Studio）** 按钮此前恒定跳转到 `/_console/studio/<pkg>/data`，Studio 的 Data 支柱又默认选中第一个对象——导致无论查看哪个对象都落到同一页。

例：`…/apps/com.example.showcase/showcase_task` 期望进入 `showcase_task` 的设计页，实际却停在 `…/studio/com.example.showcase/data`（首个对象）。

## 根因

`appStudioRoutePath`（`packages/app-shell/src/utils/appRoute.ts`）只对**接口**路由（dashboard/page/report）做深链；对象路由回退到 `appStudioDesignPath`，后者硬编码 `/studio/<pkg>/data`，丢弃了对象身份。

## 改动

1. **appRoute** — 新增 `appStudioObjectPath()`，为对象路由生成 `/studio/<pkg>/data?surface=object:<name>`（沿用 Interfaces 支柱已有的 `type:name` 参数形态）。`appStudioRoutePath` 将非接口、非 `system` 的路由类型（即对象名）走此深链；app 根与 `system` 仍回退到通用 Data 页。
2. **StudioDesignSurface `DataPillar`** — 挂载时读取 `?surface=object:<name>`，命中已加载对象则初始选中它（复用 Interfaces 支柱既有恢复模式），否则维持选中首个对象的旧行为。

## 验证

- 单测 **30/30 通过**（`appRoute.test.ts`：更新对象路由断言 + 新增 `appStudioObjectPath` 用例）。
- Type-check：改动行无新增类型错误（`@object-ui/*` 找不到模块系新建 worktree 未构建依赖所致，与本改动无关）。
- 未做实机浏览器验证（需 `:3000` 后端 + 管理员登录）。手动确认：以工作区管理员打开某对象记录页，点击「设计」按钮，应进入 Studio 并选中该对象。

🤖 Generated with [Claude Code](https://claude.com/claude-code)