### PR TITLE
feat(approvals-inbox): retire the approve/reject composer for declared actions with file attachments (#2698)

### DIFF
--- a/.changeset/approvals-composer-retire-file-params.md
+++ b/.changeset/approvals-composer-retire-file-params.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/app-shell": minor
+"@object-ui/fields": patch
+---
+
+feat(action-params): serialize file/image action params to storage id(s); retire the approvals composer
+
+Declared action params of `type: 'file'`/`'image'` now POST the portable API
+contract — the storage id(s) — instead of the upload widget's rich object:
+
+- `FileField` surfaces the id it already receives from the upload adapter
+  (`meta.fileId`) as `file_id` on each emitted file object (additive; the
+  record file-field value shape is unchanged).
+- `ActionParamDialog` maps upload-param values to their `file_id`(s) at submit
+  (`serializeParamValues`, pure + exported): single → string, `multiple` →
+  `string[]`. The api handler already forwards param values untouched, so an
+  action with a `file` param POSTs `attachments: string[]`.
+
+This lets the approvals inbox retire its last hand-wired UI — the approve/reject
+composer with its bespoke attachment upload — so the drawer renders every
+decision through `DeclaredActionsBar` with the declared `attachments` file param
+(framework side declares it; see the paired framework change). `DeclaredActionsBar`'s
+`exclude` prop stays as a general capability.

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -24,9 +24,7 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { CommentAttachment, type Attachment } from '@object-ui/plugin-detail';
 import { DeclaredActionsBar } from '@object-ui/app-shell';
-import { createObjectStackUploadAdapter } from '@object-ui/providers';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import {
   Button,
@@ -48,8 +46,6 @@ import {
   SheetHeader,
   SheetTitle,
   SheetDescription,
-  Textarea,
-  Label,
   Skeleton,
   Empty,
   EmptyTitle,
@@ -76,7 +72,7 @@ import {
   cn,
 } from '@object-ui/components';
 import { toast } from 'sonner';
-import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
+import { useAuth } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import {
   CheckCircle2,
@@ -252,7 +248,6 @@ function payloadSummary(
 export function ApprovalsInboxPage() {
   const { t, language } = useObjectTranslation();
   const { user } = useAuth();
-  const isAdmin = useIsWorkspaceAdmin();
   const { appName } = useParams<{ appName?: string }>();
   // Deep link (#2678 P1.5): notifications carry `/system/approvals?request=<id>`
   // so landing here opens that request's drawer directly. Consumed once, then
@@ -336,41 +331,13 @@ export function ApprovalsInboxPage() {
   const [selected, setSelected] = useState<ApprovalRequestRow | null>(null);
   const [actions, setActions] = useState<ApprovalActionRow[]>([]);
   const [drawerLoading, setDrawerLoading] = useState(false);
-  const [comment, setComment] = useState('');
-  const [actorOverride, setActorOverride] = useState('');
-  const [submitting, setSubmitting] = useState<'approve' | 'reject' | 'recall' | null>(null);
-  // Decision attachments (#3266): files staged in the composer, sent as
-  // `attachments: fileId[]` with the next approve/reject. Uploads go through
-  // the same presigned-storage adapter as RecordAttachmentsPanel.
-  const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
-  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  // Approve/reject/reassign/send-back/… are server-declared actions rendered by
+  // DeclaredActionsBar (objectui#2697 + framework#3300); their param dialog
+  // collects the comment and — since the shared upload-widget renderer (#2700/
+  // #2707) plus the declared `attachments` file param (#2698) — file
+  // attachments, so the inbox no longer hand-wires a decision composer. `authFetch`
+  // stays for the timeline's attachment-name resolution and signed-URL open.
   const authFetch = useMemo(() => createAuthenticatedFetch(), []);
-  const uploadAdapter = useMemo(
-    () => createObjectStackUploadAdapter({
-      baseUrl: (import.meta.env.VITE_SERVER_URL || '').replace(/\/$/, ''),
-      scope: 'attachments',
-      fetchImpl: authFetch,
-    }),
-    [authFetch],
-  );
-  const handleAttachmentUpload = useCallback(async (files: FileList) => {
-    setAttachmentError(null);
-    for (const file of Array.from(files)) {
-      try {
-        const result = await uploadAdapter.upload(file);
-        const fileId = String((result.meta as { fileId?: string } | undefined)?.fileId ?? '');
-        if (!fileId) throw new Error('upload returned no fileId');
-        setPendingAttachments(prev => [...prev, {
-          id: fileId, name: result.name, size: result.size, type: result.mimeType, url: result.url,
-        }]);
-      } catch (err) {
-        setAttachmentError((err as Error)?.message ?? String(err));
-      }
-    }
-  }, [uploadAdapter]);
-  const handleAttachmentRemove = useCallback((attachmentId: string) => {
-    setPendingAttachments(prev => prev.filter(a => a.id !== attachmentId));
-  }, []);
   // Resolve attachment fileIds → sys_file display names for the timeline chips
   // (#2678 P1.5). Best-effort, cached per id; unresolved ids fall back to a
   // generic "Attachment" label.
@@ -529,10 +496,6 @@ export function ApprovalsInboxPage() {
   const openDrawer = useCallback(async (id: string) => {
     setSelectedId(id);
     setDrawerLoading(true);
-    setComment('');
-    setActorOverride('');
-    setPendingAttachments([]);
-    setAttachmentError(null);
     try {
       const [req, acts] = await Promise.all([
         approvalsApi.getRequest(id),
@@ -553,10 +516,6 @@ export function ApprovalsInboxPage() {
     setSelectedId(null);
     setSelected(null);
     setActions([]);
-    setComment('');
-    setActorOverride('');
-    setPendingAttachments([]);
-    setAttachmentError(null);
   };
 
   // Consume the notification deep link once (see useSearchParams above).
@@ -575,77 +534,12 @@ export function ApprovalsInboxPage() {
    *   2. First identity that intersects `pending_approvers`.
    *   3. User id fallback.
    */
-  const resolveActor = useCallback((req: ApprovalRequestRow | null): string => {
-    if (actorOverride.trim()) return actorOverride.trim();
-    if (!req) return user?.id || '';
-    const pending = new Set(req.pending_approvers || []);
-    for (const id of identities) if (pending.has(id)) return id;
-    return user?.id || '';
-  }, [actorOverride, identities, user?.id]);
-
   const refreshBadge = useCallback(() => {
     if (!identities.length) return;
     approvalsApi.listRequests({ status: 'pending', approverId: identities })
       .then(res => setMyPendingCount(res.data.length))
       .catch(() => { /* best-effort */ });
   }, [identities]);
-
-  const doAction = useCallback(async (kind: 'approve' | 'reject' | 'recall') => {
-    if (!selected) return;
-    const actor = kind === 'recall' ? (user?.id || resolveActor(selected)) : resolveActor(selected);
-    if (!actor) {
-      toast.error(tr('noActor', 'Cannot determine the acting identity'));
-      return;
-    }
-    setSubmitting(kind);
-    try {
-      const body = {
-        actor_id: actor,
-        comment: comment.trim() || undefined,
-        // Decision attachments (#3266) ride approve/reject only — recall has no composer.
-        ...(kind !== 'recall' && pendingAttachments.length
-          ? { attachments: pendingAttachments.map(a => a.id) }
-          : {}),
-      };
-      const fn = kind === 'approve' ? approvalsApi.approve
-              : kind === 'reject'  ? approvalsApi.reject
-              : approvalsApi.recall;
-      const res = await fn(selected.id, body);
-      toast.success(
-        kind === 'approve'
-          ? (res.finalized ? tr('approvedFinal', 'Approved') : tr('approvedWaiting', 'Approved — waiting on the remaining approvers'))
-          : kind === 'reject' ? tr('rejectedToast', 'Rejected')
-          : tr('recalledToast', 'Request recalled'),
-      );
-      setComment('');
-      setPendingAttachments([]);
-      setAttachmentError(null);
-      // Queue processing (Fiori "My Inbox" pattern): a decision on the
-      // pending tab advances straight to the next waiting item instead of
-      // parking on the finished one. Recall keeps the drawer for review.
-      if (kind !== 'recall' && tab === 'pending') {
-        const list = filteredRef.current;
-        const idx = list.findIndex(r => r.id === selected.id);
-        const next = list[idx + 1] ?? list[idx - 1];
-        void load();
-        if (next && next.id !== selected.id) void openDrawer(next.id);
-        else closeDrawer();
-        return;
-      }
-      // Refresh drawer + list.
-      const [req, acts] = await Promise.all([
-        approvalsApi.getRequest(selected.id),
-        approvalsApi.listActions(selected.id),
-      ]);
-      setSelected(req.data);
-      setActions(acts.data);
-      void load();
-    } catch (err: any) {
-      toast.error(humanizeError(err, tr('actionFailed', 'Action failed')));
-    } finally {
-      setSubmitting(null);
-    }
-  }, [selected, resolveActor, comment, pendingAttachments, load, user?.id, humanizeError, tr, tab, openDrawer]);
 
   /** Refresh the open drawer + list after a thread interaction. */
   const refreshThread = useCallback(async (id: string) => {
@@ -657,6 +551,40 @@ export function ApprovalsInboxPage() {
     setActions(acts.data);
     void load();
   }, [load]);
+
+  /**
+   * `onDone` for the pending drawer's declared-action bar. Refreshes the acted
+   * request + list, then — on the pending tab — advances to the next waiting
+   * item when this one is no longer the current user's to act on (finalized,
+   * approved-away in a quorum, reassigned): the Fiori "My Inbox" queue-processing
+   * flow the hand-wired composer used to own, now driven generically off the
+   * refreshed row rather than a per-action handler. Stays in place otherwise
+   * (e.g. remind / request-info leave the item pending and still yours).
+   */
+  const onDecisionDone = useCallback(async () => {
+    if (!selected) return;
+    const id = selected.id;
+    try {
+      const [req, acts] = await Promise.all([
+        approvalsApi.getRequest(id),
+        approvalsApi.listActions(id),
+      ]);
+      setSelected(req.data);
+      setActions(acts.data);
+      void load();
+      const pending = new Set(req.data.pending_approvers || []);
+      const stillMine = req.data.status === 'pending' && identities.some(x => pending.has(x));
+      if (tab === 'pending' && !stillMine) {
+        const list = filteredRef.current;
+        const idx = list.findIndex(r => r.id === id);
+        const next = list[idx + 1] ?? list[idx - 1];
+        if (next && next.id !== id) { void openDrawer(next.id); return; }
+        closeDrawer();
+      }
+    } catch {
+      void refreshThread(id);
+    }
+  }, [selected, identities, tab, load, openDrawer, closeDrawer, refreshThread]);
 
   const doReply = useCallback(async () => {
     if (!selected || !reply.trim()) return;
@@ -672,22 +600,26 @@ export function ApprovalsInboxPage() {
     }
   }, [selected, reply, user?.id, refreshThread, humanizeError, tr]);
 
+  // Participant checks — drive the reply box + the "why disabled" hint (the
+  // decision buttons themselves are server-declared and gate via their own
+  // `visible` CEL). No actor-override branch: the admin "act as" escape hatch
+  // retired with the composer (cloud#861 enterprise act-as is the successor).
   const canApproveReject = useMemo(() => {
     if (!selected || selected.status !== 'pending') return false;
     const pending = new Set(selected.pending_approvers || []);
-    return identities.some(id => pending.has(id)) || actorOverride.trim().length > 0;
-  }, [selected, identities, actorOverride]);
+    return identities.some(id => pending.has(id));
+  }, [selected, identities]);
 
   const canRecall = useMemo(() => {
     if (!selected || selected.status !== 'pending') return false;
-    return selected.submitter_id === user?.id || actorOverride.trim().length > 0;
-  }, [selected, user?.id, actorOverride]);
+    return selected.submitter_id === user?.id;
+  }, [selected, user?.id]);
 
   /** ADR-0044: the submitter may resubmit (or abandon) a returned request. */
   const canResubmit = useMemo(() => {
     if (!selected || selected.status !== 'returned') return false;
-    return selected.submitter_id === user?.id || actorOverride.trim().length > 0;
-  }, [selected, user?.id, actorOverride]);
+    return selected.submitter_id === user?.id;
+  }, [selected, user?.id]);
 
 
   /** Unique process labels present in current rows (for filter dropdown). */
@@ -1686,105 +1618,25 @@ export function ApprovalsInboxPage() {
                 <>
                   <Separator />
                   <div className="space-y-3">
-                    {isAdmin && (
-                      <details className="group">
-                        <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground select-none">
-                          {tr('overrideActor', 'Act as another identity (admin)')}
-                        </summary>
-                        <div className="mt-2">
-                          <Label htmlFor="actor-override" className="text-xs">
-                            {tr('actor', 'Actor')}
-                          </Label>
-                          <input
-                            id="actor-override"
-                            type="text"
-                            value={actorOverride}
-                            onChange={(e) => setActorOverride(e.target.value)}
-                            placeholder={`${tr('auto', 'Auto')}: ${resolveActor(selected) || '—'}`}
-                            className="w-full mt-1 px-3 py-2 text-sm border rounded-md bg-background"
-                          />
-                          <div className="text-[10px] text-muted-foreground mt-1">
-                            {tr('overrideHint', 'e.g. role:sales_manager. Leave blank to use the auto-detected identity.')}
-                          </div>
-                        </div>
-                      </details>
-                    )}
-                    <div>
-                      <Label htmlFor="comment" className="text-xs">{tr('comment', 'Comment (optional)')}</Label>
-                      <div className="flex flex-wrap gap-1.5 mt-1.5">
-                        {[
-                          tr('quickPhrase1', 'Approved — meets requirements.'),
-                          tr('quickPhrase2', 'Approved with conditions — please monitor execution.'),
-                          tr('quickPhrase3', 'Please add supporting material and resubmit.'),
-                        ].map((p) => (
-                          <button
-                            key={p}
-                            type="button"
-                            onClick={() => setComment(p)}
-                            className="text-[11px] px-2 py-0.5 rounded-full border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-                          >
-                            {p}
-                          </button>
-                        ))}
-                      </div>
-                      <Textarea
-                        id="comment"
-                        value={comment}
-                        onChange={(e) => setComment(e.target.value)}
-                        rows={2}
-                        className="mt-1"
-                      />
-                      {/* Decision attachments (#3266) — staged files ride the next approve/reject. */}
-                      <CommentAttachment
-                        className="mt-2"
-                        attachments={pendingAttachments}
-                        onUpload={handleAttachmentUpload}
-                        onRemove={handleAttachmentRemove}
-                      />
-                      {attachmentError && (
-                        <div className="text-xs text-destructive mt-1">{attachmentError}</div>
-                      )}
-                    </div>
-                    <div className="flex gap-2 flex-wrap">
-                      <Button
-                        size="sm"
-                        onClick={() => doAction('approve')}
-                        disabled={!canApproveReject || submitting !== null}
-                      >
-                        <CheckCircle2 className="h-4 w-4 mr-1" />
-                        {submitting === 'approve' ? tr('approving', 'Approving…') : tr('approve', 'Approve')}
-                      </Button>
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={!canApproveReject || submitting !== null}
-                            className="border-destructive text-destructive hover:bg-destructive hover:text-destructive-foreground"
-                          >
-                            <XCircle className="h-4 w-4 mr-1" />
-                            {submitting === 'reject' ? tr('rejecting', 'Rejecting…') : tr('reject', 'Reject')}
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>{tr('rejectTitle', 'Reject this request?')}</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              {tr('rejectBody', 'This marks the request as rejected and notifies the submitter.')}
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>{tr('cancel', 'Cancel')}</AlertDialogCancel>
-                            <AlertDialogAction
-                              onClick={() => doAction('reject')}
-                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                            >
-                              {tr('reject', 'Reject')}
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    </div>
+                    {/* SERVER-DECLARED decision actions (objectui#2678 P2-4 +
+                        framework#3300). The inbox hand-wires NOTHING: approve /
+                        reject (with comment + file attachments), reassign,
+                        send-back, request-info, remind and recall all ship as the
+                        object's declared actions and render + execute here through
+                        the shared console action runtime. Each action's `visible`
+                        CEL gates it (submitter levers on `submitter_id ==
+                        ctx.user.id`; approver levers on `status == pending`), its
+                        param dialog collects the comment and — via the shared
+                        upload-widget renderer (#2700/#2707) — the `attachments`
+                        file param (#2698), and its `{id}`-interpolated
+                        `type:'api'` target resolves from the selected row. */}
+                    <DeclaredActionsBar
+                      objectName="sys_approval_request"
+                      record={selected}
+                      location="record_section"
+                      label={tr('declaredActions', 'Actions')}
+                      onDone={() => { void onDecisionDone(); }}
+                    />
                     {!canApproveReject && (
                       <div className="text-xs text-muted-foreground">
                         {canRecall
@@ -1794,25 +1646,6 @@ export function ApprovalsInboxPage() {
                             })}
                       </div>
                     )}
-                    {/* SERVER-DECLARED secondary actions (objectui#2678 P2-4 +
-                        framework#3300). The inbox no longer hand-wires send-back /
-                        request-info / reassign / remind / recall — they ship as the
-                        object's declared actions and render + execute here through
-                        the shared console action runtime with ZERO per-action code.
-                        Each action's `visible` CEL gates it (submitter levers on
-                        `submitter_id == ctx.user.id`; approver levers on
-                        `status == pending`), and its `{id}`-interpolated `type:'api'`
-                        target resolves from the selected row. approve/reject are
-                        `exclude`d because the composer above keeps them — it collects
-                        file attachments the generic param dialog can't yet. */}
-                    <DeclaredActionsBar
-                      objectName="sys_approval_request"
-                      record={selected}
-                      location="record_section"
-                      exclude={['approval_approve', 'approval_reject']}
-                      label={tr('declaredActions', 'More actions')}
-                      onDone={() => { void refreshThread(selected.id); void load(); }}
-                    />
                   </div>
                 </>
               )}
@@ -1842,7 +1675,6 @@ export function ApprovalsInboxPage() {
                         objectName="sys_approval_request"
                         record={selected}
                         location="record_section"
-                        exclude={['approval_approve', 'approval_reject']}
                         onDone={() => { void refreshThread(selected.id); void load(); }}
                       />
                     </div>

--- a/packages/app-shell/src/views/ActionParamDialog.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.test.tsx
@@ -22,7 +22,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { ActionParamDef } from '@object-ui/core';
-import { ActionParamDialog, filterVisibleParams } from './ActionParamDialog';
+import { ActionParamDialog, filterVisibleParams, serializeParamValues } from './ActionParamDialog';
 
 const p = (name: string, visible?: string): ActionParamDef => ({
   name,
@@ -189,5 +189,53 @@ describe('ActionParamDialog — shared field-widget rendering (ADR-0059)', () =>
     expect((input as HTMLInputElement).value).toBe('seed');
     confirm();
     await waitFor(() => expect(resolve).toHaveBeenCalledWith({ note: 'seed' }));
+  });
+});
+
+describe('serializeParamValues', () => {
+  const fileParam = (name: string, multiple = false): ActionParamDef =>
+    ({ name, label: name, type: 'file', ...(multiple ? { multiple: true } : {}) } as ActionParamDef);
+
+  it('is a no-op when there are no upload params', () => {
+    const values = { comment: 'hi', to: 'u1' };
+    expect(serializeParamValues([p('comment'), p('to')], values)).toBe(values);
+  });
+
+  it('maps a single file param object to its file_id', () => {
+    const out = serializeParamValues([fileParam('attachments')], {
+      comment: 'ok',
+      attachments: { file_id: 'f_123', name: 'x.pdf', url: 'https://…' },
+    });
+    expect(out).toEqual({ comment: 'ok', attachments: 'f_123' });
+  });
+
+  it('maps a multiple file param array to file_id[]', () => {
+    const out = serializeParamValues([fileParam('attachments', true)], {
+      attachments: [
+        { file_id: 'f_1', name: 'a' },
+        { file_id: 'f_2', name: 'b' },
+      ],
+    });
+    expect(out).toEqual({ attachments: ['f_1', 'f_2'] });
+  });
+
+  it('passes a bare string id through unchanged', () => {
+    expect(serializeParamValues([fileParam('attachments')], { attachments: 'f_9' }))
+      .toEqual({ attachments: 'f_9' });
+  });
+
+  it('leaves an absent / null upload value alone', () => {
+    expect(serializeParamValues([fileParam('attachments', true)], { comment: 'c' }))
+      .toEqual({ comment: 'c' });
+    expect(serializeParamValues([fileParam('attachments')], { attachments: null }))
+      .toEqual({ attachments: null });
+  });
+
+  it('does not touch non-upload params', () => {
+    const out = serializeParamValues([fileParam('attachments'), p('comment')], {
+      attachments: { file_id: 'f_1' },
+      comment: 'keep me',
+    });
+    expect(out).toEqual({ attachments: 'f_1', comment: 'keep me' });
   });
 });

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -73,6 +73,39 @@ export function filterVisibleParams(
   });
 }
 
+/**
+ * Serialize collected values for the request body. Upload widgets (`file` /
+ * `image`) hold a rich `{ file_id, name, url, … }` object — or an array of them
+ * when `multiple` — but the portable API contract is the storage id(s). Map each
+ * upload param to its `file_id` (a bare string passes through unchanged, and an
+ * object missing `file_id` is left intact so the failure is visible rather than
+ * silently POSTing `undefined`). Every non-upload value is returned as-is. Pure
+ * + exported so the mapping is unit-testable without the dialog render tree.
+ */
+export function serializeParamValues(
+  params: ActionParamDef[],
+  values: Record<string, any>,
+): Record<string, any> {
+  const uploadNames = new Set(
+    params
+      .filter((p) => {
+        const t = paramToField(p).type;
+        return t === 'file' || t === 'image';
+      })
+      .map((p) => p.name),
+  );
+  if (uploadNames.size === 0) return values;
+  const toId = (item: any) =>
+    item && typeof item === 'object' ? (item.file_id ?? item.id ?? item) : item;
+  const out: Record<string, any> = { ...values };
+  for (const name of uploadNames) {
+    const v = out[name];
+    if (v == null) continue;
+    out[name] = Array.isArray(v) ? v.map(toId) : toId(v);
+  }
+  return out;
+}
+
 /** Skeleton shown while a lazy field widget's chunk loads. */
 function WidgetFallback() {
   return <div className="h-9 w-full animate-pulse rounded-md bg-muted" aria-hidden="true" />;
@@ -135,7 +168,9 @@ export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProp
       setErrors(newErrors);
       return;
     }
-    state.resolve?.(values);
+    // Map upload params (file/image) from their rich widget objects to the
+    // storage id(s) the API expects before resolving.
+    state.resolve?.(serializeParamValues(visibleParams, values));
     onOpenChange(false);
   };
 

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -50,6 +50,12 @@ function useFileUploads(opts: {
                 setUploadProgress((prev) => ({ ...prev, [file.name]: ratio })),
             });
             return {
+              // `file_id` is the storage id the backend keys attachments by
+              // (the adapter returns it as `meta.fileId`); surfacing it here
+              // lets callers that need the id — e.g. an action param POSTing
+              // `attachments: string[]` — recover it without a second lookup.
+              // Extra key; the record file-field value shape is unchanged.
+              file_id: (result.meta as { fileId?: string } | undefined)?.fileId,
               name: result.name,
               original_name: file.name,
               size: result.size,


### PR DESCRIPTION
Completes the **#2678 P2-4** endgame (#2698). Pairs with framework#3332 (declared `attachments` param). The approvals inbox drawer now renders **every** decision — approve, reject, reassign, send-back, request-info, remind, recall, resubmit — purely through `DeclaredActionsBar`, with **zero** hand-wired action UI.

## What

### 1. Generic upload-param support (reusable — any declared action, not just approvals)
- **`FileField`** now surfaces the storage id it already receives from the upload adapter (`meta.fileId`) as **`file_id`** on each emitted file object (additive; record file-field value shape unchanged).
- **`ActionParamDialog`** maps `file`/`image` param values to their `file_id`(s) at submit — `serializeParamValues` (pure + unit-tested): single → string, `multiple` → `string[]`. So an action POSTs `attachments: string[]` (the portable API contract) instead of the widget's rich `{name,url,…}` object. The api handler already passes values through untouched, so the body is exactly `{comment, attachments:[…]}`.

### 2. Retire the composer (`ApprovalsInboxPage`)
Removed: the hand-written comment box + quick-phrase chips, the `CommentAttachment` staging UI, the Approve button + Reject dialog, `doAction`, the upload handlers, and — **with maintainer sign-off** — the admin **"act as another identity"** (`actorOverride`) escape hatch (successor: enterprise act-as, cloud#861). Both `DeclaredActionsBar` mounts drop their `exclude`, so the bar renders approve/reject too (with the declared `attachments` file param).

Kept: the participant-gated reply box, the "why disabled" hint, and the timeline's attachment chips (name resolution + signed-URL open). A generic **`onDecisionDone`** preserves the Fiori "advance to the next waiting item" queue flow — driven off the refreshed row rather than a per-action handler (advances when the item is no longer yours: finalized, approved-away in a quorum, reassigned).

**Net negative diff** (~240 lines removed from the inbox).

## Verification

Browser, against a live backend (framework main + framework#3332):
- Drawer has **no composer** (`textarea#comment` gone); approve/reject render in the bar.
- The declared **Approve** dialog renders a **file-upload widget**; staging a file + confirming POSTs `{comment, attachments:["<fileId>"]}` — the upload id **serialized correctly end-to-end** (the headline of this change). *(The observed request was a 403 only because the test admin was the request's submitter, not an approver — an authz fact of the seed, not the change; persistence of `attachments` on a real approver's decision is the pre-existing, tested `decide` path.)*
- app-shell suite green (incl. 6 new `serializeParamValues` tests); console typecheck clean; lint delta zero (pre-existing React-Compiler advisories unchanged).

## Refs
framework#3332 (declared `attachments` param) · #2700 / #2707 (shared-widget param rendering + upload guard) · #2697 (secondary-button retirement, `exclude` prop) · #2678 (P2-4) · cloud#861 (enterprise act-as, successor to the removed admin actor-override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ypkQikZ55oWUHUnMebwXA)_