### PR TITLE
fix(auth): login silent-failure UX — SSO pending states, redirect-URL contract, OAuth callback error banner (#2458 item 1)

### DIFF
--- a/apps/console/src/pages/auth/LoginPage.tsx
+++ b/apps/console/src/pages/auth/LoginPage.tsx
@@ -18,7 +18,7 @@
 
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import { useAuth, LoginForm } from '@object-ui/auth';
+import { useAuth, LoginForm, AuthErrorBanner } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Card } from '@object-ui/components';
 import { AuthLayout } from './AuthLayout';
@@ -95,6 +95,20 @@ export function LoginPage() {
     } catch {
       return null;
     }
+  }, []);
+
+  // Surface an OAuth/SSO callback failure. better-auth redirects a failed
+  // callback (expired hand-off, replayed `state`, IdP error, …) to its
+  // error URL with `?error=<code>` — the runtime points that at this login
+  // page (framework AuthManager `onAPIError.errorURL`). Without this banner
+  // the user who just SUCCEEDED at typing their password on the IdP lands
+  // back on a login form with zero explanation (objectui#2458 item 1).
+  const callbackError = useMemo(() => {
+    const code = params.get('error');
+    if (!code) return null;
+    const description = params.get('error_description');
+    return { code, description };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Read public auth config once to know whether sign-up is gated off.
@@ -189,6 +203,16 @@ export function LoginPage() {
   return (
     <AuthLayout formWidth="md">
       <div className="flex flex-col gap-6">
+        {callbackError ? (
+          <AuthErrorBanner
+            message={
+              t('auth.login.errors.oauthCallbackFailed', {
+                defaultValue:
+                  'Single sign-on could not be completed — the sign-in link expired or was already used. Please try again.',
+              }) + (callbackError.description ? ` (${callbackError.description})` : ` (${callbackError.code})`)
+            }
+          />
+        ) : null}
         {ssoTarget ? (
           <div
             role="status"

--- a/apps/console/src/pages/auth/__tests__/LoginPage.error-banner.test.tsx
+++ b/apps/console/src/pages/auth/__tests__/LoginPage.error-banner.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * LoginPage — OAuth callback `?error=` banner (objectui#2458 item 1).
+ *
+ * better-auth redirects a failed OAuth callback (expired hand-off, replayed
+ * `state`, IdP error) to its error URL with `?error=<code>`; the runtime
+ * points that at the console login page. The page must surface the code as a
+ * visible banner — before this fix the user landed on a silent login form
+ * right after successfully entering their password on the IdP.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '@object-ui/auth';
+import type { AuthClient } from '@object-ui/auth';
+import { LoginPage } from '../LoginPage';
+
+afterEach(cleanup);
+
+function createMockClient(): AuthClient {
+  return {
+    getSession: vi.fn().mockResolvedValue(null),
+    getConfig: vi.fn().mockResolvedValue({}),
+  } as unknown as AuthClient;
+}
+
+function renderLogin(search: string) {
+  window.history.replaceState({}, '', `/login${search}`);
+  return render(
+    <AuthProvider authUrl="/api/v1/auth" client={createMockClient()}>
+      <MemoryRouter initialEntries={[`/login${search}`]}>
+        <LoginPage />
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+describe('LoginPage — OAuth callback error banner', () => {
+  it('surfaces ?error= as a visible alert banner', async () => {
+    renderLogin('?error=state_mismatch');
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/state_mismatch/);
+  });
+
+  it('prefers the human-readable error_description when present', async () => {
+    renderLogin('?error=access_denied&error_description=User%20cancelled');
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/User cancelled/);
+  });
+
+  it('shows no banner on a plain login page', async () => {
+    renderLogin('');
+
+    // Wait for the form to settle, then assert no alert is present.
+    await screen.findByLabelText('Email');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/packages/auth/src/LoginForm.tsx
+++ b/packages/auth/src/LoginForm.tsx
@@ -184,6 +184,10 @@ export function LoginForm({
   // Break-glass: reveal the password form for the env owner / local admin even
   // under enforced mode (e.g. during an IdP outage).
   const [showPasswordFallback, setShowPasswordFallback] = useState(false);
+  // In-flight `/sign-in/sso` round-trip — the button needs its own pending
+  // state because SSO routing is a raw fetch, not the shared `signIn` (whose
+  // `isLoading` drives the password submit button).
+  const [ssoSubmitting, setSsoSubmitting] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -306,12 +310,14 @@ export function LoginForm({
    * error when no provider matches the domain.
    */
   const handleSso = async () => {
+    if (ssoSubmitting) return;
     setError(null);
     // SSO routes by email domain — a phone-shaped identifier can't map to an IdP.
     if (looksLikePhoneIdentifier(email)) {
       setError('Enter your email address to sign in with SSO.');
       return;
     }
+    setSsoSubmitting(true);
     try {
       const base = window.location.pathname.replace(/\/login(?:\/.*)?$/, '');
       const res = await fetch('/api/v1/auth/sign-in/sso', {
@@ -322,12 +328,15 @@ export function LoginForm({
       });
       const data = (await res.json().catch(() => ({}))) as { url?: string; message?: string };
       if (res.ok && typeof data.url === 'string') {
+        // Navigating to the IdP — keep the pending state through teardown.
         window.location.href = data.url;
         return;
       }
       setError(data.message || 'No SSO provider is configured for this email domain.');
+      setSsoSubmitting(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      setSsoSubmitting(false);
     }
   };
 
@@ -483,9 +492,11 @@ export function LoginForm({
             <button
               type="button"
               onClick={handleSso}
-              disabled={isLoading}
+              disabled={isLoading || ssoSubmitting}
+              aria-busy={ssoSubmitting}
               className="flex w-full items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-50"
             >
+              {ssoSubmitting && <AuthSpinner />}
               {l.ssoButton}
             </button>
           )}

--- a/packages/auth/src/SocialSignInButtons.tsx
+++ b/packages/auth/src/SocialSignInButtons.tsx
@@ -8,6 +8,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useAuth } from './useAuth';
+import { AuthSpinner } from './authStyles';
 import type { AuthSocialProvider } from './types';
 
 // Brand name overrides for providers whose `name` from the server may be unset
@@ -118,6 +119,10 @@ export function SocialSignInButtons({
   const [providers, setProviders] = useState<AuthSocialProvider[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Provider id of the in-flight `signInWithProvider` call. Sign-in ends in a
+  // full-page navigation, so the spinner deliberately stays on until unload —
+  // it is only cleared when the call FAILS and the user needs the button back.
+  const [pendingId, setPendingId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -151,15 +156,20 @@ export function SocialSignInButtons({
     typeof window !== 'undefined' ? window.location.href : undefined;
 
   const onClick = async (provider: AuthSocialProvider) => {
+    if (pendingId) return;
     setError(null);
+    setPendingId(provider.id);
     try {
       await signInWithProvider(provider.id, {
         callbackURL: callbackURL ?? defaultCallback,
         errorCallbackURL: errorCallbackURL ?? callbackURL ?? defaultCallback,
         type: provider.type ?? 'social',
       });
+      // Success = the browser is navigating to the provider. Keep the pending
+      // state so the button doesn't "un-busy" during the page teardown.
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      setPendingId(null);
     }
   };
 
@@ -175,9 +185,11 @@ export function SocialSignInButtons({
           key={p.id}
           type="button"
           onClick={() => onClick(p)}
+          disabled={pendingId !== null}
+          aria-busy={pendingId === p.id}
           className="inline-flex h-10 w-full items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
         >
-          <ProviderIcon id={p.id} />
+          {pendingId === p.id ? <AuthSpinner /> : <ProviderIcon id={p.id} />}
           {label} {PROVIDER_LABEL[p.id] ?? p.name}
         </button>
       ))}

--- a/packages/auth/src/__tests__/LoginForm.test.tsx
+++ b/packages/auth/src/__tests__/LoginForm.test.tsx
@@ -252,3 +252,38 @@ describe('LoginForm — phone + password sign-in (framework#2780)', () => {
     expect(signInWithPhonePassword).not.toHaveBeenCalled();
   });
 });
+
+describe('LoginForm — SSO button pending state (objectui#2458 item 1)', () => {
+  it('disables the SSO button while /sign-in/sso is in flight and surfaces failure inline', async () => {
+    let resolveFetch!: (r: Response) => void;
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => new Promise<Response>((resolve) => { resolveFetch = resolve; }));
+    try {
+      renderLogin(createMockClient({ features: { sso: true } }));
+      const button = await screen.findByRole('button', SSO_BUTTON);
+
+      fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@corp.example' } });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(button).toBeDisabled();
+        expect(button).toHaveAttribute('aria-busy', 'true');
+      });
+      // A second click while pending must not fire another request.
+      fireEvent.click(button);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      resolveFetch(new Response(JSON.stringify({ message: 'No SSO provider is configured for this email domain.' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      }));
+
+      const alert = await screen.findByRole('alert');
+      expect(alert.textContent).toMatch(/No SSO provider/);
+      expect(button).not.toBeDisabled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/packages/auth/src/__tests__/SocialSignInButtons.test.tsx
+++ b/packages/auth/src/__tests__/SocialSignInButtons.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for SocialSignInButtons — the provider buttons ("Continue with …").
+ *
+ * objectui#2458 item 1: clicking a provider button used to give ZERO feedback
+ * while the `/sign-in/oauth2` round-trip was in flight, and a sign-in call
+ * that resolved without navigating anywhere failed silently. The button must
+ * show a pending state, block double-clicks, and surface failures inline.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { AuthProvider } from '../AuthProvider';
+import { SocialSignInButtons } from '../SocialSignInButtons';
+import type { AuthClient, AuthPublicConfig } from '../types';
+
+const PROVIDER_CONFIG: AuthPublicConfig = {
+  socialProviders: [
+    { id: 'objectstack-cloud', name: 'ObjectStack', enabled: true, type: 'oidc' },
+  ],
+};
+
+function createMockClient(overrides: Partial<AuthClient> = {}): AuthClient {
+  return {
+    getSession: vi.fn().mockResolvedValue(null),
+    getConfig: vi.fn().mockResolvedValue(PROVIDER_CONFIG),
+    signInWithProvider: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as AuthClient;
+}
+
+function renderButtons(client: AuthClient) {
+  return render(
+    <AuthProvider authUrl="/api/auth" client={client}>
+      <SocialSignInButtons mode="sign-in" />
+    </AuthProvider>,
+  );
+}
+
+const BUTTON = { name: /Continue with ObjectStack/ } as const;
+
+describe('SocialSignInButtons — pending state + failure surfacing', () => {
+  it('disables the button and marks it busy while sign-in is in flight', async () => {
+    let resolveSignIn!: () => void;
+    const signInWithProvider = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolveSignIn = resolve; }),
+    );
+    renderButtons(createMockClient({ signInWithProvider }));
+
+    const button = await screen.findByRole('button', BUTTON);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'true');
+    });
+
+    // Success ends in a full-page navigation — the button must NOT re-enable
+    // during page teardown.
+    resolveSignIn();
+    await waitFor(() => expect(signInWithProvider).toHaveBeenCalledTimes(1));
+    expect(button).toBeDisabled();
+  });
+
+  it('ignores clicks while a sign-in is already in flight (no double-submit)', async () => {
+    const signInWithProvider = vi.fn().mockImplementation(() => new Promise<void>(() => {}));
+    renderButtons(createMockClient({ signInWithProvider }));
+
+    const button = await screen.findByRole('button', BUTTON);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => expect(signInWithProvider).toHaveBeenCalledTimes(1));
+  });
+
+  it('surfaces a failed sign-in as an inline alert and re-enables the button', async () => {
+    const signInWithProvider = vi.fn().mockRejectedValue(
+      new Error('Sign-in with "objectstack-cloud" did not return a redirect URL — please try again or contact your administrator.'),
+    );
+    renderButtons(createMockClient({ signInWithProvider }));
+
+    const button = await screen.findByRole('button', BUTTON);
+    fireEvent.click(button);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/did not return a redirect URL/);
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'false');
+  });
+});

--- a/packages/auth/src/__tests__/createAuthClient.test.ts
+++ b/packages/auth/src/__tests__/createAuthClient.test.ts
@@ -391,3 +391,40 @@ describe('createAuthClient — phone-number OTP (framework#2780)', () => {
     ).rejects.toMatchObject({ message: 'Invalid OTP', code: 'INVALID_OTP' });
   });
 });
+
+describe('createAuthClient — signInWithProvider redirect contract (objectui#2458 item 1)', () => {
+  // A provider sign-in that resolves WITHOUT a redirect URL used to resolve
+  // silently — the user clicked "Continue with …" and nothing happened. The
+  // client must throw so the buttons can surface an inline error.
+
+  it('oidc: rejects when /sign-in/oauth2 returns no url', async () => {
+    const { mockFn, calls } = createMockFetch({
+      '/sign-in/oauth2': { body: { redirect: false } },
+    });
+    const client = createAuthClient({ baseURL: 'http://localhost/api/auth', fetchFn: mockFn });
+    await expect(
+      client.signInWithProvider('objectstack-cloud', { type: 'oidc', callbackURL: '/x' }),
+    ).rejects.toThrow(/did not return a redirect URL/);
+    expect(calls.some((c) => c.url.includes('/sign-in/oauth2') && c.method === 'POST')).toBe(true);
+  });
+
+  it('social: rejects when /sign-in/social returns no url', async () => {
+    const { mockFn } = createMockFetch({
+      '/sign-in/social': { body: {} },
+    });
+    const client = createAuthClient({ baseURL: 'http://localhost/api/auth', fetchFn: mockFn });
+    await expect(
+      client.signInWithProvider('google', { type: 'social' }),
+    ).rejects.toThrow(/did not return a redirect URL/);
+  });
+
+  it('oidc: rejects with the server message when the endpoint errors', async () => {
+    const { mockFn } = createMockFetch({
+      '/sign-in/oauth2': { status: 400, body: { message: 'Provider not found' } },
+    });
+    const client = createAuthClient({ baseURL: 'http://localhost/api/auth', fetchFn: mockFn });
+    await expect(
+      client.signInWithProvider('objectstack-cloud', { type: 'oidc' }),
+    ).rejects.toThrow('Provider not found');
+  });
+});

--- a/packages/auth/src/createAuthClient.ts
+++ b/packages/auth/src/createAuthClient.ts
@@ -585,7 +585,12 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
         if (error) {
           throw new Error(error.message ?? `Auth request failed with status ${error.status}`);
         }
-        if (data?.url && typeof window !== 'undefined') {
+        // A missing redirect URL means the flow CANNOT continue — surface it
+        // instead of resolving silently (the user would see a dead button).
+        if (!data?.url) {
+          throw new Error(`Sign-in with "${providerId}" did not return a redirect URL — please try again or contact your administrator.`);
+        }
+        if (typeof window !== 'undefined') {
           window.location.href = data.url;
         }
         return;
@@ -599,7 +604,10 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
         throw new Error(error.message ?? `Auth request failed with status ${error.status}`);
       }
       const socialUrl = (data as { url?: string; redirect?: boolean } | null)?.url;
-      if (socialUrl && typeof window !== 'undefined') {
+      if (!socialUrl) {
+        throw new Error(`Sign-in with "${providerId}" did not return a redirect URL — please try again or contact your administrator.`);
+      }
+      if (typeof window !== 'undefined') {
         window.location.href = socialUrl;
       }
     },

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1544,6 +1544,7 @@ const en = {
       errors: {
         invalidCredentials: 'Invalid email or password. Please try again.',
         emailNotVerified: 'Please verify your email address before signing in.',
+        oauthCallbackFailed: 'Single sign-on could not be completed — the sign-in link expired or was already used. Please try again.',
       },
     },
     register: {

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1617,6 +1617,7 @@ const zh = {
       errors: {
         invalidCredentials: '邮箱或密码错误，请重试。',
         emailNotVerified: '请先验证您的邮箱后再登录。',
+        oauthCallbackFailed: '单点登录未能完成——登录链接已过期或已被使用，请重新发起登录。',
       },
     },
     register: {


### PR DESCRIPTION
Fixes item 1 (🔴 登录提交"无声失败") of #2458.

## Ownership verdict

**The login surface is objectui-owned** — the console SPA (`apps/console` + `@object-ui/auth`) serves `/_console/login` on both the cloud (:4900) and every env host; framework's better-auth server side behaves as designed with one exception (below). Live re-investigation on the run-stack rig found:

- The email/password submit **already had** a pending state, inline error banner, and post-login OAuth continuation (`followOauthAuthorize`, #2008) — these were live-verified working. Part of what the three test sessions saw was a **stale served console bundle** (the rig node-resolves `@objectstack/console` to `framework/packages/console/dist`, bypassing run-stack's overlay) plus click/typing automation artifacts.
- **One genuine silent dead-end was reproduced on current code**: when the OAuth hand-off's signed params / `state` go stale (10-min `exp`, single-use state — easy in a slow real-world session), the cloud still issues a code, the **env callback rejects with `state_mismatch`**, and better-auth's default error redirect (`/?error=state_mismatch`) loses its query on the root→console hop. The user who just typed a correct password lands on a **silent login form** — exactly the reported symptom (the env and cloud login forms are visually identical).
- The SSO/provider buttons ("Continue with ObjectStack") had **no pending state**, and a provider sign-in that resolved without a redirect URL was a **silent no-op**.

## Changes

- `SocialSignInButtons`: pending spinner + disabled while `signInWithProvider` is in flight, double-click guard, inline failure surfacing (button re-enables only on failure — success ends in navigation).
- `createAuthClient.signInWithProvider`: **throws** when the server response carries no redirect URL (both `oidc` and `social` paths) instead of resolving silently.
- `LoginForm` "Sign in with SSO": pending state on the raw `/sign-in/sso` fetch.
- `LoginPage`: renders `?error=` / `?error_description=` (better-auth OAuth callback failure codes) as a visible `AuthErrorBanner` — zh/en strings added (`auth.login.errors.oauthCallbackFailed`).
- Paired framework PR (objectstack-ai/framework — plugin-auth `onAPIError.errorURL` → `/_console/login`) makes the server land callback errors where this banner is. The banner is inert until that merges; merge this UI PR first.

## Verification (live browser on the run-stack rig, fixed bundle overlaid)

| Proof | Result |
|---|---|
| (a) wrong password | inline 邮箱或密码错误 banner, button re-enabled ✅ |
| (b) correct password, plain login | redirects to console home ✅ |
| (c) env → Continue with ObjectStack → cloud login (signed OAuth params) → 登录 | full hand-off completes, lands signed-in on the env ✅ |
| (d) backend stopped, submit | visible inline "Failed to fetch", button re-enabled — not console-only ✅ |
| `?error=state_mismatch` on login | visible banner: 单点登录未能完成——登录链接已过期或已被使用… (state_mismatch) ✅ |

Scoped tests: `packages/auth` (LoginForm / SocialSignInButtons / createAuthClient) + `apps/console` LoginPage banner — 53 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)