### PR TITLE
chore(lint): clear baseline lint errors in plugin-chatbot (#2713 Wave 3.3)

### DIFF
--- a/.changeset/lint-baseline-chatbot.md
+++ b/.changeset/lint-baseline-chatbot.md
@@ -1,0 +1,26 @@
+---
+"@object-ui/plugin-chatbot": patch
+---
+
+chore(lint): clear the baseline lint errors in plugin-chatbot (objectui#2713 Wave 3)
+
+Wave 3 of the #2713 lint-gate restoration. `@object-ui/plugin-chatbot` was red at
+baseline on `main`; cleared every **error** (no behavior change; warnings out of
+scope):
+
+- **`react-hooks/rules-of-hooks` in `useObjectChat` (8)** — the hook called
+  DIFFERENT `useCallback`s in each of its two `isApiMode` return branches, so
+  both sets were conditional (React throws if the mode toggles between renders).
+  `useChat` was already called unconditionally; this destructures its result and
+  hoists all eight callbacks (3 API + 5 local) above the `isApiMode` branch, so
+  the same hooks run in the same order every render. Only the returned surface
+  differs by mode — the callback bodies are unchanged (the API `messages` local
+  is renamed `apiMessages`). Verified against the `useObjectChat.sendFailure` /
+  `handoffContext` / `ChatbotEnhanced.sendError` suites.
+- **`react-hooks/rules-of-hooks` in `FloatingChatbotTrigger`** —
+  `useChatbotLabel` wrapped the provider-safe `useObjectTranslation` in
+  try/catch; removed the wrapper (the #2709 fix).
+- **`react-hooks/static-components` in `shimmer`** — `motion.create(Component)`
+  genuinely builds a motion component and must key off the `as` prop, so it
+  can't be module-scoped. Memoized per `Component` (stable across renders,
+  avoids the remount) and carries a justified scoped disable at the render site.

--- a/packages/plugin-chatbot/src/FloatingChatbotTrigger.tsx
+++ b/packages/plugin-chatbot/src/FloatingChatbotTrigger.tsx
@@ -14,15 +14,14 @@ import { useFloatingChatbot } from "./FloatingChatbotProvider"
 import { useObjectTranslation } from "@object-ui/react"
 
 function useChatbotLabel() {
-  try {
-    const { t } = useObjectTranslation();
-    return (key: 'openChat' | 'closeChat', fallback: string) => {
-      const v = t(`common.${key}`);
-      return !v || v === `common.${key}` ? fallback : v;
-    };
-  } catch {
-    return (_k: string, fallback: string) => fallback;
-  }
+  // useObjectTranslation is provider-safe (never throws); no try/catch, which
+  // would wrap the hook call and violate rules-of-hooks. The `fallback` still
+  // applies below when the key is missing/untranslated.
+  const { t } = useObjectTranslation();
+  return (key: 'openChat' | 'closeChat', fallback: string) => {
+    const v = t(`common.${key}`);
+    return !v || v === `common.${key}` ? fallback : v;
+  };
 }
 
 export interface FloatingChatbotTriggerProps {

--- a/packages/plugin-chatbot/src/elements/shimmer.tsx
+++ b/packages/plugin-chatbot/src/elements/shimmer.tsx
@@ -31,8 +31,13 @@ const ShimmerComponent = ({
   duration = 2,
   spread = 2,
 }: TextShimmerProps) => {
-  const MotionComponent = motion.create(
-    Component as keyof JSX.IntrinsicElements
+  // motion.create() builds a fresh motion component; it must key off the `as`
+  // prop so it can't be hoisted to module scope. Memoize per `Component` so it
+  // stays a stable reference across renders (react-hooks/static-components)
+  // instead of being re-created — and re-mounting — every render.
+  const MotionComponent = useMemo(
+    () => motion.create(Component as keyof JSX.IntrinsicElements),
+    [Component],
   );
 
   const dynamicSpread = useMemo(
@@ -41,6 +46,7 @@ const ShimmerComponent = ({
   );
 
   return (
+    // eslint-disable-next-line react-hooks/static-components -- MotionComponent is memoized per `as` prop above (stable across renders); motion.create needs the runtime tag, so it can't be declared at module scope
     <MotionComponent
       animate={{ backgroundPosition: "0% center" }}
       className={cn(

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -487,80 +487,61 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
     };
   }, []);
 
-  // ---- API mode return ----
-  if (isApiMode) {
-    const {
-      messages: aiMessages,
-      status,
-      error,
-      sendMessage: aiSendMessage,
-      regenerate,
-      stop,
-      setMessages,
-    } = chatResult as any;
+  // ---- API-mode derived state + callbacks ----
+  // `chatResult` (the useChat above) is ALWAYS called; destructure it and
+  // declare every callback below unconditionally so the hook calls the same
+  // hooks in the same order regardless of `isApiMode` (rules-of-hooks). Only
+  // the API return branch consumes these.
+  const {
+    messages: aiMessages,
+    status,
+    error,
+    sendMessage: aiSendMessage,
+    regenerate,
+    stop,
+    setMessages,
+  } = chatResult as any;
 
-    const isLoading = status === 'submitted' || status === 'streaming';
+  const isLoading = status === 'submitted' || status === 'streaming';
 
-    // Vercel AI SDK v6 UIMessage → OUI ChatMessage. The shared mapper handles
-    // parts (text, reasoning, tool-*, source-*), streaming-cursor flagging,
-    // and legacy `msg.toolInvocations` fallback. We splice `metadata` back in
-    // because `ChatbotEnhanced.ChatMessage` doesn't carry it but OUI's does.
-    const messages: OuiChatMessage[] = uiMessagesToChatMessages(aiMessages, {
-      isStreaming: isLoading,
-    }).map((m, idx) => ({
-      ...m,
-      metadata: (aiMessages[idx] as any)?.metadata,
-    })) as OuiChatMessage[];
+  // Vercel AI SDK v6 UIMessage → OUI ChatMessage. The shared mapper handles
+  // parts (text, reasoning, tool-*, source-*), streaming-cursor flagging,
+  // and legacy `msg.toolInvocations` fallback. We splice `metadata` back in
+  // because `ChatbotEnhanced.ChatMessage` doesn't carry it but OUI's does.
+  const apiMessages: OuiChatMessage[] = uiMessagesToChatMessages(aiMessages, {
+    isStreaming: isLoading,
+  }).map((m, idx) => ({
+    ...m,
+    metadata: (aiMessages[idx] as any)?.metadata,
+  })) as OuiChatMessage[];
 
-    // Local input state (v3 useChat no longer manages it) — declared above
-    // at the top of the hook to comply with the Rules of Hooks.
+  const sendMessage = useCallback(
+    (content: string) => {
+      const trimmed = content.trim();
+      if (!trimmed) return;
+      const nextMessages: OuiChatMessage[] = [
+        ...apiMessages,
+        { id: generateUniqueId('msg'), role: 'user', content: trimmed },
+      ];
+      aiSendMessage({ text: trimmed });
+      setApiInput('');
+      onSend?.(trimmed, nextMessages);
+    },
+    [aiSendMessage, onSend, apiMessages],
+  );
 
-    const sendMessage = useCallback(
-      (content: string) => {
-        const trimmed = content.trim();
-        if (!trimmed) return;
-        const nextMessages: OuiChatMessage[] = [
-          ...messages,
-          { id: generateUniqueId('msg'), role: 'user', content: trimmed },
-        ];
-        aiSendMessage({ text: trimmed });
-        setApiInput('');
-        onSend?.(trimmed, nextMessages);
-      },
-      [aiSendMessage, onSend, messages],
-    );
+  const clear = useCallback(() => {
+    setMessages([]);
+  }, [setMessages]);
 
-    const clear = useCallback(() => {
-      setMessages([]);
-    }, [setMessages]);
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setApiInput(e.target.value);
+    },
+    [],
+  );
 
-    const handleInputChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        setApiInput(e.target.value);
-      },
-      [],
-    );
-
-    return {
-      messages,
-      isLoading,
-      error,
-      sendMessage,
-      stop,
-      reload: regenerate,
-      clear,
-      // ADR-0013 D2: expose the underlying useChat setMessages so the host can
-      // re-hydrate the thread from the server after a stream-transport failure
-      // (the reply may already be persisted server-side — reconcile, don't re-run).
-      setMessages,
-      isApiMode: true,
-      input: apiInput,
-      setInput: setApiInput,
-      handleInputChange,
-    };
-  }
-
-  // ---- Local/legacy mode return ----
+  // ---- Local/legacy mode callbacks ----
   const localStop = useCallback(() => {
     if (autoResponseTimerRef.current) {
       clearTimeout(autoResponseTimerRef.current);
@@ -615,6 +596,29 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
     setLocalInput(e.target.value);
   }, []);
 
+  // ---- API mode return ----
+  // All hooks above run every render; only the returned surface differs by mode.
+  if (isApiMode) {
+    return {
+      messages: apiMessages,
+      isLoading,
+      error,
+      sendMessage,
+      stop,
+      reload: regenerate,
+      clear,
+      // ADR-0013 D2: expose the underlying useChat setMessages so the host can
+      // re-hydrate the thread from the server after a stream-transport failure
+      // (the reply may already be persisted server-side — reconcile, don't re-run).
+      setMessages,
+      isApiMode: true,
+      input: apiInput,
+      setInput: setApiInput,
+      handleInputChange,
+    };
+  }
+
+  // ---- Local/legacy mode return ----
   return {
     messages: localMessages,
     isLoading: localIsLoading,


### PR DESCRIPTION
Wave 3 of the #2713 lint-gate restoration. `@object-ui/plugin-chatbot` was **red at baseline on `main`**. **Errors only; no behavior change.**

⚠️ **This is the highest-risk change in the sweep** — the bulk is an 8-hook restructure of `useObjectChat`, a core AI-chat hook with delicate send / reconcile / handoff flows. I'd like a closer look before merge even though CI is green.

## What changed

- **`useObjectChat` — 8× `react-hooks/rules-of-hooks`** — the hook called **different `useCallback`s in each of its two `isApiMode` return branches**, so both sets were conditional. That's a real bug: React throws "rendered more/fewer hooks" if `isApiMode` ever toggles between renders. `useChat` is *already* called unconditionally (the team's comment says so). This change:
  - destructures `chatResult` unconditionally (it's always defined), and
  - hoists **all eight** callbacks (3 API + 5 local) above the `isApiMode` branch,
  so the same hooks run in the same order every render. **Only the returned object differs by mode** — every callback body is byte-identical, just de-indented; the API-mode `messages` local is renamed `apiMessages` to avoid shadowing. (See the diff: the `useObjectChat.ts` hunk is a pure move/de-indent/rename.)
- **`FloatingChatbotTrigger`** (`rules-of-hooks`) — `useChatbotLabel` wrapped the provider-safe `useObjectTranslation` in try/catch → removed (the #2709 fix).
- **`shimmer`** (`static-components`) — `motion.create(Component)` genuinely builds a motion component and must key off the `as` prop, so it can't be module-scoped. Memoized per `Component` (stable ref → no per-render remount) with a justified scoped disable at the render site.

No lint **config** was loosened.

## Verification

- **Lint:** `eslint` → **0 errors** (10 at baseline).
- **Type gate:** `turbo run build` → **9/9 tasks green** (confirms the hoisted destructure + renames type-check).
- **Tests — both sides of `useObjectChat`:**
  - `plugin-chatbot` full suite: **218 passed / 14 files**, incl. the delicate `useObjectChat.sendFailure`, `useObjectChat.handoffContext`, `ChatbotEnhanced.sendError`, `withTurnId`, `withHandoffContext`.
  - app-shell consumers: `ChatDock` / `ConsoleChatbotFab` / `chatDockReturnLocation` / `useDeferredFirstSend` → **23 passed / 4 files**.

Refs #2713 · follows #2730, #2737, #2738, #2740 · pattern from #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)