### PR TITLE
feat(app-shell): visual filterBindings editor in the dashboard widget inspector (#2578)

### DIFF
--- a/.changeset/dashboard-filter-bindings-inspector.md
+++ b/.changeset/dashboard-filter-bindings-inspector.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/app-shell": minor
+---
+
+Studio dashboard widget inspector: visual `filterBindings` editor (#2578
+item 4, framework#2501). When the dashboard declares filters (`dateRange` /
+`globalFilters`), the widget inspector shows a "Dashboard filter bindings"
+section with one row per filter: an **Apply** toggle (unticked writes
+`filterBindings[name] = false`, opting the widget out) and a field picker
+that re-targets the filter to one of THIS widget's fields (empty = default:
+the filter's own field). Previously bindings were only configurable through
+raw JSON metadata. Filter rows come from the same `resolveDashboardFilterDefs`
+normalization the runtime broadcasts from, so the editor offers exactly the
+filters the renderer will apply.

--- a/content/docs/guide/dashboard-filters.md
+++ b/content/docs/guide/dashboard-filters.md
@@ -183,6 +183,11 @@ Binding rules, in precedence order:
 That's the whole feature: changing any filter live re-scopes every bound
 widget, each against **its own** field.
 
+Bindings can also be edited visually: the Studio dashboard widget inspector
+shows a **Dashboard filter bindings** section (one row per declared filter)
+with an Apply toggle (opt-out) and a field picker for the override — no JSON
+editing required.
+
 ## Reading filter values in expressions
 
 Filter values are hosted as dashboard variables, so any widget expression can

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -319,6 +319,13 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.widget.values': 'Values (measures)',
   'engine.inspector.widget.valuesPlaceholder': 'e.g. revenue, deal_count (comma-separated)',
   'engine.inspector.widget.valuesHint': 'Dataset measure names to show.',
+  // Dashboard filter bindings (framework#2501)
+  'engine.inspector.widget.filterBindingsSection': 'Dashboard filter bindings',
+  'engine.inspector.widget.filterBindingsHint':
+    'Map each dashboard-level filter to one of this widget’s own fields, or untick Apply to opt the widget out. Empty = the filter’s own field.',
+  'engine.inspector.widget.filterBindingApply': 'Apply',
+  'engine.inspector.widget.filterBindingDefault': 'Default ({field})',
+  'engine.inspector.widget.filterBindingReset': 'Reset',
   // Flow node inspector
   'engine.inspector.flowNode.kind': 'Node',
   'engine.inspector.flowNode.close': 'Close node',
@@ -1646,6 +1653,13 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.widget.values': '值（度量）',
   'engine.inspector.widget.valuesPlaceholder': '例如：revenue, deal_count（逗号分隔）',
   'engine.inspector.widget.valuesHint': '要展示的数据集度量名。',
+  // Dashboard filter bindings (framework#2501)
+  'engine.inspector.widget.filterBindingsSection': '仪表盘过滤器绑定',
+  'engine.inspector.widget.filterBindingsHint':
+    '把每个仪表盘级过滤器映射到本组件自己的字段；取消勾选「应用」可让本组件不受该过滤器影响。留空表示使用过滤器自身的字段。',
+  'engine.inspector.widget.filterBindingApply': '应用',
+  'engine.inspector.widget.filterBindingDefault': '默认（{field}）',
+  'engine.inspector.widget.filterBindingReset': '恢复默认',
   // Flow node inspector
   'engine.inspector.flowNode.kind': '节点',
   'engine.inspector.flowNode.close': '关闭节点',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.test.tsx
@@ -11,7 +11,7 @@
 
 import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
 
 // Network-free catalogs.
 vi.mock('../previews/useDatasetCatalog', () => ({
@@ -104,5 +104,78 @@ describe('DashboardWidgetInspector — dataset binding', () => {
     const combos = screen.getAllByRole('combobox');
     expect(combos.length).toBeGreaterThan(0);
     combos.forEach((c) => expect(c).toBeDisabled());
+  });
+});
+
+describe('DashboardWidgetInspector — dashboard filter bindings (framework#2501)', () => {
+  const filteredDraft = (widgetExtra: Record<string, unknown> = {}) => ({
+    dateRange: { field: 'created_at', defaultRange: 'last_30_days' },
+    globalFilters: [
+      { name: 'region', field: 'region', label: 'Region', type: 'select', options: ['EMEA'] },
+    ],
+    widgets: [widget(widgetExtra)],
+  });
+
+  function renderFiltered(widgetExtra: Record<string, unknown> = {}, props: Record<string, unknown> = {}) {
+    return render(
+      <DashboardWidgetInspector
+        {...baseProps}
+        {...props}
+        draft={filteredDraft(widgetExtra)}
+        selection={{ kind: 'widget', id: 'w1' }}
+        onPatch={(props.onPatch as any) ?? vi.fn()}
+      />,
+    );
+  }
+
+  it('hides the section when the dashboard declares no filters', () => {
+    renderWidget();
+    expect(screen.queryByText('Dashboard filter bindings')).not.toBeInTheDocument();
+  });
+
+  it('renders one row per dashboard filter (dateRange + each globalFilter)', () => {
+    renderFiltered();
+    expect(screen.getByText('Dashboard filter bindings')).toBeInTheDocument();
+    expect(screen.getByTestId('widget-filter-binding-dateRange')).toBeInTheDocument();
+    const region = screen.getByTestId('widget-filter-binding-region');
+    expect(within(region).getByText('Region')).toBeInTheDocument();
+    // Default placeholder names the filter's own field.
+    expect(within(region).getByText('Default (region)')).toBeInTheDocument();
+  });
+
+  it('unticking Apply patches filterBindings[name] = false; re-ticking removes the entry', () => {
+    const onPatch = vi.fn();
+    renderFiltered({}, { onPatch });
+    const region = screen.getByTestId('widget-filter-binding-region');
+    fireEvent.click(within(region).getByRole('checkbox'));
+    expect(onPatch).toHaveBeenCalledWith({
+      widgets: [expect.objectContaining({ id: 'w1', filterBindings: { region: false } })],
+    });
+
+    cleanup();
+    const onPatch2 = vi.fn();
+    renderFiltered({ filterBindings: { region: false } }, { onPatch: onPatch2 });
+    const region2 = screen.getByTestId('widget-filter-binding-region');
+    const checkbox = within(region2).getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    // Opted out → the field picker is hidden for this row.
+    expect(within(region2).queryByRole('combobox')).not.toBeInTheDocument();
+    fireEvent.click(checkbox);
+    // Last remaining entry removed → filterBindings collapses to undefined.
+    expect(onPatch2).toHaveBeenCalledWith({
+      widgets: [expect.objectContaining({ id: 'w1', filterBindings: undefined })],
+    });
+  });
+
+  it('shows an existing field override and resets it back to the default binding', () => {
+    const onPatch = vi.fn();
+    renderFiltered({ filterBindings: { dateRange: 'signed_at', region: 'sales_region' } }, { onPatch });
+    const dateRow = screen.getByTestId('widget-filter-binding-dateRange');
+    expect(within(dateRow).getByText('signed_at')).toBeInTheDocument();
+    fireEvent.click(within(dateRow).getByRole('button', { name: 'Reset' }));
+    // Only the dateRange override is cleared; the region override survives.
+    expect(onPatch).toHaveBeenCalledWith({
+      widgets: [expect.objectContaining({ filterBindings: { region: 'sales_region' } })],
+    });
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
@@ -30,9 +30,10 @@ import {
   SelectValue,
 } from '@object-ui/components';
 import type { DashboardWidgetSchema } from '@object-ui/types';
+import { resolveDashboardFilterDefs, type DashboardFilterDef } from '@object-ui/core';
 import type { MetadataInspectorProps } from '../inspector-registry';
-import { t } from '../i18n';
-import { InspectorReorderButtons, moveArray } from './_shared';
+import { t, tFormat } from '../i18n';
+import { InspectorCheckboxField, InspectorReorderButtons, moveArray } from './_shared';
 import { InspectorComboField, type InspectorComboOption } from './InspectorComboField';
 import { DatasetNamesEditor } from './ReportDefaultInspector';
 import { useDatasetCatalog, useDatasetSemantics } from '../previews/useDatasetCatalog';
@@ -135,6 +136,19 @@ export function DashboardWidgetInspector({
   const dimensionOptions: ObjectFieldInfo[] = React.useMemo(
     () => semantics.dimensions.map((d) => ({ name: d.name, label: d.name, type: d.type ?? 'text', hidden: false })),
     [semantics.dimensions],
+  );
+
+  // ── Dashboard filter bindings (framework#2501) ─────────────────────────
+  // The dashboard's own dateRange + globalFilters declarations, normalized
+  // to the same flat def list the runtime broadcasts from — so the editor
+  // offers exactly the filters the renderer will apply.
+  const filterDefs: DashboardFilterDef[] = React.useMemo(
+    () =>
+      resolveDashboardFilterDefs({
+        globalFilters: (draft as any).globalFilters,
+        dateRange: (draft as any).dateRange,
+      }),
+    [draft],
   );
 
   if (selection.kind !== 'widget') {
@@ -342,6 +356,79 @@ export function DashboardWidgetInspector({
           </SelectContent>
         </Select>
       </Field>
+
+      {/* Dashboard filter bindings (framework#2501) — one row per dashboard
+          filter: an Apply toggle (unchecked writes `false` = opt out) and a
+          field picker re-targeting the filter to THIS widget's field (empty =
+          default: the filter's own field). Only rendered when the dashboard
+          declares filters. */}
+      {filterDefs.length > 0 && (
+        <div className="space-y-3 rounded-md border p-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {t('engine.inspector.widget.filterBindingsSection', locale)}
+          </div>
+          <p className="text-[10px] leading-snug text-muted-foreground">
+            {t('engine.inspector.widget.filterBindingsHint', locale)}
+          </p>
+          {filterDefs.map((def) => {
+            const bindings = (widget as any).filterBindings as
+              | Record<string, string | false>
+              | undefined;
+            const binding = bindings?.[def.name];
+            const optedOut = binding === false;
+            const override = typeof binding === 'string' ? binding : '';
+            const setBinding = (next: string | false | undefined) => {
+              const current: Record<string, string | false> = { ...(bindings ?? {}) };
+              if (next === undefined) delete current[def.name];
+              else current[def.name] = next;
+              patchWidget({
+                filterBindings: Object.keys(current).length > 0 ? current : undefined,
+              } as Partial<DashboardWidgetSchema>);
+            };
+            return (
+              <div key={def.name} className="space-y-1.5" data-testid={`widget-filter-binding-${def.name}`}>
+                <div className="flex items-center justify-between gap-2">
+                  <Label className="text-xs font-medium text-muted-foreground truncate">
+                    {def.label || def.name}
+                  </Label>
+                  <InspectorCheckboxField
+                    label={t('engine.inspector.widget.filterBindingApply', locale)}
+                    value={!optedOut}
+                    onCommit={(apply) => setBinding(apply ? undefined : false)}
+                    disabled={readOnly}
+                  />
+                </div>
+                {!optedOut && (
+                  <div className="flex items-center gap-1">
+                    <div className="min-w-0 flex-1">
+                      <InspectorComboField
+                        value={override}
+                        onCommit={(v) => setBinding(v ? v : undefined)}
+                        options={fieldComboOptions}
+                        placeholder={tFormat('engine.inspector.widget.filterBindingDefault', locale, { field: def.field })}
+                        searchPlaceholder="Search fields…"
+                        disabled={readOnly}
+                        mono
+                      />
+                    </div>
+                    {override && !readOnly && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 shrink-0 px-2 text-[10px] text-muted-foreground"
+                        onClick={() => setBinding(undefined)}
+                      >
+                        {t('engine.inspector.widget.filterBindingReset', locale)}
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       <Field id="widget-color" label={t('engine.inspector.widget.color', locale)}>
         <ColorVariantPicker


### PR DESCRIPTION
## Summary

Second follow-up round for #2578 — item 4 (Studio / designer): `filterBindings` gets a visual editor in the metadata-admin dashboard **widget inspector**. Previously per-widget bindings were only configurable through raw JSON metadata.

When the dashboard draft declares filters (`dateRange` / `globalFilters`), the widget inspector shows a **Dashboard filter bindings** section with one row per filter:

- an **Apply** toggle — unticking writes `filterBindings[name] = false` (opt the widget out); re-ticking removes the entry (back to default);
- a **field picker** (`InspectorComboField`, searchable, custom values allowed) re-targeting the filter to one of THIS widget's fields — empty means the default binding (the filter's own `field`, shown as the placeholder `Default (<field>)`); a **Reset** button clears an override.

Filter rows come from the same `resolveDashboardFilterDefs` normalization the runtime broadcasts from (`@object-ui/core`), so the editor offers exactly the filters the renderer will apply — including the built-in `dateRange` under its reserved name.

## Changes

- `packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx` — new section + patch logic (`filterBindings` collapses to `undefined` when the last entry is removed).
- `packages/app-shell/src/views/metadata-admin/i18n.ts` — `engine.inspector.widget.filterBinding*` strings, en + zh.
- `content/docs/guide/dashboard-filters.md` — note that bindings are editable visually in Studio.
- `.changeset/dashboard-filter-bindings-inspector.md` — minor bump for `@object-ui/app-shell`.

## Testing

- 4 new tests in `DashboardWidgetInspector.test.tsx` (section gated on declared filters; one row per filter incl. `dateRange`; opt-out → `false` and re-apply → entry removed; override rendering + Reset clears only that filter's entry) — 8/8 file total passing.
- `pnpm --filter "@object-ui/app-shell..." build` — clean.

Refs #2578, #2576, framework#2501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG5LQnPbQbjAAyofghzz3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG5LQnPbQbjAAyofghzz3Z)_