### PR TITLE
feat(console-ai): ChatDock DEFAULT ON — flag becomes a kill-switch (ADR-0057 P3 go-live)

### DIFF
--- a/.changeset/adr-0057-chatdock-default-on.md
+++ b/.changeset/adr-0057-chatdock-default-on.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(console-ai): the ChatDock is now DEFAULT ON (ADR-0057 P3 go-live)
+
+`features.chatDock` flips from opt-in to opt-out: the right-docked chat rail
+(FAB as launcher, `/ai` as the panel maximized, Studio right dock with center
+`[Canvas | Properties]` tabs) is the console's default chat presentation. The
+flag survives only as a server-side kill-switch — an operator sending
+`chatDock: false` restores the floating-overlay console until the final
+cleanup removes that path (epic #2409).

--- a/docs/adr/0057-console-ai-chat-one-conversation-docked.md
+++ b/docs/adr/0057-console-ai-chat-one-conversation-docked.md
@@ -2,9 +2,10 @@
 
 **Status**: Accepted (2026-07-13) — P1+P2 shipped (#2414), P4 shipped
 (#2439 / #2444 + cloud#818/#819; reliability follow-ups #2449 + cloud#820);
-P3 shipped behind the default-off `features.chatDock` rollout flag (P3a #2464,
-P3b #2465, P3c #2467 — epic #2409; flag default-on + overlay retirement are the
-remaining cleanup, tracked on the epic). Console-layer realization of the two-agent,
+P3 shipped (P3a #2464, P3b #2465, P3c #2467 — epic #2409); `features.chatDock`
+is now DEFAULT ON (kept only as a server-side kill-switch); overlay retirement +
+flag removal are the remaining cleanup, tracked on the epic. Console-layer
+realization of the two-agent,
 surface-bound model (cloud ADR-0063). **No agent, boundary, or commercial-model
 change** — this ADR only rearranges how the objectui console *renders and wires*
 chat surfaces.

--- a/packages/app-shell/src/runtime-config.test.ts
+++ b/packages/app-shell/src/runtime-config.test.ts
@@ -53,15 +53,17 @@ describe('runtime-config commercial features', () => {
         expect(getRuntimeConfig().features.aiStudio).toBe(true);
     });
 
-    it('ADR-0057 P3a chatDock defaults OFF and is opt-in (rollout flag)', async () => {
-        expect(getRuntimeConfig().features.chatDock).toBeFalsy();
-        mockConfig({ chatDock: true });
+    it('ADR-0057 chatDock defaults ON; explicit false is the kill-switch', async () => {
+        // Shipped default: the dock is on before/without any server signal.
+        expect(getRuntimeConfig().features.chatDock).toBe(true);
+        mockConfig({ aiStudio: true }); // older runtime, no chatDock key → still on
         await initRuntimeConfig();
         expect(getRuntimeConfig().features.chatDock).toBe(true);
         resetRuntimeConfigForTesting();
-        mockConfig({ aiStudio: true }); // older runtime, no chatDock key
+        // Kill-switch: only an explicit false restores the floating-overlay console.
+        mockConfig({ chatDock: false });
         await initRuntimeConfig();
-        expect(getRuntimeConfig().features.chatDock).toBeFalsy();
+        expect(getRuntimeConfig().features.chatDock).toBe(false);
     });
 });
 

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -55,11 +55,13 @@ export interface RuntimeFeatures {
    */
   sso?: boolean;
   /**
-   * ADR-0057 P3a — render the console AI chat as a right-docked, collapsible
-   * rail (the VS Code / Cursor idiom) in addition to the floating FAB. Rollout
-   * flag, DEFAULT OFF: the dock is additive and changes nothing until an
-   * operator opts in (`OS_AI_CHAT_DOCK=1` / RuntimeConfigPlugin). The FAB stays
-   * the canonical entry until P3b retires it into the dock's launcher.
+   * ADR-0057 P3 — render the console AI chat as a right-docked, collapsible
+   * rail (the VS Code / Cursor idiom); the FAB is its launcher, `/ai` is the
+   * same panel maximized, and Studio hosts it as its right dock. Shipped
+   * (P3a #2464, P3b #2465, P3c #2467) and DEFAULT ON. The flag remains only
+   * as a server-side kill-switch: an operator sending `false` restores the
+   * floating-overlay console until the final cleanup removes that path
+   * (epic #2409).
    */
   chatDock?: boolean;
 }
@@ -112,7 +114,7 @@ const defaults: RuntimeConfig = {
   singleEnvironment: false,
   defaultOrgId: null,
   defaultEnvironmentId: null,
-  features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true, customDomain: false, sso: false },
+  features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true, customDomain: false, sso: false, chatDock: true },
   // `stage: 'preview'` while the whole platform is pre-GA, so the badge shows
   // out of the box on any runtime that hasn't sent an explicit stage yet.
   branding: { productName: 'ObjectOS', productShortName: 'ObjectOS', stage: 'preview', brandColor: '#4F46E5', pwaThemeColor: '#4f46e5' },
@@ -179,8 +181,11 @@ export async function initRuntimeConfig(baseUrl: string = ''): Promise<void> {
           // them — never show a paid surface on an unknown/older runtime.
           customDomain: body.features.customDomain === true,
           sso: body.features.sso === true,
-          // ADR-0057 P3a rollout flag — default OFF (additive dock).
-          chatDock: body.features.chatDock === true,
+          // ADR-0057 — the docked chat shipped (P3a–P3c) and is now DEFAULT ON;
+          // the flag survives only as a server-side kill-switch (send `false`
+          // to fall back to the floating-overlay console until the overlay
+          // path is removed by the final cleanup, epic #2409).
+          chatDock: body.features.chatDock !== false,
         }
         : current.features,
       branding: body.branding


### PR DESCRIPTION
Go-live for ADR-0057 P3 (epic #2409), following #2467: `features.chatDock` flips from **opt-in** (`=== true`) to **opt-out** (`!== false`), and the client default is `true` — the right-docked chat (FAB as launcher, `/ai` as the panel maximized, Studio right dock with center `[Canvas | Properties]` tabs) is now the console's default presentation on every runtime, with no server config needed.

The flag survives **only as a server-side kill-switch**: an operator sending `chatDock: false` restores the floating-overlay console. The kill-switch (and the overlay path it falls back to, plus the legacy left Studio copilot) will be removed by the final cleanup PR tracked on the epic.

- `runtime-config.ts`: default `chatDock: true`; parse `!== false`; doc comment updated to shipped/kill-switch semantics.
- `runtime-config.test.ts`: the P3a "defaults OFF and is opt-in" case becomes "defaults ON; explicit false is the kill-switch".
- ADR-0057 Status line updated; changeset added.
- Suites re-run green with the new default: 18 files / 94 tests (runtime-config, layout, console/ai, console, studio-design).

The flag-on behavior itself carries #2467's ADR-0054 browser proof (rail ⇄ `/ai` same thread, Studio grid, canvas auto-maximize), captured on the local rig with exactly this configuration.

Refs #2409 · ADR-0057 §P3

🤖 Generated with [Claude Code](https://claude.com/claude-code)