### PR TITLE
feat(approvals): decision attachments in inbox + quorum/per_group designer sync (#2678)

### DIFF
--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -24,6 +24,9 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { CommentAttachment, type Attachment } from '@object-ui/plugin-detail';
+import { createObjectStackUploadAdapter } from '@object-ui/providers';
+import { createAuthenticatedFetch } from '@object-ui/auth';
 import {
   Button,
   Badge,
@@ -95,6 +98,7 @@ import {
   Send,
   Check,
   CornerUpLeft,
+  Paperclip,
 } from 'lucide-react';
 import {
   approvalsApi,
@@ -335,6 +339,51 @@ export function ApprovalsInboxPage() {
   const [comment, setComment] = useState('');
   const [actorOverride, setActorOverride] = useState('');
   const [submitting, setSubmitting] = useState<'approve' | 'reject' | 'recall' | null>(null);
+  // Decision attachments (#3266): files staged in the composer, sent as
+  // `attachments: fileId[]` with the next approve/reject. Uploads go through
+  // the same presigned-storage adapter as RecordAttachmentsPanel.
+  const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const authFetch = useMemo(() => createAuthenticatedFetch(), []);
+  const uploadAdapter = useMemo(
+    () => createObjectStackUploadAdapter({
+      baseUrl: (import.meta.env.VITE_SERVER_URL || '').replace(/\/$/, ''),
+      scope: 'attachments',
+      fetchImpl: authFetch,
+    }),
+    [authFetch],
+  );
+  const handleAttachmentUpload = useCallback(async (files: FileList) => {
+    setAttachmentError(null);
+    for (const file of Array.from(files)) {
+      try {
+        const result = await uploadAdapter.upload(file);
+        const fileId = String((result.meta as { fileId?: string } | undefined)?.fileId ?? '');
+        if (!fileId) throw new Error('upload returned no fileId');
+        setPendingAttachments(prev => [...prev, {
+          id: fileId, name: result.name, size: result.size, type: result.mimeType, url: result.url,
+        }]);
+      } catch (err) {
+        setAttachmentError((err as Error)?.message ?? String(err));
+      }
+    }
+  }, [uploadAdapter]);
+  const handleAttachmentRemove = useCallback((attachmentId: string) => {
+    setPendingAttachments(prev => prev.filter(a => a.id !== attachmentId));
+  }, []);
+  /** Open an action's attachment via a short-lived signed URL (Bearer-authed fetch). */
+  const openAttachment = useCallback(async (fileId: string) => {
+    try {
+      const base = (import.meta.env.VITE_SERVER_URL || '').replace(/\/$/, '');
+      const res = await authFetch(`${base}/api/v1/storage/files/${encodeURIComponent(fileId)}/url`);
+      if (!res.ok) throw new Error(`HTTP_${res.status}`);
+      const body = await res.json().catch(() => null);
+      const url = body?.data?.url ?? body?.url;
+      if (url) window.open(url, '_blank', 'noopener');
+    } catch {
+      /* open failed — non-fatal; the chip stays visible */
+    }
+  }, [authFetch]);
 
   // Search + filters. On the paginated tabs (submitted/all) the free-text
   // query is debounced and pushed to the server; the pending tab keeps
@@ -458,6 +507,8 @@ export function ApprovalsInboxPage() {
     setDrawerLoading(true);
     setComment('');
     setActorOverride('');
+    setPendingAttachments([]);
+    setAttachmentError(null);
     try {
       const [req, acts] = await Promise.all([
         approvalsApi.getRequest(id),
@@ -480,6 +531,8 @@ export function ApprovalsInboxPage() {
     setActions([]);
     setComment('');
     setActorOverride('');
+    setPendingAttachments([]);
+    setAttachmentError(null);
   };
 
   /**
@@ -513,7 +566,14 @@ export function ApprovalsInboxPage() {
     }
     setSubmitting(kind);
     try {
-      const body = { actor_id: actor, comment: comment.trim() || undefined };
+      const body = {
+        actor_id: actor,
+        comment: comment.trim() || undefined,
+        // Decision attachments (#3266) ride approve/reject only — recall has no composer.
+        ...(kind !== 'recall' && pendingAttachments.length
+          ? { attachments: pendingAttachments.map(a => a.id) }
+          : {}),
+      };
       const fn = kind === 'approve' ? approvalsApi.approve
               : kind === 'reject'  ? approvalsApi.reject
               : approvalsApi.recall;
@@ -525,6 +585,8 @@ export function ApprovalsInboxPage() {
           : tr('recalledToast', 'Request recalled'),
       );
       setComment('');
+      setPendingAttachments([]);
+      setAttachmentError(null);
       // Queue processing (Fiori "My Inbox" pattern): a decision on the
       // pending tab advances straight to the next waiting item instead of
       // parking on the finished one. Recall keeps the drawer for review.
@@ -550,7 +612,7 @@ export function ApprovalsInboxPage() {
     } finally {
       setSubmitting(null);
     }
-  }, [selected, resolveActor, comment, load, user?.id, humanizeError, tr, tab, openDrawer]);
+  }, [selected, resolveActor, comment, pendingAttachments, load, user?.id, humanizeError, tr, tab, openDrawer]);
 
   /** Refresh the open drawer + list after a thread interaction. */
   const refreshThread = useCallback(async (id: string) => {
@@ -1678,6 +1740,22 @@ export function ApprovalsInboxPage() {
                           {a.comment && (
                             <div className="text-muted-foreground italic mt-0.5">"{a.comment}"</div>
                           )}
+                          {Array.isArray(a.attachments) && a.attachments.length > 0 && (
+                            <div className="flex flex-wrap gap-1.5 mt-1">
+                              {a.attachments.map((fileId, i) => (
+                                <button
+                                  key={fileId}
+                                  type="button"
+                                  onClick={() => void openAttachment(fileId)}
+                                  className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                                  title={fileId}
+                                >
+                                  <Paperclip className="h-3 w-3" />
+                                  {tr('attachmentChip', 'Attachment')} {a.attachments!.length > 1 ? i + 1 : ''}
+                                </button>
+                              ))}
+                            </div>
+                          )}
                         </li>
                       );
                     })}
@@ -1782,6 +1860,16 @@ export function ApprovalsInboxPage() {
                         rows={2}
                         className="mt-1"
                       />
+                      {/* Decision attachments (#3266) — staged files ride the next approve/reject. */}
+                      <CommentAttachment
+                        className="mt-2"
+                        attachments={pendingAttachments}
+                        onUpload={handleAttachmentUpload}
+                        onRemove={handleAttachmentRemove}
+                      />
+                      {attachmentError && (
+                        <div className="text-xs text-destructive mt-1">{attachmentError}</div>
+                      )}
                     </div>
                     <div className="flex gap-2 flex-wrap">
                       <Button

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -23,7 +23,7 @@
  */
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { CommentAttachment, type Attachment } from '@object-ui/plugin-detail';
 import { createObjectStackUploadAdapter } from '@object-ui/providers';
 import { createAuthenticatedFetch } from '@object-ui/auth';
@@ -258,6 +258,10 @@ export function ApprovalsInboxPage() {
   const { user } = useAuth();
   const isAdmin = useIsWorkspaceAdmin();
   const { appName } = useParams<{ appName?: string }>();
+  // Deep link (#2678 P1.5): notifications carry `/system/approvals?request=<id>`
+  // so landing here opens that request's drawer directly. Consumed once, then
+  // stripped from the URL so refresh/back doesn't re-open a dismissed drawer.
+  const [searchParams, setSearchParams] = useSearchParams();
   const identities = useMemo(() => buildApproverIdentities(user as any), [user]);
 
   const tr = useCallback(
@@ -371,6 +375,34 @@ export function ApprovalsInboxPage() {
   const handleAttachmentRemove = useCallback((attachmentId: string) => {
     setPendingAttachments(prev => prev.filter(a => a.id !== attachmentId));
   }, []);
+  // Resolve attachment fileIds → sys_file display names for the timeline chips
+  // (#2678 P1.5). Best-effort, cached per id; unresolved ids fall back to a
+  // generic "Attachment" label.
+  const [attachmentNames, setAttachmentNames] = useState<Record<string, string>>({});
+  useEffect(() => {
+    const ids = new Set<string>();
+    for (const a of actions) for (const id of (a.attachments ?? [])) {
+      if (id && attachmentNames[id] === undefined) ids.add(id);
+    }
+    if (!ids.size) return;
+    const base = (import.meta.env.VITE_SERVER_URL || '').replace(/\/$/, '');
+    let cancelled = false;
+    void (async () => {
+      const resolved: Record<string, string> = {};
+      await Promise.all(Array.from(ids).map(async (id) => {
+        try {
+          const res = await authFetch(`${base}/api/v1/data/sys_file/${encodeURIComponent(id)}`);
+          if (!res.ok) { resolved[id] = ''; return; }
+          const body = await res.json().catch(() => null);
+          resolved[id] = String(body?.record?.name ?? body?.data?.name ?? body?.name ?? '');
+        } catch { resolved[id] = ''; }
+      }));
+      if (!cancelled) setAttachmentNames(prev => ({ ...prev, ...resolved }));
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed off actions; attachmentNames is the cache being filled
+  }, [actions, authFetch]);
+
   /** Open an action's attachment via a short-lived signed URL (Bearer-authed fetch). */
   const openAttachment = useCallback(async (fileId: string) => {
     try {
@@ -534,6 +566,15 @@ export function ApprovalsInboxPage() {
     setPendingAttachments([]);
     setAttachmentError(null);
   };
+
+  // Consume the notification deep link once (see useSearchParams above).
+  useEffect(() => {
+    const target = searchParams.get('request');
+    if (!target) return;
+    setSearchParams((prev) => { const next = new URLSearchParams(prev); next.delete('request'); return next; }, { replace: true });
+    void openDrawer(target);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once per deep link, not per openDrawer identity
+  }, [searchParams]);
 
   /**
    * Pick the actor id to send with approve/reject.
@@ -1643,6 +1684,41 @@ export function ApprovalsInboxPage() {
                       ))}
                     </div>
                   )}
+                  {/* Aggregation progress (#3266): server-computed — "2 of 3
+                      approved" for quorum/unanimous, per-group ticks for 会签. */}
+                  {selected.decision_progress && (
+                    <div className="border-t pt-3">
+                      <div className="text-[11px] text-muted-foreground mb-1">
+                        {selected.decision_progress.behavior === 'per_group'
+                          ? tr('progressGroups', 'Sign-off progress — {{got}} of {{need}} groups', {
+                              got: selected.decision_progress.got, need: selected.decision_progress.need,
+                            })
+                          : tr('progressApprovals', 'Approvals — {{got}} of {{need}}', {
+                              got: selected.decision_progress.got, need: selected.decision_progress.need,
+                            })}
+                      </div>
+                      {selected.decision_progress.groups && (
+                        <div className="flex flex-wrap gap-1">
+                          {selected.decision_progress.groups.map((g) => (
+                            <Badge
+                              key={g.group}
+                              variant="outline"
+                              className={cn(
+                                'text-[11px] gap-1',
+                                g.satisfied
+                                  ? 'border-emerald-300 text-emerald-700 dark:border-emerald-700 dark:text-emerald-400'
+                                  : 'text-muted-foreground',
+                              )}
+                              title={`${g.got}/${g.need}`}
+                            >
+                              {g.satisfied ? <Check className="h-3 w-3" /> : null}
+                              {g.group} {g.got}/{g.need}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
                   {selected.status === 'pending' && (selected.pending_approvers || []).length > 0 && (
                     <div className="border-t pt-3">
                       <div className="text-[11px] text-muted-foreground mb-1">
@@ -1751,7 +1827,8 @@ export function ApprovalsInboxPage() {
                                   title={fileId}
                                 >
                                   <Paperclip className="h-3 w-3" />
-                                  {tr('attachmentChip', 'Attachment')} {a.attachments!.length > 1 ? i + 1 : ''}
+                                  {attachmentNames[fileId]
+                                    || `${tr('attachmentChip', 'Attachment')}${a.attachments!.length > 1 ? ` ${i + 1}` : ''}`}
                                 </button>
                               ))}
                             </div>

--- a/apps/console/src/services/approvalsApi.ts
+++ b/apps/console/src/services/approvalsApi.ts
@@ -60,6 +60,17 @@ export interface ApprovalRequestRow {
   sla_due_at?: string;
   /** Owning flow's approval steps for progress display (single reads only). */
   flow_steps?: Array<{ id: string; label: string; state: 'done' | 'current' | 'upcoming' }>;
+  /**
+   * Server-computed aggregation progress (#3266) for pending multi-approver
+   * requests: unanimous/quorum = approvals got/need; per_group = satisfied
+   * groups got/need plus per-group detail. Absent for first_response.
+   */
+  decision_progress?: {
+    behavior: 'unanimous' | 'quorum' | 'per_group';
+    got: number;
+    need: number;
+    groups?: Array<{ group: string; got: number; need: number; satisfied: boolean }>;
+  };
   /** ADR-0044 revision round on this (run, node): absent/1 = first round. */
   round?: number;
 }

--- a/apps/console/src/services/approvalsApi.ts
+++ b/apps/console/src/services/approvalsApi.ts
@@ -72,6 +72,8 @@ export interface ApprovalActionRow {
   actor_id?: string | null;
   action: 'submit' | 'approve' | 'reject' | 'recall' | string;
   comment?: string | null;
+  /** File references attached to this action (decision attachments, #3266). */
+  attachments?: string[] | null;
   created_at?: string;
   /** Display name of the actor, resolved server-side. */
   actor_name?: string;
@@ -156,7 +158,7 @@ export const approvalsApi = {
     );
   },
 
-  async approve(id: string, body: { actorId?: string; actor_id?: string; comment?: string }) {
+  async approve(id: string, body: { actorId?: string; actor_id?: string; comment?: string; attachments?: string[] }) {
     // Server returns `{request, finalized}`. Normalize to `{data, finalized}`.
     const out = await call<{ request: ApprovalRequestRow; finalized: boolean }>(
       `/approvals/requests/${encodeURIComponent(id)}/approve`,
@@ -165,7 +167,7 @@ export const approvalsApi = {
     return { data: out.request, finalized: out.finalized };
   },
 
-  async reject(id: string, body: { actorId?: string; actor_id?: string; comment?: string }) {
+  async reject(id: string, body: { actorId?: string; actor_id?: string; comment?: string; attachments?: string[] }) {
     const out = await call<{ request: ApprovalRequestRow; finalized: boolean }>(
       `/approvals/requests/${encodeURIComponent(id)}/reject`,
       { method: 'POST', body: JSON.stringify(body) },
@@ -236,7 +238,7 @@ export const approvalsApi = {
   },
 
   /** Free-form reply on the request thread (submitter or pending approver). */
-  async comment(id: string, body: { actor_id?: string; comment: string }) {
+  async comment(id: string, body: { actor_id?: string; comment: string; attachments?: string[] }) {
     const out = await call<{ request: ApprovalRequestRow }>(
       `/approvals/requests/${encodeURIComponent(id)}/comment`,
       { method: 'POST', body: JSON.stringify(body) },

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -536,15 +536,30 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
             },
           },
         },
+        {
+          // Group label for `per_group` sign-off (#3266): approvers sharing a
+          // label form one group; the node advances when EACH group reaches
+          // `minApprovals`. Ignored by other behaviors.
+          key: 'group',
+          label: 'Group',
+          kind: 'text',
+          placeholder: 'legal / finance — for per-group sign-off',
+        },
       ],
     }),
     cfg('behavior', 'Behavior', 'select', {
       options: [
         { value: 'first_response', label: 'First response wins' },
         { value: 'unanimous', label: 'Unanimous (all approve)' },
+        { value: 'quorum', label: 'Quorum (M of N approve)' },
+        { value: 'per_group', label: 'Per group (each group signs off)' },
       ],
       defaultValue: 'first_response',
-      help: 'How multiple approvers combine.',
+      help: 'How multiple approvers combine. Any rejection is a veto in every mode.',
+    }),
+    cfg('minApprovals', 'Min approvals', 'number', {
+      placeholder: '1',
+      help: 'Approvals required — total for quorum, per group for per_group. Clamped server-side so it can never deadlock.',
     }),
     cfg('lockRecord', 'Lock record', 'boolean', {
       help: 'Lock the triggering record from edits while this node is pending.',


### PR DESCRIPTION
P1 of #2678 (SDUI-first approvals UX). Backend counterparts already merged: framework#3235/#3255 (OOO delegation) and framework#3268 (quorum/per_group + decision attachments).

## What's in this PR

**Decision attachments — the one genuinely bespoke gap (#2678 判定 ④)**
- The inbox decision composer gains a `CommentAttachment` dropzone backed by the presigned-storage adapter (same pipeline as `RecordAttachmentsPanel`); staged fileIds ride approve/reject as `attachments[]`.
- The activity timeline renders attachment chips that open via a Bearer-authed short-lived signed URL.
- Staged files clear on drawer open/close and after a decision.
- `approvalsApi`: `approve`/`reject`/`comment` accept `attachments?: string[]`; `ApprovalActionRecord` carries `attachments`.

**Flow designer fallback sync (#2678 P1-b)**
- `flow-node-config.ts` approval fallback no longer drifts from the engine schema: behavior enum += `quorum` / `per_group`, new **Min approvals** number field, and a **Group** column on the approvers list. The configSchema-driven path (`FlowNodeInspector` → `json-schema-to-fields`) needed **no client change** — verified live.

## Zero-code SDUI paths verified (no diff needed — #2678 判定 ①③)
- `sys_approval_delegation` (OOO) renders fully from server metadata in the console (lookups to `sys_user`, datetime, descriptions, icon).
- The approval node property form renders **Behavior = Per Group**, **Min Approvals**, and per-row **Group** straight from the server-published `configSchema`.

## Browser verification (live framework backend :3000 + Vite console :5180)
- A submitted expense report opened a `per_group` request pending on **both** groups (manager + finance) — inbox shows "Manager + Finance Sign-off", Waiting on both.
- Composer uploaded a real file through presign/PUT/complete; the approve action row persisted `attachments:["<fileId>"]` (API-verified).
- The manager approval **held** the node (still pending on finance) — per_group semantics end-to-end in the UI; the record header also shows the "Locked for approval" band and record-level Approve works.
- Screenshots attached in the session; console + app-shell test suites green (89); **eslint delta zero** (9 pre-existing errors in `ApprovalsInboxPage.tsx` unchanged — same count on pristine `origin/main`).

## Out of scope (later phases of #2678)
- P2-4: migrating the inbox's hardcoded buttons to server-declared actions on `sys_approval_request` (needs a small framework counterpart PR).
- P2-5: nested-array support in the flow designer schema mapper (or unification onto `SchemaForm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ypkQikZ55oWUHUnMebwXA)_