### PR TITLE
fix(data-objectstack): type the exportDownload test fetch mock so its type-check passes

### DIFF
--- a/packages/data-objectstack/src/exportDownload.test.ts
+++ b/packages/data-objectstack/src/exportDownload.test.ts
@@ -23,7 +23,9 @@ function csvResponse(body = 'ID,Name\n1,Acme') {
 
 describe('ObjectStackAdapter.exportDownload', () => {
   it('GETs the /export route with format, fields, orderby, header and limit', async () => {
-    const fetchImpl = vi.fn(async () => csvResponse());
+    // Typed like `fetch` so `fetchImpl.mock.calls[0]` is `[url, init]` rather
+    // than an empty tuple (the zero-arg impl would otherwise infer `never`).
+    const fetchImpl = vi.fn(async (_url: string, _init: RequestInit) => csvResponse());
     const ds = makeDS(fetchImpl);
 
     const blob = await ds.exportDownload('task', {
@@ -50,7 +52,9 @@ describe('ObjectStackAdapter.exportDownload', () => {
   });
 
   it('defaults to csv and omits optional params when not provided', async () => {
-    const fetchImpl = vi.fn(async () => csvResponse());
+    // Typed like `fetch` so `fetchImpl.mock.calls[0]` is `[url, init]` rather
+    // than an empty tuple (the zero-arg impl would otherwise infer `never`).
+    const fetchImpl = vi.fn(async (_url: string, _init: RequestInit) => csvResponse());
     const ds = makeDS(fetchImpl);
 
     await ds.exportDownload('task', {});
@@ -65,7 +69,9 @@ describe('ObjectStackAdapter.exportDownload', () => {
   });
 
   it('serializes the filter to a JSON AST query param', async () => {
-    const fetchImpl = vi.fn(async () => csvResponse());
+    // Typed like `fetch` so `fetchImpl.mock.calls[0]` is `[url, init]` rather
+    // than an empty tuple (the zero-arg impl would otherwise infer `never`).
+    const fetchImpl = vi.fn(async (_url: string, _init: RequestInit) => csvResponse());
     const ds = makeDS(fetchImpl);
 
     await ds.exportDownload('task', { filter: [['status', '=', 'open']] });


### PR DESCRIPTION
`packages/data-objectstack/src/exportDownload.test.ts` fails `tsc --noEmit` on a cold cache:

```
src/exportDownload.test.ts(39,12): error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
src/exportDownload.test.ts(40,28): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string | URL'.
src/exportDownload.test.ts(48,12): error TS18048: 'init' is possibly 'undefined'.
… (9 total)
```

**Root cause:** `vi.fn(async () => csvResponse())` infers a **zero-arg** signature, so `fetchImpl.mock.calls[0]` is typed as an empty tuple `[]`. `const [url, init] = fetchImpl.mock.calls[0]` then can't index it (`url`/`init` are `undefined`).

**Fix:** type the mock like `fetch` — `vi.fn(async (_url: string, _init: RequestInit) => csvResponse())` — so the recorded call args are `[url, init]`. Test-only; no runtime change.

Spotted while working on objectstack-ai/objectui#2723 (unrelated); splitting it out as its own PR.

## Verification
- `turbo run type-check --filter=@object-ui/data-objectstack` → 3/3 successful (deps built, then tsc), clean.
- `vitest run packages/data-objectstack/src/exportDownload.test.ts` → 4/4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
