### PR TITLE
ci(test): shard the Vitest suite across 4 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,69 @@ jobs:
       - name: Verify all packages are in changeset fixed group
         run: node scripts/check-changeset-fixed.mjs
 
+  # PRs run the suite split across 4 runners. The suite is dominated by fixed
+  # per-file cost rather than by the assertions: a PR run reported 495s wall
+  # clock of which only 178s was `tests` — the rest was `setup` (831s
+  # cumulative), `import` (199s) and `environment` (156s), each paid once per
+  # test file because `isolate: true` re-executes the module graph per file
+  # (vitest.config.mts explains why isolation has to stay on). That cost shards
+  # near-linearly, and the fixed overhead of an extra runner here is only ~30s
+  # (checkout + Node + a warm-pnpm-store install), so 4 shards cut wall clock
+  # ~3x for ~26% more runner minutes.
+  #
+  # Vitest shards by hashing each test file's path, so `unit` and `dom` files
+  # interleave across shards on their own — no manual balancing needed.
   test:
-    name: Test
+    name: Test (shard ${{ matrix.shard }}/4)
+    # Coverage instrumentation (v8 adds 40-100% overhead) is skipped on PRs;
+    # the `test-coverage` job below keeps Codecov current on push.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     # Bound the job so a stalled runner / non-exiting test worker fails fast and
-    # is retryable, instead of hanging up to GitHub's 6h default. PR runs can
-    # spend extra time rebuilding affected package graphs on cold caches.
+    # is retryable, instead of hanging up to GitHub's 6h default.
+    timeout-minutes: 20
+
+    strategy:
+      # Report every shard's failures, not just the first one to break.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Verify pnpm version
+        run: pnpm --version
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Run the canonical root Vitest project once. Running `turbo run test`
+      # here starts one Vitest process per package; several package configs
+      # intentionally inherit the root monorepo project list, so CI ends up
+      # repeating large chunks of the suite and can starve slower plugin tests.
+      - name: Run tests (shard ${{ matrix.shard }}/4)
+        run: pnpm test --shard=${{ matrix.shard }}/4
+
+  # Push to main/develop: one unsharded run so Codecov still receives a single
+  # complete report. Nothing blocks on this job, so it isn't worth the blob
+  # report merge that sharding a coverage run would require.
+  test-coverage:
+    name: Test (coverage)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     steps:
@@ -64,22 +121,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # PRs: skip coverage instrumentation (v8 adds 40-100% overhead) and
-      # run the canonical root Vitest project once. Running `turbo run test`
-      # here starts one Vitest process per package; several package configs
-      # intentionally inherit the root monorepo project list, so CI ends up
-      # repeating large chunks of the suite and can starve slower plugin tests.
-      - name: Run tests (PR — fast, no coverage)
-        if: github.event_name == 'pull_request'
-        run: pnpm test
-
-      # Push to main/develop: still run coverage so Codecov stays current.
-      - name: Run tests with coverage (push)
-        if: github.event_name == 'push'
+      - name: Run tests with coverage
         run: pnpm test:coverage --coverage.reporter=json --coverage.reporter=text
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'push'
         uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
## 问题

`Test` job 就是 CI 的关键路径:一次 PR 跑 ~8.3 分钟,而整条 CI 的 wall clock 才 ~9 分钟(E2E 只要 1.2 分钟,dev-server 0.4 分钟,docs 在 PR 上直接跳过)。

慢的不是断言本身。最近一次 PR 跑的 Vitest summary:

```
Duration 495.33s (transform 46.84s, setup 831.17s, import 198.72s,
                  tests 177.78s, environment 155.79s)
```

真正执行测试只有 **178s**;`setup` 831s / `import` 199s / `environment` 156s 都是**按测试文件重复支付**的固定开销 —— 因为 `isolate: true` 会为每个文件重新执行整张模块图。559 个测试文件里约 305 个走 `dom` project,而 `vitest.setup.dom.tsx` 会 side-effect 导入 `@object-ui/components` / `fields` / `plugin-dashboard` / `plugin-grid` 并重注册 9 个 widget,平均每个文件白付 ~2.7s。

`isolate` 必须保持开启 —— `vitest.config.mts` 里已经记录过关掉它导致上千个顺序依赖失败的历史。

## 做法

不动 isolation,把 559 个文件切到 4 个 runner 上:

- **`test`**:4 片矩阵,仅 PR,跑 `pnpm test --shard=N/4`。这里每个 job 的固定开销只有 **~30s**(checkout + Node + 走热 pnpm store 的 install 只要 6s),所以 4 片是用 **~26% 的额外 runner 分钟换 ~3x 的 wall clock**。`fail-fast: false`,一片挂掉不掩盖其他片的失败。
- **`test-coverage`**:原先 push 才跑的 coverage 路径拆成独立的不分片 job。没有任何东西阻塞它,所以保持给 Codecov 一份完整报告,不必引入 blob report 合并的复杂度和风险。

Vitest 按测试文件路径的 hash 分片,`unit` / `dom` 文件会自然交错,分片自动均衡,无需手工配平。

## 验证

- `vitest run --shard` 确实生效且**守恒**:同时命中 `unit` 和 `dom` 两个 project 的过滤器下,`2 + 2 = 4` 文件、`9 + 14 = 23` 测试。⚠️ 注意 `vitest list` **忽略** `--shard`(每片都返回全部 559 个文件),不能用它来验证。
- 分片最大的风险是**静默漏跑**(测试没跑但 CI 依旧全绿),所以本 PR 自身的 CI 就是终极校验:**4 片的 Test Files 求和必须 == 559,Tests 求和必须 == 6843**。合并前会核对。
- 全仓没有任何 branch protection / `needs:` / `workflow_run` 引用旧的 `Test` check 名(main 未开启分支保护),改名安全。

## 不在本 PR 范围

那 831s 的 `setup` 本身还可以根治 —— 把 `vitest.setup.dom.tsx` 拆成轻/重两档,只让真正依赖全量 ComponentRegistry 的测试付重量档的代价。那是结构性改动(需要梳理哪些测试依赖注册副作用),本地开发同样受益,单独开专项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)