### PR TITLE
refactor(app-shell): Studio 四支柱统一 ?surface= 深链恢复 + URL 回写

### DIFF
--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -77,13 +77,11 @@ import {
   formatNavSelParam,
   findNavPositionById,
   navIdAtPosition,
-  DESIGNER_SURFACE_PARAM,
-  parseSurfaceParam,
-  formatSurfaceParam,
 } from '../metadata-admin/nav-selection';
 import { SourcePageEditor } from '../metadata-admin/previews/SourcePageEditor';
 import { formatMetadataError, formatPublishFailures, type PublishFailure } from './metadataError';
 import { loadPackageSurfaces } from './packageSurfaces';
+import { useSurfaceDeepLink, resolveSurfaceDeepLink } from './useSurfaceDeepLink';
 import { buildObjectSkeleton, buildFlowSkeleton, buildAppSkeleton, buildPermissionSkeleton } from './skeletons';
 import { t, tFormat, useMetadataLocale } from '../metadata-admin/i18n';
 import { SuggestedBindingsPanel } from '../../components/SuggestedBindingsPanel';
@@ -973,11 +971,6 @@ function InterfacesPillar({
   // internal. Selection changes mirror back to the URL (replace).
   const [searchParams, setSearchParams] = useSearchParams();
   const navSelParam = parseNavSelParam(searchParams.get(DESIGNER_SEL_PARAM));
-  // Surface deep-link: capture the `?surface=<type>:<name>` target once, at
-  // mount, so the app-load effect can open it instead of auto-picking the first
-  // leaf. A ref keeps it out of that effect's deps (which is keyed on the
-  // package, not the URL) while the mirror effect below keeps the URL current.
-  const initialSurfaceRef = React.useRef(parseSurfaceParam(searchParams.get(DESIGNER_SURFACE_PARAM)));
   const appliedNavSelRef = React.useRef<string | null>(null);
   React.useEffect(() => {
     if (!navSelParam || navTree.length === 0) return;
@@ -1005,23 +998,8 @@ function InterfacesPillar({
   const [navHasDraft, setNavHasDraft] = React.useState(false);
   const [navSaving, setNavSaving] = React.useState<false | 'draft' | 'publish'>(false);
   const [current, setCurrent] = React.useState<Surface | null>(null);
-  // Mirror the open surface back to `?surface=<type>:<name>` (replace) so the
-  // selected menu is shareable and reload-stable — the inverse of the mount
-  // capture above. Only write once a surface is open: the first render has
-  // `current === null` before the app-load effect resolves, and clearing the
-  // param there would strip an incoming deep-link before it is applied.
-  React.useEffect(() => {
-    if (!current) return;
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.set(DESIGNER_SURFACE_PARAM, formatSurfaceParam(current));
-        return next;
-      },
-      { replace: true },
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [current]);
+  // `?surface=` capture + mirror — shared plumbing (see useSurfaceDeepLink).
+  const initialSurface = useSurfaceDeepLink(current);
   // Inspector tab — source pages carry a `source` string, not a block tree, so
   // their editor lives in a dedicated Source tab (the Properties tab has no
   // blocks to inspect). Non-source surfaces never show the tab strip.
@@ -1132,9 +1110,7 @@ function InterfacesPillar({
         })(tree);
         // A `?surface=` deep-link wins over the first-leaf default when it
         // still resolves to a leaf in this app's nav; otherwise fall back.
-        const deepLinked = initialSurfaceRef.current
-          ? findSurfaceInTree(tree, initialSurfaceRef.current)
-          : null;
+        const deepLinked = initialSurface ? findSurfaceInTree(tree, initialSurface) : null;
         setCurrent((cur) => cur ?? deepLinked ?? firstLeaf);
       } catch (e) {
         if (!cancelled) {
@@ -1693,16 +1669,13 @@ function DataPillar({
   // the header's Menu button.
   const isMobile = useIsMobile();
   const [railOpen, setRailOpen] = React.useState(false);
-  // Object deep-link: capture the `?surface=object:<name>` target once, at
-  // mount. The app→Studio bridge (ADR-0080) opens a running object's records
-  // page straight to THAT object here (see `appStudioObjectPath`); without this
-  // the rail always snapped to the first object. Captured in a ref so later
-  // in-pillar selections don't re-trigger the restore.
-  const [searchParams] = useSearchParams();
-  const initialObjectRef = React.useRef(parseSurfaceParam(searchParams.get(DESIGNER_SURFACE_PARAM)));
   const [objects, setObjects] = React.useState<Surface[]>([]);
   const [objectsLoaded, setObjectsLoaded] = React.useState(false);
   const [current, setCurrent] = React.useState<Surface | null>(null);
+  // `?surface=object:<name>` capture + mirror — the app→Studio bridge
+  // (ADR-0080, `appStudioObjectPath`) lands here with a specific object;
+  // shared plumbing (see useSurfaceDeepLink).
+  const initialSurface = useSurfaceDeepLink(current);
   const [objDraft, setObjDraft] = React.useState<Record<string, unknown>>({});
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -1761,8 +1734,7 @@ function DataPillar({
         setObjects(items);
         // Honor a `?surface=object:<name>` deep-link when it names an object we
         // actually have; otherwise open the first object as before.
-        const wanted = initialObjectRef.current;
-        const deepLinked = wanted?.type === 'object' ? items.find((o) => o.name === wanted.name) : undefined;
+        const deepLinked = resolveSurfaceDeepLink(items, initialSurface, 'object');
         setCurrent((c) => c ?? deepLinked ?? items[0] ?? null);
         // First-run: an empty writable package opens the creator right away —
         // the first thing to do here is make an object, so put the inputs up.
@@ -2479,6 +2451,10 @@ function AutomationsPillar({
   const [railOpen, setRailOpen] = React.useState(false);
   const [flows, setFlows] = React.useState<Surface[]>([]);
   const [current, setCurrent] = React.useState<Surface | null>(null);
+  // `?surface=flow:<name>` capture + mirror — shared plumbing (see
+  // useSurfaceDeepLink). No producer emits this link yet; honoring it keeps
+  // the pillars uniform so a future "design this flow" bridge just works.
+  const initialSurface = useSurfaceDeepLink(current);
   const [draft, setDraft] = React.useState<Record<string, unknown>>({});
   const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
   const [loading, setLoading] = React.useState(false);
@@ -2536,7 +2512,8 @@ function AutomationsPillar({
         const items = await loadPackageSurfaces(client, 'flow', packageId);
         if (cancelled) return;
         setFlows(items);
-        setCurrent((c) => c ?? items[0] ?? null);
+        const deepLinked = resolveSurfaceDeepLink(items, initialSurface, 'flow');
+        setCurrent((c) => c ?? deepLinked ?? items[0] ?? null);
       } catch (e) {
         if (!cancelled) setError(formatMetadataError(e));
       } finally {
@@ -2888,6 +2865,14 @@ function AccessPillar({
   const [loaded, setLoaded] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [current, setCurrent] = React.useState<string | null>(null);
+  // `?surface=permission:<name>` capture + mirror — shared plumbing (see
+  // useSurfaceDeepLink). This rail keys `current` by name, so wrap it in the
+  // surface identity the param carries.
+  const currentSurface = React.useMemo(
+    () => (current ? { type: 'permission', name: current } : null),
+    [current],
+  );
+  const initialSurface = useSurfaceDeepLink(currentSurface);
   const [query, setQuery] = React.useState('');
   // inline creator (same rail pattern as the Data pillar's object creator)
   const [creating, setCreating] = React.useState(false);
@@ -2931,7 +2916,8 @@ function AccessPillar({
       }
       const scoped = [...byName.values()];
       setPerms(scoped);
-      setCurrent((c) => c ?? scoped[0]?.name ?? null);
+      const deepLinked = resolveSurfaceDeepLink(scoped, initialSurface, 'permission');
+      setCurrent((c) => c ?? deepLinked?.name ?? scoped[0]?.name ?? null);
     } catch (e) {
       setError(formatMetadataError(e));
     } finally {

--- a/packages/app-shell/src/views/studio-design/useSurfaceDeepLink.test.ts
+++ b/packages/app-shell/src/views/studio-design/useSurfaceDeepLink.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { resolveSurfaceDeepLink } from './useSurfaceDeepLink';
+
+/**
+ * Pure half of the shared `?surface=` deep-link plumbing — the rail-restore
+ * resolution each pillar applies to its loaded list (the hook half is thin
+ * URL glue over the same nav-selection parse/format, tested separately).
+ */
+describe('resolveSurfaceDeepLink', () => {
+  const objects = [
+    { name: 'showcase_project', label: '项目' },
+    { name: 'showcase_task', label: '任务' },
+  ];
+
+  it('resolves a matching-type deep-link to its rail item', () => {
+    expect(
+      resolveSurfaceDeepLink(objects, { type: 'object', name: 'showcase_task' }, 'object'),
+    ).toBe(objects[1]);
+  });
+
+  it('returns undefined when there is no deep-link (first-item default applies)', () => {
+    expect(resolveSurfaceDeepLink(objects, null, 'object')).toBeUndefined();
+  });
+
+  it("ignores a deep-link of another pillar's surface type", () => {
+    // e.g. `?surface=page:crm_workbench` reaching the Data pillar after a
+    // pillar-tab switch must not accidentally match an object named like it.
+    expect(
+      resolveSurfaceDeepLink(objects, { type: 'page', name: 'showcase_task' }, 'object'),
+    ).toBeUndefined();
+  });
+
+  it('ignores a deep-link naming an item the rail does not have', () => {
+    expect(
+      resolveSurfaceDeepLink(objects, { type: 'object', name: 'deleted_object' }, 'object'),
+    ).toBeUndefined();
+  });
+
+  it('works for the Access pillar shape (name-keyed permission sets)', () => {
+    const perms = [{ name: 'member_default' }, { name: 'sales_manager' }];
+    expect(
+      resolveSurfaceDeepLink(perms, { type: 'permission', name: 'sales_manager' }, 'permission'),
+    ).toBe(perms[1]);
+  });
+});

--- a/packages/app-shell/src/views/studio-design/useSurfaceDeepLink.ts
+++ b/packages/app-shell/src/views/studio-design/useSurfaceDeepLink.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Shared `?surface=<type>:<name>` deep-link plumbing for the Studio pillars.
+ *
+ * Every pillar rail (Data / Interfaces / Automations / Access) opens ONE
+ * surface at a time and used to hand-roll the same two halves — or skip them:
+ *
+ *  1. CAPTURE: read the `?surface=` target once, at mount, so the pillar's
+ *     list-load effect can open it instead of auto-picking the first item.
+ *     Captured in a ref so later in-pillar selections don't re-trigger the
+ *     restore, and kept out of that effect's deps (which are keyed on the
+ *     package, not the URL).
+ *  2. MIRROR: write the open surface back to `?surface=` (replace) whenever it
+ *     changes, so the selection is shareable and reload-stable — the inverse
+ *     of the capture. Only written once a surface is open: the first render
+ *     has no selection yet, and clearing the param there would strip an
+ *     incoming deep-link before it is applied.
+ *
+ * InterfacesPillar pioneered the pattern (#code-block-menu-nav); the Data
+ * pillar grew the capture half for the app→Studio object bridge (#2446);
+ * Automations/Access had neither, so their deep-links snapped back to the
+ * first item. This hook is the single canonical implementation.
+ */
+
+import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  DESIGNER_SURFACE_PARAM,
+  parseSurfaceParam,
+  formatSurfaceParam,
+} from '../metadata-admin/nav-selection';
+
+/** The surface identity carried in the URL param. */
+export interface SurfaceTarget {
+  type: string;
+  name: string;
+}
+
+/**
+ * Capture the mount-time `?surface=` target (returned) and mirror `current`
+ * back to the URL as it changes. Pass the pillar's open surface — `null`
+ * while nothing is selected yet.
+ */
+export function useSurfaceDeepLink(
+  current: SurfaceTarget | null | undefined,
+): SurfaceTarget | null {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialRef = React.useRef(parseSurfaceParam(searchParams.get(DESIGNER_SURFACE_PARAM)));
+  // Keyed on the identity, not the object — pillars recreate their Surface
+  // objects on list reload, and a same-surface rewrite is a wasted render.
+  const type = current?.type;
+  const name = current?.name;
+  React.useEffect(() => {
+    if (!type || !name) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set(DESIGNER_SURFACE_PARAM, formatSurfaceParam({ type, name }));
+        return next;
+      },
+      { replace: true },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type, name]);
+  return initialRef.current;
+}
+
+/**
+ * Resolve a captured deep-link against the pillar's loaded rail: the matching
+ * item when the target is of this pillar's surface type AND actually exists in
+ * the list, else `undefined` so the caller falls back to its first-item
+ * default. Pure — unit-tested without rendering a pillar.
+ */
+export function resolveSurfaceDeepLink<T extends { name: string }>(
+  items: readonly T[],
+  initial: SurfaceTarget | null,
+  expectedType: string,
+): T | undefined {
+  if (!initial || initial.type !== expectedType) return undefined;
+  return items.find((item) => item.name === initial.name);
+}


### PR DESCRIPTION
## 背景

#2446 修复了「设计」按钮→Data 支柱的对象深链后,审计发现 `?surface=<type>:<name>` 深链契约在四个支柱间实现不一:

| 支柱 | 挂载捕获 `?surface=` | 选中项回写 URL |
|---|---|---|
| Interfaces | ✅(手写 ref) | ✅(手写 effect) |
| Data | ✅(#2446 手写 ref) | ❌ URL 陈旧 |
| Automations | ❌ 弹回首个 flow | ❌ |
| Access | ❌ 弹回首个权限集 | ❌ |

## 改动

1. **新增 [`useSurfaceDeepLink.ts`](../blob/feat/studio-surface-deeplink-restore/packages/app-shell/src/views/studio-design/useSurfaceDeepLink.ts)** —— 共享抽象:
   - `useSurfaceDeepLink(current)`:挂载时捕获一次 `?surface=` 目标(ref,后续选择不重触发),并把当前选中 surface 镜像回 URL(replace,按 type/name 身份 key,列表重载不空写)。
   - `resolveSurfaceDeepLink(items, initial, expectedType)`:纯函数,按支柱的 surface 类型 + 名称在 rail 列表中解析深链;类型不匹配或名称不存在则返回 undefined 回落首项。
2. **四支柱统一接入**:Interfaces 删除手写 ref + mirror effect(净简化);Data 换用共享实现并补上回写;Automations(`flow:`)/Access(`permission:`)补齐捕获 + 恢复 + 回写。
3. **行为保持**:无深链或未命中时仍默认首项;`c ??` 守卫保留,列表重载/发布后重读不会清掉用户当前选择。

未扩展 `appStudioRoutePath` 生产端:控制台没有 flow/权限集的运行时路由,不存在可桥接的上下文;消费端补齐后,未来的「设计此流程/权限集」入口可直接落地。

## 验证

- 新增 `useSurfaceDeepLink.test.ts`(5 用例:命中/无深链/跨支柱类型不误配/名称不存在/Access 名称键形态)。
- 回归:`packageSurfaces` + `nav-selection.surface` + `appRoute` + `studio-locale.i18n` + `FlowStatusDot` 共 **53 用例全部通过**。
- Type-check:新文件零错误;其余报错为 fresh worktree 未构建 `@object-ui/*` 依赖的既有噪音,与本改动无关。
- 未做实机浏览器验证(需 :3000 后端 + 管理员登录);手动确认路径:打开 `…/studio/<pkg>/data?surface=object:showcase_task` 应选中该对象,且在 rail 中切换对象后 URL 随之更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)