### PR TITLE
chore(lint): clear baseline lint errors in components (#2713 Wave 3.5)

### DIFF
--- a/.changeset/lint-baseline-components.md
+++ b/.changeset/lint-baseline-components.md
@@ -1,0 +1,33 @@
+---
+"@object-ui/components": patch
+---
+
+chore(lint): clear the baseline lint errors in components (objectui#2713 Wave 3)
+
+Wave 3 of the #2713 lint-gate restoration. `@object-ui/components` was red at
+baseline on `main`; cleared every **error** (no behavior change; warnings out of
+scope):
+
+- **`react-hooks/rules-of-hooks`** — `react-page` `ReactKindPage` had a
+  capability-gate early return *before* four hooks (incl. a `useEffect` that
+  `import()`s the react runtime). Hoisted the hooks above the gate **and guarded
+  the import** (`if (!capabilityEnabled) return` inside the effect) so a disabled
+  build still never loads the gated runtime; the disabled notice is returned
+  after the hooks. Translation helpers in `empty` / `action-bar` / `action-menu`
+  unwrap a try/catch around the provider-safe `useObjectTranslation` (the #2709
+  fix).
+- **`react-hooks/static-components`** — dynamic renderer/icon lookups
+  (`ComponentRegistry.get`, `resolveIcon`) in `action-bar` / `action-group` ×2 /
+  `action-menu`, and the five `__tests__` helpers that render a registry-resolved
+  component, are stable references → justified scoped disables.
+- **`react-hooks/purity`** — `ui/sidebar` skeleton width uses `Math.random()`
+  once per mount (`useMemo([])`) for a decorative placeholder → justified scoped
+  disable.
+- **`@typescript-eslint/no-empty-object-type`** — `ShimmerSkeletonProps` empty
+  extend → `type` alias.
+- **`no-useless-assignment`** — `test-utils` `maxDepth` dead initializer → single
+  `const`.
+- **`no-require-imports`** — `config-panel-renderer` test uses a top-level
+  `import React` instead of an in-test `require`.
+- **stale `eslint-disable`** — removed a `jsx-a11y/alt-text` directive in
+  `elements` whose plugin is not loaded in the flat config.

--- a/packages/components/src/__tests__/config-panel-renderer.test.tsx
+++ b/packages/components/src/__tests__/config-panel-renderer.test.tsx
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ConfigPanelRenderer } from '../custom/config-panel-renderer';
@@ -426,7 +427,6 @@ describe('ConfigPanelRenderer', () => {
 
   describe('section icons', () => {
     it('should render section icon when provided', () => {
-      const React = require('react');
       const schemaWithIcon: ConfigPanelSchema = {
         breadcrumb: ['Test'],
         sections: [

--- a/packages/components/src/__tests__/element-button-action.test.tsx
+++ b/packages/components/src/__tests__/element-button-action.test.tsx
@@ -16,6 +16,7 @@ import '../renderers/basic/elements';
 function ElementButton({ schema }: { schema: any }) {
   const C = ComponentRegistry.get('element:button');
   if (!C) throw new Error('element:button not registered');
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
   return <C schema={schema} />;
 }
 

--- a/packages/components/src/__tests__/metadata-viewer.test.tsx
+++ b/packages/components/src/__tests__/metadata-viewer.test.tsx
@@ -27,6 +27,7 @@ function Viewer({ properties, getItem }: { properties: any; getItem: (t: string,
   if (!C) throw new Error('element:metadata_viewer not registered');
   return (
     <MetadataCtx.Provider value={metaCtx(getItem) as any}>
+      {/* eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render */}
       <C schema={{ type: 'element:metadata_viewer', properties }} />
     </MetadataCtx.Provider>
   );

--- a/packages/components/src/__tests__/page-card-i18n-title.test.tsx
+++ b/packages/components/src/__tests__/page-card-i18n-title.test.tsx
@@ -15,6 +15,7 @@ import { ComponentRegistry } from '@object-ui/core';
 function PageCard({ schema }: { schema: any }) {
   const Component = ComponentRegistry.get('page:card');
   if (!Component) throw new Error('page:card not registered');
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
   return <Component schema={schema} />;
 }
 

--- a/packages/components/src/__tests__/page-header-actions.test.tsx
+++ b/packages/components/src/__tests__/page-header-actions.test.tsx
@@ -21,6 +21,7 @@ import {
 function PageHeader({ schema }: { schema: any }) {
   const Component = ComponentRegistry.get('page:header');
   if (!Component) throw new Error('page:header not registered');
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
   return <Component schema={schema} />;
 }
 

--- a/packages/components/src/__tests__/page-header-title.test.tsx
+++ b/packages/components/src/__tests__/page-header-title.test.tsx
@@ -16,6 +16,7 @@ import { ActionProvider, RecordContextProvider } from '@object-ui/react';
 function PageHeader({ schema }: { schema: any }) {
   const Component = ComponentRegistry.get('page:header');
   if (!Component) throw new Error('page:header not registered');
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
   return <Component schema={schema} />;
 }
 

--- a/packages/components/src/__tests__/test-utils.tsx
+++ b/packages/components/src/__tests__/test-utils.tsx
@@ -85,7 +85,6 @@ export function checkDOMStructure(container: HTMLElement): {
   const hasChildren = container.children.length > 0;
 
   // Calculate nesting depth
-  let maxDepth = 0;
   function getDepth(el: Element, depth = 0): number {
     if (el.children.length === 0) return depth;
     let max = depth;
@@ -94,7 +93,7 @@ export function checkDOMStructure(container: HTMLElement): {
     }
     return max;
   }
-  maxDepth = getDepth(container);
+  const maxDepth = getDepth(container);
 
   // Check for excessive nesting (potential performance issue)
   if (maxDepth > 20) {

--- a/packages/components/src/custom/empty.tsx
+++ b/packages/components/src/custom/empty.tsx
@@ -12,13 +12,12 @@ import { useObjectTranslation } from "@object-ui/i18n"
 import { cn } from "../lib/utils"
 
 function useEmptyValueLabel(): string {
-  try {
-    const { t } = useObjectTranslation()
-    const v = t("detail.noValue")
-    return !v || v === "detail.noValue" ? "No value" : v
-  } catch {
-    return "No value"
-  }
+  // useObjectTranslation is provider-safe (never throws); no try/catch, which
+  // would wrap the hook call and violate rules-of-hooks. The "No value"
+  // fallback still applies when the key is missing/untranslated.
+  const { t } = useObjectTranslation()
+  const v = t("detail.noValue")
+  return !v || v === "detail.noValue" ? "No value" : v
 }
 
 function Empty({ className, ...props }: React.ComponentProps<"div">) {

--- a/packages/components/src/custom/shimmer-skeleton.tsx
+++ b/packages/components/src/custom/shimmer-skeleton.tsx
@@ -30,8 +30,7 @@ import { cn } from "../lib/utils"
  * @example
  * <ShimmerSkeleton className="h-4 w-32 rounded-md" />
  */
-export interface ShimmerSkeletonProps
-  extends React.HTMLAttributes<HTMLDivElement> {}
+export type ShimmerSkeletonProps = React.HTMLAttributes<HTMLDivElement>;
 
 export function ShimmerSkeleton({
   className,

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -41,13 +41,12 @@ import { cn } from '../../lib/utils';
 import { useIsMobile } from '../../hooks/use-mobile';
 
 function useActionsLabel(): string {
-  try {
-    const { t } = useObjectTranslation();
-    const v = t('common.actions');
-    return !v || v === 'common.actions' ? 'Actions' : v;
-  } catch {
-    return 'Actions';
-  }
+  // useObjectTranslation is provider-safe (never throws); no try/catch, which
+  // would wrap the hook call and violate rules-of-hooks. The 'Actions' fallback
+  // still applies when the key is missing/untranslated.
+  const { t } = useObjectTranslation();
+  const v = t('common.actions');
+  return !v || v === 'common.actions' ? 'Actions' : v;
 }
 
 export interface ActionBarSchema {
@@ -218,6 +217,7 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
     // + system actions. This guarantees at most ONE "More" button per bar.
     const MenuRenderer = combinedOverflow.length > 0 ? ComponentRegistry.get('action:menu') : null;
     const overflowMenu = MenuRenderer ? (
+      // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered renderer (stable reference), not a component created during render
       <MenuRenderer
         schema={{
           type: 'action:menu' as const,

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -97,6 +97,7 @@ const InlineActionButton: React.FC<{
       onClick={handleClick}
     >
       {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+      {/* eslint-disable-next-line react-hooks/static-components -- resolveIcon returns a stable icon component from a static registry, not one created during render */}
       {!loading && Icon && <Icon className={cn('h-4 w-4', action.label && 'mr-2')} />}
       {action.label}
     </Button>
@@ -231,6 +232,7 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
               {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
             >
               {dropdownLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {/* eslint-disable-next-line react-hooks/static-components -- resolveIcon returns a stable icon component from a static registry, not one created during render */}
               {!dropdownLoading && TriggerIcon && <TriggerIcon className="mr-2 h-4 w-4" />}
               {schema.label || 'Actions'}
               <ChevronDown className="ml-2 h-3 w-3 opacity-50" />

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -32,13 +32,12 @@ import { Loader2, MoreHorizontal } from 'lucide-react';
 import { resolveIcon } from './resolve-icon';
 
 function useMoreActionsLabel(): string {
-  try {
-    const { t } = useObjectTranslation();
-    const v = t('detail.moreActions');
-    return !v || v === 'detail.moreActions' ? 'More actions' : v;
-  } catch {
-    return 'More actions';
-  }
+  // useObjectTranslation is provider-safe (never throws); no try/catch, which
+  // would wrap the hook call and violate rules-of-hooks. The 'More actions'
+  // fallback still applies when the key is missing/untranslated.
+  const { t } = useObjectTranslation();
+  const v = t('detail.moreActions');
+  return !v || v === 'detail.moreActions' ? 'More actions' : v;
 }
 
 export interface ActionMenuSchema {
@@ -187,6 +186,7 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
               <>
+                {/* eslint-disable-next-line react-hooks/static-components -- resolveIcon returns a stable icon component from a static registry, not one created during render */}
                 <TriggerIcon className={cn('h-4 w-4', schema.label && 'mr-2')} />
                 {schema.label && <span>{schema.label}</span>}
               </>

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -145,7 +145,6 @@ function ElementImageRenderer({ schema }: { schema: any }) {
     );
   }
   return (
-    // eslint-disable-next-line jsx-a11y/alt-text
     <img
       src={props.src}
       alt={props.alt ?? ''}

--- a/packages/components/src/renderers/layout/react-page.tsx
+++ b/packages/components/src/renderers/layout/react-page.tsx
@@ -91,16 +91,16 @@ export const ReactKindPage: React.FC<{ schema: any }> = ({ schema }) => {
   // The live data source for the injected data blocks (and the page's own
   // `useAdapter()` calls). Same object the rest of the app renders against.
   const adapter = useAdapter();
-
-  // Gate: default-closed. Off in OSS / untrusted builds.
-  if (!isCapabilityEnabled(CAP_REACT_PAGES)) {
-    return <CapabilityDisabledNotice />;
-  }
+  // Gate: default-closed. Off in OSS / untrusted builds. Read here so the hooks
+  // below stay unconditional; the disabled notice is returned after them, and
+  // the effect never loads the gated runtime when disabled.
+  const capabilityEnabled = isCapabilityEnabled(CAP_REACT_PAGES);
 
   const [runtime, setRuntime] = React.useState<RuntimeModule | null>(null);
   const [loadError, setLoadError] = React.useState<Error | null>(null);
 
   React.useEffect(() => {
+    if (!capabilityEnabled) return;
     let alive = true;
     import('@object-ui/react-runtime')
       .then((m) => alive && setRuntime(m))
@@ -108,7 +108,7 @@ export const ReactKindPage: React.FC<{ schema: any }> = ({ schema }) => {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [capabilityEnabled]);
 
   const scope = React.useMemo(
     () => ({
@@ -123,6 +123,11 @@ export const ReactKindPage: React.FC<{ schema: any }> = ({ schema }) => {
     }),
     [schema, adapter],
   );
+
+  // Capability gate — returned after all hooks above so hook order stays stable.
+  if (!capabilityEnabled) {
+    return <CapabilityDisabledNotice />;
+  }
 
   if (loadError) {
     return (

--- a/packages/components/src/ui/sidebar.tsx
+++ b/packages/components/src/ui/sidebar.tsx
@@ -668,8 +668,11 @@ const SidebarMenuSkeleton = React.forwardRef<
     showIcon?: boolean
   }
 >(({ className, showIcon = false, ...props }, ref) => {
-  // Random width between 50 to 90%.
+  // Random width between 50 to 90%. Decorative skeleton placeholder — the
+  // randomness is intentional and computed once per mount (useMemo([])), so the
+  // impurity is contained to mount.
   const width = React.useMemo(() => {
+    // eslint-disable-next-line react-hooks/purity
     return `${Math.floor(Math.random() * 40) + 50}%`
   }, [])
 


### PR DESCRIPTION
Wave 3 of the #2713 lint-gate restoration. `@object-ui/components` was **red at baseline on `main`**. **Errors only; no behavior change.**

## What changed (per rule)

- **`react-hooks/rules-of-hooks`**
  - `react-page` `ReactKindPage`: a capability-gate early return sat *before* four hooks — including a `useEffect` that `import()`s `@object-ui/react-runtime`. **Naively moving the gate down would load the gated runtime even when disabled** (the gate is default-closed in OSS/untrusted builds). Instead: hoisted the hooks above the gate **and guarded the import** (`if (!capabilityEnabled) return` inside the effect, dep `[capabilityEnabled]`), with the disabled notice returned after the hooks. So hook order is stable *and* the runtime is still never loaded when disabled.
  - `empty` / `action-bar` / `action-menu`: translation helpers unwrap a try/catch around the provider-safe `useObjectTranslation` (the #2709 fix).
- **`react-hooks/static-components`** — dynamic renderer/icon lookups (`ComponentRegistry.get`, `resolveIcon`) in `action-bar`, `action-group` (×2), `action-menu`, and the five `__tests__` helpers that render a registry-resolved component. All stable references → justified scoped disables.
- **`react-hooks/purity`** — `ui/sidebar` skeleton width uses `Math.random()` once per mount (`useMemo([])`) for a decorative placeholder → justified scoped disable.
- **`@typescript-eslint/no-empty-object-type`** — `ShimmerSkeletonProps` empty extend → `type` alias.
- **`no-useless-assignment`** — `test-utils` `maxDepth` dead initializer → single `const` at its assignment.
- **`no-require-imports`** — `config-panel-renderer` test now uses a top-level `import React` instead of an in-test `require`.
- **stale `eslint-disable`** — removed a `jsx-a11y/alt-text` directive in `elements` whose plugin isn't loaded (unknown-rule reference → ESLint v10 error).

No lint **config** was loosened.

## Verification

- **Lint:** `eslint` → **0 errors** (21 at baseline).
- **Type gate:** `turbo run build` → **8/8 tasks green**.
- **Tests:** full `components` suite green — **304 passed / 33 files**, including the five touched test helpers, `config-panel-renderer`, and the action renderers.

Refs #2713 · follows #2730, #2737, #2738, #2740, #2741, #2744 · pattern from #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)