### PR TITLE
fix(access): Studio permission matrix — Bulk column reachable at narrow widths (#2600 B3)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -950,7 +950,10 @@ function PermissionTable({
   onOpenOwd,
 }: PermissionTableProps) {
   return (
-    <table className="w-full text-sm">
+    // objectui#2600 B3 — the fixed columns (object + 9 CRUD + bulk) need ~960px;
+    // a min-width makes the enclosing overflow-auto container scroll instead of
+    // squishing the CRUD grid and clipping the Bulk column off the right edge.
+    <table className="w-full min-w-[960px] text-sm">
       <thead className="sticky top-0 bg-background border-b z-10">
         <tr>
           <th className="text-left px-4 py-2 font-medium w-72">{t('perm.col.object')}</th>


### PR DESCRIPTION
## What

**Issue #2600 · B3 (设计迭代 · 窄宽 ≈800px 布局)** — at ~800px the matrix table (`w-full`, no min-width) squished the CRUD grid and pushed the rightmost **批量 column** (读/增改删/全选/清空) off the right edge with **no scroll affordance**: the container is `overflow-auto`, but the table never grew past the viewport, so there was nothing to scroll to.

### Change
- Give the matrix table `min-w-[960px]` (object 288 + 9×56 CRUD + 176 bulk) so it keeps natural column widths and the enclosing `overflow-auto` container **scrolls horizontally** instead — a real scrollbar appears and the 批量 column becomes reachable. Wide-viewport layout is unchanged (min-width < available width).

### Scope note
The other B3 sub-items were assessed and deliberately left:
- **Header crowding** — B1 already collapsed the identity strip, so at 820px the breadcrumb now *truncates gracefully* rather than overlapping the 安全/可写 badges; no shared-PageShell change needed.
- **Rail 208px** — the fixed rail is a shared Studio component with a mobile drawer; not worth the blast radius for a narrow-desktop nicety.

## Verify (live, 820px)
- Table is **960px inside a 612px scroll container** (`canScrollX: true`).
- Scrolling right brings the full 批量 column (读/增改删/全选/清空 per row) into view — previously permanently clipped.

## Tests
CSS-class-only change; matrix + Studio guard suites still green (**38 tests**). No layout-assertion test added (brittle, low value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)