### PR TITLE
fix(app-shell): guard unsaved OWD overview rows in the Access rail and Studio header nav (#2600 follow-up)

### DIFF
--- a/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.test.tsx
+++ b/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.test.tsx
@@ -177,3 +177,40 @@ describe('PackageOwdOverviewPanel — deep-link highlight', () => {
     expect(row.className).toMatch(/bg-primary/);
   });
 });
+
+describe('PackageOwdOverviewPanel — onDirtyChange contract (objectui#2600)', () => {
+  it('reports dirty transitions and resets to clean on unmount', async () => {
+    const onDirtyChange = vi.fn();
+    const { unmount } = renderPanel(freshServer(), { onDirtyChange });
+    await screen.findByTestId('owd-row-crm_contact');
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+
+    fireEvent.change(screen.getByTestId('owd-internal-crm_contact'), { target: { value: 'public_read' } });
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    // Reverting the edit back to the baseline reports clean again.
+    fireEvent.change(screen.getByTestId('owd-internal-crm_contact'), { target: { value: 'private' } });
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+
+    // Dirty again, then unmount — a deliberately-discarded panel must clear
+    // the host's guard by itself (same contract as PermissionMatrixEditPage).
+    fireEvent.change(screen.getByTestId('owd-internal-crm_contact'), { target: { value: 'public_read' } });
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+    unmount();
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('reports clean after a successful save (edits become the new baseline)', async () => {
+    const onDirtyChange = vi.fn();
+    const server = freshServer();
+    renderPanel(server, { onDirtyChange });
+    await screen.findByTestId('owd-row-crm_contact');
+
+    fireEvent.change(screen.getByTestId('owd-internal-crm_contact'), { target: { value: 'public_read' } });
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.click(screen.getByTestId('owd-save'));
+    await waitFor(() => expect(server.saved.length).toBe(1));
+    await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(false));
+  });
+});

--- a/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx
@@ -90,6 +90,11 @@ export interface PackageOwdOverviewPanelProps {
   locale: SupportedLocale;
   /** Object to scroll to / highlight (deep-link from the permission matrix badge). */
   highlightObject?: string | null;
+  /** objectui#2600 — mirrors the unsaved-row state up to the host pillar, whose
+   * rail/header navigation unmounts this panel (SPA nav, so no beforeunload).
+   * Reports `false` on unmount so a confirmed discard clears the host's guard —
+   * same contract as PermissionMatrixEditPage's own onDirtyChange. */
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 export function PackageOwdOverviewPanel({
@@ -100,6 +105,7 @@ export function PackageOwdOverviewPanel({
   readOnly = false,
   locale,
   highlightObject,
+  onDirtyChange,
 }: PackageOwdOverviewPanelProps): React.ReactElement {
   const [rows, setRows] = React.useState<OwdRow[]>([]);
   const [edits, setEdits] = React.useState<Record<string, OwdEdit>>({});
@@ -202,6 +208,25 @@ export function PackageOwdOverviewPanel({
 
   const dirtyCount = rowState.filter((s) => s.dirty).length;
   const hasInvalid = rowState.some((s) => s.invalid);
+
+  // Report dirty transitions to the host (see onDirtyChange). Ref-stabilized
+  // so a non-memoized callback prop doesn't refire the effect; the unmount
+  // cleanup reports `false` so a deliberately-discarded panel clears the
+  // host's guard state.
+  const isDirty = dirtyCount > 0;
+  const onDirtyChangeRef = React.useRef(onDirtyChange);
+  React.useEffect(() => {
+    onDirtyChangeRef.current = onDirtyChange;
+  });
+  React.useEffect(() => {
+    onDirtyChangeRef.current?.(isDirty);
+  }, [isDirty]);
+  React.useEffect(
+    () => () => {
+      onDirtyChangeRef.current?.(false);
+    },
+    [],
+  );
 
   const doSave = React.useCallback(async () => {
     const changed = rowState.filter((s) => s.dirty && !s.invalid);

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.accessGuard.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.accessGuard.test.tsx
@@ -6,14 +6,17 @@
  * The permission matrix in the main panel is keyed by the selected set
  * (`key={current}`) and unmounts entirely when the OWD overview swaps in, so
  * before this guard existed a rail click silently REMOUNTED the matrix and
- * discarded any unsaved cell edits. The pillar now holds the editor's
- * reported dirty state (`onDirtyChange`) and gates every swap on a native
- * confirm:
+ * discarded any unsaved cell edits. The OWD overview batch-editor holds
+ * unsaved rows the same way and unmounts when a set swaps back in
+ * (objectui#2600). The pillar now holds both editors' reported dirty state
+ * (`onDirtyChange`) and gates every swap on a native confirm:
  *
  *   • dirty + switch to another set → confirm; cancel keeps the edits,
  *   • dirty + swap to the OWD overview → same confirm,
+ *   • dirty OWD rows + swap to a set / create flow → same confirm,
  *   • clean switches never prompt,
- *   • re-clicking the already-open set never prompts (nothing remounts),
+ *   • re-clicking the already-open set / overview never prompts (nothing
+ *     remounts),
  *   • a confirmed discard clears the guard (the editor resets on unmount).
  */
 
@@ -38,9 +41,7 @@ vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
 });
 
 // Rail siblings that are irrelevant to the guard — keep the render light.
-vi.mock('./PackageOwdOverviewPanel', () => ({
-  PackageOwdOverviewPanel: () => <div data-testid="owd-overview" />,
-}));
+// (The OWD overview is NOT mocked: its dirty report is under test.)
 vi.mock('../../components/SuggestedBindingsPanel', () => ({
   SuggestedBindingsPanel: () => null,
 }));
@@ -112,8 +113,10 @@ function makeClient(server: Server) {
     getDraft: async () => null,
     get: async (type: string) =>
       type === 'object' ? { fields: [{ name: 'name', label: 'Name' }] } : null,
-    save: async (_t: string, _n: string, payload: Record<string, unknown>) => {
+    save: async (_t: string, name: string, payload: Record<string, unknown>) => {
       server.saved.push(payload);
+      // Register the set so the post-create reload can list and open it.
+      server.byName[name] = payload;
       return payload;
     },
   } as any;
@@ -209,5 +212,79 @@ describe('AccessPillar — unsaved matrix edits guard', () => {
     // Not remounted — the unsaved edit is still visible.
     const row = screen.getByText('a_account').closest('tr')!;
     expect(within(row).getByRole('checkbox', { name: 'a_account Read' })).not.toBeChecked();
+  });
+});
+
+/** Swap the main panel to the (real) OWD overview and edit a row so the panel
+ * reports dirty. Assumes the open matrix is clean, so the swap never prompts. */
+async function openAndDirtyTheOwd() {
+  fireEvent.click(screen.getByRole('button', { name: 'Record sharing (OWD)' }));
+  await screen.findByTestId('owd-internal-a_account');
+  fireEvent.change(screen.getByTestId('owd-internal-a_account'), { target: { value: 'private' } });
+  await screen.findByTestId('owd-dirty-a_account');
+}
+
+const owdInternalValue = () =>
+  (screen.getByTestId('owd-internal-a_account') as HTMLSelectElement).value;
+
+describe('AccessPillar — unsaved OWD overview edits guard (#2600)', () => {
+  it('asks before swapping a dirty overview for a set; cancel keeps the edits', async () => {
+    await renderPillarOnSetA();
+    await openAndDirtyTheOwd();
+
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByRole('button', { name: 'Set A' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    // Still on the overview, edit intact.
+    expect(owdInternalValue()).toBe('private');
+
+    // Confirming the same swap discards and mounts the set A matrix.
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Set A' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await screen.findByDisplayValue('set_a');
+
+    // The discarded panel reset the guard on unmount — swapping back to the
+    // overview must NOT prompt, and it reloads the untouched baseline.
+    fireEvent.click(screen.getByRole('button', { name: 'Record sharing (OWD)' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await screen.findByTestId('owd-internal-a_account');
+    expect(owdInternalValue()).toBe('');
+  });
+
+  it('never prompts when re-clicking the OWD rail entry (nothing remounts)', async () => {
+    await renderPillarOnSetA();
+    await openAndDirtyTheOwd();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record sharing (OWD)' }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    // Not remounted — the unsaved edit is still visible.
+    expect(owdInternalValue()).toBe('private');
+  });
+
+  it('gates the create-set flow, and creating lands on the new set matrix', async () => {
+    await renderPillarOnSetA();
+    await openAndDirtyTheOwd();
+
+    // Cancel keeps the overview (and its edits) — no dialog.
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByRole('button', { name: 'New permission set' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(owdInternalValue()).toBe('private');
+
+    // Confirm opens the creator; submitting swaps the overview out for the
+    // new set's matrix (the discard the gate warned about).
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByRole('button', { name: 'New permission set' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.change(within(dialog).getByPlaceholderText('Display name (e.g. Sales permissions)'), {
+      target: { value: 'Set C' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+    await screen.findByDisplayValue('set_c');
+    expect(screen.queryByTestId('owd-overview')).not.toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.pillarNavGuard.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.pillarNavGuard.test.tsx
@@ -13,6 +13,8 @@
  *   • dirty + pillar switch → confirm; cancel keeps the pillar and its edits,
  *   • dirty + Home → same confirm; cancel stays, confirm leaves,
  *   • dirty + package switch → same confirm,
+ *   • dirty OWD overview rows + pillar switch → same confirm (the pillar
+ *     folds the overview's report into the same bit, objectui#2600 follow-up),
  *   • clean navigation never prompts,
  *   • re-clicking the open pillar never prompts (nothing unmounts),
  *   • a confirmed discard clears the guard (the pillar resets on unmount).
@@ -55,10 +57,8 @@ vi.mock('./packages-io', async (importOriginal) => {
   };
 });
 
-// Rail siblings / docks that are irrelevant to the guard — keep the render light.
-vi.mock('./PackageOwdOverviewPanel', () => ({
-  PackageOwdOverviewPanel: () => <div data-testid="owd-overview" />,
-}));
+// Rail siblings / docks that are irrelevant to the guard — keep the render
+// light. (The OWD overview is NOT mocked: its dirty report is under test.)
 vi.mock('../../components/SuggestedBindingsPanel', () => ({
   SuggestedBindingsPanel: () => null,
 }));
@@ -212,6 +212,32 @@ describe('Studio header — unsaved pillar edits guard (#2600)', () => {
 
     // The discarded pillar reset the guard on unmount — walking back to
     // Access must NOT prompt again.
+    fireEvent.click(screen.getByRole('link', { name: 'Access' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await screen.findByDisplayValue('set_a');
+  });
+
+  it('gates a pillar switch on dirty OWD overview rows (#2600 follow-up)', async () => {
+    await renderSurfaceOnAccess();
+    // Swap the main panel to the (real) OWD overview and edit a row so the
+    // panel's dirty report crosses AccessPillar into the surface guard.
+    fireEvent.click(screen.getByRole('button', { name: 'Record sharing (OWD)' }));
+    await screen.findByTestId('owd-internal-a_account');
+    fireEvent.change(screen.getByTestId('owd-internal-a_account'), { target: { value: 'private' } });
+
+    confirmSpy.mockReturnValueOnce(false);
+    fireEvent.click(screen.getByRole('link', { name: 'Interfaces' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    // Still on the overview, edit intact.
+    expect((screen.getByTestId('owd-internal-a_account') as HTMLSelectElement).value).toBe('private');
+
+    // Confirming discards and leaves; the unmounting pillar resets the guard,
+    // so walking back to Access must NOT prompt again.
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByRole('link', { name: 'Interfaces' }));
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    await screen.findByText('This package has no app yet');
+
     fireEvent.click(screen.getByRole('link', { name: 'Access' }));
     expect(confirmSpy).toHaveBeenCalledTimes(2);
     await screen.findByDisplayValue('set_a');

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -3190,10 +3190,11 @@ export function AccessPillar({
   onDraftSaved?: () => void;
   /** Courtesy gate: hide/disable permission-authoring affordances. */
   readOnly?: boolean;
-  /** objectui#2600 — mirrors the matrix's unsaved-edit state up to the Studio
-   * header, whose pillar/Home/package navigation unmounts this whole pillar
-   * (SPA nav, so no beforeunload). Reports `false` when the editor unmounts,
-   * same contract as PermissionMatrixEditPage's own onDirtyChange. */
+  /** objectui#2600 — mirrors the pillar's unsaved-edit state (permission
+   * matrix or OWD overview rows) up to the Studio header, whose
+   * pillar/Home/package navigation unmounts this whole pillar (SPA nav, so no
+   * beforeunload). Reports `false` when the pillar unmounts, same contract as
+   * PermissionMatrixEditPage's own onDirtyChange. */
   onDirtyChange?: (dirty: boolean) => void;
 }): React.ReactElement {
   const client = useMetadataClient();
@@ -3234,28 +3235,39 @@ export function AccessPillar({
   const [busy, setBusy] = React.useState(false);
   // [ADR-0090 D6] "why can this user access?" — right-side explain sheet.
   const [explainOpen, setExplainOpen] = React.useState(false);
-  // The matrix page below is keyed by `current` (and unmounts entirely when
-  // the OWD overview swaps in), so any rail-driven surface change REMOUNTS it
-  // and would silently discard unsaved matrix edits. The editor reports its
-  // dirty state up (`onDirtyChange`), and every swap is gated on this confirm
-  // — same native prompt as the metadata editor's leave guard. The editor
-  // resets its report on unmount, so a confirmed discard clears `matrixDirty`
-  // by itself.
+  // Both main-panel surfaces hold unsaved edits and unmount on a rail-driven
+  // swap: the matrix page is keyed by `current` (and unmounts entirely when
+  // the OWD overview swaps in), and the OWD overview batch-editor unmounts
+  // when a set swaps back in. Each editor reports its dirty state up
+  // (`onDirtyChange` — the two never coexist, so at most one bit is set), and
+  // every swap is gated on this confirm — same native prompt as the metadata
+  // editor's leave guard. Each editor resets its report on unmount, so a
+  // confirmed discard clears its bit by itself.
   const [matrixDirty, setMatrixDirty] = React.useState(false);
-  // The same dirty bit also gates the Studio header's pillar/Home/package
-  // navigation, which unmounts this whole pillar (objectui#2600) — mirror
-  // every report up alongside the local rail guard.
-  const reportMatrixDirty = React.useCallback(
-    (dirty: boolean) => {
-      setMatrixDirty(dirty);
-      onDirtyChange?.(dirty);
+  const [owdDirty, setOwdDirty] = React.useState(false);
+  const pillarDirty = matrixDirty || owdDirty;
+  // The combined bit also gates the Studio header's pillar/Home/package
+  // navigation, which unmounts this whole pillar (objectui#2600) — mirror it
+  // up alongside the local rail guard. Ref-stabilized like the editors' own
+  // reports; the unmount cleanup reports `false` so a discarded pillar clears
+  // the surface's guard state.
+  const onDirtyChangeRef = React.useRef(onDirtyChange);
+  React.useEffect(() => {
+    onDirtyChangeRef.current = onDirtyChange;
+  });
+  React.useEffect(() => {
+    onDirtyChangeRef.current?.(pillarDirty);
+  }, [pillarDirty]);
+  React.useEffect(
+    () => () => {
+      onDirtyChangeRef.current?.(false);
     },
-    [onDirtyChange],
+    [],
   );
-  const confirmDiscardMatrixEdits = React.useCallback(() => {
-    if (!matrixDirty) return true;
+  const confirmDiscardEdits = React.useCallback(() => {
+    if (!pillarDirty) return true;
     return window.confirm(t('engine.edit.unsavedLeaveConfirm', locale));
-  }, [matrixDirty, locale]);
+  }, [pillarDirty, locale]);
 
   const load = React.useCallback(async () => {
     try {
@@ -3327,6 +3339,9 @@ export function AccessPillar({
         setCreating(false);
         onDraftSaved?.();
         await load();
+        // Land on the new set's matrix — also from the OWD overview, whose
+        // discard the "+ New" gate already confirmed up front.
+        setOwdOpen(false);
         setCurrent(name);
       } catch (e) {
         setCreateErr(formatMetadataError(e));
@@ -3429,7 +3444,14 @@ export function AccessPillar({
             <button
               type="button"
               onClick={() => {
-                if (!confirmDiscardMatrixEdits()) return;
+                // Re-clicking the open overview is a no-op — nothing
+                // remounts, so no confirm (mirrors the set re-click below).
+                if (owdOpen) {
+                  setOwdHighlight(null);
+                  if (isMobile) setRailOpen(false);
+                  return;
+                }
+                if (!confirmDiscardEdits()) return;
                 setOwdOpen(true);
                 setOwdHighlight(null);
                 if (isMobile) setRailOpen(false);
@@ -3468,7 +3490,7 @@ export function AccessPillar({
                     if (isMobile) setRailOpen(false);
                     return;
                   }
-                  if (!confirmDiscardMatrixEdits()) return;
+                  if (!confirmDiscardEdits()) return;
                   setOwdOpen(false);
                   setCurrent(p.name);
                   if (isMobile) setRailOpen(false);
@@ -3500,9 +3522,10 @@ export function AccessPillar({
               <button
                 type="button"
                 onClick={() => {
-                  // Creating a set ends in setCurrent(newName) — a remount of
-                  // the open matrix — so gate the flow up front.
-                  if (!confirmDiscardMatrixEdits()) return;
+                  // Creating a set lands on the new set's matrix — a remount
+                  // of the open matrix, or a swap out of the OWD overview —
+                  // so gate the flow up front.
+                  if (!confirmDiscardEdits()) return;
                   setCreateErr(null);
                   setCreating(true);
                 }}
@@ -3527,6 +3550,7 @@ export function AccessPillar({
               readOnly={readOnly}
               locale={locale}
               highlightObject={owdHighlight}
+              onDirtyChange={setOwdDirty}
             />
           ) : current ? (
             /* The existing Salesforce-style matrix page, embedded unchanged —
@@ -3541,12 +3565,12 @@ export function AccessPillar({
               publishNonce={publishNonce}
               onDraftSaved={onDraftSaved}
               readOnly={readOnly}
-              onDirtyChange={reportMatrixDirty}
+              onDirtyChange={setMatrixDirty}
               embedded
               onOpenOwd={(objectName) => {
                 // The badge deep-link swaps this page out for the OWD
                 // overview — same remount, same guard.
-                if (!confirmDiscardMatrixEdits()) return;
+                if (!confirmDiscardEdits()) return;
                 setOwdHighlight(objectName || null);
                 setOwdOpen(true);
               }}


### PR DESCRIPTION
## ⚠️ Stacked on PR #2606 — serial merge

This branch contains #2606's commit (rebased over #2599, which merged to main mid-flight) plus one follow-up commit. **Merge #2606 first**, then rebase this branch — the replayed #2606 patch drops out automatically and only the follow-up commit remains. Per issue #2600's 「合并注意」, `StudioDesignSurface.tsx` PRs merge serially.

## Summary

Closes the gap #2606 explicitly left out of scope: `PackageOwdOverviewPanel` (the Access pillar's Record Sharing Baseline batch-editor) tracked its unsaved per-object rows internally (`rowState`/`dirtyCount`) but reported them to no one, so **both** unsaved-edit guards discarded them silently:

1. the Access rail guard (`confirmDiscardMatrixEdits` checked only `matrixDirty`) — switching to a permission set, opening the create flow;
2. the surface-level header guard from #2606 (`pillarDirty`) — pillar links, Home, PackageSwitcher.

### Changes

- **`PackageOwdOverviewPanel` grows `onDirtyChange`** — the exact PR #2588 contract `PermissionMatrixEditPage` uses: ref-stabilized transition reports, `false` on unmount so a confirmed discard clears the host's guard by itself.
- **`AccessPillar` folds it in as `owdDirty`** alongside `matrixDirty`. The rail confirm (`confirmDiscardEdits`, renamed) gates on the combined bit — the two main-panel surfaces never coexist, so at most one bit is set — and the combined bit mirrors up to the surface via a ref-stabilized effect with a `false`-on-unmount cleanup (replacing #2606's `reportMatrixDirty` wrapper).
- **Re-clicking the open OWD rail entry is now a no-op** (nothing remounts → no confirm), mirroring the existing set re-click exemption. Previously it ran the (vacuously clean) guard; with `owdDirty` folded in it would have prompted spuriously.
- **The create flow lands on the new set's matrix even from the OWD overview** (`setOwdOpen(false)` in `doCreate`) — the "+ New" gate warns about discarding, so the discard must actually happen; before, creating from the overview left it open with the new set silently selected underneath.

## Tests

- `PackageOwdOverviewPanel.test.tsx` +2: the onDirtyChange contract (edit → `true`, revert → `false`, unmount → `false`; save → `false`).
- `StudioDesignSurface.accessGuard.test.tsx` +3 (real panel now, stub mock removed): dirty overview → set swap prompts, cancel keeps edits, confirm discards and resets the guard; OWD rail re-click never prompts; create flow gates and lands on the new set's matrix.
- `StudioDesignSurface.pillarNavGuard.test.tsx` +1 (stub mock removed): dirty overview rows gate a header pillar switch through the real StudioDesignSurface → AccessPillar → PackageOwdOverviewPanel stack, and a confirmed discard resets the surface guard.

- `vitest run packages/app-shell/src/views/studio-design/` — 17 files / 108 tests pass
- `tsc --noEmit` in `packages/app-shell` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)