### PR TITLE
fix(form): honor field widget hint on the section-layout path

### DIFF
--- a/.changeset/form-widget-hint-section-fallback.md
+++ b/.changeset/form-widget-hint-section-fallback.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/components": patch
+---
+
+Form fields honor their object-schema `widget` render hint on the field-group /
+section layout path. `ObjectForm` renders objects that declare field groups
+(e.g. `sys_sharing_rule`) via an auto-derived section layout that passed each
+field's metadata through without hoisting its `widget` override to the top-level
+form-field config, so a field with `widget: 'object-ref'` (or `filter-condition`
+/ `recipient-picker`) degraded to its bare `type` input — an admin was asked to
+hand-type an object name instead of picking it. The form renderer now falls back
+to the field metadata's own `widget` when no top-level override is present, so
+the pickers render on sectioned forms just as they do on flat ones.

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -752,8 +752,16 @@ ComponentRegistry.register('form',
                 // Use field.id or field.name for stable keys (never use index alone)
                 const fieldKey = field.id ?? name;
 
-                // Resolve the component type: prefer widget override, fallback to field type
-                const resolvedType = widget || type;
+                // Resolve the component type: prefer an explicit form-config
+                // `widget`, then the object-schema field's own `widget` render
+                // hint (carried on the field metadata, e.g. `object-ref`,
+                // `filter-condition`, `recipient-picker`), then the bare `type`.
+                // The nested-metadata fallback matters because some field
+                // builders (e.g. the field-group/section layout path in
+                // ObjectForm) pass the field metadata through without hoisting
+                // its `widget` to the top-level form-config, which would
+                // otherwise degrade a picker field to its raw `type` input.
+                const resolvedType = widget || (fieldProps as any).field?.widget || type;
 
                 // Cascading / role-gated option lists (#2284). For option fields,
                 // narrow the set by each option's `visibleWhen` (evaluated against


### PR DESCRIPTION
## Problem

On the Setup "New Sharing Rule" form (`/_console/apps/com.objectstack.setup/sys_sharing_rule?form=new`), the **Object** field rendered as a plain free-text input instead of the intended object picker — the admin still had to hand-type a machine object name. Same for **Criteria** (`filter-condition`) and **Recipient** (`recipient-picker`).

The picker widgets ship and are registered (`field:object-ref`, `field:filter-condition`, `field:recipient-picker`), and the backend metadata correctly carries `widget: 'object-ref'` on the field — yet the form ignored the hint.

## Root cause

`ObjectForm` renders objects that declare **field groups** (like `sys_sharing_rule`) via an **auto-derived section layout**. That path passes each field's metadata through to the form renderer but does **not** hoist the field's `widget` override to the top-level form-field config. The renderer resolved the component as `widget || type`, so with the top-level `widget` missing it fell back to the bare `type` renderer — a picker field degraded to a plain text/textarea input.

Flat (schema-order) forms already carried the top-level `widget`, which is why the bug only showed on grouped objects.

## Fix

Resolve the component type as `widget || field.widget || type` in the form renderer, so the object-schema render hint carried on the field metadata is honored even when a builder doesn't lift it to the top level. Flat forms are unaffected (they already set the top-level widget); only the previously-degraded section path changes.

## Verification (in-browser)

Ran the running Console against a live backend and walked the React fiber for every field on the sys_sharing_rule create form:

| field | metadata `widget` | before | after |
|---|---|---|---|
| object_name | object-ref | TextField | **ObjectRefField** |
| criteria_json | filter-condition | TextAreaField | **FilterConditionField** |
| recipient_id | recipient-picker | TextField | **RecipientPickerField** |

Non-widget fields are unchanged (name/label → TextField, recipient_type/access_level → SelectField). Visually, **Object** now shows a "Select an object" dropdown; **Criteria**/**Recipient** show their dependent-field gates ("Select an object first." / "Select a recipient type first.").

## Changes

- `packages/components/src/renderers/form/form.tsx`: widget-hint fallback to field metadata.
- `.changeset/form-widget-hint-section-fallback.md`: `@object-ui/components` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cdr2R5KEjuNWv3ywvufj35)_