### PR TITLE
fix(form+detail): single-file children stay inline grids; drop non-spec `attachment` (#2654, #2655)

### DIFF
--- a/.changeset/inline-grid-file-mode-and-attachment-cleanup.md
+++ b/.changeset/inline-grid-file-mode-and-attachment-cleanup.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/plugin-form": minor
+"@object-ui/plugin-detail": patch
+---
+
+fix(form+detail): keep single-file children as inline grids; drop non-spec `attachment` handling
+
+Two follow-ups to the upload-in-grid work (objectui#2360):
+
+- **#2654** — Now that `file`/`image`/`avatar` fields render a compact upload
+  cell in the line-item grid, a child object with a *single* such field no
+  longer flips the smart `inlineEdit` default to a per-row form. `resolveInlineMode`
+  splits the old `FORM_ONLY_TYPES`: truly form-only types (textarea / richtext /
+  html / markdown / json / location / address) still tip to `form` on their own,
+  while file-family types only tip when several rich fields pile up
+  (`RICH_FIELD_FORM_THRESHOLD`, default 2). An explicit `inlineEdit` always wins.
+
+- **#2655** — `attachment` is not a `@objectstack/spec` field type (the spec
+  media types are file/image/avatar/video/audio), so the renderer no longer
+  models it: removed from `fieldTypeToColumnType`, the inline-mode heuristic, and
+  `RelatedList`'s auto-column `SKIP_TYPES`. Contract-first cleanup — the renderer
+  stops fossilizing a phantom type (AGENTS.md #0.1).

--- a/content/docs/fields/grid.mdx
+++ b/content/docs/fields/grid.mdx
@@ -79,6 +79,13 @@ When grid columns are auto-derived from a child object's schema (master-detail
 subforms), `file` / `image` / `avatar` fields map to `file` columns
 automatically — image-flavoured fields default to `accept: ['image/*']`.
 
+Because file/image/avatar now render in-grid, a child object with a *single*
+such field keeps the inline **grid** form factor by default (the smart
+`inlineEdit` heuristic no longer forces a per-row form for one attachment
+column). Only a truly form-only field (textarea / rich text / JSON / location)
+or **several** rich fields tips the default to the per-row form; an explicit
+`inlineEdit: 'grid' | 'form'` always wins.
+
 ## Data Format
 
 Grid data is stored as an array of objects:

--- a/e2e/live/grid-file-upload.spec.ts
+++ b/e2e/live/grid-file-upload.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Tier 0 live e2e: a `file` field on a master-detail child renders a real
+ * UPLOAD control inside the inline line-item grid — not a degraded text input —
+ * and the uploaded file persists on the line in the atomic /api/v1/batch
+ * (objectui#2360). `showcase_invoice_line.receipt` is a `Field.file()`, so every
+ * standard Invoice form's "Line Items" grid gets a per-row Receipt upload cell,
+ * auto-derived from the data model (no columns config).
+ *
+ * This codifies the manual dogfood pass that shipped #2360:
+ *   • the Receipt column auto-derives into the grid (file fields are no longer
+ *     dropped from auto-columns);
+ *   • the cell is a genuine `input[type=file]` upload control (compact button +
+ *     removable chip), never a text `<Input>`;
+ *   • picking a file uploads it through the console's UploadProvider adapter and
+ *     shows a chip with the file name;
+ *   • submit carries the resolved file object ({ name, url, … }) on the line.
+ *
+ * Live-only (needs the storage service + a real backend); runs under
+ * `pnpm test:e2e:live`, not the mocked PR e2e job.
+ */
+
+// A 1×1 PNG — smallest valid image payload for the upload round-trip.
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+test('inline line-item grid uploads a per-row file and persists it in the batch', async ({ page }) => {
+  const batches: any[] = [];
+  page.on('request', (r) => {
+    if (r.method() === 'POST' && r.url().includes('/api/v1/batch')) {
+      try { batches.push(r.postDataJSON()); } catch { /* ignore */ }
+    }
+  });
+
+  await page.goto('/apps/showcase_app/showcase_invoice');
+  await page.getByRole('button', { name: /^New$/i }).first().click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByTestId('md-form-submit')).toBeVisible();
+  await expect(dialog.getByText('Line Items', { exact: false })).toBeVisible();
+
+  const li = dialog.getByTestId('line-items');
+  // The child schema loads async — wait for real headers, then assert Receipt.
+  await li.locator('th', { hasText: 'Product' }).first().waitFor();
+  await expect(li.locator('th', { hasText: 'Receipt' })).toHaveCount(1);
+
+  // The Receipt cell is a genuine upload control, NOT a text input (#2360 core).
+  const fileInput = li.locator('input[type="file"]').first();
+  await expect(fileInput).toHaveCount(1);
+  await expect(li.locator('input[type="text"][aria-label="Receipt"]')).toHaveCount(0);
+
+  // Materialise the ghost row via a product pick (auto-fills description/price),
+  // then give the line a quantity so it's a valid billable line.
+  await li.getByTestId('lookup-trigger').first().click();
+  const option = page.getByRole('option', { name: /Widget A/i }).first();
+  await option.waitFor({ state: 'visible' });
+  await option.click();
+  await li.locator('input[aria-label="Qty"]').first().fill('1');
+
+  // Upload into the row's Receipt cell → a removable chip with the file name.
+  await fileInput.setInputFiles({ name: 'receipt.png', mimeType: 'image/png', buffer: PNG });
+  await expect(li.getByTestId('file-cell-chip').first()).toContainText('receipt.png');
+
+  // Header fields, then submit and capture the atomic batch.
+  const name = `INV-${Date.now()}`;
+  await dialog.locator('input[name="name"]').fill(name);
+  await dialog.getByTestId('lookup-trigger-account').first().click();
+  const acct = page.getByRole('option').first();
+  await acct.waitFor({ state: 'visible' });
+  await acct.click();
+  await dialog.getByTestId('select-trigger-status').first().click();
+  await page.getByTestId('select-option-draft').first().click();
+
+  await Promise.all([
+    page.waitForRequest((r) => r.url().includes('/api/v1/batch'), { timeout: 15_000 }).catch(() => null),
+    dialog.getByTestId('md-form-submit').click(),
+  ]);
+  await page.waitForTimeout(500);
+
+  expect(batches.length).toBeGreaterThan(0);
+  const ops = batches[0].operations;
+  const child = ops.find((o: any) => o.object === 'showcase_invoice_line');
+  expect(child).toBeTruthy();
+  // The uploaded file resolved to a stored object, not a blob/text placeholder.
+  const receipt = child?.data?.receipt;
+  expect(receipt).toBeTruthy();
+  expect(receipt.name || receipt.original_name).toContain('receipt');
+  expect(String(receipt.url)).toMatch(/^https?:\/\//);
+});

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -621,8 +621,9 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     // file/image are NOT skipped: they have dedicated cell renderers (name
     // chip / thumbnail), and dropping them hid business columns like a line's
     // receipt attachment (objectui#2360). Only types with no useful tabular
-    // rendering stay excluded.
-    const SKIP_TYPES = new Set(['attachment', 'rich_text', 'html', 'json']);
+    // rendering stay excluded. (`attachment` is intentionally absent — it is not
+    // a `@objectstack/spec` field type, so the renderer does not model it, #2655.)
+    const SKIP_TYPES = new Set(['rich_text', 'html', 'json']);
     const PRIORITY_NAMES = [
       'name',
       'full_name',

--- a/packages/plugin-form/src/deriveMasterDetail.test.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.test.ts
@@ -26,6 +26,19 @@ describe('fieldTypeToColumnType', () => {
     expect(fieldTypeToColumnType('master_detail')).toBe('lookup');
     expect(fieldTypeToColumnType('email')).toBe('text');
   });
+
+  it('maps the spec file-family media types to a file column', () => {
+    expect(fieldTypeToColumnType('file')).toBe('file');
+    expect(fieldTypeToColumnType('image')).toBe('file');
+    expect(fieldTypeToColumnType('avatar')).toBe('file');
+  });
+
+  // #2655: `attachment` is not a `@objectstack/spec` field type (media types are
+  // file/image/avatar/video/audio), so the renderer does not model it — it falls
+  // through to the plain-text default rather than being special-cased to file.
+  it('does not special-case the non-spec `attachment` type', () => {
+    expect(fieldTypeToColumnType('attachment')).toBe('text');
+  });
 });
 
 describe('findRelationshipField', () => {
@@ -316,6 +329,25 @@ describe('resolveInlineMode (grid vs form)', () => {
 
   it('smart default: many business fields → form', () => {
     expect(resolveInlineMode(wide, true, { relationshipField: 'parent' })).toBe('form'); // 9 fields > 8
+  });
+
+  // #2654: file-family fields render a compact upload cell in the grid now, so a
+  // LONE one no longer forces the per-row form ("attach a receipt per line").
+  it('smart default: a single file/image field stays a grid', () => {
+    const oneFile = { fields: { name: { type: 'text' }, receipt: { type: 'file' }, parent: { type: 'master_detail', reference: 'p' } } };
+    const oneImage = { fields: { name: { type: 'text' }, photo: { type: 'image' }, parent: { type: 'master_detail', reference: 'p' } } };
+    expect(resolveInlineMode(oneFile, true, { relationshipField: 'parent' })).toBe('grid');
+    expect(resolveInlineMode(oneImage, true, { relationshipField: 'parent' })).toBe('grid');
+  });
+
+  it('smart default: several rich file fields (≥2) tip to form', () => {
+    const twoFiles = { fields: { receipt: { type: 'file' }, photo: { type: 'image' }, parent: { type: 'master_detail', reference: 'p' } } };
+    expect(resolveInlineMode(twoFiles, true, { relationshipField: 'parent' })).toBe('form');
+  });
+
+  it('smart default: a file field alongside a truly form-only field → form', () => {
+    const mixed = { fields: { receipt: { type: 'file' }, notes: { type: 'textarea' }, parent: { type: 'master_detail', reference: 'p' } } };
+    expect(resolveInlineMode(mixed, true, { relationshipField: 'parent' })).toBe('form');
   });
 });
 

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -68,7 +68,6 @@ export function fieldTypeToColumnType(type: string | undefined): GridColumn['typ
     case 'file':
     case 'image':
     case 'avatar':
-    case 'attachment':
       return 'file';
     default:
       return 'text';
@@ -310,22 +309,36 @@ export function deriveFormFields(
 /** Inline-edit form factor. */
 export type InlineMode = 'grid' | 'form';
 
-/** Rich / form-only field types that read poorly in a narrow grid cell — their
- *  presence on a child tips the smart default toward the per-row `form`. */
+/** Field types that read poorly in ANY grid cell — a SINGLE one on the child
+ *  tips the smart default toward the per-row `form`. (`attachment` is absent by
+ *  design: it is not a `@objectstack/spec` field type — the spec media types are
+ *  file/image/avatar/video/audio — so the renderer does not model it, #2655.) */
 const FORM_ONLY_TYPES = new Set([
   'textarea', 'richtext', 'html', 'markdown', 'rich-text',
-  'file', 'image', 'avatar', 'attachment', 'json', 'location', 'address',
+  'json', 'location', 'address',
 ]);
+
+/** File-family types that now render a compact upload cell in the grid (#2360).
+ *  A LONE one no longer forces a per-row form — "attach a receipt per line"
+ *  stays a grid. They still count toward the rich-field tally, so several piling
+ *  up (a cramped row) tips to `form` via {@link RICH_FIELD_FORM_THRESHOLD}. */
+const GRID_CAPABLE_RICH_TYPES = new Set(['file', 'image', 'avatar']);
 
 /** Above this many editable business fields, the grid gets cramped → `form`. */
 export const SMART_FORM_FIELD_THRESHOLD = 8;
+
+/** When a child has at least this many rich fields (form-only + grid-capable
+ *  file-family combined), the row is too busy for a grid → `form`. Set to 2 so a
+ *  single file/image column stays a grid but a pile of them prefers the form. */
+export const RICH_FIELD_FORM_THRESHOLD = 2;
 
 /**
  * Resolve the inline-edit form factor for a child collection.
  *   - explicit `'grid'` / `'form'` win;
  *   - otherwise (`true` / undefined) pick by the child's shape: a `form` when it
- *     has rich/form-only fields or more than {@link SMART_FORM_FIELD_THRESHOLD}
- *     editable business fields, else a `grid`.
+ *     has a truly form-only field, several rich fields
+ *     ({@link RICH_FIELD_FORM_THRESHOLD}), or more than
+ *     {@link SMART_FORM_FIELD_THRESHOLD} editable business fields; else a `grid`.
  */
 export function resolveInlineMode(
   childSchema: ObjectSchemaLike | undefined,
@@ -335,8 +348,13 @@ export function resolveInlineMode(
   if (inlineEdit === 'grid' || inlineEdit === 'form') return inlineEdit;
   const fields = (childSchema?.fields ?? {}) as Record<string, any>;
   const names = deriveFormFields(childSchema, { relationshipField: opts.relationshipField });
-  const hasRich = names.some((n) => FORM_ONLY_TYPES.has(fields[n]?.type));
-  if (hasRich) return 'form';
+  // A single truly-form-only field (textarea/richtext/json/…) tips to form.
+  const hasFormOnly = names.some((n) => FORM_ONLY_TYPES.has(fields[n]?.type));
+  if (hasFormOnly) return 'form';
+  // File-family fields render in-grid now, so a lone one stays a grid; only a
+  // cluster of rich fields (≥ RICH_FIELD_FORM_THRESHOLD) tips to form (#2654).
+  const richCount = names.filter((n) => GRID_CAPABLE_RICH_TYPES.has(fields[n]?.type)).length;
+  if (richCount >= RICH_FIELD_FORM_THRESHOLD) return 'form';
   if (names.length > SMART_FORM_FIELD_THRESHOLD) return 'form';
   return 'grid';
 }


### PR DESCRIPTION
Two follow-ups to the upload-in-grid work (#2360 / #2585), plus a codified live-verification spec for the underlying feature.

## #2654 — a single file field no longer forces a per-row form

Now that `file`/`image`/`avatar` fields render a compact upload cell in the line-item grid, the smart `inlineEdit` heuristic shouldn't push a child with one attachment column into the per-row form.

`resolveInlineMode` splits the old catch-all `FORM_ONLY_TYPES` into two tiers:

- **`FORM_ONLY_TYPES`** (textarea, richtext, html, markdown, rich-text, json, location, address) — a *single* one still tips to `form` (these genuinely read poorly in a grid cell).
- **`GRID_CAPABLE_RICH_TYPES`** (file, image, avatar) — render in-grid now, so a *lone* one stays a `grid`; they only tip to `form` when several rich fields pile up (`RICH_FIELD_FORM_THRESHOLD`, default 2 → a cramped row).

An explicit `inlineEdit: 'grid' | 'form'` still wins over the heuristic. Net effect: "attach a receipt per expense line" now defaults to the inline grid instead of the form.

## #2655 — `attachment` is not a spec field type → renderer stops modelling it

Confirmed against `@objectstack/spec`: the media field types are `file` / `image` / `avatar` / `video` / `audio` — there is **no `attachment` type** (it appears only in a display-name hint list). No framework example declares `type: 'attachment'`.

Per contract-first (AGENTS.md #0.1 — don't fossilize a non-spec dialect in the renderer), removed the stray `attachment` handling from the three renderer-side spots this issue named:

- `fieldTypeToColumnType` — dropped the `case 'attachment'` (was mapping it to a `file` column).
- `resolveInlineMode`'s type set — removed `attachment`.
- `RelatedList` auto-column `SKIP_TYPES` — removed `attachment`.

Out of scope (other subsystems, left untouched): `DataModelDesigner`, `view-config-utils`, `InterfaceListPage` also mention `attachment` but aren't part of these issues.

## live e2e — codifies the #2360 dogfood pass

Adds `e2e/live/grid-file-upload.spec.ts` next to the sibling `showcase_invoice` live specs: the Receipt file field auto-derives a grid column, the cell is a real `input[type=file]` upload control (not a text input), uploading shows a chip, and the resolved file object persists on the line in the atomic `/api/v1/batch`. **Live-only** (needs the storage service + a real backend) — runs under `pnpm test:e2e:live`, not the mocked PR e2e job, matching how the existing live specs are gated. This turns the one-off manual verification into a repeatable, reviewed regression procedure.

## Tests

- `deriveMasterDetail.test.ts`: single file/image child → grid; two file fields → form; file + textarea → form; `fieldTypeToColumnType('attachment') === 'text'` (no special-casing) + explicit file-family mapping coverage.
- Full `@object-ui/plugin-form` + `@object-ui/plugin-detail` suites pass (46 files / 437 tests). `turbo type-check` green; touched files carry no new lint errors. New live spec typechecks and is picked up by `playwright.live.config.ts`.

Docs updated (`content/docs/fields/grid.mdx`) and a changeset added (plugin-form minor, plugin-detail patch).

Closes #2654
Closes #2655

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5tsBSEhsDZmdcHBvfymYC