### PR TITLE
chore(lint): clear baseline lint errors in app-shell (#2713 Wave 3.6 — final)

### DIFF
--- a/.changeset/lint-baseline-app-shell.md
+++ b/.changeset/lint-baseline-app-shell.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/app-shell": patch
+---
+
+chore(lint): clear the baseline lint errors in app-shell (objectui#2713 Wave 3)
+
+Final package of the #2713 lint-gate restoration — with this the whole workspace
+is at **0 lint errors**. `@object-ui/app-shell` was red at baseline on `main`;
+cleared every **error** (no behavior change; warnings out of scope):
+
+- **`react-hooks/rules-of-hooks` (12)** — hooks called after conditional early
+  returns, restructured so hook order is stable:
+  - `SchemaForm`: hoisted the `issuesByPath` `useMemo` above the RawJsonEditor
+    fallback guard, and `RecordField`'s five `useState` above its widget /
+    specialized-editor early returns.
+  - `MetadataPanel`: moved `if (!open) return null` below its three hooks.
+  - `LayeredDiff`: moved the `if (code == null)` guard below the two `useMemo`s
+    and made `rows` null-safe (`code == null ? [] : computeDiffRows(...)`).
+  - `ViewPreview`: hoisted the `object-view` `schema` `useMemo` above the three
+    render branches (the earlier branches shadow it locally).
+- **`react-hooks/static-components` (12)** — icon/inspector/preview lookups
+  (`getIcon`, `typeIcon`, `kindIcon`, `getMetadataPreview` / `…Inspector` /
+  `…DefaultInspector`) are stable registry references → justified scoped disables.
+- **`no-useless-assignment` (3)** — dead `= null` / `= []` initializers in
+  `marketplaceApi` and the two ratchet tests (the only fall-through paths
+  reassign first).
+- **`@typescript-eslint/ban-ts-comment` (2)** — the `lucide-react/dynamic.mjs`
+  imports in `getIcon` / `widgets` no longer error under the build's `tsc`, so
+  the stale `@ts-ignore` directives are removed outright.
+- **stale `eslint-disable` (1)** — removed a `@next/next/no-img-element`
+  directive in `AgentPreview` whose plugin isn't loaded in the flat config.

--- a/packages/app-shell/src/adr0054-ratchet.test.ts
+++ b/packages/app-shell/src/adr0054-ratchet.test.ts
@@ -41,7 +41,9 @@ function collectSourceFiles(): string[] {
   };
   for (const group of ['packages', 'apps']) {
     const groupDir = path.join(repoRoot, group);
-    let pkgs: string[] = [];
+    // Assigned by readdirSync below before the read; the catch `continue`s, so
+    // the loop body past the try only runs when pkgs was assigned.
+    let pkgs: string[];
     try {
       pkgs = readdirSync(groupDir);
     } catch {

--- a/packages/app-shell/src/console/home/AppCard.tsx
+++ b/packages/app-shell/src/console/home/AppCard.tsx
@@ -114,6 +114,7 @@ export function AppCard({ app, onClick, isFavorite, index = 0 }: AppCardProps) {
             accent.to,
           )}
         >
+          {/* eslint-disable-next-line react-hooks/static-components -- getIcon returns a stable icon component from a static registry, not one created during render */}
           <Icon
             className={cn('h-7 w-7', accent.text)}
           />

--- a/packages/app-shell/src/console/marketplace/marketplaceApi.ts
+++ b/packages/app-shell/src/console/marketplace/marketplaceApi.ts
@@ -323,7 +323,9 @@ export async function listInstallableOrgIds(): Promise<Set<string>> {
   if (!meId) return new Set();
 
   const url = `${base}/api/v1/data/sys_member?limit=200`;
-  let payload: any = null;
+  // Assigned in the try below before the read; the only fall-through path is a
+  // successful fetch (both the !ok branch and the catch return early).
+  let payload: any;
   try {
     const res = await fetch(url, {
       credentials: 'include',

--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -268,6 +268,7 @@ function SelectorControl({
       >
         <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
           <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded border border-sidebar-border/70 bg-sidebar-accent text-sidebar-foreground/70">
+            {/* eslint-disable-next-line react-hooks/static-components -- getIcon returns a stable icon component from a static registry, not one created during render */}
             <Icon className="h-3 w-3" />
           </span>
           <SelectValue placeholder={placeholder} className="truncate" />

--- a/packages/app-shell/src/no-refresh-key-remount.ratchet.test.ts
+++ b/packages/app-shell/src/no-refresh-key-remount.ratchet.test.ts
@@ -75,7 +75,9 @@ function collectSourceFiles(): string[] {
   };
   for (const group of ['packages', 'apps']) {
     const groupDir = path.join(repoRoot, group);
-    let pkgs: string[] = [];
+    // Assigned by readdirSync below before the read; the catch `continue`s, so
+    // the loop body past the try only runs when pkgs was assigned.
+    let pkgs: string[];
     try {
       pkgs = readdirSync(groupDir);
     } catch {

--- a/packages/app-shell/src/utils/getIcon.ts
+++ b/packages/app-shell/src/utils/getIcon.ts
@@ -13,7 +13,6 @@
 
 import React from 'react';
 import { Database } from 'lucide-react';
-// @ts-ignore - lucide-react has no `exports` field; subpath types live alongside dynamic.mjs
 import { DynamicIcon, iconNames } from 'lucide-react/dynamic.mjs';
 
 /** Convert PascalCase / camelCase / mixed names to kebab-case for DynamicIcon. */

--- a/packages/app-shell/src/views/MetadataInspector.tsx
+++ b/packages/app-shell/src/views/MetadataInspector.tsx
@@ -49,11 +49,12 @@ export function MetadataToggle({ open, onToggle, className }: { open: boolean; o
  * The side panel that renders JSON metadata sections.
  */
 export function MetadataPanel({ sections, open }: Omit<MetadataInspectorProps, 'onToggle'>) {
-  if (!open) return null;
-
   const { t } = useObjectTranslation();
   const [expandedSections, setExpandedSections] = useState<string[]>(['0']);
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  // Checked after the hooks above so hook order stays stable across renders.
+  if (!open) return null;
 
   const handleCopy = async (data: any, index: number) => {
     try {

--- a/packages/app-shell/src/views/metadata-admin/LayeredDiff.tsx
+++ b/packages/app-shell/src/views/metadata-admin/LayeredDiff.tsx
@@ -252,17 +252,8 @@ function DiffTable({
 }) {
   const [showUnchanged, setShowUnchanged] = React.useState(false);
 
-  // No baseline = pure runtime overlay; the diff table has nothing to compare.
-  if (code == null) {
-    return (
-      <div className="rounded border bg-muted/30 p-4 text-xs text-muted-foreground">
-        {t('engine.layers.diff.noBaseline', locale)}
-      </div>
-    );
-  }
-
   const rows = React.useMemo(
-    () => computeDiffRows(code, effective),
+    () => (code == null ? [] : computeDiffRows(code, effective)),
     [code, effective],
   );
 
@@ -275,6 +266,16 @@ function DiffTable({
       { unchanged: 0, modified: 0, added: 0, removed: 0 } as Record<DiffStatus, number>,
     );
   }, [rows]);
+
+  // No baseline = pure runtime overlay; the diff table has nothing to compare.
+  // Checked after the hooks above so hook order stays stable across renders.
+  if (code == null) {
+    return (
+      <div className="rounded border bg-muted/30 p-4 text-xs text-muted-foreground">
+        {t('engine.layers.diff.noBaseline', locale)}
+      </div>
+    );
+  }
 
   const visibleRows = showUnchanged
     ? rows

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -2159,6 +2159,7 @@ function MetadataResourceEditPageImpl({
                         </div>
                       </div>
                       <div className="flex-1 min-h-0 overflow-auto p-4 bg-[radial-gradient(circle_at_1px_1px,theme(colors.border)_1px,transparent_0)] [background-size:16px_16px] bg-muted/30">
+                        {/* eslint-disable-next-line react-hooks/static-components -- getMetadataPreview returns a registered component (stable), not one created during render */}
                         <PreviewComponent
                           type={type}
                           name={name}
@@ -2282,6 +2283,7 @@ function MetadataResourceEditPageImpl({
                             }))}
                           />
                         ) : selection && InspectorComponent ? (
+                          // eslint-disable-next-line react-hooks/static-components -- getMetadataInspector returns a registered component (stable), not one created during render
                           <InspectorComponent
                             type={type}
                             name={name}
@@ -2299,6 +2301,7 @@ function MetadataResourceEditPageImpl({
                             locale={locale}
                           />
                         ) : !selection && DefaultInspectorComponent ? (
+                          // eslint-disable-next-line react-hooks/static-components -- getMetadataDefaultInspector returns a registered component (stable), not one created during render
                           <DefaultInspectorComponent
                             type={type}
                             name={name}

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -476,6 +476,16 @@ export function SchemaForm({
   // Editable + truly unknown shape → keep the raw JSON editor as a
   // last resort, since we can't safely guess primitive types for
   // fields the user might add.
+  // Hoisted above the schema-synthesis guard below so this hook runs on every
+  // render (the guard can early-return a <RawJsonEditor/>).
+  const issuesByPath = React.useMemo(() => {
+    const map: Record<string, string[]> = {};
+    for (const i of issues) {
+      (map[i.path] ??= []).push(translateValidationMessage(i.message, locale));
+    }
+    return map;
+  }, [issues, locale]);
+
   let effectiveSchema: JsonSchema | undefined = schema;
   if (!effectiveSchema || typeof effectiveSchema !== 'object') {
     if (value && typeof value === 'object') {
@@ -501,14 +511,6 @@ export function SchemaForm({
       const visibleOn = (props[k] as any)?.visibleOn;
       return !visibleOn || evaluatePredicate(visibleOn, { data: predicateData });
     });
-
-  const issuesByPath = React.useMemo(() => {
-    const map: Record<string, string[]> = {};
-    for (const i of issues) {
-      (map[i.path] ??= []).push(translateValidationMessage(i.message, locale));
-    }
-    return map;
-  }, [issues, locale]);
 
   const v = value ?? {};
 
@@ -1643,6 +1645,13 @@ function RecordField({
   onChange: (v: unknown) => void;
 }) {
   const locale = useMetadataLocale();
+  // State hoisted above every early return below (the widget delegation and the
+  // specialized-editor branches) so hook order stays stable across renders.
+  const [openKey, setOpenKey] = React.useState<string | null>(null);
+  const [pendingKey, setPendingKey] = React.useState('');
+  const [keyError, setKeyError] = React.useState<string | null>(null);
+  const [dragKey, setDragKey] = React.useState<string | null>(null);
+  const [dropTarget, setDropTarget] = React.useState<string | null>(null);
   // Delegate to a registered widget if the form spec asked for one
   // explicitly (e.g. `widget: 'airtable'`). The widget owns the entire UI.
   if (widget) {
@@ -1673,9 +1682,6 @@ function RecordField({
       : {};
   const entries = Object.entries(record);
   const specs = fields.map(normaliseField).filter((s) => s.field !== keyProp);
-  const [openKey, setOpenKey] = React.useState<string | null>(null);
-  const [pendingKey, setPendingKey] = React.useState('');
-  const [keyError, setKeyError] = React.useState<string | null>(null);
 
   const emit = (next: Record<string, Record<string, unknown>>) => onChange(next);
 
@@ -1737,9 +1743,8 @@ function RecordField({
   };
 
   // Drag-to-reorder. We rebuild the Record with the new key order, since
-  // insertion order = display order for `type: 'record'`.
-  const [dragKey, setDragKey] = React.useState<string | null>(null);
-  const [dropTarget, setDropTarget] = React.useState<string | null>(null);
+  // insertion order = display order for `type: 'record'`. (dragKey/dropTarget
+  // state is declared at the top of the component with the other hooks.)
   const reorder = (sourceKey: string, targetKey: string) => {
     if (sourceKey === targetKey) return;
     const keys = entries.map(([k]) => k);

--- a/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
@@ -228,6 +228,7 @@ export function ActionPreview({ name, draft }: MetadataPreviewProps) {
           {/* On-click description */}
           <div className="rounded border border-blue-200 bg-blue-50 p-2.5 text-xs">
             <div className="flex items-center gap-1.5 font-medium text-blue-900 mb-0.5">
+              {/* eslint-disable-next-line react-hooks/static-components -- typeIcon returns a stable icon component from a static registry, not one created during render */}
               <TypeIcon className="h-3.5 w-3.5" /> On click
             </div>
             <div className="text-blue-950 font-mono break-all">

--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
@@ -105,7 +105,6 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
             <div className="rounded border bg-muted/30 p-3 flex items-start gap-3">
               <div className="h-10 w-10 rounded-full bg-background border flex items-center justify-center shrink-0 overflow-hidden">
                 {avatar ? (
-                  // eslint-disable-next-line @next/next/no-img-element
                   <img src={avatar} alt="" className="h-full w-full object-cover" />
                 ) : (
                   <Bot className="h-5 w-5 text-muted-foreground" />

--- a/packages/app-shell/src/views/metadata-admin/previews/AppNavCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AppNavCanvas.tsx
@@ -462,6 +462,7 @@ function NavCard({
         ) : (
           <span className="w-3.5" />
         )}
+        {/* eslint-disable-next-line react-hooks/static-components -- kindIcon returns a stable icon component from a static registry, not one created during render */}
         <Icon className={cn('h-3.5 w-3.5 shrink-0', tone.icon)} />
         {editing ? (
           <input

--- a/packages/app-shell/src/views/metadata-admin/previews/AppPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AppPreview.tsx
@@ -184,6 +184,7 @@ function NavRow({
         style={{ paddingLeft: `${12 + depth * 16}px` }}
         onClick={onSelect ? (e) => { e.stopPropagation(); onSelect(path, item); } : undefined}
       >
+        {/* eslint-disable-next-line react-hooks/static-components -- kindIcon returns a stable icon component from a static registry, not one created during render */}
         <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         <span className="font-medium truncate">{item.label}</span>
         {item.kind && (

--- a/packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx
@@ -120,6 +120,25 @@ export function ViewPreview({ name, draft, editing }: MetadataPreviewProps) {
     };
   }, [body, draft, name]);
 
+  // Hoisted above the early returns below so this hook runs on every render
+  // (hook order must stay stable). Only the final `object-view` branch reads it;
+  // the earlier branches shadow it with their own local `schema`/`formSchema`.
+  const schema = React.useMemo(
+    () => ({
+      type: 'object-view',
+      objectName,
+      defaultViewType,
+      defaultListView: defaultViewId,
+      listViews,
+      showSearch: true,
+      showFilters: true,
+      showCreate: false,
+      showRefresh: true,
+      showViewSwitcher: true,
+    }),
+    [objectName, defaultViewType, defaultViewId, listViews],
+  );
+
   // -------------------------------------------------------------------------
   // Raw single-schema draft (no ViewItem `config` wrapper): render directly.
   // -------------------------------------------------------------------------
@@ -170,22 +189,6 @@ export function ViewPreview({ name, draft, editing }: MetadataPreviewProps) {
   // Delegate to `object-view` — the same renderer the runtime route uses —
   // with the draft body injected so the preview reflects unsaved edits.
   // -------------------------------------------------------------------------
-  const schema = React.useMemo(
-    () => ({
-      type: 'object-view',
-      objectName,
-      defaultViewType,
-      defaultListView: defaultViewId,
-      listViews,
-      showSearch: true,
-      showFilters: true,
-      showCreate: false,
-      showRefresh: true,
-      showViewSwitcher: true,
-    }),
-    [objectName, defaultViewType, defaultViewId, listViews],
-  );
-
   return (
     <PreviewShell hint={`view · ${defaultViewType}${designMode ? ' · design' : ''}`}>
       <PreviewErrorBoundary fallbackHint="The view references an object or field that doesn't resolve.">

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -42,7 +42,6 @@ import {
   DialogTitle,
 } from '@object-ui/components';
 import { ChevronDown, ChevronsUpDown, ChevronUp, Eye, EyeOff, Plus, Search, Trash2 } from 'lucide-react';
-// @ts-ignore - lucide-react has no `exports` field; subpath types live alongside dynamic.mjs
 import { iconNames } from 'lucide-react/dynamic.mjs';
 import { useMetadataLocale, t, tFormat } from './i18n';
 import { ColorVariantPicker } from './color-variant-field';

--- a/packages/app-shell/src/views/studio-design/ObjectActionsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectActionsPanel.tsx
@@ -204,6 +204,7 @@ export function ObjectActionsPanel({
                 </button>
               </div>
             )}
+            {/* eslint-disable-next-line react-hooks/static-components -- getMetadataDefaultInspector returns a registered component (stable), not one created during render */}
             <Inspector
               type="action"
               name={String(sel.name ?? '')}

--- a/packages/app-shell/src/views/studio-design/ObjectHooksPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectHooksPanel.tsx
@@ -260,6 +260,7 @@ export function ObjectHooksPanel({
             </div>
             <div className="min-h-0 flex-1 overflow-auto">
               {HookInspector ? (
+                // eslint-disable-next-line react-hooks/static-components -- getMetadataDefaultInspector returns a registered component (stable), not one created during render
                 <HookInspector
                   type="hook"
                   name={String(draft.name ?? '')}

--- a/packages/app-shell/src/views/studio-design/ObjectSettingsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectSettingsPanel.tsx
@@ -118,6 +118,7 @@ export function ObjectSettingsPanel({
         </header>
         <div className="max-w-xl p-3">
           {DefaultInspector ? (
+            // eslint-disable-next-line react-hooks/static-components -- getMetadataDefaultInspector returns a registered component (stable), not one created during render
             <DefaultInspector
               type="object"
               name={name}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -2251,6 +2251,7 @@ export function DataPillar({
         </button>
         {current ? (
           <span className="flex min-w-0 items-center gap-2">
+            {/* eslint-disable-next-line react-hooks/static-components -- getIcon returns a stable icon component from a static registry, not one created during render */}
             <HeaderIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="truncate text-[15px] font-semibold leading-none text-foreground">{current.label}</span>
             <span className="shrink-0 rounded bg-muted/70 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">


### PR DESCRIPTION
**Final package of the #2713 lint-gate restoration** — with this, `pnpm -r lint` is at **0 errors across the whole workspace**. `@object-ui/app-shell` was **red at baseline on `main`** (30 errors, the largest). **Errors only; no behavior change.**

## What changed (per rule)

- **`react-hooks/rules-of-hooks` (12)** — hooks called after conditional early returns; each restructured so hook order is stable across renders (verified each hook's side-effect profile first):
  - `SchemaForm`: hoisted the `issuesByPath` `useMemo` above the RawJsonEditor fallback guard; hoisted `RecordField`'s five `useState` above its widget-delegation / specialized-editor early returns.
  - `MetadataPanel`: moved `if (!open) return null` below its three hooks.
  - `LayeredDiff`: moved the `if (code == null)` guard below the two `useMemo`s and made `rows` null-safe (`code == null ? [] : computeDiffRows(...)`) so the hoisted memo can't deref null.
  - `ViewPreview`: hoisted the `object-view` `schema` `useMemo` above the three render branches (the earlier branches shadow it with their own local `schema`/`formSchema`).
- **`react-hooks/static-components` (12)** — dynamic icon/inspector/preview lookups (`getIcon`, `typeIcon`, `kindIcon`, `getMetadataPreview` / `…Inspector` / `…DefaultInspector`) are stable registry references → justified scoped disables.
- **`no-useless-assignment` (3)** — dead `= null` / `= []` initializers (`marketplaceApi`, the two `*.ratchet.test.ts`) that the only fall-through paths reassign first.
- **`@typescript-eslint/ban-ts-comment` (2)** — the `lucide-react/dynamic.mjs` imports in `getIcon` / `widgets` **no longer error** under the build's `tsc` (confirmed: converting to `@ts-expect-error` reported TS2578 "unused directive"), so the stale `@ts-ignore` directives are removed outright rather than converted.
- **stale `eslint-disable` (1)** — removed a `@next/next/no-img-element` directive in `AgentPreview` whose plugin isn't loaded (unknown-rule reference → ESLint v10 error).

No lint **config** was loosened.

## Verification

- **Lint:** `eslint` → **0 errors** (30 at baseline).
- **Type gate:** `turbo run build` → **29/29 tasks green** (also caught the stale-`@ts-ignore` case above, which I then fixed).
- **Tests:** full `app-shell` suite green — **1763 passed / 211 files**, including the `adr0054-ratchet` / `no-refresh-key-remount` ratchet tests I touched and the restructured metadata-admin components.

## Closes the sweep

This is the 6th of 6 Wave-3 PRs. Across #2730, #2737, #2738, #2740, #2741, #2744, #2745 and this, all 24 packages that were red at baseline are back to 0 — **the per-package `lint` gate protects every package again** (the goal of #2713).

Refs #2713 · pattern from #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)