### PR TITLE
feat(detail): related lists paginate by default with server-side $top/$skip windows (#2711)

### DIFF
--- a/.changeset/related-list-default-pagination.md
+++ b/.changeset/related-list-default-pagination.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/plugin-detail": minor
+"@object-ui/types": patch
+---
+
+Related lists paginate by default and fetch server-side windows (#2711).
+
+`record:related_list` now applies the spec default `limit` of 5 when a node
+doesn't declare one, so detail-page related lists render pages with
+Previous/Next controls instead of dumping every child row. On the auto-fetch
+path RelatedList requests one page at a time (`$top`/`$skip`), reads the
+collection size from `QueryResult.total` (`hasMore` fallback), sends user
+column sorts as a server `$orderby`, and seeds the initial order from the
+node's `sort` prop (new `defaultSort` prop on RelatedList). Caller-provided
+`data` keeps the historical client-side slicing. Behavior change: lists that
+previously rendered all rows now show 5 per page — declare a larger `limit`
+on the `record:related_list` node to widen the window.

--- a/content/docs/guide/slotted-pages.md
+++ b/content/docs/guide/slotted-pages.md
@@ -81,6 +81,15 @@ renderer suppresses itself the same way on hand-authored pages). The server
 always enforced data access — this keeps the UI from rendering an empty
 grid with a "New" button that would be rejected on save.
 
+Related lists **paginate by default**: when a `record:related_list` node
+does not declare `limit`, the renderer applies the spec default of **5**
+records per page (`RecordRelatedListProps.limit`), fetching one page at a
+time from the server (`$top`/`$skip`) with the count badge showing the
+full collection size. Authors can raise the page size per list
+(`limit: 20`) and pin the initial order with `sort`
+(`'-created_at'` or `[{ field, order }]`); a user's column sort is sent
+to the server so ordering stays global across pages.
+
 ## Header actions: inline vs. overflow
 
 `page:header` renders the record's `record_header` actions (authored

--- a/packages/plugin-detail/README.md
+++ b/packages/plugin-detail/README.md
@@ -192,6 +192,21 @@ Tab navigation for organizing content into different views.
 
 Displays related records in list, grid, or table format.
 
+Related lists are **paged by default**: the `record:related_list` renderer
+applies the spec default `limit` of **5** when the node doesn't declare one
+(`@objectstack/spec` `RecordRelatedListProps.limit`, "Number of records to
+display initially"), so a child collection of any size renders as pages with
+Previous/Next controls instead of one flat dump. On the auto-fetch path the
+component asks the server for **one page at a time** (`$top`/`$skip`) and
+reads the collection size from `QueryResult.total` (falling back to a
+`hasMore` estimate), so large child tables never ship wholesale to the
+browser. A user column sort becomes a server `$orderby` (ordering stays
+global across pages), and the node's `sort` prop seeds the initial order.
+Passing `data` directly keeps the historical client-side slicing, and typing
+in the opt-in filter box temporarily falls back to the full-fetch client
+pipeline (the contains-filter sweeps every field, which no generic server
+filter can express).
+
 The `record:related_list` renderer is automatically gated on the current
 user's object-level `read` permission for the child object: when the
 permission system (`@object-ui/permissions`) is loaded and denies read,

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -98,6 +98,13 @@ export interface RelatedListProps {
   maxColumns?: number;
   /** Page size for pagination (enables pagination when set) */
   pageSize?: number;
+  /**
+   * Initial sort applied while the user hasn't clicked a column sort — the
+   * spec `RecordRelatedListProps.sort` shape (`'field'` / `'-field'` string or
+   * `[{field, order}]`). On the auto-fetch path this becomes the server
+   * `$orderby`, keeping page windows deterministic.
+   */
+  defaultSort?: string | Array<{ field: string; order: 'asc' | 'desc' }>;
   /** Enable column sorting */
   sortable?: boolean;
   /** Enable text filtering */
@@ -137,6 +144,24 @@ function resolveIconComponent(name: string | undefined): LucideIcon {
     .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
     .join('');
   return ((lucideIcons as Record<string, LucideIcon>)[pascal]) || Inbox;
+}
+
+/**
+ * Normalize the spec `sort` union (`'field'` / `'-field'` string or
+ * `[{field, order}]`) into the object-array form fed to `$orderby`.
+ */
+function normalizeSortSpec(
+  sort: RelatedListProps['defaultSort'],
+): Array<{ field: string; order: 'asc' | 'desc' }> {
+  if (!sort) return [];
+  if (typeof sort === 'string') {
+    const trimmed = sort.trim();
+    if (!trimmed) return [];
+    return trimmed.startsWith('-')
+      ? [{ field: trimmed.slice(1), order: 'desc' }]
+      : [{ field: trimmed, order: 'asc' }];
+  }
+  return sort.filter((s) => !!s?.field);
 }
 
 /**
@@ -200,6 +225,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   add,
   maxColumns = 6,
   pageSize,
+  defaultSort,
   sortable = false,
   filterable = false,
   collapsible = false,
@@ -221,6 +247,11 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   const [sortField, setSortField] = React.useState<string | null>(null);
   const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>('asc');
   const [filterText, setFilterText] = React.useState('');
+  // Server-reported collection size / next-page hint (windowed fetch only —
+  // see `windowed` below). `total` drives the count badge and page indicator;
+  // `hasMore` keeps "Next" usable when a non-conforming backend omits `total`.
+  const [total, setTotal] = React.useState<number | null>(null);
+  const [hasMore, setHasMore] = React.useState(false);
   const [objectSchema, setObjectSchema] = React.useState<any>(null);
   const [collapsed, setCollapsed] = React.useState(defaultCollapsed);
   // Add-by-picker (generic m2m/junction assignment). `refreshNonce` re-runs the
@@ -233,6 +264,39 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   const [lookupLabels, setLookupLabels] = React.useState<Record<string, Record<string, string>>>({});
   const { t } = useDetailTranslation();
   const { fieldLabel: resolveFieldLabel } = useSafeFieldLabel();
+
+  const effectivePageSize = pageSize && pageSize > 0 ? pageSize : 0;
+  // The built-in contains-filter is a CLIENT-side sweep over every field —
+  // inexpressible as a generic server filter. While the user is typing in it
+  // (opt-in `filterable` consumers only) we drop back to the legacy
+  // fetch-everything mode so the filter keeps seeing the whole collection.
+  const filterActive = filterable && filterText !== '';
+  // Windowed (server-paged) mode — issue #2711: on the auto-fetch path with
+  // pagination enabled, ask the server for ONE page ($top/$skip) plus the
+  // running total instead of dumping every child row into the browser.
+  // Caller-provided `data` and the raw-URL fallback keep the historical
+  // client-side slicing.
+  const windowed =
+    !dataProvided &&
+    !!api &&
+    effectivePageSize > 0 &&
+    !!dataSource &&
+    typeof dataSource.find === 'function' &&
+    !filterActive;
+  // Freeze paging/sort fetch inputs while not windowed so the fetch effect
+  // doesn't re-run (and re-download the full collection) on page clicks or
+  // column sorts that the client pipeline already handles in memory.
+  const fetchPage = windowed ? currentPage : 0;
+  const fetchSortField = windowed ? sortField : null;
+  const fetchSortDirection = windowed ? sortDirection : 'asc';
+  // Key the memo on content, not identity — inline `sort` arrays from schema
+  // nodes would otherwise re-trigger the fetch effect every render.
+  const defaultSortKey = JSON.stringify(defaultSort ?? null);
+  const defaultSortSpec = React.useMemo(
+    () => normalizeSortSpec(defaultSort),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [defaultSortKey],
+  );
 
   // Sync internal state when data prop changes (e.g., parent fetches async data)
   React.useEffect(() => {
@@ -272,19 +336,49 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           );
         }
         setRelatedData([]);
+        setTotal(null);
+        setHasMore(false);
         setLoading(false);
         return;
       }
       setLoading(true);
       const filter = { [referenceField!]: parentId } as Record<string, any>;
       if (dataSource && typeof dataSource.find === 'function') {
-        dataSource.find(api, { $filter: filter }).then((result) => {
-          const items = Array.isArray(result)
-            ? result
+        const params: Record<string, any> = { $filter: filter };
+        if (windowed) {
+          params.$top = effectivePageSize;
+          params.$skip = fetchPage * effectivePageSize;
+          // A user column sort becomes a server $orderby so ordering stays
+          // global across pages; otherwise the schema's declared `sort` wins.
+          const orderby = fetchSortField
+            ? [{ field: fetchSortField, order: fetchSortDirection }]
+            : defaultSortSpec;
+          if (orderby.length > 0) params.$orderby = orderby;
+        }
+        dataSource.find(api, params).then((result) => {
+          const isArrayResult = Array.isArray(result);
+          const items = isArrayResult
+            ? (result as any[])
             : Array.isArray((result as any)?.data)
               ? (result as any).data
               : [];
           setRelatedData(items);
+          if (windowed) {
+            const reportedTotal = !isArrayResult && typeof (result as any)?.total === 'number'
+              ? (result as any).total as number
+              : null;
+            setTotal(reportedTotal);
+            // Prefer the server's own hint; a full page implies "maybe more"
+            // when the backend reports neither total nor hasMore.
+            setHasMore(
+              !isArrayResult && typeof (result as any)?.hasMore === 'boolean'
+                ? (result as any).hasMore as boolean
+                : items.length === effectivePageSize,
+            );
+          } else {
+            setTotal(null);
+            setHasMore(false);
+          }
           setLoading(false);
         }).catch((err) => {
           console.error('Failed to fetch related data:', err);
@@ -299,6 +393,8 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           .then(result => {
             const items = Array.isArray(result) ? result : (result?.data || []);
             setRelatedData(items);
+            setTotal(null);
+            setHasMore(false);
           })
           .catch(err => {
             console.error('Failed to fetch related data:', err);
@@ -306,7 +402,23 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           .finally(() => setLoading(false));
       }
     }
-  }, [api, dataProvided, dataSource, referenceField, parentId, refreshNonce]);
+  }, [api, dataProvided, dataSource, referenceField, parentId, refreshNonce, windowed, effectivePageSize, fetchPage, fetchSortField, fetchSortDirection, defaultSortSpec]);
+
+  // Windowed mode: a page beyond the (shrunken) collection — e.g. the last
+  // row of the last page was just deleted — comes back empty. Step back one
+  // page instead of stranding the user on an empty window.
+  React.useEffect(() => {
+    if (!windowed || loading) return;
+    if (currentPage > 0 && relatedData.length === 0) {
+      setCurrentPage((p) => Math.max(0, p - 1));
+    }
+  }, [windowed, loading, relatedData, currentPage]);
+
+  // A different parent (or relationship) is a different collection — restart
+  // from the first page.
+  React.useEffect(() => {
+    setCurrentPage(0);
+  }, [api, referenceField, parentId]);
 
   // Refetch when a mutation elsewhere signals this related object changed —
   // e.g. a child row action executed through the host retargets `api` and
@@ -398,20 +510,20 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataSource, objectSchema, relatedData]);
 
-  // Filter data
+  // Filter data (client mode only — windowed mode filters/sorts server-side)
   const filteredData = React.useMemo(() => {
-    if (!filterText) return relatedData;
+    if (windowed || !filterText) return relatedData;
     const lower = filterText.toLowerCase();
     return relatedData.filter((row) =>
       Object.values(row).some((val) =>
         val !== null && val !== undefined && String(val).toLowerCase().includes(lower)
       )
     );
-  }, [relatedData, filterText]);
+  }, [relatedData, filterText, windowed]);
 
-  // Sort data
+  // Sort data (client mode only — a windowed sort is a server $orderby)
   const sortedData = React.useMemo(() => {
-    if (!sortField) return filteredData;
+    if (windowed || !sortField) return filteredData;
     return [...filteredData].sort((a, b) => {
       const aVal = a[sortField];
       const bVal = b[sortField];
@@ -421,14 +533,26 @@ export const RelatedList: React.FC<RelatedListProps> = ({
       const cmp = String(aVal).localeCompare(String(bVal), undefined, { numeric: true });
       return sortDirection === 'asc' ? cmp : -cmp;
     });
-  }, [filteredData, sortField, sortDirection]);
+  }, [filteredData, sortField, sortDirection, windowed]);
 
-  // Paginate data
-  const effectivePageSize = pageSize && pageSize > 0 ? pageSize : 0;
-  const totalPages = effectivePageSize ? Math.max(1, Math.ceil(sortedData.length / effectivePageSize)) : 1;
-  const paginatedData = effectivePageSize
+  // Paginate data. Windowed mode already holds exactly one page; client mode
+  // slices the in-memory collection as before.
+  const paginatedData = effectivePageSize && !windowed
     ? sortedData.slice(currentPage * effectivePageSize, (currentPage + 1) * effectivePageSize)
     : sortedData;
+  const totalPages = !effectivePageSize
+    ? 1
+    : windowed
+      ? total != null
+        ? Math.max(1, Math.ceil(total / effectivePageSize))
+        : currentPage + (hasMore ? 2 : 1)
+      : Math.max(1, Math.ceil(sortedData.length / effectivePageSize));
+  const canGoNext = windowed
+    ? (total != null ? (currentPage + 1) * effectivePageSize < total : hasMore)
+    : currentPage < totalPages - 1;
+  const showPagination = effectivePageSize > 0 && (windowed
+    ? currentPage > 0 || canGoNext
+    : sortedData.length > effectivePageSize);
 
   // Reset to first page when filter/sort changes
   React.useEffect(() => {
@@ -436,6 +560,9 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   }, [filterText, sortField, sortDirection]);
 
   const handleSort = React.useCallback((field: string) => {
+    // Same-batch page reset: in windowed mode sort + page feed one fetch, so
+    // resetting here avoids an extra request against the stale page index.
+    setCurrentPage(0);
     if (sortField === field) {
       setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
     } else {
@@ -769,7 +896,12 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   const handleHeaderClick = collapsible ? () => setCollapsed((c) => !c) : undefined;
 
   const SectionIcon = resolveIconComponent(icon);
-  const isEmpty = !loading && relatedData.length === 0;
+  // Badge shows the COLLECTION size: the server total in windowed mode (only
+  // one page is in memory), the loaded row count otherwise.
+  const recordCount = windowed && total != null ? total : relatedData.length;
+  // In windowed mode an empty page beyond page 0 is a transient overflow (the
+  // step-back effect above corrects it), not an empty collection.
+  const isEmpty = !loading && relatedData.length === 0 && (!windowed || currentPage === 0);
   // When the consumer explicitly enables `filterable`, always render the
   // filter input — they're opting in. (data-table's own auto-search is
   // suppressed via the viewSchema below to avoid a duplicate input.)
@@ -796,11 +928,11 @@ export const RelatedList: React.FC<RelatedListProps> = ({
               variant="secondary"
               className={cn(
                 'text-xs font-normal h-5 px-1.5',
-                relatedData.length === 0 && 'bg-muted text-muted-foreground'
+                recordCount === 0 && 'bg-muted text-muted-foreground'
               )}
-              aria-label={`${relatedData.length} records`}
+              aria-label={`${recordCount} records`}
             >
-              {relatedData.length}
+              {recordCount}
             </Badge>
             {isEmpty && (
               <span className="text-xs text-muted-foreground/70 italic ml-1 truncate">
@@ -892,7 +1024,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
         )}
 
         {/* Pagination controls */}
-        {effectivePageSize > 0 && sortedData.length > effectivePageSize && (
+        {showPagination && (
           <div className="flex items-center justify-between mt-3 pt-3 border-t">
             <Button
               variant="outline"
@@ -911,8 +1043,8 @@ export const RelatedList: React.FC<RelatedListProps> = ({
               variant="outline"
               size="sm"
               className="h-7 text-xs gap-1"
-              disabled={currentPage >= totalPages - 1}
-              onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={!canGoNext}
+              onClick={() => setCurrentPage((p) => (canGoNext ? p + 1 : p))}
             >
               {t('detail.nextPage')}
               <ChevronRight className="h-3 w-3" />
@@ -921,7 +1053,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
         )}
 
         {/* Footer "View all" link — only when records are truncated (more than displayed) */}
-        {onViewAll && !isEmpty && effectivePageSize > 0 && sortedData.length > effectivePageSize && (
+        {onViewAll && !isEmpty && showPagination && (
           <div className="mt-3 pt-3 border-t flex justify-center">
             <button
               type="button"

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -318,6 +318,10 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   }, [api, dataSource]);
 
   React.useEffect(() => {
+    // Stale-response guard: page flips re-run this effect while an earlier
+    // window may still be in flight — a slow page-2 response must not
+    // overwrite page 3 after the fact.
+    let cancelled = false;
     // Only auto-fetch when the caller didn't pass `data` at all. If the parent
     // explicitly passed an empty array, that means "no related records" — we
     // must NOT fall back to fetching all rows of the API (which would surface
@@ -356,6 +360,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           if (orderby.length > 0) params.$orderby = orderby;
         }
         dataSource.find(api, params).then((result) => {
+          if (cancelled) return;
           const isArrayResult = Array.isArray(result);
           const items = isArrayResult
             ? (result as any[])
@@ -382,7 +387,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           setLoading(false);
         }).catch((err) => {
           console.error('Failed to fetch related data:', err);
-          setLoading(false);
+          if (!cancelled) setLoading(false);
         });
       } else {
         const qs = new URLSearchParams({
@@ -391,6 +396,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
         fetch(`${api}?${qs}`)
           .then(res => res.json())
           .then(result => {
+            if (cancelled) return;
             const items = Array.isArray(result) ? result : (result?.data || []);
             setRelatedData(items);
             setTotal(null);
@@ -399,9 +405,12 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           .catch(err => {
             console.error('Failed to fetch related data:', err);
           })
-          .finally(() => setLoading(false));
+          .finally(() => { if (!cancelled) setLoading(false); });
       }
     }
+    return () => {
+      cancelled = true;
+    };
   }, [api, dataProvided, dataSource, referenceField, parentId, refreshNonce, windowed, effectivePageSize, fetchPage, fetchSortField, fetchSortDirection, defaultSortSpec]);
 
   // Windowed mode: a page beyond the (shrunken) collection — e.g. the last
@@ -1015,12 +1024,18 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           </div>
         )}
 
-        {loading ? (
+        {loading && relatedData.length === 0 ? (
+          // Placeholder only while there's nothing to show (first load). Page
+          // flips keep the previous rows in place (slightly dimmed) until the
+          // next window arrives — swapping to a placeholder collapses the
+          // card and makes the whole related section visibly jump.
           <div className="flex items-center justify-center py-6 text-muted-foreground text-sm">
             {t('detail.loading')}
           </div>
         ) : (
-          <SchemaRenderer schema={viewSchema} />
+          <div className={cn(loading && 'opacity-60 pointer-events-none transition-opacity')}>
+            <SchemaRenderer schema={viewSchema} />
+          </div>
         )}
 
         {/* Pagination controls */}

--- a/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.speclimit.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.speclimit.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Spec-default `limit` on `record:related_list` (objectui#2711).
+ *
+ * `@objectstack/spec` declares `RecordRelatedListProps.limit` with
+ * `.default(5)` ("Number of records to display initially"), but zod defaults
+ * only materialize through a spec parse — the synthesized default record page
+ * hands the renderer raw nodes. The renderer must therefore apply the
+ * contract's default itself; without it `pageSize` stayed undefined and
+ * related lists rendered EVERY child row unpaged.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordRelatedListRenderer } from '../renderers/record-related-list';
+
+// Capture what the renderer passes down to RelatedList.
+const h = vi.hoisted(() => ({ captured: null as any }));
+vi.mock('../RelatedList', () => ({
+  RelatedList: (props: any) => {
+    h.captured = props;
+    return <div data-testid="related-list" />;
+  },
+}));
+
+const ds = { find: vi.fn(async () => []) };
+
+function renderRelated(schema: Record<string, any>) {
+  return render(
+    <RecordContextProvider objectName="account" recordId="ACC-1" dataSource={ds as any}>
+      <RecordRelatedListRenderer
+        schema={{ objectName: 'contact', relationshipField: 'account_id', ...schema }}
+      />
+    </RecordContextProvider>,
+  );
+}
+
+beforeEach(() => {
+  h.captured = null;
+});
+
+describe('RecordRelatedListRenderer — spec default limit (#2711)', () => {
+  it('applies the spec default (5) when limit is omitted', () => {
+    renderRelated({});
+    expect(h.captured).toBeTruthy();
+    expect(h.captured.pageSize).toBe(5);
+  });
+
+  it('honors an explicit authored limit', () => {
+    renderRelated({ limit: 20 });
+    expect(h.captured.pageSize).toBe(20);
+  });
+
+  it('falls back to the spec default for a non-positive limit', () => {
+    // Spec: z.number().int().positive() — 0/negative never validates, so the
+    // renderer treats it as absent rather than fossilizing "0 = show all".
+    renderRelated({ limit: 0 });
+    expect(h.captured.pageSize).toBe(5);
+  });
+
+  it('passes the schema sort through as defaultSort', () => {
+    const sort = [{ field: 'due_date', order: 'desc' as const }];
+    renderRelated({ sort });
+    expect(h.captured.defaultSort).toEqual(sort);
+  });
+});

--- a/packages/plugin-detail/src/__tests__/RelatedList.serverpagination.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.serverpagination.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Server-windowed pagination for related lists (objectui#2711).
+ *
+ * With `pageSize` set and no caller-provided `data`, RelatedList must fetch
+ * ONE page (`$top`/`$skip`) instead of the whole child collection, surface
+ * the server-reported `total` in the count badge / page indicator, turn a
+ * user column sort into a server `$orderby`, and keep the historical
+ * client-side slicing when the caller supplies `data` directly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, fireEvent, screen } from '@testing-library/react';
+import * as React from 'react';
+import { RelatedList } from '../RelatedList';
+
+// Capture the schema RelatedList hands to SchemaRenderer (the data-table).
+const h = vi.hoisted(() => ({ schema: null as any }));
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    SchemaRenderer: (props: any) => {
+      h.schema = props.schema;
+      return null;
+    },
+  };
+});
+
+const rows = (start: number, count: number) =>
+  Array.from({ length: count }, (_, i) => ({ id: `c${start + i}`, name: `Row ${start + i}` }));
+
+const columns = [{ accessorKey: 'name', header: 'Name' }];
+
+/** DataSource stub serving a 12-record collection in $top/$skip windows. */
+const makeWindowedDS = (totalRecords = 12) => ({
+  find: vi.fn(async (_api: string, params: any) => {
+    const skip = params?.$skip ?? 0;
+    const top = params?.$top ?? totalRecords;
+    return {
+      data: rows(skip, Math.max(0, Math.min(top, totalRecords - skip))),
+      total: totalRecords,
+    };
+  }),
+});
+
+const nextButton = () => screen.getByRole('button', { name: /next/i }) as HTMLButtonElement;
+const prevButton = () => screen.getByRole('button', { name: /previous/i }) as HTMLButtonElement;
+
+beforeEach(() => {
+  h.schema = null;
+});
+
+describe('RelatedList — server-windowed pagination (#2711)', () => {
+  it('fetches one $top/$skip window and shows the server total, not the page size', async () => {
+    const ds = makeWindowedDS(12);
+    render(
+      <RelatedList
+        title="Contacts"
+        type="table"
+        api="contact"
+        objectName="contact"
+        referenceField="account"
+        parentId="ACC-1"
+        pageSize={5}
+        columns={columns}
+        dataSource={ds as any}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith('contact', {
+        $filter: { account: 'ACC-1' },
+        $top: 5,
+        $skip: 0,
+      });
+    });
+    // Count badge reflects the whole collection while only one page loaded.
+    await screen.findByLabelText('12 records');
+    expect(h.schema.data).toHaveLength(5);
+    screen.getByText('Page 1 of 3');
+  });
+
+  it('pages forward and back by refetching with a new $skip', async () => {
+    const ds = makeWindowedDS(12);
+    render(
+      <RelatedList
+        title="Contacts"
+        type="table"
+        api="contact"
+        objectName="contact"
+        referenceField="account"
+        parentId="ACC-1"
+        pageSize={5}
+        columns={columns}
+        dataSource={ds as any}
+      />,
+    );
+    await screen.findByText('Page 1 of 3');
+    expect(prevButton().disabled).toBe(true);
+
+    fireEvent.click(nextButton());
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith('contact', {
+        $filter: { account: 'ACC-1' },
+        $top: 5,
+        $skip: 5,
+      });
+    });
+    await screen.findByText('Page 2 of 3');
+    expect(prevButton().disabled).toBe(false);
+
+    // Last page: 12 records / 5 per page → page 3 holds 2 rows, Next disabled.
+    fireEvent.click(nextButton());
+    await screen.findByText('Page 3 of 3');
+    expect(h.schema.data).toHaveLength(2);
+    expect(nextButton().disabled).toBe(true);
+
+    fireEvent.click(prevButton());
+    await screen.findByText('Page 2 of 3');
+  });
+
+  it('sends the declared defaultSort as the server $orderby', async () => {
+    const ds = makeWindowedDS(12);
+    render(
+      <RelatedList
+        title="Tasks"
+        type="table"
+        api="task"
+        objectName="task"
+        referenceField="project"
+        parentId="P-1"
+        pageSize={5}
+        columns={columns}
+        defaultSort={[{ field: 'due_date', order: 'desc' }]}
+        dataSource={ds as any}
+      />,
+    );
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith('task', {
+        $filter: { project: 'P-1' },
+        $top: 5,
+        $skip: 0,
+        $orderby: [{ field: 'due_date', order: 'desc' }],
+      });
+    });
+  });
+
+  it("normalizes the spec string form ('-field') of defaultSort", async () => {
+    const ds = makeWindowedDS(3);
+    render(
+      <RelatedList
+        title="Tasks"
+        type="table"
+        api="task"
+        objectName="task"
+        referenceField="project"
+        parentId="P-1"
+        pageSize={5}
+        columns={columns}
+        defaultSort="-created_at"
+        dataSource={ds as any}
+      />,
+    );
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith('task', {
+        $filter: { project: 'P-1' },
+        $top: 5,
+        $skip: 0,
+        $orderby: [{ field: 'created_at', order: 'desc' }],
+      });
+    });
+  });
+
+  it('turns a user column sort into a server $orderby from page one', async () => {
+    const ds = makeWindowedDS(12);
+    render(
+      <RelatedList
+        title="Contacts"
+        type="table"
+        api="contact"
+        objectName="contact"
+        referenceField="account"
+        parentId="ACC-1"
+        pageSize={5}
+        columns={columns}
+        sortable
+        dataSource={ds as any}
+      />,
+    );
+    await screen.findByText('Page 1 of 3');
+
+    // Move off page one first, so the sort click also proves the page reset.
+    fireEvent.click(nextButton());
+    await screen.findByText('Page 2 of 3');
+
+    fireEvent.click(screen.getByRole('button', { name: /name/i }));
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith('contact', {
+        $filter: { account: 'ACC-1' },
+        $top: 5,
+        $skip: 0,
+        $orderby: [{ field: 'name', order: 'asc' }],
+      });
+    });
+    await screen.findByText('Page 1 of 3');
+  });
+
+  it('estimates hasMore from a full page when the backend reports no total', async () => {
+    // Legacy/array-shaped backend: 7 records served as raw arrays.
+    const all = rows(0, 7);
+    const ds = {
+      find: vi.fn(async (_api: string, params: any) =>
+        all.slice(params.$skip ?? 0, (params.$skip ?? 0) + (params.$top ?? all.length)),
+      ),
+    };
+    render(
+      <RelatedList
+        title="Contacts"
+        type="table"
+        api="contact"
+        objectName="contact"
+        referenceField="account"
+        parentId="ACC-1"
+        pageSize={5}
+        columns={columns}
+        dataSource={ds as any}
+      />,
+    );
+    // Full first page → assume there may be more.
+    await screen.findByText('Page 1 of 2');
+    expect(nextButton().disabled).toBe(false);
+
+    fireEvent.click(nextButton());
+    // Second page is short (2 of 5) → no further pages.
+    await screen.findByText('Page 2 of 2');
+    expect(h.schema.data).toHaveLength(2);
+    expect(nextButton().disabled).toBe(true);
+  });
+
+  it('keeps client-side slicing when the caller supplies data directly', async () => {
+    render(
+      <RelatedList
+        title="Contacts"
+        type="table"
+        api="contact"
+        objectName="contact"
+        data={rows(0, 12)}
+        pageSize={5}
+        columns={columns}
+      />,
+    );
+    // No dataSource: everything is in memory, sliced per page.
+    screen.getByText('Page 1 of 3');
+    expect(h.schema.data).toHaveLength(5);
+    expect(h.schema.data[0].id).toBe('c0');
+
+    fireEvent.click(nextButton());
+    screen.getByText('Page 2 of 3');
+    expect(h.schema.data[0].id).toBe('c5');
+  });
+
+  it('does not window the fetch when pagination is off (pageSize unset)', async () => {
+    const ds = makeWindowedDS(3);
+    render(
+      <RelatedList
+        title="Contacts"
+        type="table"
+        api="contact"
+        objectName="contact"
+        referenceField="account"
+        parentId="ACC-1"
+        columns={columns}
+        dataSource={ds as any}
+      />,
+    );
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith('contact', { $filter: { account: 'ACC-1' } });
+    });
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -29,6 +29,15 @@ const colName = (entry: any): string | null => {
 /** Extract a record's primary key, tolerating the `id` / `_id` split. */
 const rowId = (row: any): string | number | null => row?.id ?? row?._id ?? null;
 
+/**
+ * Spec default for `RecordRelatedListProps.limit` (`.default(5)` — "Number of
+ * records to display initially"). Zod materializes defaults only when the
+ * metadata passes through a spec parse; the synthesized default record page
+ * hands us raw nodes, so the renderer enforces the contract's default itself
+ * (issue #2711 — without it related lists rendered ALL child rows unpaged).
+ */
+const SPEC_DEFAULT_LIMIT = 5;
+
 const splitDesigner = (props: Record<string, any>) => {
   const { 'data-obj-id': id, 'data-obj-type': type, style, ...rest } = props || {};
   return { designer: { 'data-obj-id': id, 'data-obj-type': type, style }, rest };
@@ -163,7 +172,12 @@ export const RecordRelatedListRenderer: React.FC<RecordRelatedListRendererProps>
         referenceField={schema.relationshipField}
         parentId={parentLinkValue as any}
         columns={filteredColumns as any}
-        pageSize={schema.limit}
+        pageSize={
+          typeof schema.limit === 'number' && schema.limit > 0
+            ? schema.limit
+            : SPEC_DEFAULT_LIMIT
+        }
+        defaultSort={schema.sort}
         dataSource={ctx?.dataSource as any}
         add={
           (schema as any).add

--- a/packages/types/src/record-components.ts
+++ b/packages/types/src/record-components.ts
@@ -90,9 +90,12 @@ export interface RecordRelatedListComponentProps {
   relationshipField: string;
   /** Columns to display in the related list */
   columns?: string[];
-  /** Sort configuration */
-  sort?: Array<{ field: string; order: 'asc' | 'desc' }>;
-  /** Maximum records to display */
+  /** Sort configuration — `'field'` / `'-field'` string or explicit array (spec union) */
+  sort?: string | Array<{ field: string; order: 'asc' | 'desc' }>;
+  /**
+   * Number of records to display per page. Spec default: 5 (the renderer
+   * applies it when the node didn't pass through a zod parse).
+   */
   limit?: number;
   /** Filter conditions */
   filter?: any;


### PR DESCRIPTION
Closes #2711

## Problem

Detail-page related lists rendered EVERY child row as one flat unpaged dump (a 114-row schedule table in production), fetched wholesale with no `$top`. The spec has always said otherwise: `RecordRelatedListProps.limit` declares `.default(5)` ("Number of records to display initially"), but no layer of the renderer chain ever applied it — the synthesized record page emits nodes without `limit`, the renderer passed `pageSize=undefined`, and RelatedList's long-implemented pagination controls never enabled (`effectivePageSize > 0` never held).

## Changes

- **Spec default enforced**: `RecordRelatedListRenderer` applies the spec default `limit` of 5 when a node doesn't declare one (zod defaults only materialize through a spec parse; synthesized pages hand the renderer raw nodes), and threads the node's `sort` through as the initial order.
- **Server-windowed fetch**: on the auto-fetch path with pagination enabled, RelatedList requests one page per flip (`$top`/`$skip`), reads the collection size from `QueryResult.total` (`hasMore` estimate as fallback) for the count badge and page indicator, and sends user column sorts as a server `$orderby` so ordering stays global across pages. An over-shot empty page (last row of the last page deleted) steps back automatically. Caller-provided `data` keeps the historical client-side slicing; the opt-in contains-filter falls back to the full-fetch client pipeline while active.
- **No-flash page flips**: the "Loading" placeholder renders only on first load; page flips keep the previous window's rows mounted (dimmed) until the next window arrives, so the related section's layout never shifts. An effect-scoped cancellation guard stops a slow earlier window from overwriting a newer page.
- **Types**: `RecordRelatedListComponentProps.sort` now mirrors the spec union (`string | array`); `limit` documents the spec default. Docs (plugin-detail README + slotted-pages guide) and a changeset included.

**Behavior change**: related lists that previously rendered all rows now show 5 per page — declare a larger `limit` on the `record:related_list` node to widen the window.

## Verification

- 12 new tests (windowed fetch contract, `$skip` paging, `defaultSort`/`$orderby`, `hasMore` fallback, client-mode regression, spec-default limit); plugin-detail 249 / types 89 / app-shell 89 all green; no new lint errors (5 pre-existing on HEAD).
- Live-verified against a fresh showcase backend with **116 child contacts** under one account: badge shows 116, "Page 1 of 24", each flip issues exactly one `top=5&skip=N` request returning 5 records + `total`, no refetch of sibling lists or the parent record, zero console errors; 3/2-row lists stay unpaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)