### PR TITLE
feat(console-ai): the FAB becomes the ChatDock launcher when the dock is on (ADR-0057 P3b)

### DIFF
--- a/.changeset/adr-0057-p3b-fab-launcher.md
+++ b/.changeset/adr-0057-p3b-fab-launcher.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(console-ai): the FAB becomes the ChatDock launcher when the dock is on (ADR-0057 P3b)
+
+When `features.chatDock` is enabled, the console FAB opens the docked rail instead
+of the floating overlay — one entry point, the ADR's "FAB → launcher" step. In
+dock mode the FAB stays the lightweight button (it never mounts the heavy floating
+chatbot; the rail loads the chat on demand), and a designer "Ask AI" open signal
+(assistantBus) opens the dock too. With the flag OFF the FAB is unchanged (floating
+overlay). Supersedes P3a's edge launcher (the dock is gated on the same
+`showChatbot`, so the FAB is always present to launch it).

--- a/packages/app-shell/src/layout/ConsoleChatbotFab.tsx
+++ b/packages/app-shell/src/layout/ConsoleChatbotFab.tsx
@@ -26,25 +26,38 @@ const prefetchChatbot = () => {
 
 import type { ConsoleFloatingChatbotProps } from './ConsoleFloatingChatbot';
 
-export type ConsoleChatbotFabProps = ConsoleFloatingChatbotProps;
+export type ConsoleChatbotFabProps = ConsoleFloatingChatbotProps & {
+  /**
+   * ADR-0057 P3b — when the ChatDock is enabled, the FAB becomes the dock's
+   * LAUNCHER: a click (and a designer "Ask AI" open signal) opens the docked
+   * rail instead of arming the floating overlay, and the heavy floating chatbot
+   * is never mounted (the dock owns the chat). Absent → unchanged floating-FAB
+   * behavior.
+   */
+  onOpenDock?: () => void;
+};
 
-export function ConsoleChatbotFab(props: ConsoleChatbotFabProps) {
+export function ConsoleChatbotFab({ onOpenDock, ...props }: ConsoleChatbotFabProps) {
   const [armed, setArmed] = useState(false);
   const { t } = useObjectTranslation();
 
   // A designer surface can ask the assistant to open (e.g. an "Ask AI"
   // button) via the assistant bus — arming the lazy chatbot just like a
   // click does. Once armed, the chatbot's own trigger owns open/close.
+  // When the dock is the target (P3b), the open signal opens the dock instead.
   const { openSeq } = useAssistant();
   const seenOpenSeq = useRef(openSeq);
   useEffect(() => {
     if (openSeq !== seenOpenSeq.current) {
       seenOpenSeq.current = openSeq;
-      setArmed(true);
+      if (onOpenDock) onOpenDock();
+      else setArmed(true);
     }
-  }, [openSeq]);
+  }, [openSeq, onOpenDock]);
 
-  if (armed) {
+  // Dock mode (P3b): stay the lightweight launcher — never mount the floating
+  // overlay; the click opens the rail, which loads the chat on demand.
+  if (armed && !onOpenDock) {
     return (
       <Suspense fallback={null}>
         <ConsoleFloatingChatbot {...props} defaultOpen />
@@ -56,9 +69,9 @@ export function ConsoleChatbotFab(props: ConsoleChatbotFabProps) {
     <button
       type="button"
       aria-label={t('topbar.openAssistant', { defaultValue: 'Open {{name}} assistant', name: props.appLabel })}
-      onClick={() => setArmed(true)}
-      onMouseEnter={prefetchChatbot}
-      onFocus={prefetchChatbot}
+      onClick={() => (onOpenDock ? onOpenDock() : setArmed(true))}
+      onMouseEnter={onOpenDock ? undefined : prefetchChatbot}
+      onFocus={onOpenDock ? undefined : prefetchChatbot}
       className="fixed bottom-20 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg ring-1 ring-primary/20 transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 sm:bottom-6"
       data-testid="console-chatbot-fab"
     >

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -15,7 +15,7 @@ import { AppShell } from '@object-ui/layout';
 // shiki, streamdown, mermaid, @ai-sdk, ~20MB) only downloads on first
 // hover/click. See ConsoleChatbotFab.tsx.
 import { ConsoleChatbotFab } from './ConsoleChatbotFab';
-import { useChatDockState, ChatDockPanel, ChatDockLauncher } from './ChatDock';
+import { useChatDockState, ChatDockPanel } from './ChatDock';
 import { matchChatDockShortcut } from './chatDockState';
 import { DraftPreviewBar } from '../preview/DraftPreviewBar';
 import { UnpublishedAppBar } from '../preview/UnpublishedAppBar';
@@ -165,13 +165,13 @@ export function ConsoleLayout({
           defaultAgent={activeApp?.defaultAgent}
           objects={objects}
           userId={userId}
+          // ADR-0057 P3b — when the dock is enabled, the FAB becomes its
+          // launcher (opens the rail) instead of the floating overlay. This
+          // supersedes P3a's edge launcher: the dock is gated on `showChatbot`,
+          // so the FAB is always present to launch it.
+          onOpenDock={dockEnabled ? dock.expand : undefined}
         />
       )}
-
-      {/* ADR-0057 P3a — collapsed dock affordance (edge launcher). Shown only
-          when the dock is enabled and collapsed; expanding renders the rail via
-          AppShell `rightRail` above. */}
-      {dockEnabled && !dock.expanded && <ChatDockLauncher onExpand={dock.expand} />}
     </AppShell>
     </MobileViewSwitcherProvider>
     </CommandPaletteProvider>

--- a/packages/app-shell/src/layout/__tests__/ConsoleChatbotFab.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ConsoleChatbotFab.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ConsoleChatbotFab } from '../ConsoleChatbotFab';
 
 vi.mock('@object-ui/i18n', () => ({
@@ -20,5 +20,17 @@ describe('ConsoleChatbotFab', () => {
     expect(fab).toHaveAccessibleName('Open Workspace assistant');
     expect(fab).toHaveClass('bottom-20');
     expect(fab).toHaveClass('sm:bottom-6');
+  });
+
+  it('ADR-0057 P3b — when onOpenDock is wired, the FAB launches the dock instead of the overlay', () => {
+    const onOpenDock = vi.fn();
+    render(<ConsoleChatbotFab appLabel="Workspace" objects={[]} onOpenDock={onOpenDock} />);
+
+    // Still the lightweight launcher button (no heavy floating chatbot mounted).
+    const fab = screen.getByTestId('console-chatbot-fab');
+    fireEvent.click(fab);
+    expect(onOpenDock).toHaveBeenCalledTimes(1);
+    // The floating overlay is never armed in dock mode — the button stays.
+    expect(screen.getByTestId('console-chatbot-fab')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Builds on P3a (#2464). When `features.chatDock` is enabled, the console FAB **opens the docked rail instead of the floating overlay** — the ADR's "FAB → launcher" step. One entry point.

## What
- `ConsoleChatbotFab` gains `onOpenDock`. When set (dock enabled): a click — and a designer "Ask AI" open signal (assistantBus) — opens the dock, and the **heavy floating chatbot is never mounted** (the FAB stays the lightweight button; the rail loads the chat on demand). When absent: unchanged floating-overlay behavior.
- `ConsoleLayout` passes `dock.expand` as `onOpenDock` when the dock is enabled, and **drops P3a's edge launcher** — the dock is gated on the same `showChatbot`, so the FAB is always present to launch it.

Flag OFF → the FAB is completely unchanged. Additive.

## Verification
- **Live** (flag forced on locally): on an app view the FAB is present and the P3a edge launcher is gone; clicking the FAB opens the **dock** (`chat-dock-panel` present, floating overlay **not** mounted, FAB stays lightweight) — the docked "Assistant" rail renders the ask chat and the content reflows beside it. Screenshot in the session.
- **Unit**: `ConsoleChatbotFab` with `onOpenDock` → click calls it and never arms the overlay; the default (no `onOpenDock`) FAB is unchanged.

## Next
P3c — `/ai` = the dock maximized + the Studio copilot moves to the shared right dock (properties reflow). Per the [plan](https://github.com/objectstack-ai/objectui/issues/2409#issuecomment-4958265739).

Refs: #2464 (P3a), epic #2409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)