### PR TITLE
feat(kanban): default card fields to object highlightFields when no view-level cardFields (ADR-0085, #2162)

### DIFF
--- a/.changeset/kanban-cardfields-highlightfields-default.md
+++ b/.changeset/kanban-cardfields-highlightfields-default.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/plugin-kanban": minor
+---
+
+feat(kanban): default card fields to the object's `highlightFields` when a view configures none (ADR-0085 follow-up, #2162)
+
+`ObjectKanban` used to render explicit view-level `cardFields` and, when a board
+declared none, drop straight to a legacy semantic-field heuristic (guessing at
+amount / owner / priority). That guesswork ignored the object's own declared
+intent and diverged from every other surface.
+
+Card fields now resolve through a shared `resolveKanbanCardFields` helper in
+priority order:
+
+1. **View-level `cardFields`** — the author's explicit choice always wins.
+2. **The object's `highlightFields`** — the ADR-0085 semantic role (its curated
+   "most important fields"), the same list Grid, List and Detail already default
+   to. Entries referencing a field the object no longer declares are dropped.
+3. **The legacy semantic-field heuristic** — used only when neither is available.
+
+A board over an object with no per-view card config now shows the same curated
+fields as the object's other views, instead of best-effort guesses.

--- a/content/docs/plugins/plugin-kanban.mdx
+++ b/content/docs/plugins/plugin-kanban.mdx
@@ -116,6 +116,26 @@ interface KanbanCard {
 | `description` | string | Card description |
 | `badges` | Badge[] | Status/priority badges |
 
+### Card fields (object-driven boards)
+
+When a board is bound to an object (an `object-kanban`, or a kanban view inside
+`ListView` / `ObjectView`) instead of being given static `columns`, the fields
+rendered on each card resolve in priority order:
+
+1. **View-level `cardFields`** — the fields the view configures (a kanban view's
+   `columns`, forwarded as `cardFields`). An explicit choice always wins.
+2. **The object's `highlightFields`** — the object's ADR-0085 semantic role (its
+   curated "most important fields"), the same list the Grid, List and Detail
+   surfaces already default to. Used when the view configures no card fields, so
+   a board over an object with no per-view config still surfaces meaningful
+   fields. Entries that reference a field the object no longer declares are
+   ignored.
+3. **A legacy semantic-field heuristic** — a best-effort guess (amount, owner,
+   priority, …) used only when neither of the above is available.
+
+Defaulting to `highlightFields` keeps a card's contents consistent with the
+object's other views without every kanban view having to re-declare its fields.
+
 ## Examples
 
 ### Project Task Board

--- a/packages/plugin-kanban/src/ObjectKanban.cardFields.test.ts
+++ b/packages/plugin-kanban/src/ObjectKanban.cardFields.test.ts
@@ -1,0 +1,82 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Unit tests for `resolveKanbanCardFields` — the card-field resolution that
+ * defaults a kanban board's card fields to the object's `highlightFields`
+ * semantic role (ADR-0085) when no view-level `cardFields` are configured.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveKanbanCardFields } from './ObjectKanban';
+
+const objectDef = {
+  name: 'deal',
+  highlightFields: ['amount', 'stage', 'owner'],
+  fields: {
+    id: { type: 'text' },
+    amount: { type: 'currency' },
+    stage: { type: 'picklist' },
+    owner: { type: 'lookup' },
+    notes: { type: 'textarea' },
+  },
+};
+
+describe('resolveKanbanCardFields', () => {
+  it('uses the view-level cardFields when configured (author choice wins)', () => {
+    expect(resolveKanbanCardFields(['amount', 'notes'], objectDef)).toEqual([
+      'amount',
+      'notes',
+    ]);
+  });
+
+  it("ignores the object's highlightFields when the view declares cardFields", () => {
+    // Even though highlightFields is present, the explicit view config wins.
+    const result = resolveKanbanCardFields(['notes'], objectDef);
+    expect(result).toEqual(['notes']);
+    expect(result).not.toContain('stage');
+  });
+
+  it('defaults to the object highlightFields when no view cardFields are given (ADR-0085)', () => {
+    expect(resolveKanbanCardFields(undefined, objectDef)).toEqual([
+      'amount',
+      'stage',
+      'owner',
+    ]);
+  });
+
+  it('treats an empty cardFields array as "no view config" and falls back to highlightFields', () => {
+    expect(resolveKanbanCardFields([], objectDef)).toEqual([
+      'amount',
+      'stage',
+      'owner',
+    ]);
+  });
+
+  it('drops highlight entries that reference a field the object no longer declares', () => {
+    const stale = {
+      highlightFields: ['amount', 'ghost_field', 'stage'],
+      fields: { amount: { type: 'currency' }, stage: { type: 'picklist' } },
+    };
+    expect(resolveKanbanCardFields(undefined, stale)).toEqual(['amount', 'stage']);
+  });
+
+  it('returns [] when neither view cardFields nor object highlightFields exist', () => {
+    expect(resolveKanbanCardFields(undefined, { fields: { amount: {} } })).toEqual(
+      [],
+    );
+    expect(resolveKanbanCardFields([], null)).toEqual([]);
+    expect(resolveKanbanCardFields(undefined, undefined)).toEqual([]);
+  });
+
+  it('ignores a non-array highlightFields value', () => {
+    // `highlightFields` is typed `unknown`, so a malformed string value is a
+    // valid input to guard against — no cast needed.
+    const malformed = { highlightFields: 'amount', fields: { amount: {} } };
+    expect(resolveKanbanCardFields(undefined, malformed)).toEqual([]);
+  });
+});

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -15,6 +15,49 @@ import { getBadgeColorClasses, getCellRenderer, resolveCellRendererType } from '
 import { KanbanRenderer } from './index';
 import { KanbanSchema } from './types';
 
+/**
+ * Minimal shape of the object definition this module reads. `objectDef` is
+ * fetched via `dataSource.getObjectSchema` and is otherwise untyped here.
+ */
+interface CardFieldObjectDef {
+  /** ADR-0085 semantic role: the object's curated "most important" fields. */
+  highlightFields?: unknown;
+  /** Declared fields, keyed by field name. */
+  fields?: Record<string, unknown>;
+}
+
+/**
+ * Resolve which record fields render on each kanban card, in priority order:
+ *
+ *   1. **View-level `cardFields`** — the fields the author configured for the
+ *      view (`kanban.columns`, or the view's own columns), forwarded here as
+ *      `schema.cardFields`. An explicit choice always wins.
+ *   2. **The object's `highlightFields`** — the ADR-0085 semantic role: the
+ *      curated "most important fields" list that Grid, List and Detail already
+ *      default to. Used when the view declares no card fields, so a board over
+ *      an object with no per-view config still surfaces meaningful fields
+ *      instead of the legacy semantic-field guesswork. Filtered to fields the
+ *      object actually declares so a stale highlight entry can't reference a
+ *      dropped field.
+ *   3. **`[]`** — neither is available; the caller falls back to its legacy
+ *      semantic-field heuristic.
+ *
+ * Exported for unit testing; kept pure (no React) for that reason.
+ */
+export function resolveKanbanCardFields(
+  cardFields: unknown,
+  objectDef: CardFieldObjectDef | null | undefined,
+): string[] {
+  if (Array.isArray(cardFields) && cardFields.length > 0) {
+    return cardFields as string[];
+  }
+  const highlight = objectDef?.highlightFields;
+  if (Array.isArray(highlight)) {
+    return (highlight as string[]).filter((n) => Boolean(objectDef?.fields?.[n]));
+  }
+  return [];
+}
+
 export interface ObjectKanbanProps {
   schema: KanbanSchema;
   dataSource?: DataSource;
@@ -222,12 +265,14 @@ export const ObjectKanban: React.FC<ObjectKanbanProps> = ({
       };
 
       const descParts: string[] = [];
-      // If the view config specifies kanban.columns (passed in as schema.cardFields),
-      // render those fields explicitly — they represent what the user wants to see
-      // on each card. Otherwise fall back to the legacy semantic-field heuristic.
-      const explicitCardFields: string[] = Array.isArray((schema as any).cardFields)
-        ? (schema as any).cardFields
-        : [];
+      // Which fields to render on each card: view-level `cardFields` when the
+      // author configured them, otherwise the object's `highlightFields`
+      // semantic role (ADR-0085); `[]` drops to the legacy heuristic below.
+      // (See `resolveKanbanCardFields` for the full priority contract.)
+      const explicitCardFields: string[] = resolveKanbanCardFields(
+        (schema as any).cardFields,
+        objectDef,
+      );
       // The field used as the card title is implicit (resolved above). Don't
       // repeat its raw value in the description if the user already sees it.
       const titleFieldsToSkip = new Set<string>([


### PR DESCRIPTION
## Summary

Closes #2162 (ADR-0085 follow-up).

When a kanban board configures **no view-level `cardFields`**, `ObjectKanban` used to drop straight to a legacy semantic-field heuristic (guessing at `amount` / `owner` / `priority`). That guesswork ignored the object's own declared intent and diverged from every other surface.

Card fields now resolve through a shared, pure helper `resolveKanbanCardFields` in priority order:

1. **View-level `cardFields`** — the author's explicit choice always wins (unchanged).
2. **The object's `highlightFields`** — the ADR-0085 semantic role (its curated "most important fields"), the same list **Grid, List and Detail already default to**. Used when the view configures no card fields. Entries referencing a field the object no longer declares are dropped.
3. **The legacy semantic-field heuristic** — used only when neither of the above is available.

A board over an object with no per-view card config now shows the same curated fields as the object's other views, instead of best-effort guesses.

## Why the leaf component

`ObjectKanban` is the single point every entry path funnels through (standalone, `ListView`, `plugin-view`/`app-shell` `ObjectView`), and it already holds the fetched object definition — mirroring how `ObjectGrid` resolves its own default columns from `highlightFields`. Both `plugin-list` and `plugin-view` already pass `cardFields: []` when nothing view-specific is configured, so the fallback engages consistently without touching those call sites. Explicitly-configured view columns are still preferred — `highlightFields` slots in only as the default, not as an override.

## Changes

- `packages/plugin-kanban/src/ObjectKanban.tsx` — extract `resolveKanbanCardFields` (exported, pure) and use it for the card-field resolution.
- `packages/plugin-kanban/src/ObjectKanban.cardFields.test.ts` — unit tests for the priority contract (view wins, highlight default, empty-array fallback, stale-field filtering, no-config → `[]`, non-array guard).
- `content/docs/plugins/plugin-kanban.mdx` — documents the object-driven card-field resolution order.
- `.changeset/kanban-cardfields-highlightfields-default.md` — `@object-ui/plugin-kanban` minor.

## Testing

- `vitest run packages/plugin-kanban/` — 16 passed (3 files), incl. the 7 new resolution tests.
- `turbo run type-check --filter=@object-ui/plugin-kanban` — clean.
- ESLint on the changed files — no new problems introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011kPWhiXkpaQhCodH5MscXW)_