### PR TITLE
fix(console-ai): #2450 stale-scope pane swallow + capability-based rendering (cloud#816) + ADR-0057 decisions

### DIFF
--- a/.changeset/cloud-816-capability-rendering.md
+++ b/.changeset/cloud-816-capability-rendering.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/plugin-chatbot": minor
+"@object-ui/app-shell": patch
+---
+
+feat(console-ai): render agent behavior by declared capability (cloud#816 / ADR-0057 "B+")
+
+`GET /api/v1/ai/agents` now serves per-agent `capabilities`; the console
+consumes them instead of hard-coding `isBuildAgent(name)`:
+
+- `@object-ui/plugin-chatbot`: `AgentDescriptor.capabilities` (normalized from
+  the catalog) + new `agentHasCapability(agents, name, cap)` — declaration wins
+  when present; falls back to the legacy `isBuildAgent(name)` check when absent
+  (older server), so shipping order doesn't matter.
+- `@object-ui/app-shell`: the build-doctor drawer + `showDebug` key off
+  `'debug'`, the FAB's resume-vs-fresh keys off `'resume'`, HomePage's
+  "Build with AI" availability keys off `'authoring'`. The ADR-0063 product-axis
+  sites (surface→agent resolver, conversation scope keying, picker availability)
+  intentionally stay name-based — capability describes RENDERED behavior, not
+  which product an agent is.
+
+A future skill-driven build variant now needs no console change.

--- a/.changeset/fix-2450-resume-handoff-autosend.md
+++ b/.changeset/fix-2450-resume-handoff-autosend.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(console-ai): second handoff's auto-send no longer dies in the stale-scope pane (#2450)
+
+Mid ask→build transition, `useChatConversation` briefly still holds the OLD
+scope's conversation id (the same stale window the URL-mirror already guards).
+`<ChatPane>` was fed that raw id, so a DOOMED pane (build chatApi + stale ask id,
+about to remount) could mount — and the deferred first-send replay consumed the
+handoff stash into it, where the send died with the unmount before reaching the
+wire (observed live as "conversation resumes, zero `…/chat` POST").
+
+Two-layer fix:
+
+- **Scope-gated pane feed (structural):** the page now hands `<ChatPane>` a
+  conversation id/messages ONLY when `conversationScope === chatScope`. During
+  the stale window the pane mounts as `…:pending`, holds the stash, and replays
+  exactly once in the correctly-scoped pane — extending the existing URL-mirror
+  guard to the pane itself.
+- **Targeted stash (defense-in-depth):** the handoff seed is stamped
+  `targetAgentRoute: 'build'`; `useDeferredFirstSend` refuses to consume a
+  targeted stash in a pane bound to another agent (untargeted user-typed sends
+  keep the legacy consume-anywhere behavior).
+
+Per product decision, a second handoff landing on a conversation with a
+blueprint still Awaiting Approval just auto-sends — the build agent sees the
+pending plan in context and decides merge/supersede itself.

--- a/docs/adr/0057-console-ai-chat-one-conversation-docked.md
+++ b/docs/adr/0057-console-ai-chat-one-conversation-docked.md
@@ -1,6 +1,8 @@
 # ADR-0057: Console AI chat is one system — surfaces are views over one conversation, docked as the canonical shell
 
-**Status**: Proposed (2026-07-13). Console-layer realization of the two-agent,
+**Status**: Accepted (2026-07-13) — P1+P2 shipped (#2414), P4 shipped
+(#2439 / #2444 + cloud#818/#819; reliability follow-ups #2449 + cloud#820);
+P3 planned (implementation plan on epic #2409). Console-layer realization of the two-agent,
 surface-bound model (cloud ADR-0063). **No agent, boundary, or commercial-model
 change** — this ADR only rearranges how the objectui console *renders and wires*
 chat surfaces.
@@ -274,14 +276,18 @@ inert; AI is reached only via MCP.
 
 ## Open design questions
 
-1. **Dock side under Studio (P3).** Chat right vs properties right. Proposed: chat
-   right, properties folded into a center/left tab. Confirm the three-pane reflow.
-2. **FAB retirement path (P3).** Hard-retire, or keep the FAB as the *collapsed
-   affordance* of the dock (a bottom-right button that expands the right rail)?
-   The latter is a gentler migration and preserves the familiar entry point.
-3. **Handoff aggressiveness (P4).** Explicit "Open in Builder →" (proposed, safe)
-   vs a more seamless in-place product switch. The records-vs-app-definition
-   governance boundary (ADR-0063) argues for **explicit**.
+1. **Dock side under Studio (P3).** ~~Chat right vs properties right.~~
+   **DECIDED (2026-07-13): chat right**; properties fold into a center tab —
+   `[left: nav/tree] [center: canvas + properties] [right: chat]`.
+2. **FAB retirement path (P3).** ~~Hard-retire, or keep the FAB as the collapsed
+   affordance?~~ **DECIDED (2026-07-13): the FAB becomes the dock's collapsed
+   affordance** — the bottom-right button stays and expands the right rail
+   (gentle migration; the familiar entry point survives).
+3. **Handoff aggressiveness (P4).** **DECIDED & SHIPPED: explicit** "Open in
+   Builder →" (#2439), carrying the ask conversation as first-turn context
+   (#2444 + cloud#819). A second handoff landing on a pending blueprint simply
+   auto-sends — the agent sees the awaiting plan in context and decides
+   merge/supersede itself (product decision 2026-07-13).
 4. **`app.defaultAgent` post-ADR-0063.** Now bounded to `ask` / `build` (tenant
    custom agents withdrawn). Confirm the resolver **rejects** anything else rather
    than silently falling through.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -477,9 +477,22 @@ export function matchAiChatShortcut(e: {
 }
 
 /** A composer submission held until the conversation id that will carry it exists. */
+/** Stable empty array for the stale-scope window (#2450) — a fresh `[]` per
+ *  render would churn the pane's `initialMessages` identity for no reason. */
+const EMPTY_INITIAL_MESSAGES: HydratedUIMessage[] = [];
+
 export interface PendingFirstMessage {
   content: string;
   files?: File[];
+  /**
+   * #2450 — the agent surface this stash is FOR (e.g. `'build'` for the
+   * ADR-0057 handoff seed). The replay refuses to consume it in a pane bound to
+   * a different agent, so a stash targeted at the Builder can never be eaten by
+   * (and die in) an ask-surface pane mid route-transition. Absent = untargeted
+   * (a user-typed first send), consumed by whichever pane replays first —
+   * unchanged behavior.
+   */
+  targetAgentRoute?: string;
 }
 
 /**
@@ -520,8 +533,15 @@ export function useDeferredFirstSend(opts: {
    * the replay deps makes the seed reliably replay.
    */
   pendingSignal?: number;
+  /**
+   * #2450 — the agent surface THIS pane is bound to (route name, e.g.
+   * `'build'`). A pending message stamped with a `targetAgentRoute` is only
+   * consumed when it matches; a mismatched pane HOLDS the stash untouched so
+   * the correctly-bound pane can replay it after the route transition settles.
+   */
+  agentRoute?: string;
 }): (content: string, files?: File[]) => void {
-  const { chatApi, conversationId, pendingRef, doSend, pendingSignal } = opts;
+  const { chatApi, conversationId, pendingRef, doSend, pendingSignal, agentRoute } = opts;
   const apiMode = Boolean(chatApi);
 
   // Replay a deferred first message the instant a conversation id exists — in
@@ -532,9 +552,14 @@ export function useDeferredFirstSend(opts: {
     if (!apiMode || !conversationId) return;
     const pending = pendingRef.current;
     if (!pending) return;
+    // #2450 — a targeted stash (the handoff seed) must not be consumed by a
+    // pane bound to another agent: mid ask→build transition a doomed pane can
+    // replay first, and a send issued there dies with its unmount before it
+    // reaches the wire. Hold the stash; the matching pane replays it.
+    if (pending.targetAgentRoute && pending.targetAgentRoute !== agentRoute) return;
     pendingRef.current = null;
     doSend(pending.content, pending.files);
-  }, [apiMode, conversationId, pendingRef, doSend, pendingSignal]);
+  }, [apiMode, conversationId, pendingRef, doSend, pendingSignal, agentRoute]);
 
   return useCallback(
     (content: string, files?: File[]) => {
@@ -681,6 +706,19 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     activeId: urlConversationId ?? legacyConversationId,
     forceNew: forceNewConversation,
   });
+
+  // #2450 — feed <ChatPane> ONLY a scope-matched conversation. Right after a
+  // launcher/handoff switch (ask→build), `conversationId` still holds the OLD
+  // scope's id until the hook re-resolves — the same stale window the
+  // URL-mirror below already guards. A pane mounted on that stale id is DOOMED
+  // (it remounts the moment the id re-resolves), and the deferred first-send
+  // replay could consume the handoff stash into it, where the send dies with
+  // the unmount before reaching the wire (the observed zero-POST). Handing the
+  // pane `undefined` during the window makes it mount as `…:pending`, hold the
+  // stash, and replay exactly once in the correctly-scoped pane.
+  const scopeMatched = conversationScope === chatScope;
+  const paneConversationId = scopeMatched ? conversationId : undefined;
+  const paneInitialMessages = scopeMatched ? initialMessages : EMPTY_INITIAL_MESSAGES;
 
   // ── Route canonicalization ──────────────────────────────────────────────
   // Back-compat redirects (the agent is now in the path): bare `/ai` → the
@@ -868,7 +906,9 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
     if (!handoffPrompt || agentSegment !== 'build') return;
     if (lastSeededHandoffPromptRef.current === handoffPrompt) return;
     lastSeededHandoffPromptRef.current = handoffPrompt;
-    stashPendingFirstMessage({ content: handoffPrompt });
+    // Target the stash at the BUILD pane (#2450): mid ask→build transition a
+    // doomed pane (stale conversation id, about to remount) must not consume it.
+    stashPendingFirstMessage({ content: handoffPrompt, targetAgentRoute: 'build' });
   }, [handoffPrompt, agentSegment, stashPendingFirstMessage]);
 
   const handleSent = useCallback(
@@ -1013,17 +1053,17 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
         </div>
         <main className="flex min-w-0 flex-1 flex-col">
           <ChatPane
-            key={`${chatApi ?? 'local'}:${conversationId ?? 'pending'}`}
+            key={`${chatApi ?? 'local'}:${paneConversationId ?? 'pending'}`}
             agents={agents}
             agentsLoading={agentsLoading}
             agentsError={agentsError}
             activeAgent={activeAgent}
             chatApi={chatApi}
             apiBase={apiBase}
-            conversationId={conversationId}
+            conversationId={paneConversationId}
             editPackageId={editPackageId}
             parentHandoffConversationId={handoffParentConversationId}
-            initialMessages={initialMessages}
+            initialMessages={paneInitialMessages}
             pendingFirstMessageRef={pendingFirstMessageRef}
             pendingFirstMessageSeq={pendingFirstMessageSeq}
             onSent={handleSent}
@@ -1406,6 +1446,9 @@ export function ChatPane({
     pendingRef: pendingFirstMessageRef,
     doSend,
     pendingSignal: pendingFirstMessageSeq,
+    // #2450 — this pane's agent surface; a stash targeted at another surface
+    // (the handoff seed → 'build') is held, never consumed here.
+    agentRoute: activeAgent ? agentRouteName(activeAgent) : undefined,
   });
 
   const headerSlot = (

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -54,6 +54,7 @@ import {
   resolveAgentParam,
   isBuiltinAgentName,
   isBuildAgent,
+  agentHasCapability,
   isAskAgent,
   publishHealthFromResponse,
   detectDraftResult,
@@ -999,7 +1000,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
           publicBaseUrl={publicShareBase}
         />
       )}
-      {conversationId && isBuildAgent(activeAgent) && (
+      {conversationId && agentHasCapability(agents, activeAgent, 'debug') && (
         <BuildDebugDrawer
           apiBase={apiBase}
           conversationId={conversationId}
@@ -1069,7 +1070,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
             onSent={handleSent}
             onShare={() => setShareOpen(true)}
             onDebug={() => setDebugOpen(true)}
-            showDebug={isBuildAgent(activeAgent)}
+            showDebug={agentHasCapability(agents, activeAgent, 'debug')}
             onCanvasOpenChange={handleCanvasOpenChange}
           />
         </main>

--- a/packages/app-shell/src/console/ai/__tests__/useDeferredFirstSend.test.tsx
+++ b/packages/app-shell/src/console/ai/__tests__/useDeferredFirstSend.test.tsx
@@ -92,6 +92,64 @@ describe('useDeferredFirstSend', () => {
     expect(doSend).toHaveBeenLastCalledWith('second handoff', undefined);
   });
 
+  // #2450 — mid ask→build transition, a doomed pane (wrong agent binding) must
+  // NOT consume the handoff stash: a send issued there dies with the unmount
+  // before reaching the wire. A stash stamped `targetAgentRoute: 'build'` is
+  // HELD by any non-build pane and replayed only by the build-bound one.
+  it('holds a targeted stash in a mismatched-agent pane, replays it in the matching one', () => {
+    const pendingRef: React.MutableRefObject<PendingFirstMessage | null> = { current: null };
+    const doSend = vi.fn();
+    const { rerender } = renderHook(
+      ({ agentRoute, pendingSignal }) =>
+        useDeferredFirstSend({
+          chatApi: API,
+          conversationId: 'c1',
+          pendingRef,
+          doSend,
+          pendingSignal,
+          agentRoute,
+        }),
+      { initialProps: { agentRoute: 'ask', pendingSignal: 0 } },
+    );
+
+    // Handoff seed lands while the pane is still ask-bound (stale window):
+    // held untouched — not consumed, not sent.
+    act(() => {
+      pendingRef.current = { content: 'handoff prompt', targetAgentRoute: 'build' };
+      rerender({ agentRoute: 'ask', pendingSignal: 1 });
+    });
+    expect(doSend).not.toHaveBeenCalled();
+    expect(pendingRef.current).not.toBeNull();
+
+    // The pane re-binds to build (transition settled) → replayed exactly once.
+    act(() => rerender({ agentRoute: 'build', pendingSignal: 1 }));
+    expect(doSend).toHaveBeenCalledTimes(1);
+    expect(doSend).toHaveBeenCalledWith('handoff prompt', undefined);
+    expect(pendingRef.current).toBeNull();
+  });
+
+  it('an untargeted stash keeps the legacy consume-anywhere behavior', () => {
+    const pendingRef: React.MutableRefObject<PendingFirstMessage | null> = { current: null };
+    const doSend = vi.fn();
+    const { rerender } = renderHook(
+      ({ pendingSignal }) =>
+        useDeferredFirstSend({
+          chatApi: API,
+          conversationId: 'c1',
+          pendingRef,
+          doSend,
+          pendingSignal,
+          agentRoute: 'ask',
+        }),
+      { initialProps: { pendingSignal: 0 } },
+    );
+    act(() => {
+      pendingRef.current = { content: 'typed by user' };
+      rerender({ pendingSignal: 1 });
+    });
+    expect(doSend).toHaveBeenCalledWith('typed by user', undefined);
+  });
+
   it('sends straight through when a conversation id is already present', () => {
     const { result, pendingRef, doSend } = setup({ chatApi: API, conversationId: 'c1' });
 

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -22,7 +22,7 @@ import { useRecentItems } from '../../hooks/useRecentItems';
 import { useFavorites } from '../../hooks/useFavorites';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
-import { useAgents, isBuildAgent, isAskAgent } from '@object-ui/plugin-chatbot';
+import { useAgents, isAskAgent, agentHasCapability } from '@object-ui/plugin-chatbot';
 import { HomeAppsStrip } from './HomeAppsStrip';
 import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
@@ -55,7 +55,8 @@ function useHomeAiAvailability(): {
   return {
     aiEnabled: agents.length > 0,
     askAvailable: agents.some((a) => isAskAgent(a.name)),
-    buildAvailable: agents.some((a) => isBuildAgent(a.name)),
+    // cloud#816 — authoring availability by DECLARED capability (name-check fallback inside).
+    buildAvailable: agents.some((a) => agentHasCapability(agents, a.name, 'authoring')),
   };
 }
 

--- a/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
+++ b/packages/app-shell/src/layout/ConsoleFloatingChatbot.tsx
@@ -21,6 +21,7 @@ import {
   uiMessagesToChatMessages,
   publishHealthFromResponse,
   agentRouteName,
+  agentHasCapability,
   type ChatMessage,
   type AgentDescriptor,
 } from '@object-ui/plugin-chatbot';
@@ -948,8 +949,9 @@ export default function ConsoleFloatingChatbot({
   // drafts + the awaiting-confirm plan would otherwise be orphaned on reload);
   // the ASK/data surface opens a fresh thread each visit (each question is
   // largely self-contained, and resuming stale data answers is confusing). See
-  // `resumeMode` in useChatConversation.
-  const isBuildAgent = activeAgent ? agentRouteName(activeAgent) === 'build' : false;
+  // `resumeMode` in useChatConversation. cloud#816: decided by the agent's
+  // DECLARED `resume` capability (legacy name-check fallback inside the helper).
+  const agentResumes = agentHasCapability(agents, activeAgent, 'resume');
 
   // Server-backed conversation. Scoped by agent so each agent gets its own
   // persistent history. Hook is inert until `userId` is provided; without it
@@ -960,7 +962,7 @@ export default function ConsoleFloatingChatbot({
     userId: activeAgent ? userId : undefined,
     scope: activeAgent,
     apiBase,
-    resumeMode: isBuildAgent ? 'resume' : 'fresh',
+    resumeMode: agentResumes ? 'resume' : 'fresh',
   });
 
   // `key` forces a clean remount whenever the chat endpoint OR the resolved

--- a/packages/plugin-chatbot/src/__tests__/agentCapabilities.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/agentCapabilities.test.ts
@@ -1,0 +1,47 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * cloud#816 / ADR-0057 "B+" — hosts render agent behavior (debug drawer, Live
+ * Canvas, resume-vs-fresh) by the server-DECLARED `capabilities`, falling back
+ * to the legacy `isBuildAgent(name)` check when the catalog entry carries none
+ * (older server) — so shipping order between cloud and console doesn't matter.
+ */
+import { describe, it, expect } from 'vitest';
+import { agentHasCapability, type AgentDescriptor } from '../useAgents';
+
+const withCaps = (name: string, on: boolean): AgentDescriptor => ({
+  name,
+  label: name,
+  capabilities: { authoring: on, canvas: on, debug: on, resume: on },
+});
+
+describe('agentHasCapability', () => {
+  it('uses DECLARED capabilities when present — even against the name heuristic', () => {
+    // A skill-driven build variant with a non-"build" name still gets behavior…
+    const variant: AgentDescriptor = {
+      name: 'app_author_v2',
+      label: 'Author',
+      capabilities: { authoring: true, canvas: true, debug: false, resume: true },
+    };
+    expect(agentHasCapability([variant], 'app_author_v2', 'authoring')).toBe(true);
+    expect(agentHasCapability([variant], 'app_author_v2', 'debug')).toBe(false);
+    // …and a declared-off `build` beats the name check (declaration wins).
+    expect(agentHasCapability([withCaps('build', false)], 'build', 'debug')).toBe(false);
+  });
+
+  it('falls back to isBuildAgent(name) when capabilities are absent (older server)', () => {
+    const legacy: AgentDescriptor[] = [
+      { name: 'build', label: 'Build' },
+      { name: 'ask', label: 'Ask' },
+    ];
+    expect(agentHasCapability(legacy, 'build', 'debug')).toBe(true);
+    expect(agentHasCapability(legacy, 'ask', 'debug')).toBe(false);
+    // Alias-aware fallback (legacy id).
+    expect(agentHasCapability([], 'metadata_assistant', 'resume')).toBe(true);
+  });
+
+  it('no name → no capability', () => {
+    expect(agentHasCapability([withCaps('build', true)], undefined, 'debug')).toBe(false);
+  });
+});

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -249,11 +249,12 @@ export { useObjectChat } from './useObjectChat';
 export type { UseObjectChatOptions, UseObjectChatReturn } from './useObjectChat';
 
 // Export the agent catalog hook (talks to @objectstack/service-ai)
-export { useAgents, resolveDefaultAgentName, PLATFORM_DEFAULT_AGENT } from './useAgents';
+export { useAgents, resolveDefaultAgentName, PLATFORM_DEFAULT_AGENT, agentHasCapability } from './useAgents';
 export type {
   UseAgentsOptions,
   UseAgentsReturn,
   AgentDescriptor,
+  AgentCapabilities,
 } from './useAgents';
 
 // Export the AI-model picker allowlist hook (ADR-0028; GET /api/v1/ai/models).

--- a/packages/plugin-chatbot/src/useAgents.ts
+++ b/packages/plugin-chatbot/src/useAgents.ts
@@ -11,7 +11,25 @@
  */
 
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { resolveAgentParam } from './agentAliases';
+import { resolveAgentParam, isBuildAgent } from './agentAliases';
+
+/**
+ * cloud#816 / ADR-0057 "B+" — per-agent capabilities DECLARED by the server
+ * (`GET /api/v1/ai/agents`), so hosts render agent-specific behavior (debug
+ * drawer, Live Canvas, resume-vs-fresh) by capability instead of hard-coded
+ * `isBuildAgent(name)` checks. Optional: older servers omit it, and consumers
+ * fall back to the name check via {@link agentHasCapability}.
+ */
+export interface AgentCapabilities {
+  /** Authors app metadata — the Builder product. */
+  authoring: boolean;
+  /** Drives the ADR-0037 Live Canvas split view. */
+  canvas: boolean;
+  /** Exposes the build-doctor debug drawer. */
+  debug: boolean;
+  /** Turns resume durable multi-step runs. */
+  resume: boolean;
+}
 
 export interface AgentDescriptor {
   /** Stable identifier used in the chat URL (e.g. "sales_assistant"). */
@@ -24,6 +42,8 @@ export interface AgentDescriptor {
   role?: string;
   /** Whether this agent is currently active on the server. */
   active?: boolean;
+  /** Declared capabilities (cloud#816); absent on older servers. */
+  capabilities?: AgentCapabilities;
 }
 
 export interface UseAgentsOptions {
@@ -53,7 +73,37 @@ interface RawAgent {
   description?: string;
   role?: string;
   active?: boolean;
+  capabilities?: Partial<Record<keyof AgentCapabilities, unknown>>;
   [key: string]: unknown;
+}
+
+/** Coerce a served `capabilities` object to strict booleans; undefined if absent. */
+function normalizeCapabilities(raw: RawAgent['capabilities']): AgentCapabilities | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  return {
+    authoring: raw.authoring === true,
+    canvas: raw.canvas === true,
+    debug: raw.debug === true,
+    resume: raw.resume === true,
+  };
+}
+
+/**
+ * Whether `name`'s agent declares `cap` (cloud#816). Falls back to the legacy
+ * `isBuildAgent(name)` name check when the catalog entry carries no
+ * `capabilities` (older server) or the agent isn't in the list yet — so
+ * behavior is unchanged until the server ships the field, and degrades the
+ * same way afterwards.
+ */
+export function agentHasCapability(
+  agents: readonly AgentDescriptor[],
+  name: string | undefined,
+  cap: keyof AgentCapabilities,
+): boolean {
+  if (!name) return false;
+  const found = agents.find((a) => a.name === name);
+  if (found?.capabilities) return found.capabilities[cap];
+  return isBuildAgent(name);
 }
 
 /**
@@ -108,6 +158,7 @@ function normalize(raw: RawAgent[]): AgentDescriptor[] {
       description: a.description,
       role: a.role,
       active: a.active !== false,
+      capabilities: normalizeCapabilities(a.capabilities),
     }));
 }
 


### PR DESCRIPTION
Three related ADR-0057 items in one reviewable set (companion backend: objectstack-ai/cloud#821, merge-order independent but pair-merged):

## 1. Closes #2450 — second handoff's auto-send died in the stale-scope pane
Root cause (sharper than the issue's hypothesis): mid ask→build transition,
`useChatConversation` briefly still holds the OLD scope's conversation id — the
exact window the URL-mirror already guards (`conversationScope !== chatScope`)
— but `<ChatPane>` was fed the RAW id. A doomed pane (build chatApi + stale ask
id, about to remount) could mount, and the deferred first-send replay consumed
the handoff stash into it; the send died with the unmount before reaching the
wire. Live symptom: conversation resumes, **zero `…/chat` POST**.

- **Scope-gated pane feed (structural)**: the pane now receives id/messages only
  when `conversationScope === chatScope`; during the window it mounts as
  `…:pending`, holds the stash, and replays once in the correctly-scoped pane.
- **Targeted stash (defense-in-depth)**: the handoff seed is stamped
  `targetAgentRoute:'build'`; `useDeferredFirstSend` refuses to consume a
  targeted stash in a pane bound to another agent. Untargeted user sends keep
  consume-anywhere behavior.

Per product decision: a second handoff landing on an Awaiting-Approval blueprint
just auto-sends; the agent sees the pending plan in context.

## 2. cloud#816 consumption — render behavior by declared capability
`AgentDescriptor.capabilities` + `agentHasCapability(agents, name, cap)`
(declaration wins; falls back to `isBuildAgent(name)` when absent, so it works
against older servers). Applied to the behavior sites: build-doctor drawer +
`showDebug` → `'debug'`, FAB resume-vs-fresh → `'resume'`, HomePage "Build with
AI" availability → `'authoring'`. Product-axis sites (P2 resolver, conversation
scope keying, picker availability) intentionally stay name-based.

## 3. ADR-0057 doc — decisions recorded, Status → Accepted
Open questions 1–3 decided (chat right-dock; FAB = collapsed affordance;
explicit handoff shipped); Status reflects P1/P2/P4 shipped + P3 planned
([implementation plan](https://github.com/objectstack-ai/objectui/issues/2409#issuecomment-4958265739)).

## Tests
32/32 across `useDeferredFirstSend` (held-then-replayed across re-bind),
`useObjectChat.handoffContext`, new `agentCapabilities` (declared-wins /
fallback / alias-aware), `agentAliases`, `FloatingChatbot`; plugin-chatbot +
app-shell package builds (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)