### PR TITLE
fix(detail): gate related lists on the current user's child-object read permission (#2359)

### DIFF
--- a/content/docs/guide/slotted-pages.md
+++ b/content/docs/guide/slotted-pages.md
@@ -74,6 +74,13 @@ its own tab is a one-word change on the relationship, not a page-authoring task.
 `relatedLayout: 'tabs' | 'stack'` remains an app-level override (force
 all-own-tabs / all-stacked).
 
+Related lists are additionally gated on the current user's **object-level
+read permission** for the child object: a relationship whose child the user
+cannot read produces no section and no tab (and the `record:related_list`
+renderer suppresses itself the same way on hand-authored pages). The server
+always enforced data access — this keeps the UI from rendering an empty
+grid with a "New" button that would be rejected on save.
+
 ## Composing default + custom
 
 When you want "the default actions plus one custom button," you have

--- a/packages/app-shell/src/utils/__tests__/deriveRelatedLists.test.ts
+++ b/packages/app-shell/src/utils/__tests__/deriveRelatedLists.test.ts
@@ -183,6 +183,33 @@ describe('deriveRelatedLists', () => {
     expect(deriveRelatedLists(project, [project, other])).toEqual([]);
   });
 
+  it('drops children the current user cannot read via canRead (objectui#2359)', () => {
+    const task = {
+      name: 'task',
+      label: 'Task',
+      fields: { project: { type: 'master_detail', reference: 'project' } },
+    };
+    const note = {
+      name: 'note',
+      label: 'Note',
+      fields: { project_id: { type: 'lookup', reference: 'project' } },
+    };
+    const out = deriveRelatedLists(project, [project, task, note], {
+      canRead: (name) => name !== 'task',
+    });
+    expect(out.map((r) => r.childObject)).toEqual(['note']);
+  });
+
+  it('keeps all children when canRead is omitted (permissions still loading)', () => {
+    const task = {
+      name: 'task',
+      label: 'Task',
+      fields: { project: { type: 'master_detail', reference: 'project' } },
+    };
+    expect(deriveRelatedLists(project, [project, task])).toHaveLength(1);
+    expect(deriveRelatedLists(project, [project, task], {})).toHaveLength(1);
+  });
+
   it('handles array-shaped fields', () => {
     const task = {
       name: 'task',

--- a/packages/app-shell/src/utils/deriveRelatedLists.ts
+++ b/packages/app-shell/src/utils/deriveRelatedLists.ts
@@ -34,6 +34,12 @@
  *     ("Child Accounts"). Suppress with `relatedList: false` if unwanted.
  *   - Owned (`master_detail`) children are ordered before plain `lookup`
  *     children, preserving discovery order within each group.
+ *   - Object-level READ permission gates the whole list (objectui#2359): the
+ *     relationship graph says nothing about the CURRENT USER, so callers pass
+ *     a `canRead` predicate (wired from `usePermissions().can`) and children
+ *     the user cannot read are dropped — no header, no empty grid, no "New"
+ *     button that would 403 on save. Data access was always enforced
+ *     server-side; this closes the UI/DX gap.
  */
 
 /** Audit/ownership FKs that exist on nearly every object — never related lists. */
@@ -77,6 +83,17 @@ function fieldEntries(fields: ObjectLike['fields']): Array<[string, any]> {
   return Object.entries(fields);
 }
 
+export interface DeriveRelatedListsOptions {
+  /**
+   * Object-level READ gate for the current user (objectui#2359). Return
+   * `false` to drop every related list whose child object the user cannot
+   * read. Omit (or leave undefined) while permissions are still loading —
+   * the derivation then stays purely relationship-driven, so lists never
+   * flicker out during the fail-closed loading window.
+   */
+  canRead?: (objectName: string) => boolean;
+}
+
 /**
  * Derive the detail-page related lists for `objectDef` from the full object
  * registry. Returns owned (`master_detail`) children first, then `lookup`
@@ -85,6 +102,7 @@ function fieldEntries(fields: ObjectLike['fields']): Array<[string, any]> {
 export function deriveRelatedLists(
   objectDef: ObjectLike | null | undefined,
   objects: ObjectLike[] | null | undefined,
+  options?: DeriveRelatedListsOptions,
 ): DerivedRelatedList[] {
   if (!objectDef?.name || !Array.isArray(objects) || objects.length === 0) return [];
   const parentName = objectDef.name;
@@ -95,8 +113,14 @@ export function deriveRelatedLists(
   const owned: Working[] = [];
   const referenced: Working[] = [];
 
+  const canRead = options?.canRead;
+
   for (const child of objects) {
     if (!child?.name) continue;
+    // Permission gate: a related list surfaces the CHILD object's records, so
+    // it requires read access on the child — the FK's mere existence does not
+    // grant the current user anything (objectui#2359).
+    if (canRead && !canRead(child.name)) continue;
     for (const [fieldName, fieldDef] of fieldEntries(child.fields)) {
       if (!fieldDef) continue;
       const type = fieldDef.type;

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -13,6 +13,7 @@ import { useParams, useNavigate, useLocation, useSearchParams, Link } from 'reac
 import { RecordChatterPanel, InlineEditSaveBar, buildDefaultPageSchema, deriveFieldGroupDetailSections, extractMentions } from '@object-ui/plugin-detail';
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
 import { useAuth, createAuthenticatedFetch } from '@object-ui/auth';
+import { usePermissions } from '@object-ui/permissions';
 import { ActionProvider, useObjectTranslation, useObjectLabel, usePageAssignment, RecordContextProvider, SchemaRenderer, DiscussionContextProvider, HighlightFieldsProvider, InlineEditProvider, useGlobalUndo, useDataInvalidation, notifyDataChanged } from '@object-ui/react';
 import { buildExpandFields } from '@object-ui/core';
 import { toast } from 'sonner';
@@ -833,9 +834,20 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // out via `relatedList: false`. `relatedListTitle` / `relatedListColumns`
   // on the FK override the derived title / columns. Audit FKs are skipped and
   // children deduped — see `deriveRelatedLists`.
+  // Object-level READ gate (objectui#2359): the relationship graph alone
+  // decides WHICH lists exist, but the current user's permissions decide
+  // which they may SEE. Children the user cannot read are dropped here, so
+  // neither the section nor its tab is ever rendered (previously they showed
+  // an empty grid + a "New" button that 403'd on save). While permissions
+  // are still loading (`isLoaded === false`, e.g. no PermissionProvider in a
+  // standalone embed) the gate stays open — fail-open is safe because the
+  // server enforces data access regardless; this is purely a UI/DX filter.
+  const { can: canOnObject, isLoaded: permissionsLoaded } = usePermissions();
   const childRelations = useMemo(
-    () => deriveRelatedLists(objectDef, objects),
-    [objectDef, objects],
+    () => deriveRelatedLists(objectDef, objects, {
+      canRead: permissionsLoaded ? (name) => canOnObject(name, 'read') : undefined,
+    }),
+    [objectDef, objects, canOnObject, permissionsLoaded],
   );
 
   // ── Audit history fetch ────────────────────────────────────────────

--- a/packages/plugin-detail/README.md
+++ b/packages/plugin-detail/README.md
@@ -192,6 +192,13 @@ Tab navigation for organizing content into different views.
 
 Displays related records in list, grid, or table format.
 
+The `record:related_list` renderer is automatically gated on the current
+user's object-level `read` permission for the child object: when the
+permission system (`@object-ui/permissions`) is loaded and denies read,
+the whole section renders nothing — no header, no empty grid, no "New"
+button that would be rejected server-side. With no `PermissionProvider`
+mounted (Studio designer, standalone embeds) the gate stays open.
+
 <!-- release-metadata:v3.3.0 -->
 
 ## Compatibility

--- a/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.readgate.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.readgate.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Automatic object-level read gate on `record:related_list` (objectui#2359).
+ *
+ * A related list surfaces the CHILD object's records, so it requires `read`
+ * on that object. When the permission system is loaded and denies read, the
+ * whole section must vanish — previously the section rendered an empty grid
+ * (the data fetch 403'd server-side) plus a "New" button that 403'd on save.
+ * With no PermissionProvider mounted (Studio designer, standalone embeds)
+ * the gate stays open: `usePermissions()` reports `isLoaded: false` there.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { PermissionProvider } from '@object-ui/permissions';
+import type { ObjectPermissionConfig, RoleDefinition } from '@object-ui/types';
+import { RecordRelatedListRenderer } from '../renderers/record-related-list';
+
+// Capture whether/what the renderer passes down to RelatedList.
+const h = vi.hoisted(() => ({ captured: null as any }));
+vi.mock('../RelatedList', () => ({
+  RelatedList: (props: any) => {
+    h.captured = props;
+    return <div data-testid="related-list" />;
+  },
+}));
+
+const ds = { find: vi.fn(async () => []) };
+
+const roles: RoleDefinition[] = [
+  { name: 'restricted', label: 'Restricted', permissions: [] },
+];
+
+function contactPerms(actions: Array<'read'>): ObjectPermissionConfig[] {
+  return [{ object: 'contact', roles: { restricted: { actions } } }];
+}
+
+function renderGated(permissions: ObjectPermissionConfig[]) {
+  return render(
+    <PermissionProvider roles={roles} permissions={permissions} userRoles={['restricted']}>
+      <RecordContextProvider objectName="account" recordId="ACC-1" dataSource={ds as any}>
+        <RecordRelatedListRenderer
+          schema={{ objectName: 'contact', relationshipField: 'account_id' }}
+        />
+      </RecordContextProvider>
+    </PermissionProvider>,
+  );
+}
+
+beforeEach(() => {
+  h.captured = null;
+});
+
+describe('RecordRelatedListRenderer — automatic object-level read gate (#2359)', () => {
+  it('renders nothing at all when the user cannot read the child object', () => {
+    const { container } = renderGated(contactPerms([]));
+    expect(h.captured).toBeNull();
+    // Entirely suppressed — no header, no empty grid, no permission notice.
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the list when the user can read the child object', () => {
+    renderGated(contactPerms(['read']));
+    expect(h.captured).not.toBeNull();
+    expect(h.captured.objectName).toBe('contact');
+  });
+
+  it('renders when the permission config says nothing about the child object', () => {
+    // No config for `contact` → evaluator default-allows.
+    renderGated([]);
+    expect(h.captured).not.toBeNull();
+  });
+
+  it('renders with no PermissionProvider mounted (isLoaded=false → gate stays open)', () => {
+    render(
+      <RecordContextProvider objectName="account" recordId="ACC-1" dataSource={ds as any}>
+        <RecordRelatedListRenderer
+          schema={{ objectName: 'contact', relationshipField: 'account_id' }}
+        />
+      </RecordContextProvider>,
+    );
+    expect(h.captured).not.toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -108,6 +108,18 @@ export const RecordRelatedListRenderer: React.FC<RecordRelatedListRendererProps>
     [relatedActions, objectName, schema.relationshipField, parentLinkValue],
   );
 
+  // Automatic object-level read gate (objectui#2359). Related lists surface
+  // the CHILD object's records, so they require `read` on that object — the
+  // schema author never has to remember an explicit `requiredPermissions`
+  // opt-in for this baseline. When the permission system has loaded and
+  // denies read, the whole section vanishes (no header, no empty grid, no
+  // "New" button that would 403 on save). Gated on `isLoaded` so unmounted /
+  // still-loading permission contexts (Studio designer, standalone embeds)
+  // keep rendering — the server enforces data access either way.
+  if (perms.isLoaded && !perms.can(objectName, 'read')) {
+    return null;
+  }
+
   const required: string[] = Array.isArray((schema as any).requiredPermissions)
     ? (schema as any).requiredPermissions
     : [];


### PR DESCRIPTION
Closes #2359

## Problem

Detail-page related-list sections were derived purely from the relationship graph: every `master_detail`/`lookup` FK produced a section (header + grid + New button) even when the current user has **no read access** to the child object. The grid then showed "no related records" (the fetch 403'd server-side) and the New button 403'd on save. Data access was always enforced server-side — this was a pure UI/DX gap (issue repro: 报价单 5 张子表按分工授权给 3 个角色,仅授权 1 张子表的角色仍看到全部 5 个分区).

## Fix — auto-filter by object-level `read` (issue's option 1), wired at two layers

1. **`deriveRelatedLists`** (`app-shell`) gains an optional `canRead` predicate: children the user cannot read are dropped at derivation time, so neither the section, its own tab (`relatedList: 'primary'`), the shared **Related** tab entry, nor the reference-rail card is ever synthesized.
2. **`RecordDetailView`** wires the predicate from `usePermissions().can(name, 'read')` once permissions are loaded. Fail-open while loading / with no `PermissionProvider` mounted (standalone embeds, Studio designer) — no flicker, and the server enforces data access regardless.
3. **`record:related_list` renderer** (`plugin-detail`) additionally self-gates on `can(objectName, 'read')` (only when `perms.isLoaded`), so hand-authored pages get the same baseline without an explicit `requiredPermissions` opt-in. When denied, the whole section renders nothing — no header, no empty grid, no permission notice.

## Tests & docs

- `deriveRelatedLists.test.ts`: +2 cases (canRead drops children; omitted canRead keeps everything while permissions load).
- New `RecordRelatedListRenderer.readgate.test.tsx`: 4 cases against the real `PermissionProvider` — read denied → renders nothing at all; read allowed / no config for the object / no provider mounted → renders as before.
- Docs: `content/docs/guide/slotted-pages.md` + `packages/plugin-detail/README.md` note the automatic read gate.
- No changeset (bug fix, per AGENTS.md).

## Verification

- `plugin-detail`: 23 files / 209 tests pass.
- `app-shell`: 1379 tests pass; the one failing file (`anchors.page-seed` timeout) was verified unrelated via stash A/B — it's load-sensitive under the full parallel suite and passes standalone both with and without this change.
- `turbo build` (app-shell + plugin-detail + all deps): 40/40 tasks green.