### PR TITLE
feat(studio): CEL editor (validate + autocomplete) for field conditional rules (#1582)

### DIFF
--- a/.changeset/cel-editor-field-conditional-rules.md
+++ b/.changeset/cel-editor-field-conditional-rules.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Studio object designer: the field inspector's conditional rules (`visibleWhen` / `readonlyWhen` / `requiredWhen`) are now edited with a proper CEL editor — live syntax/semantic validation and autocomplete (object fields after `record.` / `previous.`, the runtime-bound roots `record`/`previous`/`parent`, and the CEL stdlib), backed by the same `@objectstack/formula` validators the server uses. Bare field references are flagged with the exact `record.<field>` fix, the deprecated `conditionalRequired` alias migrates to `requiredWhen` on first edit, and draft validation reports an invalid predicate on any field under its `fields.<field>.<rule>` path before save. (#1582)

--- a/content/docs/guide/metadata-diagnostics.md
+++ b/content/docs/guide/metadata-diagnostics.md
@@ -138,6 +138,17 @@ Edits clear the matching diagnostic immediately — the inline error on a
 field disappears as soon as you start typing in it, then re-validates
 on save.
 
+For **object** drafts the live validation goes beyond the Zod shape check:
+every field conditional rule (`visibleWhen` / `readonlyWhen` / `requiredWhen`,
+plus the deprecated `conditionalRequired` alias) is linted as a CEL predicate
+with the same `@objectstack/formula` validators the server uses. A predicate
+that parses but references an unknown field, or references a field bare
+instead of as `record.<field>`, surfaces under its `fields.<field>.<rule>`
+path in the banner. The field inspector's *Conditional rules* editors give
+the same verdict inline as you type — with autocomplete for the object's
+fields (after `record.` / `previous.`), the runtime-bound scope roots
+(`record`, `previous`, `parent`), and the CEL stdlib.
+
 ### 4. Governance overview page
 
 `/apps/<app>/metadata/_diagnostics` — a single sortable table of every

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -212,6 +212,29 @@ error-swallowing like `preview/capabilityLint.ts`), so the CEL parser stays out
 of the main bundle and a missing/older engine degrades to "no assistance"
 rather than breaking the editor. The bridge is `metadata-admin/celAuthoring.ts`.
 
+#### Field conditional rules — CEL editors (objectui#1582)
+
+The object designer's field inspector (`ObjectFieldInspector`, Advanced →
+*Conditional rules*) edits the ADR-0036 B2 field-level predicates
+`visibleWhen` / `readonlyWhen` / `requiredWhen` with the same
+`CelPredicateField` editor, in **`scope="record"`** mode:
+
+- These rules evaluate with the record bound **only as the `record`
+  namespace** (see `@object-ui/core`'s `evalFieldPredicate`), so a bare field
+  reference is flagged as an **error** with the exact `record.<field>` fix,
+  and autocomplete offers the roots that are actually bound at runtime —
+  `record` / `previous` / `parent` (master-detail header) — plus the stdlib;
+  typing `record.` / `previous.` completes the object's own field names.
+- Values round-trip both wire shapes: a bare CEL string or the
+  `{ dialect, source }` Expression envelope (envelope extras such as
+  `meta.rationale` are preserved on edit). The deprecated
+  `conditionalRequired` alias is read into the *Required when* editor and
+  migrated to `requiredWhen` on the first edit.
+- The same lint also runs draft-wide in `clientValidation.ts`
+  (`validateMetadataDraft('object', …)`), so an invalid predicate on any
+  field — not just the selected one — surfaces in the editor's issue banner
+  under a `fields.<field>.<rule>` path before save.
+
 ### Visual flow canvas
 
 The `flow` designer (`FlowPreview` → `FlowCanvas`) renders an automation as an

--- a/packages/app-shell/src/views/metadata-admin/CelPredicateField.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/CelPredicateField.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { CelPredicateField } from './CelPredicateField';
 import {
   tokenAt,
+  memberTokenAt,
   buildCandidates,
   filterCandidates,
   __setCelFormulaLoader,
@@ -53,6 +54,26 @@ describe('tokenAt', () => {
   });
 });
 
+describe('memberTokenAt', () => {
+  it('returns the member segment and its root', () => {
+    expect(memberTokenAt('record.sta', 10)).toEqual({ root: 'record', start: 7, end: 10, text: 'sta' });
+  });
+  it('returns an EMPTY segment right after the dot', () => {
+    expect(memberTokenAt('record.', 7)).toEqual({ root: 'record', start: 7, end: 7, text: '' });
+  });
+  it('returns null for a bare identifier (no dot)', () => {
+    expect(memberTokenAt('record', 6)).toBeNull();
+  });
+  it('returns null for a deeper chain (unknown member shape)', () => {
+    expect(memberTokenAt('record.owner.na', 15)).toBeNull();
+    expect(memberTokenAt('record.owner.', 13)).toBeNull();
+  });
+  it('returns null when the segment is digit-led or the root is missing', () => {
+    expect(memberTokenAt('record.1a', 9)).toBeNull();
+    expect(memberTokenAt('.foo', 4)).toBeNull();
+  });
+});
+
 describe('buildCandidates / filterCandidates', () => {
   const scope = {
     fields: ['organization_id', 'owner_id'],
@@ -71,6 +92,10 @@ describe('buildCandidates / filterCandidates', () => {
     expect(filterCandidates(c, 'ORG').map((x) => x.label)).toEqual(['organization_id']);
     expect(filterCandidates(c, 'organization_id')).toEqual([]); // exact excluded
     expect(filterCandidates(c, '')).toEqual([]);
+  });
+  it('returns the full (capped) catalog for an empty query when allowEmpty', () => {
+    const c = buildCandidates(scope);
+    expect(filterCandidates(c, '', true).length).toBe(c.length);
   });
 });
 
@@ -123,7 +148,7 @@ describe('CelPredicateField · autocomplete', () => {
     await waitFor(() => expect(ta.value).toBe('organization_id'));
   });
 
-  it('does not suggest after a member-access dot', async () => {
+  it('does not suggest after a member-access dot on an unknown-shape root', async () => {
     __setCelFormulaLoader(() =>
       Promise.resolve({
         validateExpression: () => ({ ok: true, errors: [], warnings: [] }),
@@ -138,5 +163,57 @@ describe('CelPredicateField · autocomplete', () => {
     // Give the catalog a beat to load; the menu must stay closed for member access.
     await new Promise((r) => setTimeout(r, 150));
     expect(screen.queryByRole('option')).toBeNull();
+  });
+
+  it('completes field names after record. — including right at the dot', async () => {
+    __setCelFormulaLoader(() =>
+      Promise.resolve({
+        validateExpression: () => ({ ok: true, errors: [], warnings: [] }),
+        introspectScope: () => ({
+          fields: ['organization_id', 'owner_id'],
+          roots: ['record', 'previous', 'parent'],
+          functions: ['has'],
+        }),
+      }),
+    );
+    const user = userEvent.setup();
+    render(<Harness initial="" scope="record" roots={['record', 'previous', 'parent']} />);
+    const ta = screen.getByRole('combobox') as HTMLTextAreaElement;
+    await user.click(ta);
+    await user.type(ta, 'record.');
+    // The full field catalog surfaces the moment the dot is typed…
+    const options = await screen.findAllByRole('option', {}, { timeout: 3000 });
+    expect(options.map((o) => o.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining('organization_id'), expect.stringContaining('owner_id')]),
+    );
+    // …and narrowing + accepting inserts the member, not a bare field.
+    await user.type(ta, 'own');
+    await screen.findByRole('option', { name: /owner_id/i }, { timeout: 3000 });
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(ta.value).toBe('record.owner_id'));
+  });
+
+  it('withholds BARE field suggestions in record scope (fields live under record.*)', async () => {
+    __setCelFormulaLoader(() =>
+      Promise.resolve({
+        validateExpression: () => ({ ok: true, errors: [], warnings: [] }),
+        introspectScope: () => ({
+          fields: ['organization_id'],
+          roots: ['record', 'previous', 'parent'],
+          functions: ['has'],
+        }),
+      }),
+    );
+    const user = userEvent.setup();
+    render(<Harness initial="" scope="record" roots={['record', 'previous', 'parent']} />);
+    const ta = screen.getByRole('combobox') as HTMLTextAreaElement;
+    await user.click(ta);
+    await user.type(ta, 'org');
+    await new Promise((r) => setTimeout(r, 150));
+    expect(screen.queryByRole('option')).toBeNull();
+    // Roots still complete bare — `rec` offers `record`.
+    await user.clear(ta);
+    await user.type(ta, 'rec');
+    expect(await screen.findByRole('option', { name: /record/i }, { timeout: 3000 })).toBeTruthy();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/CelPredicateField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/CelPredicateField.tsx
@@ -7,7 +7,9 @@
  */
 
 /**
- * CEL predicate editor for RLS `USING` / `CHECK` clauses (objectui#2413).
+ * CEL predicate editor — RLS `USING` / `CHECK` clauses (objectui#2413) and,
+ * via `scope="record"`, the field conditional rules `visibleWhen` /
+ * `readonlyWhen` / `requiredWhen` in the object field inspector (objectui#1582).
  *
  * Replaces the bare `<textarea>` with the same visual field plus three
  * author-time safeties, all backed by the framework's canonical CEL engine
@@ -31,9 +33,11 @@ import {
   lintCelPredicate,
   introspectCelScope,
   tokenAt,
+  memberTokenAt,
   buildCandidates,
   filterCandidates,
   type CelLintIssue,
+  type CelScopeInfo,
   type CelSuggestion,
   type CelSuggestionKind,
 } from './celAuthoring';
@@ -45,6 +49,14 @@ const KIND_TAG: Record<CelSuggestionKind, string> = {
   root: 'scope',
   function: 'fn',
 };
+
+/**
+ * Roots whose member shape IS the target object's field catalog, so typing
+ * `record.` / `previous.` completes to field names. `parent` (a master-detail
+ * header of some OTHER object) and `current_user` stay suppressed — suggesting
+ * this object's fields there would be wrong.
+ */
+const FIELD_MEMBER_ROOTS = new Set(['record', 'previous']);
 
 export interface CelPredicateFieldProps {
   value: string;
@@ -59,6 +71,16 @@ export interface CelPredicateFieldProps {
   fieldNames?: string[];
   /** Which RLS clause this is (drives the pushdown / fail-open advisory). */
   clause?: 'using' | 'check';
+  /**
+   * Evaluation scope of the authoring site (objectui#1582). `'flattened'`
+   * (default — RLS / flow style, fields referenced bare) or `'record'`
+   * (field conditional rules / formulas — fields live under the `record`
+   * namespace, so bare completion offers roots + functions only and the
+   * field catalog surfaces after `record.` / `previous.`).
+   */
+  scope?: 'record' | 'flattened';
+  /** Override the scope roots offered by autocomplete (see CelSchemaHint.roots). */
+  roots?: string[];
   /** Reports the current lint issues up so the editor can gate Save on errors. */
   onLintChange?: (issues: CelLintIssue[]) => void;
   t: (k: string) => string;
@@ -76,6 +98,8 @@ export function CelPredicateField({
   objectName,
   fieldNames = EMPTY_FIELDS,
   clause,
+  scope,
+  roots,
   onLintChange,
   t,
   id,
@@ -83,7 +107,7 @@ export function CelPredicateField({
   const taRef = React.useRef<HTMLTextAreaElement>(null);
   const [issues, setIssues] = React.useState<CelLintIssue[]>([]);
   const [linted, setLinted] = React.useState(false);
-  const [candidates, setCandidates] = React.useState<CelSuggestion[]>([]);
+  const [scopeInfo, setScopeInfo] = React.useState<CelScopeInfo | null>(null);
 
   const [open, setOpen] = React.useState(false);
   const [suggestions, setSuggestions] = React.useState<CelSuggestion[]>([]);
@@ -91,8 +115,9 @@ export function CelPredicateField({
   const tokenRef = React.useRef<{ start: number; end: number } | null>(null);
   const pendingCaret = React.useRef<number | null>(null);
 
-  // Stable dep for the field-name array (parent may pass a fresh array each render).
+  // Stable deps for the identifier arrays (parent may pass fresh arrays each render).
   const fieldsKey = fieldNames.join(',');
+  const rootsKey = roots ? roots.join(',') : '';
 
   // Keep the reporter out of the lint effect deps (parent may not memoize it).
   const onLintChangeRef = React.useRef(onLintChange);
@@ -104,7 +129,7 @@ export function CelPredicateField({
   React.useEffect(() => {
     let cancelled = false;
     const handle = setTimeout(() => {
-      lintCelPredicate(value, { objectName, fields: fieldNames, clause }).then((res) => {
+      lintCelPredicate(value, { objectName, fields: fieldNames, clause, scope }).then((res) => {
         if (cancelled) return;
         setIssues(res);
         setLinted(true);
@@ -116,7 +141,7 @@ export function CelPredicateField({
       clearTimeout(handle);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, objectName, fieldsKey, clause]);
+  }, [value, objectName, fieldsKey, clause, scope]);
 
   /* Report "clean" upward when the field empties (no debounce needed). */
   React.useEffect(() => {
@@ -130,14 +155,29 @@ export function CelPredicateField({
   /* Load the autocomplete catalog when the target object / fields change. */
   React.useEffect(() => {
     let cancelled = false;
-    introspectCelScope({ objectName, fields: fieldNames }).then((scope) => {
-      if (!cancelled) setCandidates(buildCandidates(scope));
+    introspectCelScope({ objectName, fields: fieldNames, scope, roots }).then((info) => {
+      if (!cancelled) setScopeInfo(info);
     });
     return () => {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [objectName, fieldsKey]);
+  }, [objectName, fieldsKey, scope, rootsKey]);
+
+  // Bare-position catalog. In `record` scope a bare field ref is a lint ERROR
+  // (the record is namespaced), so fields are withheld here and offered as
+  // member completion after `record.` / `previous.` instead.
+  const bareCandidates = React.useMemo(
+    () =>
+      scopeInfo
+        ? buildCandidates(scope === 'record' ? { ...scopeInfo, fields: [] } : scopeInfo)
+        : [],
+    [scopeInfo, scope],
+  );
+  const fieldCandidates = React.useMemo<CelSuggestion[]>(
+    () => (scopeInfo ? scopeInfo.fields.map((f) => ({ label: f, kind: 'field' as const })) : []),
+    [scopeInfo],
+  );
 
   /* Restore the caret after a controlled-value change from accepting a suggestion. */
   React.useEffect(() => {
@@ -159,15 +199,27 @@ export function CelPredicateField({
     if (!ta || disabled) return closeAc();
     const text = ta.value;
     const caret = ta.selectionStart ?? text.length;
-    const tok = tokenAt(text, caret);
-    if (!tok) return closeAc();
-    const matches = filterCandidates(candidates, tok.text);
-    if (!matches.length) return closeAc();
+    let tok: { start: number; end: number } | null = null;
+    let matches: CelSuggestion[] = [];
+    const bare = tokenAt(text, caret);
+    if (bare) {
+      tok = bare;
+      matches = filterCandidates(bareCandidates, bare.text);
+    } else {
+      // Member position: `record.` / `previous.` complete to the object's
+      // fields — including the empty segment right after the dot.
+      const member = memberTokenAt(text, caret);
+      if (member && FIELD_MEMBER_ROOTS.has(member.root)) {
+        tok = member;
+        matches = filterCandidates(fieldCandidates, member.text, true);
+      }
+    }
+    if (!tok || !matches.length) return closeAc();
     tokenRef.current = { start: tok.start, end: tok.end };
     setSuggestions(matches);
     setActive(0);
     setOpen(true);
-  }, [candidates, disabled, closeAc]);
+  }, [bareCandidates, fieldCandidates, disabled, closeAc]);
 
   const accept = React.useCallback(
     (s: CelSuggestion) => {
@@ -192,7 +244,7 @@ export function CelPredicateField({
   }, [refreshAc]);
   React.useEffect(() => {
     if (taRef.current && document.activeElement === taRef.current) refreshAcRef.current();
-  }, [candidates]);
+  }, [bareCandidates, fieldCandidates]);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (!open || suggestions.length === 0) return;

--- a/packages/app-shell/src/views/metadata-admin/celAuthoring.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/celAuthoring.test.ts
@@ -54,12 +54,46 @@ describe('celAuthoring · lintCelPredicate (real engine)', () => {
   });
 });
 
+describe('celAuthoring · lintCelPredicate in record scope (field conditional rules, #1582)', () => {
+  const RULE_HINT = { ...HINT, scope: 'record' as const };
+
+  it('is clean for a record.<field> predicate', async () => {
+    expect(await lintCelPredicate('record.status == "open"', RULE_HINT)).toEqual([]);
+  });
+
+  it('flags a BARE field reference as an error with the record.<field> fix', async () => {
+    const issues = await lintCelPredicate('status == "open"', RULE_HINT);
+    expect(issues.some((i) => i.severity === 'error' && /record\.status/.test(i.message))).toBe(true);
+  });
+
+  it('flags an unknown record.<field> as an error with did-you-mean', async () => {
+    const issues = await lintCelPredicate('record.statu == "open"', RULE_HINT);
+    expect(issues.some((i) => i.severity === 'error' && /did you mean/i.test(i.message))).toBe(true);
+  });
+
+  it('checks previous.<field> refs against the catalog too', async () => {
+    expect(await lintCelPredicate('record.status != previous.status', RULE_HINT)).toEqual([]);
+    const issues = await lintCelPredicate('previous.statu == "x"', RULE_HINT);
+    expect(issues.some((i) => i.severity === 'error')).toBe(true);
+  });
+
+  it('accepts the master-detail parent.* root without flagging it bare', async () => {
+    expect(await lintCelPredicate('parent.status == "paid"', RULE_HINT)).toEqual([]);
+  });
+});
+
 describe('celAuthoring · introspectCelScope (real engine)', () => {
   it('returns the object fields, scope roots, and stdlib functions', async () => {
     const scope = await introspectCelScope(HINT);
     expect(scope.fields).toContain('organization_id');
     expect(scope.roots).toContain('current_user');
     expect(scope.roots).toContain('record');
+    expect(scope.functions).toContain('has');
+  });
+
+  it('honors a roots override (field rules bind record/previous/parent only)', async () => {
+    const scope = await introspectCelScope({ ...HINT, scope: 'record', roots: ['record', 'previous', 'parent'] });
+    expect(scope.roots).toEqual(['record', 'previous', 'parent']);
     expect(scope.functions).toContain('has');
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/celAuthoring.ts
+++ b/packages/app-shell/src/views/metadata-admin/celAuthoring.ts
@@ -34,9 +34,9 @@
  * "no lint / no suggestions / test-run unavailable", never to an exception.
  */
 
-/** A schema hint for the policy's target object — powers field-existence lint. */
+/** A schema hint for the predicate's target object — powers field-existence lint. */
 export interface CelSchemaHint {
-  /** The policy's target object api-name (`*` / undefined => no field hints). */
+  /** The target object api-name (`*` / undefined => no field hints). */
   objectName?: string;
   /** Known field names of {@link objectName}, so `<field>` refs can be checked. */
   fields?: string[];
@@ -46,6 +46,27 @@ export interface CelSchemaHint {
    * blast-radius the issue calls out, so we advise on it (see {@link lintCelPredicate}).
    */
   clause?: 'using' | 'check';
+  /**
+   * Evaluation scope of the authoring site (mirrors the engine's
+   * `ExprSchemaHint.scope`, objectui#1582):
+   *  - `'flattened'` (default) — the record's fields are spread to bare
+   *    top-level (RLS predicates, flow conditions), so `organization_id == …`
+   *    is legal and an unknown bare identifier is only a warning.
+   *  - `'record'` — the record is bound ONLY as the `record` namespace
+   *    (field conditional rules `visibleWhen`/`readonlyWhen`/`requiredWhen`,
+   *    formulas). A bare field ref silently evaluates to null at runtime, so
+   *    the engine flags it as an ERROR with the `record.<field>` fix.
+   */
+  scope?: 'record' | 'flattened';
+  /**
+   * Override the scope roots offered by autocomplete. The engine advertises
+   * every root ANY predicate site may see (`current_user`, `os`, `vars`, …),
+   * but a given authoring surface binds only a subset — field conditional
+   * rules bind exactly `record` / `previous` / `parent` (see
+   * `@object-ui/core`'s `evalFieldPredicate`). Suggesting an unbound root
+   * would author a predicate that silently never fires.
+   */
+  roots?: string[];
 }
 
 /** A single lint finding surfaced inline under the editor. */
@@ -170,7 +191,7 @@ export async function lintCelPredicate(
     const res = mod.validateExpression('predicate', source, {
       objectName: hint.objectName,
       fields: hint.fields,
-      scope: 'flattened',
+      scope: hint.scope ?? 'flattened',
     });
     const issues: CelLintIssue[] = [];
     for (const e of res?.errors ?? []) {
@@ -222,18 +243,18 @@ export async function lintCelPredicate(
  * field suggestions from metadata even with an older/absent engine.
  */
 export async function introspectCelScope(hint: CelSchemaHint = {}): Promise<CelScopeInfo> {
-  const fallback: CelScopeInfo = { fields: hint.fields ?? [], roots: [], functions: [] };
+  const fallback: CelScopeInfo = { fields: hint.fields ?? [], roots: hint.roots ?? [], functions: [] };
   try {
     const mod = await loadFormula();
     if (!mod?.introspectScope) return fallback;
     const res = mod.introspectScope('predicate', {
       objectName: hint.objectName,
       fields: hint.fields,
-      scope: 'flattened',
+      scope: hint.scope ?? 'flattened',
     });
     return {
       fields: res?.fields ?? hint.fields ?? [],
-      roots: res?.roots ?? [],
+      roots: hint.roots ?? res?.roots ?? [],
       functions: res?.functions ?? [],
     };
   } catch {
@@ -260,7 +281,8 @@ export const MAX_CEL_SUGGESTIONS = 8;
  * The identifier segment being typed immediately before `caret`, or `null` when
  * there is nothing to complete. A segment preceded by `.` is member access
  * (`current_user.org…`) — we can't know the member shape, so we suppress rather
- * than suggest a wrong top-level identifier.
+ * than suggest a wrong top-level identifier (but see {@link memberTokenAt} for
+ * the roots whose member shape IS known).
  */
 export function tokenAt(
   text: string,
@@ -273,6 +295,35 @@ export function tokenAt(
   if (!IDENT_START.test(seg[0])) return null; // starts with a digit → not an identifier
   if (start > 0 && text[start - 1] === '.') return null; // member access → suppress
   return { start, end: caret, text: seg };
+}
+
+/**
+ * The member segment being typed immediately after `<root>.` — e.g. caret at
+ * the end of `record.sta` yields `{ root: 'record', text: 'sta' }`, and caret
+ * right after `record.` yields `{ root: 'record', text: '' }` (so the full
+ * field catalog can surface as soon as the dot is typed). Unlike
+ * {@link tokenAt} the segment may be EMPTY, and only a single-level chain
+ * qualifies: in `record.owner.name` the `name` segment's root is `owner`
+ * (unknown shape), not `record`, so it returns `null` via the root's own
+ * preceding-dot check. Returns `null` when the caret is not in a member
+ * position (objectui#1582).
+ */
+export function memberTokenAt(
+  text: string,
+  caret: number,
+): { root: string; start: number; end: number; text: string } | null {
+  let start = caret;
+  while (start > 0 && IDENT_CHAR.test(text[start - 1])) start--;
+  const seg = text.slice(start, caret);
+  if (seg && !IDENT_START.test(seg[0])) return null; // digit-led → not an identifier
+  if (start === 0 || text[start - 1] !== '.') return null; // not member access
+  // The identifier run immediately before the dot is the root.
+  let rootStart = start - 1;
+  while (rootStart > 0 && IDENT_CHAR.test(text[rootStart - 1])) rootStart--;
+  const root = text.slice(rootStart, start - 1);
+  if (!root || !IDENT_START.test(root[0])) return null;
+  if (rootStart > 0 && text[rootStart - 1] === '.') return null; // deeper chain → unknown shape
+  return { root, start, end: caret, text: seg };
 }
 
 /** Merge a scope into a single de-duplicated, ordered candidate catalog. */
@@ -291,10 +342,19 @@ export function buildCandidates(scope: CelScopeInfo): CelSuggestion[] {
   return out;
 }
 
-/** Prefix-filter the catalog for `query` (case-insensitive), excluding exact hits. */
-export function filterCandidates(candidates: CelSuggestion[], query: string): CelSuggestion[] {
+/**
+ * Prefix-filter the catalog for `query` (case-insensitive), excluding exact
+ * hits. An empty query yields nothing unless `allowEmpty` — member completion
+ * wants the full (capped) catalog the moment the dot is typed, while bare
+ * completion staying quiet until a character is typed avoids a popup on focus.
+ */
+export function filterCandidates(
+  candidates: CelSuggestion[],
+  query: string,
+  allowEmpty = false,
+): CelSuggestion[] {
   const q = query.toLowerCase();
-  if (!q) return [];
+  if (!q && !allowEmpty) return [];
   const out: CelSuggestion[] = [];
   for (const c of candidates) {
     const l = c.label.toLowerCase();

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.fieldRules.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.fieldRules.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Draft-level CEL lint for object field conditional rules (objectui#1582).
+ *
+ * The spec Zod only checks the SHAPE of `visibleWhen` / `readonlyWhen` /
+ * `requiredWhen` (`string | envelope`); these tests prove a shape-valid but
+ * unparsable/mistyped predicate now surfaces as a `fields.<key>.<rule>` issue
+ * from `validateMetadataDraft('object', …)` — against the REAL
+ * `@objectstack/formula` engine, so the draft banner reaches the same verdict
+ * as the inline editor and the server.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { validateMetadataDraft } from './clientValidation';
+import { __setCelFormulaLoader } from './celAuthoring';
+
+afterEach(() => __setCelFormulaLoader(undefined));
+
+const RULE_PATH = /^fields\..+\.(visibleWhen|readonlyWhen|requiredWhen|conditionalRequired)$/;
+
+const draftWith = (fields: unknown) => ({ name: 'account', label: 'Account', fields });
+
+describe('validateMetadataDraft — object field conditional rules (real engine)', () => {
+  it('flags a malformed predicate under its fields.<name>.<rule> path', async () => {
+    const res = await validateMetadataDraft(
+      'object',
+      draftWith({ status: { type: 'text', visibleWhen: 'record.kind ==' } }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.issues.some((i) => i.path === 'fields.status.visibleWhen')).toBe(true);
+  });
+
+  it('flags a bare field reference (record scope) with the record.<field> fix', async () => {
+    const res = await validateMetadataDraft(
+      'object',
+      draftWith({
+        amount: { type: 'number' },
+        status: { type: 'text', requiredWhen: 'amount > 1000' },
+      }),
+    );
+    const issue = res.issues.find((i) => i.path === 'fields.status.requiredWhen');
+    expect(issue).toBeTruthy();
+    expect(issue!.message).toMatch(/record\.amount/);
+  });
+
+  it('is clean for valid predicates in both wire shapes (string and envelope)', async () => {
+    const res = await validateMetadataDraft(
+      'object',
+      draftWith({
+        amount: { type: 'number' },
+        status: {
+          type: 'text',
+          visibleWhen: 'record.amount > 0',
+          readonlyWhen: { dialect: 'cel', source: 'record.amount > 10' },
+        },
+      }),
+    );
+    expect(res.issues.filter((i) => RULE_PATH.test(i.path))).toEqual([]);
+  });
+
+  it('lints the legacy conditionalRequired alias too', async () => {
+    const res = await validateMetadataDraft(
+      'object',
+      draftWith({ status: { type: 'text', conditionalRequired: '{status} == "x"' } }),
+    );
+    expect(res.issues.some((i) => i.path === 'fields.status.conditionalRequired')).toBe(true);
+  });
+
+  it('uses index paths for the ARRAY fields shape', async () => {
+    const res = await validateMetadataDraft(
+      'object',
+      draftWith([{ name: 'status', type: 'text', visibleWhen: 'record.x ==' }]),
+    );
+    expect(res.issues.some((i) => i.path === 'fields.0.visibleWhen')).toBe(true);
+  });
+
+  it('skips non-CEL dialect envelopes (the engine owns that error, not the CEL lint)', async () => {
+    const res = await validateMetadataDraft(
+      'object',
+      draftWith({ status: { type: 'text', visibleWhen: { dialect: 'js', source: '!!!' } } }),
+    );
+    expect(res.issues.filter((i) => RULE_PATH.test(i.path))).toEqual([]);
+  });
+
+  it('fails open (no CEL issues) when the engine is unavailable', async () => {
+    __setCelFormulaLoader(() => Promise.resolve(null));
+    const res = await validateMetadataDraft(
+      'object',
+      draftWith({ status: { type: 'text', visibleWhen: 'record.kind ==' } }),
+    );
+    expect(res.issues.filter((i) => RULE_PATH.test(i.path))).toEqual([]);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -21,6 +21,8 @@
  */
 
 import type { SchemaFormIssue } from './SchemaForm';
+import { lintCelPredicate } from './celAuthoring';
+import { readFields } from './previews/object-fields-io';
 
 type ZodLikeSchema = {
   safeParse: (value: unknown) => {
@@ -124,6 +126,60 @@ function nodeTypeAt(draft: unknown, index: number): string | undefined {
   return typeof node?.type === 'string' ? node.type : undefined;
 }
 
+/**
+ * Field conditional-rule keys validated as CEL predicates (ADR-0036 B2,
+ * objectui#1582). The spec's Zod only checks the SHAPE (`string | envelope`);
+ * a syntactically broken predicate round-trips fine and then silently
+ * fail-opens at runtime, so we lint the CEL here — the same
+ * `@objectstack/formula` verdict the field inspector's editor shows live.
+ */
+const FIELD_RULE_KEYS = ['visibleWhen', 'readonlyWhen', 'requiredWhen', 'conditionalRequired'] as const;
+
+/** Extract a predicate's CEL source from either wire shape (string | envelope). */
+function predicateSource(v: unknown): string | null {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object' && typeof (v as { source?: unknown }).source === 'string') {
+    // Only lint envelopes that are (implicitly) CEL — a non-CEL dialect is the
+    // engine's own error to raise, not ours to mis-lint as CEL.
+    const dialect = (v as { dialect?: unknown }).dialect;
+    if (dialect === undefined || dialect === 'cel') return (v as { source: string }).source;
+  }
+  return null;
+}
+
+/**
+ * Lint every field conditional rule on an object draft. Runs with
+ * `scope: 'record'` (fields are namespaced under `record` in these rules) and
+ * reports only lint ERRORS — warnings would be noise at the draft level; the
+ * inline editor already surfaces them where the author can act.
+ */
+async function validateObjectFieldRules(draft: unknown): Promise<SchemaFormIssue[]> {
+  const d = draft as { name?: unknown; fields?: unknown } | null | undefined;
+  const view = readFields(d?.fields);
+  if (view.entries.length === 0) return [];
+  const objectName = typeof d?.name === 'string' ? d.name : undefined;
+  const fieldNames = view.entries.map((e) => e.name);
+  const issues: SchemaFormIssue[] = [];
+  for (let i = 0; i < view.entries.length; i++) {
+    const entry = view.entries[i];
+    const pathKey = view.shape === 'array' ? String(i) : entry.name;
+    for (const key of FIELD_RULE_KEYS) {
+      const source = predicateSource(entry.def[key]);
+      if (source == null || !source.trim()) continue;
+      const findings = await lintCelPredicate(source, {
+        objectName,
+        fields: fieldNames,
+        scope: 'record',
+      });
+      for (const f of findings) {
+        if (f.severity !== 'error') continue;
+        issues.push({ path: `fields.${pathKey}.${key}`, message: f.message });
+      }
+    }
+  }
+  return issues;
+}
+
 const SCHEMA_CACHE = new Map<string, ZodLikeSchema | null>();
 
 async function getSchemaForType(type: string): Promise<ZodLikeSchema | null> {
@@ -182,8 +238,14 @@ export async function validateMetadataDraft(
   const schema = await getSchemaForType(type);
   if (!schema) return { ok: true, issues: [] };
 
+  // CEL lint for object field conditional rules — additive to the Zod shape
+  // check (a draft can be shape-valid yet carry an unparsable predicate).
+  const celIssues = type === 'object' ? await validateObjectFieldRules(draft) : [];
+
   const result = schema.safeParse(draft);
-  if (result.success) return { ok: true, issues: [] };
+  if (result.success) {
+    return celIssues.length > 0 ? { ok: false, issues: celIssues } : { ok: true, issues: [] };
+  }
 
   let rawIssues = result.error?.issues ?? [];
 
@@ -217,11 +279,14 @@ export async function validateMetadataDraft(
       return !(nodeType && FORWARD_COMPAT_FLOW_NODE_TYPES.has(nodeType));
     });
   }
-  if (rawIssues.length === 0) return { ok: true, issues: [] };
+  if (rawIssues.length === 0 && celIssues.length === 0) return { ok: true, issues: [] };
 
-  const issues: SchemaFormIssue[] = rawIssues.map((i) => ({
-    path: (i.path ?? []).map((seg) => String(seg)).join('.'),
-    message: i.message,
-  }));
+  const issues: SchemaFormIssue[] = [
+    ...rawIssues.map((i) => ({
+      path: (i.path ?? []).map((seg) => String(seg)).join('.'),
+      message: i.message,
+    })),
+    ...celIssues,
+  ];
   return { ok: false, issues };
 }

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -976,8 +976,12 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'designer.field.helpText': 'Help text',
   'designer.field.helpTextPlaceholder': 'Shown below the field on the form',
   'designer.field.minLength': 'Min length',
-  'designer.field.conditionalRequired': 'Required when (CEL)',
-  'designer.field.conditionalRequiredHint': 'Field becomes required when this predicate is true.',
+  'designer.field.conditionalRules': 'Conditional rules (CEL)',
+  'designer.field.visibleWhen': 'Visible when',
+  'designer.field.readonlyWhen': 'Read-only when',
+  'designer.field.requiredWhen': 'Required when',
+  'designer.field.conditionalRulesHint':
+    'While a predicate is true the field becomes visible / read-only / required. Reference the live record as record.<field>, the last saved values as previous.<field>, and (in master-detail line items) the header record as parent.<field>.',
   // Bulk multi-select (Tier 2)
   'designer.canvas.bulkSelected': '{n} selected',
   'designer.canvas.bulkMoveTo': 'Move to section',
@@ -2292,8 +2296,12 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'designer.field.helpText': '帮助文本',
   'designer.field.helpTextPlaceholder': '显示在表单字段下方',
   'designer.field.minLength': '最小长度',
-  'designer.field.conditionalRequired': '条件必填 (CEL)',
-  'designer.field.conditionalRequiredHint': '当此表达式为真时，该字段变为必填。',
+  'designer.field.conditionalRules': '条件规则 (CEL)',
+  'designer.field.visibleWhen': '可见条件',
+  'designer.field.readonlyWhen': '只读条件',
+  'designer.field.requiredWhen': '必填条件',
+  'designer.field.conditionalRulesHint':
+    '表达式为真时字段相应地变为可见 / 只读 / 必填。用 record.<字段> 引用当前记录，previous.<字段> 引用最近保存的值，parent.<字段>（主从明细行）引用表头记录。',
   // Bulk multi-select (Tier 2)
   'designer.canvas.bulkSelected': '已选 {n} 项',
   'designer.canvas.bulkMoveTo': '移至分组',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.test.tsx
@@ -28,8 +28,12 @@ vi.mock('../previews/useObjectFields', () => ({
 }));
 
 import { ObjectFieldInspector } from './ObjectFieldInspector';
+import { __setCelFormulaLoader } from '../celAuthoring';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+});
 
 function renderField(
   fields: Record<string, Record<string, unknown>>,
@@ -185,17 +189,83 @@ describe('ObjectFieldInspector — power props (conditional & validation)', () =
     expect(onPatch.mock.calls.at(-1)![0].fields.note.minLength).toBe(3);
   });
 
-  it('commits a conditional-required CEL predicate', () => {
+  it('commits a required-when CEL predicate (as requiredWhen)', () => {
     const { onPatch } = renderField({ note: { type: 'text' } }, 'note');
-    fireEvent.change(controlFor('Required when (CEL)'), { target: { value: 'record.x == 1' } });
-    expect(onPatch.mock.calls.at(-1)![0].fields.note.conditionalRequired).toBe('record.x == 1');
+    fireEvent.change(controlFor('Required when'), { target: { value: 'record.x == 1' } });
+    const field = onPatch.mock.calls.at(-1)![0].fields.note;
+    expect(field.requiredWhen).toBe('record.x == 1');
+    expect(field.conditionalRequired).toBeUndefined();
   });
 
-  it('offers conditional-required for non-text types too', () => {
+  it('offers the conditional rules for non-text types too', () => {
     renderField({ active: { type: 'boolean' } }, 'active');
-    expect(screen.getByText('Required when (CEL)')).toBeInTheDocument();
+    expect(screen.getByText('Conditional rules (CEL)')).toBeInTheDocument();
+    expect(screen.getByText('Visible when')).toBeInTheDocument();
+    expect(screen.getByText('Read-only when')).toBeInTheDocument();
+    expect(screen.getByText('Required when')).toBeInTheDocument();
     // Min length is text-only, so it should not show for a boolean.
     expect(screen.queryByText('Min length')).not.toBeInTheDocument();
+  });
+});
+
+describe('ObjectFieldInspector — conditional rules (CEL editors, #1582)', () => {
+  // Deterministic fake engine — the editors' live lint/autocomplete against the
+  // REAL engine is covered by CelPredicateField.test.tsx; here we test the
+  // inspector's wiring (read/write shapes, legacy migration).
+  const stubEngine = () =>
+    __setCelFormulaLoader(() =>
+      Promise.resolve({
+        validateExpression: () => ({ ok: true, errors: [], warnings: [] }),
+        introspectScope: () => ({
+          fields: ['note', 'status'],
+          roots: ['record', 'previous', 'parent'],
+          functions: ['has'],
+        }),
+      }),
+    );
+
+  it('commits a visibleWhen predicate as the bare-string shorthand', () => {
+    stubEngine();
+    const { onPatch } = renderField({ note: { type: 'text' } }, 'note');
+    fireEvent.change(controlFor('Visible when'), { target: { value: "record.status != 'draft'" } });
+    const field = onPatch.mock.calls.at(-1)![0].fields.note;
+    expect(field.visibleWhen).toBe("record.status != 'draft'");
+  });
+
+  it('reads an Expression envelope and preserves its extra keys on write', () => {
+    stubEngine();
+    const envelope = { dialect: 'cel', source: 'record.a == 1', meta: { rationale: 'AI draft' } };
+    const { onPatch } = renderField({ note: { type: 'text', readonlyWhen: envelope } }, 'note');
+    expect(controlFor('Read-only when')).toHaveValue('record.a == 1');
+    fireEvent.change(controlFor('Read-only when'), { target: { value: 'record.a == 2' } });
+    expect(onPatch.mock.calls.at(-1)![0].fields.note.readonlyWhen).toEqual({
+      dialect: 'cel',
+      source: 'record.a == 2',
+      meta: { rationale: 'AI draft' },
+    });
+  });
+
+  it('clears a rule when the editor is emptied', () => {
+    stubEngine();
+    const { onPatch } = renderField(
+      { note: { type: 'text', visibleWhen: 'record.a == 1' } },
+      'note',
+    );
+    fireEvent.change(controlFor('Visible when'), { target: { value: '' } });
+    expect(onPatch.mock.calls.at(-1)![0].fields.note.visibleWhen).toBeUndefined();
+  });
+
+  it('reads legacy conditionalRequired into Required when and migrates it on edit', () => {
+    stubEngine();
+    const { onPatch } = renderField(
+      { note: { type: 'text', conditionalRequired: 'record.x == 1' } },
+      'note',
+    );
+    expect(controlFor('Required when')).toHaveValue('record.x == 1');
+    fireEvent.change(controlFor('Required when'), { target: { value: 'record.x == 2' } });
+    const field = onPatch.mock.calls.at(-1)![0].fields.note;
+    expect(field.requiredWhen).toBe('record.x == 2');
+    expect(field.conditionalRequired).toBeUndefined();
   });
 });
 
@@ -208,7 +278,7 @@ describe('ObjectFieldInspector — read-only', () => {
   it('disables the power-prop inputs when read-only', () => {
     renderField({ note: { type: 'text' } }, 'note', { readOnly: true });
     expect(controlFor('Help text')).toBeDisabled();
-    expect(controlFor('Required when (CEL)')).toBeDisabled();
+    expect(controlFor('Required when')).toBeDisabled();
   });
 });
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -55,6 +55,7 @@ import {
   CATEGORY_LABEL_ZH,
   type FieldTypeId,
 } from '../previews/field-types';
+import { CelPredicateField } from '../CelPredicateField';
 import { t, tFormat } from '../i18n';
 
 const isZh = (locale?: string) => (locale ?? '').toLowerCase().startsWith('zh');
@@ -117,6 +118,39 @@ function defaultValueKind(type: string): DefaultKind | null {
   ];
   if (noDefault.includes(type)) return null;
   return 'text';
+}
+
+/**
+ * The scope roots a field conditional rule can actually reference at runtime:
+ * `@object-ui/core`'s `evalFieldPredicate` binds the live record as `record`,
+ * the saved record as `previous`, and (for master-detail line items) the
+ * header as `parent` — nothing else (no `current_user`), so the autocomplete
+ * must not advertise the wider RLS/flow root set (objectui#1582).
+ */
+const FIELD_RULE_ROOTS = ['record', 'previous', 'parent'];
+
+/** Read a `*When` predicate for editing: a bare string or an Expression envelope's `source`. */
+function readPredicate(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object' && typeof (v as { source?: unknown }).source === 'string') {
+    return (v as { source: string }).source;
+  }
+  return '';
+}
+
+/**
+ * Write an edited predicate back. Empty clears the rule; a value authored over
+ * an existing `{ dialect, source }` envelope preserves the envelope's other
+ * keys (`meta.rationale` from an AI draft, etc.) instead of collapsing to a
+ * bare string; otherwise the spec-blessed bare-string shorthand is written.
+ */
+function writePredicate(orig: unknown, next: string): unknown {
+  if (!next.trim()) return undefined;
+  if (orig && typeof orig === 'object' && !Array.isArray(orig)) {
+    const env = orig as Record<string, unknown>;
+    return { ...env, dialect: typeof env.dialect === 'string' ? env.dialect : 'cel', source: next };
+  }
+  return next;
 }
 
 function buildTypeOptions(locale?: string): Array<{ value: string; label: string }> {
@@ -525,17 +559,60 @@ export function ObjectFieldInspector({
           onCommit={(v) => patchDef({ placeholder: v || undefined })}
           disabled={readOnly}
         />
-        <div className="space-y-1">
-          <InspectorTextField
-            label={tr('designer.field.conditionalRequired')}
-            value={typeof def.conditionalRequired === 'string' ? (def.conditionalRequired as string) : ''}
-            onCommit={(v) => patchDef({ conditionalRequired: v || undefined })}
+        {/* Conditional rules (ADR-0036 B2) — CEL editors with live lint +
+            field autocomplete against THIS object's fields (objectui#1582). */}
+        <div className="space-y-2 border-t pt-2.5">
+          <div className="text-[11px] font-medium text-muted-foreground">
+            {tr('designer.field.conditionalRules')}
+          </div>
+          <CelPredicateField
+            id={`field-rule-visible-${entry.name}`}
+            label={tr('designer.field.visibleWhen')}
+            value={readPredicate(def.visibleWhen)}
+            onChange={(v) => patchDef({ visibleWhen: writePredicate(def.visibleWhen, v) })}
             disabled={readOnly}
-            mono
+            placeholder="record.status != 'draft'"
+            objectName={typeof (draft as any).name === 'string' ? ((draft as any).name as string) : undefined}
+            fieldNames={view.entries.map((e) => e.name)}
+            scope="record"
+            roots={FIELD_RULE_ROOTS}
+            t={tr}
+          />
+          <CelPredicateField
+            id={`field-rule-readonly-${entry.name}`}
+            label={tr('designer.field.readonlyWhen')}
+            value={readPredicate(def.readonlyWhen)}
+            onChange={(v) => patchDef({ readonlyWhen: writePredicate(def.readonlyWhen, v) })}
+            disabled={readOnly}
             placeholder="record.status == 'closed'"
+            objectName={typeof (draft as any).name === 'string' ? ((draft as any).name as string) : undefined}
+            fieldNames={view.entries.map((e) => e.name)}
+            scope="record"
+            roots={FIELD_RULE_ROOTS}
+            t={tr}
+          />
+          <CelPredicateField
+            id={`field-rule-required-${entry.name}`}
+            label={tr('designer.field.requiredWhen')}
+            // Legacy alias: `conditionalRequired` (spec @deprecated) reads into
+            // the same editor; the first edit migrates it to `requiredWhen`.
+            value={readPredicate(def.requiredWhen ?? def.conditionalRequired)}
+            onChange={(v) =>
+              patchDef({
+                requiredWhen: writePredicate(def.requiredWhen ?? def.conditionalRequired, v),
+                conditionalRequired: undefined,
+              })
+            }
+            disabled={readOnly}
+            placeholder="record.amount > 10000"
+            objectName={typeof (draft as any).name === 'string' ? ((draft as any).name as string) : undefined}
+            fieldNames={view.entries.map((e) => e.name)}
+            scope="record"
+            roots={FIELD_RULE_ROOTS}
+            t={tr}
           />
           <p className="text-[11px] text-muted-foreground/80 px-0.5 leading-snug">
-            {tr('designer.field.conditionalRequiredHint')}
+            {tr('designer.field.conditionalRulesHint')}
           </p>
         </div>
         {fieldGroups.length > 0 && (


### PR DESCRIPTION
## Summary

Closes #1582.

Studio's object-designer **field inspector** now edits the ADR-0036 B2 conditional rules — `visibleWhen` / `readonlyWhen` / `requiredWhen` — with a proper **CEL editor** (reusing `CelPredicateField` + `celAuthoring.ts` from the RLS editor, #2413) instead of a raw text input (previously only `conditionalRequired` was surfaced, unvalidated).

### What changed

- **`scope='record'` mode** in `celAuthoring.ts` / `CelPredicateField`, matching runtime semantics (`@object-ui/core` `evalFieldPredicate` binds `record` / `previous` / `parent` only — no bare-field flattening, no `current_user`):
  - lint via `@objectstack/formula` `validateExpression` — a **bare field ref is an error** with the exact `record.<field>` fix; `record.`/`previous.` member refs get field-existence checks with did-you-mean;
  - **autocomplete**: runtime-bound roots + CEL stdlib bare, and the object's own field catalog as **member completion** after `record.` / `previous.` (new `memberTokenAt` helper; the full catalog surfaces the moment the dot is typed). The RLS editor keeps its flattened behavior and gains the same member completion.
- **Inspector wiring** (`ObjectFieldInspector`, Advanced → *Conditional rules (CEL)*): three editors with autocomplete scoped to the object's fields; values round-trip both wire shapes (bare string | `{dialect, source}` envelope — envelope extras like `meta.rationale` preserved); deprecated `conditionalRequired` reads into *Required when* and migrates to `requiredWhen` on first edit.
- **Draft-wide validation** (`validateMetadataDraft('object', …)`): every field's rules are CEL-linted, so an invalid predicate on *any* field (not just the selected one) surfaces in the edit banner under `fields.<field>.<rule>` before save — the spec Zod only shape-checks these.
- i18n (en/zh), README + `metadata-diagnostics` guide, changeset.

### Verification

- `vitest run packages/app-shell/src/views/metadata-admin` → **89 files / 715 tests green** (incl. new: record-scope lint, `memberTokenAt`, member-completion UX, inspector read/write/migration, draft-wide CEL issues vs the REAL engine).
- Browser (preview gallery, `?only=object`, no backend): bare ref → readable self-correcting error; `record.st` → *unknown field `st` on `sales_order`*; `record.` → field-catalog popup; valid predicate → *Valid CEL* affordance; edits persist into the draft via `onPatch`.
- Runtime honoring of the persisted shapes is the pre-existing B2 path (`resolveFieldRuleState`, already covered by its own tests) — this PR writes exactly the wire shapes it consumes (`string | {dialect, source}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)