### PR TITLE
fix(components): pin list-view horizontal scrollbar to viewport bottom

### DIFF
--- a/.changeset/listview-hscroll-pinned.md
+++ b/.changeset/listview-hscroll-pinned.md
@@ -1,0 +1,25 @@
+---
+"@object-ui/components": patch
+---
+
+fix(components): keep the list-view horizontal scrollbar pinned to the viewport bottom
+
+In a list/grid view with many columns, the horizontal scrollbar was only
+reachable after scrolling all the way to the last row. Root cause: the shadcn
+`<Table>` wraps its `<table>` in a `overflow-auto` scroll `<div>`. When
+`DataTable` already renders the table inside a *bounded*
+`flex-1 min-h-0 overflow-auto` region, that default wrapper became a SECOND,
+height-unbounded scroll container — it stretched to the full table height, so
+its horizontal scrollbar sat at the bottom of *all* rows.
+
+- `Table` gains an optional `containerClassName` prop that overrides the
+  scroll-wrapper `<div>`'s classes (default behavior unchanged).
+- `DataTable` passes `containerClassName="overflow-visible"` so the outer
+  bounded container owns both axes and the horizontal scrollbar stays pinned to
+  the viewport bottom — reachable from any scroll position, no need to scroll to
+  the last row.
+
+Verified end-to-end against the running console (data-table with 60+ rows × 19
+columns): the horizontal scroller is now the bounded `flex-1 min-h-0
+overflow-auto` region (bottom on-screen, within the viewport) and the table can
+be scrolled fully right while still at the top row.

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -1113,7 +1113,13 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
           : "flex-1 min-h-0 overflow-auto [-webkit-overflow-scrolling:touch]",
         !borderless && "rounded-md border shadow-[inset_-8px_0_8px_-8px_rgba(0,0,0,0.08)]",
       )}>
-        <Table>
+        {/* This div is already the (bounded) scroll container for BOTH axes —
+            or, in grouped mode, the table overflows into a shared ancestor
+            scroller. Either way the shadcn <Table>'s default `overflow-auto`
+            wrapper must NOT create a second, height-unbounded scroll context;
+            otherwise the horizontal scrollbar drops to the bottom of all rows
+            and is only reachable after scrolling to the last row. */}
+        <Table containerClassName="overflow-visible">
           {caption && <TableCaption>{caption}</TableCaption>}
           <TableHeader className="sticky top-0 bg-background z-10">
             <TableRow>

--- a/packages/components/src/ui/__tests__/table-container-overflow.test.tsx
+++ b/packages/components/src/ui/__tests__/table-container-overflow.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Regression guard for the list-view horizontal-scrollbar fix.
+ *
+ * The shadcn <Table> wraps its <table> in a scroll <div>. By default that
+ * wrapper is `overflow-auto`, making it its OWN horizontal scroll container.
+ * When DataTable already renders the table inside a bounded
+ * `flex-1 min-h-0 overflow-auto` region, that default wrapper becomes a
+ * SECOND, height-unbounded scroll context: it stretches to the full table
+ * height, so its horizontal scrollbar sits below the last row — reachable
+ * only after scrolling all rows to the bottom (the reported bug).
+ *
+ * The fix lets callers pass `containerClassName="overflow-visible"` so the
+ * outer bounded container owns both axes and the horizontal scrollbar stays
+ * pinned to the viewport bottom. This relies on `cn`/twMerge collapsing the
+ * conflicting `overflow-*` utilities to the caller's value. jsdom has no
+ * layout engine, so we can't measure the scrollbar position here — instead we
+ * assert the mechanism: the override wins and the default `overflow-auto` is
+ * gone from the wrapper.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Table, TableBody, TableCell, TableRow } from '../table';
+
+function renderTable(containerClassName?: string) {
+  const { container } = render(
+    <Table containerClassName={containerClassName} data-testid="tbl">
+      <TableBody>
+        <TableRow>
+          <TableCell>cell</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+  // The wrapper <div> is the <table>'s parent element.
+  const table = container.querySelector('table')!;
+  return table.parentElement as HTMLElement;
+}
+
+describe('ui/Table scroll-wrapper container overflow', () => {
+  it('defaults the wrapper to overflow-auto (unchanged shadcn behavior)', () => {
+    const wrapper = renderTable();
+    expect(wrapper.className).toContain('overflow-auto');
+    expect(wrapper.className).toContain('relative');
+    expect(wrapper.className).toContain('w-full');
+  });
+
+  it('lets containerClass="overflow-visible" override the default overflow', () => {
+    const wrapper = renderTable('overflow-visible');
+    // twMerge must collapse the conflicting overflow utilities to the override.
+    expect(wrapper.className).toContain('overflow-visible');
+    expect(wrapper.className).not.toContain('overflow-auto');
+    // Non-conflicting base utilities are preserved.
+    expect(wrapper.className).toContain('relative');
+    expect(wrapper.className).toContain('w-full');
+  });
+});

--- a/packages/components/src/ui/table.tsx
+++ b/packages/components/src/ui/table.tsx
@@ -12,9 +12,24 @@ import { cn } from "../lib/utils"
 
 const Table = React.forwardRef<
   HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  React.HTMLAttributes<HTMLTableElement> & {
+    /**
+     * Overrides for the scroll-wrapper `<div>` around the `<table>`.
+     *
+     * By default the wrapper is its own horizontal scroll container
+     * (`overflow-auto`). When the table already lives inside a *bounded*
+     * scroll container (e.g. the flex `flex-1 min-h-0 overflow-auto` region
+     * DataTable renders it in), that default creates a SECOND, height-unbounded
+     * scroll container: the wrapper stretches to the full table height, so its
+     * horizontal scrollbar sits at the bottom of *all* rows — reachable only
+     * after scrolling to the last row. Pass `containerClassName="overflow-visible"`
+     * to let the outer bounded container own both axes and keep the horizontal
+     * scrollbar pinned to the viewport bottom.
+     */
+    containerClassName?: string
+  }
+>(({ className, containerClassName, ...props }, ref) => (
+  <div className={cn("relative w-full overflow-auto", containerClassName)}>
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}


### PR DESCRIPTION
Closes #2507

## 问题
列表/网格视图列很多时,横向滚动条只有**下拉到最后一行**才出现,看右侧字段很别扭。

## 根因
shadcn 的 `<Table>` 把 `<table>` 包在一个 `overflow-auto` 的滚动 `<div>` 里。当 `DataTable` 已经把表格放进一个**有界**的 `flex-1 min-h-0 overflow-auto` 区域时,这个默认包裹层就变成**第二个、高度无界的横向滚动容器**——它被撑到整张表的高度,于是横向滚动条落在所有行的最底部,只有滚到最后一行才够得到。

## 改动
- `Table` 新增可选 `containerClassName` prop,用于覆盖滚动包裹 `<div>` 的 class(默认行为不变)。
- `DataTable` 传 `containerClassName="overflow-visible"`,让外层有界容器同时拥有横纵两轴,横向滚动条钉在视口底部——任意滚动位置都能横滚,无需到最后一行。
- 新增回归测试 `table-container-overflow.test.tsx`,断言 `overflow-visible` 覆盖经 `cn`/twMerge 正确收敛(默认 `overflow-auto` 被替换)。

## 验证
- `turbo type-check @object-ui/components` 通过。
- 现有 data-table 测试 4 文件 20 用例 + 新增 2 用例全过。
- 真机 console 端到端实测(data-table:60+ 行 × 19 列):横向滚动条归外层有界 `flex-1 min-h-0 overflow-auto` 容器所有(clientHeight=942,非整表 2672),底边在视口内(y=1148 < winH=1181);停在首行(scrollTop=0)也能横滚到最右。