### PR TITLE
fix(plugin-report): stop TS6059 rootDir errors in dts build (#2334)

### DIFF
--- a/packages/plugin-report/vite.config.ts
+++ b/packages/plugin-report/vite.config.ts
@@ -11,11 +11,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {


### PR DESCRIPTION
Closes #2334

## Problem

`vite build` in `@object-ui/plugin-report` spewed ~93 `TS6059: … is not under 'rootDir'` errors during the `vite-plugin-dts` declaration step.

**Root cause:** vite-plugin-dts builds its type program from the package `tsconfig.json`, which extends the root `tsconfig.json` and inherits `paths` mapping `@object-ui/*` → `packages/*/src`. The dts program followed those aliases into sibling `src` trees (`core/src`, `types/src`, `react/src`, …); with `rootDir` pinned to `plugin-report/src`, tsc flagged every pulled-in file as outside `rootDir`. The emitted `.d.ts` was correct — the errors were pure noise.

## Fix

- Add `paths: {}` to the dts `compilerOptions` so `@object-ui/*` resolves to each dependency's published `dist/*.d.ts` (external, not followed into `src`). `aliasesExclude: [/^@object-ui\//]` already keeps the specifiers unrewritten, so declarations still import from `@object-ui/*`.
- Remove the dead `skipDiagnostics: true` — removed in vite-plugin-dts v4+ (repo is on `^5.0.3`), which is why it never suppressed the diagnostics.

## Verification

- `pnpm build`: **0** TS6059 (was 93), 0 other TS errors, exits 0
- `dist/*.d.ts` still emit flat and import `ReportField` / `ReportSchema` / `ReportViewerSchema` etc. from `@object-ui/types` as external
- `pnpm test`: 44/44 pass

Note: 21 sibling packages carry the identical pattern/noise; tracked as a separate follow-up (out of scope for #2334).

🤖 Generated with [Claude Code](https://claude.com/claude-code)