### PR TITLE
feat(console): dev-seeded admin credentials hint on the login page

### DIFF
--- a/.changeset/login-dev-admin-hint.md
+++ b/.changeset/login-dev-admin-hint.md
@@ -1,0 +1,6 @@
+---
+"@object-ui/console": patch
+"@object-ui/i18n": patch
+---
+
+Login page surfaces the dev-seeded admin credentials. The framework runtime seeds `admin@objectos.ai` on an empty development database, but nothing on the login page said so — new users clicked "Sign up" and landed in an empty non-admin workspace (15.1 third-party eval). When `GET /api/v1/auth/config` reports `devSeedAdmin` (dev-only; the server omits the field in production and once the default password is changed), the page renders a dismissible amber banner with the credentials. Dismissal persists per browser via localStorage.

--- a/apps/console/src/pages/auth/LoginPage.tsx
+++ b/apps/console/src/pages/auth/LoginPage.tsx
@@ -44,6 +44,8 @@ function withConsoleBase(path: string): string {
   return base + (path.startsWith('/') ? path : `/${path}`);
 }
 
+const DEV_HINT_DISMISSED_KEY = 'os.console.devAdminHintDismissed';
+
 function RouterLink(props: { href: string; className?: string; children: React.ReactNode }) {
   return (
     <Link to={props.href} className={props.className}>
@@ -67,6 +69,30 @@ export function LoginPage() {
   } = useAuth();
 
   const [signUpDisabled, setSignUpDisabled] = useState(false);
+  // Dev-only seeded-admin hint (15.1 third-party eval): the runtime seeds
+  // admin@objectos.ai on an empty dev DB, but nothing on this page said so —
+  // new users clicked "Sign up" and landed in an empty non-admin workspace.
+  // The server reports the credentials via /auth/config `devSeedAdmin` ONLY
+  // in development while the account still carries the default password, so
+  // production can never render this. Dismissal is remembered per browser.
+  const [devSeedAdmin, setDevSeedAdmin] = useState<{ email: string; password?: string } | null>(
+    null,
+  );
+  const [devHintDismissed, setDevHintDismissed] = useState<boolean>(() => {
+    try {
+      return window.localStorage.getItem(DEV_HINT_DISMISSED_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+  const dismissDevHint = () => {
+    setDevHintDismissed(true);
+    try {
+      window.localStorage.setItem(DEV_HINT_DISMISSED_KEY, '1');
+    } catch {
+      /* private mode — hide for this session only */
+    }
+  };
   const [autoSelectingOrg, setAutoSelectingOrg] = useState(false);
   // The OAuth hand-off fetch must fire at most once even though the post-login
   // effect re-runs as org state settles (it navigates away on success).
@@ -111,16 +137,27 @@ export function LoginPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Read public auth config once to know whether sign-up is gated off.
+  // Read public auth config once to know whether sign-up is gated off and
+  // whether the dev-seeded admin credentials should be surfaced.
   useEffect(() => {
     let cancelled = false;
     getAuthConfig()
       .then((cfg) => {
         if (cancelled) return;
         setSignUpDisabled(cfg?.emailPassword?.disableSignUp === true);
+        const seed = (cfg as { devSeedAdmin?: { email?: unknown; password?: unknown } } | null)
+          ?.devSeedAdmin;
+        setDevSeedAdmin(
+          seed && typeof seed.email === 'string'
+            ? {
+                email: seed.email,
+                password: typeof seed.password === 'string' ? seed.password : undefined,
+              }
+            : null,
+        );
       })
       .catch(() => {
-        /* leave default (false) — server-side gate is the source of truth */
+        /* leave defaults — server-side gate is the source of truth */
       });
     return () => {
       cancelled = true;
@@ -225,6 +262,46 @@ export function LoginPage() {
                 defaultValue: `Continue to ${ssoTarget}`,
               })}
             </span>
+          </div>
+        ) : null}
+        {devSeedAdmin && !devHintDismissed ? (
+          <div
+            role="status"
+            data-testid="dev-admin-hint"
+            className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-foreground"
+          >
+            <span className="mt-0.5 inline-block size-2 shrink-0 rounded-full bg-amber-500" />
+            <div className="flex-1">
+              <div className="font-medium">
+                {t('auth.login.devAdminHint.title', { defaultValue: 'Development instance' })}
+              </div>
+              <div className="text-muted-foreground">
+                {t('auth.login.devAdminHint.body', {
+                  defaultValue: 'Sign in with the seeded dev admin:',
+                })}{' '}
+                <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+                  {devSeedAdmin.email}
+                </code>
+                {devSeedAdmin.password ? (
+                  <>
+                    {' / '}
+                    <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+                      {devSeedAdmin.password}
+                    </code>
+                  </>
+                ) : null}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={dismissDevHint}
+              aria-label={t('auth.login.devAdminHint.dismiss', { defaultValue: 'Dismiss' })}
+              className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true" className="size-3.5 fill-current">
+                <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+              </svg>
+            </button>
           </div>
         ) : null}
         <Card className="border-border/60 px-4 py-8 shadow-sm shadow-primary/5 backdrop-blur supports-[backdrop-filter]:bg-card/95">

--- a/apps/console/src/pages/auth/__tests__/LoginPage.dev-admin-hint.test.tsx
+++ b/apps/console/src/pages/auth/__tests__/LoginPage.dev-admin-hint.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * LoginPage — dev-seeded admin credentials hint (framework 15.1 third-party
+ * eval): the runtime seeds `admin@objectos.ai` on an empty dev DB but the
+ * login page never said so, sending new users to "Sign up" and into an empty
+ * non-admin workspace. The server exposes `devSeedAdmin` on /auth/config ONLY
+ * in development while the default password still verifies; the page renders
+ * it as a dismissible banner and must render nothing when the field is
+ * absent (production).
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '@object-ui/auth';
+import type { AuthClient } from '@object-ui/auth';
+import { LoginPage } from '../LoginPage';
+
+afterEach(cleanup);
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function createMockClient(config: Record<string, unknown>): AuthClient {
+  return {
+    getSession: vi.fn().mockResolvedValue(null),
+    getConfig: vi.fn().mockResolvedValue(config),
+  } as unknown as AuthClient;
+}
+
+function renderLogin(config: Record<string, unknown>) {
+  window.history.replaceState({}, '', '/login');
+  return render(
+    <AuthProvider authUrl="/api/v1/auth" client={createMockClient(config)}>
+      <MemoryRouter initialEntries={['/login']}>
+        <LoginPage />
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+const DEV_SEED = { devSeedAdmin: { email: 'admin@objectos.ai', password: 'admin123' } };
+
+describe('LoginPage — dev-seeded admin hint', () => {
+  it('renders the credentials when the server reports devSeedAdmin', async () => {
+    renderLogin(DEV_SEED);
+
+    const hint = await screen.findByTestId('dev-admin-hint');
+    expect(hint.textContent).toContain('admin@objectos.ai');
+    expect(hint.textContent).toContain('admin123');
+  });
+
+  it('renders nothing without devSeedAdmin (production config)', async () => {
+    renderLogin({ emailPassword: { disableSignUp: false } });
+
+    // Let the config effect settle, then assert absence.
+    await waitFor(() => expect(screen.queryByTestId('dev-admin-hint')).toBeNull());
+  });
+
+  it('dismisses on click and stays dismissed via localStorage', async () => {
+    renderLogin(DEV_SEED);
+    const user = userEvent.setup();
+
+    await screen.findByTestId('dev-admin-hint');
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(screen.queryByTestId('dev-admin-hint')).toBeNull();
+    expect(window.localStorage.getItem('os.console.devAdminHintDismissed')).toBe('1');
+
+    // A re-render (new visit) must respect the stored dismissal.
+    cleanup();
+    renderLogin(DEV_SEED);
+    await waitFor(() => expect(screen.queryByTestId('dev-admin-hint')).toBeNull());
+  });
+});

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1632,6 +1632,11 @@ const en = {
       signUpText: 'Sign up',
       signingIn: 'Signing you in…',
       ssoHandoff: 'Continue to {{target}}',
+      devAdminHint: {
+        title: 'Development instance',
+        body: 'Sign in with the seeded dev admin:',
+        dismiss: 'Dismiss',
+      },
       errors: {
         invalidCredentials: 'Invalid email or password. Please try again.',
         emailNotVerified: 'Please verify your email address before signing in.',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1705,6 +1705,11 @@ const zh = {
       signUpText: '注册',
       signingIn: '正在登录…',
       ssoHandoff: '继续前往 {{target}}',
+      devAdminHint: {
+        title: '开发实例',
+        body: '可使用内置的开发管理员登录：',
+        dismiss: '关闭',
+      },
       errors: {
         invalidCredentials: '邮箱或密码错误，请重试。',
         emailNotVerified: '请先验证您的邮箱后再登录。',


### PR DESCRIPTION
## 问题(framework 15.1 第三方评估 P2 #4 前端侧)

dev 模式空库自动 seed `admin@objectos.ai/admin123`,但登录页毫无提示——新用户去「注册」,掉进普通角色的「还没有应用」空工作区。

## 实现

- `LoginPage` 复用现有 `getAuthConfig()` effect 读取新的 `devSeedAdmin` 字段(framework#3108 加入 `/api/v1/auth/config`,**服务端门控**:仅 `NODE_ENV==='development'` 且 seed 账号仍是默认密码时存在;生产由构造保证绝不出现,改密后一次重启即消失)
- 登录卡上方渲染琥珀色 `role="status"` 横幅:「开发实例 / 可使用内置的开发管理员登录:`admin@objectos.ai` / `admin123`」,凭据等宽 code 呈现
- 可关闭,`localStorage['os.console.devAdminHintDismissed']` 按浏览器持久化
- i18n:`auth.login.devAdminHint.*`(en + zh,其余 locale 走 defaultValue 回退)

## 验证

- 真浏览器(console dev :5180 → 真实 fresh 后端):横幅渲染截图 ✓ / 点击关闭消失且 reload 后仍隐藏 ✓ / 清除标记后恢复 ✓ / 无 `devSeedAdmin` 时不渲染 ✓
- vitest 新增 3 例(渲染凭据 / 生产 config 不渲染 / 关闭+localStorage 持久化),auth 页测试 9/9 绿

配套框架 PR:objectstack-ai/framework#3108(后端字段 + 终端 banner 持久化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)