### PR TITLE
refactor(app-shell): drop agent `visibility` from AgentPreview (#1901)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
@@ -5,7 +5,7 @@
  *
  * Shows the configuration an operator needs to sanity-check an agent
  * before saving:
- *   • Persona header (avatar, label, role, visibility, active flag).
+ *   • Persona header (avatar, label, role, active flag).
  *   • Model config (provider, model id, temperature, max tokens).
  *   • System prompt / instructions in a scrollable monospace block.
  *   • Skills + Tools as two collapsible chip lists.
@@ -62,7 +62,6 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
   const avatar = (d.avatar as string | undefined) || undefined;
   const instructions = String(d.instructions ?? '');
   const active = d.active !== false;
-  const visibility = String(d.visibility ?? 'organization');
   const model = (d.model ?? {}) as ModelConfig;
   const skills: string[] = Array.isArray(d.skills) ? (d.skills as string[]) : [];
   const tools: ToolRef[] = Array.isArray(d.tools) ? (d.tools as ToolRef[]) : [];
@@ -120,7 +119,6 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
                 {role && <div className="text-xs text-muted-foreground mt-0.5">{role}</div>}
                 <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
                   <Pill icon={active ? Eye : EyeOff} label={active ? 'Active' : 'Disabled'} tone={active ? 'green' : 'gray'} />
-                  <Pill icon={Lock} label={visibility} />
                   {model.provider && <Pill icon={Sparkles} label={`${model.provider}${model.model ? ` · ${model.model}` : ''}`} mono />}
                   {model.temperature != null && <Pill icon={Gauge} label={`temp ${model.temperature}`} />}
                   {model.maxTokens != null && <Pill label={`max ${model.maxTokens}t`} />}


### PR DESCRIPTION
## Summary

Companion to framework PR objectstack-ai/framework#3216, which removes the agent `visibility` field from the spec as an unenforced security property (framework #1901, ADR-0056 D8 "design+enforce or remove").

`AgentPreview` rendered `visibility` as a persona-header pill. With the field gone from the schema it always fell back to the hardcoded `'organization'` default and implied a gating dial that does not exist — so it's removed.

## Changes

- **`AgentPreview.tsx`** — remove the `visibility` read and its persona-header pill; update the component doc comment. The `Lock` icon import stays (still used by the Permissions rail block).

## Verification

No node_modules in this environment (install was declined), so no local build/test run. The change is a mechanical removal of one read and one JSX element; no other objectui reference to agent `visibility` exists (view/field/record `visibility` is an unrelated concept and is untouched).

Depends on framework#3216 (schema removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gckUwoUMWvTWfGHFgWAob

---
_Generated by [Claude Code](https://claude.ai/code/session_012gckUwoUMWvTWfGHFgWAob)_