### PR TITLE
docs: align README positioning — ObjectStack open-source runtime, ObjectOS commercial runtime environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 **Object UI is the View layer of the [ObjectStack](https://github.com/objectstack-ai/framework) ecosystem** — a standalone, schema-driven renderer that turns a JSON schema (or ObjectStack metadata) into production-grade React UI. Use it on its own with any backend, like Amis or Formily — or let it render ObjectStack apps end to end.
 
 ```
-Describe  →  ObjectStack   the metadata protocol
+Describe  →  ObjectStack   the open-source protocol, toolkit & production runtime
 Render    →  Object UI     this repo — JSON / metadata → React UI
-Run       →  ObjectOS      the runtime
+Operate   →  ObjectOS      the commercial runtime environment (Cloud & Enterprise)
 ```
 
 <p align="center">


### PR DESCRIPTION
## 背景

品牌战略调整(配套 framework#2955):ObjectStack = 开源的协议、工具链与生产 runtime;ObjectOS = 商业运行环境(Cloud & Enterprise),无免费版。README 的三行定位图仍写着 "Run → ObjectOS the runtime",与新定位不符。

## 变更内容

- **`README.md`** 三行定位图:
  - `Describe → ObjectStack` 补充 "open-source protocol, toolkit & production runtime";
  - `Run → ObjectOS the runtime` 改为 `Operate → ObjectOS the commercial runtime environment (Cloud & Enterprise)`。

单文件三行的纯文案改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162o68e5w3bpUBEVRQboUGG

---
_Generated by [Claude Code](https://claude.ai/code/session_0162o68e5w3bpUBEVRQboUGG)_