### PR TITLE
fix(fields): PeoplePicker cursor resets only on real result changes (de-flakes keyboard test)

### DIFF
--- a/.changeset/people-picker-cursor-reset-flake.md
+++ b/.changeset/people-picker-cursor-reset-flake.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/fields": patch
+---
+
+fix(fields): PeoplePicker keyboard cursor no longer resets on identity-only
+result re-emissions
+
+The cursor-reset effect keyed on the records array identity, so a background
+refetch returning the same records (StrictMode double-effect, refetch-on-focus)
+yanked the active row back to none mid-navigation — surfacing as a flaky
+ArrowDown→Enter CI test and a real (if rare) keyboard UX glitch. The reset is
+now keyed on the record-id signature, so the cursor only resets when the
+results actually change.

--- a/packages/fields/src/widgets/PeoplePicker.test.tsx
+++ b/packages/fields/src/widgets/PeoplePicker.test.tsx
@@ -179,6 +179,12 @@ describe('PeoplePicker', () => {
     await waitFor(() => expect(screen.getByText('Amy Lin')).toBeTruthy());
     const search = screen.getByTestId('people-picker-search');
     fireEvent.keyDown(search, { key: 'ArrowDown' });
+    // Wait for the cursor to actually land on the first row before committing —
+    // guards against a late background re-render swallowing the keypress (the
+    // old identity-keyed cursor reset made this flaky on slow CI).
+    await waitFor(() =>
+      expect(screen.getAllByTestId('person-row')[0].getAttribute('data-active')).toBe('true'),
+    );
     fireEvent.keyDown(search, { key: 'Enter' });
     expect(onSelect).toHaveBeenCalledWith('u1');
   });

--- a/packages/fields/src/widgets/PeoplePicker.tsx
+++ b/packages/fields/src/widgets/PeoplePicker.tsx
@@ -311,10 +311,19 @@ export function PeoplePicker({
 
   // --- keyboard cursor ---
   const [activeIndex, setActiveIndex] = useState(-1);
-  // Reset the cursor when the query changes (results replaced).
+  // Reset the cursor when the query results are actually *replaced* — keyed on
+  // the record-id signature, not the array identity. A background refetch that
+  // returns the same records (StrictMode double-effect, refetch-on-focus)
+  // re-emits a new array; resetting on identity alone yanked the cursor to -1
+  // mid-navigation (flaky ArrowDown→Enter, and a real UX nit).
+  const recordsSignature = useMemo(
+    () => query.records.map(r => String(getPersonId(r, idField))).join(' '),
+    [query.records, idField],
+  );
   useEffect(() => {
     setActiveIndex(-1);
-  }, [query.search, query.records]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.search, recordsSignature]);
   // Keep it in range if the list shrinks.
   useEffect(() => {
     setActiveIndex(i => (i >= navList.length ? navList.length - 1 : i));


### PR DESCRIPTION
Follow-up to #2585, where CI's only failure was the flaky `PeoplePicker › keyboard: ArrowDown then Enter commits the active row (single)` test.

## Root cause

The keyboard-cursor reset effect keyed on the **array identity** of `query.records`:

```ts
useEffect(() => { setActiveIndex(-1); }, [query.search, query.records]);
```

Any background re-emission of *identical* results — StrictMode double-effect, a refetch returning the same page — produces a new array, so the effect yanked the active row back to `-1` mid-navigation. On slow CI that reset landed between the test's `ArrowDown` and `Enter`, so `Enter` found no active row and `onSelect` was never called. It's also a real (if rare) keyboard UX glitch outside tests.

## Fix

- **Component**: key the reset on a record-id signature (`records.map(getPersonId).join(' ')`) instead of the array identity — the cursor now only resets when the results actually change (the documented intent: "results replaced").
- **Test**: after `ArrowDown`, `waitFor` the first `person-row` to carry `data-active` before pressing `Enter`, so the assertion no longer races render scheduling.

## Verification

- `PeoplePicker.test.tsx` run 3× consecutively: 15/15 pass each time.
- Full `@object-ui/fields` suite: 341 tests pass.
- Patch changeset added for `@object-ui/fields`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5tsBSEhsDZmdcHBvfymYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5tsBSEhsDZmdcHBvfymYC)_