### PR TITLE
fix(plugin-grid): stop row-action buttons clipping in the list actions column

### DIFF
--- a/apps/console/row-actions-preview.html
+++ b/apps/console/row-actions-preview.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Row-action Overflow Preview</title>
+    <script>
+      window.process = window.process || { env: { NODE_ENV: 'development' }, version: '', platform: 'browser' };
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/row-actions-preview.tsx"></script>
+  </body>
+</html>

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -19,6 +19,7 @@ import { DevMasterDetail } from './dev/DevMasterDetail';
 import { DevLists } from './dev/DevLists';
 import { DevModal } from './dev/DevModal';
 import { DevLookup } from './dev/DevLookup';
+import { DevRowActions } from './dev/DevRowActions';
 import {
   ConsoleShell,
   ConnectedShell,
@@ -281,6 +282,12 @@ export function App() {
             <Route path="/dev/lookup" element={
               <ProtectedRoute>
                 <DevLookup />
+              </ProtectedRoute>
+            } />
+            {/* Dev-only: row-action inline-overflow (multiple primary actions). */}
+            <Route path="/dev/row-actions" element={
+              <ProtectedRoute>
+                <DevRowActions />
               </ProtectedRoute>
             } />
             <Route path="/organizations" element={

--- a/apps/console/src/dev/DevRowActions.tsx
+++ b/apps/console/src/dev/DevRowActions.tsx
@@ -1,0 +1,87 @@
+/**
+ * Dev-only harness for row-action overflow in the list grid.
+ *
+ * Reproduces the cloud "环境 / Environments" list, where each row declares TWO
+ * `variant:'primary'` actions ("Open" + "Upgrade Plan"). Before the fix these
+ * both rendered as inline buttons in a fixed 80px-floored, overflow-hidden
+ * actions cell, so the leftmost ("Open") was clipped to a blue sliver.
+ *
+ * After the fix:
+ *  - the `_actions` column is `fitContent` (hugs its buttons, never clipped);
+ *  - only the first `maxInlineRowActions` (default 1) primaries stay inline —
+ *    the rest fold into the "⋮" overflow menu.
+ *
+ * The second grid raises `maxInlineRowActions` to 2 to show both primaries can
+ * still render inline when the author opts in (and the column grows to fit).
+ * Not part of the product nav.
+ */
+import React from 'react';
+import { ActionProvider } from '@object-ui/react';
+import { ObjectGrid } from '@object-ui/plugin-grid';
+
+const ENV_ROWS = [
+  { id: '1', name: 'hotcrm-fix-verify', org: 'hotcrm-fix-verify', type: 'production', status: 'running', host: 'os-05ayzz.objectos.app' },
+  { id: '2', name: 'Objectstack', org: 'Objectstack', type: 'production', status: 'running', host: 'os-0zpadn.objectos.app' },
+  { id: '3', name: 'hotcrm', org: "JIANGUO Zhuang's Workspace", type: 'production', status: 'running', host: 'os-48f50e60.objectos.app' },
+];
+
+// Mirrors the sys_environment row-level actions: two primaries plus secondaries
+// that live in the "⋮" overflow menu.
+const ROW_ACTION_DEFS = [
+  { name: 'open', label: 'Open', variant: 'primary' },
+  { name: 'upgrade', label: 'Upgrade Plan', variant: 'primary' },
+  { name: 'rename', label: 'Rename', variant: 'secondary' },
+  { name: 'archive', label: 'Archive', variant: 'secondary' },
+];
+
+const COLUMNS = [
+  { field: 'name', label: '名称' },
+  { field: 'org', label: '所属组织' },
+  { field: 'type', label: '类型' },
+  { field: 'status', label: '状态' },
+  { field: 'host', label: '公开主机名' },
+];
+
+function EnvGrid({ maxInlineRowActions }: { maxInlineRowActions?: number }) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'showcase_environment',
+    columns: COLUMNS,
+    data: { provider: 'value', items: ENV_ROWS },
+    rowActionDefs: ROW_ACTION_DEFS,
+    ...(maxInlineRowActions != null ? { maxInlineRowActions } : {}),
+  };
+  return (
+    <ActionProvider>
+      <ObjectGrid schema={schema} />
+    </ActionProvider>
+  );
+}
+
+export const DevRowActions: React.FC = () => (
+  <div className="mx-auto max-w-none space-y-8 p-6">
+    <div>
+      <h1 className="text-lg font-semibold">Dev · Row-action overflow (default)</h1>
+      <p className="mb-3 text-sm text-muted-foreground">
+        Two <code>variant:'primary'</code> row actions. Only <strong>Open</strong> stays inline;
+        <strong> Upgrade Plan</strong> + the secondaries fold into the <code>⋮</code> menu. The
+        actions column hugs its content and must never clip the inline button.
+      </p>
+      <div className="rounded-lg border" data-testid="grid-default">
+        <EnvGrid />
+      </div>
+    </div>
+    <div>
+      <h1 className="text-lg font-semibold">Dev · Row-action overflow (maxInlineRowActions: 2)</h1>
+      <p className="mb-3 text-sm text-muted-foreground">
+        Same data, author opts into two inline primaries — both <strong>Open</strong> and
+        <strong> Upgrade Plan</strong> render inline and the column grows to fit them.
+      </p>
+      <div className="rounded-lg border" data-testid="grid-wide">
+        <EnvGrid maxInlineRowActions={2} />
+      </div>
+    </div>
+  </div>
+);
+
+export default DevRowActions;

--- a/apps/console/src/row-actions-preview.tsx
+++ b/apps/console/src/row-actions-preview.tsx
@@ -1,0 +1,27 @@
+/**
+ * DEV-ONLY row-action overflow preview.
+ *
+ * Renders the `DevRowActions` harness (an ObjectGrid list whose rows declare
+ * two `variant:'primary'` actions, like cloud's Environments list) with no
+ * backend and no auth, so the inline-overflow fix can be browser-verified.
+ *
+ * Served as a standalone Vite entry: open /row-actions-preview.html.
+ * Excluded from the production build (no route references it).
+ */
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import { I18nProvider } from '@object-ui/i18n';
+
+// Register the grid renderer the harness renders through (side-effect import).
+import '@object-ui/plugin-grid';
+
+import { DevRowActions } from './dev/DevRowActions';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <I18nProvider>
+      <DevRowActions />
+    </I18nProvider>
+  </React.StrictMode>,
+);

--- a/packages/components/src/renderers/complex/__tests__/data-table-fit-content.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-fit-content.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: a `fitContent` column (used by the row-actions column) must size
+ * to its own content and never clip it. Bug context: the actions column had no
+ * string data, so the width auto-sizer pinned it to the 80px floor, and the
+ * fixed-width cell's `overflow-hidden` clipped multiple inline action buttons
+ * (the cloud environments list showed "Open" cut to a sliver behind "Upgrade
+ * Plan"). `fitContent` columns now hug content (`width:1%` + nowrap) with no
+ * overflow clamp; normal columns keep `overflow-hidden` truncation.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import '../data-table';
+
+function renderTable(schema: any) {
+  const DataTable = ComponentRegistry.get('data-table') as any;
+  if (!DataTable) throw new Error('data-table not registered');
+  return render(<DataTable schema={schema} />);
+}
+
+const baseSchema = {
+  data: [{ id: '1', name: 'Alice' }],
+  pagination: false,
+  searchable: false,
+  columns: [
+    { header: 'Name', accessorKey: 'name' },
+    {
+      header: 'Actions',
+      accessorKey: '_acts',
+      fitContent: true,
+      align: 'right',
+      cell: () => <button data-testid="act-btn" type="button">Open · Upgrade Plan</button>,
+    },
+  ],
+};
+
+describe('data-table fitContent column', () => {
+  beforeAll(() => {
+    expect(ComponentRegistry.has('data-table')).toBe(true);
+  });
+
+  it('does not clip the fitContent cell and hugs its content width', () => {
+    renderTable(baseSchema);
+    const cell = screen.getByTestId('act-btn').closest('td');
+    expect(cell).not.toBeNull();
+    // The actions cell must not carry the generic truncation clip.
+    expect(cell!.className).not.toContain('overflow-hidden');
+    expect(cell!.className).toContain('whitespace-nowrap');
+    // It hugs content via a 1% width with no max-width clamp.
+    const style = cell!.getAttribute('style') || '';
+    expect(style).toContain('width: 1%');
+    expect(style).not.toContain('max-width');
+  });
+
+  it('keeps overflow-hidden truncation on normal columns', () => {
+    renderTable(baseSchema);
+    const cell = screen.getByText('Alice').closest('td');
+    expect(cell).not.toBeNull();
+    expect(cell!.className).toContain('overflow-hidden');
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -400,9 +400,15 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       header: col.header || col.label,
       accessorKey: col.accessorKey || col.name,
       width: col.width,
+      fitContent: col.fitContent,
     }));
     for (const col of cols) {
       if (col.width) continue; // Skip columns with explicit widths
+      // `fitContent` columns (e.g. the row-actions column) size to their own
+      // content via a `width:1%` + nowrap cell, not a char-count estimate —
+      // estimating them from an absent string value pins them to the 80px
+      // floor and clips inline buttons. Leave them out of the width map.
+      if (col.fitContent) continue;
       const headerLen = (col.header || '').length;
       let maxLen = headerLen;
       // Sample up to 50 rows for content width estimation
@@ -1125,7 +1131,13 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                 </TableHead>
               )}
               {columns.map((col, index) => {
-                const columnWidth = columnWidths[col.accessorKey] || col.width || autoSizedWidths[col.accessorKey];
+                // `fitContent` columns hug their content (no fixed width /
+                // char-estimate) so inline row-action buttons never get clipped.
+                const isFit = (col as any).fitContent === true
+                  && !columnWidths[col.accessorKey] && !col.width;
+                const columnWidth = isFit
+                  ? '1%'
+                  : (columnWidths[col.accessorKey] || col.width || autoSizedWidths[col.accessorKey]);
                 const isDragging = draggedColumn === index;
                 const isDragOver = dragOverColumn === index;
                 const isFrozen = frozenColumns > 0 && index < frozenColumns;
@@ -1149,6 +1161,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                       isDragOver && 'border-l-2 border-primary',
                       col.align === 'right' && 'text-right',
                       col.align === 'center' && 'text-center',
+                      isFit && 'whitespace-nowrap',
                       'relative group bg-background',
                       isFrozen && 'sticky z-20',
                       isFrozen && index === frozenColumns - 1 && 'border-r-2 border-border shadow-[2px_0_4px_-2px_rgba(0,0,0,0.1)]',
@@ -1351,7 +1364,11 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                         </TableCell>
                       )}
                       {columns.map((col, colIndex) => {
-                        const columnWidth = columnWidths[col.accessorKey] || col.width || autoSizedWidths[col.accessorKey];
+                        const isFit = (col as any).fitContent === true
+                          && !columnWidths[col.accessorKey] && !col.width;
+                        const columnWidth = isFit
+                          ? '1%'
+                          : (columnWidths[col.accessorKey] || col.width || autoSizedWidths[col.accessorKey]);
                         const originalValue = row[col.accessorKey];
                         const hasPendingChange = rowChanges[col.accessorKey] !== undefined;
                         const cellValue = hasPendingChange ? rowChanges[col.accessorKey] : originalValue;
@@ -1375,7 +1392,10 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                               col.cellClassName,
                               col.align === 'right' && 'text-right',
                               col.align === 'center' && 'text-center',
-                              'overflow-hidden',
+                              // `fitContent` cells must not clip their inline
+                              // content (row-action buttons); every other column
+                              // keeps overflow-hidden for truncation.
+                              isFit ? 'whitespace-nowrap' : 'overflow-hidden',
                               isEditable && !isEditing && "cursor-text hover:bg-muted/50",
                               hasPendingChange && "font-semibold text-amber-700 dark:text-amber-400",
                               isFrozen && 'sticky z-10 bg-background',
@@ -1383,8 +1403,11 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                             )}
                             style={{
                               width: columnWidth,
-                              minWidth: columnWidth,
-                              maxWidth: columnWidth,
+                              // fit columns hug content: a `1%` width with no
+                              // max clamp lets the cell grow to its buttons and
+                              // other auto columns absorb the remaining space.
+                              minWidth: isFit ? undefined : columnWidth,
+                              maxWidth: isFit ? undefined : columnWidth,
                               ...(isFrozen && { left: frozenOffset }),
                             }}
                             onDoubleClick={(e) => {
@@ -1532,7 +1555,10 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                 );
                               })()
                             ) : (
-                              <div className="truncate w-full" title={cellValue != null && typeof cellValue !== 'object' ? String(cellValue) : undefined}>
+                              <div
+                                className={isFit ? 'w-full whitespace-nowrap' : 'truncate w-full'}
+                                title={!isFit && cellValue != null && typeof cellValue !== 'object' ? String(cellValue) : undefined}
+                              >
                                 {typeof col.cell === 'function'
                                   ? col.cell(cellValue, row)
                                   : (cellValue != null && typeof cellValue === 'object' ? String(cellValue) : formatCellValue(cellValue) as any)}

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1487,11 +1487,17 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     {
       header: t('grid.actions'),
       accessorKey: '_actions',
+      // Size to the buttons it holds (never the 80px char-estimate floor) and
+      // don't clip — otherwise multiple inline actions (e.g. Open + Upgrade)
+      // overflow the fixed-width cell and the leftmost button gets cut off.
+      fitContent: true,
+      align: 'right',
       cell: (_value: any, row: any) => (
         <RowActionMenu
           row={row}
           rowActions={customRowActions}
           rowActionDefs={rowActionDefsList}
+          maxInlineActions={(schema as any).maxInlineRowActions ?? 1}
           canEdit={canEdit}
           canDelete={canDelete}
           onEdit={onEdit}
@@ -1894,6 +1900,10 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     const saved = columnState.widths?.[key];
     if (saved) { groupedColumnWidths[key] = saved; continue; }
     if (col.width) { groupedColumnWidths[key] = col.width; continue; }
+    // `fitContent` columns (row actions) hug their content — leave them out so
+    // they aren't pinned to the 80px char-estimate floor and clipped in
+    // grouped mode the same way they were in the flat list.
+    if ((col as any).fitContent) continue;
     let maxLen = String(col.header ?? '').length;
     for (const row of data.slice(0, 50)) {
       const v = row?.[key];

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -73,6 +73,13 @@ export interface RowActionMenuProps {
   onAction?: (action: string, row: any) => void;
   /** Callback when a schema-driven row action is clicked. */
   onActionDef?: (def: RowActionDef, row: any) => void;
+  /**
+   * How many `variant:'primary'` row actions may render as inline buttons
+   * before the rest fold into the "⋮" overflow menu. Bounds the row's inline
+   * width so multiple primary actions (e.g. Open + Upgrade Plan) can't crowd
+   * and clip each other in the narrow actions column. Defaults to 1.
+   */
+  maxInlineActions?: number;
 }
 
 /**
@@ -161,12 +168,21 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
   onDelete,
   onAction,
   onActionDef,
+  maxInlineActions = 1,
 }) => {
   const t = useRowActionTranslation();
   // Surface `variant: 'primary'` row actions inline (as the row's main CTA);
-  // everything else stays in the "⋮" overflow menu.
-  const inlineDefs = (rowActionDefs ?? []).filter(d => d.variant === 'primary');
-  const menuDefs = (rowActionDefs ?? []).filter(d => d.variant !== 'primary');
+  // everything else stays in the "⋮" overflow menu. Only the first
+  // `maxInlineActions` primaries render inline — any extra primaries fold into
+  // the menu (kept above secondary actions) so a row never renders more inline
+  // buttons than the actions column can show, which previously clipped the
+  // leftmost button (e.g. "Open" hidden behind "Upgrade Plan").
+  const primaryDefs = (rowActionDefs ?? []).filter(d => d.variant === 'primary');
+  const inlineDefs = primaryDefs.slice(0, Math.max(0, maxInlineActions));
+  const menuDefs = [
+    ...primaryDefs.slice(Math.max(0, maxInlineActions)),
+    ...(rowActionDefs ?? []).filter(d => d.variant !== 'primary'),
+  ];
   const hasMenu = Boolean(
     (canEdit && onEdit) ||
     (canDelete && onDelete) ||
@@ -174,7 +190,7 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
     (rowActions?.length ?? 0) > 0,
   );
   return (
-    <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+    <div className="flex items-center justify-end gap-1 whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
       {inlineDefs.map(def => (
         <RowActionInlineButton
           key={def.name}

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: multiple `variant:'primary'` row actions must not all render as
+ * inline buttons and crowd/clip the narrow actions column. Bug context: the
+ * cloud `sys_environment` list declares TWO primary row actions ("Open" +
+ * "Upgrade Plan"); RowActionMenu rendered both inline with `justify-end`, so
+ * the leftmost ("Open") overflowed the fixed-width cell and was clipped to a
+ * sliver. Only the first `maxInlineActions` primaries now stay inline; the rest
+ * fold into the "⋮" overflow menu.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { RowActionMenu } from '../RowActionMenu';
+
+const OPEN = { name: 'open', label: 'Open', variant: 'primary' as const };
+const UPGRADE = { name: 'upgrade', label: 'Upgrade Plan', variant: 'primary' as const };
+const ARCHIVE = { name: 'archive', label: 'Archive', variant: 'secondary' as const };
+
+function renderMenu(props: Record<string, any>) {
+  return render(
+    <PredicateScopeProvider scope={{}}>
+      <RowActionMenu row={{ id: 'e1' }} onActionDef={() => {}} {...props} />
+    </PredicateScopeProvider>,
+  );
+}
+
+describe('RowActionMenu inline overflow', () => {
+  it('inlines only the first primary by default; extra primaries fold into the menu', () => {
+    renderMenu({ rowActionDefs: [OPEN, UPGRADE] });
+    // First primary renders as an inline button (the row's main CTA).
+    expect(screen.getByTestId('row-action-inline-open')).toBeInTheDocument();
+    // Second primary is NOT inline — it moved to the "⋮" overflow menu.
+    expect(screen.queryByTestId('row-action-inline-upgrade')).not.toBeInTheDocument();
+    // The overflow menu trigger exists to hold the folded action.
+    expect(screen.getByTestId('row-action-trigger')).toBeInTheDocument();
+  });
+
+  it('honors a higher maxInlineActions so both primaries stay inline', () => {
+    renderMenu({ rowActionDefs: [OPEN, UPGRADE], maxInlineActions: 2 });
+    expect(screen.getByTestId('row-action-inline-open')).toBeInTheDocument();
+    expect(screen.getByTestId('row-action-inline-upgrade')).toBeInTheDocument();
+  });
+
+  it('never inlines a non-primary action', () => {
+    renderMenu({ rowActionDefs: [OPEN, ARCHIVE] });
+    expect(screen.getByTestId('row-action-inline-open')).toBeInTheDocument();
+    expect(screen.queryByTestId('row-action-inline-archive')).not.toBeInTheDocument();
+  });
+
+  it('maxInlineActions:0 folds every primary into the menu', () => {
+    renderMenu({ rowActionDefs: [OPEN, UPGRADE], maxInlineActions: 0 });
+    expect(screen.queryByTestId('row-action-inline-open')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('row-action-inline-upgrade')).not.toBeInTheDocument();
+    expect(screen.getByTestId('row-action-trigger')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

On the cloud **环境 / Environments** list, each row's right-side action button was clipped — `Open` (进入环境) showed only as a blue sliver behind `Upgrade Plan` (升级套餐).

![before: Open clipped to a sliver]()

Two independent causes in the **shared list component** (not the action metadata — declaring two primary CTAs per row is legitimate):

1. **`RowActionMenu` inlined *every* `variant:'primary'` action** with `justify-end`. `sys_environment` ships two row-level primaries (`sso_as_owner`/"Open" + `upgrade`/"Upgrade Plan"), so they overflowed the cell and the leftmost was cut off.
2. **The data-table auto-sizer pinned the actions column to its 80px floor** (it has no string content to measure), and the cell's `overflow-hidden` + fixed `max-width` clipped whatever didn't fit.

## Fix

- **`RowActionMenu`**: only the first `maxInlineActions` (default **1**) primaries render inline; extra primaries fold into the `⋮` overflow menu, above the secondaries. Authors can opt into more via a view's `maxInlineRowActions`.
- **`data-table`**: new generic **`fitContent`** column option — the column hugs its content (`width:1%` + `whitespace-nowrap`), is exempt from the char-estimate auto-sizer and the grouped-view width precompute, and drops the `overflow-hidden` clip (both the cell and its inner wrapper). Normal columns keep truncation unchanged.
- **`ObjectGrid`**: marks the `_actions` column `fitContent` + `align:'right'`.

## Verification

Browser-tested via a no-backend console preview (`/row-actions-preview.html`, new dev-only `DevRowActions` harness):

- **Default grid** — one inline `Open` fully rendered + a `⋮` menu holding *Upgrade Plan / Rename / Archive*. No clip.
- **`maxInlineRowActions: 2` grid** — both `Open` and `Upgrade Plan` inline, column grown to fit. No clip.

Clean browser console.

## Tests

- `RowActionMenu.test.tsx` — inline-cap behavior: default caps at 1, honors a higher cap, never inlines non-primaries, `0` folds all (4 tests).
- `data-table-fit-content.test.tsx` — fitContent cell drops `overflow-hidden`, hugs content (`width:1%`, no max clamp); normal cells keep `overflow-hidden` (2 tests).
- Existing plugin-grid + data-table suites green (50 total).

## Scope note

This fixes the **cell-level clip** (the reported bug, where the table fits the viewport). The separate *wide-table horizontal-scroll* case — where enough columns push the whole actions column past the grid's own scroll edge — is **not** addressed here; pinning `_actions` sticky-right interacts with the existing `frozenColumns` default and warrants its own change. Flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)