### PR TITLE
feat(fields): MultiSelectField per-option visibleWhen cascading + dependsOn gating (#2715)

### DIFF
--- a/.changeset/multiselect-cascade-2715.md
+++ b/.changeset/multiselect-cascade-2715.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/fields": minor
+---
+
+feat(fields): MultiSelectField per-option `visibleWhen` cascading + `dependsOn` gating (parity with single select, #2715)
+
+The multi-value chip picker now implements the same ADR-0058 option
+resolution as the single `SelectField`, closing the gap #2709 opened when a
+`select` + `multiple` (and the `multiselect` type) started delegating to it.
+
+- Extracted `useCascadingOptions` — the shared hook that resolves per-option
+  `visibleWhen` filtering, `dependsOn` gating, and the live `dependentValues` +
+  predicate-scope wiring — and routed both `SingleSelectField` and
+  `MultiSelectField` through it (no duplicated resolver).
+- `MultiSelectField` narrows its offered chips against the live record +
+  `current_user`, gates behind a "select the parent first" hint while a
+  `dependsOn` field is empty, and surfaces a legible empty state instead of a
+  bare chip row.
+- Cascade-clear: when the offered set changes (parent changed / predicate
+  flipped) the widget prunes only the now-invalid selections, keeping the
+  still-offered ones — the array analogue of the single select's clear.
+- Tests: `MultiSelectField.cascade.test.tsx` mirrors `SelectField.cascade.test.tsx`
+  (gating, per-element cascade clear, role/context gating).

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -91,18 +91,22 @@ picker (the same widget the `multiselect` type uses) and stores a `string[]`.
 Delegating inside `SelectField` — rather than at a type-resolution layer — means
 every surface that renders the `select` widget (the object form, the inline grid
 editor, and the app-shell `ActionParamDialog`) gets multi-select identically,
-with no per-surface drift. Single-value selects keep the cascading dropdown
-below. (A multi-value select forgoes per-option `visibleWhen` cascading, which
-the chip picker does not implement.)
+with no per-surface drift. Both single- and multi-value selects resolve
+per-option `visibleWhen` cascading and `dependsOn` gating through the same
+[`useCascadingOptions`](./src/widgets/useCascadingOptions.ts) hook, so the
+offered chips narrow (and now-invalid selections are pruned) exactly as the
+single dropdown does.
 
 ### Cascading & role-gated select options
 
-`select` options support a per-option `visibleWhen` CEL predicate (offered only
-when TRUE, evaluated against the live record + `current_user`) and a field-level
-`dependsOn`. Together they drive dependent selects (country → province → city)
-and role-gated options with no bespoke matrix — the same primitives dependent
-lookups use. While a `dependsOn` parent is empty the control is gated; a parent
-change re-filters the list and clears a now-invalid value. Client-side hiding is
+`select` and `multiselect` options support a per-option `visibleWhen` CEL
+predicate (offered only when TRUE, evaluated against the live record +
+`current_user`) and a field-level `dependsOn`. Together they drive dependent
+selects (country → province → city) and role-gated options with no bespoke
+matrix — the same primitives dependent lookups use. While a `dependsOn` parent
+is empty the control is gated; a parent change re-filters the list and clears a
+now-invalid value (single select drops the value; multi-select prunes just the
+offered-out entries). Client-side hiding is
 UX only — gate authorization-sensitive values on the server too. See
 [`content/docs/fields/select.mdx`](../../content/docs/fields/select.mdx).
 

--- a/packages/fields/src/widgets/MultiSelectField.cascade.test.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.cascade.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Cascading / role-gated `multiselect` options (#2715) — parity with the single
+ * `SelectField` (ADR-0058 / #2284).
+ *
+ * Exercises the observable widget behaviour: the dependency gate (a "select the
+ * parent first" empty-state), and the cascade clear — but here per-element: a
+ * selection dropped from the array when the offered set no longer includes it,
+ * while still-valid selections are kept. The per-option filtering itself is
+ * unit-tested in `@object-ui/core` (`optionRules.test.ts`); here we prove the
+ * chip picker wires `dependentValues` + predicate scope into that resolver via
+ * the shared `useCascadingOptions` hook.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { MultiSelectField } from './MultiSelectField';
+
+const provinceField = {
+  name: 'province',
+  type: 'multiselect',
+  dependsOn: 'country',
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+  ],
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MultiSelectField — dependency gating (#2715)', () => {
+  it('gates with a "select parent first" hint while the controlling field is empty', () => {
+    render(
+      <MultiSelectField
+        value={[]}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: {} } as any)}
+      />,
+    );
+    const gate = screen.getByTestId('multiselect-empty-province');
+    expect(gate).toHaveTextContent(/select country first/i);
+    // Gated → no chips offered.
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('unlocks the chips once the controlling field is set', () => {
+    render(
+      <MultiSelectField
+        value={[]}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    expect(screen.queryByTestId('multiselect-empty-province')).not.toBeInTheDocument();
+    // Only the `cn` option is offered.
+    expect(screen.getByTestId('multiselect-option-zj')).toBeInTheDocument();
+    expect(screen.queryByTestId('multiselect-option-ca')).not.toBeInTheDocument();
+  });
+});
+
+describe('MultiSelectField — cascade clear (#2715)', () => {
+  it('drops only the selections the parent change no longer offers', () => {
+    const onChange = vi.fn();
+    render(
+      <MultiSelectField
+        value={['zj', 'ca']}
+        onChange={onChange}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    // 'ca' is a US province — under country=cn it is not offered, so it is
+    // pruned; the still-valid 'zj' is kept.
+    expect(onChange).toHaveBeenCalledWith(['zj']);
+  });
+
+  it('keeps selections that are all still offered', () => {
+    const onChange = vi.fn();
+    render(
+      <MultiSelectField
+        value={['zj']}
+        onChange={onChange}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('MultiSelectField — role / context gating (#2715)', () => {
+  const tierField = {
+    name: 'tiers',
+    type: 'multiselect',
+    options: [
+      { label: 'Standard', value: 'standard' },
+      { label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.positions" },
+    ],
+  } as any;
+
+  it('prunes an admin-only value for a non-admin (offered set excludes it)', () => {
+    const onChange = vi.fn();
+    render(
+      <PredicateScopeProvider scope={{ current_user: { positions: ['sales'] } }}>
+        <MultiSelectField
+          value={['standard', 'admin_only']}
+          onChange={onChange}
+          field={tierField}
+          {...({ name: 'tiers', dependentValues: {} } as any)}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(onChange).toHaveBeenCalledWith(['standard']);
+  });
+
+  it('keeps an admin-only value for an admin', () => {
+    const onChange = vi.fn();
+    render(
+      <PredicateScopeProvider scope={{ current_user: { positions: ['admin'] } }}>
+        <MultiSelectField
+          value={['standard', 'admin_only']}
+          onChange={onChange}
+          field={tierField}
+          {...({ name: 'tiers', dependentValues: {} } as any)}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -1,28 +1,88 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Badge, EmptyValue, cn } from '@object-ui/components';
+import type { OptionLike } from '@object-ui/core';
 import { FieldWidgetProps } from './types';
+import { useCascadingOptions } from './useCascadingOptions';
 
-interface Option { label: string; value: string; color?: string }
+interface Option extends OptionLike { color?: string }
 
 /**
  * MultiSelectField - select zero or more values from a fixed option set.
  *
  * Renders the configured options as toggleable chips. The stored value is a
- * string[] (the selected option values). Used for the `multiselect` field type.
+ * string[] (the selected option values). Used for the `multiselect` field type
+ * and for a `select` field declared `multiple: true`.
+ *
+ * Options support the same per-option `visibleWhen` cascading + `dependsOn`
+ * gating as the single `SelectField` (ADR-0058 / #2715), resolved through the
+ * shared {@link useCascadingOptions} hook: the offered chips narrow against the
+ * live form record + `current_user`, the control is gated behind a "select the
+ * parent first" hint while a dependency is empty, and selections no longer
+ * offered (parent changed / predicate flipped) are dropped from the array.
  */
-export function MultiSelectField({ value, onChange, field, readonly, className, ...props }: FieldWidgetProps<string[]>) {
-  const config = (field || (props as any).schema) as any;
-  const options: Option[] = config?.options || [];
+export function MultiSelectField({
+  value,
+  onChange,
+  field,
+  readonly,
+  className,
+  schema,
+  dependentValues,
+  dependsOn: dependsOnProp,
+  emptyHint: _emptyHint,
+  dataSource: _dataSource,
+  ...props
+}: FieldWidgetProps<string[]>) {
+  const config = (field || schema) as any;
+  const rawOptions: Option[] = config?.options || [];
   const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
+  const fieldName = (props as any).name || config?.name || (props as any).id || '';
+
+  const dependsOn = config?.dependsOn ?? dependsOnProp;
+  const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
+    rawOptions,
+    dependsOn,
+    dependentValues,
+  );
+
+  // Cascade clear: drop selected values the offered set no longer includes
+  // (parent changed / predicate flipped), keeping the ones still valid — unlike
+  // the scalar case we prune per-element rather than clearing the whole field.
+  useEffect(() => {
+    if (readonly) return;
+    if (selected.length === 0) return;
+    const stillOffered = selected.filter((v) => options.some((o) => o.value === v));
+    if (stillOffered.length !== selected.length) onChange(stillOffered);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options, gated]);
 
   if (readonly) {
     if (selected.length === 0) return <EmptyValue />;
     return (
       <div className="flex flex-wrap gap-1">
         {selected.map((v) => {
-          const opt = options.find((o) => o.value === v);
+          // Label from the raw set so a stored value hidden by `visibleWhen`
+          // still renders its label rather than a bare id.
+          const opt = rawOptions.find((o) => o.value === v);
           return <Badge key={v} variant="outline">{opt?.label || v}</Badge>;
         })}
+      </div>
+    );
+  }
+
+  // No offered options is unfillable — surface a legible state instead of an
+  // empty chip row: a dependency-gated list prompts for its controlling field;
+  // an unconfigured / fully-filtered list says so. Mirrors the single select.
+  if (options.length === 0) {
+    const hint = gated
+      ? `Select ${dependsOnFields.join(' / ')} first`
+      : 'No options available';
+    return (
+      <div
+        data-testid={fieldName ? `multiselect-empty-${fieldName}` : undefined}
+        className="flex min-h-9 w-full items-center rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
+      >
+        {hint}
       </div>
     );
   }
@@ -33,7 +93,10 @@ export function MultiSelectField({ value, onChange, field, readonly, className, 
   };
 
   return (
-    <div className={cn('flex flex-wrap gap-1.5', className)}>
+    <div
+      className={cn('flex flex-wrap gap-1.5', className)}
+      data-testid={fieldName ? `multiselect-${fieldName}` : undefined}
+    >
       {options.map((opt) => {
         const active = selected.includes(opt.value);
         return (
@@ -43,6 +106,7 @@ export function MultiSelectField({ value, onChange, field, readonly, className, 
             onClick={() => toggle(opt.value)}
             disabled={(props as any).disabled}
             aria-pressed={active}
+            data-testid={`multiselect-option-${opt.value}`}
             className={cn(
               'rounded-full border px-3 py-1 text-sm transition-colors',
               active

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import {
   Select,
   SelectContent,
@@ -7,17 +7,12 @@ import {
   SelectValue,
   EmptyValue,
 } from '@object-ui/components';
-import {
-  resolveVisibleOptions,
-  isOptionGroupGated,
-  resolveDependsOnFields,
-  isValueStillOffered,
-} from '@object-ui/core';
-import { SchemaRendererContext, usePredicateScope } from '@object-ui/react';
+import { isValueStillOffered } from '@object-ui/core';
 import { SelectFieldMetadata } from '@object-ui/types';
 import { useFieldTranslation } from './useFieldTranslation';
 import { FieldWidgetProps } from './types';
 import { MultiSelectField } from './MultiSelectField';
+import { useCascadingOptions } from './useCascadingOptions';
 
 /**
  * SelectField - dropdown selection widget.
@@ -30,9 +25,9 @@ import { MultiSelectField } from './MultiSelectField';
  * `ActionParamDialog` — inherits multi-select identically, with no drift
  * between them. Single-value selects keep the cascading dropdown below.
  *
- * (A `multiple` select forgoes per-option `visibleWhen` cascading, which the
- * chip picker does not implement; single selects retain it. Multi-select +
- * cascading is not a combination in use today.)
+ * Both branches resolve per-option `visibleWhen` cascading / role-gating through
+ * the shared {@link useCascadingOptions} hook (#2715), so single and multi stay
+ * in lockstep.
  */
 export function SelectField(props: FieldWidgetProps<any>) {
   const config = (props.field || (props as any).schema) as SelectFieldMetadata | undefined;
@@ -74,28 +69,11 @@ function SingleSelectField({
   // react-hook-form field name spread in by the form renderer (FormField).
   const fieldName = (props as any).name || (config as any)?.name || props.id || '';
 
-  // Live form values for cascading options — injected by the form renderer as
-  // `dependentValues` (same channel dependent lookups use), falling back to the
-  // record on SchemaRendererContext. `current_user` etc. come from the global
-  // predicate scope so role/context predicates resolve too.
-  const ctx = useContext(SchemaRendererContext) as any;
-  const record = useMemo<Record<string, unknown>>(() => {
-    return (dependentValues ?? ctx?.formValues ?? ctx?.data ?? {}) as Record<string, unknown>;
-  }, [dependentValues, ctx?.formValues, ctx?.data]);
-  const predicateScope = usePredicateScope();
-
   const dependsOn = (config as any)?.dependsOn ?? dependsOnProp;
-  const dependsOnFields = useMemo(() => resolveDependsOnFields(dependsOn), [dependsOn]);
-  const gated = useMemo(
-    () => dependsOnFields.length > 0 && isOptionGroupGated(dependsOn, record),
-    [dependsOnFields, dependsOn, record],
-  );
-
-  // Effective (offered) options after per-option `visibleWhen` filtering. Empty
-  // while gated so we never present an unfiltered set before the parent is set.
-  const options = useMemo(
-    () => (gated ? [] : resolveVisibleOptions(rawOptions, record, predicateScope)),
-    [gated, rawOptions, record, predicateScope],
+  const { options, gated, dependsOnFields } = useCascadingOptions(
+    rawOptions,
+    dependsOn,
+    dependentValues,
   );
 
   // Cascade clear: once the offered set no longer includes the current value

--- a/packages/fields/src/widgets/useCascadingOptions.ts
+++ b/packages/fields/src/widgets/useCascadingOptions.ts
@@ -1,0 +1,62 @@
+import { useContext, useMemo } from 'react';
+import {
+  resolveVisibleOptions,
+  isOptionGroupGated,
+  resolveDependsOnFields,
+  type OptionLike,
+  type DependsOnInput,
+} from '@object-ui/core';
+import { SchemaRendererContext, usePredicateScope } from '@object-ui/react';
+
+/**
+ * Shared per-option cascading / role-gating resolution for the option widgets
+ * (`SelectField` single, `MultiSelectField`) — the client half of ADR-0058
+ * (#2284). Each option may carry a `visibleWhen` CEL predicate; the offered set
+ * narrows against the live form record (`record.country == 'cn'`) + the global
+ * predicate scope (`'admin' in current_user.positions`). A field declares which
+ * sibling fields drive its list via `dependsOn`; while any is empty the list is
+ * *gated* — callers surface a "select the parent first" hint rather than an
+ * unfiltered set, mirroring the dependent-lookup UX.
+ *
+ * Extracted so single- and multi-select stay in lockstep instead of duplicating
+ * the resolver + its `dependentValues` / predicate-scope wiring (#2715).
+ */
+export interface CascadingOptionsResult<T extends OptionLike> {
+  /** Offered options after `visibleWhen` filtering. Empty while gated. */
+  options: T[];
+  /** True when a `dependsOn` field is empty — the list is gated. */
+  gated: boolean;
+  /** Normalized `dependsOn` field names (for the gate hint). */
+  dependsOnFields: string[];
+}
+
+export function useCascadingOptions<T extends OptionLike>(
+  rawOptions: readonly T[],
+  dependsOn: DependsOnInput,
+  dependentValues: Record<string, unknown> | undefined,
+): CascadingOptionsResult<T> {
+  // Live form values for cascading options — injected by the form renderer as
+  // `dependentValues` (same channel dependent lookups use), falling back to the
+  // record on SchemaRendererContext. `current_user` etc. come from the global
+  // predicate scope so role/context predicates resolve too.
+  const ctx = useContext(SchemaRendererContext) as any;
+  const record = useMemo<Record<string, unknown>>(() => {
+    return (dependentValues ?? ctx?.formValues ?? ctx?.data ?? {}) as Record<string, unknown>;
+  }, [dependentValues, ctx?.formValues, ctx?.data]);
+  const predicateScope = usePredicateScope();
+
+  const dependsOnFields = useMemo(() => resolveDependsOnFields(dependsOn), [dependsOn]);
+  const gated = useMemo(
+    () => dependsOnFields.length > 0 && isOptionGroupGated(dependsOn, record),
+    [dependsOnFields, dependsOn, record],
+  );
+
+  // Effective (offered) options after per-option `visibleWhen` filtering. Empty
+  // while gated so we never present an unfiltered set before the parent is set.
+  const options = useMemo(
+    () => (gated ? [] : resolveVisibleOptions(rawOptions, record, predicateScope)),
+    [gated, rawOptions, record, predicateScope],
+  );
+
+  return { options, gated, dependsOnFields };
+}


### PR DESCRIPTION
Closes #2715.

## What

Gives the multi-value chip picker (`MultiSelectField`) the same per-option `visibleWhen` cascading and `dependsOn` gating the single `SelectField` already has (ADR-0058). This closes the parity gap #2709 opened: once a `select` + `multiple` (and the `multiselect` type) started delegating to the chip picker, a multi-select whose options depend on a sibling field or the current user showed the **unfiltered** option set.

## Changes

- **Extract `useCascadingOptions`** (`packages/fields/src/widgets/useCascadingOptions.ts`) — the shared hook that resolves per-option `visibleWhen` filtering, `dependsOn` gating, and the `dependentValues` + predicate-scope wiring. Both `SingleSelectField` and `MultiSelectField` now route through it instead of duplicating the resolver.
- **`MultiSelectField`**: narrows offered chips against the live record + `current_user`; gates behind a "select the parent first" hint while a `dependsOn` field is empty; surfaces a legible empty state instead of a bare chip row. Adds deterministic testids (`multiselect-empty-*`, `multiselect-option-*`).
- **Cascade-clear**: prunes only the now-invalid selections when the offered set changes (the array analogue of the single select's whole-value clear), keeping the still-offered ones.
- Readonly rendering still labels stored values from the raw option set (a value hidden by `visibleWhen` keeps its label, not a bare id).
- Docs (fields README) + changeset (`@object-ui/fields` minor).

## Acceptance (from the issue)

- [x] Share option-resolution logic between `SelectField` and `MultiSelectField` (extracted hook, no duplication).
- [x] `MultiSelectField` applies `visibleWhen` filtering + `dependsOn` gating (empty/gated hint) like single select.
- [x] Cascade-clear drops selected values no longer offered when the parent changes.
- [x] Tests mirroring `SelectField.cascade.test.tsx` for the multi case.

## Tests

- New `MultiSelectField.cascade.test.tsx` (gating, per-element cascade clear, role/context gating) — mirrors `SelectField.cascade.test.tsx`.
- Verified green: `MultiSelectField.cascade` + `SelectField.cascade` + `standard-widgets` (the #2709 delegation tests) + core `optionRules` — **49 passed**.
- `tsc --noEmit` clean across `@object-ui/fields` (deps built); `eslint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)