### PR TITLE
fix(types/plugin-grid): declare spec-canonical bulkActions on ObjectGridSchema (#1763)

### DIFF
--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -789,7 +789,7 @@ A data grid that auto-fetches from an ObjectQL object definition. Includes searc
 | `selection` | `SelectionConfig` | Row selection configuration. |
 | `pagination` | `PaginationConfig` | Pagination settings. |
 | `operations` | `object` | Enabled CRUD operations. |
-| `rowActions` / `batchActions` | `string[]` | Action identifiers for rows and batch selection. |
+| `rowActions` / `bulkActions` | `string[]` | Action identifiers for rows and batch selection. `bulkActions` is the spec-aligned key; `batchActions` is a legacy alias that takes precedence when both are set. |
 | `editable` | `boolean` | Enable inline cell editing. |
 | `grouping` | `GroupingConfig` | Row grouping configuration. |
 | `frozenColumns` | `number` | Number of columns frozen on scroll. |

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1606,9 +1606,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // a bulk-delete affordance is implicitly available (canDelete + onBulkDelete
   // wired by the consumer). This gives every list a multi-select + delete UX
   // out of the box without forcing each view JSON to declare bulkActions.
-  const explicitBulkActions = schema.batchActions ?? (schema as any).bulkActions;
-  const bulkActionDefs: BulkActionDef[] = Array.isArray((schema as any).bulkActionDefs)
-    ? (schema as any).bulkActionDefs
+  const explicitBulkActions = schema.batchActions ?? schema.bulkActions;
+  const bulkActionDefs: BulkActionDef[] = Array.isArray(schema.bulkActionDefs)
+    ? schema.bulkActionDefs
     : [];
   const effectiveBulkActions: string[] =
     explicitBulkActions && explicitBulkActions.length > 0

--- a/packages/plugin-grid/src/__tests__/bulkActionsSpecKey.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionsSpecKey.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression (#1763): a direct `object-grid` schema using the spec-canonical
+ * `bulkActions` key (no legacy `batchActions`) used to silently no-op — the
+ * grid only read `batchActions`, so bulk actions just disappeared with no
+ * error. This locks in the fallback: `bulkActions` alone must auto-enable
+ * multi-select and render the bulk action button, and `batchActions` must
+ * still win when both keys are set (legacy precedence).
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+import type { ObjectGridSchema } from '@object-ui/types';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+const OBJECT = 'os_prod_plan';
+
+function makeDataSource() {
+  const rows = [
+    { id: 'r1', name: 'Plan A', status: 'draft' },
+    { id: 'r2', name: 'Plan B', status: 'draft' },
+  ];
+  return {
+    find: vi.fn(async () => ({ data: rows.map((r) => ({ ...r })), total: rows.length, hasMore: false, pageSize: 50 })),
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text' },
+        status: { type: 'text' },
+      },
+    }),
+  } as any;
+}
+
+function renderGrid(schema: ObjectGridSchema, handlers: Record<string, any> = {}) {
+  return render(
+    <ActionProvider handlers={handlers}>
+      <ObjectGrid schema={schema} dataSource={makeDataSource()} />
+    </ActionProvider>,
+  );
+}
+
+async function selectAllRows() {
+  await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+  const headerCheckbox = document.querySelector('thead [role="checkbox"]') as HTMLElement;
+  expect(headerCheckbox).toBeTruthy();
+  fireEvent.click(headerCheckbox);
+}
+
+describe('ObjectGrid — spec-canonical bulkActions key (#1763)', () => {
+  it('renders bulk actions from `bulkActions` alone (no batchActions)', async () => {
+    renderGrid({
+      type: 'object-grid',
+      objectName: OBJECT,
+      bulkActions: ['approve'],
+      columns: [
+        { field: 'name', label: 'Name' },
+        { field: 'status', label: 'Status' },
+      ],
+      pagination: { pageSize: 50 },
+    });
+
+    await selectAllRows();
+    expect(await screen.findByTestId('bulk-action-approve')).toBeInTheDocument();
+  });
+
+  it('keeps legacy precedence: batchActions wins when both keys are set', async () => {
+    renderGrid({
+      type: 'object-grid',
+      objectName: OBJECT,
+      batchActions: ['approve'],
+      bulkActions: ['reject'],
+      columns: [
+        { field: 'name', label: 'Name' },
+        { field: 'status', label: 'Status' },
+      ],
+      pagination: { pageSize: 50 },
+    });
+
+    await selectAllRows();
+    expect(await screen.findByTestId('bulk-action-approve')).toBeInTheDocument();
+    expect(screen.queryByTestId('bulk-action-reject')).not.toBeInTheDocument();
+  });
+});

--- a/packages/types/src/__tests__/p1-spec-alignment.test.ts
+++ b/packages/types/src/__tests__/p1-spec-alignment.test.ts
@@ -49,6 +49,17 @@ describe('P1.1 ListView Spec Alignment', () => {
     expect(schema.bulkActions).toHaveLength(3);
   });
 
+  it('should accept spec-canonical bulkActions on ObjectGridSchema (#1763)', () => {
+    const schema: ObjectGridSchema = {
+      type: 'object-grid',
+      objectName: 'Account',
+      bulkActions: ['delete', 'assign'],
+      batchActions: ['delete'],
+    };
+    expect(schema.bulkActions).toHaveLength(2);
+    expect(schema.batchActions).toHaveLength(1);
+  });
+
   it('should accept virtualScroll boolean', () => {
     const schema: ListViewSchema = {
       type: 'list-view',

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -594,9 +594,18 @@ export interface ObjectGridSchema extends BaseSchema {
   
   /**
    * Custom batch actions
-   * NOTE: This is ObjectUI-specific and not part of @objectstack/spec
+   * NOTE: This is ObjectUI-specific and not part of @objectstack/spec.
+   * Legacy alias of `bulkActions` — prefer `bulkActions`. When both are
+   * set, `batchActions` wins (preserved for backward compatibility).
    */
   batchActions?: string[];
+
+  /**
+   * Bulk action identifiers (action names from ActionSchema).
+   * Aligned with @objectstack/spec ListViewSchema.bulkActions — the
+   * canonical key; `batchActions` is the legacy ObjectUI alias.
+   */
+  bulkActions?: string[];
   
   /**
    * Enable inline cell editing (Grid mode)

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -129,7 +129,8 @@ export const ObjectGridSchema = BaseSchema.extend({
   showColumnTypeIcons: z.boolean().optional().describe('Show column type icons (T/Tag/Calendar) in headers. Off by default — type is usually obvious from cell content; the icons add visual noise.'),
   selection: SelectionConfigSchema.optional().describe('Selection configuration'),
   pagination: PaginationConfigSchema.optional().describe('Pagination configuration'),
-  
+  bulkActions: z.array(z.string()).optional().describe('Bulk action identifiers (spec-canonical key; batchActions is the legacy alias)'),
+
   // Legacy fields
   fields: z.array(z.string()).optional(),
   staticData: z.array(z.any()).optional(),


### PR DESCRIPTION
Evaluation + fix for #1763 (viewschema key drift).

## Evaluation of the issue against current code

**Part 1 — `bulkActions` → `batchActions` (silent no-op): still valid, but smaller than reported.** The runtime no-op for direct `object-grid` callers was already fixed at some point — `ObjectGrid` reads `schema.batchActions ?? bulkActions`. What remained was type/docs drift:
- `ObjectGridSchema` declared only the off-spec legacy key `batchActions` (its own comment: "ObjectUI-specific and not part of @objectstack/spec"), so the grid read `bulkActions` through an untyped `(schema as any)` cast.
- Producers disagree: the spec-bridge (`packages/react/src/spec-bridge/bridges/list-view.ts`) and app-shell emit `bulkActions`; the schema-builder emits `batchActions`; ListView renames `bulkActions` → `batchActions` when composing the grid schema.
- Docs only documented `batchActions` for the grid, while ROADMAP uses `bulkActions`.

**Part 2 — ObjectView form-adapter keys "not in FormViewSchema": inaccurate as stated.** `ObjectViewSchema.form` is typed `Partial<Omit<ObjectFormSchema, 'type'|'objectName'|'mode'>>`, and all 16 keys `buildFormSchema` reads (`layout`, `showSubmit`, `submitText`, `customFields`, `title`, `initialValues`, `className`, …) are declared on `ObjectFormSchema` — no casts involved. The claim only holds against `@objectstack/spec`'s `FormViewSchema`, which `ObjectView` does not consume; aligning `ObjectFormSchema` with the spec form model (sections vs groups, submitBehavior vs showSubmit/…) is a separate, larger spec-alignment effort. **No code change made for Part 2.**

## Changes

- `packages/types/src/objectql.ts`: declare `bulkActions?: string[]` on `ObjectGridSchema`, documented as the `@objectstack/spec ListViewSchema.bulkActions`-aligned canonical key; `batchActions` annotated as the legacy alias that wins when both are set (matches existing runtime precedence — zero behaviour change).
- `packages/types/src/zod/objectql.zod.ts`: mirror `bulkActions` in the grid zod schema.
- `packages/plugin-grid/src/ObjectGrid.tsx`: drop the now-unneeded `(schema as any)` casts for `bulkActions` and `bulkActionDefs` (the latter was already declared on the type).
- `content/docs/api/schema-reference.md`: ObjectGridSchema table documents `bulkActions` as the spec-aligned key with `batchActions` as legacy alias. (The CRUDSchema table's `batchActions: ActionSchema[]` is a genuinely different key on `CRUDSchema` and is left as-is.)
- Deliberately untouched: ListView's rename-passthrough and schema-builder's `batchActions` output (both still work; the rename is now merely redundant).

## Tests

- New `packages/plugin-grid/src/__tests__/bulkActionsSpecKey.test.tsx`: a direct `object-grid` schema with only `bulkActions` renders the bulk action button (locks in the formerly silent-no-op path), and `batchActions` still wins when both keys are set.
- `packages/types/src/__tests__/p1-spec-alignment.test.ts`: type-level assertion that `ObjectGridSchema` accepts `bulkActions`.
- Verified: `vitest run packages/plugin-grid packages/types` → 39 files / 376 tests passed; `@object-ui/types` tsc build + type-check clean; plugin-grid vite build clean; no `(schema as any).bulk*` left in plugin-grid.

Refs #1763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln4gqtxXuymoQmyy4iRM2z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ln4gqtxXuymoQmyy4iRM2z)_