### PR TITLE
fix(flow-designer): author the canonical config.schedule the runtime reads

### DIFF
--- a/.changeset/flow-designer-schedule-fix.md
+++ b/.changeset/flow-designer-schedule-fix.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(flow-designer): author the canonical `config.schedule` a scheduled flow's runtime reads
+
+The start-node inspector's "Cron schedule" field wrote a flat `config.cron`, but the
+automation runtime (`resolveTriggerBinding` → `normalizeSchedule`) only ever reads
+`config.schedule` — so a scheduled flow authored in the designer silently never
+bound and never fired. The field now writes the canonical nested
+`config.schedule.expression`, and a `fallbackPath` migrates an existing flat
+`config.cron` on first edit. Reading `.expression` also renders an object-shaped
+`config.schedule` (e.g. `{ type: 'cron', expression }`) as its cron string instead of
+"[object Object]" (the old legacy text field on `config.schedule` printed the object).
+The canvas node-card summary reads the nested value too. The field is also offered for
+the `time_relative` sweep cadence (optional; defaults to daily).

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.test.ts
@@ -37,6 +37,48 @@ describe('start node trigger-field gating (#5)', () => {
   });
 });
 
+describe('scheduled trigger — canonical config.schedule (not flat config.cron)', () => {
+  const fields = fieldsForNodeType('start');
+  const expr = fields.find((f) => f.id === 'schedule.expression')!;
+
+  it('replaces the dead flat `config.cron` field with a `config.schedule.expression` field', () => {
+    // The old "Cron schedule" field wrote config.cron, which resolveTriggerBinding /
+    // normalizeSchedule never read — so those scheduled flows silently never bound.
+    expect(fields.find((f) => f.id === 'cron')).toBeUndefined();
+    expect(expr).toBeDefined();
+    expect(expr.path).toEqual(['config', 'schedule', 'expression']);
+    expect(configKeyOf(expr)).toBe('schedule'); // owns the whole block (kept out of Advanced JSON)
+  });
+
+  it('reads the cron out of an object-shaped config.schedule (no "[object Object]")', () => {
+    const node = {
+      id: 'start',
+      type: 'start',
+      config: { triggerType: 'schedule', schedule: { type: 'cron', expression: '0 8 * * *' } },
+    };
+    expect(getFieldValue(node, expr)).toBe('0 8 * * *');
+  });
+
+  it('surfaces a legacy flat config.cron via fallbackPath (so it migrates on edit)', () => {
+    const node = { id: 'start', type: 'start', config: { triggerType: 'schedule', cron: '0 7 * * *' } };
+    expect(expr.fallbackPath).toEqual(['config', 'cron']);
+    expect(getFieldValue(node, expr)).toBe('0 7 * * *');
+  });
+
+  it('shows for schedule and time_relative triggers, hides for record triggers', () => {
+    const at = (tt: string) => ({ id: 'start', type: 'start', config: { triggerType: tt } });
+    expect(isFieldVisible(expr, at('schedule'), fields)).toBe(true);
+    expect(isFieldVisible(expr, at('time_relative'), fields)).toBe(true);
+    expect(isFieldVisible(expr, at('record-after-update'), fields)).toBe(false);
+  });
+
+  it('drops the raw text field on config.schedule (which rendered an object as "[object Object]")', () => {
+    expect(
+      fields.find((f) => f.path.length === 2 && f.path[0] === 'config' && f.path[1] === 'schedule'),
+    ).toBeUndefined();
+  });
+});
+
 describe('time-relative trigger fields (#1874)', () => {
   const fields = fieldsForNodeType('start');
   const triggerType = fields.find((f) => f.id === 'triggerType')!;

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -236,11 +236,24 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
       help: 'CEL predicate — the flow runs only when this is true (for time-relative sweeps it gates each matched record). Leave empty to run on every event.',
       showWhen: { field: 'triggerType', equals: ['record-after-create', 'record-after-update', 'record-before-update', 'record-after-delete', 'record-change', 'schedule', 'time_relative', 'webhook', 'event'] },
     }),
-    cfg('cron', 'Cron schedule', 'text', {
+    // Schedule descriptor — author the canonical nested `config.schedule` object
+    // the runtime actually reads (resolveTriggerBinding → normalizeSchedule). This
+    // field used to write a FLAT `config.cron`, which the backend never reads — so
+    // designer-authored scheduled flows silently never bound. `fallbackPath`
+    // migrates an existing flat `config.cron` to `config.schedule.expression` on
+    // first edit; reading `.expression` also renders an object-shaped schedule as
+    // its cron string instead of "[object Object]". Any sibling keys the runtime
+    // set (`type`, `timezone`) are preserved through edits (setAtPath merges).
+    {
+      id: 'schedule.expression',
+      path: ['config', 'schedule', 'expression'],
+      fallbackPath: ['config', 'cron'],
+      label: 'Cron schedule',
+      kind: 'text',
       placeholder: '0 7 * * *',
-      help: 'Cron expression for scheduled triggers.',
-      showWhen: { field: 'triggerType', equals: ['schedule'] },
-    }),
+      help: 'Cron expression — when the flow runs. A time-relative sweep defaults to daily if left empty.',
+      showWhen: { field: 'triggerType', equals: ['schedule', 'time_relative'] },
+    },
     // Time-relative trigger (#1874) — a `config.timeRelative` descriptor sweeps an
     // object on a schedule (daily by default) and launches the flow once per record
     // whose date field falls in the window. All fields live under the nested
@@ -300,16 +313,15 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
       help: 'Cap on records launched per sweep (default 1000).',
       showWhen: { field: 'triggerType', equals: ['time_relative'] },
     },
-    // Legacy keys — rendered only when present so older metadata never falls
-    // back to raw JSON. Prefer `condition` / `cron` above for new flows.
+    // Legacy `criteria` key — rendered only when present so older metadata never
+    // falls back to raw JSON. Prefer `condition` above for new flows. (There is no
+    // legacy `schedule` text field: the `schedule.expression` field above owns the
+    // whole `config.schedule` block and reads its `.expression`, so a bare-string
+    // or object-shaped schedule renders through it — a raw text field on
+    // `config.schedule` would print "[object Object]" for the object shape.)
     cfg('criteria', 'Entry condition (legacy)', 'expression', {
       placeholder: 'status == "active"',
       help: 'Legacy key — prefer "Entry condition" (condition).',
-      showWhen: { field: '__legacy__', equals: [] },
-    }),
-    cfg('schedule', 'Cron schedule (legacy)', 'text', {
-      placeholder: '0 9 * * *',
-      help: 'Legacy key — prefer "Cron schedule" (cron).',
       showWhen: { field: '__legacy__', equals: [] },
     }),
   ],

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -840,8 +840,24 @@ function nodeSummary(node: FlowNode): string | undefined {
     return b && typeof b === 'object' ? str((b as Record<string, unknown>)[inner]) : undefined;
   };
   const pick = (k: string) => (c ? str(c[k]) : undefined);
+  // A string inside a nested config object (e.g. config.schedule.expression), so an
+  // object-shaped descriptor summarizes as its value, not "[object Object]".
+  const cfgBlock = (key: string, inner: string) => {
+    const b = c?.[key];
+    return b && typeof b === 'object' && !Array.isArray(b) ? str((b as Record<string, unknown>)[inner]) : undefined;
+  };
   if (node.type === 'start') {
-    return pick('condition') || pick('criteria') || pick('objectName') || pick('cron') || pick('schedule') || pick('triggerType');
+    return (
+      pick('condition') ||
+      pick('criteria') ||
+      pick('objectName') ||
+      cfgBlock('schedule', 'expression') ||
+      cfgBlock('schedule', 'cron') ||
+      pick('cron') ||
+      pick('schedule') ||
+      cfgBlock('timeRelative', 'object') ||
+      pick('triggerType')
+    );
   }
   if (node.type === 'decision') {
     const conds = c?.conditions;


### PR DESCRIPTION
## The bug

The flow designer's start-node "Cron schedule" field wrote a **flat `config.cron`** string. But the automation runtime (`resolveTriggerBinding` → `normalizeSchedule`, in framework `@objectstack/service-automation` / `@objectstack/trigger-schedule`) only ever reads **`config.schedule`** — there is no `config.cron` → `config.schedule` conversion anywhere. So a `schedule` flow authored in the designer got `config.cron`, which the backend ignored → `normalizeSchedule(undefined)` → **the flow silently never bound and never fired**.

A second, related glitch: a code-authored object-shaped `config.schedule` (`{ type: 'cron', expression }`) rendered as **"[object Object]"** in the legacy bare-string text field.

(Found while adding the time-relative trigger panel; adjacent, pre-existing.)

## The fix

`packages/app-shell/.../metadata-admin/`:

- **`inspectors/flow-node-config.ts`** — replace the dead `config.cron` field with a **`config.schedule.expression`** field (the canonical shape `normalizeSchedule` reads; it infers `cron` from `expression`, and any runtime-set `type`/`timezone` are preserved through edits since `setAtPath` merges). `fallbackPath: ['config','cron']` **surfaces and migrates** an existing flat `config.cron` on first edit. Reading `.expression` renders an object-shaped schedule as its cron string, not "[object Object]". Drops the legacy bare-string `config.schedule` text field (which was the source of the "[object Object]" render). The field is also offered for the `time_relative` sweep cadence.
- **`previews/FlowCanvas.tsx`** — the node-card summary reads the nested `config.schedule.expression` (and `config.timeRelative.object`), so an object-shaped descriptor summarizes as its value.
- **`inspectors/flow-node-config.test.ts`** — covers the field path/fallback, object-shape read, `config.cron` migration read, gating, and removal of the raw `config.schedule` field.

Contract-first: the fix is on the **producer** (the designer authors the shape the runtime reads) — no lenient `config.cron` fallback was added to the backend consumer.

## Testing

- `flow-node-config.test.ts` — 18 pass (5 new). ✅
- `@object-ui/app-shell` `type-check` green; ESLint clean (0 errors). ✅
- **Browser-verified** via the console preview gallery: the sample flow's flat `config.cron: '0 9 * * *'` now surfaces in the Cron schedule field (ready to migrate on edit); no "[object Object]"; zero JS errors.

Changeset included (`@object-ui/app-shell` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHzW68suiFuu6GdJyea8U4)_