### PR TITLE
fix(console-ai): A1.b switcher hides platform built-in apps (setup/account)

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -214,6 +214,28 @@ export function deriveBoundPackageId(
   return latest;
 }
 
+/**
+ * #2466 / ADR-0057 Amendment A1.b — is this app a CODE-LOADED platform built-in
+ * (`com.objectstack.setup` / `account`, …) rather than a user- or AI-authored
+ * package? The A1.b switcher lists only authorable packages, so a built-in —
+ * which the build agent can't edit — never appears as a switch target
+ * (selecting it would deep-link `/ai/build?package=<builtin>` to a package that
+ * can't be authored).
+ *
+ * Discriminator: the platform reserves the `com.objectstack.*` package
+ * namespace for its code-delivered apps; DB-created packages (including every
+ * AI-built one — e.g. `app.xadv`) use other ids. This is the only field that
+ * reliably distinguishes them on the `/meta/app` LIST response: `_packageId` is
+ * grafted onto every list item, whereas `managedBy` / `source` are sys_metadata
+ * ROW columns the LIST handler does NOT copy onto the item body, and the
+ * resolved `lock` / `editable` envelope exists only on single-GET. Exported for
+ * unit testing.
+ */
+const PLATFORM_PACKAGE_PREFIX = 'com.objectstack.';
+export function isPlatformBuiltinApp(app: { _packageId?: unknown }): boolean {
+  return typeof app._packageId === 'string' && app._packageId.startsWith(PLATFORM_PACKAGE_PREFIX);
+}
+
 function firstUserMessageText(messages: HydratedUIMessage[]): string | undefined {
   const message = messages.find((item) => item.role === 'user');
   const text = message?.parts
@@ -1668,7 +1690,12 @@ export function ChatPane({
     const byPackage = new Map<string, string>();
     for (const app of metadataApps ?? []) {
       const pkg = (app as { _packageId?: string })._packageId;
-      if (!pkg || byPackage.has(pkg)) continue;
+      // Skip platform built-ins (setup / account …): they're code-delivered
+      // packages the build agent can't author, so they must not appear as
+      // switch targets — A1.b lists authorable packages only.
+      if (!pkg || byPackage.has(pkg) || isPlatformBuiltinApp(app as { _packageId?: unknown })) {
+        continue;
+      }
       byPackage.set(pkg, appLabel({ name: app.name, label: resolveI18nLabel(app.label, t) }));
     }
     return Array.from(byPackage, ([id, label]) => ({ id, label }));

--- a/packages/app-shell/src/console/ai/__tests__/deriveBoundPackageId.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/deriveBoundPackageId.test.ts
@@ -8,7 +8,7 @@
  * not-yet-bound "New app" draft (the magic flow's start state).
  */
 import { describe, it, expect } from 'vitest';
-import { deriveBoundPackageId } from '../AiChatPage';
+import { deriveBoundPackageId, isPlatformBuiltinApp } from '../AiChatPage';
 import type { ChatMessage } from '@object-ui/plugin-chatbot';
 
 const msg = (toolInvocations: unknown[]): ChatMessage =>
@@ -40,5 +40,31 @@ describe('deriveBoundPackageId', () => {
       msg([{ draftReview: { packageId: 'app.second' } }]),
     ];
     expect(deriveBoundPackageId(messages, undefined)).toBe('app.second');
+  });
+});
+
+// #2466 / ADR-0057 A1.b — the switcher lists authorable packages only. Platform
+// built-ins reserve the `com.objectstack.*` package namespace; user- and
+// AI-built packages use other ids. `_packageId` is the reliable signal on the
+// LIST response (managedBy/source aren't grafted onto list items).
+describe('isPlatformBuiltinApp', () => {
+  it('is true for a platform built-in (com.objectstack.setup / account)', () => {
+    expect(isPlatformBuiltinApp({ _packageId: 'com.objectstack.setup' })).toBe(true);
+    expect(isPlatformBuiltinApp({ _packageId: 'com.objectstack.account' })).toBe(true);
+  });
+
+  it('is false for an AI-built / user package (e.g. app.xadv)', () => {
+    expect(isPlatformBuiltinApp({ _packageId: 'app.xadv' })).toBe(false);
+    expect(isPlatformBuiltinApp({ _packageId: 'my.company.crm' })).toBe(false);
+  });
+
+  it('is false when there is no package id, or it is not a string', () => {
+    expect(isPlatformBuiltinApp({})).toBe(false);
+    expect(isPlatformBuiltinApp({ _packageId: undefined })).toBe(false);
+    expect(isPlatformBuiltinApp({ _packageId: 123 as unknown as string })).toBe(false);
+  });
+
+  it('does not match a package that merely contains the prefix mid-string', () => {
+    expect(isPlatformBuiltinApp({ _packageId: 'acme.com.objectstack.fake' })).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #2466 (ADR-0057 Amendment A1.b). Epic #2409.

## Problem

The A1.b package switcher lists **every** app with a `_packageId`, including code-delivered platform built-ins (`setup` / `account`, `com.objectstack.*`). Selecting one deep-links `/ai/build?package=<builtin>` to a **package the build agent can't author** — a dead end. Built-ins aren't editable and shouldn't be switch targets.

## Fix

Filter `switchablePackages` on the reserved **`com.objectstack.*`** package namespace. This is the signal that reliably distinguishes built-ins on the `/meta/app` **LIST** response:

- `_packageId` is grafted onto every list item (`getMetaItems`); AI-built / user packages use non-reserved ids (e.g. `app.xadv`), platform ones use `com.objectstack.*` (verified live: `setup`→`com.objectstack.setup`, `account`→`com.objectstack.account`, an AI-built todo app→`app.xadv`).
- `managedBy` / `source` are **sys_metadata row columns the LIST handler does NOT copy onto the item body**, and the resolved `lock`/`editable` envelope exists only on single-GET — so neither is usable for list-time filtering.

New exported predicate `isPlatformBuiltinApp(app)` drives the filter; unit-tested (built-ins excluded; AI/user packages and no-package / non-string ids handled; no false match on a mid-string prefix).

## Tests

`deriveBoundPackageId.test.ts` gains 4 `isPlatformBuiltinApp` cases; 8 tests green in that file; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)