### PR TITLE
chore(lint): clear baseline lint errors in plugin-detail (#2713 Wave 3.2)

### DIFF
--- a/.changeset/lint-baseline-detail.md
+++ b/.changeset/lint-baseline-detail.md
@@ -1,0 +1,30 @@
+---
+"@object-ui/plugin-detail": patch
+---
+
+chore(lint): clear the baseline lint errors in plugin-detail (objectui#2713 Wave 3)
+
+Wave 3 of the #2713 lint-gate restoration. `@object-ui/plugin-detail` was red at
+baseline on `main`; cleared every **error** (no behavior change; warnings out of
+scope). All nine are `react-hooks` errors — the record renderers called hooks
+after conditional early returns, which is a real fragility (React throws when the
+guard toggles between renders), so each is restructured so hooks run
+unconditionally while the rendered output stays identical:
+
+- **`record-reference-rail`** — hoisted `useState` above the empty-entries early
+  return (no dependency on it).
+- **`record-related-list`** — moved the `!objectName` placeholder return below
+  the four hooks (`usePermissions` / `useFieldPermissions` / `useRelatedRecordActions`
+  / `useMemo`); those hooks are pure context/memo reads, safe with an empty
+  object name. The object-level read gate ordering is unchanged (covered by
+  `RecordRelatedListRenderer.readgate.test`).
+- **`record-quick-actions`** — moved the `requiredPermissions` gate below
+  `useActionEngine` (a pure `useContext`/`useMemo` hook).
+- **`record-highlights`** — `useId` + `useRegisterHighlightFields` now run
+  unconditionally; the permission gate is enforced after them. Because
+  `useRegisterHighlightFields` has a register effect, it is passed `[]` when the
+  gate denies — equivalent to not registering, so no body field is ever hidden
+  for highlights that aren't rendered.
+- **`RelatedList`** `SectionIcon` (`react-hooks/static-components`) —
+  `resolveIconComponent` is a stable registry lookup, not a component created
+  during render → justified scoped disable.

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -929,6 +929,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
                 ? (<ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />)
                 : (<ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />)
             )}
+            {/* eslint-disable-next-line react-hooks/static-components -- resolveIconComponent returns a stable icon component from a static registry, not a component created during render */}
             <SectionIcon className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden />
             <span className={cn('truncate', isEmpty && 'text-muted-foreground font-medium')}>
               {title}

--- a/packages/plugin-detail/src/renderers/record-highlights.tsx
+++ b/packages/plugin-detail/src/renderers/record-highlights.tsx
@@ -43,23 +43,11 @@ export const RecordHighlightsRenderer: React.FC<RecordHighlightsRendererProps> =
   const required: string[] = Array.isArray((schema as any).requiredPermissions)
     ? (schema as any).requiredPermissions
     : [];
-  if (required.length > 0 && objectName) {
-    const ok = required.every((p) => perms.can(objectName, p as any));
-    if (!ok) {
-      return (
-        <div
-          className={className}
-          {...designer}
-          role="status"
-          aria-live="polite"
-        >
-          <p className="text-sm text-muted-foreground italic">
-            Insufficient permissions to view highlights.
-          </p>
-        </div>
-      );
-    }
-  }
+  // Evaluated up-front but enforced AFTER the hooks below (useId /
+  // useRegisterHighlightFields) so hook order stays stable across renders.
+  const highlightsAllowed =
+    !(required.length > 0 && objectName) ||
+    required.every((p) => perms.can(objectName, p as any));
 
   const rawFields: any[] = Array.isArray(schema.fields) ? schema.fields : [];
   // Normalize: spec accepts either bare strings or { name, label?, icon?, type? }
@@ -85,10 +73,27 @@ export const RecordHighlightsRenderer: React.FC<RecordHighlightsRendererProps> =
   // same fields from its body grid even for hand-authored Lightning
   // pages (where the synth-time `hideFields` plumbing doesn't apply).
   const instanceId = React.useId();
+  // Register [] when not allowed — equivalent to not registering, so
+  // RecordDetailsRenderer never hides body fields for highlights we don't show.
   useRegisterHighlightFields(
     instanceId,
-    highlightFields.map((f) => f.name),
+    highlightsAllowed ? highlightFields.map((f) => f.name) : [],
   );
+
+  if (!highlightsAllowed) {
+    return (
+      <div
+        className={className}
+        {...designer}
+        role="status"
+        aria-live="polite"
+      >
+        <p className="text-sm text-muted-foreground italic">
+          Insufficient permissions to view highlights.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className={className} {...designer}>

--- a/packages/plugin-detail/src/renderers/record-quick-actions.tsx
+++ b/packages/plugin-detail/src/renderers/record-quick-actions.tsx
@@ -94,18 +94,6 @@ export const RecordQuickActionsRenderer: React.FC<RecordQuickActionsRendererProp
   const required: string[] = Array.isArray(schema.requiredPermissions)
     ? schema.requiredPermissions
     : [];
-  if (required.length > 0 && objectName) {
-    const ok = required.every((p) => perms.can(objectName, p as any));
-    if (!ok) {
-      return (
-        <div className={className} {...designer} role="status" aria-live="polite">
-          <p className="text-sm text-muted-foreground italic">
-            Insufficient permissions to view quick actions.
-          </p>
-        </div>
-      );
-    }
-  }
 
   const location: ActionLocation = (schema.location as ActionLocation) || 'record_header';
 
@@ -121,6 +109,21 @@ export const RecordQuickActionsRenderer: React.FC<RecordQuickActionsRendererProp
       objectName: ctx?.objectName,
     } as any,
   });
+
+  // Object-level permission gate — evaluated AFTER all hooks (useActionEngine
+  // above must run every render) so hook order stays stable.
+  if (required.length > 0 && objectName) {
+    const ok = required.every((p) => perms.can(objectName, p as any));
+    if (!ok) {
+      return (
+        <div className={className} {...designer} role="status" aria-live="polite">
+          <p className="text-sm text-muted-foreground italic">
+            Insufficient permissions to view quick actions.
+          </p>
+        </div>
+      );
+    }
+  }
 
   const visibleActions = actions.length > 0 ? getActionsForLocation(location) : [];
 

--- a/packages/plugin-detail/src/renderers/record-reference-rail.tsx
+++ b/packages/plugin-detail/src/renderers/record-reference-rail.tsx
@@ -231,10 +231,13 @@ export const RecordReferenceRailRenderer: React.FC<RecordReferenceRailRendererPr
     void Promise.all(workers);
   }, [railVisible, dataSource, parentId, entriesSig]);
 
+  // useState must run unconditionally — declared above the empty-entries early
+  // return so hook order stays stable across renders.
+  const [showEmpty, setShowEmpty] = React.useState(false);
+
   if (entries.length === 0) return null;
 
   const hideEmpty = schema.hideEmpty !== false;
-  const [showEmpty, setShowEmpty] = React.useState(false);
 
   // Stable partition: an entry is "empty" only once it has finished loading
   // with total === 0. While loading or on error, we render it so users

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -74,18 +74,8 @@ export const RecordRelatedListRenderer: React.FC<RecordRelatedListRendererProps>
       : '';
   const title = pickLocalized(schema.title, language) || resolvedObjectLabel || 'Related';
 
-  if (!objectName) {
-    return (
-      <div className={className} {...designer}>
-        <div className="text-xs text-muted-foreground italic px-3 py-2 border border-dashed rounded">
-          record:related_list — missing objectName
-        </div>
-      </div>
-    );
-  }
-
   const perms = usePermissions();
-  const { readableFields } = useFieldPermissions(objectName);
+  const { readableFields } = useFieldPermissions(objectName || '');
 
   // Host-provided CRUD + action handlers for this child object. Absent when no
   // host wired the provider (Studio designer, standalone embed) — the related
@@ -116,6 +106,18 @@ export const RecordRelatedListRenderer: React.FC<RecordRelatedListRendererProps>
       }) ?? null,
     [relatedActions, objectName, schema.relationshipField, parentLinkValue],
   );
+
+  // Missing objectName renders a designer placeholder — checked AFTER the hooks
+  // above so hook order stays stable across renders.
+  if (!objectName) {
+    return (
+      <div className={className} {...designer}>
+        <div className="text-xs text-muted-foreground italic px-3 py-2 border border-dashed rounded">
+          record:related_list — missing objectName
+        </div>
+      </div>
+    );
+  }
 
   // Automatic object-level read gate (objectui#2359). Related lists surface
   // the CHILD object's records, so they require `read` on that object — the


### PR DESCRIPTION
Wave 3 of the #2713 lint-gate restoration (Waves 1–2 in #2730 / #2737; #2738 landed plugin-dashboard). `@object-ui/plugin-detail` was **red at baseline on `main`**. **Errors only; rendered output unchanged.**

All nine are `react-hooks` errors. Eight are the same real fragility: the record renderers **called hooks after a conditional early return** — React throws "rendered more/fewer hooks" if that guard toggles between renders. Each is restructured so hooks run **unconditionally** while the rendered output stays identical. I verified each hook's side-effect profile first (pure `useContext`/`useMemo` vs. effect-bearing) and picked the technique accordingly:

- **`record-reference-rail`** — `useState(false)` hoisted above the empty-entries early return (no dependency on it). Trivially safe.
- **`record-related-list`** — the `!objectName` placeholder return moved **below** the four hooks (`usePermissions`, `useFieldPermissions`, `useRelatedRecordActions`, `useMemo`). Those are pure context/memo reads (`useFieldPermissions` is `usePermissions` + `useMemo`, no fetch), safe with an empty object name (`objectName || ''`). The object-level read-gate ordering is unchanged — covered by `RecordRelatedListRenderer.readgate.test`.
- **`record-quick-actions`** — the `requiredPermissions` gate moved below `useActionEngine` (a pure `useContext` + `useMemo` engine builder, no subscribe effect).
- **`record-highlights`** — `useId` + `useRegisterHighlightFields` now run unconditionally; the permission gate is enforced **after** them. `useRegisterHighlightFields` has a register/unregister **effect**, so when the gate denies it is passed `[]` — equivalent to not registering, so `RecordDetailsRenderer` never hides a body field for highlights that aren't rendered.
- **`RelatedList`** `SectionIcon` (`react-hooks/static-components`) — `resolveIconComponent` is a stable registry lookup, not a component created during render → justified scoped disable.

No lint **config** was loosened.

## Verification

- **Lint:** `eslint` → **0 errors** (9 at baseline).
- **Type gate:** `turbo run build` → **11/11 tasks green** (confirms the `objectName` narrowing changes type-check).
- **Tests:** full `plugin-detail` suite green — **249 passed / 28 files**, including the dedicated `RecordRelatedListRenderer.readgate` / `.hostactions` / `.speclimit` tests that exercise the restructured read gate.

Refs #2713 · follows #2730, #2737, #2738 · pattern from #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)