### PR TITLE
fix(studio-design): make object canvas overridable via studio-canvas-preview registry (#2337)

### DIFF
--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -273,6 +273,18 @@ export {
   StudioDesignSurface,
   type StudioDesignSurfaceProps,
 } from './views/studio-design/StudioDesignSurface';
+// Per-type canvas renderers for the Studio design surface. Register an override
+// (e.g. a custom `object` records surface) without forking StudioDesignSurface.
+export {
+  registerStudioCanvasPreview,
+  getStudioCanvasPreview,
+  listStudioCanvasPreviewTypes,
+  StudioObjectRecordsCanvas,
+} from './views/studio-design/studio-canvas-preview';
+export type {
+  StudioCanvasPreview,
+  StudioCanvasPreviewProps,
+} from './views/studio-design/studio-canvas-preview';
 // The builder's front door: pick/create a writable package → pillar builder.
 // Standalone at `/studio` and embedded via the `studio:builder` component ref.
 export { BuilderLanding } from './views/studio-design/BuilderLanding';

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
-import { SchemaRenderer, useAdapter, SchemaRendererProvider } from '@object-ui/react';
+import { useAdapter, SchemaRendererProvider } from '@object-ui/react';
 import { StudioChatDock } from './StudioAiCopilot';
 import { nextCenterTab, type StudioCenterTab } from './centerTab';
 import {
@@ -70,6 +70,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry';
+import { getStudioCanvasPreview } from './studio-canvas-preview';
 import { PermissionMatrixEditPage } from '../metadata-admin/PermissionMatrixEditor';
 import { AccessExplainPanel } from '../metadata-admin/AccessExplainPanel';
 import { getMetadataInspector } from '../metadata-admin/inspector-registry';
@@ -1194,15 +1195,21 @@ function InterfacesPillar({
   }, [client, packageId, publishNonce, draftNonce]);
 
   const Preview = getMetadataPreview(current?.type ?? '');
+  // Studio-canvas surface override: the SAME type can render as a different
+  // surface here than in the Data pillar. Only `object` opts in today (→ the
+  // runtime records grid, not the field-form designer that is `object`'s
+  // MetadataPreview). Overridable/extendable via `registerStudioCanvasPreview`.
+  const StudioCanvas = getStudioCanvasPreview(current?.type ?? '');
   const Inspector = getMetadataInspector(current?.type ?? '');
   // The "home" (no-selection) inspector for the surface type — e.g. a page's
   // interfaceConfig form. Interface/list pages (kanban/calendar boards) have no
   // block tree, so `selection` never populates; without this the panel would
   // sit permanently on the "click a block" empty state.
   const DefaultInspector = getMetadataDefaultInspector(current?.type ?? '');
-  // Object leaves render as a runtime records grid (preview = runtime); schema
-  // editing is the Data pillar's job, so they are not draft-editable in this canvas.
-  const isEditable = !!Preview && current?.type !== 'object';
+  // A studio-canvas surface (e.g. object → runtime records grid) renders the
+  // running app, not an editable draft — schema editing is the Data pillar's
+  // job — so those leaves are not draft-editable in this canvas.
+  const isEditable = !!Preview && !StudioCanvas;
   // `kind: 'html'`/`'react'` pages are a `source` string (ADR-0080/0081),
   // rendered by SourcePageEditor as a code-editor + live-preview split — there
   // is no block tree, so `selection` never populates and the generic "click a
@@ -1351,11 +1358,14 @@ function InterfacesPillar({
           <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" /> {t('engine.studio.loading', locale)}
           </div>
-        ) : current.type === 'object' ? (
-          // Object nav leaf = the records list as the running app shows it
-          // (preview = runtime). Schema editing lives in the Data pillar, so
-          // here we render the object-view grid, not the field-form preview.
-          <SchemaRenderer schema={{ type: 'object-view', objectName: current.name } as never} />
+        ) : StudioCanvas ? (
+          // Studio-canvas surface override. The object nav leaf resolves here to
+          // the records list as the running app shows it (preview = runtime) —
+          // schema editing lives in the Data pillar, so this is the object-view
+          // grid, not the field-form preview. Default lives in
+          // `studio-canvas-preview`; downstream can override via
+          // `registerStudioCanvasPreview()` instead of forking this component.
+          <StudioCanvas type={current.type} name={current.name} draft={draft} locale={locale} />
         ) : isSourcePage ? (
           // Source pages have no block tree — the canvas shows only the live
           // preview; the code editor lives in the inspector's Source tab.

--- a/packages/app-shell/src/views/studio-design/studio-canvas-preview.test.tsx
+++ b/packages/app-shell/src/views/studio-design/studio-canvas-preview.test.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Contract tests for the Studio-canvas preview registry.
+ *
+ * The registry exists to give the Studio design surface a per-type, overridable
+ * canvas renderer, replacing the hardcoded `object → object-view grid` branch in
+ * `StudioDesignSurface` (issue #2337). These pin the three properties the
+ * surface relies on:
+ *   1. `object` ships a built-in default (so the grid still shows out of the box).
+ *   2. Unknown types resolve to `undefined` (so the surface falls back to the
+ *      generic MetadataPreview pipeline like every other type).
+ *   3. Registration is last-write-wins (so downstream can override without
+ *      forking the surface).
+ */
+import { describe, expect, it } from 'vitest';
+import type { StudioCanvasPreviewProps } from './studio-canvas-preview';
+import {
+  getStudioCanvasPreview,
+  registerStudioCanvasPreview,
+  listStudioCanvasPreviewTypes,
+  StudioObjectRecordsCanvas,
+} from './studio-canvas-preview';
+
+describe('studio-canvas-preview registry', () => {
+  it('ships a built-in default for `object` (the records grid)', () => {
+    expect(getStudioCanvasPreview('object')).toBe(StudioObjectRecordsCanvas);
+    expect(listStudioCanvasPreviewTypes()).toContain('object');
+  });
+
+  it('returns undefined for types with no override (falls back to MetadataPreview)', () => {
+    // `page`/`dashboard`/etc. have a MetadataPreview but no studio-canvas
+    // override — they must NOT be intercepted here.
+    expect(getStudioCanvasPreview('page')).toBeUndefined();
+    expect(getStudioCanvasPreview('')).toBeUndefined();
+    expect(getStudioCanvasPreview('does-not-exist')).toBeUndefined();
+  });
+
+  it('is last-write-wins so downstream can override the default', () => {
+    const original = getStudioCanvasPreview('object');
+    const Custom = (_props: StudioCanvasPreviewProps) => null;
+    try {
+      registerStudioCanvasPreview('object', Custom);
+      expect(getStudioCanvasPreview('object')).toBe(Custom);
+    } finally {
+      // Restore so registry state doesn't leak into other suites (the registry
+      // is module-global).
+      registerStudioCanvasPreview('object', original!);
+    }
+    expect(getStudioCanvasPreview('object')).toBe(StudioObjectRecordsCanvas);
+  });
+});

--- a/packages/app-shell/src/views/studio-design/studio-canvas-preview.tsx
+++ b/packages/app-shell/src/views/studio-design/studio-canvas-preview.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * StudioCanvasPreviewRegistry — per-type canvas renderers for the Studio
+ * design surface.
+ *
+ * Why a *second* registry alongside `MetadataPreviewRegistry`
+ * (`../metadata-admin/preview-registry`): the SAME metadata type is rendered
+ * differently depending on the SURFACE it appears in. An `object` in the Data
+ * pillar (metadata-admin) is the field-form DESIGNER (`ObjectPreview` →
+ * `ObjectFormCanvas`); an `object` in the Studio design canvas is the runtime
+ * records GRID — schema editing belongs to the Data pillar, so the app-builder
+ * canvas shows objects as the running app does, not a field editor.
+ *
+ * A single type-keyed registry can't express that `(type, surface)` split,
+ * which is why the object branch used to be a hardcoded special-case inside
+ * `StudioDesignSurface`. This registry is the missing surface dimension, scoped
+ * to the Studio canvas: a sensible default is registered for `object` (below),
+ * and downstream apps/plugins override it via `registerStudioCanvasPreview()`
+ * without forking `StudioDesignSurface`.
+ *
+ * Resolution contract: if a type has no studio-canvas entry,
+ * `getStudioCanvasPreview()` returns `undefined` and the surface falls back to
+ * the generic `MetadataPreview` pipeline (`getMetadataPreview`) like every
+ * other type. So this registry is purely additive — it only intercepts types
+ * that opt in.
+ *
+ * NOTE (long-term): today only `object` needs a surface-specific override. If a
+ * second surface ever needs per-type overrides, prefer folding this into a
+ * `(type, surface)`-keyed lookup on the existing MetadataPreviewRegistry rather
+ * than growing a third parallel registry.
+ */
+
+import * as React from 'react';
+import { SchemaRenderer } from '@object-ui/react';
+
+/**
+ * Props handed to a Studio-canvas renderer. Intentionally a small, read-only
+ * subset of {@link MetadataPreviewProps}: the Studio canvas renders objects as
+ * a runtime surface, not an editable draft (schema editing is the Data
+ * pillar's job), so there is no `onPatch`/`selection` here.
+ */
+export interface StudioCanvasPreviewProps {
+  /** The metadata type, e.g. 'object'. */
+  type: string;
+  /** The item's primary-key name (e.g. the object's API name). */
+  name: string;
+  /**
+   * The live draft from the design surface. Treat as immutable and untrusted
+   * (validation may be in progress). Provided for renderers that need config
+   * beyond the name; the default object renderer only needs `name`.
+   */
+  draft: Record<string, unknown>;
+  /** Optional BCP-47 locale code (e.g. 'en', 'zh-CN') for localized labels. */
+  locale?: string;
+}
+
+export type StudioCanvasPreview = React.ComponentType<StudioCanvasPreviewProps>;
+
+const REGISTRY = new Map<string, StudioCanvasPreview>();
+
+/**
+ * Register (or replace) the Studio-canvas renderer for a metadata type.
+ * Idempotent and last-write-wins, so an app can swap the default from its
+ * plugin bootstrap.
+ */
+export function registerStudioCanvasPreview(type: string, component: StudioCanvasPreview): void {
+  REGISTRY.set(type, component);
+}
+
+/** Look up the registered Studio-canvas renderer for a type, if any. */
+export function getStudioCanvasPreview(type: string): StudioCanvasPreview | undefined {
+  return REGISTRY.get(type);
+}
+
+/** Snapshot of registered Studio-canvas types (diagnostics/tests). */
+export function listStudioCanvasPreviewTypes(): string[] {
+  return Array.from(REGISTRY.keys()).sort();
+}
+
+/**
+ * Default Studio-canvas renderer for `object` leaves: the runtime records grid,
+ * exactly as the running app shows it (preview = runtime). Schema editing lives
+ * in the Data pillar, so this is the object-view grid — NOT the field-form
+ * designer that is the `object` entry in the MetadataPreviewRegistry.
+ *
+ * Exported so downstream renderers can compose/wrap it; override the default
+ * wholesale via `registerStudioCanvasPreview('object', …)`.
+ */
+export function StudioObjectRecordsCanvas({ name }: StudioCanvasPreviewProps) {
+  return <SchemaRenderer schema={{ type: 'object-view', objectName: name } as never} />;
+}
+
+// Side-effect: register the built-in defaults. Kept inline (rather than a
+// separate `previews/` folder like metadata-admin) because there is exactly one
+// default; downstream overrides run after this module loads and win.
+registerStudioCanvasPreview('object', StudioObjectRecordsCanvas);


### PR DESCRIPTION
Closes #2337.

## Problem

`StudioDesignSurface` hardcoded `current.type === 'object'` to render the object-view records grid via `<SchemaRenderer … as never>`, short-circuiting the generic `<Preview>` pipeline every other type goes through. That blocked extensibility — a downstream consumer couldn't customize the object canvas without forking the whole component.

## Why the issue's literal fix is wrong

The issue proposes letting `object` "fall through to `<Preview>`". But `getMetadataPreview('object')` already returns `ObjectPreview` — the **field-form designer** (`ObjectFormCanvas`), which is the primary authoring surface in the Data pillar (metadata-admin). Falling through would render the field designer in the Studio canvas, breaking the product invariant that *schema editing lives in the Data pillar; the app-builder canvas shows objects as the running app does* (the records grid).

## Root cause

`MetadataPreviewRegistry` is keyed only by `type`, but the **same** type must render differently per **surface**:

| surface | `object` renders as |
|---|---|
| Data pillar (metadata-admin) | field-form designer (`ObjectPreview`) |
| Studio design canvas | runtime records grid (`object-view`) |

A single type-keyed registry can't express that `(type, surface)` split — which is exactly why the object branch was hardcoded.

## Fix (approach A — surface-scoped override)

Add a small surface-scoped registry, `studio-canvas-preview`, that supplies the missing dimension:

- `object` ships a **built-in default** (`StudioObjectRecordsCanvas`) — the records grid, moved out of the hardcode.
- Downstream overrides it via `registerStudioCanvasPreview('object', …)` — last-write-wins, no fork.
- Types with **no** override resolve to `undefined` and fall back to the generic `MetadataPreview` pipeline like every other type, so this is purely additive.
- `isEditable` is now driven by the registry (`!StudioCanvas`) instead of a hardcoded `!== 'object'` string.
- Removed the now-unused bare `SchemaRenderer` import.

The default render output is byte-identical to before, so no behavior change for existing usage; the grid is now a **replaceable default** rather than an un-overridable hardcode. The field-form designer stays out of the Studio canvas.

Registry API is exported from `@object-ui/app-shell` (`registerStudioCanvasPreview` / `getStudioCanvasPreview` / `listStudioCanvasPreviewTypes` / `StudioObjectRecordsCanvas` + types).

### Long-term note
Only `object` needs a surface override today, so this is deliberately a small scoped registry (YAGNI over a full `(type, surface)` refactor of MetadataPreviewRegistry). If a second surface ever needs per-type overrides, fold this into a `(type, surface)`-keyed lookup on the existing registry rather than growing a third parallel one — the module doc-comment records this.

## Verification
- `pnpm --filter @object-ui/app-shell type-check` — clean
- studio-design suite — **81 tests / 13 files pass**, incl. new `studio-canvas-preview.test.tsx` (built-in default present, unknown → undefined fallback, last-write-wins override)
- Default output unchanged (still the `object-view` grid), so no browser regression expected; full-stack e2e not run (disproportionate for an extensibility refactor with identical default rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)