### PR TITLE
feat(i18n): localize action result dialogs via _actions.<action>.resultDialog

### DIFF
--- a/.changeset/action-result-dialog-i18n.md
+++ b/.changeset/action-result-dialog-i18n.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/i18n": minor
+"@object-ui/app-shell": patch
+---
+
+feat(i18n): localize action result dialogs via the `_actions.<action>.resultDialog` convention
+
+The post-success secret-reveal dialog (create-user temporary password, 2FA
+backup codes, OAuth client secrets) always rendered the hardcoded English
+metadata literals — the spec bundles now carry `resultDialog` translations
+(objectstack `_actions.<action>.resultDialog.*`), but nothing resolved them
+client-side.
+
+- **@object-ui/i18n.** `useObjectLabel()` gains `actionResultDialog(objectName,
+  actionName, spec)`: overlays translated `title` / `description` /
+  `acknowledge` and per-field labels onto the metadata spec, falling back to
+  the literals. The `fields` node is keyed by the LITERAL result-field path
+  (may contain dots, e.g. `"user.email"`), so it is fetched whole with
+  `returnObjects` and indexed directly — never resolved through a dotted
+  i18next key. Built-in locale packs also translate the dialog's fallback
+  `defaultTitle` / `acknowledge` (previously English in all ten locales) and
+  add the new `actions.resultDialog.copyAll` key.
+- **@object-ui/app-shell.** The result-dialog handlers in
+  `useConsoleActionRuntime` and `RecordDetailView` accept the action context
+  (already passed by `ActionRunner`) and localize the spec before opening the
+  dialog; `ActionResultDialog`'s hardcoded "Copy all" button now goes through
+  `actions.resultDialog.copyAll`.

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -128,7 +128,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   // [ADR-0066 D4] System capabilities for the action capability gate (fail-open
   // when no PermissionProvider is mounted — usePermissions returns []).
   const { systemPermissions } = usePermissions();
-  const { fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel, actionDescription } = useObjectLabel();
+  const { fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel, actionDescription, actionResultDialog } = useObjectLabel();
 
   const objectDef = useMemo(
     () => (objectName ? objects?.find((o: any) => o.name === objectName) : undefined),
@@ -161,10 +161,18 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   const serverActionInFlight = useRef<Set<string>>(new Set());
 
   const resultDialogHandler = useCallback<ResultDialogHandler>(
-    (spec: any, data: unknown) => new Promise<void>((resolve) => {
-      setResultDialogState({ open: true, spec, data, resolve });
+    (spec: any, data: unknown, action?: any) => new Promise<void>((resolve) => {
+      // Localize title/description/acknowledge + field labels via the
+      // `_actions.<action>.resultDialog` convention (metadata literals as
+      // fallback). The action's own object wins over the page object,
+      // mirroring the param-dialog localization below.
+      const objForI18n = (typeof action?.objectName === 'string' && action.objectName)
+        ? action.objectName
+        : objectName || (objectDef as any)?.name;
+      const localized = actionResultDialog(objForI18n, action?.name, spec) ?? spec;
+      setResultDialogState({ open: true, spec: localized, data, resolve });
     }),
-    [],
+    [objectName, objectDef, actionResultDialog],
   );
 
   const confirmHandler = useCallback<ConfirmationHandler>((message, options) => {

--- a/packages/app-shell/src/views/ActionResultDialog.tsx
+++ b/packages/app-shell/src/views/ActionResultDialog.tsx
@@ -219,6 +219,7 @@ function QrcodeBlock({ value }: { value: string }) {
 }
 
 function CodeListBlock({ value }: { value: string[] }) {
+  const { t } = useObjectTranslation();
   const joined = value.join('\n');
   return (
     <div className="space-y-2">
@@ -235,7 +236,7 @@ function CodeListBlock({ value }: { value: string[] }) {
         </ul>
       </div>
       <div className="flex justify-end">
-        <CopyButton value={joined} label="Copy all" />
+        <CopyButton value={joined} label={t('actions.resultDialog.copyAll') || 'Copy all'} />
       </div>
     </div>
   );

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -158,7 +158,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     };
   }, [originFromState, location.search, appName]);
   const { t, language } = useObjectTranslation();
-  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, actionParamOptionLabel, actionDescription, fieldLabel, fieldOptionLabel } = useObjectLabel();
+  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, actionParamOptionLabel, actionDescription, actionResultDialog, fieldLabel, fieldOptionLabel } = useObjectLabel();
   const { isFavorite, toggleFavorite, refreshLabel: refreshFavoriteLabel } = useFavorites();
   const { addRecentItem } = useRecentItems();
   const [isLoading, setIsLoading] = useState(true);
@@ -335,10 +335,17 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // (2FA secrets, OAuth client_secret, recovery codes).
   const [resultDialogState, setResultDialogState] = useState<ResultDialogState>({ open: false });
   const resultDialogHandler = useCallback(
-    (spec: any, data: unknown) => new Promise<void>((resolve) => {
-      setResultDialogState({ open: true, spec, data, resolve });
+    (spec: any, data: unknown, action?: any) => new Promise<void>((resolve) => {
+      // Localize title/description/acknowledge + field labels via the
+      // `_actions.<action>.resultDialog` convention (metadata literals as
+      // fallback); the action's own object wins over the page object.
+      const objForI18n = (typeof action?.objectName === 'string' && action.objectName)
+        ? action.objectName
+        : objectName || objectDef?.name;
+      const localized = actionResultDialog(objForI18n, action?.name, spec) ?? spec;
+      setResultDialogState({ open: true, spec: localized, data, resolve });
     }),
-    [],
+    [objectName, objectDef, actionResultDialog],
   );
 
   const confirmHandler = useCallback((message: string, options?: { title?: string; confirmText?: string; cancelText?: string }) => {

--- a/packages/i18n/src/__tests__/useObjectLabel-actionResultDialog.test.tsx
+++ b/packages/i18n/src/__tests__/useObjectLabel-actionResultDialog.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider } from '../provider';
+import { useObjectTranslation } from '../provider';
+import { useObjectLabel } from '../useObjectLabel';
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    I18nProvider,
+    { config: { defaultLanguage: 'en', detectBrowserLanguage: false } },
+    children,
+  );
+
+/** The metadata literal spec, as authored on sys_user.create_user. */
+const spec = {
+  title: 'User Created',
+  description: 'Copy the temporary password now — it is shown only once and never stored.',
+  acknowledge: 'I have saved this password',
+  fields: [
+    { path: 'user.email', label: 'Email', format: 'text' },
+    { path: 'user.phoneNumber', label: 'Phone Number', format: 'text' },
+    { path: 'temporaryPassword', label: 'Temporary Password', format: 'secret' },
+  ],
+};
+
+describe('useObjectLabel().actionResultDialog', () => {
+  it('falls back to the literal spec when no translation is registered', () => {
+    const { result } = renderHook(() => useObjectLabel(), { wrapper });
+    const out = result.current.actionResultDialog('sys_user', 'create_user', spec);
+    expect(out?.title).toBe('User Created');
+    expect(out?.fields?.[0].label).toBe('Email');
+  });
+
+  it('overlays translated copy and per-path field labels (dotted paths stay literal keys)', () => {
+    const { result } = renderHook(
+      () => ({ labels: useObjectLabel(), i18n: useObjectTranslation().i18n }),
+      { wrapper },
+    );
+    result.current.i18n.addResourceBundle(
+      'en',
+      'translation',
+      {
+        setup: {
+          objects: {
+            sys_user: {
+              _actions: {
+                create_user: {
+                  resultDialog: {
+                    title: '用户已创建',
+                    description: '请立即复制临时密码——它只显示一次，不会被保存。',
+                    acknowledge: '我已保存该密码',
+                    fields: {
+                      'user.email': '邮箱',
+                      temporaryPassword: '临时密码',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      true,
+      true,
+    );
+
+    const out = result.current.labels.actionResultDialog('sys_user', 'create_user', spec);
+    expect(out?.title).toBe('用户已创建');
+    expect(out?.description).toBe('请立即复制临时密码——它只显示一次，不会被保存。');
+    expect(out?.acknowledge).toBe('我已保存该密码');
+    // The dotted path resolves as ONE literal key of the fields record.
+    expect(out?.fields?.[0]).toEqual({ path: 'user.email', label: '邮箱', format: 'text' });
+    // Untranslated fields keep the metadata literal; format survives.
+    expect(out?.fields?.[1]).toEqual({ path: 'user.phoneNumber', label: 'Phone Number', format: 'text' });
+    expect(out?.fields?.[2]).toEqual({ path: 'temporaryPassword', label: '临时密码', format: 'secret' });
+    // Source spec is not mutated.
+    expect(spec.title).toBe('User Created');
+    expect(spec.fields[0].label).toBe('Email');
+  });
+
+  it('returns the spec untouched when the action name is missing', () => {
+    const { result } = renderHook(() => useObjectLabel(), { wrapper });
+    expect(result.current.actionResultDialog('sys_user', undefined, spec)).toBe(spec);
+    expect(result.current.actionResultDialog('sys_user', 'create_user', undefined)).toBeUndefined();
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -75,8 +75,9 @@ const ar = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: 'احفظ هذه القيمة الآن',
+      acknowledge: 'لقد حفظتها',
+      copyAll: 'نسخ الكل',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -75,8 +75,9 @@ const de = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: 'Diesen Wert jetzt speichern',
+      acknowledge: 'Ich habe ihn gespeichert',
+      copyAll: 'Alle kopieren',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -92,6 +92,7 @@ const en = {
     resultDialog: {
       defaultTitle: 'Save this value now',
       acknowledge: 'I have saved this',
+      copyAll: 'Copy all',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -75,8 +75,9 @@ const es = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: 'Guarda este valor ahora',
+      acknowledge: 'Lo he guardado',
+      copyAll: 'Copiar todo',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -75,8 +75,9 @@ const fr = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: 'Enregistrez cette valeur maintenant',
+      acknowledge: 'Je l\'ai enregistrée',
+      copyAll: 'Tout copier',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -75,8 +75,9 @@ const ja = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: 'この値を今すぐ保存してください',
+      acknowledge: '保存しました',
+      copyAll: 'すべてコピー',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -75,8 +75,9 @@ const ko = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: '이 값을 지금 저장하세요',
+      acknowledge: '저장했습니다',
+      copyAll: '모두 복사',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -75,8 +75,9 @@ const pt = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: 'Guarde este valor agora',
+      acknowledge: 'Eu o salvei',
+      copyAll: 'Copiar tudo',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -75,8 +75,9 @@ const ru = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: 'Сохраните это значение сейчас',
+      acknowledge: 'Я сохранил(а) это',
+      copyAll: 'Копировать всё',
     },
   },
   validation: {

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -89,8 +89,9 @@ const zh = {
   },
   actions: {
     resultDialog: {
-      defaultTitle: 'Save this value now',
-      acknowledge: 'I have saved this',
+      defaultTitle: '请立即保存此值',
+      acknowledge: '我已保存',
+      copyAll: '全部复制',
     },
   },
   validation: {

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -403,6 +403,74 @@ export function useObjectLabel() {
     },
 
     /**
+     * Resolve a translated copy of an action's post-success RESULT DIALOG
+     * (`title` / `description` / `acknowledge` + per-field labels).
+     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.resultDialog.*`,
+     * falling back to `{ns}.globalActions.{actionName}.resultDialog.*` when
+     * objectName is omitted, then to the metadata's literal strings.
+     *
+     * The `fields` translation node is keyed by the LITERAL result-field path
+     * from the action metadata (may contain dots, e.g. `"user.email"`), so it
+     * is fetched whole with `returnObjects` and indexed directly — never
+     * resolved through a dotted i18next key.
+     */
+    actionResultDialog: <T extends {
+      title?: string;
+      description?: string;
+      acknowledge?: string;
+      fields?: Array<{ path: string; label?: string; [key: string]: any }>;
+    }>(
+      objectName: string | undefined,
+      actionName: string | undefined,
+      spec: T | undefined,
+    ): T | undefined => {
+      if (!spec || !actionName) return spec;
+      const suffixesFor = (attr: string): string[] => {
+        const tail = `_actions.${actionName}.resultDialog.${attr}`;
+        return objectName
+          ? objectSuffixes(objectName, tail)
+          : [`globalActions.${actionName}.resultDialog.${attr}`];
+      };
+      const textFor = (attr: 'title' | 'description' | 'acknowledge'): string | undefined => {
+        const resolved = resolve(suffixesFor(attr), spec[attr] ?? '');
+        return resolved || spec[attr];
+      };
+      const fieldsMap = ((): Record<string, unknown> | undefined => {
+        try {
+          for (const ns of getAppNamespaces()) {
+            for (const suffix of suffixesFor('fields')) {
+              const node = t(`${ns}.${suffix}`, {
+                returnObjects: true,
+                defaultValue: null,
+                [I18N_PROBE_FLAG]: true,
+              }) as unknown;
+              if (node && typeof node === 'object' && !Array.isArray(node)) {
+                return node as Record<string, unknown>;
+              }
+            }
+          }
+        } catch {
+          // Graceful degradation when i18n provider is not available
+        }
+        return undefined;
+      })();
+      const fields = Array.isArray(spec.fields)
+        ? spec.fields.map((field) => {
+            if (!field || typeof field.path !== 'string') return field;
+            const label = fieldsMap?.[field.path];
+            return typeof label === 'string' && label.length > 0 ? { ...field, label } : field;
+          })
+        : spec.fields;
+      return {
+        ...spec,
+        title: textFor('title'),
+        description: textFor('description'),
+        acknowledge: textFor('acknowledge'),
+        fields,
+      };
+    },
+
+    /**
      * Resolve translated action-PARAMETER text (label / placeholder / helpText).
      * Convention: `{ns}.objects.{objectName}._actions.{actionName}.params.{paramName}.{attr}`.
      * Falls back to the provided value (the metadata's literal string) when no


### PR DESCRIPTION
## Problem

The one-shot secret-reveal dialog (create-user temporary password, 2FA backup codes, OAuth client secrets) always rendered hardcoded English: the result-dialog handlers passed the metadata spec straight through, and the locale packs' own fallback strings (`defaultTitle` / `acknowledge`) were English in every language.

## Changes

- **@object-ui/i18n** — `useObjectLabel()` gains `actionResultDialog(objectName, actionName, spec)`: overlays translated `title` / `description` / `acknowledge` and per-field labels from `{ns}.objects.<obj>._actions.<action>.resultDialog.*` (`globalActions` fallback), falling back to the metadata literals. The `fields` node is keyed by the **literal** result-field path (may contain dots, e.g. `"user.email"`), so it is fetched whole with `returnObjects` and indexed directly — never resolved through a dotted i18next key. All ten locale packs translate the dialog's fallback `defaultTitle`/`acknowledge` and add the new `actions.resultDialog.copyAll` key. New hook test.
- **@object-ui/app-shell** — the result-dialog handlers in `useConsoleActionRuntime` and `RecordDetailView` accept the action context (already passed by `ActionRunner`) and localize the spec before opening the dialog; `ActionResultDialog`'s hardcoded "Copy all" button now resolves through `actions.resultDialog.copyAll`.

Server-side counterpart (translation schema slot, extractor keys, platform bundle content) lands in objectstack-ai/framework. Independent to merge: without bundle content the dialog keeps rendering the metadata literals.

## Testing

- i18n package 89 tests (incl. new `actionResultDialog` hook test) and targeted ActionResultDialog / useConsoleActionRuntime suites (29) pass; app-shell `tsc` green
- End-to-end against a live showcase backend with the HMR console: create-user and set-password dialogs render fully localized in zh-CN

🤖 Generated with [Claude Code](https://claude.com/claude-code)