### PR TITLE
fix(app-shell): hydration lifts ask-decline builder handoff + changes-proposed cards

### DIFF
--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -69,6 +69,8 @@ import {
   publishHealthFromResponse,
   detectDraftResult,
   detectProposedPlan,
+  detectBuilderHandoff,
+  detectProposedChanges,
   buildProgressFromDraftReview,
   type AgentDescriptor,
   type ChatbotEnhancedToolInvocation,
@@ -160,6 +162,14 @@ export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): C
         // same merged tool result; lift it so the "Proposed plan" review card
         // survives a reload on this surface, not just in the floating chat.
         const proposedPlan = detectProposedPlan(result);
+        // The ask-agent's structured decline (suggest_builder → build_handoff)
+        // and the confirm-before-change preview (changes_proposed) ride the same
+        // merged tool result. Lift both so the "Open in Builder →" handoff card
+        // and the "确认修改" changes card survive a reload / cache restore — the
+        // live floating-chat mapper (extractToolInvocations) already lifts all
+        // four; this is its hydration counterpart.
+        const builderHandoff = detectBuilderHandoff(result);
+        const proposedChanges = detectProposedChanges(result);
         toolInvocations.push({
           toolCallId,
           toolName,
@@ -167,6 +177,8 @@ export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): C
           ...(result !== undefined ? { result } : {}),
           ...(draftReview ? { draftReview } : {}),
           ...(proposedPlan ? { proposedPlan } : {}),
+          ...(builderHandoff ? { builderHandoff } : {}),
+          ...(proposedChanges ? { proposedChanges } : {}),
           ...(part.errorText ? { errorText: String(part.errorText) } : {}),
         });
         if (!buildProgress) {

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
@@ -81,6 +81,33 @@ describe('AiChatPage hydration — tool invocation states', () => {
       assumptions: ['One shelf for now'],
     });
   });
+
+  it('lifts the ask-decline builder handoff so the "Open in Builder →" card survives a reload', () => {
+    // The `ask` agent's structured decline (suggest_builder → build_handoff)
+    // rides the merged tool output. Without lifting it on THIS converter the
+    // handoff card only shows in the live floating chat and is LOST when the
+    // conversation is reloaded or restored from the sessionStorage cache.
+    const envelope = JSON.stringify({
+      status: 'build_handoff',
+      handoff: 'build',
+      prompt: 'Build a CRM to track leads',
+      packageId: 'app.crm',
+    });
+    const [msg] = hydratedMessagesToChatMessages(
+      assistantWith([
+        {
+          type: 'tool-call',
+          toolCallId: 't1',
+          toolName: 'suggest_builder',
+          output: { type: 'text', value: envelope },
+        },
+      ]),
+    );
+    expect(msg.toolInvocations?.[0]?.builderHandoff).toEqual({
+      prompt: 'Build a CRM to track leads',
+      packageId: 'app.crm',
+    });
+  });
 });
 
 describe('shared-conversation render — flat ai_messages rows → proposed-plan card', () => {

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -318,9 +318,11 @@ export {
   uiMessagesToChatMessages,
   detectDraftResult,
   detectProposedPlan,
+  detectBuilderHandoff,
+  detectProposedChanges,
   buildProgressFromDraftReview,
 } from './mapMessages';
-export type { DraftReview, ProposedPlan } from './mapMessages';
+export type { DraftReview, ProposedPlan, BuilderHandoff, ProposedChanges } from './mapMessages';
 
 // Display helpers used internally by ChatbotEnhanced. Exported so app
 // authors composing their own chat surface get the same pretty tool-call


### PR DESCRIPTION
## Problem

`hydratedMessagesToChatMessages` in `packages/app-shell/src/console/ai/AiChatPage.tsx` rebuilds tool invocations from persisted/cached history but only lifted `draftReview` and `proposedPlan` from the tool result — it did **not** call `detectBuilderHandoff` / `detectProposedChanges`. As a result, reloading (or restoring from the sessionStorage cache) a past ask-decline conversation LOST the **"Open in Builder →"** handoff card and any **"确认修改"** changes-proposed card, even though the live floating-chat path (`packages/plugin-chatbot/src/mapMessages.ts` `extractToolInvocations`) lifts all four envelopes.

## Fix

- **`packages/app-shell/src/console/ai/AiChatPage.tsx`** — in the per-part loop, also compute `detectBuilderHandoff(result)` and `detectProposedChanges(result)` and spread `builderHandoff` / `proposedChanges` onto the pushed invocation, mirroring the floating-chat mapper. The `ChatbotEnhanced` renderer already reads both fields (`shouldRenderDetailedTool` gates on them), so the cards render on reload with no renderer change.
- **`packages/plugin-chatbot/src/index.tsx`** — export `detectBuilderHandoff` / `detectProposedChanges` and their `BuilderHandoff` / `ProposedChanges` types from the package barrel so app-shell can import them.
- **`AiChatPage.hydration.test.ts`** — new unit test asserting a hydrated `suggest_builder` tool with a `build_handoff` result envelope produces a `builderHandoff` on the invocation.

Reload counterpart to the live-latency fix in objectstack-ai/objectui#2458 item 3.

## Verification

- `AiChatPage.hydration.test.ts` — 6/6 pass (new test included)
- `pnpm --filter @object-ui/plugin-chatbot type-check` — clean
- `pnpm --filter @object-ui/app-shell type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)