### PR TITLE
fix(app-shell): Studio Access matrix — history opens in-place sheet, breadcrumb stops escaping the pillar

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/PageShell.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PageShell.tsx
@@ -34,6 +34,15 @@ export interface PageShellProps {
   stats?: Array<{ label: string; value: React.ReactNode }>;
   /** Right-side action buttons. */
   actions?: React.ReactNode;
+  /**
+   * When true, the shell is hosted inside another surface (e.g. the Studio
+   * Access pillar) instead of the routed metadata admin. The breadcrumb
+   * renders as plain text: its links resolve to `/metadata` routes that do
+   * not exist under the host's router scope, so following them would yank
+   * the user out of the embedding surface (the host provides its own
+   * navigation).
+   */
+  embedded?: boolean;
   /** Page body. */
   children: React.ReactNode;
 }
@@ -44,6 +53,7 @@ export function PageShell({
   subtitle,
   stats,
   actions,
+  embedded = false,
   children,
 }: PageShellProps) {
   const type = entry?.type ?? '';
@@ -69,16 +79,22 @@ export function PageShell({
         // sit inline to free a full row of vertical chrome.
         <div className="px-6 py-2.5 border-b bg-background flex items-center gap-3 min-h-[44px]">
           <nav className="flex items-center gap-1.5 text-xs text-muted-foreground min-w-0">
-            <Link to={metadataBase} className="hover:text-foreground shrink-0">
-              {t('engine.breadcrumb.allTypes', locale)}
-            </Link>
-            <ChevronRight className="h-3 w-3 shrink-0" />
-            <Link
-              to={`${metadataBase}/${encodeURIComponent(type)}`}
-              className="hover:text-foreground shrink-0"
-            >
-              {label}
-            </Link>
+            {embedded ? (
+              <span className="shrink-0">{label}</span>
+            ) : (
+              <>
+                <Link to={metadataBase} className="hover:text-foreground shrink-0">
+                  {t('engine.breadcrumb.allTypes', locale)}
+                </Link>
+                <ChevronRight className="h-3 w-3 shrink-0" />
+                <Link
+                  to={`${metadataBase}/${encodeURIComponent(type)}`}
+                  className="hover:text-foreground shrink-0"
+                >
+                  {label}
+                </Link>
+              </>
+            )}
             <ChevronRight className="h-3 w-3 shrink-0" />
             <span
               className="text-foreground font-medium font-mono truncate"
@@ -152,13 +168,15 @@ export function PageShell({
         // page identity here so we earn the vertical space.
         <div className="px-6 pt-5 pb-4 border-b bg-background">
           {/* Breadcrumb */}
-          <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-2">
-            <Link to={metadataBase} className="hover:text-foreground">
-              {t('engine.breadcrumb.allTypes', locale)}
-            </Link>
-            <ChevronRight className="h-3 w-3" />
-            <span className="text-foreground font-medium">{label}</span>
-          </nav>
+          {!embedded && (
+            <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-2">
+              <Link to={metadataBase} className="hover:text-foreground">
+                {t('engine.breadcrumb.allTypes', locale)}
+              </Link>
+              <ChevronRight className="h-3 w-3" />
+              <span className="text-foreground font-medium">{label}</span>
+            </nav>
+          )}
 
           {/* Title row */}
           <div className="flex items-start justify-between gap-3 flex-wrap">

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.embedded.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.embedded.test.tsx
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Embedded mode (Studio Access pillar) — the matrix editor is hosted at
+ * `/studio/:packageId/access`, where the metadata-admin routes don't exist:
+ *
+ *   • History must open as an in-place sheet, NOT navigate — the relative
+ *     `./history` target resolves to `/studio/:packageId/access/history`,
+ *     which falls through to the app's catch-all and dumps the user on Home.
+ *   • The PageShell breadcrumb must not link to `/metadata` (same dead end,
+ *     and it would yank the user out of Studio even where the route exists).
+ *
+ * Standalone metadata-admin behavior (routed history page, linked crumbs)
+ * must stay intact.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+
+function makeClient() {
+  return {
+    layered: async () => ({
+      effective: { name: 'sales_perms', label: 'Sales', objects: {}, fields: {} },
+      code: null,
+      overlay: null,
+      overlayScope: null,
+    }),
+    getDraft: async () => null,
+    list: async (type: string) => (type === 'object' ? [{ item: { name: 'a_account' } }] : []),
+    get: async (type: string) => (type === 'object' ? { fields: [] } : null),
+    save: async (_t: string, _n: string, payload: Record<string, unknown>) => payload,
+    history: async () => ({ events: [] }),
+  } as any;
+}
+
+let clientImpl: any;
+
+vi.mock('./useMetadata', () => ({
+  useMetadataClient: () => clientImpl,
+  useMetadataTypes: () => ({
+    loading: false,
+    error: null,
+    entries: [{ type: 'permission', label: 'Permission', allowOrgOverride: true }],
+  }),
+}));
+
+// AssignedUsersSection makes its own adapter calls — irrelevant here.
+vi.mock('./AssignedUsersSection', () => ({ AssignedUsersSection: () => null }));
+
+import { PermissionMatrixEditPage } from './PermissionMatrixEditor';
+
+afterEach(cleanup);
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  return <div data-testid="location-probe">{pathname}</div>;
+}
+
+async function renderMatrix(embedded: boolean) {
+  clientImpl = makeClient();
+  render(
+    <MemoryRouter initialEntries={['/current']}>
+      <LocationProbe />
+      <PermissionMatrixEditPage
+        type="permission"
+        name="sales_perms"
+        packageId="app.a"
+        embedded={embedded}
+      />
+    </MemoryRouter>,
+  );
+  await screen.findByDisplayValue('Sales');
+}
+
+describe('PermissionMatrixEditPage — embedded mode (Studio Access pillar)', () => {
+  it('embedded: History opens an in-place sheet without navigating', async () => {
+    await renderMatrix(true);
+
+    fireEvent.click(screen.getByRole('button', { name: /History/ }));
+
+    // The sheet mounts the shared HistoryPanel (empty-state fixture).
+    expect(await screen.findByText('No history yet')).toBeInTheDocument();
+    // …and the router did not move (no `./history` dead end).
+    expect(screen.getByTestId('location-probe')).toHaveTextContent('/current');
+  });
+
+  it('embedded: breadcrumb renders without /metadata links', async () => {
+    await renderMatrix(true);
+
+    expect(screen.queryByText('All Metadata Types')).not.toBeInTheDocument();
+    expect(document.querySelector('a[href^="/metadata"]')).toBeNull();
+    // The type label is still shown as plain-text context.
+    expect(screen.getByText('Permission Set')).toBeInTheDocument();
+  });
+
+  it('standalone: History still navigates to the routed history page', async () => {
+    await renderMatrix(false);
+
+    fireEvent.click(screen.getByRole('button', { name: /History/ }));
+
+    expect(screen.getByTestId('location-probe')).toHaveTextContent('/history');
+    expect(screen.queryByText('No history yet')).not.toBeInTheDocument();
+  });
+
+  it('standalone: breadcrumb keeps its /metadata links', async () => {
+    await renderMatrix(false);
+
+    expect(screen.getByText('All Metadata Types')).toBeInTheDocument();
+    expect(document.querySelector('a[href^="/metadata"]')).not.toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -61,9 +61,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@object-ui/components';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@object-ui/components';
 import { useAdapter } from '@object-ui/react';
 import { CapabilityMultiSelectField, parseCapabilityNames } from '@object-ui/fields';
 import { PageShell } from './PageShell';
+import { HistoryPanel } from './ResourceHistoryPage';
 import { useMetadataClient, useMetadataTypes, type RichMetadataTypeEntry } from './useMetadata';
 import { resolveResourceConfig } from './registry';
 import { t as translate, detectLocale } from './i18n';
@@ -178,13 +186,22 @@ export interface PermissionMatrixEditPageProps {
    * is the one that tripped.
    */
   readOnly?: boolean;
+  /**
+   * When true, the editor is hosted inside another surface (the Studio Access
+   * pillar) rather than the routed metadata admin. Relative navigation would
+   * resolve against the HOST's route (`/studio/:packageId/access/...`), where
+   * the metadata-admin routes don't exist — so History opens as an in-place
+   * sheet instead of navigating, and the PageShell breadcrumb loses its
+   * `/metadata` links (same rule as MetadataResourceEditPage's `embedded`).
+   */
+  embedded?: boolean;
 }
 
 /* ────────────────────────────────────────────────────────────────── */
 /* Component                                                          */
 /* ────────────────────────────────────────────────────────────────── */
 
-export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, publishNonce, onOpenOwd, onDirtyChange, readOnly = false }: PermissionMatrixEditPageProps) {
+export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, publishNonce, onOpenOwd, onDirtyChange, readOnly = false, embedded = false }: PermissionMatrixEditPageProps) {
   const navigate = useNavigate();
   const client = useMetadataClient();
   // Data adapter (records) — the capability picker reads the live sys_capability
@@ -231,6 +248,8 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
   >(null);
   const [filter, setFilter] = React.useState('');
   const [showOnlyEnabled, setShowOnlyEnabled] = React.useState(false);
+  // Embedded-mode History sheet (see `embedded` prop doc).
+  const [historyOpen, setHistoryOpen] = React.useState(false);
   // All permission-set api-names — the admin-scope editor's assignable
   // allowlist picks from these (ADR-0056 P3).
   const [allSetNames, setAllSetNames] = React.useState<string[]>([]);
@@ -575,7 +594,7 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
 
   if (loading) {
     return (
-      <PageShell entry={entry} itemName={name}>
+      <PageShell entry={entry} itemName={name} embedded={embedded}>
         <div className="p-6 text-sm text-muted-foreground flex items-center gap-2">
           <Loader2 className="h-4 w-4 animate-spin" /> {t('perm.loading').replace('{name}', name)}
         </div>
@@ -589,12 +608,17 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
       itemName={name}
       subtitle={t('perm.subtitle.set')}
       stats={stats}
+      embedded={embedded}
       actions={
         <>
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => navigate(`./history?type=${encodeURIComponent(type)}`)}
+            onClick={() =>
+              embedded
+                ? setHistoryOpen(true)
+                : navigate(`./history?type=${encodeURIComponent(type)}`)
+            }
           >
             <HistoryIcon className="h-4 w-4 mr-1" /> {t('engine.edit.history')}
           </Button>
@@ -801,6 +825,27 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Embedded-mode History sheet — the routed history page doesn't exist
+          under the host's router scope (see `embedded` prop doc). No rollback
+          here: under a packageId the set is package METADATA whose truth moves
+          via draft + atomic Publish (ADR-0086 D6/D7); a rollback would write a
+          live overlay behind the draft flow's back. */}
+      {embedded && (
+        <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
+          <SheetContent side="right" className="w-[92vw] sm:max-w-[720px] p-0 flex flex-col gap-0">
+            <SheetHeader className="px-4 py-3 border-b">
+              <SheetTitle className="text-base">{t('engine.edit.history')}</SheetTitle>
+              <SheetDescription className="text-xs">
+                {type} / {name}
+              </SheetDescription>
+            </SheetHeader>
+            <div className="flex-1 min-h-0 overflow-auto p-4">
+              {historyOpen && <HistoryPanel type={type} name={name} client={client} />}
+            </div>
+          </SheetContent>
+        </Sheet>
+      )}
     </PageShell>
   );
 }

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -3435,6 +3435,7 @@ export function AccessPillar({
               onDraftSaved={onDraftSaved}
               readOnly={readOnly}
               onDirtyChange={setMatrixDirty}
+              embedded
               onOpenOwd={(objectName) => {
                 // The badge deep-link swaps this page out for the OWD
                 // overview — same remount, same guard.


### PR DESCRIPTION
## Problem

The `PermissionMatrixEditPage` embedded in the **Studio Access pillar** (`/studio/:packageId/access`) reuses the metadata-admin chrome (`PageShell`) verbatim, and two of its navigation targets don't exist under Studio's router:

1. **History button** — `navigate('./history?type=permission')` resolves to `/studio/:packageId/access/history`. No route matches (`/studio/:packageId/:tab` is single-segment), so the app's catch-all (`<Route path="*">` → `/`) **dumps the user back on Home**. Reproduced in a live browser (fresh showcase backend + console dev server): clicking 历史 in the Access pillar landed on the platform home page.
2. **Breadcrumb** — `元数据 › 权限集` links to `/metadata`, which is also unrouted at top level (metadata admin lives under `/apps/:appName/…`), so it too falls into the catch-all and yanks the user out of Studio.

## Fix

An `embedded` switch on `PageShell` + `PermissionMatrixEditPage`, following the existing `MetadataResourceEditPage#embedded` precedent; the Studio `AccessPillar` passes `embedded`:

- **Embedded**: History opens a right-side **Sheet** reusing the shared `HistoryPanel` (same panel the generic edit page uses). Read-only — no rollback action, since under a `packageId` the set is package metadata whose truth moves via draft + atomic Publish (ADR-0086 D6/D7); a rollback would write a live overlay behind the draft flow's back. The breadcrumb renders as plain text (`权限集 › <name>`), no `/metadata` links.
- **Standalone metadata-admin**: unchanged — routed history page and linked crumbs still work.

## Verification

- Live browser (fresh `--fresh` showcase backend :4473 + worktree console :5473, package `com.test.historyrepro`, set `sales_perms`):
  - Before: History → kicked to Home. After: History → in-place sheet showing the real event timeline (`seq 1 · v1 · create by system`), URL stays `/studio/com.test.historyrepro/access`.
  - Breadcrumb now plain text; no link out of Studio.
- New unit tests (`PermissionMatrixEditor.embedded.test.tsx`, 4 cases): embedded opens sheet without navigating; embedded breadcrumb has no `/metadata` links; standalone still navigates to `./history`; standalone crumbs keep links.
- `vitest run` over `metadata-admin` + `studio-design`: **103 files / 785 tests pass**.
- Note: `pnpm --filter @object-ui/app-shell type-check` currently fails on **pre-existing** unrelated errors (`useAiUsage.ts`, `RecordDetailView.tsx` — stale sibling `dist` types in a fresh worktree; the exports exist in those packages' `src`). None of the four changed files produce type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
