### PR TITLE
fix(studio): stop force-opening the new-object dialog on empty packages

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -1240,7 +1240,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.data.readOnlyPackage': 'This package is read-only — switch to or create a writable package to add objects',
   'engine.studio.data.firstObjectTitle': 'Start with your first object',
   'engine.studio.data.firstObjectHint':
-    'Objects are your app’s data foundation (e.g. “Orders”, “Customers”). Enter a display name and identifier at the bottom-left to create one; then design its fields, forms, and automations, and publish once at the end.',
+    'Objects are your app’s data foundation (e.g. “Orders”, “Customers”). Create one below; then design its fields, forms, and automations, and publish once at the end.',
   'engine.studio.data.tab.records': 'Records',
   'engine.studio.data.tab.form': 'Form',
   'engine.studio.data.tab.rules': 'Validations',
@@ -2555,7 +2555,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.data.readOnlyPackage': '此包为只读——请切换到或新建一个可写的包后再添加对象',
   'engine.studio.data.firstObjectTitle': '从第一个对象开始',
   'engine.studio.data.firstObjectHint':
-    '对象是应用的数据基座(如「订单」「客户」)。在左下角输入显示名与标识符即可创建;之后为它设计字段、表单与自动化,最后一次发布。',
+    '对象是应用的数据基座(如「订单」「客户」)。点击下方按钮创建一个;之后为它设计字段、表单与自动化,最后一次发布。',
   'engine.studio.data.tab.records': '记录',
   'engine.studio.data.tab.form': '表单',
   'engine.studio.data.tab.rules': '验证',

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.emptyPackage.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.emptyPackage.test.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Empty-package behavior of the Data pillar (dogfood #2555):
+ *
+ * Visiting an empty writable package used to FORCE the "new object" creator
+ * dialog open on every mount — an unrequested modal, duplicating the guidance
+ * the empty-state panel already gives. Now the dialog stays closed and the
+ * empty state carries its own create CTA instead.
+ */
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── mocks ──────────────────────────────────────────────────────────────────
+// DataPillar's data deps: the metadata client (list/listDrafts) and the
+// package list (namespace lookup). Everything else renders for real.
+const mockClient = {
+  list: vi.fn(async () => []),
+  listDrafts: vi.fn(async () => []),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({ entries: [] }),
+  };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return {
+    ...mod,
+    fetchPackages: vi.fn(async () => []),
+  };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...mod,
+    useAdapter: () => ({}),
+  };
+});
+
+import { DataPillar } from './StudioDesignSurface';
+
+afterEach(cleanup);
+
+function renderPillar(props: Partial<React.ComponentProps<typeof DataPillar>> = {}) {
+  return render(
+    <MemoryRouter initialEntries={['/studio/com.acme.empty/data']}>
+      <DataPillar packageId="com.acme.empty" {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe('DataPillar — empty package', () => {
+  it('does NOT auto-open the new-object dialog and shows the empty-state CTA instead', async () => {
+    renderPillar();
+
+    // Wait for the object load to settle into the empty state.
+    const cta = await screen.findByTestId('empty-state-new-object');
+    expect(cta).toBeInTheDocument();
+
+    // The creator dialog must NOT be open (no dialog content in the tree).
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the creator dialog when the empty-state CTA is clicked', async () => {
+    renderPillar();
+
+    const cta = await screen.findByTestId('empty-state-new-object');
+    fireEvent.click(cta);
+
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+  });
+
+  it('hides the CTA on a read-only package', async () => {
+    renderPillar({ readOnly: true });
+
+    // Empty state still renders…
+    await waitFor(() => expect(mockClient.list).toHaveBeenCalled());
+    // …but with no create affordance and no dialog.
+    await waitFor(() =>
+      expect(screen.queryByTestId('empty-state-new-object')).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -1846,7 +1846,9 @@ function renderStudioGridList(props: {
   );
 }
 
-function DataPillar({
+// Exported for tests (StudioDesignSurface.emptyPackage.test.tsx) — the empty-
+// package behavior (no forced creator modal, empty-state CTA) lives here.
+export function DataPillar({
   packageId,
   publishNonce = 0,
   onDraftSaved,
@@ -1961,9 +1963,10 @@ function DataPillar({
         // actually have; otherwise open the first object as before.
         const deepLinked = resolveSurfaceDeepLink(items, initialSurface, 'object');
         setCurrent((c) => c ?? deepLinked ?? items[0] ?? null);
-        // First-run: an empty writable package opens the creator right away —
-        // the first thing to do here is make an object, so put the inputs up.
-        if (items.length === 0 && !readOnly) setCreating(true);
+        // An empty writable package does NOT auto-open the creator dialog —
+        // it used to, which forced an unrequested modal on EVERY visit to an
+        // empty package (dogfood #2555). The empty-state panel carries the
+        // create CTA instead.
       } catch (e) {
         if (!cancelled) setError(formatMetadataError(e));
       } finally {
@@ -2279,12 +2282,25 @@ function DataPillar({
           {!current ? (
             objectsLoaded && objects.length === 0 ? (
               /* Fresh package: the first act is creating an object — say so and
-               * point at the rail creator (already auto-opened). */
+               * offer the creator right here (no auto-opened modal, dogfood #2555). */
               <div className="flex flex-col items-center gap-2 py-16 text-center">
                 <p className="text-sm font-medium">{t('engine.studio.data.firstObjectTitle', locale)}</p>
                 <p className="max-w-sm text-[11px] leading-5 text-muted-foreground">
                   {t('engine.studio.data.firstObjectHint', locale)}
                 </p>
+                {!readOnly && (
+                  <button
+                    type="button"
+                    data-testid="empty-state-new-object"
+                    onClick={() => {
+                      setError(null);
+                      setCreating(true);
+                    }}
+                    className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                  >
+                    <Plus className="h-3.5 w-3.5" /> {t('engine.studio.data.newObject', locale)}
+                  </button>
+                )}
               </div>
             ) : (
               <div className="py-16 text-center text-sm text-muted-foreground">{t('engine.studio.data.pickObject', locale)}</div>


### PR DESCRIPTION
## Problem
Visiting an empty writable package's Data pillar (`/studio/:pkg/data`) auto-opened the "new object" creator dialog on **every mount** — an unrequested modal that duplicated the guidance the empty-state panel already gives, and re-appeared each time you navigated back. Item 1 of the dogfood follow-ups in #2555.

## Change
- `DataPillar` no longer calls `setCreating(true)` when the loaded object list is empty — the dialog only opens on an explicit user action.
- The empty-state panel gains a **"New object" CTA** (`data-testid="empty-state-new-object"`), hidden on read-only packages.
- `engine.studio.data.firstObjectHint` (en/zh) copy updated to point at the button instead of the bottom-left rail inputs.
- `DataPillar` exported for the new behavioral test.

## Tests / verification
- New `StudioDesignSurface.emptyPackage.test.tsx` (3 tests): no auto-dialog + CTA present; CTA click opens the dialog; CTA hidden on read-only.
- Browser-verified against the live app-showcase backend: visiting the empty `com.example.writabletest` package shows the empty state with the CTA and **no modal**; clicking the CTA opens the creator dialog.

Closes item 1 of #2555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)