### PR TITLE
fix(metadata-admin): seed flow createDefaults with required `type`

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -263,7 +263,12 @@ export function registerBuiltinAnchors(): void {
     createDerive: [
       { from: 'label', to: 'name', transform: 'slugify', untilUserEdits: true },
     ],
-    createDefaults: { nodes: [], edges: [] },
+    // `type` is a required FlowSchema enum (autolaunched | record_change |
+    // schedule | screen | api). Seed the canonical default so a create→save
+    // that never touches the type picker can't 422 — mirrors the server's
+    // BUILTIN_METADATA_CREATE_SEEDS and the Studio inline skeleton
+    // (buildFlowSkeleton). See objectui#2326.
+    createDefaults: { type: 'autolaunched', nodes: [], edges: [] },
   });
   // ADR-0020: `workflow` retired as a metadata type — record state machines
   // are a `state_machine` validation rule on the object (no separate anchor).

--- a/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
@@ -27,11 +27,14 @@ registerBuiltinAnchors();
  *  don't override them with a bogus string; unknown ones stay unset (schema
  *  default applies). */
 // Enum createFields the create form forces the user to pick (rendered as a
-// required <select>) but that carry no createDefault. The guard supplies a valid
+// required <select>) that carry NO createDefault — the guard supplies a valid
 // option to simulate the choice, exactly as the form requires one before save.
-const REQUIRED_PICKS: Record<string, Record<string, unknown>> = {
-  flow: { type: 'autolaunched' },
-};
+// Currently empty: `flow.type` now ships a createDefault ('autolaunched',
+// objectui#2326), so its default create output is spec-valid WITHOUT a
+// simulated pick — the fall-through below reads it from `createDefaults`, which
+// is what actually keeps the guard honest about a create→save that never
+// touches the type picker.
+const REQUIRED_PICKS: Record<string, Record<string, unknown>> = {};
 
 function placeholderFor(field: string, cfg: MetadataResourceConfig): unknown {
   const pick = REQUIRED_PICKS[cfg.type]?.[field];


### PR DESCRIPTION
## Summary

Fixes #2326. Creating a **Flow** through the generic metadata-admin create form could 422 on save when the user never touched the type picker.

Flow's registry entry lists `type` in `createFields` (so the form asks for it), but `createDefaults` only seeded `{ nodes: [], edges: [] }`. `ResourceEditPage` seeds the create draft from `createDefaults`, so `type` started **undefined** — and `buildCreateModeBody` merges `{ ...createDefaults, ...draft }`, so a save that never selected a type shipped a body with no `type`. `FlowSchema` marks `type` as a **required** enum (`autolaunched | record_change | schedule | screen | api`), so the server rejected it.

## Fix

`packages/app-shell/src/views/metadata-admin/anchors.ts`

```diff
- createDefaults: { nodes: [], edges: [] },
+ createDefaults: { type: 'autolaunched', nodes: [], edges: [] },
```

`autolaunched` is the canonical default already used by the server's `BUILTIN_METADATA_CREATE_SEEDS`, the Studio inline skeleton (`buildFlowSkeleton`), and the `FlowPreview` fallback — so this stops the drift rather than inventing a new default. The seed pre-selects the type field and guarantees a spec-valid body by default; an explicit user pick still wins via the draft-wins merge.

The optional `createSchema` from the issue is intentionally **not** added — it would replace the server's edit schema for create-mode rendering/validation (broader blast radius) and isn't needed once the default is valid.

## Guard hardening

`createConformance.test.ts` previously masked this exact case: its `REQUIRED_PICKS` supplied `flow: { type: 'autolaunched' }`, *simulating* a user pick, so the guard never exercised the real no-pick default. Dropped that entry so the test now reads `type` from `createDefaults` — it genuinely fails if the default is dropped again.

## Verification

- `createConformance.test.ts` + `createBody.test.ts` — pass (21).
- Full `metadata-admin` suite — pass (73 files / 586 tests).
- `turbo run type-check --filter=@object-ui/app-shell` — clean.
- ESLint on both changed files — 0 errors.
- Validated directly against the installed `FlowSchema` (`@objectstack/spec@14.6.0`): body **with** `type` → valid; **without** `type` → rejected (`type: invalid_value`), confirming the guard now protects the fix.

No changeset (pure bug fix, per AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CDGmX26cFMA3RfseHwf4j

---
_Generated by [Claude Code](https://claude.ai/code/session_011CDGmX26cFMA3RfseHwf4j)_