### PR TITLE
feat(grid): built-in row Edit/Delete honor per-record CEL predicates (#2614)

### DIFF
--- a/.changeset/row-crud-cel-predicates-2614.md
+++ b/.changeset/row-crud-cel-predicates-2614.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/plugin-grid': minor
+'@object-ui/components': minor
+'@object-ui/plugin-detail': minor
+'@object-ui/plugin-form': patch
+'@object-ui/app-shell': minor
+'@object-ui/types': minor
+---
+
+feat(grid): built-in row Edit/Delete honor per-record CEL predicates (#2614)
+
+The object's `userActions.edit` / `userActions.delete` now also accept an
+object form `{ enabled?, visibleWhen?, disabledWhen? }`. The predicates are
+evaluated per row on the canonical CEL engine (`useRowPredicate`, the same
+machinery custom row actions use): `visibleWhen` false → the built-in
+Edit/Delete item is not rendered for that row (fail-closed); `disabledWhen`
+true → rendered disabled (fail-soft). Wired through ObjectGrid's
+RowActionMenu and the data-table's row overflow menu (the related-list
+path), with the app-shell `crudAffordances` mirror kept in lockstep.
+Omitting the predicates (or using plain booleans) keeps today's behavior
+bit-for-bit; declared predicates evaluate only when a row's menu opens, so
+grid rendering cost is unchanged.

--- a/packages/app-shell/src/utils/crudAffordances.test.ts
+++ b/packages/app-shell/src/utils/crudAffordances.test.ts
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * UI-side mirror of the framework's `resolveCrudAffordances`. Covers the
+ * managedBy bucket defaults, the boolean overrides, and the objectui#2614
+ * object form of `userActions.edit` / `delete` (per-record CEL predicates).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveCrudAffordances } from './crudAffordances';
+
+describe('resolveCrudAffordances (app-shell mirror)', () => {
+  it('defaults to the platform bucket when managedBy is unset', () => {
+    expect(resolveCrudAffordances({})).toEqual({
+      create: true, import: true, edit: true, delete: true, exportCsv: true,
+    });
+  });
+
+  it('applies the bucket default matrix (append-only → export only)', () => {
+    expect(resolveCrudAffordances({ managedBy: 'append-only' })).toEqual({
+      create: false, import: false, edit: false, delete: false, exportCsv: true,
+    });
+  });
+
+  it('boolean userActions override the bucket default per flag', () => {
+    const aff = resolveCrudAffordances({ managedBy: 'system', userActions: { edit: true } });
+    expect(aff.edit).toBe(true);
+    expect(aff.delete).toBe(false);
+  });
+
+  describe('#2614 object form (per-record CEL predicates)', () => {
+    it('carries predicates through and resolves enabled from the bucket default', () => {
+      const aff = resolveCrudAffordances({
+        userActions: {
+          edit: { disabledWhen: 'record.frozen == true' },
+          delete: { visibleWhen: { dialect: 'cel', source: 'record.frozen != true' } },
+        },
+      });
+      expect(aff.edit).toBe(true);
+      expect(aff.delete).toBe(true);
+      expect(aff.editPredicates).toEqual({ disabledWhen: 'record.frozen == true' });
+      expect(aff.deletePredicates).toEqual({ visibleWhen: { dialect: 'cel', source: 'record.frozen != true' } });
+    });
+
+    it('object form enabled:false opts out like the bare boolean', () => {
+      const aff = resolveCrudAffordances({
+        userActions: { edit: { enabled: false, disabledWhen: 'record.frozen == true' } },
+      });
+      expect(aff.edit).toBe(false);
+      // Predicates still surface — the caller decides what a disabled
+      // affordance means; the grid path drops them with canEdit=false.
+      expect(aff.editPredicates).toEqual({ disabledWhen: 'record.frozen == true' });
+    });
+
+    it('object form without predicates is byte-identical to the boolean path', () => {
+      const aff = resolveCrudAffordances({ userActions: { edit: { enabled: true }, delete: {} } });
+      expect(aff).toEqual({
+        create: true, import: true, edit: true, delete: true, exportCsv: true,
+      });
+      expect('editPredicates' in aff).toBe(false);
+      expect('deletePredicates' in aff).toBe(false);
+    });
+  });
+});

--- a/packages/app-shell/src/utils/crudAffordances.ts
+++ b/packages/app-shell/src/utils/crudAffordances.ts
@@ -33,13 +33,33 @@ export interface CrudAffordances {
   delete: boolean;
   /** CSV / clipboard export. */
   exportCsv: boolean;
+  /**
+   * Per-record CEL predicates for the built-in row Edit/Delete actions,
+   * present only when `userActions.edit` / `delete` used the object form
+   * (objectui#2614). Carried through as authored (bare CEL string or
+   * `{ dialect, source }` envelope) for row renderers to evaluate via
+   * `useRowPredicate`; they never affect the object-level booleans above.
+   */
+  editPredicates?: RowCrudPredicates;
+  deletePredicates?: RowCrudPredicates;
 }
+
+/** Per-record predicates from the #2614 object form of a userActions flag. */
+export interface RowCrudPredicates {
+  visibleWhen?: unknown;
+  disabledWhen?: unknown;
+}
+
+/** `edit`/`delete` accept a bare boolean or the #2614 object form. */
+export type UserActionOverride =
+  | boolean
+  | { enabled?: boolean; visibleWhen?: unknown; disabledWhen?: unknown };
 
 export interface UserActionsOverride {
   create?: boolean;
   import?: boolean;
-  edit?: boolean;
-  delete?: boolean;
+  edit?: UserActionOverride;
+  delete?: UserActionOverride;
   exportCsv?: boolean;
 }
 
@@ -56,15 +76,38 @@ export interface SchemaLike {
   userActions?: UserActionsOverride | null;
 }
 
+/**
+ * Collapse an `edit`/`delete` override (boolean or #2614 object form) onto
+ * the bucket default, surfacing any per-record predicates alongside.
+ */
+function normalizeOverride(
+  v: UserActionOverride | undefined | null,
+  base: boolean,
+): { enabled: boolean; predicates?: RowCrudPredicates } {
+  if (v == null) return { enabled: base };
+  if (typeof v === 'boolean') return { enabled: v };
+  const enabled = v.enabled ?? base;
+  if (v.visibleWhen == null && v.disabledWhen == null) return { enabled };
+  const predicates: RowCrudPredicates = {};
+  if (v.visibleWhen != null) predicates.visibleWhen = v.visibleWhen;
+  if (v.disabledWhen != null) predicates.disabledWhen = v.disabledWhen;
+  return { enabled, predicates };
+}
+
 export function resolveCrudAffordances(obj: SchemaLike | null | undefined): CrudAffordances {
   const bucket = (obj?.managedBy as ManagedByBucket | undefined) ?? 'platform';
   const base = DEFAULTS[bucket] ?? DEFAULTS.platform;
   const o = obj?.userActions ?? {};
-  return {
+  const edit = normalizeOverride(o.edit, base.edit);
+  const del = normalizeOverride(o.delete, base.delete);
+  const out: CrudAffordances = {
     create:    o.create    ?? base.create,
     import:    o.import    ?? base.import,
-    edit:      o.edit      ?? base.edit,
-    delete:    o.delete    ?? base.delete,
+    edit:      edit.enabled,
+    delete:    del.enabled,
     exportCsv: o.exportCsv ?? base.exportCsv,
   };
+  if (edit.predicates) out.editPredicates = edit.predicates;
+  if (del.predicates) out.deletePredicates = del.predicates;
+  return out;
 }

--- a/packages/components/src/renderers/complex/__tests__/data-table-builtin-row-action-predicates.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-builtin-row-action-predicates.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#2614 — the data-table's BUILT-IN row Edit/Delete items honor the
+ * per-record `visibleWhen` / `disabledWhen` CEL predicates carried on
+ * `schema.rowEditPredicates` / `rowDeletePredicates` (sourced from the
+ * object's `userActions.edit` / `delete` object form). This is the path a
+ * detail page's related list renders through — the master-detail scenario
+ * from the downstream report (a frozen `task_version_check_item` row must
+ * grey out its Edit button instead of letting the user discover the freeze
+ * on Save).
+ *
+ * The subcomponent is rendered inside a controlled-open dropdown, same as
+ * the `DataTableRowActionItem` tests, because Radix mounts menu content only
+ * when open (which is also why predicate evaluation costs nothing at table
+ * render time).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { Edit } from 'lucide-react';
+import { DataTableBuiltinRowActionItem } from '../data-table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '../../../ui/dropdown-menu';
+
+const FROZEN = { id: 'r1', name: 'Check item A', frozen: true };
+const DRAFT = { id: 'r2', name: 'Check item B', frozen: false };
+
+function renderItem(props: { predicates?: any; row: any; onSelect?: (row: any) => void }) {
+  return render(
+    <PredicateScopeProvider scope={{}}>
+      <DropdownMenu open modal={false}>
+        <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DataTableBuiltinRowActionItem
+            name="edit"
+            icon={<Edit className="mr-2 h-4 w-4" />}
+            label="Edit"
+            onSelect={props.onSelect ?? (() => {})}
+            predicates={props.predicates}
+            row={props.row}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </PredicateScopeProvider>,
+  );
+}
+
+describe('data-table built-in row action — per-record CEL predicates (#2614)', () => {
+  it('renders enabled with no predicates (zero regression)', () => {
+    renderItem({ row: FROZEN });
+    const item = screen.getByTestId('row-action-builtin-edit');
+    expect(item).toBeInTheDocument();
+    expect(item).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('disabledWhen true → rendered but disabled; clicks do not fire', () => {
+    const onSelect = vi.fn();
+    renderItem({ predicates: { disabledWhen: 'record.frozen == true' }, row: FROZEN, onSelect });
+    const item = screen.getByTestId('row-action-builtin-edit');
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(item);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('disabledWhen false → enabled; clicks fire with the row', () => {
+    const onSelect = vi.fn();
+    renderItem({ predicates: { disabledWhen: 'record.frozen == true' }, row: DRAFT, onSelect });
+    fireEvent.click(screen.getByTestId('row-action-builtin-edit'));
+    expect(onSelect).toHaveBeenCalledWith(DRAFT);
+  });
+
+  it('visibleWhen false → the item is not rendered for that row', () => {
+    renderItem({ predicates: { visibleWhen: 'record.frozen != true' }, row: FROZEN });
+    expect(screen.queryByTestId('row-action-builtin-edit')).not.toBeInTheDocument();
+  });
+
+  it('accepts the canonical { dialect, source } envelope', () => {
+    renderItem({
+      predicates: { visibleWhen: { dialect: 'cel', source: 'record.frozen != true' } },
+      row: DRAFT,
+    });
+    expect(screen.getByTestId('row-action-builtin-edit')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -269,8 +269,56 @@ export const DataTableRowActionItem: React.FC<{
 };
 
 /**
+ * A built-in Edit/Delete item in the data-table's row overflow menu, gated by
+ * the per-record CEL predicates from the object's `userActions.edit` /
+ * `delete` object form (objectui#2614) — `schema.rowEditPredicates` /
+ * `rowDeletePredicates`. Mirrors `BuiltinRowActionItem` on the ObjectGrid
+ * path so BOTH row-menu renderers honor the predicates identically (the
+ * related-list case is where the master-detail scenario from the issue
+ * actually renders). Same posture: `visibleWhen` fails CLOSED, `disabledWhen`
+ * fails soft. Evaluation only happens when the menu is open (Radix mounts
+ * content lazily), so declared predicates cost nothing at table render time.
+ *
+ * Exported for unit tests — NOT part of the package's public API (the barrel
+ * only side-effect-imports this module; see `DataTableRowActionItem`).
+ */
+export const DataTableBuiltinRowActionItem: React.FC<{
+  name: 'edit' | 'delete';
+  predicates?: { visibleWhen?: unknown; disabledWhen?: unknown };
+  row: any;
+  icon: React.ReactNode;
+  label: string;
+  className?: string;
+  onSelect: (row: any) => void;
+}> = ({ name, predicates, row, icon, label, className, onSelect }) => {
+  const isVisible = useRowPredicate(predicates?.visibleWhen, row, {
+    fallback: false,
+    warnOnError: true,
+    label: `builtin:${name}:visibleWhen`,
+  });
+  const isDisabled = useRowPredicate(predicates?.disabledWhen, row, {
+    fallback: false,
+    warnOnError: true,
+    label: `builtin:${name}:disabledWhen`,
+  });
+  if (predicates?.visibleWhen != null && !isVisible) return null;
+  const disabled = predicates?.disabledWhen != null && isDisabled;
+  return (
+    <DropdownMenuItem
+      disabled={disabled}
+      onClick={() => { if (!disabled) onSelect(row); }}
+      data-testid={`row-action-builtin-${name}`}
+      className={className}
+    >
+      {icon}
+      {label}
+    </DropdownMenuItem>
+  );
+};
+
+/**
  * Enterprise-level data table component with Airtable-like features.
- * 
+ *
  * Provides comprehensive table functionality including:
  * - Multi-column sorting (ascending/descending/none)
  * - Real-time search across all columns
@@ -1796,10 +1844,14 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                   </DropdownMenuTrigger>
                                   <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
                                     {schema.onRowEdit && (
-                                      <DropdownMenuItem onClick={() => schema.onRowEdit?.(row)}>
-                                        <Edit className="mr-2 h-4 w-4" />
-                                        {t('table.edit')}
-                                      </DropdownMenuItem>
+                                      <DataTableBuiltinRowActionItem
+                                        name="edit"
+                                        predicates={schema.rowEditPredicates}
+                                        row={row}
+                                        icon={<Edit className="mr-2 h-4 w-4" />}
+                                        label={t('table.edit')}
+                                        onSelect={(r) => schema.onRowEdit?.(r)}
+                                      />
                                     )}
                                     {/* Child-object custom actions (e.g. a related
                                         list surfacing the child's `list_item`
@@ -1815,13 +1867,15 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                     ))}
                                     {schema.onRowDelete && (schema.onRowEdit || customActions.length > 0) && <DropdownMenuSeparator />}
                                     {schema.onRowDelete && (
-                                      <DropdownMenuItem
-                                        onClick={() => schema.onRowDelete?.(row)}
+                                      <DataTableBuiltinRowActionItem
+                                        name="delete"
+                                        predicates={schema.rowDeletePredicates}
+                                        row={row}
+                                        icon={<Trash2 className="mr-2 h-4 w-4" />}
+                                        label={t('table.delete')}
                                         className="text-destructive focus:text-destructive"
-                                      >
-                                        <Trash2 className="mr-2 h-4 w-4" />
-                                        {t('table.delete')}
-                                      </DropdownMenuItem>
+                                        onSelect={(r) => schema.onRowDelete?.(r)}
+                                      />
                                     )}
                                   </DropdownMenuContent>
                                 </DropdownMenu>

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -719,6 +719,17 @@ export const RelatedList: React.FC<RelatedListProps> = ({
       };
     }
 
+    // Per-record CEL predicates for the built-in row Edit/Delete, from the
+    // CHILD object's `userActions.edit` / `delete` object form (#2614) — the
+    // master-detail case where a child row freezes on a parent state change
+    // renders through this path. Boolean forms yield no predicates.
+    const uaEdit = objectSchema?.userActions?.edit;
+    const uaDelete = objectSchema?.userActions?.delete;
+    const predicatesOf = (v: any) =>
+      v != null && typeof v === 'object' && (v.visibleWhen != null || v.disabledWhen != null)
+        ? { visibleWhen: v.visibleWhen ?? undefined, disabledWhen: v.disabledWhen ?? undefined }
+        : undefined;
+
     // Auto-generate schema based on type. We disable the data-table's own
     // search/toolbar — RelatedList provides its own filter input above.
     switch (type) {
@@ -735,6 +746,8 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           rowActions: hasRowActions,
           onRowEdit,
           onRowDelete: onRowDelete ? handleDeleteRow : undefined,
+          rowEditPredicates: predicatesOf(uaEdit),
+          rowDeletePredicates: predicatesOf(uaDelete),
           onRowClick,
           // Child-object row actions (locations:['list_item']) rendered in the
           // same overflow menu, dispatched with the clicked row as target.
@@ -749,7 +762,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
       default:
         return { type: 'div', children: 'No view configured' };
     }
-  }, [type, paginatedData, effectiveColumns, schema, effectivePageSize, hasRowActions, hasCustomRowActions, rowActions, onRowAction, onRowEdit, onRowDelete, handleDeleteRow, onRowClick, isMobile, api]);
+  }, [type, paginatedData, effectiveColumns, schema, effectivePageSize, hasRowActions, hasCustomRowActions, rowActions, onRowAction, onRowEdit, onRowDelete, handleDeleteRow, onRowClick, isMobile, api, objectSchema]);
 
   const headerClassName = collapsible ? 'cursor-pointer select-none' : undefined;
   const handleHeaderClick = collapsible ? () => setCollapsed((c) => !c) : undefined;

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -230,7 +230,14 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   // Authors can still force-disable with `inlineEdit: false`.
   const NON_EDITABLE_BUCKETS = new Set(['system', 'append-only', 'better-auth']);
   const managedBy = objSchema?.managedBy as string | undefined;
-  const userEditOverride = (objSchema?.userActions as { edit?: boolean } | undefined)?.edit;
+  // `userActions.edit` is a boolean or, since #2614, an object form whose
+  // `enabled` carries the boolean (its per-record predicates gate row action
+  // buttons, not detail inline-edit, so they are ignored here).
+  const rawEditOverride = (objSchema?.userActions as { edit?: boolean | { enabled?: boolean } } | undefined)?.edit;
+  const userEditOverride =
+    typeof rawEditOverride === 'object' && rawEditOverride !== null
+      ? rawEditOverride.enabled
+      : rawEditOverride;
   const objectInlineEditable =
     userEditOverride ?? !(managedBy != null && NON_EDITABLE_BUCKETS.has(managedBy));
   const inlineEditDefault = (schema.inlineEdit ?? true) && objectInlineEditable;

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -468,9 +468,14 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     // off, so only an explicit `=== true` override unlocks. The server-side
     // write guard remains the real boundary; this is UX only.
     const managed = !!objectSchema?.managedBy && objectSchema.managedBy !== 'platform';
+    // `userActions.edit` may be the #2614 object form ({ enabled, ...CEL
+    // predicates }); only the explicit enabled boolean unlocks — predicates
+    // gate row action buttons, not the form's blanket lock.
+    const uaEdit = (objectSchema as any)?.userActions?.edit;
+    const editAffordanceOpen = uaEdit === true || (typeof uaEdit === 'object' && uaEdit !== null && uaEdit.enabled === true);
     const modeAffordanceOpen =
       schema.mode === 'edit'
-        ? (objectSchema as any)?.userActions?.edit === true
+        ? editAffordanceOpen
         : schema.mode === 'create'
           ? (objectSchema as any)?.userActions?.create === true
           : false;

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1456,7 +1456,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // (e.g. sys_environment ships a dedicated Rename + cascade-Delete instead).
   // This stops a generic "Delete" from duplicating the object's own Delete
   // action, and a generic "Edit" the object turned off from leaking back in.
-  const { canEdit, canDelete } = resolveRowCrudAffordances({
+  const { canEdit, canDelete, editPredicates, deletePredicates } = resolveRowCrudAffordances({
     operationsUpdate: operations?.update,
     operationsDelete: operations?.delete,
     wantEditAction,
@@ -1491,6 +1491,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
           maxInlineActions={(schema as any).maxInlineRowActions ?? 1}
           canEdit={canEdit}
           canDelete={canDelete}
+          editPredicates={editPredicates}
+          deletePredicates={deletePredicates}
           onEdit={onEdit}
           onDelete={onDelete}
           onAction={(action, r) => {

--- a/packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts
+++ b/packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts
@@ -37,4 +37,47 @@ describe('resolveRowCrudAffordances', () => {
     expect(resolveRowCrudAffordances({ wantEditAction: true, wantDeleteAction: true, hasOnEdit: true, hasOnDelete: true }))
       .toEqual({ canEdit: true, canDelete: true });
   });
+
+  describe('#2614 object form (per-record CEL predicates)', () => {
+    it('passes visibleWhen/disabledWhen through untouched and keeps canEdit/canDelete on', () => {
+      const res = resolveRowCrudAffordances({
+        ...wired,
+        userActions: {
+          edit: { disabledWhen: 'record.frozen == true' },
+          delete: { visibleWhen: { dialect: 'cel', source: 'record.frozen != true' } },
+        },
+      });
+      expect(res.canEdit).toBe(true);
+      expect(res.canDelete).toBe(true);
+      expect(res.editPredicates).toEqual({ disabledWhen: 'record.frozen == true' });
+      expect(res.deletePredicates).toEqual({ visibleWhen: { dialect: 'cel', source: 'record.frozen != true' } });
+    });
+
+    it('object form with enabled:false opts out like the bare boolean (and drops predicates)', () => {
+      const res = resolveRowCrudAffordances({
+        ...wired,
+        userActions: { edit: { enabled: false, disabledWhen: 'record.frozen == true' } },
+      });
+      expect(res.canEdit).toBe(false);
+      expect(res.editPredicates).toBeUndefined();
+      expect(res.canDelete).toBe(true);
+    });
+
+    it('object form without predicates adds nothing (boolean-equivalent)', () => {
+      const res = resolveRowCrudAffordances({ ...wired, userActions: { edit: { enabled: true }, delete: {} } });
+      expect(res).toEqual({ canEdit: true, canDelete: true });
+      expect(res.editPredicates).toBeUndefined();
+      expect(res.deletePredicates).toBeUndefined();
+    });
+
+    it('predicates are not surfaced when the affordance is not wired at all', () => {
+      const res = resolveRowCrudAffordances({
+        hasOnEdit: false,
+        operationsUpdate: true,
+        userActions: { edit: { disabledWhen: 'record.frozen == true' } },
+      });
+      expect(res.canEdit).toBe(false);
+      expect(res.editPredicates).toBeUndefined();
+    });
+  });
 });

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -54,6 +54,17 @@ export interface RowActionDef {
   [key: string]: any;
 }
 
+/** Per-record CEL predicates gating a built-in Edit/Delete row action
+ * (objectui#2614). Bare CEL string or `{ dialect, source }` envelope,
+ * evaluated per row via `useRowPredicate` — same machinery as custom
+ * actions' `visible` / `disabled`. */
+export interface BuiltinRowActionPredicates {
+  /** Evaluates false → the item is not rendered for this row. Fail-closed. */
+  visibleWhen?: unknown;
+  /** Evaluates true → the item renders disabled for this row. Fail-soft. */
+  disabledWhen?: unknown;
+}
+
 export interface RowActionMenuProps {
   /** The row data record */
   row: any;
@@ -65,6 +76,10 @@ export interface RowActionMenuProps {
   canEdit?: boolean;
   /** Whether delete operation is available */
   canDelete?: boolean;
+  /** Per-record predicates for the built-in Edit item (from `userActions.edit`). */
+  editPredicates?: BuiltinRowActionPredicates;
+  /** Per-record predicates for the built-in Delete item (from `userActions.delete`). */
+  deletePredicates?: BuiltinRowActionPredicates;
   /** Callback when edit is clicked */
   onEdit?: (row: any) => void;
   /** Callback when delete is clicked */
@@ -117,6 +132,54 @@ const RowActionMenuItem: React.FC<{
   );
 };
 
+/**
+ * A built-in Edit/Delete menu item gated by per-record CEL predicates
+ * (objectui#2614). Extracted into a component so `useRowPredicate` runs
+ * hook-safe, mirroring `RowActionMenuItem` for custom actions. Note the
+ * evaluation is naturally lazy: this only renders inside the (Radix)
+ * `DropdownMenuContent`, which mounts when the row's "⋮" menu opens — so
+ * declaring predicates costs nothing while the grid renders.
+ *
+ * Posture matches the spec contract (`RowCrudActionOverrideSchema`):
+ * `visibleWhen` fails CLOSED (a faulting predicate hides + warns once, so a
+ * broken predicate can't expose an affordance the author meant to gate);
+ * `disabledWhen` fails soft (button stays enabled — the server hook is the
+ * real enforcement).
+ */
+export const BuiltinRowActionItem: React.FC<{
+  name: 'edit' | 'delete';
+  predicates?: BuiltinRowActionPredicates;
+  row: any;
+  icon: React.ReactNode;
+  label: string;
+  className?: string;
+  onSelect: (row: any) => void;
+}> = ({ name, predicates, row, icon, label, className, onSelect }) => {
+  const isVisible = useRowPredicate(predicates?.visibleWhen, row, {
+    fallback: false,
+    warnOnError: true,
+    label: `builtin:${name}:visibleWhen`,
+  });
+  const isDisabled = useRowPredicate(predicates?.disabledWhen, row, {
+    fallback: false,
+    warnOnError: true,
+    label: `builtin:${name}:disabledWhen`,
+  });
+  if (predicates?.visibleWhen != null && !isVisible) return null;
+  const disabled = predicates?.disabledWhen != null && isDisabled;
+  return (
+    <DropdownMenuItem
+      disabled={disabled}
+      onClick={() => { if (!disabled) onSelect(row); }}
+      data-testid={`row-action-builtin-${name}`}
+      className={className}
+    >
+      {icon}
+      {label}
+    </DropdownMenuItem>
+  );
+};
+
 /** Map a schema action variant onto a Button variant. `primary` is the
  * accent ("default") button so the action reads as the row's main CTA. */
 function toButtonVariant(v: RowActionDef['variant']): 'default' | 'secondary' | 'destructive' | 'ghost' | 'link' {
@@ -161,6 +224,8 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
   rowActionDefs,
   canEdit,
   canDelete,
+  editPredicates,
+  deletePredicates,
   onEdit,
   onDelete,
   onAction,
@@ -211,16 +276,24 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
             {canEdit && onEdit && (
-              <DropdownMenuItem onClick={() => onEdit(row)}>
-                <Edit className="mr-2 h-4 w-4" />
-                {t('grid.edit')}
-              </DropdownMenuItem>
+              <BuiltinRowActionItem
+                name="edit"
+                predicates={editPredicates}
+                row={row}
+                icon={<Edit className="mr-2 h-4 w-4" />}
+                label={t('grid.edit')}
+                onSelect={onEdit}
+              />
             )}
             {canDelete && onDelete && (
-              <DropdownMenuItem onClick={() => onDelete(row)}>
-                <Trash2 className="mr-2 h-4 w-4" />
-                {t('grid.delete')}
-              </DropdownMenuItem>
+              <BuiltinRowActionItem
+                name="delete"
+                predicates={deletePredicates}
+                row={row}
+                icon={<Trash2 className="mr-2 h-4 w-4" />}
+                label={t('grid.delete')}
+                onSelect={onDelete}
+              />
             )}
             {menuDefs.map(def => (
               <RowActionMenuItem

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.test.tsx
@@ -15,12 +15,18 @@
  * sliver. Only the first `maxInlineActions` primaries now stay inline; the rest
  * fold into the "⋮" overflow menu.
  */
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { PredicateScopeProvider } from '@object-ui/react';
-import { RowActionMenu } from '../RowActionMenu';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@object-ui/components';
+import { Edit } from 'lucide-react';
+import { RowActionMenu, BuiltinRowActionItem } from '../RowActionMenu';
 
 const OPEN = { name: 'open', label: 'Open', variant: 'primary' as const };
 const UPGRADE = { name: 'upgrade', label: 'Upgrade Plan', variant: 'primary' as const };
@@ -92,5 +98,101 @@ describe('RowActionMenu CEL visible predicate (issue #1584)', () => {
       </PredicateScopeProvider>,
     );
     expect(screen.queryByTestId('row-action-inline-resume')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * objectui#2614 — the BUILT-IN Edit/Delete row actions honor per-record
+ * `visibleWhen` / `disabledWhen` CEL predicates from the object's
+ * `userActions.edit` / `delete` object form. Items are rendered inside a
+ * controlled-open dropdown (same pattern as the data-table's
+ * `DataTableRowActionItem` tests) because Radix mounts menu content only when
+ * open — which is also why predicate evaluation is lazy and free at grid
+ * render time.
+ */
+describe('BuiltinRowActionItem per-record CEL predicates (#2614)', () => {
+  // The downstream MES case: a task_version_check_item row is frozen once its
+  // parent version is published; the Edit button must grey out on frozen rows.
+  const FROZEN = { id: 'r1', name: 'Check item A', frozen: true };
+  const DRAFT = { id: 'r2', name: 'Check item B', frozen: false };
+
+  function renderItem(props: { predicates?: any; row: any; onSelect?: (row: any) => void }) {
+    return render(
+      <PredicateScopeProvider scope={{}}>
+        <DropdownMenu open modal={false}>
+          <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <BuiltinRowActionItem
+              name="edit"
+              icon={<Edit className="mr-2 h-4 w-4" />}
+              label="Edit"
+              onSelect={props.onSelect ?? (() => {})}
+              predicates={props.predicates}
+              row={props.row}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </PredicateScopeProvider>,
+    );
+  }
+
+  it('renders enabled with no predicates (today’s behavior, zero regression)', () => {
+    renderItem({ row: FROZEN });
+    const item = screen.getByTestId('row-action-builtin-edit');
+    expect(item).toBeInTheDocument();
+    expect(item).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('disabledWhen true → rendered but disabled, and clicks do not fire', () => {
+    const onSelect = vi.fn();
+    renderItem({ predicates: { disabledWhen: 'record.frozen == true' }, row: FROZEN, onSelect });
+    const item = screen.getByTestId('row-action-builtin-edit');
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(item);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('disabledWhen false → enabled, and clicks fire with the row', () => {
+    const onSelect = vi.fn();
+    renderItem({ predicates: { disabledWhen: 'record.frozen == true' }, row: DRAFT, onSelect });
+    const item = screen.getByTestId('row-action-builtin-edit');
+    expect(item).not.toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(item);
+    expect(onSelect).toHaveBeenCalledWith(DRAFT);
+  });
+
+  it('visibleWhen false → the item is not rendered for that row', () => {
+    renderItem({ predicates: { visibleWhen: 'record.frozen != true' }, row: FROZEN });
+    expect(screen.queryByTestId('row-action-builtin-edit')).not.toBeInTheDocument();
+  });
+
+  it('visibleWhen true → the item renders', () => {
+    renderItem({ predicates: { visibleWhen: 'record.frozen != true' }, row: DRAFT });
+    expect(screen.getByTestId('row-action-builtin-edit')).toBeInTheDocument();
+  });
+
+  it('accepts the canonical { dialect, source } envelope', () => {
+    renderItem({
+      predicates: { visibleWhen: { dialect: 'cel', source: 'record.frozen != true' } },
+      row: FROZEN,
+    });
+    expect(screen.queryByTestId('row-action-builtin-edit')).not.toBeInTheDocument();
+  });
+
+  it('a faulting visibleWhen fails CLOSED (hidden), a faulting disabledWhen fails soft (enabled)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      renderItem({ predicates: { visibleWhen: 'record.nonexistent.deep == 1' }, row: DRAFT });
+      expect(screen.queryByTestId('row-action-builtin-edit')).not.toBeInTheDocument();
+    } finally {
+      warn.mockRestore();
+    }
+    const warn2 = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      renderItem({ predicates: { disabledWhen: 'record.nonexistent.deep == 1' }, row: DRAFT });
+      expect(screen.getByTestId('row-action-builtin-edit')).not.toHaveAttribute('aria-disabled', 'true');
+    } finally {
+      warn2.mockRestore();
+    }
   });
 });

--- a/packages/plugin-grid/src/rowCrudAffordances.ts
+++ b/packages/plugin-grid/src/rowCrudAffordances.ts
@@ -27,7 +27,44 @@
  *
  * `userActions.edit` / `delete` left `undefined` (or `true`) preserves the
  * out-of-the-box behaviour — every main list keeps its Edit/Delete kebab.
+ *
+ * Since objectui#2614, `userActions.edit` / `delete` also accept an object
+ * form `{ enabled?, visibleWhen?, disabledWhen? }`: `enabled` carries the
+ * boolean opt-out, and the two CEL predicates gate the affordance
+ * **per record**. The predicates are returned untouched as
+ * `editPredicates` / `deletePredicates` for the row renderer to evaluate
+ * (they never affect the object-level `canEdit` / `canDelete` verdict).
  */
+
+/** Per-record CEL predicates for a built-in row action (objectui#2614).
+ * Kept as authored — bare CEL string or `{ dialect, source }` envelope —
+ * and handed to `useRowPredicate` untouched. */
+export interface RowCrudPredicates {
+  visibleWhen?: unknown;
+  disabledWhen?: unknown;
+}
+
+/** A `userActions.edit` / `delete` flag: bare boolean or the #2614 object form. */
+export type RowCrudUserAction =
+  | boolean
+  | { enabled?: boolean; visibleWhen?: unknown; disabledWhen?: unknown };
+
+/** Object-level enabled verdict for a userActions flag (undefined = no opt-out). */
+function isOptedOut(v: RowCrudUserAction | undefined | null): boolean {
+  if (typeof v === 'boolean') return v === false;
+  return v?.enabled === false;
+}
+
+/** Extract the per-record predicates from the object form, if any. */
+function predicatesOf(v: RowCrudUserAction | undefined | null): RowCrudPredicates | undefined {
+  if (v == null || typeof v === 'boolean') return undefined;
+  if (v.visibleWhen == null && v.disabledWhen == null) return undefined;
+  const out: RowCrudPredicates = {};
+  if (v.visibleWhen != null) out.visibleWhen = v.visibleWhen;
+  if (v.disabledWhen != null) out.disabledWhen = v.disabledWhen;
+  return out;
+}
+
 export function resolveRowCrudAffordances(opts: {
   operationsUpdate?: boolean;
   operationsDelete?: boolean;
@@ -36,13 +73,23 @@ export function resolveRowCrudAffordances(opts: {
   hasOnEdit?: boolean;
   hasOnDelete?: boolean;
   /** The object's `userActions` block ({ create, edit, delete, import }). */
-  userActions?: { edit?: boolean; delete?: boolean } | null;
-}): { canEdit: boolean; canDelete: boolean } {
-  const editOptedOut = opts.userActions?.edit === false;
-  const deleteOptedOut = opts.userActions?.delete === false;
+  userActions?: { edit?: RowCrudUserAction; delete?: RowCrudUserAction } | null;
+}): {
+  canEdit: boolean;
+  canDelete: boolean;
+  editPredicates?: RowCrudPredicates;
+  deletePredicates?: RowCrudPredicates;
+} {
+  const editOptedOut = isOptedOut(opts.userActions?.edit);
+  const deleteOptedOut = isOptedOut(opts.userActions?.delete);
   const canEdit =
     !!((opts.operationsUpdate || opts.wantEditAction) && opts.hasOnEdit) && !editOptedOut;
   const canDelete =
     !!((opts.operationsDelete || opts.wantDeleteAction) && opts.hasOnDelete) && !deleteOptedOut;
-  return { canEdit, canDelete };
+  return {
+    canEdit,
+    canDelete,
+    editPredicates: canEdit ? predicatesOf(opts.userActions?.edit) : undefined,
+    deletePredicates: canDelete ? predicatesOf(opts.userActions?.delete) : undefined,
+  };
 }

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -462,6 +462,20 @@ export interface DataTableSchema extends BaseSchema {
    */
   onRowDelete?: (row: any) => void;
   /**
+   * Per-record CEL predicates gating the built-in row Edit item
+   * (objectui#2614), from the object's `userActions.edit` object form.
+   * `visibleWhen` false → the item is not rendered for that row (fail-closed);
+   * `disabledWhen` true → rendered disabled (fail-soft). Bare CEL string or
+   * `{ dialect: 'cel', source }` envelope, evaluated per row with the record
+   * bound as `record.*` and bare fields.
+   */
+  rowEditPredicates?: { visibleWhen?: unknown; disabledWhen?: unknown };
+  /**
+   * Per-record CEL predicates gating the built-in row Delete item
+   * (objectui#2614), from the object's `userActions.delete` object form.
+   */
+  rowDeletePredicates?: { visibleWhen?: unknown; disabledWhen?: unknown };
+  /**
    * Extra per-row action definitions rendered in the row overflow menu, after
    * Edit/Delete. Each is dispatched via {@link onRowActionDef} with the clicked
    * row. Surfaces an object's own row actions in embedded tables (e.g. a detail

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -147,6 +147,14 @@ export const DataTableSchema = BaseSchema.extend({
   reorderableColumns: z.boolean().optional().describe('Allow column reordering'),
   onRowEdit: z.function().optional().describe('Row edit handler'),
   onRowDelete: z.function().optional().describe('Row delete handler'),
+  rowEditPredicates: z.object({
+    visibleWhen: z.unknown().optional(),
+    disabledWhen: z.unknown().optional(),
+  }).optional().describe('Per-record CEL predicates for the built-in row Edit item (objectui#2614)'),
+  rowDeletePredicates: z.object({
+    visibleWhen: z.unknown().optional(),
+    disabledWhen: z.unknown().optional(),
+  }).optional().describe('Per-record CEL predicates for the built-in row Delete item (objectui#2614)'),
   onSelectionChange: z.function().optional().describe('Selection change handler'),
   onColumnsReorder: z.function().optional().describe('Column reorder handler'),
   frozenColumns: z.number().optional().describe('Number of frozen columns'),


### PR DESCRIPTION
## Summary

Closes #2614 — the built-in row CRUD actions (Edit/Delete) only honored object-level booleans from `resolveCrudAffordances`, so the button that can edit couldn't be gated per record, and the custom action that can be gated can't open the native editor. `userActions.edit` / `userActions.delete` now also accept the object form:

```ts
userActions: {
  edit:   { disabledWhen: 'record.frozen == true' },  // grey out per row
  delete: { visibleWhen: 'record.frozen != true' },   // hide per row
}
```

Predicates evaluate per row on the canonical CEL engine via `useRowPredicate` — the exact machinery custom row actions already use — with the record bound as `record.*` and bare fields, ambient `features`/`user` scope merged. `visibleWhen` false → item not rendered (**fail-closed**, warn once); `disabledWhen` true → rendered disabled (**fail-soft** — the server hook remains the real enforcement).

## Wiring

- **plugin-grid** — `resolveRowCrudAffordances` passes `editPredicates`/`deletePredicates` through (object-level opt-out semantics unchanged; `enabled:false` behaves like `false`); `RowActionMenu` renders built-in Edit/Delete via a new hook-safe `BuiltinRowActionItem`.
- **components** — the data-table's built-in Edit/Delete honor new `rowEditPredicates`/`rowDeletePredicates` schema props via `DataTableBuiltinRowActionItem` (same posture). This is the path a detail page's related list renders through — the master-detail case in the downstream report.
- **plugin-detail** — `RelatedList` sources the predicates from the child object's `userActions`; `record-details` resolves the object form's `enabled` for the inline-edit gate.
- **plugin-form** — the managed-object blanket lock accepts the object form by its explicit `enabled` flag only.
- **app-shell** — `crudAffordances` mirror kept in lockstep with the framework helper (surfaces `editPredicates`/`deletePredicates`).

Spec-side change (`RowCrudActionOverrideSchema`, `resolveCrudAffordances` predicates pass-through) is the companion PR objectstack-ai/framework#3076.

## Performance

- No predicates declared → `useRowPredicate` short-circuits on `null`/boolean before touching the CEL engine: **zero added work for every existing app**.
- Predicates declared → evaluation happens only when a row's "⋮" menu opens (Radix mounts `DropdownMenuContent` lazily), i.e. two small CEL evaluations per menu-open, not per rendered row.
- Trigger visibility stays driven by the object-level booleans (no render-time per-row evaluation added).

Per the issue's note on `master_detail` parents: this lands feature (1) — authors denormalize the frozen/status flag onto the child and gate on `record.*`. Parent-record injection into the evaluation context is deferred as the optional follow-up.

## Tests

- `rowCrudAffordances.test.ts` — predicate pass-through, `enabled:false` opt-out, boolean-equivalence, not-wired case (10 tests).
- `RowActionMenu.test.tsx` — enabled/disabled/hidden per row, envelope form, click suppression when disabled, fail-closed vs fail-soft fault posture (13 tests).
- `data-table-builtin-row-action-predicates.test.tsx` — same matrix on the related-list path.
- `crudAffordances.test.ts` (app-shell mirror) — bucket defaults, boolean overrides, object form.
- Full suites green: plugin-grid (226), plugin-detail (224), plugin-form (201), components complex renderers; all touched packages build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnCZhYpQjRyg2E44RHBiNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnCZhYpQjRyg2E44RHBiNE)_