### PR TITLE
feat(plugin-gantt): summaryExtent 'self' 修复汇总条拖动回弹 + 无 schema 时 tooltip 兜底格式化

### DIFF
--- a/packages/plugin-gantt/src/GanttView.tree.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.tree.test.tsx
@@ -220,6 +220,55 @@ function renderViewWith(tasks: GanttTask[], extra: Record<string, unknown> = {})
   );
 }
 
+describe('GanttView summaryExtent (汇总条区间)', () => {
+  it("'self' renders the summary bar from its OWN dates and progress, not the children rollup", () => {
+    const tasks = [
+      makeTask('p', '2024-06-05T00:00:00.000Z', '2024-06-06T00:00:00.000Z', { progress: 30, hasOwnDates: true }),
+      makeTask('c1', '2024-06-05T00:00:00.000Z', '2024-06-08T00:00:00.000Z', { parent: 'p', progress: 100 }),
+      makeTask('c2', '2024-06-10T00:00:00.000Z', '2024-06-14T00:00:00.000Z', { parent: 'p', progress: 50 }),
+      // Same span as p's own dates, for geometry comparison.
+      makeTask('ref', '2024-06-05T00:00:00.000Z', '2024-06-06T00:00:00.000Z'),
+    ];
+    const { container } = renderViewWith(tasks, { summaryExtent: 'self' });
+    const summary = container.querySelector('[data-testid="gantt-summary-bar-p"]') as HTMLElement;
+    const ref = container.querySelector('[data-testid="gantt-task-bar-ref"]') as HTMLElement;
+    const s = geometry(summary);
+    const r = geometry(ref);
+    // Bar sits exactly on the summary's own 06-05..06-06 window…
+    expect(s.left).toBeCloseTo(r.left, 0);
+    expect(s.left + s.width).toBeCloseTo(r.left + r.width, 0);
+    // …and progress is the record's own, not the weighted child average (71).
+    expect(summary.getAttribute('data-progress')).toBe('30');
+  });
+
+  it("'self' falls back to children rollup for summaries flagged hasOwnDates:false", () => {
+    const tasks = [
+      makeTask('p', '2024-06-05T00:00:00.000Z', '2024-06-05T00:00:00.000Z', { hasOwnDates: false }),
+      makeTask('c1', '2024-06-05T00:00:00.000Z', '2024-06-08T00:00:00.000Z', { parent: 'p' }),
+      makeTask('c2', '2024-06-10T00:00:00.000Z', '2024-06-14T00:00:00.000Z', { parent: 'p' }),
+    ];
+    const { container } = renderViewWith(tasks, { summaryExtent: 'self' });
+    const summary = container.querySelector('[data-testid="gantt-summary-bar-p"]') as HTMLElement;
+    const c1 = geometry(container.querySelector('[data-testid="gantt-task-bar-c1"]') as HTMLElement);
+    const c2 = geometry(container.querySelector('[data-testid="gantt-task-bar-c2"]') as HTMLElement);
+    const s = geometry(summary);
+    expect(s.left).toBeCloseTo(c1.left, 0);
+    expect(s.left + s.width).toBeCloseTo(c2.left + c2.width, 0);
+  });
+
+  it("default ('children') keeps the rollup even when tasks carry hasOwnDates", () => {
+    const tasks = [
+      makeTask('p', '2024-06-05T00:00:00.000Z', '2024-06-06T00:00:00.000Z', { hasOwnDates: true }),
+      makeTask('c1', '2024-06-05T00:00:00.000Z', '2024-06-08T00:00:00.000Z', { parent: 'p' }),
+      makeTask('c2', '2024-06-10T00:00:00.000Z', '2024-06-14T00:00:00.000Z', { parent: 'p' }),
+    ];
+    const { container } = renderViewWith(tasks);
+    const summary = geometry(container.querySelector('[data-testid="gantt-summary-bar-p"]') as HTMLElement);
+    const c2 = geometry(container.querySelector('[data-testid="gantt-task-bar-c2"]') as HTMLElement);
+    expect(summary.left + summary.width).toBeCloseTo(c2.left + c2.width, 0);
+  });
+});
+
 describe('GanttView group nodes (无条 tree headers)', () => {
   it('renders type:group rows with no bar but keeps the expand toggle', () => {
     const { container } = renderViewWith(manufacturingTree());

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -172,6 +172,12 @@ export interface GanttTask {
    * line in the tooltip.
    */
   fields?: Array<{ label: string; value: string }>
+  /**
+   * Whether `start`/`end` came from real record data (true / undefined) or are
+   * placeholders fabricated for date-less records (false). Only consulted by
+   * `summaryExtent: 'self'`, which falls back to child rollup when false.
+   */
+  hasOwnDates?: boolean
 }
 
 /** Timeline granularity — one column per day, week, month, or quarter. */
@@ -365,6 +371,16 @@ export interface GanttViewProps {
    */
   defaultCollapsedDepth?: number
   /**
+   * How a summary bar's span is computed (汇总条区间). `'children'` (default)
+   * rolls up from the children — min start / max end / duration-weighted
+   * progress — ignoring the summary task's own dates. `'self'` draws the bar
+   * from the task's OWN start/end/progress; tasks flagged `hasOwnDates: false`
+   * still roll up (pure grouping levels have no dates of their own). In `'self'`
+   * mode ancestor bars also stop live-stretching while a child is dragged,
+   * since their extent no longer depends on the children.
+   */
+  summaryExtent?: 'children' | 'self'
+  /**
    * Persist the user's layout tweaks (granularity + column/task-list widths)
    * to `localStorage` under this key. On mount the saved layout is restored;
    * the "保存布局" toolbar button writes the current layout. Omit to disable
@@ -541,6 +557,7 @@ export function GanttView({
   groupBy,
   ungroupedLabel = 'Ungrouped',
   defaultCollapsedDepth,
+  summaryExtent = 'children',
   persistLayoutKey,
   onLayoutChange,
   onRefresh,
@@ -1394,7 +1411,13 @@ export function GanttView({
       const children = byParent.get(key) ?? [];
       const hasChildren = children.length > 0;
       const isSummary = hasChildren || t.type === 'summary';
-      const eff = hasChildren
+      // summaryExtent 'self': the summary's own dates are authoritative — the
+      // bar renders (and survives refetch at) exactly what the record says.
+      // Date-less summaries (hasOwnDates === false, e.g. pure grouping levels)
+      // still roll up from their children.
+      const usesSelfExtent =
+        hasChildren && summaryExtent === 'self' && t.hasOwnDates !== false;
+      const eff = hasChildren && !usesSelfExtent
         ? rollup(t, new Set())
         : { start: t.start, end: t.end, progress: t.progress };
       const isMilestone =
@@ -1413,7 +1436,7 @@ export function GanttView({
     // at the bottom rather than dropping rows silently.
     for (const t of displayTasks) if (!visited.has(String(t.id))) walk(t, 0);
     return out;
-  }, [displayTasks, collapsedIds]);
+  }, [displayTasks, collapsedIds, summaryExtent]);
 
   const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
@@ -2250,7 +2273,13 @@ export function GanttView({
         const previewed = computeDragChanges(dragState);
         return styleFor(previewed.start, previewed.end);
       }
-      if (row.isSummary && dragStretchAncestorIds?.has(String(row.task.id))) {
+      if (
+        row.isSummary &&
+        dragStretchAncestorIds?.has(String(row.task.id)) &&
+        // Self-extent summaries don't stretch with their children — their bar
+        // is pinned to their own dates, which a child drag doesn't change.
+        !(summaryExtent === 'self' && row.task.hasOwnDates !== false)
+      ) {
         // Re-roll this ancestor's span over its leaf descendants, substituting
         // the dragged leaf's previewed dates. Summary tasks' own start/end are
         // ignored (they may be placeholders); only leaves define the extent.

--- a/packages/plugin-gantt/src/ObjectGantt.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.test.tsx
@@ -9,12 +9,12 @@ import { DataSource } from '@object-ui/types';
 // for "Create", "View", and "Delete" so CRUD wiring can be unit-tested
 // without rendering the full timeline.
 vi.mock('./GanttView', () => ({
-  GanttView: ({ tasks, onTaskClick, onTaskUpdate, onTaskDelete, onDependencyCreate, onDependencyDelete, rescheduleOnConflict, persistLayoutKey, mobileReadOnly, defaultCollapsedDepth }: any) => {
+  GanttView: ({ tasks, onTaskClick, onTaskUpdate, onTaskDelete, onDependencyCreate, onDependencyDelete, rescheduleOnConflict, persistLayoutKey, mobileReadOnly, defaultCollapsedDepth, summaryExtent }: any) => {
     const byId = (id: any) => tasks.find((t: any) => String(t.id) === String(id));
     return (
-      <div data-testid="gantt-view" data-reschedule-on-conflict={String(!!rescheduleOnConflict)} data-persist-layout-key={persistLayoutKey || ''} data-mobile-readonly={String(!!mobileReadOnly)} data-default-collapsed-depth={defaultCollapsedDepth == null ? '' : String(defaultCollapsedDepth)}>
+      <div data-testid="gantt-view" data-reschedule-on-conflict={String(!!rescheduleOnConflict)} data-persist-layout-key={persistLayoutKey || ''} data-mobile-readonly={String(!!mobileReadOnly)} data-default-collapsed-depth={defaultCollapsedDepth == null ? '' : String(defaultCollapsedDepth)} data-summary-extent={summaryExtent ?? ''}>
         {tasks.map((t: any) => (
-          <div key={t.id} data-testid="gantt-task" data-type={t.type ?? ''} data-locked={String(!!t.locked)} data-border-color={t.borderColor ?? ''}>
+          <div key={t.id} data-testid="gantt-task" data-type={t.type ?? ''} data-locked={String(!!t.locked)} data-border-color={t.borderColor ?? ''} data-has-own-dates={String(t.hasOwnDates)}>
             <span>{t.title}</span>
             {t.fields ? (
               <div data-testid={`gv-fields-${t.id}`}>
@@ -177,6 +177,87 @@ describe('ObjectGantt', () => {
     expect(screen.getByTestId('gv-field-1-0').textContent).toBe('执行责任人=班组长-测, 操作工-测');
     // Array of scalars → joined as-is.
     expect(screen.getByTestId('gv-field-1-1').textContent).toBe('Tags=a, b');
+  });
+
+  it('falls back to quickFilters labels + ISO date sniffing when there is no object schema (api provider)', async () => {
+    // The api provider returns records but no object schema, so tooltip fields
+    // have no defs: machine values and raw ISO strings used to leak through.
+    const schema: any = {
+      type: 'gantt',
+      gantt: {
+        titleField: 'name', startDateField: 'start_date', endDateField: 'end_date',
+        tooltipFields: [
+          { field: 'node_type', label: '层级' },
+          { field: 'status', label: '状态' },
+          { field: 'start_date', label: '计划开始' },
+          { field: 'due_day', label: '截止日' },
+        ],
+        quickFilters: [
+          { field: 'node_type', options: [{ value: 'dispatch', label: '派工单' }, { value: 'plan', label: '排班计划' }] },
+          { field: 'status', options: [{ value: 'completed', label: '已完成' }, { value: 'in_progress', label: '进行中' }] },
+        ],
+      },
+      data: {
+        provider: 'value',
+        items: [{
+          id: '1', name: 'D1', node_type: 'dispatch', status: 'completed',
+          start_date: '2026-08-14T08:00:00.000Z', end_date: '2026-08-16T20:00:00.000Z',
+          due_day: '2026-08-20',
+        }],
+      },
+    };
+    render(<ObjectGantt schema={schema} />);
+    await waitFor(() => expect(screen.getByTestId('gv-fields-1')).toBeDefined());
+
+    // Quick-filter options double as the value→label map.
+    expect(screen.getByTestId('gv-field-1-0').textContent).toBe('层级=派工单');
+    expect(screen.getByTestId('gv-field-1-1').textContent).toBe('状态=已完成');
+    // ISO datetime string is formatted, not echoed raw.
+    const startText = screen.getByTestId('gv-field-1-2').textContent!;
+    expect(startText).not.toContain('T08:00');
+    expect(startText).not.toContain('Z');
+    expect(startText).toContain('2026');
+    // ISO date-only string formats through the date formatter.
+    expect(screen.getByTestId('gv-field-1-3').textContent).not.toContain('2026-08-20T');
+  });
+
+  it('marks tasks with hasOwnDates and forwards summaryExtent to GanttView', async () => {
+    const schema: any = {
+      type: 'gantt',
+      gantt: {
+        titleField: 'name', startDateField: 'start_date', endDateField: 'end_date',
+        typeField: 'gantt_type', summaryExtent: 'self',
+      },
+      data: {
+        provider: 'value',
+        items: [
+          { id: 'grp', name: 'Project', gantt_type: 'group' }, // date-less grouping level
+          { id: 'plan', name: 'Plan', gantt_type: 'summary', parent: 'grp', start_date: '2024-01-01', end_date: '2024-01-05' },
+        ],
+      },
+    };
+    render(<ObjectGantt schema={schema} />);
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeDefined());
+
+    expect(screen.getByTestId('gantt-view').getAttribute('data-summary-extent')).toBe('self');
+    const [grp, plan] = screen.getAllByTestId('gantt-task');
+    expect(grp.getAttribute('data-has-own-dates')).toBe('false');
+    expect(plan.getAttribute('data-has-own-dates')).toBe('true');
+  });
+
+  it('forwards summaryExtent from top-level (flattened ListView) config too', async () => {
+    // The console's ListView spreads view.gantt keys at the TOP level of the
+    // object-gantt schema, which getGanttConfig re-picks key by key — a new
+    // key missing from that pick list silently vanishes on the console path.
+    const schema: any = {
+      type: 'object-gantt',
+      titleField: 'name', startDateField: 'start_date', endDateField: 'end_date',
+      summaryExtent: 'self',
+      data: { provider: 'value', items: [{ id: '1', name: 'T', start_date: '2024-01-01', end_date: '2024-01-02' }] },
+    };
+    render(<ObjectGantt schema={schema} />);
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeDefined());
+    expect(screen.getByTestId('gantt-view').getAttribute('data-summary-extent')).toBe('self');
   });
 
   it('omits tooltip fields when none configured', async () => {

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -97,6 +97,17 @@ type GanttConfigEx = GanttConfig & {
    */
   lockField?: string;
   /**
+   * How a summary bar's span is computed (汇总条区间). `'children'` (default)
+   * rolls the bar up from its children — min start / max end / duration-weighted
+   * progress — and IGNORES the record's own dates. `'self'` renders the bar from
+   * the record's OWN start/end/progress (自身日期为准), falling back to rollup
+   * only for records without dates (e.g. pure grouping levels). Use `'self'`
+   * when the parent's schedule is authoritative — e.g. 排班计划 whose 派工单
+   * children are locked history: under rollup, dragging the plan persists its
+   * own dates but the bar snaps back to the children's extent on refetch.
+   */
+  summaryExtent?: 'children' | 'self';
+  /**
    * Auto-collapse tree nodes at/below this 0-indexed depth on first render
    * (默认折叠). Roots are depth 0. Every node at depth `>= defaultCollapsedDepth`
    * with children starts folded; the user can still expand them. Example: a
@@ -292,6 +303,7 @@ function getGanttConfig(schema: ObjectGridSchema | any): GanttConfigEx | null {
           parentField: schema.parentField,
           typeField: schema.typeField,
           lockField: schema.lockField,
+          summaryExtent: schema.summaryExtent,
           defaultCollapsedDepth: schema.defaultCollapsedDepth,
           tooltipFields: schema.tooltipFields,
           baselineStartField: schema.baselineStartField,
@@ -449,8 +461,24 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       return [];
     }
 
-    const { startDateField, endDateField, titleField, progressField, dependenciesField, colorField, borderColorField, parentField, typeField, lockField, tooltipFields, baselineStartField, baselineEndField } = ganttConfig;
+    const { startDateField, endDateField, titleField, progressField, dependenciesField, colorField, borderColorField, parentField, typeField, lockField, tooltipFields, baselineStartField, baselineEndField, quickFilters } = ganttConfig;
     const fieldDefs: Record<string, any> = objectSchema?.fields ?? {};
+
+    // Fallback value→label maps from the view's quickFilters config. When the
+    // data comes from an `api` provider there is no object schema, so select
+    // fields have no option defs — but the same view often declares the exact
+    // label pairs as quick-filter options (e.g. status: completed→已完成).
+    // Reuse them so the tooltip shows display labels, not raw machine values.
+    const quickFilterLabels = new Map<string, Map<string, string>>();
+    for (const qf of quickFilters ?? []) {
+      if (!qf?.field || !Array.isArray(qf.options) || !qf.options.length) continue;
+      const m = new Map<string, string>();
+      for (const opt of qf.options) {
+        if (typeof opt === 'string') m.set(opt, opt);
+        else if (opt && opt.value != null) m.set(String(opt.value), opt.label ?? String(opt.value));
+      }
+      if (m.size) quickFilterLabels.set(qf.field, m);
+    }
 
     // Resolve a value through nested paths like "account.name". Returns the
     // first non-empty string from the path (so lookups that resolve to either a
@@ -510,6 +538,20 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       if (Array.isArray(options) && options.length) {
         const opt = options.find((o) => String(o.value) === String(value));
         if (opt) return opt.label;
+      }
+      // No schema options (api provider has no object schema) → quick-filter
+      // options declared for the same field carry the display labels.
+      if (typeof value !== 'object') {
+        const qfLabel = quickFilterLabels.get(fieldName)?.get(String(value));
+        if (qfLabel != null) return qfLabel;
+      }
+      // No field def at all → sniff ISO date / datetime strings so raw
+      // `2026-08-14T08:00:00.000Z` payloads still format like real date fields.
+      if (type == null && typeof value === 'string') {
+        if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return formatDate(value);
+        if (/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(value) && !isNaN(new Date(value).getTime())) {
+          return formatDateTime(value);
+        }
       }
       switch (type) {
         case 'date':
@@ -607,6 +649,9 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         title,
         start: startDate ? new Date(startDate) : new Date(),
         end: endDate ? new Date(endDate) : new Date(),
+        // Whether the record carried real dates (vs the placeholder "today"
+        // above) — summaryExtent:'self' falls back to rollup when it didn't.
+        hasOwnDates: !!(startDate && endDate),
         progress: Math.min(100, Math.max(0, progress || 0)), // Clamp between 0-100
         dependencies: normalizeDependencies(dependencies),
         parent: parentField ? record[parentField] ?? null : undefined,
@@ -1173,6 +1218,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           }
           groupBy={groupByAccessor}
           defaultCollapsedDepth={ganttConfig?.defaultCollapsedDepth}
+          summaryExtent={ganttConfig?.summaryExtent}
           inlineEdit
           onRefresh={
             // Only meaningful when there's a live source to re-read (object or


### PR DESCRIPTION
Closes #2454

## 改动
### ① `summaryExtent: 'children' | 'self'`(默认 children,行为零变化)
- `'self'`:汇总条按记录**自身** start/end/progress 渲染;记录无日期(`hasOwnDates: false`,ObjectGantt 对无日期记录打标,如纯分组的项目/产品层)时仍回退子级 rollup。
- self 模式下,拖动子任务不再实时拉伸祖先条(祖先区间已不依赖子级)。
- `getGanttConfig` 顶层挑键清单补上 `summaryExtent`——console 的 ListView 把 view.gantt 平铺到顶层再逐键重挑,漏挑即静默丢失(与 #2448 的 data 透传同类坑,已加顶层路径回归测试)。

### ② tooltip 无 schema 兜底(api provider)
- 无字段 def 时:先查同字段 `quickFilters.options` 的 value→label 映射(dispatch→派工单、completed→已完成);
- 仍无类型时 ISO 日期/时间串自动走 formatDate/formatDateTime(不再裸吐 `2026-08-14T08:00:00.000Z`)。

## 修复的用户可见 bug(制造排班甘特真机)
- 计划条拖动 → PATCH 已持久化,但刷新后被锁定派工单的 rollup 拉回原位(自身日期静默漂移);
- 悬浮框:`层级 dispatch`、`状态 completed`、裸 ISO UTC 日期。

## 测试
- plugin-gantt 单测 21 文件 / 267 用例全绿(新增:self 自身区间/进度、hasOwnDates 回退、默认 children 不变、顶层挑键透传、quickFilters/ISO tooltip 兜底)。
- 下游真机(os-tianshun-ehr,本仓 console 构建产物):周视图拖计划条 +110px(1 列=7 天)→ PATCH 200 → 静默刷新后条形停在 +110px,服务端 08-14→08-21;派工单悬浮框全中文 + 本地化日期。截图与报告见 steedos-labs/os-project-titanwind-ehr#173。