### PR TITLE
fix(console-ai): Studio dock remembers a collapse; folded layout side-by-side at xl (ADR-0057 UX #2477)

### DIFF
--- a/.changeset/adr-0057-studio-dock-ux.md
+++ b/.changeset/adr-0057-studio-dock-ux.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(console-ai): Studio dock remembers a collapse; folded canvas+properties go side-by-side at `xl` (ADR-0057 UX follow-ups, #2477)
+
+- **Studio dock collapse is now remembered** (per-tab). The right copilot still
+  mounts expanded by default, but collapsing it to get the classic three-zone
+  canvas no longer re-opens on every pillar / package switch or Studio
+  re-entry. Backed by an explicit `'0'`/`'1'` stored flag (a default-expanded
+  surface couldn't remember a collapse when "collapsed" meant "key removed"),
+  under a Studio-specific key so it never shares state with the console dock.
+- **Folded layout shows canvas + properties side by side from `xl`** (1280),
+  lowered from `2xl`. On the common laptop the folded center used to fall into
+  tabs, which auto-hide the canvas the moment you select a block — breaking the
+  WYSIWYG "edit and watch it apply" loop. The side-by-side inspector is slimmer
+  at `xl` (and grows at `2xl`) so the canvas keeps usable width beside the dock.

--- a/packages/app-shell/src/layout/__tests__/chatDockReturnLocation.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/chatDockReturnLocation.test.tsx
@@ -13,7 +13,10 @@ import {
   readDockReturnLocation,
   armChatDockExpanded,
   parseStoredDockExpanded,
+  readStoredDockExpanded,
+  writeStoredDockExpanded,
   DOCK_EXPANDED_STORAGE_KEY,
+  DOCK_STUDIO_EXPANDED_STORAGE_KEY,
   DOCK_RETURN_TO_STORAGE_KEY,
 } from '../chatDockState';
 
@@ -47,5 +50,30 @@ describe('armChatDockExpanded', () => {
     expect(
       parseStoredDockExpanded(window.sessionStorage.getItem(DOCK_EXPANDED_STORAGE_KEY)),
     ).toBe(true);
+  });
+});
+
+describe('stored-expanded round trip (issue #2477 item 2 — Studio remembers a collapse)', () => {
+  const KEY = DOCK_STUDIO_EXPANDED_STORAGE_KEY;
+
+  it('a DEFAULT-EXPANDED surface stays collapsed after an explicit collapse', () => {
+    // First visit: nothing stored → the surface's own default (expanded) wins.
+    expect(readStoredDockExpanded(KEY, true)).toBe(true);
+    // User collapses → persisted as an explicit '0', NOT a remove…
+    writeStoredDockExpanded(KEY, false);
+    expect(window.sessionStorage.getItem(KEY)).toBe('0');
+    // …so the next mount reads collapsed instead of falling back to expanded.
+    expect(readStoredDockExpanded(KEY, true)).toBe(false);
+    // Re-expanding sticks too.
+    writeStoredDockExpanded(KEY, true);
+    expect(readStoredDockExpanded(KEY, true)).toBe(true);
+  });
+
+  it('a DEFAULT-COLLAPSED surface (console) is unchanged by explicit persistence', () => {
+    expect(readStoredDockExpanded(DOCK_EXPANDED_STORAGE_KEY, false)).toBe(false);
+    writeStoredDockExpanded(DOCK_EXPANDED_STORAGE_KEY, true);
+    expect(readStoredDockExpanded(DOCK_EXPANDED_STORAGE_KEY, false)).toBe(true);
+    writeStoredDockExpanded(DOCK_EXPANDED_STORAGE_KEY, false);
+    expect(readStoredDockExpanded(DOCK_EXPANDED_STORAGE_KEY, false)).toBe(false);
   });
 });

--- a/packages/app-shell/src/layout/__tests__/chatDockState.test.ts
+++ b/packages/app-shell/src/layout/__tests__/chatDockState.test.ts
@@ -47,15 +47,15 @@ describe('maximizedDockWidth', () => {
 });
 
 describe('parseStoredDockExpanded', () => {
-  it("only the exact '1' opts into mounting expanded", () => {
+  it("'1' → expanded, '0' → collapsed (explicit, so a default-expanded surface can remember a collapse)", () => {
     expect(parseStoredDockExpanded('1')).toBe(true);
+    expect(parseStoredDockExpanded('0')).toBe(false);
   });
 
-  it('null / other values keep the default-collapsed posture', () => {
-    expect(parseStoredDockExpanded(null)).toBe(false);
-    expect(parseStoredDockExpanded('0')).toBe(false);
-    expect(parseStoredDockExpanded('true')).toBe(false);
-    expect(parseStoredDockExpanded('')).toBe(false);
+  it('unset / garbage → null so the caller falls back to its own default', () => {
+    expect(parseStoredDockExpanded(null)).toBeNull();
+    expect(parseStoredDockExpanded('true')).toBeNull();
+    expect(parseStoredDockExpanded('')).toBeNull();
   });
 });
 

--- a/packages/app-shell/src/layout/chatDockState.ts
+++ b/packages/app-shell/src/layout/chatDockState.ts
@@ -21,6 +21,16 @@ export const DOCK_WIDTH_STORAGE_KEY = 'ai-chat-dock-width';
  * shared URL (ADR-0013 deep links stay clean).
  */
 export const DOCK_EXPANDED_STORAGE_KEY = 'ai-chat-dock-expanded';
+/**
+ * sessionStorage key for the STUDIO right dock's expanded/collapsed state.
+ * Distinct from the console key so the two surfaces never fight over one flag.
+ * The Studio copilot mounts expanded by default (it always has), but a user who
+ * collapses it to get the classic three-zone canvas keeps it collapsed across
+ * pillar / package switches and re-entering Studio in the same tab — the
+ * annoyance was it re-expanding every time (issue #2477 item 2). Per-tab
+ * (sessionStorage): a fresh tab re-defaults to the copilot-visible posture.
+ */
+export const DOCK_STUDIO_EXPANDED_STORAGE_KEY = 'ai-chat-studio-dock-expanded';
 /** Default rail width (px). */
 export const DOCK_DEFAULT_WIDTH = 420;
 /** The rail never narrower than this. */
@@ -53,29 +63,37 @@ export function maximizedDockWidth(containerWidth: number): number {
 }
 
 /**
- * Parse the stored {@link DOCK_EXPANDED_STORAGE_KEY} value — only the exact
- * `'1'` opts into mounting expanded; null/garbage keeps the default-collapsed
- * posture. Pure + exported for tests.
+ * Parse the stored expanded value — `'1'` → expanded, `'0'` → collapsed;
+ * anything else (incl. null) is "unset", returned as `null` so the caller can
+ * fall back to its own default. Distinguishing "explicitly collapsed" (`'0'`)
+ * from "never set" (null) is what lets a default-EXPANDED surface (Studio)
+ * remember a collapse — a bare remove-on-collapse would read back as unset and
+ * re-expand. Pure + exported for tests.
  */
-export function parseStoredDockExpanded(raw: string | null): boolean {
-  return raw === '1';
+export function parseStoredDockExpanded(raw: string | null): boolean | null {
+  if (raw === '1') return true;
+  if (raw === '0') return false;
+  return null;
 }
 
-/** Read a stored expanded flag; storage failures (private mode) → `fallback`. */
+/** Read a stored expanded flag; unset OR storage failure (private mode) → `fallback`. */
 export function readStoredDockExpanded(key: string, fallback: boolean): boolean {
   try {
-    const raw = window.sessionStorage.getItem(key);
-    return raw === null ? fallback : parseStoredDockExpanded(raw);
+    const parsed = parseStoredDockExpanded(window.sessionStorage.getItem(key));
+    return parsed === null ? fallback : parsed;
   } catch {
     return fallback;
   }
 }
 
-/** Persist an expanded flag (`'1'` / removed); storage failures are swallowed. */
+/**
+ * Persist an expanded flag as `'1'` / `'0'` (never a remove) — see
+ * {@link parseStoredDockExpanded} for why collapse must be stored explicitly.
+ * Storage failures are swallowed.
+ */
 export function writeStoredDockExpanded(key: string, expanded: boolean): void {
   try {
-    if (expanded) window.sessionStorage.setItem(key, '1');
-    else window.sessionStorage.removeItem(key);
+    window.sessionStorage.setItem(key, expanded ? '1' : '0');
   } catch {
     /* private mode — the rail just won't survive navigation */
   }

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -15,7 +15,10 @@ import {
   ChatDockMobileSheet,
   useChatDockState,
 } from '../../layout/ChatDock';
-import { rememberDockReturnLocation } from '../../layout/chatDockState';
+import {
+  rememberDockReturnLocation,
+  DOCK_STUDIO_EXPANDED_STORAGE_KEY,
+} from '../../layout/chatDockState';
 
 interface StudioCopilotConversationProps {
   /** The package the Studio surface is editing — scopes the build agent to it. */
@@ -127,7 +130,14 @@ export function StudioChatDock({ packageId, locale }: StudioChatDockProps): Reac
   const navigate = useNavigate();
   const location = useLocation();
   const apiBase = React.useMemo(() => resolveApiBase(), []);
-  const dock = useChatDockState({ defaultExpanded: true });
+  // Expanded by default (the copilot has always been visible), but a collapse
+  // is remembered per-tab so it doesn't re-open on every pillar / package
+  // switch or Studio re-entry (issue #2477 item 2). The console dock uses its
+  // OWN key, so the two never share a collapse.
+  const dock = useChatDockState({
+    defaultExpanded: true,
+    persistExpandedKey: DOCK_STUDIO_EXPANDED_STORAGE_KEY,
+  });
   // Under `md` the copilot presents as a bottom sheet (there is no horizontal
   // room for a rail). Its open state is LOCAL — a phone must not inherit the
   // desktop "expanded by default" posture, or the sheet would cover the Studio

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -112,13 +112,19 @@ import { resolveConsoleUrl } from '../../console/organizations/resolveHomeUrl';
 import { toast } from 'sonner';
 
 /**
- * ADR-0057 P3c follow-up — is the viewport wide enough (Tailwind `2xl`) to show
+ * ADR-0057 P3c follow-up — is the viewport wide enough (Tailwind `xl`) to show
  * the folded layout's canvas AND properties side by side beside the chat dock,
- * instead of as tabs? Mirrors `useIsMobile`'s matchMedia idiom. 2xl (not xl) on
- * purpose: with the ~420px dock plus the nav rail, an xl viewport leaves the
- * canvas under ~400px — tabs read better there.
+ * instead of as tabs? Mirrors `useIsMobile`'s matchMedia idiom.
+ *
+ * `xl` (1280), lowered from `2xl` per issue #2477 item 3: the common laptop
+ * (1280–1512) was falling into tabs, which auto-hide the canvas the moment you
+ * select a block — breaking the WYSIWYG "edit and watch it apply" loop. At
+ * 1280 the canvas is narrow (~360px after the nav rail, a slimmed side-by-side
+ * inspector, and the ~420px dock) but LIVE, which beats hidden; at 1440+ it is
+ * comfortable. Below `xl` the tabs remain (there simply isn't room for three
+ * columns plus chat).
  */
-const WIDE_VIEWPORT_BREAKPOINT = 1536;
+const WIDE_VIEWPORT_BREAKPOINT = 1280;
 function useIsWideViewport(): boolean {
   const [isWide, setIsWide] = React.useState<boolean | undefined>(undefined);
   React.useEffect(() => {
@@ -1644,9 +1650,11 @@ function InterfacesPillar({
             </aside>
           </>
         ) : isWide ? (
-          // Folded layout on a WIDE (2xl+) viewport: enough room to keep the
+          // Folded layout on a WIDE (xl+) viewport: enough room to keep the
           // canvas and the properties side by side beside the chat dock — the
           // tabs (and their auto-switch) only exist where width forces them.
+          // The inspector is slimmer at xl (and grows at 2xl) so the canvas
+          // keeps usable width once the ~420px dock is also on screen.
           <>
             {canvasEl}
             <aside
@@ -1654,8 +1662,8 @@ function InterfacesPillar({
               className={cn(
                 'flex shrink-0 flex-col overflow-hidden border-l',
                 isSourcePage && !(selection && Inspector && current) && !(editNav && navSel)
-                  ? 'w-[24rem] 2xl:w-[28rem]'
-                  : 'w-80',
+                  ? 'w-[22rem] 2xl:w-[28rem]'
+                  : 'w-72 2xl:w-80',
               )}
             >
               {inspectorHeaderEl}


### PR DESCRIPTION
First two of the post-cleanup UX follow-ups from #2477 (ADR-0057). Small, contained changes in already-touched files.

## #2 — Studio dock remembers a collapse (per-tab)
The Studio right copilot still mounts expanded by default, but a user who collapses it to get the classic three-zone canvas no longer sees it re-open on every pillar / package switch or Studio re-entry.

Root cause: the stored expanded flag used **remove-on-collapse**, so on a *default-expanded* surface "collapsed" read back as "unset" → fell to the default → re-expanded. Fixed by storing an explicit `'0'`/`'1'` (`parseStoredDockExpanded` now returns `boolean | null`, callers fall back on `null`), under a **Studio-specific** sessionStorage key so it never shares state with the console dock. Console dock behavior is unchanged (default-collapsed either way).

## #3 — Folded canvas + properties side by side from `xl` (was `2xl`)
On the common laptop (1280–1512) the folded center fell into tabs, which auto-hide the canvas the moment you select a block — breaking the WYSIWYG "edit and watch it apply" loop. Lowered the side-by-side breakpoint to `xl` (1280); the side-by-side inspector is slimmer at `xl` and grows at `2xl`, so the canvas keeps usable width beside the ~420px dock. Below `xl` the tabs remain (no room for three columns + chat).

## Verification
- `tsc --noEmit` clean; app-shell + `apps/console` build green.
- `npx vitest run` layout / console-ai / studio-design: **16 files, 81 tests green**. New coverage: the stored-flag round trip proving a default-expanded surface stays collapsed after an explicit collapse (and console default-collapsed is unaffected); `parseStoredDockExpanded` tri-state.
- Live browser proof to follow in a comment.

Refs #2477 · ADR-0057