### PR TITLE
feat(fields+form+detail): file/image upload cells in inline line-item grids (#2360)

### DIFF
--- a/.changeset/field-file-inline-grid-2360.md
+++ b/.changeset/field-file-inline-grid-2360.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/fields": minor
+"@object-ui/plugin-form": minor
+"@object-ui/plugin-detail": minor
+---
+
+feat(fields+form+detail): file/image uploads in inline line-item grids (#2360)
+
+`Field.file` in a master-detail inline grid previously degraded to a plain text
+input (no `input[type=file]` on the page → no way to upload from the grid), and
+auto-derived subform / related-list columns silently dropped file fields.
+
+- **fields**: new `FileCell` — a compact upload control for grid cells (upload
+  button + removable chips, image thumbnails), sharing the `UploadProvider`
+  pipeline with the full-size `FileField` via an extracted `useFileUploads`
+  hook. `GridField` supports `type: 'file'` columns (with `accept` /
+  `multiple`), renders file names in list/readonly modes, and no longer falls
+  back to a text `<Input>` for file columns.
+- **plugin-form**: `deriveColumns` / `hydrateColumns` no longer exclude
+  `file`/`image`/`avatar` fields — they map to `file` columns and carry the
+  field's `multiple` + `accept` (image fields default to `['image/*']`).
+- **plugin-detail**: auto-derived related-list columns no longer skip
+  `file`/`image` fields — they render through the existing FileCellRenderer /
+  ImageCellRenderer (file-name chip / thumbnail).

--- a/content/docs/fields/grid.mdx
+++ b/content/docs/fields/grid.mdx
@@ -58,9 +58,26 @@ columns: [
   { name: 'price', label: 'Price', type: 'currency', currency: 'USD' },
   { name: 'date', label: 'Date', type: 'date' },
   { name: 'status', label: 'Status', type: 'select', options: [...] },
-  { name: 'active', label: 'Active', type: 'boolean' }
+  { name: 'active', label: 'Active', type: 'boolean' },
+  { name: 'receipt', label: 'Receipt', type: 'file', accept: ['image/*', '.pdf'] }
 ]
 ```
+
+### File / image columns
+
+A `file` column renders a real upload control inside the cell — a compact
+"Upload" button that opens the native file picker, with uploaded files shown
+as removable chips (image files show a thumbnail). This covers the common
+"attach a receipt per expense line" pattern without opening the per-row form.
+
+- `accept?: string[]` — restrict the picker (e.g. `['image/*', '.pdf']`).
+- `multiple?: boolean` — allow several files per cell.
+- Uploads go through the configured `UploadProvider` adapter, exactly like the
+  full-size file field.
+
+When grid columns are auto-derived from a child object's schema (master-detail
+subforms), `file` / `image` / `avatar` fields map to `file` columns
+automatically — image-flavoured fields default to `accept: ['image/*']`.
 
 ## Data Format
 

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -55,6 +55,17 @@ Supported types out of the box:
 - **Media**: `file`, `image`
 - **System**: `formula`, `summary`, `auto_number`
 
+### File uploads in line-item grids
+
+`GridField` (the master-detail line-items grid) supports `type: 'file'` columns:
+the cell renders a compact upload button plus removable file chips (thumbnails
+for images) instead of degrading to a text input, so users can attach a receipt
+or photo per row without opening the row form (objectui#2360). Columns accept
+`accept?: string[]` and `multiple?: boolean`; uploads run through the same
+`UploadProvider` pipeline as the full-size `FileField` (the compact control is
+exported as `FileCell`). Auto-derived subform columns map `file`/`image`/
+`avatar` fields to file columns instead of dropping them.
+
 ### Cascading & role-gated select options
 
 `select` options support a per-option `visibleWhen` CEL predicate (offered only

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -5,38 +5,23 @@ import { Upload, X, File as FileIcon, ImageIcon, Camera, Loader2 } from 'lucide-
 import { FieldWidgetProps } from './types';
 
 /**
- * FileField - File upload widget with drag-and-drop support
- * Supports single and multiple file uploads with configurable accepted file types.
- * L2: File size validation, per-file progress indicators, error messages.
+ * Shared upload pipeline for the file widgets: validates size, uploads through
+ * the configured UploadProvider adapter (with progress), and merges results
+ * into the field value — append for `multiple`, replace otherwise. Extracted so
+ * the full-size FileField and the compact grid-cell {@link FileCell} stay
+ * behaviourally identical (same value shape, same error handling).
  */
-export function FileField({ value, onChange, field, readonly, ...props }: FieldWidgetProps<any>) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const cameraRef = useRef<HTMLInputElement>(null);
-  const fileField = (field || (props as any).schema) as any;
-  const multiple = fileField?.multiple || false;
-  const accept = fileField?.accept ? fileField.accept.join(',') : undefined;
-  const maxSize = fileField?.maxSize as number | undefined; // bytes
-  /**
-   * Camera capture mode for mobile devices.
-   * - `'environment'` (back camera): photos of receipts, documents, products
-   * - `'user'` (front camera): selfies, profile pictures
-   * - `false`: disable the camera button entirely
-   * @default 'environment' when accept includes image/* on a touch device
-   */
-  const captureMode = (fileField?.capture ?? null) as 'environment' | 'user' | false | null;
-  const acceptsImages = !accept || accept.split(',').some((t: string) =>
-    t.trim().startsWith('image/') || t.trim() === 'image/*' || t.trim().startsWith('.jp') || t.trim().startsWith('.png') || t.trim().startsWith('.gif') || t.trim().startsWith('.webp'),
-  );
-  // Auto-enable camera button on touch devices when image upload is permitted, unless explicitly disabled.
-  const isTouchDevice = typeof navigator !== 'undefined' && (navigator.maxTouchPoints > 0 || /Mobi|Android/i.test(navigator.userAgent));
-  const cameraEnabled = captureMode === false ? false : (captureMode ?? (acceptsImages && isTouchDevice ? 'environment' : null));
-  const [isDragOver, setIsDragOver] = useState(false);
-  const [errors, setErrors] = useState<string[]>([]);
+function useFileUploads(opts: {
+  files: any[];
+  multiple: boolean;
+  maxSize?: number;
+  onChange: (value: any) => void;
+}) {
+  const { files, multiple, maxSize, onChange } = opts;
   const { upload } = useUpload();
+  const [errors, setErrors] = useState<string[]>([]);
   const [uploadProgress, setUploadProgress] = useState<Record<string, number>>({});
   const [uploading, setUploading] = useState(false);
-
-  const files = value ? (Array.isArray(value) ? value : [value]) : [];
 
   const processFiles = useCallback(async (selectedFiles: File[]) => {
     if (selectedFiles.length === 0) return;
@@ -90,6 +75,42 @@ export function FileField({ value, onChange, field, readonly, ...props }: FieldW
       setUploadProgress({});
     }
   }, [files, multiple, onChange, maxSize, upload]);
+
+  return { processFiles, errors, uploading, uploadProgress };
+}
+
+/**
+ * FileField - File upload widget with drag-and-drop support
+ * Supports single and multiple file uploads with configurable accepted file types.
+ * L2: File size validation, per-file progress indicators, error messages.
+ */
+export function FileField({ value, onChange, field, readonly, ...props }: FieldWidgetProps<any>) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cameraRef = useRef<HTMLInputElement>(null);
+  const fileField = (field || (props as any).schema) as any;
+  const multiple = fileField?.multiple || false;
+  const accept = fileField?.accept ? fileField.accept.join(',') : undefined;
+  const maxSize = fileField?.maxSize as number | undefined; // bytes
+  /**
+   * Camera capture mode for mobile devices.
+   * - `'environment'` (back camera): photos of receipts, documents, products
+   * - `'user'` (front camera): selfies, profile pictures
+   * - `false`: disable the camera button entirely
+   * @default 'environment' when accept includes image/* on a touch device
+   */
+  const captureMode = (fileField?.capture ?? null) as 'environment' | 'user' | false | null;
+  const acceptsImages = !accept || accept.split(',').some((t: string) =>
+    t.trim().startsWith('image/') || t.trim() === 'image/*' || t.trim().startsWith('.jp') || t.trim().startsWith('.png') || t.trim().startsWith('.gif') || t.trim().startsWith('.webp'),
+  );
+  // Auto-enable camera button on touch devices when image upload is permitted, unless explicitly disabled.
+  const isTouchDevice = typeof navigator !== 'undefined' && (navigator.maxTouchPoints > 0 || /Mobi|Android/i.test(navigator.userAgent));
+  const cameraEnabled = captureMode === false ? false : (captureMode ?? (acceptsImages && isTouchDevice ? 'environment' : null));
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const files = value ? (Array.isArray(value) ? value : [value]) : [];
+  const { processFiles, errors, uploading, uploadProgress } = useFileUploads({
+    files, multiple, maxSize, onChange,
+  });
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -298,6 +319,127 @@ export function FileField({ value, onChange, field, readonly, ...props }: FieldW
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * FileCell — compact upload control for a line-item grid cell (objectui#2360).
+ *
+ * Same value shape and upload pipeline as {@link FileField}, sized for a 32px
+ * grid row: existing files render as removable chips (image thumbnail / file
+ * icon + name) and a small button opens the native file picker. No
+ * drag-and-drop zone — a grid cell has no room for one; the per-row expand
+ * form still offers the full-size FileField.
+ */
+export function FileCell({
+  value,
+  onChange,
+  disabled,
+  multiple,
+  accept,
+  maxSize,
+  'aria-label': ariaLabel,
+  'data-cell': dataCell,
+}: {
+  value: any;
+  onChange: (value: any) => void;
+  disabled?: boolean;
+  multiple?: boolean;
+  /** Comma-joined accept list for the native picker (e.g. `"image/*,.pdf"`). */
+  accept?: string;
+  /** Max file size in bytes (oversize picks are rejected with an inline error). */
+  maxSize?: number;
+  'aria-label'?: string;
+  /** Focus-grid coordinate (see GridField keyboard navigation). */
+  'data-cell'?: string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const files = value ? (Array.isArray(value) ? value : [value]) : [];
+  const { processFiles, errors, uploading } = useFileUploads({
+    files, multiple: !!multiple, maxSize, onChange,
+  });
+
+  const removeAt = (index: number) => {
+    if (multiple) {
+      const next = files.filter((_: any, i: number) => i !== index);
+      onChange(next.length > 0 ? next : null);
+    } else {
+      onChange(null);
+    }
+  };
+
+  const isImage = (file: any) => String(file?.mime_type || '').startsWith('image/');
+  const nameOf = (file: any) =>
+    typeof file === 'string' ? file : file?.name || file?.original_name || 'File';
+  const showUpload = !disabled && !uploading && (multiple || files.length === 0);
+
+  return (
+    <div className="flex min-h-8 flex-wrap items-center gap-1 px-1 py-0.5">
+      <input
+        ref={inputRef}
+        type="file"
+        multiple={multiple}
+        accept={accept}
+        onChange={(e) => {
+          processFiles(Array.from(e.target.files || []));
+          e.target.value = ''; // allow re-picking the same file
+        }}
+        className="hidden"
+      />
+      {files.map((file: any, idx: number) => (
+        <span
+          key={idx}
+          className="inline-flex max-w-40 items-center gap-1 rounded border bg-muted/50 px-1 py-0.5 text-xs"
+          title={nameOf(file)}
+          data-testid="file-cell-chip"
+        >
+          {isImage(file) && file.url ? (
+            <img src={file.url} alt={nameOf(file)} className="size-5 shrink-0 rounded object-cover" />
+          ) : (
+            <FileIcon className="size-3 shrink-0 text-muted-foreground" />
+          )}
+          <span className="truncate">{nameOf(file)}</span>
+          {!disabled && (
+            <button
+              type="button"
+              className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+              aria-label={`Remove ${nameOf(file)}`}
+              onClick={() => removeAt(idx)}
+            >
+              <X className="size-3" />
+            </button>
+          )}
+        </span>
+      ))}
+      {uploading && (
+        <span
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+          data-testid="file-cell-uploading"
+        >
+          <Loader2 className="size-3.5 animate-spin" />
+        </span>
+      )}
+      {showUpload && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+          onClick={() => inputRef.current?.click()}
+          aria-label={ariaLabel}
+          data-cell={dataCell}
+          disabled={disabled}
+        >
+          <Upload className="size-3.5" />
+          {files.length === 0 && 'Upload'}
+        </Button>
+      )}
+      {errors.length > 0 && (
+        <span className="w-full truncate text-[11px] text-destructive" title={errors.join('; ')}>
+          {errors[0]}
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
+import { UploadProvider } from '@object-ui/providers';
 import { GridField, LineItemsField, sumColumn, lookupAutofillPatch } from './GridField';
 
 const columns = [
@@ -255,6 +256,88 @@ describe('GridField / LineItemsField — editable line items', () => {
       expect(screen.getByTestId('line-items-invalid-0-description')).toBeTruthy();
       // ...but the trailing ghost row (index 1) is not.
       expect(screen.queryByTestId('line-items-invalid-1-description')).toBeNull();
+    });
+  });
+
+  describe('file columns (upload in a grid cell — #2360)', () => {
+    const fileField = {
+      columns: [
+        { field: 'description', label: 'Description', type: 'text' as const },
+        { field: 'receipt', label: 'Receipt', type: 'file' as const },
+      ],
+    } as any;
+
+    it('renders a real upload control in the cell, not a text input', () => {
+      render(<GridField value={[{ description: 'Taxi', receipt: null }]} onChange={() => {}} field={fileField} />);
+      // One upload button per row (data row + ghost), backed by a native file input.
+      expect(screen.getAllByRole('button', { name: 'Receipt' }).length).toBeGreaterThan(0);
+      expect(document.querySelector('input[type="file"]')).toBeTruthy();
+      expect(screen.queryByRole('textbox', { name: 'Receipt' })).toBeNull();
+    });
+
+    it('uploads a picked file and writes the file object into the row', async () => {
+      const onChange = vi.fn();
+      const adapter = {
+        name: 'test',
+        upload: async (f: File) => ({ url: 'https://cdn/receipt.png', name: f.name, size: f.size, mimeType: f.type }),
+      };
+      render(
+        <UploadProvider adapter={adapter as any}>
+          <GridField value={[{ description: 'Taxi', receipt: null }]} onChange={onChange} field={fileField} />
+        </UploadProvider>,
+      );
+      const file = new File(['x'], 'receipt.png', { type: 'image/png' });
+      const input = document.querySelectorAll('input[type="file"]')[0] as HTMLInputElement;
+      fireEvent.change(input, { target: { files: [file] } });
+      await waitFor(() => expect(onChange).toHaveBeenCalled());
+      expect(onChange).toHaveBeenCalledWith([
+        {
+          description: 'Taxi',
+          receipt: {
+            name: 'receipt.png',
+            original_name: 'receipt.png',
+            size: file.size,
+            mime_type: 'image/png',
+            url: 'https://cdn/receipt.png',
+          },
+        },
+      ]);
+    });
+
+    it('shows an uploaded file as a removable chip', () => {
+      const onChange = vi.fn();
+      render(
+        <GridField
+          value={[{ description: 'Taxi', receipt: { name: 'receipt.png', mime_type: 'image/png' } }]}
+          onChange={onChange}
+          field={fileField}
+        />,
+      );
+      expect(screen.getByText('receipt.png')).toBeTruthy();
+      fireEvent.click(screen.getByLabelText('Remove receipt.png'));
+      expect(onChange).toHaveBeenCalledWith([{ description: 'Taxi', receipt: null }]);
+    });
+
+    it('passes the column accept list to the native picker', () => {
+      const withAccept = {
+        columns: [{ field: 'receipt', label: 'Receipt', type: 'file' as const, accept: ['image/*', '.pdf'] }],
+      } as any;
+      render(<GridField value={[]} onChange={() => {}} field={withAccept} />);
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      expect(input.getAttribute('accept')).toBe('image/*,.pdf');
+    });
+
+    it('renders the file name read-only in readonly mode', () => {
+      render(
+        <GridField
+          value={[{ description: 'Taxi', receipt: { name: 'receipt.png' } }]}
+          onChange={() => {}}
+          field={fileField}
+          readonly
+        />,
+      );
+      expect(screen.getByText('receipt.png')).toBeTruthy();
+      expect(document.querySelector('input[type="file"]')).toBeNull();
     });
   });
 

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -18,6 +18,7 @@ import {
 import { Plus, Trash2, SlidersHorizontal, Maximize2, Copy, GripVertical } from 'lucide-react';
 import { resolveFieldRuleState } from '@object-ui/core';
 import { LookupField } from './LookupField';
+import { FileCell } from './FileField';
 
 /**
  * GridField / LineItemsField — editable child-grid ("line items") widget.
@@ -30,7 +31,7 @@ import { LookupField } from './LookupField';
  *
  * Column config (a subset of `GridColumnDefinition`):
  *   { field, label?, type?, options?, width?, required?, prefix?, step? }
- *   type ∈ 'text' | 'number' | 'currency' | 'date' | 'select'
+ *   type ∈ 'text' | 'number' | 'currency' | 'date' | 'select' | 'lookup' | 'file'
  *
  * Field-level config (from `GridFieldMetadata`):
  *   columns, min_rows, max_rows, allow_add, allow_delete, total_field
@@ -39,7 +40,7 @@ import { LookupField } from './LookupField';
 export interface GridColumn {
   field: string;
   label?: string;
-  type?: 'text' | 'number' | 'currency' | 'date' | 'select' | 'lookup';
+  type?: 'text' | 'number' | 'currency' | 'date' | 'select' | 'lookup' | 'file';
   options?: Array<{ label: string; value: string }>;
   width?: number;
   required?: boolean;
@@ -49,7 +50,11 @@ export interface GridColumn {
   reference?: string;
   displayField?: string;
   idField?: string;
+  /** Multi-value column: multi-record lookup, or multi-file upload cell. */
   multiple?: boolean;
+  /** For `type: 'file'` — accepted MIME types / extensions for the picker
+   *  (e.g. `['image/*', '.pdf']`). Omit to accept anything. */
+  accept?: string[];
   /**
    * Hidden from the grid by default but revealable via the column chooser.
    * Set by `deriveColumns` for fields beyond the default-visible budget — the
@@ -105,6 +110,7 @@ const MIN_WIDTH_BY_TYPE: Record<string, number> = {
   number: 104,
   currency: 116,
   date: 150,
+  file: 168,
 };
 const minWidthFor = (c: GridColumn): number => c.width ?? MIN_WIDTH_BY_TYPE[c.type ?? 'text'] ?? 132;
 
@@ -252,6 +258,13 @@ export function computeRow(columns: GridColumn[], row: Row): Row {
  *  currency/number → formatted, empty → em dash). Lookups render separately. */
 function displayText(c: GridColumn, value: any): string {
   if (value === null || value === undefined || value === '') return '—';
+  if (c.type === 'file') {
+    const files = Array.isArray(value) ? value : [value];
+    if (files.length === 0) return '—';
+    if (files.length > 1) return `${files.length} files`;
+    const f = files[0];
+    return typeof f === 'string' ? f : f?.name || f?.original_name || 'File';
+  }
   if (c.type === 'select' && Array.isArray(c.options)) {
     const opt = c.options.find((o) => String(o.value) === String(value));
     return opt ? opt.label : String(value);
@@ -613,6 +626,8 @@ export function GridField({
                           readonly
                           field={{ reference: c.reference, display_field: c.displayField, id_field: c.idField } as any}
                         />
+                      ) : c.type === 'file' ? (
+                        displayText(c, row[c.field])
                       ) : row[c.field] != null && row[c.field] !== '' ? (
                         String(row[c.field])
                       ) : (
@@ -697,6 +712,21 @@ export function GridField({
           compact
           field={{ reference: c.reference, display_field: c.displayField, id_field: c.idField, multiple: c.multiple, options: c.options, placeholder: '—' } as any}
           disabled={locked}
+        />
+      );
+    }
+    // File / image column → a real upload control in the cell (objectui#2360),
+    // not a text input: chips for uploaded files + a compact picker button.
+    if (c.type === 'file') {
+      return (
+        <FileCell
+          value={val}
+          onChange={(v: any) => setCellValue(rowIdx, c.field, v)}
+          multiple={c.multiple}
+          accept={Array.isArray(c.accept) && c.accept.length > 0 ? c.accept.join(',') : undefined}
+          disabled={locked}
+          aria-label={c.label || c.field}
+          data-cell={`${rowIdx}-${colIdx}`}
         />
       );
     }

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -618,7 +618,11 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     }
 
     const resolvedObjectName = relatedObjectName;
-    const SKIP_TYPES = new Set(['image', 'file', 'attachment', 'rich_text', 'html', 'json']);
+    // file/image are NOT skipped: they have dedicated cell renderers (name
+    // chip / thumbnail), and dropping them hid business columns like a line's
+    // receipt attachment (objectui#2360). Only types with no useful tabular
+    // rendering stay excluded.
+    const SKIP_TYPES = new Set(['attachment', 'rich_text', 'html', 'json']);
     const PRIORITY_NAMES = [
       'name',
       'full_name',

--- a/packages/plugin-detail/src/__tests__/RelatedList.filecolumns.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.filecolumns.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression coverage (objectui#2360): auto-derived related-list columns must
+ * NOT drop file/image fields. They have dedicated cell renderers (file-name
+ * chip / thumbnail), and excluding them hid business columns like an expense
+ * line's receipt attachment unless the author declared columns explicitly.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { RelatedList } from '../RelatedList';
+
+const fields = {
+  description: { type: 'text', label: 'Description' },
+  amount: { type: 'currency', label: 'Amount' },
+  receipt: { type: 'file', label: 'Receipt' },
+};
+
+const makeDS = (rows: any[]) => ({
+  find: vi.fn(async () => rows),
+  getObjectSchema: vi.fn(async () => ({ name: 'expense_line', fields })),
+});
+
+describe('RelatedList — file fields survive auto-derived columns', () => {
+  it('includes a file field as a column and renders its file name', async () => {
+    const rows = [{
+      id: 'l1',
+      description: 'Taxi',
+      amount: 42,
+      receipt: { name: 'receipt.pdf', size: 1024, mime_type: 'application/pdf' },
+    }];
+    render(
+      <RelatedList
+        title="Expense Lines"
+        type="table"
+        api="expense_line"
+        objectName="expense_line"
+        referenceField="expense"
+        parentId="EXP-1"
+        dataSource={makeDS(rows) as any}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Receipt')).toBeTruthy(); // the column header
+    });
+    // The FileCellRenderer shows the stored file's name, not "[object Object]".
+    expect(screen.getByText('receipt.pdf')).toBeTruthy();
+  });
+});

--- a/packages/plugin-form/src/deriveMasterDetail.test.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.test.ts
@@ -79,6 +79,22 @@ describe('deriveColumns', () => {
     // conditionalRequired is carried as the requiredWhen alias.
     expect(byName.memo.requiredWhen).toBe('record.qty >= 1');
   });
+
+  it('keeps file/image fields as upload columns instead of dropping them (#2360)', () => {
+    const schema = {
+      name: 'expense_line',
+      fields: {
+        expense: { type: 'master_detail', reference: 'expense' },
+        description: { type: 'text', label: 'Description' },
+        receipt: { type: 'file', label: 'Receipt', multiple: true, accept: ['image/*', '.pdf'] },
+        photo: { type: 'image', label: 'Photo' },
+      },
+    };
+    const byName = Object.fromEntries(deriveColumns(schema, { relationshipField: 'expense' }).map((c) => [c.field, c]));
+    expect(byName.receipt).toMatchObject({ type: 'file', multiple: true, accept: ['image/*', '.pdf'] });
+    // Image fields restrict the picker to images when no accept list is declared.
+    expect(byName.photo).toMatchObject({ type: 'file', accept: ['image/*'] });
+  });
 });
 
 describe('deriveColumns curation (column budget)', () => {
@@ -225,6 +241,19 @@ describe('hydrateColumns (fill types on bare author columns)', () => {
     );
     expect(cols.map((c) => c.field)).toEqual(['due_date', 'status']); // order kept, no extra columns
     expect(cols[0].label).toBe('合同时间'); // author label kept, not schema's "Due Date"
+  });
+
+  it('hydrates a bare file-field column into an upload column with its constraints (#2360)', () => {
+    const schema = {
+      fields: {
+        expense: { type: 'master_detail', reference: 'expense' },
+        receipt: { type: 'file', label: 'Receipt', multiple: true, accept: ['.pdf'] },
+        photo: { type: 'image', label: 'Photo' },
+      },
+    };
+    const cols = hydrateColumns([{ field: 'receipt' }, { field: 'photo' }] as any, schema);
+    expect(cols[0]).toMatchObject({ type: 'file', multiple: true, accept: ['.pdf'] });
+    expect(cols[1]).toMatchObject({ type: 'file', accept: ['image/*'] });
   });
 
   it('never overrides an explicit type the author already set', () => {

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -33,10 +33,12 @@ const SYSTEM_FIELDS = new Set([
  *  columns and the row form (the grid stamps them on drag-reorder instead). */
 const SORT_FIELD_NAMES = new Set(['position', 'sort_order', 'sequence', 'line_no', 'line_number', 'sort']);
 
-/** Field types that are not directly editable in a line-item grid. */
+/** Field types that are not directly editable in a line-item grid.
+ *  file/image/avatar are NOT here: they render a compact upload cell
+ *  (`GridColumn.type: 'file'` → FileCell) since objectui#2360. */
 const NON_EDITABLE_TYPES = new Set([
   'formula', 'summary', 'rollup', 'autonumber', 'auto_number',
-  'file', 'image', 'avatar', 'json', 'object', 'grid', 'table',
+  'json', 'object', 'grid', 'table',
   'location', 'vector', 'html', 'markdown', 'richtext',
 ]);
 
@@ -63,8 +65,27 @@ export function fieldTypeToColumnType(type: string | undefined): GridColumn['typ
     case 'lookup':
     case 'master_detail':
       return 'lookup';
+    case 'file':
+    case 'image':
+    case 'avatar':
+    case 'attachment':
+      return 'file';
     default:
       return 'text';
+  }
+}
+
+/** Image-flavoured field types whose picker should be restricted to images. */
+const IMAGE_TYPES = new Set(['image', 'avatar']);
+
+/** Carry a file field's upload constraints onto its grid column: `multiple`,
+ *  the field's `accept` list, or an `image/*` restriction for image fields.
+ *  Values already present on the column (author-supplied) are left untouched. */
+function applyFileColumnProps(col: GridColumn, d: any): void {
+  if (col.multiple == null && d?.multiple) col.multiple = true;
+  if (col.accept == null) {
+    if (Array.isArray(d?.accept) && d.accept.length > 0) col.accept = d.accept;
+    else if (IMAGE_TYPES.has(d?.type)) col.accept = ['image/*'];
   }
 }
 
@@ -187,6 +208,7 @@ export function deriveColumns(
       col.reference = d?.reference;
       col.displayField = d?.display_field || d?.reference_field;
     }
+    if (col.type === 'file') applyFileColumnProps(col, d);
     // Field-level CEL conditional rules (B2 in grids). Carried through verbatim
     // so the grid cell evaluates them per row (against the row + `parent`
     // header). requiredWhen falls back to the conditionalRequired alias.
@@ -240,6 +262,7 @@ export function hydrateColumns(
       if (next.reference == null) next.reference = d?.reference;
       if (next.displayField == null) next.displayField = d?.display_field || d?.reference_field;
     }
+    if (type === 'file') applyFileColumnProps(next, d);
     if (next.readonlyWhen == null && d?.readonlyWhen) next.readonlyWhen = d.readonlyWhen;
     if (next.requiredWhen == null && (d?.requiredWhen ?? d?.conditionalRequired)) {
       next.requiredWhen = d.requiredWhen ?? d.conditionalRequired;


### PR DESCRIPTION
Closes #2360

## Problem

A `Field.file` on a master-detail child (`inlineEdit: 'grid'` or a formView subform) was unusable in the inline grid:

1. **Auto-derived subform columns dropped file fields** — `deriveColumns` listed `file`/`image`/`avatar` in `NON_EDITABLE_TYPES`, so the column only appeared when declared explicitly.
2. **Even an explicit file column degraded to a text input** — `GridField` had no `file` branch and fell through to the generic `<Input type="text">`, so the page had no `input[type=file]` and nothing could be uploaded from the grid.
3. **Auto-derived related-list columns also skipped file/image** — `RelatedList`'s `SKIP_TYPES` excluded them even though dedicated cell renderers (`FileCellRenderer` / `ImageCellRenderer`) already exist.

## Changes

**`@object-ui/fields`**
- New `FileCell` (in `FileField.tsx`): a compact upload control sized for a 32px grid row — small "Upload" button opening the native picker, uploaded files as removable chips (image thumbnails), inline progress + error. The upload pipeline (size validation → `UploadProvider` adapter → value merge) is extracted into a shared `useFileUploads` hook so `FileField` and `FileCell` stay behaviourally identical (same value shape: `{ name, original_name, size, mime_type, url }`).
- `GridField`: `GridColumn.type` gains `'file'` (plus `accept?: string[]`; `multiple` now applies to file cells too). File columns render `FileCell` in edit mode, the file name(s) in list/readonly modes (previously `String(value)` → `[object Object]`), and get a sensible min-width.

**`@object-ui/plugin-form`**
- `fieldTypeToColumnType` maps `file`/`image`/`avatar`/`attachment` → `'file'`; those types are removed from `NON_EDITABLE_TYPES`, so `deriveColumns` keeps them as upload columns.
- `deriveColumns` / `hydrateColumns` carry the field's `multiple` and `accept` onto the column; image-flavoured fields default to `accept: ['image/*']`. Author-supplied column values always win.
- The smart inline-mode heuristic (`FORM_ONLY_TYPES` tipping a child with file fields toward the per-row `form`) is deliberately unchanged — explicit `inlineEdit: 'grid'` now just works.

**`@object-ui/plugin-detail`**
- `RelatedList` auto-derived columns no longer skip `file`/`image` (they render via the existing cell renderers). `attachment`/`rich_text`/`html`/`json` stay excluded (no useful tabular rendering).

## Tests

- `GridField.test.tsx`: file column renders a real upload control (not a text input); picking a file uploads through the `UploadProvider` adapter and writes the file object into the row; chips are removable; `accept` reaches the native input; readonly shows the file name. 
- `deriveMasterDetail.test.ts`: file/image fields survive `deriveColumns` and `hydrateColumns` with `multiple`/`accept` carried (image → `['image/*']`).
- New `RelatedList.filecolumns.test.tsx`: auto-derived related list includes the file column and renders the stored file's name.
- Full suites for the three touched packages pass (70 files / 754 tests), plus spec-bridge + plugin-view (144 tests). `turbo type-check` green; touched files lint with 0 errors.

Docs updated (`content/docs/fields/grid.mdx`, `packages/fields/README.md`) and a minor changeset added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5tsBSEhsDZmdcHBvfymYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5tsBSEhsDZmdcHBvfymYC)_