### PR TITLE
refactor(spec-bridge): derive list-view bridge types from @objectstack/spec/ui (#2231 follow-up)

### DIFF
--- a/.changeset/spec-bridge-listview-types.md
+++ b/.changeset/spec-bridge-listview-types.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/react": patch
+---
+
+refactor(spec-bridge): retire the hand-written `ListViewSpec`/`ListColumn` mirrors in the list-view bridge (#2231 follow-up)
+
+The SpecBridge's list-view bridge kept a third hand-written copy of the ListView shape
+(after the zod schema and the TS interface unified in the previous #2231 PR). It now
+derives its input type from `@objectstack/spec/ui` (`Partial<ListView>`, spec `ListColumn`),
+so the bridge can no longer drift from the protocol.
+
+Behavior fix surfaced by the real types: spec `columns` is `string[] | ListColumn[]`, but
+the old local interface only admitted `ListColumn[]` — a bare field-name column would have
+produced a broken `{ accessorKey: undefined }` mapping. String columns now map to a default
+column (`{ accessorKey: field, header: field }`).

--- a/packages/react/src/spec-bridge/bridges/list-view.ts
+++ b/packages/react/src/spec-bridge/bridges/list-view.ts
@@ -8,74 +8,23 @@
 
 import type { SchemaNode } from '@object-ui/core';
 import type { BridgeContext, BridgeFn } from '../types';
-import type { ListViewGalleryConfig, ListViewTimelineConfig } from '@object-ui/types';
+import type { ListView, ListColumn } from '@objectstack/spec/ui';
 
-interface ListColumn {
-  field: string;
-  label?: string;
-  width?: number;
-  align?: string;
-  hidden?: boolean;
-  sortable?: boolean;
-  resizable?: boolean;
-  wrap?: boolean;
-  type?: string;
-  pinned?: string;
-  summary?: any;
-  link?: any;
-  action?: any;
-}
+/**
+ * Bridge input: the spec-canonical ListView (#2231 — the former hand-written
+ * `ListViewSpec`/`ListColumn` mirrors are retired; the shape now derives from
+ * `@objectstack/spec/ui` and can no longer drift). Relaxed to `Partial` because
+ * hosts routinely hand the bridge fragmentary view-configs (every field was
+ * optional in the old mirror too, including spec-required `columns`).
+ */
+type ListViewSpec = Partial<ListView>;
 
-interface ListViewSpec {
-  name?: string;
-  label?: string;
-  type?: string;
-  data?: any;
-  columns?: ListColumn[];
-  filter?: any;
-  sort?: any;
-  searchableFields?: string[];
-  filterableFields?: string[];
-  selection?: any;
-  pagination?: any;
-  rowHeight?: string;
-  resizable?: boolean;
-  striped?: boolean;
-  bordered?: boolean;
-  grouping?: any;
-  rowColor?: any;
-  navigation?: any;
-  kanban?: any;
-  calendar?: any;
-  gantt?: any;
-  gallery?: ListViewGalleryConfig;
-  timeline?: ListViewTimelineConfig;
-  // P1.1 additions
-  rowActions?: string[];
-  bulkActions?: string[];
-  bulkActionDefs?: any[];
-  virtualScroll?: boolean;
-  conditionalFormatting?: Array<{ condition: string; style: Record<string, string> }>;
-  inlineEdit?: boolean;
-  exportOptions?: any;
-  emptyState?: { title?: string; message?: string; icon?: string };
-  userActions?: any;
-  appearance?: any;
-  /** UX-only hint: collapse appearance/grouping cluster into a single popover. */
-  compactToolbar?: boolean;
-  tabs?: any[];
-  addRecord?: any;
-  showRecordCount?: boolean;
-  allowPrinting?: boolean;
-  // P1.6 i18n & ARIA
-  aria?: { ariaLabel?: string; ariaDescribedBy?: string; role?: string };
-  sharing?: any;
-  hiddenFields?: string[];
-  fieldOrder?: string[];
-  description?: string;
-}
+function mapColumn(col: ListColumn | string): Record<string, any> {
+  // Spec-legacy shorthand: a bare field name stands for a default column.
+  if (typeof col === 'string') {
+    return { accessorKey: col, header: col };
+  }
 
-function mapColumn(col: ListColumn): Record<string, any> {
   const mapped: Record<string, any> = {
     accessorKey: col.field,
     header: col.label ?? col.field,


### PR DESCRIPTION
## Summary

Follow-up to #2622 (issue #2231). That PR unified two of the three hand-written ListView copies (the zod schema and the TS interface in `@object-ui/types`); this one retires the **third**: the SpecBridge's local `ListViewSpec`/`ListColumn` interfaces in `packages/react/src/spec-bridge/bridges/list-view.ts`.

## What changed

- The bridge's input type is now derived from the protocol: `type ListViewSpec = Partial<ListView>` with `ListView`/`ListColumn` imported from `@objectstack/spec/ui`. The 60-line hand-written mirror is deleted, so the bridge can no longer drift from the spec.
- `Partial` keeps the old semantics — every field was optional in the hand-written mirror too (including spec-required `columns`), and hosts routinely hand the bridge fragmentary view-configs.
- **Behavior fix surfaced by the real types:** spec `columns` is `string[] | ListColumn[]`, but the old local interface only admitted `ListColumn[]` — a bare field-name column would have mapped to a broken `{ accessorKey: undefined }`. String columns now map to a default column (`{ accessorKey: field, header: field }`).

## Verification

- Full build 43/43 packages green.
- `@object-ui/react` type-check: 0 errors.
- `packages/react` test suite (incl. `SpecBridge.test.ts`): 25 files, 310 tests passed.

## Remaining #2231 follow-ups (not in this PR)

- Migrate legacy vocabulary at the read-sites (`show*`→`userActions`, `fields`→`columns`, `filters`→`filter`); align `aria` to spec `AriaPropsSchema`; `objectName` → `data.provider:'object'`; unify `FormViewSchema`/`ObjectViewSchema` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBAuAYP5j1j5MguKYM84dW)_