### PR TITLE
fix(build): stop TS6059 rootDir errors in dts build across 21 packages

### DIFF
--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),

--- a/packages/fields/vite.config.ts
+++ b/packages/fields/vite.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: path.resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: path.resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
     }),
   ],

--- a/packages/layout/vite.config.ts
+++ b/packages/layout/vite.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),

--- a/packages/plugin-ai/vite.config.ts
+++ b/packages/plugin-ai/vite.config.ts
@@ -8,11 +8,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-calendar/vite.config.ts
+++ b/packages/plugin-calendar/vite.config.ts
@@ -22,11 +22,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-charts/vite.config.ts
+++ b/packages/plugin-charts/vite.config.ts
@@ -16,11 +16,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-chatbot/vite.config.ts
+++ b/packages/plugin-chatbot/vite.config.ts
@@ -16,11 +16,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-dashboard/vite.config.ts
+++ b/packages/plugin-dashboard/vite.config.ts
@@ -8,11 +8,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-designer/vite.config.ts
+++ b/packages/plugin-designer/vite.config.ts
@@ -8,11 +8,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-detail/vite.config.ts
+++ b/packages/plugin-detail/vite.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       outDir: 'dist',
       tsconfigPath: './tsconfig.json',

--- a/packages/plugin-editor/vite.config.ts
+++ b/packages/plugin-editor/vite.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),

--- a/packages/plugin-form/vite.config.ts
+++ b/packages/plugin-form/vite.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),

--- a/packages/plugin-gantt/vite.config.ts
+++ b/packages/plugin-gantt/vite.config.ts
@@ -16,11 +16,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-grid/vite.config.ts
+++ b/packages/plugin-grid/vite.config.ts
@@ -9,7 +9,11 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
       include: ['src'],
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
     }),
   ],

--- a/packages/plugin-kanban/vite.config.ts
+++ b/packages/plugin-kanban/vite.config.ts
@@ -16,11 +16,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-list/vite.config.ts
+++ b/packages/plugin-list/vite.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       outDir: 'dist',
       tsconfigPath: './tsconfig.json',

--- a/packages/plugin-map/vite.config.ts
+++ b/packages/plugin-map/vite.config.ts
@@ -16,11 +16,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-markdown/vite.config.ts
+++ b/packages/plugin-markdown/vite.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
     }),

--- a/packages/plugin-timeline/vite.config.ts
+++ b/packages/plugin-timeline/vite.config.ts
@@ -16,11 +16,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-tree/vite.config.ts
+++ b/packages/plugin-tree/vite.config.ts
@@ -16,11 +16,14 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
-      skipDiagnostics: true,
     }),
   ],
   resolve: {

--- a/packages/plugin-view/vite.config.ts
+++ b/packages/plugin-view/vite.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
     react(),
     dts({
       insertTypesEntry: true,
-      compilerOptions: { rootDir: resolve(__dirname, 'src') },
+      // Clear the inherited tsconfig `paths` so the dts type program resolves
+      // `@object-ui/*` to each dependency's published `dist/*.d.ts` (external)
+      // instead of following the workspace `src` aliases into files outside
+      // this package's `rootDir` — which would emit TS6059 rootDir errors.
+      compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx'],


### PR DESCRIPTION
## Summary

Mirrors the plugin-report fix (#2334) across the remaining **21 packages** that emitted the same ~93 TS6059 "not under rootDir" errors during their `vite build` dts step.

**Root cause:** each package's `vite.config.ts` runs `dts({ compilerOptions: { rootDir: <pkg>/src }, ... })`. The dts tsc program extends the root `tsconfig.json`, whose `paths` map `@object-ui/*` to `packages/*/src`, so tsc followed the aliases into sibling `src` trees outside `rootDir` and emitted TS6059 for every file. The emitted `.d.ts` was correct — the errors were noise.

**Fix:** add `paths: {}` to the dts `compilerOptions` so `@object-ui/*` resolves to each dependency's published `dist/*.d.ts` (external). `aliasesExclude: [/^@object-ui\//]` already keeps the specifiers unrewritten, so declarations still import from `@object-ui/*`. Also dropped the dead `skipDiagnostics: true` option where present (removed in vite-plugin-dts v4+; repo is on ^5.0.3).

## Packages (21)
components, fields, layout, plugin-ai, plugin-calendar, plugin-charts, plugin-chatbot, plugin-dashboard, plugin-designer, plugin-detail, plugin-editor, plugin-form, plugin-gantt, plugin-grid, plugin-kanban, plugin-list, plugin-map, plugin-markdown, plugin-timeline, plugin-tree, plugin-view.

## Verification
`turbo run build` for all 21 packages + their dependencies (31 tasks, `--force`):
- ✅ Exit 0, all 31 tasks successful
- ✅ **0 occurrences of TS6059** (was ~93 per package)
- ✅ emitted `dist/**/*.d.ts` still import from `@object-ui/*` as external specifiers, with 0 inlined sibling-`src` escapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)