### PR TITLE
feat(console-ai): ChatDock follow-ups — mobile sheet, wide side-by-side, exact collapse landing (ADR-0057 P3)

### DIFF
--- a/.changeset/adr-0057-p3-followups.md
+++ b/.changeset/adr-0057-p3-followups.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(console-ai): ChatDock follow-ups — mobile sheet, wide side-by-side properties, exact collapse landing (ADR-0057 P3)
+
+- Under `md` the dock presents as a bottom sheet (`ChatDockMobileSheet`) —
+  console FAB opens it; Studio gets a mobile-visible edge launcher.
+- The folded Studio layout keeps canvas AND properties side by side on 2xl+
+  viewports; tabs (and their auto-switch) only exist where width forces them.
+- Folded tabs mode flattens the source page's nested Source/Props tabs — the
+  Properties tab body is the code editor directly.
+- Maximize remembers its origin, so `/ai`'s collapse-to-dock returns to the
+  exact page (console or Studio) the user left, immune to history churn.
+- The dock's conversation honors `app.defaultAgent` via the one resolver,
+  matching the FAB's behavior.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -75,7 +75,7 @@ import {
 } from '@object-ui/plugin-chatbot';
 
 import { AppHeader } from '../../layout/AppHeader';
-import { armChatDockExpanded } from '../../layout/chatDockState';
+import { armChatDockExpanded, readDockReturnLocation } from '../../layout/chatDockState';
 import { fetchPendingDraftCount } from '../../preview/draftStatus';
 import { emitMetadataRefresh } from '../../assistant/assistantBus';
 import { getRuntimeConfig } from '../../runtime-config';
@@ -517,15 +517,28 @@ export function matchAiChatShortcut(e: {
 }
 
 /**
- * ADR-0057 P3c — where the "collapse to dock" affordance navigates: back
- * through history when react-router has an in-app entry to return to
- * (`window.history.state.idx > 0` — the router stamps a monotonically
- * increasing `idx` on entries it creates), else `/home` (the page was the
- * entry point: a deep link, a fresh tab). The dock itself is armed to open
- * expanded separately ({@link armChatDockExpanded}); this only picks the
- * landing. Pure + exported for tests.
+ * ADR-0057 P3c — where the "collapse to dock" affordance navigates, in
+ * preference order:
+ *
+ *  1. The REMEMBERED maximize origin (`storedPath`, written by the dock's own
+ *     maximize handlers at click time) — the exact page the user left, immune
+ *     to in-page history churn (conversation switches push `/ai/...` entries,
+ *     so blind history-back can land on a prior `/ai` URL instead of the
+ *     console).
+ *  2. History back, when react-router has an in-app entry to return to
+ *     (`window.history.state.idx > 0` — the router stamps a monotonically
+ *     increasing `idx` on entries it creates).
+ *  3. `/home` — the page was the entry point (deep link, fresh tab).
+ *
+ * The dock itself is armed to open expanded separately
+ * ({@link armChatDockExpanded}); this only picks the landing. Pure + exported
+ * for tests.
  */
-export function resolveCollapseToDockTarget(historyIdx: unknown): -1 | '/home' {
+export function resolveCollapseToDockTarget(
+  historyIdx: unknown,
+  storedPath?: string,
+): string | -1 {
+  if (storedPath) return storedPath;
   return typeof historyIdx === 'number' && historyIdx > 0 ? -1 : '/home';
 }
 
@@ -1078,18 +1091,19 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
           <AppHeader variant="home" />
         </div>
         {/* ADR-0057 P3c — "/ai = the ChatDock maximized": tuck this full-page
-            surface back into the console's right rail. Arms the dock to mount
-            expanded, then returns to the page the user came from (or /home on
-            a cold deep link) — the rail resolves the same (user, product)
-            conversation scope, so it shows THE SAME THREAD. Desktop-only
-            (the dock itself is `hidden md:flex`) and flag-gated: with
-            `features.chatDock` off this button does not exist and the page is
-            pixel-identical to pre-P3c. */}
+            surface back into the dock. Arms the dock to mount expanded, then
+            returns to the exact page the user maximized from (remembered by
+            the dock's own maximize handlers; falls back to history-back, then
+            /home on a cold deep link) — the dock resolves the same
+            (user, product) conversation scope, so it shows THE SAME THREAD.
+            Visible on mobile too: under `md` the dock presents as a bottom
+            sheet. Flag-gated: with `features.chatDock` off this button does
+            not exist and the page is pixel-identical to pre-P3c. */}
         {!noAgents && getRuntimeConfig().features.chatDock === true && (
           <Button
             variant="ghost"
             size="icon"
-            className="hidden h-8 w-8 shrink-0 md:inline-flex"
+            className="h-8 w-8 shrink-0"
             data-testid="ai-chat-collapse-to-dock"
             aria-label={t('console.ai.collapseToDock', { defaultValue: 'Collapse to side panel' })}
             title={t('console.ai.collapseToDock', { defaultValue: 'Collapse to side panel' })}
@@ -1097,6 +1111,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
               armChatDockExpanded();
               const target = resolveCollapseToDockTarget(
                 (window.history.state as { idx?: unknown } | null)?.idx,
+                readDockReturnLocation(),
               );
               if (target === -1) navigate(-1);
               else navigate(target);

--- a/packages/app-shell/src/console/ai/__tests__/resolveCollapseToDockTarget.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/resolveCollapseToDockTarget.test.ts
@@ -2,17 +2,26 @@
  * ObjectUI
  * Copyright (c) 2024-present ObjectStack Inc.
  *
- * ADR-0057 P3c — the `/ai` page's "collapse to dock" landing: back through
- * history when react-router has an in-app entry to return to, else /home
- * (deep link / fresh tab — nothing behind us worth going "back" to).
+ * ADR-0057 P3c — the `/ai` page's "collapse to dock" landing: the remembered
+ * maximize origin wins, else history back when react-router has an in-app
+ * entry to return to, else /home (deep link / fresh tab — nothing behind us
+ * worth going "back" to).
  */
 import { describe, it, expect } from 'vitest';
 import { resolveCollapseToDockTarget } from '../AiChatPage';
 
 describe('resolveCollapseToDockTarget', () => {
+  it('prefers the remembered maximize origin over history', () => {
+    expect(resolveCollapseToDockTarget(3, '/apps/crm/objects/deal')).toBe('/apps/crm/objects/deal');
+    // Even a deep-linked page (idx 0) returns to the stored origin.
+    expect(resolveCollapseToDockTarget(0, '/studio/com.example/interfaces')).toBe(
+      '/studio/com.example/interfaces',
+    );
+  });
+
   it('goes back when react-router stamped a positive history index', () => {
     expect(resolveCollapseToDockTarget(1)).toBe(-1);
-    expect(resolveCollapseToDockTarget(7)).toBe(-1);
+    expect(resolveCollapseToDockTarget(7, undefined)).toBe(-1);
   });
 
   it('lands on /home when this page is the entry point (idx 0)', () => {

--- a/packages/app-shell/src/layout/ChatDock.tsx
+++ b/packages/app-shell/src/layout/ChatDock.tsx
@@ -17,7 +17,15 @@
  * rail while the ADR-0037 Live Canvas is open.
  */
 import * as React from 'react';
-import { cn, Button } from '@object-ui/components';
+import {
+  cn,
+  Button,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@object-ui/components';
 import { Maximize2, MessagesSquare, PanelRightClose } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useAgents } from '@object-ui/plugin-chatbot';
@@ -210,6 +218,12 @@ export function useChatDockState(options?: ChatDockOptions): ChatDockState {
 interface ChatDockConversationProps {
   userId: string | undefined;
   apiBase: string;
+  /**
+   * `app.defaultAgent` of the active app — forwarded to the ONE resolver
+   * (bounded to ask/build there), so the dock honors the same per-app default
+   * the FAB always did. Absent → the surface default (`ask`).
+   */
+  defaultAgent?: string;
   /** ADR-0037/P3c — the Live Canvas open/close seam, forwarded to ChatPane. */
   onCanvasOpenChange?: (open: boolean) => void;
 }
@@ -221,15 +235,21 @@ interface ChatDockConversationProps {
  * the console's ambient assistant thread. Renders nothing when the AI catalog is
  * empty (OSS / no seat).
  */
-function ChatDockConversation({ userId, apiBase, onCanvasOpenChange }: ChatDockConversationProps) {
+function ChatDockConversation({
+  userId,
+  apiBase,
+  defaultAgent,
+  onCanvasOpenChange,
+}: ChatDockConversationProps) {
   const { agents, isLoading, error } = useAgents({ apiBase });
   const activeAgent = React.useMemo(
     () =>
       resolveSurfaceAgent('default', {
         agents,
+        appDefaultAgent: defaultAgent,
         aiStudioEnabled: getRuntimeConfig().features.aiStudio !== false,
       }),
-    [agents],
+    [agents, defaultAgent],
   );
   const chatApi = activeAgent
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`
@@ -274,6 +294,8 @@ export interface ChatDockPanelProps {
   /** Signed-in user id for the default (console ask) body. Unused with `children`. */
   userId?: string;
   apiBase?: string;
+  /** `app.defaultAgent` for the default body's resolver. Unused with `children`. */
+  defaultAgent?: string;
   /** Header title override (the Studio dock says "AI copilot"); default "Assistant". */
   title?: string;
   /**
@@ -301,6 +323,7 @@ export function ChatDockPanel({
   dock,
   userId,
   apiBase: apiBaseProp,
+  defaultAgent,
   title,
   onMaximize,
   children,
@@ -367,6 +390,7 @@ export function ChatDockPanel({
           <ChatDockConversation
             userId={userId}
             apiBase={apiBase}
+            defaultAgent={defaultAgent}
             onCanvasOpenChange={handleCanvasOpenChange}
           />
         )}
@@ -375,8 +399,87 @@ export function ChatDockPanel({
   );
 }
 
+export interface ChatDockMobileSheetProps {
+  /** Sheet visibility — decoupled from {@link ChatDockState} so callers can
+   *  drive it from the dock (console) or a local state (Studio). */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  userId?: string;
+  apiBase?: string;
+  /** `app.defaultAgent` for the default body's resolver. Unused with `children`. */
+  defaultAgent?: string;
+  /** Header title override; default "Assistant". */
+  title?: string;
+  /** Renders a Maximize2 header button → the full-page `/ai` surface. */
+  onMaximize?: () => void;
+  /** Body override — same contract as {@link ChatDockPanel}. */
+  children?: React.ReactNode;
+}
+
+/**
+ * The dock's UNDER-`md` presentation: a bottom sheet over the page instead of a
+ * side rail (there is no horizontal room to reflow into on a phone). Same
+ * conversation, same body contract as {@link ChatDockPanel} — chrome only.
+ * Rendered `md:hidden`, so across a live viewport resize exactly one of
+ * sheet/rail is visible.
+ */
+export function ChatDockMobileSheet({
+  open,
+  onOpenChange,
+  userId,
+  apiBase: apiBaseProp,
+  defaultAgent,
+  title,
+  onMaximize,
+  children,
+}: ChatDockMobileSheetProps) {
+  const { t } = useObjectTranslation();
+  const apiBase = React.useMemo(() => resolveApiBase(apiBaseProp), [apiBaseProp]);
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="flex h-[85svh] flex-col gap-0 p-0 md:hidden"
+        data-testid="chat-dock-mobile-sheet"
+      >
+        <SheetHeader className="shrink-0 border-b px-4 py-2.5">
+          <div className="flex items-center justify-between gap-2 pr-8">
+            <SheetTitle className="inline-flex items-center gap-1.5 text-sm font-semibold">
+              <MessagesSquare className="size-4" />
+              {title ?? t('console.ai.dock.title', { defaultValue: 'Assistant' })}
+            </SheetTitle>
+            {onMaximize ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                onClick={onMaximize}
+                aria-label={t('console.ai.dock.maximize', { defaultValue: 'Open full page' })}
+                data-testid="chat-dock-mobile-maximize"
+              >
+                <Maximize2 className="h-3.5 w-3.5" />
+              </Button>
+            ) : null}
+          </div>
+          <SheetDescription className="sr-only">
+            {t('console.ai.dock.description', { defaultValue: 'AI assistant chat' })}
+          </SheetDescription>
+        </SheetHeader>
+        <div className="min-h-0 flex-1">
+          {children ?? (
+            <ChatDockConversation userId={userId} apiBase={apiBase} defaultAgent={defaultAgent} />
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
 export interface ChatDockLauncherProps {
   onExpand: () => void;
+  /** Merged onto the default classes — e.g. the Studio mobile launcher swaps
+   *  the `hidden md:inline-flex` gate for an always-visible variant. */
+  className?: string;
 }
 
 /**
@@ -385,7 +488,7 @@ export interface ChatDockLauncherProps {
  * retired it in P3b (the FAB is that surface's launcher); the Studio dock (P3c)
  * uses it as its collapsed state, since Studio has no FAB.
  */
-export function ChatDockLauncher({ onExpand }: ChatDockLauncherProps) {
+export function ChatDockLauncher({ onExpand, className }: ChatDockLauncherProps) {
   const { t } = useObjectTranslation();
   return (
     <Button
@@ -395,7 +498,10 @@ export function ChatDockLauncher({ onExpand }: ChatDockLauncherProps) {
       data-testid="chat-dock-launcher"
       aria-label={t('console.ai.dock.open', { defaultValue: 'Open assistant' })}
       title={t('console.ai.dock.open', { defaultValue: 'Open assistant (⌘⇧I)' })}
-      className="fixed right-0 top-1/2 z-40 hidden h-16 w-7 -translate-y-1/2 rounded-l-md rounded-r-none border-r-0 bg-background shadow-md md:inline-flex"
+      className={cn(
+        'fixed right-0 top-1/2 z-40 hidden h-16 w-7 -translate-y-1/2 rounded-l-md rounded-r-none border-r-0 bg-background shadow-md md:inline-flex',
+        className,
+      )}
     >
       <MessagesSquare className="size-4" />
     </Button>

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -8,16 +8,21 @@
  * @module
  */
 
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useCallback, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { AppShell } from '@object-ui/layout';
+import { useIsMobile } from '@object-ui/components';
 
 // Lightweight FAB stub — the heavy chat chunk graph (plugin-chatbot,
 // shiki, streamdown, mermaid, @ai-sdk, ~20MB) only downloads on first
 // hover/click. See ConsoleChatbotFab.tsx.
 import { ConsoleChatbotFab } from './ConsoleChatbotFab';
-import { useChatDockState, ChatDockPanel } from './ChatDock';
-import { matchChatDockShortcut, DOCK_EXPANDED_STORAGE_KEY } from './chatDockState';
+import { useChatDockState, ChatDockPanel, ChatDockMobileSheet } from './ChatDock';
+import {
+  matchChatDockShortcut,
+  rememberDockReturnLocation,
+  DOCK_EXPANDED_STORAGE_KEY,
+} from './chatDockState';
 import { DraftPreviewBar } from '../preview/DraftPreviewBar';
 import { UnpublishedAppBar } from '../preview/UnpublishedAppBar';
 import { UnifiedSidebar } from './UnifiedSidebar';
@@ -90,6 +95,19 @@ export function ConsoleLayout({
   const dock = useChatDockState({ persistExpandedKey: DOCK_EXPANDED_STORAGE_KEY });
   const dockEnabled = showChatbot && getRuntimeConfig().features.chatDock === true;
   const navigate = useNavigate();
+  const location = useLocation();
+  // Under `md` there is no horizontal room for the rail — the dock presents as
+  // a bottom sheet instead (same conversation, chrome only). The hook (not the
+  // rail's `hidden md:` classes alone) decides which one MOUNTS, so the phone
+  // never pays for an invisible rail's chat graph.
+  const isMobile = useIsMobile();
+  // "/ai = the dock maximized": record where we maximized FROM at click time,
+  // so the page's collapse-to-dock returns exactly here (history-back could
+  // land on a prior /ai URL after in-page conversation switches).
+  const openDockFullPage = useCallback(() => {
+    rememberDockReturnLocation(`${location.pathname}${location.search}`);
+    navigate('/ai');
+  }, [location.pathname, location.search, navigate]);
 
   // Set navigation context to 'app' when this layout mounts
   useEffect(() => {
@@ -133,18 +151,18 @@ export function ConsoleLayout({
       }
       className="!p-0 overflow-y-auto overflow-x-hidden bg-muted/5"
       rightRail={
-        dockEnabled && dock.expanded ? (
+        dockEnabled && dock.expanded && !isMobile ? (
           <ChatDockPanel
             dock={dock}
             userId={userId}
+            // The dock honors the app's own default agent exactly like the FAB
+            // did — through the ONE resolver (bounded to ask/build there).
+            defaultAgent={activeApp?.defaultAgent}
             // ADR-0057 P3c — "/ai = the dock maximized": the maximize button
             // opens the full-page surface, which canonicalizes `/ai` to the
-            // default agent and resolves the same app-less `(user, product)`
-            // scope — i.e. THE SAME THREAD this rail shows. (A deployment that
-            // overrides the default agent via VITE_AI_DEFAULT_AGENT could in
-            // principle diverge from the dock's `resolveSurfaceAgent('default')`
-            // pick; both funnel through the same platform default today.)
-            onMaximize={() => navigate('/ai')}
+            // default agent and resolves the same `(user, product)` scope —
+            // i.e. THE SAME THREAD this rail shows.
+            onMaximize={openDockFullPage}
           />
         ) : undefined
       }
@@ -188,6 +206,18 @@ export function ConsoleLayout({
           // supersedes P3a's edge launcher: the dock is gated on `showChatbot`,
           // so the FAB is always present to launch it.
           onOpenDock={dockEnabled ? dock.expand : undefined}
+        />
+      )}
+
+      {/* Under `md` the FAB opens the dock as a bottom sheet (no room for a
+          rail on a phone) — same conversation, chrome only. */}
+      {dockEnabled && isMobile && (
+        <ChatDockMobileSheet
+          open={dock.expanded}
+          onOpenChange={(open) => (open ? dock.expand() : dock.collapse())}
+          userId={userId}
+          defaultAgent={activeApp?.defaultAgent}
+          onMaximize={openDockFullPage}
         />
       )}
     </AppShell>

--- a/packages/app-shell/src/layout/__tests__/ChatDock.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ChatDock.test.tsx
@@ -9,7 +9,7 @@
 import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ChatDockPanel, type ChatDockState } from '../ChatDock';
+import { ChatDockPanel, ChatDockMobileSheet, type ChatDockState } from '../ChatDock';
 
 vi.mock('@object-ui/i18n', () => ({
   useObjectTranslation: () => ({
@@ -85,5 +85,33 @@ describe('ChatDockPanel', () => {
     expect(screen.getByText('AI copilot')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('chat-dock-collapse'));
     expect(dock.collapse).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ChatDockMobileSheet', () => {
+  it('renders the children body + maximize when open, and closes via onOpenChange', () => {
+    const onOpenChange = vi.fn();
+    const onMaximize = vi.fn();
+    render(
+      <ChatDockMobileSheet open onOpenChange={onOpenChange} onMaximize={onMaximize}>
+        <div data-testid="mobile-dock-body" />
+      </ChatDockMobileSheet>,
+    );
+    expect(screen.getByTestId('chat-dock-mobile-sheet')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-dock-body')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('chat-dock-mobile-maximize'));
+    expect(onMaximize).toHaveBeenCalledTimes(1);
+    // Radix Sheet's built-in close button drives onOpenChange(false).
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders nothing while closed', () => {
+    render(
+      <ChatDockMobileSheet open={false} onOpenChange={() => {}}>
+        <div data-testid="mobile-dock-body" />
+      </ChatDockMobileSheet>,
+    );
+    expect(screen.queryByTestId('mobile-dock-body')).not.toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/layout/__tests__/chatDockReturnLocation.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/chatDockReturnLocation.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * ADR-0057 P3c follow-up — the dock's remembered maximize origin: the storage
+ * round trip, and the same-app-absolute-path trust boundary on read (a
+ * corrupted/injected value must never become an open redirect). A `.test.tsx`
+ * so it runs under happy-dom (sessionStorage exists).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  rememberDockReturnLocation,
+  readDockReturnLocation,
+  armChatDockExpanded,
+  parseStoredDockExpanded,
+  DOCK_EXPANDED_STORAGE_KEY,
+  DOCK_RETURN_TO_STORAGE_KEY,
+} from '../chatDockState';
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe('dock return-location round trip', () => {
+  it('remembers and reads an in-app path with its query', () => {
+    rememberDockReturnLocation('/apps/crm/objects/deal?view=kanban');
+    expect(readDockReturnLocation()).toBe('/apps/crm/objects/deal?view=kanban');
+  });
+
+  it('returns undefined when nothing was remembered', () => {
+    expect(readDockReturnLocation()).toBeUndefined();
+  });
+
+  it('only trusts same-app absolute paths (no open redirect)', () => {
+    window.sessionStorage.setItem(DOCK_RETURN_TO_STORAGE_KEY, 'https://evil.example/x');
+    expect(readDockReturnLocation()).toBeUndefined();
+    window.sessionStorage.setItem(DOCK_RETURN_TO_STORAGE_KEY, '//evil.example/x');
+    expect(readDockReturnLocation()).toBeUndefined();
+    window.sessionStorage.setItem(DOCK_RETURN_TO_STORAGE_KEY, 'apps/relative');
+    expect(readDockReturnLocation()).toBeUndefined();
+  });
+});
+
+describe('armChatDockExpanded', () => {
+  it("writes the '1' the dock's stored-expanded parse accepts", () => {
+    armChatDockExpanded();
+    expect(
+      parseStoredDockExpanded(window.sessionStorage.getItem(DOCK_EXPANDED_STORAGE_KEY)),
+    ).toBe(true);
+  });
+});

--- a/packages/app-shell/src/layout/chatDockState.ts
+++ b/packages/app-shell/src/layout/chatDockState.ts
@@ -93,6 +93,38 @@ export function armChatDockExpanded(): void {
   writeStoredDockExpanded(DOCK_EXPANDED_STORAGE_KEY, true);
 }
 
+/**
+ * sessionStorage key holding the in-app path (`pathname?search`) the user
+ * maximized the dock FROM — a console page, or the Studio design surface. The
+ * `/ai` page's collapse-to-dock prefers it over blind history-back, so the
+ * round trip lands exactly where the user left (history-back could land on a
+ * prior `/ai` URL after in-page conversation switches). Written by the
+ * maximize handlers at click time (the only moment the origin is known);
+ * per-tab by design.
+ */
+export const DOCK_RETURN_TO_STORAGE_KEY = 'ai-chat-dock-return-to';
+
+/** Record where a dock→`/ai` maximize departed from (see the key's doc). */
+export function rememberDockReturnLocation(path: string): void {
+  try {
+    window.sessionStorage.setItem(DOCK_RETURN_TO_STORAGE_KEY, path);
+  } catch {
+    /* private mode — collapse just falls back to history-back */
+  }
+}
+
+/** The remembered maximize origin — only an in-app absolute path is trusted. */
+export function readDockReturnLocation(): string | undefined {
+  try {
+    const raw = window.sessionStorage.getItem(DOCK_RETURN_TO_STORAGE_KEY);
+    // Reject anything that isn't a same-app absolute path ('//host' included),
+    // so a corrupted/injected value can never turn this into an open redirect.
+    return raw && raw.startsWith('/') && !raw.startsWith('//') ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export type ChatDockShortcut = 'toggle';
 
 /**

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -1,16 +1,22 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '@object-ui/auth';
-import { Button } from '@object-ui/components';
+import { Button, useIsMobile } from '@object-ui/components';
 import { Sparkles, PanelLeftClose } from 'lucide-react';
 import { useAgents } from '@object-ui/plugin-chatbot';
 import { useChatConversation } from '../../hooks/useChatConversation';
 import { chatConversationScope, chatProductOfAgent } from '../../hooks/chatScope';
 import { resolveSurfaceAgent } from '../../hooks/surfaceAgent';
 import { ChatPane, resolveApiBase, type PendingFirstMessage } from '../../console/ai/AiChatPage';
-import { ChatDockPanel, ChatDockLauncher, useChatDockState } from '../../layout/ChatDock';
+import {
+  ChatDockPanel,
+  ChatDockLauncher,
+  ChatDockMobileSheet,
+  useChatDockState,
+} from '../../layout/ChatDock';
+import { rememberDockReturnLocation } from '../../layout/chatDockState';
 
 export interface StudioAiCopilotProps {
   /** The package the Studio surface is editing — scopes the build agent to it. */
@@ -192,8 +198,15 @@ export interface StudioChatDockProps {
 export function StudioChatDock({ packageId, locale }: StudioChatDockProps): React.ReactElement | null {
   const zh = (locale ?? '').toLowerCase().startsWith('zh');
   const navigate = useNavigate();
+  const location = useLocation();
   const apiBase = React.useMemo(() => resolveApiBase(), []);
   const dock = useChatDockState({ defaultExpanded: true });
+  // Under `md` the copilot presents as a bottom sheet (there is no horizontal
+  // room for a rail). Its open state is LOCAL — a phone must not inherit the
+  // desktop "expanded by default" posture, or the sheet would cover the Studio
+  // on every load.
+  const isMobile = useIsMobile();
+  const [mobileOpen, setMobileOpen] = React.useState(false);
 
   // The catalog gate lives HERE (not in ChatDockPanel): the `children` body
   // override below bypasses the panel's default self-gating conversation.
@@ -204,7 +217,33 @@ export function StudioChatDock({ packageId, locale }: StudioChatDockProps): Reac
     [dock.maximize, dock.restore],
   );
 
+  // Record where we maximized FROM so the `/ai` page's collapse-to-dock
+  // returns to THIS Studio surface, not to some console page.
+  const openFullPage = React.useCallback(() => {
+    rememberDockReturnLocation(`${location.pathname}${location.search}`);
+    navigate(`/ai/build?package=${encodeURIComponent(packageId)}`);
+  }, [location.pathname, location.search, navigate, packageId]);
+
   if (!agentsLoading && agents.length === 0) return null;
+
+  if (isMobile) {
+    return (
+      <>
+        <ChatDockLauncher
+          onExpand={() => setMobileOpen(true)}
+          className="inline-flex md:hidden"
+        />
+        <ChatDockMobileSheet
+          open={mobileOpen}
+          onOpenChange={setMobileOpen}
+          title={zh ? 'AI 副驾' : 'AI copilot'}
+          onMaximize={openFullPage}
+        >
+          <StudioCopilotConversation packageId={packageId} />
+        </ChatDockMobileSheet>
+      </>
+    );
+  }
 
   if (!dock.expanded) {
     return <ChatDockLauncher onExpand={dock.expand} />;
@@ -214,7 +253,7 @@ export function StudioChatDock({ packageId, locale }: StudioChatDockProps): Reac
     <ChatDockPanel
       dock={dock}
       title={zh ? 'AI 副驾' : 'AI copilot'}
-      onMaximize={() => navigate(`/ai/build?package=${encodeURIComponent(packageId)}`)}
+      onMaximize={openFullPage}
     >
       <StudioCopilotConversation
         packageId={packageId}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -112,6 +112,26 @@ import { DraftChangesPanel } from '../../preview/DraftChangesPanel';
 import { resolveConsoleUrl } from '../../console/organizations/resolveHomeUrl';
 import { toast } from 'sonner';
 
+/**
+ * ADR-0057 P3c follow-up — is the viewport wide enough (Tailwind `2xl`) to show
+ * the folded layout's canvas AND properties side by side beside the chat dock,
+ * instead of as tabs? Mirrors `useIsMobile`'s matchMedia idiom. 2xl (not xl) on
+ * purpose: with the ~420px dock plus the nav rail, an xl viewport leaves the
+ * canvas under ~400px — tabs read better there.
+ */
+const WIDE_VIEWPORT_BREAKPOINT = 1536;
+function useIsWideViewport(): boolean {
+  const [isWide, setIsWide] = React.useState<boolean | undefined>(undefined);
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(min-width: ${WIDE_VIEWPORT_BREAKPOINT}px)`);
+    const onChange = () => setIsWide(window.innerWidth >= WIDE_VIEWPORT_BREAKPOINT);
+    mql.addEventListener('change', onChange);
+    setIsWide(window.innerWidth >= WIDE_VIEWPORT_BREAKPOINT);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return !!isWide;
+}
+
 const PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> = [
   { key: 'data', label: 'Data', Icon: Database },
   { key: 'automations', label: 'Automations', Icon: Workflow },
@@ -1035,14 +1055,18 @@ function InterfacesPillar({
   // to Properties; deselect → back to Canvas) while preserving a manual choice
   // in steady state — see nextCenterTab. Inert when `foldInspector` is off.
   const [centerTab, setCenterTab] = React.useState<StudioCenterTab>('canvas');
+  // Folded layout, wide viewport (2xl+): enough room to show canvas AND
+  // properties side by side beside the chat dock — no tabs, no auto-switch.
+  const isWide = useIsWideViewport();
+  const showFoldedTabs = foldInspector && !isWide;
   const hasInspectorTarget = Boolean((editNav && navSel) || selection);
   const prevInspectorTargetRef = React.useRef(hasInspectorTarget);
   React.useEffect(() => {
-    if (!foldInspector) return;
+    if (!showFoldedTabs) return;
     const hadTarget = prevInspectorTargetRef.current;
     prevInspectorTargetRef.current = hasInspectorTarget;
     setCenterTab((cur) => nextCenterTab(cur, hadTarget, hasInspectorTarget));
-  }, [foldInspector, hasInspectorTarget]);
+  }, [showFoldedTabs, hasInspectorTarget]);
   const [loading, setLoading] = React.useState(false);
   const [saving, setSaving] = React.useState<false | 'draft' | 'publish'>(false);
   const [hasDraft, setHasDraft] = React.useState(false);
@@ -1396,6 +1420,15 @@ function InterfacesPillar({
         />
       </div>
     ) : isSourcePage ? (
+      showFoldedTabs ? (
+        // Folded tabs mode: the center Canvas tab already shows the live
+        // preview, so the nested Source/Props tab strip adds nothing — the
+        // Properties tab body IS the code editor (its Props pane was only an
+        // empty state pointing back at Source).
+        <div className="mt-2 min-h-0 flex-1 border-t">
+          <SourcePageEditor mode="editor" draft={draft} onPatch={onPatch} />
+        </div>
+      ) : (
       <Tabs
         value={inspectorTab}
         onValueChange={(v) => setInspectorTab(v === 'props' ? 'props' : 'source')}
@@ -1421,6 +1454,7 @@ function InterfacesPillar({
           </div>
         </TabsContent>
       </Tabs>
+      )
     ) : DefaultInspector && current && isEditable ? (
       // No block selected → the surface's "home" inspector (e.g. a page's
       // interfaceConfig form). Selecting a sub-element from it swaps in the
@@ -1611,6 +1645,25 @@ function InterfacesPillar({
                 isSourcePage && !(selection && Inspector && current) && !(editNav && navSel)
                   ? 'w-[24rem] xl:w-[30rem] 2xl:w-[36rem]'
                   : 'w-72',
+              )}
+            >
+              {inspectorHeaderEl}
+              {inspectorBodyEl}
+            </aside>
+          </>
+        ) : isWide ? (
+          // Folded layout on a WIDE (2xl+) viewport: enough room to keep the
+          // canvas and the properties side by side beside the chat dock — the
+          // tabs (and their auto-switch) only exist where width forces them.
+          <>
+            {canvasEl}
+            <aside
+              data-testid="studio-folded-inspector"
+              className={cn(
+                'flex shrink-0 flex-col overflow-hidden border-l',
+                isSourcePage && !(selection && Inspector && current) && !(editNav && navSel)
+                  ? 'w-[24rem] 2xl:w-[28rem]'
+                  : 'w-80',
               )}
             >
               {inspectorHeaderEl}


### PR DESCRIPTION
Follow-up optimizations for the now-default-on ChatDock (#2467 P3c, #2469 go-live; epic #2409):

1. **Mobile**: under `md` the dock presents as a **bottom sheet** (`ChatDockMobileSheet`, same conversation/body contract as the rail) — the console FAB opens it, and Studio gains a mobile-visible edge launcher (`ChatDockLauncher` `className` override). Previously flag-on mobile had no chat surface at all.
2. **Wide Studio (2xl+)**: the folded layout keeps canvas AND properties **side by side** beside the chat dock (`studio-folded-inspector`); the `[Canvas | Properties]` tabs and their auto-switch only exist where width forces them (2xl chosen over xl: with the ~420px dock + nav rail, xl left the canvas under ~400px).
3. **Source pages, folded tabs mode**: the nested Source/Props tab strip is flattened — the Properties tab body IS the code editor (the center Canvas tab already shows the live preview; the inner Props pane was only an empty state).
4. **Exact collapse landing**: maximize handlers record their origin (`rememberDockReturnLocation`, sessionStorage, same-app-absolute-path trust boundary on read); `/ai`'s collapse-to-dock returns exactly there — console page or Studio surface — immune to in-page history churn (conversation switches push `/ai/...` entries, so blind history-back could land on a prior `/ai` URL). Fallback: history back, then `/home`. The button is now visible on mobile too (the sheet is its landing).
5. **Default-agent unification**: the dock's conversation passes `app.defaultAgent` through `resolveSurfaceAgent` (bounded to ask/build), matching the FAB's old behavior — an app pinning `build` now gets the same product in the rail.

## Tests
- New `chatDockReturnLocation.test.tsx` (round trip + open-redirect trust boundary + `armChatDockExpanded`), `ChatDockMobileSheet` render cases, updated `resolveCollapseToDockTarget` (stored-path priority). 89 tests green across layout/console-ai/studio suites; `tsc --noEmit` clean.

## Browser proof (ADR-0054, local rig, default-on — no flag override needed)
- Desktop 1280: FAB → rail; maximize records `/apps/setup/dashboard/system_overview`; switched conversations on `/ai` (history churn), collapse landed EXACTLY back on the recorded page with the rail expanded.
- Mobile 375: bottom sheet renders (screenshot); sheet maximize → `/ai`; collapse → back with the sheet open.
- Studio: 1680 viewport = `[nav] [canvas] [properties] [chat]` side-by-side, no tabs; 1280 = center tabs; mobile = edge launcher opens the sheet.
- (Dynamic viewport-resize re-evaluation relies on `matchMedia` change events, which the embedded test browser doesn't emit on viewport override — same mechanism as the existing `useIsMobile`; initial-load judgments verified at every width.)

Refs #2409 · ADR-0057 §P3 follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)