### PR TITLE
feat(studio-access): package-level OWD overview — audit &amp; batch-edit sharingModel (#2505)

### DIFF
--- a/.changeset/studio-access-package-owd-overview.md
+++ b/.changeset/studio-access-package-owd-overview.md
@@ -1,0 +1,26 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(studio-access): package-level OWD overview — audit & batch-edit sharingModel (objectui#2505)
+
+Add a package-scoped **"Record Sharing Baseline (OWD)"** panel to the Studio
+Access pillar, a sibling surface next to the permission-set rail. It surveys —
+and batch-edits — the org-wide default of every object the package owns, so an
+author no longer has to open each object's Settings page to audit the baseline.
+
+- **`PackageOwdOverviewPanel`** — a table of object × `sharingModel` ×
+  `externalSharingModel` covering the package's objects (published ∪ pending
+  drafts). Inline selects reuse the canonical four OWD values and the option
+  labels/help copy from `ObjectSettingsPanel`. Save writes one package-scoped
+  metadata **draft per changed object** (identical to the per-object Settings
+  write); publish flows through the unchanged security-domain gate.
+- `controlled_by_parent` rows show the master link (read-only) instead of an
+  external dial; row-level `external ≤ internal` validation (ADR-0090 D11) is
+  surfaced inline and blocks Save.
+- New shared **`owd-sharing.ts`** — `OWD_MODELS`, the `OWD_WIDTH` axis,
+  `isExternalWider`, `deriveMasterObject`.
+- The Access pillar hosts it via a pinned rail entry + the existing `?surface=`
+  deep-link (`owd:overview`); the read-only OWD badge in `PermissionMatrixEditor`
+  now links here (plain chip at environment scope, unchanged).
+- Read-only packages render the table non-editable. EN + zh-CN i18n.

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -153,13 +153,21 @@ export interface PermissionMatrixEditPageProps {
    */
   onDraftSaved?: () => void;
   publishNonce?: number;
+  /**
+   * objectui#2505 — when provided, the per-object OWD badge becomes a link that
+   * opens the package-level Record Sharing Baseline (OWD) overview, scrolled to
+   * that object. Set only by the Studio Access pillar (which hosts the sibling
+   * overview surface); omitted at environment scope / metadata-admin, where the
+   * badge stays a plain read-only chip.
+   */
+  onOpenOwd?: (objectName: string) => void;
 }
 
 /* ────────────────────────────────────────────────────────────────── */
 /* Component                                                          */
 /* ────────────────────────────────────────────────────────────────── */
 
-export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, publishNonce }: PermissionMatrixEditPageProps) {
+export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, publishNonce, onOpenOwd }: PermissionMatrixEditPageProps) {
   const navigate = useNavigate();
   const client = useMetadataClient();
   // Data adapter (records) — the capability picker reads the live sys_capability
@@ -617,6 +625,7 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
             onObjectPerm={updateObjectPerm}
             onFieldPerm={updateFieldPerm}
             onBulkSet={bulkSetObject}
+            onOpenOwd={onOpenOwd}
           />
           {/* Advanced facets (ADR-0056 P3) — RLS / tab visibility / delegated
               admin scope, structured editors instead of raw JSON. Collapsed by
@@ -687,6 +696,8 @@ interface PermissionTableProps {
   onObjectPerm: (objectName: string, action: keyof ObjectPerm, value: boolean) => void;
   onFieldPerm: (objectName: string, fieldName: string, action: keyof FieldPerm, value: boolean) => void;
   onBulkSet: (objectName: string, action: 'all' | 'none' | 'crud' | 'read') => void;
+  /** objectui#2505 — when set, the OWD badge links to the package OWD overview. */
+  onOpenOwd?: (objectName: string) => void;
 }
 
 function PermissionTable({
@@ -701,6 +712,7 @@ function PermissionTable({
   onObjectPerm,
   onFieldPerm,
   onBulkSet,
+  onOpenOwd,
 }: PermissionTableProps) {
   return (
     <table className="w-full text-sm">
@@ -760,8 +772,27 @@ function PermissionTable({
                   )}
                   <Badge
                     variant="outline"
-                    className="ml-2 text-[10px] px-1.5 py-0 align-middle text-muted-foreground"
-                    title={t('perm.owd.tip')}
+                    className={
+                      'ml-2 text-[10px] px-1.5 py-0 align-middle text-muted-foreground' +
+                      (onOpenOwd
+                        ? ' cursor-pointer hover:text-foreground hover:border-foreground/40 focus:outline-none focus:ring-1 focus:ring-primary'
+                        : '')
+                    }
+                    title={onOpenOwd ? t('perm.owd.editLink') : t('perm.owd.tip')}
+                    {...(onOpenOwd
+                      ? {
+                          role: 'button',
+                          tabIndex: 0,
+                          'data-testid': `owd-badge-${o.name}`,
+                          onClick: () => onOpenOwd(o.name),
+                          onKeyDown: (ev: React.KeyboardEvent) => {
+                            if (ev.key === 'Enter' || ev.key === ' ') {
+                              ev.preventDefault();
+                              onOpenOwd(o.name);
+                            }
+                          },
+                        }
+                      : {})}
                   >
                     {`OWD ${o.owd ? owdLabel(t, o.owd) : t('perm.owd.defaultPrivate')}`}
                   </Badge>

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -707,6 +707,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'perm.owd.tip': 'Org-wide default (sharingModel): the record-level visibility baseline for internal users, applied before positions and sharing rules. Object CRUD here gates the operation; the OWD decides which records it reaches (own vs org-wide).',
   'perm.owd.ext.tip': 'External OWD (externalSharingModel): the baseline for portal / partner principals — never wider than the internal model (ADR-0090 D11).',
   'perm.owd.defaultPrivate': 'Private (default)',
+  'perm.owd.editLink': 'Edit in the package’s Record Sharing Baseline (OWD) overview',
   'perm.owd.private': 'Private',
   'perm.owd.public_read': 'Public read',
   'perm.owd.public_read_write': 'Public read/write',
@@ -1294,6 +1295,29 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.access.new': 'New permission set',
   'engine.studio.access.emptyMain': 'Create a permission set to start configuring',
   'engine.studio.access.pick': 'Select a permission set',
+
+  // ── Record Sharing Baseline (OWD) overview (objectui#2505) ──────────────
+  'engine.studio.owd.railLabel': 'Record sharing (OWD)',
+  'engine.studio.owd.title': 'Record sharing baseline (OWD)',
+  'engine.studio.owd.subtitle': 'Object × org-wide default',
+  'engine.studio.owd.description':
+    'The org-wide default (sharingModel / externalSharingModel) for every object this package owns — audit the baseline at a glance and batch-edit it. Changes save as per-object drafts and go live through the package Publish, exactly like the per-object Settings tab.',
+  'engine.studio.owd.colObject': 'Object',
+  'engine.studio.owd.colInternal': 'Internal (sharingModel)',
+  'engine.studio.owd.colExternal': 'External (externalSharingModel)',
+  'engine.studio.owd.none': 'This package declares no objects.',
+  'engine.studio.owd.loadFailed': 'Failed to load this package’s objects.',
+  'engine.studio.owd.save': 'Save {count} change(s)',
+  'engine.studio.owd.saveNone': 'No changes',
+  'engine.studio.owd.saved': 'Saved {count} object draft(s).',
+  'engine.studio.owd.unsaved': 'Unsaved',
+  'engine.studio.owd.blockedSave':
+    'Some rows set the external baseline wider than the internal model (ADR-0090 D11). Narrow them before saving.',
+  'engine.studio.owd.widerError': 'External is wider than internal — narrow it (private < public read < public read/write).',
+  'engine.studio.owd.byParent': 'By parent → {master}',
+  'engine.studio.owd.byParentUnknown': 'By parent (master record)',
+  'engine.studio.owd.masterTip':
+    'Controlled by parent — record visibility is inherited from the master record; there is no separate external dial.',
 
   // ── Access explain panel (ADR-0090 D6 — "why can this user access?") ────
   'engine.studio.access.explain.open': 'Explain access',
@@ -1950,6 +1974,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'perm.owd.tip': '组织级默认（sharingModel）：内部用户的记录级可见性基线，先于岗位与共享规则生效。此处的对象 CRUD 决定能否执行操作，OWD 决定操作触达哪些记录（自己的还是全组织的）。',
   'perm.owd.ext.tip': '外部 OWD（externalSharingModel）：门户 / 合作伙伴等外部主体的基线 —— 不得宽于内部模型（ADR-0090 D11）。',
   'perm.owd.defaultPrivate': 'Private（默认）',
+  'perm.owd.editLink': '在本包的“记录共享基线（OWD）”总览中编辑',
   'perm.owd.private': 'Private 私有',
   'perm.owd.public_read': 'Public read 公共只读',
   'perm.owd.public_read_write': 'Public read/write 公共读写',
@@ -2533,6 +2558,29 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.access.new': '新建权限集',
   'engine.studio.access.emptyMain': '新建一个权限集开始配置',
   'engine.studio.access.pick': '选择一个权限集',
+
+  // ── 记录共享基线（OWD）总览 (objectui#2505) ──────────────────────────
+  'engine.studio.owd.railLabel': '记录共享（OWD）',
+  'engine.studio.owd.title': '记录共享基线（OWD）',
+  'engine.studio.owd.subtitle': '对象 × 组织级默认',
+  'engine.studio.owd.description':
+    '本包每个对象的组织级默认（sharingModel / externalSharingModel）—— 一屏审计基线并批量修改。改动以“逐对象草稿”保存，随包发布上线，与对象“设置”页完全一致。',
+  'engine.studio.owd.colObject': '对象',
+  'engine.studio.owd.colInternal': '内部（sharingModel）',
+  'engine.studio.owd.colExternal': '外部（externalSharingModel）',
+  'engine.studio.owd.none': '本包未声明任何对象。',
+  'engine.studio.owd.loadFailed': '加载本包对象失败。',
+  'engine.studio.owd.save': '保存 {count} 处改动',
+  'engine.studio.owd.saveNone': '无改动',
+  'engine.studio.owd.saved': '已保存 {count} 个对象草稿。',
+  'engine.studio.owd.unsaved': '未保存',
+  'engine.studio.owd.blockedSave':
+    '有行的外部基线宽于内部模型（ADR-0090 D11），请先收窄后再保存。',
+  'engine.studio.owd.widerError': '外部宽于内部 —— 请收窄（private < 公共只读 < 公共读写）。',
+  'engine.studio.owd.byParent': '受父级控制 → {master}',
+  'engine.studio.owd.byParentUnknown': '受父级控制（主记录）',
+  'engine.studio.owd.masterTip':
+    '受父级控制 —— 记录可见性继承自主记录，没有独立的外部基线开关。',
 
   // ── 访问解释面板(ADR-0090 D6 —「为什么该用户可以访问?」)────────────
   'engine.studio.access.explain.open': '解释访问权限',

--- a/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.test.tsx
+++ b/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.test.tsx
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0054 testability proofs for the package OWD overview (objectui#2505):
+ *   1. list render     — every package object appears with its OWD baseline.
+ *   2. edit → draft     — a changed row saves as that object's package draft.
+ *   3. validation block — external > internal blocks Save inline (ADR-0090 D11).
+ *   4. controlled_by_parent — master link shown, no external dial.
+ *   5. read-only        — badges only, no editing affordances.
+ *   6. deep-link        — the highlighted object's row is marked.
+ *
+ * Drives the REAL component against a fake metadata client that behaves like
+ * the server (list ∪ drafts, layered read-back, save records the payload).
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { PackageOwdOverviewPanel } from './PackageOwdOverviewPanel';
+
+interface Server {
+  /** Merged object bodies keyed by name (what layered() returns as `effective`). */
+  objects: Record<string, Record<string, unknown>>;
+  /** Draft-only object names (appear via listDrafts, not list). */
+  draftOnly: string[];
+  saved: Array<{ name: string; body: Record<string, unknown>; opts?: Record<string, unknown> }>;
+}
+
+function makeClient(server: Server) {
+  return {
+    list: async (type: string) => {
+      if (type !== 'object') return [];
+      return Object.entries(server.objects).map(([name, body]) => ({ name, label: body.label ?? name }));
+    },
+    listDrafts: async () => server.draftOnly.map((name) => ({ name })),
+    layered: async (_type: string, name: string) => ({ effective: server.objects[name] ?? {}, code: null }),
+    getDraft: async () => null,
+    save: async (_type: string, name: string, body: Record<string, unknown>, opts?: Record<string, unknown>) => {
+      server.saved.push({ name, body, opts });
+      server.objects[name] = body; // reopen reads it back
+      return body;
+    },
+  } as any;
+}
+
+function freshServer(): Server {
+  return {
+    objects: {
+      crm_account: { name: 'crm_account', label: 'Account', sharingModel: 'public_read_write' },
+      crm_contact: { name: 'crm_contact', label: 'Contact', sharingModel: 'private' },
+      crm_case: {
+        name: 'crm_case',
+        label: 'Case',
+        sharingModel: 'controlled_by_parent',
+        fields: { account: { type: 'master_detail', reference: 'crm_account' } },
+      },
+    },
+    draftOnly: [],
+    saved: [],
+  };
+}
+
+function renderPanel(server: Server, extra: Partial<React.ComponentProps<typeof PackageOwdOverviewPanel>> = {}) {
+  return render(
+    <PackageOwdOverviewPanel
+      client={makeClient(server)}
+      packageId="com.example.showcase"
+      locale="en-US"
+      {...extra}
+    />,
+  );
+}
+
+beforeEach(() => {
+  // jsdom has no layout — stub the scroll used by the deep-link highlight.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+afterEach(cleanup);
+
+describe('PackageOwdOverviewPanel — list render', () => {
+  it('lists every package object with its OWD baseline value', async () => {
+    renderPanel(freshServer());
+    await screen.findByTestId('owd-row-crm_account');
+    expect(screen.getByTestId('owd-row-crm_contact')).toBeTruthy();
+    expect(screen.getByTestId('owd-row-crm_case')).toBeTruthy();
+    expect((screen.getByTestId('owd-internal-crm_account') as HTMLSelectElement).value).toBe('public_read_write');
+    expect((screen.getByTestId('owd-internal-crm_contact') as HTMLSelectElement).value).toBe('private');
+  });
+
+  it('includes draft-only objects from listDrafts', async () => {
+    const server = freshServer();
+    server.draftOnly = ['crm_new'];
+    server.objects.crm_new = {}; // no published baseline, but layered returns {} → row still renders
+    renderPanel(server);
+    expect(await screen.findByTestId('owd-row-crm_new')).toBeTruthy();
+  });
+});
+
+describe('PackageOwdOverviewPanel — edit → per-object draft', () => {
+  it('saves only the changed object as a package-scoped draft', async () => {
+    const server = freshServer();
+    renderPanel(server);
+    await screen.findByTestId('owd-row-crm_contact');
+
+    // No changes → Save disabled.
+    expect((screen.getByTestId('owd-save') as HTMLButtonElement).disabled).toBe(true);
+
+    // Widen crm_contact private → public_read.
+    fireEvent.change(screen.getByTestId('owd-internal-crm_contact'), { target: { value: 'public_read' } });
+    expect(screen.getByTestId('owd-dirty-crm_contact')).toBeTruthy();
+    expect((screen.getByTestId('owd-save') as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(screen.getByTestId('owd-save'));
+    await waitFor(() => expect(server.saved.length).toBe(1));
+    expect(server.saved[0].name).toBe('crm_contact');
+    expect(server.saved[0].body.sharingModel).toBe('public_read');
+    expect(server.saved[0].opts).toMatchObject({ mode: 'draft', packageId: 'com.example.showcase' });
+    // Untouched objects are not written.
+    expect(server.saved.every((s) => s.name !== 'crm_account')).toBe(true);
+  });
+
+  it('drops the key when a model is cleared back to unset', async () => {
+    const server = freshServer();
+    renderPanel(server);
+    await screen.findByTestId('owd-row-crm_account');
+    fireEvent.change(screen.getByTestId('owd-internal-crm_account'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('owd-save'));
+    await waitFor(() => expect(server.saved.length).toBe(1));
+    expect('sharingModel' in server.saved[0].body).toBe(false);
+  });
+});
+
+describe('PackageOwdOverviewPanel — validation (ADR-0090 D11)', () => {
+  it('blocks Save inline when external is wider than internal', async () => {
+    const server = freshServer();
+    renderPanel(server);
+    await screen.findByTestId('owd-row-crm_contact');
+    // internal private, external public_read → wider.
+    fireEvent.change(screen.getByTestId('owd-external-crm_contact'), { target: { value: 'public_read' } });
+    expect(screen.getByTestId('owd-error-crm_contact')).toBeTruthy();
+    expect(screen.getByTestId('owd-invalid-banner')).toBeTruthy();
+    expect((screen.getByTestId('owd-save') as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe('PackageOwdOverviewPanel — controlled_by_parent', () => {
+  it('shows the master link and no external dial', async () => {
+    renderPanel(freshServer());
+    await screen.findByTestId('owd-row-crm_case');
+    const master = screen.getByTestId('owd-master-crm_case');
+    expect(master.textContent).toMatch(/crm_account/);
+    // No external select on a controlled_by_parent row.
+    expect(screen.queryByTestId('owd-external-crm_case')).toBeNull();
+  });
+});
+
+describe('PackageOwdOverviewPanel — read-only', () => {
+  it('renders badges only, with no editing affordances', async () => {
+    renderPanel(freshServer(), { readOnly: true });
+    await screen.findByTestId('owd-row-crm_account');
+    expect(screen.queryByTestId('owd-save')).toBeNull();
+    expect(screen.queryByTestId('owd-internal-crm_account')).toBeNull();
+    // The value is still shown as text.
+    const row = within(screen.getByTestId('owd-row-crm_account'));
+    expect(row.getByText(/Public read\/write/)).toBeTruthy();
+  });
+});
+
+describe('PackageOwdOverviewPanel — deep-link highlight', () => {
+  it('marks the highlighted object row', async () => {
+    renderPanel(freshServer(), { highlightObject: 'crm_contact' });
+    const row = await screen.findByTestId('owd-row-crm_contact');
+    expect(row.className).toMatch(/bg-primary/);
+  });
+});

--- a/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx
@@ -1,0 +1,425 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * PackageOwdOverviewPanel — the package-scoped Record Sharing Baseline (OWD)
+ * overview (objectui#2505).
+ *
+ * A sibling surface in the Studio Access pillar, next to the permission-set
+ * rail. Where the per-object Settings tab (`ObjectSettingsPanel`) edits one
+ * object's `sharingModel` / `externalSharingModel` at a time, this table
+ * surveys — and batch-edits — the OWD baseline of EVERY object the package
+ * owns (published ∪ pending drafts, the same merge the pillars do).
+ *
+ * Ownership boundary (ADR-0090 / permission-model.md): every row here has the
+ * same owner — the package author. This is an aggregation of N per-object
+ * editing entry points within one ownership boundary, NOT a merge of OWD into
+ * the per-principal permission-set matrix (which was considered and rejected).
+ * It has no principal dimension.
+ *
+ *   • Save = per-object metadata DRAFTs under the package scope — byte-for-byte
+ *     what the per-object Settings tab writes, just N objects in one action.
+ *     Publish then flows through the unchanged package security-domain gate.
+ *   • Row validation `external ≤ internal` (ADR-0090 D11) is surfaced inline
+ *     and blocks Save, reusing `isExternalWider` from `owd-sharing.ts`.
+ *   • `controlled_by_parent` rows show the master link (read-only) instead of
+ *     an external dial, mirroring the per-object settings behavior.
+ *   • Read-only packages render badges only (the pillar's courtesy gate).
+ */
+
+import * as React from 'react';
+import { ShieldCheck, Save, Loader2, Lock, ArrowUpRight, AlertTriangle } from 'lucide-react';
+import type { MetadataClient } from '@object-ui/data-objectstack';
+import { t, tFormat, type SupportedLocale } from '../metadata-admin/i18n';
+import { formatMetadataError } from './metadataError';
+import { isExternalWider, deriveMasterObject } from './owd-sharing';
+import { toast } from 'sonner';
+
+/** Normalize the framework draft envelope `{ type, name, item }` → body | null. */
+function extractDraftBody(resp: unknown): Record<string, unknown> | null {
+  if (!resp || typeof resp !== 'object') return null;
+  const env = resp as Record<string, unknown>;
+  if (!('item' in env)) return null;
+  const body = env.item;
+  if (!body || typeof body !== 'object') return null;
+  return Object.keys(body as object).length > 0 ? (body as Record<string, unknown>) : null;
+}
+
+/** A single object's loaded OWD baseline (already merged over any pending draft). */
+interface OwdRow {
+  name: string;
+  label: string;
+  /** Authored `sharingModel`; '' when unset (defaults to private, ADR-0090 D1). */
+  internal: string;
+  /** Authored `externalSharingModel`; '' when unset. */
+  external: string;
+  /** Master (parent) object for `controlled_by_parent` rows, if resolvable. */
+  master?: string;
+  /** True when this object already has an unpublished draft. */
+  hasDraft: boolean;
+}
+
+/** The user's working value for one row ('' = unset). */
+interface OwdEdit {
+  internal: string;
+  external: string;
+}
+
+const OWD_OPTION_KEYS: ReadonlyArray<{ value: string; key: string }> = [
+  { value: 'private', key: 'engine.studio.settings.sharingPrivate' },
+  { value: 'public_read', key: 'engine.studio.settings.sharingPublicRead' },
+  { value: 'public_read_write', key: 'engine.studio.settings.sharingPublicReadWrite' },
+  { value: 'controlled_by_parent', key: 'engine.studio.settings.sharingControlledByParent' },
+];
+
+/** Short localized label for an OWD value; unset → "(not set — defaults to Private)". */
+function owdLabel(value: string, locale: SupportedLocale): string {
+  if (!value) return t('engine.studio.settings.sharingUnset', locale);
+  const hit = OWD_OPTION_KEYS.find((o) => o.value === value);
+  return hit ? t(hit.key, locale) : value;
+}
+
+export interface PackageOwdOverviewPanelProps {
+  client: MetadataClient;
+  packageId: string;
+  /** Bumped on package publish → re-read the freshly published baseline. */
+  publishNonce?: number;
+  /** Notify the surface so its pending-changes counter refreshes after a save. */
+  onDraftSaved?: () => void;
+  /** Courtesy gate: read-only packages render badges only (ADR-0057 D10). */
+  readOnly?: boolean;
+  locale: SupportedLocale;
+  /** Object to scroll to / highlight (deep-link from the permission matrix badge). */
+  highlightObject?: string | null;
+}
+
+export function PackageOwdOverviewPanel({
+  client,
+  packageId,
+  publishNonce = 0,
+  onDraftSaved,
+  readOnly = false,
+  locale,
+  highlightObject,
+}: PackageOwdOverviewPanelProps): React.ReactElement {
+  const [rows, setRows] = React.useState<OwdRow[]>([]);
+  const [edits, setEdits] = React.useState<Record<string, OwdEdit>>({});
+  const [loaded, setLoaded] = React.useState(false);
+  const [loadError, setLoadError] = React.useState<string | null>(null);
+  const [saving, setSaving] = React.useState(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoaded(false);
+    setLoadError(null);
+    try {
+      // Objects this package owns: published records ∪ pending draft headers
+      // (the same union the Data / Access rails build). `list()` sees published
+      // metadata only, so a draft-only object appears via `listDrafts()`.
+      const [list, draftHeaders] = await Promise.all([
+        client.list<Record<string, unknown>>('object', { packageId }),
+        client.listDrafts({ packageId, type: 'object' }).catch(() => [] as Array<{ name?: string }>),
+      ]);
+      const publishedLabel = new Map<string, string>();
+      const names: string[] = [];
+      const seen = new Set<string>();
+      for (const raw of list || []) {
+        const item = ((raw as { item?: unknown }).item ?? raw) as Record<string, unknown>;
+        const name = String(item.name ?? '');
+        if (!name || seen.has(name)) continue;
+        seen.add(name);
+        names.push(name);
+        publishedLabel.set(name, String(item.label ?? name));
+      }
+      for (const d of draftHeaders || []) {
+        const name = String(d?.name ?? '');
+        if (!name || seen.has(name)) continue;
+        seen.add(name);
+        names.push(name);
+      }
+
+      // The list row carries `sharingModel` but not reliably `fields` (needed
+      // for the master link), and never the pending-draft value — so read each
+      // object's merged body (layered ∪ its draft), exactly as the per-object
+      // Settings tab does, and derive every column from that one source.
+      const built = await Promise.all(
+        names.map(async (name): Promise<OwdRow> => {
+          const [layRaw, draftResp] = await Promise.all([
+            client.layered<Record<string, unknown>>('object', name).catch(() => null),
+            client.getDraft<Record<string, unknown>>('object', name).catch(() => null),
+          ]);
+          const lay = (layRaw ?? {}) as { effective?: Record<string, unknown>; code?: Record<string, unknown> };
+          const baseline = (lay.effective ?? lay.code ?? {}) as Record<string, unknown>;
+          const draftBody = extractDraftBody(draftResp);
+          const body = draftBody ? { ...baseline, ...draftBody } : baseline;
+          const internal = typeof body.sharingModel === 'string' ? body.sharingModel : '';
+          return {
+            name,
+            label: String(body.label ?? publishedLabel.get(name) ?? name),
+            internal,
+            external: typeof body.externalSharingModel === 'string' ? body.externalSharingModel : '',
+            master: internal === 'controlled_by_parent' ? deriveMasterObject(body.fields) : undefined,
+            hasDraft: !!draftBody,
+          };
+        }),
+      );
+      built.sort((a, b) => a.label.localeCompare(b.label) || a.name.localeCompare(b.name));
+      setRows(built);
+      // Reset working edits to the freshly loaded baseline.
+      setEdits(Object.fromEntries(built.map((r) => [r.name, { internal: r.internal, external: r.external }])));
+    } catch (e) {
+      setLoadError(formatMetadataError(e));
+    } finally {
+      setLoaded(true);
+    }
+  }, [client, packageId]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load, publishNonce]);
+
+  // Deep-link highlight — scroll the linked object's row into view.
+  const rowRefs = React.useRef<Record<string, HTMLTableRowElement | null>>({});
+  React.useEffect(() => {
+    if (!highlightObject || !loaded) return;
+    const el = rowRefs.current[highlightObject];
+    if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [highlightObject, loaded]);
+
+  const setEdit = React.useCallback((name: string, patch: Partial<OwdEdit>) => {
+    setEdits((prev) => ({ ...prev, [name]: { ...prev[name], ...patch } }));
+  }, []);
+
+  // A row is dirty when its working value differs from the loaded baseline;
+  // invalid when the external baseline is wider than the internal one (D11).
+  const rowState = React.useMemo(() => {
+    return rows.map((r) => {
+      const e = edits[r.name] ?? { internal: r.internal, external: r.external };
+      const dirty = e.internal !== r.internal || e.external !== r.external;
+      const invalid = isExternalWider(e.internal, e.external);
+      return { row: r, edit: e, dirty, invalid };
+    });
+  }, [rows, edits]);
+
+  const dirtyCount = rowState.filter((s) => s.dirty).length;
+  const hasInvalid = rowState.some((s) => s.invalid);
+
+  const doSave = React.useCallback(async () => {
+    const changed = rowState.filter((s) => s.dirty && !s.invalid);
+    if (changed.length === 0) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      // Each changed row lands as that object's package-scoped DRAFT: read the
+      // fresh merged body, apply just the OWD pair (unset → drop the key), and
+      // save. Identical to the per-object Settings write, N times — publish
+      // then goes through the same package security-domain gate unchanged.
+      for (const s of changed) {
+        const [layRaw, draftResp] = await Promise.all([
+          client.layered<Record<string, unknown>>('object', s.row.name).catch(() => null),
+          client.getDraft<Record<string, unknown>>('object', s.row.name).catch(() => null),
+        ]);
+        const lay = (layRaw ?? {}) as { effective?: Record<string, unknown>; code?: Record<string, unknown> };
+        const baseline = (lay.effective ?? lay.code ?? {}) as Record<string, unknown>;
+        const draftBody = extractDraftBody(draftResp);
+        const next: Record<string, unknown> = { ...baseline, ...(draftBody ?? {}) };
+        if (s.edit.internal) next.sharingModel = s.edit.internal;
+        else delete next.sharingModel;
+        if (s.edit.external) next.externalSharingModel = s.edit.external;
+        else delete next.externalSharingModel;
+        await client.save('object', s.row.name, next, { mode: 'draft', packageId });
+      }
+      toast.success(tFormat('engine.studio.owd.saved', locale, { count: changed.length }));
+      onDraftSaved?.();
+      await load();
+    } catch (e) {
+      setSaveError(formatMetadataError(e));
+    } finally {
+      setSaving(false);
+    }
+  }, [rowState, client, packageId, onDraftSaved, load, locale]);
+
+  const canSave = !readOnly && !saving && dirtyCount > 0 && !hasInvalid;
+
+  return (
+    <div className="flex h-full flex-col" data-testid="owd-overview">
+      <div className="flex items-center gap-3 border-b px-4 py-2.5">
+        <span className="flex min-w-0 items-center gap-2">
+          <ShieldCheck className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="truncate text-[15px] font-semibold leading-none text-foreground">
+            {t('engine.studio.owd.title', locale)}
+          </span>
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+            {t('engine.studio.owd.subtitle', locale)}
+          </span>
+        </span>
+        {readOnly ? (
+          <span
+            title={t('engine.studio.pkg.readonlyHint', locale)}
+            className="ml-auto flex items-center gap-1.5 text-[11px] text-muted-foreground"
+          >
+            <Lock className="h-3 w-3" /> {t('engine.studio.pkg.readonly', locale)}
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void doSave()}
+            disabled={!canSave}
+            data-testid="owd-save"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+            {dirtyCount > 0
+              ? tFormat('engine.studio.owd.save', locale, { count: dirtyCount })
+              : t('engine.studio.owd.saveNone', locale)}
+          </button>
+        )}
+      </div>
+
+      <p className="border-b px-4 py-2 text-[11px] text-muted-foreground">
+        {t('engine.studio.owd.description', locale)}
+      </p>
+
+      {hasInvalid && (
+        <p
+          data-testid="owd-invalid-banner"
+          className="flex items-center gap-1.5 border-b bg-amber-400/10 px-4 py-2 text-[11px] text-amber-600 dark:text-amber-400"
+        >
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          {t('engine.studio.owd.blockedSave', locale)}
+        </p>
+      )}
+      {saveError && (
+        <p className="border-b bg-destructive/10 px-4 py-2 text-[11px] text-destructive">{saveError}</p>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        {!loaded ? (
+          <p className="py-16 text-center text-sm text-muted-foreground">{t('engine.studio.loading', locale)}</p>
+        ) : loadError ? (
+          <p className="py-16 text-center text-sm text-muted-foreground">{t('engine.studio.owd.loadFailed', locale)}</p>
+        ) : rows.length === 0 ? (
+          <p className="py-16 text-center text-sm text-muted-foreground">{t('engine.studio.owd.none', locale)}</p>
+        ) : (
+          <table className="w-full border-collapse text-[12px]">
+            <thead>
+              <tr className="border-b text-left text-[11px] uppercase tracking-wide text-muted-foreground">
+                <th className="px-2 py-1.5 font-medium">{t('engine.studio.owd.colObject', locale)}</th>
+                <th className="px-2 py-1.5 font-medium">{t('engine.studio.owd.colInternal', locale)}</th>
+                <th className="px-2 py-1.5 font-medium">{t('engine.studio.owd.colExternal', locale)}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rowState.map(({ row, edit, dirty, invalid }) => {
+                const isParent = edit.internal === 'controlled_by_parent';
+                return (
+                  <tr
+                    key={row.name}
+                    ref={(el) => {
+                      rowRefs.current[row.name] = el;
+                    }}
+                    data-testid={`owd-row-${row.name}`}
+                    className={
+                      'border-b align-top ' +
+                      (highlightObject === row.name ? 'bg-primary/5' : '')
+                    }
+                  >
+                    <td className="px-2 py-2">
+                      <span className="flex flex-col gap-0.5">
+                        <span className="flex items-center gap-1.5">
+                          <span className="font-medium text-foreground">{row.label}</span>
+                          {dirty && (
+                            <span
+                              data-testid={`owd-dirty-${row.name}`}
+                              className="rounded bg-amber-400/15 px-1.5 py-0.5 text-[10px] text-amber-600 dark:text-amber-300"
+                            >
+                              {t('engine.studio.owd.unsaved', locale)}
+                            </span>
+                          )}
+                          {row.hasDraft && !dirty && (
+                            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                              {t('engine.studio.unpublishedDraft', locale)}
+                            </span>
+                          )}
+                        </span>
+                        <span className="font-mono text-[10px] text-muted-foreground">{row.name}</span>
+                      </span>
+                    </td>
+
+                    {/* Internal (sharingModel) */}
+                    <td className="px-2 py-2">
+                      {readOnly ? (
+                        <span className="text-muted-foreground">{owdLabel(edit.internal, locale)}</span>
+                      ) : (
+                        <select
+                          value={edit.internal}
+                          data-testid={`owd-internal-${row.name}`}
+                          onChange={(e) => setEdit(row.name, { internal: e.target.value })}
+                          className="w-full min-w-[13rem] rounded border bg-background px-2 py-1 text-[12px]"
+                        >
+                          <option value="">{t('engine.studio.settings.sharingUnset', locale)}</option>
+                          {OWD_OPTION_KEYS.map((o) => (
+                            <option key={o.value} value={o.value}>
+                              {t(o.key, locale)}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </td>
+
+                    {/* External (externalSharingModel) — or the master link for
+                        controlled_by_parent rows (no external dial). */}
+                    <td className="px-2 py-2">
+                      {isParent ? (
+                        <span
+                          data-testid={`owd-master-${row.name}`}
+                          title={t('engine.studio.owd.masterTip', locale)}
+                          className="inline-flex items-center gap-1 text-muted-foreground"
+                        >
+                          <ArrowUpRight className="h-3.5 w-3.5" />
+                          {row.master
+                            ? tFormat('engine.studio.owd.byParent', locale, { master: row.master })
+                            : t('engine.studio.owd.byParentUnknown', locale)}
+                        </span>
+                      ) : readOnly ? (
+                        <span className="text-muted-foreground">{owdLabel(edit.external, locale)}</span>
+                      ) : (
+                        <>
+                          <select
+                            value={edit.external}
+                            data-testid={`owd-external-${row.name}`}
+                            onChange={(e) => setEdit(row.name, { external: e.target.value })}
+                            className={
+                              'w-full min-w-[13rem] rounded border bg-background px-2 py-1 text-[12px] ' +
+                              (invalid ? 'border-amber-500' : '')
+                            }
+                          >
+                            <option value="">{t('engine.studio.settings.sharingExternalUnset', locale)}</option>
+                            {OWD_OPTION_KEYS.filter((o) => o.value !== 'controlled_by_parent').map((o) => (
+                              <option key={o.value} value={o.value}>
+                                {t(o.key, locale)}
+                              </option>
+                            ))}
+                          </select>
+                          {invalid && (
+                            <span
+                              data-testid={`owd-error-${row.name}`}
+                              className="mt-1 block text-[11px] text-amber-600 dark:text-amber-500"
+                            >
+                              {t('engine.studio.owd.widerError', locale)}
+                            </span>
+                          )}
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PackageOwdOverviewPanel;

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -62,6 +62,7 @@ import {
   ExternalLink,
   Home as HomeIcon,
   Shield,
+  ShieldCheck,
   ShieldQuestion,
   Menu,
   PanelRightClose,
@@ -104,6 +105,7 @@ import { ObjectFormDesigner } from './ObjectFormDesigner';
 import { ObjectGroupInspector } from './ObjectGroupInspector';
 import { ObjectValidationsPanel } from './ObjectValidationsPanel';
 import { ObjectSettingsPanel } from './ObjectSettingsPanel';
+import { PackageOwdOverviewPanel } from './PackageOwdOverviewPanel';
 import { ObjectApiPanel } from './ObjectApiPanel';
 import { ObjectHooksPanel } from './ObjectHooksPanel';
 import { ObjectActionsPanel } from './ObjectActionsPanel';
@@ -3051,12 +3053,24 @@ function AccessPillar({
   const [loaded, setLoaded] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [current, setCurrent] = React.useState<string | null>(null);
-  // `?surface=permission:<name>` capture + mirror — shared plumbing (see
-  // useSurfaceDeepLink). This rail keys `current` by name, so wrap it in the
-  // surface identity the param carries.
+  // The Record Sharing Baseline (OWD) overview is a sibling surface to the
+  // permission-set matrix (objectui#2505) — same package-author ownership
+  // boundary, no principal dimension. `owdOpen` swaps the main panel to it;
+  // `owdHighlight` carries the object a permission-matrix badge deep-linked to.
+  const [owdOpen, setOwdOpen] = React.useState(false);
+  const [owdHighlight, setOwdHighlight] = React.useState<string | null>(null);
+  const appliedOwdDeepLink = React.useRef(false);
+  // `?surface=permission:<name>` / `?surface=owd:overview` capture + mirror —
+  // shared plumbing (see useSurfaceDeepLink). This rail keys `current` by name,
+  // so wrap the open surface in the identity the param carries.
   const currentSurface = React.useMemo(
-    () => (current ? { type: 'permission', name: current } : null),
-    [current],
+    () =>
+      owdOpen
+        ? { type: 'owd', name: 'overview' }
+        : current
+          ? { type: 'permission', name: current }
+          : null,
+    [owdOpen, current],
   );
   const initialSurface = useSurfaceDeepLink(currentSurface);
   const [query, setQuery] = React.useState('');
@@ -3102,6 +3116,14 @@ function AccessPillar({
       }
       const scoped = [...byName.values()];
       setPerms(scoped);
+      // A `?surface=owd:overview` deep-link opens the OWD overview instead of a
+      // permission set; `current` still defaults to the first set so switching
+      // back to the matrix has a target. Applied once — a later publish re-runs
+      // `load`, and we must not yank the user back to OWD then.
+      if (!appliedOwdDeepLink.current && initialSurface?.type === 'owd') {
+        appliedOwdDeepLink.current = true;
+        setOwdOpen(true);
+      }
       const deepLinked = resolveSurfaceDeepLink(scoped, initialSurface, 'permission');
       setCurrent((c) => c ?? deepLinked?.name ?? scoped[0]?.name ?? null);
     } catch (e) {
@@ -3224,6 +3246,26 @@ function AccessPillar({
             isMobile && !railOpen && '-translate-x-full',
           )}
         >
+          {/* Pinned sibling surface: the package-wide Record Sharing Baseline
+              (OWD) overview (objectui#2505). Same package-author ownership as
+              the sets below, but a distinct surface — not a permission set. */}
+          <div className="border-b p-2 pb-2">
+            <button
+              type="button"
+              onClick={() => {
+                setOwdOpen(true);
+                setOwdHighlight(null);
+                if (isMobile) setRailOpen(false);
+              }}
+              className={
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs ' +
+                (owdOpen ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
+              }
+            >
+              <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="flex-1 truncate">{t('engine.studio.owd.railLabel', locale)}</span>
+            </button>
+          </div>
           <div className="p-2 pb-0">
             <p className="px-2 pb-1 pt-1 text-[11px] font-medium text-muted-foreground">{t('engine.studio.access.heading', locale)}</p>
             <input
@@ -3243,12 +3285,13 @@ function AccessPillar({
               <button
                 key={p.name}
                 onClick={() => {
+                  setOwdOpen(false);
                   setCurrent(p.name);
                   if (isMobile) setRailOpen(false);
                 }}
                 className={
                   'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs ' +
-                  (current === p.name ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
+                  (!owdOpen && current === p.name ? 'bg-muted font-medium' : 'text-foreground/90 hover:bg-muted/60')
                 }
               >
                 <Shield className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
@@ -3285,10 +3328,24 @@ function AccessPillar({
         </nav>
 
         <main className="min-w-0 flex-1 overflow-auto">
-          {current ? (
+          {owdOpen ? (
+            /* Sibling surface: the package-wide OWD baseline overview
+             * (objectui#2505) — object × sharingModel × externalSharingModel,
+             * batch-edited as per-object drafts. */
+            <PackageOwdOverviewPanel
+              client={client}
+              packageId={packageId}
+              publishNonce={publishNonce}
+              onDraftSaved={onDraftSaved}
+              readOnly={readOnly}
+              locale={locale}
+              highlightObject={owdHighlight}
+            />
+          ) : current ? (
             /* The existing Salesforce-style matrix page, embedded unchanged —
              * objects × CRUD/VAMA/lifecycle up top, per-object field-level R/W
-             * below, its own Save + destructive-change guard included. */
+             * below, its own Save + destructive-change guard included. The
+             * read-only OWD badge deep-links to the overview above. */
             <PermissionMatrixEditPage
               key={current}
               type="permission"
@@ -3296,6 +3353,10 @@ function AccessPillar({
               packageId={packageId}
               publishNonce={publishNonce}
               onDraftSaved={onDraftSaved}
+              onOpenOwd={(objectName) => {
+                setOwdHighlight(objectName || null);
+                setOwdOpen(true);
+              }}
             />
           ) : (
             <div className="py-16 text-center text-sm text-muted-foreground">

--- a/packages/app-shell/src/views/studio-design/owd-sharing.test.ts
+++ b/packages/app-shell/src/views/studio-design/owd-sharing.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { OWD_MODELS, OWD_WIDTH, isExternalWider, deriveMasterObject } from './owd-sharing';
+
+describe('owd-sharing — canonical values (ADR-0090 D4)', () => {
+  it('offers exactly the four canonical models', () => {
+    expect([...OWD_MODELS]).toEqual([
+      'private',
+      'public_read',
+      'public_read_write',
+      'controlled_by_parent',
+    ]);
+  });
+
+  it('orders only the three org-wide-visible models on the width axis', () => {
+    expect(OWD_WIDTH).toEqual({ private: 0, public_read: 1, public_read_write: 2 });
+    // controlled_by_parent deliberately has no width — it delegates to the master.
+    expect('controlled_by_parent' in OWD_WIDTH).toBe(false);
+  });
+});
+
+describe('owd-sharing — isExternalWider (ADR-0090 D11)', () => {
+  it('flags an external baseline wider than the internal one', () => {
+    expect(isExternalWider('public_read', 'public_read_write')).toBe(true);
+    expect(isExternalWider('private', 'public_read')).toBe(true);
+  });
+
+  it('stays calm when external ≤ internal', () => {
+    expect(isExternalWider('public_read_write', 'public_read')).toBe(false);
+    expect(isExternalWider('public_read', 'public_read')).toBe(false);
+    expect(isExternalWider('private', 'private')).toBe(false);
+  });
+
+  it('never trips on off-axis values (unset / controlled_by_parent)', () => {
+    expect(isExternalWider('', 'public_read_write')).toBe(false);
+    expect(isExternalWider('private', '')).toBe(false);
+    expect(isExternalWider('controlled_by_parent', 'public_read_write')).toBe(false);
+    expect(isExternalWider('private', 'controlled_by_parent')).toBe(false);
+  });
+});
+
+describe('owd-sharing — deriveMasterObject', () => {
+  it('reads the master-detail reference from a keyed-map fields shape', () => {
+    const fields = {
+      name: { type: 'text' },
+      account: { type: 'master_detail', reference: 'crm_account' },
+    };
+    expect(deriveMasterObject(fields)).toBe('crm_account');
+  });
+
+  it('reads it from an array fields shape', () => {
+    const fields = [
+      { name: 'name', type: 'text' },
+      { name: 'parent', type: 'master_detail', reference: 'crm_case' },
+    ];
+    expect(deriveMasterObject(fields)).toBe('crm_case');
+  });
+
+  it('returns undefined when there is no master-detail field', () => {
+    expect(deriveMasterObject({ name: { type: 'text' } })).toBeUndefined();
+    expect(deriveMasterObject(undefined)).toBeUndefined();
+    // A master-detail field without a reference target resolves to undefined.
+    expect(deriveMasterObject({ p: { type: 'master_detail' } })).toBeUndefined();
+  });
+});

--- a/packages/app-shell/src/views/studio-design/owd-sharing.ts
+++ b/packages/app-shell/src/views/studio-design/owd-sharing.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Shared org-wide-default (OWD) helpers for the Studio authoring surfaces.
+ *
+ * The per-object Settings tab (`ObjectSettingsPanel`) and the package-level
+ * OWD overview (`PackageOwdOverviewPanel`) both edit the SAME record-sharing
+ * baseline — `sharingModel` / `externalSharingModel` (ADR-0090 D1/D4/D11).
+ * This module is the single home for the pieces they must agree on: the
+ * canonical value set, the D11 "external ≤ internal" width comparison, and
+ * the master-object derivation used for `controlled_by_parent` rows. Pure and
+ * DOM-free, so both surfaces can share one validated implementation.
+ */
+
+import { readFields } from '../metadata-admin/previews/object-fields-io';
+
+/**
+ * The four canonical OWD values (ADR-0090 D4). The legacy `read` / `read_write`
+ * / `full` aliases are rejected at authoring time, so authoring surfaces only
+ * ever offer these.
+ */
+export const OWD_MODELS = [
+  'private',
+  'public_read',
+  'public_read_write',
+  'controlled_by_parent',
+] as const;
+export type OwdModel = (typeof OWD_MODELS)[number];
+
+/**
+ * Relative WIDTH of the three org-wide-visible models — the D11 axis for
+ * "external must never be wider than internal". `controlled_by_parent` is
+ * deliberately absent: it delegates the baseline to the master record, so it
+ * has no place on the private < read < write ordering (mirrors the
+ * comparison ObjectSettingsPanel implemented inline).
+ */
+export const OWD_WIDTH: Record<string, number> = {
+  private: 0,
+  public_read: 1,
+  public_read_write: 2,
+};
+
+/**
+ * True when `external` sits WIDER than `internal` on the OWD_WIDTH axis — the
+ * ADR-0090 D11 violation the publish linter rejects. Values off the axis
+ * (unset, `controlled_by_parent`) never trip it.
+ */
+export function isExternalWider(
+  internal: string | undefined,
+  external: string | undefined,
+): boolean {
+  return (
+    !!external &&
+    external in OWD_WIDTH &&
+    !!internal &&
+    internal in OWD_WIDTH &&
+    OWD_WIDTH[external] > OWD_WIDTH[internal]
+  );
+}
+
+/**
+ * The master (parent) object a `controlled_by_parent` child inherits its
+ * baseline from: the `reference` target of the object's first master-detail
+ * field. Returns undefined when the object declares none (an authoring error
+ * the lint catches — surfaced here so the overview can still render the row).
+ */
+export function deriveMasterObject(fields: unknown): string | undefined {
+  for (const e of readFields(fields).entries) {
+    if ((e.def.type ?? '') === 'master_detail') {
+      const ref = e.def.reference;
+      if (typeof ref === 'string' && ref) return ref;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Closes #2505.

## Problem

A package author can only inspect and edit an object's record-sharing baseline (OWD — `sharingModel` / `externalSharingModel`) **one object at a time**, via Data → object → *Settings*. A package with 20 objects requires opening 20 settings pages to audit its baseline posture, so in practice nobody does — and "which of my objects are org-wide writable?" can't be answered at a glance (ADR-0090 D1's silent-widening failure class is invisible object-by-object).

## What this adds

A package-scoped **"Record Sharing Baseline (OWD)" panel** in the Studio **Access pillar**, as a sibling surface next to the permission-set rail (not inside the permission matrix):

- **Table of object × `sharingModel` × `externalSharingModel`** covering every object the package owns (published ∪ pending drafts — the same merge the pillars do).
- **Inline selects** using the canonical four values (`private | public_read | public_read_write | controlled_by_parent`), reusing the option labels / help copy from `ObjectSettingsPanel`.
- `controlled_by_parent` rows show the **master link** (read-only) instead of an external dial, mirroring the per-object settings behavior.
- Row-level **`external ≤ internal` validation** (ADR-0090 D11) surfaced inline; it blocks Save.
- **Save = per-object metadata drafts** under the package scope — exactly what the per-object Settings tab writes, just N objects in one action. Publish then flows through the existing security-domain gate unchanged.
- **Deep-linkable** via the existing `?surface=` plumbing (`owd:overview`); the read-only OWD badge in `PermissionMatrixEditor` now links here, scrolled to the object.
- **Read-only packages** render the table non-editable (badges only), following the pillar's courtesy gate.

This stays within one ownership boundary (every row's owner is the package author) — it is an aggregation of N per-object editing entry points, **not** a merge of OWD into the per-principal permission-set matrix.

## Changes

- `views/studio-design/owd-sharing.ts` (new) — shared `OWD_MODELS`, `OWD_WIDTH` axis, `isExternalWider` (D11), `deriveMasterObject`.
- `views/studio-design/PackageOwdOverviewPanel.tsx` (new) — the overview surface.
- `views/studio-design/StudioDesignSurface.tsx` — `AccessPillar` hosts the panel via a pinned rail entry + `?surface=owd:overview` deep-link; passes `onOpenOwd` to the matrix.
- `views/metadata-admin/PermissionMatrixEditor.tsx` — optional `onOpenOwd`; the OWD badge becomes a link when provided (plain chip otherwise, so environment-scope / metadata-admin usage is unchanged).
- `views/metadata-admin/i18n.ts` — EN + ZH strings.

## Non-goals (per the issue)

- No package-level default OWD with inheritance (would reintroduce the ambient "unset" state ADR-0090 D1 abolished).
- Not merging OWD editing into the permission-set matrix (its badge stays read-only, now linkable).
- No `enable.*` capability switches, and no changes to enforcement, lint, or the publish pipeline.

## Verification

- ADR-0054 testability proofs (`PackageOwdOverviewPanel.test.tsx`): list render, edit→per-object draft (with `mode: 'draft'` + `packageId`, unset drops the key), `external > internal` blocks Save inline, `controlled_by_parent` shows the master and no external dial, read-only badges only, deep-link highlight.
- Unit tests for the shared helpers (`owd-sharing.test.ts`).
- `tsc --noEmit` clean (turbo, 29/29). ESLint 0 errors. **16 new tests**; full `studio-design` + `PermissionMatrixEditor` suites green (**86 passed**).

## References

- framework ADR-0090 (Permission Model v2 — D1/D4/D11) · `docs/design/permission-model.md`
- objectui ADR-0056, #2348, #2403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wYveoZSpRweBkvXMY5Gg6

---
_Generated by [Claude Code](https://claude.ai/code/session_014wYveoZSpRweBkvXMY5Gg6)_