### PR TITLE
feat(fields): CheckboxesField visibleWhen cascading + dependsOn gating (completes option-widget parity)

### DIFF
--- a/.changeset/checkboxes-cascade-parity.md
+++ b/.changeset/checkboxes-cascade-parity.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/fields": minor
+"@object-ui/components": patch
+---
+
+feat(fields): CheckboxesField per-option `visibleWhen` cascading + `dependsOn` gating (completes the option-widget parity set)
+
+`checkboxes` was the last static-option widget still rendering `config.options`
+raw — with no per-option `visibleWhen` filtering, `dependsOn` gating, or cascade
+clear. It now matches `MultiSelectField` (its multi-value sibling), completing
+the ADR-0058 parity across `select` / `multiselect` / `radio` / `checkboxes`.
+
+- **`@object-ui/fields`**: `CheckboxesField` routes through the shared
+  `useCascadingOptions` hook — offered boxes narrow against the live record +
+  `current_user`, the control gates behind a "select the parent first" hint
+  while a `dependsOn` field is empty, and selections no longer offered are
+  pruned per-element from the array. Adds `checkboxes-empty-*` /
+  `checkboxes-option-*` testids.
+- **`@object-ui/components`**: adds `checkboxes` to the form renderer's option
+  field sets (`CASCADE_OPTION_FIELD_TYPES`, the cross-field cascade-clear
+  effect, and the option pre-filter) so a `checkboxes` field is threaded
+  `dependentValues` and gated identically to the other option widgets.
+- Tests: `CheckboxesField.cascade.test.tsx` mirrors `MultiSelectField.cascade.test.tsx`.

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -128,13 +128,13 @@ const DATA_SOURCE_FIELD_TYPES = new Set([
   'object-ref', 'filter-condition', 'recipient-picker',
 ]);
 
-// Option fields (`select`/`radio`/`multiselect`) support per-option `visibleWhen`
-// cascading + `dependsOn` gating (#2284/#1583): the widget re-filters its OFFERED
-// set against the live form record (`record.country == 'cn'` …). They take no
-// `dataSource`, but they DO need the live `dependentValues` record — without it a
-// cascading select never sees its controlling field and stays permanently gated
-// on the "select the parent first" hint.
-const CASCADE_OPTION_FIELD_TYPES = new Set(['select', 'radio', 'multiselect']);
+// Option fields (`select`/`radio`/`multiselect`/`checkboxes`) support per-option
+// `visibleWhen` cascading + `dependsOn` gating (#2284/#1583): the widget re-filters
+// its OFFERED set against the live form record (`record.country == 'cn'` …). They
+// take no `dataSource`, but they DO need the live `dependentValues` record —
+// without it a cascading select never sees its controlling field and stays
+// permanently gated on the "select the parent first" hint.
+const CASCADE_OPTION_FIELD_TYPES = new Set(['select', 'radio', 'multiselect', 'checkboxes']);
 
 function stripRendererOnlyProps<T extends Record<string, any>>(props: T): T {
   const {
@@ -408,7 +408,13 @@ ComponentRegistry.register('form',
         const name = f?.name;
         if (!name) continue;
         const resolvedType = (f as any).widget || f.type;
-        if (resolvedType !== 'select' && resolvedType !== 'radio' && resolvedType !== 'multiselect') continue;
+        if (
+          resolvedType !== 'select' &&
+          resolvedType !== 'radio' &&
+          resolvedType !== 'multiselect' &&
+          resolvedType !== 'checkboxes'
+        )
+          continue;
         const opts = (f as any).options as SelectOption[] | undefined;
         if (!opts || opts.length === 0) continue;
         const dependsOn = (f as any).dependsOn;
@@ -797,7 +803,10 @@ ComponentRegistry.register('form',
                 // while a declared `dependsOn` parent is still empty — surfacing a
                 // "select the parent first" hint instead of an unfiltered list.
                 const isOptionField =
-                  resolvedType === 'select' || resolvedType === 'radio' || resolvedType === 'multiselect';
+                  resolvedType === 'select' ||
+                  resolvedType === 'radio' ||
+                  resolvedType === 'multiselect' ||
+                  resolvedType === 'checkboxes';
                 const rawOptions = (fieldProps as any).options as SelectOption[] | undefined;
                 // Resolve gating + `visibleWhen` filtering through the shared
                 // core helper so this pre-filter can't drift from the widgets'

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -99,17 +99,18 @@ single dropdown does.
 
 ### Cascading & role-gated select options
 
-`select`, `multiselect`, and `radio` options support a per-option `visibleWhen`
-CEL predicate (offered only when TRUE, evaluated against the live record +
-`current_user`) and a field-level `dependsOn`. Together they drive dependent
-selects (country → province → city) and role-gated options with no bespoke
-matrix — the same primitives dependent lookups use. All three widgets resolve
-this through the shared [`useCascadingOptions`](./src/widgets/useCascadingOptions.ts)
+`select`, `multiselect`, `radio`, and `checkboxes` options support a per-option
+`visibleWhen` CEL predicate (offered only when TRUE, evaluated against the live
+record + `current_user`) and a field-level `dependsOn`. Together they drive
+dependent selects (country → province → city) and role-gated options with no
+bespoke matrix — the same primitives dependent lookups use. All four widgets
+resolve this through the shared [`useCascadingOptions`](./src/widgets/useCascadingOptions.ts)
 hook, which wraps the pure `resolveCascadingOptions` helper in `@object-ui/core`
 (also used by the form renderer's inline pre-filter, so gating and filtering
 never drift). While a `dependsOn` parent is empty the control is gated; a parent
 change re-filters the list and clears a now-invalid value (scalar `select` /
-`radio` drop the value; `multiselect` prunes just the offered-out entries).
+`radio` drop the value; multi-value `multiselect` / `checkboxes` prune just the
+offered-out entries).
 Client-side hiding is UX only — gate authorization-sensitive values on the
 server too. See
 [`content/docs/fields/select.mdx`](../../content/docs/fields/select.mdx).

--- a/packages/fields/src/widgets/CheckboxesField.cascade.test.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.cascade.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Cascading / role-gated `checkboxes` options (#2715 follow-up) — parity with
+ * `MultiSelectField` (ADR-0058 / #2284).
+ *
+ * Exercises the observable widget behaviour: the dependency gate (a "select the
+ * parent first" empty-state) and the per-element cascade clear — a selection
+ * dropped from the array when the offered set no longer includes it, while
+ * still-valid selections are kept. The per-option filtering itself is unit-tested
+ * in `@object-ui/core` (`optionRules.test.ts`); here we prove the checkbox list
+ * wires `dependentValues` + predicate scope into that resolver via the shared
+ * `useCascadingOptions` hook.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { CheckboxesField } from './CheckboxesField';
+
+const provinceField = {
+  name: 'provinces',
+  type: 'checkboxes',
+  dependsOn: 'country',
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+  ],
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CheckboxesField — dependency gating (#2715)', () => {
+  it('gates with a "select parent first" hint while the controlling field is empty', () => {
+    render(
+      <CheckboxesField
+        value={[]}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...({ name: 'provinces', dependentValues: {} } as any)}
+      />,
+    );
+    const gate = screen.getByTestId('checkboxes-empty-provinces');
+    expect(gate).toHaveTextContent(/select country first/i);
+    // Gated → no checkboxes offered.
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+  });
+
+  it('unlocks the checkboxes once the controlling field is set', () => {
+    render(
+      <CheckboxesField
+        value={[]}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...({ name: 'provinces', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    expect(screen.queryByTestId('checkboxes-empty-provinces')).not.toBeInTheDocument();
+    // Only the `cn` option is offered.
+    expect(screen.getByRole('checkbox', { name: 'Zhejiang' })).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: 'California' })).not.toBeInTheDocument();
+  });
+});
+
+describe('CheckboxesField — cascade clear (#2715)', () => {
+  it('drops only the selections the parent change no longer offers', () => {
+    const onChange = vi.fn();
+    render(
+      <CheckboxesField
+        value={['zj', 'ca']}
+        onChange={onChange}
+        field={provinceField}
+        {...({ name: 'provinces', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    // 'ca' is a US province — under country=cn it is not offered, so it is
+    // pruned; the still-valid 'zj' is kept.
+    expect(onChange).toHaveBeenCalledWith(['zj']);
+  });
+
+  it('keeps selections that are all still offered', () => {
+    const onChange = vi.fn();
+    render(
+      <CheckboxesField
+        value={['zj']}
+        onChange={onChange}
+        field={provinceField}
+        {...({ name: 'provinces', dependentValues: { country: 'cn' } } as any)}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('CheckboxesField — role / context gating (#2715)', () => {
+  const tierField = {
+    name: 'tiers',
+    type: 'checkboxes',
+    options: [
+      { label: 'Standard', value: 'standard' },
+      { label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.positions" },
+    ],
+  } as any;
+
+  it('prunes an admin-only value for a non-admin (offered set excludes it)', () => {
+    const onChange = vi.fn();
+    render(
+      <PredicateScopeProvider scope={{ current_user: { positions: ['sales'] } }}>
+        <CheckboxesField
+          value={['standard', 'admin_only']}
+          onChange={onChange}
+          field={tierField}
+          {...({ name: 'tiers', dependentValues: {} } as any)}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(onChange).toHaveBeenCalledWith(['standard']);
+  });
+
+  it('keeps an admin-only value for an admin', () => {
+    const onChange = vi.fn();
+    render(
+      <PredicateScopeProvider scope={{ current_user: { positions: ['admin'] } }}>
+        <CheckboxesField
+          value={['standard', 'admin_only']}
+          onChange={onChange}
+          field={tierField}
+          {...({ name: 'tiers', dependentValues: {} } as any)}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -1,28 +1,87 @@
-import React, { useId } from 'react';
+import React, { useId, useEffect } from 'react';
 import { Checkbox, Label, EmptyValue, Badge } from '@object-ui/components';
+import type { OptionLike } from '@object-ui/core';
 import { FieldWidgetProps } from './types';
+import { useCascadingOptions } from './useCascadingOptions';
 
-interface Option { label: string; value: string }
+type Option = OptionLike;
 
 /**
  * CheckboxesField - select zero or more values from a fixed option set, rendered
  * as a list of checkboxes. The stored value is a string[]. Used for the
  * `checkboxes` field type.
+ *
+ * Options support the same per-option `visibleWhen` cascading + `dependsOn`
+ * gating as `MultiSelectField` (ADR-0058 / #2715), resolved through the shared
+ * {@link useCascadingOptions} hook: the offered boxes narrow against the live
+ * form record + `current_user`, the control is gated behind a "select the parent
+ * first" hint while a dependency is empty, and selections no longer offered
+ * (parent changed / predicate flipped) are pruned from the array.
  */
-export function CheckboxesField({ value, onChange, field, readonly, className, ...props }: FieldWidgetProps<string[]>) {
-  const config = (field || (props as any).schema) as any;
-  const options: Option[] = config?.options || [];
+export function CheckboxesField({
+  value,
+  onChange,
+  field,
+  readonly,
+  className,
+  schema,
+  dependentValues,
+  dependsOn: dependsOnProp,
+  emptyHint: _emptyHint,
+  dataSource: _dataSource,
+  ...props
+}: FieldWidgetProps<string[]>) {
+  const config = (field || schema) as any;
+  const rawOptions: Option[] = config?.options || [];
   const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
   const groupId = useId();
+  const fieldName = (props as any).name || config?.name || (props as any).id || '';
+
+  const dependsOn = config?.dependsOn ?? dependsOnProp;
+  const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
+    rawOptions,
+    dependsOn,
+    dependentValues,
+  );
+
+  // Cascade clear: prune selected values the offered set no longer includes
+  // (parent changed / predicate flipped), keeping the ones still valid — the
+  // per-element clear the multi-value case needs (cf. the scalar select/radio).
+  useEffect(() => {
+    if (readonly) return;
+    if (selected.length === 0) return;
+    const stillOffered = selected.filter((v) => options.some((o) => o.value === v));
+    if (stillOffered.length !== selected.length) onChange(stillOffered);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options, gated]);
 
   if (readonly) {
     if (selected.length === 0) return <EmptyValue />;
     return (
       <div className="flex flex-wrap gap-1">
         {selected.map((v) => {
-          const opt = options.find((o) => o.value === v);
+          // Label from the raw set so a stored value hidden by `visibleWhen`
+          // still renders its label rather than a bare id.
+          const opt = rawOptions.find((o) => o.value === v);
           return <Badge key={v} variant="outline">{opt?.label || v}</Badge>;
         })}
+      </div>
+    );
+  }
+
+  // No offered options is unfillable — surface a legible state instead of an
+  // empty checkbox list: a dependency-gated list prompts for its controlling
+  // field; an unconfigured / fully-filtered list says so. Mirrors the select.
+  if (options.length === 0) {
+    const hint = gated
+      ? `Select ${dependsOnFields.join(' / ')} first`
+      : 'No options available';
+    return (
+      <div
+        data-testid={fieldName ? `checkboxes-empty-${fieldName}` : undefined}
+        className="flex min-h-9 w-full items-center rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
+      >
+        {hint}
       </div>
     );
   }
@@ -33,7 +92,10 @@ export function CheckboxesField({ value, onChange, field, readonly, className, .
   };
 
   return (
-    <div className={className}>
+    <div
+      className={className}
+      data-testid={fieldName ? `checkboxes-${fieldName}` : undefined}
+    >
       {options.map((opt) => {
         const id = `${groupId}-${opt.value}`;
         return (
@@ -43,6 +105,7 @@ export function CheckboxesField({ value, onChange, field, readonly, className, .
               checked={selected.includes(opt.value)}
               onCheckedChange={(checked) => toggle(opt.value, !!checked)}
               disabled={(props as any).disabled}
+              data-testid={`checkboxes-option-${opt.value}`}
             />
             <Label htmlFor={id} className="font-normal">{opt.label}</Label>
           </div>


### PR DESCRIPTION
Completes the ADR-0058 cascading / role-gated option parity across **all four** static-option widgets. `checkboxes` was the last one still rendering `config.options` raw — after #2717 (multiselect) and #2728 (radio + single-source resolver), this closes the set: `select` / `multiselect` / `radio` / `checkboxes` now behave identically.

## Why

`CheckboxesField` is the multi-value sibling of `MultiSelectField` (stores `string[]`, fixed option set) but had none of the per-option `visibleWhen` filtering, `dependsOn` gating, or cascade clear — so a `checkboxes` field with dependent / role-gated options showed the unfiltered set.

## Changes

- **`@object-ui/fields`** — `CheckboxesField` routes through the shared `useCascadingOptions` hook: offered boxes narrow against the live record + `current_user`; gates behind a "select the parent first" hint while a `dependsOn` field is empty; prunes offered-out selections **per-element** (the multi-value cascade clear). Adds `checkboxes-empty-*` / `checkboxes-option-*` testids.
- **`@object-ui/components`** — adds `checkboxes` to the form renderer's option-field sets: `CASCADE_OPTION_FIELD_TYPES` (so `dependentValues` is threaded), the cross-field cascade-clear effect, and the option pre-filter (gated `disabled` + hint). Without this the widget never sees its controlling field.

## Tests

- New `CheckboxesField.cascade.test.tsx` mirrors `MultiSelectField.cascade.test.tsx` (gating, per-element cascade clear, role/context gating).
- Verified green (**21 passed**): `CheckboxesField.cascade` + the refactored form path (`form-cascading-select`, `form-dependent-values`) + sibling `MultiSelectField.cascade` / `RadioField.cascade`.
- `tsc --noEmit` clean for `@object-ui/components` + `@object-ui/fields`; `eslint` 0 errors.

## Refs

- #2717 (multiselect) · #2728 (radio + `resolveCascadingOptions`) · ADR-0058 · server-side enforcement tracked in #2729

🤖 Generated with [Claude Code](https://claude.com/claude-code)