### PR TITLE
feat(plugin-gantt): dependencyTypes switch — hide the link-type switcher for id-only dependency stores

### DIFF
--- a/packages/plugin-gantt/src/GanttView.deptypes.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.deptypes.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * dependencyTypes:false — data sources that store bare predecessor ids have
+ * no slot for a link TYPE, so the link menu must hide the fs/ss/ff/sf
+ * switcher (a switch would be silently reverted on refetch) while keeping
+ * remove-dependency available.
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+});
+
+const tasks: GanttTask[] = [
+  { id: 'a', title: 'Task a', start: new Date('2024-06-05'), end: new Date('2024-06-08'), progress: 0 },
+  { id: 'b', title: 'Task b', start: new Date('2024-06-10'), end: new Date('2024-06-12'), progress: 0, dependencies: ['a'] },
+];
+
+function openMenu(dependencyTypes: boolean | undefined) {
+  const utils = render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView
+        tasks={tasks}
+        startDate={new Date('2024-06-01')}
+        endDate={new Date('2024-06-30')}
+        onDependencyCreate={vi.fn()}
+        onDependencyDelete={vi.fn()}
+        dependencyTypes={dependencyTypes}
+      />
+    </div>,
+  );
+  const path = utils.container.querySelector('[data-testid="gantt-link-hit-a-b"]') as SVGPathElement;
+  expect(path).toBeTruthy();
+  fireEvent.contextMenu(path);
+  const menu = utils.container.ownerDocument.querySelector('[data-testid="gantt-link-context-menu"]') as HTMLElement;
+  expect(menu).toBeTruthy();
+  return menu;
+}
+
+describe('dependencyTypes switch', () => {
+  it('default: the four type entries render', () => {
+    const menu = openMenu(undefined);
+    expect(menu.querySelector('[data-testid="gantt-link-menu-type-fs"]')).toBeTruthy();
+    expect(menu.querySelector('[data-testid="gantt-link-menu-type-sf"]')).toBeTruthy();
+  });
+
+  it('false: type switcher hidden, remove-dependency stays', () => {
+    const menu = openMenu(false);
+    expect(menu.querySelector('[data-testid="gantt-link-menu-type-fs"]')).toBeFalsy();
+    expect(menu.querySelector('[data-testid="gantt-link-menu-type-ss"]')).toBeFalsy();
+    expect(menu.querySelector('[data-testid="gantt-link-menu-remove"]')).toBeTruthy();
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -479,6 +479,14 @@ export interface GanttViewProps {
   /** Disables the refresh button while a host-driven reload is in flight. */
   refreshing?: boolean
   /**
+   * Whether the data source can persist dependency LINK TYPES (fs/ss/ff/sf).
+   * Default true. Set false when dependencies are stored as bare predecessor
+   * ids (仅存紧前 id,无类型位) — the link context menu then hides the type
+   * switcher (a switch would be silently reverted on refetch) and drag-created
+   * links are always FS regardless of which endpoints were connected.
+   */
+  dependencyTypes?: boolean
+  /**
    * Business time zone for rendering (业务时区), an IANA name like
    * 'Asia/Shanghai'. The chart's calendar math — shift bands, day columns,
    * drag snapping, the today line, start/end labels — renders this zone's
@@ -686,6 +694,7 @@ export function GanttView({
   onLayoutChange,
   onRefresh,
   refreshing = false,
+  dependencyTypes = true,
   timeZone,
   exportFileName,
   interactions,
@@ -1396,7 +1405,11 @@ export function GanttView({
         // Finish (end) vs Start (start), the target endpoint picks the second
         // letter. end→start = FS, end→end = FF, start→start = SS, start→end = SF.
         const targetEnd = cur.targetEnd ?? 'start';
-        const type: GanttLinkType = `${cur.sourceEnd === 'end' ? 'f' : 's'}${targetEnd === 'end' ? 'f' : 's'}` as GanttLinkType;
+        // Data sources without a type slot (dependencyTypes:false) always
+        // create FS — any other type would be silently lost on persist.
+        const type: GanttLinkType = dependencyTypes
+          ? (`${cur.sourceEnd === 'end' ? 'f' : 's'}${targetEnd === 'end' ? 'f' : 's'}` as GanttLinkType)
+          : 'fs';
         if (
           source && target &&
           canReceiveLink(cur.sourceId, target) &&
@@ -1417,7 +1430,7 @@ export function GanttView({
       window.removeEventListener('pointerup', onUp);
       window.removeEventListener('pointercancel', onUp);
     };
-  }, [linkDrag, tasks, onDependencyCreate, onBeforeDependencyCreate, canReceiveLink]);
+  }, [linkDrag, tasks, onDependencyCreate, onBeforeDependencyCreate, canReceiveLink, dependencyTypes]);
 
   // --- Context menu ---------------------------------------------------------
   const [ctxMenu, setCtxMenu] = React.useState<{ x: number; y: number; taskId: string | number } | null>(null);
@@ -4873,7 +4886,7 @@ export function GanttView({
                 🚫 {t('gantt.lockedHint')}
               </div>
             )}
-            {onDependencyCreate && LINK_TYPES.map((lt) => (
+            {onDependencyCreate && dependencyTypes && LINK_TYPES.map((lt) => (
               <button
                 key={lt}
                 type="button"

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -170,6 +170,14 @@ type GanttConfigEx = GanttConfig & {
    */
   autoZoomToFilter?: boolean;
   /**
+   * Whether the backing store persists dependency link TYPES (fs/ss/ff/sf).
+   * Default true. Set false when dependencies are bare predecessor ids
+   * (仅存紧前 id) — the link menu hides the type switcher (a switch would be
+   * silently reverted on refetch) and drag-created links are always FS.
+   * Forwarded to {@link GanttView}.
+   */
+  dependencyTypes?: boolean;
+  /**
    * Business time zone (业务时区), IANA name like 'Asia/Shanghai'. Renders the
    * chart's calendar — shift bands, day columns, snapping, today line, date
    * labels — in this zone's wall time for every viewer, instead of the
@@ -386,6 +394,7 @@ function getGanttConfig(schema: ObjectGridSchema | any): GanttConfigEx | null {
           interactions: schema.interactions,
           exportFileName: schema.exportFileName,
           timeZone: schema.timeZone,
+          dependencyTypes: schema.dependencyTypes,
       };
       return config;
   }
@@ -1439,6 +1448,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           defaultCollapsedDepth={ganttConfig?.defaultCollapsedDepth}
           summaryExtent={ganttConfig?.summaryExtent}
           interactions={ganttConfig?.interactions}
+          dependencyTypes={ganttConfig?.dependencyTypes}
           timeZone={ganttConfig?.timeZone}
           onBeforeTaskUpdate={onBeforeTaskUpdate}
           exportFileName={


### PR DESCRIPTION
Delivers the fix for the silently-reverting link-type switcher described in the referenced issue.

Data sources that persist dependencies as bare predecessor ids have no slot for a link TYPE: picking ss/ff/sf optimistically updated the arrow, the persist dropped the type, and the silent refetch snapped it back to FS (线条闪一下又还原) — a misleading UI where no choice but FS can stick.

New `gantt.dependencyTypes` view config (default `true`, fully backwards compatible). Declaring `false`:
- the link context menu hides the fs/ss/ff/sf switcher (remove-dependency stays);
- drag-created links are always FS regardless of which endpoints were connected.

Wired through `ObjectGantt` view metadata. Verified live against an id-only store (排班计划甘特图, `predecessors` id comma-list): the link context menu shows only the title + 移除依赖, type items 0. plugin-gantt suite green incl. 2 new tests.

Refs the issue above; follow-up to #2682 / #2683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)