### PR TITLE
fix(site): make docs build resilient to remote badge fetch failures (#2695)

### DIFF
--- a/apps/site/source.config.ts
+++ b/apps/site/source.config.ts
@@ -17,6 +17,27 @@ export const docs = defineDocs({
 
 export default defineConfig({
   mdxOptions: {
-    // MDX options
+    // `remark-image` probes every image at build time to inline width/height.
+    // For remote images (e.g. shields.io / skills.sh badges) that is a
+    // build-time network fetch, which turns an external service's availability
+    // into a hard build dependency: a shields.io hiccup (Cloudflare 520 / 1200
+    // "Too many requests") would otherwise fail the entire docs build. Make the
+    // build resilient to remote-image outages. See objectui#2695.
+    remarkImageOptions: {
+      // Bound each remote fetch so a hung connection can't stall CI.
+      external: { timeout: 10_000 },
+      // Warn (don't fail the build) when a remote image can't be sized, but keep
+      // strict behaviour for local/authored images so broken in-repo paths are
+      // still caught. Note: in the Next.js bundler pipeline local images resolve
+      // via `import` and never reach here — this guard only matters if that ever
+      // changes, at which point local failures must still be fatal.
+      onError: (error) => {
+        if (/https?:\/\//.test(error.message)) {
+          console.warn(`[remark-image] skipped remote image (build continues): ${error.message}`);
+          return;
+        }
+        throw error;
+      },
+    },
   },
 });


### PR DESCRIPTION
Closes #2695

## 问题

`Build Docs`(`@object-ui/site#build`)用 fumadocs 的 `remark-image` 插件在**构建期**拉取每一张远程图片以取得尺寸(`getImageSize`)。远程徽章(shields.io / skills.sh)因此把一个外部服务的可用性变成了构建的**硬依赖**——shields.io 一抖(Cloudflare 520 / 1200 "Too many requests")就抛错并让整个 docs 构建失败,与 PR 内容无关(见 #2684)。

## 根因定位

- 全仓 `content/docs` 里唯一**活跃**触发构建期拉取的远程徽章是 `content/docs/guide/agent-skills.md:12` 的 skills.sh 徽章。
- issue 里提到的 `shields.io` 引用都在**代码围栏内**(`plugins/plugin-markdown.mdx`),不会被 `remark-image` 处理。
- 本地图片(`dashboard-filters.md` → `/img/*.png`)在 Next.js bundler 流程里走 `import` 解析,不经过网络。

## 方案(issue 选项 1)

在 `apps/site/source.config.ts` 给 `remark-image` 配置容错:

- `external: { timeout: 10_000 }` —— 给每次远程拉取加超时,避免挂死的连接卡住 CI;
- `onError` —— 远程图片取尺寸失败时**告警而非 fail 构建**;对**本地/仓内**图片仍然 `throw`(保持严格,坏路径照样卡构建)。

只加安全网,不改成功路径:远程可达时行为不变,徽章照常内联尺寸。

## 验收对照

- [x] shields.io(或任意远程图片源)不可用时,`Build Docs` 不再整体失败;
- [x] 定位并处理了触发拉取的具体徽章引用(skills.sh @ `agent-skills.md:12`)。

## 验证

直接用**改后的真实 `source.config.ts`** 驱动 `fumadocs-core` 的 `remarkImage` 跑失败 URL:

| 场景 | 旧行为 | 新行为 |
|---|---|---|
| 远程徽章 404/DNS 失败 | **THREW**(构建失败) | **RESOLVED**(告警,构建继续)✅ |
| 本地图片缺失 | THREW | **THREW**(仍然 fatal)✅ |

`pnpm exec fumadocs-mdx` 编译配置通过(接受 `remarkImageOptions`)。

> `@object-ui/site` 在 changeset `ignore` 列表且属构建基础设施 bug 修复,无需 changeset。

🤖 Generated with [Claude Code](https://claude.com/claude-code)