### PR TITLE
test(app-shell): de-flake ObjectDefaultInspector per-op toggle assertion

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectDefaultInspector.test.tsx
@@ -251,8 +251,9 @@ describe('ObjectDefaultInspector — access section (ADR-0066 D2/D3/④/⑤)', (
     // Installed @objectstack/spec (≥ 12.7) exports
     // ObjectRequiredPermissionsSchema, so the feature-detect reveals the mode
     // toggle (progressive enhancement — hidden only when the bundled spec
-    // would reject the map shape). Let the async detect settle first.
-    await new Promise((r) => setTimeout(r, 20));
-    expect(screen.queryByTestId('object-reqperms-perop')).not.toBeNull();
+    // would reject the map shape). The detect is async, so wait for the toggle
+    // to appear instead of racing a fixed timeout — a hardcoded 20ms sometimes
+    // fired before the detect settled under CI load, yielding a flaky null.
+    expect(await screen.findByTestId('object-reqperms-perop')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

De-flakes one test in `ObjectDefaultInspector.test.tsx` that intermittently fails the `Test (shard 2/4)` job on unrelated PRs.

## Root cause

The test *"shows the per-operation toggle when the bundled spec exports the ⑤ union"* waited a **hardcoded 20 ms** for an async spec feature-detect to settle, then asserted the toggle with `queryByTestId`:

```js
await new Promise((r) => setTimeout(r, 20));
expect(screen.queryByTestId('object-reqperms-perop')).not.toBeNull();
```

Under CI load the detect sometimes hadn't resolved within 20 ms, so `queryByTestId` returned `null` and the test failed with `expected null not to be null`. This surfaced as a spurious shard failure on an unrelated PR (#2646), which passed on a plain re-run — the signature of a timing flake.

## Fix

Replace the fixed timeout + `queryByTestId` with `findByTestId`, which retries until the toggle appears (or fails with a clear timeout if it genuinely never does):

```js
expect(await screen.findByTestId('object-reqperms-perop')).toBeInTheDocument();
```

This removes the race while keeping the same assertion intent (and it still fails loudly on a real regression, just via a timeout error instead of a null).

## Testing

- Ran the file **3×** locally — 12/12 tests pass each time, no flakiness.
- Test-only change; no production code touched, no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012kdzvSM9NLL8UubgqFCZnw)_