### PR TITLE
fix(SchemaForm): render sort repeater rows for union schemas (objectstack#3379)

### DIFF
--- a/.changeset/listview-sort-blank-repeater.md
+++ b/.changeset/listview-sort-blank-repeater.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(SchemaForm): render row sub-fields for `repeater` fields whose schema is a union (objectui#3379)
+
+In Edit View Config → Columns & Filters → Sort, "Add" produced an empty row
+with no field picker or order dropdown. A View's `sort` prop is a
+`z.union([z.string(), z.array(z.object({ field, order }))])`, so its JSONSchema
+is `anyOf: [string, {field,order}[]]`. The SchemaForm repeater read
+`schema.items` at the top level — which is `undefined` for a union — and
+derived zero sub-fields.
+
+The repeater now resolves the union to its array branch and uses that branch's
+`items` for both the derived field list and the per-row controls
+(`pickSubSchema`). The legacy bare-string `sort` form remains valid in the spec
+(its removal is a separate, deferred deprecation cycle); this is purely a
+renderer fix.

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.repeaterUnion.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.repeaterUnion.test.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { useState } from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { SchemaForm } from './SchemaForm';
+
+afterEach(cleanup);
+
+/**
+ * A `repeater` form field whose JSONSchema wraps the canonical array form in
+ * a union (`anyOf`) — the exact shape of a View `sort`
+ * (`anyOf: [ "field desc" string, {field,order}[] ]`, kept a union so the
+ * legacy bare-string form still validates, see objectstack/spec view.zod).
+ *
+ * The repeater must resolve the union to its ARRAY branch and render the row
+ * sub-fields. Reading `schema.items` at the top level finds `undefined`
+ * (items live under `anyOf[1].items`) and produces a blank row with no field
+ * picker or order dropdown — the bug in objectui#3379.
+ */
+const sortUnionSchema = {
+  type: 'object',
+  properties: {
+    sort: {
+      anyOf: [
+        { type: 'string' }, // legacy "field desc"
+        {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              field: { type: 'string' },
+              order: { type: 'string', enum: ['asc', 'desc'] },
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+// Mirrors the spec's `viewForm`: `{ field: 'sort', type: 'repeater' }`.
+const sortForm = {
+  sections: [
+    {
+      label: 'Columns & Filters',
+      fields: [
+        { field: 'sort', type: 'repeater', helpText: 'Default sort order' },
+      ],
+    },
+  ],
+} as never;
+
+function Harness() {
+  const [val, setVal] = useState<Record<string, unknown>>({});
+  return (
+    <SchemaForm
+      schema={sortUnionSchema}
+      form={sortForm}
+      value={val}
+      onChange={setVal}
+    />
+  );
+}
+
+describe('SchemaForm repeater over a union schema (objectui#3379)', () => {
+  it('renders row sub-fields for a union-wrapped array (View sort)', () => {
+    render(<Harness />);
+
+    // The Sort repeater renders with its add control.
+    const addBtn = screen.getByRole('button', { name: /add item/i });
+    expect(addBtn).toBeInTheDocument();
+
+    // Adding a row must surface the field + order sub-controls — not a blank
+    // row. Before the fix the repeater derived zero sub-fields from the
+    // top-level (union) `schema.items`, so the added row was empty.
+    fireEvent.click(addBtn);
+
+    expect(screen.getByText('Field')).toBeInTheDocument();
+    expect(screen.getByText('Order')).toBeInTheDocument();
+  });
+
+  it('renders row sub-fields when editing an existing array-form sort', () => {
+    function Seeded() {
+      const [val, setVal] = useState<Record<string, unknown>>({
+        sort: [{ field: 'estimate_hours', order: 'desc' }],
+      });
+      return (
+        <SchemaForm
+          schema={sortUnionSchema}
+          form={sortForm}
+          value={val}
+          onChange={setVal}
+        />
+      );
+    }
+    render(<Seeded />);
+
+    // Expand the existing row and confirm its sub-fields resolve from the
+    // union's array branch rather than falling back to a raw JSON blob.
+    fireEvent.click(screen.getByRole('button', { name: /#1/ }));
+    expect(screen.getByText('Field')).toBeInTheDocument();
+    expect(screen.getByText('Order')).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -137,6 +137,36 @@ function resolveUnionBranch(
 }
 
 /**
+ * Resolve the row (item) schema for a `repeater` field. The repeater derives
+ * its per-row sub-fields from `items.properties`, but the field's JSONSchema
+ * may wrap the canonical array form in a union (`anyOf` / `oneOf`) — e.g. a
+ * View `sort` (`anyOf: [ "field desc" string, {field,order}[] ]`, kept as a
+ * union so the legacy bare-string form still validates). Reading
+ * `schema.items` at the top level then misses the array branch nested inside
+ * the union, leaving the repeater with zero sub-fields — a blank row with no
+ * field picker or order dropdown (objectui#3379).
+ *
+ * Resolve the union to its ARRAY branch first (forcing an array value so the
+ * score lands on that branch even before any row exists), then return its
+ * `items`, itself union-resolved against the first existing row. A plain
+ * array schema (no union) passes straight through unchanged.
+ */
+function repeaterItemSchema(
+  schema: JsonSchema | undefined,
+  value: unknown,
+): JsonSchema {
+  if (!schema) return {};
+  const arrayBranch = resolveUnionBranch(
+    schema,
+    Array.isArray(value) ? value : [],
+  );
+  const items = arrayBranch?.items as JsonSchema | undefined;
+  if (!items || typeof items !== 'object') return {};
+  const firstRow = Array.isArray(value) && value.length ? value[0] : undefined;
+  return (resolveUnionBranch(items, firstRow) ?? {}) as JsonSchema;
+}
+
+/**
  * Infer widget name from FormFieldSpec.type (Data.FieldType) and schema.
  * Priority: explicit widget > type-based inference > schema-based inference > default.
  */
@@ -967,7 +997,14 @@ function FieldControl({
     );
   }
   if (fieldSpec?.type === 'repeater') {
-    const itemSchema = (schema?.items as JsonSchema | undefined) ?? {};
+    // The row schema may be nested inside a union (`anyOf` / `oneOf`) — e.g.
+    // a View `sort` authored as `anyOf: [ string, {field,order}[] ]`. Reading
+    // `schema.items` at the top level misses the array branch and renders a
+    // blank row with no sub-fields (objectui#3379). Resolve to the array
+    // branch's items and hand RepeaterField a schema whose `items` is that
+    // object schema, so both the derived field list and `pickSubSchema`
+    // (per-row controls) see real sub-schemas.
+    const itemSchema = repeaterItemSchema(schema, value);
     const fields =
       fieldSpec.fields?.length
         ? fieldSpec.fields
@@ -976,7 +1013,7 @@ function FieldControl({
       <RepeaterField
         value={value}
         fields={fields}
-        schema={schema}
+        schema={{ ...schema, items: itemSchema }}
         readOnly={readOnly}
         widgetContext={widgetContext}
         widget={fieldSpec.widget}


### PR DESCRIPTION
## Problem

In **Edit View Config → Columns & Filters → Sort**, clicking "Add" produced an empty row with no field picker or order dropdown — users could not configure a default sort at all (objectstack#3379).

## Root cause

A View's `sort` is authored as a union:

```ts
sort: z.union([
  z.string(),                                   // legacy "field desc"
  z.array(z.object({ field, order })),          // canonical
]).optional()
```

so its derived JSONSchema is `anyOf: [ {string}, {array, items:{field,order}} ]`. The spec's `viewForm` marks `sort` as `{ type: 'repeater' }`, and the `SchemaForm` repeater path read **`schema.items` at the top level**. For a union that is `undefined` (the array's `items` live under `anyOf[1].items`), so the repeater derived **zero** sub-fields and every added row was blank.

## Fix (renderer-only, in `SchemaForm.tsx`)

Add a small `repeaterItemSchema(schema, value)` helper that resolves the union to its **array branch** (reusing the existing `resolveUnionBranch`, forcing an array value so the score lands on the array member even before any row exists) and returns that branch's `items`. The repeater block now:

- derives its field list from the resolved item schema, and
- hands `RepeaterField` a schema whose `items` is the resolved object schema, so the per-row controls (`pickSubSchema`) resolve real sub-schemas — the `field` picker and the `order` (`asc`/`desc`) select.

Plain (non-union) array repeaters pass straight through unchanged.

## Deliberate scope decision — spec is **not** changed

The linked issue suggests dropping the legacy bare-string variant from `ListViewSchema.sort` in `@objectstack/spec` and calls that "the true root cause". I did **not** do that, on purpose:

- `view.zod.ts` carries an explicit maintainer instruction directly above `sort`: *"Removal will go through its own deprecation cycle; **do not drop it here**"*, and notes the string form is *"kept covered by a live fixture"*.
- That live fixture is `examples/app-showcase/.../task.view.ts` (`sort: 'estimate_hours desc'`), which exists specifically to guard the objectui#2601 crash. Dropping the union would break it and be a breaking change to the public spec.
- The issue itself notes #3373 kept the union intentionally and flags this objectui repeater fix as the valid "companion" path.

This renderer fix resolves the user-facing bug **without** any breaking spec change or backward-compat loss. Un-deferring the string-form removal remains a separate maintainer decision — happy to open that as its own PR if desired.

## Tests

`SchemaForm.repeaterUnion.test.tsx` covers both the empty-value ("Add" surfaces `field` + `order` controls) and existing-array (`[{ field, order }]` expands to real sub-fields) cases. Both fail without the fix and pass with it. Existing `SchemaForm.*`, `ViewConfigPanel`, and `view-config-adapter` suites remain green; lint is clean on the touched code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVJsp4iA1eNUcwFphoqYu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVJsp4iA1eNUcwFphoqYu3)_