### PR TITLE
perf(test): run the `unit` project with isolate:false

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -126,6 +126,15 @@ export default defineConfig({
         test: {
           name: 'unit',
           environment: 'node',
+          // The unit project is node-env pure logic with no ComponentRegistry
+          // or DOM state to leak across files, so it can share a module graph
+          // per worker instead of re-executing it per file. Measured 3.2x
+          // faster (38s -> 12s for the project) with zero failures, holding
+          // green across repeated and shuffled runs. The `dom`/`dom-heavy`
+          // projects keep `isolate: true` — they DO leak (registry overrides,
+          // happy-dom nodes); relaxing them needs the hermeticity fixes tracked
+          // separately.
+          isolate: false,
           setupFiles: [path.resolve(__dirname, 'vitest.setup.base.ts')],
           include: ['packages/**/*.test.ts', 'examples/**/*.test.ts'],
           exclude: [...sharedExclude, ...domTsTests],


### PR DESCRIPTION
接 #2644。这是从 isolate 基准里跑出来的、**零风险可立即落地**的那一刀。

## 背景

`isolate: true` 下每个测试文件都在全新的模块注册表里重新求值自己的模块图。`dom` 系项目**必须**这样(它们会跨文件泄漏 ComponentRegistry 覆盖和 happy-dom 节点),但 `unit` 项目是 **node-env 纯逻辑**,没有这类共享可变状态。

只对 `unit` 放开隔离,worker 就能在其文件间共享一张模块图。

## 收益(实测,10 核本机)

| unit 项目单跑 | isolate:true | isolate:false |
|---|---|---|
| Duration | 38s | **12s(3.2×)** |
| import 累计 | 233s | **31s** |

这是本地 `vitest run --project unit` / watch 逻辑 TDD 的实打实提速。**全套件/CI wall 几乎不动**(108 vs 124,`dom` 项目封顶且并行跑)—— 所以这是**开发体验的赢,不是 CI 的赢**;CI 的赢要靠单独跟踪的 DOM hermetic 化专项。

## 验证(重点:证明是真 hermetic,不是碰巧顺序对)

`isolate:false` 最大的风险是「跑一次绿、之后偶发 flake」。所以没只跑一次:

- **plain + 3 个随机 seed**(`--sequence.shuffle`,seed 1 / 42 / 98765)——241 文件 / 3215 测试**每次全绿**,乱序下零失败。
- 全套件不变:566 文件 / 6894 测试(6870 pass + 24 skip)。
- CI 本身会在 4 个分片里以不同切分再跑一遍,等于额外的顺序扰动。

`dom` / `dom-heavy` 保持 `isolate: true` 不动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)