### PR TITLE
fix(i18n): apply globalActions label overlays on record-detail action bars (objectstack#3372)

### DIFF
--- a/.changeset/record-detail-global-action-labels.md
+++ b/.changeset/record-detail-global-action-labels.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/i18n": patch
+---
+
+fix(i18n): apply globalActions label overlays to actions surfaced on a record-detail action bar (objectui#3372)
+
+On a record-detail action bar the caller passes `objectDef.name` for **every**
+action, so a `globalAction` surfaced there (e.g. `log_call`) looked up
+`objects.<obj>._actions.<action>.label`, missed, and leaked the English
+metadata literal ("Log a Call") instead of its `globalActions.<action>.label`
+overlay ("记录通话"). Object-owned actions on the same bar translated fine,
+which is what made the gap visible.
+
+`useObjectLabel()`'s action resolvers now mirror the canonical
+`@objectstack/spec` resolver (`system/i18n-resolver.lookupActionField`): when an
+action is object-scoped, the object key still wins, but `globalActions.<action>.*`
+is consulted as a fallback before returning the literal. This applies uniformly
+to `actionLabel`, `actionConfirm`, `actionSuccess`, `actionDescription`,
+`actionResultDialog`, `actionParamText`, and `actionParamOptionLabel`, so a
+globalAction resolves the same on a record-detail action bar as it does
+everywhere else. App-namespace discovery also recognises a `globalActions`-only
+bundle (one with no object/field entries).

--- a/packages/i18n/src/__tests__/useObjectLabel-globalAction.test.tsx
+++ b/packages/i18n/src/__tests__/useObjectLabel-globalAction.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider, useObjectTranslation } from '../provider';
+import { useObjectLabel } from '../useObjectLabel';
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    I18nProvider,
+    { config: { defaultLanguage: 'en', detectBrowserLanguage: false } },
+    children,
+  );
+
+/**
+ * Regression for objectui#3372 — a globalAction surfaced on a record-detail
+ * action bar (where the caller passes `objectDef.name` for every action) must
+ * still pick up its `globalActions.<action>.*` overlay when no object-scoped
+ * translation exists. Mirrors the canonical `@objectstack/spec` resolver
+ * (`lookupActionField`): object-scoped wins, global is the fallback.
+ */
+describe('useObjectLabel() globalAction fallback (objectui#3372)', () => {
+  const setup = () => {
+    const { result } = renderHook(
+      () => ({ labels: useObjectLabel(), i18n: useObjectTranslation().i18n }),
+      { wrapper },
+    );
+    result.current.i18n.addResourceBundle(
+      'en',
+      'translation',
+      {
+        crm: {
+          // Object translations present → namespace is discovered via `objects`.
+          objects: {
+            crm_case: {
+              _actions: {
+                // Object action — translated under the object scope.
+                escalate_case: { label: '升级工单' },
+                // A name that exists in BOTH scopes — object must win.
+                shared_action: { label: '对象级' },
+              },
+            },
+          },
+          // Global action — translated only under the global scope.
+          globalActions: {
+            log_call: { label: '记录通话', successMessage: '通话记录成功！' },
+            shared_action: { label: '全局级' },
+          },
+        },
+      },
+      true,
+      true,
+    );
+    return result;
+  };
+
+  it('resolves an object action from the object scope (unchanged)', () => {
+    const result = setup();
+    expect(result.current.labels.actionLabel('crm_case', 'escalate_case', 'Escalate Case')).toBe(
+      '升级工单',
+    );
+  });
+
+  it('resolves a globalAction overlay even when an objectName is passed', () => {
+    const result = setup();
+    // The bug: with objectName set, `objects.crm_case._actions.log_call.label`
+    // misses, so before the fix this leaked the English literal "Log a Call".
+    expect(result.current.labels.actionLabel('crm_case', 'log_call', 'Log a Call')).toBe(
+      '记录通话',
+    );
+  });
+
+  it('still resolves a globalAction when objectName is omitted', () => {
+    const result = setup();
+    expect(result.current.labels.actionLabel(undefined, 'log_call', 'Log a Call')).toBe(
+      '记录通话',
+    );
+  });
+
+  it('prefers the object-scoped translation over the global one on a name collision', () => {
+    const result = setup();
+    expect(result.current.labels.actionLabel('crm_case', 'shared_action', 'Shared')).toBe(
+      '对象级',
+    );
+  });
+
+  it('falls back to the metadata literal when neither scope translates', () => {
+    const result = setup();
+    expect(result.current.labels.actionLabel('crm_case', 'unknown_action', 'Do Thing')).toBe(
+      'Do Thing',
+    );
+  });
+
+  it('applies the global fallback to sibling resolvers (successMessage)', () => {
+    const result = setup();
+    expect(
+      result.current.labels.actionSuccess('crm_case', 'log_call', 'Call logged.'),
+    ).toBe('通话记录成功！');
+  });
+});

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -62,6 +62,11 @@ export function useObjectLabel() {
    * Returns top-level keys (outside built-in Object UI keys) that contain
    * an `objects`, `fields`, or `apps` sub-key — e.g. "crm" when resources
    * include crm.objects.* or crm.apps.*.
+   *
+   * `globalActions` is included so an app bundle whose only translated scope
+   * is global actions (no object/field entries) is still discovered — its
+   * `globalActions.<action>.*` overlays would otherwise be unreachable
+   * (objectui#3372).
    */
   const getAppNamespaces = (): string[] => {
     if (!i18n || typeof i18n.getResourceBundle !== 'function') return [];
@@ -71,7 +76,8 @@ export function useObjectLabel() {
     return Object.keys(bundle).filter(
       (key) => !BUILTIN_KEYS.has(key) && bundle[key] && typeof bundle[key] === 'object'
         && (bundle[key].objects || bundle[key].fields || bundle[key].apps
-          || bundle[key].dashboards || bundle[key].pages || bundle[key].reports),
+          || bundle[key].dashboards || bundle[key].pages || bundle[key].reports
+          || bundle[key].globalActions),
     );
   };
 
@@ -116,6 +122,35 @@ export function useObjectLabel() {
     return base !== objectName
       ? [`objects.${objectName}.${tail}`, `objects.${base}.${tail}`]
       : [`objects.${objectName}.${tail}`];
+  };
+
+  /**
+   * Build suffix candidates for an action-scoped key, mirroring the canonical
+   * `@objectstack/spec` resolver (`lookupActionField` in `system/i18n-resolver`).
+   *
+   * When the action is object-scoped, the object key
+   * (`objects.<obj>._actions.<action>.<tail>`) wins, but the global key
+   * (`globalActions.<action>.<tail>`) is appended as a fallback so a
+   * **globalAction surfaced on an object's action bar** still picks up its
+   * `globalActions.<action>.*` overlay when no object-scoped translation
+   * exists (objectui#3372). Without this fallback, a globalAction rendered on
+   * a record-detail action bar — where the caller passes `objectDef.name` for
+   * every action — misses `objects.<obj>._actions.<action>.label` and leaks the
+   * English metadata literal.
+   *
+   * Object-less actions (`objectName` omitted) resolve straight to the global
+   * namespace, as before. Object precedence is preserved: the global key is
+   * only consulted after every object-scoped candidate misses.
+   */
+  const actionSuffixes = (
+    objectName: string | undefined,
+    actionName: string,
+    tail: string,
+  ): string[] => {
+    const globalSuffix = `globalActions.${actionName}.${tail}`;
+    return objectName
+      ? [...objectSuffixes(objectName, `_actions.${actionName}.${tail}`), globalSuffix]
+      : [globalSuffix];
   };
 
   const fieldSuffixes = (objectName: string, fieldName: string): string[] => {
@@ -348,40 +383,35 @@ export function useObjectLabel() {
 
     /**
      * Resolve translated action label.
-     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.label`.
-     * Falls back to `{ns}.globalActions.{actionName}.label` when objectName is omitted.
+     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.label`,
+     * falling back to `{ns}.globalActions.{actionName}.label` — both when
+     * objectName is omitted AND when the object-scoped key misses (so a
+     * globalAction surfaced on a record-detail action bar still resolves;
+     * objectui#3372).
      */
-    actionLabel: (objectName: string | undefined, actionName: string, fallback: string) => {
-      if (objectName) {
-        return resolve(objectSuffixes(objectName, `_actions.${actionName}.label`), fallback);
-      }
-      return resolve(`globalActions.${actionName}.label`, fallback);
-    },
+    actionLabel: (objectName: string | undefined, actionName: string, fallback: string) =>
+      resolve(actionSuffixes(objectName, actionName, 'label'), fallback),
 
     /**
      * Resolve translated action confirmation prompt.
-     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.confirmText`.
+     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.confirmText`,
+     * falling back to `{ns}.globalActions.{actionName}.confirmText`.
      * Returns undefined when no translation and no fallback exist.
      */
     actionConfirm: (objectName: string | undefined, actionName: string, fallback?: string) => {
       const fb = fallback ?? '';
-      const suffixes = objectName
-        ? objectSuffixes(objectName, `_actions.${actionName}.confirmText`)
-        : `globalActions.${actionName}.confirmText`;
-      const resolved = resolve(suffixes, fb);
+      const resolved = resolve(actionSuffixes(objectName, actionName, 'confirmText'), fb);
       return resolved || undefined;
     },
 
     /**
      * Resolve translated action success message.
-     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.successMessage`.
+     * Convention: `{ns}.objects.{objectName}._actions.{actionName}.successMessage`,
+     * falling back to `{ns}.globalActions.{actionName}.successMessage`.
      */
     actionSuccess: (objectName: string | undefined, actionName: string, fallback?: string) => {
       const fb = fallback ?? '';
-      const suffixes = objectName
-        ? objectSuffixes(objectName, `_actions.${actionName}.successMessage`)
-        : `globalActions.${actionName}.successMessage`;
-      const resolved = resolve(suffixes, fb);
+      const resolved = resolve(actionSuffixes(objectName, actionName, 'successMessage'), fb);
       return resolved || undefined;
     },
 
@@ -395,10 +425,7 @@ export function useObjectLabel() {
     actionDescription: (objectName: string | undefined, actionName: string | undefined, fallback?: string) => {
       const fb = fallback ?? '';
       if (!actionName) return fb || undefined;
-      const suffixes = objectName
-        ? objectSuffixes(objectName, `_actions.${actionName}.description`)
-        : `globalActions.${actionName}.description`;
-      const resolved = resolve(suffixes, fb);
+      const resolved = resolve(actionSuffixes(objectName, actionName, 'description'), fb);
       return resolved || undefined;
     },
 
@@ -406,8 +433,9 @@ export function useObjectLabel() {
      * Resolve a translated copy of an action's post-success RESULT DIALOG
      * (`title` / `description` / `acknowledge` + per-field labels).
      * Convention: `{ns}.objects.{objectName}._actions.{actionName}.resultDialog.*`,
-     * falling back to `{ns}.globalActions.{actionName}.resultDialog.*` when
-     * objectName is omitted, then to the metadata's literal strings.
+     * falling back to `{ns}.globalActions.{actionName}.resultDialog.*` (when
+     * objectName is omitted OR the object-scoped key misses), then to the
+     * metadata's literal strings.
      *
      * The `fields` translation node is keyed by the LITERAL result-field path
      * from the action metadata (may contain dots, e.g. `"user.email"`), so it
@@ -425,12 +453,8 @@ export function useObjectLabel() {
       spec: T | undefined,
     ): T | undefined => {
       if (!spec || !actionName) return spec;
-      const suffixesFor = (attr: string): string[] => {
-        const tail = `_actions.${actionName}.resultDialog.${attr}`;
-        return objectName
-          ? objectSuffixes(objectName, tail)
-          : [`globalActions.${actionName}.resultDialog.${attr}`];
-      };
+      const suffixesFor = (attr: string): string[] =>
+        actionSuffixes(objectName, actionName, `resultDialog.${attr}`);
       const textFor = (attr: 'title' | 'description' | 'acknowledge'): string | undefined => {
         const resolved = resolve(suffixesFor(attr), spec[attr] ?? '');
         return resolved || spec[attr];
@@ -485,11 +509,10 @@ export function useObjectLabel() {
     ) => {
       const fb = fallback ?? '';
       if (!actionName || !paramName) return fb || undefined;
-      const suffix = `_actions.${actionName}.params.${paramName}.${attr}`;
-      const suffixes = objectName
-        ? objectSuffixes(objectName, suffix)
-        : `globalActions.${actionName}.params.${paramName}.${attr}`;
-      const resolved = resolve(suffixes, fb);
+      const resolved = resolve(
+        actionSuffixes(objectName, actionName, `params.${paramName}.${attr}`),
+        fb,
+      );
       return resolved || undefined;
     },
     /**
@@ -505,11 +528,10 @@ export function useObjectLabel() {
       fallback: string,
     ) => {
       if (!actionName || !paramName) return fallback;
-      const suffix = `_actions.${actionName}.params.${paramName}.options.${optionValue}`;
-      const suffixes = objectName
-        ? objectSuffixes(objectName, suffix)
-        : `globalActions.${actionName}.params.${paramName}.options.${optionValue}`;
-      return resolve(suffixes, fallback);
+      return resolve(
+        actionSuffixes(objectName, actionName, `params.${paramName}.options.${optionValue}`),
+        fallback,
+      );
     },
   };
   }, [t, i18n]);


### PR DESCRIPTION
## Summary

Fixes objectstack-ai/objectstack#3372 — a record-detail action bar didn't apply `globalActions` label translations, though object-owned action labels translated fine.

A record-detail action bar passes `objectDef.name` for **every** action it renders. So a `globalAction` surfaced there (e.g. `log_call`) resolved `objects.<obj>._actions.<action>.label`, missed, and leaked the English metadata literal (`"Log a Call"`) instead of its `globalActions.<action>.label` overlay (`"记录通话"`). Object-owned actions on the same bar (`escalate_case` → 升级工单) translated correctly, which is what made the gap visible in a zh-CN locale.

## Root cause

`useObjectLabel()`'s action resolvers were a client-side re-implementation of the canonical `@objectstack/spec` resolver (`system/i18n-resolver.ts` → `lookupActionField`) — but they had drifted. The spec resolver, when an action is object-scoped, tries the object key **and then falls back to `globalActions.<action>`** before the literal. The objectui hook only tried the object key when an `objectName` was passed, never the global fallback. That fallback is exactly what a globalAction surfaced on a record-detail bar needs.

## Fix

Route every action resolver through a shared `actionSuffixes(objectName, actionName, tail)` helper that mirrors the spec resolver:

- **object-scoped** → `objects.<obj>._actions.<action>.<tail>` (object precedence preserved), then `globalActions.<action>.<tail>` as a fallback.
- **object-less** → `globalActions.<action>.<tail>`, as before.

Applied uniformly to `actionLabel`, `actionConfirm`, `actionSuccess`, `actionDescription`, `actionResultDialog`, `actionParamText`, and `actionParamOptionLabel`, so a globalAction resolves the same on a record-detail action bar as it does everywhere else. App-namespace discovery (`getAppNamespaces`) also now recognises a `globalActions`-only bundle (one carrying no object/field entries).

The renderer (`RecordDetailView` and siblings) is unchanged — it keeps passing `objectDef.name`; the resolver now does the right thing with it. This follows the contract-first principle: object-scoped labels always win, the global overlay is only consulted on a miss, so name collisions are safe.

## Testing

- New regression test `packages/i18n/src/__tests__/useObjectLabel-globalAction.test.tsx` (6 cases): globalAction overlay resolves with an `objectName` present, object-scoped still wins on a name collision, literal fallback when neither scope translates, and the same fallback on a sibling resolver (`successMessage`).
- `@object-ui/i18n` full suite: 106 passed.
- Action-consuming packages (components/action-bar, plugin-detail, plugin-list, plugin-grid bulk actions): 442 passed.
- `type-check` clean; lint reports only pre-existing warnings (none introduced).

## Notes

- Patch changeset added (`@object-ui/i18n`; the fixed release group bumps together) so the fix ships to downstream apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3kenXszWLsSd3D1DuM9bn)_