### PR TITLE
fix(data-objectstack): emit MutationEvents from batchTransaction and bulk so master-detail ModalForm saves refresh related lists (#2582)

### DIFF
--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -936,7 +936,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     operations: Array<{ object: string; action?: 'create' | 'update' | 'delete'; data?: any; id?: string }>,
   ): Promise<{ results: any[] }> {
     const url = `${this.baseUrl}/api/v1/batch`;
-    const response = await fetch(url, {
+    const response = await this.fetchImpl(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...this.getAuthHeaders() },
       // Send the session cookie too: in the browser console auth is cookie-based
@@ -954,7 +954,27 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         response.status,
       );
     }
-    return response.json();
+    const payload: { results: any[] } = await response.json();
+    // The whole transaction committed — emit one MutationEvent per operation so
+    // the invalidation bus (#2269) sees writes that went through /batch exactly
+    // like single create/update/delete calls (master-detail ModalForm saves
+    // otherwise leave related lists and count badges stale, #2582). `results`
+    // is index-aligned with `operations`; creates take id/record from the
+    // server echo. A failed batch rolled back entirely and throws above, so
+    // nothing is emitted for it.
+    const results = Array.isArray(payload?.results) ? payload.results : [];
+    operations.forEach((op, i) => {
+      const action = op.action ?? 'create';
+      const echo = results[i];
+      if (action === 'create') {
+        this.emitMutation({ type: 'create', resource: op.object, record: echo });
+      } else if (action === 'update') {
+        this.emitMutation({ type: 'update', resource: op.object, id: op.id ?? echo?.id ?? echo?._id, record: echo });
+      } else if (action === 'delete') {
+        this.emitMutation({ type: 'delete', resource: op.object, id: op.id });
+      }
+    });
+    return payload;
   }
 
   async bulk(resource: string, operation: 'create' | 'update' | 'delete', data: Partial<T>[]): Promise<T[]> {
@@ -986,6 +1006,10 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
           completed = created.length;
           failed = total - completed;
           emitProgress();
+          // One resource-level event for the whole batch (same contract as
+          // bulkUpdate/bulkDelete) so bound views refresh after subform child
+          // rows are created through this path (#2582).
+          if (completed > 0) this.emitMutation({ type: 'create', resource });
           return created;
         }
         
@@ -1010,6 +1034,8 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
           completed = ids.length;
           failed = total - completed;
           emitProgress();
+          // One resource-level event per batch — see the create branch.
+          if (completed > 0) this.emitMutation({ type: 'delete', resource });
           return [] as T[];
         }
         
@@ -1025,6 +1051,8 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
               completed = updated.length;
               failed = total - completed;
               emitProgress();
+              // One resource-level event per batch — see the create branch.
+              if (completed > 0) this.emitMutation({ type: 'update', resource });
               return updated;
             } catch {
               // If updateMany is not supported, fall back to individual updates
@@ -1060,6 +1088,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
             }
           }
           
+          // Rows that DID persist must still reach subscribers, even when the
+          // batch as a whole reports failure below (continueOnError semantics
+          // — the successful writes are not rolled back).
+          if (completed > 0) this.emitMutation({ type: 'update', resource });
+
           // If there were any errors, throw BulkOperationError
           if (errors.length > 0) {
             throw new BulkOperationError(
@@ -1070,7 +1103,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
               { resource, totalRecords: data.length }
             );
           }
-          
+
           return results;
         }
         

--- a/packages/data-objectstack/src/onMutation.test.ts
+++ b/packages/data-objectstack/src/onMutation.test.ts
@@ -123,3 +123,175 @@ describe('ObjectStackAdapter.onMutation', () => {
     expect(good).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * Regression for #2582: a ModalForm over an object WITH subforms delegates to
+ * MasterDetailForm, which persists parent + child rows through ONE
+ * `batchTransaction` (`POST /api/v1/batch`). That path never emitted
+ * MutationEvents, so the related list and the "相关" tab count badge stayed
+ * stale after a successful create/edit until a full page reload. The adapter
+ * must emit one event per committed operation — and nothing when the
+ * transaction failed (it rolled back entirely).
+ */
+describe('ObjectStackAdapter.batchTransaction mutation events', () => {
+  function makeBatchDS(responder: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+    const ds: any = new ObjectStackAdapter({
+      baseUrl: 'http://test.local',
+      fetch: vi.fn(responder),
+    });
+    ds.connected = true;
+    ds.connectionState = 'connected';
+    return ds;
+  }
+
+  it('emits one event per op after a committed master-detail CREATE batch', async () => {
+    const ds = makeBatchDS(async () =>
+      new Response(
+        JSON.stringify({
+          results: [
+            { id: 'p1', name: 'Task version A' },
+            { id: 'c1', task: 'p1', label: 'Check item 1' },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.batchTransaction([
+      { object: 'ehr_task_version', action: 'create', data: { name: 'Task version A' } },
+      { object: 'ehr_task_check_item', action: 'create', data: { task: { $ref: 0 }, label: 'Check item 1' } },
+    ]);
+
+    expect(events).toEqual([
+      { type: 'create', resource: 'ehr_task_version', record: { id: 'p1', name: 'Task version A' } },
+      { type: 'create', resource: 'ehr_task_check_item', record: { id: 'c1', task: 'p1', label: 'Check item 1' } },
+    ]);
+  });
+
+  it('emits update/create/delete events after a committed master-detail EDIT batch', async () => {
+    const ds = makeBatchDS(async () =>
+      new Response(
+        JSON.stringify({
+          results: [{ id: 'p1' }, { id: 'c-new' }, { id: 'c1' }, { deleted: true }],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.batchTransaction([
+      { object: 'ehr_task_version', action: 'update', id: 'p1', data: { name: 'Renamed' } },
+      { object: 'ehr_task_check_item', action: 'create', data: { task: 'p1' } },
+      { object: 'ehr_task_check_item', action: 'update', id: 'c1', data: { label: 'Edited' } },
+      { object: 'ehr_task_check_item', action: 'delete', id: 'c2' },
+    ]);
+
+    expect(events).toEqual([
+      { type: 'update', resource: 'ehr_task_version', id: 'p1', record: { id: 'p1' } },
+      { type: 'create', resource: 'ehr_task_check_item', record: { id: 'c-new' } },
+      { type: 'update', resource: 'ehr_task_check_item', id: 'c1', record: { id: 'c1' } },
+      { type: 'delete', resource: 'ehr_task_check_item', id: 'c2' },
+    ]);
+  });
+
+  it('treats an op without an explicit action as a create (the server default)', async () => {
+    const ds = makeBatchDS(async () =>
+      new Response(JSON.stringify({ results: [{ id: 'p1' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.batchTransaction([{ object: 'ehr_task_version', data: { name: 'X' } }]);
+
+    expect(events).toEqual([
+      { type: 'create', resource: 'ehr_task_version', record: { id: 'p1' } },
+    ]);
+  });
+
+  it('emits NOTHING when the batch failed — the transaction rolled back', async () => {
+    const ds = makeBatchDS(async () =>
+      new Response(JSON.stringify({ error: 'validation failed' }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await expect(
+      ds.batchTransaction([{ object: 'ehr_task_version', action: 'create', data: {} }]),
+    ).rejects.toThrow('validation failed');
+
+    expect(events).toEqual([]);
+  });
+});
+
+/**
+ * Regression for #2582 (fallback path): when the server lacks the transactional
+ * batch endpoint, MasterDetailForm persists child rows via `bulk(child,
+ * 'create', rows)` (applyDetail → createMany). `bulk` only emitted progress
+ * events, so those writes were equally invisible to the invalidation bus. Each
+ * branch now emits ONE resource-level event, matching bulkUpdate/bulkDelete.
+ */
+describe('ObjectStackAdapter.bulk mutation events', () => {
+  it('emits a single create event per bulk create call', async () => {
+    const createMany = vi.fn().mockResolvedValue([{ id: 'c1' }, { id: 'c2' }]);
+    const ds = makeDS({ createMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.bulk('ehr_task_check_item', 'create', [{ label: 'a' }, { label: 'b' }]);
+
+    expect(events).toEqual([{ type: 'create', resource: 'ehr_task_check_item' }]);
+  });
+
+  it('does not emit when a bulk create returned zero records', async () => {
+    const createMany = vi.fn().mockResolvedValue([]);
+    const ds = makeDS({ createMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.bulk('ehr_task_check_item', 'create', [{ label: 'a' }]);
+
+    expect(events).toEqual([]);
+  });
+
+  it('emits a single delete event per bulk delete call', async () => {
+    const deleteMany = vi.fn().mockResolvedValue(undefined);
+    const ds = makeDS({ deleteMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.bulk('ehr_task_check_item', 'delete', [{ id: 'c1' }, { id: 'c2' }] as any);
+
+    expect(events).toEqual([{ type: 'delete', resource: 'ehr_task_check_item' }]);
+  });
+
+  it('emits a single update event per bulk update call', async () => {
+    const updateMany = vi.fn().mockResolvedValue([{ id: 'c1' }]);
+    const ds = makeDS({ updateMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await ds.bulk('ehr_task_check_item', 'update', [{ id: 'c1', label: 'x' }] as any);
+
+    expect(events).toEqual([{ type: 'update', resource: 'ehr_task_check_item' }]);
+  });
+
+  it('bulk create failure emits nothing', async () => {
+    const createMany = vi.fn().mockRejectedValue(new Error('boom'));
+    const ds = makeDS({ createMany });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    await expect(ds.bulk('ehr_task_check_item', 'create', [{ label: 'a' }])).rejects.toThrow();
+
+    expect(events).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #2582.

## 问题

记录详情页「相关」tab 中,带子表单的子对象经 ModalForm 新建/编辑成功后,相关列表行与计数徽章不刷新,必须整页刷新。

根因:带子表单的表单由 ModalForm 委托给 MasterDetailForm,后者把父记录 + 子行打包成一个 `POST /api/v1/batch` 事务提交(`canBatch` 分支)。而 `ObjectStackAdapter.batchTransaction` 从不调用 `emitMutation` —— 单条 `create`/`update`/`delete` 都会发,唯独 batch 不发,#2269 失效总线(`onMutation` → `notifyDataChanged`)对整次写入一无所知。`bulk()`(`applyDetail` 回退路径给子行创建用)同样只发进度事件,不发 MutationEvent。

## 修复(全部在 `@object-ui/data-objectstack` 适配器层)

- **`batchTransaction`**:事务提交成功后按每个 op 补发一条 MutationEvent —— create 用与 ops 索引对齐的服务端回显 `results[i]` 取 record;update 带 `id` + record;delete 带 `id`。失败时整个事务已回滚、抛错在前,一条不发。
- **`bulk()`**:create / delete / update 三分支各补发一条 resource 级事件(不带 id),对齐既有 `bulkUpdate`/`bulkDelete` 的"每批一条"契约。update 回退路径在部分成功时也会发(成功的行不会被回滚)。
- 顺手把 `batchTransaction` 的裸 `fetch` 换成 `this.fetchImpl`,与适配器内其余原始 HTTP 调用一致,同时使其可注入测试。

事件只需 `resource`(+ 可选 `id`)即可驱动失效总线:`useMutationInvalidationBridge` 只读这两个字段。

## 测试

`packages/data-objectstack/src/onMutation.test.ts` 新增 9 个回归用例:

- batch 主从**新建**:每 op 一条事件,create 取服务端回显
- batch 主从**编辑**:update/create/update/delete 四条事件按序发出
- op 缺省 `action` 视为 create(与服务端默认一致)
- batch **失败**(非 2xx):抛错且一条不发
- bulk create / delete / update 各发一条 resource 级事件
- bulk create 零行、bulk 失败:不发

`data-objectstack` 全部 171 个测试通过;MasterDetailForm / masterDetailTx / subformHosts 共 30 个测试通过;turbo build 通过。ESLint 仅存量告警(错误均在本次未触及的行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHhyf56Z69KNL6aCAsQfKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHhyf56Z69KNL6aCAsQfKQ)_