### PR TITLE
fix(list): keep injected owner_id out of leading auto-derived list columns

### DIFF
--- a/.changeset/list-columns-owner-id.md
+++ b/.changeset/list-columns-owner-id.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/types": patch
+"@object-ui/plugin-grid": patch
+"@object-ui/app-shell": patch
+---
+
+fix(list): keep the injected `owner_id` out of the leading auto-derived columns
+
+A view-less object's default list columns are derived from the object's field
+order. The framework's `applySystemFields` spreads its injected
+system/audit/ownership fields to the FRONT of that order and stamps them
+`system: true`; `owner_id` is deliberately non-hidden and non-readonly
+(ownership is reassignable), so the old name-based exclusion lists in
+`ObjectGrid` and `InterfaceListPage` — which never listed `owner_id` — let it
+through as column #1 on many showcase list pages (e.g. `showcase_field_zoo`).
+
+Default-column derivation now classifies system fields via the shared
+`isSystemManagedField` helper, which branches on the spec `system` flag (the
+single source of truth stamped by the registry) with a name-set fallback that
+includes the ownership/tenancy FKs. `owner_id` is pushed to the end
+(`ObjectGrid`) / excluded from the business columns (`InterfaceListPage`), so
+auto-derived lists lead with business fields again and pick up future injected
+fields without editing a name list. Also declares the `system` flag on the
+`@object-ui/types` field metadata.

--- a/packages/app-shell/src/views/InterfaceListPage.defaults.test.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.defaults.test.tsx
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  defaultColumnsFromObject,
   defaultKanbanFromObject,
   defaultCalendarFromObject,
   defaultGalleryFromObject,
@@ -50,5 +51,57 @@ describe('InterfaceListPage default viz bindings', () => {
   it('ignores hidden and system fields', () => {
     const obj = { fields: { created_at: { type: 'datetime' }, hidden_sel: { type: 'select', hidden: true }, real_sel: { type: 'select' } } };
     expect(defaultKanbanFromObject(obj)).toEqual({ groupField: 'real_sel', groupByField: 'real_sel' });
+  });
+});
+
+describe('defaultColumnsFromObject', () => {
+  // Mirrors how the framework's `applySystemFields` presents an object to the
+  // console: injected system fields (owner_id, audit columns) are spread to the
+  // FRONT of the field map and carry `system: true`; owner_id is deliberately
+  // non-hidden / non-readonly because ownership is reassignable.
+  const fieldZooLike = {
+    fields: {
+      owner_id: { type: 'lookup', label: 'Owner', system: true },
+      created_at: { type: 'datetime', system: true, readonly: true },
+      created_by: { type: 'lookup', system: true, readonly: true },
+      organization_id: { type: 'lookup', system: true, hidden: true },
+      name: { type: 'text' },
+      f_email: { type: 'email' },
+      f_number: { type: 'number' },
+    },
+  };
+
+  it('does NOT lead with the injected owner_id — business fields come first', () => {
+    const cols = defaultColumnsFromObject(fieldZooLike);
+    expect(cols[0]).toBe('name');
+    expect(cols).not.toContain('owner_id');
+    expect(cols).not.toContain('created_at');
+    expect(cols).not.toContain('organization_id');
+    expect(cols).toEqual(['name', 'f_email', 'f_number']);
+  });
+
+  it('excludes owner_id even when it arrives without the system flag (name fallback)', () => {
+    const cols = defaultColumnsFromObject({
+      fields: { owner_id: { type: 'lookup' }, title: { type: 'text' } },
+    });
+    expect(cols).toEqual(['title']);
+  });
+
+  it('honors highlightFields as the curated override', () => {
+    const cols = defaultColumnsFromObject({
+      highlightFields: ['name', 'owner_id'],
+      fields: fieldZooLike.fields,
+    });
+    // Curated list wins verbatim (only dropping names with no field def).
+    expect(cols).toEqual(['name', 'owner_id']);
+  });
+
+  it('caps the auto-derived business columns at six', () => {
+    const fields: Record<string, any> = { owner_id: { type: 'lookup', system: true } };
+    for (let i = 0; i < 10; i++) fields[`b_${i}`] = { type: 'text' };
+    const cols = defaultColumnsFromObject({ fields });
+    expect(cols).toHaveLength(6);
+    expect(cols).not.toContain('owner_id');
+    expect(cols[0]).toBe('b_0');
   });
 });

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -22,6 +22,7 @@ import { useAdapter, SchemaRenderer, useNavigationOverlay } from '@object-ui/rea
 import { Empty, EmptyTitle, EmptyDescription, NavigationOverlay } from '@object-ui/components';
 import { Database } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
+import { isSystemManagedField } from '@object-ui/types';
 import { useMetadata } from '../providers/MetadataProvider';
 import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState';
 import { RecordDetailView } from './RecordDetailView';
@@ -70,14 +71,10 @@ function resolveSourceView(objectDef: any, sourceView?: string): any | undefined
  * Default column set when the resolved view carries none — mirrors
  * ObjectView's data-mode fallback so an interface page never renders a
  * column-less grid. Priority: the `highlightFields` semantic role
- * (ADR-0085), else the first business fields (system/audit columns
- * excluded).
+ * (ADR-0085), else the first business fields — framework-managed
+ * system/audit/ownership columns (including the injected, editable `owner_id`)
+ * are excluded via the shared `isSystemManagedField` classifier.
  */
-const SYSTEM_FIELDS = new Set([
-  'id', 'created_at', 'createdAt', 'updated_at', 'updatedAt',
-  'deleted_at', 'deletedAt', 'created_by', 'createdBy',
-  'updated_by', 'updatedBy', '_version', '_rev',
-]);
 export function defaultColumnsFromObject(objectDef: any): string[] {
   const curated = objectDef?.highlightFields;
   if (Array.isArray(curated) && curated.length > 0) {
@@ -86,7 +83,7 @@ export function defaultColumnsFromObject(objectDef: any): string[] {
   const fields = objectDef?.fields;
   if (fields && typeof fields === 'object') {
     return Object.entries(fields)
-      .filter(([name, f]: [string, any]) => f && !f.hidden && !SYSTEM_FIELDS.has(name))
+      .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
       .map(([name]) => name)
       .slice(0, 6);
   }
@@ -111,7 +108,7 @@ function firstFieldMatching(
   const fields = objectDef?.fields;
   if (!fields || typeof fields !== 'object') return undefined;
   const hit = Object.entries(fields).find(
-    ([name, f]: [string, any]) => f && !f.hidden && !SYSTEM_FIELDS.has(name) && pred(name, f),
+    ([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f) && pred(name, f),
   );
   return hit?.[0];
 }

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -23,6 +23,7 @@
 
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { ObjectGridSchema, DataSource, ListColumn, ViewData } from '@object-ui/types';
+import { isSystemManagedField } from '@object-ui/types';
 import type { I18nLabel } from '@objectstack/spec/ui';
 import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useObjectTranslation, useSafeFieldLabel, usePredicateScope } from '@object-ui/react';
 import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses, FieldEditWidget, hasFieldEditWidget, DISCRETE_EDIT_TYPES, coerceToSafeValue } from '@object-ui/fields';
@@ -1185,11 +1186,12 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     // marked `hidden: true`/`readonly: true` so default list views show only
     // the business fields users actually care about. Callers can still opt-in
     // to system columns by passing an explicit `fields` / `columns` prop.
-    const SYSTEM_FIELDS = new Set([
-      'id', 'created_at', 'createdAt', 'updated_at', 'updatedAt',
-      'deleted_at', 'deletedAt', 'created_by', 'createdBy',
-      'updated_by', 'updatedBy', '_version', '_rev',
-    ]);
+    //
+    // "System-managed" is decided by `isSystemManagedField`, which branches on
+    // the framework's `field.system` flag (single source of truth stamped by
+    // `applySystemFields`) — this is what keeps the injected, non-readonly
+    // `owner_id` from leading the auto-derived columns, and covers any future
+    // injected field without editing a name list here.
     const highlightFields: string[] | undefined = (objectSchema as any)?.highlightFields;
     const allFieldNames = Object.keys(objectSchema.fields || {});
     let fieldsToShow: string[];
@@ -1198,19 +1200,20 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     } else if (highlightFields?.length) {
       fieldsToShow = highlightFields.filter((n) => objectSchema.fields?.[n]);
     } else {
-      // Drop hidden + readonly system-managed fields, then push remaining
-      // system identifier/audit fields to the end as a fallback.
+      // Drop hidden + readonly system-managed fields, then push the remaining
+      // system/audit/ownership columns (e.g. the injected, editable `owner_id`)
+      // to the end as a fallback so business fields lead.
       const visibleFields = allFieldNames.filter((n) => {
         const f = objectSchema.fields?.[n];
         if (!f) return false;
         if (f.hidden) return false;
-        // Drop readonly fields when their name matches a system identifier/audit column.
-        if (f.readonly && SYSTEM_FIELDS.has(n)) return false;
+        // Drop readonly bookkeeping columns (created_at/by, updated_at/by, …).
+        if (f.readonly && isSystemManagedField(n, f)) return false;
         return true;
       });
       fieldsToShow = [
-        ...visibleFields.filter((n) => !SYSTEM_FIELDS.has(n)),
-        ...visibleFields.filter((n) => SYSTEM_FIELDS.has(n)),
+        ...visibleFields.filter((n) => !isSystemManagedField(n, objectSchema.fields?.[n])),
+        ...visibleFields.filter((n) => isSystemManagedField(n, objectSchema.fields?.[n])),
       ];
     }
 

--- a/packages/types/src/__tests__/system-fields.test.ts
+++ b/packages/types/src/__tests__/system-fields.test.ts
@@ -1,0 +1,44 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isSystemManagedField, SYSTEM_MANAGED_FIELD_NAMES } from '@object-ui/types';
+
+describe('isSystemManagedField', () => {
+  it('treats fields flagged `system: true` as system-managed (the single source of truth)', () => {
+    expect(isSystemManagedField('anything_custom', { system: true })).toBe(true);
+    // Flag wins even for a name that is not in the canonical set — covers
+    // future framework-injected fields without editing the name list.
+    expect(isSystemManagedField('brand_new_injected_field', { system: true })).toBe(true);
+  });
+
+  it('classifies the injected owner_id as system-managed by flag AND by name', () => {
+    expect(isSystemManagedField('owner_id', { system: true })).toBe(true); // stamped by registry
+    expect(isSystemManagedField('owner_id', {})).toBe(true);               // name fallback (no flag)
+    expect(isSystemManagedField('owner_id')).toBe(true);                   // name fallback (no field)
+  });
+
+  it('classifies audit / identity / tenancy columns by name when no flag is present', () => {
+    for (const name of ['id', 'created_at', 'created_by', 'updated_at', 'updated_by', 'organization_id']) {
+      expect(isSystemManagedField(name, {})).toBe(true);
+    }
+  });
+
+  it('does NOT classify author-declared business fields as system-managed', () => {
+    expect(isSystemManagedField('name', {})).toBe(false);
+    expect(isSystemManagedField('f_email', { system: false })).toBe(false);
+    expect(isSystemManagedField('amount')).toBe(false);
+  });
+
+  it('exposes owner_id and the tenancy FKs in the canonical name set', () => {
+    expect(SYSTEM_MANAGED_FIELD_NAMES.has('owner_id')).toBe(true);
+    expect(SYSTEM_MANAGED_FIELD_NAMES.has('organization_id')).toBe(true);
+    expect(SYSTEM_MANAGED_FIELD_NAMES.has('created_at')).toBe(true);
+    expect(SYSTEM_MANAGED_FIELD_NAMES.has('name')).toBe(false);
+  });
+});

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -55,7 +55,16 @@ export interface BaseFieldMetadata {
    * Whether field is read-only
    */
   readonly?: boolean;
-  
+
+  /**
+   * Auto-injected system/audit/ownership field (e.g. `created_at`,
+   * `updated_by`, `organization_id`, `owner_id`), stamped by the framework's
+   * `applySystemFields`. Surfaces that separate framework-managed bookkeeping
+   * from author-declared business fields (e.g. default list-column derivation)
+   * branch on this flag. Mirrors the spec `Field.system` property.
+   */
+  system?: boolean;
+
   /**
    * Placeholder text
    */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -430,6 +430,11 @@ export type {
   ObjectRelationship,
 } from './field-types';
 
+// System / audit / ownership field classification — runtime helper + name set,
+// used by default list-column derivation to keep framework-injected fields
+// (notably `owner_id`) out of the leading business columns.
+export { SYSTEM_MANAGED_FIELD_NAMES, isSystemManagedField } from './system-fields';
+
 // ============================================================================
 // Phase 3: Data Protocol Advanced Types
 // ============================================================================

--- a/packages/types/src/system-fields.ts
+++ b/packages/types/src/system-fields.ts
@@ -1,0 +1,56 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Canonical names of the framework-managed system / audit / ownership columns
+ * that `applySystemFields` auto-provisions onto business objects (record
+ * identity, audit `*_at` / `*_by`, soft-delete bookkeeping, and the
+ * reassignable ownership / tenant FKs).
+ *
+ * This is the DISPLAY-oriented set: it deliberately includes the *editable*
+ * ownership/tenant lookups (`owner_id`, `organization_id`, `tenant_id`,
+ * `company_id`, `space`) so that surfaces which separate bookkeeping from
+ * business data — auto-derived list columns, record pickers, related lists —
+ * don't lead with them. It is intentionally BROADER than the inline-edit
+ * "never editable" set (`owner_id` IS reassignable), which lives separately in
+ * `@object-ui/plugin-detail`.
+ *
+ * Prefer {@link isSystemManagedField}, which also honours the spec `system`
+ * flag (the single source of truth stamped by the registry) so future injected
+ * fields are covered without touching this list.
+ */
+export const SYSTEM_MANAGED_FIELD_NAMES: ReadonlySet<string> = new Set<string>([
+  // Record identity
+  'id', '_id', '__v', '_version', '_rev',
+  // Audit
+  'created', 'created_at', 'createdAt', 'created_by', 'createdBy',
+  'modified', 'modified_by',
+  'updated_at', 'updatedAt', 'updated_by', 'updatedBy',
+  // Soft-delete / lifecycle bookkeeping
+  'deleted', 'deleted_at', 'deletedAt', 'is_deleted', 'instance_state', 'locked',
+  // Ownership / tenancy (framework-injected, editable)
+  'owner_id', 'organization_id', 'tenant_id', 'company_id', 'space',
+]);
+
+/**
+ * Whether a field is a framework-managed system / audit / ownership column
+ * rather than an author-declared business field.
+ *
+ * Branches on the spec `system` flag first — the single source of truth the
+ * registry (`applySystemFields`) stamps on every field it injects — and falls
+ * back to {@link SYSTEM_MANAGED_FIELD_NAMES} for metadata that predates the
+ * flag or arrives without it. Default list-column derivation uses this so
+ * injected fields (notably `owner_id`, which is non-hidden and non-readonly
+ * because ownership is reassignable) never lead the auto-derived columns.
+ */
+export function isSystemManagedField(
+  name: string,
+  field?: { system?: boolean } | null,
+): boolean {
+  return field?.system === true || SYSTEM_MANAGED_FIELD_NAMES.has(name);
+}


### PR DESCRIPTION
## Problem

Many showcase list pages (e.g. `showcase_field_zoo` at `/_console/apps/com.example.showcase/showcase_field_zoo`) render **Owner** as the very first column, which is unexpected.

## Root cause

Two independent behaviors combine:

1. **Framework** (`applySystemFields`) auto-injects `owner_id` on user-authored business objects and spreads its injected system/audit/ownership fields to the **front** of the field map. `owner_id` is stamped `system: true` but is deliberately **non-hidden / non-readonly** (ownership is reassignable).
2. **objectui** default-column derivation (used when an object has no explicit list view) excluded "system" fields via **hardcoded name sets** in `ObjectGrid` and `InterfaceListPage` that **never listed `owner_id`**. So it slipped through and — being first in field order — became column #1.

## Fix (stable — keys off the `system` flag)

Classify system fields through a shared `isSystemManagedField(name, field)` helper in `@object-ui/types` that branches on the spec **`system` flag** (the single source of truth stamped by the registry, per `field.zod.ts`: *"Tools that surface system fields separately from author-declared business fields should branch on this flag"*), with a name-set fallback covering the ownership/tenancy FKs.

- `ObjectGrid`: system fields (incl. `owner_id`) are pushed to the **end** of the auto-derived columns instead of leading.
- `InterfaceListPage.defaultColumnsFromObject`: excluded from the auto-derived business columns.
- Declares `system?: boolean` on the `@object-ui/types` field metadata.

Because it keys off the `system` flag, future framework-injected fields are handled automatically — no name list to keep in sync.

## Verification

- **Unit** — new `@object-ui/types` classifier tests (`system-fields.test.ts`) + `defaultColumnsFromObject` tests against a field-zoo-shaped object; existing `column-features` / `mobileCardLookupDisplay` grid suites still pass.
- **Browser (Chromium via Playwright)** — rendered the real `ObjectGrid` through its server-backed derivation with the framework's injected metadata shape (`owner_id` first, `system: true`). Auto-derived columns are now `Name, Email, Number, Select, Date, Owner` — **Owner last**, business fields lead, audit/org columns excluded.

## Affected packages

`@object-ui/types`, `@object-ui/plugin-grid`, `@object-ui/app-shell` (patch; changeset included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMcdh2cNs165TSF4ub61oy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMcdh2cNs165TSF4ub61oy)_