### PR TITLE
feat(fields): RadioField visibleWhen cascading + dependsOn gating; single-source the option resolver

### DIFF
--- a/.changeset/radio-cascade-parity.md
+++ b/.changeset/radio-cascade-parity.md
@@ -1,0 +1,26 @@
+---
+"@object-ui/core": minor
+"@object-ui/fields": minor
+"@object-ui/components": patch
+---
+
+feat(fields): RadioField per-option `visibleWhen` cascading + `dependsOn` gating; single-source the option resolver
+
+Brings `RadioField` to parity with `SelectField` / `MultiSelectField` for ADR-0058
+cascading & role-gated options, and collapses the three copies of the
+gate-then-filter logic onto one shared resolver.
+
+- **`@object-ui/core`**: new pure `resolveCascadingOptions(rawOptions, record, dependsOn, scope)`
+  → `{ options, gated, dependsOnFields }` — the single source of truth for
+  `dependsOn` gating + per-option `visibleWhen` filtering.
+- **`@object-ui/fields`**: `RadioField` now narrows its offered radios against
+  the live record + `current_user`, gates behind a "select the parent first"
+  hint while a `dependsOn` field is empty, and clears a value no longer offered
+  (scalar cascade clear). The `useCascadingOptions` hook is refactored to a thin
+  React wrapper over `resolveCascadingOptions`.
+- **`@object-ui/components`**: the form renderer's inline option pre-filter and
+  cross-field cascade-clear effect now call `resolveCascadingOptions` instead of
+  re-deriving gating/filtering, so they can't drift from the widgets (no
+  behavior change).
+- Tests: `RadioField.cascade.test.tsx` mirrors the select cascade tests; core
+  gains `resolveCascadingOptions` unit coverage.

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveVisibleOptions, isOptionGroupGated, resolveDependsOnFields, isValueStillOffered } from '@object-ui/core';
+import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveCascadingOptions, isValueStillOffered } from '@object-ui/core';
 import type { FormSchema, FormField as FormFieldConfig, ValidationRule, FieldCondition, SelectOption } from '@object-ui/types';
 import { useForm } from 'react-hook-form';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from '../../ui/form';
@@ -417,9 +417,9 @@ ComponentRegistry.register('form',
         const current = form.getValues(name);
         if (current === undefined || current === null || current === '') continue;
         // While gated (a dependency is empty) the whole list is withheld — clear
-        // any prior value so it can't linger past a parent reset.
-        const gated = isOptionGroupGated(dependsOn, ruleRecord);
-        const visible = gated ? [] : resolveVisibleOptions(opts, ruleRecord, predicateScope);
+        // any prior value so it can't linger past a parent reset. Same shared
+        // resolver the widgets use, so gating/filtering stays in lockstep.
+        const { options: visible } = resolveCascadingOptions(opts, ruleRecord, dependsOn, predicateScope);
         if (!isValueStillOffered(current, visible)) {
           form.setValue(name, Array.isArray(current) ? [] : undefined, {
             shouldValidate: false,
@@ -799,16 +799,16 @@ ComponentRegistry.register('form',
                 const isOptionField =
                   resolvedType === 'select' || resolvedType === 'radio' || resolvedType === 'multiselect';
                 const rawOptions = (fieldProps as any).options as SelectOption[] | undefined;
-                const dependsOnFields = isOptionField
-                  ? resolveDependsOnFields((field as any).dependsOn)
-                  : [];
-                const optionGroupGated =
-                  dependsOnFields.length > 0 && isOptionGroupGated((field as any).dependsOn, ruleRecord);
-                const effectiveOptions = isOptionField
-                  ? optionGroupGated
-                    ? []
-                    : resolveVisibleOptions(rawOptions, ruleRecord, predicateScope)
-                  : rawOptions;
+                // Resolve gating + `visibleWhen` filtering through the shared
+                // core helper so this pre-filter can't drift from the widgets'
+                // `useCascadingOptions` hook (#2715). Non-option fields pass
+                // their options through untouched.
+                const cascade = isOptionField
+                  ? resolveCascadingOptions(rawOptions, ruleRecord, (field as any).dependsOn, predicateScope)
+                  : null;
+                const optionGroupGated = cascade?.gated ?? false;
+                const dependsOnFields = cascade?.dependsOnFields ?? [];
+                const effectiveOptions = cascade ? cascade.options : rawOptions;
                 const gatedHint = optionGroupGated
                   ? `Select ${dependsOnFields.map((fn) => fieldLabelByName[fn] || fn).join(' / ')} first`
                   : undefined;

--- a/packages/core/src/evaluator/__tests__/optionRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/optionRules.test.ts
@@ -15,6 +15,7 @@ import {
   isOptionGroupGated,
   resolveVisibleOptions,
   isValueStillOffered,
+  resolveCascadingOptions,
   type OptionLike,
 } from '../optionRules';
 
@@ -125,5 +126,42 @@ describe('isValueStillOffered — cascade clear decision', () => {
   it('handles multi-select arrays element-wise', () => {
     expect(isValueStillOffered(['zj', 'gd'], cnOptions)).toBe(true);
     expect(isValueStillOffered(['zj', 'ca'], cnOptions)).toBe(false);
+  });
+});
+
+describe('resolveCascadingOptions — one-shot resolution', () => {
+  it('gates (empty options) while a dependsOn parent is empty', () => {
+    const r = resolveCascadingOptions(provinces, {}, 'country');
+    expect(r.gated).toBe(true);
+    expect(r.options).toEqual([]);
+    expect(r.dependsOnFields).toEqual(['country']);
+  });
+
+  it('filters by visibleWhen once the parent is set', () => {
+    const r = resolveCascadingOptions(provinces, { country: 'cn' }, 'country');
+    expect(r.gated).toBe(false);
+    expect(r.options.map((o) => o.value)).toEqual(['zj', 'gd', 'other']);
+  });
+
+  it('is never gated without a dependsOn — still filters by visibleWhen', () => {
+    const r = resolveCascadingOptions(provinces, { country: 'us' }, undefined);
+    expect(r.gated).toBe(false);
+    expect(r.dependsOnFields).toEqual([]);
+    expect(r.options.map((o) => o.value)).toEqual(['ca', 'tx', 'other']);
+  });
+
+  it('threads the predicate scope for role/context gating', () => {
+    const tier: OptionLike[] = [
+      { label: 'Standard', value: 'standard' },
+      { label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.positions" },
+    ];
+    const nonAdmin = resolveCascadingOptions(tier, {}, undefined, {
+      current_user: { positions: ['sales'] },
+    });
+    expect(nonAdmin.options.map((o) => o.value)).toEqual(['standard']);
+    const admin = resolveCascadingOptions(tier, {}, undefined, {
+      current_user: { positions: ['admin'] },
+    });
+    expect(admin.options.map((o) => o.value)).toEqual(['standard', 'admin_only']);
   });
 });

--- a/packages/core/src/evaluator/optionRules.ts
+++ b/packages/core/src/evaluator/optionRules.ts
@@ -112,3 +112,37 @@ export function isValueStillOffered(
   }
   return visibleOptions.some((o) => o.value === value);
 }
+
+/** The resolved state of a cascading / role-gated option list. */
+export interface CascadingOptions<T extends OptionLike> {
+  /** Offered options after `visibleWhen` filtering. Empty while gated. */
+  options: T[];
+  /** True when a declared `dependsOn` field is empty — the list is gated. */
+  gated: boolean;
+  /** Normalized `dependsOn` field names (drives the "select the parent first" hint). */
+  dependsOnFields: string[];
+}
+
+/**
+ * Resolve an option field's offered set in one shot: normalize `dependsOn`,
+ * decide whether the list is gated (a controlling field is still empty), and —
+ * unless gated — filter by each option's `visibleWhen`. The single source of
+ * truth behind the option widgets' `useCascadingOptions` hook and the form
+ * renderer's inline pre-filter / cascade-clear, so gating and filtering can
+ * never drift between them (#2715).
+ *
+ * `gated` is true only when there IS a `dependsOn` and one of its fields is
+ * empty; a field with no `dependsOn` is never gated (its options are filtered
+ * purely by `visibleWhen`). Callers format their own hint from `dependsOnFields`.
+ */
+export function resolveCascadingOptions<T extends OptionLike>(
+  rawOptions: readonly T[] | undefined | null,
+  record: Record<string, unknown>,
+  dependsOn: DependsOnInput,
+  scope?: Record<string, unknown>,
+): CascadingOptions<T> {
+  const dependsOnFields = resolveDependsOnFields(dependsOn);
+  const gated = dependsOnFields.length > 0 && isOptionGroupGated(dependsOn, record);
+  const options = gated ? [] : resolveVisibleOptions(rawOptions, record, scope);
+  return { options, gated, dependsOnFields };
+}

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -99,15 +99,19 @@ single dropdown does.
 
 ### Cascading & role-gated select options
 
-`select` and `multiselect` options support a per-option `visibleWhen` CEL
-predicate (offered only when TRUE, evaluated against the live record +
+`select`, `multiselect`, and `radio` options support a per-option `visibleWhen`
+CEL predicate (offered only when TRUE, evaluated against the live record +
 `current_user`) and a field-level `dependsOn`. Together they drive dependent
 selects (country → province → city) and role-gated options with no bespoke
-matrix — the same primitives dependent lookups use. While a `dependsOn` parent
-is empty the control is gated; a parent change re-filters the list and clears a
-now-invalid value (single select drops the value; multi-select prunes just the
-offered-out entries). Client-side hiding is
-UX only — gate authorization-sensitive values on the server too. See
+matrix — the same primitives dependent lookups use. All three widgets resolve
+this through the shared [`useCascadingOptions`](./src/widgets/useCascadingOptions.ts)
+hook, which wraps the pure `resolveCascadingOptions` helper in `@object-ui/core`
+(also used by the form renderer's inline pre-filter, so gating and filtering
+never drift). While a `dependsOn` parent is empty the control is gated; a parent
+change re-filters the list and clears a now-invalid value (scalar `select` /
+`radio` drop the value; `multiselect` prunes just the offered-out entries).
+Client-side hiding is UX only — gate authorization-sensitive values on the
+server too. See
 [`content/docs/fields/select.mdx`](../../content/docs/fields/select.mdx).
 
 <!-- release-metadata:v3.3.0 -->

--- a/packages/fields/src/widgets/RadioField.cascade.test.tsx
+++ b/packages/fields/src/widgets/RadioField.cascade.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Cascading / role-gated `radio` options (#2715) — parity with the single
+ * `SelectField` (ADR-0058 / #2284).
+ *
+ * Exercises the observable widget behaviour: the dependency gate (a "select the
+ * parent first" empty-state) and the scalar cascade clear (a value dropped when
+ * the offered set no longer includes it). The per-option filtering itself is
+ * unit-tested in `@object-ui/core` (`optionRules.test.ts`); here we prove the
+ * radio group wires `dependentValues` + predicate scope into that resolver via
+ * the shared `useCascadingOptions` hook.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { RadioField } from './RadioField';
+
+const provinceField = {
+  name: 'province',
+  type: 'radio',
+  dependsOn: 'country',
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+  ],
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('RadioField — dependency gating (#2715)', () => {
+  it('gates with a "select parent first" hint while the controlling field is empty', () => {
+    render(
+      <RadioField
+        value={undefined}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: {} } as any)}
+      />,
+    );
+    const gate = screen.getByTestId('radio-empty-province');
+    expect(gate).toHaveTextContent(/select country first/i);
+    // Gated → no radios offered.
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  });
+
+  it('unlocks the radios once the controlling field is set', () => {
+    render(
+      <RadioField
+        value={undefined}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    expect(screen.queryByTestId('radio-empty-province')).not.toBeInTheDocument();
+    // Only the `cn` option is offered.
+    expect(screen.getByRole('radio', { name: 'Zhejiang' })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'California' })).not.toBeInTheDocument();
+  });
+});
+
+describe('RadioField — cascade clear (#2715)', () => {
+  it('clears a value the parent change no longer offers', () => {
+    const onChange = vi.fn();
+    render(
+      <RadioField
+        value={'ca'}
+        onChange={onChange}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    // 'ca' is a US province — under country=cn it is not offered, so it is dropped.
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('keeps a value that is still offered', () => {
+    const onChange = vi.fn();
+    render(
+      <RadioField
+        value={'zj'}
+        onChange={onChange}
+        field={provinceField}
+        {...({ name: 'province', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('RadioField — role / context gating (#2715)', () => {
+  const tierField = {
+    name: 'tier',
+    type: 'radio',
+    options: [
+      { label: 'Standard', value: 'standard' },
+      { label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.positions" },
+    ],
+  } as any;
+
+  it('clears an admin-only value for a non-admin (offered set excludes it)', () => {
+    const onChange = vi.fn();
+    render(
+      <PredicateScopeProvider scope={{ current_user: { positions: ['sales'] } }}>
+        <RadioField
+          value={'admin_only'}
+          onChange={onChange}
+          field={tierField}
+          {...({ name: 'tier', dependentValues: {} } as any)}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('keeps an admin-only value for an admin', () => {
+    const onChange = vi.fn();
+    render(
+      <PredicateScopeProvider scope={{ current_user: { positions: ['admin'] } }}>
+        <RadioField
+          value={'admin_only'}
+          onChange={onChange}
+          field={tierField}
+          {...({ name: 'tier', dependentValues: {} } as any)}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -1,23 +1,80 @@
-import React, { useId } from 'react';
+import React, { useId, useEffect } from 'react';
 import { RadioGroup, RadioGroupItem, Label, EmptyValue } from '@object-ui/components';
+import { isValueStillOffered, type OptionLike } from '@object-ui/core';
 import { FieldWidgetProps } from './types';
+import { useCascadingOptions } from './useCascadingOptions';
 
-interface Option { label: string; value: string }
+type Option = OptionLike;
 
 /**
  * RadioField - choose exactly one value from a fixed option set, rendered as a
  * radio group. The stored value is the selected option value (string). Used for
  * the `radio` field type.
+ *
+ * Like the single `SelectField`, options support per-option `visibleWhen`
+ * cascading + `dependsOn` gating (ADR-0058 / #2715), resolved through the shared
+ * {@link useCascadingOptions} hook: the offered radios narrow against the live
+ * form record + `current_user`, the control is gated behind a "select the parent
+ * first" hint while a dependency is empty, and a value no longer offered (parent
+ * changed / predicate flipped) is cleared.
  */
-export function RadioField({ value, onChange, field, readonly, className, ...props }: FieldWidgetProps<string>) {
-  const config = (field || (props as any).schema) as any;
-  const options: Option[] = config?.options || [];
+export function RadioField({
+  value,
+  onChange,
+  field,
+  readonly,
+  className,
+  schema,
+  dependentValues,
+  dependsOn: dependsOnProp,
+  emptyHint: _emptyHint,
+  dataSource: _dataSource,
+  ...props
+}: FieldWidgetProps<string>) {
+  const config = (field || schema) as any;
+  const rawOptions: Option[] = config?.options || [];
   const groupId = useId();
+  const fieldName = (props as any).name || config?.name || (props as any).id || '';
+
+  const dependsOn = config?.dependsOn ?? dependsOnProp;
+  const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
+    rawOptions,
+    dependsOn,
+    dependentValues,
+  );
+
+  // Cascade clear: once the offered set no longer includes the current value
+  // (parent changed / predicate flipped), drop it so no stale pair persists.
+  useEffect(() => {
+    if (readonly) return;
+    if (value === undefined || value === null || (value as unknown) === '') return;
+    if (!isValueStillOffered(value, options)) onChange?.(undefined as unknown as string);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options, gated]);
 
   if (readonly) {
     if (value == null || value === '') return <EmptyValue />;
-    const opt = options.find((o) => o.value === value);
+    // Label from the raw set so a stored value hidden by `visibleWhen` still
+    // renders its label rather than a bare id.
+    const opt = rawOptions.find((o) => o.value === value);
     return <span className="text-sm">{opt?.label || String(value)}</span>;
+  }
+
+  // No offered options is unfillable — surface a legible state instead of an
+  // empty radio group: a dependency-gated list prompts for its controlling
+  // field; an unconfigured / fully-filtered list says so. Mirrors the select.
+  if (options.length === 0) {
+    const hint = gated
+      ? `Select ${dependsOnFields.join(' / ')} first`
+      : 'No options available';
+    return (
+      <div
+        data-testid={fieldName ? `radio-empty-${fieldName}` : undefined}
+        className="flex min-h-9 w-full items-center rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
+      >
+        {hint}
+      </div>
+    );
   }
 
   return (
@@ -31,7 +88,7 @@ export function RadioField({ value, onChange, field, readonly, className, ...pro
         const id = `${groupId}-${opt.value}`;
         return (
           <div key={opt.value} className="flex items-center space-x-2">
-            <RadioGroupItem value={opt.value} id={id} />
+            <RadioGroupItem value={opt.value} id={id} data-testid={`radio-option-${opt.value}`} />
             <Label htmlFor={id} className="font-normal">{opt.label}</Label>
           </div>
         );

--- a/packages/fields/src/widgets/useCascadingOptions.ts
+++ b/packages/fields/src/widgets/useCascadingOptions.ts
@@ -1,8 +1,7 @@
 import { useContext, useMemo } from 'react';
 import {
-  resolveVisibleOptions,
-  isOptionGroupGated,
-  resolveDependsOnFields,
+  resolveCascadingOptions,
+  type CascadingOptions,
   type OptionLike,
   type DependsOnInput,
 } from '@object-ui/core';
@@ -10,25 +9,20 @@ import { SchemaRendererContext, usePredicateScope } from '@object-ui/react';
 
 /**
  * Shared per-option cascading / role-gating resolution for the option widgets
- * (`SelectField` single, `MultiSelectField`) — the client half of ADR-0058
- * (#2284). Each option may carry a `visibleWhen` CEL predicate; the offered set
- * narrows against the live form record (`record.country == 'cn'`) + the global
- * predicate scope (`'admin' in current_user.positions`). A field declares which
- * sibling fields drive its list via `dependsOn`; while any is empty the list is
- * *gated* — callers surface a "select the parent first" hint rather than an
- * unfiltered set, mirroring the dependent-lookup UX.
+ * (`SelectField` single, `MultiSelectField`, `RadioField`) — the client half of
+ * ADR-0058 (#2284). Each option may carry a `visibleWhen` CEL predicate; the
+ * offered set narrows against the live form record (`record.country == 'cn'`) +
+ * the global predicate scope (`'admin' in current_user.positions`). A field
+ * declares which sibling fields drive its list via `dependsOn`; while any is
+ * empty the list is *gated* — callers surface a "select the parent first" hint
+ * rather than an unfiltered set, mirroring the dependent-lookup UX.
  *
- * Extracted so single- and multi-select stay in lockstep instead of duplicating
- * the resolver + its `dependentValues` / predicate-scope wiring (#2715).
+ * This is the React wrapper that sources `record` (the live form values) and the
+ * predicate scope from context; the actual resolution is the pure
+ * {@link resolveCascadingOptions} in `@object-ui/core`, shared with the form
+ * renderer so gating/filtering can never drift between them (#2715).
  */
-export interface CascadingOptionsResult<T extends OptionLike> {
-  /** Offered options after `visibleWhen` filtering. Empty while gated. */
-  options: T[];
-  /** True when a `dependsOn` field is empty — the list is gated. */
-  gated: boolean;
-  /** Normalized `dependsOn` field names (for the gate hint). */
-  dependsOnFields: string[];
-}
+export type CascadingOptionsResult<T extends OptionLike> = CascadingOptions<T>;
 
 export function useCascadingOptions<T extends OptionLike>(
   rawOptions: readonly T[],
@@ -45,18 +39,8 @@ export function useCascadingOptions<T extends OptionLike>(
   }, [dependentValues, ctx?.formValues, ctx?.data]);
   const predicateScope = usePredicateScope();
 
-  const dependsOnFields = useMemo(() => resolveDependsOnFields(dependsOn), [dependsOn]);
-  const gated = useMemo(
-    () => dependsOnFields.length > 0 && isOptionGroupGated(dependsOn, record),
-    [dependsOnFields, dependsOn, record],
+  return useMemo(
+    () => resolveCascadingOptions(rawOptions, record, dependsOn, predicateScope),
+    [rawOptions, record, dependsOn, predicateScope],
   );
-
-  // Effective (offered) options after per-option `visibleWhen` filtering. Empty
-  // while gated so we never present an unfiltered set before the parent is set.
-  const options = useMemo(
-    () => (gated ? [] : resolveVisibleOptions(rawOptions, record, predicateScope)),
-    [gated, rawOptions, record, predicateScope],
-  );
-
-  return { options, gated, dependsOnFields };
 }


### PR DESCRIPTION
Follow-up to #2717 (multiselect parity). Brings `RadioField` to full parity with `SelectField` / `MultiSelectField` for ADR-0058 cascading & role-gated options, and removes the duplicated gate-then-filter logic.

## Why

`CASCADE_OPTION_FIELD_TYPES` already lists `radio`, and the object form pre-filters its options — but the standalone `RadioField` widget rendered `config.options` raw, so **outside the form renderer** (inline grid editor, `ActionParamDialog`) a `radio` with dependent / role-gated options showed the unfiltered set. Exactly the gap #2709→#2715 closed for multiselect.

While here, the `gated ? [] : resolveVisibleOptions(...)` pattern lived in **three** places (the widgets' hook + two sites in `form.tsx`) — a drift risk. Collapsed onto one pure core helper.

## Changes

- **`@object-ui/core`** — new pure `resolveCascadingOptions(rawOptions, record, dependsOn, scope)` → `{ options, gated, dependsOnFields }`, the single source of truth for `dependsOn` gating + `visibleWhen` filtering (unit tested).
- **`@object-ui/fields`** — `RadioField` narrows offered radios against the live record + `current_user`, gates behind a "select the parent first" hint, and clears a value no longer offered (scalar cascade clear). Adds `radio-empty-*` / `radio-option-*` testids. `useCascadingOptions` is now a thin React wrapper over the core helper.
- **`@object-ui/components`** — `form.tsx`'s inline option pre-filter and the cross-field cascade-clear effect call `resolveCascadingOptions` instead of re-deriving gating/filtering. **No behavior change** — human-label gate hint preserved.

## Tests

- New `RadioField.cascade.test.tsx` mirrors `SelectField.cascade.test.tsx` (gating, scalar cascade clear, role/context gating).
- Core `resolveCascadingOptions` unit coverage added.
- Verified green (**62 passed**): core `optionRules` + components `form-cascading-select` & `form-dependent-values` (the refactored form path) + fields `RadioField.cascade` / `MultiSelectField.cascade` / `SelectField.cascade` / `standard-widgets`.
- `tsc --noEmit` clean for `@object-ui/core`, `@object-ui/components`, `@object-ui/fields`; `eslint` 0 errors.

## Refs

- #2717 (multiselect parity) · #2709 (delegation) · ADR-0058

Note: client-side hiding remains UX only — server-side rejection of gated option values is tracked separately (icebox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)