### PR TITLE
fix(app-shell): package-owned permission set delete reads as reset, not delete (ADR-0094)

### DIFF
--- a/.changeset/permission-set-reset-copy.md
+++ b/.changeset/permission-set-reset-copy.md
@@ -1,0 +1,7 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Say "reset to shipped baseline" instead of "delete" when removing a package-owned permission set (ADR-0094).
+
+Deleting a `sys_permission_set` row whose `managed_by === 'package'` doesn't remove it — the backend drops the environment customization overlay and resets the set to its shipped baseline, so the row stays in the list. The confirmation dialog and success toast now say so (with `resetPackageSetConfirm` / `resetPackageSetSuccess` i18n, en + zh), instead of promising an irreversible delete the user can see doesn't happen. Environment-authored sets keep the plain delete copy. The grid row-delete passes the record through so the check needs no extra fetch; the SDUI header delete falls back to a `findOne` lookup.

--- a/packages/app-shell/src/hooks/__tests__/useObjectActions.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useObjectActions.test.tsx
@@ -139,3 +139,71 @@ describe('useObjectActions — delete handler toast de-duplication', () => {
     expect(res).toEqual({ success: false });
   });
 });
+
+// [ADR-0094] Deleting a PACKAGE-OWNED sys_permission_set row doesn't remove
+// it — the backend drops the env overlay and resets the set to its shipped
+// baseline. The copy must say so (confirm question AND success toast).
+describe('useObjectActions — package-owned permission set delete = reset copy', () => {
+  function setupPermSet(dataSource: any, onConfirmSpy: any) {
+    return renderHook(() =>
+      useObjectActions({
+        objectName: 'sys_permission_set',
+        objectLabel: 'Permission Set',
+        dataSource,
+        onConfirm: onConfirmSpy,
+        onToast,
+      }),
+    );
+  }
+
+  it('uses the reset confirm + reset success toast when the row is package-owned', async () => {
+    const dataSource = { delete: vi.fn().mockResolvedValue(undefined) };
+    const confirmSpy = vi.fn().mockResolvedValue(true);
+    const { result } = setupPermSet(dataSource, confirmSpy);
+
+    await act(async () => {
+      await result.current.deleteRecord('ps_pkg', { id: 'ps_pkg', managed_by: 'package' });
+    });
+
+    // Confirm question is the honest reset copy (i18n stub echoes defaultValue).
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(String(confirmSpy.mock.calls[0][0])).toContain('resets it to the shipped baseline');
+    // Success toast says "reset", not "deleted".
+    expect((toast as any).success).toHaveBeenCalledTimes(1);
+    expect((toast as any).success).toHaveBeenCalledWith(
+      expect.stringContaining('reset to its shipped baseline'),
+    );
+  });
+
+  it('keeps the plain delete copy for an environment-owned set', async () => {
+    const dataSource = { delete: vi.fn().mockResolvedValue(undefined) };
+    const confirmSpy = vi.fn().mockResolvedValue(true);
+    const { result } = setupPermSet(dataSource, confirmSpy);
+
+    await act(async () => {
+      await result.current.deleteRecord('ps_env', { id: 'ps_env', managed_by: 'user' });
+    });
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(String(confirmSpy.mock.calls[0][0])).toBe('objectActions.deleteConfirm');
+    expect((toast as any).success).toHaveBeenCalledWith('objectActions.deleteSuccess');
+  });
+
+  it('falls back to a findOne lookup when the caller passes only the id (SDUI header delete)', async () => {
+    const dataSource = {
+      delete: vi.fn().mockResolvedValue(undefined),
+      findOne: vi.fn().mockResolvedValue({ id: 'ps_pkg', managed_by: 'package' }),
+    };
+    const confirmSpy = vi.fn().mockResolvedValue(true);
+    const { result } = setupPermSet(dataSource, confirmSpy);
+
+    await act(async () => {
+      await result.current.execute({ type: 'delete', params: { recordId: 'ps_pkg' } } as any);
+    });
+
+    expect(dataSource.findOne).toHaveBeenCalledWith('sys_permission_set', 'ps_pkg');
+    expect((toast as any).success).toHaveBeenCalledWith(
+      expect.stringContaining('reset to its shipped baseline'),
+    );
+  });
+});

--- a/packages/app-shell/src/hooks/useObjectActions.ts
+++ b/packages/app-shell/src/hooks/useObjectActions.ts
@@ -35,8 +35,12 @@ interface ObjectActions {
   execute: (action: ActionDef) => Promise<ActionResult>;
   /** Create new record — opens the create dialog */
   create: () => void;
-  /** Delete a record by id */
-  deleteRecord: (recordId: string) => Promise<ActionResult>;
+  /**
+   * Delete a record by id. Pass the row (`record`) when available so a
+   * package-owned permission set can be recognised as a RESET rather than a
+   * delete (ADR-0094) without an extra fetch.
+   */
+  deleteRecord: (recordId: string, record?: Record<string, unknown>) => Promise<ActionResult>;
   /** Navigate to a view */
   navigateToView: (viewId: string) => void;
   /** Navigate to a record detail */

--- a/packages/app-shell/src/hooks/useObjectActions.ts
+++ b/packages/app-shell/src/hooks/useObjectActions.ts
@@ -132,10 +132,33 @@ export function useObjectActions({
         action.recordId;
       if (!recordId) return { success: false, error: t('objectActions.noRecordId') };
 
+      // [ADR-0094] "Deleting" a PACKAGE-OWNED permission set doesn't remove
+      // the row — the backend drops the environment overlay and RESETS the
+      // set to its shipped baseline. Detect it BEFORE the delete (the row
+      // still exists) so the success toast tells the truth; a caller that
+      // passed the row spares the lookup.
+      let packagedSetReset = false;
+      if (objectName === 'sys_permission_set') {
+        try {
+          const row =
+            action.params?.record?.managed_by !== undefined
+              ? action.params.record
+              : await dataSource.findOne(objectName, recordId);
+          packagedSetReset = row?.managed_by === 'package';
+        } catch { /* best-effort — fall back to the generic delete copy */ }
+      }
+
       try {
         await dataSource.delete(objectName, recordId);
         onRefresh?.();
-        toast.success(t('objectActions.deleteSuccess', { label: objectLabel || objectName }));
+        toast.success(
+          packagedSetReset
+            ? t('objectActions.resetPackageSetSuccess', {
+                label: objectLabel || objectName,
+                defaultValue: 'Permission set reset to its shipped baseline',
+              })
+            : t('objectActions.deleteSuccess', { label: objectLabel || objectName }),
+        );
         // `silent`: handler owns the localized success toast above — suppress the
         // runner's generic duplicate (see the bulk branch).
         return { success: true, reload: true, silent: true };
@@ -171,14 +194,26 @@ export function useObjectActions({
   }, [onEdit]);
 
   const deleteRecord = useCallback(
-    async (recordId: string) => {
+    async (recordId: string, record?: Record<string, unknown>) => {
+      // [ADR-0094] A package-owned permission set is never removed by the data
+      // door — the backend drops the environment overlay and RESETS the set to
+      // its shipped baseline. Ask the honest question instead of promising an
+      // irreversible delete the user can see doesn't happen (the row stays).
+      const packagedSetReset =
+        objectName === 'sys_permission_set' && (record as any)?.managed_by === 'package';
       return execute({
         type: 'delete',
-        confirmText: t('objectActions.deleteConfirm'),
-        params: { recordId },
+        confirmText: packagedSetReset
+          ? t('objectActions.resetPackageSetConfirm', {
+              defaultValue:
+                'This permission set ships with an installed package and cannot be removed. ' +
+                'Deleting resets it to the shipped baseline and discards your environment customization. Continue?',
+            })
+          : t('objectActions.deleteConfirm'),
+        params: record ? { recordId, record } : { recordId },
       });
     },
-    [execute, t],
+    [execute, t, objectName],
   );
 
   const navigateToView = useCallback(

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1482,7 +1482,9 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                         // useObjectActions.deleteRecord wraps execute() which
                         // already shows a confirmation dialog + success toast
                         // and triggers onRefresh on success.
-                        actions.deleteRecord(String(record.id));
+                        // Pass the row so sys_permission_set package rows
+                        // get the honest reset copy (ADR-0094).
+                        actions.deleteRecord(String(record.id), record);
                     }
                 }}
                 onBulkDelete={(records: any[]) => {

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -2011,6 +2011,10 @@ const en = {
     deleteFailed: 'Failed to delete {{label}}',
     noRecordId: 'No record ID provided',
     deleteConfirm: 'Are you sure you want to delete this record?',
+    resetPackageSetConfirm:
+      'This permission set ships with an installed package and cannot be removed. ' +
+      'Deleting resets it to the shipped baseline and discards your environment customization. Continue?',
+    resetPackageSetSuccess: 'Permission set reset to its shipped baseline',
     bulkDeleteSuccess: 'Deleted {{count}} {{label}} records',
     bulkDeletePartial: '{{succeeded}} deleted, {{failed}} failed',
   },

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -2093,6 +2093,9 @@ const zh = {
     deleteFailed: '删除 {{label}} 失败',
     noRecordId: '未提供记录 ID',
     deleteConfirm: '确定要删除此记录吗？',
+    resetPackageSetConfirm:
+      '该权限集随已安装的软件包发布，无法删除。删除操作将丢弃环境定制并把它重置为发布基线。是否继续？',
+    resetPackageSetSuccess: '权限集已重置为发布基线',
     bulkDeleteSuccess: '已删除 {{count}} 条 {{label}} 记录',
     bulkDeletePartial: '成功 {{succeeded}} 条，失败 {{failed}} 条',
   },


### PR DESCRIPTION
配合 framework ADR-0094(#2901 / #2905 已合并):对随软件包发布的权限集,数据门"删除"并不会移除记录——后端丢弃环境定制 overlay 并把它**重置**为发布基线,行仍留在列表里。当前 UI 的确认框写"此操作不可撤销"、成功提示写"已删除",与实际不符(用户看到行没消失)。

## 改动

- `sys_permission_set` 且 `managed_by === 'package'` 的行:确认框问"重置为发布基线?",成功提示"权限集已重置为发布基线";环境自有集保留普通删除文案。新增 i18n 键 `resetPackageSetConfirm` / `resetPackageSetSuccess`(en + zh)。
- `ObjectView` 的行删除把 record 透传进来,判断无需额外请求;SDUI header/编程式删除(只有 id)回退到 `findOne` 查一次 `managed_by`。

## 测试

`useObjectActions.test.tsx` 新增 3 例:包持有行→重置文案+重置提示;环境自有行→普通删除文案;只传 id 时 `findOne` 回退。全套 6 项通过。

> 行为的服务端真相已在 framework 真实栈实测(`showcase_contributor` 数据门删除 = 重置回基线、行保留、`managed_by:'package'` 保留)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXjD7g2JkEsdqhZFZgAo1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXjD7g2JkEsdqhZFZgAo1Q)_