### PR TITLE
chore(lint): clear baseline lint errors in plugin-gantt (#2713 Wave 3.4)

### DIFF
--- a/.changeset/lint-baseline-gantt.md
+++ b/.changeset/lint-baseline-gantt.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/plugin-gantt": patch
+---
+
+chore(lint): clear the baseline lint errors in plugin-gantt (objectui#2713 Wave 3)
+
+Wave 3 of the #2713 lint-gate restoration. `@object-ui/plugin-gantt` was red at
+baseline on `main`; cleared every **error** (no behavior change; warnings out of
+scope). 18 of the 21 were in the demo harness:
+
+- **`react-hooks/static-components` (demo, ×8)** — the `Swatch` legend cell was
+  defined inside `ManufacturingLegend`; hoisted to module scope (purely
+  props-driven, so nothing from render scope is captured).
+- **`react-hooks/rules-of-hooks` (demo, ×9)** — `App` had a `?quickfilter=1`
+  early return before ~9 hooks; moved that route below all hooks so hook order
+  is stable (the quick-filter branch renders `<QuickFilterDemo />` regardless).
+- **`react-hooks/purity` (demo, ×1)** — the demo render-timer necessarily reads
+  `performance.now()` during render (paired with an effect that measures elapsed
+  ms); justified scoped disable, demo-only.
+- **`object-ui/no-synthetic-event-trigger`** (`GanttView.interactions.test`) —
+  the Escape-closes-menu test dispatched a raw `window` `KeyboardEvent`; switched
+  to `fireEvent.keyDown(window, { key: 'Escape' })` (the pattern already used
+  elsewhere in the same file). The window-level Escape listener behaves
+  identically.
+- **`no-useless-assignment`** (`GanttView`, `ObjectGantt`) — dropped two dead
+  initializers (`ok`, `options`) that their exhaustive `try`/`catch` and
+  `if`/`else` branches overwrite before reading.

--- a/packages/plugin-gantt/demo/main.tsx
+++ b/packages/plugin-gantt/demo/main.tsx
@@ -394,14 +394,20 @@ function QuickFilterDemo() {
   );
 }
 
-/** 状态色图例 (3.4.3) — decodes the 排产计划 / 派工单 bar colors for the mfg demo. */
-function ManufacturingLegend() {
-  const Swatch = ({ color, label, hollow }: { color: string; label: string; hollow?: boolean }) => (
+/** One color swatch in the manufacturing legend. Hoisted to module scope so it
+ *  is a stable component reference (react-hooks/static-components); purely
+ *  props-driven, so nothing from the legend's render scope is captured. */
+function Swatch({ color, label, hollow }: { color: string; label: string; hollow?: boolean }) {
+  return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
       <span style={{ width: 12, height: 12, borderRadius: 3, background: hollow ? 'transparent' : color, border: hollow ? `1px solid ${color}` : 'none', display: 'inline-block' }} />
       {label}
     </span>
   );
+}
+
+/** 状态色图例 (3.4.3) — decodes the 排产计划 / 派工单 bar colors for the mfg demo. */
+function ManufacturingLegend() {
   return (
     <div
       data-testid="mfg-legend"
@@ -453,7 +459,6 @@ const shiftConfig = (showMidnight: boolean) => ({
 
 function App() {
   const params = new URLSearchParams(window.location.search);
-  if (params.get('quickfilter') === '1') return <QuickFilterDemo />;
   const perf = Number(params.get('perf') || 0);
   const edge = params.has('edge');
   const mfg = params.has('mfg');
@@ -492,6 +497,10 @@ function App() {
       return { key: String(v), label: String(v) };
     };
   }, [resourceMode, resourceField]);
+  // Demo-only render timer: capturing the render-start timestamp necessarily
+  // reads performance.now() during render (paired with the effect below that
+  // measures elapsed ms). Intentional and demo-only.
+  // eslint-disable-next-line react-hooks/purity
   const t0 = React.useMemo(() => performance.now(), []);
   const [tasks, setTasks] = React.useState<GanttTask[]>(() => {
     const base = perf > 0 ? perfFixture(perf) : edge ? edgeFixture() : mfg ? manufacturingFixture() : projectFixture();
@@ -514,6 +523,10 @@ function App() {
   React.useEffect(() => {
     (window as unknown as { __ganttTasks?: GanttTask[] }).__ganttTasks = tasks;
   }, [tasks]);
+
+  // Route to the quick-filter demo AFTER all hooks above run, so the hook order
+  // stays stable across renders (React requires the same hooks every render).
+  if (params.get('quickfilter') === '1') return <QuickFilterDemo />;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>

--- a/packages/plugin-gantt/src/GanttView.interactions.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.interactions.test.tsx
@@ -129,9 +129,9 @@ describe('GanttView context menu', () => {
     const { container } = renderView([A()], { onTaskDelete });
     fireEvent.contextMenu(container.querySelector('[data-testid="gantt-task-bar-a"]')!, { clientX: 10, clientY: 10 });
     expect(document.querySelector('[data-testid="gantt-context-menu"]')).toBeTruthy();
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-    });
+    // Dispatch through RTL's fireEvent (not a raw synthetic KeyboardEvent) —
+    // the Escape listener is on window; mirrors the existing pattern below.
+    fireEvent.keyDown(window, { key: 'Escape' });
     expect(document.querySelector('[data-testid="gantt-context-menu"]')).toBeFalsy();
     expect(onTaskDelete).not.toHaveBeenCalled();
   });

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -1042,7 +1042,8 @@ export function GanttView({
         if (onBeforeTaskUpdate) {
           const kept: typeof candidates = [];
           for (const u of candidates) {
-            let ok = true;
+            // Assigned by both the try and the catch below before it's read.
+            let ok: boolean;
             try {
               ok = (await onBeforeTaskUpdate(u.task, u.changes)) !== false;
             } catch {

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -950,7 +950,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     return quickFilterDefs.map((def) => {
       const fd = fieldDefs[def.field] ?? fieldDefs[def.field.split('.')[0]];
       const label = def.label ?? fd?.label ?? humanizeLabel(def.field);
-      let options: QuickFilterOption[] = [];
+      // Assigned by every branch of the exhaustive if/else chain below.
+      let options: QuickFilterOption[];
 
       if (def.options?.length) {
         options = def.options.map((o) =>


### PR DESCRIPTION
Wave 3 of the #2713 lint-gate restoration. `@object-ui/plugin-gantt` was **red at baseline on `main`**. **Errors only; no behavior change.** 18 of the 21 were in the demo harness (`demo/main.tsx`); the other 3 in src/test.

## What changed

- **`react-hooks/static-components`** (demo, ×8) — the `Swatch` legend cell was defined *inside* `ManufacturingLegend`. Hoisted to module scope — it's purely props-driven (`color`/`label`/`hollow`), so nothing from render scope is captured.
- **`react-hooks/rules-of-hooks`** (demo, ×9) — `App` had a `?quickfilter=1` early return **before** ~9 hooks (`useState`/`useMemo`/`useEffect`). Moved that route below all hooks so hook order is stable every render; the branch still renders `<QuickFilterDemo />`.
- **`react-hooks/purity`** (demo, ×1) — the demo render-timer necessarily reads `performance.now()` during render (paired with the effect that measures elapsed ms). Justified scoped disable, demo-only.
- **`object-ui/no-synthetic-event-trigger`** (`GanttView.interactions.test`) — the "Escape closes the context menu" test dispatched a raw `window` `KeyboardEvent` (the ADR-0054 C1 anti-pattern). Switched to `fireEvent.keyDown(window, { key: 'Escape' })` — **the exact pattern already used at line 521 of the same file**. The Escape listener is on `window` (`GanttView.tsx`), so behavior is identical.
- **`no-useless-assignment`** (`GanttView`, `ObjectGantt`) — dropped two dead initializers (`ok`, `options`) that their exhaustive `try`/`catch` and `if`/`else` chains overwrite before reading (declared without initializer; multiple assignment sites, so no follow-on `prefer-const`).

No lint **config** was loosened.

## Verification

- **Lint:** `eslint` → **0 errors** (21 at baseline).
- **Type gate:** `turbo run build` → **12/12 tasks green**.
- **Tests:** full `plugin-gantt` suite green — **338 passed / 34 files**, including `GanttView.interactions` (the Escape test I changed).

Refs #2713 · follows #2730, #2737, #2738, #2740, #2741 · pattern from #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)