### PR TITLE
polish(console-ai): ease dock canvas-maximize + per-surface chat width (ADR-0057 UX #2477)

### DIFF
--- a/.changeset/adr-0057-dock-polish.md
+++ b/.changeset/adr-0057-dock-polish.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/app-shell": patch
+---
+
+polish(console-ai): ease the dock's canvas auto-maximize, and give Studio its own chat width (ADR-0057 UX follow-ups, #2477)
+
+- **#4** The rail now eases to its new width (200ms) when the Live Canvas opens
+  (auto-maximize) or closes (tuck), instead of snapping. The transition is
+  suppressed during a manual resize drag so the width still tracks the pointer
+  1:1.
+- **#6** The Studio dock persists its width under its own key, separate from the
+  console dock. A wide console chat no longer squeezes the Studio design canvas
+  (and vice-versa) — each surface remembers the width that suits it.

--- a/packages/app-shell/src/layout/ChatDock.tsx
+++ b/packages/app-shell/src/layout/ChatDock.tsx
@@ -43,9 +43,9 @@ import {
   DOCK_WIDTH_STORAGE_KEY,
 } from './chatDockState';
 
-function readStoredWidth(): number {
+function readStoredWidth(key: string): number {
   try {
-    const raw = window.localStorage.getItem(DOCK_WIDTH_STORAGE_KEY);
+    const raw = window.localStorage.getItem(key);
     const n = raw ? Number.parseInt(raw, 10) : NaN;
     return Number.isFinite(n) && n > 0 ? n : DOCK_DEFAULT_WIDTH;
   } catch {
@@ -67,6 +67,13 @@ export interface ChatDockOptions {
    * non-persisted copilot collapse).
    */
   persistExpandedKey?: string;
+  /**
+   * localStorage key the rail WIDTH round-trips through. Defaults to the shared
+   * console key; the Studio dock passes its own ({@link
+   * DOCK_STUDIO_WIDTH_STORAGE_KEY}) so a wide console chat doesn't squeeze the
+   * design canvas, and vice-versa (issue #2477 item 6).
+   */
+  persistWidthKey?: string;
 }
 
 export interface ChatDockState {
@@ -111,11 +118,15 @@ export interface ChatDockState {
  *    does nothing.
  */
 export function useChatDockState(options?: ChatDockOptions): ChatDockState {
-  const { defaultExpanded = false, persistExpandedKey } = options ?? {};
+  const {
+    defaultExpanded = false,
+    persistExpandedKey,
+    persistWidthKey = DOCK_WIDTH_STORAGE_KEY,
+  } = options ?? {};
   const [expanded, setExpandedState] = React.useState<boolean>(() =>
     persistExpandedKey ? readStoredDockExpanded(persistExpandedKey, defaultExpanded) : defaultExpanded,
   );
-  const [width, setWidth] = React.useState<number>(() => readStoredWidth());
+  const [width, setWidth] = React.useState<number>(() => readStoredWidth(persistWidthKey));
   const [dragging, setDragging] = React.useState(false);
   const [maximized, setMaximized] = React.useState(false);
   // The latch and the width to return to when the canvas closes. Refs, not
@@ -164,7 +175,7 @@ export function useChatDockState(options?: ChatDockOptions): ChatDockState {
       const onUp = (ev: PointerEvent) => {
         const final = clampDockWidth(startWidth + (startX - ev.clientX), window.innerWidth);
         try {
-          window.localStorage.setItem(DOCK_WIDTH_STORAGE_KEY, String(Math.round(final)));
+          window.localStorage.setItem(persistWidthKey, String(Math.round(final)));
         } catch {
           /* private mode — width just won't persist */
         }
@@ -192,10 +203,10 @@ export function useChatDockState(options?: ChatDockOptions): ChatDockState {
     // a restore after a manual drag took the width over) harmless.
     if (!maximizedRef.current) return;
     maximizedRef.current = false;
-    setWidth(prevWidthRef.current ?? readStoredWidth());
+    setWidth(prevWidthRef.current ?? readStoredWidth(persistWidthKey));
     prevWidthRef.current = null;
     setMaximized(false);
-  }, []);
+  }, [persistWidthKey]);
 
   const toggle = React.useCallback(() => setExpanded((v) => !v), [setExpanded]);
   const expand = React.useCallback(() => setExpanded(() => true), [setExpanded]);
@@ -341,7 +352,14 @@ export function ChatDockPanel({
     <aside
       data-testid="chat-dock-panel"
       style={{ width: dock.width }}
-      className="relative hidden h-full shrink-0 flex-col border-l bg-background md:flex"
+      className={cn(
+        'relative hidden h-full shrink-0 flex-col border-l bg-background md:flex',
+        // ADR-0037/P3c — animate the canvas auto-maximize / tuck so the rail
+        // eases to its new width instead of snapping (issue #2477 item 4).
+        // NOT while dragging: the width must track the pointer 1:1, so the
+        // transition is suppressed for the duration of a resize drag.
+        !dock.dragging && 'transition-[width] duration-200 ease-out',
+      )}
     >
       {/* Left-edge resize handle. */}
       <div

--- a/packages/app-shell/src/layout/chatDockState.ts
+++ b/packages/app-shell/src/layout/chatDockState.ts
@@ -31,6 +31,13 @@ export const DOCK_EXPANDED_STORAGE_KEY = 'ai-chat-dock-expanded';
  * (sessionStorage): a fresh tab re-defaults to the copilot-visible posture.
  */
 export const DOCK_STUDIO_EXPANDED_STORAGE_KEY = 'ai-chat-studio-dock-expanded';
+/**
+ * localStorage key for the STUDIO dock's width, distinct from the console
+ * dock's. The two surfaces size their canvas very differently — a wide console
+ * chat should NOT squeeze the Studio design canvas (issue #2477 item 6) — so
+ * each remembers its own width.
+ */
+export const DOCK_STUDIO_WIDTH_STORAGE_KEY = 'ai-chat-studio-dock-width';
 /** Default rail width (px). */
 export const DOCK_DEFAULT_WIDTH = 420;
 /** The rail never narrower than this. */

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -18,6 +18,7 @@ import {
 import {
   rememberDockReturnLocation,
   DOCK_STUDIO_EXPANDED_STORAGE_KEY,
+  DOCK_STUDIO_WIDTH_STORAGE_KEY,
 } from '../../layout/chatDockState';
 
 interface StudioCopilotConversationProps {
@@ -137,6 +138,8 @@ export function StudioChatDock({ packageId, locale }: StudioChatDockProps): Reac
   const dock = useChatDockState({
     defaultExpanded: true,
     persistExpandedKey: DOCK_STUDIO_EXPANDED_STORAGE_KEY,
+    // Own width too — a wide console chat must not squeeze the design canvas.
+    persistWidthKey: DOCK_STUDIO_WIDTH_STORAGE_KEY,
   });
   // Under `md` the copilot presents as a bottom sheet (there is no horizontal
   // room for a rail). Its open state is LOCAL — a phone must not inherit the


### PR DESCRIPTION
The two smaller UX follow-ups from #2477 (ADR-0057), after #2478.

## #4 — Ease the canvas auto-maximize
When a `build` session opens the Live Canvas, the rail auto-maximizes; it used to **snap** to full width. Now it eases over 200ms (and eases back on tuck). The transition is suppressed while a manual resize drag is in progress, so dragging still tracks the pointer 1:1 (a transition there would lag the handle).

## #6 — Studio dock keeps its own width
The rail width used one shared localStorage key across surfaces, so a wide console chat squeezed the Studio design canvas (and vice-versa). `useChatDockState` now takes an optional `persistWidthKey`; the Studio dock passes its own (`ai-chat-studio-dock-width`). Each surface remembers the width that suits it. Mirrors the per-surface expanded key added in #2478.

## Verification
- `tsc --noEmit` clean; `npx vitest run` layout + studio-design: 5 files / 26 tests green (the stored-flag round-trip + folded-tab suites; the width-key wiring mirrors the already-tested expanded-key pattern).
- #4 is visual polish (best seen live — the rail glides instead of jumping when a build opens the canvas); #6 is a storage-key scoping change.

Refs #2477 · ADR-0057