### PR TITLE
chore(lint): clear the mechanical baseline lint errors (8 pkgs, #2713 Wave 1)

### DIFF
--- a/.changeset/lint-baseline-mechanical.md
+++ b/.changeset/lint-baseline-mechanical.md
@@ -1,0 +1,38 @@
+---
+"@object-ui/cli": patch
+"@object-ui/data-objectstack": patch
+"@object-ui/plugin-calendar": patch
+"@object-ui/plugin-designer": patch
+"@object-ui/plugin-map": patch
+"@object-ui/plugin-markdown": patch
+"@object-ui/plugin-timeline": patch
+"@object-ui/react": patch
+---
+
+chore(lint): clear the mechanical baseline lint errors so these packages' lint gates protect them again
+
+Extends the fields/core cleanup from #2709 (objectui#2713). These eight package
+lints were red at baseline on `main`, so their per-package `lint` gate could not
+catch new violations of the same class. Cleared every **error** (no behavior
+change; warnings are out of scope):
+
+- **`no-useless-catch`** (`data-objectstack`) — unwrapped five try/catch blocks
+  whose `catch` only re-threw; errors still propagate identically.
+- **`preserve-caught-error`** (`cli`, `data-objectstack`, `react`) — the caught
+  error's message is inlined into the thrown `Error`; a scoped disable with a
+  justifying comment carries each one, because these packages target ES2020
+  whose lib types the 1-arg `Error` constructor only (so `{ cause }` won't
+  compile) — same reasoning as the core case in #2709.
+- **`prefer-const`** (`plugin-calendar`, `plugin-map`) — `let`→`const` for
+  never-reassigned bindings.
+- **`no-empty-object-type`** (`plugin-designer`) — empty extend-only interfaces
+  → equivalent `type` aliases.
+- **`no-useless-assignment`** (`react`) — dropped a dead initializer that both
+  branches overwrite before it is read.
+- **`no-require-imports`** (`plugin-calendar`, `plugin-timeline` tests) —
+  hoisted `vi.mock` factories now use an `async` factory with
+  `await import('react')` instead of `require('react')`.
+- **stale `eslint-disable` directive** (`plugin-markdown`) — removed a
+  `react/no-danger` disable whose plugin is not loaded in the flat config (an
+  unknown-rule reference that ESLint v10 reports as an error); the rationale is
+  kept as a plain comment.

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -61,6 +61,10 @@ export async function buildApp(schemaPath: string, options: BuildOptions) {
     try {
       schema = parseSchemaFile(fullSchemaPath);
     } catch (error) {
+      // The caught error's message is inlined below. We can't pass it as the
+      // `Error` `cause` option because this package targets ES2020, whose lib
+      // types the 1-arg `Error` constructor only; hence the scoped disable.
+      // eslint-disable-next-line preserve-caught-error
       throw new Error(`Invalid schema file: ${error instanceof Error ? error.message : error}`);
     }
   }
@@ -123,6 +127,10 @@ export async function buildApp(schemaPath: string, options: BuildOptions) {
     console.log(chalk.cyan(`  objectui start --dir ${outDir}`));
     console.log();
   } catch (error) {
+    // The caught error's message is inlined below. We can't pass it as the
+    // `Error` `cause` option because this package targets ES2020, whose lib
+    // types the 1-arg `Error` constructor only; hence the scoped disable.
+    // eslint-disable-next-line preserve-caught-error
     throw new Error(`Build failed: ${error instanceof Error ? error.message : error}`);
   }
 }

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -105,7 +105,11 @@ export async function dev(schemaPath: string, options: DevOptions) {
     try {
       schema = parseSchemaFile(fullSchemaPath);
     } catch (error) {
-       throw new Error(`Invalid schema file: ${error instanceof Error ? error.message : error}`);
+      // The caught error's message is inlined below. We can't pass it as the
+      // `Error` `cause` option because this package targets ES2020, whose lib
+      // types the 1-arg `Error` constructor only; hence the scoped disable.
+      // eslint-disable-next-line preserve-caught-error
+      throw new Error(`Invalid schema file: ${error instanceof Error ? error.message : error}`);
     }
   }
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -59,6 +59,10 @@ export async function serve(schemaPath: string, options: ServeOptions) {
     try {
       schema = parseSchemaFile(fullSchemaPath);
     } catch (error) {
+      // The caught error's message is inlined below. We can't pass it as the
+      // `Error` `cause` option because this package targets ES2020, whose lib
+      // types the 1-arg `Error` constructor only; hence the scoped disable.
+      // eslint-disable-next-line preserve-caught-error
       throw new Error(`Invalid schema file: ${error instanceof Error ? error.message : error}`);
     }
   }

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -2022,32 +2022,25 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     config: Record<string, any>
   ): Promise<Record<string, any> | void> {
     await this.connect();
-    try {
-      // ADR-0005 metadata customization overlay: persist views under
-      // `type='view'` (NOT `type=<objectName>` — that was a pre-overlay
-      // misuse that hit `/api/v1/meta/<objectName>/<viewId>`, which the
-      // server never wired). The view's `data.object` field is what
-      // associates it back to the object on read.
-      const merged = { ...(config || {}), object: (config as any)?.object || objectName, name: viewId };
-      const result: any = await this.client.meta.saveItem(
-        'view',
-        viewId,
-        merged
-      );
-      // Invalidate cached read so next getView reflects the change
-      const cacheKey = `view:${objectName}:${viewId}`;
-      this.metadataCache.invalidate?.(cacheKey);
-      // Also invalidate the batch override map so listViewOverrides re-fetches
-      this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
-      this.metadataCache.invalidate?.(`views:${objectName}`);
-      if (result && result.item) return result.item;
-      return result ?? undefined;
-    } catch (err) {
-      // Surface the error so the caller can decide whether to toast/log;
-      // we don't swallow it here because persistence failures are
-      // operationally meaningful (unlike read fallbacks).
-      throw err;
-    }
+    // ADR-0005 metadata customization overlay: persist views under
+    // `type='view'` (NOT `type=<objectName>` — that was a pre-overlay
+    // misuse that hit `/api/v1/meta/<objectName>/<viewId>`, which the
+    // server never wired). The view's `data.object` field is what
+    // associates it back to the object on read.
+    const merged = { ...(config || {}), object: (config as any)?.object || objectName, name: viewId };
+    const result: any = await this.client.meta.saveItem(
+      'view',
+      viewId,
+      merged
+    );
+    // Invalidate cached read so next getView reflects the change
+    const cacheKey = `view:${objectName}:${viewId}`;
+    this.metadataCache.invalidate?.(cacheKey);
+    // Also invalidate the batch override map so listViewOverrides re-fetches
+    this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
+    this.metadataCache.invalidate?.(`views:${objectName}`);
+    if (result && result.item) return result.item;
+    return result ?? undefined;
   }
 
   /**
@@ -2167,14 +2160,10 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       object: spec?.object || objectName,
       data: spec?.data || { provider: 'object', object: objectName },
     };
-    try {
-      const result: any = await this.client.meta.saveItem('view', name, fullSpec);
-      this.metadataCache.invalidate?.(`views:${objectName}`);
-      if (result && result.item) return result.item;
-      return fullSpec;
-    } catch (err) {
-      throw err;
-    }
+    const result: any = await this.client.meta.saveItem('view', name, fullSpec);
+    this.metadataCache.invalidate?.(`views:${objectName}`);
+    if (result && result.item) return result.item;
+    return fullSpec;
   }
 
   /**
@@ -2204,15 +2193,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       name: viewName,
       object: current?.object || (current as any)?.data?.object || objectName,
     };
-    try {
-      const result: any = await this.client.meta.saveItem('view', viewName, merged);
-      this.metadataCache.invalidate?.(`views:${objectName}`);
-      this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
-      if (result && result.item) return result.item;
-      return merged;
-    } catch (err) {
-      throw err;
-    }
+    const result: any = await this.client.meta.saveItem('view', viewName, merged);
+    this.metadataCache.invalidate?.(`views:${objectName}`);
+    this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
+    if (result && result.item) return result.item;
+    return merged;
   }
 
   /**
@@ -2225,14 +2210,10 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     viewName: string,
   ): Promise<{ deleted: boolean }> {
     await this.connect();
-    try {
-      const result: any = await this.client.meta.deleteItem('view', viewName);
-      this.metadataCache.invalidate?.(`views:${objectName}`);
-      this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
-      return { deleted: !!(result?.deleted ?? result?.reset ?? true) };
-    } catch (err) {
-      throw err;
-    }
+    const result: any = await this.client.meta.deleteItem('view', viewName);
+    this.metadataCache.invalidate?.(`views:${objectName}`);
+    this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
+    return { deleted: !!(result?.deleted ?? result?.reset ?? true) };
   }
 
 
@@ -2299,21 +2280,17 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     schema: Record<string, any>
   ): Promise<Record<string, any> | void> {
     await this.connect();
-    try {
-      const result: any = await this.client.meta.saveItem(
-        'dashboard',
-        dashboardName,
-        schema
-      );
-      // Invalidate dashboards list and any cached dashboard read so the
-      // next render reflects the change.
-      this.metadataCache.invalidate?.('dashboards');
-      this.metadataCache.invalidate?.(`dashboard:${dashboardName}`);
-      if (result && result.item) return result.item;
-      return result ?? undefined;
-    } catch (err) {
-      throw err;
-    }
+    const result: any = await this.client.meta.saveItem(
+      'dashboard',
+      dashboardName,
+      schema
+    );
+    // Invalidate dashboards list and any cached dashboard read so the
+    // next render reflects the change.
+    this.metadataCache.invalidate?.('dashboards');
+    this.metadataCache.invalidate?.(`dashboard:${dashboardName}`);
+    if (result && result.item) return result.item;
+    return result ?? undefined;
   }
 
   /**

--- a/packages/data-objectstack/src/integration.ts
+++ b/packages/data-objectstack/src/integration.ts
@@ -143,6 +143,10 @@ export class IntegrationManager {
           }
         } catch (e) {
           if (e instanceof TypeError) {
+            // A malformed URL surfaces as its own message; we can't attach `e`
+            // as the `Error` `cause` because this package targets ES2020, whose
+            // lib types the 1-arg `Error` constructor only. Scoped disable.
+            // eslint-disable-next-line preserve-caught-error
             throw new Error(`Invalid webhook URL: ${url}`);
           }
           throw e;
@@ -168,6 +172,10 @@ export class IntegrationManager {
           }
         } catch (e) {
           if (e instanceof TypeError) {
+            // A malformed URL surfaces as its own message; we can't attach `e`
+            // as the `Error` `cause` because this package targets ES2020, whose
+            // lib types the 1-arg `Error` constructor only. Scoped disable.
+            // eslint-disable-next-line preserve-caught-error
             throw new Error(`Invalid Slack webhook URL: ${url}`);
           }
           throw e;

--- a/packages/plugin-calendar/src/CalendarView.tsx
+++ b/packages/plugin-calendar/src/CalendarView.tsx
@@ -947,7 +947,7 @@ function TimeGridView({
       type ColRun = { endMin: number }
       const cols: ColRun[] = []
       const assigned: Array<{ entry: Entry; col: number }> = []
-      let activeGroupStart = 0
+      const activeGroupStart = 0
       const flushGroup = (until: number) => {
         const groupCols = cols.length
         for (let i = activeGroupStart; i < assigned.length; i++) {
@@ -956,7 +956,7 @@ function TimeGridView({
           ;(assigned[i] as any).until = until
         }
       }
-      let _ = flushGroup // silence unused
+      const _ = flushGroup // silence unused
       void _
       const laid: Laid[] = []
       // Simpler 2-pass: assign column index greedily, then walk through and

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -285,7 +285,7 @@ export const ObjectCalendar: React.FC<ObjectCalendarProps> = ({
             ...(expand.length > 0 ? { $expand: expand } : {}),
           });
           
-          let items: any[] = extractRecords(result);
+          const items: any[] = extractRecords(result);
           
           if (isMounted) {
             setData(items);

--- a/packages/plugin-calendar/src/registration.test.tsx
+++ b/packages/plugin-calendar/src/registration.test.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { ObjectCalendarRenderer } from './index';
 
 // Mock dependencies
-vi.mock('@object-ui/react', () => {
-  const React = require('react');
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
   return {
     useSchemaContext: vi.fn(() => ({ dataSource: { type: 'mock-datasource' } })),
     SchemaRendererContext: React.createContext(null),

--- a/packages/plugin-designer/src/hooks/useDesignerHistory.ts
+++ b/packages/plugin-designer/src/hooks/useDesignerHistory.ts
@@ -9,10 +9,10 @@
 import { useUndoRedo, type UndoRedoOptions, type UndoRedoState } from './useUndoRedo';
 
 /** Options for the designer history hook */
-export interface DesignerHistoryOptions extends UndoRedoOptions {}
+export type DesignerHistoryOptions = UndoRedoOptions;
 
 /** Designer history state — command-pattern wrapper around undo/redo */
-export interface DesignerHistoryState<T> extends UndoRedoState<T> {}
+export type DesignerHistoryState<T> = UndoRedoState<T>;
 
 /**
  * Hook providing command-pattern undo/redo history for designer components.

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -416,7 +416,7 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
             ...(expand.length > 0 ? { $expand: expand } : {}),
           });
           
-          let items: any[] = extractRecords(result);
+          const items: any[] = extractRecords(result);
           setData(items);
         } else if (dataConfig?.provider === 'api') {
           console.warn('API provider not yet implemented for ObjectMap');

--- a/packages/plugin-markdown/src/Mermaid.tsx
+++ b/packages/plugin-markdown/src/Mermaid.tsx
@@ -103,7 +103,7 @@ export function Mermaid({ chart }: { chart: string }) {
       data-mermaid
       role="img"
       className="my-4 flex justify-center overflow-auto [&_svg]:h-auto [&_svg]:max-w-full"
-      // eslint-disable-next-line react/no-danger -- mermaid strict-mode SVG, rendered post-sanitize by our own trusted component
+      // mermaid strict-mode SVG, rendered post-sanitize by our own trusted component
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   )

--- a/packages/plugin-timeline/src/ObjectTimeline.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.test.tsx
@@ -5,8 +5,8 @@ import { ObjectTimeline } from './ObjectTimeline';
 import { DataSource } from '@object-ui/types';
 
 // Mock useDataScope and useNavigationOverlay
-vi.mock('@object-ui/react', () => {
-  const React = require('react');
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
   return {
     useDataScope: () => undefined,
     useNavigationOverlay: () => ({

--- a/packages/react/src/hooks/useETagCache.ts
+++ b/packages/react/src/hooks/useETagCache.ts
@@ -296,6 +296,10 @@ export function useETagCache(userConfig: ETagCacheConfig = {}): ETagCacheResult 
           }
         } catch (e) {
           if (e instanceof Error && e.message.startsWith('Unsupported')) throw e;
+          // Any other parse failure collapses to a generic message; we can't
+          // attach `e` as the `Error` `cause` because this package targets
+          // ES2020, whose lib types the 1-arg `Error` constructor only.
+          // eslint-disable-next-line preserve-caught-error
           throw new Error('Invalid URL');
         }
       }

--- a/packages/react/src/hooks/useRecordSearch.ts
+++ b/packages/react/src/hooks/useRecordSearch.ts
@@ -160,7 +160,8 @@ export function useRecordSearch(opts: UseRecordSearchOptions): UseRecordSearchRe
   // new array reference but identical content.
   const candidates = useMemo(() => {
     if (!Array.isArray(objects) || objects.length === 0) return [];
-    let pool = objects;
+    // Assigned in both branches below before it's read; no dead initializer.
+    let pool: any[];
     if (Array.isArray(objectNames) && objectNames.length > 0) {
       const byName = new Map<string, any>();
       for (const obj of objects) {


### PR DESCRIPTION
Extends the fields/core lint-gate cleanup from #2709 to the first wave of #2713 — eight packages whose per-package `lint` was **red at baseline on `main`**, so the gate could not catch new violations of the same class. **Errors only; zero behavior change** (warnings are out of scope per the issue). Grouped into one small PR because the fixes are same-class and mechanical (per the maintainer's call on #2713).

## What changed (per rule)

- **`no-useless-catch`** (`data-objectstack`, ×5) — unwrapped five `try { … } catch (err) { throw err }` blocks whose `catch` only re-threw. Errors still propagate identically; the 6 `catch` blocks that do real work are untouched.
- **`preserve-caught-error`** (`cli` ×4, `data-objectstack` ×2, `react` ×1) — each caught error's message is inlined into the thrown `Error`. A **scoped disable with a justifying comment** carries each site, because all three packages target **ES2020**, whose lib types the 1-arg `Error` constructor only (so `new Error(msg, { cause })` won't compile) — the same reasoning #2709 used for the core case. Verified: none override `lib` to ES2022.
- **`prefer-const`** (`plugin-calendar` ×3, `plugin-map` ×1) — `let`→`const` for never-reassigned bindings.
- **`no-empty-object-type`** (`plugin-designer` ×2) — empty extend-only interfaces → equivalent `type` aliases.
- **`no-useless-assignment`** (`react` ×1) — dropped a dead initializer that both branches overwrite before it's read (`let pool = objects` → `let pool: any[]`).
- **`no-require-imports`** (`plugin-calendar`, `plugin-timeline` tests) — the hoisted `vi.mock` factories now use an `async` factory with `await import('react')` instead of `require('react')` (a real fix, not a disable).
- **stale `eslint-disable` directive** (`plugin-markdown`) — removed a `react/no-danger` disable whose plugin is **not loaded** in the flat config; ESLint v10 reports the unknown-rule reference as an error. Rationale kept as a plain comment.

No lint **config** was loosened.

## Verification

- **Lint:** `eslint` → **0 errors** in all 8 packages (were 27 errors total at baseline).
- **Type gate:** `turbo run build` (the dts/declaration build CI gates on) → **21/21 tasks green** across the 8 packages + their dep graph.
- **Tests:** touched suites green — `data-objectstack` (176), `react/useRecordSearch` (10), the two changed `vi.mock` tests (7), plus `plugin-calendar`/`plugin-map`/`plugin-designer`/`cli` (60). 253 total.

## Scope / follow-ups

This is **Wave 1** of #2713 (the pure-mechanical packages that go fully to 0). Remaining red packages — the `react-hooks/rules-of-hooks` + `static-components` heavy ones (app-shell, components, plugin-gantt, plugin-detail, plugin-dashboard, plugin-chatbot, and the small mixed set) — follow in later waves.

Refs #2713 · pattern from #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)