### PR TITLE
feat(dashboard): dashboard-level filters (date / region) driving multiple charts

### DIFF
--- a/.changeset/dashboard-level-filters.md
+++ b/.changeset/dashboard-level-filters.md
@@ -1,0 +1,39 @@
+---
+"@object-ui/types": minor
+"@object-ui/core": minor
+"@object-ui/plugin-dashboard": minor
+"@object-ui/plugin-report": patch
+---
+
+feat(dashboard): dashboard-level filters (date / region) driving multiple charts (framework#2501)
+
+A dashboard's `dateRange` + `globalFilters` declarations are now wired end to
+end: the filter values live as dashboard-level variables (the page variables
+primitive, so they're also readable as `page.<name>` in widget expressions),
+a filter bar renders above the widgets, and at render time the dashboard
+broadcasts the active values into every bound widget's inline query —
+`AND`-merged with the widget's own `filter`. Charts stay inline and
+self-contained; each widget maps a filter to **its own** field.
+
+- **`@object-ui/types`** — `globalFilters[].name` (stable filter/variable key,
+  defaults to `field`) and `DashboardWidgetSchema.filterBindings`
+  (`Record<string, string | false>`: per-widget field override / `false`
+  opt-out). Zod mirrors included. **Pending paired `@objectstack/spec`
+  alignment (framework#2501)** — same precedent as `dataset` /
+  `categoryGranularity`.
+- **`@object-ui/core`** — new pure `dashboard-filters` module
+  (`resolveDashboardFilterDefs`, `dashboardFilterVariableDefs`,
+  `buildFilterCondition`, `buildWidgetScopedFilter`); `mergeFilters` lifted
+  from plugin-report (re-exported there unchanged). Date presets emit
+  date-macro tokens (`{30_days_ago}` …) so widgets resolve them at query time
+  like hand-authored filters.
+- **`@object-ui/plugin-dashboard`** — `DashboardFilterBar` (date presets +
+  custom range calendar, select with static `options` or `optionsFrom`,
+  text/number inputs, reset); `DashboardRenderer` mounts a
+  `PageVariablesProvider` when filters are declared and merges the
+  widget-scoped condition into inline widgets' `filter` and dataset widgets'
+  `runtimeFilter`. Dashboards without filters render exactly as before.
+
+Binding precedence: explicit `filterBindings` string/`false` → legacy
+`targetWidgets` allow-list → the filter's own `field` (dateRange defaults to
+`created_at`). Static-data widgets are not filtered.

--- a/content/docs/plugins/plugin-dashboard.mdx
+++ b/content/docs/plugins/plugin-dashboard.mdx
@@ -148,6 +148,51 @@ Object.entries(dashboardComponents).forEach(([type, component]) => {
 }
 ```
 
+## Dashboard-level filters
+
+A dashboard can declare top-level filters — a date range plus any number of
+select / text filters — whose values drive every bound widget at once. Filter
+values live as dashboard-level variables; each widget declares which of **its
+own** fields a filter binds to via `filterBindings`, and the dashboard merges
+the active values into each bound widget's inline query (`AND`-combined with
+the widget's own `filter`).
+
+```json
+{
+  "type": "dashboard",
+  "dateRange": { "field": "created_at", "defaultRange": "last_30_days", "allowCustomRange": true },
+  "globalFilters": [
+    { "name": "region", "field": "region", "label": "Region", "type": "select", "options": ["EMEA", "APAC", "AMER"] }
+  ],
+  "widgets": [
+    { "id": "w1", "type": "bar", "object": "invoices", "aggregate": "count" },
+    {
+      "id": "w2", "type": "line", "object": "accounts", "aggregate": "count",
+      "filterBindings": { "dateRange": "signed_at", "region": "sales_region" }
+    },
+    {
+      "id": "w3", "type": "metric", "object": "invoices", "aggregate": "count",
+      "filterBindings": { "region": false }
+    }
+  ]
+}
+```
+
+Binding rules, in precedence order:
+
+1. `filterBindings[name]` as a string — apply the filter to that field.
+2. `filterBindings[name]: false` — opt this widget out.
+3. Legacy `targetWidgets` on the filter — when set, only listed widget ids get
+   the default binding (an explicit `filterBindings` entry still wins).
+4. Otherwise the filter applies to its own `field` (the built-in date range
+   defaults to `dateRange.field ?? 'created_at'`).
+
+Date presets stay symbolic (date-macro tokens such as `{30_days_ago}`) until
+query time. Dataset-bound widgets receive the merged filter through the
+dataset query's `runtimeFilter`. Static-data widgets (inline `data` arrays)
+have no query to scope and are not filtered. Filter values are also readable
+in widget expressions as `page.<name>`.
+
 ## TypeScript Support
 
 ```plaintext

--- a/examples/schema-catalog/src/index.ts
+++ b/examples/schema-catalog/src/index.ts
@@ -387,6 +387,7 @@ import plugin_chatbot_chatbot_with_timestamps from './schemas/plugin-chatbot/cha
 import plugin_chatbot_customer_support_chat from './schemas/plugin-chatbot/customer-support-chat.json' with { type: 'json' };
 import plugin_dashboard_basic_dashboard from './schemas/plugin-dashboard/basic-dashboard.json' with { type: 'json' };
 import plugin_dashboard_e_commerce_dashboard from './schemas/plugin-dashboard/e-commerce-dashboard.json' with { type: 'json' };
+import plugin_dashboard_filtered_dashboard from './schemas/plugin-dashboard/filtered-dashboard.json' with { type: 'json' };
 import plugin_dashboard_support_dashboard from './schemas/plugin-dashboard/support-dashboard.json' with { type: 'json' };
 import plugin_editor_javascript_editor from './schemas/plugin-editor/javascript-editor.json' with { type: 'json' };
 import plugin_editor_python_editor from './schemas/plugin-editor/python-editor.json' with { type: 'json' };
@@ -3927,6 +3928,15 @@ const REGISTRY: Record<string, Example> = {
       category: 'plugin-dashboard',
     },
     schema: plugin_dashboard_support_dashboard,
+  },
+  'plugin-dashboard/filtered-dashboard': {
+    id: 'plugin-dashboard/filtered-dashboard',
+    meta: {
+      title: "Filtered Dashboard",
+      description: "Dashboard-level date + region filters driving multiple charts over different objects",
+      category: 'plugin-dashboard',
+    },
+    schema: plugin_dashboard_filtered_dashboard,
   },
   'plugin-editor/javascript-editor': {
     id: 'plugin-editor/javascript-editor',

--- a/examples/schema-catalog/src/schemas/plugin-dashboard/filtered-dashboard.json
+++ b/examples/schema-catalog/src/schemas/plugin-dashboard/filtered-dashboard.json
@@ -1,0 +1,53 @@
+{
+  "type": "dashboard",
+  "title": "Sales Overview",
+  "columns": 2,
+  "gap": 4,
+  "dateRange": {
+    "field": "created_at",
+    "defaultRange": "last_30_days",
+    "allowCustomRange": true
+  },
+  "globalFilters": [
+    {
+      "name": "region",
+      "field": "region",
+      "label": "Region",
+      "type": "select",
+      "options": ["EMEA", "APAC", "AMER"]
+    }
+  ],
+  "widgets": [
+    {
+      "id": "invoices_by_status",
+      "title": "Invoices by Status",
+      "type": "bar",
+      "object": "invoices",
+      "categoryField": "status",
+      "aggregate": "count"
+    },
+    {
+      "id": "accounts_signed",
+      "title": "Accounts Signed",
+      "type": "line",
+      "object": "accounts",
+      "categoryField": "signed_at",
+      "categoryGranularity": "month",
+      "aggregate": "count",
+      "filterBindings": {
+        "dateRange": "signed_at",
+        "region": "sales_region"
+      }
+    },
+    {
+      "id": "total_invoices",
+      "title": "Total Invoices (all regions)",
+      "type": "metric",
+      "object": "invoices",
+      "aggregate": "count",
+      "filterBindings": {
+        "region": false
+      }
+    }
+  ]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,8 @@ export * from './runtime/capabilities.js';
 export { composeStacks } from '@objectstack/spec';
 export * from './utils/drill-down.js';
 export * from './utils/date-macros.js';
+export * from './utils/dashboard-filters.js';
+export * from './utils/merge-filters.js';
 export * from './utils/compare-to.js';
 export * from './utils/chart-series.js';
 export * from './utils/dataset-format.js';

--- a/packages/core/src/utils/__tests__/dashboard-filters.test.ts
+++ b/packages/core/src/utils/__tests__/dashboard-filters.test.ts
@@ -1,0 +1,200 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveDashboardFilterDefs,
+  dashboardFilterVariableDefs,
+  buildFilterCondition,
+  buildWidgetScopedFilter,
+  DATE_RANGE_FILTER_NAME,
+  type DashboardFilterDef,
+} from '../dashboard-filters';
+import { mergeFilters } from '../merge-filters';
+
+const regionDef: DashboardFilterDef = {
+  name: 'region',
+  field: 'region',
+  type: 'select',
+  options: ['EMEA', 'APAC', 'AMER'],
+};
+
+const dateDef: DashboardFilterDef = {
+  name: DATE_RANGE_FILTER_NAME,
+  field: 'created_at',
+  type: 'dateRange',
+};
+
+describe('resolveDashboardFilterDefs', () => {
+  it('maps dateRange to the reserved name with a created_at field default', () => {
+    const defs = resolveDashboardFilterDefs({
+      dateRange: { defaultRange: 'last_30_days' },
+    });
+    expect(defs).toHaveLength(1);
+    expect(defs[0]).toMatchObject({
+      name: DATE_RANGE_FILTER_NAME,
+      field: 'created_at',
+      type: 'dateRange',
+      defaultValue: { preset: 'last_30_days' },
+    });
+  });
+
+  it('honors an explicit dateRange.field and skips a custom default preset', () => {
+    const defs = resolveDashboardFilterDefs({
+      dateRange: { field: 'closed_at', defaultRange: 'custom' },
+    });
+    expect(defs[0].field).toBe('closed_at');
+    expect(defs[0].defaultValue).toBeUndefined();
+  });
+
+  it('defaults a global filter name to its field and preserves declared names', () => {
+    const defs = resolveDashboardFilterDefs({
+      globalFilters: [
+        { field: 'region' },
+        { name: 'owner', field: 'owner_id', type: 'lookup' },
+      ],
+    });
+    expect(defs.map((d) => d.name)).toEqual(['region', 'owner']);
+    expect(defs[0].type).toBe('text');
+    expect(defs[1].field).toBe('owner_id');
+  });
+
+  it('skips entries without a field and lets duplicate names win last', () => {
+    const defs = resolveDashboardFilterDefs({
+      globalFilters: [
+        { field: '' } as any,
+        { name: 'region', field: 'region' },
+        { name: 'region', field: 'sales_region' },
+      ],
+    });
+    expect(defs).toHaveLength(1);
+    expect(defs[0].field).toBe('sales_region');
+  });
+});
+
+describe('dashboardFilterVariableDefs', () => {
+  it('produces page-variable definitions keyed by filter name', () => {
+    const vars = dashboardFilterVariableDefs([dateDef, regionDef]);
+    expect(vars).toEqual([
+      { name: DATE_RANGE_FILTER_NAME, type: 'object', defaultValue: undefined },
+      { name: 'region', type: 'string', defaultValue: undefined },
+    ]);
+  });
+});
+
+describe('buildFilterCondition', () => {
+  it('maps a date preset to symbolic macro-token bounds', () => {
+    expect(buildFilterCondition(dateDef, { preset: 'last_30_days' })).toEqual({
+      $gte: '{30_days_ago}',
+      $lte: '{today}',
+    });
+    expect(buildFilterCondition(dateDef, { preset: 'this_month' })).toEqual({
+      $gte: '{current_month_start}',
+      $lte: '{current_month_end}',
+    });
+  });
+
+  it('passes custom ISO bounds through and omits a missing bound', () => {
+    expect(buildFilterCondition(dateDef, { from: '2026-01-01', to: '2026-06-30' })).toEqual({
+      $gte: '2026-01-01',
+      $lte: '2026-06-30',
+    });
+    expect(buildFilterCondition(dateDef, { from: '2026-01-01' })).toEqual({
+      $gte: '2026-01-01',
+    });
+  });
+
+  it('maps select values to equality and arrays to $in', () => {
+    expect(buildFilterCondition(regionDef, 'EMEA')).toBe('EMEA');
+    expect(buildFilterCondition(regionDef, ['EMEA', 'APAC'])).toEqual({ $in: ['EMEA', 'APAC'] });
+  });
+
+  it('maps text to $contains and numbers to equality', () => {
+    expect(buildFilterCondition({ name: 'q', field: 'name', type: 'text' }, 'acme')).toEqual({
+      $contains: 'acme',
+    });
+    expect(buildFilterCondition({ name: 'n', field: 'amount', type: 'number' }, 42)).toBe(42);
+  });
+
+  it('returns undefined for empty values', () => {
+    expect(buildFilterCondition(regionDef, undefined)).toBeUndefined();
+    expect(buildFilterCondition(regionDef, '')).toBeUndefined();
+    expect(buildFilterCondition(regionDef, [])).toBeUndefined();
+    expect(buildFilterCondition(dateDef, {})).toBeUndefined();
+    expect(buildFilterCondition(dateDef, { preset: undefined })).toBeUndefined();
+  });
+});
+
+describe('buildWidgetScopedFilter', () => {
+  const defs = [dateDef, regionDef];
+
+  it('applies the default binding (the filter\'s own field)', () => {
+    const scoped = buildWidgetScopedFilter({ id: 'w1' }, defs, { region: 'EMEA' });
+    expect(scoped).toEqual({ region: 'EMEA' });
+  });
+
+  it('lets filterBindings override the target field per widget', () => {
+    const scoped = buildWidgetScopedFilter(
+      { id: 'w1', filterBindings: { dateRange: 'signed_at', region: 'sales_region' } },
+      defs,
+      { dateRange: { preset: 'last_7_days' }, region: 'APAC' },
+    );
+    expect(scoped).toEqual({
+      $and: [
+        { signed_at: { $gte: '{7_days_ago}', $lte: '{today}' } },
+        { sales_region: 'APAC' },
+      ],
+    });
+  });
+
+  it('opts a widget out with filterBindings: false', () => {
+    const scoped = buildWidgetScopedFilter(
+      { id: 'w1', filterBindings: { region: false } },
+      defs,
+      { region: 'EMEA' },
+    );
+    expect(scoped).toBeUndefined();
+  });
+
+  it('honors the legacy targetWidgets allow-list for default bindings', () => {
+    const gated: DashboardFilterDef = { ...regionDef, targetWidgets: ['w2'] };
+    expect(buildWidgetScopedFilter({ id: 'w1' }, [gated], { region: 'EMEA' })).toBeUndefined();
+    expect(buildWidgetScopedFilter({ id: 'w2' }, [gated], { region: 'EMEA' })).toEqual({
+      region: 'EMEA',
+    });
+    // Explicit binding wins over the allow-list.
+    expect(
+      buildWidgetScopedFilter({ id: 'w1', filterBindings: { region: 'area' } }, [gated], {
+        region: 'EMEA',
+      }),
+    ).toEqual({ area: 'EMEA' });
+  });
+
+  it('combines several active filters with $and and returns undefined when none apply', () => {
+    const scoped = buildWidgetScopedFilter({ id: 'w1' }, defs, {
+      dateRange: { preset: 'today' },
+      region: 'EMEA',
+    });
+    expect(scoped).toEqual({
+      $and: [
+        { created_at: { $gte: '{today}', $lte: '{today}' } },
+        { region: 'EMEA' },
+      ],
+    });
+    expect(buildWidgetScopedFilter({ id: 'w1' }, defs, {})).toBeUndefined();
+  });
+});
+
+describe('mergeFilters', () => {
+  it('ANDs two non-empty filters, passes single ones through, drops empties', () => {
+    expect(mergeFilters({ a: 1 }, { b: 2 })).toEqual({ $and: [{ a: 1 }, { b: 2 }] });
+    expect(mergeFilters({ a: 1 }, undefined)).toEqual({ a: 1 });
+    expect(mergeFilters(undefined, { b: 2 })).toEqual({ b: 2 });
+    expect(mergeFilters({}, undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/dashboard-filters.ts
+++ b/packages/core/src/utils/dashboard-filters.ts
@@ -1,0 +1,242 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Dashboard-level filter resolution (framework#2501).
+ *
+ * A dashboard declares top-level filters (`globalFilters` + the built-in
+ * `dateRange`). Their values live as dashboard-level variables; each widget
+ * may declare which of ITS OWN fields a filter binds to via
+ * `filterBindings`. At render time the dashboard broadcasts the filter
+ * values into each bound widget's inline query by merging a widget-scoped
+ * `FilterCondition` into the widget's own `filter`.
+ *
+ * Everything in this module is pure and synchronous so the binding rules
+ * are unit-testable in isolation from React and the data layer.
+ */
+
+import type { DashboardSchema, DashboardWidgetSchema, PageVariable } from '@object-ui/types';
+
+/** Reserved filter name for the dashboard's built-in date range. */
+export const DATE_RANGE_FILTER_NAME = 'dateRange';
+
+/** Default target field for the built-in date range filter. */
+const DATE_RANGE_DEFAULT_FIELD = 'created_at';
+
+export interface DashboardFilterDef {
+  /** Stable name — the variable key and the key widgets bind against. */
+  name: string;
+  /** Default target field when a widget declares no explicit binding. */
+  field: string;
+  label?: string;
+  type: 'text' | 'select' | 'date' | 'number' | 'lookup' | 'dateRange';
+  options?: string[];
+  optionsFrom?: {
+    object: string;
+    valueField: string;
+    labelField?: string;
+    filter?: any;
+  };
+  defaultValue?: any;
+  /** Legacy widget-id allow-list; ignored when a widget binds explicitly. */
+  targetWidgets?: string[];
+  /** dateRange only — whether the UI offers a custom from/to picker. */
+  allowCustomRange?: boolean;
+}
+
+/** Value shape held by a `dateRange`-typed filter variable. */
+export interface DateRangeValue {
+  /** One of the `DashboardSchema.dateRange.defaultRange` presets. */
+  preset?: string;
+  /** Custom range bounds as ISO dates (either bound may be omitted). */
+  from?: string;
+  to?: string;
+}
+
+/**
+ * Date-range presets → date-macro token bounds. Tokens stay symbolic in the
+ * generated condition; every widget renderer resolves them at query time via
+ * `resolveDateMacros`, exactly like hand-authored widget filters.
+ */
+const PRESET_RANGES: Record<string, { from?: string; to?: string }> = {
+  today: { from: '{today}', to: '{today}' },
+  yesterday: { from: '{yesterday}', to: '{yesterday}' },
+  this_week: { from: '{current_week_start}', to: '{current_week_end}' },
+  last_week: { from: '{last_week_start}', to: '{last_week_end}' },
+  this_month: { from: '{current_month_start}', to: '{current_month_end}' },
+  last_month: { from: '{last_month_start}', to: '{last_month_end}' },
+  this_quarter: { from: '{current_quarter_start}', to: '{current_quarter_end}' },
+  last_quarter: { from: '{last_quarter_start}', to: '{last_quarter_end}' },
+  this_year: { from: '{current_year_start}', to: '{current_year_end}' },
+  last_year: { from: '{last_year_start}', to: '{last_year_end}' },
+  last_7_days: { from: '{7_days_ago}', to: '{today}' },
+  last_30_days: { from: '{30_days_ago}', to: '{today}' },
+  last_90_days: { from: '{90_days_ago}', to: '{today}' },
+};
+
+/** Preset keys the filter bar offers, in display order. */
+export const DATE_RANGE_PRESETS = Object.keys(PRESET_RANGES);
+
+/**
+ * Normalize a dashboard schema's filter declarations into a flat list of
+ * filter definitions. The built-in `dateRange` (when declared) comes first
+ * under the reserved name `"dateRange"`; each `globalFilters` entry follows,
+ * named by its `name` (defaulting to `field`). Later duplicates win.
+ */
+export function resolveDashboardFilterDefs(
+  schema: Pick<DashboardSchema, 'globalFilters' | 'dateRange'>,
+): DashboardFilterDef[] {
+  const byName = new Map<string, DashboardFilterDef>();
+
+  if (schema.dateRange) {
+    const preset = schema.dateRange.defaultRange;
+    byName.set(DATE_RANGE_FILTER_NAME, {
+      name: DATE_RANGE_FILTER_NAME,
+      field: schema.dateRange.field || DATE_RANGE_DEFAULT_FIELD,
+      type: 'dateRange',
+      // 'custom' has no bounds of its own — start empty and let the user pick.
+      defaultValue: preset && preset !== 'custom' ? { preset } : undefined,
+      allowCustomRange: schema.dateRange.allowCustomRange,
+    });
+  }
+
+  for (const f of schema.globalFilters ?? []) {
+    if (!f?.field) continue;
+    const name = f.name || f.field;
+    if (byName.has(name) && typeof console !== 'undefined') {
+      console.warn(`[dashboard-filters] duplicate filter name "${name}" — the later definition wins`);
+    }
+    byName.set(name, {
+      name,
+      field: f.field,
+      label: f.label,
+      type: f.type ?? 'text',
+      options: f.options,
+      optionsFrom: f.optionsFrom,
+      defaultValue: f.defaultValue,
+      targetWidgets: f.targetWidgets,
+    });
+  }
+
+  return Array.from(byName.values());
+}
+
+/**
+ * Derive `PageVariable` definitions for a dashboard's filter values so the
+ * dashboard can host them in a `PageVariablesProvider` (the page/dashboard
+ * variables primitive). Filter values are then also readable in widget
+ * expressions as `page.<name>`.
+ */
+export function dashboardFilterVariableDefs(defs: DashboardFilterDef[]): PageVariable[] {
+  return defs.map((def) => ({
+    name: def.name,
+    type: def.type === 'dateRange' ? 'object' : 'string',
+    defaultValue: def.defaultValue,
+  }));
+}
+
+/** True when a filter value carries no constraint. */
+function isEmptyValue(def: DashboardFilterDef, value: unknown): boolean {
+  if (value === undefined || value === null || value === '') return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (def.type === 'dateRange' || def.type === 'date') {
+    const v = value as DateRangeValue;
+    if (typeof v !== 'object') return false;
+    return !v.preset && !v.from && !v.to;
+  }
+  if (typeof value === 'object') return Object.keys(value as object).length === 0;
+  return false;
+}
+
+/**
+ * Build the operator shape (the value side of a `FilterCondition` entry) for
+ * one filter's current value. Returns `undefined` when the value imposes no
+ * constraint. The caller keys the result by the bound field name.
+ */
+export function buildFilterCondition(
+  def: DashboardFilterDef,
+  value: unknown,
+): Record<string, unknown> | unknown | undefined {
+  if (isEmptyValue(def, value)) return undefined;
+
+  if (def.type === 'dateRange' || def.type === 'date') {
+    const v = value as DateRangeValue;
+    if (typeof v === 'object') {
+      const range = v.preset ? PRESET_RANGES[v.preset] : undefined;
+      const from = range?.from ?? v.from;
+      const to = range?.to ?? v.to;
+      if (!from && !to) return undefined;
+      return {
+        ...(from ? { $gte: from } : {}),
+        ...(to ? { $lte: to } : {}),
+      };
+    }
+    // A bare string date means equality on that day.
+    return value;
+  }
+
+  if (def.type === 'select' || def.type === 'lookup') {
+    return Array.isArray(value) ? { $in: value } : value;
+  }
+
+  if (def.type === 'text') {
+    return { $contains: value };
+  }
+
+  // number and anything else: equality.
+  return value;
+}
+
+/**
+ * Resolve which of the widget's fields a filter binds to.
+ * Returns `undefined` when the widget is not bound to this filter.
+ *
+ * Precedence: explicit `filterBindings` entry (string overrides the field,
+ * `false` opts out — both win over everything) → legacy `targetWidgets`
+ * allow-list → the filter's own default `field`.
+ */
+function resolveBoundField(
+  widget: Pick<DashboardWidgetSchema, 'id' | 'filterBindings'>,
+  def: DashboardFilterDef,
+): string | undefined {
+  const binding = widget.filterBindings?.[def.name];
+  if (binding === false) return undefined;
+  if (typeof binding === 'string' && binding) return binding;
+  if (def.targetWidgets && def.targetWidgets.length > 0) {
+    if (!widget.id || !def.targetWidgets.includes(widget.id)) return undefined;
+  }
+  return def.field;
+}
+
+/**
+ * Compute the widget-scoped `FilterCondition` for the current filter values:
+ * one `{ [boundField]: condition }` entry per active, bound filter, combined
+ * with `$and` when several apply. Returns `undefined` when nothing applies —
+ * callers then leave the widget's own filter untouched.
+ */
+export function buildWidgetScopedFilter(
+  widget: Pick<DashboardWidgetSchema, 'id' | 'filterBindings'>,
+  defs: DashboardFilterDef[],
+  values: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const conditions: Record<string, unknown>[] = [];
+
+  for (const def of defs) {
+    const value = values[def.name];
+    if (isEmptyValue(def, value)) continue;
+    const field = resolveBoundField(widget, def);
+    if (!field) continue;
+    const condition = buildFilterCondition(def, value);
+    if (condition === undefined) continue;
+    conditions.push({ [field]: condition });
+  }
+
+  if (conditions.length === 0) return undefined;
+  if (conditions.length === 1) return conditions[0];
+  return { $and: conditions };
+}

--- a/packages/core/src/utils/merge-filters.ts
+++ b/packages/core/src/utils/merge-filters.ts
@@ -1,0 +1,27 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Combine two `FilterCondition` objects via `$and`, dropping empty ones.
+ *
+ * The scope-filter combinator shared by the dataset report path and the
+ * dashboard filter broadcast: a widget's own `runtimeFilter`/`filter` is
+ * intersected with a host-supplied runtime filter. Returns `undefined` when
+ * nothing meaningful remains so callers can omit the key entirely.
+ */
+export function mergeFilters(
+  a: Record<string, unknown> | undefined,
+  b: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const hasA = a && Object.keys(a).length > 0;
+  const hasB = b && Object.keys(b).length > 0;
+  if (hasA && hasB) return { $and: [a, b] };
+  if (hasA) return a;
+  if (hasB) return b;
+  return undefined;
+}

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -195,6 +195,71 @@ const schema = {
 };
 ```
 
+## Dashboard-level filters
+
+A dashboard can declare top-level filters — a date range and any number of
+select / text filters — whose values drive **every bound widget at once**.
+The filter values live as dashboard-level variables (the page/dashboard
+variables primitive), and each widget declares which of **its own** fields a
+filter binds to. At render time the dashboard merges the active filter values
+into each bound widget's inline query (`AND`-combined with the widget's own
+`filter`).
+
+```jsonc
+{
+  "type": "dashboard",
+  "dateRange": {
+    "field": "created_at",          // default binding target
+    "defaultRange": "last_30_days", // today | this_week | … | last_90_days | custom
+    "allowCustomRange": true        // offer a custom from/to calendar
+  },
+  "globalFilters": [
+    {
+      "name": "region",             // stable filter name (defaults to field)
+      "field": "region",            // default binding target
+      "label": "Region",
+      "type": "select",             // text | select | date | number | lookup
+      "options": ["EMEA", "APAC", "AMER"]
+      // or dynamic: "optionsFrom": { "object": "accounts", "valueField": "region" }
+    }
+  ],
+  "widgets": [
+    // Default binding: the filter's own `field` (dateRange → created_at).
+    { "id": "w1", "type": "bar", "object": "invoices", "aggregate": "count" },
+    // Explicit binding: map each filter to THIS widget's own field.
+    {
+      "id": "w2", "type": "line", "object": "accounts", "aggregate": "count",
+      "filterBindings": { "dateRange": "signed_at", "region": "sales_region" }
+    },
+    // Opt out of a filter with `false`.
+    {
+      "id": "w3", "type": "metric", "object": "invoices", "aggregate": "count",
+      "filterBindings": { "region": false }
+    }
+  ]
+}
+```
+
+Binding rules, in precedence order:
+
+1. `filterBindings[name]` as a string — apply the filter to that field.
+2. `filterBindings[name]: false` — opt this widget out.
+3. Legacy `targetWidgets` on the filter — when set, only listed widget ids
+   get the default binding (an explicit `filterBindings` entry still wins).
+4. Otherwise the filter applies to its own `field` (the built-in date range
+   defaults to `dateRange.field ?? 'created_at'`).
+
+Notes:
+
+- Date presets stay symbolic (`{30_days_ago}` … date-macro tokens) until
+  query time, so widgets resolve them exactly like hand-authored filters.
+- Dataset-bound widgets receive the merged filter through the dataset
+  query's `runtimeFilter`.
+- Static-data widgets (inline `data` arrays) have no query to scope and are
+  not filtered.
+- Filter values are also readable in widget expressions as `page.<name>`
+  (e.g. `page.region`), since they are hosted as dashboard variables.
+
 ## TypeScript Support
 
 ```typescript

--- a/packages/plugin-dashboard/src/DashboardFilterBar.tsx
+++ b/packages/plugin-dashboard/src/DashboardFilterBar.tsx
@@ -1,0 +1,258 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Dashboard-level filter bar (framework#2501).
+ *
+ * Renders one control per dashboard filter definition — a preset/custom date
+ * range for the built-in `dateRange`, a Select for `select`/`lookup` filters,
+ * and an Input for `text`/`number` — writing each value into the dashboard's
+ * filter variables via `onChange`. The host (`DashboardRenderer`) broadcasts
+ * those values into every bound widget's inline query.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  cn,
+  Button,
+  Calendar,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@object-ui/components';
+import { CalendarIcon, RotateCcw } from 'lucide-react';
+import { useSafeTranslate } from '@object-ui/i18n';
+import {
+  DATE_RANGE_PRESETS,
+  type DashboardFilterDef,
+  type DateRangeValue,
+} from '@object-ui/core';
+
+/** Sentinel for the Select's clear item (Radix Select forbids empty values). */
+const ALL_VALUE = '__all__';
+/** Sentinel for the date-range Select's "Custom…" item. */
+const CUSTOM_VALUE = '__custom__';
+
+export interface DashboardFilterBarProps {
+  defs: DashboardFilterDef[];
+  values: Record<string, any>;
+  onChange: (name: string, value: any) => void;
+  onReset?: () => void;
+  dataSource?: any;
+  className?: string;
+}
+
+/** Format an ISO date (or macro token) for the trigger label. */
+function rangeLabel(value: DateRangeValue | undefined, presetLabel: (p: string) => string): string | undefined {
+  if (!value) return undefined;
+  if (value.preset) return presetLabel(value.preset);
+  if (value.from || value.to) return `${value.from ?? '…'} – ${value.to ?? '…'}`;
+  return undefined;
+}
+
+function toIsoDate(d: Date): string {
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function DateRangeFilter({ def, value, onChange }: { def: DashboardFilterDef; value: DateRangeValue | undefined; onChange: (v: DateRangeValue | undefined) => void }) {
+  const tt = useSafeTranslate();
+  const [customOpen, setCustomOpen] = useState(false);
+  const allowCustom = def.allowCustomRange !== false;
+  const presetLabel = (p: string) => tt(`dashboard.filters.range.${p}`, p.replace(/_/g, ' '));
+
+  const selectValue = value?.preset ?? (value?.from || value?.to ? CUSTOM_VALUE : ALL_VALUE);
+
+  return (
+    <div className="flex items-center gap-1" data-testid={`dashboard-filter-${def.name}`}>
+      <Select
+        value={selectValue}
+        onValueChange={(v) => {
+          if (v === ALL_VALUE) onChange(undefined);
+          else if (v === CUSTOM_VALUE) setCustomOpen(true);
+          else onChange({ preset: v });
+        }}
+      >
+        <SelectTrigger className="h-8 w-auto min-w-36 gap-1" aria-label={def.label || tt('dashboard.filters.dateRange', 'Date range')}>
+          <CalendarIcon className="size-3.5 opacity-60" />
+          <SelectValue placeholder={tt('dashboard.filters.dateRange', 'Date range')}>
+            {rangeLabel(value, presetLabel) ?? tt('dashboard.filters.allTime', 'All time')}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_VALUE}>{tt('dashboard.filters.allTime', 'All time')}</SelectItem>
+          {DATE_RANGE_PRESETS.map((p) => (
+            <SelectItem key={p} value={p}>{presetLabel(p)}</SelectItem>
+          ))}
+          {allowCustom && (
+            <SelectItem value={CUSTOM_VALUE}>{tt('dashboard.filters.custom', 'Custom…')}</SelectItem>
+          )}
+        </SelectContent>
+      </Select>
+      {allowCustom && (
+        <Popover open={customOpen} onOpenChange={setCustomOpen}>
+          {/* Invisible anchor — the popover is driven by the "Custom…" select item. */}
+          <PopoverTrigger asChild>
+            <span aria-hidden className="size-0" />
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="range"
+              numberOfMonths={2}
+              selected={{
+                from: value?.from && !value.from.startsWith('{') ? new Date(value.from) : undefined,
+                to: value?.to && !value.to.startsWith('{') ? new Date(value.to) : undefined,
+              }}
+              onSelect={(range: any) => {
+                if (!range?.from && !range?.to) { onChange(undefined); return; }
+                onChange({
+                  ...(range?.from ? { from: toIsoDate(range.from) } : {}),
+                  ...(range?.to ? { to: toIsoDate(range.to) } : {}),
+                });
+              }}
+            />
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}
+
+function SelectFilter({ def, value, onChange, dataSource }: { def: DashboardFilterDef; value: string | undefined; onChange: (v: string | undefined) => void; dataSource?: any }) {
+  const tt = useSafeTranslate();
+  const [dynamicOptions, setDynamicOptions] = useState<Array<{ value: string; label: string }> | null>(null);
+
+  // Best-effort dynamic options: fetch once, dedupe client-side, degrade to
+  // an empty list on failure (same tolerance style as DatasetWidget's
+  // option-color fetch).
+  const from = def.optionsFrom;
+  useEffect(() => {
+    if (!from || !dataSource || typeof dataSource.find !== 'function') return;
+    let cancelled = false;
+    dataSource
+      .find(from.object, {
+        fields: [from.valueField, ...(from.labelField ? [from.labelField] : [])],
+        ...(from.filter ? { $filter: from.filter } : {}),
+        top: 200,
+      })
+      .then((records: any) => {
+        if (cancelled) return;
+        const rows: any[] = Array.isArray(records) ? records : records?.items ?? [];
+        const seen = new Map<string, string>();
+        for (const r of rows) {
+          const v = r?.[from.valueField];
+          if (v === undefined || v === null || v === '') continue;
+          const key = String(v);
+          if (!seen.has(key)) seen.set(key, String(from.labelField ? r?.[from.labelField] ?? key : key));
+        }
+        setDynamicOptions(Array.from(seen, ([v, l]) => ({ value: v, label: l })));
+      })
+      .catch(() => { if (!cancelled) setDynamicOptions([]); });
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [from?.object, from?.valueField, from?.labelField, dataSource]);
+
+  const options = useMemo(() => {
+    if (def.options?.length) return def.options.map((o) => ({ value: o, label: o }));
+    return dynamicOptions ?? [];
+  }, [def.options, dynamicOptions]);
+
+  const label = def.label || def.name;
+  return (
+    <Select
+      // The variables provider initializes string variables to '' — treat
+      // any falsy value as "no selection".
+      value={value ? String(value) : ALL_VALUE}
+      onValueChange={(v) => onChange(v === ALL_VALUE ? undefined : v)}
+    >
+      <SelectTrigger className="h-8 w-auto min-w-32" aria-label={label} data-testid={`dashboard-filter-${def.name}`}>
+        <SelectValue>{value ? String(value) : `${label}: ${tt('dashboard.filters.all', 'All')}`}</SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={ALL_VALUE}>{tt('dashboard.filters.all', 'All')}</SelectItem>
+        {options.map((o) => (
+          <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function TextFilter({ def, value, onChange }: { def: DashboardFilterDef; value: any; onChange: (v: any) => void }) {
+  const [draft, setDraft] = useState<string>(value == null ? '' : String(value));
+  useEffect(() => { setDraft(value == null ? '' : String(value)); }, [value]);
+  const commit = () => {
+    const v = draft.trim();
+    if (v === '') { onChange(undefined); return; }
+    onChange(def.type === 'number' ? Number(v) : v);
+  };
+  return (
+    <Input
+      className="h-8 w-36"
+      type={def.type === 'number' ? 'number' : 'text'}
+      placeholder={def.label || def.name}
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => { if (e.key === 'Enter') commit(); }}
+      aria-label={def.label || def.name}
+      data-testid={`dashboard-filter-${def.name}`}
+    />
+  );
+}
+
+export function DashboardFilterBar({ defs, values, onChange, onReset, dataSource, className }: DashboardFilterBarProps) {
+  const tt = useSafeTranslate();
+  if (defs.length === 0) return null;
+
+  // The variables provider initializes undefined defaults to '' / {} by
+  // type — normalize those to "empty" so a pristine bar shows no Reset.
+  const isEmpty = (v: any) =>
+    v == null || v === '' || (typeof v === 'object' && Object.keys(v).length === 0);
+  const isDirty = defs.some((def) => {
+    const a = values[def.name];
+    const b = def.defaultValue;
+    if (isEmpty(a) && isEmpty(b)) return false;
+    return JSON.stringify(a ?? null) !== JSON.stringify(b ?? null);
+  });
+
+  return (
+    <div
+      className={cn('col-span-full flex flex-wrap items-center gap-2', className)}
+      data-testid="dashboard-filter-bar"
+      role="group"
+      aria-label={tt('dashboard.filters.label', 'Dashboard filters')}
+    >
+      {defs.map((def) => {
+        const value = values[def.name];
+        const set = (v: any) => onChange(def.name, v);
+        if (def.type === 'dateRange' || def.type === 'date') {
+          return <DateRangeFilter key={def.name} def={def} value={value} onChange={set} />;
+        }
+        if (def.type === 'select' || def.type === 'lookup') {
+          return <SelectFilter key={def.name} def={def} value={value} onChange={set} dataSource={dataSource} />;
+        }
+        return <TextFilter key={def.name} def={def} value={value} onChange={set} />;
+      })}
+      {onReset && isDirty && (
+        <Button variant="ghost" size="sm" onClick={onReset} className="text-muted-foreground">
+          <RotateCcw className="size-3.5" />
+          {tt('dashboard.filters.reset', 'Reset')}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -7,9 +7,15 @@
  */
 
 import type { DashboardSchema, DashboardWidgetSchema } from '@object-ui/types';
-import { SchemaRenderer, useActionEngine, useObjectLabel } from '@object-ui/react';
+import { SchemaRenderer, useActionEngine, useObjectLabel, PageVariablesProvider, usePageVariables } from '@object-ui/react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import type { ActionDef, ActionResult, ActionContext, ModalHandler } from '@object-ui/core';
+import {
+  resolveDashboardFilterDefs,
+  dashboardFilterVariableDefs,
+  buildWidgetScopedFilter,
+  mergeFilters,
+} from '@object-ui/core';
 import { cn, Card, CardHeader, CardTitle, CardContent, Button, getLazyIcon } from '@object-ui/components';
 import { forwardRef, useState, useEffect, useCallback, useMemo, useRef, Fragment } from 'react';
 import { RefreshCw } from 'lucide-react';
@@ -31,6 +37,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { isObjectProvider } from './utils';
 import { DatasetWidget } from './DatasetWidget';
+import { DashboardFilterBar } from './DashboardFilterBar';
 
 interface SortableWidgetWrapperProps {
   id: string;
@@ -168,6 +175,19 @@ function defaultChartDrill(chartType: string): { enabled: true } | undefined {
   return DRILLABLE_CHART_TYPES.has(chartType) ? { enabled: true } : undefined;
 }
 
+/**
+ * Object-backed child schema types whose `filter` reaches the data source —
+ * the injection surface for dashboard-level filters. Static-data widgets
+ * (`chart`, `data-table`, `pivot` with inline `data`) have no query to scope
+ * and are intentionally not filtered.
+ */
+const FILTERABLE_COMPONENT_TYPES = new Set([
+  'object-chart',
+  'object-metric',
+  'object-data-table',
+  'object-pivot',
+]);
+
 export interface DashboardRendererProps {
   schema: DashboardSchema;
   className?: string;
@@ -204,7 +224,7 @@ export interface DashboardRendererProps {
   [key: string]: any;
 }
 
-export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererProps>(
+const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps>(
   ({ schema, className, dataSource, onRefresh, recordCount, userActions, designMode, selectedWidgetId, onWidgetClick, onWidgetsReorder, modalHandler, scriptHandlers, hideHeaderText, ...props }, ref) => {
     // Auto-infer the grid column count when the dashboard schema doesn't
     // specify one. Spec convention is a 12-column grid (widgets use w: 3 for
@@ -232,6 +252,18 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
     const [refreshing, setRefreshing] = useState(false);
     const [isMobile, setIsMobile] = useState(false);
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    // Dashboard-level filters (framework#2501). Filter values live as
+    // dashboard variables — the outer DashboardRenderer mounts a
+    // PageVariablesProvider when the schema declares filters, so
+    // usePageVariables() resolves them here (and gracefully no-ops when the
+    // dashboard has no filters and no provider is mounted).
+    const filterDefs = useMemo(
+      () => resolveDashboardFilterDefs(schema),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [schema.globalFilters, schema.dateRange]
+    );
+    const { variables: filterValues, setVariable: setFilterValue, resetVariables: resetFilterValues } = usePageVariables();
 
     // Build ActionDef[] from header actions so useActionEngine can dispatch by name.
     const headerActionDefs = useMemo<ActionDef[]>(() => {
@@ -792,7 +824,26 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
             };
         };
         
-        const componentSchema = getComponentSchema();
+        // Broadcast the dashboard filter values into this widget's inline
+        // query: resolve the widget-scoped condition from the bindings and
+        // AND-merge it with the widget's own filter. Object-backed child
+        // schemas re-fetch on filter change, so no widget renderer changes
+        // are needed downstream.
+        const scopedFilter = filterDefs.length > 0
+            ? buildWidgetScopedFilter(widget, filterDefs, filterValues)
+            : undefined;
+        const componentSchema = (() => {
+            const cs = getComponentSchema() as Record<string, any>;
+            if (scopedFilter && cs && FILTERABLE_COMPONENT_TYPES.has(cs.type)) {
+                return { ...cs, filter: mergeFilters(cs.filter, scopedFilter) };
+            }
+            return cs;
+        })();
+        // Dataset-bound widgets render through DatasetWidget, which forwards
+        // `widget.filter` to the dataset query as `runtimeFilter`.
+        const effectiveWidget = scopedFilter && datasetBound
+            ? { ...widget, filter: mergeFilters(widget.filter, scopedFilter) }
+            : widget;
         // A `metric` widget renders its own card chrome ONLY in the inline
         // (object-metric) path. A dataset-bound metric uses DatasetWidget, which
         // renders just the value — so it must take the shared Card wrapper to get
@@ -837,7 +888,7 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                 {...designModeProps}
             >
                  {datasetBound
-                   ? <div className={cn("h-full w-full", designMode && "pointer-events-none")}><DatasetWidget widget={widget} dataSource={dataSource} /></div>
+                   ? <div className={cn("h-full w-full", designMode && "pointer-events-none")}><DatasetWidget widget={effectiveWidget} dataSource={dataSource} /></div>
                    : <SchemaRenderer schema={componentSchema} className={cn("h-full w-full", designMode && "pointer-events-none")} dataSource={dataSource} />}
                  {designMode && <div className="absolute inset-0 z-10" aria-hidden="true" data-testid="widget-click-overlay" />}
             </div>
@@ -866,7 +917,7 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
                 <CardContent className="p-0">
                     <div className={cn("h-full w-full", "p-3 sm:p-4 md:p-6", designMode && "pointer-events-none")}>
                         {datasetBound
-                          ? <DatasetWidget widget={widget} dataSource={dataSource} />
+                          ? <DatasetWidget widget={effectiveWidget} dataSource={dataSource} />
                           : <SchemaRenderer schema={componentSchema} dataSource={dataSource} />}
                     </div>
                 </CardContent>
@@ -944,6 +995,17 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
       </div>
     );
 
+    const filterBar = filterDefs.length > 0 && (
+      <DashboardFilterBar
+        defs={filterDefs}
+        values={filterValues}
+        onChange={setFilterValue}
+        onReset={resetFilterValues}
+        dataSource={dataSource}
+        className="mb-2"
+      />
+    );
+
     const recordCountBadge = recordCount !== undefined && (
       <span className="text-xs text-muted-foreground">
         {recordCount.toLocaleString()} records
@@ -991,6 +1053,7 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
       const mobileBody = (
         <div ref={ref} className={cn("flex flex-col gap-4 px-4", className)} data-user-actions={userActionsAttr} onClick={handleBackgroundClick} {...props}>
           {headerSection}
+          {filterBar}
           {refreshButton}
 
           {/* Metric cards: 2-column grid */}
@@ -1048,6 +1111,7 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
         {...props}
       >
         {headerSection}
+        {filterBar}
         {refreshButton}
         <SortableContext items={widgetIds} strategy={rectSortingStrategy} disabled={!dragEnabled}>
           {schema.widgets?.map((widget: DashboardWidgetSchema, index: number) => renderWidget(widget, index))}
@@ -1062,3 +1126,40 @@ export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererPro
     ) : desktopBody;
   }
 );
+
+DashboardRendererInner.displayName = 'DashboardRendererInner';
+
+/**
+ * DashboardRenderer — the public dashboard renderer.
+ *
+ * When the schema declares dashboard-level filters (`globalFilters` /
+ * `dateRange`, framework#2501), their values are hosted as dashboard
+ * variables in a `PageVariablesProvider` (the page/dashboard variables
+ * primitive) so the filter bar can write them, the widget broadcast can read
+ * them, and widget expressions can reference them as `page.<name>`.
+ * Dashboards without filters render exactly as before — no provider mounted.
+ *
+ * Known limitation: when a filtered dashboard is embedded inside a Page with
+ * its own variables, this inner provider shadows the outer one for widget
+ * subtrees. The primary path (`DashboardView`) mounts no outer provider.
+ */
+export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererProps>(
+  (props, ref) => {
+    const { schema } = props;
+    const filterDefs = useMemo(
+      () => resolveDashboardFilterDefs(schema),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [schema.globalFilters, schema.dateRange]
+    );
+    if (filterDefs.length === 0) {
+      return <DashboardRendererInner ref={ref} {...props} />;
+    }
+    return (
+      <PageVariablesProvider definitions={dashboardFilterVariableDefs(filterDefs)}>
+        <DashboardRendererInner ref={ref} {...props} />
+      </PageVariablesProvider>
+    );
+  }
+);
+
+DashboardRenderer.displayName = 'DashboardRenderer';

--- a/packages/plugin-dashboard/src/__tests__/DashboardRenderer.filters.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardRenderer.filters.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Dashboard-level filter broadcast (framework#2501).
+ *
+ * The widget child components (`object-chart`, …) are stubbed in the REAL
+ * component registry so the real SchemaRenderer resolves them and each stub
+ * surfaces its resolved `filter` as a DOM attribute — the page-variables
+ * provider, filter bar, binding resolution, and $and merge all run for real.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import type { DashboardSchema } from '@object-ui/types';
+import { ComponentRegistry } from '@object-ui/core';
+import { DashboardRenderer } from '../DashboardRenderer';
+
+const FilterProbe = ({ schema }: { schema: any }) => (
+  <div
+    data-testid={`widget-schema-${schema?.objectName ?? schema?.type}`}
+    data-filter={JSON.stringify(schema?.filter ?? null)}
+  />
+);
+ComponentRegistry.register('object-chart', FilterProbe);
+ComponentRegistry.register('object-metric', FilterProbe);
+
+afterEach(cleanup);
+
+const widgetFilter = (objectName: string) => {
+  const el = screen.getByTestId(`widget-schema-${objectName}`);
+  return JSON.parse(el.getAttribute('data-filter')!);
+};
+
+describe('DashboardRenderer dashboard-level filters', () => {
+  it('renders no filter bar when the schema declares no filters', () => {
+    const schema: DashboardSchema = {
+      type: 'dashboard',
+      widgets: [{ id: 'w1', type: 'bar', object: 'invoices', aggregate: 'count' }],
+    };
+    render(<DashboardRenderer schema={schema} />);
+    expect(screen.queryByTestId('dashboard-filter-bar')).not.toBeInTheDocument();
+    expect(widgetFilter('invoices')).toBeNull();
+  });
+
+  it('broadcasts the default date range into each widget via its own bound field', () => {
+    const schema: DashboardSchema = {
+      type: 'dashboard',
+      dateRange: { field: 'created_at', defaultRange: 'last_30_days', allowCustomRange: true },
+      widgets: [
+        // Default binding → dateRange.field (created_at).
+        { id: 'w1', type: 'bar', object: 'invoices', aggregate: 'count' },
+        // Explicit per-widget override → this widget's own field.
+        { id: 'w2', type: 'line', object: 'accounts', aggregate: 'count', filterBindings: { dateRange: 'signed_at' } },
+      ],
+    };
+    render(<DashboardRenderer schema={schema} />);
+
+    expect(screen.getByTestId('dashboard-filter-bar')).toBeInTheDocument();
+    expect(widgetFilter('invoices')).toEqual({
+      created_at: { $gte: '{30_days_ago}', $lte: '{today}' },
+    });
+    expect(widgetFilter('accounts')).toEqual({
+      signed_at: { $gte: '{30_days_ago}', $lte: '{today}' },
+    });
+  });
+
+  it('merges the broadcast with a widget\'s own filter and honors opt-out', () => {
+    const schema: DashboardSchema = {
+      type: 'dashboard',
+      globalFilters: [
+        { name: 'region', field: 'region', type: 'select', options: ['EMEA', 'APAC'], defaultValue: 'EMEA' },
+      ],
+      widgets: [
+        { id: 'w1', type: 'bar', object: 'invoices', aggregate: 'count', filter: { status: 'paid' } },
+        { id: 'w2', type: 'pie', object: 'accounts', aggregate: 'count', filterBindings: { region: false } },
+      ],
+    };
+    render(<DashboardRenderer schema={schema} />);
+
+    // Widget filter AND dashboard filter.
+    expect(widgetFilter('invoices')).toEqual({
+      $and: [{ status: 'paid' }, { region: 'EMEA' }],
+    });
+    // Opted out — own (absent) filter untouched.
+    expect(widgetFilter('accounts')).toBeNull();
+  });
+
+  it('re-scopes all bound widgets live when a filter value changes', async () => {
+    const schema: DashboardSchema = {
+      type: 'dashboard',
+      globalFilters: [{ name: 'q', field: 'name', type: 'text', label: 'Search' }],
+      widgets: [
+        { id: 'w1', type: 'bar', object: 'invoices', aggregate: 'count' },
+        { id: 'w2', type: 'line', object: 'accounts', aggregate: 'count', filterBindings: { q: 'title' } },
+      ],
+    };
+    render(<DashboardRenderer schema={schema} />);
+
+    expect(widgetFilter('invoices')).toBeNull();
+
+    const input = screen.getByTestId('dashboard-filter-q');
+    fireEvent.change(input, { target: { value: 'acme' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(widgetFilter('invoices')).toEqual({ name: { $contains: 'acme' } });
+      expect(widgetFilter('accounts')).toEqual({ title: { $contains: 'acme' } });
+    });
+
+    // Clearing the value removes the broadcast again.
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(widgetFilter('invoices')).toBeNull();
+      expect(widgetFilter('accounts')).toBeNull();
+    });
+  });
+
+  it('injects the merged filter into a dataset widget\'s runtimeFilter', async () => {
+    const queryDataset = vi.fn(async () => ({ rows: [{ revenue: 1 }] }));
+    const schema: DashboardSchema = {
+      type: 'dashboard',
+      globalFilters: [
+        { name: 'region', field: 'region', type: 'select', options: ['EMEA'], defaultValue: 'EMEA' },
+      ],
+      widgets: [
+        { id: 'w1', type: 'metric', dataset: 'sales', values: ['revenue'], filter: { stage: 'won' } } as any,
+      ],
+    };
+    render(<DashboardRenderer schema={schema} dataSource={{ queryDataset }} />);
+
+    await waitFor(() => {
+      expect(queryDataset).toHaveBeenCalledWith('sales', expect.objectContaining({
+        runtimeFilter: { $and: [{ stage: 'won' }, { region: 'EMEA' }] },
+      }));
+    });
+  });
+});

--- a/packages/plugin-report/src/mergeFilters.ts
+++ b/packages/plugin-report/src/mergeFilters.ts
@@ -3,23 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-/**
- * Combine two `FilterCondition` objects via `$and`, dropping empty ones.
- *
- * The scope-filter combinator shared by the dataset report path: a report's
- * own `runtimeFilter`/`filter` is intersected with a host-supplied runtime
- * filter (and, for joined reports, the container filter is folded into every
- * block). Returns `undefined` when nothing meaningful remains so callers can
- * omit the key entirely.
- */
-export function mergeFilters(
-  a: Record<string, unknown> | undefined,
-  b: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
-  const hasA = a && Object.keys(a).length > 0;
-  const hasB = b && Object.keys(b).length > 0;
-  if (hasA && hasB) return { $and: [a, b] };
-  if (hasA) return a;
-  if (hasB) return b;
-  return undefined;
-}
+// Lifted to @object-ui/core so the dashboard filter broadcast (framework#2501)
+// can share the same scope-filter combinator. Re-exported here to keep the
+// plugin-report public surface unchanged.
+export { mergeFilters } from '@object-ui/core';

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -743,6 +743,18 @@ export interface DashboardWidgetSchema {
    */
   pagination?: boolean;
   /**
+   * Per-widget bindings from a dashboard-level filter (referenced by its
+   * `name`, or the reserved name `"dateRange"` for the built-in date range)
+   * to one of THIS widget's fields:
+   * - string → apply the filter to that field (e.g. `{ dateRange: 'signed_at' }`)
+   * - false  → opt this widget out of that filter
+   * - absent → default binding: the filter's own `field`
+   *   (dateRange: `dateRange.field ?? 'created_at'`)
+   * Pending alignment with @objectstack/spec DashboardWidgetSchema
+   * (framework#2501).
+   */
+  filterBindings?: Record<string, string | false>;
+  /**
    * ARIA accessibility attributes.
    * Aligned with @objectstack/spec AriaPropsSchema.
    */
@@ -785,6 +797,13 @@ export interface DashboardSchema extends BaseSchema {
    * Aligned with @objectstack/spec GlobalFilterSchema.
    */
   globalFilters?: Array<{
+    /**
+     * Stable filter name used as the dashboard-variable key and as the key
+     * widgets reference in `filterBindings`. Defaults to `field`.
+     * Pending alignment with @objectstack/spec GlobalFilterSchema
+     * (framework#2501).
+     */
+    name?: string;
     field: string;
     label?: string;
     type?: 'text' | 'select' | 'date' | 'number' | 'lookup';

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -284,6 +284,29 @@ export const DashboardWidgetSchema = z.object({
   layout: DashboardWidgetLayoutSchema.optional().describe('Widget Layout'),
   type: z.string().optional().describe('Widget visualization type (spec shorthand)'),
   options: z.unknown().optional().describe('Widget specific configuration (spec shorthand)'),
+  filterBindings: z.record(z.string(), z.union([z.string(), z.literal(false)])).optional()
+    .describe('Per-widget dashboard-filter bindings: filter name → this widget\'s field, or false to opt out'),
+});
+
+/**
+ * Global Filter Schema — a dashboard-level filter definition.
+ * Pending alignment with @objectstack/spec GlobalFilterSchema (framework#2501: `name`).
+ */
+export const GlobalFilterSchema = z.object({
+  name: z.string().optional().describe('Stable filter name (variable key); defaults to field'),
+  field: z.string().describe('Default target field'),
+  label: z.string().optional().describe('Display label'),
+  type: z.enum(['text', 'select', 'date', 'number', 'lookup']).optional().describe('Filter control type'),
+  options: z.array(z.string()).optional().describe('Static options for select filters'),
+  optionsFrom: z.object({
+    object: z.string(),
+    valueField: z.string(),
+    labelField: z.string().optional(),
+    filter: z.any().optional(),
+  }).optional().describe('Dynamic option source'),
+  defaultValue: z.any().optional().describe('Initial value'),
+  scope: z.string().optional().describe('Filter scope'),
+  targetWidgets: z.array(z.string()).optional().describe('Widget-id allow-list'),
 });
 
 /**
@@ -294,6 +317,12 @@ export const DashboardSchema = BaseSchema.extend({
   columns: z.number().optional().describe('Number of columns'),
   gap: z.number().optional().describe('Grid gap'),
   widgets: z.array(DashboardWidgetSchema).describe('Dashboard widgets'),
+  globalFilters: z.array(GlobalFilterSchema).optional().describe('Dashboard-level filters'),
+  dateRange: z.object({
+    field: z.string().optional(),
+    defaultRange: z.string().optional(),
+    allowCustomRange: z.boolean().optional(),
+  }).optional().describe('Built-in date range filter'),
 });
 
 /**


### PR DESCRIPTION
Implements objectstack-ai/framework#2501 (objectui side).

## What

A dashboard's top-level filters (date range + select/text filters) now **drive every bound widget at once**. The schema vocabulary (`DashboardSchema.globalFilters` / `dateRange`) existed but was inert — the runtime renderer never read it. This PR wires it end to end, following the design agreed in the issue:

- **Filter values are dashboard-level variables** — `DashboardRenderer` mounts a `PageVariablesProvider` (the existing page/dashboard variables primitive) when filters are declared, so values are also readable in widget expressions as `page.<name>`. Dashboards without filters render exactly as before (no provider, byte-identical child schemas).
- **Each chart declares which of its own fields a filter binds to** — new `DashboardWidgetSchema.filterBindings: Record<string, string | false>` (e.g. the invoice chart maps `dateRange → created_at`, the account chart maps `dateRange → signed_at`; `false` opts out). Default binding is the filter's own `field`; the legacy `targetWidgets` allow-list is honored.
- **Runtime broadcast** — the widget-scoped condition is AND-merged (`mergeFilters`, lifted from plugin-report into core) into each inline widget's `filter` at the single `getComponentSchema()` seam, and into dataset widgets' `runtimeFilter`. Downstream widget renderers needed zero changes — they already refetch on filter change.
- **Date presets stay symbolic** (`{30_days_ago}` … date-macro tokens) until query time, resolved by the widgets' existing `resolveDateMacros` path; custom calendar ranges emit concrete ISO dates.

## Changes

- `@object-ui/types`: `globalFilters[].name` (stable filter/variable key, defaults to `field`) + `DashboardWidgetSchema.filterBindings`; zod mirrors. **Pending paired `@objectstack/spec` alignment (framework#2501)** — flagged in JSDoc + changeset, same precedent as `dataset` / `categoryGranularity`.
- `@object-ui/core`: new pure `dashboard-filters` module (`resolveDashboardFilterDefs`, `dashboardFilterVariableDefs`, `buildFilterCondition`, `buildWidgetScopedFilter`); `merge-filters` lifted from plugin-report (re-exported there unchanged).
- `@object-ui/plugin-dashboard`: new `DashboardFilterBar` (date presets + custom range calendar, select with static `options` / dynamic `optionsFrom`, text/number inputs, reset); `DashboardRenderer` provider split + broadcast merge.
- Example: `schema-catalog` `plugin-dashboard/filtered-dashboard` — date + region filters driving 2 charts over **different objects** with different bound fields, plus an opt-out metric (the issue's acceptance scenario).
- Docs: `plugin-dashboard` README + `content/docs/plugins/plugin-dashboard.mdx`; changeset (minor types/core/plugin-dashboard, patch plugin-report).

## Verification

- New tests: **16 core unit tests** (defs resolution, condition building incl. macro tokens, binding precedence, `$and` merge) + **5 renderer tests** (filter bar presence, default + per-widget-field broadcast, own-filter merge + opt-out, live re-scope on filter change, dataset `runtimeFilter` injection).
- Touched-package suites: **360 passed** (core/plugin-dashboard/plugin-report) + **171 passed** (types).
- `pnpm type-check` (turbo): all tasks pass except a **pre-existing** `@object-ui/data-objectstack` failure on `main` (`exportDownload.test.ts(74)`), untouched by this PR.

## Notes / follow-ups

- Paired `@objectstack/spec` PR needed in the framework repo (`GlobalFilterSchema.name`, `DashboardWidgetSchema.filterBindings`).
- Studio/designer binding editor UI is a follow-up; the metadata-admin inspector derives from the spec and picks the new props up automatically once the spec lands.
- Known limitation (documented): a filtered dashboard embedded in a Page with its own variables shadows the outer provider for widget subtrees; the primary `DashboardView` path has no outer provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U25wX5Ja3oS4dMyVHMnRsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01U25wX5Ja3oS4dMyVHMnRsK)_