### PR TITLE
fix(studio-design): remove false 'Read-only' badge for project-scoped…

### DIFF
--- a/packages/app-shell/src/views/studio-design/packages-io.ts
+++ b/packages/app-shell/src/views/studio-design/packages-io.ts
@@ -39,7 +39,7 @@ export function parsePackages(payload: unknown): PkgEntry[] {
     if (scope === 'system' || scope === 'cloud') continue; // kernel — not app packages
     const namespace =
       typeof m.namespace === 'string' && m.namespace ? m.namespace : deriveNamespaceFromPackageId(id);
-    out.push({ id, name: String(m.name ?? id), writable: scope !== 'project', namespace });
+    out.push({ id, name: String(m.name ?? id), writable: true, namespace });
   }
   return out;
 }


### PR DESCRIPTION

<img width="571" height="217" alt="Screenshot 2026-07-20 182758" src="https://github.com/user-attachments/assets/1d04bd13-1512-4478-9275-578a124c68bd" />
… packages

The Zod manifest schema defaults  to , which caused all app packages to display a misleading 'Read-only' badge in the UI. Kernel packages (system/cloud) are already filtered out on line 40, so all remaining packages should be marked writable.

Change  to .