### PR TITLE
fix(attachments): authenticated uploads + friendly denial copy in RecordAttachmentsPanel (framework #2755)

### DIFF
--- a/.changeset/attachments-2755-followups.md
+++ b/.changeset/attachments-2755-followups.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(attachments): authenticated uploads + friendly denial copy in RecordAttachmentsPanel (framework #2755)
+
+The framework now gates the storage upload routes on an authenticated session
+and enforces parent-derived attachment access. The panel's upload adapter
+accordingly authenticates with the console's Bearer token
+(`createAuthenticatedFetch` — the token console has no session cookie for
+`credentials: 'include'` to carry), and the new fail-closed 403 codes
+(`ATTACHMENT_DELETE_DENIED`, `ATTACHMENT_PARENT_ACCESS`, `PERMISSION_DENIED`)
+map to friendly copy instead of raw server errors. The delete button still
+renders for every row by design — the server is the gate, and the client
+lacks the parent-edit data to pre-compute it. `uploaded_by` is still sent for
+back-compat with older servers; current servers stamp it from the session.

--- a/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
+++ b/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { cn, Button } from '@object-ui/components';
 import { Paperclip, Upload, Trash2, Download, Loader2 } from 'lucide-react';
 import { createObjectStackUploadAdapter } from '@object-ui/providers';
+import { createAuthenticatedFetch } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/react';
 
 /**
@@ -74,8 +75,38 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
   // points elsewhere.
   const baseUrl = (import.meta as any).env?.VITE_SERVER_URL || '';
   const adapter = React.useMemo(
-    () => createObjectStackUploadAdapter({ baseUrl, scope: 'attachments' }),
+    // `fetchImpl`: the storage upload routes require an authenticated
+    // session when the server has an auth service (#2755), and the console
+    // authenticates with a Bearer token (localStorage) — there is no session
+    // cookie for `credentials: 'include'` to carry.
+    () => createObjectStackUploadAdapter({ baseUrl, scope: 'attachments', fetchImpl: createAuthenticatedFetch() }),
     [baseUrl],
+  );
+
+  /** Map the server's fail-closed 403 codes (#2755) to friendly copy. */
+  const friendlyError = React.useCallback(
+    (err: unknown): string => {
+      const anyErr = err as { code?: string; message?: unknown } | null;
+      const raw = String(anyErr?.message ?? err ?? '');
+      const has = (code: string) => anyErr?.code === code || raw.includes(code);
+      if (has('ATTACHMENT_DELETE_DENIED')) {
+        return t('detail.attachmentDeleteDenied', {
+          defaultValue: 'Only the uploader or someone who can edit this record may delete this attachment.',
+        });
+      }
+      if (has('ATTACHMENT_PARENT_ACCESS')) {
+        return t('detail.attachmentParentAccessDenied', {
+          defaultValue: "You don't have access to attach files to this record.",
+        });
+      }
+      if (has('PERMISSION_DENIED')) {
+        return t('detail.attachmentPermissionDenied', {
+          defaultValue: "You don't have permission to do that.",
+        });
+      }
+      return raw;
+    },
+    [t],
   );
 
   const refresh = React.useCallback(async () => {
@@ -121,12 +152,14 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
             file_name: uploaded.name ?? file.name,
             mime_type: uploaded.mimeType ?? file.type,
             size: uploaded.size ?? file.size,
+            // Back-compat with pre-#2755 servers; a current server stamps
+            // `uploaded_by` from the session and ignores this value.
             ...(currentUserId ? { uploaded_by: currentUserId } : {}),
           });
         }
         await refresh();
       } catch (err: any) {
-        setError(String(err?.message ?? err));
+        setError(friendlyError(err));
       } finally {
         setUploading(false);
         if (inputRef.current) inputRef.current.value = '';
@@ -143,10 +176,14 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
         await dataSource.delete('sys_attachment', row.id);
         setRows((prev) => prev.filter((r) => r.id !== row.id));
       } catch (err: any) {
-        setError(String(err?.message ?? err));
+        // The delete button deliberately renders for every row: the server
+        // is the gate (uploader-or-parent-editor, #2755) and the client
+        // lacks the parent-edit data to pre-compute it — a denial surfaces
+        // here as friendly copy instead.
+        setError(friendlyError(err));
       }
     },
-    [dataSource],
+    [dataSource, friendlyError],
   );
 
   return (

--- a/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RecordAttachmentsPanel } from '../RecordAttachmentsPanel';
+
+const ROW = {
+  id: 'a1',
+  file_id: 'f1',
+  file_name: 'report.pdf',
+  mime_type: 'application/pdf',
+  size: 1024,
+  uploaded_by: 'someone-else',
+};
+
+function makeDataSource(overrides: Partial<Record<'find' | 'create' | 'delete', any>> = {}) {
+  return {
+    find: vi.fn(async () => [ROW]),
+    create: vi.fn(async () => ({ id: 'a2' })),
+    delete: vi.fn(async () => ({})),
+    ...overrides,
+  };
+}
+
+function setup(dataSource: any) {
+  render(
+    <RecordAttachmentsPanel
+      objectName="att_case"
+      recordId="r1"
+      dataSource={dataSource}
+      currentUserId="me"
+    />,
+  );
+}
+
+beforeEach(() => vi.restoreAllMocks());
+
+describe('RecordAttachmentsPanel — server-denial error mapping (#2755)', () => {
+  it('maps ATTACHMENT_DELETE_DENIED to the friendly uploader/editor message', async () => {
+    const dataSource = makeDataSource({
+      delete: vi.fn(async () => {
+        throw new Error(
+          '403: Cannot delete attachment a1: only the uploader or a user who can edit the parent record (att_case/r1) may delete it (ATTACHMENT_DELETE_DENIED)',
+        );
+      }),
+    });
+    setup(dataSource);
+    await waitFor(() => expect(screen.getByText('report.pdf')).toBeInTheDocument());
+
+    // The delete button renders for EVERY row (server is the gate).
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Delete attachment' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Only the uploader or someone who can edit this record may delete this attachment.',
+      ),
+    );
+    // The optimistic removal must NOT have happened on failure.
+    expect(screen.getByText('report.pdf')).toBeInTheDocument();
+  });
+
+  it('maps PERMISSION_DENIED (no delete bit in the baseline) to friendly copy', async () => {
+    const dataSource = makeDataSource({
+      delete: vi.fn(async () => {
+        const err: any = new Error("[Security] Access denied: operation 'delete' …");
+        err.code = 'PERMISSION_DENIED';
+        throw err;
+      }),
+    });
+    setup(dataSource);
+    await waitFor(() => expect(screen.getByText('report.pdf')).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Delete attachment' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent("You don't have permission to do that."),
+    );
+  });
+
+  it('successful delete removes the row without an error banner', async () => {
+    const dataSource = makeDataSource();
+    setup(dataSource);
+    await waitFor(() => expect(screen.getByText('report.pdf')).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Delete attachment' }));
+
+    await waitFor(() => expect(screen.queryByText('report.pdf')).not.toBeInTheDocument());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(dataSource.delete).toHaveBeenCalledWith('sys_attachment', 'a1');
+  });
+});


### PR DESCRIPTION
Companion to framework #2969 (issue objectstack-ai/framework#2755).

The framework now gates the storage upload routes on an authenticated session and enforces parent-derived attachment access on `sys_attachment`. `RecordAttachmentsPanel` adapts:

- **Authenticated uploads** — the upload adapter now uses `createAuthenticatedFetch()` (from `@object-ui/auth`) so the presigned three-step upload carries the console's Bearer token. The token console has no session cookie for the adapter's default `credentials: 'include'` to carry, so without this the framework's new upload gate would 401.
- **Friendly denial copy** — the new fail-closed 403 codes (`ATTACHMENT_DELETE_DENIED`, `ATTACHMENT_PARENT_ACCESS`, `PERMISSION_DENIED`) map to i18n messages instead of surfacing raw server error strings, on both the upload and delete paths.
- **No delete-button gating** — the trash icon still renders for every row by design: the server is the gate (uploader-or-parent-editor), and the client lacks the parent-edit data to pre-compute it. A denial surfaces as the friendly banner after the click.
- `uploaded_by` is still sent for back-compat with pre-#2755 servers; a current server stamps it from the session and ignores the client value.

## Verification

- New `packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx` — 3 ✓ (ATTACHMENT_DELETE_DENIED → friendly copy + no optimistic removal on failure; PERMISSION_DENIED → friendly copy; successful delete removes the row with no banner).
- Full `app-shell` sweep: 1248 ✓ (165 files).

## Merge order

Framework #2969 **first** — the server gates land before the panel adapts to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0187NT3Qer9oep5dCRb9b8Lt)_