### PR TITLE
feat(plugin-list): 列表工具栏增加手动刷新按钮 (#2634)

### DIFF
--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -344,6 +344,7 @@ const en = {
       },
     },
     showAll: 'Show all',
+    refresh: 'Refresh',
     pullToRefresh: 'Pull to refresh',
     refreshing: 'Refreshing…',
     share: 'Share',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -421,6 +421,7 @@ const zh = {
       },
     },
     showAll: '显示全部',
+    refresh: '刷新',
     pullToRefresh: '下拉刷新',
     refreshing: '刷新中…',
     share: '分享',

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -245,6 +245,7 @@ const LIST_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'list.hideFields': 'Hide fields',
   'list.showAll': 'Show all',
   'list.pullToRefresh': 'Pull to refresh',
+  'list.refresh': 'Refresh',
   'list.refreshing': 'Refreshing…',
   'list.dataLimitReached': 'Showing first {{limit}} records. More data may be available.',
   'list.addRecord': 'Add record',
@@ -390,10 +391,15 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   const toolbarFlags = React.useMemo(() => {
     const ua = schema.userActions;
     const addRecordEnabled = schema.addRecord?.enabled === true && ua?.addRecordForm !== false;
+    // `refresh` is spec-canonical (`userActions.refresh`, @objectstack/spec). The
+    // installed spec type may predate it, so read defensively before falling back to
+    // the legacy `showRefresh` flag. Visible by default (opt-out, like the others).
+    const uaRefresh = (ua as { refresh?: boolean } | undefined)?.refresh;
     return {
       showSearch: ua?.search !== undefined ? ua.search : schema.showSearch !== false,
       showSort: ua?.sort !== undefined ? ua.sort : schema.showSort !== false,
       showFilters: ua?.filter !== undefined ? ua.filter : schema.showFilters !== false,
+      showRefresh: uaRefresh !== undefined ? uaRefresh : schema.showRefresh !== false,
       showDensity: ua?.rowHeight !== undefined ? ua.rowHeight : schema.showDensity !== false,
       showHideFields: schema.showHideFields === true,
       showGroup: schema.showGroup !== false,
@@ -402,7 +408,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       showAddRecord: addRecordEnabled,
       addRecordPosition: (schema.addRecord?.position === 'bottom' ? 'bottom' : 'top') as 'top' | 'bottom',
     };
-  }, [schema.userActions, schema.showSearch, schema.showSort, schema.showFilters, schema.showDensity, schema.showHideFields, schema.showGroup, schema.showColor, schema.compactToolbar, schema.addRecord, schema.userActions?.addRecordForm]);
+  }, [schema.userActions, schema.showSearch, schema.showSort, schema.showFilters, schema.showRefresh, schema.showDensity, schema.showHideFields, schema.showGroup, schema.showColor, schema.compactToolbar, schema.addRecord, schema.userActions?.addRecordForm]);
 
   const [currentView, setCurrentView] = React.useState<ViewType>(
     (schema.viewType as ViewType)
@@ -2145,6 +2151,25 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           {/* --- Separator: Appearance | Export --- */}
           {(toolbarFlags.showColor || toolbarFlags.showDensity || toolbarFlags.compactToolbar) && resolvedExportOptions && exportPermitted && (
             <div className="h-5 w-px bg-border/50 mx-1 shrink-0" />
+          )}
+
+          {/* Refresh — re-fetch the current view from the backend without a full page
+              reload. Filters / sort / pagination / search all live in component state,
+              so bumping refreshKey re-queries while preserving the view. Always visible
+              (mobile + desktop) since reloading data is a primary list action. */}
+          {toolbarFlags.showRefresh && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-muted-foreground hover:text-primary transition-colors duration-150"
+              onClick={() => setRefreshKey(k => k + 1)}
+              disabled={loading}
+              title={t('list.refresh')}
+              aria-label={t('list.refresh')}
+              data-testid="refresh-button"
+            >
+              <RotateCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
+            </Button>
           )}
 
           {/* Export */}

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -392,14 +392,14 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     const ua = schema.userActions;
     const addRecordEnabled = schema.addRecord?.enabled === true && ua?.addRecordForm !== false;
     // `refresh` is spec-canonical (`userActions.refresh`, @objectstack/spec). The
-    // installed spec type may predate it, so read defensively before falling back to
-    // the legacy `showRefresh` flag. Visible by default (opt-out, like the others).
+    // installed spec type may predate the field, so read it defensively. Visible by
+    // default (opt-out via `userActions.refresh: false`), like the other toggles.
     const uaRefresh = (ua as { refresh?: boolean } | undefined)?.refresh;
     return {
       showSearch: ua?.search !== undefined ? ua.search : schema.showSearch !== false,
       showSort: ua?.sort !== undefined ? ua.sort : schema.showSort !== false,
       showFilters: ua?.filter !== undefined ? ua.filter : schema.showFilters !== false,
-      showRefresh: uaRefresh !== undefined ? uaRefresh : schema.showRefresh !== false,
+      showRefresh: uaRefresh !== undefined ? uaRefresh : true,
       showDensity: ua?.rowHeight !== undefined ? ua.rowHeight : schema.showDensity !== false,
       showHideFields: schema.showHideFields === true,
       showGroup: schema.showGroup !== false,
@@ -408,7 +408,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       showAddRecord: addRecordEnabled,
       addRecordPosition: (schema.addRecord?.position === 'bottom' ? 'bottom' : 'top') as 'top' | 'bottom',
     };
-  }, [schema.userActions, schema.showSearch, schema.showSort, schema.showFilters, schema.showRefresh, schema.showDensity, schema.showHideFields, schema.showGroup, schema.showColor, schema.compactToolbar, schema.addRecord, schema.userActions?.addRecordForm]);
+  }, [schema.userActions, schema.showSearch, schema.showSort, schema.showFilters, schema.showDensity, schema.showHideFields, schema.showGroup, schema.showColor, schema.compactToolbar, schema.addRecord, schema.userActions?.addRecordForm]);
 
   const [currentView, setCurrentView] = React.useState<ViewType>(
     (schema.viewType as ViewType)

--- a/packages/plugin-list/src/__tests__/ListView.refreshButton.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.refreshButton.test.tsx
@@ -12,8 +12,8 @@
  * Clicking it re-queries the DataSource while the filter/sort/search state
  * (held in component state) is preserved.
  *
- * The toggle is spec-canonical (`userActions.refresh`, @objectstack/spec) with
- * a legacy `showRefresh` fallback; both default to visible (opt-out).
+ * The toggle is spec-canonical (`userActions.refresh`, @objectstack/spec) and
+ * defaults to visible (opt-out via `userActions.refresh: false`).
  */
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { render, waitFor, screen, fireEvent } from '@testing-library/react';
@@ -81,14 +81,6 @@ describe('ListView — manual refresh button (#2634)', () => {
   it('hides the refresh button when userActions.refresh is false', async () => {
     const ds = makeDataSource();
     renderList({ userActions: { refresh: false } as any }, ds);
-
-    await waitFor(() => expect(ds.find).toHaveBeenCalled());
-    expect(screen.queryByTestId('refresh-button')).not.toBeInTheDocument();
-  });
-
-  it('hides the refresh button when the legacy showRefresh flag is false', async () => {
-    const ds = makeDataSource();
-    renderList({ showRefresh: false } as any, ds);
 
     await waitFor(() => expect(ds.find).toHaveBeenCalled());
     expect(screen.queryByTestId('refresh-button')).not.toBeInTheDocument();

--- a/packages/plugin-list/src/__tests__/ListView.refreshButton.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.refreshButton.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * #2634 — the ListView toolbar must expose a manual "Refresh" button that
+ * re-fetches the current view from the backend without a full page reload.
+ * Clicking it re-queries the DataSource while the filter/sort/search state
+ * (held in component state) is preserved.
+ *
+ * The toggle is spec-canonical (`userActions.refresh`, @objectstack/spec) with
+ * a legacy `showRefresh` fallback; both default to visible (opt-out).
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ListView } from '../ListView';
+import type { ListViewSchema } from '@object-ui/types';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: (() => {
+      let store: Record<string, string> = {};
+      return {
+        getItem: (k: string) => store[k] ?? null,
+        setItem: (k: string, v: string) => { store[k] = v; },
+        clear: () => { store = {}; },
+        removeItem: (k: string) => { delete store[k]; },
+      };
+    })(),
+    configurable: true,
+  });
+});
+
+function makeDataSource() {
+  const find = vi.fn().mockResolvedValue({ data: [], total: 0 });
+  return {
+    find,
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  } as any;
+}
+
+function renderList(schema: Partial<ListViewSchema>, ds: any) {
+  return render(
+    <SchemaRendererProvider dataSource={ds}>
+      <ListView
+        schema={{ type: 'list-view', objectName: 'proj', fields: ['name'], ...schema } as any}
+        dataSource={ds}
+      />
+    </SchemaRendererProvider>,
+  );
+}
+
+describe('ListView — manual refresh button (#2634)', () => {
+  it('renders a refresh button by default and re-fetches on click', async () => {
+    const ds = makeDataSource();
+    renderList({}, ds);
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    const callsBefore = ds.find.mock.calls.length;
+
+    const btn = screen.getByTestId('refresh-button');
+    expect(btn).toBeInTheDocument();
+
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(ds.find.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+
+  it('hides the refresh button when userActions.refresh is false', async () => {
+    const ds = makeDataSource();
+    renderList({ userActions: { refresh: false } as any }, ds);
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(screen.queryByTestId('refresh-button')).not.toBeInTheDocument();
+  });
+
+  it('hides the refresh button when the legacy showRefresh flag is false', async () => {
+    const ds = makeDataSource();
+    renderList({ showRefresh: false } as any, ds);
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(screen.queryByTestId('refresh-button')).not.toBeInTheDocument();
+  });
+});

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -350,7 +350,6 @@ export const ListViewSchema = BaseSchema
     showSearch: z.boolean().optional().describe('Show search in toolbar'),
     showSort: z.boolean().optional().describe('Show sort controls in toolbar'),
     showFilters: z.boolean().optional().describe('Show filter controls in toolbar'),
-    showRefresh: z.boolean().optional().describe('Show refresh button in toolbar'),
     showHideFields: z.boolean().optional().describe('Show hide-fields button in toolbar'),
     showGroup: z.boolean().optional().describe('Show group button in toolbar'),
     showColor: z.boolean().optional().describe('Show color button in toolbar'),

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -350,6 +350,7 @@ export const ListViewSchema = BaseSchema
     showSearch: z.boolean().optional().describe('Show search in toolbar'),
     showSort: z.boolean().optional().describe('Show sort controls in toolbar'),
     showFilters: z.boolean().optional().describe('Show filter controls in toolbar'),
+    showRefresh: z.boolean().optional().describe('Show refresh button in toolbar'),
     showHideFields: z.boolean().optional().describe('Show hide-fields button in toolbar'),
     showGroup: z.boolean().optional().describe('Show group button in toolbar'),
     showColor: z.boolean().optional().describe('Show color button in toolbar'),


### PR DESCRIPTION
## 背景

修复 #2634。ObjectUI 渲染的列表(ListView)工具栏此前没有主动刷新入口 —— 后端数据变更后,用户只能靠浏览器整页 `reload`,导致筛选 / 排序 / 分页 / 滚动等页面状态全部丢失。

调研发现底层刷新能力其实大部分已具备:命令式 `refresh()`(ref)、`onMutation` 变更后自动刷新、移动端下拉刷新、`RefreshIndicator`。**唯一缺的是桌面端工具栏那颗手动刷新按钮**,本 PR 补齐它。

## 改动

- **`plugin-list/ListView.tsx`**:在工具栏(导出/分享/搜索一组的最前面)新增「刷新」图标按钮。点击 `setRefreshKey(k => k + 1)` 触发重新拉取当前视图数据;移动端与桌面端均常驻;加载时图标旋转(`animate-spin`)并 `disabled`。
- **`toolbarFlags`**:新增 `showRefresh`,**纯粹由 spec 规范的 `userActions.refresh`(`@objectstack/spec` ListView)驱动**(运行时防御读取,兼容尚未发版的 spec 类型),默认可见(opt-out,`userActions.refresh: false` 关闭),与 `search` / `sort` / `filter` / `density` 的读取方式一致。
- **i18n**:`list.refresh` 增加中英文案(`刷新` / `Refresh`)。
- **测试**:新增 `ListView.refreshButton.test.tsx`(默认渲染 + 点击重新 fetch + `userActions.refresh: false` 隐藏)。

> 注:初版曾加了一个本地 legacy `showRefresh` 标志,但 CI 的 `list-view-spec-parity` 漂移守卫要求"优先提升进 spec"。既然已在 spec 增加 `userActions.refresh`,遂删除该本地标志,改为纯协议驱动 —— 更贴合"后端协议驱动"的架构。

## 刷新时的视图状态

筛选 / 排序 / 分页 / 搜索均为组件内 state,刷新仅 bump `refreshKey` 重新 `find()`,因此这些状态自动保留。

## 协议侧配套

`userActions.refresh` 规范开关来自 `@objectstack/spec`,对应补充见 framework PR #3158。objectui 侧防御读取,**不依赖 spec 发版即可独立生效**;待 spec 发布并升级依赖后类型层面自然对齐。

## 验证

- `plugin-list` type-check ✅、`packages/types` type-check ✅
- 刷新按钮测试 3 项 ✅、`ListView.test.tsx` 126 项 ✅、漂移守卫 ✅、`i18n` parity 42 项 ✅、ESLint 0 error
- 真实 Chromium 浏览器渲染验证:刷新按钮出现在工具栏,`title`/`aria-label` = "Refresh",点击无异常

## 关联

- Closes #2634
- 下游:steedos-labs/os-project-titanwind-ehr#446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7Z2cbcb14wb99upTD6LNw