### PR TITLE
fix(plugin-gantt): 删除冗余行「定位」图标;「→」详情按钮改独立操作槽

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -415,7 +415,6 @@ const en = {
     row: {
       expand: 'Expand',
       collapse: 'Collapse',
-      locate: 'Locate on timeline',
       open: 'Open details',
     },
     aria: {

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -491,7 +491,6 @@ const zh = {
     row: {
       expand: '展开',
       collapse: '收起',
-      locate: '在甘特图上定位',
       open: '打开详情',
     },
     aria: {

--- a/packages/plugin-gantt/src/GanttView.enhancements.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.enhancements.test.tsx
@@ -86,10 +86,16 @@ describe('GanttView row click model (单击=Focus, 双击/「→」=详情)', ()
 
   it('the row 「→」 button opens detail and only renders with onTaskClick', () => {
     const onTaskClick = vi.fn();
-    const { getByTestId } = renderView([A()], { onTaskClick });
-    act(() => { fireEvent.click(getByTestId('gantt-row-open-a')); });
+    const { getByTestId, queryByTestId: q1 } = renderView([A()], { onTaskClick });
+    const openBtn = getByTestId('gantt-row-open-a');
+    act(() => { fireEvent.click(openBtn); });
     expect(onTaskClick).toHaveBeenCalledTimes(1);
     expect(onTaskClick.mock.calls[0][0].id).toBe('a');
+    // In-flow slot, not an absolute overlay — it must never cover the
+    // end-date column (#2482).
+    expect(openBtn.className).not.toContain('absolute');
+    // The hover locate icon is gone: a plain row click already locates.
+    expect(q1('gantt-row-locate-a')).toBeNull();
 
     const { queryByTestId } = renderView([makeTask('z', '2024-06-10T00:00:00.000Z', '2024-06-15T00:00:00.000Z')]);
     expect(queryByTestId('gantt-row-open-z')).toBeNull();

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -28,7 +28,6 @@ import {
   FileDown,
   Save,
   Lock,
-  Crosshair,
   RefreshCw,
   ArrowRight,
   QrCode,
@@ -2690,9 +2689,11 @@ export function GanttView({
       <style>{`
         .gantt-resize-handle:hover { background-color: rgba(255, 255, 255, 0.4); }
         .gantt-bar-hover:hover { filter: brightness(1.1); }
-        .gantt-locate-btn { opacity: 0; transition: opacity 0.15s ease; }
-        .group\\/task-row:hover .gantt-locate-btn { opacity: 0.6; }
-        .gantt-locate-btn:hover, .gantt-locate-btn:focus-visible { opacity: 1; }
+        .gantt-row-open-btn { opacity: 0; transition: opacity 0.15s ease; }
+        /* :where keeps the row-hover reveal at zero specificity so the
+           button's own :hover/:focus-visible full-opacity rule can win. */
+        :where(.group\\/task-row:hover) .gantt-row-open-btn { opacity: 0.6; }
+        .gantt-row-open-btn:hover, .gantt-row-open-btn:focus-visible { opacity: 1; }
         /* 定位闪烁: blink the located bar 3× with a thick ring + colored glow so
            it's hard to miss. The ring is an outline (not box-shadow) and the glow
            is a drop-shadow *filter* — both stay clear of the critical-path bar's
@@ -3276,45 +3277,30 @@ export function GanttView({
                     row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })
                   )}
                 </div>
-                {/* 定位到甘特图: scroll the timeline to this row's bar. Pinned to
-                    the row's right edge (flush with the chart divider) so it sits
-                    in a stable slot and never shifts the date column on hover. The
-                    `right` offset is inline because Tailwind's fractional `right-*`
-                    utilities aren't in the prebuilt CSS shipped to consumers. */}
-                {!isEditing && (
-                  <button
-                    type="button"
-                    title={t('gantt.row.locate')}
-                    aria-label={t('gantt.row.locate')}
-                    data-testid={`gantt-row-locate-${task.id}`}
-                    className="gantt-locate-btn hidden sm:block absolute top-1/2 -translate-y-1/2"
-                    style={{ right: onTaskClick ? 20 : 1 }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      scrollToTask(row.start, row.end, row.task.id);
-                    }}
-                  >
-                    <Crosshair className="w-3 h-3" />
-                  </button>
-                )}
                 {/* 跳转详情「→」: opens the detail drawer / page — the row click
                     itself is reserved for Focus-locate, so detail needs its own
-                    always-reachable affordance besides double-click. */}
-                {!isEditing && onTaskClick && (
-                  <button
-                    type="button"
-                    title={t('gantt.row.open')}
-                    aria-label={t('gantt.row.open')}
-                    data-testid={`gantt-row-open-${task.id}`}
-                    className="gantt-locate-btn hidden sm:block absolute top-1/2 -translate-y-1/2"
-                    style={{ right: 1 }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onTaskClick(task);
-                    }}
-                  >
-                    <ArrowRight className="w-3 h-3" />
-                  </button>
+                    always-reachable affordance besides double-click. A dedicated
+                    flex slot (not an absolute overlay) so it never covers the
+                    end-date column; the slot persists during inline edit to
+                    avoid layout shift. */}
+                {onTaskClick && (
+                  <div className="w-6 shrink-0 hidden sm:block" style={{ marginLeft: 4 }}>
+                    {!isEditing && (
+                      <button
+                        type="button"
+                        title={t('gantt.row.open')}
+                        aria-label={t('gantt.row.open')}
+                        data-testid={`gantt-row-open-${task.id}`}
+                        className="gantt-row-open-btn h-6 w-6 rounded-md flex items-center justify-center hover:bg-accent text-muted-foreground hover:text-foreground"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onTaskClick(task);
+                        }}
+                      >
+                        <ArrowRight className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
                 )}
                 {/* Row View/Edit/Delete stay reachable from the detail drawer
                     (double-click / 「→」 / context menu / Enter); inline edit is

--- a/packages/plugin-gantt/src/useGanttTranslation.ts
+++ b/packages/plugin-gantt/src/useGanttTranslation.ts
@@ -46,7 +46,6 @@ export const GANTT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'gantt.viewMode.year': 'Year',
   'gantt.row.expand': 'Expand',
   'gantt.row.collapse': 'Collapse',
-  'gantt.row.locate': 'Locate on timeline',
   'gantt.row.open': 'Open details',
   'gantt.aria.taskList': 'Task list',
   'gantt.tooltip.days': 'd',


### PR DESCRIPTION
Closes #2482

## 问题

#2460 落地「行单击=Focus 定位」后,任务列表行右缘遗留两个体验问题:

1. **「定位」十字准星悬停图标冗余**:它是旧交互(行单击=开抽屉)时代的定位入口,现在整行单击即定位,图标失去价值还加剧右缘拥挤。
2. **「→」详情按钮绝对定位叠在「结束」列上、热区过小**:两个按钮 `position: absolute` 锚在行右缘,悬停显示时直接压在结束日期文字上;按钮无内边距,点击热区只有 12×12px 裸图标。

## 修复(`GanttView.tsx`)

- **删除定位按钮**及其 i18n 键 `gantt.row.locate`(useGanttTranslation 兜底 + zh/en locale);定位能力由行单击承担,无功能损失。
- **「→」按钮改为行 flex 布局中的独立固定操作槽**(24px 宽、常驻占位):
  - 与日期列零重叠,悬停不再遮字;
  - 按钮 24×24px 圆角热区 + `hover:bg-accent` 底色,图标 14px;
  - 保留悬停渐显(行悬停 60% → 按钮自悬停/键盘聚焦 100%)与移动端隐藏(移动端详情入口仍为双击/长按菜单);
  - 行内编辑态保留占位、隐藏按钮,避免布局跳动。
- **顺带修复一个真机才暴露的 CSS 特异性缺陷**:行悬停规则 `.group/task-row:hover .gantt-row-open-btn`(0,3,0)压过按钮自身 `:hover { opacity: 1 }`(0,2,0),按钮自悬停时永远停在 60% 透明度——用 `:where()` 把行悬停规则降为零特异性。

## 测试

- 单元测试:plugin-gantt **303 passed**(新增断言:定位按钮不渲染、「→」非 absolute 覆盖层),i18n **176 passed**,tsc 干净。
- 真机验证:console 集成构建部署到消费项目(os-tianshun-ehr)后 Playwright 实测 **4/4 通过**,含截图——见 issue 上的[测试报告](https://github.com/objectstack-ai/objectui/issues/2482#issuecomment-4965913042):定位图标零残留;按钮 24×24、左缘 ≥ 结束列右缘(零重叠);自悬停 opacity=1 + 底色;点击开抽屉;单击定位/双击详情回归通过。