### PR TITLE
test(app-shell): make field-rule 'non-CEL dialect' fixture forward-compatible (framework#3278)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/clientValidation.fieldRules.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.fieldRules.test.ts
@@ -76,9 +76,14 @@ describe('validateMetadataDraft — object field conditional rules (real engine)
   });
 
   it('skips non-CEL dialect envelopes (the engine owns that error, not the CEL lint)', async () => {
+    // A well-typed NON-CEL dialect whose garbage `source` the CEL lint must
+    // leave alone (`predicateSource` only extracts `dialect: undefined | 'cel'`).
+    // Must stay a non-CEL dialect: `dialect: 'cel'` would make the lint OWN
+    // `'!!!'` and flag it, flipping this assertion. `template` survives the
+    // spec's `ExpressionDialect` narrowing (framework#3278 retired `js`).
     const res = await validateMetadataDraft(
       'object',
-      draftWith({ status: { type: 'text', visibleWhen: { dialect: 'js', source: '!!!' } } }),
+      draftWith({ status: { type: 'text', visibleWhen: { dialect: 'template', source: '!!!' } } }),
     );
     expect(res.issues.filter((i) => RULE_PATH.test(i.path))).toEqual([]);
   });


### PR DESCRIPTION
## What

`clientValidation.fieldRules.test.ts` — the *"skips non-CEL dialect envelopes"* test used `{ dialect: 'js', source: '!!!' }` as its fixture. framework PR #3291 (issue #3278) retires the `js` expression dialect: `ExpressionDialect` in `@objectstack/spec` narrows to `z.enum(['cel', 'cron', 'template'])`. Once objectui bumps to that spec, `{ dialect: 'js', … }` becomes shape-invalid, and the draft validator's spec-Zod pass would emit an issue at `fields.status.visibleWhen`, breaking the `.toEqual([])` assertion.

## Change

Swap the fixture to `{ dialect: 'template', source: '!!!' }` — a **well-typed, non-CEL** dialect that survives the narrowing.

Why not `dialect: 'cel'` (the obvious "bad source under a valid dialect")? The test proves the CEL lint *skips* non-CEL envelopes. `predicateSource` only extracts source when `dialect === undefined || dialect === 'cel'`, so `dialect: 'cel'` would make the lint **own** the garbage `'!!!'` and flag it — flipping the assertion. The replacement had to stay a non-CEL dialect; `template` is safest (`'!!!'` is a valid constant template → no spec-Zod content error either).

## Notes

- **Behavior-neutral today.** Published spec latest is still 15.1.1 (`js` present); no shipped spec has dropped `js` yet. `{ dialect: 'template', … }` produces the identical test outcome against both the current and the future narrowed spec, so this is a safe pre-emptive hygiene change.
- Grep confirms this was the **only** `dialect: 'js'` expression author in objectui. `language: 'js'` (L2 ScriptBody, a separate enum) is unaffected and untouched.
- Verified: the scoped test file passes (11/11) against the real `@objectstack/formula` engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)