### PR TITLE
fix(views,plugin-gantt): view.data(provider:'api') 透传甘特 + group move 跳过 locked 子孙

### DIFF
--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1319,6 +1319,10 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
             fieldTextColor: viewDef.fieldTextColor ?? listSchema.fieldTextColor,
             prefixField: viewDef.prefixField ?? listSchema.prefixField,
             showDescription: viewDef.showDescription ?? listSchema.showDescription,
+            // ViewData source override (spec `data` key): a view authored with
+            // `data: {provider:'api', read, write}` must survive this explicit
+            // picklist, or ObjectGantt falls back to provider:'object'.
+            data: (viewDef as any).data ?? (listSchema as any).data,
             // Propagate new spec properties (P0/P1/P2)
             navigation: viewDef.navigation ?? listSchema.navigation,
             selection: viewDef.selection ?? listSchema.selection,

--- a/packages/plugin-gantt/src/GanttView.dnd.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.dnd.test.tsx
@@ -357,6 +357,32 @@ describe('GanttView summary group drag', () => {
     expect(byId.get('p').end.toISOString()).toBe('2024-06-17T00:00:00.000Z');
   });
 
+  it('summary drag skips locked descendants — they are neither previewed nor committed', () => {
+    const onTaskUpdate = vi.fn();
+    const family = FAMILY.map((t) => (t.id === 'c1' ? { ...t, locked: true } : t));
+    const { container } = render(
+      <div style={{ width: 1280, height: 600 }}>
+        <GanttView
+          tasks={family}
+          startDate={new Date('2024-06-01T00:00:00.000Z')}
+          endDate={new Date('2024-06-30T00:00:00.000Z')}
+          onTaskUpdate={onTaskUpdate}
+        />
+      </div>
+    );
+    const bracket = container.querySelector('[data-testid="gantt-summary-bar-p"]') as HTMLElement;
+
+    // +220px → +2 days at columnWidth 110.
+    act(() => { bracket.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 720)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 720)); });
+
+    // Summary + c2 + grandchild shift; locked c1 gets NO update at all.
+    expect(onTaskUpdate).toHaveBeenCalledTimes(3);
+    const ids = onTaskUpdate.mock.calls.map(([task]) => String(task.id)).sort();
+    expect(ids).toEqual(['c2', 'gc', 'p']);
+  });
+
   it('summary drag with zero net movement does not emit updates', () => {
     const onTaskUpdate = vi.fn();
     const { container } = renderFamily(onTaskUpdate);

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -840,7 +840,9 @@ export function GanttView({
     (updates: Array<{ task: GanttTask; changes: Partial<Pick<GanttTask, 'title' | 'start' | 'end' | 'progress'>> }>) => {
       if (!onTaskUpdate) return;
       const batch: HistoryItem[] = [];
-      for (const { task, changes } of updates) {
+      // Central belt: a locked row (仅查看) is never committed, whatever the
+      // path — group shift, conflict reschedule, or a future caller.
+      for (const { task, changes } of updates.filter((u) => !u.task.locked)) {
         const before: Partial<GanttTask> = {};
         const after: Partial<GanttTask> = {};
         let dirty = false;
@@ -979,9 +981,10 @@ export function GanttView({
           if (cur.group) {
             // Move the summary and every descendant by the same ms offset so
             // the subtree keeps its internal spacing and durations — recorded as
-            // a single undoable batch.
+            // a single undoable batch. Locked descendants (仅查看) stay put:
+            // they must never be mutated, by drag or by group shift.
             const deltaMs = start.getTime() - cur.originStart.getTime();
-            const shifted = [task, ...collectDescendants(task.id)].map((t) => ({
+            const shifted = [task, ...collectDescendants(task.id).filter((t) => !t.locked)].map((t) => ({
               task: t,
               changes: {
                 start: new Date(t.start.getTime() + deltaMs),
@@ -1018,8 +1021,9 @@ export function GanttView({
     e: React.PointerEvent,
     opts?: { group?: boolean; originStart?: Date; originEnd?: Date }
   ) => {
-    // Synthetic Group-by rows have no real backing task to mutate.
-    if (!onTaskUpdate || task.data?.__group) return;
+    // Synthetic Group-by rows have no real backing task to mutate; locked
+    // rows (仅查看) can't be dragged from any handle, summary bars included.
+    if (!onTaskUpdate || task.data?.__group || task.locked) return;
     e.stopPropagation();
     e.preventDefault();
     setDragState({
@@ -2204,7 +2208,8 @@ export function GanttView({
   const dragGroupIds = React.useMemo(() => {
     if (dragGroupTaskId == null) return null;
     const set = new Set<string>([String(dragGroupTaskId)]);
-    for (const d of collectDescendants(dragGroupTaskId)) set.add(String(d.id));
+    // Locked descendants don't move on commit, so don't preview them moving.
+    for (const d of collectDescendants(dragGroupTaskId)) if (!d.locked) set.add(String(d.id));
     return set;
   }, [dragGroupTaskId, collectDescendants]);
 

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -512,6 +512,17 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     ) {
       return false;
     }
+    // Renderer-owned data (gantt + api provider): ListView never fetches,
+    // so don't flash its skeleton either.
+    if (
+      schema.viewType === 'gantt' &&
+      schema.data &&
+      typeof schema.data === 'object' &&
+      !Array.isArray(schema.data) &&
+      (schema.data as any).provider === 'api'
+    ) {
+      return false;
+    }
     return true;
   });
   const [objectDef, setObjectDef] = React.useState<any>(null);
@@ -862,6 +873,19 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // gate further down the file.
   const perms = usePermissions();
 
+  // A gantt view whose `data` names the api provider is fed by a composite
+  // endpoint that ObjectGantt resolves itself (resolveDataSource →
+  // ApiDataSource, reads AND write-backs). ListView must neither fetch
+  // schema.objectName rows for it nor pass its `data` prop down — the prop
+  // short-circuits the renderer's own fetch, so stale object rows would
+  // replace the endpoint's tree.
+  const ganttOwnsData =
+    currentView === 'gantt' &&
+    !!schema.data &&
+    typeof schema.data === 'object' &&
+    !Array.isArray(schema.data) &&
+    (schema.data as any).provider === 'api';
+
   // Fetch data effect — supports schema.data (ViewDataSchema) provider modes
   React.useEffect(() => {
     let isMounted = true;
@@ -898,6 +922,14 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         );
       }
       setData(items);
+      setLoading(false);
+      setDataLimitReached(false);
+      return;
+    }
+
+    // Renderer-owned data (gantt + api provider): the view component fetches
+    // from its endpoint itself; just clear the loading state.
+    if (ganttOwnsData) {
       setLoading(false);
       setDataLimitReached(false);
       return;
@@ -1129,7 +1161,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     fetchData();
 
     return () => { isMounted = false; };
-  }, [schema.objectName, schema.data, dataSource, schema.filters, effectivePageSize, currentSort, currentFilters, userFilterConditions, refreshKey, searchTerm, schema.searchableFields, expandFields, objectDefLoaded, schema.refreshTrigger, perms, serverPage, currentView, groupingConfig]); // Re-fetch on filter/sort/search/refreshTrigger/perms/page change
+  }, [schema.objectName, schema.data, dataSource, schema.filters, effectivePageSize, currentSort, currentFilters, userFilterConditions, refreshKey, searchTerm, schema.searchableFields, expandFields, objectDefLoaded, schema.refreshTrigger, perms, serverPage, currentView, groupingConfig, ganttOwnsData]); // Re-fetch on filter/sort/search/refreshTrigger/perms/page change
 
   // Any change to the result-defining inputs (object, filters, sort, search,
   // grouping, page size) invalidates the current page number — snap back to
@@ -1429,6 +1461,10 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         return {
           type: 'object-gantt',
           ...baseProps,
+          // ViewData pass-through: a view authored with `data: {provider:'api',
+          // read, write}` (composite endpoint) must reach ObjectGantt, whose
+          // getDataConfig prefers schema.data over the objectName fallback.
+          ...(schema.data ? { data: schema.data } : {}),
           startDateField: schema.gantt?.startDateField || schema.options?.gantt?.startDateField || 'start_date',
           endDateField: schema.gantt?.endDateField || schema.options?.gantt?.endDateField || 'end_date',
           progressField: schema.gantt?.progressField || schema.options?.gantt?.progressField || 'progress',
@@ -2381,7 +2417,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           <SchemaRenderer
             schema={viewComponentSchema}
             {...props}
-            data={data}
+            {...(ganttOwnsData ? {} : { data })}
             loading={loading}
             onRowSelect={setSelectedRows}
             {...(currentView === 'grid' && !(groupingConfig?.fields?.length) && serverTotal != null

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -2427,3 +2427,85 @@ describe('ListView — inline-edit toggle drives grid editability', () => {
     expect(editableCalls.at(-1)).toBe(false);
   });
 });
+
+describe('ListView — gantt view fed by an api-provider ViewData', () => {
+  // A gantt view authored with `data: {provider:'api', read, write}` is fed by
+  // a composite endpoint that ObjectGantt resolves itself (resolveDataSource →
+  // ApiDataSource). ListView must (a) forward schema.data into the gantt
+  // component schema, (b) NOT fetch schema.objectName rows itself, and (c) NOT
+  // pass its rows `data` prop down — an array prop short-circuits the
+  // renderer's own fetch, replacing the endpoint's tree with raw object rows.
+  let prevObjectGantt: ReturnType<typeof ComponentRegistry.get>;
+  let ganttCalls: any[];
+
+  beforeAll(() => {
+    prevObjectGantt = ComponentRegistry.get('object-gantt');
+    ComponentRegistry.register('object-gantt', (props: any) => {
+      ganttCalls.push(props);
+      return <div data-testid="gantt-stub" />;
+    });
+  });
+  afterAll(() => {
+    if (prevObjectGantt) {
+      ComponentRegistry.register('object-gantt', prevObjectGantt);
+    } else {
+      ComponentRegistry.unregister('object-gantt');
+    }
+  });
+  beforeEach(() => {
+    ganttCalls = [];
+    mockDataSource.find.mockClear();
+  });
+
+  const apiData = {
+    provider: 'api' as const,
+    read: { url: '/api/gantt/tree', method: 'GET' as const },
+    write: { url: '/api/gantt/task', method: 'PATCH' as const },
+  };
+
+  it('forwards schema.data to the gantt schema, skips its own fetch, and withholds the rows prop', async () => {
+    const schema = {
+      type: 'list-view',
+      objectName: 'production_plan',
+      viewType: 'gantt',
+      fields: ['name'],
+      data: apiData,
+      gantt: { startDateField: 'start_date', endDateField: 'end_date' },
+    } as unknown as ListViewSchema;
+
+    renderWithProvider(<ListView schema={schema} dataSource={mockDataSource} />);
+    expect(await screen.findByTestId('gantt-stub')).toBeInTheDocument();
+
+    // (a) the ViewData config reached the component schema
+    const last = ganttCalls.at(-1);
+    expect(last?.schema?.data).toEqual(apiData);
+    // (b) ListView did not query the bound object itself
+    expect(mockDataSource.find).not.toHaveBeenCalled();
+    // (c) no rows array prop — the schema-spread `data` (the ViewData object)
+    // must be what arrives, so ObjectGantt's own api fetch is not bypassed
+    expect(Array.isArray(last?.data)).toBe(false);
+  });
+
+  it('keeps the legacy object-provider path: ListView fetches and passes rows down', async () => {
+    mockDataSource.find.mockResolvedValue([
+      { id: '1', name: 'P1', start_date: '2026-01-01', end_date: '2026-01-02' },
+    ]);
+    const schema = {
+      type: 'list-view',
+      objectName: 'production_plan',
+      viewType: 'gantt',
+      fields: ['name'],
+      gantt: { startDateField: 'start_date', endDateField: 'end_date' },
+    } as unknown as ListViewSchema;
+
+    renderWithProvider(<ListView schema={schema} dataSource={mockDataSource} />);
+    expect(await screen.findByTestId('gantt-stub')).toBeInTheDocument();
+
+    await vi.waitFor(() => {
+      const last = ganttCalls.at(-1);
+      expect(Array.isArray(last?.data)).toBe(true);
+      expect(last?.data).toHaveLength(1);
+    });
+    expect(mockDataSource.find).toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -1015,6 +1015,10 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           fieldTextColor: activeView?.fieldTextColor ?? (schema as any).fieldTextColor,
           prefixField: activeView?.prefixField ?? (schema as any).prefixField,
           showDescription: activeView?.showDescription ?? (schema as any).showDescription,
+          // ViewData source override (spec `data` key) — e.g. gantt views fed
+          // by a composite api endpoint; without this pick the api provider
+          // never reaches the renderer.
+          data: (currentNamedViewConfig as any)?.data ?? (activeView as any)?.data ?? (schema as any).data,
           // Propagate new spec properties (P0/P1/P2)
           navigation: activeView?.navigation ?? (schema as any).navigation,
           selection: activeView?.selection ?? (schema as any).selection,

--- a/packages/plugin-view/src/__tests__/ObjectView.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.test.tsx
@@ -674,6 +674,68 @@ describe('ObjectView', () => {
       expect(callSchema?.showSort).toBe(false);
     });
 
+    it('should propagate the ViewData `data` block (api provider) into the renderListView schema', async () => {
+      const apiData = {
+        provider: 'api',
+        read: { url: '/api/gantt/tree', method: 'GET' },
+        write: { url: '/api/gantt/task', method: 'PATCH' },
+      };
+      const schema = {
+        type: 'object-view',
+        objectName: 'production_plan',
+        data: apiData,
+      } as unknown as ObjectViewSchema;
+
+      const renderListViewSpy = vi.fn(() => (
+        <div data-testid="custom-list">Custom ListView</div>
+      ));
+
+      render(
+        <ObjectView
+          schema={schema}
+          dataSource={mockDataSource}
+          renderListView={renderListViewSpy}
+        />,
+      );
+
+      expect(renderListViewSpy).toHaveBeenCalled();
+      const callSchema = (renderListViewSpy.mock.calls[0] as any)?.[0]?.schema;
+      expect(callSchema?.data).toEqual(apiData);
+    });
+
+    it('should let activeView.data override the schema-level ViewData block', async () => {
+      const viewData = {
+        provider: 'api',
+        read: { url: '/api/gantt/tree' },
+      };
+      const schema = {
+        type: 'object-view',
+        objectName: 'production_plan',
+      } as unknown as ObjectViewSchema;
+
+      const renderListViewSpy = vi.fn(() => (
+        <div data-testid="custom-list">Custom ListView</div>
+      ));
+
+      const views = [
+        { id: 'v1', label: 'View 1', type: 'gantt' as const, data: viewData } as any,
+      ];
+
+      render(
+        <ObjectView
+          schema={schema}
+          dataSource={mockDataSource}
+          views={views}
+          activeViewId="v1"
+          renderListView={renderListViewSpy}
+        />,
+      );
+
+      expect(renderListViewSpy).toHaveBeenCalled();
+      const callSchema = (renderListViewSpy.mock.calls[0] as any)?.[0]?.schema;
+      expect(callSchema?.data).toEqual(viewData);
+    });
+
     it('should propagate userFilters from activeView in renderListView', async () => {
       const schema: ObjectViewSchema = {
         type: 'object-view',


### PR DESCRIPTION
Closes #2447

## 做了什么

两个提交,对应 issue 的两个缺口:

### 1. `fix(views)`: 视图 `data(provider:'api')` 透传到甘特渲染器

对象视图声明 `data: { provider: 'api', url: ... }` 时,ListView 把 `view.data` 原样传给甘特渲染器,并置 `ganttOwnsData` 让甘特自管取数(组合接口一次返回多对象拼成的扁平树),ListView 不再重复走对象表直查。未声明 api 数据源的视图行为不变。

### 2. `fix(plugin-gantt)`: group move 跳过 locked 子孙——不预览、不提交、不发写请求

修复前:拖 summary bar 时整棵子树(含 `locked: true` 仅查看行)一起提交,每个 locked 子行各发一个注定 403 的写请求。修复后四道防线:

- 位移计算排除 locked 子孙(原地不动);
- 拖拽预览不高亮 locked 子孙;
- `commitTaskUpdates` 中央过滤——无论 group shift、`rescheduleOnConflict` 还是未来调用方,locked 行一律不提交;
- `beginDrag` 对 locked 行直接返回。

## 怎么测的

- 单测:plugin-gantt **261/261**、plugin-list **149/149** 通过;新增用例「summary 拖动时 locked 子行既不预览也不提交,仅其余行收到 onTaskUpdate」。
- 真机(ehr 制造排班甘特,Playwright 真实鼠标 + 网络层断言):拖计划 summary bar 一列 → **仅 1 个 PATCH 200、locked 派工子行 0 个 403、日期 +7 天持久化到业务表、子行日期未动**。修复前同操作实测为 1×200 + 2×403。完整 8 探针报告与截图:steedos-labs/os-project-titanwind-ehr#173。
