### PR TITLE
fix(studio): refresh builder top-bar name after a package rename

### DIFF
--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -256,15 +256,24 @@ function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string })
 
   React.useEffect(() => {
     let cancelled = false;
-    fetchPackages()
-      .then((parsed) => {
-        if (!cancelled) setPkgs(parsed);
-      })
-      .catch(() => {
-        /* leave null — switcher still works for navigation-free display */
-      });
+    const load = () => {
+      fetchPackages()
+        .then((parsed) => {
+          if (!cancelled) setPkgs(parsed);
+        })
+        .catch(() => {
+          /* leave null — switcher still works for navigation-free display */
+        });
+    };
+    load();
+    // Refresh the switcher list (and thus the top-bar package name) when a
+    // package is created or its manifest is edited elsewhere — PackageFormDialog
+    // dispatches `objectui:packages-changed` on create/edit. Without this the
+    // header showed the OLD name after a rename until a full page reload.
+    window.addEventListener('objectui:packages-changed', load);
     return () => {
       cancelled = true;
+      window.removeEventListener('objectui:packages-changed', load);
     };
   }, [packageId]);
 


### PR DESCRIPTION
## Problem (dogfood Finding 3)
In the Studio builder, `PackageSwitcher` loads the package list once (keyed on `packageId`) and derives the top-bar package name from it, but never listens for `objectui:packages-changed` — the event `PackageFormDialog` dispatches on create/edit. So after renaming the current package via **edit**, the header keeps showing the **old name until a full page reload**.

## Fix
Re-fetch the switcher list on `objectui:packages-changed` (add/remove the listener in the existing effect), so the top-bar name reflects a rename immediately.

## Verified
Dispatching `objectui:packages-changed` in the running builder triggers a `GET /api/v1/packages` refetch (confirmed via a fetch counter), which re-derives the displayed `current.name`.

> Note: the full edit→header chain also needs framework objectstack-ai/framework#2995 — the `PATCH /packages/:id` **route** was never mounted, so edit itself 405'd. That PR fixes the endpoint; this PR fixes the UI refresh once the edit succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)