### PR TITLE
fix(plugin-gantt): 详情抽屉拉取真实记录与 schema、写回失败错误 toast、锁定行连线菜单禁用

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -473,6 +473,7 @@ const en = {
     readOnly: 'Read-only',
     readOnlyHint: 'Editing is disabled for this view.',
     lockedHint: 'No edit permission',
+    writeFailed: 'Save failed — the change was rolled back',
   },
   view: {
     editViewConfig: 'Edit view config',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -549,6 +549,7 @@ const zh = {
     readOnly: '只读',
     readOnlyHint: '此视图已禁用编辑。',
     lockedHint: '无编辑权限',
+    writeFailed: '保存失败,已恢复修改前状态',
   },
   view: {
     editViewConfig: '编辑视图配置',

--- a/packages/plugin-detail/src/RecordDetailDrawer.tsx
+++ b/packages/plugin-detail/src/RecordDetailDrawer.tsx
@@ -327,6 +327,10 @@ export function RecordDetailDrawer({
                 await onFieldSave(field, value);
               } catch (err) {
                 console.error('[RecordDetailDrawer] inline field save failed:', err);
+                // Rethrow so DetailView rolls back the optimistic value and
+                // shows the failure inline — swallowing here made a rejected
+                // save look successful (stale value kept, no message).
+                throw err;
               }
             } : undefined}
             onDelete={onDelete ? async () => {

--- a/packages/plugin-detail/src/__tests__/RecordDetailDrawer.capability.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordDetailDrawer.capability.test.tsx
@@ -94,6 +94,16 @@ describe('RecordDetailDrawer capability = handler presence', () => {
     expect(onFieldSave).toHaveBeenCalledWith('name', 'World');
   });
 
+  it('rethrows a rejected field save so DetailView can roll back and show it', async () => {
+    // Swallowing here made a rejected save look successful: DetailView kept
+    // the optimistic value and never displayed the failure (#2473 第 2 项).
+    const onFieldSave = vi.fn().mockRejectedValue(new Error('仅管理责任人可修改'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    renderDrawer({ onFieldSave });
+    await expect(lastProps().onFieldSave('name', 'World')).rejects.toThrow('仅管理责任人可修改');
+    errSpy.mockRestore();
+  });
+
   it('closes the drawer after a successful delete, but not on failure', async () => {
     const onClose = vi.fn();
     const onDelete = vi.fn().mockResolvedValue(undefined);

--- a/packages/plugin-gantt/package.json
+++ b/packages/plugin-gantt/package.json
@@ -40,7 +40,8 @@
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^14.6.0",
     "lucide-react": "^1.24.0",
-    "qrcode": "^1.5.4"
+    "qrcode": "^1.5.4",
+    "sonner": "^2.0.7"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/plugin-gantt/src/GanttView.linkmenu.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.linkmenu.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Dependency-link context menu vs locked rows (#2473 第 3 项).
+ *
+ * Every action in the link menu (change type / remove) rewrites the TARGET
+ * (successor) record's dependencies field. When that record is locked the
+ * server rejects the write anyway — the menu must render read-only up front:
+ * lock hint shown, all items disabled, callbacks never invoked.
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+});
+
+function makeTasks(targetLocked: boolean): GanttTask[] {
+  return [
+    {
+      id: 'a',
+      title: 'Task a',
+      start: new Date('2024-06-05T00:00:00.000Z'),
+      end: new Date('2024-06-08T00:00:00.000Z'),
+      progress: 0,
+    },
+    {
+      id: 'b',
+      title: 'Task b',
+      start: new Date('2024-06-10T00:00:00.000Z'),
+      end: new Date('2024-06-12T00:00:00.000Z'),
+      progress: 0,
+      dependencies: ['a'],
+      locked: targetLocked,
+    },
+  ];
+}
+
+function openLinkMenu(targetLocked: boolean) {
+  const onDependencyCreate = vi.fn();
+  const onDependencyDelete = vi.fn();
+  const utils = render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView
+        tasks={makeTasks(targetLocked)}
+        startDate={new Date('2024-06-01T00:00:00.000Z')}
+        endDate={new Date('2024-06-30T00:00:00.000Z')}
+        onDependencyCreate={onDependencyCreate}
+        onDependencyDelete={onDependencyDelete}
+      />
+    </div>,
+  );
+  // The context menu handler lives on the invisible wide hit-path, not the
+  // visible stroke (see the `gantt-link-hit-*` overlay in GanttView).
+  const path = utils.container.querySelector('[data-testid="gantt-link-hit-a-b"]') as SVGPathElement;
+  expect(path).toBeTruthy();
+  fireEvent.contextMenu(path);
+  const menu = utils.container.ownerDocument.querySelector('[data-testid="gantt-link-context-menu"]') as HTMLElement;
+  expect(menu).toBeTruthy();
+  return { ...utils, menu, onDependencyCreate, onDependencyDelete };
+}
+
+describe('GanttView link context menu vs locked target', () => {
+  it('unlocked target: no lock hint, items enabled, callbacks fire', () => {
+    const { menu, onDependencyCreate, onDependencyDelete } = openLinkMenu(false);
+
+    expect(menu.querySelector('[data-testid="gantt-link-menu-locked"]')).toBeFalsy();
+
+    const ssBtn = menu.querySelector('[data-testid="gantt-link-menu-type-ss"]') as HTMLButtonElement;
+    expect(ssBtn.disabled).toBe(false);
+    fireEvent.click(ssBtn);
+    expect(onDependencyCreate).toHaveBeenCalledTimes(1);
+    expect(onDependencyCreate.mock.calls[0][2]).toBe('ss');
+
+    // Menu closed after the click — reopen for the remove action.
+    const { menu: menu2, onDependencyDelete: del2 } = openLinkMenu(false);
+    const removeBtn = menu2.querySelector('[data-testid="gantt-link-menu-remove"]') as HTMLButtonElement;
+    expect(removeBtn.disabled).toBe(false);
+    fireEvent.click(removeBtn);
+    expect(del2).toHaveBeenCalledTimes(1);
+    void onDependencyDelete;
+  });
+
+  it('locked target: lock hint shown, every item disabled, no callback fires', () => {
+    const { menu, onDependencyCreate, onDependencyDelete } = openLinkMenu(true);
+
+    expect(menu.querySelector('[data-testid="gantt-link-menu-locked"]')).toBeTruthy();
+
+    for (const lt of ['fs', 'ss', 'ff', 'sf']) {
+      const btn = menu.querySelector(`[data-testid="gantt-link-menu-type-${lt}"]`) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+      fireEvent.click(btn);
+    }
+    const removeBtn = menu.querySelector('[data-testid="gantt-link-menu-remove"]') as HTMLButtonElement;
+    expect(removeBtn.disabled).toBe(true);
+    fireEvent.click(removeBtn);
+
+    expect(onDependencyCreate).not.toHaveBeenCalled();
+    expect(onDependencyDelete).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -4266,6 +4266,10 @@ export function GanttView({
         if (!source || !target) return null;
         const itemCls = "w-full text-left px-3 py-1.5 hover:bg-accent focus:bg-accent outline-none";
         const LINK_TYPES: GanttLinkType[] = ['fs', 'ss', 'ff', 'sf'];
+        // The dependency list lives on the TARGET (successor) record — a locked
+        // target means every menu action writes a record the user can't edit,
+        // so the whole menu goes read-only with the lock hint shown inline.
+        const linkLocked = !!target.locked;
         return (
           <div
             ref={linkCtxMenuRef}
@@ -4277,15 +4281,22 @@ export function GanttView({
             <div className="px-3 py-1 text-xs text-muted-foreground truncate">
               {source.title} → {target.title}
             </div>
+            {linkLocked && (
+              <div className="px-3 py-1 text-xs text-muted-foreground" data-testid="gantt-link-menu-locked">
+                🚫 {t('gantt.lockedHint')}
+              </div>
+            )}
             {onDependencyCreate && LINK_TYPES.map((lt) => (
               <button
                 key={lt}
                 type="button"
                 role="menuitemradio"
                 aria-checked={linkCtxMenu.type === lt}
-                className={cn(itemCls, linkCtxMenu.type === lt && "font-semibold")}
+                disabled={linkLocked}
+                className={cn(itemCls, linkCtxMenu.type === lt && "font-semibold", linkLocked && "opacity-50 cursor-not-allowed hover:bg-transparent")}
                 data-testid={`gantt-link-menu-type-${lt}`}
                 onClick={() => {
+                  if (linkLocked) return;
                   setLinkCtxMenu(null);
                   if (lt !== linkCtxMenu.type) onDependencyCreate(source, target, lt);
                 }}
@@ -4300,9 +4311,14 @@ export function GanttView({
                 <button
                   type="button"
                   role="menuitem"
-                  className={cn(itemCls, "text-destructive")}
+                  disabled={linkLocked}
+                  className={cn(itemCls, "text-destructive", linkLocked && "opacity-50 cursor-not-allowed hover:bg-transparent")}
                   data-testid="gantt-link-menu-remove"
-                  onClick={() => { setLinkCtxMenu(null); onDependencyDelete(source, target); }}
+                  onClick={() => {
+                    if (linkLocked) return;
+                    setLinkCtxMenu(null);
+                    onDependencyDelete(source, target);
+                  }}
                 >
                   {t('gantt.menu.removeDependency')}
                 </button>

--- a/packages/plugin-gantt/src/ObjectGantt.drawerfetch.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.drawerfetch.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Drawer must show the real record, not the composed row (#2473 第 1 项).
+ *
+ * With `provider: 'api'` the rows are render payloads (bar colors, sort keys,
+ * node types…) composed by the endpoint — not business records. And with
+ * `objectField` a row can belong to a different object than the bound one,
+ * for which no schema is loaded. Rendering that raw payload in the drawer
+ * degrades every field to a humanized English label. When a context
+ * DataSource is available, ObjectGantt must fetch the actual record (and the
+ * foreign object's schema) and hand THAT to the drawer; the raw row stays as
+ * fallback so inline `value` data keeps working without a DataSource.
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObjectGantt } from './ObjectGantt';
+import { DataSource } from '@object-ui/types';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks, onTaskClick }: any) => (
+    <div data-testid="gantt-view">
+      {tasks.map((t: any) => (
+        <button key={t.id} data-testid={`gv-view-${t.id}`} onClick={() => onTaskClick?.(t)}>
+          {t.title}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+let drawerProps: any = null;
+vi.mock('@object-ui/plugin-detail', () => ({
+  RecordDetailDrawer: (props: any) => {
+    drawerProps = props;
+    return (
+      <div
+        data-testid="drawer-probe"
+        data-record-name={String(props.record?.name ?? '')}
+        data-has-schema={String(!!props.objectSchema)}
+      />
+    );
+  },
+  deriveRecordPageHref: () => null,
+}));
+
+// Composed rows as an api endpoint would return them: render-only keys, and
+// row 1 belongs to a foreign object (`object_name` ≠ bound object). Row
+// `grp_1` is a synthetic group header — no object_name, its id is not a real
+// record id.
+const COMPOSED_ROWS = [
+  {
+    id: '1', name: 'Composed row', object_name: 'work_orders',
+    start_date: '2024-01-01', end_date: '2024-01-05',
+    bar_color: '#f00', node_type: 'task', sort_key: '001',
+  },
+  {
+    id: 'grp_1', name: 'Synthetic group', object_name: '',
+    start_date: '2024-01-01', end_date: '2024-01-05',
+    node_type: 'group', sort_key: '000',
+  },
+];
+
+const REAL_RECORD = { id: '1', name: 'Real record', priority: 'high' };
+const FOREIGN_SCHEMA = { name: 'work_orders', fields: { name: { type: 'text' }, priority: { type: 'text' } } };
+
+function makeSchema(): any {
+  return {
+    type: 'gantt',
+    objectName: 'tasks',
+    gantt: {
+      titleField: 'name',
+      startDateField: 'start_date',
+      endDateField: 'end_date',
+      objectField: 'object_name',
+    },
+    data: { provider: 'value', items: COMPOSED_ROWS },
+  };
+}
+
+function makeContextDS(overrides: Partial<DataSource> = {}): DataSource {
+  return {
+    find: vi.fn().mockResolvedValue({ data: [] }),
+    findOne: vi.fn().mockResolvedValue(REAL_RECORD),
+    create: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue(FOREIGN_SCHEMA),
+    ...overrides,
+  } as DataSource;
+}
+
+async function openDrawer(ds?: DataSource) {
+  render(<ObjectGantt schema={makeSchema()} dataSource={ds} />);
+  await waitFor(() => expect(screen.getByTestId('gv-view-1')).toBeDefined());
+  fireEvent.click(screen.getByTestId('gv-view-1'));
+  return waitFor(() => screen.getByTestId('drawer-probe'));
+}
+
+describe('ObjectGantt drawer record fetch', () => {
+  beforeEach(() => {
+    drawerProps = null;
+  });
+
+  it('fetches the real record + schema for a foreign-object row', async () => {
+    const ds = makeContextDS();
+    const probe = await openDrawer(ds);
+
+    await waitFor(() => expect(probe.getAttribute('data-record-name')).toBe('Real record'));
+    expect(probe.getAttribute('data-has-schema')).toBe('true');
+    expect(ds.findOne).toHaveBeenCalledWith('work_orders', '1');
+    expect(ds.getObjectSchema).toHaveBeenCalledWith('work_orders');
+    expect(drawerProps.objectSchema).toEqual(FOREIGN_SCHEMA);
+  });
+
+  it('falls back to the raw row when the fetch fails', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ds = makeContextDS({ findOne: vi.fn().mockRejectedValue(new Error('boom')) });
+    const probe = await openDrawer(ds);
+
+    await waitFor(() => expect(ds.findOne).toHaveBeenCalled());
+    expect(probe.getAttribute('data-record-name')).toBe('Composed row');
+    errSpy.mockRestore();
+  });
+
+  it('falls back to the raw row without a context DataSource', async () => {
+    const probe = await openDrawer(undefined);
+    expect(probe.getAttribute('data-record-name')).toBe('Composed row');
+  });
+
+  it('routes field saves through the context DataSource for fetched records', async () => {
+    const ds = makeContextDS();
+    const probe = await openDrawer(ds);
+    await waitFor(() => expect(probe.getAttribute('data-record-name')).toBe('Real record'));
+
+    await drawerProps.onFieldSave('priority', 'low');
+    expect(ds.update).toHaveBeenCalledWith('work_orders', '1', { priority: 'low' });
+  });
+
+  it('does not open the drawer for a synthetic group row', async () => {
+    // A row without an objectField value is an endpoint-composed group header
+    // (e.g. id `grp_1`): there is no record to fetch, and rendering the raw
+    // payload would leak humanized render-only keys (#2473 第 1 项).
+    const ds = makeContextDS();
+    render(<ObjectGantt schema={makeSchema()} dataSource={ds} />);
+    await waitFor(() => expect(screen.getByTestId('gv-view-grp_1')).toBeDefined());
+    fireEvent.click(screen.getByTestId('gv-view-grp_1'));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId('drawer-probe')).toBeNull();
+    expect(ds.findOne).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a cleaned server message when the save is rejected', async () => {
+    const ds = makeContextDS({
+      update: vi.fn().mockRejectedValue(new Error(
+        'ApiDataSource: HTTP 403 Forbidden — {"error":"not_manager","message":"仅管理责任人可修改该排班计划"}',
+      )),
+    });
+    const probe = await openDrawer(ds);
+    await waitFor(() => expect(probe.getAttribute('data-record-name')).toBe('Real record'));
+
+    await expect(drawerProps.onFieldSave('priority', 'low'))
+      .rejects.toThrow('仅管理责任人可修改该排班计划');
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -23,6 +23,7 @@
  */
 
 import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { toast } from 'sonner';
 import type { ObjectGridSchema, DataSource, ViewData, GanttConfig } from '@object-ui/types';
 import { GanttConfigSchema } from '@objectstack/spec/ui';
 import { useNavigationOverlay } from '@object-ui/react';
@@ -294,6 +295,28 @@ function convertSortToQueryParams(sort: string | any[] | undefined): Record<stri
 }
 
 /**
+ * Pull a human-readable message out of a failed write. ApiDataSource embeds
+ * the raw response body at the end of its Error message
+ * (`ApiDataSource: HTTP 403 Forbidden — {"error":…,"message":…}`), so a JSON
+ * tail with `message`/`error` wins; otherwise null (caller falls back to the
+ * generic i18n text).
+ */
+function extractServerMessage(err: unknown): string | null {
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  const idx = msg.indexOf('{');
+  if (idx >= 0) {
+    try {
+      const body = JSON.parse(msg.slice(idx));
+      const m = body?.message ?? body?.error;
+      if (typeof m === 'string' && m.trim()) return m;
+    } catch {
+      /* body wasn't JSON — fall through */
+    }
+  }
+  return null;
+}
+
+/**
  * Helper to get gantt configuration from schema
  */
 function getGanttConfig(schema: ObjectGridSchema | any): GanttConfigEx | null {
@@ -361,6 +384,16 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // Tenant default currency (ADR-0053) for currency tooltips lacking a code.
   const { currency: tenantCurrency } = useLocalization();
   const { t } = useGanttTranslation();
+
+  // Surface write-back failures (拖拽/连线/删除/行内编辑) as an error toast —
+  // silent revert alone leaves the user wondering why nothing stuck (#2473).
+  // The server's own message (e.g. 403「仅管理责任人可修改该排班计划」) leads;
+  // the generic i18n text is the fallback.
+  const notifyWriteError = useCallback((err: unknown) => {
+    toast.error(t('gantt.writeFailed'), {
+      description: extractServerMessage(err) ?? undefined,
+    });
+  }, [t]);
 
   const rawDataConfig = getDataConfig(schema);
   // Memoize dataConfig using deep comparison to prevent infinite loops
@@ -947,6 +980,15 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // (a foreign row object never appears there), so derive from the routed
   // object and swap the segment. Shared by the drawer's 整页 link and the
   // context menu's 移动端二维码.
+  // With objectField configured, a row without a value is a synthetic group
+  // header composed by the endpoint (its id isn't a real record id) — no
+  // detail page, drawer or QR link exists for it.
+  const isSyntheticRow = useCallback(
+    (rec: Record<string, any> | undefined): boolean =>
+      !!ganttConfig?.objectField && !String(rec?.[ganttConfig.objectField] ?? '').trim(),
+    [ganttConfig?.objectField],
+  );
+
   const recordDetailHref = useCallback(
     (rec: Record<string, any>): { objectName: string; recordId: string | number; href: string | null } | null => {
       const rowObject = ganttConfig?.objectField
@@ -1018,6 +1060,50 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     onRowClick: navIsOverlay ? undefined : onRowClick,
   });
 
+  // #2473: an `api`-provider row is a composed render payload (bar_color,
+  // node_type, sort_key…), not the business record — and a foreign-object row
+  // has no schema at all, so the drawer degraded to humanized English labels.
+  // When the drawer opens, fetch the REAL record (and its schema for foreign
+  // objects) through the context DataSource; fall back to the raw row when
+  // there's no context DS or the fetch fails (inline `value` demos keep
+  // working unchanged).
+  const [drawerFetch, setDrawerFetch] = useState<{ key: string; record: any; schema: any } | null>(null);
+  const drawerRec = navigation.isOverlay && navigation.isOpen
+    ? (navigation.selectedRecord as Record<string, any> | null)
+    : null;
+  useEffect(() => {
+    if (!drawerRec) { setDrawerFetch(null); return; }
+    const detail = recordDetailHref(drawerRec);
+    if (!detail) { setDrawerFetch(null); return; }
+    const { objectName, recordId } = detail;
+    const needsRealRecord = dataConfig?.provider === 'api' || objectName !== resource;
+    if (!needsRealRecord || !dataSource || typeof dataSource.findOne !== 'function') {
+      setDrawerFetch(null);
+      return;
+    }
+    const key = `${objectName}:${recordId}`;
+    let cancelled = false;
+    (async () => {
+      try {
+        // Schema comes from the SAME context DataSource as the record — the
+        // component-level `objectSchema` state is unusable here: under the
+        // 'api' provider it's the adapter's `{fields: {}}` stub, which blanks
+        // every field label in the drawer.
+        const [record, schema] = await Promise.all([
+          dataSource.findOne(objectName, String(recordId)),
+          typeof dataSource.getObjectSchema === 'function'
+            ? dataSource.getObjectSchema(objectName).catch(() => null)
+            : Promise.resolve(null),
+        ]);
+        if (!cancelled) setDrawerFetch(record ? { key, record, schema } : null);
+      } catch (err) {
+        console.error('[ObjectGantt] Failed to fetch drawer record, falling back to row payload:', err);
+        if (!cancelled) setDrawerFetch(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [drawerRec, recordDetailHref, dataConfig?.provider, resource, dataSource]);
+
   // Persist a drag-driven reschedule back to the data source. Mirrors
   // ObjectCalendar.handleEventDropDefault: optimistic local patch, then
   // dataSource.update; on failure we revert and log.
@@ -1054,9 +1140,10 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       } catch (err) {
         console.error('[ObjectGantt] Failed to persist task update:', err);
         setData(prevSnapshot); // revert
+        notifyWriteError(err);
       }
     },
-    [ganttConfig, effectiveDataSource, resource, data, reload],
+    [ganttConfig, effectiveDataSource, resource, data, reload, notifyWriteError],
   );
 
   // Re-serialize a normalized dependency list back onto a record field,
@@ -1097,9 +1184,10 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       } catch (err) {
         console.error('[ObjectGantt] Failed to persist dependency:', err);
         setData(prevSnapshot); // revert
+        notifyWriteError(err);
       }
     },
-    [ganttConfig, effectiveDataSource, resource, data, reload],
+    [ganttConfig, effectiveDataSource, resource, data, reload, notifyWriteError],
   );
 
   // Persist a created/updated dependency (依赖增 + 类型选择): upsert the source
@@ -1188,17 +1276,21 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       prev.filter((r) => String(r.id ?? r._id) !== String(recordId)),
     );
     try {
-      await effectiveDataSource.delete(resource, String(recordId));
+      // ApiDataSource.delete reports failure as `false` instead of throwing —
+      // without this check a rejected delete keeps the optimistic removal.
+      const ok = await effectiveDataSource.delete(resource, String(recordId));
+      if (ok === false) throw new Error(t('gantt.writeFailed'));
       setPendingDelete(null);
       void reload({ silent: true }); // 写后回读 — parent rollups shrink after a child delete
     } catch (err) {
       console.error('[ObjectGantt] Failed to delete:', err);
       setData(prevSnapshot); // revert
       setPendingDelete(null);
+      notifyWriteError(err);
     } finally {
       setDeleting(false);
     }
-  }, [pendingDelete, effectiveDataSource, resource, data, reload]);
+  }, [pendingDelete, effectiveDataSource, resource, data, reload, notifyWriteError, t]);
 
   if (loading) {
     return (
@@ -1265,17 +1357,16 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           startDate={lockedRange?.start}
           endDate={lockedRange?.end}
           onTaskClick={(task) => {
-            navigation.handleClick(task.data);
+            // Synthetic group rows have no backing record — opening the
+            // drawer would only show the raw composed payload (#2473).
+            if (!isSyntheticRow(task.data as Record<string, any> | undefined)) {
+              navigation.handleClick(task.data);
+            }
             onTaskClick?.(task.data);
           }}
           taskUrl={(task) => {
             const rec = task.data as Record<string, any> | undefined;
-            if (!rec) return null;
-            // With objectField configured, rows lacking a value are synthetic
-            // group rows (项目/产品) — no detail page exists, so no QR item.
-            if (ganttConfig?.objectField && !String(rec[ganttConfig.objectField] ?? '').trim()) {
-              return null;
-            }
+            if (!rec || isSyntheticRow(rec)) return null;
             const href = recordDetailHref(rec)?.href;
             if (!href) return null;
             // Absolute URL: the QR is scanned on another device, so a
@@ -1317,7 +1408,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       {navigation.isOverlay && navigation.isOpen && navigation.selectedRecord && (() => {
         const rec = navigation.selectedRecord as Record<string, any>;
         const detail = recordDetailHref(rec);
-        if (!detail) return null;
+        if (!detail || isSyntheticRow(rec)) return null;
         const { objectName, recordId } = detail;
         const fullPageHref = detail.href ?? undefined;
         const titleText = ganttConfig?.titleField
@@ -1328,22 +1419,47 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         const recLocked =
           !!(schema as any).readOnly ||
           (ganttConfig?.lockField ? !!rec[ganttConfig.lockField] : false);
+        // #2473: prefer the fetched business record + schema over the raw row
+        // payload (see the drawerFetch effect above for why they can differ).
+        const fetched = drawerFetch?.key === `${objectName}:${recordId}` ? drawerFetch : null;
+        const drawerRecord = fetched?.record ?? rec;
+        const drawerSchema = fetched?.schema
+          ?? (objectName === resource ? (objectSchema as any) : undefined);
+        // Field saves on a fetched record write the BUSINESS object through the
+        // context DataSource (the gantt endpoint only understands composed
+        // rows); everything else keeps the gantt-endpoint write path.
+        const saveDS = fetched && dataSource ? dataSource : effectiveDataSource;
 
         return (
           <RecordDetailDrawer
             open
             onClose={navigation.close}
             title={titleText}
-            record={rec}
+            record={drawerRecord}
             objectName={objectName}
             recordId={recordId}
-            dataSource={effectiveDataSource ?? undefined}
-            objectSchema={objectName === resource ? (objectSchema as any) : undefined}
+            dataSource={saveDS ?? undefined}
+            objectSchema={drawerSchema}
             width={navigation.width as any}
             fullPageHref={fullPageHref}
             onFieldSave={recLocked ? undefined : async (field, value) => {
-              if (!effectiveDataSource?.update) return;
-              await effectiveDataSource.update(objectName, String(recordId), { [field]: value });
+              if (!saveDS?.update) return;
+              try {
+                await saveDS.update(objectName, String(recordId), { [field]: value });
+              } catch (err) {
+                // DetailView rolls back and shows the (cleaned) message inline
+                // next to the field — surface the server's reason, not the raw
+                // "ApiDataSource: HTTP 403 …" transport string.
+                const serverMsg = extractServerMessage(err);
+                throw serverMsg ? new Error(serverMsg) : err;
+              }
+              if (fetched) {
+                setDrawerFetch((prev) =>
+                  prev && prev.key === fetched.key
+                    ? { ...prev, record: { ...prev.record, [field]: value } }
+                    : prev,
+                );
+              }
               setData((prev) => prev.map((r) =>
                 String(r.id ?? r._id) === String(recordId)
                   ? { ...r, [field]: value }
@@ -1353,7 +1469,14 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
             }}
             onDelete={recLocked ? undefined : async () => {
               if (!effectiveDataSource?.delete) return;
-              await effectiveDataSource.delete(objectName, String(recordId));
+              try {
+                // ApiDataSource.delete reports failure as `false`, not a throw.
+                const ok = await effectiveDataSource.delete(objectName, String(recordId));
+                if (ok === false) throw new Error(t('gantt.writeFailed'));
+              } catch (err) {
+                notifyWriteError(err);
+                throw err;
+              }
               setData((prev) => prev.filter((r) =>
                 String(r.id ?? r._id) !== String(recordId),
               ));

--- a/packages/plugin-gantt/src/ObjectGantt.writeerror.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.writeerror.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Write-failure surfacing (#2473 第 2 项).
+ *
+ * A rejected write used to be console.error'd and silently reverted — the
+ * server's reason (e.g. a 403 permission message in the response body) never
+ * reached the user. ObjectGantt must raise a toast on every failed write,
+ * with the server-provided message extracted from the ApiDataSource error
+ * string ("ApiDataSource: HTTP 403 Forbidden — {json body}") as description.
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObjectGantt } from './ObjectGantt';
+import { DataSource } from '@object-ui/types';
+import { toast } from 'sonner';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks, onTaskUpdate }: any) => (
+    <div data-testid="gantt-view">
+      {tasks.map((t: any) => (
+        <div key={t.id} data-testid="gantt-task">{t.title}</div>
+      ))}
+      <button
+        data-testid="gv-update-first"
+        onClick={() => onTaskUpdate?.(tasks[0], {
+          start: new Date('2024-02-01T00:00:00.000Z'),
+          end: new Date('2024-02-05T00:00:00.000Z'),
+        })}
+      >
+        update
+      </button>
+    </div>
+  ),
+}));
+
+const ROWS = [
+  { id: '1', name: 'Task 1', start_date: '2024-01-01', end_date: '2024-01-05' },
+];
+
+const SCHEMA: any = {
+  type: 'gantt',
+  gantt: {
+    titleField: 'name',
+    startDateField: 'start_date',
+    endDateField: 'end_date',
+  },
+  data: { provider: 'object', object: 'tasks' },
+};
+
+function makeDataSource(overrides: Partial<DataSource> = {}): DataSource {
+  return {
+    find: vi.fn().mockResolvedValue({ data: ROWS }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({ fields: {} }),
+    ...overrides,
+  } as DataSource;
+}
+
+async function renderAndFailUpdate(updateError: Error) {
+  const ds = makeDataSource({ update: vi.fn().mockRejectedValue(updateError) });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  render(<ObjectGantt schema={SCHEMA} dataSource={ds} />);
+  await waitFor(() => expect(screen.getByText('Task 1')).toBeDefined());
+  fireEvent.click(screen.getByTestId('gv-update-first'));
+  await waitFor(() => expect(ds.update).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+  errSpy.mockRestore();
+  return (toast.error as any).mock.calls[0];
+}
+
+describe('ObjectGantt write-failure toast', () => {
+  beforeEach(() => {
+    (toast.error as any).mockClear();
+  });
+
+  it('extracts the server message from an ApiDataSource-style error body', async () => {
+    const [title, opts] = await renderAndFailUpdate(new Error(
+      'ApiDataSource: HTTP 403 Forbidden — {"error":"not_manager","message":"仅管理责任人可修改该排班计划"}',
+    ));
+    expect(title).toBe('Save failed — the change was rolled back');
+    expect(opts.description).toBe('仅管理责任人可修改该排班计划');
+  });
+
+  it('falls back to `error` when the body has no `message`', async () => {
+    const [, opts] = await renderAndFailUpdate(new Error(
+      'ApiDataSource: HTTP 500 Internal Server Error — {"error":"boom"}',
+    ));
+    expect(opts.description).toBe('boom');
+  });
+
+  it('omits the description for errors without a parseable body', async () => {
+    const [title, opts] = await renderAndFailUpdate(new Error('network down'));
+    expect(title).toBe('Save failed — the change was rolled back');
+    expect(opts.description).toBeUndefined();
+  });
+
+  it('does not toast on a successful write', async () => {
+    const ds = makeDataSource();
+    render(<ObjectGantt schema={SCHEMA} dataSource={ds} />);
+    await waitFor(() => expect(screen.getByText('Task 1')).toBeDefined());
+    fireEvent.click(screen.getByTestId('gv-update-first'));
+    await waitFor(() => expect(ds.update).toHaveBeenCalledTimes(1));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-gantt/src/useGanttTranslation.ts
+++ b/packages/plugin-gantt/src/useGanttTranslation.ts
@@ -87,6 +87,7 @@ export const GANTT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'gantt.readOnly': 'Read-only',
   'gantt.readOnlyHint': 'Editing is disabled for this view.',
   'gantt.lockedHint': 'No edit permission',
+  'gantt.writeFailed': 'Save failed — the change was rolled back',
 };
 
 function fallback(key: string, options?: Record<string, unknown>): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1904,6 +1904,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@types/qrcode':
         specifier: ^1.5.6


### PR DESCRIPTION
Closes #2473

## 问题

在 `provider: 'api'` 模式下,甘特图的行数据是端点组合的渲染载荷(条形颜色、排序键、节点类型等),不是业务记录。由此引出三个缺陷:

1. **详情抽屉展示组合行原始载荷**:字段退化为英文大写标签(如 `PLAN_TYPE`),且展示的是渲染字段而非业务字段。组件持有的 `objectSchema` 在 api 模式下是适配器的 `{fields: {}}` 桩,传给抽屉后所有字段标签为空。
2. **写回失败静默**:拖拽/依赖/删除/行内编辑触发的写请求被服务端拒绝(如 403)时,界面无任何提示,条形回弹但用户不知道原因。`RecordDetailDrawer` 的 `onFieldSave` 还会吞掉异常,导致行内编辑失败看起来像成功。
3. **锁定行的连线右键菜单可操作**:菜单中的改类型/移除都会改写目标(后继)记录的依赖字段,目标行锁定时服务端必然拒绝,但菜单仍然全部可点。

## 修复

### 1. 抽屉拉取真实记录 + 真实 schema(`ObjectGantt.tsx`)
- 打开抽屉时,通过上下文 DataSource `findOne` 拉取真实记录,并同时 `getObjectSchema` 拉取该对象的真实元数据 schema(支持 `objectField` 跨对象行);拉取失败或无 DataSource 时回退原始行数据,保证 `value` 内联数据场景不回归。
- 配置了 `objectField` 但该字段为空的行是端点合成的分组表头(其 id 不是真实记录 id):新增 `isSyntheticRow` 判定,此类行不再打开抽屉,与已有的二维码抑制逻辑对齐。
- 抽屉内行内编辑的保存,路由到与拉取记录相同的 DataSource 与对象。

### 2. 写回失败错误 toast(`ObjectGantt.tsx`、`RecordDetailDrawer.tsx`、i18n)
- 新增 `extractServerMessage`:从 `ApiDataSource: HTTP 403 Forbidden — {json}` 形态的错误中解析出服务端 `message`/`error`。
- 拖拽更新、依赖增删、删除记录的失败路径统一走 `toast.error(t('gantt.writeFailed'), { description: 服务端消息 })`;新增 i18n 键 `gantt.writeFailed`(中英)。
- `RecordDetailDrawer.onFieldSave` 不再吞异常而是向上抛出,DetailView 得以回滚乐观值并显示失败;删除返回 `false` 也按失败处理(保持抽屉打开)。

### 3. 锁定目标行的连线菜单禁用(`GanttView.tsx`)
- 连线右键菜单在目标行 `locked` 时:显示锁定提示行(`gantt-link-menu-locked`),4 个类型项 + 移除项全部 disabled 且回调不触发。

## 测试

- 单元测试:plugin-gantt **303 passed**(新增 `ObjectGantt.drawerfetch.test.tsx`、`ObjectGantt.writeerror.test.tsx`、`GanttView.linkmenu.test.tsx`),plugin-detail **186 passed**(新增 `RecordDetailDrawer.capability.test.tsx` 的 rethrow 用例)。
- 真机验证:console 构建部署到消费项目(os-tianshun-ehr)后 Playwright 实测 **6/6 通过**,含截图 —— 详见 issue 上的[测试报告](https://github.com/objectstack-ai/objectui/issues/2473#issuecomment-4965489390):
  - 抽屉展示真实记录 + 全中文真实 schema 标签;
  - 合成分组行不打开抽屉;跨对象行(`objectField`)抽屉正确拉取外部对象记录与 schema;
  - 服务端 403 → toast 显示「保存失败,已恢复修改前状态 / 仅管理责任人可修改该排班计划」,条形位置回滚 Δx=0;
  - 锁定行连线菜单提示 + 全项禁用,未发出写请求;未锁定行对照组正常。