### PR TITLE
feat(flow-designer): search box + keyboard nav + recents in the add-node palette

### DIFF
--- a/.changeset/flow-palette-search.md
+++ b/.changeset/flow-palette-search.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Flow builder: add a search box, keyboard navigation, and a "Recently used" group to the Add-node palette (#1943). Typing filters across all categories (label + hint + type, case-insensitive), ↑/↓ + Enter inserts the highlighted node, and the empty-query view is topped by a localStorage MRU of recently inserted node types. Works with the server-merged palette, so plugin-contributed nodes are searchable too.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verify
+description: Verify metadata-admin designer (previews) changes end-to-end in a real browser without a backend, via the console preview gallery.
+user-invocable: false
+---
+
+# Verifying metadata-admin designer changes (no backend needed)
+
+The console ships a dev-only gallery that renders every registered metadata
+designer (`packages/app-shell/src/views/metadata-admin/previews/*`) with
+representative sample drafts, in edit mode, with zero backend:
+
+```bash
+cd apps/console && pnpm exec vite --port <free-port> --strictPort
+# open http://localhost:<free-port>/preview-gallery.html
+# isolate one designer: /preview-gallery.html?only=flow   (or ?only=dashboard, page, …)
+```
+
+Sample drafts live in `apps/console/src/preview-samples.ts` (keyed by metadata
+type: `flow`, `workflow`, `object`, …). Server-driven affordances (e.g. the
+flow palette's `GET /api/v1/automation/actions`) fail fetch and fall back to
+their hardcoded defaults — that IS the offline path, not an error.
+
+## Driving it headlessly
+
+The chrome-devtools MCP may lack a Chrome binary in remote sessions. Use the
+repo's own Playwright instead — the pre-installed executable is at
+`/opt/pw-browsers/chromium-1194/chrome-linux/chrome` (probe with
+`find /opt/pw-browsers -name chrome` if the version moved):
+
+```js
+import { chromium } from '@playwright/test';
+const browser = await chromium.launch({ executablePath: '<probed path>' });
+```
+
+Gotcha: a driver script must live **inside** the repo (e.g.
+`node_modules/.drive.mjs` — ignored by git) so Node resolves
+`@playwright/test`; a script in `/tmp` won't resolve workspace deps.
+
+Useful selectors: cmdk internals are addressable via `[cmdk-item]`,
+`[cmdk-group-heading]`, `[cmdk-empty]`, `[cmdk-item][data-selected="true"]`;
+flow canvas node cards match `.group.absolute`.
+
+Cleanup: kill only the vite server you started (`kill $(lsof -ti tcp:<port>)`).

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -503,6 +503,10 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.add.step': 'Add step',
   'engine.inspector.add.action': 'Add action',
   'engine.inspector.add.nav': 'Add nav item',
+  // Flow designer add-node palette (search box + recents, #1943)
+  'engine.flowPalette.search': 'Search nodes…',
+  'engine.flowPalette.empty': 'No matching nodes.',
+  'engine.flowPalette.recent': 'Recently used',
   // Reorder buttons (used in InspectorShell header)
   'engine.inspector.reorder.up': 'Move up',
   'engine.inspector.reorder.down': 'Move down',
@@ -1812,6 +1816,10 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.add.step': '添加步骤',
   'engine.inspector.add.action': '添加动作',
   'engine.inspector.add.nav': '添加导航项',
+  // Flow designer add-node palette (search box + recents, #1943)
+  'engine.flowPalette.search': '搜索节点…',
+  'engine.flowPalette.empty': '没有匹配的节点。',
+  'engine.flowPalette.recent': '最近使用',
   // Reorder buttons
   'engine.inspector.reorder.up': '上移',
   'engine.inspector.reorder.down': '下移',

--- a/packages/app-shell/src/views/metadata-admin/previews/NodePalette.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/NodePalette.test.tsx
@@ -1,0 +1,206 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * NodePalette (#1943) — search box, keyboard navigation, and the
+ * "Recently used" group. Rendered controlled (`open`) with a fixture item
+ * list that includes a synthetic plugin item to stand in for the
+ * server-merged palette.
+ */
+
+import * as React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { NodePalette, type PaletteItem } from './flow-canvas-parts';
+import { readPaletteRecents } from './flowPaletteRecents';
+
+beforeAll(() => {
+  // Radix Popover / cmdk probe pointer-capture APIs the test DOM lacks.
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Multi-category fixture incl. a plugin-contributed (server-merged) item. */
+const ITEMS: PaletteItem[] = [
+  { type: 'create_record', label: 'Create record', hint: 'Insert a new record', category: 'Data' },
+  { type: 'decision', label: 'Decision', hint: 'Branch on a condition', category: 'Logic' },
+  { type: 'screen', label: 'Screen', hint: 'Collect input from a user', category: 'Human' },
+  { type: 'plugin.http', label: 'HTTP Call', hint: 'Call an external API', category: 'Integration' },
+  { type: 'end', label: 'End', hint: 'Terminate the flow', category: 'Flow' },
+];
+
+function renderPalette(overrides: { onPick?: (type: string) => void; open?: boolean } = {}) {
+  const onPick = overrides.onPick ?? vi.fn();
+  const view = render(
+    <NodePalette
+      items={ITEMS}
+      open={overrides.open ?? true}
+      onOpenChange={() => {}}
+      onPick={onPick}
+    >
+      <button type="button">Add node</button>
+    </NodePalette>,
+  );
+  return { onPick, view };
+}
+
+/** The palette's search input (rendered by cmdk inside the portaled popover). */
+function searchInput(): HTMLInputElement {
+  return screen.getByPlaceholderText('Search nodes…') as HTMLInputElement;
+}
+
+describe('NodePalette search & filtering', () => {
+  it('shows the full grouped list for an empty query', () => {
+    renderPalette();
+    for (const heading of ['Data', 'Logic', 'Human', 'Integration', 'Flow']) {
+      expect(screen.getByText(heading)).toBeTruthy();
+    }
+    for (const item of ITEMS) {
+      expect(screen.getByText(item.label)).toBeTruthy();
+    }
+  });
+
+  it('filters across all categories and hides empty sections', async () => {
+    renderPalette();
+    // 'record' hits Create record's label (Data) and nothing else.
+    fireEvent.change(searchInput(), { target: { value: 'record' } });
+    await waitFor(() => {
+      expect(screen.getByText('Create record')).toBeTruthy();
+      expect(screen.queryByText('Decision')).toBeNull();
+      expect(screen.queryByText('Logic')).toBeNull();
+      expect(screen.queryByText('Flow')).toBeNull();
+    });
+  });
+
+  it('matches on hint text', async () => {
+    renderPalette();
+    // 'condition' appears only in Decision's hint.
+    fireEvent.change(searchInput(), { target: { value: 'condition' } });
+    await waitFor(() => {
+      expect(screen.getByText('Decision')).toBeTruthy();
+      expect(screen.queryByText('Screen')).toBeNull();
+    });
+  });
+
+  it('is case-insensitive', async () => {
+    renderPalette();
+    fireEvent.change(searchInput(), { target: { value: 'SCREEN' } });
+    await waitFor(() => {
+      expect(screen.getByText('Screen')).toBeTruthy();
+      expect(screen.queryByText('End')).toBeNull();
+    });
+  });
+
+  it('finds server-merged plugin items by label and by type', async () => {
+    renderPalette();
+    fireEvent.change(searchInput(), { target: { value: 'http' } });
+    await waitFor(() => {
+      expect(screen.getByText('HTTP Call')).toBeTruthy();
+    });
+    // Match by registered type, too (display name differs from type).
+    fireEvent.change(searchInput(), { target: { value: 'plugin.' } });
+    await waitFor(() => {
+      expect(screen.getByText('HTTP Call')).toBeTruthy();
+      expect(screen.queryByText('Screen')).toBeNull();
+    });
+  });
+
+  it('shows the empty state when nothing matches', async () => {
+    renderPalette();
+    fireEvent.change(searchInput(), { target: { value: 'zzz-no-such-node' } });
+    await waitFor(() => {
+      expect(screen.getByText('No matching nodes.')).toBeTruthy();
+      expect(screen.queryByText('Screen')).toBeNull();
+    });
+  });
+
+  it('resets the query when reopened', async () => {
+    const onPick = vi.fn();
+    const { rerender } = render(
+      <NodePalette items={ITEMS} open onOpenChange={() => {}} onPick={onPick}>
+        <button type="button">Add node</button>
+      </NodePalette>,
+    );
+    fireEvent.change(searchInput(), { target: { value: 'screen' } });
+    await waitFor(() => expect(screen.queryByText('End')).toBeNull());
+    rerender(
+      <NodePalette items={ITEMS} open={false} onOpenChange={() => {}} onPick={onPick}>
+        <button type="button">Add node</button>
+      </NodePalette>,
+    );
+    rerender(
+      <NodePalette items={ITEMS} open onOpenChange={() => {}} onPick={onPick}>
+        <button type="button">Add node</button>
+      </NodePalette>,
+    );
+    await waitFor(() => {
+      expect(searchInput().value).toBe('');
+      expect(screen.getByText('End')).toBeTruthy();
+    });
+  });
+});
+
+describe('NodePalette keyboard navigation', () => {
+  it('ArrowDown + Enter picks the highlighted (second) item', async () => {
+    const { onPick } = renderPalette();
+    const input = searchInput();
+    // cmdk auto-highlights the first item; one ArrowDown moves to the second.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(onPick).toHaveBeenCalledWith('decision');
+    });
+  });
+
+  it('Enter picks the single match after narrowing', async () => {
+    const { onPick } = renderPalette();
+    const input = searchInput();
+    fireEvent.change(input, { target: { value: 'terminate' } });
+    await waitFor(() => expect(screen.queryByText('Decision')).toBeNull());
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(onPick).toHaveBeenCalledWith('end');
+    });
+  });
+});
+
+describe('NodePalette recently used', () => {
+  it('surfaces stored recents (dropping unknown types) only while the query is empty', async () => {
+    // 'ghost.type' stands in for a since-uninstalled plugin node.
+    localStorage.setItem('flow-palette-recents', JSON.stringify(['plugin.http', 'ghost.type']));
+    renderPalette();
+    expect(screen.getByText('Recently used')).toBeTruthy();
+    // The plugin item renders twice: once under recents, once in its category.
+    expect(screen.getAllByText('HTTP Call')).toHaveLength(2);
+    expect(screen.queryByText('ghost.type')).toBeNull();
+
+    fireEvent.change(searchInput(), { target: { value: 'record' } });
+    await waitFor(() => {
+      expect(screen.queryByText('Recently used')).toBeNull();
+    });
+  });
+
+  it('records a pick at the front of the MRU list', async () => {
+    localStorage.setItem('flow-palette-recents', JSON.stringify(['end']));
+    const { onPick } = renderPalette();
+    fireEvent.click(screen.getByText('Decision'));
+    await waitFor(() => {
+      expect(onPick).toHaveBeenCalledWith('decision');
+    });
+    expect(readPaletteRecents()).toEqual(['decision', 'end']);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -35,8 +35,21 @@ import {
   Zap,
   type LucideIcon,
 } from 'lucide-react';
-import { cn, Popover, PopoverTrigger, PopoverContent } from '@object-ui/components';
+import {
+  cn,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@object-ui/components';
+import { t as tr } from '../i18n';
 import { NODE_W, NODE_H, type Point } from './flow-canvas-layout';
+import { readPaletteRecents, recordPaletteRecent } from './flowPaletteRecents';
 
 export function nodeIcon(type: string): LucideIcon {
   switch (type) {
@@ -561,14 +574,62 @@ export interface NodePaletteProps {
   children: React.ReactNode;
 }
 
-/** Compact popover listing the node types an author can add, grouped by category. */
-export function NodePalette({ items = NODE_PALETTE, onPick, open, onOpenChange, children }: NodePaletteProps) {
+/** Section heading style shared by the category groups and the recents group. */
+const PALETTE_GROUP_CLASS =
+  'p-0 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:pt-1 ' +
+  '[&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold ' +
+  '[&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.08em] ' +
+  '[&_[cmdk-group-heading]]:text-muted-foreground ' +
+  '[&:not(:first-child)]:mt-1 [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/60 [&:not(:first-child)]:pt-1';
+
+/**
+ * Searchable popover listing the node types an author can add (#1943).
+ * Grouped by category when the query is empty; typing filters across all
+ * categories (label + hint + type, case-insensitive). Built on cmdk's
+ * `Command` for ↑/↓ + Enter keyboard navigation — with `shouldFilter`
+ * disabled so our exact substring filter keeps the canonical category order
+ * instead of cmdk's fuzzy re-ranking. A "Recently used" group (localStorage
+ * MRU) tops the empty-query view.
+ */
+export function NodePalette({ locale, items = NODE_PALETTE, onPick, open, onOpenChange, children }: NodePaletteProps) {
+  const [q, setQ] = React.useState('');
+  // Lazy init covers mounting in the already-open state (tests, controlled use).
+  const [recents, setRecents] = React.useState<string[]>(() => (open ? readPaletteRecents() : []));
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  // Watching `open` (not onOpenChange) covers both close paths: outside-click/
+  // Escape fires onOpenChange, but a pick closes via the parent's setState
+  // only. Render-phase adjustment (not an effect) per react.dev's "adjusting
+  // state when a prop changes"; re-reading recents per open keeps them fresh.
+  const [prevOpen, setPrevOpen] = React.useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setRecents(readPaletteRecents());
+    else setQ('');
+  }
+
+  const query = q.trim().toLowerCase();
+
+  // Filter before grouping, so a query naturally matches across every
+  // category — including server-merged plugin items (they are just entries in
+  // `items`). `type` is matched too so plugin nodes are findable by their
+  // registered type even when a descriptor's display name differs.
+  const filtered = React.useMemo(() => {
+    if (!query) return items;
+    return items.filter(
+      (i) =>
+        i.label.toLowerCase().includes(query) ||
+        (i.hint ?? '').toLowerCase().includes(query) ||
+        i.type.toLowerCase().includes(query),
+    );
+  }, [items, query]);
+
   // Bucket items by category (falling back to the type's inferred category, so
   // engine-only / plugin nodes still land in a sensible section), then render
   // sections in the canonical order. Empty sections are skipped.
   const grouped = React.useMemo(() => {
     const buckets = new Map<NodeCategory, PaletteItem[]>();
-    for (const item of items) {
+    for (const item of filtered) {
       const cat = item.category ?? nodeCategory(item.type);
       const list = buckets.get(cat) ?? [];
       list.push(item);
@@ -577,16 +638,30 @@ export function NodePalette({ items = NODE_PALETTE, onPick, open, onOpenChange, 
     return NODE_CATEGORY_ORDER.map((cat) => [cat, buckets.get(cat) ?? []] as const).filter(
       ([, list]) => list.length > 0,
     );
-  }, [items]);
+  }, [filtered]);
 
-  const renderItem = (item: PaletteItem) => {
+  // "Recently used" — empty-query state only, intersected against the live
+  // items so types from since-uninstalled plugins silently drop out.
+  const recentItems = React.useMemo(() => {
+    if (query) return [];
+    const byType = new Map(items.map((i) => [i.type, i] as const));
+    return recents.map((t) => byType.get(t)).filter((i): i is PaletteItem => !!i);
+  }, [items, recents, query]);
+
+  const handlePick = (type: string) => {
+    recordPaletteRecent(type);
+    onPick(type);
+  };
+
+  const renderItem = (item: PaletteItem, recent?: boolean) => {
     const tone = nodeTone(item.type);
     return (
-      <button
-        key={item.type}
-        type="button"
-        onClick={() => onPick(item.type)}
-        className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-accent"
+      <CommandItem
+        key={recent ? `recent:${item.type}` : item.type}
+        // cmdk requires unique values; recents duplicate grouped entries.
+        value={recent ? `recent:${item.type}` : item.type}
+        onSelect={() => handlePick(item.type)}
+        className="gap-2.5 rounded-lg px-2 py-1.5 [&_svg]:size-[15px]"
       >
         <span className={cn('flex h-7 w-7 shrink-0 items-center justify-center rounded-md', tone.chip)}>
           <NodeTypeIcon type={item.type} className={cn('h-[15px] w-[15px]', tone.icon)} />
@@ -595,7 +670,7 @@ export function NodePalette({ items = NODE_PALETTE, onPick, open, onOpenChange, 
           <div className="truncate text-[13px] font-medium">{item.label}</div>
           {item.hint && <div className="truncate text-[11px] text-muted-foreground">{item.hint}</div>}
         </div>
-      </button>
+      </CommandItem>
     );
   };
 
@@ -608,16 +683,36 @@ export function NodePalette({ items = NODE_PALETTE, onPick, open, onOpenChange, 
       <PopoverContent
         align="end"
         sideOffset={6}
-        className="max-h-[66vh] w-60 overflow-y-auto rounded-xl border bg-popover/95 p-1.5 shadow-xl shadow-foreground/[0.08] ring-1 ring-black/[0.03] backdrop-blur-md"
+        className="w-60 overflow-hidden rounded-xl border bg-popover/95 p-0 shadow-xl shadow-foreground/[0.08] ring-1 ring-black/[0.03] backdrop-blur-md"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }}
       >
-        {grouped.map(([category, list], gi) => (
-          <div key={category} className={cn(gi > 0 && 'mt-1 border-t border-border/60 pt-1')}>
-            <div className="px-2 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              {category}
-            </div>
-            {list.map(renderItem)}
-          </div>
-        ))}
+        <Command shouldFilter={false} loop className="bg-transparent">
+          <CommandInput
+            ref={inputRef}
+            value={q}
+            onValueChange={setQ}
+            placeholder={tr('engine.flowPalette.search', locale)}
+            className="h-9 text-[13px]"
+          />
+          <CommandList className="max-h-[56vh] p-1">
+            <CommandEmpty className="py-6 text-center text-xs text-muted-foreground">
+              {tr('engine.flowPalette.empty', locale)}
+            </CommandEmpty>
+            {recentItems.length > 0 && (
+              <CommandGroup heading={tr('engine.flowPalette.recent', locale)} className={PALETTE_GROUP_CLASS}>
+                {recentItems.map((item) => renderItem(item, true))}
+              </CommandGroup>
+            )}
+            {grouped.map(([category, list]) => (
+              <CommandGroup key={category} heading={category} className={PALETTE_GROUP_CLASS}>
+                {list.map((item) => renderItem(item))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
       </PopoverContent>
     </Popover>
   );

--- a/packages/app-shell/src/views/metadata-admin/previews/flowPaletteRecents.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flowPaletteRecents.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * flowPaletteRecents — tiny localStorage MRU of node types the author recently
+ * inserted from the flow designer's add-node palette (#1943). Surfaced as a
+ * "Recently used" group at the top of the palette when the search box is
+ * empty, so frequent nodes stop needing a scroll or a search.
+ *
+ * Deliberately not user-scoped (node types are not sensitive — same call as
+ * the `grid-columns-*` keys) and not debounced (writes happen once per pick).
+ * Consumers intersect the stored types against the live palette, so types
+ * from since-uninstalled plugins simply drop out of view; the storage itself
+ * self-heals on the next pick.
+ */
+
+const KEY = 'flow-palette-recents';
+
+/** Most-recent-first cap — keeps the group glanceable, not a second palette. */
+const MAX_RECENTS = 5;
+
+/** Read the MRU list. Returns `[]` on missing/corrupt storage or during SSR. */
+export function readPaletteRecents(): string[] {
+  try {
+    if (typeof localStorage === 'undefined') return [];
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((t): t is string => typeof t === 'string').slice(0, MAX_RECENTS);
+  } catch {
+    return [];
+  }
+}
+
+/** Move `type` to the front of the MRU list (deduped, capped). */
+export function recordPaletteRecent(type: string): void {
+  if (!type) return;
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const next = [type, ...readPaletteRecents().filter((t) => t !== type)].slice(0, MAX_RECENTS);
+    localStorage.setItem(KEY, JSON.stringify(next));
+  } catch {
+    /* quota / privacy mode — recents are a nicety, never an error */
+  }
+}


### PR DESCRIPTION
Closes #1943.

## What

The flow designer's **Add-node** palette is a ~20-item scrolling list across 5 categories, and it grows as the server/plugins contribute nodes. This PR adds a **search box** at the top of the palette, **↑/↓ + Enter** keyboard navigation, and a **"Recently used"** group.

## How

`NodePalette` (in `packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx`) now embeds the repo's existing cmdk `Command` (from `@object-ui/components`) inside the same Radix Popover — no new dependency, props unchanged, callers untouched:

- **Filtering** is our own case-insensitive substring match over `label + hint + type`, applied *before* category bucketing, so a query naturally matches across all categories. `shouldFilter={false}` sidesteps cmdk's fuzzy re-ranking, preserving the canonical `NODE_CATEGORY_ORDER`. Empty query keeps today's full grouped list.
- **Keyboard**: cmdk supplies ArrowUp/ArrowDown (with `loop`), Enter-to-insert, and the listbox ARIA wiring. The search input autofocuses on open (AddWidgetPicker precedent).
- **Server-merged palette**: filtering operates on the already-merged `items` prop from `useFlowNodePalette()`, so plugin-contributed nodes are searchable by engine label, description, or registered type. No change to the merge logic.
- **Recently used** (new `flowPaletteRecents.ts`): a localStorage MRU (cap 5) recorded on pick, rendered as a top group only while the query is empty, intersected against the live items so types from since-uninstalled plugins silently drop out.
- **i18n**: 3 new keys (`engine.flowPalette.search/empty/recent`) in both the en and zh dicts.
- Also commits a small project verify skill (`.claude/skills/verify/SKILL.md`) documenting the backend-free way to drive these designers (preview gallery + Playwright) discovered while verifying this change.

Docs note: `content/docs` doesn't cover the flow designer palette (internal metadata-admin UI), so no doc updates per rule #2.

## Acceptance criteria (from #1943)

- [x] Typing filters the palette across all categories (matches label and hint, case-insensitive) — hint-only words like `concurrently` → Parallel work too.
- [x] Empty query shows the full grouped list (current behavior).
- [x] Keyboard: arrow keys move, Enter inserts the highlighted node.
- [x] Works with the server-merged palette (plugin nodes included).
- [x] Nice-to-have: "Recently used" group.

## Testing

- New `NodePalette.test.tsx` (happy-dom + Testing Library, 11 cases): cross-category filter, hint match, case-insensitivity, plugin-item search by label/type, empty state, ArrowDown+Enter insert, narrow-then-Enter, recents (incl. stale-type drop + MRU write), query reset on reopen.
- Full previews suite green (21 files / 213 tests); `turbo run build --filter=@object-ui/app-shell` (tsc across 29 packages) passes; eslint on touched files: 0 errors.
- **Verified end-to-end in a real browser** (console `/preview-gallery.html?only=flow` + Playwright): autofocus, `scr` → Screen/Script, `http` → HTTP request, `SCREEN` case-insensitive, empty state, ArrowDown+Enter inserted a node onto the canvas, reopen showed "Recently used" with the query reset, garbage input → clean empty state, Enter on an empty list no-ops, Escape closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j35dppNPaEp1ULzHoUxYn

---
_Generated by [Claude Code](https://claude.ai/code/session_011j35dppNPaEp1ULzHoUxYn)_