### PR TITLE
fix(components): exit inline edit mode for injected cell editors (#2321)

### DIFF
--- a/.changeset/inline-edit-exit-mode.md
+++ b/.changeset/inline-edit-exit-mode.md
@@ -1,0 +1,25 @@
+---
+"@object-ui/components": patch
+---
+
+fix(components): exit inline edit mode for injected cell editors (#2321)
+
+Non-discrete inline-edit cells (text, number, date, lookup, user, currency,
+percent, …) got permanently stuck in edit mode: the host-injected `@object-ui/fields`
+widget staged its value on every change but had no way to leave edit mode, so
+clicking outside, pressing Enter, and the row Save button all failed to dismiss
+the editor. Only discrete pickers (select/boolean/radio/rating), which commit on
+selection, exited correctly.
+
+The DataTable now gives injected widget editors the same exit affordances the
+built-in `<input>` editors have:
+
+- **Click-outside** commits the staged value and exits, via a capture-phase
+  document `pointerdown` listener. It is portal-aware — clicking inside a lookup
+  popover / record-picker dialog the widget itself opened does not exit, and a
+  modal that merely hosts the grid does not suppress the commit.
+- **Enter** commits and exits (a multi-line `textarea` keeps inserting newlines).
+- **Escape** reverts this session's staged changes and exits.
+
+Keys that bubble up through a React portal from the widget's own popover keep
+driving that popover rather than the cell. Built-in editors are untouched.

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -468,6 +468,19 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   // input also blurs. This flag tells the blur handler not to save again so we
   // don't double-commit (Enter) or resurrect a cancelled value (Escape).
   const skipBlurSaveRef = useRef(false);
+  // DOM node of a host-injected widget editor (rendered via `renderCellEditor`),
+  // captured while it's mounted. The built-in `<input>` editors commit via their
+  // own onBlur, but the injected widgets (text, number, date, lookup, …) have no
+  // such handler — a document-level pointerdown listener (see below) uses this
+  // node to detect click-outside and commit them. Null ⇒ no injected editor is
+  // active (a built-in editor, or nothing, is showing).
+  const injectedEditorElRef = useRef<HTMLDivElement | null>(null);
+  // Snapshot of the active cell's pending value when editing began, so Escape /
+  // cancel can revert this session's changes. Injected widgets stage on every
+  // change (unlike built-ins, which only commit on blur/Enter), so without this
+  // an Escape would leave the half-typed value staged. `had` distinguishes "no
+  // pending change existed" from "the pending value was undefined".
+  const editRevertRef = useRef<{ had: boolean; value: any } | null>(null);
 
   // Update columns when schema changes
   useEffect(() => {
@@ -777,6 +790,11 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     const currentValue = paginatedData[rowIndex][columnKey];
     const valueToEdit = rowChanges?.[columnKey] ?? currentValue ?? '';
     setEditValue(valueToEdit);
+    // Snapshot the cell's pending state so Escape/cancel can revert an injected
+    // widget edit (which stages on every change) back to exactly what it was.
+    editRevertRef.current = rowChanges && columnKey in rowChanges
+      ? { had: true, value: rowChanges[columnKey] }
+      : { had: false, value: undefined };
   };
 
   const saveEdit = (force: boolean = false, explicitValue?: any) => {
@@ -807,16 +825,56 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       schema.onCellChange(globalIndex, columnKey, valueToStage, row);
     }
 
+    editRevertRef.current = null;
+    editingCellRef.current = null;
+    setEditingCell(null);
+    setEditValue('');
+  };
+
+  // Latest-ref to `saveEdit` so the document-level click-outside listener (whose
+  // closure is captured once per edit session) always commits with the CURRENT
+  // editValue rather than a stale one. Updated in an effect (after every render)
+  // so it's current well before any user pointer event fires.
+  const saveEditRef = useRef(saveEdit);
+  useEffect(() => {
+    saveEditRef.current = saveEdit;
+  });
+
+  // Exit edit mode. When `revert` is true, roll the active cell's pending value
+  // back to the snapshot taken when editing began (see `editRevertRef`) — this
+  // is what makes Escape/cancel discard an injected widget's staged changes. For
+  // built-in editors (which don't stage until commit) the snapshot equals the
+  // live pending value, so the revert is a no-op.
+  const exitEdit = (revert: boolean) => {
+    const active = editingCellRef.current;
+    const snap = editRevertRef.current;
+    editRevertRef.current = null;
+    if (revert && active && snap) {
+      const { rowIndex, columnKey } = active;
+      setPendingChanges((prev) => {
+        const cur = prev.get(rowIndex);
+        const staged = !!cur && columnKey in cur;
+        if (!staged && !snap.had) return prev; // nothing changed for this cell
+        const next = new Map(prev);
+        const rc = { ...(cur || {}) };
+        if (snap.had) rc[columnKey] = snap.value;
+        else delete rc[columnKey];
+        if (Object.keys(rc).length > 0) next.set(rowIndex, rc);
+        else next.delete(rowIndex);
+        return next;
+      });
+    }
     editingCellRef.current = null;
     setEditingCell(null);
     setEditValue('');
   };
 
   const cancelEdit = () => {
+    // A built-in <input>'s ensuing blur must not re-save the value we're
+    // discarding; injected editors have no such blur, so they call `exitEdit`
+    // directly (setting this flag there would leak to the next built-in blur).
     skipBlurSaveRef.current = true;
-    editingCellRef.current = null;
-    setEditingCell(null);
-    setEditValue('');
+    exitEdit(true);
   };
 
   // Stage an in-flight edit into pendingChanges WITHOUT closing the editor —
@@ -992,6 +1050,45 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       editInputRef.current.focus();
       editInputRef.current.select();
     }
+  }, [editingCell]);
+
+  // Commit a host-injected widget editor on click-outside (objectui#2321).
+  //
+  // Built-in `<input>` editors commit via their own onBlur (handleEditBlur), but
+  // the widgets injected through `renderCellEditor` (text, number, date, lookup,
+  // …) have no such handler, so without this they stay stuck in edit mode when
+  // the user clicks away. A capture-phase document listener (capture so a cell's
+  // own `stopPropagation` can't hide it) commits the staged value and exits edit
+  // mode when the pointer goes down truly outside the editor — but NOT inside a
+  // Radix overlay the widget itself opened (a lookup popover / record-picker
+  // dialog renders in a portal at <body> yet is logically part of the editor).
+  // Only armed while an INJECTED editor is mounted (`injectedEditorElRef` set);
+  // built-in editors keep their existing blur path untouched.
+  useEffect(() => {
+    if (!editingCell) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const el = injectedEditorElRef.current;
+      if (!el) return; // built-in editor → its own onBlur handles the commit
+      const target = e.target as Node | null;
+      if (!target || el.contains(target)) return; // inside the editor itself
+      if (target instanceof Element) {
+        // A transient popper (Popover/Select/Menu) the widget opened. Guard on
+        // `!contains(el)` so a popper that merely HOSTS the grid never suppresses
+        // the commit — only one stacked ABOVE the editor does.
+        const popper = target.closest('[data-radix-popper-content-wrapper]');
+        if (popper && !popper.contains(el)) return;
+        // A dialog/sheet the widget opened (e.g. the lookup record-picker) —
+        // again only when it's a nested overlay above the editor, not the modal
+        // that happens to contain the whole grid.
+        const dialog = target.closest('[role="dialog"],[role="alertdialog"]');
+        if (dialog && !dialog.contains(el)) return;
+      }
+      // Truly outside → commit the staged value and exit edit mode, matching the
+      // built-in inputs' commit-on-blur.
+      saveEditRef.current(true);
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
   }, [editingCell]);
 
   // Cleanup on unmount
@@ -1467,7 +1564,42 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                     commit: (v?: any) => saveEdit(true, v),
                                     cancel: cancelEdit,
                                   });
-                                  if (node != null) return node;
+                                  if (node != null) {
+                                    // Wrap the injected widget so it gains the
+                                    // exit-edit-mode affordances the built-in
+                                    // editors have: Enter commits, Escape cancels,
+                                    // and — via `injectedEditorElRef` + the
+                                    // document pointerdown listener above — a
+                                    // click-outside commits (objectui#2321).
+                                    // Keydowns bubbling up through a React portal
+                                    // from the widget's own popover (e.g. a lookup
+                                    // search box) carry a target OUTSIDE this
+                                    // wrapper, so the `contains` guard ignores them
+                                    // — Enter/Escape there drive the popover, not
+                                    // the cell. Enter commits only from a single-
+                                    // line `<input>` (text/number/date/…); on a
+                                    // picker's `<button>` trigger or a multi-line
+                                    // textarea it's left alone so Enter opens the
+                                    // dropdown / inserts a newline as usual.
+                                    return (
+                                      <div
+                                        ref={(n) => { injectedEditorElRef.current = n; }}
+                                        className="w-full"
+                                        onKeyDown={(e) => {
+                                          if (!e.currentTarget.contains(e.target as Node)) return;
+                                          if (e.key === 'Enter' && (e.target as HTMLElement).tagName === 'INPUT') {
+                                            e.preventDefault();
+                                            saveEdit(true);
+                                          } else if (e.key === 'Escape') {
+                                            e.preventDefault();
+                                            exitEdit(true);
+                                          }
+                                        }}
+                                      >
+                                        {node}
+                                      </div>
+                                    );
+                                  }
                                 }
 
                                 if (editType === 'date') {

--- a/packages/plugin-grid/src/__tests__/inlineEditExitMode.test.tsx
+++ b/packages/plugin-grid/src/__tests__/inlineEditExitMode.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * Exiting inline edit mode for host-injected widget editors (objectui#2321).
+ *
+ * The ObjectGrid injects the dedicated @object-ui/fields widget for each field
+ * type (text, number, date, lookup, …) as the in-cell editor. Non-discrete
+ * types stage their value on every change and used to have NO way to leave edit
+ * mode — click-outside, Enter, and the Save button all failed to dismiss the
+ * editor, leaving the cell permanently stuck showing the widget.
+ *
+ * These tests drive the real DataTable ← ObjectGrid path against an in-memory
+ * fake server and assert the editor actually exits (its <input> / trigger is
+ * gone) while the staged value is preserved (or reverted, for Escape).
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+  // Radix popover uses pointer capture; jsdom lacks these.
+  if (!(Element.prototype as any).hasPointerCapture) {
+    (Element.prototype as any).hasPointerCapture = () => false;
+  }
+  if (!(Element.prototype as any).setPointerCapture) {
+    (Element.prototype as any).setPointerCapture = () => {};
+  }
+  if (!(Element.prototype as any).releasePointerCapture) {
+    (Element.prototype as any).releasePointerCapture = () => {};
+  }
+});
+
+const OBJECT = 'os_widget_zoo';
+
+function makeDataSource() {
+  const store: Record<string, any> = {
+    r1: { id: 'r1', name: 'Row One', qty: 10 },
+    r2: { id: 'r2', name: 'Row Two', qty: 20 },
+  };
+  const users: Record<string, any> = {
+    u1: { id: 'u1', name: 'Dev Admin' },
+    u2: { id: 'u2', name: 'Team Lead' },
+  };
+  const find = vi.fn(async (object: string) => {
+    const src = object === 'users' ? users : store;
+    const data = Object.values(src).map((r) => ({ ...r }));
+    return { data, total: data.length, hasMore: false, pageSize: 50 };
+  });
+  const findOne = vi.fn(async (object: string, id: string) => {
+    const src = object === 'users' ? users : store;
+    return src[id] ? { ...src[id] } : null;
+  });
+  const update = vi.fn(async (_object: string, id: string, changes: Record<string, any>) => {
+    store[id] = { ...store[id], ...changes };
+    return { ...store[id] };
+  });
+  return {
+    store,
+    find,
+    findOne,
+    update,
+    getObjectSchema: async (name: string) => {
+      if (name === 'users') {
+        return { name, fields: { id: { type: 'text' }, name: { type: 'text' } } };
+      }
+      return {
+        name,
+        fields: {
+          id: { type: 'text' },
+          name: { type: 'text', label: 'Name' },
+          qty: { type: 'number', label: 'Qty' },
+          manager: { type: 'lookup', label: 'Manager', reference_to: 'users' },
+        },
+      };
+    },
+  } as any;
+}
+
+function renderGrid(ds: any, columns: any[]) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    editable: true,
+    singleClickEdit: true,
+    columns,
+    pagination: { pageSize: 50 },
+  };
+  return render(
+    <ActionProvider>
+      <SchemaRendererProvider dataSource={ds}>
+        <div>
+          <button data-testid="outside">outside</button>
+          <ObjectGrid schema={schema} dataSource={ds} />
+        </div>
+      </SchemaRendererProvider>
+    </ActionProvider>,
+  );
+}
+
+/** Find the <td> in `row` whose displayed text matches exactly. */
+const cellByText = (row: HTMLElement, text: string) =>
+  Array.from(row.querySelectorAll('td')).find(
+    (td) => td.textContent?.trim() === text,
+  ) as HTMLElement;
+
+const firstRow = (container: HTMLElement) =>
+  container.querySelector('tbody tr') as HTMLElement;
+
+describe('ObjectGrid — injected text/number editor exits edit mode', () => {
+  const textCols = [
+    { field: 'name', label: 'Name', type: 'text' },
+    { field: 'qty', label: 'Qty', type: 'number' },
+  ];
+
+  it('click-outside commits the staged value and exits edit mode (text)', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds, textCols);
+    await waitFor(() => expect(screen.getByText('Row One')).toBeInTheDocument());
+
+    const nameTd = cellByText(firstRow(container), 'Row One');
+    fireEvent.click(nameTd);
+
+    const input = await waitFor(() => {
+      const el = nameTd.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'Row One EDITED' } });
+
+    // Click truly outside the editor.
+    fireEvent.pointerDown(screen.getByTestId('outside'));
+
+    // Editor is gone…
+    await waitFor(() => expect(nameTd.querySelector('input')).toBeNull());
+    // …and the staged value remains (pending change).
+    expect(within(nameTd).getByText('Row One EDITED')).toBeInTheDocument();
+  });
+
+  it('Enter commits the staged value and exits edit mode (number)', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds, textCols);
+    await waitFor(() => expect(screen.getByText('Row One')).toBeInTheDocument());
+
+    const qtyTd = cellByText(firstRow(container), '10');
+    fireEvent.click(qtyTd);
+
+    const input = await waitFor(() => {
+      const el = qtyTd.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      return el;
+    });
+    fireEvent.change(input, { target: { value: '42' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(qtyTd.querySelector('input')).toBeNull());
+    expect(within(qtyTd).getByText('42')).toBeInTheDocument();
+  });
+
+  it('Escape reverts the staged value and exits edit mode (text)', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds, textCols);
+    await waitFor(() => expect(screen.getByText('Row One')).toBeInTheDocument());
+
+    const nameTd = cellByText(firstRow(container), 'Row One');
+    fireEvent.click(nameTd);
+
+    const input = await waitFor(() => {
+      const el = nameTd.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'discard me' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    await waitFor(() => expect(nameTd.querySelector('input')).toBeNull());
+    // Reverted to the original value — no pending change left behind.
+    expect(within(nameTd).getByText('Row One')).toBeInTheDocument();
+    expect(within(nameTd).queryByText('discard me')).toBeNull();
+  });
+
+  it('a staged injected edit persists through Save All after exiting', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds, textCols);
+    await waitFor(() => expect(screen.getByText('Row One')).toBeInTheDocument());
+
+    const nameTd = cellByText(firstRow(container), 'Row One');
+    fireEvent.click(nameTd);
+    const input = await waitFor(() => {
+      const el = nameTd.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'Row One SAVED' } });
+    fireEvent.pointerDown(screen.getByTestId('outside'));
+    await waitFor(() => expect(nameTd.querySelector('input')).toBeNull());
+
+    const saveAll = await waitFor(() => {
+      const btn = Array.from(container.querySelectorAll('button')).find((b) =>
+        /Save All|全部保存/.test(b.textContent || ''),
+      ) as HTMLButtonElement;
+      expect(btn).toBeTruthy();
+      return btn;
+    });
+    fireEvent.click(saveAll);
+
+    await waitFor(() => expect(ds.update).toHaveBeenCalledWith(OBJECT, 'r1', { name: 'Row One SAVED' }));
+    expect(ds.store.r1.name).toBe('Row One SAVED');
+  });
+});
+
+describe('ObjectGrid — injected lookup editor exits edit mode', () => {
+  const lookupCols = [
+    { field: 'name', label: 'Name', type: 'text', editable: false },
+    { field: 'manager', label: 'Manager', type: 'lookup' },
+  ];
+
+  it('picking an option keeps the editor open; click-outside then exits and retains the value', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds, lookupCols);
+    await waitFor(() => expect(screen.getByText('Row One')).toBeInTheDocument());
+
+    const managerTd = () => {
+      const row = firstRow(container);
+      const tds = Array.from(row.querySelectorAll('td'));
+      return tds[tds.length - 1] as HTMLElement; // manager is the last data column
+    };
+
+    // Enter edit mode, open the popover.
+    fireEvent.click(managerTd());
+    const trigger = await waitFor(() => {
+      const btn = managerTd().querySelector('button');
+      expect(btn).toBeTruthy();
+      return btn as HTMLButtonElement;
+    });
+    fireEvent.click(trigger);
+
+    // Pick "Dev Admin" from the popover (rendered in a portal at <body>).
+    const option = await waitFor(() => {
+      const el = screen.getByText('Dev Admin');
+      expect(el).toBeInTheDocument();
+      return el;
+    });
+    // Clicking inside the widget's own popover must NOT prematurely exit the
+    // editor — the click-outside guard treats the portal as part of the editor.
+    fireEvent.pointerDown(option);
+    fireEvent.click(option);
+
+    // The staged value shows and the editor (trigger button) is still mounted.
+    await waitFor(() =>
+      expect(within(managerTd()).getByText('Dev Admin')).toBeInTheDocument(),
+    );
+    expect(managerTd().querySelector('button')).toBeTruthy();
+
+    // Now click truly outside → commit + exit.
+    fireEvent.pointerDown(screen.getByTestId('outside'));
+    await waitFor(() => expect(managerTd().querySelector('button')).toBeNull());
+    // Value retained as a pending change.
+    expect(within(managerTd()).getByText('Dev Admin')).toBeInTheDocument();
+  });
+
+  it('Enter on the picker trigger does not prematurely exit edit mode', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds, lookupCols);
+    await waitFor(() => expect(screen.getByText('Row One')).toBeInTheDocument());
+
+    const managerTd = () => {
+      const row = firstRow(container);
+      const tds = Array.from(row.querySelectorAll('td'));
+      return tds[tds.length - 1] as HTMLElement;
+    };
+
+    fireEvent.click(managerTd());
+    const trigger = await waitFor(() => {
+      const btn = managerTd().querySelector('button');
+      expect(btn).toBeTruthy();
+      return btn as HTMLButtonElement;
+    });
+
+    // Enter belongs to the picker (open its dropdown), NOT the cell — the editor
+    // must stay open. Only a single-line <input> commits on Enter.
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(managerTd().querySelector('button')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #2321.

## Problem

Non-discrete inline-edit cells in the ObjectGrid list view — **text, number, email, date, datetime, currency, percent, lookup, user, …** (essentially everything except `select`/`boolean`/`radio`/`rating`) — got **permanently stuck in edit mode**. Clicking outside, pressing Enter, and the row Save button all failed to dismiss the editor. The only escape was clicking a different row's cell.

### Root cause

`ObjectGrid.renderCellEditor` injects the dedicated `@object-ui/fields` widget as the in-cell editor. Discrete types call `commit(v)` on change (which exits edit mode); everything else calls `stage(v)`, which writes the value into `pendingChanges` but **never exits edit mode**. The `DataTable`'s blur-commit handler was wired only to its own built-in `<input>` editors, not to the injected widgets, and there was no click-outside or keyboard handler for them — so the edit session stayed open forever.

## Fix

The fix lives entirely in `DataTable` (the component that owns the edit lifecycle) and gives injected widget editors the same exit affordances the built-in `<input>` editors already have:

- **Click-outside** commits the staged value and exits, via a capture-phase `document` `pointerdown` listener. It is **portal-aware**: clicking inside a lookup popover / record-picker dialog the widget itself opened does *not* exit (that portal is logically part of the editor), and a modal that merely *hosts* the grid does not suppress the commit (the `!contains(editor)` guards distinguish the two).
- **Enter** commits and exits — but only from a single-line `<input>`, so a picker's `<button>` trigger still opens its dropdown and a multi-line `<textarea>` still inserts newlines.
- **Escape** reverts this session's staged changes (restoring the pre-edit snapshot) and exits, matching the `InlineEditing` component's cancel semantics.

Keys that bubble up through a React portal from the widget's own popover (e.g. a lookup search box) carry a target *outside* the cell wrapper, so a `contains` guard leaves them to drive the popover, not the cell. Built-in editors keep their existing blur/keydown path untouched.

## Tests

New `packages/plugin-grid/src/__tests__/inlineEditExitMode.test.tsx` drives the real `ObjectGrid → DataTable` path against an in-memory fake server:

- text: click-outside commits the staged value and exits
- number: Enter commits and exits
- text: Escape reverts and exits (no pending change left behind)
- a staged injected edit persists through **Save All** after exiting
- lookup: picking an option in the popover keeps the editor open (doesn't prematurely exit); a subsequent click-outside exits and retains the value
- lookup: Enter on the picker trigger does not prematurely exit

### Verification
- `vitest run inlineEdit` — 10 passed (6 new + existing persistence/lookup repro)
- Full `plugin-grid` suite — 206 passed; `data-table` component tests — 31 passed
- `@object-ui/components` `type-check` clean; `eslint` on the changed file: 0 errors, no new warnings

Includes a patch changeset for `@object-ui/components`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VpQ3nUCSgYmyaJVSzTtEHj)_