### PR TITLE
feat(report): drill a date-bucket cell into its time range, not a superset (#1752)

### DIFF
--- a/.changeset/report-drill-down-range-filter.md
+++ b/.changeset/report-drill-down-range-filter.md
@@ -1,0 +1,30 @@
+---
+"@object-ui/core": minor
+"@object-ui/app-shell": minor
+"@object-ui/plugin-report": minor
+"@object-ui/plugin-dashboard": minor
+---
+
+feat(report): drill a date-bucket cell into its time range, not a superset (#1752)
+
+Clicking a report/dashboard cell grouped by a `dateGranularity` date dimension
+("2026-Q2") used to drill into a **superset** — the date dimension was skipped,
+so the record list spanned every time bucket. It now scopes to the clicked
+bucket's half-open range, consuming the framework's new `drillRanges` sidecar.
+
+- **`@object-ui/core`** — `buildDatasetDrillFilter` accepts the per-row
+  `drillRanges` and emits an ObjectQL range operator object
+  (`{ [field]: { $gte, $lt } }`) alongside the equality dims.
+- **`@object-ui/plugin-report` / `@object-ui/plugin-dashboard`** — the report
+  renderer and dashboard widget forward `drillRanges`, and a **date-only**
+  report (no equality drill dim) is now drillable via the range alone.
+- **`@object-ui/app-shell`** — the "Open in list →" escape hatch
+  (`useOpenRecordList`) now targets the ADR-0055 **bare data surface**
+  (`/:object/data`, "the URL is the view" — no baked-in view filter to
+  over-narrow the drill) and serializes a range to the
+  `filter[field][gte|lt]` operator contract. `ObjectDataPage` parses those
+  operators (equality shorthand unchanged), renders a range as a single chip,
+  and removes both bounds together. A new `drillUrlFilters` module owns the
+  write/read serialization so both sides can't drift (round-trip tested).
+
+Companion to the framework analytics change (objectstack-ai/framework#3256).

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -43,6 +43,12 @@ import { usePermissions, useFieldPermissions } from '@object-ui/permissions';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState';
 import {
+  parseUrlFilterTriples,
+  groupFilterChips,
+  deleteFieldFilterParams,
+  type FilterTriple,
+} from './drillUrlFilters';
+import {
   defaultColumnsFromObject,
   defaultKanbanFromObject,
   defaultCalendarFromObject,
@@ -54,19 +60,6 @@ import { getIcon } from '../utils/getIcon';
 import { useMetadataClient } from './metadata-admin/useMetadata';
 import { createRuntimeMetadata } from './runtime-metadata-persistence';
 import { CreateViewDialog } from './CreateViewDialog';
-
-/** Filter triple shape shared with view metadata: [field, operator, value]. */
-type FilterTriple = [string, string, unknown];
-
-/** Parse `filter[<field>]=<value>` search params into equality triples. */
-function parseUrlFilterTriples(searchParams: URLSearchParams): FilterTriple[] {
-  const out: FilterTriple[] = [];
-  searchParams.forEach((value, key) => {
-    const m = /^filter\[(.+)\]$/.exec(key);
-    if (m && m[1] && value !== '') out.push([m[1], '=', value]);
-  });
-  return out;
-}
 
 /** Field types the auto-derived user-filter bar offers as dropdowns. */
 const USER_FILTER_TYPES = new Set(['select', 'multiselect', 'radio', 'enum', 'boolean']);
@@ -126,13 +119,14 @@ export function ObjectDataPage({ dataSource, objects }: any) {
     ) as FilterTriple[];
   }, [filterParamsKey, canRead, user?.id]);
 
+  // One display chip per field — a date-bucket drill's two range triples
+  // (>= start, < end) collapse into a single "start → end" chip (#1752).
+  const filterChips = React.useMemo(() => groupFilterChips(urlFilters), [urlFilters]);
+
   const removeUrlFilter = React.useCallback(
     (field: string) => {
-      setSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete(`filter[${field}]`);
-        return next;
-      });
+      // Clears the equality param AND both range-bound operator params for the field.
+      setSearchParams((prev) => deleteFieldFilterParams(new URLSearchParams(prev), field));
     },
     [setSearchParams],
   );
@@ -345,13 +339,13 @@ export function ObjectDataPage({ dataSource, objects }: any) {
           <span className="text-xs text-muted-foreground">
             {t('console.objectData.filteredBy', { defaultValue: 'Filtered by' })}
           </span>
-          {urlFilters.map(([field, , value]) => (
+          {filterChips.map(({ field, text }) => (
             <span
               key={field}
               className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs"
             >
               <span className="font-medium">{fieldLabel(objectDef.name, field, field)}</span>
-              <span className="text-muted-foreground">= {String(value)}</span>
+              <span className="text-muted-foreground">{text}</span>
               <button
                 type="button"
                 onClick={() => removeUrlFilter(field)}

--- a/packages/app-shell/src/views/drillUrlFilters.test.ts
+++ b/packages/app-shell/src/views/drillUrlFilters.test.ts
@@ -1,0 +1,106 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseUrlFilterTriples,
+  serializeDrillFilterParams,
+  deleteFieldFilterParams,
+  groupFilterChips,
+  type FilterTriple,
+} from './drillUrlFilters';
+
+const parse = (qs: string) => parseUrlFilterTriples(new URLSearchParams(qs));
+
+describe('parseUrlFilterTriples', () => {
+  it('parses the equality shorthand', () => {
+    expect(parse('filter[status]=open')).toEqual([['status', '=', 'open']]);
+  });
+
+  it('parses range/comparison operators into ObjectQL ops', () => {
+    expect(parse('filter[close_date][gte]=2026-04-01&filter[close_date][lt]=2026-07-01')).toEqual([
+      ['close_date', '>=', '2026-04-01'],
+      ['close_date', '<', '2026-07-01'],
+    ]);
+  });
+
+  it('keeps relationship-path field names intact', () => {
+    expect(parse('filter[account.region]=NA')).toEqual([['account.region', '=', 'NA']]);
+  });
+
+  it('ignores an unknown operator (never downgrades it to equality)', () => {
+    expect(parse('filter[x][bogus]=1')).toEqual([]);
+  });
+
+  it('skips empty values', () => {
+    expect(parse('filter[status]=')).toEqual([]);
+  });
+});
+
+describe('serializeDrillFilterParams', () => {
+  it('serializes an equality value', () => {
+    expect(serializeDrillFilterParams({ status: 'open' }).toString()).toBe('filter%5Bstatus%5D=open');
+  });
+
+  it('serializes an ObjectQL range operator object to gte/lt params', () => {
+    const qs = serializeDrillFilterParams({ close_date: { $gte: '2026-04-01', $lt: '2026-07-01' } });
+    expect(qs.get('filter[close_date][gte]')).toBe('2026-04-01');
+    expect(qs.get('filter[close_date][lt]')).toBe('2026-07-01');
+  });
+
+  it('skips null/undefined and never stringifies an unknown object to "[object Object]"', () => {
+    const qs = serializeDrillFilterParams({ a: null, b: undefined, weird: { nope: 1 } });
+    expect(qs.toString()).toBe('');
+  });
+});
+
+describe('round-trip: serialize → parse (write and read sides agree)', () => {
+  it('a mixed equality + date-range drill filter survives the URL round-trip', () => {
+    const filter = { stage: 'qualification', close_date: { $gte: '2026-06-01', $lt: '2026-07-01' } };
+    const triples = parseUrlFilterTriples(serializeDrillFilterParams(filter));
+    expect(triples).toEqual<FilterTriple[]>([
+      ['stage', '=', 'qualification'],
+      ['close_date', '>=', '2026-06-01'],
+      ['close_date', '<', '2026-07-01'],
+    ]);
+  });
+});
+
+describe('deleteFieldFilterParams', () => {
+  it('removes the equality AND both range-bound params for a field, leaving others', () => {
+    const params = new URLSearchParams(
+      'filter[close_date][gte]=2026-06-01&filter[close_date][lt]=2026-07-01&filter[stage]=qualification',
+    );
+    deleteFieldFilterParams(params, 'close_date');
+    expect(params.toString()).toBe('filter%5Bstage%5D=qualification');
+  });
+});
+
+describe('groupFilterChips', () => {
+  it('collapses a date range into a single from → to chip', () => {
+    expect(
+      groupFilterChips([
+        ['close_date', '>=', '2026-04-01'],
+        ['close_date', '<', '2026-07-01'],
+      ]),
+    ).toEqual([{ field: 'close_date', text: '2026-04-01 → 2026-07-01' }]);
+  });
+
+  it('renders an equality chip and preserves field order', () => {
+    expect(
+      groupFilterChips([
+        ['stage', '=', 'qualification'],
+        ['close_date', '>=', '2026-04-01'],
+        ['close_date', '<', '2026-07-01'],
+      ]),
+    ).toEqual([
+      { field: 'stage', text: '= qualification' },
+      { field: 'close_date', text: '2026-04-01 → 2026-07-01' },
+    ]);
+  });
+});

--- a/packages/app-shell/src/views/drillUrlFilters.ts
+++ b/packages/app-shell/src/views/drillUrlFilters.ts
@@ -1,0 +1,118 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * URL filter (de)serialization shared by the drill "escape hatch"
+ * (`useOpenRecordList`, the WRITE side) and the ADR-0055 bare data surface
+ * (`ObjectDataPage`, the READ side). Keeping both sides in ONE module keeps the
+ * `filter[<field>][<op>]` operator contract (#1752) from drifting between the
+ * code that emits a URL and the code that parses it back.
+ *
+ * Contract:
+ *   - equality      `filter[field]=value`              → `[field, '=', value]`
+ *   - range / cmp   `filter[field][gte|lte|gt|lt]=v`   → `[field, '>=' | … , v]`
+ * A date-bucket drill emits `gte` + `lt` to scope a list to a time bucket.
+ */
+
+/** Filter triple shape shared with view metadata: [field, operator, value]. */
+export type FilterTriple = [string, string, unknown];
+
+/** URL range/comparison operator suffix → ObjectQL operator (READ side). */
+export const URL_FILTER_OPS: Record<string, string> = { gte: '>=', lte: '<=', gt: '>', lt: '<' };
+
+/** ObjectQL range operator key → URL param suffix (WRITE side). Inverse of the
+ *  relevant `URL_FILTER_OPS` entries. */
+export const RANGE_OP_PARAM: Record<string, string> = { $gte: 'gte', $lte: 'lte', $gt: 'gt', $lt: 'lt' };
+
+/**
+ * Parse `filter[<field>]=<value>` (equality) and `filter[<field>][<op>]=<value>`
+ * (range/comparison) search params into ObjectQL triples. An unknown operator
+ * suffix is ignored (never silently downgraded to equality).
+ */
+export function parseUrlFilterTriples(searchParams: URLSearchParams): FilterTriple[] {
+  const out: FilterTriple[] = [];
+  searchParams.forEach((value, key) => {
+    if (value === '') return;
+    // Operator form FIRST — the field capture must not swallow the `[op]` suffix.
+    const mOp = /^filter\[([^\]]+)\]\[([a-z]+)\]$/.exec(key);
+    if (mOp) {
+      const op = URL_FILTER_OPS[mOp[2]];
+      if (op) out.push([mOp[1], op, value]);
+      return;
+    }
+    const m = /^filter\[([^\]]+)\]$/.exec(key);
+    if (m && m[1]) out.push([m[1], '=', value]);
+  });
+  return out;
+}
+
+/**
+ * Serialize a drill filter object into `filter[...]` search params. An ObjectQL
+ * range operator object (`{ $gte, $lt }`) becomes `filter[field][gte|lt]`; a
+ * plain value becomes `filter[field]`. `null`/`undefined` values and objects
+ * with no recognized operator are skipped (drill degrades to a superset) rather
+ * than stringified to `"[object Object]"`.
+ */
+export function serializeDrillFilterParams(
+  filter: Record<string, unknown> | undefined,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  if (!filter) return params;
+  for (const [field, value] of Object.entries(filter)) {
+    if (value == null) continue;
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      for (const [op, suffix] of Object.entries(RANGE_OP_PARAM)) {
+        const bound = (value as Record<string, unknown>)[op];
+        if (bound != null) params.set(`filter[${field}][${suffix}]`, String(bound));
+      }
+      continue; // handled (range ops) or skipped — never String(object)
+    }
+    params.set(`filter[${field}]`, String(value));
+  }
+  return params;
+}
+
+/**
+ * Delete the equality param AND every operator param (both range bounds) for a
+ * field, so removing a date-range chip drops the whole range together (#1752).
+ * Mutates and returns `params`.
+ */
+export function deleteFieldFilterParams(params: URLSearchParams, field: string): URLSearchParams {
+  const prefix = `filter[${field}]`;
+  for (const key of Array.from(params.keys())) {
+    if (key === prefix || key.startsWith(`${prefix}[`)) params.delete(key);
+  }
+  return params;
+}
+
+/**
+ * Group filter triples into ONE display chip per field, preserving first-seen
+ * order. A date-bucket drill contributes two triples for the same field
+ * (`>= start`, `< end`); they collapse into a single `start → end` range chip.
+ */
+export function groupFilterChips(triples: FilterTriple[]): Array<{ field: string; text: string }> {
+  const order: string[] = [];
+  const byField = new Map<string, FilterTriple[]>();
+  for (const tr of triples) {
+    if (!byField.has(tr[0])) {
+      byField.set(tr[0], []);
+      order.push(tr[0]);
+    }
+    byField.get(tr[0])!.push(tr);
+  }
+  return order.map((field) => {
+    const list = byField.get(field)!;
+    const gte = list.find(([, op]) => op === '>=' || op === '>');
+    const lt = list.find(([, op]) => op === '<' || op === '<=');
+    const text =
+      gte || lt
+        ? `${gte ? String(gte[2]) : '…'} → ${lt ? String(lt[2]) : '…'}`
+        : `= ${String(list[0][2])}`;
+    return { field, text };
+  });
+}

--- a/packages/app-shell/src/views/useOpenRecordList.ts
+++ b/packages/app-shell/src/views/useOpenRecordList.ts
@@ -8,15 +8,17 @@
 
 import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { serializeDrillFilterParams } from './drillUrlFilters';
 
 /**
  * `useOpenRecordList` — the console's implementation of the drill "escape
  * hatch" (`DrillNavigationContext.openRecordList`).
  *
- * Navigates to an object's full list page, scoped by a record filter, using the
- * console's `/apps/:appName/:object?filter[field]=value` route shape (the same
- * format `ReportView`'s drill navigation uses). Wire it into a
- * `DrillNavigationProvider` so the dashboard/report drill drawers can offer
+ * Navigates to the object's ADR-0055 bare data surface, scoped by a record
+ * filter, using the console's `/apps/:appName/:object/data?filter[...]` route
+ * shape. Equality dims serialize to `filter[field]=value`; a date-bucket drill's
+ * range serializes to `filter[field][gte]=…&filter[field][lt]=…` (#1752). Wire it
+ * into a `DrillNavigationProvider` so the dashboard/report drill drawers can offer
  * "Open in list →" and honor `drillDown.target: 'navigate'`.
  */
 export function useOpenRecordList(): (objectName: string, filter?: Record<string, unknown>) => void {
@@ -25,16 +27,16 @@ export function useOpenRecordList(): (objectName: string, filter?: Record<string
 
   return useCallback(
     (objectName: string, filter?: Record<string, unknown>) => {
-      const params = new URLSearchParams();
-      if (filter) {
-        for (const [field, value] of Object.entries(filter)) {
-          if (value == null) continue;
-          params.set(`filter[${field}]`, String(value));
-        }
-      }
-      const qs = params.toString();
+      // A date-bucket drill carries an ObjectQL range operator object
+      // (`{ $gte, $lt }`); the shared serializer emits it as `filter[field][gte|lt]`
+      // (never "[object Object]"). Equality dims stay `filter[field]=value` (#1752).
+      const qs = serializeDrillFilterParams(filter).toString();
       const base = appName ? `/apps/${appName}` : '';
-      navigate(`${base}/${objectName}${qs ? `?${qs}` : ''}`);
+      // ADR-0055 bare data surface (`/:object/data`): "the URL is the view" — no
+      // saved-view filter is baked in, so the drill scope is exactly these
+      // conditions. (The object route stacks URL filters ON TOP of the default
+      // view's own filter, which can silently over-narrow a drill.)
+      navigate(`${base}/${objectName}/data${qs ? `?${qs}` : ''}`);
     },
     [navigate, appName],
   );

--- a/packages/core/src/utils/dataset-format.ts
+++ b/packages/core/src/utils/dataset-format.ts
@@ -131,6 +131,17 @@ export function buildDatasetFieldHelpers(
 }
 
 /**
+ * A half-open date-range drill scope for one time-bucketed dimension (#1752):
+ * the object FIELD to filter and its inclusive `gte` / exclusive `lt` bounds
+ * (the server's `drillRanges` sidecar entry).
+ */
+export interface DatasetDrillRange {
+  field: string;
+  gte: unknown;
+  lt: unknown;
+}
+
+/**
  * Build the record-list filter for a drilled dataset bucket (ADR-0021 D2).
  *
  * Each drillable dimension maps to its underlying object field, filtered by the
@@ -140,6 +151,13 @@ export function buildDatasetFieldHelpers(
  * "is empty" filter). The render-time `runtimeFilter` is ANDed in so the drilled
  * list stays within the same slice the aggregate was computed over.
  *
+ * A time-bucketed date dimension (#1752) drills by RANGE, not equality — a
+ * humanized bucket ("2026-Q2") can't be exact-matched, so the server sends a
+ * half-open `[gte, lt)` per date dim in `rawRanges` instead of a raw value.
+ * Each becomes an ObjectQL range operator object (`{ $gte, $lt }`) so the drill
+ * scopes the list to the clicked time bucket instead of every bucket (which the
+ * old date-dim skip degraded to — a superset).
+ *
  * Shared by the dashboard `DatasetWidget` and the report renderer so a drill
  * filters identically (and correctly, including lookups) on both surfaces.
  */
@@ -148,11 +166,17 @@ export function buildDatasetDrillFilter(
   drillDims: string[],
   dimensionFields: Record<string, string>,
   runtimeFilter?: Record<string, unknown>,
+  rawRanges?: Record<string, DatasetDrillRange>,
 ): Record<string, unknown> {
   const drillFilter: Record<string, unknown> = {};
   for (const d of drillDims) {
     const raw = rawRow?.[d];
     drillFilter[dimensionFields[d]] = raw === '' || raw === undefined ? null : raw;
+  }
+  if (rawRanges) {
+    for (const r of Object.values(rawRanges)) {
+      if (r && r.field) drillFilter[r.field] = { $gte: r.gte, $lt: r.lt };
+    }
   }
   return runtimeFilter ? { ...runtimeFilter, ...drillFilter } : drillFilter;
 }

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -39,6 +39,7 @@ import {
   buildDatasetFieldHelpers,
   buildDatasetDrillFilter,
   type DatasetResultField,
+  type DatasetDrillRange,
 } from '@object-ui/core';
 import { cn, Skeleton, ChartSkeleton, GridSkeleton } from '@object-ui/components';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
@@ -48,7 +49,7 @@ import { DrillDownDrawer } from './DrillDownDrawer';
 
 type Row = Record<string, unknown>;
 interface DatasetTotals { dimensions: string[]; rows: Row[] }
-interface DatasetResult { rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Row[]; totals?: DatasetTotals[] }
+interface DatasetResult { rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Row[]; drillRanges?: Array<Record<string, DatasetDrillRange>>; totals?: DatasetTotals[] }
 interface DatasetCapableSource {
   queryDataset?: (dataset: string, selection: unknown) => Promise<DatasetResult>;
 }
@@ -193,7 +194,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     [rawFilter],
   );
 
-  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; totals?: DatasetTotals[]; error?: string }>({ status: 'idle', rows: [] });
+  const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; drillRanges?: Array<Record<string, DatasetDrillRange>>; totals?: DatasetTotals[]; error?: string }>({ status: 'idle', rows: [] });
   // Drill-through (ADR-0021 D2): the clicked bucket's record-list filter + title.
   const [drill, setDrill] = useState<{ filter: Record<string, unknown>; title: string } | null>(null);
   // Per-category colors: when the chart's first dimension is a select/lookup
@@ -228,7 +229,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       ...(compareTo ? { compareTo } : {}),
       ...(totalsGroupings ? { totals: { groupings: totalsGroupings } } : {}),
     })
-      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [], fields: Array.isArray(res?.fields) ? res.fields : [], object: res?.object, dimensionFields: res?.dimensionFields, drillRawRows: Array.isArray(res?.drillRawRows) ? res.drillRawRows : undefined, totals: Array.isArray(res?.totals) ? res.totals : undefined }); })
+      .then((res) => { if (!cancelled) setState({ status: 'ok', rows: Array.isArray(res?.rows) ? res.rows : [], fields: Array.isArray(res?.fields) ? res.fields : [], object: res?.object, dimensionFields: res?.dimensionFields, drillRawRows: Array.isArray(res?.drillRawRows) ? res.drillRawRows : undefined, drillRanges: Array.isArray(res?.drillRanges) ? res.drillRanges : undefined, totals: Array.isArray(res?.totals) ? res.totals : undefined }); })
       .catch((e) => { if (!cancelled) setState({ status: 'error', rows: [], error: String((e as Error)?.message ?? e) }); });
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -325,12 +326,14 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // Available when the server returned the dataset's base object + at least one
   // drillable dimension this widget groups by. Tables/pivots drill by row index;
   // charts map a clicked segment back to its dataset row (see handleChartDrill).
-  const { object: drillObject, dimensionFields, drillRawRows } = state;
+  const { object: drillObject, dimensionFields, drillRawRows, drillRanges } = state;
   const drillDims = dimensionFields ? dimensions.filter((d) => d in dimensionFields) : [];
-  const canDrill = !!drillObject && drillDims.length > 0;
+  // #1752: a date-only widget has no equality drill dim but still drills by the
+  // server's per-row date RANGE, so the presence of ranges makes it drillable too.
+  const canDrill = !!drillObject && (drillDims.length > 0 || !!drillRanges?.length);
   const openDrill = (index: number, title: string) => {
-    if (!drillObject || !dimensionFields) return;
-    const merged = buildDrillFilter(drillRawRows?.[index], drillDims, dimensionFields, runtimeFilter);
+    if (!drillObject) return;
+    const merged = buildDrillFilter(drillRawRows?.[index], drillDims, dimensionFields ?? {}, runtimeFilter, drillRanges?.[index]);
     setDrill({ filter: merged, title: title || String(widget?.title ?? '') });
   };
   const drillDrawer = drill && drillObject ? (

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -219,6 +219,18 @@ describe('DatasetWidget', () => {
     expect(await screen.findByTestId('dataset-drill-row')).toBeInTheDocument();
   });
 
+  it('#1752 marks a date-ONLY pivot drillable via the server range sidecar (no equality dim)', async () => {
+    const src = { queryDataset: vi.fn(async () => ({
+      rows: [{ close_date: '2026-Q2', task_count: 5 }],
+      fields: [{ name: 'close_date', type: 'date', label: 'Close Date' }, { name: 'task_count', type: 'number', label: 'Tasks' }],
+      object: 'showcase_task',
+      // No dimensionFields — a date bucket isn't equality-drillable; only a range sidecar.
+      drillRanges: [{ close_date: { field: 'close_date', gte: '2026-04-01', lt: '2026-07-01' } }],
+    })) };
+    render(<DatasetWidget widget={{ type: 'pivot', dataset: 'tasks', dimensions: ['close_date'], values: ['task_count'] }} dataSource={src} />);
+    expect(await screen.findByTestId('dataset-drill-row')).toBeInTheDocument();
+  });
+
   it('buildDrillFilter filters by the RAW stored value, not the display label', () => {
     // The raw-values row carries the stored value "open"; the display label
     // "Open" never reaches the filter.
@@ -238,6 +250,31 @@ describe('DatasetWidget', () => {
   it('buildDrillFilter normalizes a missing/empty raw value to null', () => {
     expect(buildDrillFilter({ status: '' }, ['status'], { status: 'status' })).toEqual({ status: null });
     expect(buildDrillFilter(undefined, ['status'], { status: 'status' })).toEqual({ status: null });
+  });
+
+  // ── #1752 date-bucket RANGE drill ────────────────────────────────────────
+  it('buildDrillFilter emits a half-open range for a date bucket (not equality)', () => {
+    expect(
+      buildDrillFilter(undefined, [], {}, undefined, {
+        close_date: { field: 'close_date', gte: '2026-04-01', lt: '2026-07-01' },
+      }),
+    ).toEqual({ close_date: { $gte: '2026-04-01', $lt: '2026-07-01' } });
+  });
+
+  it('buildDrillFilter ANDs an equality dim, a date range, and the runtime filter together', () => {
+    expect(
+      buildDrillFilter(
+        { stage: 'qualification' },
+        ['stage'],
+        { stage: 'stage' },
+        { archived: false },
+        { close_date: { field: 'close_date', gte: '2026-06-01', lt: '2026-07-01' } },
+      ),
+    ).toEqual({
+      archived: false,
+      stage: 'qualification',
+      close_date: { $gte: '2026-06-01', $lt: '2026-07-01' },
+    });
   });
 
   // ── pivot cross-tab ──────────────────────────────────────────────────────

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -49,6 +49,7 @@ import {
   buildDatasetFieldHelpers,
   buildDatasetDrillFilter,
   type DatasetResultField,
+  type DatasetDrillRange,
 } from '@object-ui/core';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
 import { mergeFilters } from './mergeFilters';
@@ -71,6 +72,7 @@ interface DatasetCapableSource {
     object?: string;
     dimensionFields?: Record<string, string>;
     drillRawRows?: Row[];
+    drillRanges?: Array<Record<string, DatasetDrillRange>>;
     totals?: DatasetTotals[];
   }>;
 }
@@ -167,6 +169,7 @@ function useDatasetRows(
     object?: string;
     dimensionFields?: Record<string, string>;
     drillRawRows?: Row[];
+    drillRanges?: Array<Record<string, DatasetDrillRange>>;
     totals?: DatasetTotals[];
     error?: string;
   }>({
@@ -205,6 +208,7 @@ function useDatasetRows(
             object: res?.object,
             dimensionFields: res?.dimensionFields,
             drillRawRows: Array.isArray(res?.drillRawRows) ? res.drillRawRows : undefined,
+            drillRanges: Array.isArray(res?.drillRanges) ? res.drillRanges : undefined,
             totals: Array.isArray(res?.totals) ? res.totals : undefined,
           });
         }
@@ -290,9 +294,14 @@ function DatasetReportTable({
     // emit an exact field→raw filter (correct for select/lookup dims, which a
     // display-label groupKey would mis-filter); the host then filters with no
     // extra metadata round-trip. Older server → groupKey-only fallback.
+    // #1752: a time-bucketed date dim contributes a RANGE (not an equality dim),
+    // so the fast path also fires when the server sent a range for this row —
+    // covering a date-ONLY report that has no equality drill dim at all.
+    const rowRanges = state.drillRanges?.[index];
+    const hasRange = !!rowRanges && Object.keys(rowRanges).length > 0;
     const objectFilter =
-      state.object && state.dimensionFields && drillDims.length > 0
-        ? buildDatasetDrillFilter(state.drillRawRows?.[index], drillDims, state.dimensionFields, runtimeFilter)
+      state.object && (drillDims.length > 0 || hasRange)
+        ? buildDatasetDrillFilter(state.drillRawRows?.[index], drillDims, state.dimensionFields ?? {}, runtimeFilter, rowRanges)
         : undefined;
     onDrill!({ dataset, groupKey, runtimeFilter, object: state.object, objectFilter });
   };
@@ -547,9 +556,13 @@ function DatasetMatrixTable({
     ? [...rows, ...columnsAcross].filter((d) => d in state.dimensionFields!)
     : [];
   const drillCell = (rowKey: Row, colKey: Row, index: number) => {
+    // #1752: include the date-bucket range sidecar so an "X by time" cell scopes
+    // to the clicked time bucket, not every bucket in that row/column.
+    const cellRanges = state.drillRanges?.[index];
+    const hasRange = !!cellRanges && Object.keys(cellRanges).length > 0;
     const objectFilter =
-      state.object && state.dimensionFields && drillDims.length > 0
-        ? buildDatasetDrillFilter(state.drillRawRows?.[index], drillDims, state.dimensionFields, runtimeFilter)
+      state.object && (drillDims.length > 0 || hasRange)
+        ? buildDatasetDrillFilter(state.drillRawRows?.[index], drillDims, state.dimensionFields ?? {}, runtimeFilter, cellRanges)
         : undefined;
     onDrill!({ dataset, groupKey: { ...rowKey, ...colKey }, runtimeFilter, object: state.object, objectFilter });
   };

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -27,6 +27,7 @@ type MockResult = {
   object?: string;
   dimensionFields?: Record<string, string>;
   drillRawRows?: MockRows;
+  drillRanges?: Array<Record<string, { field: string; gte: unknown; lt: unknown }>>;
   totals?: Array<{ dimensions: string[]; rows: MockRows }>;
 };
 
@@ -44,6 +45,7 @@ function makeSource(byDataset: Record<string, MockRows | MockResult>) {
         ...(entry?.object ? { object: entry.object } : {}),
         ...(entry?.dimensionFields ? { dimensionFields: entry.dimensionFields } : {}),
         ...(entry?.drillRawRows ? { drillRawRows: entry.drillRawRows } : {}),
+        ...(entry?.drillRanges ? { drillRanges: entry.drillRanges } : {}),
         ...(entry?.totals ? { totals: entry.totals } : {}),
       };
     }),
@@ -499,6 +501,33 @@ describe('DatasetReportRenderer', () => {
       groupKey: { status: 'In Progress' },
       // raw stored value, mapped to the underlying object field, ANDed with scope
       objectFilter: { owner: 'me', status: 'in_progress' },
+    }));
+  });
+
+  it('#1752 drill: a date-bucketed row emits a half-open RANGE objectFilter (not equality)', async () => {
+    const src = makeSource({
+      pipe_by_quarter: {
+        rows: [{ close_date: '2026-Q2', revenue: 1000 }],
+        object: 'opportunity',
+        // A date bucket isn't equality-drillable → no dimensionFields; a range sidecar instead.
+        drillRanges: [{ close_date: { field: 'close_date', gte: '2026-04-01', lt: '2026-07-01' } }],
+      },
+    });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'pipe_by_quarter', rows: ['close_date'], values: ['revenue'] }}
+        dataSource={src}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-drill-row')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('dataset-drill-row'));
+    expect(onDrill).toHaveBeenCalledWith(expect.objectContaining({
+      dataset: 'pipe_by_quarter',
+      object: 'opportunity',
+      // the clicked quarter scopes the drilled list to [2026-04-01, 2026-07-01)
+      objectFilter: { close_date: { $gte: '2026-04-01', $lt: '2026-07-01' } },
     }));
   });
 


### PR DESCRIPTION
## Why

objectui half of framework#1752 (companion: objectstack-ai/framework#3256). Clicking a report/dashboard cell grouped by a `dateGranularity` date dimension ("2026-Q2") drilled into a **superset** — the date dimension was skipped, so the record list spanned every time bucket. It now scopes to the clicked bucket's half-open range.

## What

- **`@object-ui/core`** — `buildDatasetDrillFilter` takes the server's per-row `drillRanges` sidecar and emits an ObjectQL range operator object (`{ [field]: { $gte, $lt } }`) alongside the equality dims. New exported `DatasetDrillRange` type.
- **`@object-ui/plugin-report` / `@object-ui/plugin-dashboard`** — the report renderer (table + matrix) and dashboard widget forward `drillRanges`; the drill fast-path now fires on a range too, so a **date-only** report (no equality drill dim) is drillable via the range alone.
- **`@object-ui/app-shell`**
  - `useOpenRecordList` ("Open in list →") now targets the **ADR-0055 bare data surface** (`/:object/data`) instead of the object route. The bare surface bakes in no saved-view filter — *"the URL is the view"* — so the drill scope is exactly the drilled conditions; the object route stacks URL filters on top of the default view and can silently over-narrow a drill.
  - It serializes a range to the `filter[field][gte|lt]` operator contract (ADR-0055's rich-operator follow-up) instead of stringifying `{ $gte, $lt }` to `"[object Object]"`.
  - `ObjectDataPage` parses those operators (equality `filter[field]` unchanged), FLS-trims both bounds together (they share the field), renders a range as a **single chip**, and removes both bounds together.
  - New `drillUrlFilters` module owns the write (`serializeDrillFilterParams`) and read (`parseUrlFilterTriples`) sides so the URL contract can't drift between them.

## Design notes

- The in-memory drill filter is the primary contract; the drawer peek (the main UX) is fully scoped by it with no URL round-trip. The URL is a secondary, degradable projection used only by the escape hatch.
- Bounds are computed server-side (framework#3256); the client does **zero** date math — it forwards and serializes.

## Testing

- `drillUrlFilters` round-trip: `serialize → parse` yields the exact triples (write & read sides agree); operator parse, unknown-op ignore, paired FLS removal, single range chip.
- `buildDrillFilter` range + equality + runtime-filter merge; date-ONLY widget drillable via range.
- `DatasetReportRenderer`: a date-bucketed row emits a `{ $gte, $lt }` `objectFilter`.
- Green: plugin-dashboard 41/41, plugin-report 28/28, drillUrlFilters 12/12; `type-check` clean for core / app-shell / plugin-report / plugin-dashboard.

## Note

`pnpm lint` surfaces one **pre-existing** error in `DatasetReportRenderer` (`ChartComponent` at the chart block — untouched by this diff) and pre-existing `no-explicit-any` warnings; the Lint workflow is `workflow_dispatch`-only, and this diff introduces no new lint problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCXBnmMQTwjmFkjtpEe11f

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCXBnmMQTwjmFkjtpEe11f)_