### PR TITLE
fix(plugin-gantt): mirror the row 「→」 slot in the task-list header — 开始/结束 columns align again

### DIFF
--- a/.changeset/gantt-header-open-slot-align.md
+++ b/.changeset/gantt-header-open-slot-align.md
@@ -1,0 +1,10 @@
+---
+"@object-ui/plugin-gantt": patch
+---
+
+fix(plugin-gantt): align the task-list header with the row date columns
+
+Every data row reserves a trailing w-6 (+4px) slot for the 「→」 open-details
+button whenever `onTaskClick` is live, but the header row didn't — so the
+开始/结束 header labels sat 28px to the right of the date values they caption.
+The header now mirrors the slot under the same condition.

--- a/packages/plugin-gantt/src/GanttView.headeralign.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.headeralign.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Task-list header ↔ row column alignment.
+ *
+ * Every data row reserves a trailing w-6 (+4px gap) slot for the 「→」
+ * open-details button whenever `onTaskClick` is live. The header row must
+ * mirror that slot, otherwise the 开始/结束 header labels sit 28px to the
+ * right of the date values they caption.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+  window.localStorage.clear();
+});
+
+function makeTask(id: string): GanttTask {
+  return {
+    id,
+    title: `Task ${id}`,
+    start: new Date('2024-06-10T00:00:00.000Z'),
+    end: new Date('2024-06-15T00:00:00.000Z'),
+    progress: 0,
+  };
+}
+
+function renderView(props: Partial<React.ComponentProps<typeof GanttView>> = {}) {
+  return render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView
+        tasks={[makeTask('a')]}
+        startDate={new Date('2024-06-01T00:00:00.000Z')}
+        endDate={new Date('2024-06-30T00:00:00.000Z')}
+        {...props}
+      />
+    </div>
+  );
+}
+
+describe('GanttView task-list header mirrors the row 「→」 slot', () => {
+  it('renders the header spacer when onTaskClick is live (rows reserve the slot)', () => {
+    const { container } = renderView({ onTaskClick: vi.fn() });
+    expect(container.querySelector('[data-testid="gantt-header-open-spacer"]')).toBeTruthy();
+    // Sanity: the rows do reserve the slot this spacer mirrors.
+    expect(container.querySelector('[data-testid="gantt-row-open-a"]')).toBeTruthy();
+  });
+
+  it('renders no header spacer when onTaskClick is absent (rows have no slot)', () => {
+    const { container } = renderView();
+    expect(container.querySelector('[data-testid="gantt-header-open-spacer"]')).toBeNull();
+    expect(container.querySelector('[data-testid="gantt-row-open-a"]')).toBeNull();
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -3428,6 +3428,18 @@ export function GanttView({
                 <div className="w-16 gantt-sm-w20 text-right">{t('gantt.column.end')}</div>
               </>
             )}
+            {/* Mirror of the data rows' 「→」 open-details slot (w-6 + 4px gap).
+                Every row reserves it whenever onTaskClick is live, so the
+                header must too — otherwise the 开始/结束 labels sit 28px to the
+                right of the values they caption. */}
+            {onTaskClick && (
+              <div
+                className="w-6 shrink-0 hidden sm:block"
+                style={{ marginLeft: 4 }}
+                aria-hidden="true"
+                data-testid="gantt-header-open-spacer"
+              />
+            )}
           </div>
           
           {/* Timeline Header — two scale rows: group (month/year) over units */}


### PR DESCRIPTION
## Problem

Every task-list data row reserves a trailing `w-6` (+4px gap) slot for the 「→」 open-details button whenever `onTaskClick` is live (added with the dedicated-slot design so rows don't shift during inline edit). The header row never mirrored that slot, so the 开始/结束 header labels sat **28px to the right** of the date values they caption — visibly misaligned.

## Fix

Add the matching spacer to the list header under the same condition (`onTaskClick` present) and the same `hidden sm:block` gate, so header and rows share identical column geometry in every state.

## Verification

- Live (dev console against a real app backend): header start/end cell right edges now equal the row date cell right edges exactly (`getBoundingClientRect` 451/531 = 451/531, `aligned: true`).
- New regression suite `GanttView.headeralign.test.tsx`: spacer renders when `onTaskClick` is live (rows reserve the slot), absent otherwise.
- plugin-gantt 338/338, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)