### PR TITLE
feat(flow-designer): connector picker lists dispatchable connectors + marks declarative instances (ADR-0096)

### DIFF
--- a/.changeset/adr-0096-connector-origin.md
+++ b/.changeset/adr-0096-connector-origin.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(flow-designer): connector picker lists dispatchable connectors + marks declarative instances (ADR-0096)
+
+The `connector_action` node's connector picker read `client.list('connector')` —
+the declared `connectors:` metadata, which includes inert catalog descriptors and
+**misses** plugin-registered connectors. It now reads the runtime registry
+(`GET /api/v1/automation/connectors`), i.e. exactly the connectors a
+`connector_action` can dispatch: plugin connectors and materialized declarative
+instances (framework ADR-0096). Declarative instances are annotated `· declarative`
+(from the descriptor's new `origin` field) so authors can tell a materialized
+metadata connector apart from a plugin one. Degrades to empty on fetch failure;
+the field stays free-text editable. Tolerates an older backend with no `origin`.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.connector.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.connector.test.ts
@@ -11,7 +11,7 @@
 // option-mapping the picker relies on (the fetch/render is thin glue on top).
 
 import { describe, it, expect } from 'vitest';
-import { resolveConnectorName, connectorActionsToOptions } from './FlowReferenceField';
+import { resolveConnectorName, connectorActionsToOptions, connectorsToOptions } from './FlowReferenceField';
 
 describe('resolveConnectorName', () => {
   const ctx = (connectorConfig: unknown) => ({ draft: {}, node: { connectorConfig } as Record<string, unknown> });
@@ -54,5 +54,29 @@ describe('connectorActionsToOptions', () => {
     ]);
     expect(connectorActionsToOptions(undefined)).toEqual([]);
     expect(connectorActionsToOptions('nope')).toEqual([]);
+  });
+});
+
+describe('connectorsToOptions (ADR-0096 connector picker)', () => {
+  it('maps the runtime registry to {value,label}, annotating declarative instances', () => {
+    expect(
+      connectorsToOptions([
+        { name: 'billing', label: 'Billing API', origin: 'declarative' },
+        { name: 'rest', label: 'REST', origin: 'plugin' },
+        { name: 'slack', origin: 'plugin' }, // no label → name is the label
+      ]),
+    ).toEqual([
+      { value: 'billing', label: 'Billing API (billing) · declarative' },
+      { value: 'rest', label: 'REST (rest)' },
+      { value: 'slack', label: 'slack' },
+    ]);
+  });
+
+  it('tolerates a missing origin (older backend) and malformed entries / non-arrays', () => {
+    expect(connectorsToOptions([{ name: 'x', label: 'X' }, null, { label: 'no name' }, { name: '' }])).toEqual([
+      { value: 'x', label: 'X (x)' },
+    ]);
+    expect(connectorsToOptions(undefined)).toEqual([]);
+    expect(connectorsToOptions('nope')).toEqual([]);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
@@ -137,6 +137,26 @@ export function connectorActionsToOptions(actions: unknown): Option[] {
 }
 
 /**
+ * The runtime connector registry (`GET /api/v1/automation/connectors`) → connector
+ * picker options (exported for test). Each descriptor is `{ name, label?, origin? }`.
+ *
+ * A materialized declarative instance (ADR-0096, `origin: 'declarative'`) is
+ * annotated `· declarative` so an author can tell it apart from a plugin-registered
+ * connector — both are equally dispatchable, but the provenance differs. The
+ * option `value` stays the bare connector name, so selecting it commits the name.
+ */
+export function connectorsToOptions(connectors: unknown): Option[] {
+  if (!Array.isArray(connectors)) return [];
+  return connectors
+    .filter((c): c is { name: string; label?: string; origin?: string } =>
+      !!c && typeof (c as { name?: unknown }).name === 'string' && !!(c as { name: string }).name)
+    .map((c) => {
+      const base = typeof c.label === 'string' && c.label && c.label !== c.name ? `${c.label} (${c.name})` : c.name;
+      return { value: c.name, label: c.origin === 'declarative' ? `${base} · declarative` : base };
+    });
+}
+
+/**
  * Fetch a metadata type's items as combobox options. `type === undefined`
  * disables the fetch (returns empty), so the hook can be called
  * unconditionally regardless of the reference kind.
@@ -214,6 +234,40 @@ function useConnectorActionOptions(connectorName: string | undefined): { options
   return state;
 }
 
+/**
+ * Fetch the runtime connector registry (`GET /api/v1/automation/connectors`) as
+ * connector picker options. Unlike a generic `client.list('connector')` — which
+ * lists declared `connectors:` metadata (including inert catalog descriptors, and
+ * missing plugin-registered connectors) — this lists exactly the **dispatchable**
+ * connectors a `connector_action` node can call: plugin connectors AND materialized
+ * declarative instances (ADR-0096), the latter annotated by origin. `enabled === false`
+ * disables the fetch (hook stays unconditional). Degrades to empty on any failure.
+ */
+function useConnectorListOptions(enabled: boolean): { options: Option[] } {
+  const [state, setState] = React.useState<{ options: Option[] }>({ options: [] });
+  React.useEffect(() => {
+    if (!enabled) {
+      setState({ options: [] });
+      return;
+    }
+    let cancelled = false;
+    fetch('/api/v1/automation/connectors', { credentials: 'include', headers: { Accept: 'application/json' } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((payload) => {
+        if (cancelled) return;
+        const connectors = payload?.data?.connectors ?? payload?.connectors ?? [];
+        setState({ options: connectorsToOptions(connectors) });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ options: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+  return state;
+}
+
 export interface ReferenceComboboxProps {
   /** The resolved concrete reference, or undefined → plain free text. */
   resolved: ResolvedRef | undefined;
@@ -246,8 +300,15 @@ export function ReferenceCombobox({ resolved, value, onCommit, onBlur, disabled,
   const connectorName = resolved ? resolveConnectorName(resolved.kind, resolved.connectorSource, ctx) : undefined;
   const { options: connectorActionOptions } = useConnectorActionOptions(kind === 'connector-action' ? connectorName : undefined);
 
+  // connector: the dispatchable runtime registry (plugin + materialized declarative
+  // instances, ADR-0096), NOT the generic declared-metadata list — see the hook.
+  const { options: connectorListOptions } = useConnectorListOptions(kind === 'connector');
+
   // Flat metadata-list kinds (object / flow / role / user / team / …).
-  const listType = kind && kind !== 'object-field' && kind !== 'node' && kind !== 'connector-action' ? KIND_TO_META_TYPE[kind] : undefined;
+  const listType =
+    kind && kind !== 'object-field' && kind !== 'node' && kind !== 'connector-action' && kind !== 'connector'
+      ? KIND_TO_META_TYPE[kind]
+      : undefined;
   const { options: listOptions } = useMetadataListOptions(listType);
 
   const options = React.useMemo<Option[]>(() => {
@@ -258,6 +319,7 @@ export function ReferenceCombobox({ resolved, value, onCommit, onBlur, disabled,
       }));
     }
     if (kind === 'connector-action') return connectorActionOptions;
+    if (kind === 'connector') return connectorListOptions;
     if (kind === 'node') {
       const nodes = Array.isArray(ctx.draft.nodes) ? (ctx.draft.nodes as Array<Record<string, unknown>>) : [];
       const currentId = typeof ctx.node?.id === 'string' ? ctx.node.id : undefined;
@@ -271,7 +333,7 @@ export function ReferenceCombobox({ resolved, value, onCommit, onBlur, disabled,
     }
     if (listType) return listOptions;
     return [];
-  }, [kind, listType, objectFields, connectorActionOptions, listOptions, ctx.draft, ctx.node]);
+  }, [kind, listType, objectFields, connectorActionOptions, connectorListOptions, listOptions, ctx.draft, ctx.node]);
 
   // For an object-field whose object can't be resolved, tell the author why the
   // suggestions are empty — but still let them type a value.


### PR DESCRIPTION
Studio-side follow-up to framework ADR-0096 (declarative provider-bound connectors). Complements framework #3001 (which adds `origin` to the connector descriptor).

## Problem

The flow designer's `connector_action` node has a **connector** picker and an **action** picker (`FlowReferenceField.tsx`). They read from two different sources:

- **action** picker → `GET /api/v1/automation/connectors` (the runtime registry — the dispatchable connectors).
- **connector** picker → `client.list('connector')` (declared `connectors:` **metadata**).

That split is subtly wrong: `client.list('connector')` lists declared metadata, which **includes inert catalog descriptors** (not dispatchable) and **misses plugin-registered connectors** (`rest`, `slack`, …). And it has no way to show that a connector is a materialized declarative instance (ADR-0096).

## Change

Point the **connector** picker at the same runtime registry the action picker uses (`/api/v1/automation/connectors`) — so it offers exactly the connectors a `connector_action` can actually dispatch: plugin connectors **and** materialized declarative instances. Declarative instances are annotated `· declarative` (from the descriptor's new `origin` field), so an author can tell a metadata-materialized connector apart from a plugin one.

- New pure `connectorsToOptions(connectors)` (origin-annotated) + `useConnectorListOptions(enabled)` hook, mirroring the existing `useConnectorActionOptions` fetch pattern. Degrades to empty on any fetch failure; the picker stays free-text editable; tolerates an older backend with no `origin`.
- The `connector` kind no longer routes through the generic `useMetadataListOptions`.

## Verification

- Unit tests for `connectorsToOptions` (declarative annotation, missing-origin fallback for older backends, malformed / non-array input). `FlowReferenceField.connector.test.ts` green (8 tests).
- `type-check` clean (turbo, 29 tasks). ESLint 0 errors; the `set-state-in-effect` warnings match the file's existing hook pattern (`useMetadataListOptions` / `useConnectorActionOptions`). Changeset included.

## Dependency

The `· declarative` annotation needs the descriptor's `origin` field from framework #3001. This PR is safe to land independently — without `origin`, connectors simply render without the suffix (the fallback is covered by a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbmw3pMqNJfPbkvwh9Fkjs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbmw3pMqNJfPbkvwh9Fkjs)_