### PR TITLE
chore(lint): clear baseline lint errors in plugin-dashboard (#2713 Wave 3.1)

### DIFF
--- a/.changeset/lint-baseline-dashboard.md
+++ b/.changeset/lint-baseline-dashboard.md
@@ -1,0 +1,29 @@
+---
+"@object-ui/plugin-dashboard": patch
+---
+
+chore(lint): clear the baseline lint errors in plugin-dashboard (objectui#2713 Wave 3)
+
+First package of Wave 3 in the #2713 lint-gate restoration. `@object-ui/plugin-dashboard`
+was red at baseline on `main`; cleared every **error** (no behavior change;
+warnings out of scope):
+
+- **`react-hooks/rules-of-hooks`** (`ObjectDataTable`) — `useObjectTranslation`
+  was wrapped in try/catch; removed the wrapper (the hook is provider-safe and
+  never throws — the #2709 fix). English defaults still stand until a
+  translation resolves.
+- **`react-hooks/static-components`** (`MetricCard`, `MetricWidget`) —
+  `getLazyIcon(name)` returns a module-cached, stable component per name (not a
+  component created during render), so the render sites carry a justified scoped
+  disable.
+- **`no-irregular-whitespace`** (`DatasetWidget`) — the literal U+FEFF BOM
+  prepended to the exported CSV blob (Excel UTF-8 detection) is written as the
+  `﻿` escape: byte-identical at runtime, no literal irregular-whitespace char.
+- **`no-useless-escape`** (`recordFields`) — dropped a needless `\$` inside a
+  character class (`[\$¥€£]` → `[$¥€£]`).
+- **`no-sparse-arrays`** (`recordFields`) — the `|| [, '']` match fallback is
+  written `[undefined, '']` so index 0 is an explicit hole, not a sparse one.
+- **`no-useless-assignment`** (`PivotTable`) — the `suffix` accumulator is now a
+  single `const` at its one assignment site instead of a dead-initialized `let`.
+- **`no-require-imports`** (`DashboardRenderer.designMode` test) — the hoisted
+  `vi.mock` factory uses an `async` factory with `await import('react')`.

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -110,7 +110,7 @@ export function toCsv(rows: Array<Array<string | number | null | undefined>>): s
 function downloadCsv(filename: string, rows: Array<Array<string | number | null | undefined>>): void {
   if (typeof document === 'undefined') return;
   const base = filename && filename.trim() ? filename.trim() : 'export';
-  const blob = new Blob([`﻿${toCsv(rows)}`], { type: 'text/csv;charset=utf-8;' });
+  const blob = new Blob([`\uFEFF${toCsv(rows)}`], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;

--- a/packages/plugin-dashboard/src/MetricCard.tsx
+++ b/packages/plugin-dashboard/src/MetricCard.tsx
@@ -58,6 +58,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
           {resolveLabel(title)}
         </CardTitle>
         {IconComponent && (
+          // eslint-disable-next-line react-hooks/static-components -- getLazyIcon returns a module-cached stable component per name, not one created during render
           <IconComponent className="h-4 w-4 text-muted-foreground" />
         )}
       </CardHeader>

--- a/packages/plugin-dashboard/src/MetricWidget.tsx
+++ b/packages/plugin-dashboard/src/MetricWidget.tsx
@@ -235,6 +235,7 @@ export const MetricWidget = ({
   const resolvedIcon = useMemo(() => {
     if (typeof icon === 'string') {
       const IconComponent = getLazyIcon(icon);
+      // eslint-disable-next-line react-hooks/static-components -- getLazyIcon returns a module-cached stable component per name, not one created during render
       return IconComponent ? <IconComponent className="h-4 w-4" /> : null;
     }
     return icon;

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -141,13 +141,15 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
   const { fieldLabel, fieldOptionLabel } = useSafeFieldLabel();
   let noDataLabel = 'No data available';
   let noDataSourceLabel = 'No data source available for';
-  try {
-    const { t } = useObjectTranslation();
-    const a = t('dashboard.noDataAvailable');
-    if (a && a !== 'dashboard.noDataAvailable') noDataLabel = a;
-    const b = t('dashboard.noDataSourceFor');
-    if (b && b !== 'dashboard.noDataSourceFor') noDataSourceLabel = b;
-  } catch {/* no i18n provider */}
+  // useObjectTranslation is provider-safe (react-i18next falls back to the
+  // global instance and never throws), so call it directly — no try/catch,
+  // which would make the hook conditional. The English defaults above stand
+  // until a translation resolves.
+  const { t } = useObjectTranslation();
+  const a = t('dashboard.noDataAvailable');
+  if (a && a !== 'dashboard.noDataAvailable') noDataLabel = a;
+  const b = t('dashboard.noDataSourceFor');
+  if (b && b !== 'dashboard.noDataSourceFor') noDataSourceLabel = b;
 
   const [fetchedData, setFetchedData] = useState<any[]>([]);
   const [objectSchema, setObjectSchema] = useState<any>(null);

--- a/packages/plugin-dashboard/src/PivotTable.tsx
+++ b/packages/plugin-dashboard/src/PivotTable.tsx
@@ -47,7 +47,6 @@ function formatValue(value: number, format?: string): string {
   if (!format) return String(value);
 
   let prefix = '';
-  let suffix = '';
   let useGrouping = false;
   let decimals: number | undefined;
 
@@ -77,7 +76,7 @@ function formatValue(value: number, format?: string): string {
   }
 
   // Remaining characters become suffix
-  suffix = fmt.replace(/[0-9#.f]/g, '');
+  const suffix = fmt.replace(/[0-9#.f]/g, '');
 
   const formatted = decimals !== undefined ? value.toFixed(decimals) : String(value);
 

--- a/packages/plugin-dashboard/src/__tests__/DashboardRenderer.designMode.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardRenderer.designMode.test.tsx
@@ -5,8 +5,8 @@ import type { DashboardSchema } from '@object-ui/types';
 
 // Mock SchemaRenderer to avoid pulling in the full renderer tree.
 // Forwards className and includes an interactive child to simulate real chart content.
-vi.mock('@object-ui/react', () => {
-  const React = require('react');
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
   return {
     SchemaRenderer: ({ schema, className }: { schema: any; className?: string }) => (
       <div data-testid="schema-renderer" className={className}>

--- a/packages/plugin-dashboard/src/recordFields.tsx
+++ b/packages/plugin-dashboard/src/recordFields.tsx
@@ -152,7 +152,7 @@ export function buildFieldMeta(params: BuildFieldMetaParams): FieldMeta {
 export function isNumericFieldMeta(fieldMeta: Pick<FieldMeta, 'type' | 'format'>): boolean {
   return (
     NUMERIC_FIELD_TYPES.has(fieldMeta.type as string) ||
-    (typeof fieldMeta.format === 'string' && /^[\$¥€£]|%$|0/.test(fieldMeta.format))
+    (typeof fieldMeta.format === 'string' && /^[$¥€£]|%$|0/.test(fieldMeta.format))
   );
 }
 
@@ -181,7 +181,7 @@ export function renderFieldValue(
     return formatCurrency(value, fieldMeta.currency || inferred || tenantCurrency);
   }
   if (typeof fmt === 'string' && /%/.test(fmt) && typeof value === 'number') {
-    const decimals = (fmt.match(/0\.(0+)%/) || [, ''] as any)[1].length;
+    const decimals = (fmt.match(/0\.(0+)%/) || [undefined, ''] as any)[1].length;
     const normalized = value > 1 ? value / 100 : value;
     return formatPercent(normalized * 100, decimals);
   }


### PR DESCRIPTION
First package of **Wave 3** in the #2713 lint-gate restoration (Waves 1–2 landed in #2730 / #2737). `@object-ui/plugin-dashboard` was **red at baseline on `main`**. **Errors only; no behavior change.**

Wave 3 packages are shipped **one per PR with a review checkpoint** (they contain the genuine hook-order restructures); this is the smallest/lowest-risk of the six.

## What changed (per rule)

- **`react-hooks/rules-of-hooks`** (`ObjectDataTable`) — `useObjectTranslation` was wrapped in `try/catch` (making the hook conditional). Removed the wrapper — the hook is provider-safe (react-i18next falls back to the global instance, never throws), the exact #2709 fix. The English defaults still stand until a translation resolves.
- **`react-hooks/static-components`** (`MetricCard`, `MetricWidget`) — `getLazyIcon(name)` returns a **module-cached, stable** component per name (verified: `lazy-icon.tsx` memoizes in a module-level `Map`; its own doc shows the `const Icon = getLazyIcon(name); <Icon/>` pattern). Not a component created during render → justified scoped disable.
- **`no-irregular-whitespace`** (`DatasetWidget`) — the flagged char is a literal **U+FEFF BOM** deliberately prepended to the exported CSV blob (Excel UTF-8 detection). Rewritten as the `﻿` **escape**: byte-identical at runtime, no literal irregular-whitespace char (real fix, not a disable). Same treatment as `plugin-grid/ImportWizard` in #2737.
- **`no-useless-escape`** (`recordFields`) — `\$` inside a character class is redundant (`[\$¥€£]` → `[$¥€£]`); identical regex.
- **`no-sparse-arrays`** (`recordFields`) — the `|| [, '']` match fallback is written `[undefined, '']` so index 0 is an explicit value, not a sparse hole; `[1]` is still `''`.
- **`no-useless-assignment`** (`PivotTable`) — `suffix` is now a single `const` at its one assignment site instead of a dead-initialized `let` (also avoids the follow-on `prefer-const`).
- **`no-require-imports`** (`DashboardRenderer.designMode` test) — hoisted `vi.mock` factory uses an `async` factory with `await import('react')`.

No lint **config** was loosened.

## Verification

- **Lint:** `eslint` → **0 errors** (8 at baseline).
- **Type gate:** `turbo run build` → **11/11 tasks green**.
- **Tests:** `plugin-dashboard` suite green — **122 passed / 24 skipped (16 files)**.

Refs #2713 · follows #2730, #2737 · pattern from #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)