### PR TITLE
docs: update repo references for framework → objectstack rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## What is Object UI?
 
-**Object UI is the View layer of the [ObjectStack](https://github.com/objectstack-ai/framework) ecosystem** — a standalone, schema-driven renderer that turns a JSON schema (or ObjectStack metadata) into production-grade React UI. Use it on its own with any backend, like Amis or Formily — or let it render ObjectStack apps end to end.
+**Object UI is the View layer of the [ObjectStack](https://github.com/objectstack-ai/objectstack) ecosystem** — a standalone, schema-driven renderer that turns a JSON schema (or ObjectStack metadata) into production-grade React UI. Use it on its own with any backend, like Amis or Formily — or let it render ObjectStack apps end to end.
 
 ```
 Describe  →  ObjectStack   the open-source protocol, toolkit & production runtime

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -15,7 +15,7 @@
   (`visibleWhen`/`readonlyWhen`/`requiredWhen` via `fieldRules.ts`, which delegates
   to `@objectstack/formula`'s `ExpressionEngine`) now tracks the 15.x engine — and
   will pick up the framework's `dateField == today()` equality fix
-  (objectstack-ai/framework#3205) automatically at the next 15.x release via the
+  (objectstack-ai/objectstack#3205) automatically at the next 15.x release via the
   caret range. Renderer/action `visible`/`disabled` predicates are unaffected (they
   use the home-grown JS evaluator — tracked separately in #2661).
 

--- a/packages/app-shell/CHANGELOG.md
+++ b/packages/app-shell/CHANGELOG.md
@@ -212,7 +212,7 @@
     and removes both bounds together. A new `drillUrlFilters` module owns the
     write/read serialization so both sides can't drift (round-trip tested).
 
-  Companion to the framework analytics change (objectstack-ai/framework#3256).
+  Companion to the framework analytics change (objectstack-ai/objectstack#3256).
 
 - e7a8de7: feat(flow-designer): map free-form object maps → keyValue (and numeric arrays → numberList) in the schema-driven inspector (#3304)
 
@@ -323,7 +323,7 @@ actionName, spec)`: overlays translated `title` / `description` /
   (`visibleWhen`/`readonlyWhen`/`requiredWhen` via `fieldRules.ts`, which delegates
   to `@objectstack/formula`'s `ExpressionEngine`) now tracks the 15.x engine — and
   will pick up the framework's `dateField == today()` equality fix
-  (objectstack-ai/framework#3205) automatically at the next 15.x release via the
+  (objectstack-ai/objectstack#3205) automatically at the next 15.x release via the
   caret range. Renderer/action `visible`/`disabled` predicates are unaffected (they
   use the home-grown JS evaluator — tracked separately in #2661).
 
@@ -2138,7 +2138,7 @@ unauthenticated` in the token-based console, while the runtime data adapter's
   object / field / flow / role / connector / template references were already
   pickers). Unit-tested (`resolveConnectorName`, `connectorActionsToOptions`).
 
-- 7a6837c: Studio package-create dogfood follow-ups (objectstack-ai/framework#2615):
+- 7a6837c: Studio package-create dogfood follow-ups (objectstack-ai/objectstack#2615):
 
   - Read-only packages now gate authoring affordances client-side (Add field, New object/flow/permission set, nav Edit, Save draft, Publish, Create app) with a "switch to a writable package" hint, instead of letting doomed edits pile up until the server 422s (objectui#2259). Records stay fully usable; the field inspector opens read-only.
   - New fields auto-derive their API name from the label while still auto-named — now also for the Data pillar's generic `field_N` names, so relabeling "New field" to "Status" yields a `status` column instead of `field_2` forever (objectui#2260).
@@ -3815,7 +3815,7 @@ unauthenticated` in the token-based console, while the runtime data adapter's
   panel inside their Studio Preview tab, so connecting a mature external
   database and registering its tables as ObjectStack objects is a
   point-and-click flow instead of a CLI-only one. The panel pairs with the
-  framework backend shipped in objectstack-ai/framework#1390
+  framework backend shipped in objectstack-ai/objectstack#1390
   (`registerExternalDatasourceRoutes` → `/api/v1/datasources/:name/external/*`).
 
   ObjectStack is metadata-driven: `datasource` is a metadata type, so it is
@@ -4242,7 +4242,7 @@ unauthenticated` in the token-based console, while the runtime data adapter's
   allowSkip, showStepIndicator, split\*). Page-level layouts only — `drawer`/`modal`
   are presentation/open-modes, not record-page layouts, so they fall back to `simple`.
 
-  Refs objectstack-ai/framework#1890
+  Refs objectstack-ai/objectstack#1890
 
 - 0ad72a6: fix: pass full gantt config to renderer, render multi-value lookups in gantt tooltips, persist `bodyExtra` on dataSource actions, and complete zh/en gantt labels
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -59,7 +59,7 @@
 
   Together with the `^15.1.1` alignment (#2662), a renderer CEL predicate now
   reaches the identical verdict as the server — including the framework's
-  `dateField == today()` equality fix (objectstack-ai/framework#3205) once it
+  `dateField == today()` equality fix (objectstack-ai/objectstack#3205) once it
   lands in a published 15.x. The broader home-grown-vs-canonical divergence
   motivation is #2661.
 
@@ -148,7 +148,7 @@
     and removes both bounds together. A new `drillUrlFilters` module owns the
     write/read serialization so both sides can't drift (round-trip tested).
 
-  Companion to the framework analytics change (objectstack-ai/framework#3256).
+  Companion to the framework analytics change (objectstack-ai/objectstack#3256).
 
 ### Patch Changes
 
@@ -163,7 +163,7 @@
   (`visibleWhen`/`readonlyWhen`/`requiredWhen` via `fieldRules.ts`, which delegates
   to `@objectstack/formula`'s `ExpressionEngine`) now tracks the 15.x engine — and
   will pick up the framework's `dateField == today()` equality fix
-  (objectstack-ai/framework#3205) automatically at the next 15.x release via the
+  (objectstack-ai/objectstack#3205) automatically at the next 15.x release via the
   caret range. Renderer/action `visible`/`disabled` predicates are unaffected (they
   use the home-grown JS evaluator — tracked separately in #2661).
 
@@ -736,7 +736,7 @@
   (plugin-charts) and `DatasetWidget` (plugin-dashboard) both use it, so
   multi-dimension charts render consistently as grouped/coloured bars.
 
-  Refs objectstack-ai/objectui#1759, objectstack-ai/framework#1890
+  Refs objectstack-ai/objectui#1759, objectstack-ai/objectstack#1890
 
 - 7c239fd: Add `ComponentRegistry.unregister(type, namespace?)` — the inverse of
   `register()`. Clears the namespaced key and the bare-name fallback (when it

--- a/packages/data-objectstack/CHANGELOG.md
+++ b/packages/data-objectstack/CHANGELOG.md
@@ -80,7 +80,7 @@
   (`visibleWhen`/`readonlyWhen`/`requiredWhen` via `fieldRules.ts`, which delegates
   to `@objectstack/formula`'s `ExpressionEngine`) now tracks the 15.x engine — and
   will pick up the framework's `dateField == today()` equality fix
-  (objectstack-ai/framework#3205) automatically at the next 15.x release via the
+  (objectstack-ai/objectstack#3205) automatically at the next 15.x release via the
   caret range. Renderer/action `visible`/`disabled` predicates are unaffected (they
   use the home-grown JS evaluator — tracked separately in #2661).
 

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -296,7 +296,7 @@ child write fails.
 Whether the adapter can rely on server atomicity is decided **at connect time**,
 not by firing a batch and reading the failure. `connect()` reads the
 `capabilities.transactionalBatch` flag from `GET /api/v1/discovery`
-([framework #3298](https://github.com/objectstack-ai/framework/issues/3298)),
+([framework #3298](https://github.com/objectstack-ai/objectstack/issues/3298)),
 which the server sets to `true` only when the `/batch` route is mounted **and**
 the runtime engine can honour a transaction (`declared === enforced`):
 
@@ -326,9 +326,9 @@ would turn "saves, less safe" into "no save path" on older backends
 
 Atomic cross-object saves are **guaranteed only against ObjectStack backends on
 the 16.x line that advertise `capabilities.transactionalBatch: true`** — the
-endpoint landed in [framework #1604](https://github.com/objectstack-ai/framework/issues/1604)
+endpoint landed in [framework #1604](https://github.com/objectstack-ai/objectstack/issues/1604)
 and its discovery capability in
-[framework #3298](https://github.com/objectstack-ai/framework/issues/3298).
+[framework #3298](https://github.com/objectstack-ai/objectstack/issues/3298).
 ObjectUI does not hard-require it: against an older backend a master-detail save
 still succeeds, but non-atomically via the fallback above. Treat the advertised
 capability as the floor for the atomicity guarantee, not as a connection

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -506,7 +506,7 @@ function formatRelativeDays(diffDays: number, locale?: string): string {
 
 /**
  * Format date as relative time (e.g., "3 days ago", "Today", "Overdue 3d"),
- * localized via `Intl.RelativeTimeFormat` (objectstack-ai/framework#3040).
+ * localized via `Intl.RelativeTimeFormat` (objectstack-ai/objectstack#3040).
  *
  * `dueLike` gates the "Overdue" wording — a past `start_date`/`created_at`
  * isn't overdue, only a past due/deadline-semantic field is. Non-due-like

--- a/packages/plugin-charts/CHANGELOG.md
+++ b/packages/plugin-charts/CHANGELOG.md
@@ -429,7 +429,7 @@
   `ObjectView` emit the dataset shape. The legacy inline aggregate is kept as a
   deprecated fallback so pre-ADR-0021 metadata keeps rendering.
 
-  Refs objectstack-ai/framework#1890
+  Refs objectstack-ai/objectstack#1890
 
 - ab168e4: Dashboard charts no longer render blank on first paint. Recharts'
   `ResponsiveContainer` was a child of a `flex … justify-center` box, so it

--- a/packages/plugin-dashboard/CHANGELOG.md
+++ b/packages/plugin-dashboard/CHANGELOG.md
@@ -69,7 +69,7 @@
     and removes both bounds together. A new `drillUrlFilters` module owns the
     write/read serialization so both sides can't drift (round-trip tested).
 
-  Companion to the framework analytics change (objectstack-ai/framework#3256).
+  Companion to the framework analytics change (objectstack-ai/objectstack#3256).
 
 - 199fa83: feat(dashboard): retire the pre-ADR-0021 inline-analytics renderer branches (framework#3320)
 
@@ -541,7 +541,7 @@
   - A dataset-bound `metric` widget takes the shared Card wrapper (title + border)
     like kpi/gauge, instead of rendering as bare untitled text.
 
-  Requires `AnalyticsResult.fields[].label`/`format` (objectstack-ai/framework#1683).
+  Requires `AnalyticsResult.fields[].label`/`format` (objectstack-ai/objectstack#1683).
 
 - 92449ef: Dataset-bound dashboard widgets now render their TRUE chart family instead of
   always a bar chart.

--- a/packages/plugin-form/CHANGELOG.md
+++ b/packages/plugin-form/CHANGELOG.md
@@ -901,7 +901,7 @@ parentData, details)` — emits a parent `update` op (index 0) then diffs each
   `type:'tabbed'` form view now renders tabbed in the modal too — not just on the
   full-page route (#1762). Non-breaking; `FormView.type` enum unchanged.
 
-  Refs objectstack-ai/framework#1890, ADR-0050
+  Refs objectstack-ai/objectstack#1890, ADR-0050
 
 - 650bd1f: fix(forms/dashboard/related-list): four business-facing rendering fixes found while QA-ing a showcase workspace
 

--- a/packages/plugin-report/CHANGELOG.md
+++ b/packages/plugin-report/CHANGELOG.md
@@ -26,7 +26,7 @@
     and removes both bounds together. A new `drillUrlFilters` module owns the
     write/read serialization so both sides can't drift (round-trip tested).
 
-  Companion to the framework analytics change (objectstack-ai/framework#3256).
+  Companion to the framework analytics change (objectstack-ai/objectstack#3256).
 
 ### Patch Changes
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -63,7 +63,7 @@
 
   Together with the `^15.1.1` alignment (#2662), a renderer CEL predicate now
   reaches the identical verdict as the server — including the framework's
-  `dateField == today()` equality fix (objectstack-ai/framework#3205) once it
+  `dateField == today()` equality fix (objectstack-ai/objectstack#3205) once it
   lands in a published 15.x. The broader home-grown-vs-canonical divergence
   motivation is #2661.
 


### PR DESCRIPTION
## Summary

Follow-up to the GitHub repository rename **`objectstack-ai/framework` → `objectstack-ai/objectstack`**. Replaces references to the old repo path (doc links, ADR cross-references, metadata) across 12 files.

## Deliberately unchanged
- Local sibling-checkout references (`../framework`) — these point at the on-disk dev checkout directory, not the GitHub repo, and the cross-repo dev stack still uses that directory name.
- Common-noun uses of "framework".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kPznpkdptgo2hvW7wMDNw

---
_Generated by [Claude Code](https://claude.ai/code/session_011kPznpkdptgo2hvW7wMDNw)_