### PR TITLE
fix(plugin-grid): pin the row-actions column right so it survives horizontal scroll

### DIFF
--- a/apps/console/src/dev/DevRowActions.tsx
+++ b/apps/console/src/dev/DevRowActions.tsx
@@ -81,6 +81,18 @@ export const DevRowActions: React.FC = () => (
         <EnvGrid maxInlineRowActions={2} />
       </div>
     </div>
+    <div>
+      <h1 className="text-lg font-semibold">Dev · Row-action sticky-right (narrow / horizontal scroll)</h1>
+      <p className="mb-3 text-sm text-muted-foreground">
+        A deliberately narrow container so the table scrolls horizontally. The
+        <strong> 操作</strong> column stays pinned to the right edge (always reachable), while the
+        first <strong>名称</strong> column stays frozen on the left. Scroll the grid sideways to check
+        both edges hold.
+      </p>
+      <div className="max-w-md overflow-hidden rounded-lg border" data-testid="grid-scroll">
+        <EnvGrid />
+      </div>
+    </div>
   </div>
 );
 

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1492,6 +1492,11 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       // overflow the fixed-width cell and the leftmost button gets cut off.
       fitContent: true,
       align: 'right',
+      // Stick to the right edge so the actions stay reachable when a wide table
+      // scrolls horizontally (otherwise the last column sits past the scroll
+      // extent and is hidden). Excluded from the frozen-column decision below so
+      // this auto-pin doesn't cancel the default left-freeze of the first column.
+      pinned: 'right',
       cell: (_value: any, row: any) => (
         <RowActionMenu
           row={row}
@@ -1538,6 +1543,13 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const unpinnedCols = columnsWithActions.filter((c: any) => !c.pinned);
   const hasPinnedColumns = pinnedLeftCols.length > 0 || pinnedRightCols.length > 0;
   const rightPinnedClasses = 'sticky right-0 z-10 bg-background border-l border-border';
+  // The `_actions` column is auto-pinned right (above), so it must be excluded
+  // from the frozen-column decision — otherwise every list with row actions
+  // would trip `hasPinnedColumns` and lose the implicit left-freeze of its
+  // first column. Only USER-declared pins should drive freezing.
+  const userLeftPinnedCount = pinnedLeftCols.filter((c: any) => c.accessorKey !== '_actions').length;
+  const hasUserPinnedColumns =
+    userLeftPinnedCount > 0 || pinnedRightCols.some((c: any) => c.accessorKey !== '_actions');
 
   // Density-driven cell padding/font (applied to every column so it actually reaches <td>).
   // `h-*` enforces a minimum row height so the action-button column doesn't dictate it.
@@ -1573,9 +1585,11 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       ]
     : columnsWithActions.map(applyDensity);
 
-  // Calculate frozenColumns: if pinned columns exist, use left-pinned count; otherwise use schema default
-  const effectiveFrozenColumns = hasPinnedColumns
-    ? pinnedLeftCols.length
+  // Calculate frozenColumns: if the USER pinned columns, use their left-pinned
+  // count; otherwise fall back to the schema default (freeze the first column).
+  // The auto-pinned actions column is intentionally not counted here.
+  const effectiveFrozenColumns = hasUserPinnedColumns
+    ? userLeftPinnedCount
     : (schema.frozenColumns ?? 1);
 
   // Determine selection mode (support both new and legacy formats)

--- a/packages/plugin-grid/src/__tests__/row-action-sticky.test.tsx
+++ b/packages/plugin-grid/src/__tests__/row-action-sticky.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The row-actions column is auto-pinned to the right so it stays reachable when
+ * a wide table scrolls horizontally (otherwise it sits past the scroll extent
+ * and is hidden). Critically, this auto-pin must NOT cancel the default
+ * left-freeze of the first column — only USER-declared pins drive freezing.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+const ROWS = [
+  { id: '1', name: 'Alice', amount: 100 },
+  { id: '2', name: 'Bob', amount: 200 },
+];
+
+function renderGrid(opts?: Record<string, any>) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'test_object',
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'amount', label: 'Amount', type: 'number' },
+    ],
+    data: { provider: 'value', items: ROWS },
+    rowActionDefs: [{ name: 'open', label: 'Open', variant: 'primary' }],
+    ...opts,
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} />
+    </ActionProvider>,
+  );
+}
+
+describe('row-actions column sticky-right', () => {
+  it('sticks the actions column to the right edge', async () => {
+    renderGrid();
+    await waitFor(() => expect(screen.getAllByTestId('row-action-inline-open').length).toBeGreaterThan(0));
+    const actionsCell = screen.getAllByTestId('row-action-inline-open')[0].closest('td');
+    expect(actionsCell).not.toBeNull();
+    expect(actionsCell!.className).toContain('sticky');
+    expect(actionsCell!.className).toContain('right-0');
+  });
+
+  it('preserves the default left-freeze of the first column despite the auto-pin', async () => {
+    const { container } = renderGrid();
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+    // First body column (Name) must still be frozen-left (sticky, not right-0).
+    const firstCell = screen.getByText('Alice').closest('td');
+    expect(firstCell).not.toBeNull();
+    expect(firstCell!.className).toContain('sticky');
+    expect(firstCell!.className).not.toContain('right-0');
+    // Sanity: the frozen column pins to the left edge, not the right.
+    expect(container.querySelector('td.right-0')).not.toBeNull(); // the actions column
+  });
+
+  it('still surfaces the actions inline button (no regression from pinning)', async () => {
+    renderGrid();
+    await waitFor(() => expect(screen.getAllByTestId('row-action-inline-open').length).toBe(ROWS.length));
+  });
+});


### PR DESCRIPTION
Follow-up to #2484 (which fixed the **cell-level clip**). This addresses the deferred **wide-table horizontal-scroll** case: when a list has enough columns to overflow the grid's own scroll container, the actions column sat past the scroll extent and was hidden until you scrolled fully right.

## Fix

- **Auto-pin `_actions` right** (`pinned:'right'`, reusing the existing sticky `rightPinnedClasses`). The actions column now sticks to the right edge and stays reachable during horizontal scroll.
- **Decouple the auto-pin from the freeze decision.** The existing `hasPinnedColumns ? pinnedLeftCols.length : frozenColumns` logic disables the implicit first-column left-freeze whenever *any* column is pinned. Auto-pinning actions would therefore unfreeze every list's first column. The freeze decision now considers **user-declared pins only** (excludes `_actions`), so the auto-pin *composes with* rather than *cancels* the default left-freeze.

## Verification

Console preview (`/row-actions-preview.html`, new "narrow / horizontal scroll" section). Under a real `scrollLeft=300` on the grid's scroller (scrollWidth 1063 > clientWidth 446):

| column | computed | result |
|---|---|---|
| actions (`_actions`) | `position:sticky; right:0px` | pinned to the right edge ✓ |
| first column | `position:sticky; left:0px` | frozen at the left edge ✓ |

Both edges hold simultaneously — the middle columns scroll between them. Clean browser console.

## Tests

`row-action-sticky.test.tsx` (3): actions column is sticky-right; first column keeps its left-freeze despite the auto-pin; inline buttons still render. Existing pinned-column + row-action suites green (plugin-grid **108**, data-table **15**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)