### PR TITLE
test(app-shell): value-shape parity net for action params (#2714)

### DIFF
--- a/docs/adr/0059-action-params-shared-field-widgets.md
+++ b/docs/adr/0059-action-params-shared-field-widgets.md
@@ -87,15 +87,43 @@ or special-casing one fails CI. This mirrors the `FieldEditWidget` ↔
 `FORM_FIELD_TYPES` drift test that caught `lookup` falling back to a text box
 inline.
 
-## Value shapes
+## Value shapes (the emitted-shape contract)
 
-Widgets emit their own value shapes and the dialog passes them through
-untouched to the action runner (`resolve(values)`), exactly as before for the
-previously-supported types (`select` → string, `number` → number, `boolean` →
-boolean, `date` → `YYYY-MM-DD`, lookup → id / id[]). New types follow their
-widget's contract — e.g. `file` → uploaded-file descriptor(s)
-(`{ name, url, … }`, array when `multiple`). Endpoint authors declare params
-with the shape their route expects, same as record forms.
+Routing every param through its real widget means each param emits **its
+widget's own value shape** on confirm, and the dialog passes that through to the
+action runner (`resolve(values)`). An endpoint's input contract depends on
+getting the shape it declared, so the emitted shapes are pinned as a contract —
+one entry per `FORM_FIELD_TYPES` widget key — in
+`packages/app-shell/src/utils/paramValueShape.ts` (`PARAM_VALUE_SHAPES` /
+`expectedParamShape()`), and guarded by `paramValueShape.test.ts` (objectui#2714).
+The shapes below are the value the dialog **POSTs** — i.e. after
+`serializeParamValues` (so `file`/`image` are already their fileId string; see
+Follow-ups and objectui#2698 / #2710):
+
+| Param `type` (spelling → widget) | Emitted (POST) shape | Notes |
+|---|---|---|
+| `text` `textarea` `email` `phone` `url` `password`/`secret` `markdown` `html` `richtext` `code`/`json` `color` `avatar` `signature` `qrcode` | `string` | Free/encoded text, hex, or data-URL string. |
+| `date` `datetime` `time` | `string` | ISO-ish: `YYYY-MM-DD`, `…THH:mm`, `HH:mm`. |
+| `number` `currency` `percent` `slider` `rating` | `number` | A real number, **not** a string; `null` when cleared. |
+| `boolean`/`checkbox`/`toggle` | `boolean` | Rendered as the dialog's inline checkbox row. |
+| `select` | `string`, or **`string[]` when `multiple`** | `multiple` delegates to the chip picker (objectui#2709). |
+| `radio` | `string` | Single option value. |
+| `multiselect` `checkboxes` `tags` | `string[]` | Always an array of values. |
+| `lookup`/`reference` `master_detail` `user` `owner` `tree` | id `string`, or **`string[]` when `multiple`** | Record id(s). `master_detail` renders the single-value lookup (parent id). A targetless `lookup`/`reference` (no `referenceTo`) falls back to a plain text `string`. |
+| `file` `image` `video`/`audio` | fileId `string`, or **`string[]` when `multiple`** | Widget state holds a `{ file_id, name, url, … }` descriptor; `serializeParamValues` maps it to the storage id on confirm (objectui#2698 / #2710). |
+| `object`/`composite`/`record` `location` `address` `geolocation` | `object` | Structured JSON value. |
+| `grid`/`repeater` | `object[]` | Array of row objects. |
+| `formula` `summary` `autonumber`/`auto_number` `vector` | — (nothing) | Computed / read-only widgets never call `onChange`. |
+
+(`object-ref` / `filter-condition` / `recipient-picker` are widget-hint-only —
+reached via a field `widget:` override, never a bare param `type` — so they are
+outside the declarable-param contract, though the drift guard still covers them.)
+
+Endpoint authors declare params with the shape their route expects, same as
+record forms. If a widget swap ever changed a param's emitted shape, the
+`paramValueShape` net (contract table + the `ActionParamDialog` render proofs
+that drive the real widget and classify what it emits) fails before the change
+can break an endpoint silently.
 
 ## Consequences
 

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -126,6 +126,15 @@ pins param support ⊇ form support. `required` validation and `visible` CEL
 gating are applied by the dialog; file/image uploads use the ambient
 `UploadProvider`, lookup/user pickers the surrounding `SchemaRendererContext`.
 
+Because each param now emits its widget's own value shape on confirm, the shape
+the dialog **POSTs** for every type is pinned as a contract in
+`utils/paramValueShape.ts` (`PARAM_VALUE_SHAPES` / `expectedParamShape`) and
+guarded by `paramValueShape.test.ts` (#2714): `number`→number, `boolean`→boolean,
+`date`/`datetime`/`time`→string, `select`→string (`string[]` when `multiple`),
+`lookup`/`user`→id string(s), `file`/`image`→fileId string(s) (via
+`serializeParamValues`, #2698/#2710), `object`/`address`→object, `grid`→object[].
+See the full table in [ADR-0059](../../docs/adr/0059-action-params-shared-field-widgets.md#value-shapes-the-emitted-shape-contract).
+
 ## Metadata designers
 
 The metadata-admin engine (`src/views/metadata-admin`) renders an in-app editor

--- a/packages/app-shell/src/utils/paramValueShape.test.ts
+++ b/packages/app-shell/src/utils/paramValueShape.test.ts
@@ -1,0 +1,214 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * paramValueShape — the value-shape parity net for action params (#2714).
+ *
+ * ADR-0059 routes every param through the shared form field-widget renderer, so
+ * each param emits its widget's own value shape on confirm. This is the drift
+ * guard (mirroring `paramToField.test.ts`'s style) pinning that contract:
+ *   1. Coverage — every `FORM_FIELD_TYPES` widget key has a declared shape, so a
+ *      new widget can't land without someone stating what a param of that type
+ *      POSTs (the whole "a widget swap silently changed the shape" failure mode).
+ *   2. Contracts — the shapes endpoints rely on are pinned by value
+ *      (`number`→number, `boolean`→boolean, `date`→string, `select`→string,
+ *      `select+multiple`→string[], `lookup`→id(s), `file`→fileId(s)).
+ *
+ * The `file`/`image` → fileId serialization itself is owned by #2698/#2710
+ * (`serializeParamValues`); this net asserts the post-serialize endpoint shape
+ * and the general contract for the non-upload types.
+ */
+import { describe, it, expect } from 'vitest';
+import { FORM_FIELD_TYPES } from '@object-ui/fields';
+import type { ActionParamDef } from '@object-ui/core';
+import {
+  PARAM_VALUE_SHAPES,
+  expectedParamShape,
+  resolveShapeSpec,
+  classifyValueShape,
+  type ValueShapeTag,
+} from './paramValueShape';
+
+const p = (over: Partial<ActionParamDef>): ActionParamDef => ({
+  name: 'x',
+  label: 'X',
+  type: 'text',
+  ...over,
+});
+
+describe('emitted value-shape contract — FORM_FIELD_TYPES coverage (drift guard)', () => {
+  it('declares a shape for every form field type — none left undeclared', () => {
+    // If this fails: a widget type was added to `fieldWidgetMap` (and so to
+    // `FORM_FIELD_TYPES`) without declaring the value shape a param of that type
+    // emits. Add an entry to PARAM_VALUE_SHAPES stating what the dialog POSTs —
+    // do not delete this assertion.
+    const undeclared = FORM_FIELD_TYPES.filter((t) => !(t in PARAM_VALUE_SHAPES));
+    expect(undeclared).toEqual([]);
+  });
+
+  it('has no stale contract entries pointing at removed widget types', () => {
+    const formTypes = new Set(FORM_FIELD_TYPES);
+    const stale = Object.keys(PARAM_VALUE_SHAPES).filter((t) => !formTypes.has(t));
+    expect(stale).toEqual([]);
+  });
+
+  it('resolves every declared type to a concrete shape (never throws / undefined)', () => {
+    const VALID: ValueShapeTag[] = [
+      'none', 'string', 'number', 'boolean', 'object',
+      'string[]', 'number[]', 'boolean[]', 'object[]',
+    ];
+    for (const type of FORM_FIELD_TYPES) {
+      const single = resolveShapeSpec(PARAM_VALUE_SHAPES[type], false);
+      const multi = resolveShapeSpec(PARAM_VALUE_SHAPES[type], true);
+      expect(VALID).toContain(single);
+      expect(VALID).toContain(multi);
+    }
+  });
+});
+
+describe('expectedParamShape — pinned endpoint contracts', () => {
+  // The shapes an action runner / endpoint input contract relies on. Pinned by
+  // value so a widget swap that changes what a param POSTs fails here.
+  const cases: Array<[string, Partial<ActionParamDef>, ValueShapeTag]> = [
+    // Scalars endpoints depend on being their real JS type
+    ['number → number (not a string)', { type: 'number' }, 'number'],
+    ['currency → number', { type: 'currency' }, 'number'],
+    ['percent → number', { type: 'percent' }, 'number'],
+    ['boolean → boolean', { type: 'boolean' }, 'boolean'],
+    ['date → string', { type: 'date' }, 'string'],
+    ['datetime → string', { type: 'datetime' }, 'string'],
+    ['time → string', { type: 'time' }, 'string'],
+    ['text → string', { type: 'text' }, 'string'],
+    ['color → string', { type: 'color' }, 'string'],
+    ['code → string', { type: 'code' }, 'string'],
+
+    // Selection
+    ['select → string', { type: 'select' }, 'string'],
+    ['select + multiple → string[] (#2709)', { type: 'select', multiple: true }, 'string[]'],
+    ['radio → string', { type: 'radio' }, 'string'],
+    ['multiselect → string[]', { type: 'multiselect' }, 'string[]'],
+    ['checkboxes → string[]', { type: 'checkboxes' }, 'string[]'],
+    ['tags → string[]', { type: 'tags' }, 'string[]'],
+
+    // Record pickers → id(s)
+    ['lookup (with referenceTo) → string id', { type: 'lookup', referenceTo: 'space_users' }, 'string'],
+    ['lookup + multiple → string[] ids', { type: 'lookup', referenceTo: 'space_users', multiple: true }, 'string[]'],
+    ['user → string id', { type: 'user' }, 'string'],
+    ['user + multiple → string[] ids', { type: 'user', multiple: true }, 'string[]'],
+
+    // Uploads → fileId(s) AFTER serializeParamValues (#2698/#2710)
+    ['file → fileId string', { type: 'file' }, 'string'],
+    ['file + multiple → fileId string[]', { type: 'file', multiple: true }, 'string[]'],
+    ['image → fileId string', { type: 'image' }, 'string'],
+
+    // Structured objects
+    ['object → object', { type: 'object' }, 'object'],
+    ['address → object', { type: 'address' }, 'object'],
+    ['grid → object[]', { type: 'grid' }, 'object[]'],
+  ];
+
+  it.each(cases)('%s', (_label, over, expected) => {
+    expect(expectedParamShape(p(over))).toBe(expected);
+  });
+
+  it('a lookup param WITHOUT referenceTo posts a plain string (text fallback, matches the dialog)', () => {
+    // paramToField degrades a targetless lookup/reference to a text input — the
+    // picker cannot query without a target object — so it POSTs a bare string.
+    expect(expectedParamShape(p({ type: 'lookup' }))).toBe('string');
+    expect(expectedParamShape(p({ type: 'reference' }))).toBe('string');
+  });
+
+  it('legacy param spellings resolve to their canonical shape', () => {
+    expect(expectedParamShape(p({ type: 'checkbox' }))).toBe('boolean');
+    expect(expectedParamShape(p({ type: 'datetime-local' }))).toBe('string');
+    expect(expectedParamShape(p({ type: 'autonumber' }))).toBe('none'); // computed
+  });
+
+  it('an unknown param type falls back to a plain string (text widget)', () => {
+    expect(expectedParamShape(p({ type: 'no-such-type' }))).toBe('string');
+  });
+
+  it('computed / read-only widget types emit nothing (none)', () => {
+    for (const type of ['formula', 'summary', 'auto_number', 'vector']) {
+      expect(resolveShapeSpec(PARAM_VALUE_SHAPES[type], false)).toBe('none');
+    }
+  });
+});
+
+describe('resolveShapeSpec — multiple promotion', () => {
+  it('promotes a scalar|array spec to base[] only when multiple', () => {
+    const spec = PARAM_VALUE_SHAPES.select;
+    expect(resolveShapeSpec(spec, false)).toBe('string');
+    expect(resolveShapeSpec(spec, true)).toBe('string[]');
+  });
+
+  it('keeps an inherently-array spec as base[] regardless of multiple', () => {
+    const spec = PARAM_VALUE_SHAPES.tags;
+    expect(resolveShapeSpec(spec, false)).toBe('string[]');
+    expect(resolveShapeSpec(spec, true)).toBe('string[]');
+  });
+
+  it('keeps a plain scalar spec as base regardless of multiple', () => {
+    const spec = PARAM_VALUE_SHAPES.number;
+    expect(resolveShapeSpec(spec, false)).toBe('number');
+    expect(resolveShapeSpec(spec, true)).toBe('number');
+  });
+
+  it('computed specs resolve to none regardless of multiple', () => {
+    expect(resolveShapeSpec(PARAM_VALUE_SHAPES.formula, true)).toBe('none');
+  });
+});
+
+describe('classifyValueShape — runtime classifier (backs the render proofs)', () => {
+  it('classifies scalars by their JS type', () => {
+    expect(classifyValueShape('hi')).toBe('string');
+    expect(classifyValueShape(42)).toBe('number');
+    expect(classifyValueShape(true)).toBe('boolean');
+    expect(classifyValueShape({ latitude: 1, longitude: 2 })).toBe('object');
+  });
+
+  it('treats null / undefined as none (no value emitted)', () => {
+    expect(classifyValueShape(null)).toBe('none');
+    expect(classifyValueShape(undefined)).toBe('none');
+  });
+
+  it('tags a non-empty array by its first element base', () => {
+    expect(classifyValueShape(['a', 'b'])).toBe('string[]');
+    expect(classifyValueShape([1, 2])).toBe('number[]');
+    expect(classifyValueShape([{ id: 1 }])).toBe('object[]');
+  });
+
+  it('degrades an empty array to the generic array tag (base unknowable)', () => {
+    expect(classifyValueShape([])).toBe('array');
+  });
+});
+
+describe('contract ↔ realistic value agreement', () => {
+  // A representative emitted value per endpoint-relied param, classified back to
+  // the declared contract. Documents "what a type:'X' param POSTs looks like"
+  // and pins that the classifier and the resolver share one vocabulary.
+  const samples: Array<[Partial<ActionParamDef>, unknown]> = [
+    [{ type: 'number' }, 42],
+    [{ type: 'boolean' }, true],
+    [{ type: 'date' }, '2026-07-20'],
+    [{ type: 'datetime' }, '2026-07-20T14:30'],
+    [{ type: 'select' }, 'prod'],
+    [{ type: 'select', multiple: true }, ['prod', 'stage']],
+    [{ type: 'multiselect' }, ['a', 'b']],
+    [{ type: 'lookup', referenceTo: 'space_users' }, 'usr_123'],
+    [{ type: 'lookup', referenceTo: 'space_users', multiple: true }, ['usr_1', 'usr_2']],
+    [{ type: 'file' }, 'file_abc'], // post-serialize fileId
+    [{ type: 'file', multiple: true }, ['file_1', 'file_2']],
+    [{ type: 'object' }, { key: 'v' }],
+    [{ type: 'grid' }, [{ id: '1' }, { id: '2' }]],
+  ];
+
+  it.each(samples)('%o classifies to its declared shape', (over, sample) => {
+    expect(classifyValueShape(sample)).toBe(expectedParamShape(p(over)));
+  });
+});

--- a/packages/app-shell/src/utils/paramValueShape.ts
+++ b/packages/app-shell/src/utils/paramValueShape.ts
@@ -1,0 +1,244 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * paramValueShape — the emitted **value-shape contract** for action params.
+ *
+ * Since ADR-0059 (#2700/#2704) `ActionParamDialog` routes every param through
+ * the shared form field-widget renderer (`paramToField()` → `getLazyFieldWidget`),
+ * so each param now emits **its widget's own value shape** on confirm. Those
+ * shapes differ per type — `number` emits a `number`, `boolean` a `boolean`,
+ * `date` an ISO string, `select` a `string` (`string[]` when `multiple`, #2709),
+ * `lookup`/`user` an id `string`/`string[]`, `file`/`image` a fileId `string`/
+ * `string[]` after `serializeParamValues` (#2698/#2710) — and an endpoint's
+ * input contract depends on getting the shape it declared.
+ *
+ * This module is that contract, made explicit and machine-checkable:
+ *   - {@link PARAM_VALUE_SHAPES} — the table: one entry per `FORM_FIELD_TYPES`
+ *     widget key, describing the shape the dialog POSTs for that type.
+ *   - {@link expectedParamShape} — resolves a concrete `ActionParamDef` to its
+ *     emitted shape, reusing the SAME `paramToField()` the dialog uses (so the
+ *     contract can't drift from the dialog's own type resolution) and folding in
+ *     `multiple` and the `file`/`image` fileId serialization.
+ *   - {@link classifyValueShape} — a runtime classifier for render proofs to
+ *     assert what a widget actually emitted matches the declared contract.
+ *
+ * The paired drift test (`paramValueShape.test.ts`, mirroring the
+ * `paramToField` drift guard's style) fails if a new widget type lands without
+ * a declared shape, or if a pinned endpoint contract changes.
+ */
+import type { ActionParamDef } from '@object-ui/core';
+import { paramToField } from './paramToField';
+
+/**
+ * The vocabulary of emitted value shapes. A closed union so the table, the
+ * resolver, and the runtime classifier all speak the same language.
+ *
+ * `'none'` = the widget is computed/read-only and emits no param value (its
+ * cell holds display-only state). `'array'` is only produced by
+ * {@link classifyValueShape} for an *empty* array whose element type can't be
+ * inferred — the resolver never returns it (it always knows the base).
+ */
+export type ValueShapeTag =
+  | 'none'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'object'
+  | 'string[]'
+  | 'number[]'
+  | 'boolean[]'
+  | 'object[]'
+  | 'array';
+
+/** The base JS type a single emitted value carries. */
+type BaseShape = 'string' | 'number' | 'boolean' | 'object';
+
+/**
+ * How a widget type's `multiple` flag affects the emitted cardinality:
+ *   - `'scalar'`      — always a single `base` value (`text`, `number`, `date`…).
+ *   - `'scalar|array'`— a single `base`, or `base[]` when the param is `multiple`
+ *                       (`select`, `lookup`, `user`, `file`, …).
+ *   - `'array'`       — always `base[]`, regardless of `multiple`
+ *                       (`multiselect`, `tags`, `checkboxes`, `grid`).
+ */
+type Cardinality = 'scalar' | 'scalar|array' | 'array';
+
+export interface ParamValueShapeSpec {
+  /**
+   * The JS type each emitted value carries **at the endpoint boundary** — i.e.
+   * the value the dialog POSTs after `serializeParamValues`. For `file`/`image`
+   * that is the fileId `string` (the widget holds a `{ file_id, name, url, … }`
+   * descriptor in local state, which the dialog serializes to its id on confirm;
+   * see #2698/#2710); every other type passes its widget value through untouched.
+   */
+  readonly base: BaseShape;
+  /** How `multiple` promotes the cardinality — see {@link Cardinality}. */
+  readonly cardinality: Cardinality;
+  /**
+   * `true` for computed/read-only widgets that never call `onChange`
+   * (`formula`, `summary`, `auto_number`, `vector`). They render display-only,
+   * so a param of the type emits nothing (`'none'`).
+   */
+  readonly computed?: boolean;
+  /**
+   * `true` for widget-hint-only keys that are reached through a field `widget:`
+   * override, never a bare param `type` (`object-ref`, `filter-condition`,
+   * `recipient-picker`). Listed so the drift guard's `FORM_FIELD_TYPES` coverage
+   * is total, but they are outside the declarable-param contract.
+   */
+  readonly widgetHintOnly?: boolean;
+  /** One-line description for the documented contract table. */
+  readonly note: string;
+}
+
+/**
+ * The emitted value-shape contract, keyed by `FORM_FIELD_TYPES` widget key.
+ *
+ * Every key in `@object-ui/fields`' `fieldWidgetMap` MUST have an entry here —
+ * the drift guard asserts full coverage, so adding a new widget type without
+ * declaring the shape a param of that type POSTs fails CI. Keep entries ordered
+ * to match `fieldWidgetMap` for easy diffing.
+ */
+export const PARAM_VALUE_SHAPES: Readonly<Record<string, ParamValueShapeSpec>> = Object.freeze({
+  // Text-ish → string
+  text: { base: 'string', cardinality: 'scalar', note: 'Free text.' },
+  textarea: { base: 'string', cardinality: 'scalar', note: 'Multi-line text.' },
+  email: { base: 'string', cardinality: 'scalar', note: 'Email address string.' },
+  phone: { base: 'string', cardinality: 'scalar', note: 'Phone number string.' },
+  url: { base: 'string', cardinality: 'scalar', note: 'URL string.' },
+  password: { base: 'string', cardinality: 'scalar', note: 'Secret string (masked input).' },
+  markdown: { base: 'string', cardinality: 'scalar', note: 'Markdown source string (RichTextField).' },
+  html: { base: 'string', cardinality: 'scalar', note: 'HTML source string (RichTextField).' },
+  richtext: { base: 'string', cardinality: 'scalar', note: 'Rich-text source string.' },
+  code: { base: 'string', cardinality: 'scalar', note: 'Code/JSON source string (json alias resolves here).' },
+  color: { base: 'string', cardinality: 'scalar', note: 'Hex color string (e.g. #8B5CF6).' },
+  avatar: { base: 'string', cardinality: 'scalar', note: 'Data-URL / base64 image string.' },
+  signature: { base: 'string', cardinality: 'scalar', note: 'Signature data-URL string.' },
+  qrcode: { base: 'string', cardinality: 'scalar', note: 'Encoded QR payload string.' },
+
+  // Date/time → ISO-ish string
+  date: { base: 'string', cardinality: 'scalar', note: 'ISO date string (YYYY-MM-DD).' },
+  datetime: { base: 'string', cardinality: 'scalar', note: 'datetime-local string (YYYY-MM-DDTHH:mm).' },
+  time: { base: 'string', cardinality: 'scalar', note: 'Time string (HH:mm).' },
+
+  // Numeric → number
+  number: { base: 'number', cardinality: 'scalar', note: 'Numeric value — NOT a string (null when cleared).' },
+  currency: { base: 'number', cardinality: 'scalar', note: 'Numeric amount.' },
+  percent: { base: 'number', cardinality: 'scalar', note: 'Numeric percent.' },
+  slider: { base: 'number', cardinality: 'scalar', note: 'Numeric slider value.' },
+  rating: { base: 'number', cardinality: 'scalar', note: 'Numeric rating (1..n).' },
+
+  // Boolean
+  boolean: { base: 'boolean', cardinality: 'scalar', note: 'true / false (dialog renders an inline checkbox).' },
+
+  // Single-value selection → string, promotes to string[] when multiple
+  select: { base: 'string', cardinality: 'scalar|array', note: 'Option value string; multiple → string[] via the chip picker (#2709).' },
+  radio: { base: 'string', cardinality: 'scalar', note: 'Single option value string.' },
+
+  // Inherently multi-value selection → string[]
+  multiselect: { base: 'string', cardinality: 'array', note: 'Always string[] of option values.' },
+  checkboxes: { base: 'string', cardinality: 'array', note: 'Always string[] of checked values.' },
+  tags: { base: 'string', cardinality: 'array', note: 'Always string[] of free tags.' },
+
+  // Record pickers → id string(s)
+  lookup: { base: 'string', cardinality: 'scalar|array', note: 'Referenced record id; multiple → id[]. (No referenceTo → falls back to a text string.)' },
+  master_detail: { base: 'string', cardinality: 'scalar|array', note: 'Parent record id — renders the single-value LookupField, not a child list.' },
+  user: { base: 'string', cardinality: 'scalar|array', note: 'sys_user id; multiple → id[].' },
+  owner: { base: 'string', cardinality: 'scalar|array', note: 'Owner (sys_user) id; multiple → id[].' },
+
+  // Uploads → fileId string(s) after serializeParamValues (#2698/#2710)
+  file: { base: 'string', cardinality: 'scalar|array', note: 'fileId string after serialize; multiple → fileId[]. Widget state holds a { file_id, name, url, … } descriptor pre-serialize.' },
+  image: { base: 'string', cardinality: 'scalar|array', note: 'fileId string after serialize; multiple → fileId[]. Same descriptor→id serialization as file.' },
+
+  // Structured object values (stored as JSON on the row)
+  object: { base: 'object', cardinality: 'scalar', note: 'Parsed JSON object (null when empty).' },
+  location: { base: 'object', cardinality: 'scalar', note: '{ latitude, longitude } object.' },
+  address: { base: 'object', cardinality: 'scalar', note: 'Structured address object.' },
+  geolocation: { base: 'object', cardinality: 'scalar', note: '{ latitude, longitude, … } object.' },
+  grid: { base: 'object', cardinality: 'array', note: 'Array of row objects (embedded table).' },
+
+  // Computed / read-only — never emit a param value
+  formula: { base: 'string', cardinality: 'scalar', computed: true, note: 'Computed — read-only, emits nothing.' },
+  summary: { base: 'number', cardinality: 'scalar', computed: true, note: 'Computed roll-up — read-only, emits nothing.' },
+  auto_number: { base: 'string', cardinality: 'scalar', computed: true, note: 'Auto-generated — read-only, emits nothing.' },
+  vector: { base: 'number', cardinality: 'array', computed: true, note: 'Embedding vector — read-only display, emits nothing.' },
+
+  // Widget-hint-only pickers — reached via a field `widget:` override, never a
+  // bare param `type`. Present for total FORM_FIELD_TYPES coverage only.
+  'object-ref': { base: 'string', cardinality: 'scalar', widgetHintOnly: true, note: 'Object name string. Widget-hint only — not a declarable param type.' },
+  'filter-condition': { base: 'object', cardinality: 'scalar', widgetHintOnly: true, note: 'Filter/criteria object. Widget-hint only — not a declarable param type.' },
+  'recipient-picker': { base: 'string', cardinality: 'scalar', widgetHintOnly: true, note: 'Recipient id string. Widget-hint only — not a declarable param type.' },
+});
+
+/** Concrete `base[]` tag for a base shape. */
+function arrayTagOf(base: BaseShape): ValueShapeTag {
+  return `${base}[]` as ValueShapeTag;
+}
+
+/**
+ * Resolve a spec + `multiple` flag to the concrete shape the dialog emits.
+ * Computed widgets → `'none'`. Inherently-array widgets → `base[]`. Scalar-or-
+ * array widgets → `base[]` when `multiple`, else `base`. Plain scalars → `base`.
+ */
+export function resolveShapeSpec(spec: ParamValueShapeSpec, multiple: boolean): ValueShapeTag {
+  if (spec.computed) return 'none';
+  switch (spec.cardinality) {
+    case 'array':
+      return arrayTagOf(spec.base);
+    case 'scalar|array':
+      return multiple ? arrayTagOf(spec.base) : spec.base;
+    case 'scalar':
+    default:
+      return spec.base;
+  }
+}
+
+/**
+ * The concrete value shape the dialog POSTs for a given param definition.
+ *
+ * Resolves through the SAME `paramToField()` adapter the dialog renders with —
+ * so it inherits the real widget-type resolution (aliases, the
+ * lookup-without-`referenceTo` → text fallback, `multiple` inheritance) and can
+ * never drift from what the dialog actually mounts. The resolved
+ * `{ type, multiple }` then indexes {@link PARAM_VALUE_SHAPES}.
+ */
+export function expectedParamShape(param: ActionParamDef): ValueShapeTag {
+  const field = paramToField(param);
+  const spec = PARAM_VALUE_SHAPES[field.type as string];
+  // paramToField only ever yields a FORM_FIELD_TYPES key (or 'text'), all of
+  // which are in the table; guard defensively so an unseen key surfaces loudly.
+  if (!spec) {
+    throw new Error(`No value-shape contract for resolved widget type "${field.type}" (param "${param.name}")`);
+  }
+  return resolveShapeSpec(spec, field.multiple === true);
+}
+
+/**
+ * Classify a runtime value into a {@link ValueShapeTag}. Used by the dialog
+ * render proofs to assert what a widget actually emitted on confirm matches the
+ * declared contract ({@link expectedParamShape}).
+ *
+ * `null`/`undefined` → `'none'`. A non-empty array is tagged by its first
+ * element's base (`['a'] → 'string[]'`); an empty array can't reveal its base,
+ * so it degrades to the generic `'array'` — pass a populated value in proofs.
+ */
+export function classifyValueShape(value: unknown): ValueShapeTag {
+  if (value === null || value === undefined) return 'none';
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 'array';
+    const elem = classifyValueShape(value[0]);
+    // First element is itself a scalar/object tag here (proofs never nest arrays).
+    return arrayTagOf((elem === 'none' ? 'object' : elem) as BaseShape);
+  }
+  const t = typeof value;
+  if (t === 'string') return 'string';
+  if (t === 'number') return 'number';
+  if (t === 'boolean') return 'boolean';
+  return 'object';
+}

--- a/packages/app-shell/src/views/ActionParamDialog.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.test.tsx
@@ -23,6 +23,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { ActionParamDef } from '@object-ui/core';
 import { ActionParamDialog, filterVisibleParams, serializeParamValues } from './ActionParamDialog';
+import { expectedParamShape, classifyValueShape } from '../utils/paramValueShape';
 
 const p = (name: string, visible?: string): ActionParamDef => ({
   name,
@@ -189,6 +190,88 @@ describe('ActionParamDialog — shared field-widget rendering (ADR-0059)', () =>
     expect((input as HTMLInputElement).value).toBe('seed');
     confirm();
     await waitFor(() => expect(resolve).toHaveBeenCalledWith({ note: 'seed' }));
+  });
+});
+
+describe('emitted value-shape parity (contract-tied render proofs, #2714)', () => {
+  // Each proof drives the REAL widget and asserts the value the dialog resolves
+  // on confirm matches the shape declared in `paramValueShape.ts`. This ties the
+  // declarative contract table to what the widgets actually emit — a silent
+  // widget-onChange swap that changed a param's POST shape fails here, not just
+  // in the pure table. Covers the endpoint-relied contracts drivable without a
+  // dataSource; the lookup/user id contract is pinned in `paramValueShape.test.ts`.
+
+  it('number param emits a number matching its declared contract', async () => {
+    const param = def({ name: 'count', type: 'number' });
+    const resolve = openDialog([param]);
+    const input = await screen.findByLabelText('Param One');
+    fireEvent.change(input, { target: { value: '42' } });
+    confirm();
+    await waitFor(() => expect(resolve).toHaveBeenCalled());
+    const emitted = resolve.mock.calls[0][0].count;
+    expect(emitted).toBe(42);
+    expect(classifyValueShape(emitted)).toBe(expectedParamShape(param)); // 'number'
+  });
+
+  it('datetime param emits an ISO-ish string matching its declared contract', async () => {
+    const param = def({ name: 'when', type: 'datetime' });
+    const resolve = openDialog([param]);
+    const input = await screen.findByLabelText('Param One');
+    expect(input.getAttribute('type')).toBe('datetime-local');
+    fireEvent.change(input, { target: { value: '2026-07-20T14:30' } });
+    confirm();
+    await waitFor(() => expect(resolve).toHaveBeenCalled());
+    const emitted = resolve.mock.calls[0][0].when;
+    expect(emitted).toBe('2026-07-20T14:30');
+    expect(classifyValueShape(emitted)).toBe(expectedParamShape(param)); // 'string'
+  });
+
+  it('time param emits a string matching its declared contract', async () => {
+    const param = def({ name: 'at', type: 'time' });
+    const resolve = openDialog([param]);
+    const input = await screen.findByLabelText('Param One');
+    expect(input.getAttribute('type')).toBe('time');
+    fireEvent.change(input, { target: { value: '09:15' } });
+    confirm();
+    await waitFor(() => expect(resolve).toHaveBeenCalled());
+    const emitted = resolve.mock.calls[0][0].at;
+    expect(emitted).toBe('09:15');
+    expect(classifyValueShape(emitted)).toBe(expectedParamShape(param)); // 'string'
+  });
+
+  it('select+multiple param emits a string[] matching its declared contract (#2709)', async () => {
+    const param = def({
+      name: 'envs',
+      type: 'select',
+      multiple: true,
+      options: [
+        { label: 'Production', value: 'prod' },
+        { label: 'Staging', value: 'stage' },
+      ],
+    });
+    const resolve = openDialog([param]);
+    // A `multiple` select renders the chip picker (MultiSelectField) — plain
+    // toggle buttons, not a Radix combobox — so it is drivable in JSDOM.
+    fireEvent.click(await screen.findByRole('button', { name: 'Production' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Staging' }));
+    confirm();
+    await waitFor(() => expect(resolve).toHaveBeenCalled());
+    const emitted = resolve.mock.calls[0][0].envs;
+    expect(emitted).toEqual(['prod', 'stage']);
+    expect(classifyValueShape(emitted)).toBe(expectedParamShape(param)); // 'string[]'
+  });
+
+  it('a file param emits a fileId string after serialize (#2698/#2710), matching its contract', () => {
+    // The FileField upload widget can't complete a presigned upload in JSDOM, so
+    // the emitted-shape proof for file/image lives at the serialize boundary:
+    // a resolved { file_id } descriptor serializes to the fileId string the
+    // contract declares. (End-to-end upload UX is covered by #2710's suite.)
+    const param = def({ name: 'attachment', type: 'file' });
+    const out = serializeParamValues([param], {
+      attachment: { file_id: 'file_abc', name: 'x.pdf', url: 'https://…' },
+    });
+    expect(out.attachment).toBe('file_abc');
+    expect(classifyValueShape(out.attachment)).toBe(expectedParamShape(param)); // 'string'
   });
 });
 


### PR DESCRIPTION
Closes #2714.

## Why

Since ADR-0059 (#2700 / #2704), `ActionParamDialog` routes **every** param through the shared form field-widget renderer (`paramToField()` → `getLazyFieldWidget`). That was the whole win — but it also means each param now emits **its widget's own value shape** on confirm, and those shapes differ (`number`→number, `boolean`→boolean, `date`→string, `select`→string / `select+multiple`→`string[]`, `lookup`/`user`→id(s), `file`/`image`→fileId(s)). #2700's acceptance called for value-shape parity coverage, but no test net pinned it — so a future widget swap could silently change a param's emitted shape and break an endpoint's input contract with no failing test.

## What

**The contract (`packages/app-shell/src/utils/paramValueShape.ts`)**
- `PARAM_VALUE_SHAPES` — one entry per `FORM_FIELD_TYPES` widget key, describing the shape the dialog **POSTs** (i.e. after `serializeParamValues`, so `file`/`image` are already their fileId string).
- `expectedParamShape(param)` — resolves a concrete `ActionParamDef` to its emitted shape by reusing the **same** `paramToField()` the dialog renders with, so the contract can't drift from the dialog's own type resolution; it then folds in `multiple` and the fileId serialization.
- `classifyValueShape(value)` — runtime classifier backing the render proofs.

**The net (`paramValueShape.test.ts`, mirroring the `paramToField` drift test)**
- **Coverage / drift guard:** every `FORM_FIELD_TYPES` key has a declared shape — a new widget can't land without stating what a param of that type POSTs.
- **Pinned contracts:** `number`→number, `boolean`→boolean, `date`/`datetime`/`time`→string, `select`→string, `select+multiple`→`string[]` (#2709), `lookup`/`user`→id(s), `file`→fileId(s), `multiselect`/`tags`→`string[]`, `object`/`address`→object, `grid`→`object[]`, computed types (`formula`/`summary`/`auto_number`/`vector`)→none.

**Reality tie (`ActionParamDialog.test.tsx`)**
- Contract-tied render proofs that drive the **real** widget (number / datetime / time / select+multiple / file) and assert the value the dialog resolves classifies to the declared contract — so a silent widget-`onChange` swap fails at the render layer too, not just in the table.

**Docs**
- Emitted-shape table added to [ADR-0059](docs/adr/0059-action-params-shared-field-widgets.md) (replacing the earlier prose, and correcting the now-stale `file`→descriptor line to the post-#2710 fileId contract) and referenced from the app-shell README.

## Out of scope (owned elsewhere)

The `file`/`image` → fileId serialization itself is **#2698 / #2710** (`serializeParamValues`). This net **adopts** that (asserts the post-serialize endpoint shape) rather than duplicating it.

## Test / verify

- `paramValueShape.test.ts` — 54 pass (`unit` project, node env).
- `ActionParamDialog.test.tsx` — 28 pass (`dom` project), incl. the 5 new contract-tied proofs.
- `paramToField.test.ts` — still green.
- `turbo run build --filter=@object-ui/app-shell` — 29/29 successful (app-shell `tsc` executed clean); eslint clean on new lines.

No changeset: internal test-net + contract module (not exported from the package's public `index.ts`) + docs; no runtime or public-API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)