### PR TITLE
fix(approvals-inbox): align participant gating with the server-computed viewer block (framework#3310)

### DIFF
--- a/.changeset/approvals-viewer-gating-sync.md
+++ b/.changeset/approvals-viewer-gating-sync.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/console": patch
+---
+
+fix(approvals-inbox): align participant gating with the server-computed `viewer` block
+
+Consume framework#3310's per-viewer capability: `ApprovalRequestRow` gains an
+optional `viewer: { can_act, is_submitter }`, and the approvals inbox's
+participant checks (the reply box + the "why disabled" hint) prefer it over the
+client-side identity heuristic when present. This keeps the hint from ever
+contradicting the declared decision buttons — whose `visible` CEL now gates on
+`record.viewer.*` — and correctly recognizes position/team-addressed approvers
+that the client heuristic couldn't resolve. The heuristic remains as a fallback
+for a backend that predates `viewer`.

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -602,22 +602,29 @@ export function ApprovalsInboxPage() {
 
   // Participant checks — drive the reply box + the "why disabled" hint (the
   // decision buttons themselves are server-declared and gate via their own
-  // `visible` CEL). No actor-override branch: the admin "act as" escape hatch
-  // retired with the composer (cloud#861 enterprise act-as is the successor).
+  // `visible` CEL). Prefer the server-computed `viewer` block (framework#3310)
+  // so the hint never contradicts the buttons — it already reflects position/
+  // team approver resolution, which the client identity heuristic below can't.
+  // The heuristic stays as a fallback for a backend that predates `viewer`.
+  // No actor-override branch: the admin "act as" escape hatch retired with the
+  // composer (cloud#861 enterprise act-as is the successor).
   const canApproveReject = useMemo(() => {
     if (!selected || selected.status !== 'pending') return false;
+    if (selected.viewer) return selected.viewer.can_act;
     const pending = new Set(selected.pending_approvers || []);
     return identities.some(id => pending.has(id));
   }, [selected, identities]);
 
   const canRecall = useMemo(() => {
     if (!selected || selected.status !== 'pending') return false;
+    if (selected.viewer) return selected.viewer.is_submitter;
     return selected.submitter_id === user?.id;
   }, [selected, user?.id]);
 
   /** ADR-0044: the submitter may resubmit (or abandon) a returned request. */
   const canResubmit = useMemo(() => {
     if (!selected || selected.status !== 'returned') return false;
+    if (selected.viewer) return selected.viewer.is_submitter;
     return selected.submitter_id === user?.id;
   }, [selected, user?.id]);
 

--- a/apps/console/src/services/approvalsApi.ts
+++ b/apps/console/src/services/approvalsApi.ts
@@ -71,6 +71,19 @@ export interface ApprovalRequestRow {
     need: number;
     groups?: Array<{ group: string; got: number; need: number; satisfied: boolean }>;
   };
+  /**
+   * Server-computed capability for the current viewer (framework#3310), attached
+   * by getRequest/listRequests. Declared decision actions gate their `visible`
+   * CEL on it — approver actions on `viewer.can_act`, submitter levers on
+   * `viewer.is_submitter` — so the drawer never offers a decision the caller
+   * can't make. Absent on rows not read through the approvals service.
+   */
+  viewer?: {
+    /** The caller is a current pending approver (mirrors the service's authz). */
+    can_act: boolean;
+    /** The caller submitted this request. */
+    is_submitter: boolean;
+  };
   /** ADR-0044 revision round on this (run, node): absent/1 = first round. */
   round?: number;
 }


### PR DESCRIPTION
Console half of **framework#3310**. Consumes the new server-computed per-viewer capability so the inbox's participant gating matches the (now precisely gated) declared decision buttons.

## What

- **`ApprovalRequestRow`** (`services/approvalsApi.ts`) gains an optional `viewer: { can_act, is_submitter }` — attached by `getRequest`/`listRequests` on the framework side.
- The inbox's participant checks — the **reply box** and the **"why disabled" hint** — now prefer `record.viewer` over the client-side identity heuristic when present. This keeps the hint from contradicting the declared decision buttons (whose `visible` CEL now gates on `record.viewer.*`) and correctly recognizes **position/team-addressed approvers** the client heuristic couldn't resolve. The heuristic remains as a fallback for a backend that predates `viewer`.

No new UI: the decision buttons themselves are server-declared and gate via their own CEL — this PR only aligns the surrounding hint/reply affordances.

## Verification

Browser, live backend (framework#3310):
- A **submitter** viewing their own pending request sees **only remind + recall** in the bar — approve / reject / reassign / send-back / request-info all hidden (previously they leaked through `status == "pending"` gating and 403'd on click).
- `getRequest` returned `viewer: {can_act:false, is_submitter:true}`; the reply box + hint render consistently with the buttons.
- console typecheck clean; lint delta zero.

## Refs
framework#3310 (server `viewer` capability) · #2697 / #2710 (button retirement) · #2678 (P2-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ypkQikZ55oWUHUnMebwXA)_