### PR TITLE
fix(metadata-admin): give hook create form a createSchema so object renders as a ref:object picker

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/anchors.hook-create-schema.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.hook-create-schema.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { registerBuiltinAnchors } from './anchors';
+import { resolveResourceConfig } from './registry';
+
+/**
+ * #2324 — Hook's create form defined `createFields` but no `createSchema`, so
+ * the flat form had no property types and every field (incl. `object`) rendered
+ * as a plain text input instead of an object picker. Guard that the hook create
+ * schema exists and gives `object` the `ref:object` widget, mirroring `page`.
+ */
+registerBuiltinAnchors();
+
+type CreateSchema = {
+  type?: string;
+  required?: string[];
+  properties?: Record<string, { widget?: string } | undefined>;
+};
+
+describe('hook createSchema (#2324 — object field must be a ref:object picker)', () => {
+  const cfg = resolveResourceConfig('hook');
+  const schema = cfg.createSchema as CreateSchema | undefined;
+
+  it('declares a createSchema on the hook resource', () => {
+    expect(schema).toBeTruthy();
+    expect(schema?.type).toBe('object');
+  });
+
+  it('renders the object field via the ref:object widget (not plain text)', () => {
+    expect(schema?.properties?.object?.widget).toBe('ref:object');
+  });
+
+  it('covers every asked-for create field with a typed property', () => {
+    const props = schema?.properties ?? {};
+    for (const field of cfg.createFields ?? []) {
+      expect(props[field], `createField '${field}' has no createSchema property`).toBeTruthy();
+    }
+  });
+
+  it('requires the spec-required `object` binding up front', () => {
+    expect(schema?.required ?? []).toContain('object');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -99,6 +99,36 @@ export function registerBuiltinAnchors(): void {
     createDerive: [
       { from: 'label', to: 'name', transform: 'slugify', untilUserEdits: true },
     ],
+    // Without a createSchema the flat create form has no property types, so
+    // every field (incl. `object`) falls back to a plain text input. Declare
+    // one — mirroring `page`/`view` — so `object` gets the `ref:object` picker.
+    // `object` is spec-required on HookSchema (alongside `name`, `events`);
+    // `events` is supplied by createDefaults below, so the form asks only for
+    // identity + the bound object.
+    createSchema: {
+      type: 'object',
+      required: ['label', 'name', 'object'],
+      properties: {
+        label: { type: 'string', title: 'Label', description: 'Human-readable hook name.' },
+        name: {
+          type: 'string',
+          title: 'Name',
+          description: 'Hook key (snake_case).',
+          pattern: '^[a-z_][a-z0-9_]*$',
+        },
+        object: {
+          type: 'string',
+          title: 'Object',
+          widget: 'ref:object',
+          description: 'The object whose row lifecycle (beforeInsert / afterUpdate / …) this hook runs on.',
+        },
+        description: {
+          type: 'string',
+          title: 'Description',
+          description: 'What this hook does.',
+        },
+      },
+    },
     createDefaults: { events: [] },
   });
 


### PR DESCRIPTION
## Summary

Fixes #2324. When creating a new **Hook** in Metadata admin, every field (`label`, `name`, `object`, `description`) rendered as a plain text input — the `object` field was missing its object dropdown.

## Root cause

In `packages/app-shell/src/views/metadata-admin/anchors.ts`, the `hook` resource declared `createFields: ['label', 'name', 'object', 'description']` but **no `createSchema`**. Without a schema the flat create form has no per-property type information, so every field falls back to a plain text input and `object` never receives `widget: 'ref:object'`. `page` and `view` (both object-bound) already ship a `createSchema` — hook was the outlier.

## Fix

Add a `createSchema` to the `hook` resource, mirroring `page`/`view`:

- `object` → `widget: 'ref:object'` (the object picker — the reported miss)
- `name` → snake_case `pattern`
- `label` / `description` → titles + help text

`object` is spec-required on `HookSchema` (alongside `name` and `events`), so it is marked `required` in the create form up front. `events` continues to be supplied by `createDefaults: { events: [] }`, so **the saved wire body is unchanged** and create→save conformance is unaffected (the conformance guard reads `createFields`/`createDefaults`/`createBuildBody`, not `createSchema`).

## Testing

- `packages/app-shell/src/views/metadata-admin/anchors.hook-create-schema.test.ts` — new registry-level regression test: asserts the hook `createSchema` exists, gives `object` the `ref:object` widget, covers every `createField`, and requires `object`.
- `pnpm exec vitest run createConformance createBody anchors.page-seed anchors.hook-create-schema` → all pass (30 tests).
- `turbo run type-check --filter=@object-ui/app-shell` → green.
- `eslint` on changed files → 0 errors, 0 warnings.

## Note (out of scope)

`trigger` (same file) has the identical shape — `createFields: ['label','name','object']` with no `createSchema` — so its `object` field is a plain text input too. Left untouched to keep this PR scoped to #2324; happy to follow up in a separate change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9zi4zvZgEMqY7crdZfps5)_