### PR TITLE
refactor(data): master-detail 保存统一走原子 batchTransaction,把非原子回退隔离进适配器 (#2679)

### DIFF
--- a/.changeset/master-detail-batch-transaction-adapter.md
+++ b/.changeset/master-detail-batch-transaction-adapter.md
@@ -1,0 +1,41 @@
+---
+"@object-ui/types": minor
+"@object-ui/core": minor
+"@object-ui/data-objectstack": minor
+"@object-ui/plugin-form": minor
+"@object-ui/runner": minor
+---
+
+feat(data): unify master-detail saves behind `DataSource.batchTransaction`, isolate the non-atomic fallback in the adapter (#2679)
+
+Master-detail saves (`MasterDetailForm`, `LineItemsPanel`) now always persist
+through `dataSource.batchTransaction(operations)` — one ordered cross-object
+operation list, with `{ $ref: <op index> }` linking a child to a parent created
+in the same batch. The form no longer contains any client-side orchestration or
+best-effort compensation-delete; that atomicity anti-pattern is gone from the UI
+layer (framework #1604 / framework ADR-0034 item 4).
+
+- **`@object-ui/types`** — `batchTransaction?` is now a first-class (optional)
+  method on the `DataSource` contract, typed via `BatchTransactionOperation` /
+  `BatchRef`. Replaces the previous `(dataSource as any).batchTransaction`
+  method-sniffing.
+- **`@object-ui/core`** — new `emulateBatchTransaction(dataSource, operations)`
+  (sequential writes, `$ref` resolution, best-effort reverse-order compensation)
+  and `runBatchTransaction(dataSource, operations)` (prefers the adapter's method,
+  emulates otherwise). `ApiDataSource` / `ValueDataSource` implement
+  `batchTransaction` via the emulation.
+- **`@object-ui/data-objectstack`** — `ObjectStackAdapter.batchTransaction` uses
+  the server's atomic `POST /api/v1/batch`, prefers the typed
+  `client.data.batchTransaction` SDK method when the installed client exposes it,
+  and degrades to the client-side emulation ONLY when the endpoint is missing
+  (404/405) or the runtime can't do transactions (501). Real errors (400/401/403/
+  409/500) still surface. This is the isolated, tested home of the non-atomic
+  fallback.
+- **`@object-ui/plugin-form`** — removed `applyDetail` / `createMany` /
+  `ApplyDetailResult` from `masterDetailTx.ts`; `MasterDetailForm` and
+  `LineItemsPanel` build ops and call `runBatchTransaction`. `LineItemsPanel`
+  saves are now atomic on a capable backend, with the rollup folded into the same
+  batch.
+
+No behavior change on a current ObjectStack backend (it has `/api/v1/batch`);
+older/limited backends keep a working — now clearly non-atomic — save path.

--- a/content/docs/guide/data-source.md
+++ b/content/docs/guide/data-source.md
@@ -29,6 +29,14 @@ export interface DataSource<T = unknown> {
     opts?: { ifMatch?: string },
   ): Promise<boolean>;
 
+  // Optional: atomically persist an ordered set of cross-object operations
+  // (master-detail save). `{ $ref: <op index> }` links a child to a parent
+  // created earlier in the same batch. Adapters without server-side atomicity
+  // may emulate it — see below.
+  batchTransaction?(
+    operations: BatchTransactionOperation[],
+  ): Promise<{ results: any[] }>;
+
   getObjectSchema(objectName: string): Promise<unknown>;
 }
 ```
@@ -162,4 +170,19 @@ await dataSource.find('users', {
 });
 ```
 
-Data-aware plugins may also use optional methods such as `bulkUpdate`, `bulkDelete`, `getView`, or `listViewOverrides` when an adapter supports them. Keep the required CRUD methods implemented first, then add optional capabilities as your UI needs them.
+Data-aware plugins may also use optional methods such as `batchTransaction`, `bulkUpdate`, `bulkDelete`, `getView`, or `listViewOverrides` when an adapter supports them. Keep the required CRUD methods implemented first, then add optional capabilities as your UI needs them.
+
+### Cross-object atomic writes (`batchTransaction`)
+
+Master-detail saves (a parent record plus its child line items) go through
+`dataSource.batchTransaction(operations)` — one ordered list of cross-object
+create/update/delete operations, where a child's foreign key can be
+`{ $ref: <parent op index> }` to point at a parent created in the same batch.
+The `@object-ui/data-objectstack` adapter maps this to the server's atomic
+`POST /api/v1/batch` endpoint (commit-all-or-roll-back-all). Adapters without a
+transactional endpoint don't need to hand-write orchestration: call
+`emulateBatchTransaction(dataSource, operations)` from `@object-ui/core`, which
+executes the operations sequentially (resolving `$ref`s) with best-effort
+compensation on failure. UI components never branch on atomicity — they call
+`runBatchTransaction(dataSource, operations)` (also from `@object-ui/core`),
+which uses the adapter's method when present and emulates otherwise.

--- a/docs/adr/0001-master-detail-subform.md
+++ b/docs/adr/0001-master-detail-subform.md
@@ -320,3 +320,30 @@ config — so the standard derived form picks it up automatically.
 Showcase: `showcase_invoice` + `showcase_invoice_line` + `showcase_product`
 exercise the whole set. See the objectstack-ui / objectstack-data skills for the
 data-model recipe.
+
+---
+
+## Addendum (2026-07, #2679): persistence unified behind `DataSource.batchTransaction`
+
+The original design above persisted the parent and its children with a
+**client-orchestrated** write plus **best-effort cleanup** on partial failure
+(create the parent, then the children, and if a child fails delete the
+just-created parent). That cleanup was an atomicity anti-pattern — racy, unable
+to undo side effects (hooks/rollups/webhooks already fired), and a second
+behavior to maintain alongside the server's real transaction.
+
+Superseded in part by #2679 (tracking framework #1604 / framework ADR-0034
+item 4):
+
+- `batchTransaction` is now a first-class (optional) method on the `DataSource`
+  contract (`@object-ui/types`), typed via `BatchTransactionOperation`.
+- `MasterDetailForm` and `LineItemsPanel` always build one ordered operation
+  list and hand it to `runBatchTransaction(dataSource, ops)` — no
+  master-detail-specific orchestration or compensation remains in the form.
+- The non-atomic fallback is isolated to a single, tested helper
+  (`emulateBatchTransaction` in `@object-ui/core`): sequential writes with
+  `$ref` resolution and best-effort compensation. `ObjectStackAdapter` uses the
+  server's atomic `POST /api/v1/batch` and only falls back to emulation when the
+  endpoint is absent (404/405) or the runtime can't do transactions (501).
+- Hard removal of the emulation is gated on the server advertising a batch
+  capability via discovery (not yet advertised), so the fallback stays for now.

--- a/packages/core/src/adapters/ApiDataSource.ts
+++ b/packages/core/src/adapters/ApiDataSource.ts
@@ -11,6 +11,7 @@
 
 import type {
   DataSource,
+  BatchTransactionOperation,
   QueryParams,
   QueryResult,
   HttpRequest,
@@ -18,6 +19,7 @@ import type {
   AggregateParams,
   AggregateResult,
 } from '@object-ui/types';
+import { emulateBatchTransaction } from './batchTransaction.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -298,6 +300,19 @@ export class ApiDataSource<T = any> implements DataSource<T> {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Client-side (non-atomic) cross-object batch — a generic REST endpoint has
+   * no transactional batch primitive, so this delegates to the shared
+   * emulation (sequential writes + `$ref` resolution + best-effort
+   * compensation). Adapters fronting a server that DOES offer an atomic batch
+   * should override this to issue a single request.
+   */
+  batchTransaction(
+    operations: BatchTransactionOperation[],
+  ): Promise<{ results: any[] }> {
+    return emulateBatchTransaction(this, operations);
   }
 
   async getObjectSchema(_objectName: string): Promise<any> {

--- a/packages/core/src/adapters/ValueDataSource.ts
+++ b/packages/core/src/adapters/ValueDataSource.ts
@@ -11,12 +11,14 @@
 
 import type {
   DataSource,
+  BatchTransactionOperation,
   MutationEvent,
   QueryParams,
   QueryResult,
   AggregateParams,
   AggregateResult,
 } from '@object-ui/types';
+import { emulateBatchTransaction } from './batchTransaction.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -377,6 +379,17 @@ export class ValueDataSource<T = any> implements DataSource<T> {
       }
     }
     return results;
+  }
+
+  /**
+   * Client-side (non-atomic) cross-object batch — this in-memory adapter has
+   * no server transaction, so it delegates to the shared emulation. Per-op
+   * MutationEvents come from the `create`/`update`/`delete` primitives above.
+   */
+  batchTransaction(
+    operations: BatchTransactionOperation[],
+  ): Promise<{ results: any[] }> {
+    return emulateBatchTransaction(this, operations);
   }
 
   async getObjectSchema(_objectName: string): Promise<any> {

--- a/packages/core/src/adapters/__tests__/batchTransaction.test.ts
+++ b/packages/core/src/adapters/__tests__/batchTransaction.test.ts
@@ -1,0 +1,188 @@
+/**
+ * ObjectUI — batchTransaction emulation tests
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { BatchTransactionOperation, DataSource } from '@object-ui/types';
+import { emulateBatchTransaction, runBatchTransaction } from '../batchTransaction';
+import { ValueDataSource } from '../ValueDataSource';
+
+/**
+ * Minimal recording DataSource: `create` mints sequential ids, every call is
+ * spied so tests can assert order and compensation. `idShape` controls which
+ * field the created id is exposed under (to prove `$ref` resolution across
+ * `id` / `_id` / `recordId`).
+ */
+function makeRecordingDataSource(opts?: {
+  idShape?: 'id' | '_id' | 'recordId';
+  failCreateOn?: string; // object name whose create rejects
+}): DataSource & {
+  calls: Array<{ op: string; object: string; id?: string | number }>;
+} {
+  const idShape = opts?.idShape ?? 'id';
+  let seq = 0;
+  const calls: Array<{ op: string; object: string; id?: string | number }> = [];
+  return {
+    calls,
+    find: vi.fn(),
+    findOne: vi.fn(),
+    getObjectSchema: vi.fn(),
+    create: vi.fn(async (object: string, data: any) => {
+      calls.push({ op: 'create', object });
+      if (opts?.failCreateOn === object) {
+        throw new Error(`create failed for ${object}`);
+      }
+      const id = `${object}-${++seq}`;
+      return { [idShape]: id, ...data };
+    }),
+    update: vi.fn(async (object: string, id: string | number, data: any) => {
+      calls.push({ op: 'update', object, id });
+      return { id, ...data };
+    }),
+    delete: vi.fn(async (object: string, id: string | number) => {
+      calls.push({ op: 'delete', object, id });
+      return true;
+    }),
+  } as any;
+}
+
+describe('emulateBatchTransaction — happy path', () => {
+  it('executes ops in order and returns index-aligned results', async () => {
+    const ds = makeRecordingDataSource();
+    const ops: BatchTransactionOperation[] = [
+      { object: 'project', action: 'create', data: { name: 'Apollo' } },
+      { object: 'task', action: 'update', id: 't1', data: { title: 'Kickoff' } },
+      { object: 'note', action: 'delete', id: 'n9' },
+    ];
+    const { results } = await emulateBatchTransaction(ds, ops);
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toMatchObject({ id: 'project-1', name: 'Apollo' });
+    expect(results[1]).toMatchObject({ id: 't1', title: 'Kickoff' });
+    expect(results[2]).toBe(true);
+    expect(ds.calls.map((c) => c.op)).toEqual(['create', 'update', 'delete']);
+  });
+
+  it('defaults a missing action to create', async () => {
+    const ds = makeRecordingDataSource();
+    await emulateBatchTransaction(ds, [{ object: 'project', data: { name: 'X' } }]);
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('emulateBatchTransaction — $ref resolution', () => {
+  it.each(['id', '_id', 'recordId'] as const)(
+    'resolves { $ref: 0 } against the parent created under %s',
+    async (idShape) => {
+      const ds = makeRecordingDataSource({ idShape });
+      const ops: BatchTransactionOperation[] = [
+        { object: 'project', action: 'create', data: { name: 'Apollo' } },
+        { object: 'task', action: 'create', data: { title: 'A', project: { $ref: 0 } } },
+      ];
+      await emulateBatchTransaction(ds, ops);
+
+      // The child's create payload had its { $ref: 0 } rewritten to the
+      // parent's minted id.
+      expect(ds.create).toHaveBeenLastCalledWith('task', {
+        title: 'A',
+        project: 'project-1',
+      });
+    },
+  );
+
+  it('throws (and compensates) on a forward / unresolved $ref', async () => {
+    const ds = makeRecordingDataSource();
+    const ops: BatchTransactionOperation[] = [
+      { object: 'project', action: 'create', data: { name: 'P' } },
+      // references op 5, which does not exist yet
+      { object: 'task', action: 'create', data: { project: { $ref: 5 } } },
+    ];
+    await expect(emulateBatchTransaction(ds, ops)).rejects.toThrow(/\$ref/);
+    // The one successful create (op 0) is compensated.
+    expect(ds.delete).toHaveBeenCalledWith('project', 'project-1');
+  });
+});
+
+describe('emulateBatchTransaction — failure compensation', () => {
+  it('deletes created records in reverse order (children before parent) and rethrows', async () => {
+    const ds = makeRecordingDataSource({ failCreateOn: 'invoice_line_bad' });
+    const ops: BatchTransactionOperation[] = [
+      { object: 'invoice', action: 'create', data: { no: 'INV-1' } },
+      { object: 'invoice_line', action: 'create', data: { amt: 10, invoice: { $ref: 0 } } },
+      { object: 'invoice_line_bad', action: 'create', data: { amt: 20, invoice: { $ref: 0 } } },
+    ];
+    await expect(emulateBatchTransaction(ds, ops)).rejects.toThrow(/create failed/);
+
+    const deletes = ds.calls.filter((c) => c.op === 'delete');
+    // Only the two successful creates are compensated, newest first.
+    expect(deletes).toEqual([
+      { op: 'delete', object: 'invoice_line', id: 'invoice_line-2' },
+      { op: 'delete', object: 'invoice', id: 'invoice-1' },
+    ]);
+  });
+
+  it('does NOT compensate updates or deletes (only creates)', async () => {
+    const ds = makeRecordingDataSource({ failCreateOn: 'boom' });
+    const ops: BatchTransactionOperation[] = [
+      { object: 'thing', action: 'update', id: 'x1', data: { a: 1 } },
+      { object: 'boom', action: 'create', data: {} },
+    ];
+    await expect(emulateBatchTransaction(ds, ops)).rejects.toThrow();
+    // The update ran but no create succeeded → nothing to compensate.
+    expect(ds.delete).not.toHaveBeenCalled();
+  });
+
+  it('swallows a compensation-delete failure and still rethrows the original error', async () => {
+    const ds = makeRecordingDataSource({ failCreateOn: 'child' });
+    (ds.delete as any).mockRejectedValueOnce(new Error('delete blew up'));
+    const ops: BatchTransactionOperation[] = [
+      { object: 'parent', action: 'create', data: {} },
+      { object: 'child', action: 'create', data: {} },
+    ];
+    await expect(emulateBatchTransaction(ds, ops)).rejects.toThrow(/create failed for child/);
+  });
+});
+
+describe('runBatchTransaction — delegation', () => {
+  it('prefers a native batchTransaction when present', async () => {
+    const native = vi.fn(async () => ({ results: ['native'] }));
+    const ds = { ...makeRecordingDataSource(), batchTransaction: native } as any;
+    const res = await runBatchTransaction(ds, [{ object: 'x', data: {} }]);
+    expect(native).toHaveBeenCalledTimes(1);
+    expect(res.results).toEqual(['native']);
+    // The emulation primitives were NOT used.
+    expect(ds.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back to emulation when batchTransaction is absent', async () => {
+    const ds = makeRecordingDataSource();
+    delete (ds as any).batchTransaction;
+    await runBatchTransaction(ds, [{ object: 'x', action: 'create', data: {} }]);
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('emulateBatchTransaction — MutationEvents fire exactly once per op', () => {
+  it('drives a real ValueDataSource and emits one event per operation (no double-emit)', async () => {
+    const ds = new ValueDataSource({ items: [] as any[] });
+    const events: any[] = [];
+    ds.onMutation((e) => events.push(e));
+
+    await ds.batchTransaction([
+      { object: 'project', action: 'create', data: { id: 'p1', name: 'Apollo' } },
+      { object: 'task', action: 'create', data: { id: 't1', title: 'A', project: { $ref: 0 } } },
+    ]);
+
+    // Two creates → exactly two events, emitted by the primitives (the
+    // emulation helper itself must not emit).
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.type)).toEqual(['create', 'create']);
+    // $ref resolved end-to-end through the real adapter.
+    const stored = await ds.findOne('task', 't1');
+    expect(stored).toMatchObject({ project: 'p1' });
+  });
+});

--- a/packages/core/src/adapters/batchTransaction.ts
+++ b/packages/core/src/adapters/batchTransaction.ts
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI — batchTransaction emulation
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Client-side emulation of {@link DataSource.batchTransaction} for adapters
+ * that lack a server-side transactional batch endpoint. This is the single,
+ * tested home for the non-atomic fallback (ObjectStack objectui #2679 /
+ * framework #1604 / ADR-0034 item 4): components call `runBatchTransaction`
+ * unconditionally and never orchestrate cross-object writes themselves.
+ *
+ * The emulation runs operations sequentially — NOT the old `bulk('create')`
+ * grouping — because sequential execution is what makes `{ $ref: i }`
+ * resolution and ordered semantics correct (a child create must observe the
+ * parent's freshly-minted id). Line-item counts are small, so the extra
+ * round-trips are acceptable.
+ */
+
+import type { BatchTransactionOperation, DataSource } from '@object-ui/types';
+
+/** Best-effort id extraction across the record shapes adapters return. */
+function idOf(rec: any): string | undefined {
+  if (rec == null) return undefined;
+  return rec.id ?? rec._id ?? rec.recordId;
+}
+
+/**
+ * Replace top-level `{ $ref: i }` values in an op payload with the id produced
+ * by operation `i`. Only backward references are valid — a forward or
+ * unresolved ref throws (the builders only ever emit `{ $ref: 0 }` pointing at
+ * an already-executed parent, so this is a guard, not a normal path).
+ */
+function resolveRefs(
+  data: Record<string, any>,
+  results: any[],
+): Record<string, any> {
+  const out: Record<string, any> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      typeof (value as any).$ref === 'number'
+    ) {
+      const refIndex = (value as any).$ref as number;
+      const id = idOf(results[refIndex]);
+      if (id === undefined) {
+        throw new Error(
+          `batchTransaction: field "${key}" references operation ${refIndex}, ` +
+            `which has not produced an id (forward or invalid $ref)`,
+        );
+      }
+      out[key] = id;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Emulate an atomic batch over a plain DataSource by executing its `create`/
+ * `update`/`delete` primitives in order.
+ *
+ * NOT atomic: on failure it best-effort compensates by deleting the records
+ * it created (reverse order — children before parent), then rethrows the
+ * original error. Updates and deletes that already ran cannot be undone; a
+ * compensation delete that itself fails is swallowed (`Promise.allSettled`).
+ * This is the documented reason a server-backed `batchTransaction` is
+ * strictly better — a true transaction simply never commits.
+ *
+ * MutationEvents are deliberately NOT emitted here: the underlying
+ * `create`/`update`/`delete` primitives already emit per-op on adapters that
+ * support `onMutation`, so emitting here too would double-fire.
+ */
+export async function emulateBatchTransaction<T = any>(
+  dataSource: DataSource<T>,
+  operations: BatchTransactionOperation[],
+): Promise<{ results: any[] }> {
+  const results: any[] = [];
+  const created: Array<{ object: string; id: string }> = [];
+
+  try {
+    for (const op of operations) {
+      const action = op.action ?? 'create';
+      if (action === 'create') {
+        const record = await dataSource.create(
+          op.object,
+          resolveRefs(op.data ?? {}, results) as Partial<T>,
+        );
+        results.push(record);
+        const id = idOf(record);
+        if (id) created.push({ object: op.object, id });
+      } else if (action === 'update') {
+        if (op.id == null) {
+          throw new Error(`batchTransaction: update on "${op.object}" requires an id`);
+        }
+        results.push(
+          await dataSource.update(
+            op.object,
+            op.id,
+            resolveRefs(op.data ?? {}, results) as Partial<T>,
+          ),
+        );
+      } else {
+        if (op.id == null) {
+          throw new Error(`batchTransaction: delete on "${op.object}" requires an id`);
+        }
+        results.push(await dataSource.delete(op.object, op.id));
+      }
+    }
+    return { results };
+  } catch (err) {
+    // Best-effort compensation: undo the creates we made, newest first, so a
+    // child is removed before the parent it points at. Failures are ignored —
+    // there is nothing more we can do client-side.
+    if (created.length > 0) {
+      await Promise.allSettled(
+        [...created].reverse().map((c) => dataSource.delete(c.object, c.id)),
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Persist an ordered cross-object batch, preferring the adapter's native
+ * (potentially atomic) `batchTransaction` and falling back to
+ * {@link emulateBatchTransaction} when the adapter does not implement it.
+ *
+ * This is the single entry point UI components should call — they stay
+ * ignorant of whether the underlying save is truly atomic.
+ */
+export function runBatchTransaction<T = any>(
+  dataSource: DataSource<T>,
+  operations: BatchTransactionOperation[],
+): Promise<{ results: any[] }> {
+  return typeof dataSource.batchTransaction === 'function'
+    ? dataSource.batchTransaction(operations)
+    : emulateBatchTransaction(dataSource, operations);
+}

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -13,3 +13,4 @@
 export { ApiDataSource, type ApiDataSourceConfig } from './ApiDataSource.js';
 export { ValueDataSource, type ValueDataSourceConfig } from './ValueDataSource.js';
 export { resolveDataSource, type ResolveDataSourceOptions } from './resolveDataSource.js';
+export { emulateBatchTransaction, runBatchTransaction } from './batchTransaction.js';

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -9,6 +9,7 @@
 import { ObjectStackClient, type QueryOptions as ObjectStackQueryOptions } from '@objectstack/client';
 import type {
   DataSource,
+  BatchTransactionOperation,
   MutationEvent,
   QueryParams,
   QueryResult,
@@ -23,7 +24,11 @@ import type {
   ImportJobUndoResult,
   ListImportJobsOptions,
 } from '@object-ui/types';
-import { convertFiltersToAST, normalizeSchemaReferenceKeys } from '@object-ui/core';
+import {
+  convertFiltersToAST,
+  emulateBatchTransaction,
+  normalizeSchemaReferenceKeys,
+} from '@object-ui/core';
 import { MetadataCache } from './cache/MetadataCache';
 import {
   ObjectStackError,
@@ -404,6 +409,12 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   // so optional collections like sys_presence don't hammer the server with
   // failing requests on every record open / panel render.
   private missingResources = new Set<string>();
+  // Set once the server has told us it can't do a cross-object transactional
+  // batch (POST /api/v1/batch answered 404/405/501). After that, batchTransaction
+  // stops probing the endpoint and serves every call via the client-side
+  // emulation — the non-atomic fallback lives HERE, isolated to the one adapter
+  // that has to cope with a backend lacking server atomicity (#2679).
+  private batchUnsupported = false;
   // Subscribers registered via onMutation(). Emitted after each successful
   // create/update/delete so data-bound views (ListView, ObjectView, kanban,
   // calendar) auto-refresh — the interface ListView relies on to reflect
@@ -927,14 +938,47 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * @returns Promise resolving to array of results
    */
   /**
-   * Cross-object transactional batch (ObjectStack #1604). Runs the operations
-   * in ONE server transaction — commit all or roll back all. A field value of
-   * `{ $ref: <earlier op index> }` resolves to that op's created id, so a child
-   * can reference its parent created earlier in the same batch (master-detail).
+   * Cross-object transactional batch (ObjectStack #1604 / ADR-0034 item 4).
+   * Runs the operations in ONE server transaction — commit all or roll back
+   * all. A field value of `{ $ref: <earlier op index> }` resolves to that op's
+   * created id, so a child can reference its parent created earlier in the same
+   * batch (master-detail).
+   *
+   * Transport preference: the published `@objectstack/client` SDK method when
+   * available (framework #3271), else a raw `POST /api/v1/batch`. Either way,
+   * if the backend has no such endpoint (404/405) or a runtime that can't do
+   * transactions (501), we degrade to a client-side, NON-atomic emulation via
+   * {@link emulateBatchTransaction} so a save is still possible — this is the
+   * isolated home of the non-atomic fallback. Hard removal of the emulation is
+   * gated on the server advertising a batch capability via discovery (the
+   * current discovery payload does not), so the fallback stays for now.
    */
   async batchTransaction(
-    operations: Array<{ object: string; action?: 'create' | 'update' | 'delete'; data?: any; id?: string }>,
+    operations: BatchTransactionOperation[],
   ): Promise<{ results: any[] }> {
+    // Already known-unsupported on this backend — skip the probe entirely.
+    if (this.batchUnsupported) {
+      return emulateBatchTransaction(this, operations);
+    }
+
+    // Prefer the typed SDK method when the installed client exposes it
+    // (feature-detect, same pattern as updateMany/import). Older clients that
+    // predate it fall through to the raw-fetch mainline below.
+    const sdkBatch = (this.client.data as any).batchTransaction;
+    if (typeof sdkBatch === 'function') {
+      await this.connect();
+      try {
+        const payload: { results: any[] } = await sdkBatch.call(this.client.data, operations);
+        this.emitBatchMutations(operations, payload?.results);
+        return payload;
+      } catch (err) {
+        if (this.batchStatusUnsupported(this.errorStatusOf(err))) {
+          return this.fallbackToEmulation(operations, this.errorStatusOf(err));
+        }
+        throw err;
+      }
+    }
+
     const url = `${this.baseUrl}/api/v1/batch`;
     const response = await this.fetchImpl(url, {
       method: 'POST',
@@ -947,6 +991,14 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       body: JSON.stringify({ operations }),
     });
     if (!response.ok) {
+      // Endpoint missing (404/405) or runtime can't do transactions (the
+      // framework rest-server answers 501 "Transactional batch not supported
+      // by this runtime") → degrade to the non-atomic client emulation. Every
+      // other status (400 validation, 401/403 auth, 409 conflict, 500 fault)
+      // is a real error the caller must see — never silently retried.
+      if (this.batchStatusUnsupported(response.status)) {
+        return this.fallbackToEmulation(operations, response.status);
+      }
       const error = await response.json().catch(() => ({ message: response.statusText }));
       throw new ObjectStackError(
         error.error || error.message || `Batch failed with status ${response.status}`,
@@ -955,14 +1007,55 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       );
     }
     const payload: { results: any[] } = await response.json();
-    // The whole transaction committed — emit one MutationEvent per operation so
-    // the invalidation bus (#2269) sees writes that went through /batch exactly
-    // like single create/update/delete calls (master-detail ModalForm saves
-    // otherwise leave related lists and count badges stale, #2582). `results`
-    // is index-aligned with `operations`; creates take id/record from the
-    // server echo. A failed batch rolled back entirely and throws above, so
-    // nothing is emitted for it.
-    const results = Array.isArray(payload?.results) ? payload.results : [];
+    this.emitBatchMutations(operations, payload?.results);
+    return payload;
+  }
+
+  /** True for statuses that mean "this backend can't do a transactional batch". */
+  private batchStatusUnsupported(status: number | undefined): boolean {
+    return status === 404 || status === 405 || status === 501;
+  }
+
+  /** Best-effort HTTP status extraction from a thrown SDK/client error. */
+  private errorStatusOf(err: unknown): number | undefined {
+    if (!err || typeof err !== 'object') return undefined;
+    const e = err as Record<string, unknown>;
+    const s = e.httpStatus ?? e.status ?? e.statusCode;
+    return typeof s === 'number' ? s : undefined;
+  }
+
+  /** Mark the endpoint unsupported (warn once) and serve via emulation. */
+  private fallbackToEmulation(
+    operations: BatchTransactionOperation[],
+    status: number | undefined,
+  ): Promise<{ results: any[] }> {
+    if (!this.batchUnsupported) {
+      this.batchUnsupported = true;
+      console.warn(
+        `ObjectStackAdapter: POST /api/v1/batch unavailable (HTTP ${status ?? '?'}) — ` +
+          'falling back to non-atomic client-side batch emulation. Cross-object ' +
+          'saves on this backend are best-effort, not transactional.',
+      );
+    }
+    return emulateBatchTransaction(this, operations);
+  }
+
+  /**
+   * Emit one MutationEvent per committed operation so the invalidation bus
+   * (#2269) sees writes that went through /batch exactly like single
+   * create/update/delete calls — master-detail ModalForm saves otherwise leave
+   * related lists and count badges stale (#2582). `results` is index-aligned
+   * with `operations`; creates take id/record from the server echo.
+   *
+   * Only called on the server-committed paths. The emulation branch drives the
+   * adapter's own create/update/delete primitives, which already emit — so it
+   * must NOT be routed through here, or events would double-fire.
+   */
+  private emitBatchMutations(
+    operations: BatchTransactionOperation[],
+    rawResults: unknown,
+  ): void {
+    const results = Array.isArray(rawResults) ? rawResults : [];
     operations.forEach((op, i) => {
       const action = op.action ?? 'create';
       const echo = results[i];
@@ -974,7 +1067,6 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         this.emitMutation({ type: 'delete', resource: op.object, id: op.id });
       }
     });
-    return payload;
   }
 
   async bulk(resource: string, operation: 'create' | 'update' | 'delete', data: Partial<T>[]): Promise<T[]> {

--- a/packages/data-objectstack/src/onMutation.test.ts
+++ b/packages/data-objectstack/src/onMutation.test.ts
@@ -233,6 +233,87 @@ describe('ObjectStackAdapter.batchTransaction mutation events', () => {
 });
 
 /**
+ * #2679: when POST /api/v1/batch is unavailable (endpoint missing → 404/405, or
+ * a runtime without transactions → 501), the adapter degrades to a client-side,
+ * NON-atomic emulation instead of failing the save. This is the isolated home of
+ * the non-atomic fallback — the form no longer carries it. Real errors (4xx/5xx
+ * other than those three) must still surface, never be silently downgraded.
+ */
+describe('ObjectStackAdapter.batchTransaction fallback (no server atomicity)', () => {
+  function makeFallbackDS(opts: { batchStatus: number; clientData: Record<string, any> }) {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: 'nope' }), {
+        status: opts.batchStatus,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const ds: any = new ObjectStackAdapter({ baseUrl: 'http://test.local', fetch: fetchMock });
+    ds.connected = true;
+    ds.connectionState = 'connected';
+    ds.client = { data: opts.clientData };
+    return { ds, fetchMock };
+  }
+
+  it('404 → warns once, saves via the create primitive, and caches the detection', async () => {
+    const create = vi.fn(async (_o: string, d: any) => ({ record: { id: 'p1', ...d } }));
+    const { ds, fetchMock } = makeFallbackDS({ batchStatus: 404, clientData: { create } });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    const res = await ds.batchTransaction([{ object: 'proj', action: 'create', data: { name: 'A' } }]);
+
+    expect(res.results[0]).toMatchObject({ id: 'p1', name: 'A' });
+    expect(create).toHaveBeenCalledWith('proj', { name: 'A' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    // Events come from the create primitive ONCE — not also re-emitted by the
+    // committed-batch path (no double emission).
+    expect(events).toEqual([{ type: 'create', resource: 'proj', record: { id: 'p1', name: 'A' } }]);
+
+    const probes = fetchMock.mock.calls.length;
+    // A second batch short-circuits: the endpoint is known-unsupported, so we
+    // never probe POST /api/v1/batch again.
+    await ds.batchTransaction([{ object: 'proj', action: 'create', data: { name: 'B' } }]);
+    expect(fetchMock.mock.calls.length).toBe(probes);
+    warn.mockRestore();
+  });
+
+  it('501 (runtime without transactions) also degrades to emulation', async () => {
+    const create = vi.fn(async (_o: string, d: any) => ({ record: { id: 'p1', ...d } }));
+    const { ds } = makeFallbackDS({ batchStatus: 501, clientData: { create } });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await ds.batchTransaction([{ object: 'proj', action: 'create', data: { name: 'A' } }]);
+    expect(create).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('a real error (400) surfaces as ObjectStackError — never downgraded to emulation', async () => {
+    const create = vi.fn();
+    const { ds } = makeFallbackDS({ batchStatus: 400, clientData: { create } });
+    await expect(
+      ds.batchTransaction([{ object: 'proj', action: 'create', data: {} }]),
+    ).rejects.toThrow(/nope/);
+    // No client-side writes happened — the batch was rejected, not retried.
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('prefers the SDK client.data.batchTransaction when present (no raw fetch)', async () => {
+    const sdkBatch = vi.fn(async () => ({ results: [{ id: 'p1', name: 'A' }] }));
+    const { ds, fetchMock } = makeFallbackDS({ batchStatus: 500, clientData: { batchTransaction: sdkBatch } });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    const res = await ds.batchTransaction([{ object: 'proj', action: 'create', data: { name: 'A' } }]);
+
+    expect(sdkBatch).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled(); // raw /api/v1/batch not used
+    expect(res.results[0]).toMatchObject({ id: 'p1' });
+    // Committed via the SDK → one event per op (emitted once).
+    expect(events).toEqual([{ type: 'create', resource: 'proj', record: { id: 'p1', name: 'A' } }]);
+  });
+});
+
+/**
  * Regression for #2582 (fallback path): when the server lacks the transactional
  * batch endpoint, MasterDetailForm persists child rows via `bulk(child,
  * 'create', rows)` (applyDetail → createMany). `bulk` only emitted progress

--- a/packages/plugin-form/src/LineItemsPanel.test.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { registerAllFields } from '@object-ui/fields';
+import { SchemaRendererProvider } from '@object-ui/react';
+import { LineItemsPanel } from './LineItemsPanel';
+
+registerAllFields();
+
+// One existing child line so load() populates `original` and an edit produces
+// a diff. The panel edits details of an ALREADY-SAVED parent (parentId known),
+// so there is never a $ref — children carry the parent id directly.
+function makeDataSource(overrides: any = {}) {
+  return {
+    getObjectSchema: vi.fn().mockResolvedValue(null),
+    find: vi.fn().mockResolvedValue({ data: [{ id: 'l1', amount: 10 }] }),
+    create: vi.fn(async (_o: string, d: any) => ({ id: 'newline', ...d })),
+    update: vi.fn(async (o: string, id: string, d: any) => ({ id, ...d })),
+    delete: vi.fn(async () => true),
+    ...overrides,
+  } as any;
+}
+
+const schema = {
+  childObject: 'po_line',
+  relationshipField: 'po',
+  parentObject: 'po',
+  parentId: 'p1',
+  amountField: 'amount',
+  totalField: 'total_amount',
+  columns: [{ field: 'amount', label: 'Amount', type: 'number' }],
+} as any;
+
+function renderPanel(ds: any) {
+  return render(
+    <SchemaRendererProvider dataSource={ds}>
+      <LineItemsPanel schema={schema} />
+    </SchemaRendererProvider>,
+  );
+}
+
+/** Wait for load() to finish, edit the first line's Amount → mark dirty. */
+async function editFirstLine(to: string) {
+  const cell = await waitFor(() => {
+    const el = screen.getAllByLabelText('Amount')[0] as HTMLInputElement | undefined;
+    if (!el) throw new Error('grid not ready');
+    return el;
+  });
+  fireEvent.change(cell, { target: { value: to } });
+}
+
+describe('LineItemsPanel — save via batchTransaction (#2679)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('builds an edit batch (parent rollup as op 0 + child diff) and calls batchTransaction once', async () => {
+    const batchTransaction = vi.fn().mockResolvedValue({ results: [] });
+    const ds = makeDataSource({ batchTransaction });
+    renderPanel(ds);
+
+    await editFirstLine('15');
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(batchTransaction).toHaveBeenCalledTimes(1));
+    const ops = batchTransaction.mock.calls[0][0];
+    // op 0 is the parent update carrying the rolled-up total (10 → 15).
+    expect(ops[0]).toEqual({
+      object: 'po',
+      action: 'update',
+      id: 'p1',
+      data: { total_amount: 15 },
+    });
+    // The edited line is a child update carrying the parent FK directly.
+    const childUpdate = ops.find((o: any) => o.object === 'po_line' && o.action === 'update');
+    expect(childUpdate).toMatchObject({ id: 'l1', data: { po: 'p1', amount: 15 } });
+  });
+
+  it('still saves against an adapter without batchTransaction (emulation drives update primitives)', async () => {
+    const ds = makeDataSource(); // no batchTransaction
+    renderPanel(ds);
+
+    await editFirstLine('20');
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    // Emulation applies op 0 (parent rollup) and the child update via the
+    // adapter's own update() primitive.
+    await waitFor(() =>
+      expect(ds.update).toHaveBeenCalledWith('po', 'p1', { total_amount: 20 }),
+    );
+    await waitFor(() =>
+      expect(ds.update).toHaveBeenCalledWith('po_line', 'l1', expect.objectContaining({ po: 'p1', amount: 20 })),
+    );
+  });
+});

--- a/packages/plugin-form/src/LineItemsPanel.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.tsx
@@ -28,7 +28,8 @@ import {
 } from '@object-ui/components';
 import { LineItemsField, type GridColumn } from '@object-ui/fields';
 import { useSchemaContext, useRecordContext } from '@object-ui/react';
-import { applyDetail } from './masterDetailTx';
+import { buildMasterDetailEditBatch, sumRows } from './masterDetailTx';
+import { runBatchTransaction } from '@object-ui/core';
 
 export interface LineItemsPanelSchema {
   type?: 'record:line_items';
@@ -117,17 +118,30 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
     setSaving(true);
     setError(null);
     try {
-      await applyDetail(dataSource, parentObject || schema.childObject, parentId, {
-        childObject: schema.childObject,
-        relationshipField: schema.relationshipField,
-        rows,
-        original,
-        amountField: schema.amountField,
-        // only roll up when we know the parent object to write the total onto
-        totalField: parentObject ? schema.totalField : undefined,
-        // Strip computed / read-only columns from each child row payload.
-        childSchema,
-      });
+      // Only roll the line total up onto the parent when we know the parent
+      // object AND a target field — same gate as before. When we do, the parent
+      // update rides in the SAME batch as the child writes, so the rollup is now
+      // atomic with them (on an adapter that supports it) instead of a separate
+      // trailing update.
+      const canRollup = !!(parentObject && schema.totalField);
+      const parentPatch = canRollup
+        ? { [schema.totalField!]: sumRows(rows, schema.amountField || 'amount') }
+        : {};
+      let ops = buildMasterDetailEditBatch(parentObject ?? '', parentId, parentPatch, [
+        {
+          childObject: schema.childObject,
+          relationshipField: schema.relationshipField,
+          rows,
+          original,
+          // Strip computed / read-only columns from each child row payload.
+          childSchema,
+        },
+      ]);
+      // With no parent object / rollup to write, there is nothing to update on
+      // the parent — drop op 0. Safe: edit-batch children carry the parentId
+      // directly (no $ref), so slicing off the parent op shifts no references.
+      if (!canRollup) ops = ops.slice(1);
+      if (ops.length) await runBatchTransaction(dataSource, ops);
       await load();
     } catch (e: any) {
       setError(e?.message || 'Failed to save line items');

--- a/packages/plugin-form/src/MasterDetailForm.test.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.test.tsx
@@ -144,6 +144,77 @@ describe('MasterDetailForm — submit feedback (never silent)', () => {
   });
 });
 
+describe('MasterDetailForm — non-atomic fallback (emulation via runBatchTransaction)', () => {
+  // A DataSource WITHOUT a batchTransaction method: runBatchTransaction falls
+  // back to emulateBatchTransaction, which drives create/update/delete in order
+  // and compensates on failure. This is the "adapter has no server atomicity"
+  // path — the form code is identical, only the adapter differs.
+  beforeEach(() => {
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  const detailSchema = {
+    objectName: 'po',
+    mode: 'create',
+    fields: ['ref'],
+    details: [
+      { childObject: 'po_line', relationshipField: 'po', columns: [{ field: 'qty', label: 'Qty', type: 'number' }] },
+    ],
+  } as any;
+
+  async function fillHeaderAndLine(container: HTMLElement) {
+    const input = await waitFor(() => {
+      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+      if (!el) throw new Error('parent form not ready');
+      return el;
+    });
+    fireEvent.change(input, { target: { value: 'PO-1' } });
+    // Fill the first (ghost) line so it persists as a real child row.
+    const qty = await waitFor(() => screen.getAllByLabelText('Qty')[0] as HTMLInputElement);
+    fireEvent.change(qty, { target: { value: '5' } });
+  }
+
+  it('create: emulation creates the parent then the child with $ref resolved to the parent id', async () => {
+    const create = vi.fn(async (object: string, data: any) => ({
+      id: object === 'po' ? 'po1' : 'line1',
+      ...data,
+    }));
+    const ds = makeDataSource({ create }); // NO batchTransaction
+
+    const { container } = render(<MasterDetailForm schema={detailSchema} dataSource={ds} />);
+    await fillHeaderAndLine(container);
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => expect(create).toHaveBeenCalledWith('po', expect.objectContaining({ ref: 'PO-1' })));
+    // The child's { $ref: 0 } was resolved to the parent's minted id ('po1').
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith('po_line', expect.objectContaining({ po: 'po1' })),
+    );
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('create: a failing child create compensates by deleting the just-created parent + error toast', async () => {
+    const create = vi.fn(async (object: string, data: any) => {
+      if (object === 'po_line') throw new Error('child create failed');
+      return { id: 'po1', ...data };
+    });
+    const del = vi.fn(async () => true);
+    const ds = makeDataSource({ create, delete: del }); // NO batchTransaction
+
+    const { container } = render(<MasterDetailForm schema={detailSchema} dataSource={ds} />);
+    await fillHeaderAndLine(container);
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    // Best-effort compensation removes the orphan parent that was created before
+    // the child failed — the non-atomic path's stand-in for a rollback.
+    await waitFor(() => expect(del).toHaveBeenCalledWith('po', 'po1'));
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});
+
 describe('MasterDetailForm — parent-scoped line rules ("paid invoice → lock lines", #1581)', () => {
   // Parent header carries a `status` text field (a real <select> can't be driven
   // by synthetic events in jsdom — that path is covered by the live e2e spec).

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -12,24 +12,31 @@
  * transaction (see ADR-0001).
  *
  * The parent fields are rendered by the existing <ObjectForm>; the child
- * collection(s) by <LineItemsField>. On submit we:
- *   1. create/update the parent (ObjectForm owns this, via its `onSuccess`),
- *   2. set the relationship FK on each line and bulk-create them,
- *   3. (optional) roll the line total up onto a parent field,
- *   4. on child failure, best-effort delete the just-created parent and rethrow
- *      so the form surfaces the error with the user's input intact.
+ * collection(s) by <LineItemsField>. On submit we build ONE ordered
+ * cross-object operation list — parent create/update as op 0, each child a
+ * create/update/delete linked to it (via `{ $ref: 0 }` on create, or the
+ * known parent id on edit) — and hand it to `dataSource.batchTransaction`
+ * through {@link runBatchTransaction}. Client-side rollups are folded into the
+ * parent payload so they commit in the same batch.
+ *
+ * The form is deliberately ignorant of atomicity: a server with the
+ * transactional `/api/v1/batch` endpoint commits all-or-nothing, while an
+ * adapter without one emulates the batch internally (sequential writes with
+ * best-effort compensation, see `emulateBatchTransaction` in `@object-ui/core`).
+ * Either way there is no master-detail-specific cleanup code here (ObjectStack
+ * objectui #2679 / framework ADR-0034 item 4).
  *
  * No `@objectstack/spec` change: the relationship is a `master_detail` (or
- * `lookup`) FK on the child object; there is no server batch endpoint, so the
- * multi-object write is orchestrated here.
+ * `lookup`) FK on the child object.
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DataSource } from '@object-ui/types';
+import { runBatchTransaction } from '@object-ui/core';
 import { LineItemsField, type GridColumn } from '@object-ui/fields';
 import { Button, Card, CardContent, CardHeader, CardTitle, cn, toast } from '@object-ui/components';
 import { ObjectForm } from './ObjectForm';
-import { applyDetail, idOf, buildMasterDetailBatch, buildMasterDetailEditBatch, sumRows } from './masterDetailTx';
+import { buildMasterDetailBatch, buildMasterDetailEditBatch, sumRows } from './masterDetailTx';
 import { deriveDetail, hydrateColumns, type InlineMode } from './deriveMasterDetail';
 
 export interface MasterDetailDetailConfig {
@@ -528,69 +535,16 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
     [schema, releaseSave],
   );
 
-  /** Persist all child collections for a known parent id. Returns created ids
-   *  (create mode) so the caller can clean up on a later failure. */
-  const persistDetails = useCallback(
-    async (parentId: string) => {
-      const createdIds: Array<{ object: string; id: string }> = [];
-      for (let i = 0; i < details.length; i++) {
-        const d = details[i];
-        const { rows, original } = stateRef.current[i];
-        if (!d.relationshipField) continue; // unresolved — skip (save is gated)
-        const { created } = await applyDetail(dataSource!, schema.objectName, parentId, {
-          childObject: d.childObject,
-          relationshipField: d.relationshipField,
-          rows,
-          // edit mode diffs against the loaded snapshot; create mode creates all.
-          original: isEdit ? original : undefined,
-          amountField: d.amountField,
-          totalField: d.totalField,
-          // Strip computed / read-only columns from each child row payload.
-          childSchema: childSchemasRef.current[d.childObject],
-        });
-        createdIds.push(...created);
-      }
-      return createdIds;
-    },
-    [details, isEdit, dataSource, schema.objectName],
-  );
-
-  /** Chained after the parent ObjectForm create/update succeeds. */
-  const handleParentSaved = useCallback(
-    async (parent: any) => {
-      const parentId = idOf(parent) ?? schema.recordId;
-      if (!parentId) throw new Error('MasterDetailForm: parent record has no id after save');
-      if (!dataSource) throw new Error('MasterDetailForm: dataSource is required');
-
-      let created: Array<{ object: string; id: string }> = [];
-      try {
-        created = await persistDetails(parentId);
-      } catch (err) {
-        // Best-effort cleanup so we don't leave an orphan parent on create.
-        if (!isEdit) {
-          await Promise.allSettled([
-            ...created.map((c) => dataSource.delete(c.object, c.id)),
-            dataSource.delete(schema.objectName, parentId),
-          ]);
-        }
-        throw err;
-      }
-      await handleSaved(parent);
-    },
-    [dataSource, isEdit, persistDetails, schema, handleSaved],
-  );
-
-  // When the server exposes the transactional batch endpoint, the parent + its
-  // children are persisted in ONE atomic transaction (commit all or roll back
-  // all) — no client-side best-effort cleanup. This now covers BOTH create
-  // (parent + child creates via `$ref`) and edit (parent update + child
-  // create/update/delete diffs). Otherwise fall back to the client-orchestrated
-  // path (handleParentSaved).
-  const canBatch = typeof (dataSource as any)?.batchTransaction === 'function';
-
+  // Persistence ALWAYS goes through dataSource.batchTransaction: the parent and
+  // all child collections are expressed as one ordered operation list and
+  // handed to runBatchTransaction, which uses the adapter's atomic endpoint
+  // when present and emulates it (sequential + best-effort compensation)
+  // otherwise. This covers BOTH create (parent + child creates via `$ref`) and
+  // edit (parent update + child create/update/delete diffs). There is no
+  // separate client-orchestrated / cleanup path anymore (#2679).
   const submitViaBatch = useCallback(
     async (parentValues: Record<string, any>) => {
-      const ds: any = dataSource;
+      if (!dataSource) throw new Error('MasterDetailForm: dataSource is required');
       const parentData: Record<string, any> = { ...parentValues };
       // Client-side rollups merged into the parent payload (hooks can't do
       // nested writes — see ADR-0001).
@@ -620,7 +574,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
               childSchema: childSchemasRef.current[d.childObject],
             })),
           );
-      const res = await ds.batchTransaction(ops);
+      const res = await runBatchTransaction(dataSource, ops);
       // create → parent is op 0; edit → echo the parent values back.
       return res?.results?.[0] ?? { ...parentData, id: schema.recordId };
     },
@@ -646,14 +600,14 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
       title: schema.title,
       showSubmit: false,
       showCancel: false,
-      // Atomic path: ObjectForm validates + hands values to submitViaBatch
-      // (which persists parent+children in one transaction), then handleSaved
-      // (toast + reset + page onSuccess). The non-atomic path persists children
-      // in handleParentSaved, which also ends in handleSaved.
-      ...(canBatch ? { submitHandler: submitViaBatch, onSuccess: handleSaved } : { onSuccess: handleParentSaved }),
+      // ObjectForm validates + hands the parent values to submitViaBatch (which
+      // persists parent + children as one batch via dataSource.batchTransaction),
+      // then handleSaved (toast + reset + page onSuccess).
+      submitHandler: submitViaBatch,
+      onSuccess: handleSaved,
       onError: handleError,
     }),
-    [schema, handleParentSaved, canBatch, submitViaBatch, handleSaved, handleError],
+    [schema, submitViaBatch, handleSaved, handleError],
   );
 
   const formHostRef = useRef<HTMLDivElement>(null);

--- a/packages/plugin-form/src/masterDetailTx.test.ts
+++ b/packages/plugin-form/src/masterDetailTx.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { diffRows, sumRows, applyDetail, idOf, isBlankRow, buildMasterDetailBatch, buildMasterDetailEditBatch } from './masterDetailTx';
+import { describe, it, expect } from 'vitest';
+import { diffRows, sumRows, idOf, isBlankRow, buildMasterDetailBatch, buildMasterDetailEditBatch } from './masterDetailTx';
 
 describe('buildMasterDetailBatch — atomic master-detail ops', () => {
   it('puts the parent first and references it via $ref:0 on each child FK', () => {
@@ -78,6 +78,20 @@ describe('buildMasterDetailEditBatch — atomic master-detail edit ops', () => {
     expect(ops.filter((o) => o.action === 'delete')).toHaveLength(0);
     expect(ops.filter((o) => o.action === 'create')).toHaveLength(0);
   });
+
+  it('folds a caller-computed rollup into op 0 so it commits in the same batch (#2679)', () => {
+    // Acceptance criterion: the rollup total is no longer a separate trailing
+    // parent update — the caller sums the lines and passes it as a parent field,
+    // and it rides in op 0 (the parent update) inside the same transaction.
+    const rows = [{ id: 'l1', amount: 15 }, { amount: 30 }];
+    const total = sumRows(rows, 'amount');
+    const ops = buildMasterDetailEditBatch('po', 'p1', { total_amount: total }, [
+      { childObject: 'po_line', relationshipField: 'po', rows, original: [{ id: 'l1', amount: 10 }] },
+    ]);
+    expect(ops[0]).toEqual({ object: 'po', action: 'update', id: 'p1', data: { total_amount: 45 } });
+    // No separate parent update anywhere else in the batch.
+    expect(ops.filter((o) => o.object === 'po')).toHaveLength(1);
+  });
 });
 
 describe('masterDetailTx — pure helpers', () => {
@@ -102,109 +116,6 @@ describe('masterDetailTx — pure helpers', () => {
     expect(d.toUpdate).toEqual([{ id: 'l1', amount: 15 }]);
     expect(d.toCreate).toEqual([{ amount: 30 }]);
     expect(d.toDelete).toEqual(['l2']);
-  });
-});
-
-function mockDataSource(overrides: any = {}) {
-  return {
-    create: vi.fn(async (_obj: string, data: any) => ({ id: 'new-' + Math.random().toString(36).slice(2, 7), ...data })),
-    update: vi.fn(async (_obj: string, id: string, data: any) => ({ id, ...data })),
-    delete: vi.fn(async () => true),
-    bulk: vi.fn(async (_obj: string, _op: string, rows: any[]) => rows.map((r, i) => ({ id: 'b' + i, ...r }))),
-    ...overrides,
-  } as any;
-}
-
-describe('applyDetail — client-orchestrated child write', () => {
-  it('create mode: sets FK, bulk-creates children, rolls up the total', async () => {
-    const ds = mockDataSource();
-    const res = await applyDetail(ds, 'expense_claim', 'claim_1', {
-      childObject: 'expense_line',
-      relationshipField: 'expense_claim',
-      rows: [{ amount: 10 }, { amount: 32.5 }],
-      amountField: 'amount',
-      totalField: 'total_amount',
-    });
-
-    // FK injected on every row, single bulk call
-    expect(ds.bulk).toHaveBeenCalledTimes(1);
-    expect(ds.bulk).toHaveBeenCalledWith('expense_line', 'create', [
-      { amount: 10, expense_claim: 'claim_1' },
-      { amount: 32.5, expense_claim: 'claim_1' },
-    ]);
-    // rollup written onto the parent
-    expect(ds.update).toHaveBeenCalledWith('expense_claim', 'claim_1', { total_amount: 42.5 });
-    // created ids surfaced for cleanup
-    expect(res.created).toEqual([
-      { object: 'expense_line', id: 'b0' },
-      { object: 'expense_line', id: 'b1' },
-    ]);
-  });
-
-  it('tolerates a bulk() that returns {records:[...]} instead of an array', async () => {
-    // Mirrors the real ObjectStack adapter, whose createMany can resolve to a
-    // wrapped shape rather than a bare array (regression: "newRecords is not iterable").
-    const ds = mockDataSource({
-      bulk: vi.fn(async (_o: string, _op: string, rows: any[]) => ({
-        records: rows.map((r, i) => ({ id: 'w' + i, ...r })),
-      })),
-    });
-    const res = await applyDetail(ds, 'expense_claim', 'claim_1', {
-      childObject: 'expense_line',
-      relationshipField: 'expense_claim',
-      rows: [{ amount: 10 }, { amount: 5 }],
-      amountField: 'amount',
-      totalField: 'total_amount',
-    });
-    expect(res.created).toEqual([
-      { object: 'expense_line', id: 'w0' },
-      { object: 'expense_line', id: 'w1' },
-    ]);
-    expect(ds.update).toHaveBeenCalledWith('expense_claim', 'claim_1', { total_amount: 15 });
-  });
-
-  it('create mode without bulk falls back to per-row create', async () => {
-    const ds = mockDataSource({ bulk: undefined });
-    await applyDetail(ds, 'po', 'po_1', {
-      childObject: 'po_line',
-      relationshipField: 'po',
-      rows: [{ qty: 1 }, { qty: 2 }],
-    });
-    expect(ds.create).toHaveBeenCalledTimes(2);
-    expect(ds.create).toHaveBeenCalledWith('po_line', { qty: 1, po: 'po_1' });
-    expect(ds.create).toHaveBeenCalledWith('po_line', { qty: 2, po: 'po_1' });
-  });
-
-  it('edit mode: creates new, updates changed, deletes removed', async () => {
-    const ds = mockDataSource();
-    await applyDetail(ds, 'expense_claim', 'claim_1', {
-      childObject: 'expense_line',
-      relationshipField: 'expense_claim',
-      original: [{ id: 'l1', amount: 10 }, { id: 'l2', amount: 20 }],
-      rows: [{ id: 'l1', amount: 15 }, { amount: 30 }], // edit l1, drop l2, add one
-      amountField: 'amount',
-      totalField: 'total_amount',
-    });
-
-    // new row created (with FK)
-    expect(ds.bulk).toHaveBeenCalledWith('expense_line', 'create', [{ amount: 30, expense_claim: 'claim_1' }]);
-    // changed row updated (with FK)
-    expect(ds.update).toHaveBeenCalledWith('expense_line', 'l1', { id: 'l1', amount: 15, expense_claim: 'claim_1' });
-    // removed row deleted
-    expect(ds.delete).toHaveBeenCalledWith('expense_line', 'l2');
-    // rollup reflects the current rows (15 + 30 = 45)
-    expect(ds.update).toHaveBeenCalledWith('expense_claim', 'claim_1', { total_amount: 45 });
-  });
-
-  it('skips rollup when no totalField is configured', async () => {
-    const ds = mockDataSource();
-    await applyDetail(ds, 'expense_claim', 'claim_1', {
-      childObject: 'expense_line',
-      relationshipField: 'expense_claim',
-      rows: [{ amount: 10 }],
-    });
-    // only the bulk create — no parent update
-    expect(ds.update).not.toHaveBeenCalled();
   });
 });
 
@@ -259,24 +170,6 @@ describe('child payload sanitize (childSchema supplied)', () => {
     const cre = ops.find((o) => o.object === 'inv_line' && o.action === 'create');
     expect(cre!.data).toEqual({ product: 'New', quantity: 2, unit_price: 10, amount: 5, invoice: 'inv1' });
     expect(cre!.data).not.toHaveProperty('note_calc');
-  });
-
-  it('applyDetail sanitizes create and update child payloads', async () => {
-    const ds = mockDataSource();
-    await applyDetail(ds, 'invoice', 'inv1', {
-      childObject: 'inv_line', relationshipField: 'invoice',
-      original: [{ id: 'l1', product: 'Widget', quantity: 1, unit_price: 10, amount: 10 }],
-      rows: [dirtyRow({ id: 'l1', amount: 25 }), dirtyRow({ product: 'New', amount: 5 })],
-      childSchema: LINE_SCHEMA,
-    });
-    // Update: computed/id stripped, stored amount + FK kept.
-    expect(ds.update).toHaveBeenCalledWith('inv_line', 'l1', {
-      product: 'Widget', quantity: 2, unit_price: 10, amount: 25, invoice: 'inv1',
-    });
-    // Create (via bulk): computed dropped, amount kept.
-    expect(ds.bulk).toHaveBeenCalledWith('inv_line', 'create', [
-      { product: 'New', quantity: 2, unit_price: 10, amount: 5, invoice: 'inv1' },
-    ]);
   });
 
   it('leaves rows untouched when no childSchema is supplied (backward compatible)', () => {

--- a/packages/plugin-form/src/masterDetailTx.ts
+++ b/packages/plugin-form/src/masterDetailTx.ts
@@ -7,13 +7,15 @@
  */
 
 /**
- * Pure helpers for the master-detail (parent + line items) client-orchestrated
- * write. Kept free of React so the transaction logic is unit-testable in
- * isolation (see ADR-0001). Both <MasterDetailForm> and <LineItemsPanel>
- * delegate their child persistence here.
+ * Pure helpers that turn a master-detail (parent + line items) edit into a flat
+ * list of cross-object batch operations. Kept free of React so the build logic
+ * is unit-testable in isolation (see ADR-0001). Both <MasterDetailForm> and
+ * <LineItemsPanel> build ops here and hand them to `dataSource.batchTransaction`
+ * (via `runBatchTransaction`) — the persistence itself lives in the adapter,
+ * not here (ObjectStack objectui #2679).
  */
 
-import type { DataSource } from '@object-ui/types';
+import type { BatchTransactionOperation } from '@object-ui/types';
 import { sanitizeFormData } from './sanitize';
 
 export const idOf = (rec: any): string | undefined =>
@@ -63,14 +65,13 @@ export interface BatchEditDetailInput extends BatchDetailInput {
   original: Record<string, any>[];
 }
 
-export interface BatchOp {
-  object: string;
-  action: 'create' | 'update' | 'delete';
-  /** Present for create/update. */
-  data?: Record<string, any>;
-  /** Present for update/delete. */
-  id?: string;
-}
+/**
+ * @deprecated Use {@link BatchTransactionOperation} from `@object-ui/types`.
+ * Retained as a structural alias so existing imports keep compiling. The
+ * builders below always set `action`, so the widened (optional-action) alias
+ * is a superset that costs nothing at the call sites.
+ */
+export type BatchOp = BatchTransactionOperation;
 
 const ID_KEYS = new Set(['id', '_id', 'recordId']);
 
@@ -170,94 +171,3 @@ export function sumRows(rows: Record<string, any>[], field: string): number {
   }, 0);
 }
 
-/**
- * Normalize whatever a create/bulk call resolves to into an array of records.
- * Adapters vary: some return `T[]`, others `{ records: [...] }` / `{ data: [...] }`
- * or a single record. We only use the result to collect ids for cleanup, so a
- * best-effort coercion keeps the happy path from throwing on an odd shape.
- */
-function toRecordArray(res: any): any[] {
-  if (Array.isArray(res)) return res;
-  if (res && Array.isArray(res.records)) return res.records;
-  if (res && Array.isArray(res.data)) return res.data;
-  if (res && (res.id || res._id)) return [res];
-  return [];
-}
-
-/** Create child rows, preferring a single bulk call when the adapter has one. */
-async function createMany(
-  dataSource: DataSource,
-  childObject: string,
-  rows: Record<string, any>[],
-): Promise<any[]> {
-  if (rows.length === 0) return [];
-  if (typeof dataSource.bulk === 'function') {
-    return toRecordArray(await dataSource.bulk(childObject, 'create', rows));
-  }
-  const created = await Promise.all(rows.map((r) => dataSource.create(childObject, r)));
-  return toRecordArray(created);
-}
-
-export interface ApplyDetailOptions {
-  childObject: string;
-  relationshipField: string;
-  rows: Record<string, any>[];
-  /** Loaded snapshot — when present we diff (edit mode); otherwise create-all. */
-  original?: Record<string, any>[];
-  /** Numeric child column to sum. */
-  amountField?: string;
-  /** Parent field to receive the rolled-up sum. */
-  totalField?: string;
-  /** When supplied, child write payloads are sanitized against it (drops
-   *  computed / read-only / unknown fields). Omit to persist rows as-is. */
-  childSchema?: ChildSchema;
-}
-
-export interface ApplyDetailResult {
-  /** Child object + id pairs created in this call (for cleanup on failure). */
-  created: Array<{ object: string; id: string }>;
-}
-
-/**
- * Persist one child collection for a known parent id. Sets the relationship FK
- * on every row, then creates / updates / deletes, then (optionally) rolls the
- * line total up onto the parent. Hooks can't do nested writes, so the rollup
- * happens here on the client.
- */
-export async function applyDetail(
-  dataSource: DataSource,
-  parentObject: string,
-  parentId: string,
-  opts: ApplyDetailOptions,
-): Promise<ApplyDetailResult> {
-  const created: Array<{ object: string; id: string }> = [];
-  const withFk = opts.rows
-    // Drop blank/ghost lines that were never filled in (keep existing rows).
-    .filter((r) => idOf(r) || !isBlankRow(r, opts.relationshipField))
-    .map((r) => ({ ...r, [opts.relationshipField]: parentId }));
-
-  if (opts.original !== undefined) {
-    const { toCreate, toUpdate, toDelete } = diffRows(opts.original, withFk);
-    const newRecords = await createMany(dataSource, opts.childObject, toCreate.map((r) => toWritable(r, opts.childSchema)));
-    for (const rec of newRecords) {
-      const id = idOf(rec);
-      if (id) created.push({ object: opts.childObject, id });
-    }
-    // idOf(r) is read BEFORE sanitize so update routing survives dropping the id.
-    await Promise.all(toUpdate.map((r) => dataSource.update(opts.childObject, idOf(r)!, toWritable(r, opts.childSchema))));
-    await Promise.all(toDelete.map((id) => dataSource.delete(opts.childObject, id)));
-  } else {
-    const newRecords = await createMany(dataSource, opts.childObject, withFk.map((r) => toWritable(r, opts.childSchema)));
-    for (const rec of newRecords) {
-      const id = idOf(rec);
-      if (id) created.push({ object: opts.childObject, id });
-    }
-  }
-
-  if (opts.totalField) {
-    const total = sumRows(opts.rows, opts.amountField || 'amount');
-    await dataSource.update(parentObject, parentId, { [opts.totalField]: total });
-  }
-
-  return { created };
-}

--- a/packages/runner/src/lib/mockDataSource.ts
+++ b/packages/runner/src/lib/mockDataSource.ts
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { DataSource } from '@object-ui/core';
+import type { DataSource, BatchTransactionOperation } from '@object-ui/core';
+import { emulateBatchTransaction } from '@object-ui/core';
 
 /**
  * 模拟数据源 (Mock Adapter)
@@ -38,6 +39,12 @@ export class MockDataSource implements DataSource {
 
   async delete(resource: string, id: string): Promise<any> {
     return true;
+  }
+
+  batchTransaction(
+    operations: BatchTransactionOperation[],
+  ): Promise<{ results: any[] }> {
+    return emulateBatchTransaction(this, operations);
   }
 
   async getObjectSchema(objectName: string): Promise<any> {

--- a/packages/types/examples/rest-data-source.ts
+++ b/packages/types/examples/rest-data-source.ts
@@ -17,8 +17,16 @@ import type { DataSource, QueryParams, QueryResult } from '../src/index';
 
 /**
  * REST API Data Source Implementation
- * 
+ *
  * A generic REST API adapter that works with any REST backend.
+ *
+ * Note: the optional `batchTransaction(operations)` method (used by
+ * master-detail saves) is omitted here. If your backend has no atomic
+ * cross-object endpoint, you don't need to hand-write orchestration —
+ * implement it as `emulateBatchTransaction(this, operations)` from
+ * `@object-ui/core` (sequential writes + `{ $ref }` resolution + best-effort
+ * compensation). Omit it entirely and callers fall back to the same emulation
+ * automatically via `runBatchTransaction`.
  */
 export class RestDataSource<T = any> implements DataSource<T> {
   constructor(private baseUrl: string) {}

--- a/packages/types/src/data.ts
+++ b/packages/types/src/data.ts
@@ -143,6 +143,39 @@ export interface FileUploadResult {
 }
 
 /**
+ * A `{ $ref: n }` placeholder inside a {@link BatchTransactionOperation}'s
+ * `data`. Resolves to the id created by operation `n` (which must appear
+ * earlier in the same batch) — used to link a child to a parent created in
+ * the same transaction (master-detail create).
+ */
+export interface BatchRef {
+  $ref: number;
+}
+
+/**
+ * One operation in a cross-object transactional batch. Field names match the
+ * server contract of `POST /api/v1/batch` (ObjectStack framework #1604 /
+ * ADR-0034 item 4).
+ *
+ * Distinct from the driver-level `BatchOperation` in `data-protocol.ts`
+ * (which speaks `type`/`table`) — this is the DataSource-level, object-aware
+ * shape consumed by {@link DataSource.batchTransaction}.
+ */
+export interface BatchTransactionOperation {
+  /** Target object/table name. */
+  object: string;
+  /** Operation to perform — defaults to `'create'` when omitted. */
+  action?: 'create' | 'update' | 'delete';
+  /** Target record id — required for `update` and `delete`. */
+  id?: string;
+  /**
+   * Write payload for `create`/`update`. A value may be a
+   * `{ $ref: <earlier op index> }` placeholder (see {@link BatchRef}).
+   */
+  data?: Record<string, any>;
+}
+
+/**
  * Universal data source interface.
  * This is the core abstraction that makes Object UI backend-agnostic.
  * 
@@ -287,6 +320,30 @@ export interface DataSource<T = any> {
     resource: string,
     ids: ReadonlyArray<string | number>,
   ): Promise<number>;
+
+  /**
+   * Atomically persist an ordered set of cross-object operations (optional).
+   *
+   * Contract: **either every operation commits or none do**. `results` is
+   * index-aligned with `operations` — a create/update echoes the written
+   * record, a delete echoes `true`. A field value inside an op's `data` may
+   * be a `{ $ref: <earlier op index> }` placeholder (see {@link BatchRef})
+   * that resolves to the id produced by that earlier operation, so a child
+   * row can reference a parent created in the SAME batch (master-detail).
+   *
+   * Backends with a transactional batch endpoint should issue one server
+   * call (true atomicity). Adapters WITHOUT server-side atomicity must still
+   * implement this method by emulating it client-side with best-effort
+   * compensation — see `emulateBatchTransaction` in `@object-ui/core`.
+   * Callers may therefore assume this method always saves, but only a
+   * server-backed implementation is genuinely atomic.
+   *
+   * @param operations - Ordered cross-object operations
+   * @returns `{ results }` index-aligned with `operations`
+   */
+  batchTransaction?(
+    operations: BatchTransactionOperation[],
+  ): Promise<{ results: any[] }>;
 
   /**
    * Cancel (recall) the active pending approval request for a record.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -269,6 +269,8 @@ export type {
   QueryParams,
   QueryResult,
   DataSource,
+  BatchRef,
+  BatchTransactionOperation,
   DataScope,
   DataContext,
   DataBinding,


### PR DESCRIPTION
## 背景

承接 framework#1604 / framework ADR-0034 item 4。`masterDetailTx → batchTransaction → POST /api/v1/batch` 的接线已存在且工作正常;本 PR 按 issue #2679 首选的**方案 A(契约先行)**清理非原子客户端回退路径。

Issue 点名的三块"回退清理":`canBatch` 方法嗅探门、`handleParentSaved` 的 best-effort 补偿删除、`applyDetail` 的 `created` 簿记。关键发现:`canBatch` 是**方法**嗅探而非**端点**嗅探——`ObjectStackAdapter` 永远有该方法,所以旧后端(无 `/batch`)场景今天其实是 404 直接失败,表单回退分支从不触发。真正的旧后端保护必须做在适配器内。

## 改动

- **`@object-ui/types`**:`batchTransaction?` 提升为 `DataSource` 契约的一等(可选)方法,类型 `BatchTransactionOperation` / `BatchRef`,去掉 `(dataSource as any)` 嗅探。可选而非必选,避免在 minor 里破坏外部实现方。
- **`@object-ui/core`**:新增 `emulateBatchTransaction`(顺序执行 + `$ref` 解析 + 失败时逆序 best-effort 补偿删除)与 `runBatchTransaction`(有适配器方法则用,否则模拟)。`ApiDataSource` / `ValueDataSource` / `MockDataSource` 均以该 helper 实现 `batchTransaction`。
- **`@object-ui/data-objectstack`**:`ObjectStackAdapter.batchTransaction` 优先用已发布客户端的 `client.data.batchTransaction`(framework #3271,特性探测),否则走 `POST /api/v1/batch`;仅当端点缺失(404/405)或运行时不支持事务(**501**,framework rest-server 对此返回 501)时降级到客户端模拟。400/401/403/409/500 等真实错误照常抛出。抽出 `emitBatchMutations` 共用,缓存探测结果避免重复探测。**这是非原子回退唯一、有测试的落点。**
- **`@object-ui/plugin-form`**:从 `masterDetailTx.ts` 删除 `applyDetail` / `createMany` / `ApplyDetailResult`;`MasterDetailForm` 与 `LineItemsPanel` 一律构建 ops 交给 `runBatchTransaction`,表单不再有主子表专属编排/补偿代码。`LineItemsPanel` 保存 + rollup 在有能力后端上现在也原子(rollup 并进同一批的父 op)。

## 行为差异(注意)

- 编辑态子创建现在也会被补偿(旧 `handleParentSaved` 仅 `!isEdit` 补偿)。
- 模拟走顺序 create,替代旧 `bulk('create')` 分组($ref 解析与有序语义所需;行项目量小)。
- 当前 ObjectStack 后端(有 `/batch`)无行为变化;旧/受限后端保留可用但明确非原子的保存路径。硬删除模拟卡在"discovery 广播 batch 能力"这一前提上(尚未广播)。

## 测试 / 验证

- 新增 `core/adapters/__tests__/batchTransaction.test.ts`(顺序/索引对齐、`$ref` id/_id/recordId 解析与前向 ref 抛错+补偿、逆序仅补偿 created、`runBatchTransaction` 委托/回退、驱动真 `ValueDataSource` 断言事件不双发)。
- `MasterDetailForm.test.tsx` 新增两例无 `batchTransaction` 的模拟路径(端到端 `$ref` 解析、子失败→父补偿删除+错误 toast);现有三例原子测试不变。
- 新增 `LineItemsPanel.test.tsx`(op0=含 rollup 的父 update + 子 diff;无 `batchTransaction` 仍可保存)。
- `onMutation.test.ts` 新增适配器回退用例(404/501 warn 一次+原语保存+缓存;400 抛错不回退;SDK-present 走 SDK 不裸 fetch、事件恰一轮);`masterDetailTx.test.ts` 删 `applyDetail` 用例,补 rollup 折入 op0 验收 pin。
- 全绿:`@object-ui/core` 89、`@object-ui/plugin-form` 205、`@object-ui/data-objectstack` 89、`@object-ui/runner` 6;5 个受改包 `build` 全过。
- 变更文档:`content/docs/guide/data-source.md`、`docs/adr/0001` addendum、`rest-data-source.ts` 示例注释;changeset(minor,通过 fixed-group 校验)。

> 说明:data-objectstack 仓库既有的 7 个 lint error(`no-useless-catch` / `preserve-caught-error`,均在本 PR 未触及的 index.ts L2025+/integration.ts)与 `exportDownload.test.ts` 的 type-check error 属**存量问题**(已用 stash 对照确认,本 PR 未新增 error)。

## 后续(不在本 PR)

- framework PR #3271 发版后,适配器的 SDK 特性探测自动生效(已埋好)。
- discovery 广播 batch 能力后,按 issue 验收第 4 条评估硬删除模拟(另开 issue)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCrTB7b5qFX2yyHJEGB5xa)_