### PR TITLE
fix(data-objectstack): emit mutation events from batchTransaction/bulk so related lists refresh after master-detail saves (#2582)

### DIFF
--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -954,7 +954,26 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         response.status,
       );
     }
-    return response.json();
+    const payload = (await response.json()) as { results?: any[] };
+    // The transaction committed — surface every op as a normal mutation event,
+    // exactly as the per-record create/update/delete methods do. Master-detail
+    // saves go through here (parent + children in ONE /batch call), and without
+    // these events the invalidation bridge (objectui#2269) never hears about
+    // the write: related lists and count badges on the parent's detail page
+    // stayed stale until a full page reload.
+    const results = Array.isArray(payload?.results) ? payload.results : [];
+    operations.forEach((op, i) => {
+      const type = op.action ?? 'create';
+      const record = results[i];
+      const id = op.id ?? (record != null && typeof record === 'object' ? (record.id ?? record._id) : undefined);
+      this.emitMutation({
+        type,
+        resource: op.object,
+        ...(type !== 'delete' && record != null && typeof record === 'object' ? { record: { ...record } } : {}),
+        ...(id != null ? { id } : {}),
+      } as MutationEvent<T>);
+    });
+    return payload as { results: any[] };
   }
 
   async bulk(resource: string, operation: 'create' | 'update' | 'delete', data: Partial<T>[]): Promise<T[]> {
@@ -986,6 +1005,9 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
           completed = created.length;
           failed = total - completed;
           emitProgress();
+          // One resource-scoped event per bulk call (mirrors bulkUpdate /
+          // bulkDelete) so onMutation readers refresh after bulk writes too.
+          if (completed > 0) this.emitMutation({ type: 'create', resource });
           return created;
         }
         
@@ -1010,6 +1032,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
           completed = ids.length;
           failed = total - completed;
           emitProgress();
+          if (completed > 0) this.emitMutation({ type: 'delete', resource });
           return [] as T[];
         }
         
@@ -1025,6 +1048,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
               completed = updated.length;
               failed = total - completed;
               emitProgress();
+              if (completed > 0) this.emitMutation({ type: 'update', resource });
               return updated;
             } catch {
               // If updateMany is not supported, fall back to individual updates
@@ -1060,6 +1084,9 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
             }
           }
           
+          // Partial successes DID mutate data — notify before surfacing errors.
+          if (completed > 0) this.emitMutation({ type: 'update', resource });
+
           // If there were any errors, throw BulkOperationError
           if (errors.length > 0) {
             throw new BulkOperationError(
@@ -1070,7 +1097,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
               { resource, totalRecords: data.length }
             );
           }
-          
+
           return results;
         }
         

--- a/packages/data-objectstack/src/onMutation.test.ts
+++ b/packages/data-objectstack/src/onMutation.test.ts
@@ -112,6 +112,121 @@ describe('ObjectStackAdapter.onMutation', () => {
     expect(events).toEqual([]);
   });
 
+  it('emits one event per operation after a committed batchTransaction (master-detail save)', async () => {
+    // Regression (related-list stale after ModalForm create): MasterDetailForm
+    // persists parent + children through ONE `/api/v1/batch` transaction, so
+    // no per-record create/update/delete ever runs. batchTransaction must emit
+    // the equivalent mutation events itself, or the invalidation bridge
+    // (objectui#2269) never fires and the parent detail page's related lists +
+    // count badges stay stale until a full reload.
+    const ds = makeDS({});
+    const batchFetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          results: [
+            { id: 'parent-1', name: 'P' },
+            { id: 'child-1', parent: 'parent-1' },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', batchFetch);
+    try {
+      const events: MutationEvent[] = [];
+      ds.onMutation((e: MutationEvent) => events.push(e));
+
+      const res = await ds.batchTransaction([
+        { object: 'parent_obj', action: 'create', data: { name: 'P' } },
+        { object: 'child_obj', action: 'create', data: { parent: { $ref: 0 } } },
+      ]);
+
+      expect(res.results).toHaveLength(2);
+      expect(events).toEqual([
+        { type: 'create', resource: 'parent_obj', id: 'parent-1', record: { id: 'parent-1', name: 'P' } },
+        { type: 'create', resource: 'child_obj', id: 'child-1', record: { id: 'child-1', parent: 'parent-1' } },
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('emits update/delete events for the edit-mode batch (diffed child ops)', async () => {
+    const ds = makeDS({});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ results: [{ id: 'parent-1' }, { id: 'child-1' }, null] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    try {
+      const events: MutationEvent[] = [];
+      ds.onMutation((e: MutationEvent) => events.push(e));
+
+      await ds.batchTransaction([
+        { object: 'parent_obj', action: 'update', id: 'parent-1', data: { name: 'P2' } },
+        { object: 'child_obj', action: 'update', id: 'child-1', data: { qty: 2 } },
+        { object: 'child_obj', action: 'delete', id: 'child-2' },
+      ]);
+
+      expect(events).toEqual([
+        { type: 'update', resource: 'parent_obj', id: 'parent-1', record: { id: 'parent-1' } },
+        { type: 'update', resource: 'child_obj', id: 'child-1', record: { id: 'child-1' } },
+        { type: 'delete', resource: 'child_obj', id: 'child-2' },
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('does not emit when batchTransaction fails', async () => {
+    const ds = makeDS({});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ error: 'rolled back' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    try {
+      const events: MutationEvent[] = [];
+      ds.onMutation((e: MutationEvent) => events.push(e));
+
+      await expect(ds.batchTransaction([{ object: 'parent_obj', action: 'create', data: {} }]))
+        .rejects.toThrow('rolled back');
+      expect(events).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('emits a single resource-scoped create event per bulk create call', async () => {
+    const createMany = vi.fn().mockResolvedValue([{ id: 'a' }, { id: 'b' }]);
+    const ds = makeDS({ createMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.bulk('child_obj', 'create', [{ name: 'A' }, { name: 'B' }]);
+
+    expect(events).toEqual([{ type: 'create', resource: 'child_obj' }]);
+  });
+
+  it('emits a single delete event per bulk delete call', async () => {
+    const deleteMany = vi.fn().mockResolvedValue(undefined);
+    const ds = makeDS({ deleteMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.bulk('child_obj', 'delete', [{ id: 'a' }, { id: 'b' }]);
+
+    expect(events).toEqual([{ type: 'delete', resource: 'child_obj' }]);
+  });
+
   it('isolates a throwing listener so the mutation still resolves and others fire', async () => {
     const update = vi.fn().mockResolvedValue({ record: { id: 'r1' } });
     const ds = makeDS({ update });


### PR DESCRIPTION
Fixes #2582

## 问题

带子表单的对象在相关列表经 ModalForm 新建/编辑成功后,相关列表行、区块计数、「相关」tab 徽章全部不刷新,必须整页刷新。

## 根因

MasterDetailForm 把父+子行打包成一个 `/api/v1/batch` 事务提交,而 `ObjectStackAdapter.batchTransaction` 从不 `emitMutation`,#2269 失效总线(`onMutation` → `notifyDataChanged`)对整次写入无感知。`bulk()`(applyDetail 回退路径)同样只发进度事件不发 MutationEvent。

## 改动

- `batchTransaction`:事务提交成功后按每个 op 补发 MutationEvent(create 从服务端回显的 `results` 取 id/record;失败回滚时一条不发)
- `bulk()`:create/delete/update 三分支各补发一条 resource 级事件,对齐既有 `bulkUpdate`/`bulkDelete`
- `onMutation.test.ts`:新增 5 个回归测试(batch 新建 op 逐条发、编辑 batch 的 update/delete、失败不发、bulk create/delete 各一条)

## 验证

- `vitest run packages/data-objectstack`:15 文件 167 测试全过(其中 onMutation 11 个)
- tsc `--noEmit` 错误数改动前后一致(9 个,均为预先存在于 exportDownload.test.ts,与本改动无关)
- 真机:tianshun-ehr 真实 metadata(`objectstack dev --fresh` :3000 + console dev :5180),任务版本 detail → 任务检查项 新建/编辑——toast 弹出的同时列表行、区块计数 (1)→(2)、相关 tab 徽章 1→2 全部即时更新,零刷新;修复前同一操作稳定复现「toast 成功但列表纹丝不动」