### PR TITLE
feat(kanban): default lane field honours the ADR-0085 stageField role

### DIFF
--- a/.changeset/stagefield-kanban-default-lanes.md
+++ b/.changeset/stagefield-kanban-default-lanes.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/types': minor
+'@object-ui/app-shell': minor
+'@object-ui/plugin-list': minor
+'@object-ui/plugin-detail': patch
+---
+
+feat(kanban): default lane field honours the ADR-0085 `stageField` role
+
+Kanban views without an explicit `groupByField`/`groupField` hard-coded their
+lane field to the literal `'status'` (in both app-shell's ObjectView options
+and plugin-list's ListView fallback) — ignoring the object's declared
+lifecycle and even inventing a field the object doesn't have. The default now
+resolves through the shared `stageField` detector:
+
+1. explicit view config (unchanged, always wins);
+2. the object's `stageField` semantic role;
+3. `stageField: false` → **no default lanes** (the status-shaped field is
+   declared non-linear; the board renders its empty state until the view
+   picks a lane field explicitly);
+4. else the shared name/type heuristic (status / stage / state / phase by
+   name, then status/stage by type) — never a nonexistent field.
+
+`detectStatusField` moved from `@object-ui/plugin-detail` to
+`@object-ui/types` (new export, with the `StatusFieldSource` input type) so
+plugin-list and app-shell share the exact semantics; plugin-detail re-exports
+it unchanged.
+
+Also fixes ListView's pre-existing rules-of-hooks error while touching the
+file: `useListFieldLabel` wrapped `useObjectLabel()` in try/catch (hook-order
+desync risk; the hook is provider-safe) — same fix as objectui#2595's
+`useFieldLabel`.
+
+Behavior change is limited to kanban views with no explicit lane field on
+objects that either declare `stageField` (now honoured), declare
+`stageField: false` (now suppressed), or have no status-shaped field at all
+(previously grouped by a nonexistent `status` into one "undefined" lane; now
+an honest empty state). Objects with a real `status` field — the common case —
+are unchanged.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -37,6 +37,7 @@ import { Plus, Upload, Star, StarOff, Table as TableIcon, KanbanSquare, Calendar
 import { useFavorites } from '../hooks/useFavorites';
 import { getIcon } from '../utils/getIcon';
 import type { ListViewSchema, ViewNavigationConfig, FeedItem } from '@object-ui/types';
+import { detectStatusField } from '@object-ui/types';
 import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
 import { ViewConfigPanel } from './ViewConfigPanel';
 import { useMetadataClient } from './metadata-admin/useMetadata';
@@ -1403,8 +1404,21 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
             ...(viewDef.sort?.length ? { sort: viewDef.sort } : {}),
             options: {
                 kanban: {
-                    groupBy: viewDef.kanban?.groupByField || viewDef.kanban?.groupField || 'status',
-                    groupField: viewDef.kanban?.groupByField || viewDef.kanban?.groupField || 'status',
+                    // ADR-0085: when the view doesn't pick a lane field, the
+                    // object's declared lifecycle (`stageField`) decides —
+                    // including the strict `stageField: false` suppression
+                    // (no default lanes; the status-shaped field is declared
+                    // non-linear) and the shared name/type heuristic, which
+                    // never invents a field the object doesn't have (the old
+                    // hard-coded 'status' did).
+                    ...(() => {
+                        const lane =
+                            viewDef.kanban?.groupByField ||
+                            viewDef.kanban?.groupField ||
+                            detectStatusField(objectDef as any) ||
+                            undefined;
+                        return lane ? { groupBy: lane, groupField: lane } : {};
+                    })(),
                     titleField: viewDef.kanban?.titleField || objectDef.titleField || 'name',
                     cardFields: viewDef.kanban?.columns,
                 },

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -24,6 +24,7 @@
  */
 
 import { deriveFieldGroupLayout } from '@objectstack/spec/data';
+import { detectStatusField } from '@object-ui/types';
 import { inferDetailColumns } from '../autoLayout';
 
 /** Minimal shape of an object definition we read here. We deliberately
@@ -227,29 +228,13 @@ function toNodeArray(slot: any | any[] | undefined): any[] {
 /**
  * Detect the canonical "status" / "stage" field on an object definition.
  *
- * Heuristic — same as DetailView's `autoSummaryFields`:
- *   1) the top-level `objectDef.stageField` semantic role (spec-typed since
- *      ADR-0085). `false` = the status-shaped field is NOT a linear flow —
- *      suppress stage detection entirely (no `record:path`, #2065).
- *   2) else first field named status / stage / state / phase
- *   3) else null
+ * The implementation moved to `@object-ui/types` (`detectStatusField`) so
+ * non-detail consumers of the `stageField` role — kanban default lanes in
+ * app-shell/plugin-list — share the exact semantics (incl. the strict
+ * `stageField: false` suppression). Re-exported here unchanged for the
+ * long-standing plugin-detail import path.
  */
-export function detectStatusField(def?: ObjectDefLike): string | null {
-  if (!def) return null;
-  const hint = def.stageField;
-  if (hint === false) return null;
-  if (typeof hint === 'string' && hint) return hint;
-  const fields = def.fields || {};
-  const candidates = ['status', 'stage', 'state', 'phase'];
-  for (const key of candidates) {
-    if (key in fields) return key;
-  }
-  for (const [name, field] of Object.entries(fields)) {
-    const t = (field?.type || '').toLowerCase();
-    if (t === 'status' || t === 'stage') return name;
-  }
-  return null;
-}
+export { detectStatusField };
 
 /**
  * Derive stage values from an object field's `options` (picklist).

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -17,6 +17,7 @@ import { UserFilters } from './UserFilters';
 import { SchemaRenderer, useNavigationOverlay } from '@object-ui/react';
 import { useDensityMode } from '@object-ui/react';
 import type { ListViewSchema } from '@object-ui/types';
+import { detectStatusField } from '@object-ui/types';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { resolveConditionalFormatting, buildExpandFields, buildExportFileName } from '@object-ui/core';
 import { useObjectTranslation, useObjectLabel, useSafeFieldLabel } from '@object-ui/i18n';
@@ -227,12 +228,6 @@ const LIST_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'list.viewSettingsHint': 'Grouping, color, density, and visible fields.',
 };
 
-// Stable module-level fallback used when no I18nProvider is mounted.
-// Reusing the same function reference across renders keeps downstream
-// `useCallback`/`useMemo` deps stable (otherwise filterFields and tFieldLabel
-// would invalidate every render in the no-provider case).
-const FALLBACK_FIELD_LABEL = (_objectName: string, _fieldName: string, fallback: string) => fallback;
-
 const fallbackListT = (key: string, options?: Record<string, unknown>) => {
   let value = LIST_DEFAULT_TRANSLATIONS[key] || key;
   if (options) {
@@ -262,15 +257,15 @@ function useListViewTranslation() {
 }
 
 /**
- * Safe wrapper for useObjectLabel that falls back to identity when I18nProvider is unavailable.
+ * Thin selector over useObjectLabel. The underlying hook is provider-safe
+ * (optional context + global i18n fallback), so no try/catch — wrapping a
+ * hook call in try/catch violates rules-of-hooks: a throw after other hooks
+ * ran would desync hook order on the next render (same fix as
+ * fields#useFieldLabel, objectui#2595).
  */
 function useListFieldLabel() {
-  try {
-    const { fieldLabel, actionLabel, objectLabel } = useObjectLabel();
-    return { fieldLabel, actionLabel, objectLabel };
-  } catch {
-    return { fieldLabel: FALLBACK_FIELD_LABEL, actionLabel: undefined as any, objectLabel: undefined as any };
-  }
+  const { fieldLabel, actionLabel, objectLabel } = useObjectLabel();
+  return { fieldLabel, actionLabel, objectLabel };
 }
 
 /**
@@ -1347,8 +1342,16 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         return {
           type: 'object-kanban',
           ...baseProps,
-          groupBy: schema.kanban?.groupField || schema.options?.kanban?.groupField || 'status',
-          groupField: schema.kanban?.groupField || schema.options?.kanban?.groupField || 'status',
+          // ADR-0085: no explicit lane field → the object's declared
+          // lifecycle (`stageField`, incl. strict-false suppression) via the
+          // shared detector — mirrors ObjectView's default so a schema that
+          // omits groupField behaves the same on both entry paths. objectDef
+          // loads async: until it lands this stays undefined and the board
+          // re-derives lanes once it does.
+          groupBy: schema.kanban?.groupField || schema.options?.kanban?.groupField
+            || detectStatusField(objectDef) || undefined,
+          groupField: schema.kanban?.groupField || schema.options?.kanban?.groupField
+            || detectStatusField(objectDef) || undefined,
           ...(schema.kanban?.titleField || schema.options?.kanban?.titleField
             ? { titleField: schema.kanban?.titleField || schema.options?.kanban?.titleField }
             : {}),
@@ -1492,7 +1495,10 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         };
       }
     }
-  }, [currentView, schema, currentSort, effectiveFields, groupingConfig, rowColorConfig, navigation.handleClick, density.mode, galleryCardSize, inlineEdit]);
+  // objectDef is in the deps because the kanban default lane field derives
+  // from it (ADR-0085 stageField) and it loads async — without it the board
+  // would keep the null-def result forever.
+  }, [currentView, schema, currentSort, effectiveFields, groupingConfig, rowColorConfig, navigation.handleClick, density.mode, galleryCardSize, inlineEdit, objectDef]);
 
   const hasFilters = currentFilters.conditions && currentFilters.conditions.length > 0;
 

--- a/packages/types/src/__tests__/record-semantics.test.ts
+++ b/packages/types/src/__tests__/record-semantics.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { detectStatusField } from '../record-semantics';
+
+describe('detectStatusField (ADR-0085 stageField role)', () => {
+  it('returns null for missing defs', () => {
+    expect(detectStatusField(undefined)).toBeNull();
+    expect(detectStatusField(null)).toBeNull();
+  });
+
+  it('honours an explicit stageField role', () => {
+    expect(
+      detectStatusField({ stageField: 'pipeline', fields: { pipeline: {}, status: {} } }),
+    ).toBe('pipeline');
+  });
+
+  it('stageField: false suppresses detection even with a status-named field', () => {
+    expect(
+      detectStatusField({ stageField: false, fields: { status: { type: 'select' } } }),
+    ).toBeNull();
+  });
+
+  it('falls back to conventional names in order', () => {
+    expect(detectStatusField({ fields: { phase: {}, stage: {} } })).toBe('stage');
+    expect(detectStatusField({ fields: { state: {} } })).toBe('state');
+  });
+
+  it('falls back to status/stage TYPES when no conventional name exists', () => {
+    expect(
+      detectStatusField({ fields: { lifecycle: { type: 'Status' } } }),
+    ).toBe('lifecycle');
+  });
+
+  it('returns null when nothing matches — callers must not invent a field', () => {
+    expect(detectStatusField({ fields: { name: { type: 'text' } } })).toBeNull();
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -66,6 +66,10 @@ export type {
 } from './app';
 export { menuItemToNavigationItem, isValidAppName, wizardDraftToAppSchema } from './app';
 
+// Object-level semantic-role readers (ADR-0085), shared across surfaces.
+export { detectStatusField } from './record-semantics';
+export type { StatusFieldSource } from './record-semantics';
+
 // ============================================================================
 // Base Types - The Foundation
 // ============================================================================

--- a/packages/types/src/record-semantics.ts
+++ b/packages/types/src/record-semantics.ts
@@ -1,0 +1,54 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Object-level semantic-role readers (ADR-0085) shared across surfaces.
+ *
+ * `detectStatusField` began life in `@object-ui/plugin-detail`'s page
+ * synthesizer, but the `stageField` role is consumed by MORE than detail
+ * pages (kanban default lanes, future list/report affordances), and those
+ * consumers (`plugin-list`, `app-shell`) can't depend on plugin-detail.
+ * The single source lives here; plugin-detail re-exports it unchanged.
+ */
+
+/** Minimal duck-typed slice of an object definition read by the detectors. */
+export interface StatusFieldSource {
+  /** Semantic role (ADR-0085): the linear-lifecycle field. `false` = the
+   *  status-shaped field is NOT a linear flow — suppress stage heuristics. */
+  stageField?: string | false;
+  fields?: Record<string, { type?: string } | undefined>;
+}
+
+/**
+ * Detect the canonical "status" / "stage" field on an object definition.
+ *
+ * Resolution order:
+ *   1) the top-level `objectDef.stageField` semantic role (spec-typed since
+ *      ADR-0085). `false` = the status-shaped field is NOT a linear flow —
+ *      suppress stage detection entirely (no `record:path`, no default
+ *      kanban lane field; #2065).
+ *   2) else the first field named status / stage / state / phase
+ *   3) else the first field of type status / stage
+ *   4) else null
+ */
+export function detectStatusField(def?: StatusFieldSource | null): string | null {
+  if (!def) return null;
+  const hint = def.stageField;
+  if (hint === false) return null;
+  if (typeof hint === 'string' && hint) return hint;
+  const fields = def.fields || {};
+  const candidates = ['status', 'stage', 'state', 'phase'];
+  for (const key of candidates) {
+    if (key in fields) return key;
+  }
+  for (const [name, field] of Object.entries(fields)) {
+    const t = (field?.type || '').toLowerCase();
+    if (t === 'status' || t === 'stage') return name;
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Wires the last actionable "future consumer" from ADR-0085's `stageField` table: **kanban default grouping**. Kanban views without an explicit `groupByField`/`groupField` hard-coded their lane field to the literal `'status'` — in **two** places (app-shell `ObjectView` options and plugin-list `ListView`'s fallback) — ignoring the object's declared lifecycle and even inventing a field the object doesn't have.

The default now resolves:
1. explicit view config (unchanged, always wins);
2. the object's **`stageField`** semantic role;
3. **`stageField: false`** → no default lanes (the status-shaped field is declared non-linear; honest empty state until the view picks one explicitly);
4. else the shared name/type heuristic (`status`/`stage`/`state`/`phase` by name, then status/stage by type) — never a nonexistent field.

## How

- **`detectStatusField` moves to `@object-ui/types`** (new export + `StatusFieldSource` input type) — plugin-list and app-shell can't depend on plugin-detail, and the role's semantics must stay single-sourced (ADR-0078 §2 spirit). `@object-ui/plugin-detail` re-exports it unchanged, so its long-standing import path keeps working.
- Both hard-coded `|| 'status'` sites now go through the detector. `ListView`'s `viewComponentSchema` memo gains `objectDef` in its deps — the def loads async, and without the dep the board would keep the null-def lane forever.
- **Drive-by (same file, same class as objectui#2595):** `useListFieldLabel` wrapped `useObjectLabel()` in try/catch — hook-order desync risk; the hook is provider-safe. Removed, along with the now-unused module fallback.

## Behavior change (scoped)

Only kanban views **without** an explicit lane field, on objects that: declare `stageField` (now honoured), declare `stageField: false` (now suppressed), or have **no** status-shaped field at all (previously grouped by nonexistent `status` into one "undefined" lane; now an honest empty state). Objects with a real `status` field — the common case, incl. all showcase/CRM views — resolve to `status` exactly as before.

## Out-of-scope findings (recorded, no code)

- **Report bucketing**: `plugin-report` has no default-grouping heuristic — reports always declare grouping explicitly, so there is no seam to wire `stageField` into today.
- **List badges**: already served — select cells render option-color badges (with #2577's ellipsis polish).
- **Docs drift for #3029**: the 6 flagged docs only reference the audit plugin/`os validate` generically; no doc encodes the old summary text or enumerates lint rules. Clean, no edits needed.

## Verification

- vitest: types + synth + plugin-list **417** ✓ · plugin-list + app-shell/views **179** ✓ (new `record-semantics` suite covers role/false/name/type/null paths; the synth's existing `detectStatusField` suite now exercises the re-export)
- `turbo run type-check` (types, plugin-list, app-shell, plugin-detail) ✓
- eslint: **0 errors** on touched files (ListView: 1 pre-existing → 0)

Refs framework#2548 wrap-up plan (item 4) · ADR-0085 §1 consumers table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpaFMPowSn4nAWsjeGZib

---
_Generated by [Claude Code](https://claude.ai/code/session_016wpaFMPowSn4nAWsjeGZib)_