### PR TITLE
feat(detail): record-level inline edit — shared InlineEditContext + one atomic Save (#2407 P1)

### DIFF
--- a/.changeset/record-inline-edit-context.md
+++ b/.changeset/record-inline-edit-context.md
@@ -1,0 +1,36 @@
+---
+"@object-ui/react": minor
+"@object-ui/plugin-detail": minor
+---
+
+feat(detail): record-level inline edit — shared `InlineEditContext` + one atomic Save (objectui#2407 P1)
+
+Lift the inline-edit session out of `DetailView`'s private state into a
+record-level, shared context so a record page's surfaces can share ONE draft and
+commit it in ONE atomic, cross-field-validated write (replacing the per-field
+save loop).
+
+- **`InlineEditContext` / `InlineEditProvider` / `useInlineEdit`** (@object-ui/react)
+  — pure UI state (`editing`, `canEdit`, `draft`, `autoFocusField`, `saving`,
+  `error` + `enter` / `setField` / `cancel` / `reset`). A *separate* context from
+  `RecordContext` (mirrors `HighlightFieldsContext`) so per-keystroke draft churn
+  doesn't re-render other `record:*` consumers.
+- **`<InlineEditSaveBar>`** (@object-ui/plugin-detail) — the record-level sticky
+  Save/Cancel bar. Commits the whole draft in ONE
+  `dataSource.update(obj, id, draft, { ifMatch: data.updated_at })` → `refresh()`;
+  a `409 CONCURRENT_UPDATE` reuses `<ConcurrentUpdateDialog>` (reload / overwrite).
+  A callback mode (`onFieldSave`) preserves the drawer's per-field persistence
+  contract with plugin-gantt/calendar/kanban.
+- **`DetailView`** now consumes `useInlineEdit()` instead of owning inline-edit
+  state; its header/inline Save-Cancel bars and per-field batch-save are removed
+  (the approval-lock badge stays). Rendered without a provider it is simply
+  read-only.
+- **`record:details`** and **`RecordDetailDrawer`** each wrap their `DetailView`
+  in an `<InlineEditProvider>` + `<InlineEditSaveBar>`. The object-lifecycle /
+  permission gate flows through `canEdit`; computed / readonly / system fields
+  and the OCC path are unchanged.
+
+Guardrails preserved: computed (`formula`/`summary`/`rollup`/`auto_number`) +
+`readonly` + system fields expose no editor; `canEdit` gate; OCC (`ifMatch` +
+`ConcurrentUpdateDialog`); the atomic partial update carries only user-edited
+keys (never computed/read-only). Editable highlights ride on top of this in P2.

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -42,7 +42,7 @@ import { RecordComments } from './RecordComments';
 import { ActivityTimeline } from './ActivityTimeline';
 import { HistoryTimeline } from './HistoryTimeline';
 import { RecordMetaFooter } from './RecordMetaFooter';
-import { SchemaRenderer, useSafeFieldLabel, useDataInvalidation } from '@object-ui/react';
+import { SchemaRenderer, useSafeFieldLabel, useDataInvalidation, useInlineEdit } from '@object-ui/react';
 import { buildExpandFields, getRecordDisplayName, formatTitleTemplate } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
@@ -51,6 +51,10 @@ import { useDetailTranslation } from './useDetailTranslation';
 
 /** Default page size for related lists in the detail view */
 const DEFAULT_RELATED_PAGE_SIZE = 5;
+
+/** Stable empty draft so the section `data`-merge identity is preserved when
+ *  no <InlineEditProvider> is mounted (bare / read-only DetailView). */
+const EMPTY_DRAFT: Record<string, any> = {};
 
 /**
  * Resolve the human-readable title for the detail header.
@@ -119,10 +123,13 @@ export interface DetailViewProps {
   onEdit?: () => void;
   onDelete?: () => void;
   onBack?: () => void;
-  /** Enable inline editing toggle for detail fields */
+  /**
+   * Opt into inline editing. When true AND an `<InlineEditProvider>` is present
+   * (with `canEdit`), fields surface the double-click / hover-pencil affordance
+   * and edits stage into the shared draft (objectui#2407 P1). The Save/Cancel
+   * bar + atomic persistence live in `<InlineEditSaveBar>`, rendered by the host.
+   */
   inlineEdit?: boolean;
-  /** Callback when a field value is saved inline */
-  onFieldSave?: (field: string, value: any, record: any) => void | Promise<void>;
   /**
    * Optional discussion content rendered as a dedicated "Discussion" tab when
    * autoTabs is enabled. Lets the host page mount a rich chatter panel without
@@ -167,7 +174,6 @@ export const DetailView: React.FC<DetailViewProps> = ({
   onDelete,
   onBack,
   inlineEdit = false,
-  onFieldSave,
   discussionSlot,
   rightRail: _rightRail,
   objectLabel,
@@ -179,12 +185,18 @@ export const DetailView: React.FC<DetailViewProps> = ({
   const [loading, setLoading] = React.useState(!rawSchema.data && !!((rawSchema.api && rawSchema.resourceId) || (dataSource && rawSchema.objectName && rawSchema.resourceId)));
   const [internalFavorite, setInternalFavorite] = React.useState(false);
   const isFavorite = isFavoriteProp ?? internalFavorite;
-  const [isInlineEditing, setIsInlineEditing] = React.useState(false);
-  const [editedValues, setEditedValues] = React.useState<Record<string, any>>({});
-  const [isSaving, setIsSaving] = React.useState(false);
+  // Inline-edit session is lifted to a shared record-level context
+  // (objectui#2407 P1): DetailView no longer owns the edit draft/flags — it
+  // reads them from <InlineEditProvider>. `inline` is null when a host renders
+  // DetailView without a provider (bare / legacy usage) → read-only. The
+  // Save/Cancel bar + atomic persistence live in <InlineEditSaveBar>.
+  const inline = useInlineEdit();
+  const isInlineEditing = inline?.editing ?? false;
+  const editedValues = inline?.draft ?? EMPTY_DRAFT;
+  const autoFocusField = inline?.autoFocusField ?? null;
+  // Retained local error state for the approval-cancel flow ONLY — the
+  // inline-edit draft now surfaces its own errors through the save bar.
   const [saveError, setSaveError] = React.useState<string | null>(null);
-  // Field to auto-focus when inline edit is entered by double-clicking a field.
-  const [autoFocusField, setAutoFocusField] = React.useState<string | null>(null);
   const [objectSchema, setObjectSchema] = React.useState<any>(null);
   const [idCopied, setIdCopied] = React.useState(false);
   const [reloadTick, setReloadTick] = React.useState(0);
@@ -532,73 +544,14 @@ export const DetailView: React.FC<DetailViewProps> = ({
     if (isFavoriteProp === undefined) setInternalFavorite(next);
   }, [isFavorite, isFavoriteProp, onToggleFavorite]);
 
-  const handleInlineEditToggle = React.useCallback(async () => {
-    if (isInlineEditing) {
-      // Save changes
-      const changes = Object.entries(editedValues);
-      if (changes.length > 0) {
-        const previousData = data;
-        const updatedData = { ...data, ...editedValues };
-        // Optimistic update so the UI reflects the change immediately.
-        setData(updatedData);
-        setSaveError(null);
-        setIsSaving(true);
-        try {
-          if (onFieldSave) {
-            // Persist sequentially so a single backend error short-circuits
-            // and we can roll back without partially-applied state.
-            for (const [field, value] of changes) {
-              await onFieldSave(field, value, updatedData);
-            }
-          }
-          setEditedValues({});
-          setIsInlineEditing(false);
-          setAutoFocusField(null);
-        } catch (err: any) {
-          // Roll back optimistic update and stay in edit mode so the user
-          // can correct the input or cancel.
-          setData(previousData);
-          const raw = err?.message || err?.error || String(err ?? 'Save failed');
-          // Strip noisy prefixes for friendlier display:
-          //   "[ObjectStack] RECORD_LOCKED: record is locked..."
-          //     → "record is locked..."
-          //   "RECORD_LOCKED: record is locked..."
-          //     → "record is locked..."
-          const cleaned = raw
-            .replace(/^\[[^\]]+\]\s*/, '')
-            .replace(/^[A-Z][A-Z0-9_]+:\s*/, '');
-          setSaveError(cleaned);
-        } finally {
-          setIsSaving(false);
-        }
-        return;
-      }
-      setEditedValues({});
-    }
-    setIsInlineEditing(!isInlineEditing);
-    setSaveError(null);
-  }, [isInlineEditing, editedValues, data, onFieldSave]);
-
-  const handleInlineEditCancel = React.useCallback(() => {
-    setEditedValues({});
-    setIsInlineEditing(false);
-    setSaveError(null);
-    setAutoFocusField(null);
-  }, []);
-
-  const handleInlineFieldChange = React.useCallback((field: string, value: any) => {
-    setEditedValues(prev => ({ ...prev, [field]: value }));
-  }, []);
-
-  // Enter whole-record inline edit focused on a single field. Wired to the
-  // per-field double-click / hover-pencil affordances in DetailSection.
-  // Mirrors Salesforce: editing any field flips the record into inline edit
-  // with a single Save/Cancel bar, rather than a standalone "Edit fields" toggle.
-  const handleEnterInlineEditField = React.useCallback((fieldName: string) => {
-    setAutoFocusField(fieldName);
-    setIsInlineEditing(true);
-    setSaveError(null);
-  }, []);
+  // Thin bindings from the shared inline-edit context down into each
+  // DetailSection, so the section render sites below stay unchanged. Staging a
+  // field edit routes to the shared draft; entering edit is gated by `canEdit`
+  // (object-lifecycle + permission) at the context source. Save/Cancel and
+  // persistence are owned by <InlineEditSaveBar>, not DetailView.
+  const handleInlineFieldChange = inline?.setField;
+  const handleEnterInlineEditField =
+    inline && inline.canEdit ? inline.enter : undefined;
 
   // Keyboard shortcuts for prev/next record navigation (← / →)
   React.useEffect(() => {
@@ -619,25 +572,6 @@ export const DetailView: React.FC<DetailViewProps> = ({
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [schema.recordNavigation]);
-
-  // Cross-component bridge — lets the page-header overflow menu toggle
-  // inline-edit mode without prop drilling. Dispatched by the
-  // `sys_inline_edit` system action injected from RecordDetailView.
-  // The window event is namespaced with the record id so multiple
-  // detail views (drawer + main pane) don't toggle each other.
-  React.useEffect(() => {
-    if (!inlineEdit || schema.showHeader !== false) return;
-    const eventName = 'objectui:record:inline-edit-toggle';
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { recordId?: string; objectName?: string } | undefined;
-      if (detail?.recordId && schema.recordId && detail.recordId !== schema.recordId) return;
-      if (detail?.objectName && schema.objectName && detail.objectName !== schema.objectName) return;
-      handleInlineEditToggle();
-    };
-    window.addEventListener(eventName, handler);
-    return () => window.removeEventListener(eventName, handler);
-  }, [inlineEdit, schema.showHeader, schema.recordId, schema.objectName, handleInlineEditToggle]);
-
 
   // Auto-discovery of related panels via INVERSE references (other objects
   // whose FK points to the current record) is the responsibility of the
@@ -1015,53 +949,10 @@ export const DetailView: React.FC<DetailViewProps> = ({
               </div>
             )}
 
-            {/* Inline-edit Save / Cancel bar — rendered only WHILE editing.
-                There is no idle "Edit fields" toggle: inline edit is entered by
-                double-clicking a field (or its hover pencil). The primary Edit
-                CTA below opens the full record form. */}
-            {inlineEdit && isInlineEditing && (
-              <>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleInlineEditCancel}
-                      className="gap-2 hidden sm:inline-flex"
-                    >
-                      <X className="h-4 w-4" />
-                      <span className="hidden sm:inline">{t('detail.cancel')}</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t('detail.cancelEdit')}</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant={isInlineEditing ? 'default' : 'outline'}
-                      size="sm"
-                      onClick={handleInlineEditToggle}
-                      className="gap-2 hidden sm:inline-flex"
-                    >
-                      {isInlineEditing ? (
-                        <>
-                          <Check className="h-4 w-4" />
-                          <span className="hidden sm:inline">{t('detail.save')}</span>
-                        </>
-                      ) : (
-                        <>
-                          <Edit className="h-4 w-4" />
-                          <span className="hidden sm:inline">{t('detail.editInline')}</span>
-                        </>
-                      )}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {isInlineEditing ? t('detail.saveChanges') : t('detail.editFieldsInline')}
-                  </TooltipContent>
-                </Tooltip>
-              </>
-            )}
+            {/* The inline-edit Save / Cancel bar now lives in the record-level
+                <InlineEditSaveBar> (rendered by the host), not the header —
+                so the highlights strip and the details body share one bar and
+                one atomic Save (objectui#2407 P1). */}
 
             {/* Share moved into the unified overflow menu (sys_share) so the
                 header focuses on the primary Edit CTA. */}
@@ -1103,88 +994,51 @@ export const DetailView: React.FC<DetailViewProps> = ({
         <HeaderHighlight fields={schema.highlightFields} data={data} objectName={schema.objectName} objectSchema={objectSchema} />
       )}
 
-      {/* Inline-edit affordances — when the DetailView's own header
-          is suppressed (e.g. composed under a Lightning-style page:header),
-          we only render this band while the user is ACTIVELY editing or
-          when there's something the user needs to see (approval lock,
-          save error). The default "Edit fields" entry-point lives in the
-          page:header overflow menu via the `sys_inline_edit` system
-          action so we don't introduce an orphan toolbar row that visually
-          floats between the tab strip and the first section card.
-          Mirrors how Salesforce / HubSpot / Dynamics route field-edit
-          intents through a single top-right menu rather than a separate
-          page-level toolbar. */}
+      {/* Approval-lock band — when the DetailView's own header is suppressed
+          (composed under a Lightning-style page:header), surface the approval
+          lock reason + recall affordance inline. The inline-edit Save / Cancel
+          bar itself now lives in the record-level <InlineEditSaveBar>
+          (objectui#2407 P1); this band is lock-only. */}
       {inlineEdit && schema.showHeader === false && (() => {
         // Detect approval lock on the live record. When `approval_status`
         // is `pending`/`in_approval`, the backend will reject any update
         // with RECORD_LOCKED — show the lock badge inline so users see
-        // a clear reason instead of clicking and failing.
+        // a clear reason instead of editing and failing on save.
         const approvalStatus = data?.approval_status;
         const isLocked = approvalStatus === 'pending' || approvalStatus === 'in_approval';
-        // Idle (not editing, not saving, no error, not locked): no band.
-        if (!isInlineEditing && !isSaving && !saveError && !isLocked) return null;
+        // Nothing to surface (not locked, no approval-cancel error): no band.
+        if (!isLocked && !saveError) return null;
         return (
         <div className="flex flex-col items-end gap-1">
-          <div className="flex items-center justify-end gap-2">
-            {isLocked && !isInlineEditing && (
-              <>
-                <span
-                  role="status"
-                  className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800"
-                  title={t('detail.lockedTooltip')}
-                >
-                  <Lock className="h-3 w-3" />
-                  <span>{t('detail.lockedByApproval')}</span>
-                </span>
-                {dataSource?.cancelPendingApproval && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleCancelApproval}
-                    disabled={isCancellingApproval}
-                    className="gap-2 border-amber-300 text-amber-800 hover:bg-amber-50"
-                    title={t('detail.cancelApprovalTooltip')}
-                  >
-                    <X className="h-4 w-4" />
-                    <span>
-                      {isCancellingApproval
-                        ? t('detail.cancelApprovalInFlight')
-                        : t('detail.cancelApproval')}
-                    </span>
-                  </Button>
-                )}
-              </>
-            )}
-            {isInlineEditing && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleInlineEditCancel}
-                className="gap-2"
-                disabled={isSaving}
+          {isLocked && (
+            <div className="flex items-center justify-end gap-2">
+              <span
+                role="status"
+                className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800"
+                title={t('detail.lockedTooltip')}
               >
-                <X className="h-4 w-4" />
-                <span>{t('detail.cancel')}</span>
-              </Button>
-            )}
-            <Button
-              variant={isInlineEditing ? 'default' : 'outline'}
-              size="sm"
-              onClick={handleInlineEditToggle}
-              className="gap-2"
-              disabled={isSaving || (isLocked && !isInlineEditing)}
-              title={isLocked && !isInlineEditing ? t('detail.lockedTooltip') : undefined}
-            >
-              {isInlineEditing ? <Check className="h-4 w-4" /> : <Edit className="h-4 w-4" />}
-              <span>
-                {isSaving
-                  ? t('detail.saving')
-                  : isInlineEditing
-                    ? t('detail.save')
-                    : t('detail.editFieldsInline')}
+                <Lock className="h-3 w-3" />
+                <span>{t('detail.lockedByApproval')}</span>
               </span>
-            </Button>
-          </div>
+              {dataSource?.cancelPendingApproval && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCancelApproval}
+                  disabled={isCancellingApproval}
+                  className="gap-2 border-amber-300 text-amber-800 hover:bg-amber-50"
+                  title={t('detail.cancelApprovalTooltip')}
+                >
+                  <X className="h-4 w-4" />
+                  <span>
+                    {isCancellingApproval
+                      ? t('detail.cancelApprovalInFlight')
+                      : t('detail.cancelApproval')}
+                  </span>
+                </Button>
+              )}
+            </div>
+          )}
           {saveError && (
             <div
               role="alert"

--- a/packages/plugin-detail/src/InlineEditSaveBar.tsx
+++ b/packages/plugin-detail/src/InlineEditSaveBar.tsx
@@ -1,0 +1,288 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * InlineEditSaveBar — the record-level sticky Save/Cancel bar for inline edit
+ * (objectui#2407 P1). Reads the shared `InlineEditContext` (draft / editing /
+ * saving / error) and commits the WHOLE draft in ONE atomic write, so
+ * cross-field validation runs against a consistent record instead of the old
+ * per-field save-on-blur loop.
+ *
+ * Two persistence modes:
+ *   - **DataSource mode** (record page): one `dataSource.update(obj, id, draft,
+ *     { ifMatch: data.updated_at })` → `refresh()`. A `409 CONCURRENT_UPDATE`
+ *     opens `<ConcurrentUpdateDialog>` (reload / overwrite), reusing the OCC UX
+ *     that previously lived in `record:details`.
+ *   - **Callback mode** (standalone drawer): loops a caller-supplied
+ *     `onFieldSave(field, value)` over the draft, preserving the drawer's
+ *     existing per-field persistence contract with plugin-gantt/calendar/kanban.
+ *
+ * The bar renders nothing unless the record is actively being edited.
+ */
+
+import * as React from 'react';
+import { Button, cn } from '@object-ui/components';
+import { Check, X, Loader2 } from 'lucide-react';
+import { useInlineEdit } from '@object-ui/react';
+import { useDetailTranslation } from './useDetailTranslation';
+import {
+  ConcurrentUpdateDialog,
+  isConcurrentUpdateError,
+  type ConcurrentUpdateConflict,
+} from './ConcurrentUpdateDialog';
+
+export interface InlineEditSaveBarProps {
+  /** DataSource for the atomic-update path (record page). */
+  dataSource?: any;
+  /** Object machine name for the atomic-update path. */
+  objectName?: string;
+  /** Record id for the atomic-update path. */
+  recordId?: string | number | null;
+  /** Current server record — supplies `updated_at` for the OCC `ifMatch` token. */
+  data?: any;
+  /** Re-fetch the record after a successful save / reload. */
+  refresh?: () => void | Promise<void>;
+  /** Map a field machine name to a user-facing label (for the conflict dialog). */
+  fieldLabelFor?: (name: string) => string | undefined;
+  /**
+   * Callback-persistence mode (drawer): when provided, the save loops this
+   * per-field callback over the draft instead of issuing a DataSource update.
+   * Takes precedence over the DataSource path.
+   */
+  onFieldSave?: (field: string, value: any) => void | Promise<void>;
+  /** When true, disables Save and shows a lock hint (e.g. approval-locked). */
+  locked?: boolean;
+  /** Tooltip/label explaining why the record is locked. */
+  lockedHint?: string;
+  className?: string;
+}
+
+/** Strip noisy backend prefixes so the inline error reads cleanly. */
+function cleanError(err: any): string {
+  const raw = err?.message || err?.error || String(err ?? 'Save failed');
+  return String(raw)
+    .replace(/^\[[^\]]+\]\s*/, '')
+    .replace(/^[A-Z][A-Z0-9_]+:\s*/, '');
+}
+
+/**
+ * Issue a partial-record update through whichever method the DataSource
+ * exposes. Mirrors the update/updateOne/patch fallback + `ifMatch` OCC token
+ * that `record:details` used for its per-field save.
+ */
+async function updateVia(
+  ds: any,
+  objectName: string,
+  recordId: string | number,
+  patch: Record<string, any>,
+  opts?: { ifMatch?: string },
+): Promise<void> {
+  if (typeof ds?.update === 'function') {
+    await ds.update(objectName, recordId, patch, opts);
+  } else if (typeof ds?.updateOne === 'function') {
+    await ds.updateOne(objectName, recordId, patch, opts);
+  } else if (typeof ds?.patch === 'function') {
+    await ds.patch(objectName, recordId, patch, opts);
+  } else {
+    throw new Error(
+      '[InlineEditSaveBar] DataSource exposes no update/updateOne/patch method; cannot persist inline edit',
+    );
+  }
+}
+
+export const InlineEditSaveBar: React.FC<InlineEditSaveBarProps> = ({
+  dataSource,
+  objectName,
+  recordId,
+  data,
+  refresh,
+  fieldLabelFor,
+  onFieldSave,
+  locked = false,
+  lockedHint,
+  className,
+}) => {
+  const { t } = useDetailTranslation();
+  const inline = useInlineEdit();
+  const [conflict, setConflict] = React.useState<ConcurrentUpdateConflict | null>(null);
+  const [conflictBusy, setConflictBusy] = React.useState(false);
+
+  const canAtomic = !!dataSource && !!objectName && recordId != null;
+
+  /**
+   * Build the conflict payload for `<ConcurrentUpdateDialog>` from a 409. A
+   * single-field draft shows the classic per-field before/after; a multi-field
+   * draft shows a record-level summary (the dialog JSON-stringifies objects).
+   */
+  const buildConflict = React.useCallback(
+    (draft: Record<string, any>, err: any): ConcurrentUpdateConflict => {
+      const keys = Object.keys(draft);
+      const current = (err?.currentRecord ?? null) as Record<string, unknown> | null;
+      if (keys.length === 1) {
+        const f = keys[0];
+        return {
+          field: f,
+          label: fieldLabelFor?.(f),
+          pendingValue: draft[f],
+          currentValue: current ? current[f] : undefined,
+          currentVersion: err?.currentVersion,
+          currentRecord: current,
+        };
+      }
+      const currentSubset = current
+        ? Object.fromEntries(keys.map((k) => [k, current[k]]))
+        : undefined;
+      return {
+        field: keys.join(', '),
+        label: t('detail.concurrentUpdateRecordLabel', { defaultValue: 'this record' }),
+        pendingValue: draft,
+        currentValue: currentSubset,
+        currentVersion: err?.currentVersion,
+        currentRecord: current,
+      };
+    },
+    [fieldLabelFor, t],
+  );
+
+  const handleSave = React.useCallback(async () => {
+    if (!inline) return;
+    const draft = inline.draft;
+    const entries = Object.entries(draft);
+    // No edits staged → just leave edit mode (matches the old empty-save path).
+    if (entries.length === 0) {
+      inline.reset();
+      return;
+    }
+    inline.setSaving(true);
+    inline.setError(null);
+    try {
+      if (onFieldSave) {
+        // Callback mode (drawer): persist each edited field sequentially so a
+        // single backend rejection short-circuits, preserving the caller's
+        // per-field contract.
+        for (const [field, value] of entries) {
+          await onFieldSave(field, value);
+        }
+      } else if (canAtomic) {
+        // DataSource mode (record page): ONE atomic write of only the edited
+        // keys, OCC-guarded by the record's current updated_at.
+        const ifMatch =
+          typeof data?.updated_at === 'string' ? (data.updated_at as string) : undefined;
+        await updateVia(dataSource, objectName!, recordId!, draft, ifMatch ? { ifMatch } : undefined);
+        await refresh?.();
+      }
+      inline.reset();
+    } catch (err) {
+      if (isConcurrentUpdateError(err) && canAtomic) {
+        // Stay in edit mode; the dialog drives reload / overwrite.
+        setConflict(buildConflict(draft, err));
+      } else {
+        inline.setError(cleanError(err));
+      }
+    } finally {
+      inline.setSaving(false);
+    }
+  }, [inline, onFieldSave, canAtomic, data, dataSource, objectName, recordId, refresh, buildConflict]);
+
+  const closeConflict = React.useCallback(() => {
+    setConflict(null);
+    setConflictBusy(false);
+  }, []);
+
+  const handleConflictReload = React.useCallback(async () => {
+    setConflictBusy(true);
+    try {
+      await refresh?.();
+    } finally {
+      // Discard the pending draft — the user chose the server's version.
+      inline?.reset();
+      closeConflict();
+    }
+  }, [refresh, inline, closeConflict]);
+
+  const handleConflictOverwrite = React.useCallback(async () => {
+    if (!conflict || !canAtomic) {
+      closeConflict();
+      return;
+    }
+    setConflictBusy(true);
+    try {
+      // Re-key the write against the version the server reported in the 409 —
+      // "I've seen the newer record, apply my whole draft on top of it."
+      const draft = inline?.draft ?? {};
+      const opts = conflict.currentVersion ? { ifMatch: conflict.currentVersion } : undefined;
+      await updateVia(dataSource, objectName!, recordId!, draft, opts);
+      await refresh?.();
+      inline?.reset();
+    } catch (err) {
+      inline?.setError(cleanError(err));
+    } finally {
+      closeConflict();
+    }
+  }, [conflict, canAtomic, inline, dataSource, objectName, recordId, refresh, closeConflict]);
+
+  // Render nothing unless a provider is present and the record is being edited.
+  if (!inline || !inline.editing) return null;
+
+  return (
+    <>
+      <div
+        className={cn(
+          'sticky bottom-0 z-30 mt-4 flex flex-wrap items-center justify-end gap-2 rounded-md border bg-background/95 px-3 py-2 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/80',
+          className,
+        )}
+        role="region"
+        aria-label={t('detail.editFieldsInline')}
+      >
+        {inline.error && (
+          <div
+            role="alert"
+            className="mr-auto max-w-md rounded-md border border-destructive/20 bg-destructive/10 px-2 py-1 text-xs text-destructive"
+          >
+            {inline.error}
+          </div>
+        )}
+        {/* The lock REASON is surfaced by DetailView's approval-lock band; here
+            we only disable Save so a locked record can't be written. */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={inline.cancel}
+          disabled={inline.saving}
+          className="gap-2"
+        >
+          <X className="h-4 w-4" />
+          <span>{t('detail.cancel')}</span>
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          onClick={handleSave}
+          disabled={inline.saving || locked}
+          className="gap-2"
+          title={locked ? lockedHint : undefined}
+        >
+          {inline.saving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Check className="h-4 w-4" />
+          )}
+          <span>{inline.saving ? t('detail.saving') : t('detail.save')}</span>
+        </Button>
+      </div>
+      <ConcurrentUpdateDialog
+        open={!!conflict}
+        conflict={conflict}
+        busy={conflictBusy}
+        onCancel={closeConflict}
+        onReload={handleConflictReload}
+        onOverwrite={handleConflictOverwrite}
+      />
+    </>
+  );
+};
+
+export default InlineEditSaveBar;

--- a/packages/plugin-detail/src/RecordDetailDrawer.tsx
+++ b/packages/plugin-detail/src/RecordDetailDrawer.tsx
@@ -28,7 +28,9 @@ import {
   SheetTitle,
 } from '@object-ui/components';
 import type { DataSource } from '@object-ui/types';
+import { InlineEditProvider } from '@object-ui/react';
 import { DetailView } from './DetailView';
+import { InlineEditSaveBar } from './InlineEditSaveBar';
 import { useDetailTranslation } from './useDetailTranslation';
 
 /**
@@ -283,6 +285,10 @@ export function RecordDetailDrawer({
           <SheetTitle>{title}</SheetTitle>
         </SheetHeader>
         <div className="px-6 pt-6 pb-6">
+          {/* One inline-edit session scoped to this drawer. `canEdit` gates on
+              handler presence so an omitted onFieldSave yields a strictly
+              read-only drawer (objectui#2407 P1). */}
+          <InlineEditProvider canEdit={!!onFieldSave}>
           <DetailView
             dataSource={dataSource}
             // Capability = handler presence: a caller that omits onFieldSave /
@@ -322,17 +328,6 @@ export function RecordDetailDrawer({
                   ]
                 : undefined,
             } as any}
-            onFieldSave={onFieldSave ? async (field, value) => {
-              try {
-                await onFieldSave(field, value);
-              } catch (err) {
-                console.error('[RecordDetailDrawer] inline field save failed:', err);
-                // Rethrow so DetailView rolls back the optimistic value and
-                // shows the failure inline — swallowing here made a rejected
-                // save look successful (stale value kept, no message).
-                throw err;
-              }
-            } : undefined}
             onDelete={onDelete ? async () => {
               try {
                 await onDelete();
@@ -342,6 +337,22 @@ export function RecordDetailDrawer({
               }
             } : undefined}
           />
+          {/* Record-level Save/Cancel bar. Callback mode: loops the caller's
+              per-field onFieldSave over the draft, preserving the drawer's
+              existing persistence contract (plugin-gantt/calendar/kanban). */}
+          <InlineEditSaveBar
+            onFieldSave={onFieldSave ? async (field, value) => {
+              try {
+                await onFieldSave(field, value);
+              } catch (err) {
+                console.error('[RecordDetailDrawer] inline field save failed:', err);
+                // Rethrow so the save bar surfaces the failure inline and keeps
+                // the draft — swallowing made a rejected save look successful.
+                throw err;
+              }
+            } : undefined}
+          />
+          </InlineEditProvider>
         </div>
       </SheetContent>
     </Sheet>

--- a/packages/plugin-detail/src/__tests__/InlineEditContext.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineEditContext.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InlineEditProvider, useInlineEdit } from '@object-ui/react';
+
+/**
+ * `InlineEditContext` (objectui#2407 P1) — the record-level inline-edit session
+ * lifted out of DetailView so the details body and (P2) the highlights strip
+ * share ONE draft. These tests pin the pure-UI-state contract: enter/exit,
+ * draft staging, and the `canEdit` gate.
+ */
+
+function Probe() {
+  const inline = useInlineEdit();
+  if (!inline) return <div data-testid="state">no-provider</div>;
+  return (
+    <div>
+      <span data-testid="editing">{String(inline.editing)}</span>
+      <span data-testid="draft">{JSON.stringify(inline.draft)}</span>
+      <span data-testid="focus">{inline.autoFocusField ?? ''}</span>
+      <button onClick={() => inline.enter('status')}>enter</button>
+      <button onClick={() => inline.setField('status', 'active')}>set</button>
+      <button onClick={() => inline.cancel()}>cancel</button>
+    </div>
+  );
+}
+
+describe('InlineEditContext', () => {
+  it('returns null outside a provider (bare DetailView → read-only)', () => {
+    render(<Probe />);
+    expect(screen.getByTestId('state').textContent).toBe('no-provider');
+  });
+
+  it('enter() flips into edit mode and records the auto-focus field', () => {
+    render(
+      <InlineEditProvider canEdit>
+        <Probe />
+      </InlineEditProvider>,
+    );
+    expect(screen.getByTestId('editing').textContent).toBe('false');
+    fireEvent.click(screen.getByText('enter'));
+    expect(screen.getByTestId('editing').textContent).toBe('true');
+    expect(screen.getByTestId('focus').textContent).toBe('status');
+  });
+
+  it('setField() stages ONLY the edited keys into the draft', () => {
+    render(
+      <InlineEditProvider canEdit>
+        <Probe />
+      </InlineEditProvider>,
+    );
+    fireEvent.click(screen.getByText('enter'));
+    fireEvent.click(screen.getByText('set'));
+    expect(screen.getByTestId('draft').textContent).toBe('{"status":"active"}');
+  });
+
+  it('cancel() exits edit mode and discards the draft', () => {
+    render(
+      <InlineEditProvider canEdit>
+        <Probe />
+      </InlineEditProvider>,
+    );
+    fireEvent.click(screen.getByText('enter'));
+    fireEvent.click(screen.getByText('set'));
+    fireEvent.click(screen.getByText('cancel'));
+    expect(screen.getByTestId('editing').textContent).toBe('false');
+    expect(screen.getByTestId('draft').textContent).toBe('{}');
+  });
+
+  it('gates enter() behind canEdit — a non-editable record never enters edit', () => {
+    render(
+      <InlineEditProvider canEdit={false}>
+        <Probe />
+      </InlineEditProvider>,
+    );
+    fireEvent.click(screen.getByText('enter'));
+    expect(screen.getByTestId('editing').textContent).toBe('false');
+  });
+});

--- a/packages/plugin-detail/src/__tests__/InlineEditSaveBar.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineEditSaveBar.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { InlineEditProvider, useInlineEdit } from '@object-ui/react';
+import { InlineEditSaveBar } from '../InlineEditSaveBar';
+
+/**
+ * `<InlineEditSaveBar>` (objectui#2407 P1) commits the whole inline-edit draft
+ * in ONE atomic write. These tests pin the acceptance contract:
+ *   - DataSource mode issues exactly ONE `update` carrying only edited fields,
+ *     OCC-guarded by `ifMatch: data.updated_at`, then refreshes;
+ *   - a 409 keeps the record in edit and opens the conflict resolver;
+ *   - callback mode (drawer) loops the caller's per-field save;
+ *   - Cancel discards the draft without writing.
+ */
+
+// Drives the shared context so the bar has a draft to save. Buttons carry
+// distinctive labels so the bar's own "Save" / "Cancel" stay unambiguous.
+function Harness() {
+  const inline = useInlineEdit()!;
+  return (
+    <>
+      <button onClick={() => inline.enter('status')}>edit-enter</button>
+      <button onClick={() => inline.setField('status', 'active')}>edit-status</button>
+      <button onClick={() => inline.setField('budget', 100)}>edit-budget</button>
+    </>
+  );
+}
+
+function stageTwoFields() {
+  fireEvent.click(screen.getByText('edit-enter'));
+  fireEvent.click(screen.getByText('edit-status'));
+  fireEvent.click(screen.getByText('edit-budget'));
+}
+
+describe('InlineEditSaveBar — DataSource (atomic OCC) mode', () => {
+  it('issues exactly ONE update with only the edited fields + ifMatch, then refreshes', async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar
+          dataSource={{ update }}
+          objectName="proj"
+          recordId="p1"
+          data={{ updated_at: 'v1' }}
+          refresh={refresh}
+        />
+      </InlineEditProvider>,
+    );
+
+    stageTwoFields();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(update).toHaveBeenCalledWith(
+      'proj',
+      'p1',
+      { status: 'active', budget: 100 },
+      { ifMatch: 'v1' },
+    );
+    await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+    // Save exits edit mode → the bar (and its Save button) unmounts.
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).toBeNull());
+  });
+
+  it('opens the conflict resolver on a 409 and stays in edit (no reset)', async () => {
+    const update = vi.fn().mockRejectedValue({
+      code: 'CONCURRENT_UPDATE',
+      currentVersion: 'v2',
+      currentRecord: { status: 'taken' },
+    });
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar
+          dataSource={{ update }}
+          objectName="proj"
+          recordId="p1"
+          data={{ updated_at: 'v1' }}
+          refresh={vi.fn()}
+        />
+      </InlineEditProvider>,
+    );
+
+    fireEvent.click(screen.getByText('edit-enter'));
+    fireEvent.click(screen.getByText('edit-status'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    // The ConcurrentUpdateDialog (Radix AlertDialog) surfaces the conflict with
+    // a Reload / Overwrite resolver — proof the save stayed in edit rather than
+    // silently discarding the draft. (The open modal aria-hides the background
+    // bar, so we assert against the dialog's own controls.)
+    await waitFor(() => expect(screen.getByRole('alertdialog')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /overwrite/i })).toBeInTheDocument();
+  });
+});
+
+describe('InlineEditSaveBar — callback (drawer) mode', () => {
+  it('loops the caller onFieldSave over each edited field', async () => {
+    const onFieldSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar onFieldSave={onFieldSave} />
+      </InlineEditProvider>,
+    );
+
+    stageTwoFields();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onFieldSave).toHaveBeenCalledTimes(2));
+    expect(onFieldSave).toHaveBeenCalledWith('status', 'active');
+    expect(onFieldSave).toHaveBeenCalledWith('budget', 100);
+  });
+});
+
+describe('InlineEditSaveBar — Cancel', () => {
+  it('discards the draft without any write', () => {
+    const update = vi.fn();
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar dataSource={{ update }} objectName="proj" recordId="p1" data={{}} refresh={vi.fn()} />
+      </InlineEditProvider>,
+    );
+
+    fireEvent.click(screen.getByText('edit-enter'));
+    fireEvent.click(screen.getByText('edit-status'));
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-detail/src/__tests__/RecordDetailDrawer.capability.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordDetailDrawer.capability.test.tsx
@@ -29,6 +29,7 @@ import { RecordDetailDrawer } from '../RecordDetailDrawer';
  */
 
 const captured = vi.hoisted(() => ({ props: [] as any[] }));
+const capturedBar = vi.hoisted(() => ({ props: [] as any[] }));
 
 vi.mock('../DetailView', () => ({
   DetailView: (props: any) => {
@@ -37,9 +38,24 @@ vi.mock('../DetailView', () => ({
   },
 }));
 
+// Inline-edit persistence moved out of DetailView into <InlineEditSaveBar>
+// (objectui#2407 P1). Capture the save bar's props to assert the drawer wires
+// the host's per-field onFieldSave into it (callback-persistence mode).
+vi.mock('../InlineEditSaveBar', () => ({
+  InlineEditSaveBar: (props: any) => {
+    capturedBar.props.push(props);
+    return null;
+  },
+}));
+
 function lastProps() {
   expect(captured.props.length).toBeGreaterThan(0);
   return captured.props[captured.props.length - 1];
+}
+
+function lastBarProps() {
+  expect(capturedBar.props.length).toBeGreaterThan(0);
+  return capturedBar.props[capturedBar.props.length - 1];
 }
 
 function renderDrawer(extra: Partial<React.ComponentProps<typeof RecordDetailDrawer>> = {}) {
@@ -58,6 +74,7 @@ function renderDrawer(extra: Partial<React.ComponentProps<typeof RecordDetailDra
 
 beforeEach(() => {
   captured.props.length = 0;
+  capturedBar.props.length = 0;
 });
 
 describe('RecordDetailDrawer capability = handler presence', () => {
@@ -66,8 +83,10 @@ describe('RecordDetailDrawer capability = handler presence', () => {
     const props = lastProps();
     expect(props.inlineEdit).toBe(true);
     expect(props.schema.showDelete).toBe(true);
-    expect(typeof props.onFieldSave).toBe('function');
+    // onFieldSave no longer rides on DetailView — it wires into the save bar.
+    expect(props.onFieldSave).toBeUndefined();
     expect(typeof props.onDelete).toBe('function');
+    expect(typeof lastBarProps().onFieldSave).toBe('function');
   });
 
   it('renders strictly read-only when both handlers are omitted', () => {
@@ -77,6 +96,8 @@ describe('RecordDetailDrawer capability = handler presence', () => {
     expect(props.schema.showDelete).toBe(false);
     expect(props.onFieldSave).toBeUndefined();
     expect(props.onDelete).toBeUndefined();
+    // The save bar also receives no persistence handler (read-only).
+    expect(lastBarProps().onFieldSave).toBeUndefined();
   });
 
   it('gates each capability independently (save without delete)', () => {
@@ -90,17 +111,17 @@ describe('RecordDetailDrawer capability = handler presence', () => {
   it('forwards field saves to the host handler', async () => {
     const onFieldSave = vi.fn().mockResolvedValue(undefined);
     renderDrawer({ onFieldSave });
-    await lastProps().onFieldSave('name', 'World');
+    await lastBarProps().onFieldSave('name', 'World');
     expect(onFieldSave).toHaveBeenCalledWith('name', 'World');
   });
 
-  it('rethrows a rejected field save so DetailView can roll back and show it', async () => {
-    // Swallowing here made a rejected save look successful: DetailView kept
-    // the optimistic value and never displayed the failure (#2473 第 2 项).
+  it('rethrows a rejected field save so the save bar can keep the draft and show it', async () => {
+    // Swallowing here made a rejected save look successful: the value looked
+    // persisted and the failure was never displayed (#2473 第 2 项).
     const onFieldSave = vi.fn().mockRejectedValue(new Error('仅管理责任人可修改'));
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     renderDrawer({ onFieldSave });
-    await expect(lastProps().onFieldSave('name', 'World')).rejects.toThrow('仅管理责任人可修改');
+    await expect(lastBarProps().onFieldSave('name', 'World')).rejects.toThrow('仅管理责任人可修改');
     errSpy.mockRestore();
   });
 

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -51,6 +51,8 @@ export { SectionGroup } from './SectionGroup';
 export { HeaderHighlight } from './HeaderHighlight';
 export { InlineFieldInput, extractLookupId, TEXTUAL_REF_FALLBACK_TYPES } from './InlineFieldInput';
 export type { InlineFieldInputProps } from './InlineFieldInput';
+export { InlineEditSaveBar } from './InlineEditSaveBar';
+export type { InlineEditSaveBarProps } from './InlineEditSaveBar';
 export { inferDetailColumns, isWideFieldType, applyAutoSpan, applyDetailAutoLayout } from './autoLayout';
 export { useDetailTranslation, DETAIL_DEFAULT_TRANSLATIONS, createSafeTranslationHook } from './useDetailTranslation';
 export { RecordComments } from './RecordComments';

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx
@@ -39,6 +39,10 @@ vi.mock('@object-ui/react', async () => {
     useSafeFieldLabel: () => (React.useRef(0), {
       sectionLabel: (_obj: string, _name: string, fallback: string) => fallback,
     }),
+    // The inline-edit session provider is a passthrough here — this suite
+    // exercises the renderer's rules-of-hooks contract, not the edit flow.
+    InlineEditProvider: ({ children }: any) => children,
+    useInlineEdit: () => (React.useRef(0), null),
   };
 });
 
@@ -57,9 +61,10 @@ vi.mock('@object-ui/permissions', async () => {
 vi.mock('../../DetailView', () => ({
   DetailView: (props: any) => <div data-testid="detail-view" data-object={props?.schema?.objectName} />,
 }));
-vi.mock('../../ConcurrentUpdateDialog', () => ({
-  ConcurrentUpdateDialog: () => null,
-  isConcurrentUpdateError: () => false,
+// Save + OCC now live in <InlineEditSaveBar> (objectui#2407 P1); stub it so the
+// suite stays focused on the renderer's hook ordering.
+vi.mock('../../InlineEditSaveBar', () => ({
+  InlineEditSaveBar: () => null,
 }));
 
 import { RecordDetailsRenderer } from '../record-details';

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -11,16 +11,12 @@
  */
 
 import React from 'react';
-import { useRecordContext, useHighlightFieldNames, useSafeFieldLabel } from '@object-ui/react';
+import { useRecordContext, useHighlightFieldNames, useSafeFieldLabel, InlineEditProvider } from '@object-ui/react';
 import { useFieldPermissions, usePermissions } from '@object-ui/permissions';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { RecordDetailsComponentProps } from '@object-ui/types';
 import { DetailView } from '../DetailView';
-import {
-  ConcurrentUpdateDialog,
-  isConcurrentUpdateError,
-  type ConcurrentUpdateConflict,
-} from '../ConcurrentUpdateDialog';
+import { InlineEditSaveBar } from '../InlineEditSaveBar';
 
 /** Normalize a field entry (string | {field} | {name}) to its machine name. */
 const fieldName = (entry: any): string | null => {
@@ -68,14 +64,6 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   // instance via HighlightFieldsContext (used to dedupe them out of the grid).
   const liveHighlightNames = useHighlightFieldNames();
 
-  /**
-   * Optimistic Concurrency Control state for inline edits: a `409
-   * CONCURRENT_UPDATE` opens a resolution dialog instead of silently retrying
-   * or overwriting.
-   */
-  const [conflict, setConflict] = React.useState<ConcurrentUpdateConflict | null>(null);
-  const [conflictBusy, setConflictBusy] = React.useState(false);
-
   const fieldLabelFor = React.useCallback(
     (name: string): string | undefined => {
       const all: any[] = [
@@ -95,122 +83,12 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
     [schema.fields, schema.sections]
   );
 
-  /**
-   * Persist a single inline-edited field through the bound DataSource and
-   * trigger a context refresh so the new value re-hydrates from the server
-   * after save. Without this wiring the DetailView only updated its own
-   * local `data` state — the change would visibly stick until the user
-   * reloaded the page, then silently revert because nothing was sent to
-   * the backend.
-   *
-   * Passes the record's `updated_at` as `ifMatch` so the server can reject the
-   * write with `409 CONCURRENT_UPDATE` when a concurrent writer has bumped the
-   * row; on conflict we open a resolution dialog.
-   */
-  const handleInlineFieldSave = React.useCallback(
-    async (field: string, value: any) => {
-      const ds: any = ctx?.dataSource;
-      const recordId = ctx?.recordId;
-      const objName = ctx?.objectName;
-      if (!ds || !recordId || !objName) return;
-      const ifMatch =
-        typeof (ctx?.data as any)?.updated_at === 'string'
-          ? ((ctx?.data as any).updated_at as string)
-          : undefined;
-      const opts = ifMatch ? { ifMatch } : undefined;
-      try {
-        if (typeof ds.update === 'function') {
-          await ds.update(objName, recordId, { [field]: value }, opts);
-        } else if (typeof ds.updateOne === 'function') {
-          await ds.updateOne(objName, recordId, { [field]: value }, opts);
-        } else if (typeof ds.patch === 'function') {
-          await ds.patch(objName, recordId, { [field]: value }, opts);
-        } else {
-          console.warn('[record:details] DataSource exposes no update/updateOne/patch method; cannot persist inline edit');
-          return;
-        }
-        if (typeof ctx?.refresh === 'function') {
-          await ctx.refresh();
-        }
-      } catch (err) {
-        if (isConcurrentUpdateError(err)) {
-          const current = err.currentRecord ?? null;
-          setConflict({
-            field,
-            label: fieldLabelFor(field),
-            pendingValue: value,
-            currentValue: current ? (current as Record<string, unknown>)[field] : undefined,
-            currentVersion: err.currentVersion,
-            currentRecord: current,
-          });
-          // Re-throw so DetailView rolls back its optimistic local state.
-          // The dialog drives the eventual resolution (reload / overwrite).
-          throw err;
-        }
-        console.error('[record:details] Inline-edit save failed', err);
-        // Re-throw so DetailView can roll back the optimistic local state and
-        // surface the failure to the user. Without this the value would
-        // appear to stick until the next reload, masking backend rejections
-        // (e.g. RECORD_LOCKED while an approval is in progress).
-        throw err;
-      }
-    },
-    [ctx?.dataSource, ctx?.recordId, ctx?.objectName, ctx?.data, ctx?.refresh, fieldLabelFor]
-  );
-
-  const closeConflict = React.useCallback(() => {
-    setConflict(null);
-    setConflictBusy(false);
-  }, []);
-
-  const handleConflictReload = React.useCallback(async () => {
-    setConflictBusy(true);
-    try {
-      if (typeof ctx?.refresh === 'function') {
-        await ctx.refresh();
-      }
-    } finally {
-      closeConflict();
-    }
-  }, [ctx?.refresh, closeConflict]);
-
-  const handleConflictOverwrite = React.useCallback(async () => {
-    if (!conflict) {
-      closeConflict();
-      return;
-    }
-    const ds: any = ctx?.dataSource;
-    const recordId = ctx?.recordId;
-    const objName = ctx?.objectName;
-    if (!ds || !recordId || !objName) {
-      closeConflict();
-      return;
-    }
-    setConflictBusy(true);
-    try {
-      // Re-key the write against the latest known server version. The
-      // server's `currentVersion` from the 409 is now the freshest
-      // token we hold, so passing it through still uses OCC — it just
-      // means "I've seen this newer version, apply my change on top".
-      const opts = conflict.currentVersion
-        ? { ifMatch: conflict.currentVersion }
-        : undefined;
-      if (typeof ds.update === 'function') {
-        await ds.update(objName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
-      } else if (typeof ds.updateOne === 'function') {
-        await ds.updateOne(objName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
-      } else if (typeof ds.patch === 'function') {
-        await ds.patch(objName, recordId, { [conflict.field]: conflict.pendingValue }, opts);
-      }
-      if (typeof ctx?.refresh === 'function') {
-        await ctx.refresh();
-      }
-    } catch (err) {
-      console.error('[record:details] Overwrite-on-conflict failed', err);
-    } finally {
-      closeConflict();
-    }
-  }, [conflict, ctx?.dataSource, ctx?.recordId, ctx?.objectName, ctx?.refresh, closeConflict]);
+  // Inline-edit save + OCC now live in the record-level <InlineEditSaveBar>
+  // (objectui#2407 P1): it commits the whole draft in ONE atomic
+  // `dataSource.update(..., { ifMatch: data.updated_at })` and reuses
+  // <ConcurrentUpdateDialog> on a 409. This renderer just supplies the draft
+  // scope (<InlineEditProvider>) + the save bar with the bound record's
+  // DataSource / id / version / refresh.
 
   // ── Conditional returns (safe now — all hooks above have run) ────────────
 
@@ -394,22 +272,33 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
     inlineEdit: inlineEditDefault,
   };
 
+  // Approval-locked records (pending / in_approval) can't be written — the
+  // backend rejects with RECORD_LOCKED — so disable Save on the bar. DetailView
+  // renders the lock REASON badge; the save bar just prevents the write.
+  const approvalStatus = (ctx.data as any)?.approval_status;
+  const locked = approvalStatus === 'pending' || approvalStatus === 'in_approval';
+
   return (
     <div className={className} {...designer}>
-      <DetailView
-        schema={synthesized}
-        dataSource={ctx.dataSource as any}
-        inlineEdit={inlineEditDefault}
-        onFieldSave={handleInlineFieldSave}
-      />
-      <ConcurrentUpdateDialog
-        open={!!conflict}
-        conflict={conflict}
-        busy={conflictBusy}
-        onCancel={closeConflict}
-        onReload={handleConflictReload}
-        onOverwrite={handleConflictOverwrite}
-      />
+      {/* One shared inline-edit session for this record. In P2 this provider
+          lifts to the page host so the highlights strip shares the same draft;
+          for now it scopes the details body + its atomic Save bar. */}
+      <InlineEditProvider canEdit={inlineEditDefault}>
+        <DetailView
+          schema={synthesized}
+          dataSource={ctx.dataSource as any}
+          inlineEdit={inlineEditDefault}
+        />
+        <InlineEditSaveBar
+          dataSource={ctx.dataSource as any}
+          objectName={ctx.objectName}
+          recordId={ctx.recordId ?? undefined}
+          data={ctx.data}
+          refresh={ctx.refresh}
+          fieldLabelFor={fieldLabelFor}
+          locked={locked}
+        />
+      </InlineEditProvider>
     </div>
   );
 };

--- a/packages/react/src/context/InlineEditContext.tsx
+++ b/packages/react/src/context/InlineEditContext.tsx
@@ -1,0 +1,140 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * InlineEditContext — record-level inline-edit session shared across the
+ * `record:*` renderers of a record page (objectui#2407 P1). Lifting the
+ * edit session out of `DetailView`'s private state lets the details body and
+ * (P2) the highlights strip share ONE draft + ONE atomic Save.
+ *
+ * This is a *separate* context from `RecordContext` (mirrors
+ * `HighlightFieldsContext`) on purpose: the draft mutates on every keystroke,
+ * and routing that churn through `RecordContext` would re-render every
+ * `record:*` consumer. Consumers that don't edit stay subscribed only to
+ * `RecordContext` and never re-render on draft changes.
+ *
+ * The context holds PURE UI state — it knows nothing about the DataSource,
+ * OCC, or how a draft is persisted. The atomic save + conflict handling live
+ * in `<InlineEditSaveBar>` (@object-ui/plugin-detail), which reads this
+ * context for the draft/editing flags and drives `saving`/`error`/`reset`.
+ */
+
+import React from 'react';
+
+export interface InlineEditContextValue {
+  /** True while the record is in inline-edit mode. */
+  editing: boolean;
+  /**
+   * Whether inline editing is allowed at all for this record — the object
+   * lifecycle / permission gate, decided by the host. When false, `enter()`
+   * is a no-op and consumers must not surface the edit affordance.
+   */
+  canEdit: boolean;
+  /**
+   * Draft of user-edited values. Holds ONLY the keys the user actually
+   * changed, so the save path never writes computed / read-only / untouched
+   * fields. Read a field's live value as `draft[name] ?? data[name]`.
+   */
+  draft: Record<string, any>;
+  /** Field to auto-focus when edit was entered from a specific field. */
+  autoFocusField: string | null;
+  /** True while an atomic save is in flight (driven by the save bar). */
+  saving: boolean;
+  /** Last save error message, or null (driven by the save bar). */
+  error: string | null;
+  /** Enter inline-edit mode, optionally focused on `field`. No-op when `!canEdit`. */
+  enter: (field?: string) => void;
+  /** Stage a single field edit into the draft. */
+  setField: (field: string, value: any) => void;
+  /** Exit edit mode and discard the draft (Cancel). */
+  cancel: () => void;
+  /** Exit edit mode and clear the draft — used after a successful save. */
+  reset: () => void;
+  /** Set the in-flight saving flag (used by the save bar). */
+  setSaving: (saving: boolean) => void;
+  /** Set or clear the save error message (used by the save bar). */
+  setError: (error: string | null) => void;
+}
+
+const InlineEditContext = React.createContext<InlineEditContextValue | null>(null);
+
+export interface InlineEditProviderProps {
+  /**
+   * Whether inline editing is allowed (object-lifecycle + permission gate).
+   * Threaded into `canEdit` so `enter()` and the edit affordance are gated at
+   * a single source. Defaults to `true`.
+   */
+  canEdit?: boolean;
+  children: React.ReactNode;
+}
+
+export const InlineEditProvider: React.FC<InlineEditProviderProps> = ({
+  canEdit = true,
+  children,
+}) => {
+  const [editing, setEditing] = React.useState(false);
+  const [draft, setDraft] = React.useState<Record<string, any>>({});
+  const [autoFocusField, setAutoFocusField] = React.useState<string | null>(null);
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const enter = React.useCallback(
+    (field?: string) => {
+      // Object-lifecycle / permission gate: never enter edit on a record the
+      // host has marked non-editable, even if a stray affordance fires.
+      if (!canEdit) return;
+      setAutoFocusField(field ?? null);
+      setEditing(true);
+      setError(null);
+    },
+    [canEdit],
+  );
+
+  const setField = React.useCallback((field: string, value: any) => {
+    setDraft((prev) => ({ ...prev, [field]: value }));
+  }, []);
+
+  // Cancel and reset share the same teardown (clear draft, exit edit, clear
+  // transient state). They are named separately so call sites read
+  // intentionally — `cancel()` on the Cancel button, `reset()` after a
+  // successful save — and so the two can diverge later without touching callers.
+  const teardown = React.useCallback(() => {
+    setDraft({});
+    setEditing(false);
+    setAutoFocusField(null);
+    setSaving(false);
+    setError(null);
+  }, []);
+
+  const value = React.useMemo<InlineEditContextValue>(
+    () => ({
+      editing,
+      canEdit,
+      draft,
+      autoFocusField,
+      saving,
+      error,
+      enter,
+      setField,
+      cancel: teardown,
+      reset: teardown,
+      setSaving,
+      setError,
+    }),
+    [editing, canEdit, draft, autoFocusField, saving, error, enter, setField, teardown],
+  );
+
+  return <InlineEditContext.Provider value={value}>{children}</InlineEditContext.Provider>;
+};
+
+/**
+ * Read the current inline-edit session. Returns `null` when called outside an
+ * `<InlineEditProvider>` — a `DetailView` rendered without a provider (bare /
+ * legacy usage) simply treats the record as read-only rather than throwing.
+ */
+export function useInlineEdit(): InlineEditContextValue | null {
+  return React.useContext(InlineEditContext);
+}

--- a/packages/react/src/context/index.ts
+++ b/packages/react/src/context/index.ts
@@ -6,6 +6,7 @@ export * from './NotificationContext';
 export * from './DndContext';
 export * from './AppShellContext';
 export * from './RecordContext';
+export * from './InlineEditContext';
 export * from './DiscussionContext';
 export * from './DrillNavigationContext';
 export * from './RelatedRecordActionsContext';


### PR DESCRIPTION
## What & why

**P1 of #2407** (follow-up to #2402; builds on the merged step-0 refactor #2529). Lifts the inline-edit session out of `DetailView`'s private state into a **record-level shared context**, so a record page's surfaces share **ONE draft** and commit it in **ONE atomic, cross-field-validated write** — replacing the old per-field save loop. This isolates the riskiest plumbing; **editable highlights are P2**.

Per the issue's own risk-isolation intent, this PR keeps the provider hosted by `record:details` / `RecordDetailDrawer` and **leaves app-shell untouched** (the legacy `DetailView` path in `RecordDetailView` never wired inline edit). P2 lifts the provider to the app-shell page host so the highlights strip can share the same draft.

## Changes

| Area | Change |
|---|---|
| **`InlineEditContext`** (`@object-ui/react`, new) | `InlineEditProvider` + `useInlineEdit`. Pure UI state: `editing`, `canEdit`, `draft`, `autoFocusField`, `saving`, `error` + `enter` / `setField` / `cancel` / `reset`. A *separate* context from `RecordContext` (mirrors `HighlightFieldsContext`) so per-keystroke draft churn doesn't re-render other `record:*` consumers. |
| **`<InlineEditSaveBar>`** (`plugin-detail`, new) | Record-level sticky Save/Cancel bar. **DataSource mode:** ONE `update(obj, id, draft, { ifMatch: data.updated_at })` → `refresh()`; a `409 CONCURRENT_UPDATE` reuses `<ConcurrentUpdateDialog>` (reload / overwrite). **Callback mode:** loops the drawer's per-field `onFieldSave`. |
| `DetailView` | Consumes `useInlineEdit()` instead of owning inline-edit state; header/inline Save-Cancel bars + per-field batch-save removed (`onFieldSave` prop dropped); approval-lock badge retained. No provider → read-only. |
| `record:details` | `DetailView` consumes the shared context; its per-field save + own OCC dialog are replaced by `<InlineEditProvider>` (canEdit = object-lifecycle gate) + `<InlineEditSaveBar>`. |
| `RecordDetailDrawer` | Wraps its `DetailView` in a local `<InlineEditProvider>` + `<InlineEditSaveBar>` (callback mode), preserving the plugin-gantt/calendar/kanban per-field contract. |

`draft` holds only user-edited keys → computed / read-only / untouched fields are never sent.

## Guardrails preserved

Computed (`formula`/`summary`/`rollup`/`auto_number`) + `readonly` + system fields expose no editor; `canEdit` object-lifecycle / permission gate; OCC (`ifMatch` + `ConcurrentUpdateDialog`); atomic partial update never writes computed/read-only fields; FLS/permission field filtering unchanged.

## Verification

- `@object-ui/react` + `plugin-detail` **vite builds clean**; `plugin-detail` **type-check clean**.
- **200 tests pass (21 files)** — new `InlineEditContext` suite (enter/setField/cancel/`canEdit` gate) + `InlineEditSaveBar` suite (**exactly one** `update` with only edited fields + `ifMatch`; `409 → ConcurrentUpdateDialog`; callback-mode per-field loop; Cancel discards without writing) + updated `record:details` / `RecordDetailDrawer` suites + existing `DetailSection` inline-edit suites.
- `app-shell` type-check is clean **with respect to this change** (the `onFieldSave` prop removal produced no errors); the only remaining error is a **pre-existing, unrelated** `Cannot find module '@objectstack/formula'` in `metadata-admin/celAuthoring.ts` (missing external dep in this sandbox; resolvable in CI). This PR does not touch app-shell.
- ⏳ Live browser pass on the showcase record page (double-click a body field → single atomic PATCH; 409 resolver) pending a running console/backend — same manual step deferred in #2402.

## Acceptance criteria (P1)

- [x] `InlineEditContext` / `InlineEditProvider` / `useInlineEdit` exported from `@object-ui/react`.
- [x] Double-click / pencil on a body field enters edit via the shared context; one record-level Save/Cancel bar.
- [x] Save issues exactly ONE `update` with only edited fields; 409 → `ConcurrentUpdateDialog`.
- [x] Standalone `DetailView` (drawer) still edits + saves.
- [x] Existing inline-edit tests pass; new tests for atomic save + standalone.

## Next

**P2** — editable highlights on the shared draft (using the `<InlineFieldInput>` from #2529 + this context); lift the `InlineEditProvider` to the app-shell page host so highlights + details share one draft and one Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1f7TvqYMo41g9RbQ6H2od)_