### PR TITLE
feat(flow-designer): pick the target node per branch in the Decision Branches editor (#1942)

### DIFF
--- a/.changeset/flow-decision-branch-target.md
+++ b/.changeset/flow-decision-branch-target.md
@@ -1,0 +1,26 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(flow-designer): pick the target node per branch in the Decision Branches editor (#1942)
+
+The decision node's Branches editor gains a **Target** column — a node picker
+scoped to the flow's own nodes — so a business user can author the whole
+decision (conditions *and* destinations) in one table, mirroring Salesforce
+Flow Decision Outcomes. Completes #1930 (the per-edge Branch picker) from the
+node side.
+
+- The column is **virtual**: its value is derived from the decision's outgoing
+  edges (the routing source of truth) and never persisted on
+  `config.conditions`, so it round-trips with the `FlowEdgeInspector` Branch
+  picker and canvas rewiring for free.
+- Picking a target creates the branch's out-edge if missing, or updates /
+  retargets the existing one in place, carrying the branch's condition, label,
+  and default flag. Clearing a target detaches (removes) that branch's edge —
+  never the node it pointed at. Custom per-edge guards, fault/back edges, and
+  surplus canvas wiring are never touched.
+- A branch list committed with no targets anywhere (e.g. an engine-published
+  configSchema form without the column) keeps the legacy #1927 by-order edge
+  mirror, byte-for-byte.
+- New pure module `flow-decision-edges.ts` with unit tests for the
+  branch→edge reconciliation.

--- a/content/docs/guide/flow-designer.md
+++ b/content/docs/guide/flow-designer.md
@@ -107,6 +107,14 @@ For node types whose engine executor publishes a `configSchema` (ADR-0018), the
 inspector renders a **server-driven property form** from that schema — so a
 plugin's node gets a real config UI without the designer hardcoding its fields.
 
+A **Decision** node's Branches editor defines each branch's label, CEL
+expression, **and target node** in one table: the **Target** column picks the
+downstream node, wiring (creating, retargeting, or detaching) the branch's
+outgoing edge with its condition, label, and default flag. The same binding can
+also be edited from the edge side — select a connector and use its **Branch**
+picker — and the two stay in sync, because the routing always lives on the
+edges.
+
 ## Validate, simulate, inspect runs
 
 The toolbar toggles four side panels:

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -328,6 +328,19 @@ Config keys come in three editable shapes so authors never hand-write JSON:
   `{name,label,type,required,visibleWhen}` definitions) — use a column-driven
   **object-list repeater** (`objectList` kind).
 
+A `decision` node's **Branches** repeater additionally shows a per-branch
+**Target** column (#1942) — a node picker scoped to this flow — so the whole
+decision (conditions *and* destinations) is authored in one table, like
+Salesforce Flow Decision Outcomes. The column is **virtual**: it is derived
+from the decision's outgoing edges (routing truth lives on `edge.condition` /
+`label` / `isDefault`, which the engine and simulator evaluate) and is never
+stored on `config.conditions`. Picking a target creates or retargets the
+branch's out-edge carrying its condition/label/default; clearing it detaches
+(removes) that edge — never the node. Because edges stay the single source of
+truth, it round-trips with the reciprocal per-edge **Branch** picker in
+`FlowEdgeInspector` (#1930) and with canvas rewiring; custom hand-written edge
+guards and fault/back edges are never touched (`flow-decision-edges.ts`).
+
 Anything still not covered by a field (nested objects, arrays, plugin-specific
 keys) lives in an **optional** Advanced (JSON) escape hatch: it is shown only
 when such keys already exist, and is otherwise reachable through a low-emphasis

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
@@ -33,6 +33,7 @@ import {
   type FlowConfigField,
 } from './flow-node-config';
 import { jsonSchemaToFlowFields } from './json-schema-to-fields';
+import { applyDecisionBranches, syncDecisionEdgesByOrder, withBranchTargets } from './flow-decision-edges';
 import { useActionConfigSchemas } from '../previews/useFlowNodePalette';
 import { FlowNodeConfigField } from './FlowNodeConfigField';
 import { useFlowScope } from './useFlowScope';
@@ -59,40 +60,18 @@ interface FlowEdge {
 }
 
 /**
- * Mirror a decision node's `conditions` (branches) onto its outgoing sequence
- * edges, in declared order: branch i -> the i-th out-edge. A branch whose
- * expression is `true` marks its edge as the default/else path; an empty
- * expression clears the guard. Fault / back edges are left untouched.
- *
- * This is what lets a decision authored entirely in Studio actually route at
- * runtime: the engine and the simulator branch on `edge.condition`, NOT on
- * `node.config.conditions` (which is only a node-local branch list). Without
- * the mirror, every out-edge stays unconditional and all branches fire.
+ * The decision Branches editor field: the `config.conditions` list whose
+ * columns include the virtual `target` column (#1942). For it, the value shown
+ * is augmented with per-branch targets derived from the out-edges, and a
+ * commit reconciles the chosen targets back onto the edges — see
+ * `flow-decision-edges` for the full semantics.
  */
-function syncDecisionEdges(decisionId: string, conditions: unknown, edges: FlowEdge[]): FlowEdge[] {
-  const branches = Array.isArray(conditions) ? conditions : [];
-  let bi = 0;
-  return edges.map((e) => {
-    if (e.source !== decisionId || e.type === 'fault' || e.type === 'back') return e;
-    const branch = branches[bi++] as Record<string, unknown> | undefined;
-    if (!branch || typeof branch !== 'object') return e;
-    const expr = typeof branch.expression === 'string' ? branch.expression.trim() : '';
-    const label = typeof branch.label === 'string' ? branch.label.trim() : '';
-    const next: FlowEdge = { ...e };
-    if (label) next.label = label;
-    else delete next.label;
-    if (expr && expr !== 'true') {
-      next.condition = expr;
-      delete next.isDefault;
-    } else if (expr === 'true') {
-      next.isDefault = true;
-      delete next.condition;
-    } else {
-      delete next.condition;
-      delete next.isDefault;
-    }
-    return next;
-  });
+function isBranchTargetField(field: FlowConfigField): boolean {
+  return (
+    field.kind === 'objectList' &&
+    configKeyOf(field) === 'conditions' &&
+    (field.columns ?? []).some((c) => c.key === 'target')
+  );
 }
 
 function asConfig(node: FlowNode | null): Record<string, unknown> {
@@ -202,20 +181,32 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
 
   const setField = (field: FlowConfigField, value: unknown) => {
     const path = field.path;
-    let nextNode = setAtPath(node, path, value);
+    const draftEdges = Array.isArray((draft as { edges?: unknown }).edges)
+      ? ((draft as { edges: FlowEdge[] }).edges)
+      : [];
+    // Decision branches drive routing — mirror them onto the node's outgoing
+    // edges so the engine/simulator can actually branch (they read
+    // edge.condition, not node.config.conditions). The Branches editor's
+    // Target column (#1942) additionally wires each branch to its downstream
+    // node: applyDecisionBranches strips the virtual `target` cells from the
+    // stored conditions and creates / updates / detaches the matching edges.
+    let stored = value;
+    let nextEdges: FlowEdge[] | undefined;
+    if (isBranchTargetField(field)) {
+      const applied = applyDecisionBranches(node.id, value, draftEdges);
+      stored = applied.conditions.length ? applied.conditions : undefined;
+      nextEdges = applied.edges;
+    } else if (node.type === 'decision' && path.length === 2 && path[0] === 'config' && path[1] === 'conditions') {
+      // A decision branch list without a Target column (engine-published
+      // configSchema form) keeps the legacy by-order mirror.
+      nextEdges = syncDecisionEdgesByOrder(node.id, value, draftEdges);
+    }
+    let nextNode = setAtPath(node, path, stored);
     // Migrate-on-edit: writing the canonical path drops any looser fallback
     // location, so the node never carries a stale duplicate (engine + designer agree).
     if (field.fallbackPath) nextNode = setAtPath(nextNode, field.fallbackPath, undefined);
     const patch: Record<string, unknown> = { nodes: spliceArray(nodes, index, nextNode) };
-    // Decision branches drive routing — mirror them onto the node's outgoing
-    // edges so the engine/simulator can actually branch (they read
-    // edge.condition, not node.config.conditions).
-    if (node.type === 'decision' && path.length === 2 && path[0] === 'config' && path[1] === 'conditions') {
-      const draftEdges = Array.isArray((draft as { edges?: unknown }).edges)
-        ? ((draft as { edges: FlowEdge[] }).edges)
-        : [];
-      patch.edges = syncDecisionEdges(node.id, value, draftEdges);
-    }
+    if (nextEdges) patch.edges = nextEdges;
     onPatch(patch);
   };
 
@@ -292,7 +283,17 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
         <FlowNodeConfigField
           key={field.id}
           field={field}
-          value={getFieldValue(node, field)}
+          // The Branches editor's Target column (#1942) is virtual: derived
+          // from the node's out-edges, never stored on the branch rows.
+          value={
+            isBranchTargetField(field)
+              ? withBranchTargets(
+                  node.id,
+                  getFieldValue(node, field),
+                  Array.isArray((draft as { edges?: unknown }).edges) ? ((draft as { edges: FlowEdge[] }).edges) : [],
+                )
+              : getFieldValue(node, field)
+          }
           onCommit={(v) => setField(field, v)}
           disabled={readOnly}
           locale={locale}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-decision-edges.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-decision-edges.test.ts
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import {
+  applyDecisionBranches,
+  syncDecisionEdgesByOrder,
+  withBranchTargets,
+  edgeBindsBranch,
+  type DecisionEdge,
+} from './flow-decision-edges';
+
+const DEC = 'dec_1';
+const edge = (e: Partial<DecisionEdge> & { target: string }): DecisionEdge => ({ source: DEC, ...e });
+
+describe('withBranchTargets — Target column derivation (#1942)', () => {
+  it('pairs branches to bound edges (#1930 matching) regardless of edge order', () => {
+    const branches = [
+      { label: 'Yes', expression: 'amount > 10' },
+      { label: 'No', expression: 'true' },
+    ];
+    // Edges deliberately out of branch order: default edge first.
+    const edges = [edge({ target: 'n_no', isDefault: true }), edge({ target: 'n_yes', condition: 'amount > 10' })];
+    expect(withBranchTargets(DEC, branches, edges)).toEqual([
+      { label: 'Yes', expression: 'amount > 10', target: 'n_yes' },
+      { label: 'No', expression: 'true', target: 'n_no' },
+    ]);
+  });
+
+  it('matches a `{ dialect, source }` edge condition against the branch expression', () => {
+    const branches = [{ label: 'Hot', expression: 'score > 90' }];
+    const edges = [edge({ target: 'n1', condition: { dialect: 'cel', source: 'score > 90' } })];
+    expect(withBranchTargets(DEC, branches, edges)[0].target).toBe('n1');
+  });
+
+  it('falls back to by-order pairing for unbound edges (#1927 legacy flows)', () => {
+    const branches = [{ label: 'A', expression: 'a' }, { label: 'B', expression: 'b' }];
+    const edges = [edge({ target: 'n1' }), edge({ target: 'n2' })]; // unstamped
+    expect(withBranchTargets(DEC, branches, edges).map((b) => b.target)).toEqual(['n1', 'n2']);
+  });
+
+  it('skips fault/back edges and other nodes’ edges; leaves surplus branches target-less', () => {
+    const branches = [{ label: 'A', expression: 'a' }, { label: 'B', expression: 'b' }];
+    const edges = [
+      edge({ target: 'n_err', type: 'fault' }),
+      edge({ target: 'n_loop', type: 'back' }),
+      { source: 'other', target: 'nx' },
+      edge({ target: 'n1', condition: 'a' }),
+    ];
+    const out = withBranchTargets(DEC, branches, edges);
+    expect(out[0].target).toBe('n1');
+    expect(out[1].target).toBeUndefined();
+  });
+
+  it('drops a stale stored `target` key that no edge backs (edges are the source of truth)', () => {
+    const branches = [{ label: 'A', expression: 'a', target: 'n_ghost' }];
+    expect(withBranchTargets(DEC, branches, [])).toEqual([{ label: 'A', expression: 'a' }]);
+  });
+});
+
+describe('applyDecisionBranches — commit reconciliation (#1942)', () => {
+  it('strips the virtual target column from the stored conditions', () => {
+    const { conditions } = applyDecisionBranches(DEC, [{ label: 'A', expression: 'a', target: 'n1' }], []);
+    expect(conditions).toEqual([{ label: 'A', expression: 'a' }]);
+  });
+
+  it('creates the out-edge when the branch has a target but no edge yet', () => {
+    const { edges } = applyDecisionBranches(
+      DEC,
+      [
+        { label: 'Yes', expression: 'amount > 10', target: 'n_yes' },
+        { label: 'Else', expression: 'true', target: 'n_no' },
+      ],
+      [],
+    );
+    expect(edges).toEqual([
+      { source: DEC, target: 'n_yes', label: 'Yes', condition: 'amount > 10' },
+      { source: DEC, target: 'n_no', label: 'Else', isDefault: true },
+    ]);
+  });
+
+  it('updates the existing edge in place, carrying condition/label/default', () => {
+    const existing = [edge({ id: 'e1', target: 'n1', condition: 'old' })];
+    const { edges } = applyDecisionBranches(DEC, [{ label: 'A', expression: 'fresh', target: 'n1' }], existing);
+    expect(edges).toEqual([{ id: 'e1', source: DEC, target: 'n1', label: 'A', condition: 'fresh' }]);
+  });
+
+  it('retargets the branch’s bound edge when a different node is picked (edge identity kept)', () => {
+    const existing = [edge({ id: 'e1', target: 'n1', condition: 'a', label: 'A' })];
+    const { edges } = applyDecisionBranches(DEC, [{ label: 'A', expression: 'a', target: 'n3' }], existing);
+    expect(edges).toEqual([{ id: 'e1', source: DEC, target: 'n3', label: 'A', condition: 'a' }]);
+  });
+
+  it('prefers target+binding matches so twin edges to one node keep their own branches', () => {
+    // A moves n1 → n3 while B stays on n1; e2 is B's edge (binds B), e1 is A's.
+    const existing = [
+      edge({ id: 'eA', target: 'n1', condition: 'a' }),
+      edge({ id: 'eB', target: 'n1', condition: 'b' }),
+    ];
+    const { edges } = applyDecisionBranches(
+      DEC,
+      [
+        { label: 'A', expression: 'a', target: 'n3' },
+        { label: 'B', expression: 'b', target: 'n1' },
+      ],
+      existing,
+    );
+    expect(edges).toEqual([
+      { id: 'eA', source: DEC, target: 'n3', label: 'A', condition: 'a' },
+      { id: 'eB', source: DEC, target: 'n1', label: 'B', condition: 'b' },
+    ]);
+  });
+
+  it('clearing a target detaches the branch’s edge — other edges and nodes untouched', () => {
+    const existing = [
+      edge({ id: 'e1', target: 'n1', condition: 'a' }),
+      edge({ id: 'e2', target: 'n2', isDefault: true }),
+    ];
+    const { edges } = applyDecisionBranches(
+      DEC,
+      [
+        { label: 'A', expression: 'a' }, // target cleared
+        { label: 'Else', expression: 'true', target: 'n2' },
+      ],
+      existing,
+    );
+    expect(edges).toEqual([{ id: 'e2', source: DEC, target: 'n2', label: 'Else', isDefault: true }]);
+  });
+
+  it('never deletes custom / surplus / fault edges bound to no branch', () => {
+    const existing = [
+      edge({ id: 'custom', target: 'n9', condition: 'hand > written' }),
+      edge({ id: 'fault', target: 'n_err', type: 'fault' }),
+      edge({ id: 'e1', target: 'n1', condition: 'a' }),
+    ];
+    const { edges } = applyDecisionBranches(
+      DEC,
+      [
+        { label: 'A', expression: 'a', target: 'n1' },
+        { label: 'New', expression: 'n' }, // no target, binds nothing
+      ],
+      existing,
+    );
+    expect(edges).toEqual(existing.map((e, i) => (i === 2 ? { ...e, label: 'A' } : e)));
+  });
+
+  it('falls back to the by-order mirror when no branch carries a target (server-schema form)', () => {
+    const existing = [edge({ id: 'e1', target: 'n1' }), edge({ id: 'e2', target: 'n2' })];
+    const { conditions, edges } = applyDecisionBranches(
+      DEC,
+      [
+        { label: 'A', expression: 'a' },
+        { label: 'Else', expression: 'true' },
+      ],
+      existing,
+    );
+    expect(conditions).toEqual([
+      { label: 'A', expression: 'a' },
+      { label: 'Else', expression: 'true' },
+    ]);
+    expect(edges).toEqual([
+      { id: 'e1', source: DEC, target: 'n1', label: 'A', condition: 'a' },
+      { id: 'e2', source: DEC, target: 'n2', label: 'Else', isDefault: true },
+    ]);
+  });
+
+  it('round-trips with the FlowEdgeInspector branch picker: apply, then re-derive', () => {
+    const committed = [
+      { label: 'Yes', expression: 'amount > 10', target: 'n_yes' },
+      { label: 'Else', expression: 'true', target: 'n_no' },
+    ];
+    const { conditions, edges } = applyDecisionBranches(DEC, committed, []);
+    // The edge the picker (#1930) would select for each branch is the one we
+    // wrote — and the display derivation re-injects the exact same targets.
+    expect(edges.every((e, i) => edgeBindsBranch(conditions[i], e))).toBe(true);
+    expect(withBranchTargets(DEC, conditions, edges)).toEqual(committed);
+  });
+});
+
+describe('syncDecisionEdgesByOrder — legacy #1927 mirror', () => {
+  it('stamps branch i onto the i-th plain out-edge, leaving fault/back/surplus alone', () => {
+    const edges = [
+      edge({ target: 'n_err', type: 'fault' }),
+      edge({ target: 'n1' }),
+      edge({ target: 'n2' }),
+      edge({ target: 'n3', condition: 'stale' }),
+    ];
+    const out = syncDecisionEdgesByOrder(
+      DEC,
+      [
+        { label: 'A', expression: 'a' },
+        { label: 'Else', expression: 'true' },
+      ],
+      edges,
+    );
+    expect(out).toEqual([
+      edges[0],
+      { source: DEC, target: 'n1', label: 'A', condition: 'a' },
+      { source: DEC, target: 'n2', label: 'Else', isDefault: true },
+      edges[3],
+    ]);
+  });
+
+  it('an empty expression clears both guard and default flag', () => {
+    const out = syncDecisionEdgesByOrder(DEC, [{ label: 'A' }], [edge({ target: 'n1', condition: 'x', isDefault: true })]);
+    expect(out).toEqual([{ source: DEC, target: 'n1', label: 'A' }]);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-decision-edges.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-decision-edges.ts
@@ -1,0 +1,249 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * flow-decision-edges — pure branch↔edge reconciliation for decision nodes
+ * (#1927 / #1930 / #1942).
+ *
+ * A decision's routing lives on its outgoing EDGES (`edge.condition` /
+ * `edge.label` / `edge.isDefault`) — that is what the engine and the simulator
+ * evaluate. `node.config.conditions` is only the node-local branch list
+ * (`{ label, expression }`, per the spec decision shape). The Branches editor
+ * additionally shows a per-branch **Target** column (#1942): its value is
+ * DERIVED from the current edges here (never persisted on the branch — edges
+ * stay the single source of truth, so it round-trips with the per-edge Branch
+ * picker in `FlowEdgeInspector`, #1930), and committing the editor applies the
+ * chosen targets back onto the edges:
+ *
+ *   • branch has a target and a matching out-edge → update it in place
+ *     (retargeting when the author picked a different node);
+ *   • branch has a target but no edge            → create the out-edge;
+ *   • branch's target was cleared                → remove ("detach") the edge
+ *     that was bound to that branch — never the node it pointed at;
+ *   • edges bound to NO branch (custom per-edge guards authored in
+ *     `FlowEdgeInspector`, fault/back edges, surplus canvas wiring) are never
+ *     touched or deleted.
+ *
+ * A commit in which NO branch carries a target (the engine-published
+ * configSchema form has no Target column, and older flows) falls back to the
+ * #1927 by-order mirror, so those paths behave exactly as before.
+ *
+ * "Bound to a branch" follows the same matching the `FlowEdgeInspector`
+ * Branch picker uses: a default-ish branch (expression empty or `true`) binds
+ * the `isDefault` edge; otherwise match by condition text, then by label.
+ */
+
+import { conditionText } from '../previews/flow-canvas-layout';
+
+export interface DecisionEdge {
+  id?: string;
+  source: string;
+  target: string;
+  /** CEL guard — a bare string or the spec's `{ dialect, source }` shape. */
+  condition?: unknown;
+  label?: string;
+  isDefault?: boolean;
+  type?: string;
+  [k: string]: unknown;
+}
+
+/** `conditionText` narrowed for the loose `unknown` condition this module carries. */
+const condText = (c: unknown): string | undefined =>
+  conditionText(c as string | { source?: string } | undefined);
+
+/** A branch row as committed by the editor (freeform per the spec config). */
+export type DecisionBranch = Record<string, unknown>;
+
+const branchExpr = (b: DecisionBranch): string =>
+  typeof b.expression === 'string' ? b.expression.trim() : '';
+const branchName = (b: DecisionBranch): string =>
+  typeof b.label === 'string' ? b.label.trim() : '';
+const branchTarget = (b: DecisionBranch): string =>
+  typeof b.target === 'string' ? b.target.trim() : '';
+/** Default/else branch: an empty or literal-`true` expression (#1930 matcher). */
+const isDefaultish = (b: DecisionBranch): boolean => {
+  const e = branchExpr(b);
+  return e === '' || e === 'true';
+};
+
+export function asBranchArray(conditions: unknown): DecisionBranch[] {
+  return Array.isArray(conditions)
+    ? (conditions.filter((c) => c && typeof c === 'object' && !Array.isArray(c)) as DecisionBranch[])
+    : [];
+}
+
+/**
+ * Whether an edge is BOUND to a branch — mirrors `FlowEdgeInspector`'s
+ * branch-picker matching so the two editors agree on which edge is which
+ * branch: default-ish branch ↔ the `isDefault` edge, else condition text,
+ * else (non-empty) label.
+ */
+export function edgeBindsBranch(branch: DecisionBranch, edge: DecisionEdge): boolean {
+  if (isDefaultish(branch)) return edge.isDefault === true;
+  const expr = branchExpr(branch);
+  const cond = condText(edge.condition);
+  if (expr && cond === expr) return true;
+  const name = branchName(branch);
+  return name !== '' && edge.label === name;
+}
+
+/** The decision's plain out-edges (fault / back edges never carry branches). */
+const isCandidate = (decisionId: string) => (e: DecisionEdge): boolean =>
+  e.source === decisionId && e.type !== 'fault' && e.type !== 'back';
+
+/**
+ * Stamp a branch's routing onto an edge (the #1927 mirror rules): a non-`true`
+ * expression becomes the guard, a literal `true` marks the default/else path,
+ * an empty expression clears both; the label follows the branch label.
+ */
+function mirrorBranchOntoEdge(edge: DecisionEdge, branch: DecisionBranch): DecisionEdge {
+  const expr = branchExpr(branch);
+  const label = branchName(branch);
+  const next: DecisionEdge = { ...edge };
+  if (label) next.label = label;
+  else delete next.label;
+  if (expr && expr !== 'true') {
+    next.condition = expr;
+    delete next.isDefault;
+  } else if (expr === 'true') {
+    next.isDefault = true;
+    delete next.condition;
+  } else {
+    delete next.condition;
+    delete next.isDefault;
+  }
+  return next;
+}
+
+/**
+ * The legacy #1927 by-order mirror: branch i stamps the i-th plain out-edge.
+ * Used when no committed branch carries an explicit target (see module doc).
+ */
+export function syncDecisionEdgesByOrder(
+  decisionId: string,
+  conditions: unknown,
+  edges: DecisionEdge[],
+): DecisionEdge[] {
+  const branches = asBranchArray(conditions);
+  const candidate = isCandidate(decisionId);
+  let bi = 0;
+  return edges.map((e) => {
+    if (!candidate(e)) return e;
+    const branch = branches[bi++];
+    return branch ? mirrorBranchOntoEdge(e, branch) : e;
+  });
+}
+
+/**
+ * Derive the Target column for display: pair each branch with the out-edge
+ * bound to it (#1930 matching), then pair the remainder by order (the #1927
+ * mirror keeps unannotated flows aligned that way). Returns the branches with
+ * `target` injected from the paired edge — and any stale stored `target` key
+ * dropped, since edges are the source of truth.
+ */
+export function withBranchTargets(
+  decisionId: string,
+  conditions: unknown,
+  edges: DecisionEdge[],
+): DecisionBranch[] {
+  const branches = asBranchArray(conditions);
+  if (branches.length === 0) return branches;
+  const candidates = edges
+    .map((_, i) => i)
+    .filter((i) => isCandidate(decisionId)(edges[i]));
+  const claimed = new Set<number>();
+  const pairing = new Map<number, number>();
+  branches.forEach((b, bi) => {
+    const ei = candidates.find((i) => !claimed.has(i) && edgeBindsBranch(b, edges[i]));
+    if (ei !== undefined) {
+      claimed.add(ei);
+      pairing.set(bi, ei);
+    }
+  });
+  branches.forEach((_, bi) => {
+    if (pairing.has(bi)) return;
+    const ei = candidates.find((i) => !claimed.has(i));
+    if (ei !== undefined) {
+      claimed.add(ei);
+      pairing.set(bi, ei);
+    }
+  });
+  return branches.map((b, bi) => {
+    const { target: _stale, ...rest } = b;
+    const ei = pairing.get(bi);
+    return ei !== undefined ? { ...rest, target: edges[ei].target } : rest;
+  });
+}
+
+/**
+ * Apply a Branches-editor commit: returns the spec-clean `conditions` to store
+ * (the virtual `target` column stripped) and the reconciled `edges`.
+ *
+ * With no targets anywhere the edge pass is the legacy by-order mirror.
+ * Otherwise branches claim edges in three deterministic tiers — exact target
+ * AND binding, exact target, binding alone (a retarget keeps the edge's
+ * identity and extra keys) — unmatched targeted branches create a fresh edge,
+ * and a target-less branch detaches (removes) the edge still bound to it.
+ */
+export function applyDecisionBranches(
+  decisionId: string,
+  committed: unknown,
+  edges: DecisionEdge[],
+): { conditions: DecisionBranch[]; edges: DecisionEdge[] } {
+  const branches = asBranchArray(committed);
+  const conditions = branches.map((b) => {
+    const { target: _t, ...rest } = b;
+    return rest;
+  });
+
+  if (!branches.some((b) => branchTarget(b) !== '')) {
+    return { conditions, edges: syncDecisionEdgesByOrder(decisionId, conditions, edges) };
+  }
+
+  const candidates = edges
+    .map((_, i) => i)
+    .filter((i) => isCandidate(decisionId)(edges[i]));
+  const claimed = new Set<number>();
+  const pairing = new Map<number, number>();
+
+  const tiers: Array<(b: DecisionBranch, e: DecisionEdge) => boolean> = [
+    (b, e) => e.target === branchTarget(b) && edgeBindsBranch(b, e),
+    (b, e) => e.target === branchTarget(b),
+    (b, e) => edgeBindsBranch(b, e),
+  ];
+  for (const matches of tiers) {
+    branches.forEach((b, bi) => {
+      if (pairing.has(bi) || branchTarget(b) === '') return;
+      const ei = candidates.find((i) => !claimed.has(i) && matches(b, edges[i]));
+      if (ei !== undefined) {
+        claimed.add(ei);
+        pairing.set(bi, ei);
+      }
+    });
+  }
+
+  const updated = new Map<number, DecisionEdge>();
+  const created: DecisionEdge[] = [];
+  const removed = new Set<number>();
+  branches.forEach((b, bi) => {
+    const target = branchTarget(b);
+    if (target === '') {
+      // Explicitly unbound: detach the edge still bound to this branch (never
+      // a claimed edge, never an edge bound to no branch at all).
+      const ei = candidates.find((i) => !claimed.has(i) && edgeBindsBranch(b, edges[i]));
+      if (ei !== undefined) {
+        claimed.add(ei);
+        removed.add(ei);
+      }
+      return;
+    }
+    const ei = pairing.get(bi);
+    if (ei !== undefined) updated.set(ei, mirrorBranchOntoEdge({ ...edges[ei], target }, b));
+    else created.push(mirrorBranchOntoEdge({ source: decisionId, target }, b));
+  });
+
+  const nextEdges = edges
+    .map((e, i) => (removed.has(i) ? null : updated.get(i) ?? e))
+    .filter((e): e is DecisionEdge => e !== null)
+    .concat(created);
+  return { conditions, edges: nextEdges };
+}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -253,10 +253,13 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
   ],
   decision: [
     cfg('conditions', 'Branches', 'objectList', {
-      help: 'Each branch has a label and a CEL expression (spec decision shape). A branch whose expression is "true" is the default/else path.',
+      help: 'Each branch has a label, a CEL expression, and a target node. A branch whose expression is "true" is the default/else path. Picking a target wires the branch’s outgoing edge (creating or updating it); clearing it detaches that edge.',
       columns: [
         { key: 'label', label: 'Label', kind: 'text', placeholder: 'Has deals' },
         { key: 'expression', label: 'Expression', kind: 'expression', placeholder: 'expiring_deals.length > 0' },
+        // #1942 — virtual column: derived from / applied to the out-edges by
+        // FlowNodeInspector (flow-decision-edges), never stored on the branch.
+        { key: 'target', label: 'Target', kind: 'reference', placeholder: 'next node', ref: { kind: 'node' } },
       ],
     }),
     cfg('condition', 'Condition (single)', 'expression', {


### PR DESCRIPTION
## Summary

Closes #1942.

The decision node's **Branches** editor gains a **Target** column — a node-reference picker scoped to this flow's nodes — so the whole decision (conditions *and* destinations) is authored in one table, mirroring Salesforce Flow **Decision Outcomes**. This completes #1930 (the per-edge Branch picker) from the node side.

## Design: edges stay the single source of truth

The Target column is **virtual**: its displayed value is *derived* from the decision's outgoing edges (the engine and simulator route on `edge.condition` / `label` / `isDefault`), and it is **never persisted** on `config.conditions` (which keeps the spec-clean `{ label, expression }` shape). Committing the editor reconciles the chosen targets back onto the edges (`flow-decision-edges.ts`):

- **create** the out-edge when the branch has a target but no edge yet, carrying its condition / label / default flag;
- **update / retarget** the existing bound edge in place (edge identity and extra keys preserved), using three deterministic claim tiers — exact target + binding, exact target, binding alone;
- **detach** (remove) the branch's bound edge when its target is cleared — never the node it pointed at;
- **never touch** custom hand-written edge guards, fault/back edges, or surplus canvas wiring;
- a commit with **no targets anywhere** (e.g. an engine-published `configSchema` form without the column) keeps the legacy #1927 **by-order mirror** byte-for-byte.

"Bound to a branch" uses the same matching as the `FlowEdgeInspector` Branch picker (default-ish branch ↔ `isDefault` edge, else condition text, else label), so editing in either place round-trips.

## Acceptance criteria

- [x] Target column in the Decision Branches editor (node picker scoped to this flow's nodes — the existing `ref.kind: 'node'` picker source)
- [x] Choosing a target creates the out-edge if missing / updates the existing one, carrying condition/label/default
- [x] Round-trips with the `FlowEdgeInspector` Branch picker (#1930)
- [x] Clearing a target detaches the edge, never deletes a node
- [x] Unit tests for the branch→edge reconciliation (16 new tests)

## Testing

- `vitest run …/inspectors/` — 20 files, 230 tests pass (16 new in `flow-decision-edges.test.ts`)
- `pnpm --filter @object-ui/app-shell type-check` — clean
- Docs updated: `content/docs/guide/flow-designer.md`, `packages/app-shell/README.md`; changeset (minor) included

🤖 Generated with [Claude Code](https://claude.com/claude-code)