### PR TITLE
i18n: localize the AI edit-app surfaces (build canvas label + Studio edit starters)

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1236,6 +1236,8 @@ const en = {
         "Couldn't send your message. It's kept below — please try again.",
       askAgent: 'Ask {{agent}}...',
       assistant: 'Assistant',
+      liveCanvas: 'Live preview — {{app}} (draft)',
+      liveCanvasUnlisted: 'Live app — {{app}} (unlisted until published)',
       loadingAgents: 'Loading agents...',
       askAnything: 'Ask anything...',
       emptyTitle: 'Start a conversation',
@@ -1252,6 +1254,12 @@ const en = {
           title: 'Ask your data',
           description:
             'Ask questions about your records — counts, lists, and summaries across the data you can access.',
+        },
+        editApp: {
+          title: 'Editing “{{app}}”',
+          titleGeneric: 'Edit this app',
+          description:
+            'What would you like to change? I’ll modify this app in place — add a field, object, view or automation, or adjust what’s already there.',
         },
       },
       clearConversation: 'Clear',
@@ -1321,6 +1329,12 @@ const en = {
           help: 'What can you help me with?',
           availableObjects: 'List the available data objects.',
           recentActivity: 'Summarize my recent activity.',
+        },
+        editApp: {
+          addField: 'Add a field to one of the objects.',
+          addObject: 'Add a new object and relate it to an existing one.',
+          addDashboard: 'Add a dashboard for the key metrics.',
+          addAutomation: 'Add an automation — an approval, a status flow, or a notification.',
         },
       },
     },

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1310,6 +1310,8 @@ const zh = {
       sendFailedGeneric: '消息发送失败，请重试。你的消息已保留在输入框中。',
       askAgent: '向 {{agent}} 提问...',
       assistant: '助手',
+      liveCanvas: '草稿预览 · {{app}}',
+      liveCanvasUnlisted: '运行预览 · {{app}}(未发布 · 仅自己可见)',
       loadingAgents: '正在加载助手...',
       askAnything: '输入你的问题...',
       emptyTitle: '开始对话',
@@ -1324,6 +1326,11 @@ const zh = {
         ask: {
           title: '向你的数据提问',
           description: '针对你的记录提问 —— 在你有权访问的数据范围内进行计数、列举和汇总。',
+        },
+        editApp: {
+          title: '正在编辑「{{app}}」',
+          titleGeneric: '编辑此应用',
+          description: '想改点什么？我会就地修改这个应用 —— 加字段、对象、视图或自动化，或调整已有内容。',
         },
       },
       clearConversation: '清空',
@@ -1395,6 +1402,12 @@ const zh = {
           help: '你可以帮我做什么？',
           availableObjects: '列出可用的数据对象。',
           recentActivity: '总结我的最近动态。',
+        },
+        editApp: {
+          addField: '给某个对象加一个字段。',
+          addObject: '新增一个对象，并关联到已有对象。',
+          addDashboard: '加一个展示关键指标的仪表盘。',
+          addAutomation: '加一个自动化 —— 审批、状态流转或通知。',
         },
       },
     },


### PR DESCRIPTION
Follow-up polish from the Studio UX teardown — strings that render **English on a Chinese UI** because their keys were never added to the locale bundles (they only carried inline `defaultValue`s, so `t()` fell back to English).

## Localized
- **AI build page right pane (LiveCanvas) header** — `console.ai.liveCanvas` / `liveCanvasUnlisted`. Was "Live app — X (unlisted until published)"; ZH now "运行预览 · X（未发布 · 仅自己可见）", which also makes clearer that this pane is the RUNNING app, not the designer (the exact confusion the teardown surfaced).
- **Studio copilot edit-an-app empty state + starters** — `console.ai.empty.editApp.*` ("Editing X / What would you like to change?") and `console.ai.suggestions.editApp.*` (Add a field / object / dashboard / automation). These showed English in the Chinese Studio dock.

## Nature of the change
Bundle-only. Keys added to both `en.ts` (verbatim to existing defaultValues → EN unchanged) and `zh.ts`. No component/call-site changes — the call sites already reference these keys; they just had no translation to resolve to.

## Testing
i18n suite green (94 tests / 8 files); locale files parse + structural tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)