### PR TITLE
feat(studio): visualize loop/parallel/try_catch nested regions on the flow canvas (#2670 Phase 1)

### DIFF
--- a/.changeset/flow-designer-nested-regions.md
+++ b/.changeset/flow-designer-nested-regions.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/app-shell": minor
+---
+
+feat(studio): visualize loop / parallel / try_catch nested regions on the flow designer canvas (#2670)
+
+The flow designer rendered ADR-0031 structured control-flow containers
+(`loop` / `parallel` / `try_catch`) as opaque single node cards — their nested
+regions (`config.body` / `config.branches[]` / `config.try`/`catch`) were only
+visible, and only editable, as raw JSON in the inspector's Advanced block.
+
+A container card now carries a **"show nested regions"** control that opens a
+read-only popover rendering the region(s) as a mini-canvas — the same
+top-to-bottom node/edge layout as the parent graph, produced by the shared
+`computeLayout` and scaled to fit — with a header per region (a named branch or
+`Branch N`, and `Try` / `Catch`; a loop body has none). Legacy flat loops (a
+`loop` with no `config.body`) and all ordinary nodes render exactly as before.
+
+Read-only for now (Phase 1 of #2670): the region renders in a floating popover,
+so it needs **no change to the canvas layout or edge routing** — zero regression
+risk to existing flows. Inline push-down nesting on the canvas and nested editing
+are tracked as the next increments on #2670.

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
@@ -98,3 +98,69 @@ describe('FlowCanvas — inline cycle/error surfacing', () => {
     expect(container.querySelectorAll('[data-invalid="true"]').length).toBe(0);
   });
 });
+
+describe('FlowCanvas — nested container regions (#2670)', () => {
+  it('reveals a loop body region in a popover when the container control is opened', async () => {
+    const nodes = [
+      { id: 'start', type: 'start' },
+      {
+        id: 'each',
+        type: 'loop',
+        label: 'For each order',
+        config: { body: { nodes: [{ id: 'charge', type: 'http', label: 'Charge card' }], edges: [] } },
+      },
+    ];
+    render(
+      <FlowCanvas
+        nodes={nodes}
+        edges={[{ source: 'start', target: 'each' }]}
+        editable={false}
+        designMode={false}
+        selectedId={null}
+        onSelect={() => {}}
+      />,
+    );
+    // Closed by default: the body step is not rendered, but a "show regions" control is.
+    expect(screen.queryByText('Charge card')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /show nested regions/i }));
+    // Open: the loop body node now renders nested in the popover.
+    expect(await screen.findByText('Charge card')).toBeInTheDocument();
+  });
+
+  it('labels parallel branches and try/catch handlers when opened', async () => {
+    const nodes = [
+      {
+        id: 'p',
+        type: 'parallel',
+        label: 'Fan out',
+        config: {
+          branches: [
+            { name: 'Slack', nodes: [{ id: 'a', type: 'http', label: 'Notify Slack' }], edges: [] },
+            { nodes: [{ id: 'b', type: 'http', label: 'Notify CRM' }], edges: [] },
+          ],
+        },
+      },
+    ];
+    render(
+      <FlowCanvas nodes={nodes} edges={[]} editable={false} designMode={false} selectedId={null} onSelect={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /show nested regions/i }));
+    expect(await screen.findByText('Slack')).toBeInTheDocument(); // named branch
+    expect(screen.getByText('Branch 2')).toBeInTheDocument(); // unnamed → indexed
+    expect(screen.getByText('Notify CRM')).toBeInTheDocument();
+  });
+
+  it('does not add a region control to a legacy flat loop (no config.body)', () => {
+    render(
+      <FlowCanvas
+        nodes={[{ id: 'l', type: 'loop', label: 'Legacy loop', config: { collection: '{items}' } }]}
+        edges={[]}
+        editable={false}
+        designMode={false}
+        selectedId={null}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /nested regions/i })).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -41,6 +41,7 @@ import {
   isBackEdge,
   edgeKey,
   conditionText,
+  extractRegions,
   type FlowNode,
   type FlowEdge,
   type Point,
@@ -822,6 +823,7 @@ export function FlowCanvas({
                 }
                 invalid={invalidNodeSet.has(node.id)}
                 badge={nodeBadges.get(node.id)}
+                regions={extractRegions(node)}
               />
             );
           })}

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.test.ts
@@ -8,6 +8,7 @@ import {
   backEdgePath,
   backEdgeLabelAnchor,
   bottomAnchor,
+  extractRegions,
   NODE_W,
   NODE_H,
   type FlowNode,
@@ -85,5 +86,48 @@ describe('computeLayout — back-edges excluded from layering (ADR-0044)', () =>
     ];
     const pos = computeLayout(nodes, edges);
     expect(pos.get('a')!.y).toBeGreaterThan(pos.get('w')!.y);
+  });
+});
+
+describe('extractRegions (#2670 structured containers)', () => {
+  const region = (n: string) => ({ nodes: [{ id: n, type: 'http' }], edges: [] });
+
+  it('returns [] for an ordinary node', () => {
+    expect(extractRegions({ id: 'x', type: 'create_record' })).toEqual([]);
+  });
+
+  it('returns [] for a legacy flat loop (no config.body)', () => {
+    expect(extractRegions({ id: 'l', type: 'loop', config: { collection: '{items}' } })).toEqual([]);
+    // ...and for an empty body region.
+    expect(extractRegions({ id: 'l', type: 'loop', config: { body: { nodes: [], edges: [] } } })).toEqual([]);
+  });
+
+  it('extracts a loop body as one unlabeled region', () => {
+    const out = extractRegions({ id: 'l', type: 'loop', config: { body: region('send') } });
+    expect(out).toHaveLength(1);
+    expect(out[0].label).toBeUndefined();
+    expect(out[0].key).toBe('body');
+    expect(out[0].nodes.map((n) => n.id)).toEqual(['send']);
+  });
+
+  it('extracts parallel branches, labeled by name then Branch N', () => {
+    const out = extractRegions({
+      id: 'p',
+      type: 'parallel',
+      config: { branches: [{ name: 'notify', ...region('a') }, region('b')] },
+    });
+    expect(out.map((r) => r.label)).toEqual(['notify', 'Branch 2']);
+    expect(out.map((r) => r.key)).toEqual(['branch-0', 'branch-1']);
+  });
+
+  it('extracts try + catch, in order, labeled', () => {
+    const out = extractRegions({
+      id: 't',
+      type: 'try_catch',
+      config: { try: region('risky'), catch: region('recover') },
+    });
+    expect(out.map((r) => r.label)).toEqual(['Try', 'Catch']);
+    // catch is optional — a try-only container yields just the try region.
+    expect(extractRegions({ id: 't', type: 'try_catch', config: { try: region('risky') } }).map((r) => r.label)).toEqual(['Try']);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.ts
@@ -61,6 +61,66 @@ export function hasManualPosition(node: FlowNode): boolean {
 }
 
 /**
+ * A structured-region sub-graph carried in a container node's config (ADR-0031),
+ * tagged with a header label for the designer.
+ */
+export interface LabeledRegion {
+  /** Stable key within the container (`body` / `branch-N` / `try` / `catch`). */
+  key: string;
+  /** Header shown above the region — `undefined` for a loop body (no header). */
+  label?: string;
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+}
+
+/** Coerce a config value to a region iff it is a non-empty `{ nodes, edges }`. */
+function asRegion(v: unknown): { nodes: FlowNode[]; edges: FlowEdge[] } | null {
+  if (!v || typeof v !== 'object') return null;
+  const r = v as { nodes?: unknown; edges?: unknown };
+  if (!Array.isArray(r.nodes) || r.nodes.length === 0) return null;
+  return { nodes: r.nodes as FlowNode[], edges: Array.isArray(r.edges) ? (r.edges as FlowEdge[]) : [] };
+}
+
+/**
+ * The nested regions a structured control-flow container carries in its config
+ * (ADR-0031): `loop.body`, `parallel.branches[]`, `try_catch.try`/`catch`.
+ *
+ * Returns `[]` for ordinary nodes AND for a **legacy flat `loop`** (a `loop`
+ * with no `config.body`) — the constructs are additive, so those stay plain
+ * cards. The designer renders the returned regions read-only, nested under the
+ * container.
+ */
+export function extractRegions(node: FlowNode): LabeledRegion[] {
+  const cfg = (node.config ?? {}) as Record<string, unknown>;
+  switch (node.type) {
+    case 'loop': {
+      const body = asRegion(cfg.body);
+      return body ? [{ key: 'body', label: undefined, ...body }] : [];
+    }
+    case 'parallel': {
+      const out: LabeledRegion[] = [];
+      (Array.isArray(cfg.branches) ? cfg.branches : []).forEach((b, i) => {
+        const region = asRegion(b);
+        if (!region) return;
+        const name = (b as { name?: unknown }).name;
+        out.push({ key: `branch-${i}`, label: typeof name === 'string' && name ? name : `Branch ${i + 1}`, ...region });
+      });
+      return out;
+    }
+    case 'try_catch': {
+      const out: LabeledRegion[] = [];
+      const tryR = asRegion(cfg.try);
+      if (tryR) out.push({ key: 'try', label: 'Try', ...tryR });
+      const catchR = asRegion(cfg.catch);
+      if (catchR) out.push({ key: 'catch', label: 'Catch', ...catchR });
+      return out;
+    }
+    default:
+      return [];
+  }
+}
+
+/**
  * Compute a deterministic layered (top-to-bottom) layout.
  *
  * - Edges with a dangling endpoint are ignored for layering.

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import {
   AlertCircle,
   AlertTriangle,
+  ChevronRight,
   Code,
   CircleDot,
   CircleStop,
@@ -48,7 +49,8 @@ import {
   CommandList,
 } from '@object-ui/components';
 import { t as tr } from '../i18n';
-import { NODE_W, NODE_H, type Point } from './flow-canvas-layout';
+import { NODE_W, NODE_H, type Point, type LabeledRegion } from './flow-canvas-layout';
+import { FlowRegionView } from './flow-region-view';
 import { useFlowPaletteRecents } from '../../../context/FlowPaletteRecentsProvider';
 
 export function nodeIcon(type: string): LucideIcon {
@@ -412,6 +414,13 @@ export interface NodeCardProps {
    * `revise` and declared `back` edges in a single gesture.
    */
   onAddReviseLoop?: () => void;
+  /**
+   * #2670: structured-region sub-graphs this node contains (`loop.body`,
+   * `parallel.branches`, `try_catch.try`/`catch`). When present, the card gains
+   * an expand toggle that renders them read-only, nested beneath the header.
+   * Empty / absent for ordinary nodes and legacy flat loops → a plain card.
+   */
+  regions?: LabeledRegion[];
 }
 
 /**
@@ -434,8 +443,10 @@ export function NodeCard({
   onSelect,
   onAppend,
   onAddReviseLoop,
+  regions,
 }: NodeCardProps) {
   const tone = nodeTone(type);
+  const hasRegions = !!regions && regions.length > 0;
   return (
     <div
       // `group` so the hover-revealed affordances (append "+", revise loop)
@@ -503,6 +514,38 @@ export function NodeCard({
           </div>
         </div>
       </div>
+      {hasRegions && (
+        // #2670: the container's nested regions render read-only in a Popover
+        // anchored to the card — floating (portaled) so it never overlaps the
+        // canvas's other nodes and needs no change to the layout / edge routing.
+        // (Inline, push-down nesting on the canvas is the next increment.)
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Show nested regions"
+              title="Show nested regions"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              className="absolute right-1.5 top-1.5 z-20 inline-flex h-5 w-5 items-center justify-center rounded-md border bg-background/90 text-muted-foreground shadow-sm transition-colors hover:border-primary hover:text-primary"
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            side="right"
+            sideOffset={8}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="max-h-[60vh] w-[280px] overflow-auto p-2"
+          >
+            <div className="pb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              {type === 'loop' ? 'Loop body' : type === 'parallel' ? 'Parallel branches' : 'Try / Catch'}
+            </div>
+            <FlowRegionView regions={regions!} maxWidth={244} />
+          </PopoverContent>
+        </Popover>
+      )}
       {badge && (
         <span
           title={badge.title}

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-region-view.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-region-view.tsx
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * flow-region-view — read-only rendering of a structured control-flow region
+ * (ADR-0031 `loop.body` / `parallel.branches[]` / `try_catch.try`/`catch`) as a
+ * nested mini-canvas inside its container's card on the flow designer canvas
+ * (#2670, Phase 1).
+ *
+ * It reuses the top-level canvas layout math (`computeLayout` / `diagramSize` /
+ * `edgePath`) at full scale, then fits the whole region into the container's
+ * width with a single CSS `scale` transform — so there is **no new layout
+ * engine**, and a region reads as the same top-to-bottom flow as the parent
+ * graph. Read-only: no drag / insert; a nested container inside a region renders
+ * as a plain box (recursive on-canvas expansion is a later increment).
+ */
+
+import * as React from 'react';
+import { cn } from '@object-ui/components';
+import {
+  computeLayout,
+  diagramSize,
+  edgePath,
+  bottomAnchor,
+  topAnchor,
+  isBackEdge,
+  rightAnchor,
+  backEdgePath,
+  NODE_W,
+  NODE_H,
+  type FlowNode,
+  type LabeledRegion,
+} from './flow-canvas-layout';
+import { NodeTypeIcon, nodeTone } from './flow-canvas-parts';
+
+/** Read-only node box inside a region — a compact echo of `NodeCard`. */
+function RegionNode({ node, x, y }: { node: FlowNode; x: number; y: number }) {
+  const tone = nodeTone(node.type);
+  return (
+    <div
+      className="absolute flex items-center gap-2 rounded-lg border border-border/70 bg-card px-2 py-1.5 shadow-sm"
+      style={{ left: x, top: y, width: NODE_W, height: NODE_H }}
+    >
+      <div className={cn('flex h-7 w-7 shrink-0 items-center justify-center rounded-md', tone.chip)}>
+        <NodeTypeIcon type={node.type} className={cn('h-4 w-4', tone.icon)} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[12px] font-semibold leading-tight text-foreground" title={node.label || node.id}>
+          {node.label || node.id}
+        </div>
+        <div className={cn('text-[10px] font-semibold uppercase tracking-[0.08em]', tone.label)}>{node.type}</div>
+      </div>
+    </div>
+  );
+}
+
+/** One region laid out with the shared engine, then scaled to fit `maxWidth`. */
+function RegionCanvas({ region, maxWidth }: { region: LabeledRegion; maxWidth: number }) {
+  const layout = React.useMemo(() => computeLayout(region.nodes, region.edges), [region.nodes, region.edges]);
+  const { width, height } = React.useMemo(() => diagramSize(layout), [layout]);
+  const scale = Math.min(1, maxWidth / Math.max(width, 1));
+  return (
+    <div className="relative" style={{ width: width * scale, height: height * scale }}>
+      <div
+        className="absolute left-0 top-0"
+        style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left' }}
+      >
+        <svg className="pointer-events-none absolute left-0 top-0 overflow-visible" width={width} height={height}>
+          {region.edges.map((edge, i) => {
+            const sp = layout.get(edge.source);
+            const tp = layout.get(edge.target);
+            if (!sp || !tp) return null;
+            const back = isBackEdge(edge);
+            const from = back ? rightAnchor(sp) : bottomAnchor(sp);
+            const to = back ? rightAnchor(tp) : topAnchor(tp);
+            return (
+              <path
+                key={edge.id || `${edge.source}-${edge.target}-${i}`}
+                d={back ? backEdgePath(from, to) : edgePath(from, to)}
+                strokeDasharray={back ? '5 4' : undefined}
+                className={cn('fill-none', back ? 'stroke-amber-500/60' : 'stroke-muted-foreground/40')}
+                strokeWidth={1.5}
+              />
+            );
+          })}
+        </svg>
+        {region.nodes.map((n) => {
+          const p = layout.get(n.id);
+          return p ? <RegionNode key={n.id} node={n} x={p.x} y={p.y} /> : null;
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Render a container's nested regions read-only, each fit to `maxWidth`, with a
+ * header per region (`Branch N` / `Try` / `Catch`; a loop body has no header).
+ */
+export function FlowRegionView({ regions, maxWidth }: { regions: LabeledRegion[]; maxWidth: number }) {
+  return (
+    <div className="flex flex-col gap-2">
+      {regions.map((region) => (
+        <div key={region.key} className="rounded-md border border-dashed border-border/60 bg-muted/20 p-1.5">
+          {region.label && (
+            <div className="pb-1 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+              {region.label}
+            </div>
+          )}
+          <RegionCanvas region={region} maxWidth={maxWidth} />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Phase 1 of #2670** — the ADR-0031 "designer rendering" follow-up to the Runs-panel nesting (#2667). The flow designer canvas rendered structured control-flow containers (`loop` / `parallel` / `try_catch`) as **opaque single node cards**; their nested regions (`config.body` / `config.branches[]` / `config.try`/`catch`) were only visible — and only editable — as **raw JSON** in the inspector's Advanced block.

A container card now carries a **"show nested regions"** control that opens a **read-only popover** rendering the region(s) as a mini-canvas — the same top-to-bottom node/edge layout as the parent graph — so an author can *see the structure without reading JSON*.

## What changed

- **`flow-canvas-layout.ts`** — `extractRegions(node)` (pure): pulls a container's labeled regions from `config`. Returns `[]` for ordinary nodes and for a **legacy flat `loop`** (no `config.body`), which stay plain cards.
- **`flow-region-view.tsx`** (new) — a read-only mini-canvas for a region: reuses the shared `computeLayout` / `diagramSize` / `edgePath` at full scale, then fits the whole region to the popover width with a single CSS transform. **No new layout engine.**
- **`flow-canvas-parts.tsx` (`NodeCard`)** — when a node has regions, a chevron control opens a `Popover` with the region view, each region headed by its label (a named branch or `Branch N`, and `Try` / `Catch`; a loop body has none).
- **`FlowCanvas.tsx`** — passes `extractRegions(node)` to each card.

## Design note — why a popover (zero regression)

The region renders in a **floating, portaled Popover**, so it never overlaps the canvas's other nodes and requires **no change to `computeLayout`, `diagramSize`, or the edge routing** — every existing flat flow renders byte-identically. (An earlier inline-growth prototype overlapped the nodes below an expanded container; push-down layout would mean threading variable heights through the shared layout + edge anchors — deferred deliberately.)

**Deferred to the next increments on #2670:** inline push-down nesting on the canvas (regions embedded in the flow, siblings pushed down), nested selection + a structured region inspector, nested editing (add/drag/reparent), and client-side region validation. This PR does not close #2670.

## Verification

- `flow-canvas-layout.test.ts` — `extractRegions` unit tests (ordinary / legacy-loop / loop body / parallel-branch labels / try+catch).
- `FlowCanvas.test.tsx` — render tests: opening a loop shows its body node; parallel branch labels (`Branch 2`) + handlers render; a legacy flat loop has no region control.
- **19/19** tests pass; `turbo type-check` clean; ESLint 0 errors.
- **Browser-verified** in the offline preview gallery (Playwright): loop body, named + indexed parallel branches, and Try/Catch handlers all render in their popovers with the main flow chain intact and no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuvxWgoadqryqBcjs7TpVi)_