### PR TITLE
fix(plugin-list): show active search keyword on the toolbar search button

### DIFF
--- a/.changeset/list-search-keyword-chip.md
+++ b/.changeset/list-search-keyword-chip.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/plugin-list": patch
+---
+
+The list toolbar search button now shows the active keyword inline (mirroring
+the Sort button's count badge). Previously a search term restored from
+localStorage after navigating away and back kept filtering the list while the
+search popover stayed collapsed — the only cue was a slightly darker magnifier
+icon, so users couldn't tell a keyword filter was still active. The keyword is
+rendered (truncated at 8rem) next to the magnifier whenever a search is active,
+and clicking it opens the popover pre-filled for editing or clearing.

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -2267,13 +2267,24 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "hidden sm:inline-flex h-7 w-7 p-0 text-muted-foreground hover:text-primary text-xs transition-colors duration-150",
-                    searchTerm && "text-foreground font-medium"
+                    "hidden sm:inline-flex h-7 text-muted-foreground hover:text-primary text-xs transition-colors duration-150",
+                    searchTerm ? "px-2 text-foreground font-medium" : "w-7 p-0"
                   )}
                   data-testid="search-icon-button"
-                  title={t('list.search')}
+                  title={searchTerm ? `${t('list.search')}: ${searchTerm}` : t('list.search')}
                 >
                   <Search className="h-3.5 w-3.5" />
+                  {/* Persisted keyword restored from storage keeps filtering after
+                      navigation while the popover starts closed — surface it on the
+                      trigger so the active search is visible without opening it. */}
+                  {searchTerm && (
+                    <span
+                      className="ml-1.5 max-w-[8rem] truncate text-[11px]"
+                      data-testid="search-active-keyword"
+                    >
+                      {searchTerm}
+                    </span>
+                  )}
                 </Button>
               </PopoverTrigger>
               <PopoverContent align="end" className="w-[calc(100vw-2rem)] sm:w-64 p-2" data-testid="search-popover">

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -933,6 +933,35 @@ describe('ListView', () => {
       expect(searchBtn.className).toContain('text-foreground');
       expect(searchBtn.className).toContain('font-medium');
     });
+
+    it('should show the active keyword on the search button while typing', () => {
+      const schema: ListViewSchema = {
+        type: 'list-view',
+        objectName: 'contacts',
+        viewType: 'grid',
+        fields: ['name', 'email'],
+      };
+
+      renderWithProvider(<ListView schema={schema} />);
+      fireEvent.click(screen.getByTestId('search-icon-button'));
+      fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'alice' } });
+      expect(screen.getByTestId('search-active-keyword')).toHaveTextContent('alice');
+    });
+
+    it('should show the restored keyword on the search button without opening the popover', () => {
+      const schema: ListViewSchema = {
+        type: 'list-view',
+        objectName: 'contacts',
+        viewType: 'grid',
+        fields: ['name', 'email'],
+      };
+
+      // Simulates returning to a list whose search term was persisted: the
+      // filter is applied via initialSearchTerm but the popover starts closed.
+      renderWithProvider(<ListView schema={schema} initialSearchTerm="11" />);
+      expect(screen.queryByTestId('search-popover')).not.toBeInTheDocument();
+      expect(screen.getByTestId('search-active-keyword')).toHaveTextContent('11');
+    });
   });
 
   // ============================


### PR DESCRIPTION
Fixes #2471

## 问题

放大镜搜索的关键字持久化在 `localStorage`,离开列表再返回时仍在过滤数据,但搜索弹框收起、几乎没有可见提示,用户看不出列表正处于关键字过滤状态。

## 修复

搜索激活时,放大镜按钮内联显示当前关键字(对齐「排序」按钮计数徽标的设计语言,`max-w-[8rem]` 截断,`title` 提示完整关键字);点击即打开弹框预填关键字,可修改或点 X 清除。未激活时按钮保持原有 7×7 图标样式,无任何变化。

## 测试

- 真机 UI 实测(objectui console dev + ObjectOS 12.4 后端,admin 实登):输入 `Dev` → 切走 → 返回,弹框收起但按钮显示 `🔍 Dev`,`localStorage` 值 `{"search":"Dev"}`;点击徽标弹框预填可清除。截图见 #2471。
- 单元测试:`plugin-list` 125 通过,新增 2 个用例(输入时徽标显示;`initialSearchTerm` 恢复且弹框关闭时徽标显示)。
- `tsc --noEmit` 通过。

含 changeset(`@object-ui/plugin-list` patch)。

Co-Authored-By: Claude <noreply@anthropic.com>