### PR TITLE
fix(studio): Access pillar no longer silently discards unsaved permission-matrix edits on rail switch

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.dirty.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.dirty.test.tsx
@@ -1,0 +1,127 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * PermissionMatrixEditPage `onDirtyChange` contract — the hook the Studio
+ * Access pillar's unsaved-changes guard hangs on. The pillar keys this page
+ * per set (`key={current}`), so a rail switch REMOUNTS it; the host can only
+ * warn before discarding edits if the editor reports its dirty state up:
+ *
+ *   • clean after the initial load,
+ *   • dirty as soon as a matrix cell changes,
+ *   • clean again after a successful Save (draft becomes the new baseline),
+ *   • reset to false on unmount (a confirmed discard must clear the guard).
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+let clientImpl: any;
+
+vi.mock('./useMetadata', () => ({
+  useMetadataClient: () => clientImpl,
+  useMetadataTypes: () => ({
+    loading: false,
+    error: null,
+    entries: [{ type: 'permission', label: 'Permission', allowOrgOverride: true }],
+  }),
+}));
+
+import { PermissionMatrixEditPage } from './PermissionMatrixEditor';
+
+afterEach(cleanup);
+
+interface Server {
+  set: Record<string, unknown>;
+  saved: Array<Record<string, unknown>>;
+}
+
+function freshServer(): Server {
+  return {
+    saved: [],
+    set: {
+      name: 'sales_perms',
+      label: 'Sales',
+      objects: {
+        a_account: { allowRead: true, allowCreate: true },
+      },
+      fields: {},
+    },
+  };
+}
+
+function makeClient(server: Server) {
+  return {
+    layered: async () => ({
+      effective: server.set,
+      code: null,
+      overlay: null,
+      overlayScope: null,
+    }),
+    getDraft: async () => null,
+    list: async (type: string) => {
+      if (type === 'object') return [{ item: { name: 'a_account' } }];
+      return [];
+    },
+    get: async (type: string) =>
+      type === 'object' ? { fields: [{ name: 'name', label: 'Name' }] } : null,
+    save: async (_t: string, _n: string, payload: Record<string, unknown>) => {
+      server.saved.push(payload);
+      server.set = payload;
+      return payload;
+    },
+  } as any;
+}
+
+function renderMatrix(onDirtyChange: (dirty: boolean) => void) {
+  return render(
+    <MemoryRouter>
+      <PermissionMatrixEditPage
+        type="permission"
+        name="sales_perms"
+        packageId="app.a"
+        onDirtyChange={onDirtyChange}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('PermissionMatrixEditPage — onDirtyChange', () => {
+  it('reports clean on load, dirty on edit, clean again after save', async () => {
+    const server = freshServer();
+    clientImpl = makeClient(server);
+    const onDirtyChange = vi.fn();
+    renderMatrix(onDirtyChange);
+
+    await screen.findByText('a_account');
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+
+    // Any matrix mutation flips the report to dirty.
+    const row = screen.getByText('a_account').closest('tr')!;
+    fireEvent.click(within(row).getByRole('button', { name: 'None' }));
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    // Save re-anchors the baseline — clean again, no reload needed.
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(server.saved).toHaveLength(1));
+    await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(false));
+  });
+
+  it('resets the report to false on unmount (discard must clear the guard)', async () => {
+    const server = freshServer();
+    clientImpl = makeClient(server);
+    const onDirtyChange = vi.fn();
+    const view = renderMatrix(onDirtyChange);
+
+    await screen.findByText('a_account');
+    const row = screen.getByText('a_account').closest('tr')!;
+    fireEvent.click(within(row).getByRole('button', { name: 'None' }));
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    // The host remounts this page (key switch) after a confirmed discard —
+    // the outgoing instance must not leave the guard armed.
+    view.unmount();
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -161,13 +161,21 @@ export interface PermissionMatrixEditPageProps {
    * badge stays a plain read-only chip.
    */
   onOpenOwd?: (objectName: string) => void;
+  /**
+   * Fires on every unsaved-edit transition (false → true → false). The Studio
+   * Access pillar keys this page per set (`key={name}`) and swaps it out for
+   * the OWD overview, so the HOST must know before a surface switch whether a
+   * remount would discard edits. Reset to `false` on unmount so a discarded
+   * editor never leaves the host thinking edits are still pending.
+   */
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 /* ────────────────────────────────────────────────────────────────── */
 /* Component                                                          */
 /* ────────────────────────────────────────────────────────────────── */
 
-export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, publishNonce, onOpenOwd }: PermissionMatrixEditPageProps) {
+export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, publishNonce, onOpenOwd, onDirtyChange }: PermissionMatrixEditPageProps) {
   const navigate = useNavigate();
   const client = useMetadataClient();
   // Data adapter (records) — the capability picker reads the live sys_capability
@@ -187,6 +195,18 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
     objects: {},
     fields: {},
   });
+  // Snapshot of the last loaded/saved draft — the anchor `isDirty` compares
+  // against. `null` until the first load lands (nothing to be dirty against).
+  const baselineRef = React.useRef<string | null>(null);
+  /** Set the draft AND re-anchor the dirty baseline to it (load + post-save). */
+  const resetDraftBaseline = React.useCallback((next: PermissionSetDraft) => {
+    try {
+      baselineRef.current = JSON.stringify(next);
+    } catch {
+      baselineRef.current = null;
+    }
+    setDraft(next);
+  }, []);
   const [objects, setObjects] = React.useState<ObjectSummary[]>([]);
   const [fieldsByObject, setFieldsByObject] = React.useState<Record<string, FieldSummary[]>>({});
   const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
@@ -269,9 +289,9 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
         // Save from a fresh read (see doSave).
         if (packageId) {
           const sliced = scopePermissionSet(full, list.map((o) => o.name));
-          setDraft({ ...full, objects: sliced.objects, fields: sliced.fields });
+          resetDraftBaseline({ ...full, objects: sliced.objects, fields: sliced.fields });
         } else {
-          setDraft(full);
+          resetDraftBaseline(full);
         }
       } catch (err: any) {
         setError(err?.message ?? String(err));
@@ -282,7 +302,7 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
     return () => {
       cancelled = true;
     };
-  }, [client, type, name, packageId, publishNonce]);
+  }, [client, type, name, packageId, publishNonce, resetDraftBaseline]);
 
   /* ── Lazy-load fields when an object is expanded ─────────── */
   async function ensureFields(objectName: string) {
@@ -347,6 +367,51 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
   // (objectui#2413): a malformed predicate silently mis-scopes rows, so we
   // don't let it persist.
   const [celErrorCount, setCelErrorCount] = React.useState(0);
+
+  // Dirty detection — cheap JSON snapshot comparison against the last
+  // loaded/saved baseline (same approach as ResourceEditPage). Every mutation
+  // funnels through setDraft (matrix checkboxes, header inputs, capabilities,
+  // advanced facets), so comparing the draft covers them all.
+  const isDirty = React.useMemo(() => {
+    const snap = baselineRef.current;
+    if (snap == null) return false;
+    try {
+      return JSON.stringify(draft) !== snap;
+    } catch {
+      return false;
+    }
+  }, [draft]);
+
+  // Report dirty transitions to the host (see onDirtyChange). Ref-stabilized
+  // so a non-memoized callback prop doesn't refire the effect; the unmount
+  // cleanup reports `false` so a deliberately-discarded editor clears the
+  // host's guard state.
+  const onDirtyChangeRef = React.useRef(onDirtyChange);
+  React.useEffect(() => {
+    onDirtyChangeRef.current = onDirtyChange;
+  });
+  React.useEffect(() => {
+    onDirtyChangeRef.current?.(isDirty);
+  }, [isDirty]);
+  React.useEffect(
+    () => () => {
+      onDirtyChangeRef.current?.(false);
+    },
+    [],
+  );
+
+  // Browser-native "leave site?" prompt on tab close / reload with unsaved
+  // matrix edits — same guard ResourceEditPage installs.
+  React.useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Required for Chrome to actually show the prompt.
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
 
   function toggleExpand(objectName: string) {
     setExpanded((prev) => {
@@ -449,11 +514,11 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
       if (packageId) {
         // The draft is now the pending truth for display; the published baseline
         // hasn't moved. Show what we just staged and let the surface count it.
-        setDraft(toDisplayDraft(toSave));
+        resetDraftBaseline(toDisplayDraft(toSave));
         onDraftSaved?.();
       } else {
         const lay = await client.layered<PermissionSetDraft>(type, payload.name);
-        setDraft(toDisplayDraft((lay.effective ?? toSave) as PermissionSetDraft));
+        resetDraftBaseline(toDisplayDraft((lay.effective ?? toSave) as PermissionSetDraft));
       }
       setDestructive(null);
     } catch (err: any) {

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.accessGuard.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.accessGuard.test.tsx
@@ -1,0 +1,213 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Access pillar — unsaved-changes guard on rail-driven surface swaps.
+ *
+ * The permission matrix in the main panel is keyed by the selected set
+ * (`key={current}`) and unmounts entirely when the OWD overview swaps in, so
+ * before this guard existed a rail click silently REMOUNTED the matrix and
+ * discarded any unsaved cell edits. The pillar now holds the editor's
+ * reported dirty state (`onDirtyChange`) and gates every swap on a native
+ * confirm:
+ *
+ *   • dirty + switch to another set → confirm; cancel keeps the edits,
+ *   • dirty + swap to the OWD overview → same confirm,
+ *   • clean switches never prompt,
+ *   • re-clicking the already-open set never prompts (nothing remounts),
+ *   • a confirmed discard clears the guard (the editor resets on unmount).
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+let clientImpl: any;
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useMetadataClient: () => clientImpl,
+    useMetadataTypes: () => ({
+      loading: false,
+      error: null,
+      entries: [{ type: 'permission', label: 'Permission', allowOrgOverride: true }],
+    }),
+  };
+});
+
+// Rail siblings that are irrelevant to the guard — keep the render light.
+vi.mock('./PackageOwdOverviewPanel', () => ({
+  PackageOwdOverviewPanel: () => <div data-testid="owd-overview" />,
+}));
+vi.mock('../../components/SuggestedBindingsPanel', () => ({
+  SuggestedBindingsPanel: () => null,
+}));
+vi.mock('../metadata-admin/AccessExplainPanel', () => ({
+  AccessExplainPanel: () => null,
+}));
+vi.mock('./StudioAiCopilot', () => ({
+  StudioChatDock: () => null,
+}));
+
+import { AccessPillar } from './StudioDesignSurface';
+
+// jsdom has no matchMedia — useIsMobile (rail overlay) needs a stub.
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as any;
+
+interface Server {
+  byName: Record<string, Record<string, unknown>>;
+  saved: Array<Record<string, unknown>>;
+}
+
+function freshServer(): Server {
+  return {
+    saved: [],
+    byName: {
+      set_a: {
+        name: 'set_a',
+        label: 'Set A',
+        objects: { a_account: { allowRead: true } },
+        fields: {},
+      },
+      set_b: {
+        name: 'set_b',
+        label: 'Set B',
+        objects: { a_account: {} },
+        fields: {},
+      },
+    },
+  };
+}
+
+function makeClient(server: Server) {
+  return {
+    // Serves BOTH the pillar rail (list('permission', { packageId })) and the
+    // embedded matrix (list('object', { packageId }) + list('permission', {})
+    // for the assignable-set allowlist).
+    list: async (type: string) => {
+      if (type === 'permission') {
+        return Object.values(server.byName).map((s) => ({ name: s.name, label: s.label }));
+      }
+      if (type === 'object') return [{ name: 'a_account' }];
+      return [];
+    },
+    listDrafts: async () => [],
+    layered: async (_type: string, name: string) => ({
+      effective: server.byName[name],
+      code: null,
+      overlay: null,
+      overlayScope: null,
+    }),
+    getDraft: async () => null,
+    get: async (type: string) =>
+      type === 'object' ? { fields: [{ name: 'name', label: 'Name' }] } : null,
+    save: async (_t: string, _n: string, payload: Record<string, unknown>) => {
+      server.saved.push(payload);
+      return payload;
+    },
+  } as any;
+}
+
+// This jsdom environment ships no window.confirm at all — install a mock
+// outright rather than spying.
+let confirmSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  clientImpl = makeClient(freshServer());
+  confirmSpy = vi.fn();
+  window.confirm = confirmSpy as unknown as typeof window.confirm;
+});
+
+afterEach(cleanup);
+
+async function renderPillarOnSetA() {
+  render(
+    <MemoryRouter>
+      <AccessPillar packageId="app.a" />
+    </MemoryRouter>,
+  );
+  // First set is auto-selected; its matrix header carries the set name.
+  await screen.findByDisplayValue('set_a');
+}
+
+/** Flip a cell in the open matrix so the editor reports dirty. */
+function dirtyTheMatrix() {
+  const row = screen.getByText('a_account').closest('tr')!;
+  fireEvent.click(within(row).getByRole('button', { name: 'None' }));
+}
+
+describe('AccessPillar — unsaved matrix edits guard', () => {
+  it('asks before switching sets when dirty; cancel keeps the edits in place', async () => {
+    await renderPillarOnSetA();
+    dirtyTheMatrix();
+
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByRole('button', { name: 'Set B' }));
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    // Still on set A, and the edit survived (row "None" left Read unchecked —
+    // a remount would have reloaded allowRead: true).
+    expect(screen.getByDisplayValue('set_a')).toBeInTheDocument();
+    const row = screen.getByText('a_account').closest('tr')!;
+    expect(within(row).getByRole('checkbox', { name: 'a_account Read' })).not.toBeChecked();
+
+    // Confirming the same switch discards and loads set B.
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Set B' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await screen.findByDisplayValue('set_b');
+  });
+
+  it('switches sets without prompting when the matrix is clean', async () => {
+    await renderPillarOnSetA();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set B' }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    await screen.findByDisplayValue('set_b');
+  });
+
+  it('gates the OWD overview swap too, and a confirmed discard clears the guard', async () => {
+    await renderPillarOnSetA();
+    dirtyTheMatrix();
+
+    // Cancel keeps the matrix mounted.
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByRole('button', { name: 'Record sharing (OWD)' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('owd-overview')).not.toBeInTheDocument();
+
+    // Confirm swaps to the overview (matrix unmounts → guard resets).
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Record sharing (OWD)' }));
+    expect(await screen.findByTestId('owd-overview')).toBeInTheDocument();
+
+    // Back to a set: the discarded editor must NOT have left the guard armed.
+    fireEvent.click(screen.getByRole('button', { name: 'Set A' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await screen.findByDisplayValue('set_a');
+  });
+
+  it('never prompts when re-clicking the already-open set (nothing remounts)', async () => {
+    await renderPillarOnSetA();
+    dirtyTheMatrix();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set A' }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    // Not remounted — the unsaved edit is still visible.
+    const row = screen.getByText('a_account').closest('tr')!;
+    expect(within(row).getByRole('checkbox', { name: 'a_account Read' })).not.toBeChecked();
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -3070,7 +3070,8 @@ function AutomationsPillar({
  * leaving other packages' contributed rows untouched (P0). Save writes a package
  * DRAFT and publishes with the whole package via the top-bar Publish (P2, D6).
  */
-function AccessPillar({
+// Exported for tests — routed only through StudioDesignSurface in production.
+export function AccessPillar({
   packageId,
   publishNonce,
   onDraftSaved,
@@ -3120,6 +3121,18 @@ function AccessPillar({
   const [busy, setBusy] = React.useState(false);
   // [ADR-0090 D6] "why can this user access?" — right-side explain sheet.
   const [explainOpen, setExplainOpen] = React.useState(false);
+  // The matrix page below is keyed by `current` (and unmounts entirely when
+  // the OWD overview swaps in), so any rail-driven surface change REMOUNTS it
+  // and would silently discard unsaved matrix edits. The editor reports its
+  // dirty state up (`onDirtyChange`), and every swap is gated on this confirm
+  // — same native prompt as the metadata editor's leave guard. The editor
+  // resets its report on unmount, so a confirmed discard clears `matrixDirty`
+  // by itself.
+  const [matrixDirty, setMatrixDirty] = React.useState(false);
+  const confirmDiscardMatrixEdits = React.useCallback(() => {
+    if (!matrixDirty) return true;
+    return window.confirm(t('engine.edit.unsavedLeaveConfirm', locale));
+  }, [matrixDirty, locale]);
 
   const load = React.useCallback(async () => {
     try {
@@ -3293,6 +3306,7 @@ function AccessPillar({
             <button
               type="button"
               onClick={() => {
+                if (!confirmDiscardMatrixEdits()) return;
                 setOwdOpen(true);
                 setOwdHighlight(null);
                 if (isMobile) setRailOpen(false);
@@ -3325,6 +3339,13 @@ function AccessPillar({
               <button
                 key={p.name}
                 onClick={() => {
+                  // Re-clicking the already-open set is a no-op — nothing
+                  // remounts, so no confirm.
+                  if (!owdOpen && current === p.name) {
+                    if (isMobile) setRailOpen(false);
+                    return;
+                  }
+                  if (!confirmDiscardMatrixEdits()) return;
                   setOwdOpen(false);
                   setCurrent(p.name);
                   if (isMobile) setRailOpen(false);
@@ -3356,6 +3377,9 @@ function AccessPillar({
               <button
                 type="button"
                 onClick={() => {
+                  // Creating a set ends in setCurrent(newName) — a remount of
+                  // the open matrix — so gate the flow up front.
+                  if (!confirmDiscardMatrixEdits()) return;
                   setCreateErr(null);
                   setCreating(true);
                 }}
@@ -3393,7 +3417,11 @@ function AccessPillar({
               packageId={packageId}
               publishNonce={publishNonce}
               onDraftSaved={onDraftSaved}
+              onDirtyChange={setMatrixDirty}
               onOpenOwd={(objectName) => {
+                // The badge deep-link swaps this page out for the OWD
+                // overview — same remount, same guard.
+                if (!confirmDiscardMatrixEdits()) return;
                 setOwdHighlight(objectName || null);
                 setOwdOpen(true);
               }}


### PR DESCRIPTION
## Problem

In the Studio **Access** pillar, the main-panel permission matrix (`PermissionMatrixEditPage`) is keyed by the selected set (`key={current}`) and is swapped out entirely when the OWD overview opens. Clicking another permission set (or the OWD button) in the left rail therefore **remounted the matrix and silently discarded all unsaved checkbox edits** — no confirmation dialog, no `beforeunload` prompt. Reproduced on a live stack.

## Fix

**`PermissionMatrixEditor.tsx`**
- Track dirty state via a JSON snapshot baseline re-anchored on load and after a successful save (same approach as `ResourceEditPage`'s `isDirty`). Every mutation funnels through `setDraft` (matrix cells, header inputs, capabilities, advanced facets), so the comparison covers them all.
- New `onDirtyChange?: (dirty: boolean) => void` prop reporting transitions up; reset to `false` on unmount so a confirmed discard clears the host's guard.
- Install the standard `beforeunload` guard while dirty (tab close / reload), mirroring `ResourceEditPage`.

**`StudioDesignSurface.tsx` (AccessPillar)**
- Holds the reported dirty flag and gates every rail-driven surface swap on the existing `engine.edit.unsavedLeaveConfirm` native confirm:
  - switching to another permission set,
  - opening the OWD overview (pinned rail button **and** the matrix's per-object OWD badge deep-link),
  - starting the new-set creator (it ends in `setCurrent(newName)` — a remount).
- Re-clicking the already-open set is a no-op and never prompts.
- `AccessPillar` is now exported for tests.

## Tests

- `PermissionMatrixEditor.dirty.test.tsx` — `onDirtyChange` contract: clean after load, dirty on edit, clean again after save, reset to false on unmount.
- `StudioDesignSurface.accessGuard.test.tsx` — drives the REAL `AccessPillar` + embedded matrix: cancel keeps the edits mounted and intact, confirm discards and switches, clean switches never prompt, OWD swap is gated, no-op re-clicks never prompt, and a confirmed discard clears the guard for the next switch.

`packages/app-shell`: 186 test files / 1386 tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)