### PR TITLE
fix(studio): confirm before header SPA nav discards unsaved pillar edits (#2600)

### DIFF
--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.pillarNavGuard.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.pillarNavGuard.test.tsx
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Studio header — unsaved-changes guard on SPA navigation (objectui#2600).
+ *
+ * The pillar links, the Home button and the PackageSwitcher are pure
+ * react-router client navigation, so the editors' `beforeunload` guard never
+ * fires; before this guard existed they unmounted a dirty pillar silently and
+ * discarded its unsaved edits. Pillars now mirror their dirty state up to the
+ * surface (same `onDirtyChange` contract as the Access rail guard, PR #2588),
+ * and every header-driven departure gates on a native confirm:
+ *
+ *   • dirty + pillar switch → confirm; cancel keeps the pillar and its edits,
+ *   • dirty + Home → same confirm; cancel stays, confirm leaves,
+ *   • dirty + package switch → same confirm,
+ *   • clean navigation never prompts,
+ *   • re-clicking the open pillar never prompts (nothing unmounts),
+ *   • a confirmed discard clears the guard (the pillar resets on unmount).
+ *
+ * Rendered through the real StudioDesignSurface + AccessPillar +
+ * PermissionMatrixEditPage stack (mocking only data I/O and heavy rail
+ * siblings), so the dirty report crosses every real seam.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+let clientImpl: any;
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useMetadataClient: () => clientImpl,
+    useMetadataTypes: () => ({
+      loading: false,
+      error: null,
+      entries: [{ type: 'permission', label: 'Permission', allowOrgOverride: true }],
+    }),
+  };
+});
+
+// The surface's package list (header switcher + writability gate) — two
+// writable packages so the switcher has somewhere to go.
+vi.mock('./packages-io', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    fetchPackages: vi.fn(async () => [
+      { id: 'app.a', name: 'App A', writable: true, namespace: 'a' },
+      { id: 'app.b', name: 'App B', writable: true, namespace: 'b' },
+    ]),
+  };
+});
+
+// Rail siblings / docks that are irrelevant to the guard — keep the render light.
+vi.mock('./PackageOwdOverviewPanel', () => ({
+  PackageOwdOverviewPanel: () => <div data-testid="owd-overview" />,
+}));
+vi.mock('../../components/SuggestedBindingsPanel', () => ({
+  SuggestedBindingsPanel: () => null,
+}));
+vi.mock('../metadata-admin/AccessExplainPanel', () => ({
+  AccessExplainPanel: () => null,
+}));
+vi.mock('./StudioAiCopilot', () => ({
+  StudioChatDock: () => null,
+}));
+vi.mock('../../preview/DraftChangesPanel', () => ({
+  DraftChangesPanel: () => null,
+}));
+
+import { StudioDesignSurface } from './StudioDesignSurface';
+
+// jsdom has no matchMedia — useIsMobile / useIsWideViewport need a stub.
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as any;
+
+// Radix Popover (PackageSwitcher) floats via floating-ui, which observes size.
+(globalThis as any).ResizeObserver =
+  (globalThis as any).ResizeObserver ??
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+interface Server {
+  byName: Record<string, Record<string, unknown>>;
+  saved: Array<Record<string, unknown>>;
+}
+
+function freshServer(): Server {
+  return {
+    saved: [],
+    byName: {
+      set_a: {
+        name: 'set_a',
+        label: 'Set A',
+        objects: { a_account: { allowRead: true } },
+        fields: {},
+      },
+    },
+  };
+}
+
+function makeClient(server: Server) {
+  return {
+    // Serves the Access rail (list('permission')), the embedded matrix
+    // (list('object') + object get), the header's app probe (list('app')),
+    // and — after a pillar switch — the Interfaces pillar's app resolution.
+    list: async (type: string) => {
+      if (type === 'permission') {
+        return Object.values(server.byName).map((s) => ({ name: s.name, label: s.label }));
+      }
+      if (type === 'object') return [{ name: 'a_account' }];
+      return [];
+    },
+    listDrafts: async () => [],
+    layered: async (_type: string, name: string) => ({
+      effective: server.byName[name],
+      code: null,
+      overlay: null,
+      overlayScope: null,
+    }),
+    getDraft: async () => null,
+    get: async (type: string) =>
+      type === 'object' ? { fields: [{ name: 'name', label: 'Name' }] } : null,
+    save: async (_t: string, _n: string, payload: Record<string, unknown>) => {
+      server.saved.push(payload);
+      return payload;
+    },
+  } as any;
+}
+
+// This jsdom environment ships no window.confirm at all — install a mock
+// outright rather than spying.
+let confirmSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  clientImpl = makeClient(freshServer());
+  confirmSpy = vi.fn();
+  window.confirm = confirmSpy as unknown as typeof window.confirm;
+  // The surface's pending-drafts counter polls over raw fetch — stub it flat.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => [],
+    })) as unknown as typeof fetch,
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+async function renderSurfaceOnAccess() {
+  render(
+    <MemoryRouter initialEntries={['/studio/app.a/access']}>
+      <Routes>
+        <Route path="/studio/:packageId/:tab" element={<StudioDesignSurface />} />
+        <Route path="/home" element={<div data-testid="home-page" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  // First set is auto-selected; its matrix header carries the set name.
+  await screen.findByDisplayValue('set_a');
+}
+
+/** Flip a cell in the open matrix so the editor reports dirty. */
+function dirtyTheMatrix() {
+  const row = screen.getByText('a_account').closest('tr')!;
+  fireEvent.click(within(row).getByRole('button', { name: 'None' }));
+}
+
+const matrixEditSurvived = () => {
+  // Row "None" left Read unchecked — a remount would reload allowRead: true.
+  const row = screen.getByText('a_account').closest('tr')!;
+  expect(within(row).getByRole('checkbox', { name: 'a_account Read' })).not.toBeChecked();
+};
+
+describe('Studio header — unsaved pillar edits guard (#2600)', () => {
+  it('asks before a pillar switch when dirty; cancel keeps the pillar and its edits', async () => {
+    await renderSurfaceOnAccess();
+    dirtyTheMatrix();
+
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByRole('link', { name: 'Interfaces' }));
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByDisplayValue('set_a')).toBeInTheDocument();
+    matrixEditSurvived();
+
+    // Confirming the same switch discards and lands on the Interfaces pillar.
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByRole('link', { name: 'Interfaces' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await screen.findByText('This package has no app yet');
+    expect(screen.queryByDisplayValue('set_a')).not.toBeInTheDocument();
+
+    // The discarded pillar reset the guard on unmount — walking back to
+    // Access must NOT prompt again.
+    fireEvent.click(screen.getByRole('link', { name: 'Access' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await screen.findByDisplayValue('set_a');
+  });
+
+  it('switches pillars without prompting when clean', async () => {
+    await renderSurfaceOnAccess();
+
+    fireEvent.click(screen.getByRole('link', { name: 'Interfaces' }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    await screen.findByText('This package has no app yet');
+  });
+
+  it('never prompts when re-clicking the open pillar (nothing unmounts)', async () => {
+    await renderSurfaceOnAccess();
+    dirtyTheMatrix();
+
+    fireEvent.click(screen.getByRole('link', { name: 'Access' }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue('set_a')).toBeInTheDocument();
+    matrixEditSurvived();
+  });
+
+  it('gates the Home button; cancel stays, confirm leaves the studio', async () => {
+    await renderSurfaceOnAccess();
+    dirtyTheMatrix();
+
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByTitle('Back to home'));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByDisplayValue('set_a')).toBeInTheDocument();
+    matrixEditSurvived();
+
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByTitle('Back to home'));
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument();
+  });
+
+  it('gates a package switch; cancel keeps the edits in place', async () => {
+    await renderSurfaceOnAccess();
+    dirtyTheMatrix();
+
+    // Open the switcher (its label resolves once fetchPackages lands).
+    fireEvent.click(await screen.findByRole('button', { name: /App A/ }));
+    const other = await screen.findByRole('button', { name: /App B/ });
+
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(other);
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByDisplayValue('set_a')).toBeInTheDocument();
+    matrixEditSurvived();
+
+    // Confirming jumps to the other package (header re-labels; matrix reloads).
+    fireEvent.click(await screen.findByRole('button', { name: /App A/ }));
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(await screen.findByRole('button', { name: /App B/ }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await waitFor(() =>
+      expect(screen.getByTitle('Switch / create package')).toHaveTextContent('App B'),
+    );
+  });
+
+  it('never prompts a clean package switch', async () => {
+    await renderSurfaceOnAccess();
+
+    fireEvent.click(await screen.findByRole('button', { name: /App A/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /App B/ }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByTitle('Switch / create package')).toHaveTextContent('App B'),
+    );
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -244,7 +244,19 @@ function extractDraftBody(resp: unknown): Record<string, unknown> | null {
  * navigation, create a new writable base via the standard CreatePackageDialog,
  * and open the standard PackageDetailSheet (info + disable / duplicate / delete
  * / publish …) for the current package. */
-function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string }): React.ReactElement {
+function PackageSwitcher({
+  packageId,
+  tab,
+  beforeNavigate,
+}: {
+  packageId: string;
+  tab: string;
+  /** objectui#2600 — veto hook for package-switch navigation: return false to
+   * stay put (the surface prompts about unsaved pillar edits). Not consulted
+   * for the deleted-package eviction in onManageChanged — that navigation is
+   * forced (the package under the editor is gone). */
+  beforeNavigate?: () => boolean;
+}): React.ReactElement {
   const navigate = useNavigate();
   const locale = useMetadataLocale();
   const [open, setOpen] = React.useState(false);
@@ -377,6 +389,10 @@ function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string })
                   type="button"
                   onClick={() => {
                     setOpen(false);
+                    // Re-picking the open package would re-navigate to the same
+                    // URL — nothing unmounts, so no veto and no history churn.
+                    if (p.id === packageId) return;
+                    if (beforeNavigate && !beforeNavigate()) return;
                     navigate(`/studio/${encodeURIComponent(p.id)}/${tab}`);
                   }}
                   className={
@@ -430,7 +446,13 @@ function PackageSwitcher({ packageId, tab }: { packageId: string; tab: string })
       <CreatePackageDialog
         open={createOpen}
         onOpenChange={setCreateOpen}
-        onCreated={(id) => navigate(`/studio/${encodeURIComponent(id)}/data`)}
+        onCreated={(id) => {
+          // Same veto as a switch: the jump into the new package unmounts the
+          // current pillar. Declining keeps the edits; the created package
+          // stays reachable from the list above.
+          if (beforeNavigate && !beforeNavigate()) return;
+          navigate(`/studio/${encodeURIComponent(id)}/data`);
+        }}
       />
       <PackageDetailSheet
         pkg={manage}
@@ -474,6 +496,33 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
     };
   }, [packageId]);
   const readOnly = pkgWritable === false;
+
+  // objectui#2600 — the header's pillar links, Home button and PackageSwitcher
+  // are pure SPA client navigation, so the editors' `beforeunload` guard never
+  // fires; a dirty pillar unmounts silently and its unsaved edits are gone
+  // (Access matrix cells, Interfaces nav). Each pillar mirrors its dirty state
+  // up (the PR #2588 `onDirtyChange` contract) and every header-driven
+  // departure gates on the same native confirm the pillars use internally.
+  // Pillars reset their report on unmount, so a confirmed discard clears the
+  // flag by itself.
+  const [pillarDirty, setPillarDirty] = React.useState(false);
+  const confirmLeavePillar = React.useCallback(() => {
+    if (!pillarDirty) return true;
+    return window.confirm(t('engine.edit.unsavedLeaveConfirm', locale));
+  }, [pillarDirty, locale]);
+  // Browser-native "leave site?" prompt on tab close / reload while a pillar
+  // is dirty. The matrix editor installs its own (double registration is
+  // harmless); the Interfaces nav editor has none, so this closes that gap.
+  React.useEffect(() => {
+    if (!pillarDirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Required for Chrome to actually show the prompt.
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [pillarDirty]);
 
   // Package-level publish (ADR-0033/0037/0048): edits accumulate as per-item
   // drafts STAMPED with this package (each save passes packageId → the draft row's
@@ -653,14 +702,17 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
           {/* Never a dead end: walk back to the platform Home / builder landing. */}
           <button
             type="button"
-            onClick={() => shellNavigate('/home')}
+            onClick={() => {
+              if (!confirmLeavePillar()) return;
+              shellNavigate('/home');
+            }}
             title={t('engine.studio.home', locale)}
             className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             <HomeIcon className="h-4 w-4" />
           </button>
           <div className="shrink-0">
-            <PackageSwitcher packageId={packageId} tab={tab} />
+            <PackageSwitcher packageId={packageId} tab={tab} beforeNavigate={confirmLeavePillar} />
           </div>
           <span className="shrink-0 text-muted-foreground">·</span>
           <nav className="flex shrink-0 gap-1">
@@ -668,6 +720,15 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
               <Link
                 key={p.key}
                 to={`/studio/${packageId}/${p.key}`}
+                onClick={(e) => {
+                  // Re-clicking the open pillar re-navigates to the same URL —
+                  // nothing unmounts. Modified/aux clicks open a new tab and
+                  // leave this one (and its edits) alone; react-router defers
+                  // those to the browser, so don't veto them either.
+                  if (tab === p.key) return;
+                  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+                  if (!confirmLeavePillar()) e.preventDefault();
+                }}
                 className={
                   'inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-colors ' +
                   (tab === p.key
@@ -748,7 +809,13 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
           ) : tab === 'automations' ? (
             <AutomationsPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} readOnly={readOnly} />
           ) : tab === 'access' ? (
-            <AccessPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} readOnly={readOnly} />
+            <AccessPillar
+              packageId={packageId}
+              publishNonce={publishNonce}
+              onDraftSaved={onDraftSaved}
+              readOnly={readOnly}
+              onDirtyChange={setPillarDirty}
+            />
           ) : (
             <InterfacesPillar
               packageId={packageId}
@@ -758,6 +825,7 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
               onCreateApp={readOnly ? undefined : () => setAppCreating(true)}
               readOnly={readOnly}
               foldInspector={chatDockMode}
+              onDirtyChange={setPillarDirty}
             />
           )}
         </div>
@@ -987,6 +1055,7 @@ function InterfacesPillar({
   onCreateApp,
   readOnly = false,
   foldInspector = false,
+  onDirtyChange,
 }: {
   packageId: string;
   publishNonce?: number;
@@ -1003,6 +1072,11 @@ function InterfacesPillar({
    * into center `[canvas | properties]` tabs instead of its own right aside.
    * Default false → the classic three-zone layout, pixel-identical. */
   foldInspector?: boolean;
+  /** objectui#2600 — mirrors the unsaved-nav-edit state (`navDirty`) up to the
+   * Studio header, whose pillar/Home/package navigation unmounts this whole
+   * pillar (SPA nav, so no beforeunload). Reports `false` on unmount so a
+   * confirmed discard clears the surface's guard. */
+  onDirtyChange?: (dirty: boolean) => void;
 }): React.ReactElement {
   const client = useMetadataClient();
   const locale = useMetadataLocale();
@@ -1051,6 +1125,23 @@ function InterfacesPillar({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navSel]);
   const [navDirty, setNavDirty] = React.useState(false);
+  // Mirror `navDirty` up to the surface (see the onDirtyChange prop doc).
+  // Ref-stabilized like PermissionMatrixEditPage's report, so a non-memoized
+  // callback prop doesn't refire the effect; the unmount cleanup reports
+  // `false` so a deliberately-discarded pillar clears the host's guard state.
+  const onDirtyChangeRef = React.useRef(onDirtyChange);
+  React.useEffect(() => {
+    onDirtyChangeRef.current = onDirtyChange;
+  });
+  React.useEffect(() => {
+    onDirtyChangeRef.current?.(navDirty);
+  }, [navDirty]);
+  React.useEffect(
+    () => () => {
+      onDirtyChangeRef.current?.(false);
+    },
+    [],
+  );
   const [navHasDraft, setNavHasDraft] = React.useState(false);
   const [navSaving, setNavSaving] = React.useState<false | 'draft' | 'publish'>(false);
   const [current, setCurrent] = React.useState<Surface | null>(null);
@@ -3092,12 +3183,18 @@ export function AccessPillar({
   publishNonce,
   onDraftSaved,
   readOnly = false,
+  onDirtyChange,
 }: {
   packageId: string;
   publishNonce?: number;
   onDraftSaved?: () => void;
   /** Courtesy gate: hide/disable permission-authoring affordances. */
   readOnly?: boolean;
+  /** objectui#2600 — mirrors the matrix's unsaved-edit state up to the Studio
+   * header, whose pillar/Home/package navigation unmounts this whole pillar
+   * (SPA nav, so no beforeunload). Reports `false` when the editor unmounts,
+   * same contract as PermissionMatrixEditPage's own onDirtyChange. */
+  onDirtyChange?: (dirty: boolean) => void;
 }): React.ReactElement {
   const client = useMetadataClient();
   const locale = useMetadataLocale();
@@ -3145,6 +3242,16 @@ export function AccessPillar({
   // resets its report on unmount, so a confirmed discard clears `matrixDirty`
   // by itself.
   const [matrixDirty, setMatrixDirty] = React.useState(false);
+  // The same dirty bit also gates the Studio header's pillar/Home/package
+  // navigation, which unmounts this whole pillar (objectui#2600) — mirror
+  // every report up alongside the local rail guard.
+  const reportMatrixDirty = React.useCallback(
+    (dirty: boolean) => {
+      setMatrixDirty(dirty);
+      onDirtyChange?.(dirty);
+    },
+    [onDirtyChange],
+  );
   const confirmDiscardMatrixEdits = React.useCallback(() => {
     if (!matrixDirty) return true;
     return window.confirm(t('engine.edit.unsavedLeaveConfirm', locale));
@@ -3434,7 +3541,7 @@ export function AccessPillar({
               publishNonce={publishNonce}
               onDraftSaved={onDraftSaved}
               readOnly={readOnly}
-              onDirtyChange={setMatrixDirty}
+              onDirtyChange={reportMatrixDirty}
               embedded
               onOpenOwd={(objectName) => {
                 // The badge deep-link swaps this page out for the OWD


### PR DESCRIPTION
## Summary

Follow-up to #2600 / PR #2588. The A1 fix guarded **rail-driven** swaps inside the Access pillar, but the Studio **header** was still unguarded: the pillar links (Data/Automations/Interfaces/Access) are plain react-router `<Link>`s, the Home button calls `shellNavigate('/home')`, and the PackageSwitcher calls `navigate(...)` — all pure SPA client navigation, so the editors' `beforeunload` guard never fires and a dirty pillar unmounts silently, discarding its unsaved edits (Access `matrixDirty`, Interfaces `navDirty`).

- **Dirty state lifted to the surface**: `AccessPillar` and `InterfacesPillar` grow an `onDirtyChange` prop (the PR #2588 contract — report `false` on unmount so a confirmed discard clears the guard by itself). AccessPillar forwards the matrix editor's report alongside its local rail guard; InterfacesPillar mirrors `navDirty` ref-stabilized, same as `PermissionMatrixEditPage`'s own report.
- **Every header departure gates on `window.confirm(t('engine.edit.unsavedLeaveConfirm'))`**: pillar links (`e.preventDefault()` on decline), Home, PackageSwitcher row clicks, and the post-create jump into a new package.
- **Never prompts when nothing unmounts**: re-clicking the open pillar / open package, and modified/aux clicks (new tab) are exempt. The deleted-package eviction in `onManageChanged` stays unguarded — that navigation is forced.
- **Bonus gap closed**: a surface-level `beforeunload` guard keyed on the lifted dirty bit — Interfaces nav edits previously had **no** reload/close guard at all (the matrix editor has its own; double registration is harmless).

## Tests

New `StudioDesignSurface.pillarNavGuard.test.tsx` (6 cases), rendered through the real `StudioDesignSurface` + `AccessPillar` + `PermissionMatrixEditPage` stack with the same mock seams as `StudioDesignSurface.accessGuard.test.tsx`: dirty pillar switch (cancel keeps edits / confirm lands + guard resets), clean switch, same-pillar re-click, Home button both ways, package switch both ways, clean package switch.

- `vitest run packages/app-shell/src/views/studio-design/` — 17 files / 102 tests pass
- `tsc --noEmit` in `packages/app-shell` — clean (after building workspace deps)

Not covered: driving `navDirty` end-to-end (needs a full app + nav-canvas drag setup); its mirror is the same 10-line pattern the matrix path exercises. The OWD overview panel's internal `dirtyCount` is intentionally out of scope (also not covered by the existing rail guard) — noted on #2600.

## Merge note (issue #2600 「合并注意」)

Touches `StudioDesignSurface.tsx` (AccessPillar mount point + props) — same file as A2 (readOnly) and PR #2599 (A3). Per the issue: **serial merge**, rebase whichever lands later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)