### PR TITLE
feat(grid,list,core,i18n): 导出文件名本地化 + 导入模板中文化修复

### DIFF
--- a/.changeset/export-filename-and-import-template-i18n.md
+++ b/.changeset/export-filename-and-import-template-i18n.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/core': patch
+'@object-ui/plugin-grid': patch
+'@object-ui/plugin-list': patch
+'@object-ui/i18n': patch
+---
+
+导出/导入模板的下载文件名与内容本地化。
+
+**导出文件名**:CSV/Excel/JSON 导出下载不再是 `<对象名>.<扩展名>`(如 `contracts.csv`),改为「对象显示名-时间戳.扩展名」(如 `合同-20260714-153045.xlsx`);`exportOptions.fileNamePrefix` 配置仍优先。`@object-ui/core` 新增 `buildExportFileName(ext, { prefix, label, objectName }, now?)` 与 `sanitizeFileNameBase(raw)`,ObjectGrid 与 ListView 的所有导出路径(服务端流式与前端兜底)统一走它。
+
+**导入模板**:「下载模板」修复两处英文漏出——示例行的 select/多选取值改为优先取选项**显示标签**(如 `准备中`)而非 ASCII slug(`prepare`,服务端导入两者都接受);模板文件名本地化为 `{{object}}-导入模板.csv`(新增 i18n key `grid.import.templateFileName`,英文回退 `{{object}}-import-template.csv`)。

--- a/.changeset/export-filename-and-import-template-i18n.md
+++ b/.changeset/export-filename-and-import-template-i18n.md
@@ -2,11 +2,13 @@
 '@object-ui/core': patch
 '@object-ui/plugin-grid': patch
 '@object-ui/plugin-list': patch
+'@object-ui/plugin-view': patch
+'@object-ui/app-shell': patch
 '@object-ui/i18n': patch
 ---
 
 导出/导入模板的下载文件名与内容本地化。
 
-**导出文件名**:CSV/Excel/JSON 导出下载不再是 `<对象名>.<扩展名>`(如 `contracts.csv`),改为「对象显示名-时间戳.扩展名」(如 `合同-20260714-153045.xlsx`);`exportOptions.fileNamePrefix` 配置仍优先。`@object-ui/core` 新增 `buildExportFileName(ext, { prefix, label, objectName }, now?)` 与 `sanitizeFileNameBase(raw)`,ObjectGrid 与 ListView 的所有导出路径(服务端流式与前端兜底)统一走它。
+**导出文件名**:CSV/Excel/JSON 导出下载不再是 `<对象名>.<扩展名>`(如 `contracts.csv`),改为「对象显示名-视图名-时间戳.扩展名」(如 `任务-In Progress-20260714-153045.xlsx`);`exportOptions.fileNamePrefix` 配置仍优先(且作为完整前缀,不再追加视图名)。视图名与对象名重复时自动省略;`@object-ui/core` 新增 `buildExportFileName(ext, { prefix, label, objectName, viewLabel }, now?)` 与 `sanitizeFileNameBase(raw)`,ObjectGrid 与 ListView 的所有导出路径(服务端流式与前端兜底)统一走它。app-shell/plugin-view 的 ObjectView 现将当前视图的显示标签写进传给 ListView 的 schema(`label`),使导出文件名能区分同一对象的不同保存视图。
 
 **导入模板**:「下载模板」修复两处英文漏出——示例行的 select/多选取值改为优先取选项**显示标签**(如 `准备中`)而非 ASCII slug(`prepare`,服务端导入两者都接受);模板文件名本地化为 `{{object}}-导入模板.csv`(新增 i18n key `grid.import.templateFileName`,英文回退 `{{object}}-import-template.csv`)。

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1249,6 +1249,9 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
 
         const fullSchema: ListViewSchema = {
             ...listSchema,
+            // The active view's display label (same string the ViewTabBar
+            // shows) — ListView appends it to export download filenames.
+            label: viewDef.label ?? listSchema.label,
             // Propagate appearance/view-config properties for live preview
             rowHeight: viewDef.rowHeight ?? listSchema.rowHeight,
             densityMode: viewDef.densityMode ?? listSchema.densityMode,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,3 +45,4 @@ export * from './utils/compare-to.js';
 export * from './utils/chart-series.js';
 export * from './utils/dataset-format.js';
 export * from './utils/record-title.js';
+export * from './utils/export-filename.js';

--- a/packages/core/src/utils/__tests__/export-filename.test.ts
+++ b/packages/core/src/utils/__tests__/export-filename.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { buildExportFileName, sanitizeFileNameBase } from '../export-filename';
+
+const NOW = new Date(2026, 6, 14, 15, 30, 45); // 2026-07-14 15:30:45 local
+
+describe('buildExportFileName', () => {
+  it('prefers the translated object label over the API name', () => {
+    expect(buildExportFileName('xlsx', { label: '合同', objectName: 'contracts' }, NOW))
+      .toBe('合同-20260714-153045.xlsx');
+  });
+
+  it('lets an explicit configured prefix win over the label', () => {
+    expect(buildExportFileName('csv', { prefix: 'my-report', label: '合同' }, NOW))
+      .toBe('my-report-20260714-153045.csv');
+  });
+
+  it('falls back to the object API name, then to "export"', () => {
+    expect(buildExportFileName('csv', { objectName: 'contracts' }, NOW))
+      .toBe('contracts-20260714-153045.csv');
+    expect(buildExportFileName('json', {}, NOW))
+      .toBe('export-20260714-153045.json');
+  });
+
+  it('zero-pads single-digit date/time parts', () => {
+    const early = new Date(2026, 0, 5, 9, 8, 7);
+    expect(buildExportFileName('csv', { label: 'a' }, early))
+      .toBe('a-20260105-090807.csv');
+  });
+
+  it('sanitizes filesystem-hostile characters but keeps CJK intact', () => {
+    expect(buildExportFileName('csv', { label: '合同/审批: 2026?' }, NOW))
+      .toBe('合同_审批_ 2026-20260714-153045.csv');
+  });
+
+  it('falls through when a candidate sanitizes to nothing', () => {
+    expect(buildExportFileName('csv', { prefix: '///', label: '合同' }, NOW))
+      .toBe('合同-20260714-153045.csv');
+  });
+});
+
+describe('sanitizeFileNameBase', () => {
+  it('strips reserved characters and control chars', () => {
+    expect(sanitizeFileNameBase('a<b>c:d"e/f\\g|h?i*j')).toBe('a_b_c_d_e_f_g_h_i_j');
+    expect(sanitizeFileNameBase('a\u0000b\u001fc')).toBe('a_b_c');
+  });
+
+  it('trims leading/trailing dots, spaces, underscores', () => {
+    expect(sanitizeFileNameBase('  .hidden. ')).toBe('hidden');
+    expect(sanitizeFileNameBase('__name__')).toBe('name');
+  });
+
+  it('returns empty string for unusable input', () => {
+    expect(sanitizeFileNameBase(undefined)).toBe('');
+    expect(sanitizeFileNameBase('***')).toBe('');
+  });
+
+  it('caps overlong bases at 80 chars', () => {
+    expect(sanitizeFileNameBase('x'.repeat(200))).toHaveLength(80);
+  });
+});

--- a/packages/core/src/utils/__tests__/export-filename.test.ts
+++ b/packages/core/src/utils/__tests__/export-filename.test.ts
@@ -36,6 +36,35 @@ describe('buildExportFileName', () => {
     expect(buildExportFileName('csv', { prefix: '///', label: '合同' }, NOW))
       .toBe('合同-20260714-153045.csv');
   });
+
+  it('appends the active view label after the object base', () => {
+    expect(buildExportFileName('csv', { label: '任务', viewLabel: 'In Progress' }, NOW))
+      .toBe('任务-In Progress-20260714-153045.csv');
+    expect(buildExportFileName('xlsx', { label: '合同', viewLabel: '进行中' }, NOW))
+      .toBe('合同-进行中-20260714-153045.xlsx');
+  });
+
+  it('skips the view label when it duplicates the base (case-insensitive)', () => {
+    expect(buildExportFileName('csv', { label: '任务', viewLabel: '任务' }, NOW))
+      .toBe('任务-20260714-153045.csv');
+    expect(buildExportFileName('csv', { objectName: 'Tasks', viewLabel: 'tasks' }, NOW))
+      .toBe('Tasks-20260714-153045.csv');
+  });
+
+  it('does not append the view label to an explicit configured prefix', () => {
+    expect(buildExportFileName('csv', { prefix: 'my-report', label: '任务', viewLabel: 'In Progress' }, NOW))
+      .toBe('my-report-20260714-153045.csv');
+  });
+
+  it('ignores a view label that sanitizes to nothing', () => {
+    expect(buildExportFileName('csv', { label: '任务', viewLabel: '***' }, NOW))
+      .toBe('任务-20260714-153045.csv');
+  });
+
+  it('caps the combined base at 80 chars', () => {
+    const name = buildExportFileName('csv', { label: 'x'.repeat(70), viewLabel: 'y'.repeat(70) }, NOW);
+    expect(name).toBe(`${'x'.repeat(70)}-${'y'.repeat(9)}-20260714-153045.csv`);
+  });
 });
 
 describe('sanitizeFileNameBase', () => {

--- a/packages/core/src/utils/export-filename.ts
+++ b/packages/core/src/utils/export-filename.ts
@@ -38,23 +38,35 @@ export interface ExportFileNameParts {
   label?: string;
   /** Object API name — fallback when no label is available. */
   objectName?: string;
+  /**
+   * Active list-view label (e.g. `In Progress`), appended after the object
+   * base so exports from different saved views don't read identically.
+   * Skipped when it duplicates the base, and not appended to an explicit
+   * `prefix` (configured prefixes are authoritative as-is).
+   */
+  viewLabel?: string;
 }
 
 /**
  * Build `<base>-<YYYYMMDD>-<HHMMSS>.<ext>` in the user's local time, e.g.
- * `合同-20260714-153045.xlsx`. The timestamp keeps repeated exports of the
- * same object distinct and sortable.
+ * `合同-进行中-20260714-153045.xlsx`. The timestamp keeps repeated exports of
+ * the same object distinct and sortable.
  */
 export function buildExportFileName(
   ext: string,
   parts: ExportFileNameParts = {},
   now: Date = new Date(),
 ): string {
-  const base =
-    sanitizeFileNameBase(parts.prefix) ||
+  const prefix = sanitizeFileNameBase(parts.prefix);
+  let base =
+    prefix ||
     sanitizeFileNameBase(parts.label) ||
     sanitizeFileNameBase(parts.objectName) ||
     'export';
+  const view = sanitizeFileNameBase(parts.viewLabel);
+  if (!prefix && view && view.toLowerCase() !== base.toLowerCase()) {
+    base = `${base}-${view}`.slice(0, MAX_BASE_LENGTH);
+  }
   const pad = (n: number) => String(n).padStart(2, '0');
   const stamp =
     `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +

--- a/packages/core/src/utils/export-filename.ts
+++ b/packages/core/src/utils/export-filename.ts
@@ -1,0 +1,63 @@
+/**
+ * Download filename builder for data exports (csv / xlsx / json).
+ *
+ * Exports used to download as `<objectApiName>.<ext>` (e.g. `contracts.csv`),
+ * which reads poorly for end users and silently collides in the Downloads
+ * folder. This builds `<base>-<YYYYMMDD>-<HHMMSS>.<ext>` where the base falls
+ * back through: explicit configured prefix (`exportOptions.fileNamePrefix`) →
+ * translated object label (e.g. 合同) → object API name → 'export'.
+ */
+
+/** Windows-reserved + control characters that cannot appear in a filename. */
+const ILLEGAL_FILENAME_CHARS = /[\\\/:*?"<>|\u0000-\u001f]+/g;
+
+/** Longest base we emit — keeps the full name comfortably under OS limits. */
+const MAX_BASE_LENGTH = 80;
+
+/**
+ * Sanitize a candidate base name for cross-platform filesystem safety while
+ * keeping non-ASCII letters (e.g. Chinese object labels) intact. Returns an
+ * empty string when nothing usable survives, so callers can fall through.
+ */
+export function sanitizeFileNameBase(raw: string | undefined | null): string {
+  if (!raw) return '';
+  return String(raw)
+    .replace(ILLEGAL_FILENAME_CHARS, '_')
+    .replace(/\s+/g, ' ')
+    .replace(/_{2,}/g, '_')
+    // Leading/trailing dots, underscores and spaces are dropped: Windows
+    // strips trailing dots/spaces, and a leading dot hides the file on unix.
+    .replace(/^[\s._-]+|[\s._-]+$/g, '')
+    .slice(0, MAX_BASE_LENGTH);
+}
+
+export interface ExportFileNameParts {
+  /** Explicit prefix from view config (`exportOptions.fileNamePrefix`) — wins when set. */
+  prefix?: string;
+  /** Human-readable (translated) object label — the preferred base. */
+  label?: string;
+  /** Object API name — fallback when no label is available. */
+  objectName?: string;
+}
+
+/**
+ * Build `<base>-<YYYYMMDD>-<HHMMSS>.<ext>` in the user's local time, e.g.
+ * `合同-20260714-153045.xlsx`. The timestamp keeps repeated exports of the
+ * same object distinct and sortable.
+ */
+export function buildExportFileName(
+  ext: string,
+  parts: ExportFileNameParts = {},
+  now: Date = new Date(),
+): string {
+  const base =
+    sanitizeFileNameBase(parts.prefix) ||
+    sanitizeFileNameBase(parts.label) ||
+    sanitizeFileNameBase(parts.objectName) ||
+    'export';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const stamp =
+    `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+    `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `${base}-${stamp}.${ext}`;
+}

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -256,6 +256,7 @@ const zh = {
       // 下载模板
       downloadTemplate: '下载模板',
       downloadTemplateHint: '获取带正确列的 CSV（必填字段标 *）。',
+      templateFileName: '{{object}}-导入模板',
       // 校验（服务端 dryRun 预检）
       validate: '校验数据',
       validateHint: '导入前在服务端逐行校验。',

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -12,6 +12,7 @@ import {
 } from '@object-ui/components';
 import { Upload, FileSpreadsheet, CheckCircle2, AlertCircle, X, ArrowRight, ArrowLeft, Save, Trash2, ClipboardPaste, Download, Undo2 } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
+import { sanitizeFileNameBase } from '@object-ui/core';
 import type {
   DataSource,
   ImportRequestOptions,
@@ -48,6 +49,7 @@ const IMPORT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'grid.import.browseFiles': 'Browse Files',
   'grid.import.downloadTemplate': 'Download template',
   'grid.import.downloadTemplateHint': 'Get a CSV with the right columns (required fields marked *).',
+  'grid.import.templateFileName': '{{object}}-import-template',
   'grid.import.parsing': 'Parsing…',
   'grid.import.pasteHint': 'or paste (Ctrl/⌘+V) rows copied from Excel or Google Sheets',
   'grid.import.legacyXls': "Legacy .xls files aren't supported — please re-save as .xlsx.",
@@ -604,15 +606,18 @@ function buildFailedRowsCsv(
 }
 
 /** Pick a representative allowed value from a select field's options, for the
- *  template example row. Prefers the stored value over the display label. */
+ *  template example row. Prefers the display label over the stored value: the
+ *  server's import coercion accepts either (it matches value OR label,
+ *  case-insensitively), and the label is what a localized user recognizes —
+ *  an ASCII slug like `prepare` reads as English leakage in a zh template. */
 function firstOptionValue(
   options: ImportWizardProps['fields'][number]['options'],
 ): string | undefined {
   const first = options?.[0];
   if (first === undefined || first === null) return undefined;
   if (typeof first === 'string') return first;
-  if (first.value !== undefined && first.value !== null) return String(first.value);
   if (first.label) return first.label;
+  if (first.value !== undefined && first.value !== null) return String(first.value);
   return undefined;
 }
 
@@ -683,7 +688,10 @@ const StepUpload: React.FC<{
   onFileLoaded: (headers: string[], rows: string[][]) => void;
   fields: ImportWizardProps['fields'];
   objectName: string;
-}> = ({ onFileLoaded, fields, objectName }) => {
+  /** Localized display label — used for the template filename so a zh user
+   *  downloads `合同-导入模板.csv` rather than `contracts-template.csv`. */
+  objectLabel?: string;
+}> = ({ onFileLoaded, fields, objectName, objectLabel }) => {
   const { t } = useImportTranslation();
   const [dragOver, setDragOver] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -755,7 +763,12 @@ const StepUpload: React.FC<{
             type="button"
             variant="ghost"
             size="sm"
-            onClick={() => downloadTextFile(`${objectName || 'import'}-template.csv`, buildImportTemplateCsv(fields))}
+            onClick={() => {
+              const base = sanitizeFileNameBase(
+                t('grid.import.templateFileName', { object: objectLabel || objectName || 'import' }),
+              );
+              downloadTextFile(`${base || 'import-template'}.csv`, buildImportTemplateCsv(fields));
+            }}
             data-testid="import-download-template"
           >
             <Download className="mr-1 h-4 w-4" /> {t('grid.import.downloadTemplate')}
@@ -2059,7 +2072,7 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
           <ImportHistoryPanel objectName={objectName} dataSource={dataSource} t={t} />
         ) : !result ? (
           <>
-            {step === 'upload' && <StepUpload onFileLoaded={handleFileLoaded} fields={fields} objectName={objectName} />}
+            {step === 'upload' && <StepUpload onFileLoaded={handleFileLoaded} fields={fields} objectName={objectName} objectLabel={label} />}
             {step === 'mapping' && (
               <StepMapping
                 headers={headers}

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -34,7 +34,7 @@ import {
   RefreshIndicator,
 } from '@object-ui/components';
 import { usePullToRefresh } from '@object-ui/mobile';
-import { evaluatePlainCondition, buildExpandFields } from '@object-ui/core';
+import { evaluatePlainCondition, buildExpandFields, buildExportFileName } from '@object-ui/core';
 import { ChevronRight, ChevronDown, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock, Loader2 } from 'lucide-react';
 import { useRowColor } from './useRowColor';
 import { useGroupedData } from './useGroupedData';
@@ -1270,7 +1270,15 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     const exportConfig = schema.exportOptions;
     const maxRecords = exportConfig?.maxRecords || 0;
     const includeHeaders = exportConfig?.includeHeaders !== false;
-    const prefix = exportConfig?.fileNamePrefix || schema.objectName || 'export';
+    // Download filename: `<配置前缀|对象中文标签|API名>-<日期时间>.<ext>`, e.g.
+    // `合同-20260714-153045.xlsx`. The translated object label (when the
+    // schema has loaded) beats the raw API name; a configured
+    // exportOptions.fileNamePrefix beats both.
+    const fileNameFor = (ext: string) => buildExportFileName(ext, {
+      prefix: exportConfig?.fileNamePrefix,
+      label: objectSchema?.label,
+      objectName: objectName || schema.objectName,
+    });
 
     // Server-streamed path: csv / xlsx / json via dataSource.exportDownload.
     // XLSX is server-only; type-aware value formatting, field resolution and
@@ -1309,7 +1317,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');
           a.href = url;
-          a.download = `${prefix}.${format}`;
+          a.download = fileNameFor(format);
           a.rel = 'noopener';
           document.body.appendChild(a);
           a.click();
@@ -1358,12 +1366,12 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       exportData.forEach(record => {
         rows.push(fields.map((f: string) => escapeCsvValue(record[f])).join(','));
       });
-      downloadFile(new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' }), `${prefix}.csv`);
+      downloadFile(new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' }), fileNameFor('csv'));
     } else if (format === 'json') {
-      downloadFile(new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' }), `${prefix}.json`);
+      downloadFile(new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' }), fileNameFor('json'));
     }
     setShowExport(false);
-  }, [data, schema.exportOptions, schema.operations?.export, schema.objectName, objectName, generateColumns, dataSource, hasInlineData, schemaFilter, schemaSort]);
+  }, [data, schema.exportOptions, schema.operations?.export, schema.objectName, objectName, objectSchema, generateColumns, dataSource, hasInlineData, schemaFilter, schemaSort]);
 
   if (error) {
     return (

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1270,14 +1270,15 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     const exportConfig = schema.exportOptions;
     const maxRecords = exportConfig?.maxRecords || 0;
     const includeHeaders = exportConfig?.includeHeaders !== false;
-    // Download filename: `<配置前缀|对象中文标签|API名>-<日期时间>.<ext>`, e.g.
-    // `合同-20260714-153045.xlsx`. The translated object label (when the
-    // schema has loaded) beats the raw API name; a configured
-    // exportOptions.fileNamePrefix beats both.
+    // Download filename: `<配置前缀|对象中文标签|API名>-<视图名>-<日期时间>.<ext>`,
+    // e.g. `合同-进行中-20260714-153045.xlsx`. The translated object label (when
+    // the schema has loaded) beats the raw API name; a configured
+    // exportOptions.fileNamePrefix beats both (and suppresses the view label).
     const fileNameFor = (ext: string) => buildExportFileName(ext, {
       prefix: exportConfig?.fileNamePrefix,
       label: objectSchema?.label,
       objectName: objectName || schema.objectName,
+      viewLabel: schema.label || schema.title,
     });
 
     // Server-streamed path: csv / xlsx / json via dataSource.exportDownload.

--- a/packages/plugin-grid/src/importTemplate.test.ts
+++ b/packages/plugin-grid/src/importTemplate.test.ts
@@ -17,14 +17,17 @@ describe('buildImportTemplateCsv', () => {
     expect(example).toBe(',name@example.com,0,2024-01-31,true');
   });
 
-  it('seeds select example from the first option value, preferring value over label', () => {
+  it('seeds select example from the first option, preferring the display label over the value', () => {
+    // Import coercion accepts value OR label, and the label is what a
+    // localized user recognizes (e.g. `准备中` instead of the slug `prepare`).
     const csv = buildImportTemplateCsv([
-      { name: 'stage', label: 'Stage', type: 'select', options: [{ label: 'New Lead', value: 'new' }, { label: 'Won', value: 'won' }] },
+      { name: 'stage', label: 'Stage', type: 'select', options: [{ label: '准备中', value: 'prepare' }, { label: 'Won', value: 'won' }] },
       { name: 'tier', label: 'Tier', type: 'select', options: ['gold', 'silver'] },
+      { name: 'valueOnly', label: 'ValueOnly', type: 'select', options: [{ value: 'v1' }] },
       { name: 'empty', label: 'Empty', type: 'select' },
     ]);
     const example = csv.split('\n')[1];
-    expect(example).toBe('new,gold,');
+    expect(example).toBe('准备中,gold,v1,');
   });
 
   it('escapes labels containing commas per RFC 4180', () => {

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -18,7 +18,7 @@ import { SchemaRenderer, useNavigationOverlay } from '@object-ui/react';
 import { useDensityMode } from '@object-ui/react';
 import type { ListViewSchema } from '@object-ui/types';
 import { usePullToRefresh } from '@object-ui/mobile';
-import { evaluatePlainCondition, buildExpandFields } from '@object-ui/core';
+import { evaluatePlainCondition, buildExpandFields, buildExportFileName } from '@object-ui/core';
 import { useObjectTranslation, useObjectLabel, useSafeFieldLabel } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
 
@@ -312,10 +312,10 @@ function useListViewTranslation() {
  */
 function useListFieldLabel() {
   try {
-    const { fieldLabel, actionLabel } = useObjectLabel();
-    return { fieldLabel, actionLabel };
+    const { fieldLabel, actionLabel, objectLabel } = useObjectLabel();
+    return { fieldLabel, actionLabel, objectLabel };
   } catch {
-    return { fieldLabel: FALLBACK_FIELD_LABEL, actionLabel: undefined as any };
+    return { fieldLabel: FALLBACK_FIELD_LABEL, actionLabel: undefined as any, objectLabel: undefined as any };
   }
 }
 
@@ -360,7 +360,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   const showViewSwitcher = showViewSwitcherProp ?? (propSchema as any)?.showViewSwitcher ?? false;
   // i18n support for record count and other labels
   const { t } = useListViewTranslation();
-  const { fieldLabel: resolveFieldLabel, actionLabel: resolveActionLabel } = useListFieldLabel();
+  const { fieldLabel: resolveFieldLabel, actionLabel: resolveActionLabel, objectLabel: resolveObjectLabel } = useListFieldLabel();
   const { translateOptions } = useSafeFieldLabel();
 
   // Kernel level default: Ensure viewType is always a RENDERABLE kind.
@@ -1608,7 +1608,18 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     const exportConfig = resolvedExportOptions;
     const maxRecords = exportConfig?.maxRecords || 0;
     const includeHeaders = exportConfig?.includeHeaders !== false;
-    const prefix = exportConfig?.fileNamePrefix || schema.objectName || 'export';
+    // Download filename: `<配置前缀|对象中文标签|API名>-<日期时间>.<ext>`, e.g.
+    // `合同-20260714-153045.xlsx`. The translated object label (client i18n
+    // override → server-translated objectDef.label) beats the raw API name;
+    // a configured exportOptions.fileNamePrefix beats both.
+    const translatedLabel = objectDef?.label && objectDef?.name && typeof resolveObjectLabel === 'function'
+      ? resolveObjectLabel(objectDef)
+      : objectDef?.label;
+    const fileNameFor = (ext: string) => buildExportFileName(ext, {
+      prefix: exportConfig?.fileNamePrefix,
+      label: translatedLabel,
+      objectName: schema.objectName,
+    });
 
     // Server-streamed path: csv / xlsx / json via dataSource.exportDownload.
     // XLSX is server-only; type-aware value formatting, field resolution and
@@ -1657,7 +1668,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');
           a.href = url;
-          a.download = `${prefix}.${format}`;
+          a.download = fileNameFor(format);
           a.rel = 'noopener';
           document.body.appendChild(a);
           a.click();
@@ -1711,7 +1722,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${prefix}.csv`;
+      a.download = fileNameFor('csv');
       a.click();
       URL.revokeObjectURL(url);
     } else if (format === 'json') {
@@ -1719,12 +1730,12 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${prefix}.json`;
+      a.download = fileNameFor('json');
       a.click();
       URL.revokeObjectURL(url);
     }
     setShowExport(false);
-  }, [data, effectiveFields, resolvedExportOptions, schema.objectName, schema.filters, exportPermitted, dataSource, currentFilters, userFilterConditions, currentSort]);
+  }, [data, effectiveFields, resolvedExportOptions, schema.objectName, schema.filters, exportPermitted, dataSource, currentFilters, userFilterConditions, currentSort, objectDef, resolveObjectLabel]);
 
   // All available fields for hide/show (with i18n)
   const allFields = React.useMemo(() => {

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1608,10 +1608,11 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     const exportConfig = resolvedExportOptions;
     const maxRecords = exportConfig?.maxRecords || 0;
     const includeHeaders = exportConfig?.includeHeaders !== false;
-    // Download filename: `<配置前缀|对象中文标签|API名>-<日期时间>.<ext>`, e.g.
-    // `合同-20260714-153045.xlsx`. The translated object label (client i18n
-    // override → server-translated objectDef.label) beats the raw API name;
-    // a configured exportOptions.fileNamePrefix beats both.
+    // Download filename: `<配置前缀|对象中文标签|API名>-<视图名>-<日期时间>.<ext>`,
+    // e.g. `合同-进行中-20260714-153045.xlsx`. The translated object label
+    // (client i18n override → server-translated objectDef.label) beats the raw
+    // API name; a configured exportOptions.fileNamePrefix beats both (and
+    // suppresses the view label).
     const translatedLabel = objectDef?.label && objectDef?.name && typeof resolveObjectLabel === 'function'
       ? resolveObjectLabel(objectDef)
       : objectDef?.label;
@@ -1619,6 +1620,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       prefix: exportConfig?.fileNamePrefix,
       label: translatedLabel,
       objectName: schema.objectName,
+      viewLabel: schema.label || (schema as any).title,
     });
 
     // Server-streamed path: csv / xlsx / json via dataSource.exportDownload.

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -981,6 +981,9 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           type: 'list-view',
           objectName: schema.objectName,
           viewType: currentViewType as any,
+          // Active view's display label — ListView appends it to export
+          // download filenames.
+          label: (currentNamedViewConfig as any)?.label ?? activeView?.label,
           fields: currentNamedViewConfig?.columns || activeView?.columns || schema.table?.fields,
           filters: mergedFilters,
           sort: mergedSort,


### PR DESCRIPTION
## 背景

用户反馈:
1. **导出功能(CSV/Excel)文件名**:下载得到 `contracts.csv` 这种裸对象名,希望优化为「对象显示名-时间戳」(如 `任务-20260714-153045.xlsx`)。
2. **导入「下载模板」仍有英文**:示例行是 ASCII slug(如 `prepare`/`active`),模板文件名也是英文。

服务端配套 PR:framework#2911(Content-Disposition 本地化 + 系统字段标签内置回退,"Owner"→「所有者」在那边修)。

## 变更

### `@object-ui/core`
- 新增 `buildExportFileName(ext, { prefix, label, objectName }, now?)` 与 `sanitizeFileNameBase(raw)`:生成「显示名-yyyymmdd-hhmmss.扩展名」;`exportOptions.fileNamePrefix` 配置仍优先;非法文件名字符清洗但保留 Unicode(中文不丢)。

### `@object-ui/plugin-grid` / `@object-ui/plugin-list`
- ObjectGrid 与 ListView 的**所有**导出路径(服务端流式下载与前端兜底导出)统一走 `buildExportFileName`,浏览器落盘名从 `contracts.csv` 变为 `合同-20260714-153045.csv`。

### 导入模板(ImportWizard)
- 示例行 select/多选取值改为**优先取选项显示标签**(如 `准备中`)而非 slug(`prepare`);服务端导入 coercion 对 label/value 都接受,回填不受影响。
- 模板文件名本地化:新增 i18n key `grid.import.templateFileName`(zh `{{object}}-导入模板`,en 回退 `{{object}}-import-template`),经 `sanitizeFileNameBase` 清洗。

## 测试

- 单测:core 新增 10 例(buildExportFileName/sanitizeFileNameBase)、plugin-grid 194 通过(含模板示例值取 label 断言)、plugin-list 149 通过、i18n 176 通过。core 套件另有 1 例 `FormulaFunctions` DATEFORMAT 时区环境性失败,与本 PR 无关(diff 未触及)。
- **真机实测**(showcase dev 栈,中文界面,hook `a.download` 捕获真实落盘名):
  - 导出 CSV → `任务-20260714-064550.csv`;导出 XLSX → `任务-20260714-064607.xlsx`。
  - 导入向导「下载模板」→ 文件名 `任务-导入模板.csv`;模板内容表头「所有者,标题 *,项目 *,…,创建时间,…」,示例行 select 值为显示标签(`Backlog`/`Low`)而非 slug。

## 追加(842a766eb):导出文件名带上当前视图名

用户第三轮诉求「文件名称中能加上视图名称么」——同一对象不同保存视图的导出此前完全同名。

- 格式升级为 `<对象显示名>-<视图名>-<时间戳>.<扩展名>`,如 `任务-In Progress-20260714-082725.csv`。
- `buildExportFileName` 新增 `viewLabel`:`fileNamePrefix` 配置后不追加视图名;视图名与对象名重复(大小写不敏感)时省略;组合 base 截断 80 字符。
- 根因补齐:app-shell 与 plugin-view 的 ObjectView 此前从不把 `viewDef.label` 写进传给 ListView 的 schema,现已传递(顺带让 overlay 详情标题显示视图名)。
- 单测 export-filename 15/15、plugin-list 149、plugin-grid 194、plugin-view 28、app-shell 698;真机落盘名见 PR 评论实测报告。

关联 issue:objectstack-ai/framework#2916(服务端 PR framework#2911 合并即关闭)
