### PR TITLE
feat(dashboard-filters): #2578 item-5 enhancements — nested variable merging, metadata-aware default bindings, server-side optionsFrom distinct

### DIFF
--- a/.changeset/dashboard-filters-item5-enhancements.md
+++ b/.changeset/dashboard-filters-item5-enhancements.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/react": minor
+"@object-ui/core": minor
+"@object-ui/plugin-dashboard": minor
+---
+
+Dashboard-level filters — the three #2578 item-5 enhancements (framework#2501):
+
+- **react**: nested `PageVariablesProvider`s now MERGE instead of shadowing
+  wholesale. A filtered dashboard embedded in a Page with its own `variables`
+  keeps the outer page variables readable inside widget subtrees (`page.*`);
+  an inner definition shadows only the SAME name; writes route to the scope
+  that defines the variable (writing an outer-defined name from inside the
+  nested subtree updates the outer provider); `resetVariables` stays local.
+  Names defined nowhere still write locally, exactly as before.
+- **core**: `buildWidgetScopedFilter` accepts an optional `knownFields` set —
+  a DEFAULT binding whose target field is not on the widget's object is
+  skipped with a console warning instead of emitting a query the backend
+  empty-matches. Explicit `filterBindings` strings are always honoured (a
+  typo surfaces as a visibly empty widget, never a silently dropped filter).
+  Omitting `knownFields` preserves the previous unchecked behaviour.
+- **plugin-dashboard**: `DashboardRenderer` feeds `knownFields` from
+  `dataSource.getObjectSchema` for inline `object` widgets (best-effort —
+  unchecked while metadata loads or when the source can't describe objects).
+  `optionsFrom` dynamic filter options now resolve DISTINCT values
+  server-side via a dataset GROUP BY (`queryDataset` with an inline draft)
+  when the data source supports it, falling back to the previous client-side
+  top-200 dedupe otherwise.

--- a/content/docs/guide/dashboard-filters.md
+++ b/content/docs/guide/dashboard-filters.md
@@ -130,9 +130,10 @@ Options can be static (`options`) or fetched from an object at runtime:
 }
 ```
 
-`optionsFrom` fetches records through the dashboard's data source and
-de-duplicates values client-side (top 200 records; server-side distinct is a
-planned enhancement).
+With a dataset-capable data source, `optionsFrom` resolves distinct values
+**server-side** (a GROUP BY over the source object), so the option list is
+complete regardless of row count. Data sources without dataset queries fall
+back to a best-effort client-side dedupe over the first 200 records.
 
 ### Step 4 — bind each widget's own fields
 
@@ -223,25 +224,30 @@ dataset widget forwards to the dataset query as `runtimeFilter`. Inline
 (`object`-based) and dataset-bound widgets can mix freely on one filtered
 dashboard.
 
+## Nested variable scopes
+
+When a filtered dashboard is embedded inside a Page that declares its own
+`variables`, the two scopes **merge**: inside the dashboard subtree, `page.*`
+resolves the outer Page's variables plus the dashboard's filter values, and a
+dashboard filter only shadows an outer variable that has the **same name**.
+Writes route to the scope that defines the variable — setting an outer-page
+variable from inside the dashboard updates the outer scope, so both subtrees
+stay in sync.
+
 ## Known limitations
 
-- **Embedding a Page with its own `variables`** — the dashboard hosts its
-  filter values in its own variables provider. When a dashboard and a
-  surrounding Page both declare variables, expressions inside the dashboard
-  resolve `page.*` against the **innermost** provider only: the outer Page's
-  variables are shadowed inside the dashboard subtree. Workaround: don't rely
-  on outer-page variables inside a filtered dashboard's widgets (or duplicate
-  the value into a dashboard filter). Merging nested variable contexts is a
-  candidate future enhancement.
 - **Static-data widgets are not filtered** — a widget with an inline `data`
   array has no query to scope, so dashboard filters do not apply to it. Bind
   the widget to an `object` (or a `dataset`) if it should respond to filters.
-- **Default bindings assume the field exists** — when a filter's default
-  `field` does not exist on a widget's object, the widget's query returns
-  empty (or errors, depending on the backend). Map the filter to the right
-  field with `filterBindings: { "<name>": "<field>" }`, or opt the widget out
-  with `filterBindings: { "<name>": false }`. Metadata-aware skipping is a
-  planned enhancement.
+- **Default bindings are metadata-checked for `object` widgets only** — when
+  a filter's default `field` does not exist on an inline widget's object, the
+  binding is skipped with a console warning instead of issuing a query that
+  matches nothing. Dataset-bound widgets can't be checked this way (the
+  dashboard doesn't know the dataset's base-object fields), so map their
+  filters explicitly with `filterBindings: { "<name>": "<field>" }` or opt
+  out with `false`. Explicit string bindings are always honoured as written —
+  a typo shows up as a visibly empty widget rather than a silently dropped
+  filter.
 
 ## i18n
 

--- a/packages/core/src/utils/__tests__/dashboard-filters.test.ts
+++ b/packages/core/src/utils/__tests__/dashboard-filters.test.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   resolveDashboardFilterDefs,
   dashboardFilterVariableDefs,
@@ -187,6 +187,38 @@ describe('buildWidgetScopedFilter', () => {
       ],
     });
     expect(buildWidgetScopedFilter({ id: 'w1' }, defs, {})).toBeUndefined();
+  });
+
+  it('skips a DEFAULT binding whose field is not on the object (knownFields), with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const known = new Set(['status', 'signed_at']);
+      // Default region binding targets `region`, which the object lacks → skipped.
+      expect(buildWidgetScopedFilter({ id: 'w1' }, [regionDef], { region: 'EMEA' }, known)).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain('does not exist');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('always honours an EXPLICIT filterBindings string, even when knownFields lacks it', () => {
+    const known = new Set(['status']);
+    const scoped = buildWidgetScopedFilter(
+      { id: 'w1', filterBindings: { region: 'sales_region' } },
+      [regionDef],
+      { region: 'EMEA' },
+      known,
+    );
+    // The author asked for that field — a typo surfaces as an empty widget,
+    // never a silently-dropped filter.
+    expect(scoped).toEqual({ sales_region: 'EMEA' });
+  });
+
+  it('applies no metadata check when knownFields is omitted (metadata unavailable)', () => {
+    expect(buildWidgetScopedFilter({ id: 'w1' }, [regionDef], { region: 'EMEA' })).toEqual({
+      region: 'EMEA',
+    });
   });
 });
 

--- a/packages/core/src/utils/dashboard-filters.ts
+++ b/packages/core/src/utils/dashboard-filters.ts
@@ -218,11 +218,21 @@ function resolveBoundField(
  * one `{ [boundField]: condition }` entry per active, bound filter, combined
  * with `$and` when several apply. Returns `undefined` when nothing applies —
  * callers then leave the widget's own filter untouched.
+ *
+ * Metadata-aware default bindings (#2578 item 5): when `knownFields` is
+ * provided (the widget's object field names), a DEFAULT binding whose target
+ * field is not on the object is skipped with a console warning instead of
+ * emitting a query the backend will empty-match or reject. An EXPLICIT
+ * `filterBindings` string is always honoured — the author asked for that
+ * field, so a typo surfaces as a visible (fixable) empty widget rather than
+ * being silently dropped. Callers omit `knownFields` when metadata is not
+ * (yet) available, preserving the previous behaviour.
  */
 export function buildWidgetScopedFilter(
   widget: Pick<DashboardWidgetSchema, 'id' | 'filterBindings'>,
   defs: DashboardFilterDef[],
   values: Record<string, unknown>,
+  knownFields?: ReadonlySet<string>,
 ): Record<string, unknown> | undefined {
   const conditions: Record<string, unknown>[] = [];
 
@@ -231,6 +241,17 @@ export function buildWidgetScopedFilter(
     if (isEmptyValue(def, value)) continue;
     const field = resolveBoundField(widget, def);
     if (!field) continue;
+    const isExplicit = typeof widget.filterBindings?.[def.name] === 'string';
+    if (!isExplicit && knownFields && !knownFields.has(field)) {
+      if (typeof console !== 'undefined') {
+        console.warn(
+          `[dashboard-filters] skipping filter "${def.name}" on widget "${widget.id ?? '?'}": ` +
+            `default field "${field}" does not exist on the widget's object — ` +
+            `map it with filterBindings: { "${def.name}": "<field>" } or opt out with false`,
+        );
+      }
+      continue;
+    }
     const condition = buildFilterCondition(def, value);
     if (condition === undefined) continue;
     conditions.push({ [field]: condition });

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -259,6 +259,13 @@ Notes:
   not filtered.
 - Filter values are also readable in widget expressions as `page.<name>`
   (e.g. `page.region`), since they are hosted as dashboard variables.
+- `optionsFrom` resolves distinct option values server-side (a dataset
+  GROUP BY) when the data source supports dataset queries, falling back to
+  a client-side dedupe over the first 200 records otherwise.
+- Default bindings are metadata-aware for inline `object` widgets: a default
+  field that doesn't exist on the widget's object is skipped with a console
+  warning instead of emitting a query that matches nothing. Explicit
+  `filterBindings` strings are always honoured as written.
 
 ## TypeScript Support
 

--- a/packages/plugin-dashboard/src/DashboardFilterBar.tsx
+++ b/packages/plugin-dashboard/src/DashboardFilterBar.tsx
@@ -135,32 +135,83 @@ function SelectFilter({ def, value, onChange, dataSource }: { def: DashboardFilt
   const tt = useSafeTranslate();
   const [dynamicOptions, setDynamicOptions] = useState<Array<{ value: string; label: string }> | null>(null);
 
-  // Best-effort dynamic options: fetch once, dedupe client-side, degrade to
-  // an empty list on failure (same tolerance style as DatasetWidget's
-  // option-color fetch).
+  // Dynamic options, server-side first (#2578 item 5): when the data source
+  // supports dataset queries, distinct values come from a GROUP BY on the
+  // server (an inline dataset draft over the source object), so the option
+  // list is complete regardless of row count. Falls back to the original
+  // best-effort client-side dedupe (top 200 records) when dataset queries
+  // are unavailable or the draft is rejected; degrades to an empty list on
+  // total failure (same tolerance style as DatasetWidget's option-color
+  // fetch).
   const from = def.optionsFrom;
   useEffect(() => {
-    if (!from || !dataSource || typeof dataSource.find !== 'function') return;
+    if (!from || !dataSource) return;
     let cancelled = false;
-    dataSource
-      .find(from.object, {
-        fields: [from.valueField, ...(from.labelField ? [from.labelField] : [])],
-        ...(from.filter ? { $filter: from.filter } : {}),
-        top: 200,
-      })
-      .then((records: any) => {
-        if (cancelled) return;
-        const rows: any[] = Array.isArray(records) ? records : records?.items ?? [];
-        const seen = new Map<string, string>();
-        for (const r of rows) {
-          const v = r?.[from.valueField];
-          if (v === undefined || v === null || v === '') continue;
-          const key = String(v);
-          if (!seen.has(key)) seen.set(key, String(from.labelField ? r?.[from.labelField] ?? key : key));
-        }
-        setDynamicOptions(Array.from(seen, ([v, l]) => ({ value: v, label: l })));
-      })
-      .catch(() => { if (!cancelled) setDynamicOptions([]); });
+
+    const clientSideFallback = () => {
+      if (typeof dataSource.find !== 'function') {
+        if (!cancelled) setDynamicOptions([]);
+        return;
+      }
+      dataSource
+        .find(from.object, {
+          fields: [from.valueField, ...(from.labelField ? [from.labelField] : [])],
+          ...(from.filter ? { $filter: from.filter } : {}),
+          top: 200,
+        })
+        .then((records: any) => {
+          if (cancelled) return;
+          const rows: any[] = Array.isArray(records) ? records : records?.items ?? [];
+          const seen = new Map<string, string>();
+          for (const r of rows) {
+            const v = r?.[from.valueField];
+            if (v === undefined || v === null || v === '') continue;
+            const key = String(v);
+            if (!seen.has(key)) seen.set(key, String(from.labelField ? r?.[from.labelField] ?? key : key));
+          }
+          setDynamicOptions(Array.from(seen, ([v, l]) => ({ value: v, label: l })));
+        })
+        .catch(() => { if (!cancelled) setDynamicOptions([]); });
+    };
+
+    if (typeof dataSource.queryDataset === 'function') {
+      const dimensions = [{ name: from.valueField, field: from.valueField }];
+      if (from.labelField && from.labelField !== from.valueField) {
+        dimensions.push({ name: from.labelField, field: from.labelField });
+      }
+      dataSource
+        .queryDataset(
+          {
+            name: 'dashboard_filter_options',
+            label: 'Dashboard filter options',
+            object: from.object,
+            dimensions,
+            measures: [{ name: 'option_count', aggregate: 'count' }],
+          },
+          {
+            dimensions: dimensions.map((d) => d.name),
+            measures: ['option_count'],
+            ...(from.filter ? { runtimeFilter: from.filter } : {}),
+            order: { [from.valueField]: 'asc' as const },
+            limit: 1000,
+          },
+        )
+        .then((res: any) => {
+          if (cancelled) return;
+          const rows: any[] = Array.isArray(res?.rows) ? res.rows : [];
+          const seen = new Map<string, string>();
+          for (const r of rows) {
+            const v = r?.[from.valueField];
+            if (v === undefined || v === null || v === '') continue;
+            const key = String(v);
+            if (!seen.has(key)) seen.set(key, String(from.labelField ? r?.[from.labelField] ?? key : key));
+          }
+          setDynamicOptions(Array.from(seen, ([v, l]) => ({ value: v, label: l })));
+        })
+        .catch(() => { if (!cancelled) clientSideFallback(); });
+    } else {
+      clientSideFallback();
+    }
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [from?.object, from?.valueField, from?.labelField, dataSource]);

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -265,6 +265,38 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
     );
     const { variables: filterValues, setVariable: setFilterValue, resetVariables: resetFilterValues } = usePageVariables();
 
+    // Metadata-aware default bindings (#2578 item 5): fetch each inline
+    // widget object's field names once so buildWidgetScopedFilter can skip a
+    // DEFAULT binding whose field doesn't exist on that object (explicit
+    // filterBindings strings are always honoured). Best-effort — while a
+    // schema is loading (or the data source can't describe objects), the
+    // entry stays absent and the previous unchecked behaviour applies.
+    const [objectFieldSets, setObjectFieldSets] = useState<Record<string, ReadonlySet<string>>>({});
+    useEffect(() => {
+      if (filterDefs.length === 0 || !dataSource || typeof (dataSource as any).getObjectSchema !== 'function') return;
+      const objects = Array.from(
+        new Set(
+          (schema.widgets ?? [])
+            .map((w: DashboardWidgetSchema) => (w as any).object)
+            .filter((o: unknown): o is string => typeof o === 'string' && o.length > 0),
+        ),
+      );
+      let cancelled = false;
+      for (const objectName of objects) {
+        (dataSource as any)
+          .getObjectSchema(objectName)
+          .then((objSchema: any) => {
+            if (cancelled) return;
+            const fields = objSchema?.fields;
+            if (!fields || typeof fields !== 'object') return;
+            setObjectFieldSets((prev) => ({ ...prev, [objectName]: new Set(Object.keys(fields)) }));
+          })
+          .catch(() => { /* stay unchecked for this object */ });
+      }
+      return () => { cancelled = true; };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [filterDefs.length, dataSource, schema.widgets]);
+
     // Build ActionDef[] from header actions so useActionEngine can dispatch by name.
     const headerActionDefs = useMemo<ActionDef[]>(() => {
       const actions = schema.header?.actions ?? [];
@@ -830,7 +862,12 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
         // schemas re-fetch on filter change, so no widget renderer changes
         // are needed downstream.
         const scopedFilter = filterDefs.length > 0
-            ? buildWidgetScopedFilter(widget, filterDefs, filterValues)
+            ? buildWidgetScopedFilter(
+                widget,
+                filterDefs,
+                filterValues,
+                typeof (widget as any).object === 'string' ? objectFieldSets[(widget as any).object] : undefined,
+              )
             : undefined;
         const componentSchema = (() => {
             const cs = getComponentSchema() as Record<string, any>;
@@ -1139,9 +1176,10 @@ DashboardRendererInner.displayName = 'DashboardRendererInner';
  * them, and widget expressions can reference them as `page.<name>`.
  * Dashboards without filters render exactly as before — no provider mounted.
  *
- * Known limitation: when a filtered dashboard is embedded inside a Page with
- * its own variables, this inner provider shadows the outer one for widget
- * subtrees. The primary path (`DashboardView`) mounts no outer provider.
+ * When a filtered dashboard is embedded inside a Page with its own
+ * variables, the nested providers MERGE (#2578 item 5): outer page variables
+ * stay readable inside widget subtrees, and only a same-named filter shadows
+ * the outer variable.
  */
 export const DashboardRenderer = forwardRef<HTMLDivElement, DashboardRendererProps>(
   (props, ref) => {

--- a/packages/plugin-dashboard/src/__tests__/DashboardFilterBar.options.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardFilterBar.options.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * DashboardFilterBar — `optionsFrom` dynamic options, server-side first
+ * (#2578 item 5): with a dataset-capable data source, distinct option values
+ * come from a server GROUP BY (inline dataset draft over the source object);
+ * the original client-side top-200 dedupe is only the fallback.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { DashboardFilterBar } from '../DashboardFilterBar';
+import type { DashboardFilterDef } from '@object-ui/core';
+
+afterEach(cleanup);
+
+const defs: DashboardFilterDef[] = [
+  {
+    name: 'industry',
+    field: 'industry',
+    type: 'select',
+    optionsFrom: { object: 'accounts', valueField: 'industry', labelField: 'industry' },
+  } as DashboardFilterDef,
+];
+
+function renderBar(dataSource: any) {
+  return render(
+    <DashboardFilterBar defs={defs} values={{}} onChange={vi.fn()} dataSource={dataSource} />,
+  );
+}
+
+describe('DashboardFilterBar — optionsFrom fetching', () => {
+  it('uses a server-side dataset query (GROUP BY distinct) when available', async () => {
+    const queryDataset = vi.fn().mockResolvedValue({
+      rows: [
+        { industry: 'finance', option_count: 3 },
+        { industry: 'retail', option_count: 2 },
+      ],
+    });
+    const find = vi.fn();
+    renderBar({ queryDataset, find });
+
+    await waitFor(() => expect(queryDataset).toHaveBeenCalledTimes(1));
+    const [draft, selection] = queryDataset.mock.calls[0];
+    expect(draft).toMatchObject({
+      object: 'accounts',
+      dimensions: [{ name: 'industry', field: 'industry' }],
+      measures: [{ name: 'option_count', aggregate: 'count' }],
+    });
+    expect(selection).toMatchObject({
+      dimensions: ['industry'],
+      measures: ['option_count'],
+      order: { industry: 'asc' },
+    });
+    // The server path won — no record scan needed.
+    expect(find).not.toHaveBeenCalled();
+    expect(screen.getByTestId('dashboard-filter-industry')).toBeInTheDocument();
+  });
+
+  it('falls back to the client-side top-200 dedupe when the dataset query fails', async () => {
+    const queryDataset = vi.fn().mockRejectedValue(new Error('datasets unsupported'));
+    const find = vi.fn().mockResolvedValue([
+      { industry: 'finance' },
+      { industry: 'finance' },
+      { industry: 'retail' },
+    ]);
+    renderBar({ queryDataset, find });
+
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
+    expect(find).toHaveBeenCalledWith('accounts', expect.objectContaining({ top: 200 }));
+  });
+
+  it('uses the client-side path directly when the data source has no queryDataset', async () => {
+    const find = vi.fn().mockResolvedValue([{ industry: 'retail' }]);
+    renderBar({ find });
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/react/src/hooks/__tests__/usePageVariables.test.tsx
+++ b/packages/react/src/hooks/__tests__/usePageVariables.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * PageVariablesProvider — nested context MERGING (objectui#2578, item 5).
+ *
+ * A nested provider (e.g. a filtered dashboard embedded in a Page with its
+ * own `variables`) must not shadow the outer scope wholesale: inside the
+ * nested subtree the outer variables stay readable, an inner definition with
+ * the same name deliberately shadows the outer one, and writes route to the
+ * scope that DEFINES the variable.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { PageVariablesProvider, usePageVariables } from '../usePageVariables';
+import type { PageVariable } from '@object-ui/types';
+
+afterEach(cleanup);
+
+/** Renders a variable's value and a button that writes to it. */
+function Probe({ id, name, writeValue }: { id: string; name: string; writeValue?: any }) {
+  const { variables, setVariable } = usePageVariables();
+  return (
+    <div>
+      <span data-testid={`${id}-value`}>{JSON.stringify(variables[name] ?? null)}</span>
+      <button data-testid={`${id}-write`} onClick={() => setVariable(name, writeValue)} />
+    </div>
+  );
+}
+
+function ResetProbe({ id }: { id: string }) {
+  const { resetVariables } = usePageVariables();
+  return <button data-testid={`${id}-reset`} onClick={resetVariables} />;
+}
+
+const defs = (...vars: Array<[string, any]>): PageVariable[] =>
+  vars.map(([name, defaultValue]) => ({ name, type: 'string', defaultValue }) as PageVariable);
+
+describe('PageVariablesProvider — single scope', () => {
+  it('initializes from definitions and writes locally', () => {
+    render(
+      <PageVariablesProvider definitions={defs(['region', 'emea'])}>
+        <Probe id="p" name="region" writeValue="apac" />
+      </PageVariablesProvider>,
+    );
+    expect(screen.getByTestId('p-value').textContent).toBe('"emea"');
+    fireEvent.click(screen.getByTestId('p-write'));
+    expect(screen.getByTestId('p-value').textContent).toBe('"apac"');
+  });
+});
+
+describe('PageVariablesProvider — nested scopes merge (objectui#2578)', () => {
+  it('outer variables stay readable inside a nested provider', () => {
+    render(
+      <PageVariablesProvider definitions={defs(['outer_var', 'from-outer'])}>
+        <PageVariablesProvider definitions={defs(['inner_var', 'from-inner'])}>
+          <Probe id="outer-read" name="outer_var" />
+          <Probe id="inner-read" name="inner_var" />
+        </PageVariablesProvider>
+      </PageVariablesProvider>,
+    );
+    expect(screen.getByTestId('outer-read-value').textContent).toBe('"from-outer"');
+    expect(screen.getByTestId('inner-read-value').textContent).toBe('"from-inner"');
+  });
+
+  it('an inner definition with the same name shadows the outer one', () => {
+    render(
+      <PageVariablesProvider definitions={defs(['region', 'outer-region'])}>
+        <Probe id="outer" name="region" />
+        <PageVariablesProvider definitions={defs(['region', 'inner-region'])}>
+          <Probe id="inner" name="region" />
+        </PageVariablesProvider>
+      </PageVariablesProvider>,
+    );
+    expect(screen.getByTestId('outer-value').textContent).toBe('"outer-region"');
+    expect(screen.getByTestId('inner-value').textContent).toBe('"inner-region"');
+  });
+
+  it('writing an outer-defined name from inside the nested subtree updates the OUTER scope', () => {
+    render(
+      <PageVariablesProvider definitions={defs(['outer_var', 'initial'])}>
+        <Probe id="outer" name="outer_var" />
+        <PageVariablesProvider definitions={defs(['inner_var', ''])}>
+          <Probe id="inner" name="outer_var" writeValue="written-from-inner" />
+        </PageVariablesProvider>
+      </PageVariablesProvider>,
+    );
+    fireEvent.click(screen.getByTestId('inner-write'));
+    // Both subtrees observe the update — the write routed to the defining scope.
+    expect(screen.getByTestId('outer-value').textContent).toBe('"written-from-inner"');
+    expect(screen.getByTestId('inner-value').textContent).toBe('"written-from-inner"');
+  });
+
+  it('a name defined nowhere is created locally and never leaks to the outer scope', () => {
+    render(
+      <PageVariablesProvider definitions={defs(['outer_var', ''])}>
+        <Probe id="outer" name="adhoc" />
+        <PageVariablesProvider definitions={defs(['inner_var', ''])}>
+          <Probe id="inner" name="adhoc" writeValue="local-only" />
+        </PageVariablesProvider>
+      </PageVariablesProvider>,
+    );
+    fireEvent.click(screen.getByTestId('inner-write'));
+    expect(screen.getByTestId('inner-value').textContent).toBe('"local-only"');
+    expect(screen.getByTestId('outer-value').textContent).toBe('null');
+  });
+
+  it('resetVariables resets only the local scope', () => {
+    render(
+      <PageVariablesProvider definitions={defs(['outer_var', 'outer-default'])}>
+        <Probe id="outer" name="outer_var" writeValue="outer-dirty" />
+        <PageVariablesProvider definitions={defs(['inner_var', 'inner-default'])}>
+          <Probe id="inner" name="inner_var" writeValue="inner-dirty" />
+          <ResetProbe id="inner" />
+        </PageVariablesProvider>
+      </PageVariablesProvider>,
+    );
+    fireEvent.click(screen.getByTestId('outer-write'));
+    fireEvent.click(screen.getByTestId('inner-write'));
+    fireEvent.click(screen.getByTestId('inner-reset'));
+    // Inner back to default; outer keeps its dirty value.
+    expect(screen.getByTestId('inner-value').textContent).toBe('"inner-default"');
+    expect(screen.getByTestId('outer-value').textContent).toBe('"outer-dirty"');
+  });
+});

--- a/packages/react/src/hooks/usePageVariables.tsx
+++ b/packages/react/src/hooks/usePageVariables.tsx
@@ -85,6 +85,16 @@ export interface PageVariablesProviderProps {
  * Initializes variables from their definitions and provides read/write access
  * to all child components via the usePageVariables hook.
  *
+ * Nesting MERGES contexts (objectui#2578): a nested provider (e.g. a filtered
+ * dashboard embedded in a Page that declares its own `variables`) no longer
+ * shadows the outer scope wholesale. Inside the nested subtree, `variables`
+ * exposes the outer values plus the inner ones (an inner definition with the
+ * SAME name shadows the outer one, deliberately), and writes route to the
+ * scope that DEFINES the variable — writing an outer-defined name from inside
+ * the nested subtree updates the outer provider, so both subtrees stay in
+ * sync. Names defined nowhere are written locally. `resetVariables` resets
+ * only the local scope's definitions.
+ *
  * @example
  * ```tsx
  * <PageVariablesProvider definitions={[
@@ -99,27 +109,58 @@ export const PageVariablesProvider: React.FC<PageVariablesProviderProps> = ({
   definitions,
   children,
 }) => {
-  const [variables, setVariablesState] = useState<Record<string, any>>(() =>
+  const parent = useContext(PageVariablesContext);
+
+  const [ownVariables, setVariablesState] = useState<Record<string, any>>(() =>
     initializeVariables(definitions)
   );
 
-  const setVariable = useCallback((name: string, value: any) => {
-    setVariablesState((prev) => ({ ...prev, [name]: value }));
-  }, []);
+  const defs = useMemo<PageVariable[]>(() => definitions ?? [], [definitions]);
 
-  const setVariables = useCallback((updates: Record<string, any>) => {
-    setVariablesState((prev) => ({ ...prev, ...updates }));
-  }, []);
+  // Names THIS provider owns (defines). Writes to a name an ancestor defines
+  // — and this provider doesn't — delegate upward; everything else (own
+  // names AND names defined nowhere) writes locally, so ad-hoc variables
+  // behave exactly as before.
+  const ownNames = useMemo(() => new Set(defs.map((d) => d.name)), [defs]);
+
+  const setVariable = useCallback(
+    (name: string, value: any) => {
+      if (!ownNames.has(name) && parent && parent.definitions.some((d) => d.name === name)) {
+        parent.setVariable(name, value);
+        return;
+      }
+      setVariablesState((prev) => ({ ...prev, [name]: value }));
+    },
+    [ownNames, parent]
+  );
+
+  const setVariables = useCallback(
+    (updates: Record<string, any>) => {
+      for (const [name, value] of Object.entries(updates)) setVariable(name, value);
+    },
+    [setVariable]
+  );
 
   const resetVariables = useCallback(() => {
     setVariablesState(initializeVariables(definitions));
   }, [definitions]);
 
-  const defs = useMemo<PageVariable[]>(() => definitions ?? [], [definitions]);
+  // Merged view: outer scope first, own values win on name collisions.
+  const variables = useMemo<Record<string, any>>(
+    () => (parent ? { ...parent.variables, ...ownVariables } : ownVariables),
+    [parent, ownVariables]
+  );
+  const mergedDefs = useMemo<PageVariable[]>(
+    () =>
+      parent
+        ? [...parent.definitions.filter((d) => !ownNames.has(d.name)), ...defs]
+        : defs,
+    [parent, defs, ownNames]
+  );
 
   const value = useMemo<PageVariablesContextValue>(
-    () => ({ variables, definitions: defs, setVariable, setVariables, resetVariables }),
-    [variables, defs, setVariable, setVariables, resetVariables]
+    () => ({ variables, definitions: mergedDefs, setVariable, setVariables, resetVariables }),
+    [variables, mergedDefs, setVariable, setVariables, resetVariables]
   );
 
   return (


### PR DESCRIPTION
## Summary

Third (final) follow-up round for #2578 — the three item-5 enhancements, all objectui-side (framework#2501):

**1. Nested `PageVariablesProvider` merging (`@object-ui/react`)** — a filtered dashboard embedded in a Page with its own `variables` no longer shadows the outer scope wholesale:

- inside the nested subtree, `page.*` exposes the outer variables plus the inner ones; an inner definition shadows only the **same name** (deliberately);
- writes route to the scope that **defines** the variable — writing an outer-defined name from inside the nested subtree updates the outer provider, so both subtrees stay in sync; names defined nowhere still write locally, exactly as before;
- `resetVariables` resets only the local scope (the dashboard's Reset button never clears page state).

**2. Metadata-aware default bindings (`@object-ui/core` + `plugin-dashboard`)** — `buildWidgetScopedFilter` takes an optional `knownFields` set; a DEFAULT binding whose target field doesn't exist on the widget's object is skipped with a console warning instead of emitting a query the backend empty-matches. `DashboardRenderer` feeds `knownFields` from `dataSource.getObjectSchema` for inline `object` widgets (best-effort — unchecked while metadata loads / for dataset widgets / when the source can't describe objects). Explicit `filterBindings` strings are always honoured as written — a typo surfaces as a visibly empty widget, never a silently dropped filter.

**3. Server-side distinct for `optionsFrom` (`plugin-dashboard`)** — dynamic filter options now resolve DISTINCT values server-side via a dataset GROUP BY (`queryDataset` with an inline draft over the source object, ordered, limit 1000) when the data source supports dataset queries; the previous best-effort client-side top-200 dedupe remains as the fallback (and on draft rejection).

## Docs

- `content/docs/guide/dashboard-filters.md` — known-limitations section rewritten: the nested-shadowing and missing-field limitations are lifted; a new "Nested variable scopes" section documents the merge semantics; `optionsFrom` paragraph updated.
- `packages/plugin-dashboard/README.md` — notes updated to match.

## Testing

- 12 new tests: 6 for nested-provider merging (`usePageVariables.test.tsx`), 3 for `knownFields` skip/honour/absent semantics (`dashboard-filters.test.ts`), 3 for the optionsFrom server-first/fallback paths (`DashboardFilterBar.options.test.tsx`).
- Full suites of the three touched packages: 85 files / 1452 tests passing; `core` / `react` / `plugin-dashboard` builds clean.
- Changeset: minor for `@object-ui/react`, `@object-ui/core`, `@object-ui/plugin-dashboard`.

Refs #2578, #2576, framework#2501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG5LQnPbQbjAAyofghzz3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG5LQnPbQbjAAyofghzz3Z)_