### PR TITLE
fix(app-nav): exclude record-detail pages from the 'page' nav picker (#2333)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/AppNavInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/AppNavInspector.tsx
@@ -50,6 +50,7 @@ import {
   deriveObjectTargetMode,
   clearedTargetPatch,
   ensureNavId,
+  isStaticPageOption,
 } from './nav-target';
 
 interface NavItem {
@@ -145,8 +146,13 @@ function writeSiblings(draft: Record<string, unknown>, hops: Hop[], nextSiblings
   return { [rootKey]: root };
 }
 
+type MetadataOptionRow = { name?: string; label?: string; type?: string; pageType?: string };
+
 /** Fetch a metadata type's items as combobox options (name → label (name)). */
-function useMetadataOptions(type: string | undefined): { options: Array<{ value: string; label: string }>; loading: boolean } {
+function useMetadataOptions(
+  type: string | undefined,
+  rowFilter?: (row: MetadataOptionRow) => boolean,
+): { options: Array<{ value: string; label: string }>; loading: boolean } {
   const client = useMetadataClient();
   const [state, setState] = React.useState<{ options: Array<{ value: string; label: string }>; loading: boolean }>({
     options: [],
@@ -160,11 +166,12 @@ function useMetadataOptions(type: string | undefined): { options: Array<{ value:
     let cancelled = false;
     setState((s) => ({ ...s, loading: true }));
     client
-      .list<{ name?: string; label?: string }>(type)
+      .list<MetadataOptionRow>(type)
       .then((rows) => {
         if (cancelled) return;
         const options = (Array.isArray(rows) ? rows : [])
           .filter((r) => r && typeof r.name === 'string' && r.name)
+          .filter((r) => (rowFilter ? rowFilter(r) : true))
           .map((r) => ({
             value: String(r.name),
             label: typeof r.label === 'string' && r.label && r.label !== r.name ? `${r.label} (${r.name})` : String(r.name),
@@ -177,7 +184,7 @@ function useMetadataOptions(type: string | undefined): { options: Array<{ value:
     return () => {
       cancelled = true;
     };
-  }, [client, type]);
+  }, [client, type, rowFilter]);
   return state;
 }
 
@@ -284,7 +291,7 @@ export function AppNavInspector({ selection, draft, name, onPatch, onClearSelect
   // the Rules of Hooks satisfied; `undefined` type disables the fetch.
   const objectOptions = useMetadataOptions(navType === 'object' ? 'object' : undefined);
   const targetMeta = navType && navType !== 'object' ? NAV_TYPE_TARGETS[navType].metaType : undefined;
-  const targetOptions = useMetadataOptions(targetMeta);
+  const targetOptions = useMetadataOptions(targetMeta, targetMeta === 'page' ? isStaticPageOption : undefined);
   const viewOptionsRaw = useMetadataOptions(navType === 'object' && objectMode === 'view' ? 'view' : undefined);
   // Views are named `<object>.<key>` (MetadataProvider) — scope the picker
   // to the bound object instead of offering the whole workspace's views.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/__tests__/nav-target.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/__tests__/nav-target.test.ts
@@ -10,6 +10,7 @@ import {
   OBJECT_MODE_FIELDS,
   ensureNavId,
   NAV_TYPE_TARGETS,
+  isStaticPageOption,
 } from '../nav-target';
 
 describe('inferNavItemType', () => {
@@ -79,5 +80,27 @@ describe('NAV_TYPE_TARGETS', () => {
     expect(NAV_TYPE_TARGETS.page).toEqual({ targetKey: 'pageName', metaType: 'page' });
     expect(NAV_TYPE_TARGETS.url).toEqual({ targetKey: 'url' });
     expect(NAV_TYPE_TARGETS.group).toEqual({});
+  });
+});
+
+describe('isStaticPageOption — page picker excludes record-detail pages (#2333)', () => {
+  it('excludes record pages (bare type and pageType)', () => {
+    expect(isStaticPageOption({ type: 'record' })).toBe(false);
+    expect(isStaticPageOption({ pageType: 'record' })).toBe(false);
+  });
+  it('keeps static page kinds', () => {
+    for (const type of ['list', 'home', 'app', 'utility']) {
+      expect(isStaticPageOption({ type })).toBe(true);
+    }
+  });
+  it('pageType wins over bare type (mirrors usePageAssignment)', () => {
+    // A record page carrying a stale bare `type` is still excluded…
+    expect(isStaticPageOption({ pageType: 'record', type: 'list' })).toBe(false);
+    // …and a static page is kept even if a bare `type: record` lingers.
+    expect(isStaticPageOption({ pageType: 'list', type: 'record' })).toBe(true);
+  });
+  it('keeps rows missing both discriminators (only confirmed record pages excluded)', () => {
+    expect(isStaticPageOption({})).toBe(true);
+    expect(isStaticPageOption({ name: 'x' })).toBe(true);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/nav-target.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/nav-target.ts
@@ -39,6 +39,21 @@ export const NAV_TYPE_TARGETS: Record<
   group: {},
 };
 
+/**
+ * Whether a `page` metadata list row can back a `type: 'page'` nav item.
+ *
+ * Record-detail pages (`type: 'record'`) require a specific record id to
+ * render, but a `type: 'page'` nav item resolves to a static
+ * `/apps/{app}/page/{name}` URL with no mechanism to pass one — so linking one
+ * from navigation is always broken at runtime (#2333). Exclude them from the
+ * page picker. Mirrors usePageAssignment's record discriminator: `pageType`
+ * wins over the bare `type` field. Rows missing both are kept (only a confirmed
+ * record page is excluded).
+ */
+export function isStaticPageOption(row: { type?: string; pageType?: string }): boolean {
+  return (row.pageType ?? row.type) !== 'record';
+}
+
 /** Typed target fields across the whole union. */
 const TYPED_TARGET_FIELDS = [
   'objectName',


### PR DESCRIPTION
Closes #2333

## Problem

When creating a navigation item of type **"page"**, the target dropdown listed **all** pages — including record-detail pages (`type: 'record'`). A `type: 'page'` nav item resolves to a static `/apps/{app}/page/{name}` URL with no mechanism to pass a record id, so selecting a record-detail page always produces a broken target at runtime.

## Fix

Added a pure `isStaticPageOption` predicate in `nav-target.ts` and threaded an optional `rowFilter` through `useMetadataOptions`, applied **only** for the `page` metaType. Record-detail pages are excluded; every other page kind (`list`, `home`, `app`, `utility`) is kept.

- Mirrors `usePageAssignment`'s record discriminator — `pageType` wins over bare `type`.
- Rows missing both discriminators are kept, so **only confirmed record pages** are dropped (safe default).
- The filter reference is stable (module-level or `undefined`), so it doesn't retrigger the fetch effect.
- Object/dashboard/report/view pickers are unaffected.

## Testing

- Added `isStaticPageOption` unit tests to `nav-target.test.ts` (record exclusion, static-kind retention, `pageType`-over-`type` precedence, missing-discriminator retention). Full file: **16 passed**.
- `pnpm turbo run type-check --filter=@object-ui/app-shell` passes (29/29).

Not visually verified in the browser — the change is a scoped metadata-list filter with direct unit coverage over the exact predicate, and standing up the console + backend + seeded record pages would be disproportionate for a one-dropdown filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)