### PR TITLE
chore(metadata-admin): stop surfacing metadata fields the spec dropped (framework#2377)

### DIFF
--- a/.changeset/drop-orphaned-dead-metadata-display.md
+++ b/.changeset/drop-orphaned-dead-metadata-display.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/app-shell": patch
+---
+
+chore(metadata-admin): stop surfacing metadata fields the spec dropped (framework#2377)
+
+`@objectstack/spec` removes a batch of dead, unenforced author-facing metadata
+properties (ADR-0049 enforce-or-remove, framework PR #3176). Two of them were
+still *displayed* — never enforced, but shown — in the Studio metadata-admin,
+which is the same false affordance on the UI side. Both were read defensively
+off raw documents, so this is a display-only cleanup with no runtime impact:
+
+- **`dataset` measure `certified`** — `useDatasetCatalog` populated a
+  `DatasetMeasureInfo.certified` flag (and `DatasetDefaultInspector` carried it
+  in its local `Measure` type) that nothing ever rendered. Dropped both; the
+  measure picker/inspector is unchanged otherwise.
+- **`agent.planning.strategy` / `allowReplan`** — `AgentPreview`'s Planning rail
+  listed both alongside the one live knob. Narrowed the `KeyVals` keys to
+  `['maxIterations']` (the only planning field the runtime reads).
+
+Test fixtures that set `certified` were updated. No public component API change.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.test.tsx
@@ -25,7 +25,7 @@ const draft = {
   object: 'opportunity',
   include: ['account'],
   dimensions: [{ name: 'region', field: 'account.region', type: 'string' }],
-  measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount', certified: true }],
+  measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
 };
 
 describe('DatasetDefaultInspector', () => {
@@ -51,7 +51,6 @@ describe('DatasetDefaultInspector', () => {
     const patch = onPatch.mock.calls[0][0];
     expect(patch.measures).toHaveLength(2);
     expect(patch.measures[1]).toMatchObject({ aggregate: 'sum' });
-    expect(patch.measures[1]).not.toHaveProperty('certified');
   });
 
   it('adds a dimension via onPatch', () => {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
@@ -108,7 +108,6 @@ type Measure = {
   label?: string;
   aggregate?: string;
   field?: string;
-  certified?: boolean;
   format?: string;
   currency?: string;
   derived?: DerivedSpec;

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.test.tsx
@@ -18,7 +18,7 @@ const catalog: DatasetCatalogEntry[] = [
       { name: 'close_quarter', type: 'date' },
     ],
     measures: [
-      { name: 'total_amount', aggregate: 'sum', certified: true },
+      { name: 'total_amount', aggregate: 'sum' },
       { name: 'deal_count', aggregate: 'count' },
     ],
   },

--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
@@ -173,7 +173,7 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
           <div className="border-l bg-muted/20 p-3 text-xs space-y-3">
             {planning && Object.keys(planning).length > 0 && (
               <RailBlock icon={BrainCircuit} title="Planning">
-                <KeyVals data={planning} keys={['strategy', 'maxIterations', 'allowReplan']} />
+                <KeyVals data={planning} keys={['maxIterations']} />
               </RailBlock>
             )}
             {memory && Object.keys(memory).length > 0 && (

--- a/packages/app-shell/src/views/metadata-admin/previews/useDatasetCatalog.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/useDatasetCatalog.ts
@@ -31,8 +31,6 @@ export interface DatasetMeasureInfo {
   name: string;
   /** Aggregate function (sum / avg / count / …) — display hint only. */
   aggregate?: string;
-  /** Whether the dataset author certified this measure. */
-  certified?: boolean;
 }
 
 export interface DatasetCatalogEntry {
@@ -77,7 +75,6 @@ export function toCatalogEntry(doc: Record<string, unknown>): DatasetCatalogEntr
         .map((m) => ({
           name: m.name as string,
           aggregate: typeof m.aggregate === 'string' ? (m.aggregate as string) : undefined,
-          certified: m.certified === true,
         }))
     : [];
   return { name, label: resolveLabel(doc.label, name), dimensions, measures };


### PR DESCRIPTION
Companion cleanup to framework PR **objectstack-ai/framework#3176** (ADR-0049 enforce-or-remove). That PR removes a batch of dead, unenforced author-facing metadata properties from `@objectstack/spec`. Two of them were still **displayed** (never enforced, just shown) in the Studio metadata-admin — the same false affordance on the UI side. Both were read defensively off raw documents (`Record<string, unknown>`, `=== true`, dynamic keys), so **removing the spec fields does not break objectui** — this PR just stops the UI from surfacing fields the spec no longer supports.

## Changes (all in `@object-ui/app-shell`, display-only)

- **`dataset` measure `certified`** — `useDatasetCatalog` populated a `DatasetMeasureInfo.certified` flag, and `DatasetDefaultInspector` carried `certified` in its local `Measure` type, but **nothing ever rendered it** (a `grep` across the repo finds it only in these type/population sites and test fixtures — no badge/consumer). Dropped the type field + its population.
- **`agent.planning.strategy` / `allowReplan`** — `AgentPreview`'s Planning rail listed both via `<KeyVals keys={['strategy','maxIterations','allowReplan']}>`. Narrowed to `['maxIterations']` — the only planning field the runtime actually reads (kept live in the spec).

Test fixtures that set `certified` were updated (`DatasetDefaultInspector.test.tsx`, `ReportDefaultInspector.test.tsx`). No public component API change.

## Verification
- metadata-admin suite green: **799 tests / 98 files passed** (`vitest run metadata-admin`), including the two edited inspector tests.
- The remaining `tsc` errors in this package are pre-existing build-order noise (unbuilt `@object-ui/*` sibling `.d.ts`, plus untouched implicit-`any`s in `StudioDesignSurface.tsx`) — none are in the files this PR touches.

## Coordination
Independent of the framework merge — safe to land before or after #3176 (objectui reads these fields defensively either way). Best merged around the same window so the spec and Studio stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011XchBKhKdjbhQZymt9Gn9B)_