### PR TITLE
feat(data-objectstack): gate non-atomic batch fallback on discovery `transactionalBatch` capability (#2693)

### DIFF
--- a/.changeset/batch-transactional-capability-gate.md
+++ b/.changeset/batch-transactional-capability-gate.md
@@ -1,0 +1,32 @@
+---
+"@object-ui/data-objectstack": minor
+---
+
+feat(data-objectstack): gate the non-atomic batch fallback on the discovery `transactionalBatch` capability (#2693)
+
+`ObjectStackAdapter.batchTransaction` now negotiates atomic cross-object batch
+**declaratively** instead of only probing at runtime. At `connect()` the adapter
+reads `capabilities.transactionalBatch` from `GET /api/v1/discovery`
+(framework #3298 — `declared === enforced`; the server advertises `true` only
+when the `/batch` route is mounted *and* the runtime engine can honour a
+transaction):
+
+- **Declared `true`** — the adapter TRUSTS server atomicity: it calls `/batch`
+  and surfaces any failure (including `404`/`405`/`501`) as a real error. No
+  runtime probe, no non-atomic client-side compensation.
+- **Declared `false`, or absent** (backend predates #3298) — the legacy path is
+  unchanged: probe `/batch` and, on `404`/`405`/`501`, fall back to the
+  non-atomic `emulateBatchTransaction`. Keeping this avoids regressing older
+  backends from "saves, less safe" to "no save path" (#2679 compat constraint).
+
+Both the hierarchical wire shape (`{ transactionalBatch: { enabled: true } }`)
+and the flat form the client SDK normalizes to (`{ transactionalBatch: true }`)
+are accepted. `@object-ui/core`'s generic `emulateBatchTransaction` /
+`runBatchTransaction` are untouched and remain the fallback for adapters with no
+server-side transaction (`ValueDataSource`, `MockDataSource`, …).
+
+Docs: the adapter README and the data-source guide now document the capability
+table and the minimum-backend note — atomic cross-object saves are guaranteed
+only against backends advertising the capability (framework #3298 / #1604).
+
+Picks up #2679 acceptance item 4; unblocked by framework#3298 (merged).

--- a/content/docs/guide/data-source.md
+++ b/content/docs/guide/data-source.md
@@ -186,3 +186,16 @@ executes the operations sequentially (resolving `$ref`s) with best-effort
 compensation on failure. UI components never branch on atomicity — they call
 `runBatchTransaction(dataSource, operations)` (also from `@object-ui/core`),
 which uses the adapter's method when present and emulates otherwise.
+
+The `@object-ui/data-objectstack` adapter decides whether it can trust server
+atomicity **declaratively**, at connect time: it reads the
+`capabilities.transactionalBatch` flag from `GET /api/v1/discovery`
+(framework #3298). When the backend advertises `true`, the adapter treats any
+`/batch` failure as a real error — no non-atomic client-side compensation. When
+the flag is `false` or absent (a backend predating #3298), it keeps the legacy
+behaviour: probe `/batch` and fall back to the non-atomic emulation on
+`404`/`405`/`501`. Atomic cross-object saves are therefore guaranteed only
+against backends that advertise the capability; older ones still save, but
+best-effort. See the
+[adapter README](../../../packages/data-objectstack/README.md#cross-object-atomic-batch-batchtransaction)
+for the full capability table and minimum-backend note.

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -272,6 +272,68 @@ await dataSource.bulk('users', 'delete', [
 - Provides partial success reporting for resilient error handling
 - Atomic operations where supported by the backend
 
+## Cross-Object Atomic Batch (`batchTransaction`)
+
+`bulk()` above operates on **one** object. To persist a set of **cross-object**
+writes as a single all-or-nothing unit — the master-detail case, where a parent
+and its children must commit or roll back together — use `batchTransaction`:
+
+```typescript
+// Create a parent and a child that references it, atomically.
+// `{ $ref: 0 }` resolves to the id minted by operation 0 (the parent).
+await dataSource.batchTransaction([
+  { object: 'invoice',      action: 'create', data: { no: 'INV-1' } },
+  { object: 'invoice_line', action: 'create', data: { invoice: { $ref: 0 }, amount: 10 } },
+]);
+```
+
+On a supporting backend this is one `POST /api/v1/batch` that commits or rolls
+back the whole set in a single server transaction — no orphaned parent if a
+child write fails.
+
+### Declarative capability negotiation (`transactionalBatch`)
+
+Whether the adapter can rely on server atomicity is decided **at connect time**,
+not by firing a batch and reading the failure. `connect()` reads the
+`capabilities.transactionalBatch` flag from `GET /api/v1/discovery`
+([framework #3298](https://github.com/objectstack-ai/framework/issues/3298)),
+which the server sets to `true` only when the `/batch` route is mounted **and**
+the runtime engine can honour a transaction (`declared === enforced`):
+
+| Discovery `capabilities.transactionalBatch` | `batchTransaction` behaviour |
+| --- | --- |
+| `true` | **Trusts server atomicity.** Calls `/batch`; any failure — including `404`/`405`/`501` — surfaces as a real error. No non-atomic client-side fallback. |
+| `false` | Backend can't do an atomic batch (route absent, or a runtime without transactions) → falls back to the non-atomic client-side emulation below. |
+| *absent* | Backend predates #3298 and advertises nothing → the legacy runtime probe stays: try `/batch`, and on `404`/`405`/`501` fall back to emulation. |
+
+The hierarchical wire shape (`{ transactionalBatch: { enabled: true } }`) and the
+flat form the client SDK normalizes to (`{ transactionalBatch: true }`) are both
+accepted.
+
+### Non-atomic fallback
+
+When the capability is `false` or absent, the adapter degrades to a client-side
+emulation (`@object-ui/core`'s `emulateBatchTransaction`): the operations run in
+order and, on failure, it best-effort deletes the records it created (children
+before parent) before rethrowing. This is **not** a transaction — a create's
+side effects (hooks, rollups, webhooks) are not undone by a later delete, and a
+mid-batch network drop leaves no chance to compensate. It exists only so a save
+is still possible against a backend that lacks server atomicity; removing it
+would turn "saves, less safe" into "no save path" on older backends
+([objectui #2679](https://github.com/objectstack-ai/objectui/issues/2679)).
+
+### Minimum supported backend
+
+Atomic cross-object saves are **guaranteed only against ObjectStack backends on
+the 16.x line that advertise `capabilities.transactionalBatch: true`** — the
+endpoint landed in [framework #1604](https://github.com/objectstack-ai/framework/issues/1604)
+and its discovery capability in
+[framework #3298](https://github.com/objectstack-ai/framework/issues/3298).
+ObjectUI does not hard-require it: against an older backend a master-detail save
+still succeeds, but non-atomically via the fallback above. Treat the advertised
+capability as the floor for the atomicity guarantee, not as a connection
+prerequisite.
+
 ## User-Scoped State Adapter
 
 In addition to the main `DataSource` adapter, this package ships
@@ -348,6 +410,7 @@ new ObjectStackAdapter(config: {
 - `update(resource, id, data)` - Update an existing record
 - `delete(resource, id)` - Delete a record
 - `bulk(resource, operation, data)` - Batch operations (create/update/delete)
+- `batchTransaction(operations)` - Cross-object atomic batch (master-detail); atomic when the backend advertises `transactionalBatch`, else non-atomic client-side fallback
 - `getObjectSchema(objectName)` - Get schema metadata (cached)
 - `getCacheStats()` - Get cache statistics
 - `invalidateCache(key?)` - Invalidate cache entries

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -179,6 +179,44 @@ export function clearSharedDiscoveryCache(): void {
 }
 
 /**
+ * Read the cross-object atomic-batch capability from a `discovery` document
+ * (framework #3298 / objectui #2693). The server advertises it hierarchically
+ * under `capabilities.transactionalBatch.enabled`; the published
+ * `@objectstack/client` also accepts the flat `capabilities.transactionalBatch:
+ * boolean` form and normalizes the two — mirror that here so the adapter reads
+ * the same bit regardless of which shape reaches it.
+ *
+ * Returns:
+ *   - `true`  — the backend GUARANTEES an atomic `/batch` (declared === enforced,
+ *     i.e. the route is mounted AND the runtime can honour a transaction): the
+ *     client may drop its non-atomic fallback and treat any batch failure as a
+ *     real error.
+ *   - `false` — the backend explicitly does NOT (route absent, or a runtime that
+ *     can't open a transaction).
+ *   - `undefined` — the capability is absent, i.e. the backend predates #3298;
+ *     the caller must keep the legacy runtime-probe fallback (we can't tell
+ *     whether `/batch` exists without trying it).
+ */
+export function readTransactionalBatchCapability(
+  discovery: unknown,
+): boolean | undefined {
+  const caps = (discovery as { capabilities?: unknown } | null | undefined)?.capabilities;
+  if (!caps || typeof caps !== 'object') return undefined;
+  const value = (caps as Record<string, unknown>).transactionalBatch;
+  // Flat form: `{ transactionalBatch: true }`.
+  if (typeof value === 'boolean') return value;
+  // Hierarchical form: `{ transactionalBatch: { enabled: true } }`.
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof (value as { enabled?: unknown }).enabled === 'boolean'
+  ) {
+    return (value as { enabled: boolean }).enabled;
+  }
+  return undefined;
+}
+
+/**
  * Detect "missing resource" errors regardless of where they originate.
  *
  * The ObjectStack client decorates thrown errors with `httpStatus` (and a
@@ -415,6 +453,15 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   // emulation — the non-atomic fallback lives HERE, isolated to the one adapter
   // that has to cope with a backend lacking server atomicity (#2679).
   private batchUnsupported = false;
+  // The server's declared cross-object atomic-batch capability, read from
+  // discovery at connect() (framework #3298 / objectui #2693). `true` → the
+  // backend GUARANTEES an atomic `/batch`, so batchTransaction trusts it and
+  // never degrades to the non-atomic emulation (any failure surfaces as a real
+  // error). `false` or `undefined` (capability absent → backend predates #3298)
+  // → keep the legacy runtime-probe + emulation fallback so a save is still
+  // possible; dropping it there would turn "saves, less safe" into "no save
+  // path" on older backends (#2679 compatibility constraint).
+  private atomicBatchCapability: boolean | undefined;
   // Subscribers registered via onMutation(). Emitted after each successful
   // create/update/delete so data-bound views (ListView, ObjectView, kanban,
   // calendar) auto-refresh — the interface ListView relies on to reflect
@@ -489,6 +536,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         // Prime the underlying client's cached discovery so capability/route
         // helpers continue to work without a redundant fetch.
         (this.client as unknown as { discoveryInfo?: unknown }).discoveryInfo = data;
+
+        // Record the declared cross-object atomic-batch capability (#3298) so
+        // batchTransaction can decide declaratively at call time whether it may
+        // trust server atomicity instead of runtime-probing 404/405/501.
+        this.atomicBatchCapability = readTransactionalBatchCapability(data);
 
         this.connected = true;
         this.reconnectAttempts = 0;
@@ -945,19 +997,39 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * batch (master-detail).
    *
    * Transport preference: the published `@objectstack/client` SDK method when
-   * available (framework #3271), else a raw `POST /api/v1/batch`. Either way,
-   * if the backend has no such endpoint (404/405) or a runtime that can't do
-   * transactions (501), we degrade to a client-side, NON-atomic emulation via
-   * {@link emulateBatchTransaction} so a save is still possible — this is the
-   * isolated home of the non-atomic fallback. Hard removal of the emulation is
-   * gated on the server advertising a batch capability via discovery (the
-   * current discovery payload does not), so the fallback stays for now.
+   * available (framework #3271), else a raw `POST /api/v1/batch`.
+   *
+   * Fallback decision — declarative capability negotiation (framework #3298 /
+   * objectui #2693). At connect() we read `capabilities.transactionalBatch`
+   * from discovery:
+   *   - Declared `true` → the backend GUARANTEES atomicity (declared ===
+   *     enforced). We TRUST it: any batch failure — including 404/405/501 —
+   *     surfaces as a real error. No runtime probe, no non-atomic client-side
+   *     compensation. This is the path modern backends take.
+   *   - Declared `false`, or ABSENT (backend predates #3298) → we can't rely on
+   *     server atomicity, so we keep the legacy behaviour: try `/batch`, and on
+   *     404/405 (no endpoint) or 501 (runtime without transactions) degrade to
+   *     the client-side, NON-atomic {@link emulateBatchTransaction} so a save is
+   *     still possible. Removing that here would regress older backends from
+   *     "saves, less safe" to "no save path" (#2679 compatibility constraint).
+   *     The non-atomic fallback stays isolated to THIS adapter.
    */
   async batchTransaction(
     operations: BatchTransactionOperation[],
   ): Promise<{ results: any[] }> {
-    // Already known-unsupported on this backend — skip the probe entirely.
-    if (this.batchUnsupported) {
+    // Ensure discovery (and thus the #3298 capability) is loaded so the
+    // decision below is declarative, not "fire a batch and read the status".
+    await this.connect();
+
+    // When the backend declares atomic batch support we never degrade: a
+    // failure is a real error, not a cue to fall back. Otherwise (declared
+    // false, or capability absent on a pre-#3298 backend) the runtime-probe +
+    // emulation fallback below stays active.
+    const guaranteed = this.atomicBatchCapability === true;
+
+    // Already probed-and-degraded on a non-declaring backend — skip the probe.
+    // (Unreachable once `guaranteed`: that path never sets `batchUnsupported`.)
+    if (!guaranteed && this.batchUnsupported) {
       return emulateBatchTransaction(this, operations);
     }
 
@@ -966,14 +1038,14 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     // predate it fall through to the raw-fetch mainline below.
     const sdkBatch = (this.client.data as any).batchTransaction;
     if (typeof sdkBatch === 'function') {
-      await this.connect();
       try {
         const payload: { results: any[] } = await sdkBatch.call(this.client.data, operations);
         this.emitBatchMutations(operations, payload?.results);
         return payload;
       } catch (err) {
-        if (this.batchStatusUnsupported(this.errorStatusOf(err))) {
-          return this.fallbackToEmulation(operations, this.errorStatusOf(err));
+        const status = this.errorStatusOf(err);
+        if (!guaranteed && this.batchStatusUnsupported(status)) {
+          return this.fallbackToEmulation(operations, status);
         }
         throw err;
       }
@@ -991,12 +1063,14 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       body: JSON.stringify({ operations }),
     });
     if (!response.ok) {
-      // Endpoint missing (404/405) or runtime can't do transactions (the
-      // framework rest-server answers 501 "Transactional batch not supported
-      // by this runtime") → degrade to the non-atomic client emulation. Every
-      // other status (400 validation, 401/403 auth, 409 conflict, 500 fault)
-      // is a real error the caller must see — never silently retried.
-      if (this.batchStatusUnsupported(response.status)) {
+      // On a non-declaring backend, endpoint missing (404/405) or runtime can't
+      // do transactions (the framework rest-server answers 501 "Transactional
+      // batch not supported by this runtime") → degrade to the non-atomic client
+      // emulation. When the backend DECLARED support (`guaranteed`), even these
+      // are hard errors — a server that advertised the capability must honour it.
+      // Every other status (400 validation, 401/403 auth, 409 conflict, 500
+      // fault) is a real error the caller must see — never silently retried.
+      if (!guaranteed && this.batchStatusUnsupported(response.status)) {
         return this.fallbackToEmulation(operations, response.status);
       }
       const error = await response.json().catch(() => ({ message: response.statusText }));

--- a/packages/data-objectstack/src/onMutation.test.ts
+++ b/packages/data-objectstack/src/onMutation.test.ts
@@ -17,8 +17,12 @@
  * issued by ObjectGrid's default batch-save were silent and the grid kept
  * showing stale rows until a manual reload.
  */
-import { describe, it, expect, vi } from 'vitest';
-import { ObjectStackAdapter } from './index';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ObjectStackAdapter,
+  clearSharedDiscoveryCache,
+  readTransactionalBatchCapability,
+} from './index';
 import type { MutationEvent } from '@object-ui/types';
 
 function makeDS(stub: Record<string, any>) {
@@ -374,5 +378,171 @@ describe('ObjectStackAdapter.bulk mutation events', () => {
     await expect(ds.bulk('ehr_task_check_item', 'create', [{ label: 'a' }])).rejects.toThrow();
 
     expect(events).toEqual([]);
+  });
+});
+
+/**
+ * #2693 / framework#3298 — declarative capability negotiation for atomic batch.
+ *
+ * The adapter reads `capabilities.transactionalBatch` from discovery at
+ * connect(). When the backend DECLARES support it TRUSTS server atomicity and
+ * never degrades to the non-atomic client emulation — a batch failure (even
+ * 404/405/501) is a real error. When the capability is ABSENT (backend predates
+ * #3298) or explicitly `false`, the legacy runtime-probe + emulation fallback
+ * stays active so a save is still possible (#2679 compatibility constraint).
+ */
+describe('ObjectStackAdapter.batchTransaction capability gate (#2693 / framework#3298)', () => {
+  // The discovery cache is module-level and shared across files in the (unit)
+  // project — reset it so each case reads its own advertised capability.
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  function makeCapabilityDS(opts: {
+    /** Value placed at `capabilities.transactionalBatch`; omit to leave it absent. */
+    capability?: boolean | { enabled: boolean };
+    batchStatus: number;
+    /** Response body for the `/batch` call (defaults to an error envelope). */
+    batchBody?: unknown;
+    clientData?: Record<string, any>;
+  }) {
+    const capabilities: Record<string, unknown> = {};
+    if (opts.capability !== undefined) capabilities.transactionalBatch = opts.capability;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/v1/discovery')) {
+        return new Response(
+          JSON.stringify({ success: true, data: { name: 't', version: '1.0.0', capabilities } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      // POST /api/v1/batch
+      return new Response(JSON.stringify(opts.batchBody ?? { error: 'nope' }), {
+        status: opts.batchStatus,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const ds: any = new ObjectStackAdapter({
+      baseUrl: 'http://test.local',
+      autoReconnect: false,
+      fetch: fetchMock,
+    });
+    // Feature-detect target for the SDK batch method + emulation primitives.
+    ds.client = { data: opts.clientData ?? {} };
+    return { ds, fetchMock };
+  }
+
+  it('declared transactionalBatch:true → a 404 is a hard error, NOT downgraded to emulation', async () => {
+    const create = vi.fn();
+    const { ds } = makeCapabilityDS({ capability: { enabled: true }, batchStatus: 404, clientData: { create } });
+
+    await expect(
+      ds.batchTransaction([{ object: 'proj', action: 'create', data: {} }]),
+    ).rejects.toThrow(/nope/);
+    // A declared-atomic backend is trusted: no client-side compensation ran.
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('declared transactionalBatch:true → 501 is also a hard error (no emulation)', async () => {
+    const create = vi.fn();
+    const { ds } = makeCapabilityDS({ capability: { enabled: true }, batchStatus: 501, clientData: { create } });
+
+    await expect(
+      ds.batchTransaction([{ object: 'proj', action: 'create', data: {} }]),
+    ).rejects.toThrow();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('accepts the flat boolean capability shape too', async () => {
+    const create = vi.fn();
+    const { ds } = makeCapabilityDS({ capability: true, batchStatus: 404, clientData: { create } });
+
+    await expect(
+      ds.batchTransaction([{ object: 'proj', action: 'create', data: {} }]),
+    ).rejects.toThrow();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('declared support → a committed batch commits via /batch and emits one event per op', async () => {
+    const { ds } = makeCapabilityDS({
+      capability: { enabled: true },
+      batchStatus: 200,
+      batchBody: { results: [{ id: 'p1', name: 'A' }, { id: 'c1', proj: 'p1' }] },
+    });
+    const events: MutationEvent[] = [];
+    ds.onMutation((e: MutationEvent) => events.push(e));
+
+    const res = await ds.batchTransaction([
+      { object: 'proj', action: 'create', data: { name: 'A' } },
+      { object: 'item', action: 'create', data: { proj: { $ref: 0 } } },
+    ]);
+
+    expect(res.results).toHaveLength(2);
+    expect(events).toEqual([
+      { type: 'create', resource: 'proj', record: { id: 'p1', name: 'A' } },
+      { type: 'create', resource: 'item', record: { id: 'c1', proj: 'p1' } },
+    ]);
+  });
+
+  it('declared transactionalBatch:false → 404 still degrades to non-atomic emulation', async () => {
+    const create = vi.fn(async (_o: string, d: any) => ({ record: { id: 'p1', ...d } }));
+    const { ds } = makeCapabilityDS({ capability: { enabled: false }, batchStatus: 404, clientData: { create } });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const res = await ds.batchTransaction([{ object: 'proj', action: 'create', data: { name: 'A' } }]);
+
+    expect(create).toHaveBeenCalledWith('proj', { name: 'A' });
+    expect(res.results[0]).toMatchObject({ id: 'p1', name: 'A' });
+    warn.mockRestore();
+  });
+
+  it('capability ABSENT (backend predates #3298) → 404 degrades to emulation (back-compat)', async () => {
+    const create = vi.fn(async (_o: string, d: any) => ({ record: { id: 'p1', ...d } }));
+    const { ds } = makeCapabilityDS({ batchStatus: 404, clientData: { create } }); // no capability advertised
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await ds.batchTransaction([{ object: 'proj', action: 'create', data: { name: 'A' } }]);
+
+    expect(create).toHaveBeenCalledWith('proj', { name: 'A' });
+    warn.mockRestore();
+  });
+
+  it('declared support → a real error (400) surfaces unchanged', async () => {
+    const create = vi.fn();
+    const { ds } = makeCapabilityDS({ capability: { enabled: true }, batchStatus: 400, clientData: { create } });
+
+    await expect(
+      ds.batchTransaction([{ object: 'proj', action: 'create', data: {} }]),
+    ).rejects.toThrow(/nope/);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Unit coverage for the discovery capability reader — it must accept both the
+ * hierarchical `{ enabled }` wire shape (what the framework producers emit) and
+ * the flat boolean the client SDK normalizes to, and return `undefined` for a
+ * pre-#3298 backend that advertises nothing.
+ */
+describe('readTransactionalBatchCapability (#3298 shape reader)', () => {
+  it('reads the hierarchical { enabled } form', () => {
+    expect(readTransactionalBatchCapability({ capabilities: { transactionalBatch: { enabled: true } } })).toBe(true);
+    expect(readTransactionalBatchCapability({ capabilities: { transactionalBatch: { enabled: false } } })).toBe(false);
+  });
+
+  it('reads the flat boolean form', () => {
+    expect(readTransactionalBatchCapability({ capabilities: { transactionalBatch: true } })).toBe(true);
+    expect(readTransactionalBatchCapability({ capabilities: { transactionalBatch: false } })).toBe(false);
+  });
+
+  it('returns undefined when the capability (or the whole map) is absent', () => {
+    expect(readTransactionalBatchCapability({ capabilities: {} })).toBeUndefined();
+    expect(readTransactionalBatchCapability({ capabilities: { comments: { enabled: true } } })).toBeUndefined();
+    expect(readTransactionalBatchCapability({})).toBeUndefined();
+    expect(readTransactionalBatchCapability(null)).toBeUndefined();
+    expect(readTransactionalBatchCapability(undefined)).toBeUndefined();
+  });
+
+  it('ignores a malformed capability value', () => {
+    expect(readTransactionalBatchCapability({ capabilities: { transactionalBatch: { enabled: 'yes' } } })).toBeUndefined();
+    expect(readTransactionalBatchCapability({ capabilities: { transactionalBatch: 'true' } })).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #2693. Picks up #2679 acceptance item 4. Unblocked by **framework#3298** (the discovery capability bit), which merged today.

## Background

Until now `ObjectStackAdapter.batchTransaction` learned whether a backend could do an atomic cross-object `/batch` only by **firing one and reading the status** (404/405 → no route, 501 → runtime without transactions), then degrading to the non-atomic client-side emulation in `@object-ui/core`. framework#3298 added a declarative signal so the client can decide **at connect time** instead.

## The contract (from framework#3298, merged)

Discovery now carries a capability bit. All three server producers (`rest-server`, `plugin-hono-server`, `metadata-protocol`) emit the hierarchical shape and the client SDK normalizes it:

- Wire: `discovery.capabilities.transactionalBatch.enabled: boolean`
- Client SDK (`@objectstack/client` ≥16.0.0-rc.1): flattened to `client.capabilities.transactionalBatch: boolean`
- Semantics: `true` = route mounted **and** the runtime can honour a transaction (**declared === enforced**); `false` = neither; **absent** = backend predates #3298.

## Change

`connect()` reads `capabilities.transactionalBatch` into a tri-state; `batchTransaction` gates its fallback on it:

| `capabilities.transactionalBatch` | `batchTransaction` behaviour |
| --- | --- |
| `true` | **Trusts server atomicity.** Calls `/batch`; any failure — incl. 404/405/501 — is a real error. No probe, no client-side compensation. |
| `false` | Legacy: probe `/batch`, degrade to non-atomic emulation on 404/405/501. |
| *absent* | Legacy path unchanged (can't tell without trying). |

The reader accepts both the hierarchical `{ enabled }` shape and the flat boolean the SDK normalizes to.

**Why the fallback is not hard-removed:** #2679's compatibility note is explicit that deleting it against backends without `/batch` turns *"saves, less safe"* into *"no save path"*. So the compensation branch is **gated off** for declared-support backends (the modern path) but retained as the fallback for `false`/absent backends. `@object-ui/core`'s generic `emulateBatchTransaction` / `runBatchTransaction` are **untouched** and remain the fallback for adapters with no server transaction (`ValueDataSource`, `MockDataSource`, …).

## Acceptance mapping (#2693)

- ✅ Adapter decides on the discovery capability bit — no 404-probe degradation for declared-support backends.
- ✅ `ObjectStackAdapter` no longer runs client-side compensation on the declared-support path (the branch survives only as the fallback for undeclared/false backends, per the #2679 compat constraint).
- ✅ core's generic `emulateBatchTransaction` retained only for adapters without server transactions.
- ✅ Minimum supported backend documented (adapter README + data-source guide).

## Tests

- Declared `true` + 404 / 501 → hard error, **no** client-side compensation.
- Flat-boolean `true` normalized identically.
- Declared support + committed `/batch` → still emits one mutation event per op.
- Declared support + real error (400) → surfaces unchanged.
- Declared `false` / absent + 404 → still degrades to emulation (back-compat).
- Unit test for `readTransactionalBatchCapability` across hierarchical / flat / absent / malformed shapes.

Full `unit` project green (252 files, 3454 tests); `data-objectstack` 187/187; package type-check and eslint clean (only pre-existing `any` warnings).

## Notes

- Changeset: `@object-ui/data-objectstack` minor.
- No `@objectstack/client` dependency bump needed — the capability is read from the discovery document the adapter already fetches, so the strict path works regardless of the installed client patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1UuBuaurza8a2XWSUaDQr)_