### PR TITLE
chore(lint): clear baseline lint errors in 9 more packages (#2713 Wave 2)

### DIFF
--- a/.changeset/lint-baseline-wave2.md
+++ b/.changeset/lint-baseline-wave2.md
@@ -1,0 +1,45 @@
+---
+"@object-ui/i18n": patch
+"@object-ui/plugin-kanban": patch
+"@object-ui/plugin-grid": patch
+"@object-ui/plugin-view": patch
+"@object-ui/plugin-list": patch
+"@object-ui/plugin-charts": patch
+"@object-ui/plugin-report": patch
+"@object-ui/layout": patch
+"@object-ui/collaboration": patch
+---
+
+chore(lint): clear the baseline lint errors in nine more packages (objectui#2713 Wave 2)
+
+Second wave of the #2713 lint-gate restoration (after #2730). These nine package
+lints were red at baseline on `main`, so their per-package `lint` gate could not
+catch new violations. Cleared every **error** (no behavior change; warnings out
+of scope):
+
+- **`react-hooks/rules-of-hooks`** (`i18n`, `plugin-grid`, `plugin-view`,
+  `plugin-list`) — translation helpers (`useSafeFieldLabel`,
+  `useRowActionTranslation`, `useViewLabel`, `useViewTabLabel`, `useMoreLabel`)
+  wrapped a provider-safe hook (`useObjectTranslation`/`useObjectLabel`, which
+  never throw) in try/catch; removed the wrapper (the same fix #2709 applied in
+  fields). `plugin-kanban` `ObjectKanban` moved its `if (error)` early return
+  below the `useCallback` so hooks run unconditionally. `collaboration`
+  `__unsafe_usePresenceContext` keeps its deliberate danger-prefix name via a
+  justified scoped disable.
+- **`react-hooks/static-components`** (`layout`, `plugin-list`, `plugin-report`)
+  — dynamic-icon / registry lookups (`resolveIcon`, `useRegistryComponent`) are
+  stable component references, not components created during render → scoped
+  disable with justification. `plugin-charts` `TreemapCell` was a *genuine*
+  inline component and is hoisted to module scope (it is purely props-driven).
+- **`no-irregular-whitespace`** (`plugin-grid` `ImportWizard`) — the literal
+  U+FEFF BOM prepended to exported CSV/text blobs (so Excel detects UTF-8) is
+  now written as the `﻿` escape: byte-identical at runtime, no literal
+  irregular-whitespace character in source.
+- **`no-useless-assignment`** (`plugin-grid` `BulkActionDialog`) — dropped a
+  dead `= null` initializer that the exhaustive `switch` (incl. `default`)
+  overwrites before it is read.
+- **`no-unsafe-function-type`** (`plugin-view` `ViewTabBar`) — the dnd-kit
+  render-prop `listeners` map is typed `Record<string, (...args: any[]) => void>`
+  instead of bare `Function`.
+- **`no-require-imports`** (`plugin-kanban`, `plugin-view` tests) — hoisted
+  `vi.mock` factories use an `async` factory with `await import('react')`.

--- a/packages/collaboration/src/PresenceProvider.tsx
+++ b/packages/collaboration/src/PresenceProvider.tsx
@@ -128,5 +128,10 @@ export function useRecordPresence(
  * @internal
  */
 export function __unsafe_usePresenceContext(): PresenceSource {
+  // This IS a hook (a thin useContext wrapper that must be called under the
+  // Rules of Hooks); the `__unsafe_` prefix is a deliberate danger signal for
+  // this @internal test-only accessor, so the name doesn't start with `use`.
+  // Scoped disable rather than renaming away the intentional prefix.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return React.useContext(PresenceContext);
 }

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -471,14 +471,10 @@ const SAFE_FIELD_LABEL_FALLBACK = {
  * may be rendered outside an i18n context.
  */
 export function useSafeFieldLabel() {
-  let resolved: ReturnType<typeof useObjectLabel> | null = null;
-  try {
-    resolved = useObjectLabel();
-  } catch {
-    resolved = null;
-  }
-  // useObjectLabel already returns a stable (memoized) object per language —
-  // pass-through avoids creating a fresh wrapper here. The module-level
-  // fallback object is reused when no provider is mounted.
-  return resolved ?? SAFE_FIELD_LABEL_FALLBACK;
+  // useObjectLabel delegates to the provider-safe useObjectTranslation (react-
+  // i18next falls back to the global instance and never throws), so it needs no
+  // try/catch — wrapping the hook call would violate rules-of-hooks. It already
+  // returns a stable memoized object; the module-level fallback stays as a
+  // defensive default, reached only if it ever returns nullish.
+  return useObjectLabel() ?? SAFE_FIELD_LABEL_FALLBACK;
 }

--- a/packages/layout/src/AppSchemaRenderer.tsx
+++ b/packages/layout/src/AppSchemaRenderer.tsx
@@ -317,6 +317,7 @@ function InternalSidebar({
                       className="size-6 object-contain"
                     />
                   ) : (
+                    // eslint-disable-next-line react-hooks/static-components -- resolveIcon returns a stable icon component from a static registry, not a component created during render
                     <Icon className="size-4" />
                   )}
                 </div>

--- a/packages/layout/src/NavigationRenderer.tsx
+++ b/packages/layout/src/NavigationRenderer.tsx
@@ -977,6 +977,7 @@ function NavigationItemRenderer({
           onClick={() => onAction?.(item)}
           className={mobileBtnClass}
         >
+          {/* eslint-disable-next-line react-hooks/static-components -- resolveIcon returns a stable icon component from a static registry, not a component created during render */}
           <Icon className={navIconClass} />
           <span>{actionLabel}</span>
           {item.badge != null && (
@@ -1017,6 +1018,7 @@ function NavigationItemRenderer({
 
   const content = (
     <>
+      {/* eslint-disable-next-line react-hooks/static-components -- resolveIcon returns a stable icon component from a static registry, not a component created during render */}
       <Icon className={navIconClass} />
       <span>{itemLabel}</span>
       {item.badge != null && (

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -128,6 +128,26 @@ export interface AdvancedChartImplProps {
 }
 
 /**
+ * Treemap leaf cell — paints each leaf rect with its palette fill + label.
+ * Hoisted to module scope so it is a stable component reference rather than one
+ * re-created on every AdvancedChartImpl render (react-hooks/static-components).
+ * It is purely props-driven: Recharts injects the cell geometry (x/y/width/
+ * height) and datum (name/fill) as props, so no render-scope closure is needed.
+ */
+function TreemapCell(props: any) {
+  const { x, y, width, height, name, fill } = props;
+  if (width <= 0 || height <= 0) return null;
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={height} fill={fill} stroke="hsl(var(--background))" strokeWidth={2} />
+      {width > 48 && height > 18 ? (
+        <text x={x + 6} y={y + 18} fill="#fff" fontSize={12} className="pointer-events-none">{name}</text>
+      ) : null}
+    </g>
+  );
+}
+
+/**
  * AdvancedChartImpl - The heavy implementation that imports Recharts with full features
  * This component is lazy-loaded to avoid including Recharts in the initial bundle
  */
@@ -426,18 +446,6 @@ export default function AdvancedChartImpl({
       size: Number(row?.[dataKey]) || 0,
       fill: resolveColor(palette[idx % palette.length]),
     }));
-    const TreemapCell = (props: any) => {
-      const { x, y, width, height, name, fill } = props;
-      if (width <= 0 || height <= 0) return null;
-      return (
-        <g>
-          <rect x={x} y={y} width={width} height={height} fill={fill} stroke="hsl(var(--background))" strokeWidth={2} />
-          {width > 48 && height > 18 ? (
-            <text x={x + 6} y={y + 18} fill="#fff" fontSize={12} className="pointer-events-none">{name}</text>
-          ) : null}
-        </g>
-      );
-    };
     return (
       <ChartContainer config={config} className={className}>
         <Treemap data={tmData} dataKey="size" nameKey="name" isAnimationActive content={<TreemapCell />} {...treemapClickProps}>

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -677,7 +677,7 @@ function buildImportTemplateCsv(fields: ImportWizardProps['fields']): string {
  *  reads non-ASCII correctly). No-op in non-DOM environments. */
 function downloadTextFile(filename: string, text: string, mime = 'text/csv;charset=utf-8'): void {
   if (typeof document === 'undefined' || typeof URL?.createObjectURL !== 'function') return;
-  const blob = new Blob([`﻿${text}`], { type: mime });
+  const blob = new Blob([`\uFEFF${text}`], { type: mime });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
@@ -2036,7 +2036,7 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
     if (errorsByRow.size === 0) return;
     const csv = buildFailedRowsCsv(headers, rows, mapping, errorsByRow);
     try {
-      const blob = new Blob([`﻿${csv}`], { type: 'text/csv;charset=utf-8' });
+      const blob = new Blob([`\uFEFF${csv}`], { type: 'text/csv;charset=utf-8' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -513,7 +513,9 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChang
     </Label>
   );
 
-  let control: React.ReactNode = null;
+  // Assigned by every switch branch (including `default`) before it's read
+  // below — no dead initializer needed.
+  let control: React.ReactNode;
   switch (param.type) {
     case 'boolean':
       control = (

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -24,15 +24,14 @@ const ROW_ACTION_FALLBACKS: Record<string, string> = {
 };
 
 function useRowActionTranslation() {
-  try {
-    const { t } = useObjectTranslation();
-    return (key: string) => {
-      const v = t(key);
-      return v === key ? (ROW_ACTION_FALLBACKS[key] ?? key) : v;
-    };
-  } catch {
-    return (key: string) => ROW_ACTION_FALLBACKS[key] ?? key;
-  }
+  // useObjectTranslation is provider-safe (react-i18next falls back to the
+  // global instance and never throws), so no try/catch — wrapping the hook call
+  // would violate rules-of-hooks. The per-key fallback still applies below.
+  const { t } = useObjectTranslation();
+  return (key: string) => {
+    const v = t(key);
+    return v === key ? (ROW_ACTION_FALLBACKS[key] ?? key) : v;
+  };
 }
 
 /**

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -500,14 +500,6 @@ export const ObjectKanban: React.FC<ObjectKanbanProps> = ({
     onRowClick: externalClick,
   });
 
-  if (error) {
-      return (
-        <div className="p-4 border border-destructive/50 rounded bg-destructive/10 text-destructive">
-            Error loading kanban data: {error.message}
-        </div>
-      );
-  }
-
   // Pass through to the renderer
   const detailTitle = schema.objectName
     ? `${schema.objectName.charAt(0).toUpperCase() + schema.objectName.slice(1).replace(/_/g, ' ')} Detail`
@@ -572,6 +564,16 @@ export const ObjectKanban: React.FC<ObjectKanbanProps> = ({
     },
     [schema.groupBy, schema.objectName, dataSource, hasExternalData, tt],
   );
+
+  // Error branch renders only after every hook above has run, so hook order
+  // stays stable across renders (no early return before the hooks).
+  if (error) {
+    return (
+      <div className="p-4 border border-destructive/50 rounded bg-destructive/10 text-destructive">
+        Error loading kanban data: {error.message}
+      </div>
+    );
+  }
 
   return (
     <>

--- a/packages/plugin-kanban/src/registration.test.tsx
+++ b/packages/plugin-kanban/src/registration.test.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { ObjectKanbanRenderer } from './index';
 
 // Mock dependencies
-vi.mock('@object-ui/react', () => {
-  const React = require('react');
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
   return {
     useSchemaContext: vi.fn(() => ({ dataSource: { type: 'mock-datasource' } })),
     SchemaRendererContext: React.createContext(null),

--- a/packages/plugin-list/src/UserFilters.tsx
+++ b/packages/plugin-list/src/UserFilters.tsx
@@ -13,13 +13,12 @@ import type { ListViewSchema } from '@object-ui/types';
 import { useSafeFieldLabel, useObjectTranslation } from '@object-ui/i18n';
 
 function useMoreLabel(): string {
-  try {
-    const { t } = useObjectTranslation();
-    const v = t('common.more');
-    return !v || v === 'common.more' ? 'More' : v;
-  } catch {
-    return 'More';
-  }
+  // useObjectTranslation is provider-safe (never throws); no try/catch, which
+  // would wrap the hook call and violate rules-of-hooks. The 'More' fallback
+  // still applies when the key is missing/untranslated.
+  const { t } = useObjectTranslation();
+  const v = t('common.more');
+  return !v || v === 'common.more' ? 'More' : v;
 }
 
 /** Resolved option with optional count */

--- a/packages/plugin-list/src/components/TabBar.tsx
+++ b/packages/plugin-list/src/components/TabBar.tsx
@@ -176,6 +176,7 @@ export const TabBarSelect: React.FC<TabBarProps> = ({
             className="h-7 px-2 text-xs font-medium text-foreground gap-1.5 max-w-[60vw] truncate"
             aria-label="Switch view"
           >
+            {/* eslint-disable-next-line react-hooks/static-components -- resolveIcon returns a stable lucide icon component from a static registry, not a component created during render */}
             {ActiveIcon && <ActiveIcon className="h-3.5 w-3.5 shrink-0" />}
             <span className="truncate">{activeTab?.label ?? ''}</span>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -456,6 +456,7 @@ function DatasetReportChart({
   return (
     <div className="rounded-md border bg-card p-3" data-testid="dataset-report-chart">
       {title ? <h3 className="mb-2 text-sm font-semibold">{title}</h3> : null}
+      {/* eslint-disable-next-line react-hooks/static-components -- ChartComponent is a stable registry lookup (useRegistryComponent), not a component created during render */}
       <ChartComponent
         schema={{
           chartType: mapReportChartType(chart.type),

--- a/packages/plugin-view/src/ManageViewsDialog.tsx
+++ b/packages/plugin-view/src/ManageViewsDialog.tsx
@@ -69,17 +69,16 @@ import type { ViewTabItem } from './ViewTabBar';
  * missing or the provider is absent.
  */
 function useViewLabel() {
-  try {
-    const { t } = useObjectTranslation();
-    return (key: string, fallback: string, vars?: Record<string, unknown>): string => {
-      const v = t(key, vars as any);
-      // i18next's `t()` is typed `string | object`; coerce so render sites and
-      // aria-labels always receive a string (an object child white-screens React).
-      return !v || v === key ? fallback : String(v);
-    };
-  } catch {
-    return (_k: string, fallback: string) => fallback;
-  }
+  // useObjectTranslation is provider-safe (never throws); no try/catch, which
+  // would wrap the hook call and violate rules-of-hooks. The `fallback` still
+  // applies below when the key is missing/untranslated.
+  const { t } = useObjectTranslation();
+  return (key: string, fallback: string, vars?: Record<string, unknown>): string => {
+    const v = t(key, vars as any);
+    // i18next's `t()` is typed `string | object`; coerce so render sites and
+    // aria-labels always receive a string (an object child white-screens React).
+    return !v || v === key ? fallback : String(v);
+  };
 }
 
 export interface ManageViewsDialogProps {

--- a/packages/plugin-view/src/ViewTabBar.tsx
+++ b/packages/plugin-view/src/ViewTabBar.tsx
@@ -90,17 +90,16 @@ import type { ViewTabBarConfig } from '@object-ui/types';
 import { useObjectTranslation } from '@object-ui/react';
 
 function useViewTabLabel() {
-  try {
-    const { t } = useObjectTranslation();
-    return (key: string, fallback: string, vars?: Record<string, unknown>): string => {
-      const v = t(key, vars as any);
-      // i18next's `t()` is typed `string | object`; coerce so render sites and
-      // aria-labels always receive a string (an object child white-screens React).
-      return !v || v === key ? fallback : String(v);
-    };
-  } catch {
-    return (_k: string, fallback: string) => fallback;
-  }
+  // useObjectTranslation is provider-safe (never throws); no try/catch, which
+  // would wrap the hook call and violate rules-of-hooks. The `fallback` still
+  // applies below when the key is missing/untranslated.
+  const { t } = useObjectTranslation();
+  return (key: string, fallback: string, vars?: Record<string, unknown>): string => {
+    const v = t(key, vars as any);
+    // i18next's `t()` is typed `string | object`; coerce so render sites and
+    // aria-labels always receive a string (an object child white-screens React).
+    return !v || v === key ? fallback : String(v);
+  };
 }
 
 /** Visibility group sort order: private → team → organization → public */
@@ -211,7 +210,7 @@ const SortableTab: React.FC<{
   children: (props: {
     setNodeRef: (node: HTMLElement | null) => void;
     style: React.CSSProperties;
-    listeners: Record<string, Function> | undefined;
+    listeners: Record<string, (...args: any[]) => void> | undefined;
     attributes: Record<string, unknown>;
     isDragging: boolean;
   }) => React.ReactNode;
@@ -414,7 +413,7 @@ export const ViewTabBar: React.FC<ViewTabBarProps> = ({
     const visibilityIcon = getVisibilityIcon(view);
 
     const buildTabContent = (dragHandleProps?: {
-      listeners: Record<string, Function> | undefined;
+      listeners: Record<string, (...args: any[]) => void> | undefined;
       attributes: Record<string, unknown>;
       isDragging?: boolean;
     }) => (

--- a/packages/plugin-view/src/__tests__/ObjectView.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.test.tsx
@@ -12,8 +12,8 @@ import { ObjectView } from '../ObjectView';
 import type { ObjectViewSchema, DataSource } from '@object-ui/types';
 
 // Mock @object-ui/react to avoid circular dependency issues
-vi.mock('@object-ui/react', () => {
-  const React = require('react');
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
   return {
     SchemaRenderer: ({ schema }: any) => (
       <div data-testid="schema-renderer" data-schema-type={schema?.type}>


### PR DESCRIPTION
Second wave of the #2713 lint-gate restoration (after #2730 landed Wave 1). Nine packages whose per-package `lint` was **red at baseline on `main`** — the gate could not catch new violations of the same class. **Errors only; no behavior change** (warnings out of scope per the issue).

## What changed (per rule)

- **`react-hooks/rules-of-hooks`** (`i18n`, `plugin-grid`, `plugin-view` ×2, `plugin-list`) — translation helpers (`useSafeFieldLabel`, `useRowActionTranslation`, `useViewLabel`, `useViewTabLabel`, `useMoreLabel`) wrapped a **provider-safe** hook (`useObjectTranslation` / `useObjectLabel`, which fall back to the global i18next instance and never throw) in `try/catch`. Removed the wrapper — the exact fix #2709 applied in `fields`. Verified `useObjectLabel` itself only calls the provider-safe `useObjectTranslation`.
  - `plugin-kanban` `ObjectKanban`: moved the `if (error)` early return **below** the `useCallback` so all hooks run unconditionally (identical rendering, stable hook order).
  - `collaboration` `__unsafe_usePresenceContext`: an unused `@internal` test helper whose `__unsafe_` prefix is a deliberate danger signal — kept the name via a **justified scoped disable** rather than renaming away the convention.
- **`react-hooks/static-components`** (`layout` ×3, `plugin-list` ×1, `plugin-report` ×1) — dynamic-icon / registry lookups (`resolveIcon`, `useRegistryComponent`) are **stable component references**, not components created during render → scoped disable with justification.
  - `plugin-charts` `TreemapCell` was a **genuine** inline component (defined in render). It's purely props-driven (Recharts injects cell geometry + datum), so it's **hoisted to module scope** — a real fix, not a disable.
- **`no-irregular-whitespace`** (`plugin-grid` `ImportWizard` ×2) — the flagged char is a literal **U+FEFF BOM** deliberately prepended to exported CSV/text blobs so Excel detects UTF-8. Rewritten as the `﻿` **escape sequence**: byte-identical at runtime, no literal irregular-whitespace char in source (real fix, not a disable).
- **`no-useless-assignment`** (`plugin-grid` `BulkActionDialog`) — dropped a dead `= null` initializer that the exhaustive `switch` (incl. `default`) overwrites before it is read.
- **`no-unsafe-function-type`** (`plugin-view` `ViewTabBar` ×2) — the dnd-kit render-prop `listeners` map is now `Record<string, (...args: any[]) => void>` instead of bare `Function`.
- **`no-require-imports`** (`plugin-kanban`, `plugin-view` tests) — hoisted `vi.mock` factories use an `async` factory with `await import('react')`.

No lint **config** was loosened.

## Verification

- **Lint:** `eslint` → **0 errors** in all 9 packages (20 errors at baseline).
- **Type gate:** `turbo run build` (the dts build CI gates on) → **22/22 tasks green**.
- **Tests:** all 9 package suites green — **701 tests / 69 files** (incl. the changed `vi.mock` factories, the kanban early-return move, the i18n/grid/view/list hook unwraps, and the charts `TreemapCell` hoist).

## Scope

Wave 2 of #2713. Remaining: **Wave 3** — the heavy `rules-of-hooks` + `static-components` packages (app-shell, components, plugin-gantt, plugin-detail, plugin-dashboard, plugin-chatbot), which contain genuine hook-order restructures and will go as per-package PRs with a review checkpoint.

Refs #2713 · follows #2730 · pattern from #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)