### PR TITLE
feat(dashboard): retire pre-ADR-0021 inline-analytics renderer branches (framework#3320)

### DIFF
--- a/.changeset/retire-dashboard-legacy-analytics-3320.md
+++ b/.changeset/retire-dashboard-legacy-analytics-3320.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/types": minor
+"@object-ui/plugin-dashboard": minor
+"@object-ui/plugin-designer": minor
+---
+
+feat(dashboard): retire the pre-ADR-0021 inline-analytics renderer branches (framework#3320)
+
+Follow-up to the dashboard analytics migration (framework#3251 / objectui#2703).
+Authoring already emits only the semantic-layer shape (`dataset` + `dimensions` +
+`values`); this removes the renderer's now-unauthored legacy read-branches.
+
+- **types**: drop the `@deprecated` inline-analytics keys (`object`,
+  `categoryField`, `categoryGranularity`, `valueField`, `aggregate`, `measures`)
+  from `DashboardWidgetSchema`. They were retained in #2703 only so the renderer
+  could read legacy/static metadata during the transition.
+- **plugin-dashboard**: `DashboardRenderer` no longer emits the object-bound
+  metric / chart / pivot / table / list branches from the top-level `object` +
+  analytics keys. It keeps the renderer-internal static paths (`options.data` /
+  `widget.data` array and the `provider: 'object'` async config) and
+  `widget.component`. The dashboard renderer no longer emits `object-pivot` /
+  `pivot` at all — dataset pivots render through `DatasetWidget` (grouped table /
+  cross-tab); the `ObjectPivotTable` / `PivotTable` components stay as public
+  SDUI blocks for other surfaces. `DashboardGridLayout` gets the same treatment.
+- **graceful fallback**: a widget that still carries the retired inline shape in
+  stored metadata (top-level `object`, no `dataset`, no inline `options.data`)
+  now renders a visible error placeholder prompting a rebind to a dataset, rather
+  than a blank chart/grid.
+- **plugin-designer**: `DashboardEditor` drops its inline object / value-field /
+  aggregate fields (analytics binding is authored via the dataset picker in
+  app-shell's `DashboardWidgetInspector` / plugin-dashboard's `WidgetConfigPanel`).

--- a/packages/plugin-dashboard/src/DashboardGridLayout.tsx
+++ b/packages/plugin-dashboard/src/DashboardGridLayout.tsx
@@ -172,26 +172,24 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
     const options = (widget.options || {}) as Record<string, any>;
     if (widgetType === 'bar' || widgetType === 'horizontal-bar' || widgetType === 'line' || widgetType === 'area' || widgetType === 'pie' || widgetType === 'donut' || widgetType === 'scatter' || widgetType === 'funnel') {
       const widgetData = (widget as any).data || options.data;
-      // Widget-level fields (from config panel) override options-level fields
-      const xAxisKey = widget.categoryField || options.xField || 'name';
-      const yField = widget.valueField || options.yField || 'value';
+      const xAxisKey = options.xField || 'name';
+      const yField = options.yField || 'value';
 
-      // provider: 'object' — delegate to ObjectChart for async data loading
+      // provider: 'object' — delegate to ObjectChart for async data loading.
+      // Field/aggregate config comes from the nested data provider (the
+      // pre-ADR-0021 top-level analytics keys were retired in framework#3320).
       if (isObjectProvider(widgetData)) {
-        // Merge widget-level fields with data provider config.
-        // Widget-level fields take precedence so that config panel
-        // edits are immediately reflected in the live preview.
         const providerAgg = widgetData.aggregate;
         const effectiveAggregate = providerAgg ? {
-          field: widget.valueField || providerAgg.field,
-          function: widget.aggregate || providerAgg.function,
-          groupBy: widget.categoryField || providerAgg.groupBy,
+          field: providerAgg.field,
+          function: providerAgg.function,
+          groupBy: providerAgg.groupBy,
         } : undefined;
         const effectiveYField = effectiveAggregate?.field || yField;
         return {
           type: 'object-chart',
           chartType: widgetType,
-          objectName: widget.object || widgetData.object,
+          objectName: widgetData.object,
           aggregate: effectiveAggregate,
           xAxisKey: xAxisKey,
           series: [{ dataKey: effectiveYField }],
@@ -200,28 +198,8 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
         };
       }
 
-      // No explicit data provider but widget has object binding
-      // (e.g. newly created widget via config panel) — build object-chart
-      if (!widgetData && widget.object) {
-        const aggregate = widget.aggregate ? {
-          field: widget.valueField || 'value',
-          function: widget.aggregate,
-          groupBy: widget.categoryField || 'name',
-        } : undefined;
-        return {
-          type: 'object-chart',
-          chartType: widgetType,
-          objectName: widget.object,
-          aggregate,
-          xAxisKey: xAxisKey,
-          series: [{ dataKey: widget.valueField || 'value' }],
-          colors: CHART_COLORS,
-          className: "h-full"
-        };
-      }
-
       const dataItems = Array.isArray(widgetData) ? widgetData : widgetData?.items || [];
-      
+
       return {
         type: 'chart',
         chartType: widgetType,
@@ -242,21 +220,8 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
         return {
           type: 'data-table',
           ...restOptions,
-          objectName: widget.object || widgetData.object,
+          objectName: widgetData.object,
           dataProvider: widgetData,
-          data: [],
-          searchable: false,
-          pagination: false,
-          className: "border-0"
-        };
-      }
-
-      // No explicit data provider but widget has object binding
-      if (!widgetData && widget.object) {
-        return {
-          type: 'data-table',
-          ...options,
-          objectName: widget.object,
           data: [],
           searchable: false,
           pagination: false,
@@ -283,7 +248,7 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
         return {
           type: 'pivot',
           ...restOptions,
-          objectName: widget.object || widgetData.object,
+          objectName: widgetData.object,
           dataProvider: widgetData,
           data: [],
         };

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -178,15 +178,30 @@ function defaultChartDrill(chartType: string): { enabled: true } | undefined {
 /**
  * Object-backed child schema types whose `filter` reaches the data source —
  * the injection surface for dashboard-level filters. Static-data widgets
- * (`chart`, `data-table`, `pivot` with inline `data`) have no query to scope
- * and are intentionally not filtered.
+ * (`chart`, `data-table` with inline `data`) have no query to scope and are
+ * intentionally not filtered.
  */
 const FILTERABLE_COMPONENT_TYPES = new Set([
   'object-chart',
   'object-metric',
   'object-data-table',
-  'object-pivot',
 ]);
+
+/**
+ * Placeholder schema for a widget that still carries the retired pre-ADR-0021
+ * inline-analytics binding — top-level `object` + `categoryField`/`valueField`/
+ * `aggregate` — with no `dataset` and no inline `options.data`. No authoring
+ * surface emits this shape anymore (framework#3320); any surviving stored
+ * metadata renders this visible error placeholder (not a blank) so an author can
+ * rebind the widget to a dataset.
+ */
+const LEGACY_RETIRED_WIDGET_SCHEMA = {
+  type: 'text',
+  value: 'This widget uses a retired data format. Edit it to bind a dataset.',
+  variant: 'caption',
+  align: 'center',
+  className: 'flex h-full w-full items-center justify-center rounded border border-dashed border-destructive/40 bg-destructive/5 p-4 text-center text-destructive',
+} as const;
 
 export interface DashboardRendererProps {
   schema: DashboardSchema;
@@ -264,38 +279,6 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
       [schema.globalFilters, schema.dateRange]
     );
     const { variables: filterValues, setVariable: setFilterValue, resetVariables: resetFilterValues } = usePageVariables();
-
-    // Metadata-aware default bindings (#2578 item 5): fetch each inline
-    // widget object's field names once so buildWidgetScopedFilter can skip a
-    // DEFAULT binding whose field doesn't exist on that object (explicit
-    // filterBindings strings are always honoured). Best-effort — while a
-    // schema is loading (or the data source can't describe objects), the
-    // entry stays absent and the previous unchecked behaviour applies.
-    const [objectFieldSets, setObjectFieldSets] = useState<Record<string, ReadonlySet<string>>>({});
-    useEffect(() => {
-      if (filterDefs.length === 0 || !dataSource || typeof (dataSource as any).getObjectSchema !== 'function') return;
-      const objects = Array.from(
-        new Set(
-          (schema.widgets ?? [])
-            .map((w: DashboardWidgetSchema) => (w as any).object)
-            .filter((o: unknown): o is string => typeof o === 'string' && o.length > 0),
-        ),
-      );
-      let cancelled = false;
-      for (const objectName of objects) {
-        (dataSource as any)
-          .getObjectSchema(objectName)
-          .then((objSchema: any) => {
-            if (cancelled) return;
-            const fields = objSchema?.fields;
-            if (!fields || typeof fields !== 'object') return;
-            setObjectFieldSets((prev) => ({ ...prev, [objectName]: new Set(Object.keys(fields)) }));
-          })
-          .catch(() => { /* stay unchecked for this object */ });
-      }
-      return () => { cancelled = true; };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [filterDefs.length, dataSource, schema.widgets]);
 
     // Build ActionDef[] from header actions so useActionEngine can dispatch by name.
     const headerActionDefs = useMemo<ActionDef[]>(() => {
@@ -498,73 +481,21 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
             // Handle Shorthand Registry Mappings
             const widgetType = widget.type;
             const options = (widget.options || {}) as Record<string, any>;
+            // Renderer-internal data sources only (ADR-0021): the inline
+            // `options.data` / `widget.data` array, or the `provider: 'object'`
+            // async config (which carries its OWN nested `object`/`aggregate`).
+            // The pre-ADR-0021 top-level analytics keys (`object`, `categoryField`,
+            // `valueField`, `aggregate`, …) are no longer read — their renderer
+            // branches were retired in framework#3320.
+            const widgetData = (widget as any).data || options.data;
 
-            // Metric widgets with object binding — delegate to ObjectMetricWidget
-            // for async data loading with proper error/loading states.
-            // Static metric options (label, value, trend, icon) are passed as
-            // fallback values that render only when no dataSource is available.
-            if (widgetType === 'metric' && widget.object) {
-                const widgetData = options.data;
-                const aggregate = isObjectProvider(widgetData) && widgetData.aggregate
-                    ? {
-                        field: widget.valueField || widgetData.aggregate.field,
-                        function: widget.aggregate || widgetData.aggregate.function,
-                        // Prefer explicit categoryField or aggregate.groupBy; otherwise, default to a single bucket.
-                        groupBy: widget.categoryField ?? widgetData.aggregate.groupBy ?? '_all',
-                    }
-                    : widget.aggregate ? {
-                        field: widget.valueField || 'value',
-                        function: widget.aggregate,
-                        // Default to a single group unless the user explicitly configures a categoryField.
-                        groupBy: widget.categoryField || '_all',
-                    } : undefined;
-
-                return {
-                    type: 'object-metric',
-                    objectName: widget.object || (isObjectProvider(widgetData) ? widgetData.object : undefined),
-                    aggregate,
-                    filter: (isObjectProvider(widgetData) ? widgetData.filter : undefined) || widget.filter,
-                    label: options.label || tWidgetTitle(widget) || '',
-                    fallbackValue: options.value,
-                    trend: options.trend,
-                    icon: options.icon,
-                    description: options.description,
-                    colorVariant: (widget as any).colorVariant,
-                    format: options.format,
-                    currency: options.currency,
-                    prefix: options.prefix,
-                    suffix: options.suffix,
-                    drillDown: options.drillDown ?? { enabled: true },
-                    title: options.label || tWidgetTitle(widget) || '',
-                    compareTo: (widget as any).compareTo,
-                };
-            }
-
-            // gauge / solid-gauge / kpi / bullet with object binding → render as
-            // object-metric (all are a single aggregated value, optionally vs a target).
-            if (METRIC_LIKE_TYPES.has(widgetType || '') && widget.object) {
-                const aggregate = widget.aggregate ? {
-                    field: widget.valueField || 'value',
-                    function: widget.aggregate,
-                    groupBy: widget.categoryField || '_all',
-                } : undefined;
-                return {
-                    type: 'object-metric',
-                    objectName: widget.object,
-                    aggregate,
-                    filter: widget.filter,
-                    label: options.label || tWidgetTitle(widget) || '',
-                    fallbackValue: options.fallbackValue ?? options.value,
-                    icon: options.icon,
-                    description: options.description,
-                    colorVariant: (widget as any).colorVariant,
-                    format: options.format,
-                    currency: options.currency,
-                    prefix: options.prefix,
-                    suffix: options.suffix,
-                    invert: options.invert,
-                    compareTo: (widget as any).compareTo,
-                };
+            // Retired legacy inline-analytics widget (framework#3320): still carries
+            // the pre-ADR-0021 top-level `object` binding with no `dataset` and no
+            // inline `options.data`. No authoring surface emits this anymore, so it
+            // is stale stored metadata — render a visible error placeholder (not a
+            // blank) prompting a rebind to a dataset.
+            if (!widgetData && (widget as any).object) {
+                return LEGACY_RETIRED_WIDGET_SCHEMA;
             }
 
             // Normalize spec-level chart families onto a renderer-supported base
@@ -573,44 +504,29 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
             const resolvedWidgetType = (widgetType && CHART_TYPE_ALIASES[widgetType]) || widgetType;
 
             if (resolvedWidgetType && SUPPORTED_CHART_TYPES.has(resolvedWidgetType)) {
-                // Support data at widget level or nested inside options
-                const widgetData = (widget as any).data || options.data;
-                // Widget-level fields (from config panel) override options-level fields
-                const xAxisKey = widget.categoryField || options.xField || 'name';
-                const yField = widget.valueField || options.yField || 'value';
+                const xAxisKey = options.xField || 'name';
+                const yField = options.yField || 'value';
 
-                // provider: 'object' — delegate to ObjectChart for async data loading
+                // provider: 'object' — delegate to ObjectChart for async data loading.
+                // Field/aggregate config comes from the nested data provider.
                 if (isObjectProvider(widgetData)) {
-                    // Merge widget-level fields with data provider config.
-                    // Widget-level fields take precedence so that config panel
-                    // edits are immediately reflected in the live preview.
                     const providerAgg = widgetData.aggregate;
-                    const effectiveGroupBy = (() => {
-                        const baseField = widget.categoryField || providerAgg?.groupBy;
-                        if (!baseField) return undefined;
-                        if (widget.categoryGranularity && typeof baseField === 'string') {
-                            // Structured GroupBy node — engine date-buckets it server-side.
-                            return { field: baseField, dateGranularity: widget.categoryGranularity } as any;
-                        }
-                        return baseField;
-                    })();
                     const effectiveAggregate = providerAgg ? {
-                        field: widget.valueField || providerAgg.field,
-                        function: widget.aggregate || providerAgg.function,
-                        groupBy: effectiveGroupBy,
+                        field: providerAgg.field,
+                        function: providerAgg.function,
+                        groupBy: providerAgg.groupBy,
                     } : undefined;
                     const effectiveYField = effectiveAggregate?.field || yField;
-                    const objectForLabel = widget.object || widgetData.object;
                     return {
                         type: 'object-chart',
                         chartType: resolvedWidgetType,
-                        objectName: objectForLabel,
+                        objectName: widgetData.object,
                         aggregate: effectiveAggregate,
                         filter: widgetData.filter || widget.filter,
                         xAxisKey: xAxisKey,
                         series: [{
                             dataKey: effectiveYField,
-                            label: resolveSeriesLabel(objectForLabel, effectiveYField, effectiveAggregate?.function),
+                            label: resolveSeriesLabel(widgetData.object, effectiveYField, effectiveAggregate?.function),
                         }],
                         colors: CHART_COLORS,
                         drillDown: options.drillDown ?? defaultChartDrill(resolvedWidgetType),
@@ -619,36 +535,9 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                     };
                 }
 
-                // No explicit data provider but widget has object binding
-                // (e.g. newly created widget via config panel) — build object-chart
-                if (!widgetData && widget.object) {
-                    const baseField = widget.categoryField || 'name';
-                    const structuredGroupBy = widget.categoryGranularity
-                        ? ({ field: baseField, dateGranularity: widget.categoryGranularity } as any)
-                        : baseField;
-                    const aggregate = widget.aggregate ? {
-                        field: widget.valueField || 'value',
-                        function: widget.aggregate,
-                        groupBy: structuredGroupBy,
-                    } : undefined;
-                    const yKey = widget.valueField || 'value';
-                    return {
-                        type: 'object-chart',
-                        chartType: resolvedWidgetType,
-                        objectName: widget.object,
-                        aggregate,
-                        filter: widget.filter,
-                        xAxisKey: xAxisKey,
-                        series: [{ dataKey: yKey, label: resolveSeriesLabel(widget.object, yKey, widget.aggregate) }],
-                        colors: CHART_COLORS,
-                        drillDown: options.drillDown ?? defaultChartDrill(resolvedWidgetType),
-                        compareTo: (widget as any).compareTo,
-                        className: "h-[200px] sm:h-[250px] md:h-[300px]"
-                    };
-                }
-
+                // Static inline data array.
                 const dataItems = Array.isArray(widgetData) ? widgetData : widgetData?.items || [];
-                
+
                 return {
                     type: 'chart',
                     chartType: resolvedWidgetType,
@@ -656,7 +545,7 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                     xAxisKey: xAxisKey,
                     series: [{
                         dataKey: yField,
-                        label: resolveSeriesLabel(widget.object, yField, widget.aggregate),
+                        label: resolveSeriesLabel(undefined, yField, undefined),
                     }],
                     colors: CHART_COLORS,
                     className: "h-[200px] sm:h-[250px] md:h-[300px]"
@@ -664,47 +553,24 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
             }
 
             if (widgetType === 'table') {
-                // Support data at widget level or nested inside options
-                const widgetData = (widget as any).data || options.data;
-
-                // Default-on drill-to-record for object-backed tables: clicking a
-                // row opens that record in a detail drawer. Static (data-array)
-                // tables stay opt-in (no object to fetch the record's schema from).
-                const isObjectTable = isObjectProvider(widgetData) || (!widgetData && !!widget.object);
-                const tableDrill = isObjectTable
-                    ? (options.drillDown ?? { enabled: true, mode: 'record' as const })
-                    : undefined;
-
-                // provider: 'object' — use ObjectDataTable for async data loading
+                // provider: 'object' — use ObjectDataTable for async data loading.
+                // Default-on drill-to-record: a click opens the record in a drawer.
                 if (isObjectProvider(widgetData)) {
                     const { data: _data, ...restOptions } = options;
                     return {
                         type: 'object-data-table',
                         ...restOptions,
-                        objectName: widget.object || widgetData.object,
+                        objectName: widgetData.object,
                         dataProvider: widgetData,
                         filter: widgetData.filter || widget.filter,
                         searchable: widget.searchable ?? false,
                         pagination: widget.pagination ?? false,
-                        drillDown: tableDrill,
+                        drillDown: options.drillDown ?? { enabled: true, mode: 'record' as const },
                         className: "border-0"
                     };
                 }
 
-                // No explicit data provider but widget has object binding
-                if (!widgetData && widget.object) {
-                    return {
-                        type: 'object-data-table',
-                        ...options,
-                        objectName: widget.object,
-                        filter: widget.filter,
-                        searchable: widget.searchable ?? false,
-                        pagination: widget.pagination ?? false,
-                        drillDown: tableDrill,
-                        className: "border-0"
-                    };
-                }
-
+                // Static (data-array) table — drill-to-record stays opt-in.
                 return {
                     type: 'data-table',
                     ...options,
@@ -715,101 +581,33 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                 };
             }
 
+            // Pivot widgets are authored as dataset-bound (ADR-0021) and render via
+            // DatasetWidget (a grouped table / cross-tab). The dashboard renderer no
+            // longer emits the `object-pivot` / `pivot` blocks (framework#3320); the
+            // ObjectPivotTable / PivotTable components remain public SDUI blocks for
+            // other surfaces. A non-dataset pivot reaching here is stale metadata —
+            // show the retired placeholder rather than a blank grid.
             if (widgetType === 'pivot') {
-                const widgetData = (widget as any).data || options.data;
-                // Pivot config can live either at widget top-level (when edited
-                // through WidgetConfigPanel) or under widget.options (static
-                // metadata).  Top-level wins so live edits are reflected.
-                const w = widget as any;
-                const pivotProps = {
-                    rowField: w.rowField ?? options.rowField,
-                    columnField: w.columnField ?? options.columnField,
-                    valueField: w.valueField ?? options.valueField,
-                    aggregation: w.aggregation ?? options.aggregation ?? 'sum',
-                    showRowTotals: w.showRowTotals ?? options.showRowTotals,
-                    showColumnTotals: w.showColumnTotals ?? options.showColumnTotals,
-                    format: w.format ?? options.format,
-                };
-
-                // Phase-1 default-on policy: object-backed pivot tables enable
-                // drill-down by default. Authors can disable explicitly with
-                // `drillDown: { enabled: false }` on widget options. Static
-                // (data-array) pivots stay opt-in because we cannot derive a
-                // server-side filter for them.
-                const isObjectPivot = isObjectProvider(widgetData) || (!widgetData && !!widget.object);
-                const pivotOptions = (isObjectPivot && options.drillDown === undefined)
-                    ? { ...options, drillDown: { enabled: true } }
-                    : options;
-
-                // provider: 'object' — use ObjectPivotTable for async data loading
-                if (isObjectProvider(widgetData)) {
-                    const { data: _data, ...restOptions } = pivotOptions;
-                    return {
-                        type: 'object-pivot',
-                        ...restOptions,
-                        ...pivotProps,
-                        objectName: widget.object || widgetData.object,
-                        dataProvider: widgetData,
-                        filter: widgetData.filter || widget.filter,
-                    };
-                }
-
-                // No explicit data provider but widget has object binding
-                if (!widgetData && widget.object) {
-                    return {
-                        type: 'object-pivot',
-                        ...pivotOptions,
-                        ...pivotProps,
-                        objectName: widget.object,
-                        filter: widget.filter,
-                    };
-                }
-
-                return {
-                    type: 'pivot',
-                    ...options,
-                    ...pivotProps,
-                    data: Array.isArray(widgetData) ? widgetData : widgetData?.items || [],
-                };
+                return LEGACY_RETIRED_WIDGET_SCHEMA;
             }
 
             // List widget — render as a compact rows-only data table.
             // List shares table semantics (raw records) but typically without
             // search / pagination chrome.
             if (widgetType === 'list') {
-                const widgetData = (widget as any).data || options.data;
-
-                // Default-on drill-to-record for object-backed lists (same policy
-                // as the table widget — a list row is a record).
-                const isObjectList = isObjectProvider(widgetData) || (!widgetData && !!widget.object);
-                const listDrill = isObjectList
-                    ? (options.drillDown ?? { enabled: true, mode: 'record' as const })
-                    : undefined;
-
+                // provider: 'object' — default-on drill-to-record (a list row is a
+                // record), same policy as the table widget.
                 if (isObjectProvider(widgetData)) {
                     const { data: _data, ...restOptions } = options;
                     return {
                         type: 'object-data-table',
                         ...restOptions,
-                        objectName: widget.object || widgetData.object,
+                        objectName: widgetData.object,
                         dataProvider: widgetData,
                         filter: widgetData.filter || widget.filter,
                         searchable: false,
                         pagination: false,
-                        drillDown: listDrill,
-                        className: "border-0",
-                    };
-                }
-
-                if (!widgetData && widget.object) {
-                    return {
-                        type: 'object-data-table',
-                        ...options,
-                        objectName: widget.object,
-                        filter: widget.filter,
-                        searchable: false,
-                        pagination: false,
-                        drillDown: listDrill,
+                        drillDown: options.drillDown ?? { enabled: true, mode: 'record' as const },
                         className: "border-0",
                     };
                 }
@@ -862,12 +660,7 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
         // schemas re-fetch on filter change, so no widget renderer changes
         // are needed downstream.
         const scopedFilter = filterDefs.length > 0
-            ? buildWidgetScopedFilter(
-                widget,
-                filterDefs,
-                filterValues,
-                typeof (widget as any).object === 'string' ? objectFieldSets[(widget as any).object] : undefined,
-              )
+            ? buildWidgetScopedFilter(widget, filterDefs, filterValues)
             : undefined;
         const componentSchema = (() => {
             const cs = getComponentSchema() as Record<string, any>;

--- a/packages/plugin-dashboard/src/__tests__/DashboardRenderer.filters.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardRenderer.filters.test.tsx
@@ -9,116 +9,127 @@
 /**
  * Dashboard-level filter broadcast (framework#2501).
  *
- * The widget child components (`object-chart`, …) are stubbed in the REAL
- * component registry so the real SchemaRenderer resolves them and each stub
- * surfaces its resolved `filter` as a DOM attribute — the page-variables
- * provider, filter bar, binding resolution, and $and merge all run for real.
+ * ADR-0021: widgets bind a semantic-layer `dataset` and render through
+ * DatasetWidget, which forwards the widget's EFFECTIVE `filter` (its own filter
+ * AND the dashboard broadcast, resolved through the same bindings + `$and` merge)
+ * to `dataSource.queryDataset` as `runtimeFilter`. We assert that call so the
+ * page-variables provider, filter bar, binding resolution, and merge all run for
+ * real. Date macros (`{today}`, `{30_days_ago}`) are resolved client-side before
+ * the query, so date-range assertions check the SHAPE, not the literal tokens.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import type { DashboardSchema } from '@object-ui/types';
-import { ComponentRegistry } from '@object-ui/core';
 import { DashboardRenderer } from '../DashboardRenderer';
-
-const FilterProbe = ({ schema }: { schema: any }) => (
-  <div
-    data-testid={`widget-schema-${schema?.objectName ?? schema?.type}`}
-    data-filter={JSON.stringify(schema?.filter ?? null)}
-  />
-);
-ComponentRegistry.register('object-chart', FilterProbe);
-ComponentRegistry.register('object-metric', FilterProbe);
 
 afterEach(cleanup);
 
-const widgetFilter = (objectName: string) => {
-  const el = screen.getByTestId(`widget-schema-${objectName}`);
-  return JSON.parse(el.getAttribute('data-filter')!);
+/** A dataset data source that records every `queryDataset` call. */
+const makeQueryDataset = () => vi.fn(async () => ({ rows: [{ count: 1 }], fields: [] }));
+
+/** The `runtimeFilter` of the LAST `queryDataset` call for a given dataset. */
+const lastRuntimeFilter = (
+  queryDataset: ReturnType<typeof makeQueryDataset>,
+  dataset: string,
+): unknown => {
+  const calls = queryDataset.mock.calls.filter((c) => c[0] === dataset);
+  if (calls.length === 0) return undefined;
+  return (calls[calls.length - 1][1] as { runtimeFilter?: unknown })?.runtimeFilter;
 };
 
 describe('DashboardRenderer dashboard-level filters', () => {
-  it('renders no filter bar when the schema declares no filters', () => {
+  it('renders no filter bar when the schema declares no filters', async () => {
+    const queryDataset = makeQueryDataset();
     const schema: DashboardSchema = {
       type: 'dashboard',
-      widgets: [{ id: 'w1', type: 'bar', object: 'invoices', aggregate: 'count' }],
+      widgets: [{ id: 'w1', type: 'bar', dataset: 'invoices', values: ['count'] }],
     };
-    render(<DashboardRenderer schema={schema} />);
+    render(<DashboardRenderer schema={schema} dataSource={{ queryDataset }} />);
     expect(screen.queryByTestId('dashboard-filter-bar')).not.toBeInTheDocument();
-    expect(widgetFilter('invoices')).toBeNull();
+    await waitFor(() => expect(queryDataset).toHaveBeenCalledWith('invoices', expect.anything()));
+    expect(lastRuntimeFilter(queryDataset, 'invoices')).toBeUndefined();
   });
 
-  it('broadcasts the default date range into each widget via its own bound field', () => {
+  it('broadcasts the default date range into each widget via its own bound field', async () => {
+    const queryDataset = makeQueryDataset();
     const schema: DashboardSchema = {
       type: 'dashboard',
       dateRange: { field: 'created_at', defaultRange: 'last_30_days', allowCustomRange: true },
       widgets: [
         // Default binding → dateRange.field (created_at).
-        { id: 'w1', type: 'bar', object: 'invoices', aggregate: 'count' },
+        { id: 'w1', type: 'bar', dataset: 'invoices', values: ['count'] },
         // Explicit per-widget override → this widget's own field.
-        { id: 'w2', type: 'line', object: 'accounts', aggregate: 'count', filterBindings: { dateRange: 'signed_at' } },
+        { id: 'w2', type: 'line', dataset: 'accounts', values: ['count'], filterBindings: { dateRange: 'signed_at' } },
       ],
     };
-    render(<DashboardRenderer schema={schema} />);
+    render(<DashboardRenderer schema={schema} dataSource={{ queryDataset }} />);
 
     expect(screen.getByTestId('dashboard-filter-bar')).toBeInTheDocument();
-    expect(widgetFilter('invoices')).toEqual({
-      created_at: { $gte: '{30_days_ago}', $lte: '{today}' },
-    });
-    expect(widgetFilter('accounts')).toEqual({
-      signed_at: { $gte: '{30_days_ago}', $lte: '{today}' },
+    await waitFor(() => {
+      expect(lastRuntimeFilter(queryDataset, 'invoices')).toEqual({
+        created_at: { $gte: expect.any(String), $lte: expect.any(String) },
+      });
+      expect(lastRuntimeFilter(queryDataset, 'accounts')).toEqual({
+        signed_at: { $gte: expect.any(String), $lte: expect.any(String) },
+      });
     });
   });
 
-  it('merges the broadcast with a widget\'s own filter and honors opt-out', () => {
+  it('merges the broadcast with a widget\'s own filter and honors opt-out', async () => {
+    const queryDataset = makeQueryDataset();
     const schema: DashboardSchema = {
       type: 'dashboard',
       globalFilters: [
         { name: 'region', field: 'region', type: 'select', options: ['EMEA', 'APAC'], defaultValue: 'EMEA' },
       ],
       widgets: [
-        { id: 'w1', type: 'bar', object: 'invoices', aggregate: 'count', filter: { status: 'paid' } },
-        { id: 'w2', type: 'pie', object: 'accounts', aggregate: 'count', filterBindings: { region: false } },
+        { id: 'w1', type: 'bar', dataset: 'invoices', values: ['count'], filter: { status: 'paid' } },
+        { id: 'w2', type: 'pie', dataset: 'accounts', values: ['count'], filterBindings: { region: false } },
       ],
     };
-    render(<DashboardRenderer schema={schema} />);
+    render(<DashboardRenderer schema={schema} dataSource={{ queryDataset }} />);
 
     // Widget filter AND dashboard filter.
-    expect(widgetFilter('invoices')).toEqual({
-      $and: [{ status: 'paid' }, { region: 'EMEA' }],
+    await waitFor(() => {
+      expect(lastRuntimeFilter(queryDataset, 'invoices')).toEqual({
+        $and: [{ status: 'paid' }, { region: 'EMEA' }],
+      });
     });
-    // Opted out — own (absent) filter untouched.
-    expect(widgetFilter('accounts')).toBeNull();
+    // Opted out — own (absent) filter untouched, so no runtimeFilter.
+    expect(lastRuntimeFilter(queryDataset, 'accounts')).toBeUndefined();
   });
 
   it('re-scopes all bound widgets live when a filter value changes', async () => {
+    const queryDataset = makeQueryDataset();
     const schema: DashboardSchema = {
       type: 'dashboard',
       globalFilters: [{ name: 'q', field: 'name', type: 'text', label: 'Search' }],
       widgets: [
-        { id: 'w1', type: 'bar', object: 'invoices', aggregate: 'count' },
-        { id: 'w2', type: 'line', object: 'accounts', aggregate: 'count', filterBindings: { q: 'title' } },
+        { id: 'w1', type: 'bar', dataset: 'invoices', values: ['count'] },
+        { id: 'w2', type: 'line', dataset: 'accounts', values: ['count'], filterBindings: { q: 'title' } },
       ],
     };
-    render(<DashboardRenderer schema={schema} />);
+    render(<DashboardRenderer schema={schema} dataSource={{ queryDataset }} />);
 
-    expect(widgetFilter('invoices')).toBeNull();
+    await waitFor(() => expect(queryDataset).toHaveBeenCalledWith('invoices', expect.anything()));
+    expect(lastRuntimeFilter(queryDataset, 'invoices')).toBeUndefined();
 
     const input = screen.getByTestId('dashboard-filter-q');
     fireEvent.change(input, { target: { value: 'acme' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
     await waitFor(() => {
-      expect(widgetFilter('invoices')).toEqual({ name: { $contains: 'acme' } });
-      expect(widgetFilter('accounts')).toEqual({ title: { $contains: 'acme' } });
+      expect(lastRuntimeFilter(queryDataset, 'invoices')).toEqual({ name: { $contains: 'acme' } });
+      expect(lastRuntimeFilter(queryDataset, 'accounts')).toEqual({ title: { $contains: 'acme' } });
     });
 
     // Clearing the value removes the broadcast again.
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     await waitFor(() => {
-      expect(widgetFilter('invoices')).toBeNull();
-      expect(widgetFilter('accounts')).toBeNull();
+      expect(lastRuntimeFilter(queryDataset, 'invoices')).toBeUndefined();
+      expect(lastRuntimeFilter(queryDataset, 'accounts')).toBeUndefined();
     });
   });
 

--- a/packages/plugin-dashboard/src/__tests__/DashboardRenderer.legacyRetired.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardRenderer.legacyRetired.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Graceful fallback for retired pre-ADR-0021 inline-analytics widgets
+ * (framework#3320). The renderer no longer emits the object-bound
+ * metric/chart/pivot/table/list branches. A widget that still carries the
+ * inline shape in stored metadata — top-level `object` (+ `categoryField` /
+ * `valueField` / `aggregate`), no `dataset`, no inline `options.data` — must
+ * render a VISIBLE error placeholder prompting a rebind, not a blank widget.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { DashboardSchema } from '@object-ui/types';
+import { DashboardRenderer } from '../DashboardRenderer';
+
+afterEach(cleanup);
+
+describe('DashboardRenderer retired legacy widgets', () => {
+  // `object` is no longer part of DashboardWidgetSchema — cast to mimic stored
+  // legacy metadata that predates the ADR-0021 dataset shape.
+  const legacyWidget = (extra: Record<string, unknown>) => ({ id: 'w1', ...extra } as any);
+
+  it.each([
+    ['chart', { type: 'bar', object: 'invoices', categoryField: 'month', valueField: 'amount', aggregate: 'sum' }],
+    ['metric', { type: 'metric', object: 'invoices', aggregate: 'count' }],
+    ['pivot', { type: 'pivot', object: 'invoices', rowField: 'region', valueField: 'amount' }],
+    ['table', { type: 'table', object: 'invoices' }],
+  ])('renders a visible placeholder for a legacy %s widget', (_kind, widget) => {
+    const schema: DashboardSchema = { type: 'dashboard', widgets: [legacyWidget(widget)] };
+    render(<DashboardRenderer schema={schema} />);
+    expect(screen.getByText(/retired data format/i)).toBeInTheDocument();
+  });
+
+  it('does NOT show the placeholder for a dataset-bound widget', () => {
+    const schema: DashboardSchema = {
+      type: 'dashboard',
+      widgets: [{ id: 'w1', type: 'bar', dataset: 'invoices', values: ['count'] }],
+    };
+    render(<DashboardRenderer schema={schema} dataSource={{ queryDataset: async () => ({ rows: [] }) }} />);
+    expect(screen.queryByText(/retired data format/i)).not.toBeInTheDocument();
+  });
+
+  it('does NOT show the placeholder for a static options.data widget', () => {
+    const schema: DashboardSchema = {
+      type: 'dashboard',
+      widgets: [{ id: 'w1', type: 'bar', options: { data: [{ name: 'A', value: 1 }] } }],
+    };
+    render(<DashboardRenderer schema={schema} />);
+    expect(screen.queryByText(/retired data format/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/plugin-designer/src/DashboardEditor.tsx
+++ b/packages/plugin-designer/src/DashboardEditor.tsx
@@ -181,11 +181,6 @@ function WidgetCard({
         <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600">
           {meta.label}
         </span>
-        {widget.object && (
-          <span className="text-[10px] text-gray-400">
-            {widget.object}
-          </span>
-        )}
       </div>
     </div>
   );
@@ -257,54 +252,10 @@ function WidgetPropertyPanel({
         </select>
       </div>
 
-      {/* Data source */}
-      <div className="space-y-1">
-        <label htmlFor="widget-object" className="text-xs font-medium text-gray-600">Data Source (Object)</label>
-        <input
-          id="widget-object"
-          data-testid="widget-prop-object"
-          type="text"
-          value={widget.object ?? ''}
-          onChange={(e) => onChange({ object: e.target.value })}
-          disabled={readOnly}
-          placeholder="e.g. orders"
-          className="block w-full rounded-md border border-gray-300 px-2.5 py-1.5 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50"
-        />
-      </div>
-
-      {/* Value field */}
-      <div className="space-y-1">
-        <label htmlFor="widget-value-field" className="text-xs font-medium text-gray-600">Value Field</label>
-        <input
-          id="widget-value-field"
-          data-testid="widget-prop-value-field"
-          type="text"
-          value={widget.valueField ?? ''}
-          onChange={(e) => onChange({ valueField: e.target.value })}
-          disabled={readOnly}
-          placeholder="e.g. amount"
-          className="block w-full rounded-md border border-gray-300 px-2.5 py-1.5 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50"
-        />
-      </div>
-
-      {/* Aggregate */}
-      <div className="space-y-1">
-        <label htmlFor="widget-aggregate" className="text-xs font-medium text-gray-600">Aggregate</label>
-        <select
-          id="widget-aggregate"
-          data-testid="widget-prop-aggregate"
-          value={widget.aggregate ?? 'count'}
-          onChange={(e) => onChange({ aggregate: e.target.value })}
-          disabled={readOnly}
-          className="block w-full rounded-md border border-gray-300 px-2.5 py-1.5 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50"
-        >
-          <option value="count">Count</option>
-          <option value="sum">Sum</option>
-          <option value="avg">Average</option>
-          <option value="min">Min</option>
-          <option value="max">Max</option>
-        </select>
-      </div>
+      {/* Analytics binding (data source / dimensions / measures) is authored via
+          the dataset picker in app-shell's DashboardWidgetInspector / plugin-
+          dashboard's WidgetConfigPanel. The pre-ADR-0021 inline object /
+          valueField / aggregate fields were retired in framework#3320. */}
 
       {/* Color variant */}
       <div className="space-y-1">

--- a/packages/types/src/__tests__/p1-spec-alignment.test.ts
+++ b/packages/types/src/__tests__/p1-spec-alignment.test.ts
@@ -307,20 +307,18 @@ describe('P1.2 FormView Spec Alignment', () => {
 // P1.3 Dashboard Spec Alignment
 // ============================================================================
 describe('P1.3 Dashboard Spec Alignment', () => {
-  it('should accept widget data binding properties', () => {
+  it('should accept widget dataset binding properties (ADR-0021)', () => {
     const widget: DashboardWidgetSchema = {
       type: 'bar-chart',
       title: 'Revenue by Region',
-      object: 'Opportunity',
       filter: [['stage', '=', 'Closed Won']],
-      categoryField: 'region',
-      valueField: 'amount',
-      aggregate: 'sum',
+      dataset: 'opportunity_metrics',
+      dimensions: ['region'],
+      values: ['amount'],
     };
-    expect(widget.object).toBe('Opportunity');
-    expect(widget.categoryField).toBe('region');
-    expect(widget.valueField).toBe('amount');
-    expect(widget.aggregate).toBe('sum');
+    expect(widget.dataset).toBe('opportunity_metrics');
+    expect(widget.dimensions).toEqual(['region']);
+    expect(widget.values).toEqual(['amount']);
   });
 
   it('should accept widget color variants', () => {
@@ -337,17 +335,16 @@ describe('P1.3 Dashboard Spec Alignment', () => {
     });
   });
 
-  it('should accept widget measures (pivot/matrix)', () => {
+  it('should accept dataset-bound pivot widgets (matrix)', () => {
     const widget: DashboardWidgetSchema = {
       type: 'pivot',
       title: 'Sales Matrix',
-      measures: [
-        { valueField: 'amount', aggregate: 'sum', label: 'Total Sales', format: '$0,0' },
-        { valueField: 'count', aggregate: 'count', label: 'Deal Count' },
-      ],
+      dataset: 'sales_metrics',
+      dimensions: ['region', 'quarter'],
+      values: ['total_amount', 'deal_count'],
     };
-    expect(widget.measures).toHaveLength(2);
-    expect(widget.measures![0].label).toBe('Total Sales');
+    expect(widget.values).toEqual(['total_amount', 'deal_count']);
+    expect(widget.dimensions).toHaveLength(2);
   });
 
   it('should accept globalFilters with optionsFrom', () => {

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -709,44 +709,6 @@ export interface DashboardWidgetSchema {
    */
   filter?: any;
   /**
-   * @deprecated Pre-ADR-0021 inline single-object query. Removed from the
-   * authorable spec at @objectstack/spec 9.0.0 and no longer emitted by any
-   * Studio surface — bind a `dataset` instead. Retained here only so the
-   * renderer can still read legacy/static widget metadata during the
-   * transition; will be removed once renderer legacy branches are retired.
-   */
-  object?: string;
-  /**
-   * @deprecated Pre-ADR-0021 inline analytics key — use `dataset` +
-   * `dimensions`. See `object`.
-   */
-  categoryField?: string;
-  /**
-   * @deprecated Pre-ADR-0021 inline analytics key — the bound dataset's
-   * dimension declares its own `dateGranularity`. See `object`.
-   */
-  categoryGranularity?: 'day' | 'week' | 'month' | 'quarter' | 'year';
-  /**
-   * @deprecated Pre-ADR-0021 inline analytics key — use `dataset` + `values`.
-   * See `object`.
-   */
-  valueField?: string;
-  /**
-   * @deprecated Pre-ADR-0021 inline analytics key — the bound dataset's
-   * measure declares its own `aggregate`. See `object`.
-   */
-  aggregate?: string;
-  /**
-   * @deprecated Pre-ADR-0021 inline pivot measures — use `dataset` + `values`.
-   * See `object`.
-   */
-  measures?: Array<{
-    valueField: string;
-    aggregate: string;
-    label?: string;
-    format?: string;
-  }>;
-  /**
    * Responsive configuration per breakpoint.
    * Aligned with @objectstack/spec DashboardWidgetSchema.responsive.
    */

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -88,6 +88,8 @@ const heavyDomTests = [
   'packages/components/src/__tests__/page-header-title.test.tsx',
   'packages/plugin-calendar/src/registration.test.tsx',
   'packages/plugin-dashboard/src/__tests__/DashboardRenderer.designMode.test.tsx',
+  'packages/plugin-dashboard/src/__tests__/DashboardRenderer.filters.test.tsx',
+  'packages/plugin-dashboard/src/__tests__/DashboardRenderer.legacyRetired.test.tsx',
   'packages/plugin-kanban/src/registration.test.tsx',
 ];
 


### PR DESCRIPTION
Follow-up to the dashboard analytics migration (framework#3251 · objectui#2703 · strict flip #3316). Authoring already emits only the semantic-layer shape (`dataset` + `dimensions` + `values`); this retires the renderer's now-unauthored legacy read-branches and drops the `@deprecated` type keys.

Closes objectstack-ai/framework#3320.

## Precondition audit (the blocking item) — clean
No traceable producer still emits the inline-analytics keys:
- **framework** examples (`app-crm`, `app-todo`, `app-showcase`) + the `system_overview` platform built-in: 100% `dataset`-shaped, zero legacy widget keys.
- **cloud**: no stored `.dashboard.ts`; the AI-studio blueprint emitter produces `dataset`/`dimensions`/`values`.
- Runtime customer-stored metadata is not code-visible → covered by the visible-placeholder fallback below.
- **New finding:** `plugin-designer/DashboardEditor.tsx` was a *live* authoring surface that #2703 missed (still emitted inline `object`/`valueField`/`aggregate`). Its legacy fields are stripped here so it stops producing legacy keys.

## Changes
- **types**: drop the `@deprecated` inline-analytics keys (`object`, `categoryField`, `categoryGranularity`, `valueField`, `aggregate`, `measures`) from `DashboardWidgetSchema`.
- **plugin-dashboard**: `DashboardRenderer` no longer emits the object-bound metric/chart/pivot/table/list branches; removes the `object`-keyed `objectFieldSets` machinery. It **keeps** the renderer-internal static paths (`options.data`/`widget.data` array + `provider:'object'`) and `widget.component`. It no longer emits `object-pivot`/`pivot` — dataset pivots render via `DatasetWidget` (grouped table / cross-tab); `ObjectPivotTable`/`PivotTable` stay as public SDUI blocks. `DashboardGridLayout` gets the same treatment.
- **graceful fallback**: a widget still carrying the retired inline shape (top-level `object`, no `dataset`, no inline `options.data`) now renders a **visible error placeholder** prompting a rebind to a dataset, rather than a blank.
- **plugin-designer**: `DashboardEditor` drops its inline object / value-field / aggregate fields (analytics binding is authored via the dataset picker in app-shell's `DashboardWidgetInspector` / plugin-dashboard's `WidgetConfigPanel`).
- **tests**: migrate `p1-spec-alignment` + `DashboardRenderer.filters` fixtures to the dataset shape (filters now asserts `DatasetWidget`'s `queryDataset` `runtimeFilter`); add `DashboardRenderer.legacyRetired` covering the placeholder + the kept static/dataset paths.

## Two judgment calls for review
1. **`table`/`list` object-bound branches retired too** — beyond checkbox‑1's literal enumeration (metric/chart/pivot), but forced by dropping `object` from the type. Capability is preserved via `options.data` `provider:'object'` + `DatasetWidget`; the placeholder catches stale metadata.
2. **Static `pivot` emission stopped as well** — per checkbox 2 ("stop the dashboard renderer from emitting them"), a non-dataset pivot now shows the placeholder rather than a static `PivotTable`.

## Verification
- `@object-ui/types` `tsc --noEmit` clean; `plugin-dashboard` / `plugin-designer` builds (tsc dts) clean.
- vitest green: `DashboardRenderer.filters` (5/5), `DashboardRenderer.legacyRetired` (6/6), `DatasetWidget` (41/41), `dashboard-config` (16/16), `p1-spec-alignment` dataset tests.
- The pre-existing `data-objectstack` `exportDownload.test.ts` type-check failure is unrelated (unchanged vs `main`, no dashboard-type dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
