### PR TITLE
feat(detail+fields+components+app-shell): record inline-edit polish — expanded-value passthrough, approval-lock preflight, numeric inputs, edit-CTA gate, keyboard shortcuts (#2572)

### DIFF
--- a/.changeset/record-inline-edit-polish-2572.md
+++ b/.changeset/record-inline-edit-polish-2572.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-detail': patch
+'@object-ui/fields': patch
+'@object-ui/components': patch
+'@object-ui/app-shell': patch
+---
+
+Record-level inline edit polish (objectui#2572, follow-up to #2407) — the five
+rough edges from the live showcase verification pass:
+
+- **Expanded reference values pass through to the picker.** `InlineFieldInput`
+  no longer collapses an `$expand`-ed record object to a bare id before
+  handing it to `LookupField` / `UserField` — the picker resolves the display
+  name it already carries instead of re-fetching the referenced record via
+  `findOne` (or sticking on the placeholder when it can't). `LookupField`
+  still hands its Level-2 pickers (PeoplePicker / RecordPickerDialog) bare
+  ids, collapsed via the existing `normalizeId`.
+- **Approval-lock preflight.** The record page now re-reads the approval
+  state whenever the record is invalidated (a save can *trigger* an approval
+  flow that locks the record), derives one `approvalLocked` signal
+  (`approval_status` pending/in_approval OR an open pending request), gates
+  the inline-edit session's `canEdit` with it — hiding the pencil affordances
+  and no-op'ing `enter()` on a locked record — and drives the save bar's
+  `locked`/`lockedHint` so users can't type into a draft that Save would
+  reject with `RECORD_LOCKED`.
+- **Numeric field types edit with the real numeric widgets.** `number` /
+  `currency` / `percent` route to `NumberField` / `CurrencyField` /
+  `PercentField` (the same widgets the form uses) instead of a free-text
+  input: numeric keyboard, symbol adornment, fraction↔percent display
+  conversion, and numbers (not strings) into the draft. `NumberField` and
+  `CurrencyField` now surface metadata `min`/`max` on the input, `NumberField`
+  honors an explicit `step` and steps by 1 for `scale: 0` (previously fell
+  back to `any`).
+- **Header Edit CTA stands down during an inline session.** The synthesized
+  `sys_edit` action carries `disableDuringInlineEdit`, and the `page:header`
+  renderer greys such actions out while `InlineEditContext.editing` — the
+  classic form-edit surface can no longer be stacked on top of a live inline
+  draft.
+- **Keyboard shortcuts for the shared edit session.** `InlineEditSaveBar`
+  binds **Esc → cancel** (deferring to any open Radix layer — popover /
+  select / dialog — which owns Escape for "close") and **Cmd/Ctrl+Enter →
+  save**, both respecting `saving`/`locked`.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -797,6 +797,31 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   const approvalsRef = useRef(approvals);
   approvalsRef.current = approvals;
 
+  // Approval-lock preflight (objectui#2572 item 2): re-read the approval
+  // state whenever this record is invalidated on the bus — a saved edit can
+  // TRIGGER an approval flow (e.g. a budget change), and without this
+  // re-fetch the page kept the pre-save snapshot: the user could re-enter
+  // inline edit, fill a whole draft, and only learn about the lock when Save
+  // came back RECORD_LOCKED. Skips the initial mount (the hook fetches on
+  // mount itself); the ref keeps the effect off the approvals identity.
+  const skippedInitialApprovalsRefresh = useRef(false);
+  useEffect(() => {
+    if (!skippedInitialApprovalsRefresh.current) {
+      skippedInitialApprovalsRefresh.current = true;
+      return;
+    }
+    void approvalsRef.current.refresh();
+  }, [recordInvalidationNonce]);
+
+  // The shared lock signal for the inline-edit session: the record's own
+  // `approval_status` (what the DetailView lock band keys off) OR an open
+  // pending request from the approvals API — the latter catches backends
+  // that lock via the request record without materializing the field.
+  const approvalLocked =
+    (pageRecord as any)?.approval_status === 'pending' ||
+    (pageRecord as any)?.approval_status === 'in_approval' ||
+    !!approvals.pendingRequest;
+
   const approvalHandler = useCallback(async (action: ActionDef) => {
     const target = action.target || action.name;
     const params = (action.params && !Array.isArray(action.params))
@@ -1655,6 +1680,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         locations: ['record_header'],
         variant: 'default',
         order: 100,
+        // objectui#2572 item 4 — while a shared inline-edit draft is live,
+        // the page:header renderer greys this CTA out so the classic form
+        // can't be stacked on top of the draft (two competing edit sessions
+        // with no reconciliation).
+        disableDuringInlineEdit: true,
         onClick: () => onEdit({ id: pureRecordId }),
       } as any);
     }
@@ -1770,8 +1800,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         {/* objectui#2407 P2 — ONE record-level inline-edit session spanning
             the highlights strip AND the details body (both descend from this
             provider), committed together by the single <InlineEditSaveBar>
-            below. `canEdit` carries the object-lifecycle / permission gate. */}
-        <InlineEditProvider canEdit={resolveCrudAffordances(objectDef as any).edit}>
+            below. `canEdit` carries the object-lifecycle / permission gate
+            AND the approval lock (objectui#2572 item 2): a locked record
+            hides the pencil affordances and no-ops `enter()`, so users can't
+            type into a draft that Save would reject with RECORD_LOCKED. */}
+        <InlineEditProvider canEdit={resolveCrudAffordances(objectDef as any).edit && !approvalLocked}>
         <HighlightFieldsProvider>
         <DiscussionContextProvider
           items={feedItems as any}
@@ -1869,7 +1902,10 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                 data={pageRecord}
                 refresh={notifyRecordChanged}
                 fieldLabelFor={(name: string) => (objectDef as any)?.fields?.[name]?.label || fieldLabel(objectName || '', name, name)}
-                locked={(pageRecord as any)?.approval_status === 'pending' || (pageRecord as any)?.approval_status === 'in_approval'}
+                locked={approvalLocked}
+                lockedHint={t('detail.lockedTooltip', {
+                  defaultValue: 'This record has a pending approval request; editing is locked',
+                })}
               />
             </div>
             <MetadataPanel

--- a/packages/components/src/__tests__/page-header-actions.test.tsx
+++ b/packages/components/src/__tests__/page-header-actions.test.tsx
@@ -7,11 +7,14 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { useEffect } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ComponentRegistry } from '@object-ui/core';
 import {
   ActionProvider,
   RecordContextProvider,
+  InlineEditProvider,
+  useInlineEdit,
 } from '@object-ui/react';
 
 function PageHeader({ schema }: { schema: any }) {
@@ -219,6 +222,59 @@ describe('PageHeaderRenderer — actions slot', () => {
       },
     );
     expect(screen.getByRole('button', { name: /编辑/i })).toBeTruthy();
+  });
+});
+
+describe('PageHeaderRenderer — inline-edit session gate (objectui#2572)', () => {
+  // Enters the shared inline-edit session on mount, simulating a user
+  // double-clicking a field in the record body.
+  function EnterInlineEdit() {
+    const inline = useInlineEdit()!;
+    useEffect(() => {
+      inline.enter();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return null;
+  }
+
+  function renderWithInlineEdit(opts: { editing: boolean; actions: any[] }) {
+    return render(
+      <ActionProvider>
+        <RecordContextProvider
+          objectName="proj"
+          recordId="1"
+          data={{ id: '1' }}
+          objectSchema={{ name: 'proj', label: 'Project' }}
+          headerSystemActions={opts.actions}
+        >
+          <InlineEditProvider canEdit>
+            {opts.editing && <EnterInlineEdit />}
+            <PageHeader schema={{ type: 'page:header', title: 'Project' }} />
+          </InlineEditProvider>
+        </RecordContextProvider>
+      </ActionProvider>,
+    );
+  }
+
+  const editCta = { name: 'sys_edit', label: 'Edit', disableDuringInlineEdit: true };
+
+  it('disables a `disableDuringInlineEdit` action while the session is active', () => {
+    renderWithInlineEdit({ editing: true, actions: [editCta] });
+    expect(screen.getByRole('button', { name: /Edit/i })).toBeDisabled();
+  });
+
+  it('keeps the action enabled when no session is active', () => {
+    renderWithInlineEdit({ editing: false, actions: [editCta] });
+    expect(screen.getByRole('button', { name: /Edit/i })).toBeEnabled();
+  });
+
+  it('leaves unflagged actions alone during the session', () => {
+    renderWithInlineEdit({
+      editing: true,
+      actions: [editCta, { name: 'convert', label: 'Convert' }],
+    });
+    expect(screen.getByRole('button', { name: /Edit/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Convert/i })).toBeEnabled();
   });
 });
 

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { ComponentRegistry, ExpressionEvaluator, getRecordDisplayName } from '@object-ui/core';
-import { useRecordContext, useAction, usePredicateScope, usePageVariables } from '@object-ui/react';
+import { useRecordContext, useAction, usePredicateScope, usePageVariables, useInlineEdit } from '@object-ui/react';
 import { renderChildren, cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { RelatedCountStore, useRelatedCountVersion } from '../../hooks/related-count-store';
@@ -748,6 +748,13 @@ export function cleanupTitleSeparators(s: string): string {
 const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { designer } = splitDesignerProps(props);
   const ctx = useRecordContext();
+  // Record-level inline-edit session (objectui#2572 item 4): while a shared
+  // inline draft is active, header actions flagged `disableDuringInlineEdit`
+  // (the host's Edit CTA) grey out so the classic form-edit surface can't be
+  // stacked on top of the live draft — two competing edit sessions with no
+  // reconciliation. `useInlineEdit` is null outside an InlineEditProvider
+  // (non-record pages), which leaves everything enabled.
+  const inlineEditing = !!useInlineEdit()?.editing;
   // Ambient host scope (signed-in user / app / features), fed by app-shell's
   // ExpressionProvider. Needed so header-action `visible` CEL predicates can
   // gate on `ctx.user.*` (e.g. sys_environment "Change Plan (admin)" →
@@ -972,13 +979,19 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       if (!src) return false;
       try { return !!dEvaluator.evaluateExpression(src); } catch { return false; }
     };
+    // A live inline-edit session disables actions the host flagged with
+    // `disableDuringInlineEdit` (objectui#2572 item 4) — see `inlineEditing`
+    // at the top of the renderer.
+    const isActionDisabled = (action: any): boolean =>
+      (inlineEditing && action?.disableDuringInlineEdit === true) ||
+      resolveDisabled(action?.disabled);
     const renderButton = (action: any, idx: number) => {
       const label = resolveLabel(action, idx);
       // `variant: 'primary'` is valid ActionSchema but not a Shadcn Button
       // variant — map it to `default` (same as action-button.tsx).
       const variant = action.variant === 'primary' ? 'default' : (action.variant || 'default');
       const size = action.size || 'sm';
-      const disabled = resolveDisabled(action.disabled);
+      const disabled = isActionDisabled(action);
       const icon = typeof action.icon === 'string' ? action.icon : null;
       return (
         <Button
@@ -1022,7 +1035,7 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
             <DropdownMenuContent align="end" className="w-44">
               {overflowActions.map((action, idx) => {
                 const label = resolveLabel(action, idx + inlineActions.length);
-                const disabled = resolveDisabled(action.disabled);
+                const disabled = isActionDisabled(action);
                 const icon = typeof action.icon === 'string' ? action.icon : null;
                 const isDestructive =
                   action.variant === 'destructive' || action.name === 'sys_delete';

--- a/packages/fields/src/standard-widgets.test.tsx
+++ b/packages/fields/src/standard-widgets.test.tsx
@@ -104,6 +104,41 @@ describe('Standard Field Widgets', () => {
       );
       expect(container.textContent).toBe('99.9');
     });
+
+    it('should surface metadata min/max on the input (objectui#2572)', () => {
+      render(
+        <NumberField
+          value={5}
+          onChange={mockOnChange}
+          field={{ type: 'number', min: 0, max: 100 } as any}
+        />
+      );
+      const input = screen.getByRole('spinbutton');
+      expect(input).toHaveAttribute('min', '0');
+      expect(input).toHaveAttribute('max', '100');
+    });
+
+    it('should step by 1 for scale: 0 (whole numbers), not "any"', () => {
+      render(
+        <NumberField
+          value={5}
+          onChange={mockOnChange}
+          field={{ type: 'number', scale: 0 } as any}
+        />
+      );
+      expect(screen.getByRole('spinbutton')).toHaveAttribute('step', '1');
+    });
+
+    it('should honor an explicit metadata step over the scale-derived one', () => {
+      render(
+        <NumberField
+          value={5}
+          onChange={mockOnChange}
+          field={{ type: 'number', scale: 2, step: 5 } as any}
+        />
+      );
+      expect(screen.getByRole('spinbutton')).toHaveAttribute('step', '5');
+    });
   });
 
   describe('TextField', () => {

--- a/packages/fields/src/widgets/CurrencyField.tsx
+++ b/packages/fields/src/widgets/CurrencyField.tsx
@@ -81,6 +81,11 @@ export function CurrencyField({ value, onChange, field, readonly, errorMessage, 
         placeholder={currencyField?.placeholder || '0.00'}
         disabled={readonly || props.disabled}
         className={`${symbol ? 'pl-8' : ''} ${className || ''}`}
+        // Surface the field's declared range (e.g. `min: 0` on a budget) so the
+        // browser's spinner/keyboard affordances respect it (objectui#2572);
+        // server-side validation still owns enforcement.
+        min={typeof currencyField?.min === 'number' ? currencyField.min : undefined}
+        max={typeof currencyField?.max === 'number' ? currencyField.max : undefined}
         step={Math.pow(10, -precision).toFixed(precision)}
         aria-invalid={!!errorMessage}
       />

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -544,6 +544,16 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
     [idField],
   );
 
+  // Level-2 pickers (PeoplePicker / RecordPickerDialog) operate on bare ids —
+  // their seed queries and selected-row matching compare against `idField`
+  // values. Collapse any `$expand`-ed record objects (passed through
+  // uncollapsed by the inline editor, objectui#2572) before handing the value
+  // down, or the seed fetch would query for a bogus object-shaped id.
+  const pickerValue = useMemo(
+    () => (multiple ? (Array.isArray(value) ? value.map(normalizeId) : []) : normalizeId(value)),
+    [multiple, value, normalizeId],
+  );
+
   // Resolve a raw field value into its display option. An expanded-reference
   // object is mapped directly (mirroring the read cell's display-name path) so
   // the inline editor shows the record's name instead of the placeholder; a bare
@@ -914,7 +924,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
           subtitleFields={subtitleFields}
           avatarField={avatarField}
           pageSize={lookupPageSize}
-          value={value}
+          value={pickerValue}
           onSelect={onChange}
           onSelectRecords={handlePickerSelectRecords}
           lookupFilters={lookupFilters}
@@ -1135,7 +1145,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
           titleFormat={refTitleFormat}
           idField={idField}
           pageSize={lookupPageSize}
-          value={value}
+          value={pickerValue}
           onSelect={onChange}
           onSelectRecords={handlePickerSelectRecords}
           lookupFilters={lookupFilters}

--- a/packages/fields/src/widgets/NumberField.tsx
+++ b/packages/fields/src/widgets/NumberField.tsx
@@ -14,8 +14,16 @@ export function NumberField({ value, onChange, field, readonly, ...props }: Fiel
 
   const numberField = (field || (props as any).schema) as NumberFieldMetadata;
   // Step follows `scale` (decimal places), not `precision` (total digit count):
-  // a decimal(10, 0) column has 0 decimal places, so the input should step by 1.
+  // a decimal(10, 0) column has 0 decimal places, so the input should step by 1
+  // (`scale: 0` is a valid declaration — hence the typeof check, not truthiness).
+  // An explicit `step` in the metadata wins over the derived one.
   const scale = numberField?.scale;
+  const step =
+    typeof numberField?.step === 'number'
+      ? numberField.step
+      : typeof scale === 'number'
+        ? Math.pow(10, -scale)
+        : 'any';
 
   // Filter out non-DOM props
   const { inputType, ...domProps } = props as any;
@@ -31,7 +39,11 @@ export function NumberField({ value, onChange, field, readonly, ...props }: Fiel
       }}
       placeholder={numberField?.placeholder}
       disabled={readonly || domProps.disabled}
-      step={scale ? Math.pow(10, -scale) : 'any'}
+      // Surface the field's declared range so the browser's spinner/keyboard
+      // affordances respect it (server-side validation still owns enforcement).
+      min={typeof numberField?.min === 'number' ? numberField.min : undefined}
+      max={typeof numberField?.max === 'number' ? numberField.max : undefined}
+      step={step}
     />
   );
 }

--- a/packages/plugin-detail/README.md
+++ b/packages/plugin-detail/README.md
@@ -199,6 +199,26 @@ the whole section renders nothing — no header, no empty grid, no "New"
 button that would be rejected server-side. With no `PermissionProvider`
 mounted (Studio designer, standalone embeds) the gate stays open.
 
+### InlineEditSaveBar & InlineFieldInput
+
+The record-level inline-edit session (#2407): double-clicking a field (or its
+hover pencil) in the highlights strip or details body stages edits into ONE
+shared draft (`InlineEditProvider` from `@object-ui/react`), committed by
+`<InlineEditSaveBar>` as a single atomic OCC-guarded update. Polish shipped in
+#2572:
+
+- **Editors**: `InlineFieldInput` routes every field type to the same widget
+  the form uses — including `number` / `currency` / `percent` (numeric
+  keyboard, `min`/`max`/`step` from metadata, fraction↔percent conversion) and
+  reference pickers, which receive `$expand`-ed record objects as-is so the
+  display name renders without a hydration re-fetch.
+- **Keyboard shortcuts**: while the session is active, **Esc** cancels (open
+  popovers/dialogs keep owning Escape for "close") and **Cmd/Ctrl+Enter**
+  saves; both respect the in-flight `saving` and `locked` states.
+- **Approval lock**: hosts pass `locked` / `lockedHint` to the save bar and
+  gate `InlineEditProvider.canEdit` when the record is approval-locked, so a
+  locked record hides its edit affordances instead of rejecting at Save.
+
 <!-- release-metadata:v3.3.0 -->
 
 ## Compatibility

--- a/packages/plugin-detail/src/InlineEditSaveBar.tsx
+++ b/packages/plugin-detail/src/InlineEditSaveBar.tsx
@@ -20,6 +20,10 @@
  *     `onFieldSave(field, value)` over the draft, preserving the drawer's
  *     existing per-field persistence contract with plugin-gantt/calendar/kanban.
  *
+ * While the session is active the bar also owns the record-level keyboard
+ * shortcuts (objectui#2572): **Esc** cancels (when no popover/dialog is open)
+ * and **Cmd/Ctrl+Enter** saves — both respecting `saving`/`locked`.
+ *
  * The bar renders nothing unless the record is actively being edited.
  */
 
@@ -223,6 +227,45 @@ export const InlineEditSaveBar: React.FC<InlineEditSaveBarProps> = ({
       closeConflict();
     }
   }, [conflict, canAtomic, inline, dataSource, objectName, recordId, refresh, closeConflict]);
+
+  // Record-level keyboard shortcuts for the shared edit session
+  // (objectui#2572 item 5): Cmd/Ctrl+Enter commits the draft, Esc cancels.
+  // Installed only while editing. Esc defers to any open Radix layer
+  // (popover / select / dropdown / dialog) — those own Escape for "close the
+  // layer", so the session only cancels when nothing is stacked on top.
+  // Both respect the in-flight `saving` state; save also respects `locked`
+  // and stands down while the conflict dialog drives the session.
+  const editing = !!inline?.editing;
+  const saving = !!inline?.saving;
+  const cancel = inline?.cancel;
+  const conflictOpen = !!conflict;
+  React.useEffect(() => {
+    if (!editing) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        if (saving || locked || conflictOpen) return;
+        e.preventDefault();
+        void handleSave();
+        return;
+      }
+      if (e.key === 'Escape') {
+        if (e.defaultPrevented || saving || conflictOpen) return;
+        // An open floating layer (lookup/select popover, dropdown, dialog)
+        // owns this Esc — let it close instead of tearing down the draft.
+        if (
+          document.querySelector(
+            '[data-radix-popper-content-wrapper], [role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',
+          )
+        ) {
+          return;
+        }
+        e.preventDefault();
+        cancel?.();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [editing, saving, locked, conflictOpen, handleSave, cancel]);
 
   // Render nothing unless a provider is present and the record is being edited.
   if (!inline || !inline.editing) return null;

--- a/packages/plugin-detail/src/InlineFieldInput.tsx
+++ b/packages/plugin-detail/src/InlineFieldInput.tsx
@@ -12,6 +12,9 @@ import {
   BooleanField,
   LookupField,
   UserField,
+  NumberField,
+  CurrencyField,
+  PercentField,
   CapabilityMultiSelectField,
   coerceToSafeValue,
 } from '@object-ui/fields';
@@ -68,9 +71,10 @@ export interface InlineFieldInputProps {
  * highlights strip (objectui#2407) — renders an identical editor. Covers every
  * widget the detail body handles: `SelectField`, `BooleanField`, `LookupField`,
  * `UserField`, `CapabilityMultiSelectField` (#2403), the `permission-facet-link`
- * read-only facet (#2403), and the plain number/date/text input (with ISO date
- * coercion + object-value guarding so an unexpanded reference never leaks
- * "[object Object]").
+ * read-only facet (#2403), the numeric widgets (`NumberField` /
+ * `CurrencyField` / `PercentField`, objectui#2572), and the plain date/text
+ * input (with ISO date coercion + object-value guarding so an unexpanded
+ * reference never leaks "[object Object]").
  *
  * Editability GATING (computed types, `readonly`, system fields, object
  * lifecycle) stays with the host — this component only renders the editor once
@@ -127,8 +131,13 @@ export const InlineFieldInput: React.FC<InlineFieldInputProps> = ({
   }
   // Reference fields (lookup / master_detail / tree / user / owner) store an id
   // but may arrive `$expand`-ed as a record object. A plain text input would
-  // stringify that to "[object Object]", so render the real picker and feed it
-  // the id extracted from the (possibly expanded) value.
+  // stringify that to "[object Object]", so render the real picker. The value
+  // is passed through UNCOLLAPSED (objectui#2572 item 1): `LookupField`
+  // resolves an expanded record object directly (display name included), so
+  // stripping it to a bare id here would force the picker's hydration effect
+  // to re-fetch the referenced record just to recover the name the record
+  // page's `populate=` already delivered. `extractLookupId` stays exported for
+  // write-side callers that need the bare id.
   const isUserRef = editType === 'user' || editType === 'owner';
   const isLookupRef =
     editType === 'lookup' ||
@@ -140,14 +149,29 @@ export const InlineFieldInput: React.FC<InlineFieldInputProps> = ({
     return (
       <RefWidget
         field={field as any}
-        value={extractLookupId(value)}
+        value={value}
         onChange={(v: any) => onChange(v)}
         dataSource={dataSource}
       />
     );
   }
+  // Numeric types → the SAME dedicated widgets the form uses (objectui#2572
+  // item 3), so inline edit gets a real number input (numeric keyboard,
+  // min/max/step from the field metadata) and currency/percent keep their
+  // symbol adornment + display conversion instead of a free-text input.
+  // (`decimal`/`integer` are not spec FieldTypes — metadata should declare
+  // `number` with `scale`, so they are deliberately not aliased here.)
+  if (editType === 'number') {
+    return <NumberField field={field as any} value={value} onChange={(v: any) => onChange(v)} autoFocus={autoFocus} />;
+  }
+  if (editType === 'currency') {
+    return <CurrencyField field={field as any} value={value} onChange={(v: any) => onChange(v)} autoFocus={autoFocus} />;
+  }
+  if (editType === 'percent') {
+    return <PercentField field={field as any} value={value} onChange={(v: any) => onChange(v)} autoFocus={autoFocus} />;
+  }
   const isDate = editType === 'date' || editType === 'datetime';
-  const inputType = editType === 'number' ? 'number' : isDate ? 'date' : 'text';
+  const inputType = isDate ? 'date' : 'text';
   // <input type="date"> needs a YYYY-MM-DD string; raw ISO timestamps
   // ("2026-02-14T14:46:20.862Z") leave the picker blank. Slice down to the date
   // portion so existing values round-trip correctly.

--- a/packages/plugin-detail/src/__tests__/InlineEditSaveBar.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineEditSaveBar.test.tsx
@@ -125,6 +125,107 @@ describe('InlineEditSaveBar — callback (drawer) mode', () => {
   });
 });
 
+describe('InlineEditSaveBar — keyboard shortcuts (objectui#2572)', () => {
+  it('Cmd/Ctrl+Enter commits the draft in one atomic update', async () => {
+    const update = vi.fn().mockResolvedValue({});
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar
+          dataSource={{ update }}
+          objectName="proj"
+          recordId="p1"
+          data={{ updated_at: 'v1' }}
+          refresh={vi.fn()}
+        />
+      </InlineEditProvider>,
+    );
+
+    stageTwoFields();
+    fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(update).toHaveBeenCalledWith(
+      'proj',
+      'p1',
+      { status: 'active', budget: 100 },
+      { ifMatch: 'v1' },
+    );
+  });
+
+  it('Cmd/Ctrl+Enter is a no-op while locked', () => {
+    const update = vi.fn();
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar dataSource={{ update }} objectName="proj" recordId="p1" data={{}} refresh={vi.fn()} locked />
+      </InlineEditProvider>,
+    );
+
+    stageTwoFields();
+    fireEvent.keyDown(window, { key: 'Enter', ctrlKey: true });
+    expect(update).not.toHaveBeenCalled();
+    // Session stays live — the bar is still rendered.
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('Esc cancels the session without a write', () => {
+    const update = vi.fn();
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar dataSource={{ update }} objectName="proj" recordId="p1" data={{}} refresh={vi.fn()} />
+      </InlineEditProvider>,
+    );
+
+    stageTwoFields();
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+  });
+
+  it('Esc defers to an open floating layer (popover owns the key)', () => {
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar dataSource={{ update: vi.fn() }} objectName="proj" recordId="p1" data={{}} refresh={vi.fn()} />
+      </InlineEditProvider>,
+    );
+
+    stageTwoFields();
+    // Simulate an open Radix layer (lookup/select popover) in the DOM.
+    const popper = document.createElement('div');
+    popper.setAttribute('data-radix-popper-content-wrapper', '');
+    document.body.appendChild(popper);
+    try {
+      fireEvent.keyDown(window, { key: 'Escape' });
+      // The session must survive — Esc belonged to the popover.
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    } finally {
+      popper.remove();
+    }
+
+    // With the layer gone, Esc tears the session down.
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+  });
+
+  it('shortcuts are inert while not editing', () => {
+    const update = vi.fn();
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar dataSource={{ update }} objectName="proj" recordId="p1" data={{}} refresh={vi.fn()} />
+      </InlineEditProvider>,
+    );
+
+    fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
 describe('InlineEditSaveBar — Cancel', () => {
   it('discards the draft without any write', () => {
     const update = vi.fn();

--- a/packages/plugin-detail/src/__tests__/InlineFieldInput.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineFieldInput.test.tsx
@@ -80,6 +80,72 @@ describe('InlineFieldInput', () => {
     expect(arg).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
   });
 
+  it('passes an $expand-ed reference value through so the picker shows the name without re-fetching (objectui#2572)', async () => {
+    const findOne = vi.fn();
+    const find = vi.fn().mockResolvedValue({ data: [], total: 0 });
+    render(
+      <InlineFieldInput
+        field={{ name: 'account', type: 'lookup', reference_to: 'accounts' }}
+        value={{ id: 'a1', name: 'Northwind Traders' }}
+        onChange={vi.fn()}
+        dataSource={{ find, findOne }}
+      />,
+    );
+    // The expanded record already carries its display name — the chip must
+    // render it synchronously, with NO hydration fetch for the id.
+    expect(await screen.findByText('Northwind Traders')).toBeInTheDocument();
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('renders currency as a numeric input honoring the metadata min (objectui#2572)', () => {
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput
+        field={{ name: 'budget', type: 'currency', min: 0 }}
+        value={5000}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveAttribute('type', 'number');
+    expect(input).toHaveAttribute('min', '0');
+    fireEvent.change(input, { target: { value: '6000' } });
+    // Numeric widgets emit real numbers (not free-typed strings).
+    expect(onChange).toHaveBeenCalledWith(6000);
+  });
+
+  it('renders number as a numeric input emitting numbers, honoring scale', () => {
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput
+        field={{ name: 'headcount', type: 'number', scale: 0 }}
+        value={12}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByRole('spinbutton');
+    // `scale: 0` must step by 1 (whole numbers), not fall back to "any".
+    expect(input).toHaveAttribute('step', '1');
+    fireEvent.change(input, { target: { value: '15' } });
+    expect(onChange).toHaveBeenCalledWith(15);
+  });
+
+  it('renders percent with the display conversion (stored fraction ↔ shown %)', () => {
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput
+        field={{ name: 'completion', type: 'percent' }}
+        value={0.5}
+        onChange={onChange}
+      />,
+    );
+    // Stored 0.5 renders as "50" (%); typing 75 stores 0.75.
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveValue(50);
+    fireEvent.change(input, { target: { value: '75' } });
+    expect(onChange).toHaveBeenCalledWith(0.75);
+  });
+
   it('auto-focuses the input when autoFocus is set', () => {
     render(
       <InlineFieldInput


### PR DESCRIPTION
Closes #2572 — all five polish items from the live showcase verification pass of the record-level inline edit (#2407 / #2529 / #2542 / #2549).

## 1. Expanded-value passthrough (no more re-fetch just to show a name)

`InlineFieldInput` no longer collapses an `$expand`-ed reference record to a bare id before handing it to `LookupField` / `UserField` — the picker's `resolveSelectedOption` maps the object directly, so the display name the record page's `populate=` already delivered renders synchronously with **zero** hydration `findOne`. Complementary fix in `LookupField`: the Level-2 pickers (`PeoplePicker` / `RecordPickerDialog`) *do* operate on bare ids (seed queries, selected-row matching), so the value handed to them is collapsed via the existing `normalizeId` — an object-shaped id can no longer leak into a `$in` seed filter. `extractLookupId` stays exported for write-side callers.

## 2. Approval-lock preflight

`RecordDetailView` now:
- re-runs `useRecordApprovals().refresh()` on every record invalidation (skipping the initial mount) — a save can *trigger* an approval flow (verified live: `flow:showcase_budget_approval`), and the approvals snapshot previously stayed frozen at page load;
- derives one `approvalLocked` signal — `approval_status` `pending`/`in_approval` (what the DetailView lock band keys off) **or** an open pending request from the approvals API;
- gates `InlineEditProvider.canEdit` with it, so a locked record hides the hover pencils and `enter()` no-ops — users can no longer type a whole draft only to be rejected with `RECORD_LOCKED` at Save;
- drives the save bar's existing `locked` + `lockedHint` props from the same signal.

## 3. Numeric field types edit with real numeric widgets

`number` / `currency` / `percent` route to `NumberField` / `CurrencyField` / `PercentField` — the SAME widgets the form uses — instead of the free-text fallback: numeric keyboard, currency symbol adornment, fraction↔percent display conversion, and numbers (not strings) staged into the draft. Supporting widget fixes:
- `NumberField` + `CurrencyField` surface metadata `min`/`max` on the input (Project.budget's `min: 0` is no longer ignored);
- `NumberField` honors an explicit metadata `step` and steps by 1 for `scale: 0` (previously `0` was falsy → `step="any"`).

`decimal` / `integer` are **not** `@objectstack/spec` FieldTypes (metadata should declare `number` with `scale`), so per AGENTS.md commandment #0.1 they are deliberately not aliased in the renderer.

## 4. Header Edit CTA stands down during an inline session

The synthesized `sys_edit` action carries a new `disableDuringInlineEdit` flag; the `page:header` renderer greys flagged actions out (inline buttons and overflow menu items) while `InlineEditContext.editing` is true — the classic form-edit surface can no longer be stacked on top of a live inline draft. Outside an `InlineEditProvider` the hook returns null and nothing changes.

## 5. Keyboard shortcuts for the shared edit session

`InlineEditSaveBar` installs record-level bindings while the session is active:
- **Esc → cancel**, deferring to any open Radix layer (`[data-radix-popper-content-wrapper]`, open `dialog`/`alertdialog`) — popovers keep owning Escape for "close";
- **Cmd/Ctrl+Enter → save**, respecting `saving` / `locked` and standing down while the conflict dialog drives the session.

## Verification

- New unit tests: expanded-lookup passthrough (no `findOne`, name renders), currency/number/percent inline editors (min, scale-0 step, numeric emission, % conversion), header-CTA disable under a live session, all five shortcut behaviors (commit, locked no-op, cancel, defer-to-popover, inert-when-idle), NumberField min/max/step.
- Full suites green: plugin-detail + fields + react (546), components (246), fields + app-shell (1769).
- `turbo run build` green for the four touched packages (includes `tsc` typecheck for app-shell/fields).
- Pre-existing eslint error in `page-header-actions.test.tsx` (`Cannot create components during render` on the untouched `PageHeader` helper) exists on `main` and is not introduced here.
- Item 2's end-to-end behavior (budget save → flow lock → pencils hide) follows the issue's live-verification path; this environment has no framework backend installed, so that pass is unit-covered here and worth a quick dogfood re-run on the showcase stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQjNZDdqmz2QHGQndpjZrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQjNZDdqmz2QHGQndpjZrR)_