### PR TITLE
perf(test): default DOM tests to a light setup; isolate heavy registry setup

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -52,19 +52,66 @@ const domTsTests = [
   'packages/react/src/hooks/__tests__/useRecordSearch.test.ts',
 ];
 
+// Test files that render through the ComponentRegistry and therefore need the
+// heavy `vitest.setup.dom.tsx` (the four side-effect package imports + widget
+// re-registrations). They run in the `dom-heavy` project; every other DOM test
+// gets the trimmed `vitest.setup.dom-light.tsx` default.
+//
+// This list was derived empirically: run the whole `dom` project under the
+// light setup and every file here is one that failed (e.g. "page:card not
+// registered", or an element that never rendered). It is a small minority
+// (~20 of ~310 DOM files) — the other ~290 never touch the registry and used
+// to pay ~3.3s/file of setup for nothing.
+//
+// If a NEW test renders a schema / page:* / dashboard / grid widget and fails
+// with "<type> not registered", add it here. Misfiling is self-correcting, not
+// silent: a heavy test left out of this list lands in the light `dom` project
+// and fails loudly in CI (it can never be skipped), so coverage cannot be lost
+// — only a red build that points at the fix.
+const heavyDomTests = [
+  'packages/app-shell/src/console/ai/LiveCanvas.test.tsx',
+  'packages/app-shell/src/console/ai/__tests__/ConversationsSidebar.test.tsx',
+  'packages/app-shell/src/console/organizations/__tests__/CreateWorkspaceDialog.test.tsx',
+  'packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx',
+  'packages/app-shell/src/layout/__tests__/AiUsageIndicator.test.tsx',
+  'packages/app-shell/src/layout/__tests__/ChatDock.test.tsx',
+  'packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx',
+  'packages/app-shell/src/preview/__tests__/DraftPreviewBar.test.tsx',
+  'packages/app-shell/src/views/metadata-admin/AccessExplainPanel.test.tsx',
+  'packages/app-shell/src/views/metadata-admin/AssignedUsersSection.test.tsx',
+  'packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx',
+  'packages/app-shell/src/views/metadata-admin/previews/PagePreview.test.tsx',
+  'packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx',
+  'packages/components/src/__tests__/action-bar.test.tsx',
+  'packages/components/src/__tests__/page-card-i18n-title.test.tsx',
+  'packages/components/src/__tests__/page-header-actions.test.tsx',
+  'packages/components/src/__tests__/page-header-title.test.tsx',
+  'packages/plugin-calendar/src/registration.test.tsx',
+  'packages/plugin-dashboard/src/__tests__/DashboardRenderer.designMode.test.tsx',
+  'packages/plugin-kanban/src/registration.test.tsx',
+];
+
 export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
     testTimeout: 15000, // Increase default timeout for integration tests with MSW
     exclude: sharedExclude,
-    // Two root-level projects split by environment cost. The heavy DOM setup
-    // (vitest.setup.dom.tsx imports @object-ui/components / fields /
-    // plugin-dashboard / plugin-grid from source and re-registers widgets)
-    // used to run for EVERY file: with `isolate: true` that module graph
-    // re-executes per file, and a CI run spent ~20 min cumulative in setup
-    // for ~2 min of actual tests. Pure-logic *.test.ts files now run in the
-    // `unit` project: node env + vitest.setup.base.ts only.
+    // Three root-level projects split by environment cost.
+    //
+    // - `unit`: pure-logic *.test.ts in node env + vitest.setup.base.ts only.
+    // - `dom`: React tests in happy-dom with the LIGHT setup — jsdom polyfills,
+    //   jest-dom and RTL cleanup, but none of the @object-ui/components / fields
+    //   / plugin-dashboard / plugin-grid graphs.
+    // - `dom-heavy`: the ~20 `heavyDomTests` that render through the
+    //   ComponentRegistry, with the full `vitest.setup.dom.tsx`.
+    //
+    // Why the split: with `isolate: true` every setup import re-executes per
+    // file. The old single DOM setup pulled the four heavy package graphs into
+    // every one of ~300 DOM files (~3.3s/file of setup) even though ~290 never
+    // touch the registry — a CI run spent ~20 min cumulative in setup for ~3
+    // min of actual tests. Restricting that graph to the files that need it
+    // leaves the common case paying only the light setup.
     //
     // (The former `environmentMatchGlobs` split silently stopped working on
     // Vitest 4 — the option was removed — so every file was paying happy-dom
@@ -89,12 +136,24 @@ export default defineConfig({
         test: {
           name: 'dom',
           environment: 'happy-dom',
-          setupFiles: [path.resolve(__dirname, 'vitest.setup.dom.tsx')],
+          setupFiles: [path.resolve(__dirname, 'vitest.setup.dom-light.tsx')],
           include: [
             'packages/**/*.test.tsx',
             'examples/**/*.test.tsx',
             ...domTsTests,
           ],
+          // heavyDomTests render through the registry — they run in `dom-heavy`
+          // with the full setup, so keep them out of the light project.
+          exclude: [...sharedExclude, ...heavyDomTests],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'dom-heavy',
+          environment: 'happy-dom',
+          setupFiles: [path.resolve(__dirname, 'vitest.setup.dom.tsx')],
+          include: [...heavyDomTests],
         },
       },
       path.resolve(__dirname, './apps/console/vitest.config.ts'),

--- a/vitest.setup.dom-light.tsx
+++ b/vitest.setup.dom-light.tsx
@@ -1,0 +1,38 @@
+/**
+ * ObjectUI — light DOM test setup (default for the `dom` project)
+ *
+ * Just enough to render a React component with @testing-library: jsdom-ish
+ * polyfills (via vitest.setup.base), jest-dom matchers, and RTL auto-cleanup.
+ * It deliberately does NOT import @object-ui/components / fields /
+ * plugin-dashboard / plugin-grid or re-register any widgets.
+ *
+ * Under `isolate: true` every setup import re-executes per test file, and the
+ * old single DOM setup pulled those four package graphs into ~300 files that
+ * mostly never render through the ComponentRegistry — ~3.3s of pure setup per
+ * file. Tests that DO drive the registry (SchemaRenderer, or page / dashboard /
+ * grid widgets) run in the `dom-heavy` project instead, which keeps the full
+ * `vitest.setup.dom.tsx`. See `heavyDomTests` in vitest.config.mts.
+ *
+ * If a test renders a component that resolves other components by type and you
+ * see "<type> not registered" or an element that never appears, it belongs in
+ * `heavyDomTests`, not here.
+ */
+
+import './vitest.setup.base';
+import '@testing-library/jest-dom';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// RTL installs its auto-cleanup afterEach only on first import; with modules
+// cached across files in a worker, later files would accumulate DOM nodes.
+// Register cleanup here so every test file gets an unmount.
+afterEach(() => {
+  cleanup();
+});
+
+// jsdom/happy-dom do not implement Element.prototype.scrollIntoView; some
+// components call it inside effects. Polyfill as a no-op so component tests
+// don't throw inside React's commit phase.
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {};
+}

--- a/vitest.setup.dom.tsx
+++ b/vitest.setup.dom.tsx
@@ -1,14 +1,16 @@
 /**
- * ObjectUI — DOM test setup
+ * ObjectUI — heavy DOM test setup (the `dom-heavy` project + apps/console)
  *
- * Heavy setup for tests that render React components. Registers ObjectUI
+ * For tests that render through the ComponentRegistry. Registers ObjectUI
  * component widgets (text, email, password, textarea, image, html, avatar,
  * select, slider, grid) and pulls in @object-ui/components, @object-ui/fields,
  * @object-ui/plugin-dashboard, @object-ui/plugin-grid for their side-effect
  * registrations.
  *
- * Pure-logic unit tests should use `vitest.setup.base.ts` instead to avoid
- * paying this boot cost.
+ * This graph is expensive (~3.3s/file under `isolate: true`), so it is NOT the
+ * default. Most `dom` tests use the trimmed `vitest.setup.dom-light.tsx`; only
+ * the files listed in `heavyDomTests` (vitest.config.mts) run here. Pure-logic
+ * unit tests use `vitest.setup.base.ts`.
  */
 
 import './vitest.setup.base';


### PR DESCRIPTION
接 #2641 —— 那个 PR 把 Vitest 套件分片,但只是把成本**并行**掉了。本 PR 削减成本本身。

## 问题

一次 CI 跑的 Vitest summary 里,`setup` 是最大单项:累计 **990s**,而真正执行测试(`tests`)只有 205s。原因是 `vitest.setup.dom.tsx` 会 side-effect 导入 `@object-ui/components` / `fields` / `plugin-dashboard` / `plugin-grid` 并重注册 9 个 widget,而在 `isolate: true` 下这张模块图**对每个 DOM 测试文件都重新执行一遍**。实测每文件约 **3.3s 纯 setup**。

但把整个 `dom` 项目在精简 setup 下跑一遍后发现:~310 个 DOM 文件里只有 **~20 个**真的会通过 ComponentRegistry 渲染;其余 ~290 个白付了那 3.3s。

## 做法

按需求把 DOM 测试拆成两个 project:

- **`dom`(默认)**:新增轻量 `vitest.setup.dom-light.tsx` —— 只有 base polyfill + jest-dom + RTL cleanup,不碰那 4 个重包的模块图。
- **`dom-heavy`**:`heavyDomTests` 里那 ~20 个驱动注册表的文件,保留完整的 `vitest.setup.dom.tsx`(`apps/console` 也仍然用它)。

`heavyDomTests` 是**实测**出来的,不是猜的:清单里每个文件都是在轻量 setup 下**失败**的那些(例如 `page:card not registered`)。这份清单**自纠错** —— 漏掉的重文件会落到轻量 `dom` 项目里并在 CI 里响亮地失败,所以覆盖不会被静默丢掉,最坏只是一个红 CI + 指向修法的报错。

## 验证(守恒,同一 commit)

在 base commit(`6c539601`)上,用我的改动前后各跑一次全量 `pnpm test`:

| | 拆分前 | 拆分后 |
|---|---|---|
| Test Files | 566(565 pass + 1 skip) | 566(565 pass + 1 skip) |
| Tests | 6892(6868 pass + 24 skip) | 6892(6868 pass + 24 skip) |

**完全一致** —— 零测试丢失、零新增失败,行为保持不变。本地累计 `setup` 从 ~990s 降到 ~167s。

分片(#2641)不受影响:文件总数不变(566),4 片仍按文件路径 hash 均衡。本 PR 自身的 4 片 CI 求和(Test Files == 566、Tests == 6892)即终极校验,合并前会核对。

## 说明

- 只改测试基础设施(config + 两个 setup 文件),不碰任何产品代码或测试断言。
- `isolate` **保持开启**(`vitest.config.mts` 记录过关掉它导致的上千个顺序依赖失败)。
- 一个已知的良性噪声:`dom-heavy` 跑时 happy-dom 会打印一条对 `localhost:3000` 的 `fetch()` aborted 的未处理拒绝 —— 这是既有行为(测试全 pass),非本 PR 引入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)