### PR TITLE
fix(plugin-view): coerce i18n tab-label helpers to string (TS2322)

### DIFF
--- a/packages/plugin-view/src/ManageViewsDialog.tsx
+++ b/packages/plugin-view/src/ManageViewsDialog.tsx
@@ -71,9 +71,11 @@ import type { ViewTabItem } from './ViewTabBar';
 function useViewLabel() {
   try {
     const { t } = useObjectTranslation();
-    return (key: string, fallback: string, vars?: Record<string, unknown>) => {
+    return (key: string, fallback: string, vars?: Record<string, unknown>): string => {
       const v = t(key, vars as any);
-      return !v || v === key ? fallback : v;
+      // i18next's `t()` is typed `string | object`; coerce so render sites and
+      // aria-labels always receive a string (an object child white-screens React).
+      return !v || v === key ? fallback : String(v);
     };
   } catch {
     return (_k: string, fallback: string) => fallback;

--- a/packages/plugin-view/src/ViewTabBar.tsx
+++ b/packages/plugin-view/src/ViewTabBar.tsx
@@ -92,9 +92,11 @@ import { useObjectTranslation } from '@object-ui/react';
 function useViewTabLabel() {
   try {
     const { t } = useObjectTranslation();
-    return (key: string, fallback: string, vars?: Record<string, unknown>) => {
+    return (key: string, fallback: string, vars?: Record<string, unknown>): string => {
       const v = t(key, vars as any);
-      return !v || v === key ? fallback : v;
+      // i18next's `t()` is typed `string | object`; coerce so render sites and
+      // aria-labels always receive a string (an object child white-screens React).
+      return !v || v === key ? fallback : String(v);
     };
   } catch {
     return (_k: string, fallback: string) => fallback;


### PR DESCRIPTION
## What

`useViewTabLabel()` in [`ViewTabBar.tsx`](packages/plugin-view/src/ViewTabBar.tsx) and the identical `useViewLabel()` in [`ManageViewsDialog.tsx`](packages/plugin-view/src/ManageViewsDialog.tsx) returned the raw `t()` result. i18next types `t()` as `string | object` (it can resolve a key to an object), so the helper's return type was `string | object`.

That value is rendered directly as a React child and passed as `aria-label` at ~35 call sites, so `vite build`'s declaration-generation (dts) pass emitted `error TS2322: Type 'string | object' is not assignable to type 'ReactNode'` (and to `string | undefined` for aria-labels).

Because `plugin-view` builds with `vite build` (no type-check gate), these did **not** fail the build — but they are real: if `t()` ever resolves a key to an object, React throws and white-screens. This is the known "i18n/expression value is `string | object`, rendered raw → white-screen" class.

## Fix

Coerce the resolved value with `String(v)` and annotate the helper return type as `string`, in both helpers. Behavior-preserving for the normal (string) case.

## Scope

The task named `ViewTabBar.tsx`; while verifying at the package level, the `vite build` dts pass surfaced the identical bug (22 TS2322s) in the sibling `ManageViewsDialog.tsx` — same copied helper, same root cause, same package. Fixed both so the package is clean of this class. Out of scope for the docs-build fix in #2718; tracked separately.

## Verification

- `pnpm --filter @object-ui/plugin-view build` — before: TS2322 from both files; after: **no `TS2322` / `error TS`**, declaration files build cleanly, `✓ built`.
- `eslint` on both files reports only pre-existing warnings/errors (conditional hook, `vars as any`, `Function` type, setState-in-effect) — none introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)