### PR TITLE
feat(components): add `variant === 'primary'` tie-break to action:bar ordering (#2339)

### DIFF
--- a/packages/components/src/__tests__/action-bar.test.tsx
+++ b/packages/components/src/__tests__/action-bar.test.tsx
@@ -230,6 +230,47 @@ describe('ActionBar (action:bar)', () => {
       expect(inlineText.indexOf('Alpha')).toBeLessThan(inlineText.indexOf('Bravo'));
       expect(inlineText.indexOf('Bravo')).toBeLessThan(inlineText.indexOf('Charlie'));
     });
+
+    it('tie-break: a `primary` action wins the primary slot when nobody sets `order`', () => {
+      const { container } = renderComponent({
+        type: 'action:bar',
+        location: 'record_header',
+        maxVisible: 1,
+        actions: [
+          // Registered first, but plain variant — the tie-break must let the
+          // `primary` sibling registered after it claim the primary slot.
+          { name: 'export', label: 'Export', type: 'script', locations: ['record_header'] },
+          { name: 'submit', label: 'Submit', type: 'script', variant: 'primary', locations: ['record_header'] },
+        ],
+      });
+      const toolbar = container.querySelector('[role="toolbar"]');
+      // 1 inline primary button + 1 overflow menu trigger
+      expect(toolbar!.children.length).toBe(2);
+      const inlineText = Array.from(toolbar!.querySelectorAll(inlineButtonsSelector))
+        .map(b => b.textContent)
+        .join(' ');
+      expect(inlineText).toContain('Submit');
+      expect(inlineText).not.toContain('Export');
+    });
+
+    it('`order` outranks the `primary` tie-break', () => {
+      const { container } = renderComponent({
+        type: 'action:bar',
+        location: 'record_header',
+        maxVisible: 5,
+        actions: [
+          // `primary` variant but no `order` (= 0); the explicit low-`order`
+          // sibling must still sort ahead of it — `order` is the primary key.
+          { name: 'submit', label: 'Submit', type: 'script', variant: 'primary', locations: ['record_header'] },
+          { name: 'approve', label: 'Approve', type: 'script', order: -100, locations: ['record_header'] },
+        ],
+      });
+      const toolbar = container.querySelector('[role="toolbar"]');
+      const inlineText = Array.from(toolbar!.querySelectorAll(inlineButtonsSelector))
+        .map(b => b.textContent)
+        .join('|');
+      expect(inlineText.indexOf('Approve')).toBeLessThan(inlineText.indexOf('Submit'));
+    });
   });
 
   describe('systemActions', () => {

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -134,15 +134,31 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
         seen.add(a.name);
         return true;
       });
-      // Order by explicit `order` (lower = earlier / more prominent) before the
-      // inline/overflow split. Stable: actions that leave `order` unset (treated
-      // as 0) keep their incoming order, so this only moves actions that opt in.
-      // This is what lets an injected Approve/Reject with a negative `order`
-      // float into the primary-button slot instead of the "More" overflow menu
-      // (#2670 / objectui#2339), and lets authors order their own record_header
-      // actions declaratively via `Action.order`.
-      if (deduped.some(a => a.order !== undefined)) {
-        return [...deduped].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+      // Order the actions before the inline/overflow split so the first one
+      // lands in the primary-button slot. The rule (objectui#2339) is:
+      //   1. `order` ascending (unset = 0; lower = more prominent)
+      //   2. `variant === 'primary'` preferred as a tie-break within equal order
+      //   3. original registration order (stable) for the remaining ties
+      // The sort is stable and every key defaults to a no-op, so a toolbar where
+      // nobody sets `order` and nobody is `primary` keeps its exact registration
+      // order. This is what lets an injected Approve/Reject with a negative
+      // `order` float into the primary slot instead of the "More" overflow menu
+      // (#2670), lets authors declaratively promote an action via `Action.order`,
+      // and — when several unordered actions tie at the default `order` 0 — lets
+      // the `primary`-variant action claim the primary button without the author
+      // having to also assign an `order`.
+      const needsOrdering = deduped.some(
+        a => a.order !== undefined || a.variant === 'primary',
+      );
+      if (needsOrdering) {
+        return [...deduped].sort((a, b) => {
+          const byOrder = (a.order ?? 0) - (b.order ?? 0);
+          if (byOrder !== 0) return byOrder;
+          // Tie-break: a `primary` action outranks a non-primary sibling.
+          const ap = a.variant === 'primary' ? 0 : 1;
+          const bp = b.variant === 'primary' ? 0 : 1;
+          return ap - bp; // equal → stable sort preserves registration order
+        });
       }
       return deduped;
     }, [schema.actions, schema.location]);


### PR DESCRIPTION
Completes the record-header primary-button ordering rule from **#2339**. Follow-up to the merged **#2340**.

## Background

Issue #2339 specified a three-key ordering for choosing the record-header primary button:

1. `order ?? 0` ascending (lower = more prominent)
2. `variant === 'primary'` preferred — **tie-break** within equal `order`
3. original registration order (stable)

PR #2340 shipped keys **1** and **3** but deliberately dropped the `primary` tie-break (key 2), noting the injected Approve button gets the slot via `order: -100` regardless. That left a real gap: when several **app-declared** `record_header` actions all leave `order` unset (so they tie at the default `0`) and one is styled `variant: 'primary'`, the primary action did **not** claim the primary button — the author had to also assign an explicit `order`.

## Change

`packages/components/src/renderers/action/action-bar.tsx` — the pre-split sort now adds `variant === 'primary'` as the secondary key:

- `order` ascending (unset = `0`) stays the primary key.
- On an `order` tie, a `primary` action outranks a non-primary sibling.
- The sort remains **stable**, so remaining ties keep registration order.
- The ordering gate now fires on either an explicit `order` **or** a `primary` variant, so a toolbar with **neither** is still a no-op (byte-for-byte unchanged registration order — the #2340 backward-compat guarantee holds).

## Tests

`packages/components/src/__tests__/action-bar.test.tsx` — +2 cases in the `order` block:

- **primary tie-break wins** the primary slot when nobody sets `order` (primary action registered *last* still gets promoted).
- **`order` outranks the tie-break** (an explicit low `order` beats a `primary` variant with default `order`).

Verification (in-worktree):
- `pnpm exec vitest run packages/components/src/__tests__/action-bar.test.tsx` — **23 passed** (21 existing + 2 new).
- `pnpm --filter @object-ui/components type-check` — clean.

Refs #2339, #2340, framework#2670, framework#2682

🤖 Generated with [Claude Code](https://claude.com/claude-code)