### PR TITLE
fix(components): pin sticky leading cells at measured header widths

### DIFF
--- a/packages/components/src/renderers/complex/__tests__/data-table-sticky-offsets.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-sticky-offsets.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: pinned leading cells (checkbox / row number / frozen data
+ * columns) must stick at the CUMULATIVE MEASURED widths of the cells before
+ * them, not at hardcoded 40px estimates. Bug context (titanwind-ehr#418): the
+ * table's auto layout collapsed the checkbox column to its ~28px min-content
+ * while the row-number cell stuck at `left: 40px`, leaving a ~12px uncovered
+ * strip between them where horizontally scrolled cells showed through.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import '../data-table';
+
+/** Header-cell widths the mocked layout reports (checkbox, #, then data columns). */
+const HEADER_WIDTHS = [28, 47, 160, 140, 120];
+
+function mockRect(width: number): DOMRect {
+  return {
+    width, height: 40, top: 0, left: 0, bottom: 40, right: width, x: 0, y: 0,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+const originalGetRect = HTMLElement.prototype.getBoundingClientRect;
+
+function renderTable(schema: any) {
+  const DataTable = ComponentRegistry.get('data-table') as any;
+  if (!DataTable) throw new Error('data-table not registered');
+  return render(<DataTable schema={schema} />);
+}
+
+const schema = {
+  data: [
+    { id: '1', code: 'PP-001', product: 'Tower T1', island: 'Welding' },
+    { id: '2', code: 'PP-002', product: 'Tower T1', island: 'Welding' },
+  ],
+  pagination: false,
+  searchable: false,
+  selectable: true,
+  showRowNumbers: true,
+  frozenColumns: 1,
+  columns: [
+    { header: 'Code', accessorKey: 'code', width: 160 },
+    { header: 'Product', accessorKey: 'product', width: 140 },
+    { header: 'Island', accessorKey: 'island', width: 120 },
+  ],
+};
+
+describe('data-table sticky offsets follow measured header widths', () => {
+  beforeAll(() => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      function (this: HTMLElement) {
+        if (this.tagName === 'TH' && this.parentElement) {
+          const index = Array.prototype.indexOf.call(this.parentElement.children, this);
+          return mockRect(HEADER_WIDTHS[index] ?? 100);
+        }
+        return originalGetRect.call(this);
+      },
+    );
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pins the row-number and frozen data cells at cumulative measured widths', () => {
+    const { container } = renderTable(schema);
+
+    const headCells = container.querySelectorAll('thead th');
+    // Checkbox header sticks at the container edge via the `left-0` utility.
+    expect(headCells[0].className).toContain('left-0');
+    // Row-number header sticks right after the MEASURED 28px checkbox column
+    // (the pre-fix hardcoded 40px left a 12px show-through strip).
+    expect((headCells[1] as HTMLElement).style.left).toBe('28px');
+    // First frozen data column sticks after checkbox (28) + row number (47).
+    expect((headCells[2] as HTMLElement).style.left).toBe('75px');
+
+    const bodyCells = document.querySelectorAll('tbody tr')[0].querySelectorAll('td');
+    expect(bodyCells[0].className).toContain('left-0');
+    expect((bodyCells[1] as HTMLElement).style.left).toBe('28px');
+    expect((bodyCells[2] as HTMLElement).style.left).toBe('75px');
+  });
+
+  it('keeps non-sticky layout untouched when nothing is frozen', () => {
+    const { container } = renderTable({ ...schema, frozenColumns: 0 });
+    const headCells = container.querySelectorAll('thead th');
+    expect(headCells[1].className).not.toContain('sticky');
+    expect((headCells[1] as HTMLElement).style.left).toBe('');
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -7,7 +7,7 @@
  */
 
 // Enterprise-level DataTable Component (Airtable-like)
-import React, { useState, useMemo, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useRef, useEffect, useLayoutEffect } from 'react';
 import { cn } from '../../lib/utils';
 import { resolveIcon } from '../action/resolve-icon';
 import { useGridFieldAuthoring } from '../../context/gridFieldAuthoring';
@@ -428,6 +428,52 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   const [pageSize, setPageSize] = useState(initialPageSize);
   const [columns, setColumns] = useState(initialColumns);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+
+  // Sticky-left offsets for the leading pinned cells (checkbox, row number,
+  // frozen data columns), measured from the REAL rendered header-cell widths.
+  // The table's auto layout does not guarantee the utility columns their
+  // declared `w-10`: the checkbox column can collapse to its ~28px min-content
+  // while the row-number column stretches past 40px. Hardcoded 40px offsets
+  // then leave an uncovered strip between pinned cells where horizontally
+  // scrolled content shows through (titanwind-ehr#418), so pin each cell at
+  // the cumulative measured width of the cells before it instead.
+  const headerRowRef = useRef<HTMLTableRowElement | null>(null);
+  const [measuredStickyLefts, setMeasuredStickyLefts] = useState<number[] | null>(null);
+  const stickyLeadingCount = frozenColumns > 0
+    ? (selectable ? 1 : 0) + (showRowNumbers ? 1 : 0) + Math.min(frozenColumns, columns.length)
+    : 0;
+
+  useLayoutEffect(() => {
+    const headerRow = headerRowRef.current;
+    if (stickyLeadingCount === 0 || !headerRow) {
+      setMeasuredStickyLefts(null);
+      return;
+    }
+    const measure = () => {
+      const cells = Array.from(headerRow.children).slice(0, stickyLeadingCount) as HTMLElement[];
+      let acc = 0;
+      const lefts = cells.map((cell) => {
+        const left = acc;
+        acc += cell.getBoundingClientRect().width;
+        return left;
+      });
+      setMeasuredStickyLefts((prev) =>
+        prev && prev.length === lefts.length && prev.every((v, i) => Math.abs(v - lefts[i]) < 0.5)
+          ? prev
+          : lefts
+      );
+    };
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    // Header-cell widths ARE the column widths, and they change outside React
+    // (column resize drag, density toggle, content growth), so re-measure on
+    // any of the observed cells resizing.
+    const observer = new ResizeObserver(measure);
+    Array.from(headerRow.children)
+      .slice(0, stickyLeadingCount)
+      .forEach((cell) => observer.observe(cell));
+    return () => observer.disconnect();
+  }, [stickyLeadingCount, columns]);
   const [draggedColumn, setDraggedColumn] = useState<number | null>(null);
   const [dragOverColumn, setDragOverColumn] = useState<number | null>(null);
   const [editingCell, setEditingCell] = useState<{ rowIndex: number; columnKey: string } | null>(null);
@@ -1214,7 +1260,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
         <Table containerClassName="overflow-visible">
           {caption && <TableCaption>{caption}</TableCaption>}
           <TableHeader className="sticky top-0 bg-background z-10">
-            <TableRow>
+            <TableRow ref={headerRowRef}>
               {selectable && (
                 <TableHead className={cn("w-10 bg-background px-3", frozenColumns > 0 && "sticky left-0 z-20")}>
                   <Checkbox
@@ -1224,7 +1270,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                 </TableHead>
               )}
               {showRowNumbers && (
-                <TableHead className={cn("w-10 bg-background text-center px-3", frozenColumns > 0 && "sticky z-20")} style={frozenColumns > 0 ? { left: selectable ? 40 : 0 } : undefined}>
+                <TableHead className={cn("w-10 bg-background text-center px-3", frozenColumns > 0 && "sticky z-20")} style={frozenColumns > 0 ? { left: measuredStickyLefts?.[selectable ? 1 : 0] ?? (selectable ? 40 : 0) } : undefined}>
                   <span className="text-xs text-muted-foreground">#</span>
                 </TableHead>
               )}
@@ -1240,7 +1286,8 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                 const isDragOver = dragOverColumn === index;
                 const isFrozen = frozenColumns > 0 && index < frozenColumns;
                 const frozenOffset = isFrozen
-                  ? columns.slice(0, index).reduce((sum, c, i) => {
+                  ? measuredStickyLefts?.[(selectable ? 1 : 0) + (showRowNumbers ? 1 : 0) + index]
+                    ?? columns.slice(0, index).reduce((sum, c, i) => {
                       if (i < frozenColumns) {
                         const w = columnWidths[c.accessorKey] || c.width || autoSizedWidths[c.accessorKey];
                         return sum + (typeof w === 'number' ? w : w ? parseInt(String(w), 10) || 150 : 150);
@@ -1440,7 +1487,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                         </TableCell>
                       )}
                       {showRowNumbers && (
-                        <TableCell className={cn("text-center w-10 relative", cellClassName, frozenColumns > 0 && "sticky z-10 bg-background")} style={frozenColumns > 0 ? { left: selectable ? 40 : 0 } : undefined}>
+                        <TableCell className={cn("text-center w-10 relative", cellClassName, frozenColumns > 0 && "sticky z-10 bg-background")} style={frozenColumns > 0 ? { left: measuredStickyLefts?.[selectable ? 1 : 0] ?? (selectable ? 40 : 0) } : undefined}>
                           <span className={cn("text-xs text-muted-foreground tabular-nums select-none", !selectable && schema.onRowClick && "group-hover/row:invisible")}>
                             {globalIndex + 1}
                           </span>
@@ -1474,7 +1521,8 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                         const isEditable = editable && col.editable !== false;
                         const isFrozen = frozenColumns > 0 && colIndex < frozenColumns;
                         const frozenOffset = isFrozen
-                          ? columns.slice(0, colIndex).reduce((sum, c, i) => {
+                          ? measuredStickyLefts?.[(selectable ? 1 : 0) + (showRowNumbers ? 1 : 0) + colIndex]
+                            ?? columns.slice(0, colIndex).reduce((sum, c, i) => {
                               if (i < frozenColumns) {
                                 const w = columnWidths[c.accessorKey] || c.width || autoSizedWidths[c.accessorKey];
                                 return sum + (typeof w === 'number' ? w : w ? parseInt(String(w), 10) || 150 : 150);


### PR DESCRIPTION
Closes #2591(下游报告:steedos-labs/os-project-titanwind-ehr#418)

## 问题

grid 列表固定列横向滚动时,左侧固定区(复选框 / 行号 / 冻结列)遮不住下层内容:sticky 偏移写死为 40px / 150px 估算值,而表格自动布局把复选框列压到 ~28px 实宽(shadcn 原语的 `[&:has([role=checkbox])]:pr-0`),固定单元格之间留下 ~12px 未遮挡竖条,滚过去的单元格从缝里透出。

## 修复

`data-table.tsx`:`useLayoutEffect` 里用 `getBoundingClientRect` 实测表头单元格宽度,按累计实测宽度给每个前导固定单元格设 `left`;`ResizeObserver` 覆盖列宽拖拽、密度切换等 React 之外的宽度变化;实测值就绪前保留原硬编码值兜底。

## 验证

- **app-showcase 真机对照**(framework `objectstack dev`,同环境只换 console dist):修复前表头 + 5/5 行实测缝隙 12px / 8.45px(`left` 写死 0/40/80);修复后 `left` 为实测 0/28/59.55px,scrollLeft 0 / 中 / 满滚 + 900px 视口重排后全程零缝隙,无 console 报错;
- 新增回归测试 `data-table-sticky-offsets.test.tsx`(mock 表头实宽,断言累计偏移;`frozenColumns: 0` 时不受影响);
- 相关 data-table 测试 8 个文件 67 个用例全绿;`tsc --noEmit` 干净;
- 纯 bug 修复,无 changeset(按 AGENTS.md)。