### PR TITLE
fix(detail): highlight strip lookup editor honors ObjectStack `reference` key (#2407)

### DIFF
--- a/packages/plugin-detail/src/HeaderHighlight.tsx
+++ b/packages/plugin-detail/src/HeaderHighlight.tsx
@@ -82,6 +82,11 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
             // Enrich field metadata from objectSchema
             const objectDefField = objectSchema?.fields?.[field.name];
             const resolvedType = field.type || objectDefField?.type;
+            // Backend object schemas use the ObjectStack-convention `reference`
+            // key (DetailSection normalizes the same pair) — without it the
+            // lookup editor has no target object to hydrate or search against.
+            const refTarget =
+              objectDefField?.reference_to || (objectDefField as any)?.reference;
             const enrichedField = {
               name: field.name,
               label: field.label,
@@ -91,7 +96,10 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
               ...(objectDefField?.precision !== undefined && { precision: objectDefField.precision }),
               ...((objectDefField as any)?.scale !== undefined && { scale: (objectDefField as any).scale }),
               ...(objectDefField?.format && { format: objectDefField.format }),
-              ...(objectDefField?.reference_to && { reference_to: objectDefField.reference_to }),
+              ...(refTarget && { reference_to: refTarget }),
+              ...((objectDefField as any)?.reference_field && {
+                reference_field: (objectDefField as any).reference_field,
+              }),
               ...((objectDefField as any)?.widget && { widget: (objectDefField as any).widget }),
             };
 

--- a/packages/plugin-detail/src/__tests__/HeaderHighlight.editable.test.tsx
+++ b/packages/plugin-detail/src/__tests__/HeaderHighlight.editable.test.tsx
@@ -6,10 +6,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { InlineEditProvider, useInlineEdit } from '@object-ui/react';
 import { HeaderHighlight } from '../HeaderHighlight';
+
+// Probe the LookupField editor so the reference-key tests can assert which
+// relation target the enriched field carried. Everything else in
+// @object-ui/fields stays real (cell renderers, other editors).
+vi.mock('@object-ui/fields', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, any>>();
+  return {
+    ...actual,
+    LookupField: ({ field }: any) => (
+      <div
+        data-testid="lookup-editor"
+        data-reference-to={field?.reference_to ?? ''}
+        data-reference-field={field?.reference_field ?? ''}
+      />
+    ),
+  };
+});
 
 /**
  * objectui#2407 P2 — the highlights strip becomes editable against the SHARED
@@ -90,5 +107,58 @@ describe('HeaderHighlight — editable highlights (P2)', () => {
     );
     fireEvent.doubleClick(screen.getByText('Alice'));
     expect(screen.queryByDisplayValue('Alice')).toBeNull();
+  });
+});
+
+/**
+ * objectui#2407 P2 follow-up — backend object schemas use the
+ * ObjectStack-convention `reference` key (e.g. showcase_project.account has
+ * `"reference": "showcase_account"`), not `reference_to`. The strip must
+ * normalize both (like DetailSection) or the lookup editor gets no target
+ * object: it can neither hydrate the current value nor search candidates.
+ */
+describe('HeaderHighlight — lookup highlight reference-key normalization', () => {
+  const lookupFields = [{ name: 'account', label: 'Account' }] as any;
+  const lookupData = { account: 'acc-1' };
+
+  // Enters the shared edit session on the lookup field directly (its read-mode
+  // rendering of a bare id is not what these tests are about).
+  function EnterEdit() {
+    const inline = useInlineEdit();
+    return (
+      <button type="button" onClick={() => inline!.enter('account')}>
+        enter-edit
+      </button>
+    );
+  }
+
+  const renderStrip = (accountField: Record<string, any>) => {
+    render(
+      <InlineEditProvider canEdit>
+        <HeaderHighlight
+          fields={lookupFields}
+          data={lookupData}
+          objectSchema={{ fields: { account: accountField } }}
+        />
+        <EnterEdit />
+      </InlineEditProvider>,
+    );
+    fireEvent.click(screen.getByText('enter-edit'));
+    return screen.getByTestId('lookup-editor');
+  };
+
+  it('passes the backend `reference` key to the LookupField as reference_to', () => {
+    const editor = renderStrip({
+      type: 'lookup',
+      reference: 'showcase_account',
+      reference_field: 'name',
+    });
+    expect(editor.getAttribute('data-reference-to')).toBe('showcase_account');
+    expect(editor.getAttribute('data-reference-field')).toBe('name');
+  });
+
+  it('still honors the `reference_to` key', () => {
+    const editor = renderStrip({ type: 'lookup', reference_to: 'showcase_account' });
+    expect(editor.getAttribute('data-reference-to')).toBe('showcase_account');
   });
 });


### PR DESCRIPTION
## Problem

Follow-up to #2407 P2 (#2549): the record-highlights strip's inline-edit **lookup editor is broken** when the backend object schema uses the ObjectStack-convention `reference` key instead of `reference_to` — which is what the backend actually serves (e.g. `showcase_project.account` has `"reference": "showcase_account"`).

Verified live on the showcase app (Project record): entering record-level inline edit, the 客户/account highlight lookup shows the "选择..." placeholder instead of the current value (Northwind), and opening the picker shows "未找到选项" — the `LookupField` receives no reference target, so it can neither hydrate the current value nor search candidates. `team_members` (type `user`, `reference: sys_user`) is affected the same way.

The details-body path works because `DetailSection` already normalizes both keys (`objectDefField.reference_to || objectDefField.reference`).

## Fix

In `HeaderHighlight.tsx`, build the enriched field's reference target the same dual-key way as `DetailSection`:

- `refTarget = objectDefField?.reference_to || objectDefField?.reference`, spread as `reference_to`
- also copy `reference_field` for parity with `DetailSection`

## Tests

New regression tests in `HeaderHighlight.editable.test.tsx` (LookupField probed via partial module mock):

- a lookup highlight whose schema field carries the backend `reference` key (+ `reference_field`) hands the target through to the `LookupField` editor
- the `reference_to` spelling keeps working

`pnpm exec vitest run packages/plugin-detail` → 23 files / 211 tests pass; `pnpm --filter @object-ui/plugin-detail type-check` clean.

Refs #2407

🤖 Generated with [Claude Code](https://claude.com/claude-code)