### PR TITLE
fix(plugin-chatbot): build-result summary truncates on mobile instead of overflowing (#2493)

### DIFF
--- a/.changeset/fix-build-card-mobile-overflow.md
+++ b/.changeset/fix-build-card-mobile-overflow.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/plugin-chatbot": patch
+---
+
+fix(plugin-chatbot): build-result summary truncates on mobile instead of overflowing (#2493)
+
+The draft-review card's summary line (`built N artifact(s) — …`) is a nowrap
+`truncate` span, but its flex row lacked the `min-w-0` that lets `truncate`
+actually bite — so on a phone the long summary expanded the chat column past
+the viewport and the whole chat scrolled sideways. The span now gets
+`min-w-0 flex-1` (truncating within the row) and the action row is `flex-wrap`
+so its buttons drop to a new line on a narrow screen rather than forcing
+horizontal scroll. Desktop is unchanged (there's room, so nothing wraps or
+truncates).

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -1769,7 +1769,9 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             (onReviewDraft ||
               (onPublishDrafts && tool.draftReview.packageId)) ? (
               <>
-                <div className="flex items-center gap-2 p-3 border-t bg-muted/30">
+                {/* flex-wrap so the action buttons drop to a new line on a
+                    narrow (mobile) row instead of forcing horizontal scroll. */}
+                <div className="flex flex-wrap items-center gap-2 p-3 border-t bg-muted/30">
                   {onPublishDrafts && tool.draftReview.packageId ? (
                     draftIsPublished ? (
                       // Published (auto or manual): a stable status badge, not a
@@ -1855,7 +1857,10 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     )
                   ) : null}
                   {tool.draftReview.summary ? (
-                    <span className="truncate text-xs text-muted-foreground">
+                    // min-w-0 + flex-1 so this nowrap summary TRUNCATES within the
+                    // row instead of expanding it past the viewport on mobile
+                    // (#2493 — a flex child needs min-w-0 for `truncate` to bite).
+                    <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
                       {tool.draftReview.summary}
                     </span>
                   ) : null}

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -515,6 +515,38 @@ describe('ChatbotEnhanced (AI Elements composition)', () => {
     expect(screen.getByText('Parameters')).toBeInTheDocument();
   });
 
+  it('#2493 — the draft-review summary can truncate (min-w-0) and its action row wraps, so it does not overflow on mobile', () => {
+    const longSummary =
+      'built 5 artifact(s) — live in your new app, grouped under app.pi8e — objects, views and a task board, all wired and ready to publish';
+    const draftTool: ChatMessage = {
+      id: 'ov1',
+      role: 'assistant',
+      content: 'Built your app.',
+      toolInvocations: [
+        {
+          toolCallId: 'tc-ov',
+          toolName: 'apply_blueprint',
+          state: 'output-available',
+          result: { status: 'drafted', drafted: [{ type: 'app', name: 'todo_app' }] },
+          draftReview: {
+            items: [{ type: 'app', name: 'todo_app' }],
+            packageId: 'app.pi8e',
+            summary: longSummary,
+          },
+        },
+      ],
+    };
+    render(<ChatbotEnhanced messages={[draftTool]} onReviewDraft={vi.fn()} />);
+    const summary = screen.getByText(longSummary);
+    // The summary is a flex child that must be shrinkable + clipped, or its
+    // nowrap text expands the chat column past a phone viewport (the bug).
+    expect(summary).toHaveClass('truncate');
+    expect(summary).toHaveClass('min-w-0');
+    // And the action row wraps so its buttons never force horizontal scroll.
+    const row = summary.closest('div');
+    expect(row?.className).toContain('flex-wrap');
+  });
+
   it('expands the verification chip into the actual lint findings (ADR-0038 L1)', () => {
     const issueTool: ChatMessage = {
       id: 'a2',


### PR DESCRIPTION
Closes #2493 — the horizontal-overflow found while fixing the mobile Live Canvas (#2492).

## Bug
On mobile `/ai/build`, the chat scrolled sideways. The culprit is the draft-review card's summary line:

```
<span class="truncate text-xs text-muted-foreground">built N artifact(s) — live in your new app, grouped under app.…</span>
```

`truncate` sets `white-space:nowrap`, but a flex child needs `min-w-0` for the ellipsis to actually constrain layout (flex items default to `min-width:auto`, refusing to shrink below content). Without it, the ~2100px nowrap summary expanded its flex row → the chat column → past the ~500px viewport.

## Fix
- The summary span gets `min-w-0 flex-1` → it truncates within the row.
- The action row (publish / review / preview / verify-chip) gets `flex-wrap` → on a narrow screen the buttons drop to a new line instead of forcing horizontal scroll.

Desktop is unchanged — there's room, so nothing wraps or truncates. Audited the card's other truncate lines: the tool-group title (line ~3445) already sits in a `min-w-0` flex container; the verify chip is `shrink-0`. Only the summary needed it.

## Verification
- `tsc --noEmit` clean; `npx vitest run ChatbotEnhanced.test.tsx` → 82 tests green (the summary is queried by text, not class).
- Live browser proof (mobile viewport, real build) to follow in a comment.

Refs #2493