### PR TITLE
feat(studio): Design-in-Studio bridge from the AI build canvas

### DIFF
--- a/packages/app-shell/src/console/ai/LiveCanvas.test.tsx
+++ b/packages/app-shell/src/console/ai/LiveCanvas.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * ADR-0080 reverse bridge: the Live Canvas (the build session's result pane,
+ * which renders the RUNNING app) must offer an explicit jump into the Studio
+ * design surface — otherwise a builder who wants to fine-tune structure after a
+ * build is stranded (the pane's only other action is close).
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LiveCanvas } from './LiveCanvas';
+
+vi.mock('@object-ui/i18n', () => ({
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importActual) => ({
+  ...(await importActual<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate,
+}));
+
+describe('LiveCanvas — Design in Studio bridge', () => {
+  beforeEach(() => navigate.mockClear());
+
+  it('renders a Design in Studio control that opens the package’s design surface', () => {
+    render(
+      <LiveCanvas appName="项目管理" appSegment="app.v6gq" materialized refreshKey={0} onClose={() => {}} />,
+    );
+    const btn = screen.getByTestId('live-canvas-open-designer');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(navigate).toHaveBeenCalledWith('/studio/app.v6gq/interfaces');
+  });
+
+  it('omits the bridge when the app has no addressable package segment', () => {
+    render(<LiveCanvas appName="Draft" refreshKey={0} onClose={() => {}} />);
+    expect(screen.queryByTestId('live-canvas-open-designer')).not.toBeInTheDocument();
+  });
+
+  it('still renders the close control', () => {
+    render(<LiveCanvas appName="项目管理" appSegment="app.v6gq" materialized refreshKey={0} onClose={() => {}} />);
+    expect(screen.getByTestId('live-canvas-close')).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/console/ai/LiveCanvas.tsx
+++ b/packages/app-shell/src/console/ai/LiveCanvas.tsx
@@ -20,7 +20,8 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { X, Eye } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { X, Eye, Hammer } from 'lucide-react';
 import { Button } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 
@@ -63,6 +64,7 @@ function canvasSrc(appName: string, materialized: boolean): string {
 
 export function LiveCanvas({ appName, appSegment, materialized = false, refreshKey, onClose }: LiveCanvasProps) {
   const { t } = useObjectTranslation();
+  const navigate = useNavigate();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   // Route on the package-id segment (unique), display by name (friendly).
   const routeSeg = appSegment && appSegment.length ? appSegment : appName;
@@ -105,6 +107,25 @@ export function LiveCanvas({ appName, appSegment, materialized = false, refreshK
                 defaultValue: 'Live preview — {{app}} (draft)',
               })}
         </span>
+        {/* Bridge to the design surface — this pane is the RUNNING app, so the
+            builder needs an explicit way to jump into the Studio designer to
+            fine-tune structure/layout (previously the only action here was
+            close, stranding users who wanted to keep editing). ADR-0080 reverse
+            bridge, mirroring the running app's own "Design in Studio" header. */}
+        {appSegment && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => navigate(`/studio/${appSegment}/interfaces`)}
+            data-testid="live-canvas-open-designer"
+            className="gap-1.5"
+            title={t('topbar.designInStudio', { defaultValue: 'Design in Studio' })}
+            aria-label={t('topbar.designInStudio', { defaultValue: 'Design in Studio' })}
+          >
+            <Hammer className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">{t('topbar.designInStudio', { defaultValue: 'Design in Studio' })}</span>
+          </Button>
+        )}
         <Button size="sm" variant="ghost" onClick={onClose} data-testid="live-canvas-close">
           <X className="h-3.5 w-3.5" />
         </Button>


### PR DESCRIPTION
Follow-up to the Studio UX teardown (#2504), grounded by **actually driving the full build flow**.

## What the flow test surfaced
Home → **用 AI 搭建** opens a *full-screen* chat page (`/_console/ai/build/conv…`); after **开始搭建**, its right pane is the **live RUNNING app** (点新建 = real record) — not the designer. That pane's only control was **close**, so a builder who wanted to keep editing (tweak a field/view/layout) had **no way to reach the Studio design surface** from here. This is a big part of why the three surfaces — AI build / Studio designer / running app — feel disconnected.

## Change
Add a **"Design in Studio"** control to the `LiveCanvas` header that navigates to the package's design surface (`/studio/<pkg>/interfaces`), gated on an addressable package segment. It mirrors the running app's own AppHeader bridge — same already-localized `topbar.designInStudio` label and `Hammer` icon — closing the build → designer loop.

## Testing
- `type-check` green; behavioral test (`LiveCanvas.test.tsx`): the control renders + navigates to the right route, is omitted without a package segment, and the close control is preserved.
- ⚠️ Not pixel-verified in a browser — the local rig serves framework's console, not this objectui; the change follows the proven AppHeader bridge pattern.

Part of the "one app, one workbench" direction from the teardown (surfaces should be summonable tools over one persistent app preview, not three separate full-screen destinations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)