### PR TITLE
refactor(plugin-detail): extract &lt;InlineFieldInput&gt; from DetailSection (#2407 step 0)

### DIFF
--- a/.changeset/inline-field-input-extraction.md
+++ b/.changeset/inline-field-input-extraction.md
@@ -1,0 +1,25 @@
+---
+"@object-ui/plugin-detail": patch
+---
+
+refactor(plugin-detail): extract `<InlineFieldInput>` from `DetailSection`
+
+Lift the inline-edit input branch out of `DetailSection` into a standalone,
+reusable `<InlineFieldInput>` component (objectui#2407, step 0 — the
+behavior-preserving refactor that precedes the record-level `InlineEditContext`
+and editable-highlights work).
+
+Behavior is unchanged: `<InlineFieldInput>` renders the exact same type-aware
+editors the detail body handled inline — `SelectField`, `BooleanField`,
+`LookupField`, `UserField`, `CapabilityMultiSelectField`, the
+`permission-facet-link` read-only facet, and the plain number/date/text input
+(with ISO-date coercion and `$expand`-ed-reference safety so an object value
+never leaks `"[object Object]"`). `DetailSection` now delegates to it and keeps
+the field-editability gate (computed / `readonly` / system-field / object
+lifecycle) exactly as before. The `extractLookupId` helper and the
+`TEXTUAL_REF_FALLBACK_TYPES` set move alongside the component.
+
+This lets any record-level surface (the details body **and** the highlights
+strip) share one editor, shrinking the surface of the follow-up
+editable-highlights change. Covered by the existing `DetailSection` inline-edit
+suites plus a new `InlineFieldInput` parity test.

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -25,13 +25,14 @@ import {
 } from '@object-ui/components';
 import { ChevronDown, ChevronRight, Copy, Check, Eye, EyeOff, Pencil } from 'lucide-react';
 import { SchemaRenderer } from '@object-ui/react';
-import { getCellRenderer, resolveCellRendererType, SelectField, BooleanField, LookupField, UserField, CapabilityMultiSelectField, coerceToSafeValue } from '@object-ui/fields';
+import { getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
 import type { DetailViewSection as DetailViewSectionType, DetailViewField, FieldMetadata } from '@object-ui/types';
 import { applyDetailAutoLayout } from './autoLayout';
 import { useDetailTranslation } from './useDetailTranslation';
 import { useSafeFieldLabel } from '@object-ui/react';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
 import { NON_EDITABLE_SYSTEM_FIELDS } from './systemFields';
+import { InlineFieldInput, TEXTUAL_REF_FALLBACK_TYPES } from './InlineFieldInput';
 
 /**
  * Compute responsive col-span classes so that col-span never exceeds the
@@ -64,29 +65,6 @@ export function getResponsiveSpanClass(span: number | undefined, columns: number
   if (span >= 4) return 'md:col-span-2 lg:col-span-3 xl:col-span-4';
 
   return '';
-}
-
-/**
- * Field types that carry a `reference_to` for relational metadata but are NOT
- * edited via the lookup picker (they have their own dedicated inputs/renderers).
- * Used so the inline-edit branch doesn't hijack them into a record picker.
- */
-const TEXTUAL_REF_FALLBACK_TYPES = new Set(['formula', 'summary', 'rollup', 'auto_number']);
-
-/**
- * Extract the id a reference widget expects from a value that may already be
- * an `$expand`-ed record object (`{ id, name, ... }`), an array of those, or a
- * bare id. Mirrors the display logic in `LookupCellRenderer` so edit-mode and
- * read-mode agree on which id a relationship points at.
- */
-function extractLookupId(value: unknown): unknown {
-  if (value == null) return value;
-  if (Array.isArray(value)) return value.map(extractLookupId);
-  if (typeof value === 'object') {
-    const obj = value as Record<string, unknown>;
-    return obj.id ?? obj._id ?? obj.value ?? '';
-  }
-  return value;
 }
 
 export interface VirtualScrollOptions {
@@ -335,112 +313,13 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
         </div>
         {isEditing && fieldEditable ? (
           <div className="min-h-[44px] sm:min-h-0">
-            {(() => {
-              const editType = enrichedField.type || field.type;
-              // Per-field widget override (ADR-0056 P2) — honor a `widget` hint
-              // before the type switch so a structured editor (e.g. the
-              // capability multi-select on sys_permission_set.system_permissions)
-              // replaces the raw type in inline edit too, matching the form path.
-              const editWidget = (enrichedField as any).widget || (field as any).widget;
-              // Permission facets are designed in Studio, never edited in Setup —
-              // even in section edit mode they stay a read-only summary + deep-link.
-              if (editWidget === 'permission-facet-link') {
-                return <PermissionFacetLink value={value} field={enrichedField as any} />;
-              }
-              if (editWidget === 'capability-multiselect') {
-                return (
-                  <CapabilityMultiSelectField
-                    value={value}
-                    onChange={(v: any) => onFieldChange?.(field.name, v)}
-                    field={enrichedField as any}
-                    dataSource={dataSource}
-                  />
-                );
-              }
-              // Picklist → real Select widget so users see localized
-              // option labels and can't free-type invalid values.
-              if (editType === 'select' && Array.isArray(enrichedField.options) && enrichedField.options.length > 0) {
-                return (
-                  <SelectField
-                    field={enrichedField as any}
-                    value={value == null ? '' : String(value)}
-                    onChange={(v) => onFieldChange?.(field.name, v)}
-                  />
-                );
-              }
-              // Boolean → Switch widget instead of free-text "true"/"false".
-              if (editType === 'boolean') {
-                return (
-                  <BooleanField
-                    field={enrichedField as any}
-                    value={!!value}
-                    onChange={(v) => onFieldChange?.(field.name, v)}
-                  />
-                );
-              }
-              // Reference fields (lookup / master_detail / tree / user / owner)
-              // store an id but may arrive `$expand`-ed as a record object. A
-              // plain text input would stringify that to "[object Object]", so
-              // render the real picker and feed it the id extracted from the
-              // (possibly expanded) value.
-              const isUserRef = editType === 'user' || editType === 'owner';
-              const isLookupRef =
-                editType === 'lookup' ||
-                editType === 'master_detail' ||
-                editType === 'tree' ||
-                (!!enrichedField.reference_to && !TEXTUAL_REF_FALLBACK_TYPES.has(editType as string));
-              if (isUserRef || isLookupRef) {
-                const RefWidget = isUserRef ? UserField : LookupField;
-                return (
-                  <RefWidget
-                    field={enrichedField as any}
-                    value={extractLookupId(value)}
-                    onChange={(v: any) => onFieldChange?.(field.name, v)}
-                    dataSource={dataSource}
-                  />
-                );
-              }
-              const isDate = editType === 'date' || editType === 'datetime';
-              const inputType = editType === 'number' ? 'number' : isDate ? 'date' : 'text';
-              // <input type="date"> needs a YYYY-MM-DD string; raw ISO
-              // timestamps ("2026-02-14T14:46:20.862Z") leave the picker
-              // blank. Slice down to the date portion so existing values
-              // round-trip correctly.
-              const inputValue = value == null
-                ? ''
-                : isDate
-                  ? (() => {
-                      const s = String(value);
-                      if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s.slice(0, 10);
-                      const d = new Date(s);
-                      return isNaN(d.getTime()) ? '' : d.toLocaleDateString('en-CA');
-                    })()
-                  // Coerce objects (e.g. an unexpanded reference that slipped
-                  // through type detection) to a readable label rather than
-                  // leaking "[object Object]" into the input.
-                  : typeof value === 'object'
-                    ? String(coerceToSafeValue(value) ?? '')
-                    : String(value);
-              return (
-                <input
-                  type={inputType}
-                  autoFocus={autoFocusField === field.name}
-                  className="w-full px-2 py-1.5 text-sm border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
-                  value={inputValue}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    // Re-emit dates as full ISO so backend validation that
-                    // expects ISO timestamps keeps working.
-                    if (isDate && v) {
-                      const iso = new Date(v + 'T00:00:00').toISOString();
-                      onFieldChange?.(field.name, iso);
-                    } else {
-                      onFieldChange?.(field.name, v);
-                    }
-                  }}
-                />
-              );
-            })()}
+            <InlineFieldInput
+              field={enrichedField}
+              value={value}
+              onChange={(v) => onFieldChange?.(field.name, v)}
+              dataSource={dataSource}
+              autoFocus={autoFocusField === field.name}
+            />
           </div>
         ) : (
         <div

--- a/packages/plugin-detail/src/InlineFieldInput.tsx
+++ b/packages/plugin-detail/src/InlineFieldInput.tsx
@@ -1,0 +1,187 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from 'react';
+import {
+  SelectField,
+  BooleanField,
+  LookupField,
+  UserField,
+  CapabilityMultiSelectField,
+  coerceToSafeValue,
+} from '@object-ui/fields';
+import { PermissionFacetLink } from './renderers/PermissionFacetLink';
+
+/**
+ * Field types that carry a `reference_to` for relational metadata but are NOT
+ * edited via the lookup picker (they have their own dedicated inputs/renderers).
+ * Used so the inline-edit branch doesn't hijack them into a record picker.
+ *
+ * Exported because `DetailSection`'s per-field editability gate keys off the
+ * same set (a computed field is never editable), so the two must not drift.
+ */
+export const TEXTUAL_REF_FALLBACK_TYPES = new Set(['formula', 'summary', 'rollup', 'auto_number']);
+
+/**
+ * Extract the id a reference widget expects from a value that may already be
+ * an `$expand`-ed record object (`{ id, name, ... }`), an array of those, or a
+ * bare id. Mirrors the display logic in `LookupCellRenderer` so edit-mode and
+ * read-mode agree on which id a relationship points at.
+ */
+export function extractLookupId(value: unknown): unknown {
+  if (value == null) return value;
+  if (Array.isArray(value)) return value.map(extractLookupId);
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    return obj.id ?? obj._id ?? obj.value ?? '';
+  }
+  return value;
+}
+
+export interface InlineFieldInputProps {
+  /**
+   * Enriched field metadata — `type` plus any objectSchema enrichment (options,
+   * currency, precision, format, reference_to, widget…). The caller owns
+   * enrichment so read-mode and edit-mode agree on the same resolved field
+   * shape. Kept as a loose bag (matching the widgets' `field` props) since the
+   * exact key set varies by field type.
+   */
+  field: Record<string, any>;
+  /** Current field value (may be an `$expand`-ed record object for references). */
+  value: any;
+  /** Called with the next value whenever the user edits the field. */
+  onChange: (value: any) => void;
+  /** DataSource used by reference (lookup / master_detail / user) pickers. */
+  dataSource?: any;
+  /** Auto-focus the underlying input on mount (wired to the entered field). */
+  autoFocus?: boolean;
+}
+
+/**
+ * The single inline-edit input for a record field, extracted from
+ * `DetailSection` so any record-level surface — the details body AND the
+ * highlights strip (objectui#2407) — renders an identical editor. Covers every
+ * widget the detail body handles: `SelectField`, `BooleanField`, `LookupField`,
+ * `UserField`, `CapabilityMultiSelectField` (#2403), the `permission-facet-link`
+ * read-only facet (#2403), and the plain number/date/text input (with ISO date
+ * coercion + object-value guarding so an unexpanded reference never leaks
+ * "[object Object]").
+ *
+ * Editability GATING (computed types, `readonly`, system fields, object
+ * lifecycle) stays with the host — this component only renders the editor once
+ * the host has decided the field is editable.
+ */
+export const InlineFieldInput: React.FC<InlineFieldInputProps> = ({
+  field,
+  value,
+  onChange,
+  dataSource,
+  autoFocus,
+}) => {
+  const editType = field.type;
+  // Per-field widget override (ADR-0056 P2) — honor a `widget` hint before the
+  // type switch so a structured editor (e.g. the capability multi-select on
+  // sys_permission_set.system_permissions) replaces the raw type in inline
+  // edit too, matching the form path.
+  const editWidget = (field as any).widget;
+  // Permission facets are designed in Studio, never edited in Setup — even in
+  // section edit mode they stay a read-only summary + deep-link.
+  if (editWidget === 'permission-facet-link') {
+    return <PermissionFacetLink value={value} field={field as any} />;
+  }
+  if (editWidget === 'capability-multiselect') {
+    return (
+      <CapabilityMultiSelectField
+        value={value}
+        onChange={(v: any) => onChange(v)}
+        field={field as any}
+        dataSource={dataSource}
+      />
+    );
+  }
+  // Picklist → real Select widget so users see localized option labels and
+  // can't free-type invalid values.
+  if (editType === 'select' && Array.isArray(field.options) && field.options.length > 0) {
+    return (
+      <SelectField
+        field={field as any}
+        value={value == null ? '' : String(value)}
+        onChange={(v) => onChange(v)}
+      />
+    );
+  }
+  // Boolean → Switch widget instead of free-text "true"/"false".
+  if (editType === 'boolean') {
+    return (
+      <BooleanField
+        field={field as any}
+        value={!!value}
+        onChange={(v) => onChange(v)}
+      />
+    );
+  }
+  // Reference fields (lookup / master_detail / tree / user / owner) store an id
+  // but may arrive `$expand`-ed as a record object. A plain text input would
+  // stringify that to "[object Object]", so render the real picker and feed it
+  // the id extracted from the (possibly expanded) value.
+  const isUserRef = editType === 'user' || editType === 'owner';
+  const isLookupRef =
+    editType === 'lookup' ||
+    editType === 'master_detail' ||
+    editType === 'tree' ||
+    (!!field.reference_to && !TEXTUAL_REF_FALLBACK_TYPES.has(editType as string));
+  if (isUserRef || isLookupRef) {
+    const RefWidget = isUserRef ? UserField : LookupField;
+    return (
+      <RefWidget
+        field={field as any}
+        value={extractLookupId(value)}
+        onChange={(v: any) => onChange(v)}
+        dataSource={dataSource}
+      />
+    );
+  }
+  const isDate = editType === 'date' || editType === 'datetime';
+  const inputType = editType === 'number' ? 'number' : isDate ? 'date' : 'text';
+  // <input type="date"> needs a YYYY-MM-DD string; raw ISO timestamps
+  // ("2026-02-14T14:46:20.862Z") leave the picker blank. Slice down to the date
+  // portion so existing values round-trip correctly.
+  const inputValue = value == null
+    ? ''
+    : isDate
+      ? (() => {
+          const s = String(value);
+          if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s.slice(0, 10);
+          const d = new Date(s);
+          return isNaN(d.getTime()) ? '' : d.toLocaleDateString('en-CA');
+        })()
+      // Coerce objects (e.g. an unexpanded reference that slipped through type
+      // detection) to a readable label rather than leaking "[object Object]".
+      : typeof value === 'object'
+        ? String(coerceToSafeValue(value) ?? '')
+        : String(value);
+  return (
+    <input
+      type={inputType}
+      autoFocus={autoFocus}
+      className="w-full px-2 py-1.5 text-sm border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+      value={inputValue}
+      onChange={(e) => {
+        const v = e.target.value;
+        // Re-emit dates as full ISO so backend validation that expects ISO
+        // timestamps keeps working.
+        if (isDate && v) {
+          const iso = new Date(v + 'T00:00:00').toISOString();
+          onChange(iso);
+        } else {
+          onChange(v);
+        }
+      }}
+    />
+  );
+};

--- a/packages/plugin-detail/src/__tests__/InlineFieldInput.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineFieldInput.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InlineFieldInput } from '../InlineFieldInput';
+
+/**
+ * `<InlineFieldInput>` is the edit-input branch extracted verbatim from
+ * `DetailSection` (objectui#2407, step 0) so the details body and the highlights
+ * strip render an identical editor. These tests pin the parity contract the
+ * extraction must preserve: type-aware widget routing, `$expand`-ed reference
+ * safety, ISO date coercion, object-value guarding, and auto-focus.
+ *
+ * Assertions are provider-free (matching the existing DetailSection inline-edit
+ * suites) so they hold whether or not i18n / permission providers are mounted.
+ */
+describe('InlineFieldInput', () => {
+  it('renders an editable text input and emits typed values via onChange', () => {
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput
+        field={{ name: 'title', type: 'text' }}
+        value="Hello"
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByDisplayValue('Hello');
+    expect(input).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: 'Hi there' } });
+    expect(onChange).toHaveBeenCalledWith('Hi there');
+  });
+
+  it('never leaks "[object Object]" for an $expand-ed reference value', () => {
+    render(
+      <InlineFieldInput
+        field={{ name: 'project', type: 'master_detail', reference_to: 'projects' }}
+        value={{ _id: 'p1', name: 'Apollo' }}
+        onChange={vi.fn()}
+      />,
+    );
+    // The reference renders the lookup picker (not a raw text input), so the
+    // stringified object must never surface anywhere.
+    expect(screen.queryByText(/\[object Object\]/)).toBeNull();
+    expect(screen.queryByDisplayValue(/\[object Object\]/)).toBeNull();
+  });
+
+  it('never leaks "[object Object]" for an object value on a plain field', () => {
+    render(
+      <InlineFieldInput
+        field={{ name: 'meta', type: 'text' }}
+        value={{ foo: 'bar' }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.queryByDisplayValue(/\[object Object\]/)).toBeNull();
+  });
+
+  it('slices an ISO timestamp to YYYY-MM-DD for the date input and re-emits ISO on change', () => {
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput
+        field={{ name: 'due', type: 'date' }}
+        value="2026-02-14T14:46:20.862Z"
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByDisplayValue('2026-02-14');
+    expect(input).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: '2026-03-01' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    // Re-emitted as a full ISO timestamp (TZ-independent shape assertion).
+    const arg = onChange.mock.calls[0][0];
+    expect(typeof arg).toBe('string');
+    expect(arg).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('auto-focuses the input when autoFocus is set', () => {
+    render(
+      <InlineFieldInput
+        field={{ name: 'title', type: 'text' }}
+        value="Hello"
+        onChange={vi.fn()}
+        autoFocus
+      />,
+    );
+    expect(screen.getByDisplayValue('Hello')).toHaveFocus();
+  });
+});

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -49,6 +49,8 @@ export type {
 } from './ConcurrentUpdateDialog';
 export { SectionGroup } from './SectionGroup';
 export { HeaderHighlight } from './HeaderHighlight';
+export { InlineFieldInput, extractLookupId, TEXTUAL_REF_FALLBACK_TYPES } from './InlineFieldInput';
+export type { InlineFieldInputProps } from './InlineFieldInput';
 export { inferDetailColumns, isWideFieldType, applyAutoSpan, applyDetailAutoLayout } from './autoLayout';
 export { useDetailTranslation, DETAIL_DEFAULT_TRANSLATIONS, createSafeTranslationHook } from './useDetailTranslation';
 export { RecordComments } from './RecordComments';


### PR DESCRIPTION
## What & why

Follow-up to #2402, first PR of **#2407** ("Record-level inline edit: editable highlights + one atomic Save"). That issue is deliberately split into three sequential PRs; the maintainer's execution note asks to land **step 0 — the behavior-preserving `<InlineFieldInput>` extraction — first**, because it is already covered by the #2402 `DetailSection` inline-edit tests and shrinks the surface of the later editable-highlights work.

This PR is exactly that step **0**. It contains **zero UX/behavior change** — it only lifts the inline-edit input branch out of `DetailSection` into a standalone, reusable component so any record-level surface (the details body **and**, later, the highlights strip) can render one identical editor.

## Changes

| Area | Change |
|---|---|
| **`InlineFieldInput.tsx`** (new) | The edit-input branch extracted verbatim from `DetailSection`. Renders the same type-aware editors: `SelectField`, `BooleanField`, `LookupField`, `UserField`, `CapabilityMultiSelectField` (#2403), the `permission-facet-link` read-only facet (#2403), and the plain number/date/text `<input>` (ISO-date coercion + `$expand`-ed reference safety so an object value never leaks `"[object Object]"`). `extractLookupId` + `TEXTUAL_REF_FALLBACK_TYPES` move here. |
| `DetailSection` | Delegates the edit branch to `<InlineFieldInput>`; re-imports `TEXTUAL_REF_FALLBACK_TYPES` for its editability gate. The gate itself (computed / `readonly` / system-field / object-lifecycle) and the surrounding `min-h` wrapper are unchanged, so the rendered DOM is identical. |
| `index.tsx` | Export `InlineFieldInput` (+ `InlineFieldInputProps`, `extractLookupId`, `TEXTUAL_REF_FALLBACK_TYPES`). |
| tests | New `InlineFieldInput.test.tsx` parity suite (widget routing, `$expand`-ed reference & object-value safety, ISO date round-trip, auto-focus). |

The input widget only is extracted; the editability **gating** stays with the host — `<InlineFieldInput>` renders the editor only once the host has decided a field is editable.

## Guardrails preserved

Computed (`formula`/`summary`/`rollup`/`auto_number`) + `readonly` + system fields expose no editor; object-lifecycle gate unchanged; OCC / partial-update save path (`record:details` → `DetailView`) untouched. Pure refactor — no save-semantics change (that is P1).

## Verification

- `plugin-detail` **type-check** clean, **vite build** ✓ (declarations emitted).
- **191 tests pass (19 files)** — the existing `DetailSection.inlineEdit` / `DetailSection.doubleClickEdit` suites, the `record-details` inline-save + OCC-conflict test (which drives the full save path through the extracted component), and the new `InlineFieldInput` parity test.
- No new lint errors introduced.

## Next (separate PRs, per #2407)

- **P1** — record-level `InlineEditContext` + one atomic OCC save; `DetailView` (page + standalone) delegates; delete its local batch save. Highlights stay read-only.
- **P2** — editable highlights on top of the shared draft, using this `<InlineFieldInput>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1f7TvqYMo41g9RbQ6H2od)_