### PR TITLE
chore(designer): drop the inert object "Enabled" toggle (framework#2377)

### DIFF
--- a/.changeset/drop-inert-object-enabled-toggle.md
+++ b/.changeset/drop-inert-object-enabled-toggle.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/plugin-designer": patch
+"@object-ui/types": patch
+---
+
+chore(designer): drop the inert object "Enabled" toggle (framework#2377)
+
+The object designer showed an **Enabled** column (`ObjectManager` grid) and an
+editable **Enabled** boolean (add/edit object form), backed solely by the object
+`active` metadata property. `active` had no runtime consumer and was removed from
+`@objectstack/spec` (framework#3199, ADR-0049 enforce-or-remove) — so the toggle
+never disabled anything. Toggling it "off" left the object fully queryable and
+usable: a false affordance.
+
+Removed the column, the form field, the `active`↔`enabled` mapping/write-back in
+`MetadataObjectsPage`, the `enabled?` field on the designer `ObjectDefinition`
+type, and the now-unused `appDesigner.objectManager.enabled` string. Non-breaking:
+the metadata write path registers objects via `ObjectSchema.parse()`, which already
+strips unknown keys, and `ObjectDefinition.enabled` was designer-only.
+
+`isSystem` is unchanged (it stays a live spec property).

--- a/apps/console/src/components/schema/objectDetailWidgets.tsx
+++ b/apps/console/src/components/schema/objectDetailWidgets.tsx
@@ -271,14 +271,6 @@ export function ObjectPropertiesWidget({ schema }: { schema: ObjectWidgetSchema 
         </h3>
         <dl className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <div className="space-y-1.5">
-            <dt className="text-xs font-medium text-muted-foreground">状态</dt>
-            <dd>
-              <Badge variant={object.enabled !== false ? 'default' : 'secondary'} className="font-normal">
-                {object.enabled !== false ? '已启用' : '已禁用'}
-              </Badge>
-            </dd>
-          </div>
-          <div className="space-y-1.5">
             <dt className="text-xs font-medium text-muted-foreground">字段数量</dt>
             <dd className="text-sm font-medium">
               {(object.fieldCount ?? fields.length)} 个字段

--- a/apps/console/src/services/MetadataService.ts
+++ b/apps/console/src/services/MetadataService.ts
@@ -78,7 +78,6 @@ function toObjectPayload(obj: ObjectDefinition, fields?: FieldMetadataPayload[])
     icon: obj.icon,
     group: obj.group,
     sortOrder: obj.sortOrder,
-    enabled: obj.enabled,
     fields,
     relationships: obj.relationships,
   };

--- a/apps/console/src/utils/metadataConverters.ts
+++ b/apps/console/src/utils/metadataConverters.ts
@@ -82,7 +82,6 @@ export function toObjectDefinition(obj: MetadataObject, index: number): ObjectDe
     group: obj.name?.startsWith('sys_') ? 'System Objects' : 'Custom Objects',
     sortOrder: index,
     isSystem: obj.name?.startsWith('sys_') || false,
-    enabled: obj.enabled !== false,
     fieldCount: fields.length,
     relationships: Array.isArray(obj.relationships)
       ? obj.relationships.map((r) => ({

--- a/packages/app-shell/src/services/MetadataService.ts
+++ b/packages/app-shell/src/services/MetadataService.ts
@@ -78,7 +78,6 @@ function toObjectPayload(obj: ObjectDefinition, fields?: FieldMetadataPayload[])
     icon: obj.icon,
     group: obj.group,
     sortOrder: obj.sortOrder,
-    enabled: obj.enabled,
     fields,
     relationships: obj.relationships,
   };

--- a/packages/app-shell/src/utils/metadataConverters.ts
+++ b/packages/app-shell/src/utils/metadataConverters.ts
@@ -84,7 +84,6 @@ export function toObjectDefinition(obj: MetadataObject, index: number): ObjectDe
     group: obj.name?.startsWith('sys_') ? 'System Objects' : 'Custom Objects',
     sortOrder: index,
     isSystem: obj.name?.startsWith('sys_') || false,
-    enabled: obj.enabled !== false,
     fieldCount: fields.length,
     relationships: Array.isArray(obj.relationships)
       ? obj.relationships.map((r) => ({

--- a/packages/plugin-designer/src/MetadataObjectsPage.tsx
+++ b/packages/plugin-designer/src/MetadataObjectsPage.tsx
@@ -47,7 +47,6 @@ interface ServerObjectSchema {
   icon?: string;
   group?: string;
   isSystem?: boolean;
-  active?: boolean;
   fields?: Record<string, unknown>;
   [key: string]: unknown;
 }
@@ -90,7 +89,6 @@ function toObjectDefinition(raw: ServerObjectSchema): ObjectDefinition {
     icon: raw.icon,
     group: raw.group,
     isSystem: raw.isSystem ?? false,
-    enabled: raw.active !== false,
     fieldCount,
   };
 }
@@ -195,7 +193,6 @@ export function MetadataObjectsPage({
         icon: updated.icon,
         group: updated.group,
         isSystem: updated.isSystem,
-        active: updated.enabled !== false,
       };
       // Don't issue redundant saves if nothing visible changed.
       if (
@@ -205,7 +202,6 @@ export function MetadataObjectsPage({
         && prev[updated.name].description === merged.description
         && prev[updated.name].icon === merged.icon
         && prev[updated.name].group === merged.group
-        && (prev[updated.name].active ?? true) === merged.active
       ) {
         continue;
       }

--- a/packages/plugin-designer/src/ObjectManager.tsx
+++ b/packages/plugin-designer/src/ObjectManager.tsx
@@ -108,7 +108,6 @@ export function ObjectManager({
     { field: 'label', label: t('appDesigner.objectManager.objectLabel'), width: 160 },
     { field: 'group', label: t('appDesigner.objectManager.group'), width: 130 },
     { field: 'fieldCount', label: 'Fields', width: 80 },
-    { field: 'enabled', label: t('appDesigner.objectManager.enabled'), width: 80 },
   ], [t]);
 
   const gridSchema = useMemo<ObjectGridSchema>(() => ({
@@ -165,7 +164,6 @@ export function ObjectManager({
         icon: data.icon ? String(data.icon) : undefined,
         group: data.group ? String(data.group) : undefined,
         sortOrder: typeof data.sortOrder === 'number' ? data.sortOrder : undefined,
-        enabled: data.enabled !== false,
       };
       onObjectsChange?.(objects.map((o) => (o.id === editingObject.id ? updated : o)));
     } else {
@@ -180,7 +178,6 @@ export function ObjectManager({
         group: data.group ? String(data.group) : undefined,
         sortOrder: typeof data.sortOrder === 'number' ? data.sortOrder : undefined,
         isSystem: false,
-        enabled: data.enabled !== false,
         fieldCount: 0,
       };
       onObjectsChange?.([...objects, newObj]);
@@ -216,7 +213,6 @@ export function ObjectManager({
       { name: 'icon', label: t('appDesigner.objectManager.icon'), type: 'select', options: ICON_OPTIONS.map((i) => ({ label: i, value: i })), disabled: readOnly },
       { name: 'group', label: t('appDesigner.objectManager.group'), type: 'select', options: OBJECT_GROUPS.map((g) => ({ label: g, value: g })), disabled: readOnly },
       { name: 'sortOrder', label: t('appDesigner.objectManager.sortOrder'), type: 'number', disabled: readOnly },
-      { name: 'enabled', label: t('appDesigner.objectManager.enabled'), type: 'boolean', disabled: readOnly },
     ],
     initialValues: editingObject
       ? {
@@ -227,9 +223,8 @@ export function ObjectManager({
           icon: editingObject.icon || '',
           group: editingObject.group || '',
           sortOrder: editingObject.sortOrder ?? 0,
-          enabled: editingObject.enabled !== false,
         }
-      : { enabled: true },
+      : {},
     onSuccess: handleFormSuccess,
     onCancel: () => handleFormClose(false),
     readOnly,

--- a/packages/plugin-designer/src/__tests__/ObjectManager.test.tsx
+++ b/packages/plugin-designer/src/__tests__/ObjectManager.test.tsx
@@ -26,7 +26,6 @@ const MOCK_OBJECTS: ObjectDefinition[] = [
     group: 'Custom Objects',
     sortOrder: 1,
     isSystem: false,
-    enabled: true,
     fieldCount: 12,
     relationships: [
       { relatedObject: 'contacts', type: 'one-to-many', label: 'Contacts' },
@@ -39,7 +38,6 @@ const MOCK_OBJECTS: ObjectDefinition[] = [
     group: 'Custom Objects',
     sortOrder: 2,
     isSystem: false,
-    enabled: true,
     fieldCount: 8,
   },
   {
@@ -48,7 +46,6 @@ const MOCK_OBJECTS: ObjectDefinition[] = [
     label: 'Users',
     group: 'System Objects',
     isSystem: true,
-    enabled: true,
     fieldCount: 5,
   },
 ];

--- a/packages/plugin-designer/src/hooks/useDesignerTranslation.ts
+++ b/packages/plugin-designer/src/hooks/useDesignerTranslation.ts
@@ -142,7 +142,6 @@ const DESIGNER_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'appDesigner.objectManager.group': 'Group',
   'appDesigner.objectManager.noGroup': 'No Group',
   'appDesigner.objectManager.sortOrder': 'Sort Order',
-  'appDesigner.objectManager.enabled': 'Enabled',
   'appDesigner.objectManager.relationships': 'Relationships',
   'appDesigner.objectManager.systemBadge': 'System',
   'appDesigner.objectManager.fieldCount': '{{count}} fields',

--- a/packages/types/src/designer.ts
+++ b/packages/types/src/designer.ts
@@ -656,8 +656,6 @@ export interface ObjectDefinition {
   sortOrder?: number;
   /** Whether this is a system object (non-deletable) */
   isSystem?: boolean;
-  /** Whether this object is enabled/active */
-  enabled?: boolean;
   /** Field count (read-only, for display) */
   fieldCount?: number;
   /** Relationships to other objects */


### PR DESCRIPTION
Companion to framework **#3199** (ADR-0049 enforce-or-remove). That PR removes the object `active` metadata property from `@objectstack/spec` — it had no runtime consumer. The object designer surfaced it as an **Enabled** control, so this removes that false affordance.

## What was removed
- **`ObjectManager`**: the **Enabled** grid column and the editable **Enabled** boolean in the add/edit-object form (+ its read/write/initialValues).
- **`MetadataObjectsPage`**: the `active` ↔ `enabled` mapping, the write-back of `active` on save, and the redundant-save comparison on it.
- **`@object-ui/types`**: the `ObjectDefinition.enabled?` field.
- **`app-shell`**: `MetadataService.toObjectPayload` no longer sends `enabled: obj.enabled`; `metadataConverters` no longer derives it. *(These two consumers were surfaced by CI — the initial scoping missed them; fixed in the second commit.)*
- The now-unused `appDesigner.objectManager.enabled` i18n string.

Toggling "Enabled" off never disabled anything (the object stayed fully queryable/usable) — the misleading-control class ADR-0049 targets.

## Explicitly NOT touched
- **`ObjectMetadataPayload.enabled`** (the payload type field) stays — it is the **independent soft-delete marker** (`enabled: false, _deleted: true` in `MetadataService`), unrelated to the object active/enabled toggle.
- `isSystem` — stays a live spec property.

## Why it's safe
- **Non-breaking**: the runtime registers objects via `ObjectSchema.parse()`, which strips unknown keys — a stale `active` in a payload is a no-op, not an error.

## Verification
- `@object-ui/types` `tsc --noEmit` clean; `plugin-designer` suite green (23 tests). The app-shell tsc regression from the missed consumers was caught by CI and fixed; re-running CI to confirm green.

## Coordination
Independent of the framework merge. Best landed around the same window as #3199 so the Studio and spec stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)