### PR TITLE
fix(app-shell): skip resultDialog fields whose path does not resolve

### DIFF
--- a/packages/app-shell/src/views/ActionResultDialog.tsx
+++ b/packages/app-shell/src/views/ActionResultDialog.tsx
@@ -10,7 +10,10 @@
  *   - `spec.fields[]` selects what to render. Each entry has a dot `path`
  *     into `data` and an optional `format` (qrcode/code-list/secret/
  *     text/json). When `fields` is omitted, the dialog renders the whole
- *     payload as JSON.
+ *     payload as JSON. Entries whose `path` does not resolve in the payload
+ *     are skipped — the response shape varies per request (e.g. no
+ *     `temporaryPassword` when the admin typed one), and a labelled
+ *     `undefined` row would be noise.
  *   - The dialog has NO close button — the user must click acknowledge.
  *     This is the whole point: a toast would let them dismiss the value
  *     before reading it.
@@ -59,11 +62,22 @@ export function ActionResultDialog({ state, onAcknowledge }: ActionResultDialogP
   const { spec, data } = state;
 
   // Synthesise a single-field render plan when the action did not declare
-  // explicit fields — keeps the dialog body uniform.
-  const fields = useMemo<ResultDialogFieldSpec[]>(() => {
-    if (spec?.fields && spec.fields.length > 0) return spec.fields;
-    return [{ path: '', label: undefined, format: spec?.format ?? 'json' }];
-  }, [spec]);
+  // explicit fields — keeps the dialog body uniform. Declared fields whose
+  // path does not resolve in the payload are dropped: the value is
+  // response-shape dependent (e.g. `temporaryPassword` only exists when the
+  // server generated one), and a labelled `undefined` row helps nobody.
+  const fields = useMemo<Array<{ field: ResultDialogFieldSpec; value: unknown }>>(() => {
+    const declared: ResultDialogFieldSpec[] =
+      spec?.fields && spec.fields.length > 0
+        ? spec.fields
+        : [{ path: '', label: undefined, format: spec?.format ?? 'json' }];
+    return declared
+      .map((field) => ({
+        field,
+        value: field.path === '' ? data : readPath(data, field.path),
+      }))
+      .filter(({ field, value }) => field.path === '' || value !== undefined);
+  }, [spec, data]);
 
   return (
     <Dialog
@@ -87,11 +101,11 @@ export function ActionResultDialog({ state, onAcknowledge }: ActionResultDialogP
         </DialogHeader>
 
         <div className="space-y-4 py-2">
-          {fields.map((field, idx) => (
+          {fields.map(({ field, value }, idx) => (
             <ResultField
               key={`${field.path}-${idx}`}
               field={field}
-              value={field.path === '' ? data : readPath(data, field.path)}
+              value={value}
               defaultFormat={spec?.format}
             />
           ))}

--- a/packages/app-shell/src/views/__tests__/ActionResultDialog.test.tsx
+++ b/packages/app-shell/src/views/__tests__/ActionResultDialog.test.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ResultDialogSpec } from '@object-ui/core';
+import { ActionResultDialog } from '../ActionResultDialog';
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@object-ui/i18n')>()),
+  useObjectTranslation: () => ({ t: (key: string) => key }),
+}));
+// jsdom has no canvas; the qrcode path is not under test.
+vi.mock('qrcode', () => ({ toCanvas: vi.fn() }));
+
+function open(spec: ResultDialogSpec, data: unknown) {
+  render(
+    <ActionResultDialog
+      state={{ open: true, spec, data }}
+      onAcknowledge={() => {}}
+    />,
+  );
+}
+
+describe('ActionResultDialog — unresolved field paths are skipped', () => {
+  const spec: ResultDialogSpec = {
+    title: 'User Created',
+    fields: [
+      { path: 'user.email', label: 'Email', format: 'text' },
+      { path: 'temporaryPassword', label: 'Temporary Password', format: 'secret' },
+    ],
+  };
+
+  it('drops a declared field whose path does not resolve in the payload', () => {
+    // Admin typed the password themselves — the server never minted one, so
+    // the response has no `temporaryPassword` key at all.
+    open(spec, { user: { email: 'a@example.com' } });
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('a@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('Temporary Password')).not.toBeInTheDocument();
+    // No JsonBlock fallback rendering the literal `undefined` either.
+    expect(screen.queryByText('undefined')).not.toBeInTheDocument();
+  });
+
+  it('renders every declared field when all paths resolve', () => {
+    open(spec, { user: { email: 'a@example.com' }, temporaryPassword: 'p@ss' });
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Temporary Password')).toBeInTheDocument();
+    // Secret renders masked until revealed.
+    expect(screen.getByText('••••')).toBeInTheDocument();
+  });
+
+  it('still falls back to whole-payload JSON when no fields are declared', () => {
+    open({ title: 'Done' }, { anything: 1 });
+
+    expect(screen.getByText(/"anything": 1/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #2673

## What

`ActionResultDialog` now resolves field values while building the render plan and drops any declared field whose non-empty `path` is absent from the response payload (`readPath` → `undefined`). The empty-path whole-payload JSON fallback is unchanged. Previously such rows still rendered, and the `text`/`secret` guards degraded them to a `JsonBlock` printing the literal `undefined`.

Declared `resultDialog` fields are now safe for response-shape-dependent keys — e.g. `sys_user.create_user`'s `temporaryPassword` (absent when the admin typed the password) and the upcoming `user.phoneNumber` echo (objectstack-ai/framework#3260, absent for email-only users).

## Tests

New `ActionResultDialog.test.tsx`:
- drops a declared field whose path does not resolve (no label, no literal `undefined`)
- renders every declared field when all paths resolve (secret stays masked)
- still falls back to whole-payload JSON when no fields are declared

`turbo run type-check --filter=@object-ui/app-shell` green; eslint clean. Pure bug fix — no changeset per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)