### PR TITLE
fix(app-shell): render View create-form Object field as ref:object picker

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/anchors.object-widget.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.object-widget.test.ts
@@ -1,0 +1,52 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// GUARD — a create-form `object` field must render as the object PICKER
+// (`widget: 'ref:object'`), never a bare text input. Regression guard for
+// objectui#2322: the View createSchema declared `object` as a plain
+// `type: 'string'` (no widget), so the create form showed a typo-prone text box
+// instead of the object dropdown the Page create form already offered. Reads the
+// ACTUAL createSchema from the registry so it can't drift from what the form
+// renders, and covers every authorable type at once so the same asymmetry
+// (one type gets the picker, a sibling silently doesn't) can't reappear.
+
+import { describe, it, expect } from 'vitest';
+import { registerBuiltinAnchors } from './anchors';
+import { listMetadataResources } from './registry';
+
+registerBuiltinAnchors();
+
+type SchemaProp = { widget?: unknown };
+
+// Every create form that binds a new record to an existing object exposes that
+// choice as an `object` create field. Collect them straight from the registry.
+const withObjectCreateField = listMetadataResources()
+  .map((cfg) => {
+    const props = (cfg.createSchema as { properties?: Record<string, SchemaProp> } | undefined)
+      ?.properties;
+    return { type: cfg.type, objectProp: props?.object };
+  })
+  .filter((r): r is { type: string; objectProp: SchemaProp } => r.objectProp !== undefined);
+
+describe("createSchema `object` field uses the ref:object picker (objectui#2322)", () => {
+  it('discovers the object-binding create forms (no silent cap)', () => {
+    const types = withObjectCreateField.map((r) => r.type).sort();
+    console.log(`[create-object-widget] object-binding create forms: ${types.join(', ')}`);
+    // page + view both bind to an object — the guard below must actually cover them.
+    expect(types).toEqual(expect.arrayContaining(['page', 'view']));
+  });
+
+  for (const { type, objectProp } of withObjectCreateField) {
+    it(`${type}: createSchema.object declares widget 'ref:object'`, () => {
+      expect(
+        objectProp.widget,
+        `${type} create form renders 'object' as a plain text input — add widget: 'ref:object' so it picks from existing objects`,
+      ).toBe('ref:object');
+    });
+  }
+});

--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -217,6 +217,7 @@ export function registerBuiltinAnchors(): void {
         object: {
           type: 'string',
           title: 'Object',
+          widget: 'ref:object',
           description: 'The object this view displays.',
         },
         kind: {


### PR DESCRIPTION
Fixes #2322

## Summary

When creating a new **View** in the metadata-admin UI, the **Object** field rendered as a plain text input instead of the object dropdown, forcing users to hand-type the object name (typo-prone). The **Page** create form already renders a proper picker for the same field.

## Root cause

In `packages/app-shell/src/views/metadata-admin/anchors.ts`, the View `createSchema` declared its `object` property as a bare `type: 'string'` with no widget hint:

```ts
object: {
  type: 'string',
  title: 'Object',
  description: 'The object this view displays.',
}
```

`SchemaForm` honors a `widget` declared on a raw createSchema property (`SchemaForm.tsx:572-574`) and maps `'ref:object'` → `RefObjectWidget` (an object-name dropdown, `widgets.tsx:1808`). The Page `createSchema` sets `widget: 'ref:object'` on its `object` field; View was simply missing it, so `SchemaForm` fell back to type inference (`string` → text input).

## Fix

Add `widget: 'ref:object'` to View's `object` property, exactly mirroring the working Page field:

```ts
object: {
  type: 'string',
  title: 'Object',
  widget: 'ref:object',
  description: 'The object this view displays.',
}
```

This is a metadata-source correction (the `createSchema` is the create-form contract), not a lenient renderer fallback — consistent with the contract-first rule (#0.1).

## Regression guard

Added `anchors.object-widget.test.ts`. It reads the **actual** `createSchema` from the registry (so it can't drift from what the form renders) and asserts that **every** create form binding a record to an object (`page`, `view`, …) declares `widget: 'ref:object'` on its `object` field — so this asymmetry (one type gets the picker, a sibling silently doesn't) can't reappear on a future type. This gap slipped past the existing `createConformance` guard because that one checks spec-validity of the *saved output* (a string either way), not the *widget* used to author it.

## Verification

- `anchors.object-widget.test.ts` — passes; discovers `page, view` and asserts both use the picker (pre-fix, `view` would fail).
- `createConformance.test.ts` — still green (no registry regression).
- ESLint clean on both changed files.
- `tsc --noEmit` error set is byte-identical with vs. without the change (the pre-existing errors are unbuilt-workspace-dep noise, unrelated to this diff).

Pure bug fix → no changeset.

## Out of scope (noted for maintainers)

`default-schemas.ts` (the fallback **edit** schema) declares `report.object` without `ref:object` too. That's a separate surface (edit form, not the create form this issue is about), so it's intentionally left untouched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EkVkBJTumqnTAPavaZLJcz)_