### PR TITLE
feat(app-shell): DeclaredActionsBar — server-declared actions in the approvals inbox (#2678 P2-4)

### DIFF
--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -25,6 +25,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { CommentAttachment, type Attachment } from '@object-ui/plugin-detail';
+import { DeclaredActionsBar } from '@object-ui/app-shell';
 import { createObjectStackUploadAdapter } from '@object-ui/providers';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import {
@@ -2054,6 +2055,24 @@ export function ApprovalsInboxPage() {
                             })}
                       </div>
                     )}
+                    {/* SERVER-DECLARED actions (objectui#2678 P2-4). Additive to the
+                        rich composer above: renders whatever `sys_approval_request`
+                        actions the backend declares at `record_section`
+                        (approval_approve / approval_reject / approval_reassign),
+                        executed through the shared console action runtime with ZERO
+                        inbox-specific per-action code — a follow-up retires the
+                        hardcoded buttons above. The record is the selected request
+                        row, so a `type:'api'` target like
+                        `/api/v1/approvals/requests/{id}/…` resolves `{id}` from it.
+                        Renders nothing (incl. its divider/label) when the object
+                        declares no such actions. */}
+                    <DeclaredActionsBar
+                      objectName="sys_approval_request"
+                      record={selected}
+                      location="record_section"
+                      label={tr('declaredActions', 'Actions')}
+                      onDone={() => { void refreshThread(selected.id); void load(); }}
+                    />
                   </div>
                 </>
               )}

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -133,8 +133,9 @@ export {
   ReportView,
   SearchResultsPage,
   ViewConfigPanel,
+  DeclaredActionsBar,
 } from './views';
-export type { RecordFormPageProps } from './views';
+export type { RecordFormPageProps, DeclaredActionsBarProps } from './views';
 
 // Hooks
 export {

--- a/packages/app-shell/src/views/DeclaredActionsBar.tsx
+++ b/packages/app-shell/src/views/DeclaredActionsBar.tsx
@@ -1,0 +1,220 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * DeclaredActionsBar — render + execute an object's SERVER-DECLARED actions for
+ * a single record at a given location, with ZERO per-action host code.
+ *
+ * A bespoke page (e.g. the approvals inbox) that already has a record in hand
+ * can drop this bar in to surface the actions the backend declares on that
+ * object (`objectDef.actions[]`) — filtered to a `location`
+ * (`record_section`, `record_header`, …) and each action's `visible` CEL —
+ * and have them execute through the *same* console action runtime ObjectView /
+ * RecordDetailView use: confirm dialogs, param-collection dialogs, result
+ * dialogs, the authenticated api/flow/server handlers, and refresh-after.
+ *
+ * It is fully self-contained: it fetches the object definition through the
+ * metadata provider (unless `actions` is passed explicitly), resolves the
+ * `dataSource` from the adapter, and mounts its own `ActionProvider` +
+ * runtime dialogs. Each button dispatches the declared action with the record
+ * stashed under `params._rowRecord`, exactly the shape ObjectGrid row actions
+ * and RelatedRecordActionsBridge use — so a `type:'api'` action whose target is
+ * `/api/v1/approvals/requests/{id}/approve` resolves `{id}` from the record and
+ * POSTs with any collected params (comment, to, …).
+ *
+ * Degrades gracefully: no matching declared actions → renders nothing.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { Button, Separator, cn } from '@object-ui/components';
+import {
+  ActionProvider,
+  useAction,
+  useCondition,
+  toPredicateInput,
+} from '@object-ui/react';
+import type { ActionDef } from '@object-ui/core';
+import { Loader2 } from 'lucide-react';
+import { useConsoleActionRuntime } from '../hooks/useConsoleActionRuntime';
+import { useAdapter } from '../providers/AdapterProvider';
+import { useMetadataItem } from '../providers/MetadataProvider';
+import { getIcon } from '../utils/getIcon';
+
+export interface DeclaredActionsBarProps {
+  /** Object whose declared actions to render (e.g. `sys_approval_request`). */
+  objectName: string;
+  /**
+   * The record the actions run against. Stashed under `params._rowRecord`, so
+   * `{token}` URL interpolation and `defaultFromRow` params resolve from it —
+   * on the approvals inbox this is the `sys_approval_request` row itself, so
+   * `{id}` resolves to the request id.
+   */
+  record: any;
+  /** Action location to filter by (e.g. `record_section`). */
+  location: string;
+  /** Called after a successful action so the host can refresh. */
+  onDone?: () => void;
+  /**
+   * Declared actions to render. When omitted, they are fetched from the
+   * object's metadata definition. Passing them explicitly avoids the metadata
+   * round-trip (and lets a host that already holds the object def reuse it).
+   */
+  actions?: ActionDef[];
+  /** Extra classes for the toolbar wrapper. */
+  className?: string;
+  /**
+   * Optional section label. When set, a divider + label is rendered above the
+   * buttons — but ONLY when there are actions to show (the whole component
+   * returns null when empty), so the host never gets an orphan divider.
+   */
+  label?: string;
+}
+
+/**
+ * One declared-action button. Extracted so the `visible` CEL predicate can be
+ * evaluated with a hook (rules-of-hooks) and so the dispatch can carry the
+ * record. Mirrors `action:button` (fail-closed `visible`) but injects the
+ * record under `params._rowRecord` — which `action:button` does NOT do, and
+ * which the api handler needs to resolve `{id}` and inject the record id.
+ */
+const DeclaredActionButton: React.FC<{
+  action: ActionDef;
+  objectName: string;
+  record: any;
+}> = ({ action, objectName, record }) => {
+  const { execute } = useAction();
+  const [loading, setLoading] = useState(false);
+
+  const recordData = record != null && typeof record === 'object' ? (record as Record<string, any>) : {};
+  // `visible` fails CLOSED on a throwing predicate — mirrors action:button and
+  // ActionEngine.getActionsForLocation: a guard that can't be evaluated hides
+  // the action rather than exposing one whose precondition is broken.
+  const isVisible = useCondition(toPredicateInput((action as any).visible), recordData, {
+    throwOnError: true,
+    label: `declared action "${action.name ?? action.label ?? 'action'}" (visible)`,
+  });
+
+  const handleClick = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      // Same dispatch shape as ObjectGrid.onActionDef / RelatedRecordActionsBridge:
+      // forward the full def (type/target/recordIdParam/bodyShape/refreshAfter/…),
+      // surface a `params` ARRAY as `actionParams` (the runner's param-dialog
+      // input), and reserve `params` for the `_rowRecord` stash the api handler
+      // reads for `{id}` interpolation + record-id injection.
+      const { params: rawParams, ...rest } = action as ActionDef & { params?: unknown };
+      const dispatch: any = {
+        ...rest,
+        objectName,
+        params: { _rowRecord: record },
+      };
+      if (Array.isArray(rawParams) && rawParams.length > 0) {
+        dispatch.actionParams = rawParams;
+      }
+      await execute(dispatch as ActionDef);
+    } finally {
+      setLoading(false);
+    }
+  }, [action, execute, loading, objectName, record]);
+
+  if ((action as any).visible && !isVisible) return null;
+
+  const iconName = typeof (action as any).icon === 'string' ? (action as any).icon as string : undefined;
+  const variant = (action as any).variant === 'primary'
+    ? 'default'
+    : ((action as any).variant || 'outline');
+  const label = action.label || action.name;
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={variant as any}
+      disabled={loading}
+      onClick={handleClick}
+      data-testid={`declared-action-${action.name}`}
+    >
+      {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+      {/* `getIcon` returns a (memoised) component — instantiate it via
+          createElement so it is not a component "created during render" in JSX
+          position (react-hooks/static-components), mirroring ObjectDataPage. */}
+      {!loading && iconName
+        ? React.createElement(getIcon(iconName), { className: cn('h-4 w-4', label && 'mr-2') })
+        : null}
+      {label}
+    </Button>
+  );
+};
+
+export function DeclaredActionsBar({
+  objectName,
+  record,
+  location,
+  onDone,
+  actions: actionsProp,
+  className,
+  label,
+}: DeclaredActionsBarProps) {
+  const dataSource = useAdapter();
+  // Fetch the object def (and its declared actions) unless the host passed
+  // them in. `useMetadataItem` no-ops when `name` is undefined.
+  const { item: objectDef } = useMetadataItem('object', actionsProp ? undefined : objectName);
+
+  const allActions: ActionDef[] = useMemo(
+    () => (actionsProp ?? (objectDef as any)?.actions ?? []) as ActionDef[],
+    [actionsProp, objectDef],
+  );
+
+  const located = useMemo(
+    () => allActions.filter((a: any) => Array.isArray(a?.locations) && a.locations.includes(location)),
+    [allActions, location],
+  );
+
+  // Mount the shared console action runtime — confirm/param/result dialogs, the
+  // authenticated api/flow/server handlers, SPA nav, paused-flow runner. Its
+  // `onRefresh` fires on any refresh-requesting success (the default), which is
+  // exactly the host's `onDone`. The object def is threaded through `objects`
+  // so field-backed params resolve their labels/defaults.
+  const runtime = useConsoleActionRuntime({
+    dataSource,
+    objects: objectDef ? [objectDef] : [],
+    objectName,
+    onRefresh: onDone,
+  });
+
+  // Degrade gracefully — nothing declared at this location renders nothing (no
+  // toolbar chrome, no provider churn).
+  if (located.length === 0) return null;
+
+  return (
+    <ActionProvider {...runtime.actionProviderProps}>
+      <div className={cn('space-y-2', className)}>
+        {label && (
+          <>
+            <Separator />
+            <div className="text-xs font-medium text-muted-foreground">{label}</div>
+          </>
+        )}
+        <div role="toolbar" aria-label={label || 'Actions'} className="flex flex-row flex-wrap items-center gap-2">
+          {located.map((action) => (
+            <DeclaredActionButton
+              key={action.name}
+              action={action}
+              objectName={objectName}
+              record={record}
+            />
+          ))}
+        </div>
+      </div>
+      {runtime.dialogs}
+    </ActionProvider>
+  );
+}
+
+export default DeclaredActionsBar;

--- a/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
+++ b/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * DeclaredActionsBar (objectui#2678 P2-4) — renders + executes an object's
+ * SERVER-DECLARED actions for a single record at a location, with no
+ * per-action host code. Coverage:
+ *   • filters declared actions by `location`;
+ *   • renders nothing when nothing matches (graceful degrade);
+ *   • dispatches with the record stashed under `params._rowRecord` (so the api
+ *     handler resolves `{id}`) and a `params` ARRAY surfaced as `actionParams`
+ *     (the runner's param-dialog input).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// Capture the execute dispatch from the shared runner.
+const executeSpy = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock('@object-ui/react', () => ({
+  ActionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAction: () => ({ execute: executeSpy }),
+  // `visible` predicate: our test actions omit `visible`, so this is unused,
+  // but keep it truthy so a `visible`-carrying action would still render.
+  useCondition: () => true,
+  toPredicateInput: (v: unknown) => v,
+}));
+
+// The runtime is exercised in its own suite; here it's an inert shell so the
+// bar mounts without the full auth/i18n/router provider stack.
+vi.mock('../../hooks/useConsoleActionRuntime', () => ({
+  useConsoleActionRuntime: () => ({ actionProviderProps: {}, dialogs: null }),
+}));
+
+vi.mock('../../providers/AdapterProvider', () => ({ useAdapter: () => ({}) }));
+vi.mock('../../providers/MetadataProvider', () => ({
+  // The tests pass `actions` explicitly, so the metadata fetch is skipped.
+  useMetadataItem: () => ({ item: null, loading: false, error: null }),
+}));
+
+vi.mock('../../utils/getIcon', () => ({ getIcon: () => () => null }));
+
+vi.mock('@object-ui/components', () => ({
+  Button: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props}>{children}</button>
+  ),
+  Separator: () => <hr />,
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}));
+
+import { DeclaredActionsBar } from '../DeclaredActionsBar';
+
+const REQUEST = { id: 'req_1', status: 'pending', record_id: 'proj_9' };
+
+const ACTIONS = [
+  {
+    name: 'approval_approve', type: 'api', label: 'Approve',
+    target: '/api/v1/approvals/requests/{id}/approve',
+    locations: ['record_section'],
+  },
+  {
+    name: 'approval_reassign', type: 'api', label: 'Reassign',
+    target: '/api/v1/approvals/requests/{id}/reassign',
+    locations: ['record_section'],
+    params: [{ name: 'to', label: 'To', type: 'text' }],
+  },
+  {
+    name: 'approval_bulk', type: 'api', label: 'Bulk',
+    target: '/api/v1/approvals/bulk',
+    locations: ['list_toolbar'],
+  },
+];
+
+beforeEach(() => executeSpy.mockClear());
+
+describe('DeclaredActionsBar', () => {
+  it('renders only the actions declared at the requested location', () => {
+    render(
+      <DeclaredActionsBar
+        objectName="sys_approval_request"
+        record={REQUEST}
+        location="record_section"
+        actions={ACTIONS as any}
+      />,
+    );
+    expect(screen.getByTestId('declared-action-approval_approve')).toBeInTheDocument();
+    expect(screen.getByTestId('declared-action-approval_reassign')).toBeInTheDocument();
+    // `list_toolbar`-only action must not surface at `record_section`.
+    expect(screen.queryByTestId('declared-action-approval_bulk')).toBeNull();
+  });
+
+  it('renders nothing when no declared action matches the location', () => {
+    const { container } = render(
+      <DeclaredActionsBar
+        objectName="sys_approval_request"
+        record={REQUEST}
+        location="record_header"
+        actions={ACTIONS as any}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('dispatches with the record under params._rowRecord so {id} resolves', async () => {
+    render(
+      <DeclaredActionsBar
+        objectName="sys_approval_request"
+        record={REQUEST}
+        location="record_section"
+        actions={ACTIONS as any}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('declared-action-approval_approve'));
+    await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1));
+    const dispatch = executeSpy.mock.calls[0][0];
+    expect(dispatch).toMatchObject({
+      name: 'approval_approve',
+      type: 'api',
+      objectName: 'sys_approval_request',
+      target: '/api/v1/approvals/requests/{id}/approve',
+      params: { _rowRecord: REQUEST },
+    });
+    // No collection params → no `actionParams`.
+    expect(dispatch.actionParams).toBeUndefined();
+  });
+
+  it('surfaces a `params` array as `actionParams` for the param dialog', async () => {
+    render(
+      <DeclaredActionsBar
+        objectName="sys_approval_request"
+        record={REQUEST}
+        location="record_section"
+        actions={ACTIONS as any}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('declared-action-approval_reassign'));
+    await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1));
+    const dispatch = executeSpy.mock.calls[0][0];
+    expect(dispatch.actionParams).toEqual([{ name: 'to', label: 'To', type: 'text' }]);
+    // The array is NOT left on `params` (which is reserved for the row stash).
+    expect(dispatch.params).toEqual({ _rowRecord: REQUEST });
+  });
+
+  it('renders a labeled divider only when actions are present', () => {
+    render(
+      <DeclaredActionsBar
+        objectName="sys_approval_request"
+        record={REQUEST}
+        location="record_section"
+        label="Actions"
+        actions={ACTIONS as any}
+      />,
+    );
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+    // Empty location → no divider/label chrome at all.
+    const { container: empty } = render(
+      <DeclaredActionsBar
+        objectName="sys_approval_request"
+        record={REQUEST}
+        location="record_header"
+        label="Actions"
+        actions={ACTIONS as any}
+      />,
+    );
+    expect(empty.firstChild).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/index.ts
+++ b/packages/app-shell/src/views/index.ts
@@ -12,3 +12,4 @@ export { ActionResultDialog, type ResultDialogState } from './ActionResultDialog
 export { MetadataToggle, MetadataPanel } from './MetadataInspector';
 export { ViewConfigPanel } from './ViewConfigPanel';
 export { CreateViewDialog } from './CreateViewDialog';
+export { DeclaredActionsBar, type DeclaredActionsBarProps } from './DeclaredActionsBar';


### PR DESCRIPTION
Frontend half of **#2678 P2-4**. Backend half (declared `approval_approve`/`approval_reject`/`approval_reassign` on `sys_approval_request`) merged as framework#3282.

## What

**`DeclaredActionsBar`** (new, `packages/app-shell/src/views/`) — a reusable component that renders + executes an object's **server-declared** actions for any `(objectName, record, location)`:
- Object metadata (and its `actions[]`) from the app-shell `MetadataProvider` (or an explicit `actions` prop).
- Execution reuses the console action runtime end-to-end: the `_rowRecord` dispatch shape `ObjectGrid` uses (so `{id}` in `type:'api'` targets resolves from the record), generic param/confirm/result dialogs, `visible` CEL fail-closed, `refreshAfter` → `onDone`.
- No matching actions → renders nothing (no orphan divider).

**Approvals inbox**: the drawer mounts the bar additively under an "Actions" divider — the three declared decision actions render and execute with **zero inbox-specific per-action code**. The hardcoded composer stays for now; a follow-up retires it once the declared set covers everything.

## Why

This is the structural fix from the #2678 audit: the inbox was a 1961-line hand-written page where every new approval capability meant new buttons. With this bar + framework#3282, decision capabilities ship as **backend metadata** — enterprise act-as (cloud#861) included — and render on any surface that mounts the bar.

## Verification

- **Browser, against a live backend** (framework main incl. #3282, Vite console): the drawer shows the declared Approve/Reject/Reassign under "Actions"; clicking declared **Approve** opened the generic param dialog, collected the comment, executed `/api/v1/approvals/requests/{id}/approve`, and the per_group request held exactly as the hardcoded path does (audit row: `approve · "Approved via declared SDUI action"`; progress manager ✓ 1/1, finance 0/1).
- 5 new unit tests (location filtering, visible gating, dispatch, graceful degrade, label); app-shell suite green; console build clean; eslint delta zero.

## Refs
#2678 (P2-4) · framework#3282 (backend half, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ypkQikZ55oWUHUnMebwXA)_