### PR TITLE
feat(data): thread the host's authenticated fetch into provider:'api' data sources (#2725)

### DIFF
--- a/.changeset/api-provider-auth-fetch.md
+++ b/.changeset/api-provider-auth-fetch.md
@@ -1,0 +1,33 @@
+---
+"@object-ui/react": minor
+"@object-ui/auth": minor
+"@object-ui/app-shell": patch
+"@object-ui/plugin-gantt": patch
+---
+
+feat(data): thread the host's authenticated fetch into `provider: 'api'` data sources (#2725)
+
+`provider: 'api'` view data sources went through a bare `globalThis.fetch`, so
+custom endpoints (gantt composite trees, report aggregates) carried only
+same-origin cookies while every native `/api/v1/*` request carried
+`Authorization: Bearer` — the moment cookie HMAC verification failed (dev
+restart rotating the fallback auth secret, cookie expiry/rotation in prod)
+those views 401'd while the rest of the app kept working.
+
+- **`@object-ui/react`** — `SchemaRendererProvider` accepts an optional
+  `apiFetch`; nested providers inherit it from their parent so re-wrapped
+  subtrees (react pages, preview surfaces) keep the host's authentication.
+  `useViewData` defaults the api-provider adapter's fetch to the context
+  `apiFetch` (explicit `adapterOptions.fetch` still wins).
+- **`@object-ui/auth`** — `createAuthenticatedFetch` gains a
+  `sameOriginOnly` option: cross-origin URLs pass through to the bare fetch
+  with no `Authorization` / `X-Tenant-ID` / `Accept-Language`, so metadata-
+  supplied third-party URLs never see the platform token.
+- **`@object-ui/app-shell`** — the console wires
+  `createAuthenticatedFetch({ sameOriginOnly: true })` (settle-signal wrapped)
+  as `apiFetch` on the root `SchemaRendererProvider`.
+- **`@object-ui/plugin-gantt`** — `ObjectGantt` resolves its api-provider
+  DataSource with the context `apiFetch`, covering reads and write-backs.
+
+Behaviour is unchanged for hosts that don't provide `apiFetch` (bare fetch +
+cookies, as before).

--- a/content/docs/plugins/plugin-gantt.mdx
+++ b/content/docs/plugins/plugin-gantt.mdx
@@ -255,6 +255,12 @@ The dependencies field should contain an array of task IDs that this task depend
 }
 ```
 
+When the view renders inside a `SchemaRendererProvider` that supplies an
+`apiFetch` (the console host wires an authenticated fetch there), api-provider
+requests carry the same credentials — `Authorization`, tenant, and locale
+headers — as native platform requests. Without it, requests fall back to the
+bare global fetch and rely on same-origin cookies alone.
+
 ## Event Handling
 
 ### Task Click

--- a/packages/app-shell/src/console/ConsoleShell.tsx
+++ b/packages/app-shell/src/console/ConsoleShell.tsx
@@ -12,12 +12,13 @@
 
 import { Suspense, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { AuthGuard, useAuth } from '@object-ui/auth';
+import { AuthGuard, useAuth, createAuthenticatedFetch } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { SchemaRendererProvider, ActionProvider } from '@object-ui/react';
 import { useActionModal } from '../hooks/useActionModal';
 import { createObjectStackUserStateAdapter } from '@object-ui/data-objectstack';
 import { AdapterProvider, useAdapter } from '../providers/AdapterProvider';
+import { withSettleSignal } from '../observability/settleSignal';
 import { MetadataProvider, useMetadata } from '../providers/MetadataProvider';
 import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
 import { PreviewModeProvider } from '../preview/PreviewModeContext';
@@ -115,6 +116,14 @@ export function ConnectedShell({ children }: { children: ReactNode }) {
   );
 }
 
+// Authenticated fetch for `provider: 'api'` view data sources (#2725): custom
+// endpoints get the same Authorization / X-Tenant-ID / Accept-Language headers
+// as the native adapter channel, so a cookie whose HMAC signature rotated
+// (e.g. dev-server restart) no longer strands them on 401. `sameOriginOnly`
+// keeps the bearer token off third-party hosts a view's URL may point at, and
+// withSettleSignal keeps these requests visible to the ADR-0054 C5 idle probe.
+const apiProviderFetch = withSettleSignal(createAuthenticatedFetch({ sameOriginOnly: true }));
+
 function ConnectedShellInner({ children }: { children: ReactNode }) {
   const adapter = useAdapter();
   const { language } = useObjectTranslation();
@@ -149,7 +158,7 @@ function ConnectedShellInner({ children }: { children: ReactNode }) {
   // Expose the adapter via SchemaRendererContext so descendant hooks like
   // useDiscovery() (used to gate the global AI chatbot) can resolve it.
   return (
-    <SchemaRendererProvider dataSource={adapter}>
+    <SchemaRendererProvider dataSource={adapter} apiFetch={apiProviderFetch}>
       <MetadataProvider key={language} adapter={adapter}>
         <UserStateBridge />
         <GlobalCreateModalProvider dataSource={adapter}>

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -126,10 +126,16 @@ Displays current user info with avatar and sign-out:
 
 ### createAuthenticatedFetch
 
-Creates a fetch wrapper that injects auth tokens into DataSource requests:
+Creates a fetch wrapper that injects the stored Bearer token (plus
+`X-Tenant-ID` and `Accept-Language`) into API requests:
 
 ```tsx
-const authedFetch = createAuthenticatedFetch({ getToken: () => session.token });
+const authedFetch = createAuthenticatedFetch();
+
+// For fetches whose target URL comes from view metadata (`provider: 'api'`
+// data sources), restrict credential injection to the current page's origin
+// so the platform token never leaks to third-party hosts:
+const apiProviderFetch = createAuthenticatedFetch({ sameOriginOnly: true });
 ```
 
 ## Preview Mode

--- a/packages/auth/src/__tests__/createAuthenticatedFetch.test.tsx
+++ b/packages/auth/src/__tests__/createAuthenticatedFetch.test.tsx
@@ -83,4 +83,32 @@ describe('createAuthenticatedFetch', () => {
     await createAuthenticatedFetch()(API_URL, { headers: { 'Accept-Language': 'ja' } });
     expect(calls[0].headers.get('Accept-Language')).toBe('ja');
   });
+
+  // ── sameOriginOnly (#2725) — provider:'api' fetches must not leak the
+  //    bearer token to third-party hosts a view's metadata URL may name ──
+
+  it('sameOriginOnly: still injects the token on same-origin API calls', async () => {
+    vi.spyOn(TokenStorage, 'get').mockReturnValue('tok123');
+    const calls = stubFetch();
+    await createAuthenticatedFetch({ sameOriginOnly: true })('/api/gantt/tree');
+    expect(calls[0].headers.get('Authorization')).toBe('Bearer tok123');
+  });
+
+  it('sameOriginOnly: passes cross-origin URLs through with no auth/tenant headers', async () => {
+    vi.spyOn(TokenStorage, 'get').mockReturnValue('tok123');
+    ActiveOrganizationStorage.set('org-42');
+    document.documentElement.lang = 'zh-CN';
+    const calls = stubFetch();
+    await createAuthenticatedFetch({ sameOriginOnly: true })('https://third-party.example.com/api/x');
+    expect(calls[0].headers.get('Authorization')).toBeNull();
+    expect(calls[0].headers.get('X-Tenant-ID')).toBeNull();
+    expect(calls[0].headers.get('Accept-Language')).toBeNull();
+  });
+
+  it('without sameOriginOnly, cross-origin /api/ URLs keep the legacy attach behaviour', async () => {
+    vi.spyOn(TokenStorage, 'get').mockReturnValue('tok123');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()('https://third-party.example.com/api/x');
+    expect(calls[0].headers.get('Authorization')).toBe('Bearer tok123');
+  });
 });

--- a/packages/auth/src/createAuthenticatedFetch.ts
+++ b/packages/auth/src/createAuthenticatedFetch.ts
@@ -56,6 +56,29 @@ export const ActiveOrganizationStorage = {
   },
 };
 
+export interface CreateAuthenticatedFetchOptions {
+  /**
+   * When true, requests whose URL resolves to a different origin than the
+   * current page are passed through to the bare global fetch — no
+   * Authorization, X-Tenant-ID, or Accept-Language headers are attached.
+   *
+   * Use this for fetches whose target URL comes from view metadata
+   * (`provider: 'api'` data sources): those may point at third-party hosts
+   * that must never see the platform bearer token.
+   */
+  sameOriginOnly?: boolean;
+}
+
+/** True when `url` resolves to a different origin than the current page. */
+function isCrossOrigin(url: string): boolean {
+  if (typeof window === 'undefined' || !window.location) return true;
+  try {
+    return new URL(url, window.location.href).origin !== window.location.origin;
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Creates an authenticated fetch wrapper that injects the Bearer token
  * from localStorage into every request to the ObjectStack API.
@@ -74,10 +97,15 @@ export const ActiveOrganizationStorage = {
  * });
  * ```
  */
-export function createAuthenticatedFetch(): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
+export function createAuthenticatedFetch(
+  options?: CreateAuthenticatedFetchOptions,
+): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
   return async (input: RequestInfo | URL, init?: RequestInit) => {
     const headers = new Headers(init?.headers);
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    if (options?.sameOriginOnly && isCrossOrigin(url)) {
+      return fetch(input, init);
+    }
     const isApiCall = /\/api\//i.test(url);
     const token = TokenStorage.get();
     if (token && isApiCall) {

--- a/packages/plugin-gantt/src/ObjectGantt.apifetch.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.apifetch.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * provider:'api' must use the host-authenticated fetch (#2725).
+ *
+ * The composite endpoint behind an api-provider gantt is a platform endpoint
+ * like any other — its requests must carry the host's session credentials
+ * (Authorization / tenant headers), not ride on cookies alone. The host
+ * publishes an authenticated fetch via SchemaRendererContext.apiFetch;
+ * ObjectGantt must thread it into resolveDataSource so ApiDataSource uses it
+ * instead of the bare global fetch.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SchemaRendererProvider } from '@object-ui/react';
+import { ObjectGantt } from './ObjectGantt';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks }: any) => (
+    <div data-testid="gantt-view">
+      {tasks.map((t: any) => (
+        <div key={t.id} data-testid={`gv-view-${t.id}`}>{t.title}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@object-ui/plugin-detail', () => ({
+  RecordDetailDrawer: () => null,
+  deriveRecordPageHref: () => null,
+}));
+
+const ROWS = [
+  { id: '1', name: 'Task A', start_date: '2024-01-01', end_date: '2024-01-05' },
+];
+
+function makeSchema(): any {
+  return {
+    type: 'gantt',
+    objectName: 'tasks',
+    gantt: {
+      titleField: 'name',
+      startDateField: 'start_date',
+      endDateField: 'end_date',
+    },
+    data: { provider: 'api', read: { url: '/api/gantt/tree', method: 'GET' } },
+  };
+}
+
+function makeApiFetch() {
+  return vi.fn(async () =>
+    new Response(JSON.stringify({ data: ROWS, total: ROWS.length }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe("ObjectGantt provider:'api' host auth fetch", () => {
+  const bareFetch = vi.fn(async () => new Response('{}', { status: 401 }));
+
+  beforeEach(() => {
+    bareFetch.mockClear();
+    vi.stubGlobal('fetch', bareFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reads through SchemaRendererContext.apiFetch, not the bare global fetch', async () => {
+    const apiFetch = makeApiFetch();
+
+    render(
+      <SchemaRendererProvider dataSource={null} apiFetch={apiFetch as any}>
+        <ObjectGantt schema={makeSchema()} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('gv-view-1')).toBeDefined());
+    expect(apiFetch).toHaveBeenCalled();
+    const [calledUrl] = apiFetch.mock.calls[0] as unknown as [string];
+    expect(String(calledUrl)).toContain('/api/gantt/tree');
+    expect(bareFetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the global fetch when no apiFetch is in context', async () => {
+    bareFetch.mockImplementation(async () =>
+      new Response(JSON.stringify({ data: ROWS, total: ROWS.length }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    render(<ObjectGantt schema={makeSchema()} />);
+
+    await waitFor(() => expect(screen.getByTestId('gv-view-1')).toBeDefined());
+    expect(bareFetch).toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -22,11 +22,11 @@
  * - Works with object/api/value data providers
  */
 
-import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import React, { useContext, useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import type { ObjectGridSchema, DataSource, ViewData, GanttConfig } from '@object-ui/types';
 import { GanttConfigSchema } from '@objectstack/spec/ui';
-import { useNavigationOverlay } from '@object-ui/react';
+import { useNavigationOverlay, SchemaRendererContext } from '@object-ui/react';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import { RecordDetailDrawer, deriveRecordPageHref } from '@object-ui/plugin-detail';
 import {
@@ -458,10 +458,14 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // Every read AND write-back below goes through this single adapter, so the
   // 'api' provider now supports reschedule / dependency / delete / inline-edit
   // write-backs — not just object-backed views.
+  // Host-authenticated fetch (SchemaRendererContext.apiFetch) so the 'api'
+  // provider's custom endpoints carry the same Authorization/tenant headers
+  // as native requests instead of relying on cookies alone (#2725).
+  const apiFetch = useContext(SchemaRendererContext)?.apiFetch;
   const effectiveDataSource = useMemo(
-    () => resolveDataSource(dataConfig, dataSource ?? null),
+    () => resolveDataSource(dataConfig, dataSource ?? null, { fetch: apiFetch }),
     // dataConfig is already memoized by deep value above.
-    [dataConfig, dataSource],
+    [dataConfig, dataSource, apiFetch],
   );
 
   // Unified resource name for find/update/delete. For 'object' it's the bound

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -81,6 +81,30 @@ function App() {
 }
 ```
 
+### SchemaRendererProvider
+
+Injects the host's data source (and optional capabilities) into every renderer
+below it:
+
+```tsx
+import { SchemaRendererProvider } from '@object-ui/react'
+
+<SchemaRendererProvider
+  dataSource={adapter}
+  // Optional: host-authenticated fetch used by `provider: 'api'` view data
+  // sources, so custom endpoints carry the same credentials (Authorization,
+  // tenant, locale headers) as the native data channel. When omitted,
+  // ApiDataSource falls back to the bare global fetch (cookies only).
+  apiFetch={authenticatedFetch}
+>
+  <SchemaRenderer schema={schema} />
+</SchemaRendererProvider>
+```
+
+Nested providers inherit `apiFetch` from their parent when they don't supply
+their own, so re-wrapped subtrees (embedded pages, preview surfaces) keep the
+host's authentication.
+
 ## Hooks
 
 ### useSchemaContext

--- a/packages/react/src/__tests__/SchemaRendererProvider.smoke.test.tsx
+++ b/packages/react/src/__tests__/SchemaRendererProvider.smoke.test.tsx
@@ -63,6 +63,50 @@ describe('useSchemaContext provider requirement', () => {
   });
 });
 
+describe('SchemaRendererProvider apiFetch inheritance (#2725)', () => {
+  const ApiFetchProbe: React.FC = () => {
+    const { apiFetch } = useSchemaContext();
+    return <div data-testid="api-fetch-probe">{(apiFetch as any)?.__name ?? 'none'}</div>;
+  };
+
+  const namedFetch = (name: string) => {
+    const fn = (async () => new Response('{}')) as any;
+    fn.__name = name;
+    return fn;
+  };
+
+  it('nested provider without apiFetch inherits the parent host fetch', () => {
+    render(
+      <SchemaRendererProvider dataSource={{}} apiFetch={namedFetch('host')}>
+        <SchemaRendererProvider dataSource={{ inner: true }}>
+          <ApiFetchProbe />
+        </SchemaRendererProvider>
+      </SchemaRendererProvider>
+    );
+    expect(screen.getByTestId('api-fetch-probe')).toHaveTextContent('host');
+  });
+
+  it('nested provider with its own apiFetch overrides the parent', () => {
+    render(
+      <SchemaRendererProvider dataSource={{}} apiFetch={namedFetch('host')}>
+        <SchemaRendererProvider dataSource={{}} apiFetch={namedFetch('inner')}>
+          <ApiFetchProbe />
+        </SchemaRendererProvider>
+      </SchemaRendererProvider>
+    );
+    expect(screen.getByTestId('api-fetch-probe')).toHaveTextContent('inner');
+  });
+
+  it('apiFetch stays undefined when no provider supplies one', () => {
+    render(
+      <SchemaRendererProvider dataSource={{}}>
+        <ApiFetchProbe />
+      </SchemaRendererProvider>
+    );
+    expect(screen.getByTestId('api-fetch-probe')).toHaveTextContent('none');
+  });
+});
+
 describe('SchemaRenderer + SchemaRendererProvider integration', () => {
   beforeEach(() => {
     ComponentRegistry.register('test-ctx-consumer', ContextConsumer);

--- a/packages/react/src/__tests__/useViewData.test.tsx
+++ b/packages/react/src/__tests__/useViewData.test.tsx
@@ -420,3 +420,68 @@ describe('useViewData — edge cases', () => {
     expect(mockDS.find).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// provider: 'api' — host-authenticated fetch (#2725)
+// ---------------------------------------------------------------------------
+
+describe("useViewData — provider: 'api' host auth fetch", () => {
+  const apiViewData: ViewData = {
+    provider: 'api',
+    read: { url: '/api/gantt/tree', method: 'GET' },
+  } as ViewData;
+
+  function jsonResponse() {
+    return new Response(JSON.stringify({ data: [{ id: '1' }], total: 1 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  function apiFetchWrapper(apiFetch: typeof fetch) {
+    return ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        SchemaRendererContext.Provider,
+        { value: { dataSource: null, apiFetch } },
+        children,
+      );
+  }
+
+  it('routes api-provider requests through the context apiFetch', async () => {
+    const apiFetch = vi.fn(async () => jsonResponse()) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useViewData({ viewData: apiViewData, resource: 'tasks' }),
+      { wrapper: apiFetchWrapper(apiFetch) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(apiFetch).toHaveBeenCalled();
+    expect(result.current.data).toEqual([{ id: '1' }]);
+  });
+
+  it('lets an explicit adapterOptions.fetch win over the context apiFetch', async () => {
+    const contextFetch = vi.fn(async () => jsonResponse()) as unknown as typeof fetch;
+    const explicitFetch = vi.fn(async () => jsonResponse()) as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () =>
+        useViewData({
+          viewData: apiViewData,
+          resource: 'tasks',
+          adapterOptions: { fetch: explicitFetch },
+        }),
+      { wrapper: apiFetchWrapper(contextFetch) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(explicitFetch).toHaveBeenCalled();
+    expect(contextFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/context/SchemaRendererContext.tsx
+++ b/packages/react/src/context/SchemaRendererContext.tsx
@@ -1,28 +1,47 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import type { DebugFlags } from '@object-ui/core';
 
+/**
+ * Host-provided fetch used for `provider: 'api'` view data sources so custom
+ * endpoints carry the same credentials (Authorization, tenant, locale headers)
+ * as the native data channel. Optional — when absent, ApiDataSource falls back
+ * to the bare global fetch (cookies only).
+ */
+export type ApiFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
 interface SchemaRendererContextType {
   dataSource: any;
   debug?: boolean;
   debugFlags?: DebugFlags;
+  apiFetch?: ApiFetch;
 }
 
 const SchemaRendererContext = createContext<SchemaRendererContextType | null>(null);
 
 export { SchemaRendererContext };
 
-export const SchemaRendererProvider = ({ 
-  children, 
-  dataSource, 
+export const SchemaRendererProvider = ({
+  children,
+  dataSource,
   debug,
   debugFlags,
-}: { 
-  children: React.ReactNode; 
-  dataSource: any; 
+  apiFetch,
+}: {
+  children: React.ReactNode;
+  dataSource: any;
   debug?: boolean;
   debugFlags?: DebugFlags;
+  apiFetch?: ApiFetch;
 }) => {
-  const value = useMemo(() => ({ dataSource, debug, debugFlags }), [dataSource, debug, debugFlags]);
+  // Nested providers (react-page, studio preview surfaces) re-wrap with their
+  // own dataSource but rarely know about the host's authenticated fetch —
+  // inherit it from the parent context so provider:'api' auth survives nesting.
+  const parent = useContext(SchemaRendererContext);
+  const effectiveApiFetch = apiFetch ?? parent?.apiFetch;
+  const value = useMemo(
+    () => ({ dataSource, debug, debugFlags, apiFetch: effectiveApiFetch }),
+    [dataSource, debug, debugFlags, effectiveApiFetch],
+  );
   return (
     <SchemaRendererContext.Provider value={value}>
       {children}

--- a/packages/react/src/hooks/useViewData.ts
+++ b/packages/react/src/hooks/useViewData.ts
@@ -94,18 +94,26 @@ export function useViewData<T = any>(options: UseViewDataOptions<T>): UseViewDat
     skip = false,
   } = options;
 
-  // Get context DataSource
+  // Get context DataSource + host-authenticated fetch
   const context = useContext(SchemaRendererContext);
   const contextDataSource = context?.dataSource ?? null;
+  const contextApiFetch = context?.apiFetch;
 
   // Resolve the DataSource — memoize to prevent re-creation on every render.
   // We key on the viewData provider + config identity.
   const resolvedDataSource = useMemo(() => {
     if (explicitDataSource) return explicitDataSource;
-    return resolveDataSource<T>(viewData, contextDataSource, adapterOptions);
+    // Default the 'api' provider's fetch to the host's authenticated fetch
+    // (SchemaRendererContext.apiFetch) so custom endpoints carry the same
+    // credentials as native requests; explicit adapterOptions still win.
+    return resolveDataSource<T>(viewData, contextDataSource, {
+      fetch: contextApiFetch,
+      ...adapterOptions,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     explicitDataSource,
+    contextApiFetch,
     viewData?.provider,
     // For 'api' provider, key on read/write URLs
     viewData?.provider === 'api' ? (viewData as any).read?.url : undefined,


### PR DESCRIPTION
Fixes #2725

## Problem

`provider: 'api'` view data sources went through a bare `globalThis.fetch`, so custom endpoints (gantt composite trees, report aggregates) carried only same-origin cookies while every native `/api/v1/*` request carried `Authorization: Bearer`. The moment cookie HMAC verification failed (dev restart rotating the fallback auth secret, cookie expiry/rotation in prod), those views 401'd while the rest of the app kept working.

The injection points existed from day one (`ApiDataSource` accepts `fetch`/`defaultHeaders`, `resolveDataSource` passes them through) but no caller ever wired them — see the [root-cause confirmation on the issue](https://github.com/objectstack-ai/objectui/issues/2725#issuecomment-5018689840).

## Changes

- **`@object-ui/react`** — `SchemaRendererProvider` accepts an optional `apiFetch`; nested providers inherit it from their parent, so re-wrapped subtrees (react pages, studio preview surfaces) keep the host's authentication. `useViewData` defaults the api-provider adapter's fetch to the context `apiFetch` (explicit `adapterOptions.fetch` still wins).
- **`@object-ui/auth`** — `createAuthenticatedFetch` gains a `sameOriginOnly` option: cross-origin URLs pass through to the bare fetch with no `Authorization` / `X-Tenant-ID` / `Accept-Language`, so metadata-supplied third-party URLs never see the platform token.
- **`@object-ui/app-shell`** — the console wires `withSettleSignal(createAuthenticatedFetch({ sameOriginOnly: true }))` as `apiFetch` on the root `SchemaRendererProvider`, so api-provider requests carry the same credentials as the native adapter channel and stay visible to the ADR-0054 C5 idle probe.
- **`@object-ui/plugin-gantt`** — `ObjectGantt` resolves its api-provider DataSource with the context `apiFetch`, covering reads AND write-backs.

Backward compatible: hosts that don't provide `apiFetch` keep the current behaviour (bare fetch + cookies).

## Tests

- `auth`: `sameOriginOnly` attaches on same-origin, strips all credential headers cross-origin, legacy no-option behaviour unchanged (3 new).
- `react`: `useViewData` routes api-provider requests through the context `apiFetch` / explicit override wins (2 new); provider nesting inheritance (3 new).
- `plugin-gantt`: `ObjectGantt` reads through `SchemaRendererContext.apiFetch` instead of the bare global fetch, and still falls back without one (2 new).
- Full suites green: auth 89, react 89, plugin-gantt 340; `turbo run build --filter=@object-ui/app-shell` (29 packages) passes.

Docs updated (`react`/`auth` READMEs, `plugin-gantt.mdx`) + changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
