### PR TITLE
feat(metadata-admin): create form-family views through the View create UI (#2323)

### DIFF
--- a/.changeset/view-create-form-family.md
+++ b/.changeset/view-create-form-family.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(metadata-admin): create form-family views through the View create UI (#2323)
+
+`ViewItemSchema` is a discriminated union on `viewKind` (`list` | `form`), but the
+View create form could only ever emit `viewKind: 'list'` — its `createBuildBody`
+hardcoded the family and routed the chosen `kind` straight into `config.type`, so
+form-family views were unreachable through the create UI.
+
+- **Create schema** now asks for the **view family** up front (`viewKind`:
+  List / Form) and offers the layout types appropriate to that family — the
+  existing list layouts (grid / kanban / gallery / calendar / timeline / gantt /
+  chart) for `list`, and the `FormViewSchema` layouts (simple / tabbed / wizard /
+  split / drawer / modal) for `form`.
+- **`createBuildBody`** discriminates on `viewKind`: a form view builds a
+  `FormViewSchema` config (`{ type, data, sections: [] }`) instead of the list
+  `{ type, columns: [], data }`. Both build outputs validate against the real
+  `@objectstack/spec` `ViewItemSchema`.
+- **SchemaForm** flat (create) rendering now honors per-property `visibleOn`, so
+  the list-layout picker shows only for List and the form-layout picker only for
+  Form. Additive and a no-op when a property has no predicate.

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.flatVisibility.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.flatVisibility.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SchemaForm } from './SchemaForm';
+
+afterEach(cleanup);
+
+/**
+ * Flat (non-sectioned) schema-driven rendering must honor per-property
+ * `visibleOn`, so a create form driven by a bare JSONSchema (no FormView
+ * layout) can gate a field on a sibling value. This is what lets the View
+ * create form show the list layout picker only for `viewKind: 'list'` and the
+ * form layout picker only for `viewKind: 'form'` (objectui#2323).
+ */
+
+// Mirrors the shape of the View createSchema's family-gated layout pickers.
+const schema = {
+  type: 'object',
+  properties: {
+    viewKind: { type: 'string', title: 'View family', enum: ['list', 'form'] },
+    kind: {
+      type: 'string',
+      title: 'List layout',
+      enum: ['grid', 'kanban'],
+      visibleOn: "data.viewKind == 'list'",
+    },
+    formType: {
+      type: 'string',
+      title: 'Form layout',
+      enum: ['simple', 'tabbed'],
+      visibleOn: "data.viewKind == 'form'",
+    },
+  },
+};
+
+describe('SchemaForm flat path — per-property visibleOn (objectui#2323)', () => {
+  it('shows the list layout picker and hides the form one for a list draft', () => {
+    render(<SchemaForm schema={schema} value={{ viewKind: 'list' }} onChange={() => {}} />);
+    expect(screen.getByText('View family')).toBeInTheDocument();
+    expect(screen.getByText('List layout')).toBeInTheDocument();
+    expect(screen.queryByText('Form layout')).not.toBeInTheDocument();
+  });
+
+  it('shows the form layout picker and hides the list one for a form draft', () => {
+    render(<SchemaForm schema={schema} value={{ viewKind: 'form' }} onChange={() => {}} />);
+    expect(screen.getByText('View family')).toBeInTheDocument();
+    expect(screen.getByText('Form layout')).toBeInTheDocument();
+    expect(screen.queryByText('List layout')).not.toBeInTheDocument();
+  });
+
+  it('fails open — a field with no visibleOn always renders', () => {
+    render(<SchemaForm schema={schema} value={{}} onChange={() => {}} />);
+    // `viewKind` has no predicate, so it shows even before a family is picked.
+    expect(screen.getByText('View family')).toBeInTheDocument();
+    // Neither gated picker matches an empty draft.
+    expect(screen.queryByText('List layout')).not.toBeInTheDocument();
+    expect(screen.queryByText('Form layout')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -487,9 +487,17 @@ export function SchemaForm({
   // Resolve top-level object properties.
   const props = (effectiveSchema.properties ?? {}) as Record<string, JsonSchema>;
   const required: string[] = Array.isArray(effectiveSchema.required) ? effectiveSchema.required : [];
-  const keys = orderKeys(Object.keys(props), fieldOrder).filter(
-    (k) => !hiddenFields.includes(k),
-  );
+  // Per-property `visibleOn` predicate context — the current draft under
+  // `data`, mirroring the sectioned form's field-level filtering. Lets a flat
+  // (create) schema gate a field on a sibling value (e.g. show the list layout
+  // picker only when `data.viewKind == 'list'`). No `visibleOn` → always shown.
+  const predicateData = (value ?? {}) as Record<string, unknown>;
+  const keys = orderKeys(Object.keys(props), fieldOrder)
+    .filter((k) => !hiddenFields.includes(k))
+    .filter((k) => {
+      const visibleOn = (props[k] as any)?.visibleOn;
+      return !visibleOn || evaluatePredicate(visibleOn, { data: predicateData });
+    });
 
   const issuesByPath = React.useMemo(() => {
     const map: Record<string, string[]> = {};

--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -199,13 +199,13 @@ export function registerBuiltinAnchors(): void {
       groupLabel: 'Views',
       order: 30,
     }],
-    createFields: ['label', 'name', 'object', 'kind'],
+    createFields: ['label', 'name', 'object', 'viewKind', 'kind', 'formType'],
     createDerive: [
       { from: 'label', to: 'name', transform: 'slugify', untilUserEdits: true },
     ],
     createSchema: {
       type: 'object',
-      required: ['label', 'name', 'object', 'kind'],
+      required: ['label', 'name', 'object', 'viewKind'],
       properties: {
         label: { type: 'string', title: 'Label', description: 'Human-readable view name.' },
         name: {
@@ -219,33 +219,67 @@ export function registerBuiltinAnchors(): void {
           title: 'Object',
           description: 'The object this view displays.',
         },
+        // The family discriminator (ViewItemSchema is a discriminated union on
+        // `viewKind`). Picks which config shape — and therefore which layout
+        // picker below — applies.
+        viewKind: {
+          type: 'string',
+          title: 'View family',
+          enum: ['list', 'form'],
+          default: 'list',
+          description:
+            'List views show many records as a collection (grid, kanban, …). Form views show one record as a field layout (simple, tabbed, …).',
+        },
+        // List-family layout. Shown only when `viewKind` is 'list'; its value
+        // becomes the list `config.type`.
         kind: {
           type: 'string',
-          title: 'View kind',
+          title: 'List layout',
           enum: ['grid', 'kanban', 'gallery', 'calendar', 'timeline', 'gantt', 'chart'],
           default: 'grid',
           description: 'Pick a starter layout. Switch later in the designer.',
+          visibleOn: "data.viewKind == 'list'",
+        },
+        // Form-family layout (FormViewSchema.type). Shown only when `viewKind`
+        // is 'form'; its value becomes the form `config.type`.
+        formType: {
+          type: 'string',
+          title: 'Form layout',
+          enum: ['simple', 'tabbed', 'wizard', 'split', 'drawer', 'modal'],
+          default: 'simple',
+          description: 'Pick a starter form layout. Switch later in the designer.',
+          visibleOn: "data.viewKind == 'form'",
         },
       },
     },
     // Emit a canonical ViewItem. `name` is the globally-unique qualified id
-    // `<object>.<key>`; the layout `kind` (grid/kanban/…) is all list-family,
-    // so `viewKind` is 'list' and the chosen layout lives at `config.type`.
+    // `<object>.<key>`; `viewKind` discriminates the config shape. A list view
+    // carries the chosen list layout (grid/kanban/…) at `config.type`; a form
+    // view carries the chosen form layout (simple/tabbed/…) at `config.type`
+    // with a `sections` body instead of `columns`.
     createBuildBody: (draft) => {
       const object = String(draft.object ?? '');
       const key = String(draft.name ?? '');
       const qualifiedName =
         key.includes('.') || !object ? key : `${object}.${key}`;
+      const isForm = draft.viewKind === 'form';
+      const config = isForm
+        ? {
+            type: (draft.formType as string) || 'simple',
+            data: { provider: 'object', object },
+            sections: [],
+          }
+        : {
+            type: (draft.kind as string) || 'grid',
+            columns: [],
+            data: { provider: 'object', object },
+          };
       return {
         name: qualifiedName,
         object,
-        viewKind: 'list',
+        viewKind: isForm ? 'form' : 'list',
         label: draft.label,
-        config: {
-          type: (draft.kind as string) || 'grid',
-          columns: [],
-          data: { provider: 'object', object },
-        },
+        config,
       };
     },
   });

--- a/packages/app-shell/src/views/metadata-admin/view-create-body.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/view-create-body.test.ts
@@ -1,0 +1,131 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// View create-body conformance (objectui#2323).
+//
+// `ViewItemSchema` is a discriminated union on `viewKind` with both a `list`
+// and a `form` variant. The create form must be able to produce BOTH families,
+// and each build output must validate against the REAL spec `ViewItemSchema`
+// (not the lenient aggregated container the client validator strips through).
+//
+// Regression guard: `createBuildBody` used to hardcode `viewKind: 'list'` and
+// route the draft `kind` straight into `config.type`, so form-family views were
+// unreachable through the create UI.
+
+import { describe, it, expect } from 'vitest';
+import { ViewItemSchema } from '@objectstack/spec/ui';
+import { registerBuiltinAnchors } from './anchors';
+import { getMetadataResource } from './registry';
+
+registerBuiltinAnchors();
+
+function viewConfig() {
+  const cfg = getMetadataResource('view');
+  if (!cfg?.createBuildBody) {
+    throw new Error('view resource must define createBuildBody');
+  }
+  return cfg;
+}
+
+function build(draft: Record<string, unknown>): Record<string, unknown> {
+  return viewConfig().createBuildBody!(draft) as Record<string, unknown>;
+}
+
+function expectSpecValid(body: unknown) {
+  const res = ViewItemSchema.safeParse(body);
+  expect(
+    res.success,
+    `ViewItem rejected by spec: ${JSON.stringify(res.error?.issues)}\nbody=${JSON.stringify(body)}`,
+  ).toBe(true);
+}
+
+describe('view createBuildBody — ViewItem family discrimination (objectui#2323)', () => {
+  it('defaults to a spec-valid list-family ViewItem when viewKind is unset', () => {
+    const body = build({ label: 'All Leads', name: 'all_leads', object: 'crm_lead' });
+    expect(body.viewKind).toBe('list');
+    expect((body.config as Record<string, unknown>).type).toBe('grid');
+    expect((body.config as Record<string, unknown>).columns).toEqual([]);
+    expect(body.config).not.toHaveProperty('sections');
+    expectSpecValid(body);
+  });
+
+  it('carries the chosen list layout at config.type for a list view', () => {
+    const body = build({
+      label: 'Board',
+      name: 'board',
+      object: 'crm_lead',
+      viewKind: 'list',
+      kind: 'kanban',
+    });
+    expect(body.viewKind).toBe('list');
+    expect((body.config as Record<string, unknown>).type).toBe('kanban');
+    expect(body.config).toHaveProperty('columns');
+    expectSpecValid(body);
+  });
+
+  it('builds a spec-valid form-family ViewItem carrying the chosen form layout', () => {
+    const body = build({
+      label: 'Intake',
+      name: 'intake',
+      object: 'crm_lead',
+      viewKind: 'form',
+      formType: 'tabbed',
+    });
+    expect(body.viewKind).toBe('form');
+    const config = body.config as Record<string, unknown>;
+    expect(config.type).toBe('tabbed');
+    // Form views carry a `sections` body, never a list `columns` array.
+    expect(config).toHaveProperty('sections');
+    expect(config).not.toHaveProperty('columns');
+    expect(config.data).toEqual({ provider: 'object', object: 'crm_lead' });
+    expectSpecValid(body);
+  });
+
+  it('defaults the form layout to `simple` when formType is unset', () => {
+    const body = build({ label: 'Detail', name: 'detail', object: 'crm_lead', viewKind: 'form' });
+    expect(body.viewKind).toBe('form');
+    expect((body.config as Record<string, unknown>).type).toBe('simple');
+    expectSpecValid(body);
+  });
+
+  it('accepts every form layout the spec enumerates', () => {
+    for (const formType of ['simple', 'tabbed', 'wizard', 'split', 'drawer', 'modal']) {
+      const body = build({ label: 'F', name: `f_${formType}`, object: 'crm_lead', viewKind: 'form', formType });
+      expect((body.config as Record<string, unknown>).type).toBe(formType);
+      expectSpecValid(body);
+    }
+  });
+
+  it('qualifies the view name to <object>.<key> for both families', () => {
+    expect(build({ label: 'All', name: 'all', object: 'crm_lead' }).name).toBe('crm_lead.all');
+    expect(
+      build({ label: 'Intake', name: 'intake', object: 'crm_lead', viewKind: 'form' }).name,
+    ).toBe('crm_lead.intake');
+    // An already-qualified key is left untouched.
+    expect(build({ label: 'X', name: 'crm_lead.x', object: 'crm_lead' }).name).toBe('crm_lead.x');
+  });
+});
+
+describe('view create form contract exposes both families (objectui#2323)', () => {
+  it('lists viewKind + formType among the create fields', () => {
+    const cfg = viewConfig();
+    expect(cfg.createFields).toContain('viewKind');
+    expect(cfg.createFields).toContain('formType');
+  });
+
+  it('offers list vs form families and per-family layouts in the create schema', () => {
+    const props = (viewConfig().createSchema as Record<string, any>)?.properties ?? {};
+    expect(props.viewKind?.enum).toEqual(['list', 'form']);
+    expect(props.kind?.enum).toEqual(['grid', 'kanban', 'gallery', 'calendar', 'timeline', 'gantt', 'chart']);
+    expect(props.formType?.enum).toEqual(['simple', 'tabbed', 'wizard', 'split', 'drawer', 'modal']);
+    // Each layout picker is gated to its family so the form shows only the
+    // relevant one (rendered via SchemaForm's `visibleOn` support).
+    expect(props.kind?.visibleOn).toBe("data.viewKind == 'list'");
+    expect(props.formType?.visibleOn).toBe("data.viewKind == 'form'");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2323. `ViewItemSchema` is a discriminated union on `viewKind` (`list` | `form`), but the View create form could only ever emit `viewKind: 'list'`. Its `createBuildBody` hardcoded the family (`viewKind: 'list'`) and routed the chosen `kind` straight into `config.type`, so **form-family views were unreachable through the create UI**.

## Root cause

In `packages/app-shell/src/views/metadata-admin/anchors.ts` (the `view` resource):

- **`createFields` / `createSchema`** had no family discriminator — only a `kind` field whose enum was the `ListViewSchema.type` values (grid/kanban/gallery/calendar/timeline/gantt/chart).
- **`createBuildBody`** hardcoded `viewKind: 'list'`; there was no path that produced a `viewKind: 'form'` ViewItem with a `FormViewSchema` config.

## Changes

- **Create schema asks for the view family up front.** New `viewKind` picker (List / Form), then a per-family layout picker:
  - `list` → `kind` (grid / kanban / gallery / calendar / timeline / gantt / chart)
  - `form` → `formType` (simple / tabbed / wizard / split / drawer / modal), sourced from `FormViewSchema.type`
- **`createBuildBody` discriminates on `viewKind`.** A form view now builds a `FormViewSchema` config `{ type, data: { provider: 'object', object }, sections: [] }` instead of the list `{ type, columns: [], data }`. Both outputs validate against the real `@objectstack/spec` `ViewItemSchema`.
- **`SchemaForm` flat (create) rendering now honors per-property `visibleOn`.** This lets the create schema gate a field on a sibling value, so the list-layout picker shows only for List and the form-layout picker only for Form. Additive and a **no-op** when a property has no predicate (mirrors the sectioned form's existing field-level `visibleOn` behavior; fail-open on parse error).

## Tests

- `view-create-body.test.ts` — new. Validates `createBuildBody('view')` output for both families (and the defaults) against the real spec `ViewItemSchema`, checks name qualification, and pins the create-form contract (`viewKind`/`formType` fields, per-family `visibleOn` gating).
- `SchemaForm.flatVisibility.test.tsx` — new. Pins the flat-path `visibleOn` behavior: list draft shows the list picker only, form draft shows the form picker only, and predicate-less fields always render.
- Existing `createConformance.test.ts` (default list create output stays spec-valid) and the wider `metadata-admin` + `view-config-adapter` suites continue to pass (603 tests). `@object-ui/app-shell` type-checks clean.

## Notes

- Contract-first (AGENTS.md #0.1): no renderer-side fallback was added — the create body is built to match the spec's discriminated union shape, and both variants are validated against `@objectstack/spec` `ViewItemSchema`.
- Changeset included (`minor` for `@object-ui/app-shell`).

Closes #2323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pyoyU25xohiy5YFMn2ZQp

---
_Generated by [Claude Code](https://claude.ai/code/session_012pyoyU25xohiy5YFMn2ZQp)_