### PR TITLE
fix(plugin-chatbot): ask-decline shows a live pending indicator + earlier handoff card (#2458)

### DIFF
--- a/.changeset/ask-decline-pending-indicator.md
+++ b/.changeset/ask-decline-pending-indicator.md
@@ -1,0 +1,9 @@
+---
+"@object-ui/plugin-chatbot": patch
+---
+
+Make the ask-decline wait feel responsive: live thinking indicator + handoff card the moment `suggest_builder` lands (#2458 item 3).
+
+When the `ask` agent declines a build-shaped request, the ~20s before the "Open in Builder →" card is dominated by the LLM's time-to-tool-call. During that wait the chat could show dead air — a blank bubble, or the static "执行过程" activity note (a hydrated-history affordance) when the backend streamed a `(called …)` tool-call placeholder.
+
+`ChatbotEnhanced` now shows the existing live thinking indicator (`ThinkingDots`) whenever a streaming assistant turn has nothing visible yet — including whitespace-only content, a mid-stream `(called …)` placeholder, and hidden reasoning in `summary` mode. The static "执行过程" note is reserved for FINISHED (re-hydrated) tool-call-only turns (#772 preserved). The `builderHandoff` card already renders at `output-available` with no gate on the trailing prose, so it surfaces the instant the tool result arrives; the typing cursor now only paints beside real streaming prose (no lone cursor during the tool phase).

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -2380,14 +2380,6 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                   !isUser && !tools.some((t) => Boolean(t.proposedPlan))
                     ? message.blueprintProgress
                     : undefined;
-                const isEmptyAssistantStreaming =
-                  !isUser &&
-                  Boolean(message.streaming) &&
-                  !message.content &&
-                  tools.length === 0 &&
-                  !reasoning &&
-                  !buildProgress &&
-                  !blueprintProgress; // a streaming design/build shows its panel, not the dots
                 const summaryTools =
                   !isUser && processVisibility === 'summary'
                     ? tools.filter(
@@ -2408,6 +2400,30 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     : !isUser && processVisibility !== 'debug'
                       ? tools.filter(shouldRenderDetailedTool)
                       : [];
+                // Real, showable prose for this turn. Whitespace-only text and the
+                // persisted "(called …)" tool-call placeholder are NOT visible
+                // prose: the placeholder is a hydrated-history affordance (renders
+                // as the quiet 执行过程 note only once the turn has ENDED), and a
+                // lone whitespace part must never paint a blank bubble mid-stream.
+                const hasVisibleProse =
+                  !isUser &&
+                  message.content.trim().length > 0 &&
+                  !isToolCallPlaceholder(message.content);
+                // Nothing is visible for this streaming turn yet → show the live
+                // thinking indicator instead of dead air. Covers the ask-decline
+                // wait (tool-call latency before `suggest_builder` lands): no
+                // prose, no rendered tool row (summary chip / detailed card), no
+                // shown reasoning (only surfaced in debug), no build/design panel.
+                const reasoningVisible = processVisibility === 'debug' && Boolean(reasoning);
+                const isEmptyAssistantStreaming =
+                  !isUser &&
+                  Boolean(message.streaming) &&
+                  !hasVisibleProse &&
+                  summaryTools.length === 0 &&
+                  detailedTools.length === 0 &&
+                  !reasoningVisible &&
+                  !buildProgress &&
+                  !blueprintProgress; // a streaming design/build shows its panel, not the dots
                 return (
                   <Message key={message.id} from={formatMessageProps(message.role)}>
                     <div
@@ -2482,23 +2498,23 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                         ) : null
                       ) : isEmptyAssistantStreaming ? (
                         <ThinkingDots />
-                      ) : message.content ? (
-                        isToolCallPlaceholder(message.content) ? (
-                          // #772: a re-hydrated tool-call-only turn is persisted
-                          // with an internal placeholder ("(called todo_write,
-                          // propose_blueprint)"); render a quiet localized
-                          // activity note instead of leaking it as prose.
-                          <span
-                            className="text-xs italic text-muted-foreground/70"
-                            title={message.content}
-                          >
-                            {L.agentActivity}
-                          </span>
-                        ) : (
-                          <MessageResponse>{message.content}</MessageResponse>
-                        )
+                      ) : hasVisibleProse ? (
+                        <MessageResponse>{message.content}</MessageResponse>
+                      ) : !message.streaming && isToolCallPlaceholder(message.content) ? (
+                        // #772: a re-hydrated tool-call-only turn is persisted with
+                        // an internal placeholder ("(called todo_write,
+                        // propose_blueprint)"); render a quiet localized activity
+                        // note instead of leaking it as prose. Only once the turn
+                        // has ENDED — mid-stream the live tool row / ThinkingDots
+                        // carry the status, so the static note never flashes.
+                        <span
+                          className="text-xs italic text-muted-foreground/70"
+                          title={message.content}
+                        >
+                          {L.agentActivity}
+                        </span>
                       ) : null}
-                      {message.streaming && !isEmptyAssistantStreaming ? (
+                      {message.streaming && hasVisibleProse ? (
                         <span
                           aria-hidden
                           className="ml-0.5 inline-block w-[2px] h-4 align-middle bg-current animate-pulse"

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx
@@ -155,6 +155,83 @@ describe('ChatbotEnhanced (AI Elements composition)', () => {
     expect(screen.getByTestId('builder-handoff-open')).toBeDisabled();
   });
 
+  // #2458 item 3 — the ask-decline handoff card is the actionable payload; it
+  // must surface the moment `suggest_builder` reaches `output-available`, while
+  // the turn is STILL streaming and the trailing one-line prose hasn't arrived
+  // (content still empty). We must not withhold it until the text part finishes.
+  it('renders the handoff card at output-available while still streaming, before prose arrives (#2458)', () => {
+    const onOpenBuilder = vi.fn();
+    const messages: ChatMessage[] = [
+      { id: 'u1', role: 'user', content: '帮我搭一个客户管理应用' },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: '', // no prose yet — the sentence streams in AFTER the card
+        streaming: true,
+        toolInvocations: [
+          {
+            toolCallId: 't1',
+            toolName: 'suggest_builder',
+            state: 'output-available',
+            builderHandoff: { prompt: '客户管理应用', packageId: 'com.acme.crm' },
+          },
+        ],
+      },
+    ];
+    render(<ChatbotEnhanced messages={messages} isLoading onOpenBuilder={onOpenBuilder} />);
+    // The actionable card is present and live despite the unfinished stream.
+    expect(screen.getByTestId('builder-handoff')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('builder-handoff-open'));
+    expect(onOpenBuilder).toHaveBeenCalledWith({
+      prompt: '客户管理应用',
+      packageId: 'com.acme.crm',
+    });
+  });
+
+  // #2458 item 3 — while the ask agent is still deciding (no prose, no rendered
+  // tool row yet), a mid-stream turn whose only text is the persisted
+  // "(called …)" tool-call placeholder must show the LIVE thinking indicator,
+  // not the static 执行过程 note (a hydrated-history affordance) or a blank bubble.
+  it('shows live thinking dots — not the static activity note — for a mid-stream tool-call placeholder', () => {
+    render(
+      <ChatbotEnhanced
+        isLoading
+        labels={{ agentActivity: 'AGENT_ACTIVITY_NOTE' }}
+        messages={[
+          { id: 'u1', role: 'user', content: '帮我搭一个客户管理应用' },
+          {
+            id: 'a1',
+            role: 'assistant',
+            content: '(called suggest_builder)',
+            streaming: true,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Assistant is responding/i)).toBeInTheDocument();
+    expect(screen.queryByText('AGENT_ACTIVITY_NOTE')).not.toBeInTheDocument();
+  });
+
+  // The static 执行过程 note is still the right thing once the turn has ENDED
+  // (re-hydrated history): a tool-call-only turn shows the quiet activity note,
+  // never leaks the internal placeholder as prose (#772 preserved).
+  it('keeps the quiet activity note for a FINISHED tool-call placeholder turn (#772)', () => {
+    render(
+      <ChatbotEnhanced
+        labels={{ agentActivity: 'AGENT_ACTIVITY_NOTE' }}
+        messages={[
+          {
+            id: 'a1',
+            role: 'assistant',
+            content: '(called suggest_builder)',
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText('AGENT_ACTIVITY_NOTE')).toBeInTheDocument();
+    expect(screen.queryByText('(called suggest_builder)')).not.toBeInTheDocument();
+  });
+
   const planMessage = (questions: string[]): ChatMessage[] => [
     {
       id: 'a1',


### PR DESCRIPTION
## What & why

Item **#3** of objectstack-ai/objectui#2458 — the **ask-decline latency feel**. When the `ask` agent declines a build-shaped request, the ~20s before the "Open in Builder →" card is dominated by the LLM's time-to-tool-call (`gpt-4`, react planning). During that wait the chat could show dead air:

- a blank bubble (whitespace-only streamed content), or
- the static **"执行过程"** activity note — a *re-hydrated-history* affordance (#772) — when the backend streamed a `(called suggest_builder)` tool-call placeholder mid-stream.

## Investigation

- The console (`AiChatPage`) drives the **live** stream through `useObjectChat` → `mapMessages`, default `processVisibility="summary"`.
- The ask agent (cloud `ask-agent.ts`) is instructed to call `suggest_builder` **first, then one short sentence** — so the wait is LLM tool-call latency, not prose. The card can't render sooner; the win is the **pending indicator**.
- The `builderHandoff` card (ChatbotEnhanced) already renders on `tool.builderHandoff` with **no gate on prose / stream completion** — so it surfaces at `output-available`, before the trailing sentence. Confirmed and now locked with a test.

## Changes (`ChatbotEnhanced.tsx`)

- Redefined `isEmptyAssistantStreaming` as "streaming turn with nothing **visible** yet": no real prose (whitespace-only and `(called …)` placeholders don't count), no rendered tool row (summary chip / detailed card), no *shown* reasoning (only surfaced in `debug`), no build/design panel → renders the existing **`ThinkingDots`** indicator (mirrors the existing streaming affordance, per the ticket).
- The static **"执行过程"** note is now reserved for **finished** (re-hydrated) tool-call-only turns — `#772` behaviour preserved, verified by a test.
- The typing cursor now paints only beside real streaming prose (no lone cursor during the tool phase).

## Goal 3 (prose need)

The ask agent already emits just "one short sentence" for a decline (cloud `ask-agent.ts`) — already minimal. No prompt change made; touching the P4 handoff contract was explicitly out of scope.

## Tests

`packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.test.tsx` (86 pass):
- handoff card renders at `output-available` **while streaming, before prose arrives**;
- **live dots, not 执行过程**, for a mid-stream `(called …)` placeholder;
- **执行过程 note preserved** for a finished placeholder turn (#772).

## Browser proof

Rendered the **real** `ChatbotEnhanced` (from source, console-default `summary` mode) through the exact ask-decline stream phases (a live `gpt-4` rig is needed to reproduce the 20s wall-clock; the harness reproduces each phase deterministically):

1. **Wait / `(called …)` placeholder** → live thinking indicator (`Assistant is responding`), no blank, no 执行过程.
2. **`suggest_builder` → `output-available`, still streaming, no prose** → full "Open in Builder →" card (prompt + actionable button).
3. **One-line prose** fills in below the card afterward.

## Follow-up (out of scope, flagged separately)

`hydratedMessagesToChatMessages` (app-shell `AiChatPage`) lifts `draftReview`/`proposedPlan` on reload but **not** `builderHandoff`/`proposedChanges`, so a *reloaded* ask-decline loses the card. Spawned as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)