### PR TITLE
fix(auth): gate DeviceAuthPage on features.deviceAuthorization (framework#2874 / #2513)

### DIFF
--- a/.changeset/device-auth-feature-gate.md
+++ b/.changeset/device-auth-feature-gate.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/auth": patch
+"@object-ui/console": patch
+---
+
+fix(auth): gate the device-approval page on `features.deviceAuthorization` (framework#2874 / #2513)
+
+`DeviceAuthPage` hit the RFC 8628 `/device*` endpoints unconditionally, even
+though the better-auth `deviceAuthorization` plugin is opt-in (off by default) —
+so on a deployment without it the page rendered an approve form that only failed
+on submit. It now reads `features.deviceAuthorization` from the public auth
+config and shows a plain "not enabled" notice when the capability is off,
+matching the "form follows plugin" honesty guard the framework side introduced
+in #2874. `AuthPublicConfig.features` gains the `deviceAuthorization` flag
+(previously absent from the client type). A config-fetch error fails open so a
+transient blip never hides a legitimately-enabled page.

--- a/apps/console/src/pages/auth/DeviceAuthPage.tsx
+++ b/apps/console/src/pages/auth/DeviceAuthPage.tsx
@@ -7,7 +7,7 @@
  * device-authorization endpoints directly via fetch.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Navigate, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { CheckCircle2 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -55,7 +55,7 @@ export function DeviceAuthPage() {
   // warning copy below is what carries the anti-phishing weight.
   const runtimeName = params.get('runtime_name') ?? '';
   const runtimeVersion = params.get('runtime_version') ?? '';
-  const { user, isLoading } = useAuth();
+  const { user, isLoading, getAuthConfig } = useAuth();
   const navigate = useNavigate();
 
   const [submitting, setSubmitting] = useState(false);
@@ -63,6 +63,29 @@ export function DeviceAuthPage() {
   const [approved, setApproved] = useState(false);
   const [denied, setDenied] = useState(false);
   const [error, setError] = useState('');
+  // Whether the server actually wires the deviceAuthorization plugin
+  // (framework#2874 / objectui#2513). `null` while the public config is still
+  // loading. The `/device*` endpoints only exist when this is on, so we gate
+  // the whole page on it instead of rendering a form that would only fail on
+  // submit with "not enabled".
+  const [deviceAuthEnabled, setDeviceAuthEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getAuthConfig()
+      .then((config) => {
+        if (active) setDeviceAuthEnabled(config?.features?.deviceAuthorization === true);
+      })
+      .catch(() => {
+        // Config unreachable → don't hard-block a page that may legitimately
+        // work; fall back to the prior behavior and let the endpoints surface
+        // the real error.
+        if (active) setDeviceAuthEnabled(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [getAuthConfig]);
 
   if (!code) {
     return (
@@ -83,7 +106,31 @@ export function DeviceAuthPage() {
     );
   }
 
-  if (isLoading) {
+  // Gate on the deviceAuthorization capability before anything else that
+  // requires it (login round-trip, claim/approve): if the plugin is off the
+  // endpoints 404, so tell the user plainly instead of advertising a form
+  // that can't work (framework#2874 / objectui#2513).
+  if (deviceAuthEnabled === false) {
+    return (
+      <PageShell>
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle>
+              {t('auth.device.disabledTitle', { defaultValue: 'Device authorization not enabled' })}
+            </CardTitle>
+            <CardDescription>
+              {t('auth.device.disabledDescription', {
+                defaultValue:
+                  'This deployment does not have device authorization enabled, so this device cannot be approved here.',
+              })}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  if (isLoading || deviceAuthEnabled === null) {
     return (
       <PageShell>
         <Card>

--- a/apps/console/src/pages/auth/__tests__/DeviceAuthPage.test.tsx
+++ b/apps/console/src/pages/auth/__tests__/DeviceAuthPage.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * DeviceAuthPage — deviceAuthorization capability gate (framework#2874 /
+ * objectui#2513).
+ *
+ * The RFC 8628 device-approval endpoints (`/device`, `/device/approve`,
+ * `/device/deny`) only exist when the opt-in better-auth deviceAuthorization
+ * plugin is wired. The page reads `features.deviceAuthorization` from the
+ * public auth config and, when it is off, shows a plain "not enabled" notice
+ * instead of an approve form that would only fail on submit.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '@object-ui/auth';
+import type { AuthClient } from '@object-ui/auth';
+import { DeviceAuthPage } from '../DeviceAuthPage';
+
+afterEach(cleanup);
+
+function createMockClient(opts: { deviceAuthorization?: boolean; signedIn?: boolean }): AuthClient {
+  return {
+    getSession: vi
+      .fn()
+      .mockResolvedValue(
+        opts.signedIn ? { user: { id: 'u1', email: 'me@example.com' }, session: {} } : null,
+      ),
+    getConfig: vi.fn().mockResolvedValue({
+      features:
+        opts.deviceAuthorization === undefined
+          ? {}
+          : { deviceAuthorization: opts.deviceAuthorization },
+    }),
+  } as unknown as AuthClient;
+}
+
+function renderDevice(client: AuthClient, search = '?user_code=WDJB-MJHT') {
+  window.history.replaceState({}, '', `/auth/device${search}`);
+  return render(
+    <AuthProvider authUrl="/api/v1/auth" client={client}>
+      <MemoryRouter initialEntries={[`/auth/device${search}`]}>
+        <DeviceAuthPage />
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+describe('DeviceAuthPage — deviceAuthorization gate', () => {
+  it('shows a "not enabled" notice and no approve form when the flag is off', async () => {
+    renderDevice(createMockClient({ deviceAuthorization: false }));
+
+    expect(await screen.findByText(/not enabled/i)).toBeTruthy();
+    expect(screen.queryByText(/Approve device/i)).toBeNull();
+  });
+
+  it('treats an absent flag as off (opt-in default)', async () => {
+    renderDevice(createMockClient({}));
+
+    expect(await screen.findByText(/not enabled/i)).toBeTruthy();
+    expect(screen.queryByText(/Approve device/i)).toBeNull();
+  });
+
+  it('renders the approve form when the flag is on and the user is signed in', async () => {
+    renderDevice(createMockClient({ deviceAuthorization: true, signedIn: true }));
+
+    expect(await screen.findByText(/Approve device/i)).toBeTruthy();
+    expect(screen.queryByText(/not enabled/i)).toBeNull();
+  });
+});

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -163,6 +163,15 @@ export interface AuthPublicConfig {
      * entry (framework#2766 / #2782).
      */
     admin?: boolean;
+    /**
+     * better-auth deviceAuthorization plugin mounted server-side
+     * (`auth.plugins.deviceAuthorization`, opt-in / off by default). Gates the
+     * RFC 8628 device-approval page: when falsy the `/device`, `/device/approve`
+     * and `/device/deny` endpoints aren't wired, so the UI shows an
+     * "not enabled" notice instead of a form that only fails on submit
+     * (framework#2874 / objectui#2513).
+     */
+    deviceAuthorization?: boolean;
   };
 }
 


### PR DESCRIPTION
Closes #2513。framework#2874 双面审计里发现的唯一 UI 侧实缺口。

## 问题

RFC 8628 设备授权端点(`/device`、`/device/approve`、`/device/deny`)只在 opt-in 的 better-auth `deviceAuthorization` 插件挂载时才存在(默认关),但 `DeviceAuthPage` 无条件裸打这些端点——插件关闭的部署里,页面照样渲染 approve 表单,用户点了才在提交时报错。正是 #2874 要消除的「UI 宣传 runtime 没有的能力」类缺口(此处为登录/设备面的实例)。

## 改动

- `packages/auth/src/types.ts`:`AuthPublicConfig.features` 补 `deviceAuthorization?: boolean`(此前客户端类型里根本没有这个键)。
- `apps/console/src/pages/auth/DeviceAuthPage.tsx`:挂载时经 `getAuthConfig()` 读该 flag(沿用 `LoginForm`/`ForgotPasswordForm` 既有模式);flag 关闭时在**登录往返 / claim / approve 之前**渲染「未启用」提示卡,而非裸打端点。config 拉取失败时 **fail-open**(回退旧行为,让端点自己报错),避免一次网络抖动永久隐藏一个真正启用的页面。
- 测试:flag 关 / 缺失 → 提示卡、无表单;flag 开 + 已登录 → 表单。

## 验证

- `apps/console` 新测试 3 项全绿;`@object-ui/auth` + `@object-ui/console` turbo build(含 `tsc`)通过;改动文件 eslint 干净。

## 说明

- 服务端本来就 fail-closed,这是可用性/诚实宣传问题,非权限提升。
- 反向缺口(`passkeys`/`magicLink` 有广告无 UI)是独立类别,单独跟踪在 #2514,不在本 PR。
- 对应 framework 侧注册表:`packages/spec/src/kernel/public-auth-features.ts` 的 `deviceAuthorization` 条目 exempt.reason 指向本 issue(framework PR #2965)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGofzwNXvtahMGk8TQqXdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGofzwNXvtahMGk8TQqXdx)_