### PR TITLE
fix(plugin-list): userFilters 胶囊保留作者标签,不被 i18n 骨架翻译覆盖 (framework#2951)

### DIFF
--- a/packages/plugin-list/src/UserFilters.tsx
+++ b/packages/plugin-list/src/UserFilters.tsx
@@ -239,7 +239,16 @@ function resolveFields(
     let resolvedLabel = f.label ?? objectLabel;
     if (i18n?.objectName) {
       options = i18n.translateOptions(i18n.objectName, f.field, options as any) as ResolvedOption[];
-      resolvedLabel = i18n.fieldLabel(i18n.objectName, f.field, f.label || objectLabel || f.field);
+      const authored = f.label || objectLabel;
+      const resolved = i18n.fieldLabel(i18n.objectName, f.field, authored || f.field);
+      // Guard against auto-extracted skeleton entries: `os i18n extract` emits
+      // `fields.<obj>.<field> = "<field>"` for fields with no authored label, and
+      // the resolver happily returns that key-valued "translation" — clobbering
+      // an explicitly authored `f.label` (e.g. '项目类型' → 'project_type'). A
+      // translation equal to the raw field key carries no information, so keep the
+      // authored label when the resolver only found the skeleton. A *real*
+      // translation (differs from the key) still wins, preserving localization.
+      resolvedLabel = resolved === f.field && authored ? authored : resolved;
     }
 
     return {

--- a/packages/plugin-list/src/UserFilters.tsx
+++ b/packages/plugin-list/src/UserFilters.tsx
@@ -179,6 +179,10 @@ function resolveFields(
     let referenceTo: string | undefined;
     let displayField: string | undefined;
     let idField: string | undefined;
+    // Object-level field label from objectDef, used as a fallback when the
+    // view author didn't supply `f.label` (or it was stripped during compile).
+    // Without this the chip degrades to the raw snake_case field key.
+    let objectLabel: string | undefined;
 
     if (objectDef?.fields) {
       const fieldDef =
@@ -188,6 +192,7 @@ function resolveFields(
       if (fieldDef) {
         // Adopt field type from objectDef when caller didn't specify
         if (!resolvedType) resolvedType = fieldDef.type;
+        objectLabel = fieldDef.label;
         // Capture lookup metadata regardless of caller-specified type
         referenceTo = fieldDef.reference_to ?? fieldDef.reference;
         displayField = fieldDef.display_field ?? fieldDef.reference_field;
@@ -226,11 +231,15 @@ function resolveFields(
       }));
     }
 
-    // i18n: translate option labels and field label via the resolver
-    let resolvedLabel = f.label;
+    // i18n: translate option labels and field label via the resolver.
+    // Fallback chain for the displayed label: author-supplied `f.label` →
+    // objectDef's `label` → raw field key. The i18n resolver takes the same
+    // chain as its untranslated fallback so a stripped/omitted `f.label` still
+    // renders a human label instead of the snake_case key.
+    let resolvedLabel = f.label ?? objectLabel;
     if (i18n?.objectName) {
       options = i18n.translateOptions(i18n.objectName, f.field, options as any) as ResolvedOption[];
-      resolvedLabel = i18n.fieldLabel(i18n.objectName, f.field, f.label || f.field);
+      resolvedLabel = i18n.fieldLabel(i18n.objectName, f.field, f.label || objectLabel || f.field);
     }
 
     return {

--- a/packages/plugin-list/src/__tests__/UserFilters.test.tsx
+++ b/packages/plugin-list/src/__tests__/UserFilters.test.tsx
@@ -139,3 +139,70 @@ describe('UserFilters — selection persistence (ADR-0047)', () => {
     expect(onSelectionsChange).toHaveBeenCalledWith({ _tab: ['urgent'] });
   });
 });
+
+describe('UserFilters — dropdown chip label fallback', () => {
+  it('falls back to the objectDef field label when the view omits f.label', () => {
+    // Compile can strip `label` off userFilters.fields; the chip must not
+    // degrade to the raw snake_case key when the object still knows the label.
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'status' }] }}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('filter-badge-status').textContent).toContain('Status');
+    expect(screen.getByTestId('filter-badge-status').textContent).not.toContain('status');
+  });
+
+  it('prefers an author-supplied f.label over the objectDef label', () => {
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'status', label: 'Stage' }] }}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('filter-badge-status').textContent).toContain('Stage');
+  });
+
+  it('renders the author-supplied label verbatim (issue repro: explicit label must not degrade to key)', () => {
+    // Mirrors the reported config: fields carry an explicit Chinese label.
+    // The chip must show the label, never the snake_case field key.
+    render(
+      <UserFilters
+        config={{
+          element: 'dropdown',
+          fields: [
+            { field: 'project_type', label: '项目类型' },
+            { field: 'manager', label: '管理责任人' },
+          ],
+        }}
+        objectDef={{ name: 'projects', fields: { project_type: { type: 'select' }, manager: { type: 'lookup' } } }}
+        data={[]}
+        onFilterChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('filter-badge-project_type').textContent).toContain('项目类型');
+    expect(screen.getByTestId('filter-badge-project_type').textContent).not.toContain('project_type');
+    expect(screen.getByTestId('filter-badge-manager').textContent).toContain('管理责任人');
+  });
+
+  it('falls back to the raw field key when neither a label nor an objectDef entry exists', () => {
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'orphan_field', options: [{ label: 'X', value: 'x' }] }] }}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('filter-badge-orphan_field').textContent).toContain('orphan_field');
+  });
+});

--- a/packages/plugin-list/src/__tests__/UserFilters.test.tsx
+++ b/packages/plugin-list/src/__tests__/UserFilters.test.tsx
@@ -9,6 +9,7 @@
 import * as React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
 import { UserFilters } from '../UserFilters';
 
 const objectDef = {
@@ -204,5 +205,63 @@ describe('UserFilters — dropdown chip label fallback', () => {
     );
 
     expect(screen.getByTestId('filter-badge-orphan_field').textContent).toContain('orphan_field');
+  });
+});
+
+describe('UserFilters — i18n resolver overrides an explicit author label (regression)', () => {
+  // A tenant's translation bundle often carries auto-extracted skeleton entries
+  // where the value equals the field key (e.g. `os i18n extract` emits
+  // `fields.<obj>.<field> = "<field>"` when the field has no authored label).
+  // The dropdown chip runs the author-supplied `f.label` through the
+  // convention-based `fieldLabel` resolver as the *fallback*, but the resolver
+  // returns any matching bundle entry — including a key-valued skeleton — which
+  // then OVERRIDES the explicit label. This is the mechanism behind the reported
+  // symptom: chips render raw snake_case keys despite the config declaring
+  // Chinese labels.
+  const withBundle = (bundle: Record<string, unknown>) =>
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      return (
+        <I18nProvider
+          config={{
+            defaultLanguage: 'en',
+            detectBrowserLanguage: false,
+            resources: { en: bundle },
+          }}
+        >
+          {children}
+        </I18nProvider>
+      );
+    };
+
+  it('keeps the explicit label when the bundle only holds a key-valued skeleton', () => {
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'project_type', label: '项目类型' }] }}
+        objectDef={{ name: 'projects', fields: { project_type: { type: 'select' } } }}
+        data={[]}
+        onFilterChange={() => {}}
+      />,
+      // Bundle mirrors an extracted skeleton: value === field key. Before the fix
+      // this clobbered '项目类型' with 'project_type' (the reported symptom).
+      { wrapper: withBundle({ crm: { fields: { projects: { project_type: 'project_type' } } } }) },
+    );
+
+    const chip = screen.getByTestId('filter-badge-project_type').textContent;
+    expect(chip).toContain('项目类型');
+    expect(chip).not.toContain('project_type');
+  });
+
+  it('a real translation still wins (resolver working as intended)', () => {
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'project_type', label: 'Project Type' }] }}
+        objectDef={{ name: 'projects', fields: { project_type: { type: 'select' } } }}
+        data={[]}
+        onFilterChange={() => {}}
+      />,
+      { wrapper: withBundle({ crm: { fields: { projects: { project_type: '项目类型' } } } }) },
+    );
+
+    expect(screen.getByTestId('filter-badge-project_type').textContent).toContain('项目类型');
   });
 });


### PR DESCRIPTION
## 问题

对象列表视图配置 `userFilters`(`element: 'dropdown'`,ADR-0047 值胶囊)后,胶囊标签显示原始字段 key(如 `project_type`),而不是配置的 `label`(如 `项目类型`)或字段的对象级标签。

对应 issue:**objectstack-ai/framework#2951**。

## 根因(经完整链路排查)

issue 提出三个假设,排查结论:

- **② framework 编译/下发剥离 `label`** → **不成立**。已逐层核对 framework `main`:zod schema(`view.zod.ts` `UserFilterFieldSchema`,普通 `z.object`,`label` 为已声明键)→ compile → 容器展开(`structuredClone` 深拷贝)→ registry 原样存储 → `/api/v1/meta/view`(无字段投影)→ i18n translate(仅改顶层 `label`),**每一步都完整保留 `label`**。剥离不在 framework。
- **③ console 缺 `label` 时不回退对象级标签** → **成立**。
- **真正的线上症状**(显式写了 `label` 却显示 key)→ objectui 客户端的 i18n 覆盖:`UserFilters` 胶囊把作者写的 `f.label` 当 fallback 丢进约定式 `fieldLabel()` 解析器,而解析器会返回 bundle 中任何命中的条目 —— **包括 `os i18n extract` 生成的骨架条目 `fields.<对象>.<字段> = "<字段名>"`**,这条"翻译"把显式 label 覆盖成了 key。

## 改动(均在 objectui 客户端)

1. **`UserFilters.tsx` — 骨架翻译不再覆盖显式标签**(commit `387daa4`):解析结果等于原始字段 key 时视为无信息骨架,保留作者写的 label;真实翻译(值 ≠ key)仍生效,本地化能力不丢。修复线上症状。
2. **`UserFilters.tsx` — 缺 label 时回退对象级标签**(commit `510ff7d`):`f.label` 缺失时回退到 objectDef 的字段 `label`,而非 snake_case key。对应 issue ③。

## 测试

`packages/plugin-list/src/__tests__/UserFilters.test.tsx` 新增用例并全绿(11 passed):
- 显式 label 优先于对象级 label;
- 缺 label 时回退对象级 label;
- 二者都缺时才回退裸 key;
- **回归**:注入骨架条目 `project_type: "project_type"` + 配置 `label: '项目类型'`,断言胶囊显示 `项目类型`(修复前显示 `project_type`);
- 真实翻译仍能覆盖显式 label(本地化不回退)。

Refs objectstack-ai/framework#2951
