### PR TITLE
fix(app-shell): close view config panel on discard in edit mode (#2320)

### DIFF
--- a/packages/app-shell/src/views/ViewConfigPanel.test.tsx
+++ b/packages/app-shell/src/views/ViewConfigPanel.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * ViewConfigPanel discard/close behavior (objectui#2320).
+ *
+ * Discard must revert any unsaved edits AND close the panel in edit mode,
+ * consistent with create mode. Edits reach the host list preview only through
+ * `onViewUpdate`, so discard replays the opening values through the same seam.
+ */
+
+// Swap the heavy spec-driven inspector for a light stub that lets a test drive
+// `onPatch` — the seam ViewConfigPanel mirrors edits back to the host with.
+vi.mock('./metadata-admin/inspectors/ViewVariantInspector', () => ({
+  ViewVariantInspector: ({ draft, onPatch }: any) => (
+    <button
+      type="button"
+      data-testid="mock-inspector-edit"
+      onClick={() =>
+        onPatch({ config: { ...(draft?.config ?? {}), columns: ['a', 'b', 'c'] } })
+      }
+    >
+      edit
+    </button>
+  ),
+}));
+
+// The ADR-0034 draft/publish chrome does its own async metadata reads; stub it
+// out so these tests stay focused on the local discard/close behavior.
+vi.mock('./RuntimeDraftBar', () => ({
+  RuntimeDraftBar: () => null,
+}));
+
+import { ViewConfigPanel } from './ViewConfigPanel';
+
+const objectDef = {
+  name: 'obj',
+  fields: {
+    a: { label: 'A', type: 'text' },
+    b: { label: 'B', type: 'text' },
+    c: { label: 'C', type: 'text' },
+  },
+};
+
+function makeProps(overrides: Record<string, any> = {}) {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    activeView: { id: 'v1', type: 'grid', columns: ['a', 'b'], filter: [], sort: [] },
+    objectDef,
+    onViewUpdate: vi.fn(),
+    onSave: vi.fn(),
+    onCreate: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('ViewConfigPanel — discard', () => {
+  it('edit mode: Discard closes the panel even with no edits (objectui#2320)', () => {
+    const props = makeProps({ mode: 'edit' });
+    render(<ViewConfigPanel {...props} />);
+
+    fireEvent.click(screen.getByTestId('view-config-discard'));
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('edit mode: Discard reverts the host list preview to the opening view, then closes', () => {
+    const props = makeProps({ mode: 'edit' });
+    render(<ViewConfigPanel {...props} />);
+
+    // Simulate an inspector edit → mirrored to the host list via onViewUpdate.
+    fireEvent.click(screen.getByTestId('mock-inspector-edit'));
+    expect(props.onViewUpdate).toHaveBeenCalledWith('columns', ['a', 'b', 'c']);
+
+    props.onViewUpdate.mockClear();
+
+    // Discard → host is told to restore the original columns, then closed.
+    fireEvent.click(screen.getByTestId('view-config-discard'));
+    expect(props.onViewUpdate).toHaveBeenCalledWith('columns', ['a', 'b']);
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('create mode: Discard closes the panel without creating', () => {
+    const props = makeProps({ mode: 'create' });
+    render(<ViewConfigPanel {...props} />);
+
+    fireEvent.click(screen.getByTestId('view-config-discard'));
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(props.onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-shell/src/views/ViewConfigPanel.tsx
+++ b/packages/app-shell/src/views/ViewConfigPanel.tsx
@@ -192,14 +192,30 @@ export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, obje
         setIsDirty(false);
     }, [draft, onSave, onCreate, mode]);
 
+    // Discard = revert any unsaved edits AND close the panel, in both modes
+    // (objectui#2320). Create mode has no committed view to preview against, so
+    // there's nothing to revert on the host — just close (matching prior
+    // behavior). Edit mode also restores the host's live list preview: edits
+    // reach the list only through `onViewUpdate` (see `handlePatch`), so we
+    // replay the panel's opening values — and clear any keys the edits
+    // introduced — through the same seam, then reset the local draft.
     const handleDiscard = useCallback(() => {
-        if (mode === 'create') {
-            onClose();
-            return;
+        if (mode === 'edit') {
+            if (onViewUpdate) {
+                const original = inspectorDraftToRuntimeView(initialDraft);
+                const edited = inspectorDraftToRuntimeView(draftRef.current);
+                const fields = new Set([...Object.keys(edited), ...Object.keys(original)]);
+                for (const field of fields) {
+                    if (field === 'id') continue;
+                    onViewUpdate(field, original[field]);
+                }
+            }
+            draftRef.current = initialDraft;
+            setDraft(initialDraft);
+            setIsDirty(false);
         }
-        setDraft(initialDraft);
-        setIsDirty(false);
-    }, [initialDraft, mode, onClose]);
+        onClose();
+    }, [initialDraft, mode, onClose, onViewUpdate]);
 
     // ADR-0034 (#1515): resume a pending draft into the inspector when the
     // panel reopens (flag-ON only; the bar never fires this when the flag is


### PR DESCRIPTION
## Summary

Fixes #2320 — the ViewConfigPanel **Discard** button did not close the panel in **edit** mode.

In `edit` mode, `handleDiscard` only reset the local inspector draft and never called `onClose`, so the right-rail panel stayed open after clicking Discard. `create` mode already closed correctly. On top of that, any unsaved edits still lingered in the host's **live list preview**: edits reach the list only through `onViewUpdate` (the host accumulates them into `viewDraft`, and the list renders from `activeView = { ...baseView, ...viewDraft }`), and the old discard never reverted that.

## Change

`handleDiscard` (edit mode) now:
1. **Reverts the host's live list preview** to the view as it was when the panel opened — it replays the original values back through the same `onViewUpdate` seam edits flow through, and clears any keys the edits introduced — so the list returns to its prior state.
2. Resets the local inspector draft.
3. **Closes the panel** via `onClose()`.

`create` mode keeps its existing behavior (nothing to revert on the host, since its provisional view id never matches the active view — just close). Both modes now close on discard, giving the standard `discard = revert + close` UX.

## Test plan

- Added `ViewConfigPanel.test.tsx` regression tests:
  - edit mode: Discard closes the panel even with no edits (the reported bug)
  - edit mode: Discard reverts the host list preview to the opening view, then closes
  - create mode: Discard closes without creating
- `pnpm exec vitest run` — 16/16 passing (new tests + existing `view-config-adapter` / `RuntimeDraftBar` suites)
- `turbo run type-check --filter=@object-ui/app-shell` — clean
- `eslint` on the changed files — 0 errors

No changeset (pure bug fix). No public API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NooKvj3igznTTQrVVj5CNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NooKvj3igznTTQrVVj5CNu)_