### PR TITLE
fix(actions): defuse the three action-visibility traps (#2358) — clean rebase, replaces #2575

### DIFF
--- a/packages/app-shell/src/providers/ExpressionProvider.tsx
+++ b/packages/app-shell/src/providers/ExpressionProvider.tsx
@@ -51,10 +51,12 @@ interface ExpressionProviderProps {
 export function ExpressionProvider({ children, user = {}, app = {}, data = {}, features = {} }: ExpressionProviderProps) {
   const value = useMemo(() => {
     // ADR-0068: expose the SAME user object under the canonical `current_user`
-    // plus the back-compat `user` alias and the server-RLS-parity `ctx.user`
-    // alias, so a predicate authored against any one form evaluates identically
-    // on client, server-formula, and server-RLS.
-    const context = { current_user: user, user, ctx: { user }, app, data, features };
+    // plus the back-compat `user` alias, the server-RLS-parity `ctx.user`
+    // alias, and the server-CEL-parity `os.user` alias (the spec's canonical
+    // identity scope — `{{os.user.id}}` per @objectstack/spec expression docs),
+    // so a predicate authored against any one form evaluates identically on
+    // client, server-formula, and server-RLS (#2358 trap 1).
+    const context = { current_user: user, user, ctx: { user }, os: { user }, app, data, features };
     const evaluator = new ExpressionEvaluator(context);
     return { user, app, data, features, evaluator };
   }, [user, app, data, features]);
@@ -62,9 +64,10 @@ export function ExpressionProvider({ children, user = {}, app = {}, data = {}, f
   // Also feed the predicate scope used by useCondition/useExpression in
   // @object-ui/react so action visibility predicates (e.g. on toolbar
   // buttons) can see deployment-level flags like features.multiOrgEnabled.
-  // Mirror the canonical `current_user`/`user`/`ctx.user` aliases here too.
+  // Mirror the canonical `current_user`/`user`/`ctx.user`/`os.user` aliases
+  // here too.
   const scope = useMemo(
-    () => ({ current_user: user, user, ctx: { user }, app, data, features }),
+    () => ({ current_user: user, user, ctx: { user }, os: { user }, app, data, features }),
     [user, app, data, features],
   );
 
@@ -84,7 +87,7 @@ export function useExpressionContext(): ExpressionContextValue {
   if (!ctx) {
     // Return a safe default so components can be used outside the provider
     const fallback = { user: {}, app: {}, data: {}, features: {} };
-    const evalContext = { current_user: {}, ctx: { user: {} }, ...fallback };
+    const evalContext = { current_user: {}, ctx: { user: {} }, os: { user: {} }, ...fallback };
     return { ...fallback, evaluator: new ExpressionEvaluator(evalContext) };
   }
   return ctx;

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1461,11 +1461,15 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     // drawer continues to hide them via `DEFAULT_SYSTEM_FIELDS` in
     // `@object-ui/plugin-detail/RecordDetailDrawer`.
 
-    // Filter actions for record_header location and deduplicate by name
+    // Filter actions for the record page header and deduplicate by name.
+    // Both header locations are included: `record_header` renders inline,
+    // `record_more` renders inside the header's ⋯ overflow menu (the spec's
+    // "overflow menu under the More/⋯ button" location — PageHeaderRenderer
+    // routes record_more-only actions into the overflow; #2358 trap 2).
     const recordHeaderActions = (() => {
       const seen = new Set<string>();
       const base = (objectDef.actions || []).filter((a: any) => {
-        if (!a.locations?.includes('record_header')) return false;
+        if (!a.locations?.includes('record_header') && !a.locations?.includes('record_more')) return false;
         if (!a.name) return true;
         if (seen.has(a.name)) return false;
         seen.add(a.name);

--- a/packages/components/src/__tests__/page-header-actions.test.tsx
+++ b/packages/components/src/__tests__/page-header-actions.test.tsx
@@ -15,6 +15,7 @@ import {
   RecordContextProvider,
   InlineEditProvider,
   useInlineEdit,
+  PredicateScopeProvider,
 } from '@object-ui/react';
 
 function PageHeader({ schema }: { schema: any }) {
@@ -23,9 +24,9 @@ function PageHeader({ schema }: { schema: any }) {
   return <Component schema={schema} />;
 }
 
-function renderHeader(schema: any, opts?: { record?: any; objectSchema?: any; execute?: any; headerSystemActions?: any[] }) {
+function renderHeader(schema: any, opts?: { record?: any; objectSchema?: any; execute?: any; headerSystemActions?: any[]; scope?: any }) {
   const execute = opts?.execute ?? vi.fn(async () => ({ success: true }));
-  const ui = (
+  let ui = (
     <ActionProvider>
       {opts?.record !== undefined ? (
         <RecordContextProvider
@@ -42,6 +43,9 @@ function renderHeader(schema: any, opts?: { record?: any; objectSchema?: any; ex
       )}
     </ActionProvider>
   );
+  if (opts?.scope) {
+    ui = <PredicateScopeProvider scope={opts.scope}>{ui}</PredicateScopeProvider>;
+  }
   const utils = render(ui);
   return { ...utils, execute };
 }
@@ -377,5 +381,182 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
     expect(screen.getByRole('button', { name: /Convert Lead/i })).toBeTruthy();
     expect(screen.queryByRole('button', { name: /^Delete$/i })).toBeNull();
     expect(screen.getByRole('button', { name: /More actions/i })).toBeTruthy();
+  });
+});
+
+// #2358 — the three action-visibility traps. NOTE: the diagnostics warn ONCE
+// per (action name, predicate) pair via a module-level Set, so every test
+// below uses unique action names/predicates to stay independent.
+describe('PageHeaderRenderer — #2358 action visibility traps', () => {
+  describe('trap 2: record_more routes to the ⋯ overflow menu', () => {
+    it('renders a record_more-only action in the overflow, never inline', () => {
+      renderHeader(
+        {
+          type: 'page:header',
+          actions: [
+            { name: 'convert2358', label: 'Convert Lead' },
+            { name: 'export_pdf_2358', label: 'Export PDF', locations: ['record_more'] },
+          ],
+        },
+        { record: { id: '1' } },
+      );
+      // The plain action stays inline; the record_more action must NOT get
+      // an inline button — it lives inside the ⋯ dropdown (trigger present).
+      expect(screen.getByRole('button', { name: /Convert Lead/i })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: /Export PDF/i })).toBeNull();
+      expect(screen.getByRole('button', { name: /More actions/i })).toBeTruthy();
+    });
+
+    it('renders the ⋯ menu even when a record_more action is the ONLY action', () => {
+      renderHeader(
+        {
+          type: 'page:header',
+          actions: [
+            { name: 'archive_2358', label: 'Archive Record', locations: ['record_more'] },
+          ],
+        },
+        { record: { id: '1' } },
+      );
+      expect(screen.queryByRole('button', { name: /Archive Record/i })).toBeNull();
+      expect(screen.getByRole('button', { name: /More actions/i })).toBeTruthy();
+    });
+
+    it('still excludes locations that are neither record_header nor record_more', () => {
+      renderHeader(
+        {
+          type: 'page:header',
+          actions: [
+            { name: 'list_only_2358', label: 'List Only', locations: ['list_item'] },
+          ],
+        },
+        { record: { id: '1' } },
+      );
+      expect(screen.queryByRole('button', { name: /List Only/i })).toBeNull();
+      expect(screen.queryByRole('button', { name: /More actions/i })).toBeNull();
+    });
+  });
+
+  describe('trap 1: os.user identity alias (server CEL parity)', () => {
+    it('shows an action gated on os.user.* when the ambient user matches', () => {
+      renderHeader(
+        {
+          type: 'page:header',
+          actions: [
+            {
+              name: 'admin_gate_2358',
+              label: 'Admin Gate',
+              visible: 'os.user.role == "admin"',
+            },
+          ],
+        },
+        { record: { id: '1' }, scope: { user: { id: 'u1', role: 'admin' } } },
+      );
+      expect(screen.getByRole('button', { name: /Admin Gate/i })).toBeTruthy();
+    });
+
+    it('hides an os.user.* gated action when the ambient user does not match', () => {
+      renderHeader(
+        {
+          type: 'page:header',
+          actions: [
+            {
+              name: 'admin_gate_no_match_2358',
+              label: 'Admin Gate',
+              visible: 'os.user.role == "admin"',
+            },
+          ],
+        },
+        { record: { id: '1' }, scope: { user: { id: 'u1', role: 'viewer' } } },
+      );
+      expect(screen.queryByRole('button', { name: /Admin Gate/i })).toBeNull();
+    });
+  });
+
+  describe('unified diagnostics: no more silent fail-closed hide', () => {
+    it('hides a throwing predicate AND warns once with the action name', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const schema = {
+          type: 'page:header',
+          actions: [
+            {
+              name: 'bad_scope_2358',
+              label: 'Bad Scope',
+              visible: 'undeclared_var_2358 == 1',
+            },
+          ],
+        };
+        const { unmount } = renderHeader(schema, { record: { id: '1' } });
+        expect(screen.queryByRole('button', { name: /Bad Scope/i })).toBeNull();
+        const matching = () =>
+          warn.mock.calls.filter(c => String(c[0]).includes('bad_scope_2358'));
+        expect(matching()).toHaveLength(1);
+        expect(String(matching()[0][0])).toMatch(/predicate threw/);
+        expect(String(matching()[0][0])).toContain('undeclared_var_2358 == 1');
+        // Re-render must not spam the warning (deduped per action+predicate).
+        unmount();
+        renderHeader(schema, { record: { id: '1' } });
+        expect(matching()).toHaveLength(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('trap 3: warns when a predicate references record fields absent from the payload', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        renderHeader(
+          {
+            type: 'page:header',
+            actions: [
+              {
+                name: 'hidden_field_gate_2358',
+                label: 'Hidden Field Gate',
+                visible: 'record.secret_level_2358 == "high"',
+              },
+            ],
+          },
+          // Non-empty payload WITHOUT the referenced field — mirrors the
+          // server stripping `hidden: true` fields from detail payloads.
+          { record: { id: '1', status: 'new' } },
+        );
+        expect(screen.queryByRole('button', { name: /Hidden Field Gate/i })).toBeNull();
+        const hits = warn.mock.calls.filter(c =>
+          String(c[0]).includes('hidden_field_gate_2358'),
+        );
+        expect(hits).toHaveLength(1);
+        expect(String(hits[0][0])).toContain('secret_level_2358');
+        expect(String(hits[0][0])).toMatch(/not present in the record payload/);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('does not fire the missing-field warning for present-but-null fields', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        renderHeader(
+          {
+            type: 'page:header',
+            actions: [
+              {
+                name: 'null_field_gate_2358',
+                label: 'Null Field Gate',
+                visible: 'record.approver_2358 == "u1"',
+              },
+            ],
+          },
+          { record: { id: '1', approver_2358: null } },
+        );
+        // Legitimately empty field → predicate is false, action hidden, but
+        // no "missing field" noise.
+        expect(screen.queryByRole('button', { name: /Null Field Gate/i })).toBeNull();
+        expect(
+          warn.mock.calls.filter(c => String(c[0]).includes('null_field_gate_2358')),
+        ).toHaveLength(0);
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
 });

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -115,7 +115,10 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
 
     // Fails CLOSED on a throwing predicate — mirrors ActionEngine's
     // getActionsForLocation contract (see action-button.tsx for rationale).
-    const isVisible = useCondition(toPredicateInput(schema.visible), undefined, { throwOnError: true });
+    const isVisible = useCondition(toPredicateInput(schema.visible), undefined, {
+      throwOnError: true,
+      label: `action:bar${schema.location ? ` (${schema.location})` : ''} (visible)`,
+    });
     const isMobile = useIsMobile();
 
     // Filter business actions by location and deduplicate by name

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -55,7 +55,10 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
     // `visible` fails CLOSED on a throwing predicate (mirrors ActionEngine's
     // getActionsForLocation) — a precondition that can't be evaluated should
     // hide the action, not silently show one whose guard is broken.
-    const isVisible = useCondition(toPredicateInput(schema.visible), recordData, { throwOnError: true });
+    const isVisible = useCondition(toPredicateInput(schema.visible), recordData, {
+      throwOnError: true,
+      label: `action "${schema.name ?? schema.label ?? 'action:button'}" (visible)`,
+    });
     // Spec field is `disabled` (boolean | CEL predicate — disabled when TRUE).
     // It previously had zero consumers (the renderer only read a non-spec
     // `enabled`), so a spec-authored `disabled` guard did nothing (#1885,

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -66,7 +66,10 @@ const ActionMenuItem: React.FC<{
 }> = ({ action, onExecute }) => {
   // Fails CLOSED on a throwing predicate — mirrors ActionEngine's
   // getActionsForLocation contract (see action-button.tsx for rationale).
-  const isVisible = useCondition(toPredicateInput(action.visible), undefined, { throwOnError: true });
+  const isVisible = useCondition(toPredicateInput(action.visible), undefined, {
+    throwOnError: true,
+    label: `action "${action.name ?? action.label ?? 'action:menu item'}" (visible)`,
+  });
   const isEnabled = useCondition(toPredicateInput(action.enabled));
 
   const iconElement = useMemo(() => {
@@ -112,7 +115,10 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
 
     // Fails CLOSED on a throwing predicate — mirrors ActionEngine's
     // getActionsForLocation contract (see action-button.tsx for rationale).
-    const isVisible = useCondition(toPredicateInput(schema.visible), undefined, { throwOnError: true });
+    const isVisible = useCondition(toPredicateInput(schema.visible), undefined, {
+      throwOnError: true,
+      label: `action:menu "${schema.label ?? schema.icon ?? 'menu'}" (visible)`,
+    });
 
     const TriggerIcon = resolveIcon(schema.icon) || MoreHorizontal;
     const variant = schema.variant || 'ghost';

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -745,6 +745,53 @@ export function cleanupTitleSeparators(s: string): string {
   return out;
 }
 
+/**
+ * One-time diagnostics for header-action `visible` / `hidden` predicates
+ * (#2358). Both warn-once per (action, predicate) pair so re-renders don't
+ * spam the console, mirroring ActionEngine's `warnHiddenPredicate` (#2183).
+ */
+const _warnedHeaderPredicates = new Set<string>();
+
+/** Warn when a predicate THREW — the action is fail-closed hidden. */
+function warnHeaderActionPredicate(name: unknown, source: string, err: unknown): void {
+  const key = `throw::${String(name)}::${source}`;
+  if (_warnedHeaderPredicates.has(key)) return;
+  _warnedHeaderPredicates.add(key);
+  const msg = err instanceof Error ? err.message : String(err);
+  console.warn(
+    `[page:header] action "${String(name)}" hidden: its predicate threw — ${msg}. ` +
+    `Predicate: ${source}. Header-action predicates evaluate against ` +
+    `{ record, user, os.user, ctx.user, app, features, <record fields> }.`,
+  );
+}
+
+/**
+ * Warn when a predicate references `record.<field>` keys that are absent from
+ * the loaded record payload (#2358 trap 3): the server strips `hidden: true`
+ * fields from detail payloads, so such a predicate silently resolves to
+ * `undefined` and fail-closed hides the action with no error to catch. A key
+ * that is present-but-null does NOT trigger this (legitimately empty field).
+ * Skipped while the record is empty/loading to avoid false positives.
+ */
+function warnMissingRecordFields(name: unknown, source: string, record: unknown): void {
+  if (!record || typeof record !== 'object' || Object.keys(record as object).length === 0) return;
+  const re = /\brecord\.([A-Za-z_][A-Za-z0-9_]*)/g;
+  const missing: string[] = [];
+  for (let m = re.exec(source); m; m = re.exec(source)) {
+    if (!(m[1] in (record as Record<string, unknown>)) && !missing.includes(m[1])) missing.push(m[1]);
+  }
+  if (missing.length === 0) return;
+  const key = `missing::${String(name)}::${source}`;
+  if (_warnedHeaderPredicates.has(key)) return;
+  _warnedHeaderPredicates.add(key);
+  console.warn(
+    `[page:header] action "${String(name)}" predicate references record field(s) ` +
+    `not present in the record payload: ${missing.join(', ')}. Predicate: ${source}. ` +
+    `Hidden (hidden: true) fields are stripped from detail payloads server-side, ` +
+    `so a predicate gating on one may evaluate to a hide-by-default verdict.`,
+  );
+}
+
 const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { designer } = splitDesignerProps(props);
   const ctx = useRecordContext();
@@ -826,6 +873,10 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       record: recordData,
       data: recordData,
       user: scopeUser,
+      // Server-CEL-parity identity alias (#2358 trap 1): the spec's canonical
+      // CEL identity scope is `os.user.*`, so a predicate authored against the
+      // server dialect resolves here too instead of throwing (fail-closed).
+      os: (predicateScope as any)?.os ?? { user: scopeUser },
       ctx: {
         user: scopeUser,
         record: recordData,
@@ -835,19 +886,29 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       },
     };
     const evaluator = new ExpressionEvaluator(evalCtx);
-    const evalExpr = (src: string): any => {
+    // Fail-closed BUT diagnosable (#2358): a throwing `visible`/`hidden`
+    // predicate still hides the action, but now warns once (action name +
+    // predicate + reason) instead of silently swallowing the error — a
+    // predicate that throws is almost always an authoring bug (wrong scope
+    // variable, bare field reference), not a real precondition.
+    const evalExpr = (src: string, actionName: unknown): any => {
       try {
         return evaluator.evaluateExpression(src);
-      } catch {
+      } catch (err) {
+        warnHeaderActionPredicate(actionName, src, err);
         return undefined;
       }
     };
     const filterAction = (a: any): boolean => {
-      // Location filter — when `locations` is declared, require record_header.
-      // Missing/empty `locations` defaults to "show here" since the action
-      // is inlined on the header itself.
+      // Location filter — when `locations` is declared, require record_header
+      // or record_more (the latter renders in the header's ⋯ overflow menu —
+      // see renderHeaderActions; #2358 trap 2). Missing/empty `locations`
+      // defaults to "show here" since the action is inlined on the header
+      // itself.
       if (Array.isArray(a?.locations) && a.locations.length > 0) {
-        if (!a.locations.includes('record_header')) return false;
+        if (!a.locations.includes('record_header') && !a.locations.includes('record_more')) {
+          return false;
+        }
       }
       // Boolean / expression visibility — supports both `visible: false`,
       // `visible: 'record.status == "open"'` and the structured shape
@@ -864,7 +925,8 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
                 ? (v as any).source
                 : null;
           if (src) {
-            const result = evalExpr(src);
+            warnMissingRecordFields(a?.name, src, recordData);
+            const result = evalExpr(src, a?.name);
             // On evaluation error (undefined), hide the action rather than
             // risk surfacing a destructive button in the wrong state.
             if (!result) return false;
@@ -884,7 +946,8 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
                 ? (h as any).source
                 : null;
           if (src) {
-            const result = evalExpr(src);
+            warnMissingRecordFields(a?.name, src, recordData);
+            const result = evalExpr(src, a?.name);
             if (result) return false;
           }
         }
@@ -940,9 +1003,13 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     // Inline/overflow split (objectui#2361) — up to `maxVisible` actions
     // render side-by-side as buttons; the rest collapse into a `⋯` overflow
     // menu. Which actions stay inline is metadata-driven:
-    //   1. `component: 'action:menu'` forces an action into the `⋯` menu
+    //   1. actions declaring ONLY `record_more` (not `record_header`) are the
+    //      spec's "overflow menu under the ⋯ button" location — they are
+    //      always routed into the overflow menu and never occupy an inline
+    //      slot, regardless of how few actions the header has (#2358 trap 2);
+    //   2. `component: 'action:menu'` forces an action into the `⋯` menu
     //      regardless of the count (chrome actions like Share/Delete);
-    //   2. the remainder is pre-sorted by `order` / `variant: 'primary'`
+    //   3. the remainder is pre-sorted by `order` / `variant: 'primary'`
     //      (see the headerActions memo above), so the first `maxVisible`
     //      claim the inline slots.
     // `maxVisible` / `mobileMaxVisible` are overridable on the page:header
@@ -955,20 +1022,46 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     const maxVisible = isMobile
       ? (readMax(schema?.mobileMaxVisible ?? schema?.properties?.mobileMaxVisible) ?? 1)
       : (readMax(schema?.maxVisible ?? schema?.properties?.maxVisible) ?? 3);
-    const menuOnly = headerActions.filter((a: any) => a?.component === 'action:menu');
-    const buttonable = headerActions.filter((a: any) => a?.component !== 'action:menu');
+    const isMoreOnly = (a: any): boolean =>
+      Array.isArray(a?.locations) &&
+      a.locations.length > 0 &&
+      a.locations.includes('record_more') &&
+      !a.locations.includes('record_header');
+    const moreOnlyActions = headerActions.filter(isMoreOnly);
+    const menuOnly = headerActions.filter(
+      (a: any) => !isMoreOnly(a) && a?.component === 'action:menu',
+    );
+    const buttonable = headerActions.filter(
+      (a: any) => !isMoreOnly(a) && a?.component !== 'action:menu',
+    );
     const inlineActions = buttonable.slice(0, maxVisible);
-    const overflowActions = [...buttonable.slice(maxVisible), ...menuOnly];
+    const overflowActions = [
+      ...buttonable.slice(maxVisible),
+      ...menuOnly,
+      ...moreOnlyActions,
+    ];
     const useOverflow = overflowActions.length > 0;
     // Resolve a `disabled` predicate against the record. Mirrors the `visible`
     // evaluation above — a boolean OR a CEL expression (`'record.status == …'`
     // or the `{ dialect, source }` envelope). Without this a CEL `disabled`
     // silently did nothing (only boolean was honoured).
     const dRecord: any = ctx?.data;
+    const dScopeUser = (predicateScope as any)?.user;
     const dEvaluator = new ExpressionEvaluator({
       ...(dRecord && typeof dRecord === 'object' ? dRecord : {}),
       record: dRecord,
       data: dRecord,
+      // Same identity scope as the `visible` evaluation above so a
+      // user-gated `disabled` predicate resolves instead of faulting.
+      user: dScopeUser,
+      os: (predicateScope as any)?.os ?? { user: dScopeUser },
+      ctx: {
+        user: dScopeUser,
+        record: dRecord,
+        data: dRecord,
+        app: (predicateScope as any)?.app,
+        features: (predicateScope as any)?.features,
+      },
     });
     const resolveDisabled = (d: any): boolean => {
       if (d === undefined || d === null) return false;

--- a/packages/core/src/actions/ActionEngine.ts
+++ b/packages/core/src/actions/ActionEngine.ts
@@ -84,7 +84,7 @@ function warnHiddenPredicate(name: unknown, raw: unknown, err: unknown): void {
   // eslint-disable-next-line no-console
   console.warn(
     `[ActionEngine] action "${String(name)}" hidden: its \`visible\` predicate threw — ${msg}. ` +
-    `Predicate: ${src}. Action predicates evaluate against { record, recordId, objectName, user, … }; ` +
+    `Predicate: ${src}. Action predicates evaluate against { record, recordId, objectName, user, os.user, … }; ` +
     `use \`record.<field>\` (not a bare field).`,
   );
 }

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -297,6 +297,24 @@ export interface ActionParamDef {
   dependsOn?: unknown[];
 }
 
+/**
+ * Bind the server-CEL-parity `os.user` identity alias into an action context
+ * (#2358 trap 1). `@objectstack/spec` documents the canonical CEL identity
+ * scope as `os.user.*` (server formula / validation / sharing), while client
+ * contexts historically only bound `user`. Deriving the alias here means an
+ * action `visible` predicate authored as `os.user.role == "admin"` evaluates
+ * identically on client and server instead of throwing (and being fail-closed
+ * hidden). `os.user` always tracks `context.user`; other consumer-provided
+ * keys under `os` are preserved.
+ */
+function withIdentityAlias(context: ActionContext): ActionContext {
+  const user = context.user;
+  if (user === undefined) return context;
+  const os = context.os;
+  if (os && typeof os === 'object' && os.user === user) return context;
+  return { ...context, os: { ...(os && typeof os === 'object' ? os : {}), user } };
+}
+
 export class ActionRunner {
   private handlers = new Map<string, ActionHandler>();
   private scripts = new Map<string, ActionHandler>();
@@ -310,8 +328,8 @@ export class ActionRunner {
   private resultDialogHandler: ResultDialogHandler | null;
 
   constructor(context: ActionContext = {}) {
-    this.context = context;
-    this.evaluator = new ExpressionEvaluator(context);
+    this.context = withIdentityAlias(context);
+    this.evaluator = new ExpressionEvaluator(this.context);
     // Default confirmation: window.confirm (can be overridden)
     this.confirmHandler = async (message: string) => window.confirm(message);
     this.toastHandler = null;
@@ -1054,8 +1072,10 @@ export class ActionRunner {
   }
 
   updateContext(newContext: Partial<ActionContext>): void {
-    this.context = { ...this.context, ...newContext };
-    this.evaluator.updateContext(newContext);
+    this.context = withIdentityAlias({ ...this.context, ...newContext });
+    // Feed the merged (re-aliased) context so a refreshed `user` also
+    // refreshes the derived `os.user` binding in the evaluator scope.
+    this.evaluator.updateContext(this.context);
   }
 
   getContext(): ActionContext {

--- a/packages/core/src/actions/__tests__/ActionEngine.visibility.test.ts
+++ b/packages/core/src/actions/__tests__/ActionEngine.visibility.test.ts
@@ -175,4 +175,44 @@ describe('ActionEngine.getActionsForLocation — visibility filter', () => {
     }
   });
 
+  // #2358 trap 1 — the spec's canonical CEL identity scope is `os.user.*`
+  // (server formula / validation / sharing). The runner derives an `os.user`
+  // alias from `context.user` so a predicate authored against the server
+  // dialect evaluates identically on the client instead of throwing and
+  // being fail-closed hidden.
+  describe('os.user identity alias (#2358)', () => {
+    it('resolves os.user.* predicates from context.user', () => {
+      const engine = makeEngine({ user: { id: 'u1', role: 'admin' } });
+      engine.registerAction(
+        { name: 'admin_only', type: 'api', visible: 'os.user.role == "admin"' } as any,
+        { locations: ['record_section'] },
+      );
+      engine.registerAction(
+        { name: 'manager_only', type: 'api', visible: 'os.user.role == "manager"' } as any,
+        { locations: ['record_section'] },
+      );
+      expect(engine.getActionsForLocation('record_section').map(a => a.name)).toEqual(['admin_only']);
+    });
+
+    it('keeps a consumer-provided os namespace but tracks os.user', () => {
+      const engine = makeEngine({ user: { id: 'u1' }, os: { tenant: 't1' } });
+      engine.registerAction(
+        { name: 'both', type: 'api', visible: 'os.user.id == "u1" && os.tenant == "t1"' } as any,
+        { locations: ['record_section'] },
+      );
+      expect(engine.getActionsForLocation('record_section')).toHaveLength(1);
+    });
+
+    it('refreshes os.user when updateContext replaces user', () => {
+      const engine = makeEngine({ user: { id: 'u1', role: 'viewer' } });
+      engine.registerAction(
+        { name: 'admin_gate', type: 'api', visible: 'os.user.role == "admin"' } as any,
+        { locations: ['record_section'] },
+      );
+      expect(engine.getActionsForLocation('record_section')).toHaveLength(0);
+      engine.updateContext({ user: { id: 'u1', role: 'admin' } });
+      expect(engine.getActionsForLocation('record_section')).toHaveLength(1);
+    });
+  });
+
 });

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -169,7 +169,9 @@ describe('ActionRunner', () => {
       const action: ActionDef = { type: 'my-action', params: { foo: 'bar' } };
       const result = await runner.execute(action);
 
-      expect(handler).toHaveBeenCalledWith(action, context);
+      // The runner context carries the derived `os.user` identity alias
+      // (server-CEL parity, #2358) alongside the caller-provided keys.
+      expect(handler).toHaveBeenCalledWith(action, { ...context, os: { user: context.user } });
       expect(result.success).toBe(true);
       expect(result.data).toBe(42);
     });
@@ -342,7 +344,7 @@ describe('ActionRunner', () => {
         modal: modalSchema,
       });
 
-      expect(modalHandler).toHaveBeenCalledWith(modalSchema, context);
+      expect(modalHandler).toHaveBeenCalledWith(modalSchema, { ...context, os: { user: context.user } });
       expect(result.success).toBe(true);
       expect(result.data).toEqual({ saved: true });
     });
@@ -375,7 +377,7 @@ describe('ActionRunner', () => {
       const action: ActionDef = { type: 'flow', target: 'approval_flow' };
       const result = await runner.execute(action);
 
-      expect(flowHandler).toHaveBeenCalledWith(action, context);
+      expect(flowHandler).toHaveBeenCalledWith(action, { ...context, os: { user: context.user } });
       expect(result.success).toBe(true);
     });
 

--- a/packages/react/src/hooks/__tests__/useExpression.test.ts
+++ b/packages/react/src/hooks/__tests__/useExpression.test.ts
@@ -111,6 +111,29 @@ describe('useCondition', () => {
       );
       expect(result.current).toBe(true);
     });
+
+    it('warns ONCE with the label when a fail-closed predicate throws (#2358)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const SRC = '${undeclaredWarnProbe2358.field}';
+        const { unmount } = renderHook(() =>
+          useCondition(SRC, { data: {} }, { throwOnError: true, label: 'action "probe_2358" (visible)' }),
+        );
+        const matching = () =>
+          warn.mock.calls.filter(c => String(c[0]).includes('probe_2358'));
+        expect(matching()).toHaveLength(1);
+        expect(String(matching()[0][0])).toMatch(/hidden\/disabled/);
+        expect(String(matching()[0][0])).toContain(SRC);
+        // Remount with the same predicate → deduped, no second warning.
+        unmount();
+        renderHook(() =>
+          useCondition(SRC, { data: {} }, { throwOnError: true, label: 'action "probe_2358" (visible)' }),
+        );
+        expect(matching()).toHaveLength(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
 });
 

--- a/packages/react/src/hooks/useExpression.ts
+++ b/packages/react/src/hooks/useExpression.ts
@@ -113,10 +113,13 @@ export function useExpression(
  * const isVisible = useCondition('${data.status === "active"}', { data });
  * ```
  */
+/** One-time registry for fail-closed predicate warnings (see useCondition). */
+const _warnedConditions = new Set<string>();
+
 export function useCondition(
   condition: string | boolean | undefined,
   context: Record<string, any> = {},
-  options?: { throwOnError?: boolean }
+  options?: { throwOnError?: boolean; label?: string }
 ): boolean {
   const scope = usePredicateScope();
   // We evaluate directly without caching the evaluator to avoid issues with context changes
@@ -130,13 +133,27 @@ export function useCondition(
         // real action rather than passive display content.
         try {
           return evaluator.evaluateCondition(condition, { throwOnError: true });
-        } catch {
+        } catch (err) {
+          // A throwing predicate is almost always an authoring bug (wrong
+          // scope variable, bare field reference) — warn once per
+          // (label, predicate) so the silent hide is diagnosable (#2358)
+          // without spamming re-renders.
+          const src = typeof condition === 'string' ? condition : String(condition);
+          const key = `${options?.label ?? ''}::${src}`;
+          if (!_warnedConditions.has(key)) {
+            _warnedConditions.add(key);
+            const msg = err instanceof Error ? err.message : String(err);
+            console.warn(
+              `[object-ui] ${options?.label ?? 'a component'} was hidden/disabled: ` +
+              `its predicate threw — ${msg}. Predicate: ${src}.`,
+            );
+          }
           return false;
         }
       }
       return evaluator.evaluateCondition(condition);
     },
-    [condition, context, scope, options?.throwOnError]
+    [condition, context, scope, options?.throwOnError, options?.label]
   );
 }
 


### PR DESCRIPTION
Closes #2358. Replaces #2575.

## Why a new PR

#2575's conflict-resolution PR (#2608) was **squash-merged** into its head branch, which discarded main's commit history while keeping its content. That pushed the merge-base back to the branch's creation point, so every subsequent commit on main re-conflicted against the branch — including phantom conflicts in files the PR never touched — and polluted #2575's diff to 206 files (+7889/−4327) instead of the real 13 files. This PR is the original commit (`758559e`) cherry-picked onto latest main (`b4d6ee3`) with conflicts resolved once, restoring a clean, reviewable diff.

## What (unchanged from #2575)

All three action-visibility traps share one root cause: `visible` evaluation failure is fail-closed **silently**. This PR fixes the two client-side traps outright, adds a heuristic warning for the third, and makes every fail-closed hide diagnosable:

- **Trap 1 — `os.user` identity alias (spec parity)**: `ExpressionProvider`, `ActionRunner`/`ActionEngine`, and the `page:header` evaluator now expose an `os.user` alias derived from the signed-in user, so predicates authored against the server CEL dialect (`os.user.*`) no longer throw and fail-closed hide for everyone. Consumer-provided `os` keys are preserved; `updateContext` re-derives the alias.
- **Trap 2 — `record_more` never rendered**: `RecordDetailView` and `PageHeaderRenderer` accept `record_more` alongside `record_header`; `record_more`-only actions are always routed into the ⋯ overflow menu and never occupy an inline slot.
- **Unified diagnostics**: a throwing `visible`/`hidden` predicate still hides the action but now warns once per (action, predicate) with the action name, predicate source, failure reason, and scope shape — covering the `page:header` evaluator and `useCondition({ throwOnError })` consumers via a new `label` option.
- **Trap 3 (verified, heuristic warning)**: the server does not strip `hidden: true` fields; only FLS masking removes fields. The header evaluator warns once when a predicate references `record.` keys absent from a non-empty payload; present-but-`null` fields don't trigger it.

## Conflict resolutions vs latest main

- `containers.tsx`: kept #2361's metadata-driven `maxVisible` / `action:menu` split (which replaced the old fixed `INLINE_MAX` split this branch originally patched) and layered the `record_more` rule on top — overflow order: past-`maxVisible` buttonables, `action:menu`-pinned, then `record_more`-only. Also kept #2604's `isActionDisabled` inline-edit gating.
- `page-header-actions.test.tsx`: kept all appended suites — the #2358 trap suite plus main's #2361 split and #2572 inline-edit gate suites.

## Tests

- `page-header-actions.test.tsx` + `ActionRunner.test.ts` + `ActionEngine.visibility.test.ts` + `useExpression.test.ts`: 127/127 pass on the rebased tree.
- `packages/components` `tsc --noEmit`: clean.

Bug fix — no changeset per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SswcPC6fzV3qHomg1DFGUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SswcPC6fzV3qHomg1DFGUE)_