### PR TITLE
fix(fields+detail): resolve pre-existing rules-of-hooks violations in cell renderers

### DIFF
--- a/.changeset/rules-of-hooks-cell-renderers.md
+++ b/.changeset/rules-of-hooks-cell-renderers.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/fields': patch
+'@object-ui/plugin-detail': patch
+---
+
+fix(fields+detail): resolve the pre-existing rules-of-hooks violations in the cell renderers
+
+- `CurrencyCellRenderer` / `EmailCellRenderer` / `PhoneCellRenderer` called
+  hooks (`useLocalization`, `useFieldLabel`, `useState`) **after** their
+  empty-value early return — a value flipping between null and set changed
+  the hook count between renders (latent "Rendered more hooks than during
+  the previous render" crash). Hooks now run unconditionally before the
+  early return.
+- `useFieldLabel` wrapped `useObjectTranslation()` in try/catch; a throw
+  after other hooks ran would desync hook order. The underlying hook is
+  provider-safe (optional context + global i18n fallback), so the guard is
+  removed.
+- `ReferenceCellRenderer` no longer constructs JSX inside try/catch (the
+  try can't catch render errors anyway) — the display string is computed in
+  the try, rendered outside.
+- `RecordMetaFooter`'s UserRef renders the registry cell renderer via
+  `React.createElement` instead of a locally-assigned capitalized JSX tag
+  (flagged as component-creation-during-render; the registry reference is
+  stable).
+
+No behavior change intended; eslint react-hooks errors on these files drop
+to zero.

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -260,15 +260,15 @@ function useLookupName(
  * default when no I18nProvider is available or when the key is missing.
  */
 function useFieldLabel() {
-  try {
-    const { t } = useObjectTranslation();
-    return (key: string, fallback: string) => {
-      const v = t(key);
-      return !v || v === key ? fallback : v;
-    };
-  } catch {
-    return (_k: string, fallback: string) => fallback;
-  }
+  // useObjectTranslation is provider-safe (its context read is optional and
+  // react-i18next falls back to the global instance), so no try/catch —
+  // wrapping a hook call in try/catch violates rules-of-hooks: a throw after
+  // some hooks ran would desync hook order on the next render.
+  const { t } = useObjectTranslation();
+  return (key: string, fallback: string) => {
+    const v = t(key);
+    return !v || v === key ? fallback : v;
+  };
 }
 
 import { TextField } from './widgets/TextField';
@@ -586,14 +586,16 @@ export function NumberCellRenderer({ value, field }: CellRendererProps): React.R
  * Currency field cell renderer
  */
 export function CurrencyCellRenderer({ value, field }: CellRendererProps): React.ReactElement {
+  // Hooks before the empty-value early return — a value flipping between
+  // null and set must not change the hook count between renders.
+  const { currency: tenantCurrency } = useLocalization();
   if (value == null) return <EmptyValue />;
-  
+
   const safe = coerceToSafeValue(value);
   // Resolve the display currency via the shared precedence: field `currency` →
   // `currencyConfig.defaultCurrency` → the tenant default (ADR-0053). When none
   // is known, render a plain number — never a guessed symbol (silently assuming
   // USD mis-displays non-USD orgs, e.g. RMB amounts shown as $).
-  const { currency: tenantCurrency } = useLocalization();
   const currency = resolveFieldCurrency(field as any, tenantCurrency);
   const num = Number(safe);
   const formatted = !isNaN(num)
@@ -1082,11 +1084,12 @@ export function SelectCellRenderer({ value, field }: CellRendererProps): React.R
  * Email field cell renderer
  */
 export function EmailCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  // Hooks before the empty-value early return (rules-of-hooks).
+  const label = useFieldLabel();
+  const [copied, setCopied] = React.useState(false);
   if (!value) return <EmptyValue />;
 
-  const label = useFieldLabel();
   const safe = String(coerceToSafeValue(value) ?? '');
-  const [copied, setCopied] = React.useState(false);
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1156,11 +1159,12 @@ export function UrlCellRenderer({ value }: CellRendererProps): React.ReactElemen
  * Phone field cell renderer
  */
 export function PhoneCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  // Hooks before the empty-value early return (rules-of-hooks).
+  const label = useFieldLabel();
+  const [copied, setCopied] = React.useState(false);
   if (!value) return <EmptyValue />;
 
-  const label = useFieldLabel();
   const safe = String(coerceToSafeValue(value) ?? '');
-  const [copied, setCopied] = React.useState(false);
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1336,15 +1340,18 @@ export function LookupCellRenderer({ value, field }: CellRendererProps): React.R
   if (typeof value === 'string') {
     const s = value.trim();
     if (s.startsWith('{') && s.endsWith('}')) {
+      // Compute inside try, render outside — constructing JSX in a try/catch
+      // doesn't catch its render errors anyway (react-hooks/error-boundaries).
+      let parsedDisplay = '';
       try {
         const parsed = JSON.parse(s) as Record<string, unknown>;
         if (parsed && typeof parsed === 'object') {
-          const display =
+          parsedDisplay =
             resolveLookupRecordName(parsed, refSchema, displayField) ||
             String(parsed.externalId ?? parsed.id ?? parsed._id ?? '');
-          if (display) return <span className="truncate">{display}</span>;
         }
       } catch { /* not JSON — fall through to normal resolution */ }
+      if (parsedDisplay) return <span className="truncate">{parsedDisplay}</span>;
     }
   }
 

--- a/packages/plugin-detail/src/RecordMetaFooter.tsx
+++ b/packages/plugin-detail/src/RecordMetaFooter.tsx
@@ -93,11 +93,18 @@ const UserRef: React.FC<UserRefProps> = ({ value, objectSchema, fieldName }) => 
   };
   const resolvedType = resolveCellRendererType(enrichedField as { type?: string }) || enrichedField.type;
   if (resolvedType) {
-    const CellRenderer = getCellRenderer(resolvedType);
-    if (CellRenderer) {
+    const cellRenderer = getCellRenderer(resolvedType);
+    if (cellRenderer) {
+      // createElement over a JSX tag: the registry returns a STABLE component
+      // reference, but a locally-assigned capitalized tag reads as "component
+      // created during render" to the hooks lint (state would reset if it
+      // were). Direct invocation makes the stable-reference intent explicit.
       return (
         <span className="inline-flex items-center [&_a]:text-inherit [&_a]:hover:underline">
-          <CellRenderer value={value} field={enrichedField as unknown as FieldMetadata} />
+          {React.createElement(cellRenderer, {
+            value,
+            field: enrichedField as unknown as FieldMetadata,
+          })}
         </span>
       );
     }


### PR DESCRIPTION
## What

Cleans up the pre-existing `react-hooks` **errors** surfaced (but deliberately left out of scope) during the #2577 lint pass. These are real latent-crash bugs, not style: a conditional hook means a value flipping between null and set changes the hook count between renders ("Rendered more hooks than during the previous render").

- **`CurrencyCellRenderer` / `EmailCellRenderer` / `PhoneCellRenderer`** called hooks (`useLocalization`, `useFieldLabel`, `useState`) *after* their empty-value early return. Hooks now run unconditionally before it.
- **`useFieldLabel`** wrapped `useObjectTranslation()` in try/catch — a throw after other hooks ran would desync hook order. The underlying hook is provider-safe (optional context read + react-i18next global-instance fallback), so the guard is removed.
- **`ReferenceCellRenderer`** no longer constructs JSX inside try/catch (`react-hooks/error-boundaries` — the try can't catch render errors anyway); the display string is computed in the try, rendered outside.
- **`RecordMetaFooter` UserRef** renders the registry cell renderer via `React.createElement` instead of a locally-assigned capitalized JSX tag — the registry reference is stable, but the lint can't know that, and direct invocation makes the intent explicit.

No intended behavior change.

## Verification

- eslint react-hooks errors on `packages/fields/src/index.tsx` + `packages/plugin-detail/src/RecordMetaFooter.tsx`: **9 → 0** (remaining output is pre-existing `no-explicit-any` warnings)
- vitest fields + plugin-detail: **556 ✓**
- `turbo run type-check` both packages ✓

Refs framework#2548 (follow-up item #2 from the wrap-up plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpaFMPowSn4nAWsjeGZib

---
_Generated by [Claude Code](https://claude.ai/code/session_016wpaFMPowSn4nAWsjeGZib)_