### PR TITLE
feat(plugin-gantt): manual-scheduling summary bars, interaction switches, beforeTaskUpdate veto + tooltip/scrollbar/cursor fixes

### DIFF
--- a/packages/plugin-gantt/src/GanttView.interactionswitches.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.interactionswitches.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Interaction switches (交互开关) + onBeforeTaskUpdate veto unit tests.
+ *
+ * `interactions: { move / resize / progress / link }` — the DHTMLX
+ * drag_move/drag_resize/drag_progress/drag_links model: each switch hides one
+ * affordance while the others keep working, and only ever narrows what
+ * readOnly / row locks already allow. `onBeforeTaskUpdate` is the
+ * MS-Project/Bryntum beforeTaskEdit veto on the central commit path.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GanttView, type GanttInteractions, type GanttTask } from './GanttView';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+});
+
+function pointer(type: string, clientX: number) {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX,
+    clientY: 100,
+    pointerType: 'mouse',
+    button: 0,
+    isPrimary: true,
+  } as PointerEventInit);
+}
+
+const baseTask: GanttTask = {
+  id: 't1',
+  title: 'Demo task',
+  start: new Date('2024-06-10T00:00:00.000Z'),
+  end: new Date('2024-06-15T00:00:00.000Z'),
+  progress: 40,
+  dependencies: [],
+};
+
+function renderView(opts: {
+  interactions?: GanttInteractions;
+  onTaskUpdate?: (task: GanttTask, changes: any) => void;
+  onBeforeTaskUpdate?: (task: GanttTask, changes: any) => boolean | Promise<boolean>;
+  onDependencyCreate?: (s: GanttTask, t: GanttTask, ty: any) => void;
+}) {
+  return render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView
+        tasks={[baseTask]}
+        startDate={new Date('2024-06-01T00:00:00.000Z')}
+        endDate={new Date('2024-06-30T00:00:00.000Z')}
+        onTaskUpdate={opts.onTaskUpdate ?? vi.fn()}
+        onBeforeTaskUpdate={opts.onBeforeTaskUpdate}
+        onDependencyCreate={opts.onDependencyCreate}
+        interactions={opts.interactions}
+      />
+    </div>
+  );
+}
+
+describe('interaction switches', () => {
+  it('default (no interactions prop): every affordance renders', () => {
+    const { container } = renderView({ onDependencyCreate: vi.fn() });
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-t1"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-progress-handle-t1"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-link-dot-end-t1"]')).toBeTruthy();
+  });
+
+  it('resize:false hides the grips but the bar still moves', () => {
+    const onTaskUpdate = vi.fn();
+    const { container } = renderView({ interactions: { resize: false }, onTaskUpdate });
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-t1"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-right-t1"]')).toBeFalsy();
+
+    const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 830)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 830)); });
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [, changes] = onTaskUpdate.mock.calls[0];
+    expect(changes.start.toISOString()).toBe('2024-06-13T00:00:00.000Z');
+  });
+
+  it('move:false kills body drag but the resize grips still work', () => {
+    const onTaskUpdate = vi.fn();
+    const { container } = renderView({ interactions: { move: false }, onTaskUpdate });
+
+    const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 830)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 830)); });
+    expect(onTaskUpdate).not.toHaveBeenCalled();
+
+    const handle = container.querySelector('[data-testid="gantt-task-resize-right-t1"]') as HTMLElement;
+    expect(handle).toBeTruthy();
+    act(() => { handle.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 720)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 720)); });
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [, changes] = onTaskUpdate.mock.calls[0];
+    expect(changes.start.toISOString()).toBe('2024-06-10T00:00:00.000Z');
+    expect(changes.end.toISOString()).toBe('2024-06-17T00:00:00.000Z');
+  });
+
+  it('progress:false hides the progress handle only', () => {
+    const { container } = renderView({ interactions: { progress: false } });
+    expect(container.querySelector('[data-testid="gantt-progress-handle-t1"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-t1"]')).toBeTruthy();
+  });
+
+  it('link:false removes the connector dots even with onDependencyCreate', () => {
+    const { container } = renderView({
+      interactions: { link: false },
+      onDependencyCreate: vi.fn(),
+    });
+    expect(container.querySelector('[data-testid="gantt-link-dot-start-t1"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-link-dot-end-t1"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-t1"]')).toBeTruthy();
+  });
+});
+
+describe('onBeforeTaskUpdate veto', () => {
+  it('a false veto cancels the update before it reaches onTaskUpdate', async () => {
+    const onTaskUpdate = vi.fn();
+    const veto = vi.fn().mockResolvedValue(false);
+    const { container } = renderView({ onTaskUpdate, onBeforeTaskUpdate: veto });
+
+    const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 830)); });
+    await act(async () => { window.dispatchEvent(pointer('pointerup', 830)); });
+
+    expect(veto).toHaveBeenCalledTimes(1);
+    expect(veto.mock.calls[0][0].id).toBe('t1');
+    expect(onTaskUpdate).not.toHaveBeenCalled();
+  });
+
+  it('a true veto lets the update through unchanged', async () => {
+    const onTaskUpdate = vi.fn();
+    const veto = vi.fn().mockResolvedValue(true);
+    const { container } = renderView({ onTaskUpdate, onBeforeTaskUpdate: veto });
+
+    const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 830)); });
+    await act(async () => { window.dispatchEvent(pointer('pointerup', 830)); });
+
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [, changes] = onTaskUpdate.mock.calls[0];
+    expect(changes.start.toISOString()).toBe('2024-06-13T00:00:00.000Z');
+  });
+
+  it('a throwing veto is treated as false (fail-closed)', async () => {
+    const onTaskUpdate = vi.fn();
+    const veto = vi.fn().mockRejectedValue(new Error('boom'));
+    const { container } = renderView({ onTaskUpdate, onBeforeTaskUpdate: veto });
+
+    const bar = container.querySelector('[data-testid="gantt-task-bar-t1"]') as HTMLElement;
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 830)); });
+    await act(async () => { window.dispatchEvent(pointer('pointerup', 830)); });
+
+    expect(onTaskUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.summaryedit.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.summaryedit.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Summary-bar editability (手动排程汇总条) unit tests.
+ *
+ * The MS-Project rule: a summary whose OWN dates are authoritative
+ * (`summaryExtent: 'self'` + `hasOwnDates !== false`) edits like a task bar —
+ * edge grips resize its own start/end, connector dots draw dependencies —
+ * while its middle still group-moves the whole subtree. Rollup summaries
+ * (children define the span) stay move-only: derived dates have no field to
+ * persist to.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+});
+
+function pointer(type: string, clientX: number) {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX,
+    clientY: 100,
+    pointerType: 'mouse',
+    button: 0,
+    isPrimary: true,
+  } as PointerEventInit);
+}
+
+function makeTasks(overrides?: { lockedParent?: boolean }): GanttTask[] {
+  return [
+    {
+      id: 'p1',
+      title: 'Plan',
+      start: new Date('2024-06-10T00:00:00.000Z'),
+      end: new Date('2024-06-15T00:00:00.000Z'),
+      progress: 0,
+      dependencies: [],
+      hasOwnDates: true,
+      locked: overrides?.lockedParent ?? false,
+    },
+    {
+      id: 'c1',
+      title: 'Child order',
+      start: new Date('2024-06-11T00:00:00.000Z'),
+      end: new Date('2024-06-12T00:00:00.000Z'),
+      progress: 0,
+      dependencies: [],
+      parent: 'p1',
+    },
+  ];
+}
+
+function renderView(opts: {
+  tasks?: GanttTask[];
+  summaryExtent?: 'children' | 'self';
+  onTaskUpdate?: (task: GanttTask, changes: any) => void;
+  onDependencyCreate?: (s: GanttTask, t: GanttTask, ty: any) => void;
+}) {
+  return render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView
+        tasks={opts.tasks ?? makeTasks()}
+        startDate={new Date('2024-06-01T00:00:00.000Z')}
+        endDate={new Date('2024-06-30T00:00:00.000Z')}
+        summaryExtent={opts.summaryExtent}
+        onTaskUpdate={opts.onTaskUpdate}
+        onDependencyCreate={opts.onDependencyCreate}
+      />
+    </div>
+  );
+}
+
+describe('self-extent summary bar editability', () => {
+  it('renders resize grips on a self-dated summary bar', () => {
+    const { container } = renderView({ summaryExtent: 'self', onTaskUpdate: vi.fn() });
+    expect(container.querySelector('[data-testid="gantt-summary-bar-p1"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-p1"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-right-p1"]')).toBeTruthy();
+  });
+
+  it('rollup summary (summaryExtent children) gets NO resize grips', () => {
+    const { container } = renderView({ onTaskUpdate: vi.fn() });
+    expect(container.querySelector('[data-testid="gantt-summary-bar-p1"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-p1"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="gantt-task-resize-right-p1"]')).toBeFalsy();
+  });
+
+  it('locked summary gets NO resize grips even in self mode', () => {
+    const { container } = renderView({
+      summaryExtent: 'self',
+      tasks: makeTasks({ lockedParent: true }),
+      onTaskUpdate: vi.fn(),
+    });
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-p1"]')).toBeFalsy();
+  });
+
+  it('read-only view gets NO resize grips even in self mode', () => {
+    const { container } = render(
+      <div style={{ width: 1280, height: 600 }}>
+        <GanttView
+          tasks={makeTasks()}
+          startDate={new Date('2024-06-01T00:00:00.000Z')}
+          endDate={new Date('2024-06-30T00:00:00.000Z')}
+          summaryExtent="self"
+          onTaskUpdate={vi.fn()}
+          readOnly
+        />
+      </div>
+    );
+    expect(container.querySelector('[data-testid="gantt-task-resize-left-p1"]')).toBeFalsy();
+  });
+
+  it('resize-right on a summary commits ONLY the summary own end (no children)', () => {
+    const onTaskUpdate = vi.fn();
+    const { container } = renderView({ summaryExtent: 'self', onTaskUpdate });
+    const handle = container.querySelector('[data-testid="gantt-task-resize-right-p1"]') as HTMLElement;
+    expect(handle).toBeTruthy();
+
+    // columnWidth at width>=1024 = 110 → +220px = +2 days.
+    act(() => { handle.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 720)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 720)); });
+
+    expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+    const [task, changes] = onTaskUpdate.mock.calls[0];
+    expect(task.id).toBe('p1');
+    expect(changes.start.toISOString()).toBe('2024-06-10T00:00:00.000Z');
+    expect(changes.end.toISOString()).toBe('2024-06-17T00:00:00.000Z');
+  });
+
+  it('dragging the summary body still group-moves the whole subtree', () => {
+    const onTaskUpdate = vi.fn();
+    const { container } = renderView({ summaryExtent: 'self', onTaskUpdate });
+    const bar = container.querySelector('[data-testid="gantt-summary-bar-p1"]') as HTMLElement;
+
+    // jsdom rects are zero-width → the edge-zone resolver returns 'move',
+    // exercising the middle-of-bar path. +330px → +3 days.
+    act(() => { bar.dispatchEvent(pointer('pointerdown', 500)); });
+    act(() => { window.dispatchEvent(pointer('pointermove', 830)); });
+    act(() => { window.dispatchEvent(pointer('pointerup', 830)); });
+
+    expect(onTaskUpdate).toHaveBeenCalledTimes(2);
+    const ids = onTaskUpdate.mock.calls.map(([t]: [GanttTask]) => t.id).sort();
+    expect(ids).toEqual(['c1', 'p1']);
+    const parentCall = onTaskUpdate.mock.calls.find(([t]: [GanttTask]) => t.id === 'p1')!;
+    expect(parentCall[1].start.toISOString()).toBe('2024-06-13T00:00:00.000Z');
+    expect(parentCall[1].end.toISOString()).toBe('2024-06-18T00:00:00.000Z');
+  });
+
+  it('summary bars grow connector dots for drag-to-link', () => {
+    const { container } = renderView({
+      summaryExtent: 'self',
+      onTaskUpdate: vi.fn(),
+      onDependencyCreate: vi.fn(),
+    });
+    expect(container.querySelector('[data-testid="gantt-link-dot-start-p1"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="gantt-link-dot-end-p1"]')).toBeTruthy();
+  });
+
+  it('no connector dots without onDependencyCreate', () => {
+    const { container } = renderView({ summaryExtent: 'self', onTaskUpdate: vi.fn() });
+    expect(container.querySelector('[data-testid="gantt-link-dot-end-p1"]')).toBeFalsy();
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tooltipflip.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.tooltipflip.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tooltip flip on bottom rows (最后一行悬浮狂闪).
+ *
+ * A downward tooltip on one of the LAST rows pokes past the rows box, growing
+ * the scroller's scrollHeight while shown; with the user scrolled to the
+ * bottom, browser scroll clamping/anchoring re-adjusts scrollTop on every
+ * mount/unmount and the tooltip flickers in a loop. Bottom rows therefore
+ * flip the tooltip ABOVE the bar (upward overflow never extends the
+ * scrollable area). Top rows keep the downward tooltip.
+ */
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+});
+
+function makeTasks(n: number): GanttTask[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `t${i}`,
+    title: `Task ${i}`,
+    start: new Date('2024-06-10T00:00:00.000Z'),
+    end: new Date('2024-06-15T00:00:00.000Z'),
+    progress: 0,
+    dependencies: [],
+  }));
+}
+
+function hoverBar(container: HTMLElement, id: string) {
+  const bar = container.querySelector(`[data-testid="gantt-task-bar-${id}"]`) as HTMLElement;
+  expect(bar).toBeTruthy();
+  act(() => {
+    fireEvent.mouseEnter(bar);
+  });
+  return container.querySelector(`[data-testid="gantt-tooltip-${id}"]`) as HTMLElement | null;
+}
+
+describe('tooltip flip on bottom rows', () => {
+  it('last row of a tall chart renders the tooltip ABOVE the bar (bottom set, top unset)', () => {
+    const tasks = makeTasks(20);
+    const { container } = render(
+      <div style={{ width: 1280, height: 600 }}>
+        <GanttView
+          tasks={tasks}
+          startDate={new Date('2024-06-01T00:00:00.000Z')}
+          endDate={new Date('2024-06-30T00:00:00.000Z')}
+        />
+      </div>
+    );
+    const tip = hoverBar(container, 't19');
+    expect(tip).toBeTruthy();
+    expect(tip!.style.bottom).not.toBe('');
+    expect(tip!.style.top).toBe('');
+  });
+
+  it('a top row keeps the downward tooltip (top set, bottom unset)', () => {
+    const tasks = makeTasks(20);
+    const { container } = render(
+      <div style={{ width: 1280, height: 600 }}>
+        <GanttView
+          tasks={tasks}
+          startDate={new Date('2024-06-01T00:00:00.000Z')}
+          endDate={new Date('2024-06-30T00:00:00.000Z')}
+        />
+      </div>
+    );
+    const tip = hoverBar(container, 't0');
+    expect(tip).toBeTruthy();
+    expect(tip!.style.top).not.toBe('');
+    expect(tip!.style.bottom).toBe('');
+  });
+
+  it('short charts (no room above) never flip', () => {
+    const tasks = makeTasks(3);
+    const { container } = render(
+      <div style={{ width: 1280, height: 600 }}>
+        <GanttView
+          tasks={tasks}
+          startDate={new Date('2024-06-01T00:00:00.000Z')}
+          endDate={new Date('2024-06-30T00:00:00.000Z')}
+        />
+      </div>
+    );
+    const tip = hoverBar(container, 't2');
+    expect(tip).toBeTruthy();
+    expect(tip!.style.top).not.toBe('');
+    expect(tip!.style.bottom).toBe('');
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -2308,22 +2308,47 @@ export function GanttView({
   const hTrackRef = React.useRef<HTMLDivElement>(null);
   const hThumbRef = React.useRef<HTMLDivElement>(null);
   const hDragRef = React.useRef<{ startX: number; startLeft: number } | null>(null);
+  const vBarRef = React.useRef<HTMLDivElement>(null);
+  const vTrackRef = React.useRef<HTMLDivElement>(null);
+  const vThumbRef = React.useRef<HTMLDivElement>(null);
+  const vDragRef = React.useRef<{ startY: number; startTop: number } | null>(null);
   const syncHScrollbar = React.useCallback(() => {
     const tl = timelineRef.current;
     const bar = hBarRef.current;
     const track = hTrackRef.current;
     const thumb = hThumbRef.current;
-    if (!tl || !bar || !track || !thumb) return;
-    const needed = tl.scrollWidth > tl.clientWidth + 1;
-    bar.style.display = needed ? 'block' : 'none';
-    if (!needed) return;
-    const trackW = track.clientWidth;
-    if (trackW <= 0) return;
-    const thumbW = Math.min(trackW, Math.max(40, (tl.clientWidth / tl.scrollWidth) * trackW));
-    const maxScroll = tl.scrollWidth - tl.clientWidth;
-    const left = maxScroll > 0 ? (tl.scrollLeft / maxScroll) * (trackW - thumbW) : 0;
-    thumb.style.width = `${thumbW}px`;
-    thumb.style.transform = `translateX(${left}px)`;
+    if (tl && bar && track && thumb) {
+      const needed = tl.scrollWidth > tl.clientWidth + 1;
+      bar.style.display = needed ? 'block' : 'none';
+      if (needed) {
+        const trackW = track.clientWidth;
+        if (trackW > 0) {
+          const thumbW = Math.min(trackW, Math.max(40, (tl.clientWidth / tl.scrollWidth) * trackW));
+          const maxScroll = tl.scrollWidth - tl.clientWidth;
+          const left = maxScroll > 0 ? (tl.scrollLeft / maxScroll) * (trackW - thumbW) : 0;
+          thumb.style.width = `${thumbW}px`;
+          thumb.style.transform = `translateX(${left}px)`;
+        }
+      }
+    }
+    // Vertical twin — same math on the other axis.
+    const vBar = vBarRef.current;
+    const vTrack = vTrackRef.current;
+    const vThumb = vThumbRef.current;
+    if (tl && vBar && vTrack && vThumb) {
+      const needed = tl.scrollHeight > tl.clientHeight + 1;
+      vBar.style.display = needed ? 'block' : 'none';
+      if (needed) {
+        const trackH = vTrack.clientHeight;
+        if (trackH > 0) {
+          const thumbH = Math.min(trackH, Math.max(40, (tl.clientHeight / tl.scrollHeight) * trackH));
+          const maxScroll = tl.scrollHeight - tl.clientHeight;
+          const top = maxScroll > 0 ? (tl.scrollTop / maxScroll) * (trackH - thumbH) : 0;
+          vThumb.style.height = `${thumbH}px`;
+          vThumb.style.transform = `translateY(${top}px)`;
+        }
+      }
+    }
   }, []);
   // Re-measure after every render: cheap (a couple of style writes) and it
   // tracks every input that moves the geometry — zoom, view mode, container
@@ -2372,6 +2397,48 @@ export function GanttView({
     if (usable <= 0) return;
     const targetLeft = Math.min(Math.max(e.clientX - r.x - thumbW / 2, 0), usable);
     tl.scrollLeft = (targetLeft / usable) * maxScroll;
+  };
+  const onVThumbPointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const tl = timelineRef.current;
+    const track = vTrackRef.current;
+    const thumb = vThumbRef.current;
+    if (!tl || !track || !thumb) return;
+    vDragRef.current = { startY: e.clientY, startTop: tl.scrollTop };
+    const trackH = track.clientHeight;
+    const thumbH = thumb.getBoundingClientRect().height;
+    const maxScroll = tl.scrollHeight - tl.clientHeight;
+    const pxRatio = trackH - thumbH > 0 ? maxScroll / (trackH - thumbH) : 0;
+    const onMove = (ev: PointerEvent) => {
+      const cur = vDragRef.current;
+      if (!cur) return;
+      tl.scrollTop = cur.startTop + (ev.clientY - cur.startY) * pxRatio;
+    };
+    const onUp = () => {
+      vDragRef.current = null;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+  };
+  const onVTrackPointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0 || e.target !== e.currentTarget) return;
+    const tl = timelineRef.current;
+    const track = vTrackRef.current;
+    const thumb = vThumbRef.current;
+    if (!tl || !track || !thumb) return;
+    const r = track.getBoundingClientRect();
+    const thumbH = thumb.getBoundingClientRect().height;
+    const maxScroll = tl.scrollHeight - tl.clientHeight;
+    const usable = r.height - thumbH;
+    if (usable <= 0) return;
+    const targetTop = Math.min(Math.max(e.clientY - r.y - thumbH / 2, 0), usable);
+    tl.scrollTop = (targetTop / usable) * maxScroll;
   };
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
@@ -2871,48 +2938,16 @@ export function GanttView({
           .gantt-sm-w20 { width: 80px; }
           .gantt-sm-hidden { display: none; }
         }
-        /* Persistent, grabbable timeline scrollbars. macOS (and iOS) default to
-           overlay scrollbars that collapse to 0px and auto-hide, so the
-           timeline's vertical scrollbar was nearly impossible to find. Defining
-           ::-webkit-scrollbar opts this pane into a classic, always-visible bar
-           regardless of the OS overlay preference. The thumb gets a min size so
-           that with thousands of virtualized rows (scrollHeight in the hundreds
-           of thousands of px) it never shrinks to an un-grabbable sliver. Scoped
-           to the gantt pane so the host app's own scrollbars are untouched, and
-           themed with neutral rgba (not theme utilities, which don't always
-           reach a consuming app) so it's visible on any background. */
-        /* Firefox (and any engine without ::-webkit-scrollbar) only: the
-           standard props. We must NOT set these unconditionally — modern Chrome
-           now honors scrollbar-width and, when it's present, IGNORES the
-           ::-webkit-scrollbar rule below, falling back to the 0px auto-hiding
-           overlay bar we're trying to replace. */
-        @supports not selector(::-webkit-scrollbar) {
-          [data-testid="gantt-timeline"] {
-            scrollbar-width: thin;
-            scrollbar-color: rgba(130,130,130,0.55) transparent;
-          }
-        }
-        [data-testid="gantt-timeline"]::-webkit-scrollbar {
-          width: 14px;
-          height: 14px;
-        }
-        [data-testid="gantt-timeline"]::-webkit-scrollbar-track {
-          background: transparent;
-        }
-        [data-testid="gantt-timeline"]::-webkit-scrollbar-thumb {
-          background-color: rgba(130,130,130,0.55);
-          border-radius: 8px;
-          border: 3px solid transparent;
-          background-clip: padding-box;
-          min-height: 40px;
-          min-width: 40px;
-        }
-        [data-testid="gantt-timeline"]::-webkit-scrollbar-thumb:hover {
-          background-color: rgba(110,110,110,0.85);
-        }
-        [data-testid="gantt-timeline"]::-webkit-scrollbar-corner {
-          background: transparent;
-        }
+        /* The timeline's NATIVE scrollbars are fully hidden — both axes are
+           replaced by the self-drawn bars (水平底部 / 垂直右侧). Styling the
+           native bar is a dead end: overlay-scrollbar engines (macOS "show
+           while scrolling", embedded Chromium) ignore ::-webkit-scrollbar
+           theming yet still flash their own auto-hiding bar on scroll, which
+           doubled up with the self-drawn one (双滚动条). scrollbar-width:none
+           is honored by overlay engines too; the ::-webkit rule covers older
+           WebKit. Wheel/trackpad/programmatic scrolling is unaffected. */
+        [data-testid="gantt-timeline"] { scrollbar-width: none; }
+        [data-testid="gantt-timeline"]::-webkit-scrollbar { display: none; width: 0; height: 0; }
         /* The task-list pane scrolls in lockstep with the timeline, so its own
            vertical scrollbar (butted against the divider) was a confusing second
            bar. Hide it — the pane stays wheel/drag-scrollable and synced. */
@@ -4370,6 +4405,40 @@ export function GanttView({
                 })()}
 
               </div>
+            </div>
+          </div>
+
+          {/* Self-drawn vertical scrollbar (自绘垂直滚动条) — the native bars
+              are fully hidden (see the style block), so this is the one
+              vertical affordance; synced with the timeline's scrollTop. */}
+          <div
+            ref={vBarRef}
+            className="shrink-0 border-l bg-card/95 select-none"
+            style={{ width: 14, display: 'none' }}
+            data-testid="gantt-vscrollbar"
+          >
+            <div
+              ref={vTrackRef}
+              className="relative h-full"
+              onPointerDown={onVTrackPointerDown}
+              role="scrollbar"
+              aria-controls="gantt-timeline"
+              aria-orientation="vertical"
+            >
+              <div
+                ref={vThumbRef}
+                className="absolute rounded-full"
+                style={{
+                  left: 2,
+                  right: 2,
+                  top: 0,
+                  height: 0,
+                  backgroundColor: 'rgba(130,130,130,0.55)',
+                  cursor: 'grab',
+                }}
+                data-testid="gantt-vscrollbar-thumb"
+                onPointerDown={onVThumbPointerDown}
+              />
             </div>
           </div>
         </div>

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -2296,6 +2296,84 @@ export function GanttView({
     [scrollToDate],
   );
 
+  // --- Always-visible horizontal scrollbar (自绘水平滚动条) ----------------
+  // The native bar can't be relied on here: overlay-scrollbar engines (macOS
+  // "show while scrolling", embedded Chromium) silently ignore the
+  // ::-webkit-scrollbar styling injected above, and in tall host layouts the
+  // pane's bottom edge sits below the viewport so even a rendered bar is out
+  // of sight. So we draw our own track + thumb, stickied to the visible
+  // bottom, synced 1:1 with the timeline's scrollLeft. Everything is
+  // DOM-ref-driven — no per-frame React state.
+  const hBarRef = React.useRef<HTMLDivElement>(null);
+  const hTrackRef = React.useRef<HTMLDivElement>(null);
+  const hThumbRef = React.useRef<HTMLDivElement>(null);
+  const hDragRef = React.useRef<{ startX: number; startLeft: number } | null>(null);
+  const syncHScrollbar = React.useCallback(() => {
+    const tl = timelineRef.current;
+    const bar = hBarRef.current;
+    const track = hTrackRef.current;
+    const thumb = hThumbRef.current;
+    if (!tl || !bar || !track || !thumb) return;
+    const needed = tl.scrollWidth > tl.clientWidth + 1;
+    bar.style.display = needed ? 'block' : 'none';
+    if (!needed) return;
+    const trackW = track.clientWidth;
+    if (trackW <= 0) return;
+    const thumbW = Math.min(trackW, Math.max(40, (tl.clientWidth / tl.scrollWidth) * trackW));
+    const maxScroll = tl.scrollWidth - tl.clientWidth;
+    const left = maxScroll > 0 ? (tl.scrollLeft / maxScroll) * (trackW - thumbW) : 0;
+    thumb.style.width = `${thumbW}px`;
+    thumb.style.transform = `translateX(${left}px)`;
+  }, []);
+  // Re-measure after every render: cheap (a couple of style writes) and it
+  // tracks every input that moves the geometry — zoom, view mode, container
+  // resize, task-list drag — without enumerating them as deps.
+  React.useEffect(() => { syncHScrollbar(); });
+  const onHThumbPointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const tl = timelineRef.current;
+    const track = hTrackRef.current;
+    const thumb = hThumbRef.current;
+    if (!tl || !track || !thumb) return;
+    hDragRef.current = { startX: e.clientX, startLeft: tl.scrollLeft };
+    const trackW = track.clientWidth;
+    const thumbW = thumb.getBoundingClientRect().width;
+    const maxScroll = tl.scrollWidth - tl.clientWidth;
+    const pxRatio = trackW - thumbW > 0 ? maxScroll / (trackW - thumbW) : 0;
+    const onMove = (ev: PointerEvent) => {
+      const cur = hDragRef.current;
+      if (!cur) return;
+      tl.scrollLeft = cur.startLeft + (ev.clientX - cur.startX) * pxRatio;
+    };
+    const onUp = () => {
+      hDragRef.current = null;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+  };
+  const onHTrackPointerDown = (e: React.PointerEvent) => {
+    // Clicking the empty track jumps the view; hits on the thumb itself are
+    // handled (and stopped) by the thumb's own pointerdown.
+    if (e.button !== 0 || e.target !== e.currentTarget) return;
+    const tl = timelineRef.current;
+    const track = hTrackRef.current;
+    const thumb = hThumbRef.current;
+    if (!tl || !track || !thumb) return;
+    const r = track.getBoundingClientRect();
+    const thumbW = thumb.getBoundingClientRect().width;
+    const maxScroll = tl.scrollWidth - tl.clientWidth;
+    const usable = r.width - thumbW;
+    if (usable <= 0) return;
+    const targetLeft = Math.min(Math.max(e.clientX - r.x - thumbW / 2, 0), usable);
+    tl.scrollLeft = (targetLeft / usable) * maxScroll;
+  };
+
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const el = e.currentTarget;
     // Track the left-edge date as the user's anchor intent — but only for
@@ -2310,6 +2388,8 @@ export function GanttView({
     if (headerRef.current) {
         headerRef.current.scrollLeft = el.scrollLeft;
     }
+    // Sync the self-drawn horizontal scrollbar thumb.
+    syncHScrollbar();
     // Sync vertical scroll to task list. Assign only when it differs so the
     // browser fires no scroll event on the list (a no-op assignment is silent),
     // which is what keeps the two-way sync below from looping.
@@ -4291,6 +4371,42 @@ export function GanttView({
 
               </div>
             </div>
+          </div>
+        </div>
+
+        {/* Always-visible horizontal scrollbar (自绘水平滚动条): sticky to the
+            visible bottom so it stays reachable even when the pane's bottom
+            edge extends past the viewport. Hidden by syncHScrollbar when the
+            timeline fits. */}
+        <div
+          ref={hBarRef}
+          className="shrink-0 border-t bg-card/95 select-none"
+          style={{ position: 'sticky', bottom: 0, zIndex: 30, display: 'none' }}
+          data-testid="gantt-hscrollbar"
+        >
+          <div
+            ref={hTrackRef}
+            className="relative"
+            style={{ marginLeft: taskListWidth, height: 14 }}
+            onPointerDown={onHTrackPointerDown}
+            role="scrollbar"
+            aria-controls="gantt-timeline"
+            aria-orientation="horizontal"
+          >
+            <div
+              ref={hThumbRef}
+              className="absolute rounded-full"
+              style={{
+                top: 2,
+                bottom: 2,
+                left: 0,
+                width: 0,
+                backgroundColor: 'rgba(130,130,130,0.55)',
+                cursor: 'grab',
+              }}
+              data-testid="gantt-hscrollbar-thumb"
+              onPointerDown={onHThumbPointerDown}
+            />
           </div>
         </div>
       </div>

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -259,6 +259,24 @@ export interface GanttMarker {
   color?: string
 }
 
+/**
+ * Per-interaction switches (交互开关) — the DHTMLX `drag_move` / `drag_resize` /
+ * `drag_progress` / `drag_links` model. Each defaults to true; flipping one off
+ * hides that affordance everywhere while the others keep working. They only
+ * NARROW what the write callbacks / `readOnly` / row locks already allow —
+ * never widen.
+ */
+export interface GanttInteractions {
+  /** Bar / subtree dragging (move along the timeline). */
+  move?: boolean
+  /** Edge resize grips (change duration). */
+  resize?: boolean
+  /** The progress drag handle. */
+  progress?: boolean
+  /** Dependency UI: drag-to-link dots AND the create/delete menu entries. */
+  link?: boolean
+}
+
 export interface GanttViewProps {
   tasks: GanttTask[]
   /** Initial timeline granularity (also switchable from the toolbar). */
@@ -413,6 +431,27 @@ export interface GanttViewProps {
   onRefresh?: () => void | Promise<void>
   /** Disables the refresh button while a host-driven reload is in flight. */
   refreshing?: boolean
+  /**
+   * Per-interaction switches (交互开关). Omit for all-on. See
+   * {@link GanttInteractions}: e.g. `{ resize: false }` keeps bars movable and
+   * links drawable but pins every duration; `{ link: false }` removes the
+   * dependency drag-dots and the create/delete menu entries. Subject to
+   * `readOnly` and per-row locks — these switches only narrow.
+   */
+  interactions?: GanttInteractions
+  /**
+   * Veto hook for task edits (the MS-Project/Bryntum `beforeTaskDrag` /
+   * `beforeTaskEdit` pattern). Runs on the central commit path — bar drag,
+   * edge resize, group move, progress drag, inline edit, conflict
+   * auto-reschedule — AFTER the built-in guards (locked rows never reach it).
+   * Return false (sync or async) to cancel that task's update; other tasks in
+   * the same batch still apply. Undo/redo bypasses it: restoring a previous
+   * state must not be vetoable.
+   */
+  onBeforeTaskUpdate?: (
+    task: GanttTask,
+    changes: Partial<Pick<GanttTask, 'title' | 'start' | 'end' | 'progress'>>,
+  ) => boolean | Promise<boolean>
 }
 
 /** Persisted layout snapshot written by the "保存布局" toolbar button. */
@@ -583,6 +622,8 @@ export function GanttView({
   onLayoutChange,
   onRefresh,
   refreshing = false,
+  interactions,
+  onBeforeTaskUpdate,
 }: GanttViewProps) {
   const { t, language } = useGanttTranslation();
   // Locale for every user-facing date label. Falls back to the runtime default
@@ -601,10 +642,18 @@ export function GanttView({
   // get a read-only thumbnail (移动端只读缩略). `onTaskClick` / `onViewChange`
   // stay live: they don't mutate.
   const effectiveReadOnly = readOnly || (mobileReadOnly && isNarrow);
+  // Interaction switches (default all on). `link` folds into the dependency
+  // handlers right here so every downstream consumer — drag-dots, context-menu
+  // create/delete entries, link menus — inherits it; move/resize/progress are
+  // enforced at their interaction sites (they share onTaskUpdate).
+  const ixMove = interactions?.move !== false;
+  const ixResize = interactions?.resize !== false;
+  const ixProgress = interactions?.progress !== false;
+  const ixLink = interactions?.link !== false;
   const onTaskUpdate = effectiveReadOnly ? undefined : onTaskUpdateProp;
   const onTaskDelete = effectiveReadOnly ? undefined : onTaskDeleteProp;
-  const onDependencyCreate = effectiveReadOnly ? undefined : onDependencyCreateProp;
-  const onDependencyDelete = effectiveReadOnly ? undefined : onDependencyDeleteProp;
+  const onDependencyCreate = effectiveReadOnly || !ixLink ? undefined : onDependencyCreateProp;
+  const onDependencyDelete = effectiveReadOnly || !ixLink ? undefined : onDependencyDeleteProp;
   const onTaskReorder = effectiveReadOnly ? undefined : onTaskReorderProp;
   const inlineEdit = effectiveReadOnly ? false : inlineEditProp;
   const autoSchedule = effectiveReadOnly ? false : autoScheduleProp;
@@ -880,34 +929,54 @@ export function GanttView({
   const commitTaskUpdates = React.useCallback(
     (updates: Array<{ task: GanttTask; changes: Partial<Pick<GanttTask, 'title' | 'start' | 'end' | 'progress'>> }>) => {
       if (!onTaskUpdate) return;
-      const batch: HistoryItem[] = [];
       // Central belt: a locked row (仅查看) is never committed, whatever the
       // path — group shift, conflict reschedule, or a future caller.
-      for (const { task, changes } of updates.filter((u) => !u.task.locked)) {
-        const before: Partial<GanttTask> = {};
-        const after: Partial<GanttTask> = {};
-        let dirty = false;
-        for (const k of Object.keys(changes) as Array<keyof GanttTask>) {
-          const next = (changes as Record<string, unknown>)[k as string];
-          const prev = (task as unknown as Record<string, unknown>)[k as string];
-          const same =
-            next instanceof Date && prev instanceof Date
-              ? next.getTime() === prev.getTime()
-              : next === prev;
-          (before as Record<string, unknown>)[k as string] = prev;
-          (after as Record<string, unknown>)[k as string] = next;
-          if (!same) dirty = true;
+      const candidates = updates.filter((u) => !u.task.locked);
+      // The host veto (onBeforeTaskUpdate) may be async, so the whole commit
+      // is — callers stay fire-and-forget. A veto (false return or a throw)
+      // drops that task's update; the rest of the batch still applies.
+      void (async () => {
+        let approved = candidates;
+        if (onBeforeTaskUpdate) {
+          const kept: typeof candidates = [];
+          for (const u of candidates) {
+            let ok = true;
+            try {
+              ok = (await onBeforeTaskUpdate(u.task, u.changes)) !== false;
+            } catch {
+              ok = false;
+            }
+            if (ok) kept.push(u);
+          }
+          approved = kept;
         }
-        onTaskUpdate(task, changes);
-        if (dirty) batch.push({ taskId: String(task.id), before, after });
-      }
-      if (batch.length) {
-        undoStackRef.current.push(batch);
-        redoStackRef.current = [];
-        setHistoryVersion((v) => v + 1);
-      }
+        const batch: HistoryItem[] = [];
+        for (const { task, changes } of approved) {
+          const before: Partial<GanttTask> = {};
+          const after: Partial<GanttTask> = {};
+          let dirty = false;
+          for (const k of Object.keys(changes) as Array<keyof GanttTask>) {
+            const next = (changes as Record<string, unknown>)[k as string];
+            const prev = (task as unknown as Record<string, unknown>)[k as string];
+            const same =
+              next instanceof Date && prev instanceof Date
+                ? next.getTime() === prev.getTime()
+                : next === prev;
+            (before as Record<string, unknown>)[k as string] = prev;
+            (after as Record<string, unknown>)[k as string] = next;
+            if (!same) dirty = true;
+          }
+          onTaskUpdate(task, changes);
+          if (dirty) batch.push({ taskId: String(task.id), before, after });
+        }
+        if (batch.length) {
+          undoStackRef.current.push(batch);
+          redoStackRef.current = [];
+          setHistoryVersion((v) => v + 1);
+        }
+      })();
     },
-    [onTaskUpdate],
+    [onTaskUpdate, onBeforeTaskUpdate],
   );
 
   // --- 拖拽冲突校验 + 顺延确认 (Group 2) ---
@@ -2335,7 +2404,10 @@ export function GanttView({
           new Date(row.end.getTime() + deltaMs)
         );
       }
-      if (!row.isSummary && dragState.taskId === row.task.id) {
+      // The dragged bar itself under a NON-group drag: a leaf move/resize, or a
+      // self-extent summary resizing its own dates. Group moves are handled
+      // above via dragGroupIds (which already includes the dragged summary).
+      if (dragState.taskId === row.task.id && !dragState.group) {
         const previewed = computeDragChanges(dragState);
         return styleFor(previewed.start, previewed.end);
       }
@@ -3450,7 +3522,14 @@ export function GanttView({
                    // Per-node lock (仅查看): treat like read-only for this row —
                    // no move/resize/progress/link, but onTaskClick still fires.
                    const isLocked = !!task.locked;
-                   const canDrag = !!onTaskUpdate && !row.isSummary && !isLocked;
+                   // Per-interaction gates: the row must be editable at all
+                   // (handler, not summary, not locked) AND the corresponding
+                   // interaction switch must be on.
+                   const editableRow = !!onTaskUpdate && !row.isSummary && !isLocked;
+                   const canMove = editableRow && ixMove;
+                   const canResize = editableRow && ixResize;
+                   const canProgress = editableRow && ixProgress;
+                   const canDrag = canMove || canResize;
                    // A bar that is explicitly non-editable — the whole view is
                    // read-only, or this row is locked (仅查看) — gets a not-allowed
                    // cursor so hovering signals "can't drag/resize here". A plain
@@ -3544,8 +3623,18 @@ export function GanttView({
                      // Summary bar: a solid row-centered bar (slightly slimmer
                      // than task bars) with the title and a darker progress
                      // fill, like svar/MS-Project group bars. Children drive
-                     // its range; dragging it moves the whole subtree.
+                     // its range; dragging its middle moves the whole subtree.
                      const summaryColor = task.color || '#0d9488';
+                     // A summary whose OWN dates are authoritative (summaryExtent
+                     // 'self' + it carries real dates) edits like a task bar: the
+                     // end zones resize its own start/end and it grows link
+                     // connectors. A rollup summary (children define the span)
+                     // stays move-only — resizing derived dates has no field to
+                     // persist to.
+                     const summaryOwnsDates =
+                       summaryExtent === 'self' && task.hasOwnDates !== false;
+                     const summaryMovable = !!onTaskUpdate && ixMove;
+                     const summaryResizable = !!onTaskUpdate && ixResize && summaryOwnsDates && !isLocked;
                      return (
                       <div
                         key={task.id}
@@ -3556,9 +3645,10 @@ export function GanttView({
                         {baselineEl}
                         <div
                           className={cn(
-                            'gantt-bar-hover absolute rounded-sm border shadow-sm flex items-center px-2 select-none',
-                            onTaskUpdate && 'cursor-grab active:cursor-grabbing',
+                            'gantt-bar-hover absolute rounded-sm border shadow-sm flex items-center px-2 select-none group',
+                            summaryMovable && 'cursor-grab active:cursor-grabbing',
                             isDragging && 'ring-2 ring-primary z-10',
+                            isLinkTarget && 'ring-2 ring-primary',
                             flashTaskId === task.id && 'gantt-flash z-10'
                           )}
                           /* Explicit colors: alpha utilities aren't emitted in
@@ -3571,7 +3661,7 @@ export function GanttView({
                             // Inline not-allowed: the cursor-not-allowed utility isn't
                             // emitted in the prebuilt components CSS, so drive the
                             // read-only cursor from style rather than a class.
-                            cursor: onTaskUpdate ? undefined : barReadOnly ? 'not-allowed' : 'pointer',
+                            cursor: summaryMovable || summaryResizable ? undefined : barReadOnly ? 'not-allowed' : 'pointer',
                             backgroundColor: summaryColor,
                             borderColor: isCrit ? CRIT_COLOR : task.borderColor || 'hsl(var(--primary-foreground) / 0.2)',
                             boxShadow: isCrit ? `0 0 0 2px ${CRIT_COLOR}` : task.borderColor ? `0 0 0 2px ${task.borderColor}` : undefined,
@@ -3581,9 +3671,24 @@ export function GanttView({
                           data-progress={Math.round(row.progress)}
                           onMouseEnter={() => setHoveredTaskId(task.id)}
                           onMouseLeave={() => setHoveredTaskId((cur) => (cur === task.id ? null : cur))}
+                          onPointerMove={captureLinkTarget}
                           onPointerDown={(e) => {
                             if (e.button !== 0) return;
-                            // Group move: the summary bar drags the whole subtree.
+                            // Self-dated summary: the end zones resize its own
+                            // start/end (non-group, persists to this record); the
+                            // middle still group-moves the whole subtree. Corner
+                            // grips below handle a direct edge hit, but a click
+                            // aimed at the edge often lands just inside, so resolve
+                            // from the pointer offset here too. Rollup summaries
+                            // stay move-only.
+                            if (summaryResizable) {
+                              const mode = resolveBarDragMode(e.clientX, e.currentTarget.getBoundingClientRect());
+                              if (mode !== 'move') {
+                                beginDrag(task, mode, e);
+                                return;
+                              }
+                            }
+                            if (!summaryMovable) return;
                             beginDrag(task, 'move', e, { group: true, originStart: row.start, originEnd: row.end });
                           }}
                           onClick={() => {
@@ -3601,9 +3706,90 @@ export function GanttView({
                             className="absolute left-0 top-0 bottom-0 pointer-events-none"
                             style={{ width: `${Math.round(row.progress)}%`, backgroundColor: 'rgba(0, 0, 0, 0.2)', borderTopLeftRadius: 'var(--radius-sm)', borderBottomLeftRadius: 'var(--radius-sm)' }}
                           />
+                          {/* Resize grips — only for a self-dated summary wide
+                              enough to host them (mirrors the leaf task bar). */}
+                          {summaryResizable && liveStyle.width >= 14 && (
+                            <>
+                              <div
+                                className="gantt-resize-handle absolute left-0 top-0"
+                                style={{ width: RESIZE_EDGE_PX, height: resizeHandleHeight, cursor: 'ew-resize' }}
+                                data-testid={`gantt-task-resize-left-${task.id}`}
+                                onPointerDown={(e) => {
+                                  if (e.button !== 0) return;
+                                  beginDrag(task, 'resize-left', e);
+                                }}
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                              <div
+                                className="gantt-resize-handle absolute right-0 top-0"
+                                style={{ width: RESIZE_EDGE_PX, height: resizeHandleHeight, cursor: 'ew-resize' }}
+                                data-testid={`gantt-task-resize-right-${task.id}`}
+                                onPointerDown={(e) => {
+                                  if (e.button !== 0) return;
+                                  beginDrag(task, 'resize-right', e);
+                                }}
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                            </>
+                          )}
                           <span className="relative text-[10px] text-white font-medium truncate pointer-events-none">
                             {task.title}
                           </span>
+                          {/* Connector dots — same drag-to-link affordance as leaf
+                              bars, so dependencies (3.4.5) can be drawn between
+                              summary plans, not only via the right-click menu. */}
+                          {onDependencyCreate && !isLocked && (['start', 'end'] as const).map((end) => {
+                            const isSource =
+                              linkDrag != null &&
+                              String(linkDrag.sourceId) === String(task.id) &&
+                              linkDrag.sourceEnd === end;
+                            const visible = isSource || hoveredTaskId === task.id;
+                            const grabbable = visible && linkDrag == null;
+                            return (
+                              <div
+                                key={end}
+                                className="absolute top-1/2 -translate-y-1/2 z-20 flex items-center transition-opacity"
+                                style={{
+                                  [end === 'start' ? 'left' : 'right']: -28,
+                                  height: 24,
+                                  width: 30,
+                                  cursor: 'crosshair',
+                                  opacity: visible ? 1 : 0,
+                                  pointerEvents: grabbable ? 'auto' : 'none',
+                                  justifyContent: end === 'start' ? 'flex-start' : 'flex-end',
+                                  paddingLeft: end === 'start' ? 4 : 0,
+                                  paddingRight: end === 'end' ? 4 : 0,
+                                }}
+                                data-testid={`gantt-link-dot-${end}-${task.id}`}
+                                onPointerDown={(e) => {
+                                  if (e.button !== 0) return;
+                                  e.stopPropagation();
+                                  e.preventDefault();
+                                  const rect = contentRef.current?.getBoundingClientRect();
+                                  setLinkDrag({
+                                    sourceId: task.id,
+                                    sourceEnd: end,
+                                    x: rect ? e.clientX - rect.left : 0,
+                                    y: rect ? e.clientY - rect.top : 0,
+                                    targetId: null,
+                                    targetEnd: null,
+                                  });
+                                }}
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <div
+                                  className="rounded-full"
+                                  style={{
+                                    height: 12,
+                                    width: 12,
+                                    backgroundColor: 'hsl(var(--background))',
+                                    border: '2px solid hsl(var(--primary))',
+                                    boxShadow: isSource ? '0 0 0 3px hsl(var(--primary) / 0.25)' : '0 1px 2px rgba(0,0,0,0.25)',
+                                  }}
+                                />
+                              </div>
+                            );
+                          })}
                         </div>
                         {isDragging && dragState && (
                           <div
@@ -3634,7 +3820,7 @@ export function GanttView({
                         <div
                           className={cn(
                             "gantt-bar-hover absolute rotate-45 rounded-[2px] border shadow-sm select-none",
-                            canDrag && "cursor-grab active:cursor-grabbing",
+                            canMove && "cursor-grab active:cursor-grabbing",
                             isDragging && "ring-2 ring-primary z-10",
                             isLinkTarget && "ring-2 ring-primary",
                             flashTaskId === task.id && "gantt-flash z-10"
@@ -3647,7 +3833,7 @@ export function GanttView({
                             // Inline not-allowed: the cursor-not-allowed utility isn't
                             // emitted in the prebuilt components CSS, so drive the
                             // read-only cursor from style rather than a class.
-                            cursor: canDrag ? undefined : barReadOnly ? 'not-allowed' : 'pointer',
+                            cursor: canMove ? undefined : barReadOnly ? 'not-allowed' : 'pointer',
                             backgroundColor: isCrit ? CRIT_COLOR : task.color || '#3b82f6',
                             borderColor: isCrit ? CRIT_COLOR : task.borderColor || 'hsl(var(--primary-foreground) / 0.2)',
                             boxShadow: isCrit ? `0 0 0 2px ${CRIT_COLOR}` : task.borderColor ? `0 0 0 2px ${task.borderColor}` : undefined,
@@ -3666,7 +3852,7 @@ export function GanttView({
                           }}
                           onContextMenu={(e) => openContextMenu(task, e)}
                           onPointerMove={captureLinkTarget}
-                          onPointerDown={canDrag ? (e) => {
+                          onPointerDown={canMove ? (e) => {
                             if (e.button !== 0) return;
                             beginDrag(task, 'move', e);
                           } : undefined}
@@ -3746,14 +3932,17 @@ export function GanttView({
                           // so a direct hit still wins. But a click aimed at the edge often
                           // lands just inside the bar (headless coordinate quantization), so
                           // resolve the mode from the pointer's offset here too: the end
-                          // bands resize, the middle moves (edge-zone drag).
+                          // bands resize, the middle moves (edge-zone drag). Each zone only
+                          // engages when its interaction switch allows; a resize zone with
+                          // resize off falls back to a plain move (DHTMLX parity).
                           if (e.button !== 0) return;
-                          const mode = resolveBarDragMode(e.clientX, e.currentTarget.getBoundingClientRect());
-                          beginDrag(task, mode, e);
+                          const zone = resolveBarDragMode(e.clientX, e.currentTarget.getBoundingClientRect());
+                          const mode = zone !== 'move' && canResize ? zone : canMove ? 'move' : null;
+                          if (mode) beginDrag(task, mode, e);
                         } : undefined}
                       >
                         {/* Resize handles — only when bar is wide enough to host them */}
-                        {canDrag && liveStyle.width >= 14 && (
+                        {canResize && liveStyle.width >= 14 && (
                           <>
                             <div
                               className="gantt-resize-handle absolute left-0 top-0"
@@ -3793,7 +3982,7 @@ export function GanttView({
                             shows on hover / while dragging, and its hit area lives
                             in the bottom half so grabbing it never competes with a
                             bar move (top) or a link drag (the centred end dots). */}
-                        {canDrag && liveStyle.width >= 30 && (
+                        {canProgress && liveStyle.width >= 30 && (
                           <div
                             className={cn(
                               "absolute bottom-0 h-1/2 w-4 -translate-x-1/2 cursor-col-resize flex items-end justify-center pb-px",

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3492,8 +3492,9 @@ export function GanttView({
                 {rowWindow.startIdx > 0 && (
                   <div style={{ height: rowWindow.startIdx * rowHeight }} aria-hidden="true" />
                 )}
-                {rows.slice(rowWindow.startIdx, rowWindow.endIdx).map((row) => {
+                {rows.slice(rowWindow.startIdx, rowWindow.endIdx).map((row, winIdx) => {
                    const task = row.task;
+                   const absRowIdx = rowWindow.startIdx + winIdx;
                    const isCrit = isCriticalTask(task.id);
                    const baseStyle = styleFor(row.start, row.end);
                    // Baseline (planned) reference strip beneath the live bar.
@@ -3566,10 +3567,30 @@ export function GanttView({
                    const durationDays = Math.max(1, Math.round(
                      (row.end.getTime() - row.start.getTime()) / MS_PER_DAY
                    ));
+                   // Tooltip flip (bottom rows, 最后一行悬浮狂闪): a downward
+                   // tooltip on one of the last rows overflows the rows box,
+                   // growing the scroller's scrollHeight while shown. With the
+                   // user scrolled to the bottom, the browser's scroll
+                   // clamping/anchoring then re-adjusts scrollTop every time the
+                   // tooltip mounts/unmounts — the bar slides under the
+                   // stationary cursor, hover re-fires, and the tooltip
+                   // flickers in a loop. Upward overflow never extends the
+                   // scrollable area, so rows whose downward tooltip would
+                   // poke past the content box flip it above the bar instead
+                   // (only when there's room above to be useful).
+                   const TOOLTIP_EST_PX = 300;
+                   const tooltipFlipsUp =
+                     (absRowIdx + 1) * rowHeight + TOOLTIP_EST_PX > totalRowsHeight &&
+                     absRowIdx * rowHeight > TOOLTIP_EST_PX;
                    const tooltip = hoveredTaskId === task.id && !dragState && !progressDrag && !linkDrag ? (
                      <div
                        className="absolute z-30 pointer-events-none rounded-md border bg-popover text-popover-foreground px-2.5 py-1.5 text-xs shadow-md whitespace-nowrap"
-                       style={{ left: Math.max(liveStyle.left + 8, 4), top: rowHeight - 8 }}
+                       style={{
+                         left: Math.max(liveStyle.left + 8, 4),
+                         ...(tooltipFlipsUp
+                           ? { bottom: rowHeight - 8 }
+                           : { top: rowHeight - 8 }),
+                       }}
                        role="tooltip"
                        data-testid={`gantt-tooltip-${task.id}`}
                      >

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3654,7 +3654,10 @@ export function GanttView({
                      // persist to.
                      const summaryOwnsDates =
                        summaryExtent === 'self' && task.hasOwnDates !== false;
-                     const summaryMovable = !!onTaskUpdate && ixMove;
+                     // Locked summaries were already unmovable (beginDrag rejects
+                     // them) — folding the lock in here also fixes the cursor:
+                     // 仅查看 rows now show not-allowed (🚫) instead of grab.
+                     const summaryMovable = !!onTaskUpdate && ixMove && !isLocked;
                      const summaryResizable = !!onTaskUpdate && ixResize && summaryOwnsDates && !isLocked;
                      return (
                       <div

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -38,6 +38,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  cn,
 } from '@object-ui/components';
 import { extractRecords, buildExpandFields, getRecordDisplayName, resolveDataSource } from '@object-ui/core';
 import {
@@ -1348,7 +1349,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   }
 
   return (
-    <div className={className}>
+    <div className={cn('flex h-full min-h-0 flex-col', className)}>
       {resolvedQuickFilters.length > 0 && (
         <QuickFilterBar
           filters={resolvedQuickFilters}
@@ -1365,7 +1366,13 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           }}
         />
       )}
-      <div className="h-[calc(100vh-200px)] min-h-[600px]">
+      {/* Fill the host's flex cell instead of guessing with a viewport calc:
+          `100vh - 200px` overshoots whenever the chrome above (tabs, toolbar,
+          quick filters) exceeds 200px, and the overflow-hidden host then CLIPS
+          the pane's bottom edge — swallowing the horizontal scrollbar
+          (水平滚动条被裁掉). flex-1/min-h-0 tracks the real available height;
+          the min-h keeps standalone embeds (no sized parent) usable. */}
+      <div className="flex-1 min-h-[420px]">
         {ganttConfig?.resourceView && assigneeAccessor ? (
           <ResourceWorkload
             tasks={displayTasks}

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -50,7 +50,7 @@ import {
   formatPercent,
   formatCurrency,
 } from '@object-ui/fields';
-import { GanttView, type GanttTask, type GanttDependency, type GanttLinkType, type GanttTaskType, type GanttViewMode } from './GanttView';
+import { GanttView, type GanttTask, type GanttDependency, type GanttInteractions, type GanttLinkType, type GanttTaskType, type GanttViewMode } from './GanttView';
 import { ResourceWorkload } from './ResourceWorkload';
 import { QuickFilterBar, type QuickFilterField, type QuickFilterOption } from './QuickFilterBar';
 import type { WorkingCalendar } from './scheduling';
@@ -169,6 +169,14 @@ type GanttConfigEx = GanttConfig & {
    */
   autoZoomToFilter?: boolean;
   /**
+   * Per-interaction switches (交互开关): `move` / `resize` / `progress` / `link`,
+   * each defaulting to true. Metadata-drivable so a view can e.g. allow bar
+   * moves but pin durations (`{ resize: false }`) or keep the dependency UI
+   * read-only (`{ link: false }`). They only narrow what `readOnly` / row locks
+   * already allow. Forwarded to {@link GanttView}.
+   */
+  interactions?: GanttInteractions;
+  /**
    * Shift segmentation (班次/排班分段). When set, the day-mode timeline splits each
    * 排班日 (shift-day, starting at `dayStart`) into the configured bands (白班 |
    * 夜班…): a two-tier header (date over band), per-band column tints, and
@@ -240,6 +248,16 @@ export interface ObjectGanttProps {
   onRowClick?: (record: any) => void;
   onEdit?: (record: any) => void;
   onDelete?: (record: any) => void;
+  /**
+   * Veto hook for task edits, forwarded to {@link GanttView}. Called with the
+   * gantt task and the pending changes on every commit path (drag, resize,
+   * group move, progress, inline edit, auto-reschedule); return false (sync or
+   * async) to cancel that task's update before it reaches the data source.
+   */
+  onBeforeTaskUpdate?: (
+    task: GanttTask,
+    changes: Partial<Pick<GanttTask, 'title' | 'start' | 'end' | 'progress'>>,
+  ) => boolean | Promise<boolean>;
 }
 
 /**
@@ -349,6 +367,7 @@ function getGanttConfig(schema: ObjectGridSchema | any): GanttConfigEx | null {
           quickFilters: schema.quickFilters,
           autoZoomToFilter: schema.autoZoomToFilter,
           timeSegments: schema.timeSegments,
+          interactions: schema.interactions,
       };
       return config;
   }
@@ -375,6 +394,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   className,
   onTaskClick,
   onRowClick,
+  onBeforeTaskUpdate,
   ...rest
 }) => {
   const [data, setData] = useState<any[]>([]);
@@ -1394,6 +1414,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           groupBy={groupByAccessor}
           defaultCollapsedDepth={ganttConfig?.defaultCollapsedDepth}
           summaryExtent={ganttConfig?.summaryExtent}
+          interactions={ganttConfig?.interactions}
+          onBeforeTaskUpdate={onBeforeTaskUpdate}
           inlineEdit
           onRefresh={
             // Only meaningful when there's a live source to re-read (object or


### PR DESCRIPTION
Delivers the fixes and capabilities described in #2676. Five commits, each independently verified live against a real 4-level 排班计划 dataset (project/product groups → self-dated summary plans → locked dispatch leaves) plus 323 green plugin-gantt tests.

## What changed

### 1b0ac32f4 — self-dated summary bars edit like tasks + interaction switches + veto hook
- **Editability follows date ownership** (the MS-Project/Bryntum/Syncfusion manual-scheduling rule): a summary with `summaryExtent: 'self'` and its own dates grows edge-resize grips and drag-to-link connector dots; dragging its middle still group-moves the whole subtree; rollup summaries (derived dates) stay move-only.
- **`interactions: { move, resize, progress, link }`** view-config switches — DHTMLX `drag_move`/`drag_resize`/`drag_progress`/`drag_links` model. Default all on; they only narrow what `readOnly`/row locks already allow. `link: false` removes both the connector dots and the menu create/delete entries.
- **`onBeforeTaskUpdate`** async veto on the central commit belt (bar drag, edge resize, group move, progress, inline edit, conflict reschedule). Fail-closed on throw; per-task veto within a batch; undo/redo exempt by design. Forwarded through `ObjectGantt` along with `gantt.interactions` from view metadata.
- Non-group drag preview now covers the dragged summary, so a summary resize tracks the pointer.

### f22db0550 — last-row tooltip flicker (最后一行悬浮狂闪)
Bottom rows flip the hover tooltip above the bar. A downward tooltip on a last row grew the scroller's scrollHeight while shown; with the view scrolled to the bottom, scroll clamping/anchoring re-adjusted scrollTop on every mount/unmount and the tooltip strobed under a stationary cursor. Upward absolute overflow never extends the scrollable area, so the loop is physically gone. Top rows and short charts unchanged.

### b4cf61085 — locked summary cursor
Locked (仅查看) summary bars now show `not-allowed` (🚫) instead of `grab`, matching leaf bars — they were already unmovable, only the cursor lied.

### e298de8e6 + 145ef5b43 — horizontal scrollbar unreachable / doubled
- `ObjectGantt` now fills its host flex cell (`flex-1 min-h-0`) instead of guessing with `h-[calc(100vh-200px)]`, which overshot whenever the chrome above exceeded 200px and got the pane's bottom edge clipped by the overflow-hidden host — swallowing the scrollbar area (53px in the console layout). A min-h keeps standalone embeds usable.
- Native timeline scrollbars are fully hidden (`scrollbar-width: none` — honored by overlay engines that ignore `::-webkit-scrollbar` theming and would otherwise flash a second auto-hiding bar) and replaced by **self-drawn track+thumb bars on both axes**: ref-driven (no per-frame React state), synced 1:1 with scrollLeft/scrollTop, thumb drag + track-click jump, auto-hidden when content fits, task-list lockstep sync preserved.

## Verification

- plugin-gantt: 29 files / **323 tests green** (16 new for summary editability + switch matrix + veto true/false/throw, 3 new for tooltip flip), `tsc --noEmit` clean.
- Live against `@objectstack/runtime` 15.1.1 with a real 4-level tree: edge-resize persists only the plan's own dates (children untouched), connector-dot drag writes the dependency field (cycle guard intact), body drag group-moves skipping locked children and still raises the conflict/auto-reschedule dialog, locked leaves stay inert, link context menu (type switch + remove) works, bottom-row tooltip renders upward with scrollHeight constant, exactly one horizontal bar renders flush with the visible bottom, and both self-drawn bars pan correctly by thumb drag and track click.

Refs #2676

🤖 Generated with [Claude Code](https://claude.com/claude-code)