### PR TITLE
feat(flow-designer): add 'position' xRef picker kind for approval approvers / escalateTo (#2778)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
@@ -55,6 +55,7 @@ const KIND_TO_META_TYPE: Partial<Record<ReferenceKind, string>> = {
   object: 'object',
   flow: 'flow',
   role: 'role',
+  position: 'position',
   user: 'user',
   team: 'team',
   queue: 'queue',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -46,7 +46,9 @@ export type FlowConfigFieldKind =
  *   • `object-field`  → a field of some object; the object is resolved via
  *                       {@link FlowReferenceSpec.objectSource}
  *   • `flow`          → a flow, by name (`client.list('flow')`)
- *   • `role`          → a security role (`client.list('role')`)
+ *   • `role`          → a better-auth org-membership tier (`client.list('role')`)
+ *   • `position`      → a position / 岗位 by machine name (`client.list('position')`);
+ *                       holders resolve via `sys_user_position` (ADR-0090 D3)
  *   • `node`          → another node in *this* flow, by id (read from the draft)
  *   • `user` / `team` / `queue` / `department` → the matching metadata list
  *                       (`client.list(kind)`); empty in dev, populated per tenant
@@ -61,6 +63,7 @@ export type ReferenceKind =
   | 'object-field'
   | 'flow'
   | 'role'
+  | 'position'
   | 'node'
   | 'user'
   | 'team'
@@ -413,6 +416,7 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
           options: [
             { value: 'user', label: 'User' },
             { value: 'role', label: 'Role' },
+            { value: 'position', label: 'Position' },
             { value: 'team', label: 'Team' },
             { value: 'department', label: 'Department' },
             { value: 'manager', label: 'Manager' },
@@ -427,13 +431,14 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
           key: 'value',
           label: 'Value',
           kind: 'reference',
-          placeholder: 'user id / role / field — per type',
+          placeholder: 'user id / role / position / field — per type',
           ref: {
             kindFrom: 'type',
             objectSource: '$trigger',
             map: {
               user: 'user',
               role: 'role',
+              position: 'position',
               team: 'team',
               department: 'department',
               field: 'object-field',
@@ -473,7 +478,7 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
       ],
       showWhen: { field: 'escalation.enabled', equals: ['true'] },
     },
-    { id: 'escalation.escalateTo', path: ['config', 'escalation', 'escalateTo'], label: 'Escalate to', kind: 'reference', ref: { kind: 'role' }, placeholder: 'user id / role / manager level', showWhen: { field: 'escalation.enabled', equals: ['true'] } },
+    { id: 'escalation.escalateTo', path: ['config', 'escalation', 'escalateTo'], label: 'Escalate to', kind: 'reference', ref: { kind: 'position' }, placeholder: 'position machine name / user id', showWhen: { field: 'escalation.enabled', equals: ['true'] } },
     { id: 'escalation.notifySubmitter', path: ['config', 'escalation', 'notifySubmitter'], label: 'Notify submitter', kind: 'boolean', showWhen: { field: 'escalation.enabled', equals: ['true'] } },
     // ADR-0044 send-back-for-revision guard. Surfaces from the engine's
     // published configSchema when online; this hardcoded copy keeps it visible

--- a/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.test.ts
@@ -18,14 +18,14 @@ const APPROVAL_CONFIG_SCHEMA = {
       items: {
         type: 'object',
         properties: {
-          type: { type: 'string', enum: ['user', 'role', 'team', 'department', 'manager', 'field', 'queue'] },
+          type: { type: 'string', enum: ['user', 'role', 'position', 'team', 'department', 'manager', 'field', 'queue'] },
           value: {
-            description: 'User id / role / team / department / field / queue — per `type`',
+            description: 'User id / membership tier / position / team / department / field / queue — per `type`',
             type: 'string',
             xRef: {
               kindFrom: 'type',
               objectSource: '$trigger',
-              map: { user: 'user', role: 'role', team: 'team', department: 'department', field: 'object-field', queue: 'queue' },
+              map: { user: 'user', role: 'role', position: 'position', team: 'team', department: 'department', field: 'object-field', queue: 'queue' },
             },
           },
         },
@@ -52,7 +52,7 @@ const APPROVAL_CONFIG_SCHEMA = {
         enabled: { default: false, description: 'Enable SLA-based escalation for this node', type: 'boolean' },
         timeoutHours: { type: 'number', minimum: 1, description: 'Hours before escalation triggers' },
         action: { default: 'notify', description: 'Action on escalation timeout', type: 'string', enum: ['reassign', 'auto_approve', 'auto_reject', 'notify'] },
-        escalateTo: { description: 'User id, role, or manager level to escalate to', type: 'string', xRef: { kind: 'role' } },
+        escalateTo: { description: 'User id or position machine name to escalate to', type: 'string', xRef: { kind: 'position' } },
         notifySubmitter: { default: true, description: 'Notify the original submitter on escalation', type: 'boolean' },
       },
       required: ['timeoutHours'],
@@ -103,16 +103,16 @@ describe('jsonSchemaToFlowFields', () => {
     expect(colKeys).toEqual(['type', 'value']);
     const typeCol = approvers.columns!.find((c) => c.key === 'type')!;
     expect(typeCol.kind).toBe('select');
-    expect(typeCol.options!.map((o) => o.value)).toEqual(['user', 'role', 'team', 'department', 'manager', 'field', 'queue']);
+    expect(typeCol.options!.map((o) => o.value)).toEqual(['user', 'role', 'position', 'team', 'department', 'manager', 'field', 'queue']);
     const valueCol = approvers.columns!.find((c) => c.key === 'value')!;
     // Polymorphic reference: the picker follows the row's `type`.
     expect(valueCol.kind).toBe('reference');
     expect(valueCol.ref).toEqual({
       kindFrom: 'type',
       objectSource: '$trigger',
-      map: { user: 'user', role: 'role', team: 'team', department: 'department', field: 'object-field', queue: 'queue' },
+      map: { user: 'user', role: 'role', position: 'position', team: 'team', department: 'department', field: 'object-field', queue: 'queue' },
     });
-    expect(valueCol.placeholder).toBe('User id / role / team / department / field / queue — per `type`');
+    expect(valueCol.placeholder).toBe('User id / membership tier / position / team / department / field / queue — per `type`');
   });
 
   it('maps a static-kind xRef column into a reference column', () => {
@@ -199,6 +199,29 @@ describe('jsonSchemaToFlowFields', () => {
     expect(weird.ref).toBeUndefined();
   });
 
+  it('recognizes the position kind (ADR-0090 D3) — static and polymorphic', () => {
+    const fields = jsonSchemaToFlowFields({
+      type: 'object',
+      properties: {
+        approver: { type: 'string', xRef: { kind: 'position' } },
+        rows: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { value: { type: 'string', xRef: { kindFrom: 'type', map: { position: 'position' } } } },
+          },
+        },
+      },
+    })!;
+    const approver = fields.find((f) => f.id === 'approver')!;
+    expect(approver.kind).toBe('reference');
+    expect(approver.ref).toEqual({ kind: 'position' });
+    const rows = fields.find((f) => f.id === 'rows')!;
+    const valueCol = rows.columns!.find((c) => c.key === 'value')!;
+    expect(valueCol.kind).toBe('reference');
+    expect(valueCol.ref).toEqual({ kindFrom: 'type', map: { position: 'position' } });
+  });
+
   it('flattens a nested object and gates siblings behind its enabled toggle', () => {
     const fields = jsonSchemaToFlowFields(APPROVAL_CONFIG_SCHEMA)!;
     const enabled = fields.find((f) => f.id === 'escalation.enabled')!;
@@ -221,7 +244,7 @@ describe('jsonSchemaToFlowFields', () => {
     // A nested xRef string flattens into a reference field, still gated.
     const escalateTo = fields.find((f) => f.id === 'escalation.escalateTo')!;
     expect(escalateTo.kind).toBe('reference');
-    expect(escalateTo.ref).toEqual({ kind: 'role' });
+    expect(escalateTo.ref).toEqual({ kind: 'position' });
     expect(escalateTo.showWhen).toEqual({ field: 'escalation.enabled', equals: ['true'] });
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.ts
@@ -60,6 +60,7 @@ const REFERENCE_KINDS: ReadonlySet<string> = new Set<ReferenceKind>([
   'object-field',
   'flow',
   'role',
+  'position',
   'node',
   'user',
   'team',


### PR DESCRIPTION
Closes #2778.

## What
Implements the `position` xRef picker kind in the Studio flow designer's approval-node inspector, matching the framework `@objectstack/spec` contract after ADR-0090 D3 (org roles renamed to *positions*; holders resolve via `sys_user_position`).

The framework spec (PRs framework#2738, framework#2767) added `position` to the approval approver type enum, to the `approvers[].value` polymorphic xRef map, and switched `escalation.escalateTo`'s xRef from `role` to `position`. This wires the designer to that contract.

## Changes
- **flow-node-config.ts** — add `position` to `ReferenceKind`; add a **Position** option to the approvers `type` select and `position: 'position'` to the value picker map; switch `escalateTo` from `role` → `position` (placeholder updated).
- **FlowReferenceField.tsx** — map `position` → the `position` metadata list, so the combobox suggests known positions (degrades to free text when the catalog is empty).
- **json-schema-to-fields.ts** — recognize `position` so an engine-published xRef isn't degraded to free text.
- **tests** — mirror the current published schema (position in enum/map, `escalateTo` kind `position`) and add a static+polymorphic `position` regression test.

## Verification
- **28/28 unit tests pass** across `json-schema-to-fields.test.ts`, `flow-node-config.test.ts`, `FlowReferenceField.connector.test.ts`.
- **Browser-verified end-to-end** against a live app-showcase backend + console dev server: the approvers `value` picker for a `position` row lists real backend positions (`contributor, manager, exec, auditor, ops, field_ops_delegate, client_portal_user`), and the `escalateTo` field renders a position picker listing the same. Both driven by the running engine's published config schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)