### PR TITLE
fix(metadata-admin): dashboard label fallback + skill activation editors (#1878)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/default-schemas.ts
+++ b/packages/app-shell/src/views/metadata-admin/default-schemas.ts
@@ -159,6 +159,35 @@ const SCHEMAS: Record<string, Record<string, unknown>> = {
       ...headerProps,
       instructions: { type: 'string', title: 'Instructions', format: 'multiline' },
       tools: { type: 'array', title: 'Tools', items: { type: 'string' } },
+      surface: {
+        type: 'string',
+        title: 'Surface',
+        description: "Agent surface this skill binds to (ADR-0063).",
+        enum: ['ask', 'build', 'both'],
+      },
+      triggerPhrases: {
+        type: 'array',
+        title: 'Trigger Phrases',
+        description: 'Natural-language phrases that activate this skill.',
+        items: { type: 'string' },
+      },
+      triggerConditions: {
+        type: 'array',
+        title: 'Trigger Conditions',
+        description: 'Programmatic activation conditions (context field / operator / value). The activation-critical field — previously only hand-editable (#1878/#1895).',
+        items: {
+          type: 'object',
+          properties: {
+            field: { type: 'string', title: 'Field' },
+            operator: {
+              type: 'string',
+              title: 'Operator',
+              enum: ['eq', 'neq', 'in', 'not_in', 'contains'],
+            },
+            value: { type: 'string', title: 'Value' },
+          },
+        },
+      },
     },
   },
 

--- a/packages/plugin-dashboard/src/DashboardGridLayout.tsx
+++ b/packages/plugin-dashboard/src/DashboardGridLayout.tsx
@@ -306,7 +306,7 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
     <div ref={containerRef} className={cn("w-full", className)} data-testid="grid-layout">
       {hasDndProvider && <DndEditModeBridge editMode={editMode} />}
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-2xl font-bold">{schema.title || 'Dashboard'}</h2>
+        <h2 className="text-2xl font-bold">{schema.title || schema.label || 'Dashboard'}</h2>
         <div className="flex gap-2">
           {editMode ? (
             <>


### PR DESCRIPTION
## Summary

objectui-side follow-through on the metadata-liveness audit umbrella (framework #1878, reopened). Companion to framework PR objectstack-ai/framework#3223.

### #1891 — Naming drift (dashboard `title` vs `label`)
`DashboardGridLayout` read only `schema.title`, but the spec's canonical top-level key is **`label`** (only widgets carry `title`). A spec-compliant dashboard therefore rendered the literal **"Dashboard"** header. Now falls back to `schema.label`, matching `DashboardView`'s existing `title → label` precedence.

### #1895 — Designer authoring gaps (skill)
The skill authoring form (`metadata-admin/default-schemas.ts`) exposed only `name`/`instructions`/`tools`, so the activation-critical fields could only be authored by hand-editing metadata. Added editors for:
- **`surface`** (`ask` | `build` | `both`)
- **`triggerPhrases`** — natural-language activation phrases
- **`triggerConditions`** — programmatic `field` / `operator` / `value` conditions (the activation-critical field)

## Testing
- `@object-ui/plugin-dashboard` suite: **89 passing**
- Changed files introduce **no new type errors** (the repo's pre-existing `type-check` failures are unbuilt-workspace-dep module-resolution errors, unrelated to this diff).

## Notes / not in this PR
- The flow `http` vs `http_request` naming drift (#1891) is already resolved in the current HEAD — `NODE_PALETTE` authors canonical `http`; remaining `http_request` branches are back-compat recognizers only.
- Flow `notify` palette node (#1895) and the tool executor (#1892) are larger designer/runtime features left for a dedicated change (they need node rendering + config panels / an engine executor, and should be browser-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LddW4NaQBdf5FTEnBPpnUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LddW4NaQBdf5FTEnBPpnUJ)_