### PR TITLE
feat(console-ai): mobile chat sheet bridges to full-page /ai — cleanly (ADR-0057 UX #2477)

### DIFF
--- a/.changeset/adr-0057-mobile-fullpage-bridge.md
+++ b/.changeset/adr-0057-mobile-fullpage-bridge.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(console-ai): mobile chat sheet bridges to full-page /ai (conversation history + share) — cleanly (ADR-0057 UX #2477 item 1)
+
+The mobile chat bottom sheet gets a maximize button back — it opens the
+full-page `/ai`, which on mobile already carries the conversation-history
+sidebar and share, so the sheet doesn't need a second copy of either. This is
+the missing mobile path to switch/resume threads.
+
+The button navigates **deferred**: an earlier cut jumped straight from the
+click and tore the still-open Radix sheet down mid-close (the route change
+unmounts the console synchronously, leaking the sheet's scroll-lock/overlay
+onto the destination — "tap maximize → the chat's just gone"). Now the click
+only closes the sheet; a `useEffect` fires the navigation once `open` has
+flipped false — after Radix released the body on that commit and before the
+sheet unmounts — so `/ai` lands clean. Applies to both the console sheet
+(→ `/ai`) and the Studio copilot sheet (→ `/ai/build?package=…`, same thread).
+
+Live Canvas on mobile `/ai` (the beside-chat split has no room on a phone) is
+tracked separately (#2481).

--- a/packages/app-shell/src/layout/ChatDock.tsx
+++ b/packages/app-shell/src/layout/ChatDock.tsx
@@ -428,6 +428,12 @@ export interface ChatDockMobileSheetProps {
   defaultAgent?: string;
   /** Header title override; default "Assistant". */
   title?: string;
+  /**
+   * Open the full-page `/ai` surface (which on mobile already carries the
+   * conversation-history sidebar + share). Runs DEFERRED — see the doc below
+   * for why the sheet must close before this navigates.
+   */
+  onMaximize?: () => void;
   /** Body override — same contract as {@link ChatDockPanel}. */
   children?: React.ReactNode;
 }
@@ -439,16 +445,17 @@ export interface ChatDockMobileSheetProps {
  * Rendered `md:hidden`, so across a live viewport resize exactly one of
  * sheet/rail is visible.
  *
- * NO maximize affordance here, unlike the desktop rail: at 85svh this sheet is
- * ALREADY the maximal mobile chat, so "maximize" only ever meant "navigate to
- * the full-page `/ai`". But navigating away from an OPEN Radix sheet tears it
- * down mid-close — the route change unmounts the whole console synchronously,
- * so the scroll-lock / overlay never release and the destination page lands
- * blank-and-frozen ("tap maximize → the chat's just gone"). Moving the button
- * and closing-before-navigating both failed to make that clean, and the button
- * bought nothing the sheet didn't already show — so it's simply removed. The
- * full-page `/ai` stays reachable through normal navigation, and its
- * collapse-to-dock returns here.
+ * The maximize button bridges to the full-page `/ai` — the mobile-native place
+ * for conversation history + share (both already live there, so the sheet
+ * needn't grow a second copy). This bridge is DEFERRED, not immediate: an
+ * earlier cut navigated straight from the click and tore the still-OPEN Radix
+ * sheet down mid-close — the route change unmounts the console synchronously,
+ * so the scroll-lock / overlay never released and `/ai` landed blank-and-frozen
+ * ("tap maximize → the chat's just gone", the bug that first removed this
+ * button). The fix: the click only CLOSES the sheet (`onOpenChange(false)`);
+ * once `open` has flipped false — after Radix's own child effects have released
+ * the body on that same commit, and before this parent-level effect runs — we
+ * navigate. So the sheet is already cleanly unmounted when the route changes.
  */
 export function ChatDockMobileSheet({
   open,
@@ -457,10 +464,19 @@ export function ChatDockMobileSheet({
   apiBase: apiBaseProp,
   defaultAgent,
   title,
+  onMaximize,
   children,
 }: ChatDockMobileSheetProps) {
   const { t } = useObjectTranslation();
   const apiBase = React.useMemo(() => resolveApiBase(apiBaseProp), [apiBaseProp]);
+  // Armed by the maximize click; fired once the sheet has actually closed.
+  const pendingMaximizeRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!open && pendingMaximizeRef.current) {
+      pendingMaximizeRef.current = false;
+      onMaximize?.();
+    }
+  }, [open, onMaximize]);
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -469,11 +485,32 @@ export function ChatDockMobileSheet({
         data-testid="chat-dock-mobile-sheet"
       >
         <SheetHeader className="shrink-0 border-b px-4 py-2">
-          {/* Leave room (pr-8) for SheetContent's built-in close ✕ at right-4. */}
-          <SheetTitle className="inline-flex items-center gap-1.5 pr-8 text-sm font-semibold">
-            <MessagesSquare className="size-4" />
-            {title ?? t('console.ai.dock.title', { defaultValue: 'Assistant' })}
-          </SheetTitle>
+          {/* Maximize sits NEXT TO THE TITLE (left), finger-sized, well clear of
+              SheetContent's built-in close ✕ (absolute right-4) so a thumb can't
+              confuse the two. `pr-8` still reserves room for that ✕. */}
+          <div className="flex items-center gap-1 pr-8">
+            <SheetTitle className="inline-flex items-center gap-1.5 text-sm font-semibold">
+              <MessagesSquare className="size-4" />
+              {title ?? t('console.ai.dock.title', { defaultValue: 'Assistant' })}
+            </SheetTitle>
+            {onMaximize ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 text-muted-foreground hover:text-foreground"
+                // Only CLOSE here — the deferred effect above navigates once the
+                // sheet is cleanly shut (see the component doc).
+                onClick={() => {
+                  pendingMaximizeRef.current = true;
+                  onOpenChange(false);
+                }}
+                aria-label={t('console.ai.dock.maximize', { defaultValue: 'Open full page' })}
+                data-testid="chat-dock-mobile-maximize"
+              >
+                <Maximize2 className="h-4 w-4" />
+              </Button>
+            ) : null}
+          </div>
           <SheetDescription className="sr-only">
             {t('console.ai.dock.description', { defaultValue: 'AI assistant chat' })}
           </SheetDescription>

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -201,6 +201,9 @@ export function ConsoleLayout({
           onOpenChange={(open) => (open ? dock.expand() : dock.collapse())}
           userId={userId}
           defaultAgent={activeApp?.defaultAgent}
+          // Bridge to full-page /ai (history + share live there on mobile). The
+          // sheet defers the navigation until it has cleanly closed.
+          onMaximize={openDockFullPage}
         />
       )}
     </AppShell>

--- a/packages/app-shell/src/layout/__tests__/ChatDock.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ChatDock.test.tsx
@@ -98,12 +98,49 @@ describe('ChatDockMobileSheet', () => {
     );
     expect(screen.getByTestId('chat-dock-mobile-sheet')).toBeInTheDocument();
     expect(screen.getByTestId('mobile-dock-body')).toBeInTheDocument();
-    // No maximize on mobile — the sheet IS the maximal presentation, and
-    // navigating away from an open Radix sheet left the page blank/frozen.
+    // No maximize button unless a target is wired.
     expect(screen.queryByTestId('chat-dock-mobile-maximize')).not.toBeInTheDocument();
     // The built-in close ✕ / Escape drives onOpenChange(false).
     fireEvent.keyDown(document.body, { key: 'Escape' });
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('maximize CLOSES first and only navigates once the sheet has shut (deferred bridge)', () => {
+    const onOpenChange = vi.fn();
+    const onMaximize = vi.fn();
+    const { rerender } = render(
+      <ChatDockMobileSheet open onOpenChange={onOpenChange} onMaximize={onMaximize}>
+        <div />
+      </ChatDockMobileSheet>,
+    );
+    // Clicking maximize must NOT navigate yet — navigating from an open Radix
+    // sheet leaks its scroll-lock/overlay onto the destination. It only closes.
+    fireEvent.click(screen.getByTestId('chat-dock-mobile-maximize'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onMaximize).not.toHaveBeenCalled();
+    // The controlled parent honors the close → `open` flips false → NOW the
+    // deferred effect fires the navigation, with the sheet already unmounted.
+    rerender(
+      <ChatDockMobileSheet open={false} onOpenChange={onOpenChange} onMaximize={onMaximize}>
+        <div />
+      </ChatDockMobileSheet>,
+    );
+    expect(onMaximize).toHaveBeenCalledTimes(1);
+  });
+
+  it('a normal close (no maximize) never navigates', () => {
+    const onMaximize = vi.fn();
+    const { rerender } = render(
+      <ChatDockMobileSheet open onOpenChange={() => {}} onMaximize={onMaximize}>
+        <div />
+      </ChatDockMobileSheet>,
+    );
+    rerender(
+      <ChatDockMobileSheet open={false} onOpenChange={() => {}} onMaximize={onMaximize}>
+        <div />
+      </ChatDockMobileSheet>,
+    );
+    expect(onMaximize).not.toHaveBeenCalled();
   });
 
   it('renders nothing while closed', () => {

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -177,6 +177,9 @@ export function StudioChatDock({ packageId, locale }: StudioChatDockProps): Reac
           open={mobileOpen}
           onOpenChange={setMobileOpen}
           title={zh ? 'AI 副驾' : 'AI copilot'}
+          // Bridge to the package's full-page build thread; deferred so the
+          // sheet closes cleanly before the route changes.
+          onMaximize={openFullPage}
         >
           <StudioCopilotConversation packageId={packageId} />
         </ChatDockMobileSheet>


### PR DESCRIPTION
#2477 item 1. Restores the mobile path to conversation history + share, without the bug that first removed it.

## What
The mobile chat bottom sheet gets a **maximize** button back. It opens full-page `/ai`, which on mobile **already** carries the conversation-history sidebar and share — so the sheet doesn't grow a second copy of either; it just bridges to the mobile-native full surface. This is the missing way for phone users to switch / resume threads.

## Why deferred navigation
An earlier cut navigated straight from the click and tore the still-**open** Radix sheet down mid-close — the route change unmounts the console synchronously, so the sheet's scroll-lock / overlay never released and `/ai` landed **blank-and-frozen** (*"tap maximize → the chat's just gone"* — the bug that first removed this button). The fix: the click only **closes** the sheet; a `useEffect` fires the navigation once `open` has flipped `false` — after Radix released the body on that commit (its child effects run before this parent-level effect) and before the sheet unmounts — so `/ai` lands clean. Both the console sheet (→ `/ai`) and the Studio copilot sheet (→ `/ai/build?package=…`, same thread).

Live Canvas on mobile `/ai` (the beside-chat split has no room on a phone) is tracked separately — #2481.

## Verification
- `tsc --noEmit` clean; app-shell + `apps/console` build green; `npx vitest run` layout/console-ai/studio: 91 tests green. New: the mobile sheet click closes-then-navigates (never navigates while open; a plain close never navigates).
- **Live (390px phone viewport, rig):** FAB → sheet with maximize → tap maximize → lands on `/ai/ask/conv_…` (same thread), `sheetGone`, **`body { pointer-events:auto; overflow:visible }`, no leftover overlay** (the blank/frozen bug is gone). `/ai` on mobile: history sidebar opens, share present, collapse-to-dock returns to the exact console page and re-opens the sheet; closing the sheet restores the body cleanly. Screenshot in the review.

Refs #2477 · ADR-0057