### PR TITLE
feat(plugin-gantt): #2460 交互批次——行单击定位/双击详情、按日吸附拖拽、布局含收纳+筛选、移动端二维码、锁定提示

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -416,6 +416,7 @@ const en = {
       expand: 'Expand',
       collapse: 'Collapse',
       locate: 'Locate on timeline',
+      open: 'Open details',
     },
     aria: {
       taskList: 'Task list',
@@ -432,6 +433,14 @@ const en = {
       removeDependency: 'Remove dependency',
       noCandidates: 'No available tasks',
       searchTasks: 'Search tasks…',
+      qrcode: 'Mobile QR code',
+    },
+    qr: {
+      title: 'Open on mobile',
+      hint: 'Scan with a phone to open the details',
+      copy: 'Copy link',
+      copied: 'Copied',
+      close: 'Close',
     },
     delete: {
       title: 'Delete this task?',
@@ -463,6 +472,7 @@ const en = {
     },
     readOnly: 'Read-only',
     readOnlyHint: 'Editing is disabled for this view.',
+    lockedHint: 'No edit permission',
   },
   view: {
     editViewConfig: 'Edit view config',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -492,6 +492,7 @@ const zh = {
       expand: '展开',
       collapse: '收起',
       locate: '在甘特图上定位',
+      open: '打开详情',
     },
     aria: {
       taskList: '任务列表',
@@ -508,6 +509,14 @@ const zh = {
       removeDependency: '移除依赖',
       noCandidates: '无可用任务',
       searchTasks: '搜索任务…',
+      qrcode: '移动端二维码',
+    },
+    qr: {
+      title: '在手机上打开',
+      hint: '用手机扫码打开详情页',
+      copy: '复制链接',
+      copied: '已复制',
+      close: '关闭',
     },
     delete: {
       title: '删除此任务？',
@@ -539,6 +548,7 @@ const zh = {
     },
     readOnly: '只读',
     readOnlyHint: '此视图已禁用编辑。',
+    lockedHint: '无编辑权限',
   },
   view: {
     editViewConfig: '编辑视图配置',

--- a/packages/plugin-gantt/package.json
+++ b/packages/plugin-gantt/package.json
@@ -39,13 +39,15 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^14.6.0",
-    "lucide-react": "^1.24.0"
+    "lucide-react": "^1.24.0",
+    "qrcode": "^1.5.4"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@types/qrcode": "^1.5.6",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.3",

--- a/packages/plugin-gantt/src/GanttView.enhancements.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.enhancements.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * Tests for the #2460 interaction batch: row click model (单击=Focus 定位,
+ * 双击/「→」=详情), day-snap dragging in coarse granularities (周/月拖拽按日吸附),
+ * collapse-state persistence in 保存布局, the locked-row tooltip hint
+ * (无编辑权限), and the 移动端二维码 context-menu flow.
+ *
+ * Conventions match the other suites: innerWidth=1280 → columnWidth 110,
+ * rowHeight 40; window pointer events dispatched inside act().
+ */
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GanttView, type GanttTask, type GanttLayout } from './GanttView';
+
+// jsdom/happy-dom has no canvas; stub the encoder so the dialog resolves a src.
+vi.mock('qrcode', () => ({
+  toDataURL: vi.fn().mockResolvedValue('data:image/png;base64,STUB'),
+}));
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+  window.localStorage.clear();
+});
+
+function makeTask(id: string, start: string, end: string, extra: Partial<GanttTask> = {}): GanttTask {
+  return { id, title: `Task ${id}`, start: new Date(start), end: new Date(end), progress: 0, ...extra };
+}
+
+const A = () => makeTask('a', '2024-06-10T00:00:00.000Z', '2024-06-15T00:00:00.000Z');
+
+function renderView(tasks: GanttTask[], props: Partial<React.ComponentProps<typeof GanttView>> = {}) {
+  return render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView
+        tasks={tasks}
+        startDate={new Date('2024-06-01T00:00:00.000Z')}
+        endDate={new Date('2024-06-30T00:00:00.000Z')}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function pointer(type: string, clientX: number, clientY = 100) {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX,
+    clientY,
+    pointerType: 'mouse',
+    button: 0,
+    isPrimary: true,
+  } as PointerEventInit);
+}
+
+describe('GanttView row click model (单击=Focus, 双击/「→」=详情)', () => {
+  it('a single row click selects the row WITHOUT opening detail', () => {
+    const onTaskClick = vi.fn();
+    const { getByTestId } = renderView([A()], { onTaskClick });
+    const row = getByTestId('gantt-task-row-a');
+    act(() => { fireEvent.click(row); });
+    expect(onTaskClick).not.toHaveBeenCalled();
+    expect(row.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('double-click opens detail when inline edit is unavailable', () => {
+    const onTaskClick = vi.fn();
+    const { getByTestId } = renderView([A()], { onTaskClick });
+    act(() => { fireEvent.doubleClick(getByTestId('gantt-task-row-a')); });
+    expect(onTaskClick).toHaveBeenCalledTimes(1);
+    expect(onTaskClick.mock.calls[0][0].id).toBe('a');
+  });
+
+  it('double-click prefers inline edit over detail when editable', () => {
+    const onTaskClick = vi.fn();
+    const { getByTestId, container } = renderView([A()], {
+      onTaskClick,
+      onTaskUpdate: vi.fn(),
+      inlineEdit: true,
+    });
+    act(() => { fireEvent.doubleClick(getByTestId('gantt-task-row-a')); });
+    expect(onTaskClick).not.toHaveBeenCalled();
+    // The title input replaces the label while editing.
+    expect(container.querySelector('input[value="Task a"]')).toBeTruthy();
+  });
+
+  it('the row 「→」 button opens detail and only renders with onTaskClick', () => {
+    const onTaskClick = vi.fn();
+    const { getByTestId } = renderView([A()], { onTaskClick });
+    act(() => { fireEvent.click(getByTestId('gantt-row-open-a')); });
+    expect(onTaskClick).toHaveBeenCalledTimes(1);
+    expect(onTaskClick.mock.calls[0][0].id).toBe('a');
+
+    const { queryByTestId } = renderView([makeTask('z', '2024-06-10T00:00:00.000Z', '2024-06-15T00:00:00.000Z')]);
+    expect(queryByTestId('gantt-row-open-z')).toBeNull();
+  });
+});
+
+describe('GanttView coarse-granularity drag snaps by DAY (周/月拖拽按日吸附)', () => {
+  it('week view: +47px ≈ 3 day-steps, not a whole-week snap', () => {
+    const onTaskUpdate = vi.fn();
+    const { container } = renderView([A()], { onTaskUpdate, viewMode: 'week' });
+    const bar = container.querySelector('[data-testid="gantt-task-bar-a"]') as HTMLElement;
+    expect(bar).toBeTruthy();
+
+    // pxPerDay = 110 / 7 ≈ 15.71; +47px → round(2.99) = +3 days. A per-column
+    // snap would have produced 0 (round(47/110)) or a jump of ±7 days.
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 547)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 547)); });
+
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [task, changes] = onTaskUpdate.mock.calls[0];
+    expect(task.id).toBe('a');
+    expect(changes.start.toISOString()).toBe('2024-06-13T00:00:00.000Z');
+    expect(changes.end.toISOString()).toBe('2024-06-18T00:00:00.000Z');
+  });
+
+  it('month view: +11px ≈ 3 day-steps', () => {
+    const onTaskUpdate = vi.fn();
+    const { container } = renderView([A()], { onTaskUpdate, viewMode: 'month' });
+    const bar = container.querySelector('[data-testid="gantt-task-bar-a"]') as HTMLElement;
+
+    // pxPerDay = 110 / 30.44 ≈ 3.61; +11px → round(3.04) = +3 days.
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 511)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 511)); });
+
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [, changes] = onTaskUpdate.mock.calls[0];
+    expect(changes.start.toISOString()).toBe('2024-06-13T00:00:00.000Z');
+    expect(changes.end.toISOString()).toBe('2024-06-18T00:00:00.000Z');
+  });
+});
+
+describe('GanttView 保存布局 covers collapse state (收纳/展开)', () => {
+  const TREE = () => [
+    makeTask('p', '2024-06-03T00:00:00.000Z', '2024-06-20T00:00:00.000Z'),
+    makeTask('c', '2024-06-05T00:00:00.000Z', '2024-06-10T00:00:00.000Z', { parent: 'p' }),
+  ];
+
+  it('persists the collapsed set on save', () => {
+    const { getByTestId, queryByTestId } = renderView(TREE(), { persistLayoutKey: 'proj1' });
+    expect(queryByTestId('gantt-task-row-c')).toBeTruthy();
+    act(() => { fireEvent.click(getByTestId('gantt-row-toggle-p')); });
+    expect(queryByTestId('gantt-task-row-c')).toBeNull();
+    act(() => { fireEvent.click(getByTestId('gantt-save-layout')); });
+    const saved = JSON.parse(window.localStorage.getItem('gantt-layout:proj1')!) as GanttLayout;
+    expect(saved.collapsedIds).toEqual(['p']);
+  });
+
+  it('restores a persisted collapsed set on mount', () => {
+    window.localStorage.setItem(
+      'gantt-layout:proj2',
+      JSON.stringify({ viewMode: 'day', columnWidth: null, taskListCollapsed: false, collapsedIds: ['p'] } satisfies GanttLayout),
+    );
+    const { getByTestId, queryByTestId } = renderView(TREE(), { persistLayoutKey: 'proj2' });
+    expect(queryByTestId('gantt-task-row-c')).toBeNull();
+    // Expanding again brings the child back — the restored state is live.
+    act(() => { fireEvent.click(getByTestId('gantt-row-toggle-p')); });
+    expect(queryByTestId('gantt-task-row-c')).toBeTruthy();
+  });
+
+  it('a saved EMPTY collapse state beats defaultCollapsedDepth', () => {
+    // Control: without a snapshot, depth-0 default collapse hides the child.
+    const first = renderView(TREE(), { persistLayoutKey: 'proj3', defaultCollapsedDepth: 0 });
+    expect(first.queryByTestId('gantt-task-row-c')).toBeNull();
+    first.unmount();
+
+    window.localStorage.setItem(
+      'gantt-layout:proj3',
+      JSON.stringify({ viewMode: 'day', columnWidth: null, taskListCollapsed: false, collapsedIds: [] } satisfies GanttLayout),
+    );
+    const second = renderView(TREE(), { persistLayoutKey: 'proj3', defaultCollapsedDepth: 0 });
+    expect(second.queryByTestId('gantt-task-row-c')).toBeTruthy();
+  });
+});
+
+describe('GanttView locked-row tooltip hint (无编辑权限)', () => {
+  it('shows the locked hint in the hover tooltip for locked tasks only', () => {
+    const tasks = [
+      makeTask('a', '2024-06-03T00:00:00.000Z', '2024-06-08T00:00:00.000Z', { locked: true }),
+      makeTask('b', '2024-06-10T00:00:00.000Z', '2024-06-15T00:00:00.000Z'),
+    ];
+    const { container } = renderView(tasks);
+
+    fireEvent.mouseEnter(container.querySelector('[data-testid="gantt-task-bar-a"]')!);
+    const hint = container.querySelector('[data-testid="gantt-tooltip-locked-a"]') as HTMLElement;
+    expect(hint).toBeTruthy();
+    expect(hint.textContent).toContain('No edit permission');
+    fireEvent.mouseLeave(container.querySelector('[data-testid="gantt-task-bar-a"]')!);
+
+    fireEvent.mouseEnter(container.querySelector('[data-testid="gantt-task-bar-b"]')!);
+    expect(container.querySelector('[data-testid="gantt-tooltip-locked-b"]')).toBeNull();
+  });
+});
+
+describe('GanttView 移动端二维码 (context-menu QR share)', () => {
+  const URL_A = 'https://app.example.com/app/x/rec/record/a';
+  const ctxMenu = () => document.querySelector('[data-testid="gantt-context-menu"]');
+  const qrItem = () => document.querySelector('[data-testid="gantt-context-menu-qrcode"]');
+  const dialog = () => document.querySelector('[data-testid="gantt-qr-dialog"]');
+
+  it('offers the QR item only when taskUrl yields a URL', () => {
+    // taskUrl → null with other actions present: menu opens, QR item hidden.
+    const { container, unmount } = renderView([A()], { taskUrl: () => null, onTaskClick: vi.fn() });
+    fireEvent.contextMenu(container.querySelector('[data-testid="gantt-task-bar-a"]')!, { clientX: 10, clientY: 10 });
+    expect(ctxMenu()).toBeTruthy();
+    expect(qrItem()).toBeNull();
+    unmount();
+
+    // No taskUrl at all: no QR item.
+    const { container: c2, unmount: u2 } = renderView([A()], { onTaskClick: vi.fn() });
+    fireEvent.contextMenu(c2.querySelector('[data-testid="gantt-task-bar-a"]')!, { clientX: 10, clientY: 10 });
+    expect(qrItem()).toBeNull();
+    u2();
+
+    // taskUrl alone (read-only view) still opens the menu with the QR item.
+    const { container: c3 } = renderView([A()], { taskUrl: () => URL_A });
+    fireEvent.contextMenu(c3.querySelector('[data-testid="gantt-task-bar-a"]')!, { clientX: 10, clientY: 10 });
+    expect(qrItem()).toBeTruthy();
+  });
+
+  it('opens no empty menu when taskUrl is the only action and yields null', () => {
+    const { container } = renderView([A()], { taskUrl: () => null });
+    fireEvent.contextMenu(container.querySelector('[data-testid="gantt-task-bar-a"]')!, { clientX: 10, clientY: 10 });
+    expect(ctxMenu()).toBeNull();
+  });
+
+  it('opens the QR dialog with the encoded image and the link, closes cleanly', async () => {
+    const { container } = renderView([A()], { taskUrl: (t) => `https://app.example.com/rec/${t.id}` });
+    fireEvent.contextMenu(container.querySelector('[data-testid="gantt-task-bar-a"]')!, { clientX: 10, clientY: 10 });
+    fireEvent.click(qrItem()!);
+
+    // Menu closes, dialog opens with the target URL and (async) the stub PNG.
+    expect(ctxMenu()).toBeNull();
+    expect(dialog()).toBeTruthy();
+    expect(document.querySelector('[data-testid="gantt-qr-url"]')!.textContent).toBe('https://app.example.com/rec/a');
+    await waitFor(() => {
+      const img = document.querySelector('[data-testid="gantt-qr-image"]') as HTMLImageElement;
+      expect(img?.getAttribute('src')).toBe('data:image/png;base64,STUB');
+    });
+
+    fireEvent.click(document.querySelector('[data-testid="gantt-qr-close"]')!);
+    expect(dialog()).toBeNull();
+  });
+
+  it('closes the QR dialog on Escape', () => {
+    const { container } = renderView([A()], { taskUrl: () => URL_A });
+    fireEvent.contextMenu(container.querySelector('[data-testid="gantt-task-bar-a"]')!, { clientX: 10, clientY: 10 });
+    fireEvent.click(qrItem()!);
+    expect(dialog()).toBeTruthy();
+    act(() => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })); });
+    expect(dialog()).toBeNull();
+  });
+
+  it('copies the link via the copy button', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', { value: { writeText }, configurable: true });
+    const { container } = renderView([A()], { taskUrl: () => URL_A });
+    fireEvent.contextMenu(container.querySelector('[data-testid="gantt-task-bar-a"]')!, { clientX: 10, clientY: 10 });
+    fireEvent.click(qrItem()!);
+    fireEvent.click(document.querySelector('[data-testid="gantt-qr-copy"]')!);
+    expect(writeText).toHaveBeenCalledWith(URL_A);
+    // Feedback flips to the copied state.
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="gantt-qr-copy"]')!.textContent).toContain('Copied');
+    });
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -30,7 +30,12 @@ import {
   Lock,
   Crosshair,
   RefreshCw,
+  ArrowRight,
+  QrCode,
+  Copy,
+  Check,
 } from "lucide-react"
+import { toDataURL as qrToDataURL } from "qrcode"
 import {
   cn,
   Button,
@@ -264,6 +269,13 @@ export interface GanttViewProps {
   /** Extra vertical marker lines rendered like the Today marker. */
   markers?: GanttMarker[]
   onTaskClick?: (task: GanttTask) => void
+  /**
+   * Absolute detail-page URL for a task, used by the context menu's
+   * 「移动端二维码」 item (QR + copy link for opening on a phone). Return
+   * null/undefined for rows without a detail page (synthetic group rows) to
+   * hide the item.
+   */
+  taskUrl?: (task: GanttTask) => string | null | undefined
   onTaskUpdate?: (task: GanttTask, changes: Partial<Pick<GanttTask, 'title' | 'start' | 'end' | 'progress'>>) => void
   onTaskDelete?: (task: GanttTask) => void
   /** Notified when the user switches granularity from the toolbar. */
@@ -412,6 +424,12 @@ export interface GanttLayout {
   taskListCollapsed: boolean
   /** User-dragged task-list (name column) width in px, or null when auto-sized. */
   taskListWidth?: number | null
+  /**
+   * Ids of rows the user had collapsed when saving (展开状态). Present (even
+   * empty) means the saved expand/collapse state wins over
+   * `defaultCollapsedDepth`; absent (older snapshots) leaves the default.
+   */
+  collapsedIds?: string[]
 }
 
 // --- Export helpers (导出 PNG / PDF) — module-level, no React deps. ---
@@ -514,7 +532,10 @@ function readSavedLayout(key: string | undefined): GanttLayout | null {
       typeof p.columnWidth === 'number' && isFinite(p.columnWidth) ? p.columnWidth : null;
     const taskListWidth =
       typeof p.taskListWidth === 'number' && isFinite(p.taskListWidth) ? p.taskListWidth : null;
-    return { viewMode, columnWidth, taskListCollapsed: !!p.taskListCollapsed, taskListWidth };
+    const collapsedIds = Array.isArray(p.collapsedIds)
+      ? p.collapsedIds.filter((x): x is string => typeof x === 'string')
+      : undefined;
+    return { viewMode, columnWidth, taskListCollapsed: !!p.taskListCollapsed, taskListWidth, collapsedIds };
   } catch {
     return null;
   }
@@ -537,6 +558,7 @@ export function GanttView({
   endDate,
   markers,
   onTaskClick,
+  taskUrl,
   onTaskUpdate: onTaskUpdateProp,
   onTaskDelete: onTaskDeleteProp,
   onViewChange,
@@ -787,9 +809,9 @@ export function GanttView({
   }, [childrenByParent]);
 
   // Drag-and-drop state for rescheduling a bar (move + resize from either edge).
-  // unitDelta is the snapped offset, in columns of the active granularity, from
-  // the original position; preview is rendered by overriding left/width when
-  // dragState.taskId matches.
+  // unitDelta is the snapped offset from the original position — in DAYS on
+  // every granularity except day-with-shift-bands, where it counts bands;
+  // preview is rendered by overriding left/width when dragState.taskId matches.
   type DragMode = 'move' | 'resize-left' | 'resize-right';
   const [dragState, setDragState] = React.useState<{
     taskId: string | number;
@@ -814,10 +836,13 @@ export function GanttView({
       segActive && shiftSegments
         ? Math.min(...shiftSegments.bands.map((b) => b.durMs))
         : MS_PER_DAY;
-    // Folded axes advance by working columns (Fri +1 → Mon); otherwise snap to
-    // whole calendar units. foldShiftRef is set during render (below).
+    // Folded/segmented axes advance by visible columns (Fri +1 → Mon, band →
+    // band); both only exist in day mode. Every other granularity snaps by
+    // whole DAYS — dragging in week/month view must not jump 7/30 days per
+    // step (unitDelta is a day count there; the pointer handler divides the
+    // pixel delta by pxPerDay to match).
     const shift = (date: Date, n: number) =>
-      foldShiftRef.current ? foldShiftRef.current(date, n) : addUnits(date, n, viewMode);
+      foldShiftRef.current ? foldShiftRef.current(date, n) : addUnits(date, n, 'day');
     let start = new Date(s.originStart);
     let end = new Date(s.originEnd);
     if (s.mode === 'move') {
@@ -975,11 +1000,14 @@ export function GanttView({
     if (!dragState) return;
     // In shift mode each drag step is one band wide (smallest band, so every
     // band boundary is reachable), not a whole day — so Δx / bandWidth = bands
-    // moved, matching shiftByWorkingColumns walking band columns.
+    // moved, matching shiftByWorkingColumns walking band columns. In every
+    // other granularity a step is one DAY of pixels (pxPerDay), matching
+    // computeDragChanges advancing by days — coarse views (week/month/…) snap
+    // per day instead of per column. In plain day view pxPerDay === columnWidth.
     const segActive = viewMode === 'day' && !!shiftSegments && shiftSegments.bands.length > 0;
     const dragColWidth = segActive && shiftSegments
       ? (pxPerDay * Math.min(...shiftSegments.bands.map((b) => b.durMs))) / MS_PER_DAY
-      : columnWidth;
+      : pxPerDay;
     const onMove = (e: PointerEvent) => {
       const cur = dragStateRef.current;
       if (!cur) return;
@@ -1204,6 +1232,36 @@ export function GanttView({
     };
   }, [ctxMenu]);
 
+  // --- 移动端二维码 (share-to-mobile QR) -------------------------------------
+  // Context-menu item: encode the row's absolute detail URL as a QR so the
+  // record opens on a phone by scanning, plus a copy-link button. The data URL
+  // is generated async when the dialog opens; null while pending/failed.
+  const [qrShare, setQrShare] = React.useState<{ task: GanttTask; url: string } | null>(null);
+  const [qrDataUrl, setQrDataUrl] = React.useState<string | null>(null);
+  const [qrCopied, setQrCopied] = React.useState(false);
+  React.useEffect(() => {
+    if (!qrShare) { setQrDataUrl(null); setQrCopied(false); return; }
+    let cancelled = false;
+    qrToDataURL(qrShare.url, { width: 220, margin: 1 })
+      .then((d) => { if (!cancelled) setQrDataUrl(d); })
+      .catch(() => { if (!cancelled) setQrDataUrl(null); });
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setQrShare(null); };
+    window.addEventListener('keydown', onKey);
+    return () => { cancelled = true; window.removeEventListener('keydown', onKey); };
+  }, [qrShare]);
+  const copyQrLink = React.useCallback(() => {
+    if (!qrShare) return;
+    const done = () => {
+      setQrCopied(true);
+      window.setTimeout(() => setQrCopied(false), 1500);
+    };
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(qrShare.url).then(done).catch(() => {
+        /* clipboard denied — the URL stays visible/selectable in the dialog */
+      });
+    }
+  }, [qrShare]);
+
   // --- Dependency link context menu (依赖增删 + 类型选择) ---------------------
   // Right-clicking a dependency link opens a small menu to switch its type
   // (FS/SS/FF/SF) or remove it. Closing mirrors the task context menu.
@@ -1272,9 +1330,11 @@ export function GanttView({
     e.preventDefault();
     e.stopPropagation();
     setSelectedTaskId(task.id);
-    if (!hasTaskMenuActions) return;
+    // 移动端二维码 alone justifies a menu — but only when this row actually
+    // yields a URL (synthetic group rows return null), so no empty menu opens.
+    if (!hasTaskMenuActions && !(taskUrl && taskUrl(task))) return;
     setCtxMenu({ x: e.clientX, y: e.clientY, taskId: task.id });
-  }, [hasTaskMenuActions]);
+  }, [hasTaskMenuActions, taskUrl]);
 
   const openLinkContextMenu = React.useCallback(
     (sourceId: string | number, targetId: string | number, type: GanttLinkType, e: React.MouseEvent) => {
@@ -1304,7 +1364,9 @@ export function GanttView({
     progress: number;
   };
 
-  const [collapsedIds, setCollapsedIds] = React.useState<Set<string>>(() => new Set());
+  const [collapsedIds, setCollapsedIds] = React.useState<Set<string>>(
+    () => new Set(restoredLayout?.collapsedIds ?? [])
+  );
   const toggleCollapsed = React.useCallback((id: string | number) => {
     setCollapsedIds((prev) => {
       const next = new Set(prev);
@@ -1318,7 +1380,9 @@ export function GanttView({
   // the parent chain to derive each node's 0-indexed depth and fold every node
   // at/below the threshold that actually has children. Runs a single time so the
   // user's later expand/collapse is never clobbered by a data refresh.
-  const defaultCollapseSeeded = React.useRef(false);
+  // A saved layout that recorded collapsedIds (even an empty list = all
+  // expanded) IS the user's intent — skip the defaultCollapsedDepth seed.
+  const defaultCollapseSeeded = React.useRef(restoredLayout?.collapsedIds != null);
   React.useEffect(() => {
     if (defaultCollapseSeeded.current) return;
     if (defaultCollapsedDepth == null || displayTasks.length === 0) return;
@@ -2600,11 +2664,12 @@ export function GanttView({
       columnWidth: columnWidthOverride,
       taskListCollapsed,
       taskListWidth: taskListWidthOverride,
+      collapsedIds: Array.from(collapsedIds),
     };
     if (persistLayoutKey) writeSavedLayout(persistLayoutKey, layout);
     onLayoutChange?.(layout);
     setLayoutSaved(true);
-  }, [viewMode, columnWidthOverride, taskListCollapsed, taskListWidthOverride, persistLayoutKey, onLayoutChange]);
+  }, [viewMode, columnWidthOverride, taskListCollapsed, taskListWidthOverride, collapsedIds, persistLayoutKey, onLayoutChange]);
   // Briefly reflect a save in the button's aria-pressed for feedback/testability.
   React.useEffect(() => {
     if (!layoutSaved) return;
@@ -3077,6 +3142,7 @@ export function GanttView({
                 )}
                 style={{ height: rowHeight, touchAction: 'manipulation' }}
                 role="treeitem"
+                data-testid={`gantt-task-row-${task.id}`}
                 aria-level={row.depth + 1}
                 aria-selected={isSelected}
                 aria-expanded={row.hasChildren ? !isCollapsed : undefined}
@@ -3104,10 +3170,15 @@ export function GanttView({
                 } : undefined}
                 onContextMenu={(e) => openContextMenu(task, e)}
                 onClick={() => {
+                  // Focus 查看: a single row click selects + locates the bar on
+                  // the timeline (scroll + pulse) WITHOUT opening the detail
+                  // drawer. Detail is on double-click, the row's 「→」 button,
+                  // the context menu 查看 and keyboard Enter.
                   setSelectedTaskId(task.id);
-                  if (!isEditing) onTaskClick?.(task);
+                  if (!isEditing) scrollToTask(row.start, row.end, task.id);
                 }}
                 onDoubleClick={() => {
+                  if (isEditing) return;
                   if (inlineEdit && onTaskUpdate && !row.isSummary && !task.locked) {
                     setEditingTask(task.id);
                     setEditValues({
@@ -3116,6 +3187,8 @@ export function GanttView({
                       end: task.end.toLocaleDateString('en-CA'),
                       progress: String(task.progress),
                     });
+                  } else {
+                    onTaskClick?.(task);
                   }
                 }}
               >
@@ -3213,8 +3286,9 @@ export function GanttView({
                     type="button"
                     title={t('gantt.row.locate')}
                     aria-label={t('gantt.row.locate')}
+                    data-testid={`gantt-row-locate-${task.id}`}
                     className="gantt-locate-btn hidden sm:block absolute top-1/2 -translate-y-1/2"
-                    style={{ right: 1 }}
+                    style={{ right: onTaskClick ? 20 : 1 }}
                     onClick={(e) => {
                       e.stopPropagation();
                       scrollToTask(row.start, row.end, row.task.id);
@@ -3223,10 +3297,28 @@ export function GanttView({
                     <Crosshair className="w-3 h-3" />
                   </button>
                 )}
-                {/* Row actions removed: View / Edit / Delete are reachable
-                    from the side drawer that opens on row click (DetailView
-                    has inline-edit + a delete in its more-actions menu).
-                    Inline edit is also still triggerable via row double-click. */}
+                {/* 跳转详情「→」: opens the detail drawer / page — the row click
+                    itself is reserved for Focus-locate, so detail needs its own
+                    always-reachable affordance besides double-click. */}
+                {!isEditing && onTaskClick && (
+                  <button
+                    type="button"
+                    title={t('gantt.row.open')}
+                    aria-label={t('gantt.row.open')}
+                    data-testid={`gantt-row-open-${task.id}`}
+                    className="gantt-locate-btn hidden sm:block absolute top-1/2 -translate-y-1/2"
+                    style={{ right: 1 }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onTaskClick(task);
+                    }}
+                  >
+                    <ArrowRight className="w-3 h-3" />
+                  </button>
+                )}
+                {/* Row View/Edit/Delete stay reachable from the detail drawer
+                    (double-click / 「→」 / context menu / Enter); inline edit is
+                    still triggerable via row double-click when enabled. */}
               </div>
               );
             })}
@@ -3435,6 +3527,15 @@ export function GanttView({
                            {' · '}{Math.round(row.progress)}%
                          </div>
                        )}
+                       {task.locked || (effectiveReadOnly && !onTaskUpdate) ? (
+                         <div
+                           className="text-muted-foreground"
+                           style={{ marginTop: 4 }}
+                           data-testid={`gantt-tooltip-locked-${task.id}`}
+                         >
+                           {'🚫 '}{t('gantt.lockedHint')}
+                         </div>
+                       ) : null}
                      </div>
                    ) : null;
 
@@ -4020,6 +4121,21 @@ export function GanttView({
                 {t('gantt.menu.view')}
               </button>
             )}
+            {taskUrl && (() => {
+              const url = taskUrl(task);
+              if (!url) return null;
+              return (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={itemCls}
+                  data-testid="gantt-context-menu-qrcode"
+                  onClick={() => { setCtxMenu(null); setQrShare({ task, url }); }}
+                >
+                  {t('gantt.menu.qrcode')}
+                </button>
+              );
+            })()}
             {inlineEdit && onTaskUpdate && row && !row.isSummary && !task.locked && (
               <button
                 type="button"
@@ -4086,6 +4202,62 @@ export function GanttView({
           </div>
         );
       })()}
+
+      {/* 移动端二维码 dialog — scan to open the record's detail page on a phone. */}
+      {qrShare && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          data-testid="gantt-qr-dialog"
+          onClick={() => setQrShare(null)}
+        >
+          <div
+            role="dialog"
+            aria-label={t('gantt.qr.title')}
+            className="w-[280px] rounded-lg border bg-popover text-popover-foreground p-4 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-1 flex items-center gap-2 text-sm font-medium">
+              <QrCode className="h-4 w-4 shrink-0" />
+              <span className="truncate">{qrShare.task.title}</span>
+            </div>
+            <div className="mb-2 text-xs text-muted-foreground">{t('gantt.qr.hint')}</div>
+            {qrDataUrl ? (
+              <img
+                src={qrDataUrl}
+                alt={t('gantt.qr.title')}
+                data-testid="gantt-qr-image"
+                className="mx-auto block h-[220px] w-[220px] rounded bg-white"
+              />
+            ) : (
+              <div className="flex h-[220px] items-center justify-center text-sm text-muted-foreground">
+                …
+              </div>
+            )}
+            <div className="mt-2 break-all text-[11px] text-muted-foreground" data-testid="gantt-qr-url">
+              {qrShare.url}
+            </div>
+            <div className="mt-3 flex justify-end gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="gantt-qr-copy"
+                onClick={copyQrLink}
+              >
+                {qrCopied ? <Check className="mr-1 h-3 w-3" /> : <Copy className="mr-1 h-3 w-3" />}
+                {qrCopied ? t('gantt.qr.copied') : t('gantt.qr.copy')}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                data-testid="gantt-qr-close"
+                onClick={() => setQrShare(null)}
+              >
+                {t('gantt.qr.close')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Dependency link context menu (类型选择 + 移除) — fixed-position. */}
       {linkCtxMenu && (() => {

--- a/packages/plugin-gantt/src/ObjectGantt.persistfilters.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.persistfilters.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * ObjectGantt-side tests for the #2460 batch: quick-filter persistence riding
+ * on 保存布局 (sibling localStorage key + restore on mount), per-level tooltip
+ * fields skipping empty values (悬浮分层字段), and the taskUrl passed down for
+ * the 移动端二维码 item (null for synthetic rows without an objectField value).
+ *
+ * GanttView is mocked to a thin shell exposing what ObjectGantt feeds it.
+ */
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectGantt } from './ObjectGantt';
+
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks, onLayoutChange, taskUrl }: any) => (
+    <div data-testid="gantt-view" data-count={tasks.length} data-ids={tasks.map((t: any) => t.id).join(',')}>
+      {tasks.map((t: any) => (
+        <div key={t.id} data-testid={`gv-task-${t.id}`}>
+          <span data-testid={`gv-fields-${t.id}`}>
+            {(t.fields ?? []).map((f: any) => `${f.label}=${f.value}`).join('|')}
+          </span>
+          <span data-testid={`gv-url-${t.id}`}>{taskUrl ? String(taskUrl(t)) : 'no-fn'}</span>
+        </div>
+      ))}
+      {onLayoutChange && (
+        <button
+          data-testid="mock-save-layout"
+          onClick={() => onLayoutChange({ viewMode: 'day', columnWidth: null, taskListCollapsed: false })}
+        />
+      )}
+    </div>
+  ),
+}));
+
+const INLINE = [
+  { id: '1', name: 'Alpha', start: '2024-01-01', end: '2024-01-05', status: 'todo' },
+  { id: '2', name: 'Beta', start: '2024-02-01', end: '2024-02-10', status: 'doing' },
+];
+
+function schema(extra: Record<string, any> = {}) {
+  return {
+    type: 'gantt',
+    startDateField: 'start',
+    endDateField: 'end',
+    titleField: 'name',
+    data: { provider: 'value', items: INLINE },
+    quickFilters: [{ field: 'status', label: '状态', options: ['todo', 'doing'] }],
+    ...extra,
+  } as any;
+}
+
+const gv = (c: HTMLElement) => c.querySelector('[data-testid="gantt-view"]') as HTMLElement;
+// No objectName + value provider → persist key gantt:default.
+const FILTERS_KEY = 'gantt-layout:gantt:default:filters';
+
+beforeEach(() => window.localStorage.clear());
+
+describe('ObjectGantt quick-filter persistence (保存布局收纳筛选)', () => {
+  it('writes the active filters to the sibling key when the layout is saved', async () => {
+    const { container, getByTestId } = render(<ObjectGantt schema={schema()} />);
+    await waitFor(() => expect(gv(container).getAttribute('data-count')).toBe('2'));
+    fireEvent.click(getByTestId('quick-filter-trigger-status'));
+    fireEvent.click(getByTestId('quick-filter-option-status-doing'));
+    await waitFor(() => expect(gv(container).getAttribute('data-count')).toBe('1'));
+
+    fireEvent.click(getByTestId('mock-save-layout'));
+    expect(JSON.parse(window.localStorage.getItem(FILTERS_KEY)!)).toEqual({ status: ['doing'] });
+  });
+
+  it('restores persisted filters on mount', async () => {
+    window.localStorage.setItem(FILTERS_KEY, JSON.stringify({ status: ['doing'] }));
+    const { container } = render(<ObjectGantt schema={schema()} />);
+    await waitFor(() => expect(gv(container).getAttribute('data-count')).toBe('1'));
+    expect(gv(container).getAttribute('data-ids')).toBe('2');
+  });
+
+  it('ignores malformed persisted filters', async () => {
+    window.localStorage.setItem(FILTERS_KEY, '{oops');
+    const { container } = render(<ObjectGantt schema={schema()} />);
+    await waitFor(() => expect(gv(container).getAttribute('data-count')).toBe('2'));
+  });
+
+  it('does not persist or restore when persistLayout is false', async () => {
+    window.localStorage.setItem(FILTERS_KEY, JSON.stringify({ status: ['doing'] }));
+    const { container, queryByTestId } = render(<ObjectGantt schema={schema({ persistLayout: false })} />);
+    // Snapshot ignored AND no onLayoutChange handed down (no save hook).
+    await waitFor(() => expect(gv(container).getAttribute('data-count')).toBe('2'));
+    expect(queryByTestId('mock-save-layout')).toBeNull();
+  });
+});
+
+describe('ObjectGantt tooltip fields skip empty values (悬浮分层字段)', () => {
+  it('drops rows whose value is null/empty instead of rendering a dash', async () => {
+    const items = [
+      { id: '1', name: 'Plan', start: '2024-01-01', end: '2024-01-05', category: '排产', qty: 0, owner: '' },
+      { id: '2', name: 'Dispatch', start: '2024-02-01', end: '2024-02-10', owner: '张三', tags: [] },
+    ];
+    const s = schema({
+      data: { provider: 'value', items },
+      quickFilters: undefined,
+      tooltipFields: ['category', 'qty', 'owner', 'tags', 'missing'],
+    });
+    const { container, getByTestId } = render(<ObjectGantt schema={s} />);
+    await waitFor(() => expect(gv(container).getAttribute('data-count')).toBe('2'));
+    // Row 1: category + qty (0 is a real value) survive; empty owner, absent
+    // missing are dropped. Row 2: only owner survives (empty array dropped).
+    // Labels come humanized (Title Case) from resolveFieldLabel.
+    expect(getByTestId('gv-fields-1').textContent).toBe('Category=排产|Qty=0');
+    expect(getByTestId('gv-fields-2').textContent).toBe('Owner=张三');
+  });
+});
+
+describe('ObjectGantt taskUrl for 移动端二维码', () => {
+  it('returns null for synthetic rows when objectField is configured but empty', async () => {
+    const items = [
+      { id: 'grp', name: '项目组', start: '2024-01-01', end: '2024-02-10', object_name: '' },
+      { id: 'r1', name: '计划', start: '2024-01-01', end: '2024-01-05', object_name: 'plan_obj' },
+    ];
+    const s = schema({ data: { provider: 'value', items }, quickFilters: undefined, objectField: 'object_name' });
+    const { container, getByTestId } = render(<ObjectGantt schema={s} />);
+    await waitFor(() => expect(gv(container).getAttribute('data-count')).toBe('2'));
+    expect(getByTestId('gv-url-grp').textContent).toBe('null');
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -98,6 +98,14 @@ type GanttConfigEx = GanttConfig & {
    */
   lockField?: string;
   /**
+   * Record field carrying the row's OBJECT API NAME (行级对象名). Mixed-object
+   * trees (an `api` provider composing e.g. 排班计划 rows with 派工单 children)
+   * need the detail drawer and its full-page link to follow each row's REAL
+   * object — otherwise a child row's 「→」 builds a URL under the view's bound
+   * object and 404s. Empty/missing value → falls back to the bound object.
+   */
+  objectField?: string;
+  /**
    * How a summary bar's span is computed (汇总条区间). `'children'` (default)
    * rolls the bar up from its children — min start / max end / duration-weighted
    * progress — and IGNORES the record's own dates. `'self'` renders the bar from
@@ -304,6 +312,7 @@ function getGanttConfig(schema: ObjectGridSchema | any): GanttConfigEx | null {
           parentField: schema.parentField,
           typeField: schema.typeField,
           lockField: schema.lockField,
+          objectField: schema.objectField,
           summaryExtent: schema.summaryExtent,
           defaultCollapsedDepth: schema.defaultCollapsedDepth,
           tooltipFields: schema.tooltipFields,
@@ -606,9 +615,14 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         const fieldName = typeof entry === 'string' ? entry : entry?.field;
         if (!fieldName) continue;
         const explicitLabel = typeof entry === 'object' ? entry.label : undefined;
+        const raw = resolvePath(record, fieldName);
+        // Per-level tooltips (悬浮分层字段): mixed trees list the UNION of every
+        // level's fields here; a row omits the ones that don't apply to it, so
+        // an absent value must drop the line, not render a placeholder dash.
+        if (raw == null || raw === '' || (Array.isArray(raw) && raw.length === 0)) continue;
         rows.push({
           label: resolveFieldLabel(fieldName, explicitLabel),
-          value: formatFieldValue(resolvePath(record, fieldName), fieldName),
+          value: formatFieldValue(raw, fieldName),
         });
       }
       return rows.length ? rows : undefined;
@@ -891,11 +905,65 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     });
   }, [quickFilterDefs, objectSchema, lookupOptions, data, resolveFilterKey]);
 
-  const [filterValues, setFilterValues] = useState<Record<string, string[]>>({});
+  // 保存布局 covers the quick-filter chips too: GanttView persists its own
+  // snapshot under persistLayoutKey and fires onLayoutChange; the chips live up
+  // here, so they get a sibling localStorage key and restore on mount.
+  const persistLayoutKey =
+    (schema as any).persistLayout === false
+      ? undefined
+      : `${schema.objectName || (dataConfig?.provider === 'object' ? dataConfig.object : '') || 'gantt'}:${(schema as any).viewName || 'default'}`;
+  const filtersStorageKey = persistLayoutKey ? `gantt-layout:${persistLayoutKey}:filters` : null;
+  const [filterValues, setFilterValues] = useState<Record<string, string[]>>(() => {
+    if (!filtersStorageKey || typeof window === 'undefined') return {};
+    try {
+      const parsed = JSON.parse(window.localStorage.getItem(filtersStorageKey) || 'null');
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+      const out: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (Array.isArray(v)) out[k] = v.filter((x): x is string => typeof x === 'string');
+      }
+      return out;
+    } catch {
+      return {};
+    }
+  });
+  const persistFilters = useCallback(() => {
+    if (!filtersStorageKey || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(filtersStorageKey, JSON.stringify(filterValues));
+    } catch {
+      /* storage unavailable / full — non-fatal */
+    }
+  }, [filtersStorageKey, filterValues]);
   const handleFilterChange = useCallback((field: string, values: string[]) => {
     setFilterValues((prev) => ({ ...prev, [field]: values }));
   }, []);
   const clearFilters = useCallback(() => setFilterValues({}), []);
+
+  // Detail-page href for a row, honouring objectField (mixed-object trees):
+  // the link must follow the ROW's object, not the view's bound one — a 派工单
+  // row opened under the 排班计划 route otherwise builds a 404 URL.
+  // deriveRecordPageHref needs the routed object's segment in the current path
+  // (a foreign row object never appears there), so derive from the routed
+  // object and swap the segment. Shared by the drawer's 整页 link and the
+  // context menu's 移动端二维码.
+  const recordDetailHref = useCallback(
+    (rec: Record<string, any>): { objectName: string; recordId: string | number; href: string | null } | null => {
+      const rowObject = ganttConfig?.objectField
+        ? String(rec[ganttConfig.objectField] ?? '').trim()
+        : '';
+      const objectName = rowObject || resource;
+      const recordId = rec.id ?? rec._id;
+      if (!objectName || recordId == null) return null;
+      const routedHref = resource ? deriveRecordPageHref(resource, recordId) : null;
+      const href =
+        !resource || objectName === resource
+          ? routedHref
+          : routedHref?.replace(`/${resource}/record/`, `/${objectName}/record/`) ?? null;
+      return { objectName, recordId, href };
+    },
+    [ganttConfig?.objectField, resource],
+  );
 
   // Apply the active filters in memory: a task matches when, for every dimension
   // with a non-empty selection, its resolved key is among the selected values.
@@ -1200,6 +1268,20 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
             navigation.handleClick(task.data);
             onTaskClick?.(task.data);
           }}
+          taskUrl={(task) => {
+            const rec = task.data as Record<string, any> | undefined;
+            if (!rec) return null;
+            // With objectField configured, rows lacking a value are synthetic
+            // group rows (项目/产品) — no detail page exists, so no QR item.
+            if (ganttConfig?.objectField && !String(rec[ganttConfig.objectField] ?? '').trim()) {
+              return null;
+            }
+            const href = recordDetailHref(rec)?.href;
+            if (!href) return null;
+            // Absolute URL: the QR is scanned on another device, so a
+            // path-relative href would be useless there.
+            return typeof window === 'undefined' ? href : new URL(href, window.location.href).toString();
+          }}
           onTaskUpdate={handleTaskUpdateDefault}
           onTaskDelete={requestDelete}
           onDependencyCreate={ganttConfig?.dependenciesField ? handleDependencyCreate : undefined}
@@ -1213,11 +1295,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           showBaselines={(schema as any).showBaselines !== false}
           readOnly={!!(schema as any).readOnly}
           mobileReadOnly={(schema as any).mobileReadOnly !== false}
-          persistLayoutKey={
-            (schema as any).persistLayout === false
-              ? undefined
-              : `${schema.objectName || (dataConfig?.provider === 'object' ? dataConfig.object : '') || 'gantt'}:${(schema as any).viewName || 'default'}`
-          }
+          persistLayoutKey={persistLayoutKey}
+          onLayoutChange={filtersStorageKey ? persistFilters : undefined}
           groupBy={groupByAccessor}
           defaultCollapsedDepth={ganttConfig?.defaultCollapsedDepth}
           summaryExtent={ganttConfig?.summaryExtent}
@@ -1236,10 +1315,11 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         )}
       </div>
       {navigation.isOverlay && navigation.isOpen && navigation.selectedRecord && (() => {
-        const objectName = resource;
         const rec = navigation.selectedRecord as Record<string, any>;
-        const recordId = rec.id ?? rec._id;
-        if (!objectName || recordId == null) return null;
+        const detail = recordDetailHref(rec);
+        if (!detail) return null;
+        const { objectName, recordId } = detail;
+        const fullPageHref = detail.href ?? undefined;
         const titleText = ganttConfig?.titleField
           ? String(rec[ganttConfig.titleField] ?? t('gantt.drawer.fallbackTitle'))
           : t('gantt.drawer.fallbackTitle');
@@ -1258,12 +1338,12 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
             objectName={objectName}
             recordId={recordId}
             dataSource={effectiveDataSource ?? undefined}
-            objectSchema={objectSchema as any}
+            objectSchema={objectName === resource ? (objectSchema as any) : undefined}
             width={navigation.width as any}
-            fullPageHref={deriveRecordPageHref(objectName, recordId) ?? undefined}
+            fullPageHref={fullPageHref}
             onFieldSave={recLocked ? undefined : async (field, value) => {
               if (!effectiveDataSource?.update) return;
-              await effectiveDataSource.update(resource, String(recordId), { [field]: value });
+              await effectiveDataSource.update(objectName, String(recordId), { [field]: value });
               setData((prev) => prev.map((r) =>
                 String(r.id ?? r._id) === String(recordId)
                   ? { ...r, [field]: value }
@@ -1273,7 +1353,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
             }}
             onDelete={recLocked ? undefined : async () => {
               if (!effectiveDataSource?.delete) return;
-              await effectiveDataSource.delete(resource, String(recordId));
+              await effectiveDataSource.delete(objectName, String(recordId));
               setData((prev) => prev.filter((r) =>
                 String(r.id ?? r._id) !== String(recordId),
               ));

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -99,7 +99,7 @@ type GanttConfigEx = GanttConfig & {
   lockField?: string;
   /**
    * Record field carrying the row's OBJECT API NAME (行级对象名). Mixed-object
-   * trees (an `api` provider composing e.g. 排班计划 rows with 派工单 children)
+   * trees (an `api` provider composing parent-object rows with child-object rows)
    * need the detail drawer and its full-page link to follow each row's REAL
    * object — otherwise a child row's 「→」 builds a URL under the view's bound
    * object and 404s. Empty/missing value → falls back to the bound object.
@@ -941,8 +941,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   const clearFilters = useCallback(() => setFilterValues({}), []);
 
   // Detail-page href for a row, honouring objectField (mixed-object trees):
-  // the link must follow the ROW's object, not the view's bound one — a 派工单
-  // row opened under the 排班计划 route otherwise builds a 404 URL.
+  // the link must follow the ROW's object, not the view's bound one — a child-object
+  // row opened under the bound object's route otherwise builds a 404 URL.
   // deriveRecordPageHref needs the routed object's segment in the current path
   // (a foreign row object never appears there), so derive from the routed
   // object and swap the segment. Shared by the drawer's 整页 link and the

--- a/packages/plugin-gantt/src/useGanttTranslation.ts
+++ b/packages/plugin-gantt/src/useGanttTranslation.ts
@@ -47,9 +47,16 @@ export const GANTT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'gantt.row.expand': 'Expand',
   'gantt.row.collapse': 'Collapse',
   'gantt.row.locate': 'Locate on timeline',
+  'gantt.row.open': 'Open details',
   'gantt.aria.taskList': 'Task list',
   'gantt.tooltip.days': 'd',
   'gantt.menu.view': 'View details',
+  'gantt.menu.qrcode': 'Mobile QR code',
+  'gantt.qr.title': 'Open on mobile',
+  'gantt.qr.hint': 'Scan with a phone to open the details',
+  'gantt.qr.copy': 'Copy link',
+  'gantt.qr.copied': 'Copied',
+  'gantt.qr.close': 'Close',
   'gantt.menu.edit': 'Edit inline',
   'gantt.menu.delete': 'Delete',
   'gantt.menu.addPredecessor': 'Add predecessor…',
@@ -79,6 +86,7 @@ export const GANTT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'gantt.resource.empty': 'No tasks to allocate.',
   'gantt.readOnly': 'Read-only',
   'gantt.readOnlyHint': 'Editing is disabled for this view.',
+  'gantt.lockedHint': 'No edit permission',
 };
 
 function fallback(key: string, options?: Record<string, unknown>): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,7 +812,7 @@ importers:
         version: 9.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 6.0.3(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -833,7 +833,7 @@ importers:
         version: 5.2.1
       vite:
         specifier: ^8.1.4
-        version: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.25
@@ -852,7 +852,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/collaboration:
     dependencies:
@@ -1120,7 +1120,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/data-objectstack:
     dependencies:
@@ -1895,6 +1895,9 @@ importers:
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1902,6 +1905,9 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -13908,11 +13914,6 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       maplibre-gl: 5.24.0
-
-  '@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
Closes #2460

## plugin-gantt 新增能力(全部通用、由 schema 配置驱动,无任何项目硬编码)

| 能力 | 配置方式 | 行为 |
|---|---|---|
| 行单击定位 | 默认开启 | 任务列表行单击选中(`aria-selected`)并滚动图表定位到任务条,带闪烁高亮 |
| 双击/行内「→」打开详情 | `onTaskOpen` 回调 | 行/条双击、行内箭头、右键"查看"、Enter 均触发宿主的详情回调 |
| 行级对象路由 | `objectField: '<字段名>'` | 树中不同层级的行可属于不同 object,详情/链接按行上该字段的值路由;无值的合成行自动禁用相关入口 |
| 按日吸附拖拽 | 默认开启 | 周/月/季/年视图下拖拽、伸缩均按整天步进(`unitDelta` 记天数),提交前预览、失败回弹 |
| 布局持久化扩展 | `persistLayout`(已有) | 保存布局新增:任务列表收纳状态、树展开状态(`collapsedIds`)、快捷筛选选中值(sibling localStorage key,mount 恢复,损坏 JSON 容错) |
| 二维码/复制链接 | `taskUrl: (task) => string \| null` | 右键菜单新增"移动端二维码"弹窗与复制链接;返回 null 的行菜单项禁用 |
| 锁定行提示 | `locked`(已有行属性) | 锁定行悬浮显示「🚫 无编辑权限」(i18n `gantt.lockedHint`),拖拽零位移、零请求 |
| 悬浮字段空值跳过 | `tooltipFields`(已有) | tooltip 按行取值,null/空串/空数组的字段整行不渲染(不再出现"字段名 —") |

i18n:新增 key 中英双语齐全(`packages/i18n/src/locales/{zh,en}.ts`)。

## 测试

- 单测:本分支(off origin/main)`pnpm --filter @object-ui/plugin-gantt test` → **23 files / 291 tests 全绿**;新增 `GanttView.enhancements.test.tsx`、`ObjectGantt.persistfilters.test.tsx` 覆盖上述全部能力。
- 真机 UI 实测:在一个消费本地构建 console 的下游项目里 Playwright 11/11 全绿(悬浮字段、锁定提示+拖拽零请求、行单击/双击、行级对象路由、二维码/复制链接、布局恢复、周视图整日吸附拖拽),操作截图与完整报告见 https://github.com/objectstack-ai/objectui/issues/2460#issuecomment-4960054751 。
- 注:本地全仓 `turbo build` 中 `@object-ui/site`(经 `@object-ui/fields` 的 TS6059 rootDir 报错,均在 packages/core/fields)失败为 origin/main 既有问题,本分支未触碰这两个包;本 PR CI 全绿。