### PR TITLE
fix(plugin-grid): default ImportWizard 'run automations & triggers' to ON (framework#2922)

### DIFF
--- a/.changeset/import-run-automations-default-on.md
+++ b/.changeset/import-run-automations-default-on.md
@@ -1,0 +1,8 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+ImportWizard now defaults the "Run automations & triggers" checkbox to ON
+(framework#2922): automations always ran on import before the server honored
+the flag, so preserving behavior means opt-out rather than opt-in. The reset
+path restores the same default.

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -1468,7 +1468,9 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
   const [writeMode, setWriteMode] = useState<ImportWriteMode>('insert');
   const [matchFields, setMatchFields] = useState<string[]>([]);
   const [createMissingOptions, setCreateMissingOptions] = useState(false);
-  const [runAutomations, setRunAutomations] = useState(false);
+  // Default ON: automations always ran on import before framework#2922 wired
+  // the flag up server-side, so preserving behavior means opt-out, not opt-in.
+  const [runAutomations, setRunAutomations] = useState(true);
   const [skipBlankMatchKey, setSkipBlankMatchKey] = useState(false);
   // Opt-in: route this import through a background job even when the row count
   // is under the async threshold. This is the only way to obtain an undoable
@@ -1970,7 +1972,7 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
     setStep('upload'); setHeaders([]); setRows([]); setMapping({}); setProgress(0); setResult(null);
     setCorrections({}); setSelectedTemplateId(null); setMappingName(null);
     setWriteMode('insert'); setMatchFields([]);
-    setCreateMissingOptions(false); setRunAutomations(false); setSkipBlankMatchKey(false);
+    setCreateMissingOptions(false); setRunAutomations(true); setSkipBlankMatchKey(false);
     setJobId(null); setAsyncCounts(null);
     setValidating(false); setDryRunResult(null);
     setShowHistory(false);


### PR DESCRIPTION
## Summary

Companion to objectstack-ai/framework#2941 (fixes objectstack-ai/framework#2922).

Automations always ran on import before the server honored the `runAutomations` flag, so preserving behavior means **opt-out rather than opt-in**: the ImportWizard "Run automations & triggers" checkbox now defaults to checked (`useState(true)`), and the wizard reset path restores the same default.

Server-side, the framework PR makes the flag actually effective (`skipAutomations` suppresses metadata-bound automation hooks + flow dispatch while audit/security system hooks still run) and flips the REST default to `runAutomations !== false` — this PR aligns the UI default with that contract.

## Tests
- `@object-ui/plugin-grid`: 27 files / 194 tests pass. Existing import request-builder tests pass explicit `runAutomations` values, so they are unaffected by the state default.

Changeset included (patch: plugin-grid).