### PR TITLE
fix(command-palette): surface record search hits from /api/v1/search (#3371)

### DIFF
--- a/.changeset/command-palette-global-search.md
+++ b/.changeset/command-palette-global-search.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/data-objectstack": patch
+"@object-ui/react": patch
+"@object-ui/app-shell": patch
+"@object-ui/types": patch
+---
+
+Command palette (⌘K) now surfaces record search hits from the platform's global
+search endpoint (`GET /api/v1/search`).
+
+Previously the palette only ran a per-object `find({ $search })` fanout (the
+metadata-driven ADR-0061 search), which misses records that only the global
+search index knows about — so typing a well-known record name returned no
+records even though `/api/v1/search` served them. `ObjectStackAdapter` now
+exposes a `searchAll(query, { limit, objects })` method that calls the unified
+endpoint, `useRecordSearch` prefers it when present (falling back to the fanout
+otherwise), and the palette renders the resulting record hits grouped by object.

--- a/packages/app-shell/src/chrome/CommandPalette.tsx
+++ b/packages/app-shell/src/chrome/CommandPalette.tsx
@@ -117,6 +117,31 @@ export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSour
   );
   const showRecentRecords = open && inputValue.trim().length === 0 && recentRecords.length > 0;
 
+  // Group the (server-ranked) record hits by object so the palette lists them
+  // under per-object headings — issue #3371 asks for record hits "grouped by
+  // object". The object with the top-ranked hit leads (first-seen order), and
+  // within each group the server's relevance order is preserved.
+  const recordGroups = useMemo(() => {
+    const order: string[] = [];
+    const byObject = new Map<
+      string,
+      { objectLabel: string; icon?: string; hits: typeof recordHits }
+    >();
+    for (const hit of recordHits) {
+      let group = byObject.get(hit.objectName);
+      if (!group) {
+        group = { objectLabel: hit.objectLabel, icon: hit.icon, hits: [] };
+        byObject.set(hit.objectName, group);
+        order.push(hit.objectName);
+      }
+      group.hits.push(hit);
+    }
+    return order.map((name) => {
+      const group = byObject.get(name)!;
+      return { objectName: name, ...group };
+    });
+  }, [recordHits]);
+
   return (
     <CommandDialog
       open={open}
@@ -171,24 +196,28 @@ export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSour
           </CommandGroup>
         )}
 
-        {/* Record search — only renders when there are async hits */}
-        {recordHits.length > 0 && (
-          <CommandGroup
-            heading={
-              <span className="inline-flex items-center gap-2">
-                {t('console.commandPalette.records', { defaultValue: 'Records' })}
-                {isSearching && (
-                  <span
-                    aria-hidden
-                    className="inline-block h-1.5 w-1.5 rounded-full bg-primary motion-safe:animate-pulse"
-                  />
-                )}
-              </span>
-            }
-          >
-            {recordHits.map((hit) => {
-              const Icon = getIcon(hit.icon);
-              return (
+        {/* Record search hits from the platform's global search
+            (/api/v1/search), grouped by object (issue #3371). The searching
+            pulse rides the first group's heading so it stays visible while a
+            refined query is in flight over an existing result set. */}
+        {recordGroups.map((group, groupIndex) => {
+          const Icon = getIcon(group.icon);
+          return (
+            <CommandGroup
+              key={`records:${group.objectName}`}
+              heading={
+                <span className="inline-flex items-center gap-2">
+                  {group.objectLabel}
+                  {isSearching && groupIndex === 0 && (
+                    <span
+                      aria-hidden
+                      className="inline-block h-1.5 w-1.5 rounded-full bg-primary motion-safe:animate-pulse"
+                    />
+                  )}
+                </span>
+              }
+            >
+              {group.hits.map((hit) => (
                 <CommandItem
                   key={`${hit.objectName}:${hit.recordId}`}
                   // Embed the live query so cmdk's client-side filter doesn't
@@ -198,12 +227,16 @@ export function CommandPalette({ apps, activeApp, objects, onAppChange, dataSour
                 >
                   <Icon className="mr-2 h-4 w-4" />
                   <span className="truncate">{hit.display}</span>
-                  <span className="ml-auto text-xs text-muted-foreground">{hit.objectLabel}</span>
+                  {hit.subtitle && (
+                    <span className="ml-auto max-w-[45%] truncate text-xs text-muted-foreground">
+                      {hit.subtitle}
+                    </span>
+                  )}
                 </CommandItem>
-              );
-            })}
-          </CommandGroup>
-        )}
+              ))}
+            </CommandGroup>
+          );
+        })}
         {/* Object Navigation */}
         {navItems.filter(i => i.type === 'object').length > 0 && (
           <CommandGroup heading={t('console.commandPalette.objects')}>

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -13,6 +13,8 @@ import type {
   MutationEvent,
   QueryParams,
   QueryResult,
+  GlobalSearchResult,
+  GlobalSearchHit,
   FileUploadResult,
   ExportDownloadRequest,
   ImportRequestOptions,
@@ -725,6 +727,103 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     };
     promise.then(cleanup, cleanup);
     return promise;
+  }
+
+  /**
+   * Full-text search across every searchable object in a single round-trip.
+   *
+   * Hits `GET /api/v1/search?q=`, the platform's global search endpoint served
+   * by the registered search service (the pinyin full-text plugin) and backed
+   * by `metadata-protocol`'s `searchAll`. Unlike `find(resource, { $search })`
+   * — a per-object metadata-driven search (ADR-0061) — this consults the search
+   * index and ranks hits across objects, so it surfaces records the per-object
+   * fanout misses. Global affordances (⌘K command palette, search page) prefer
+   * this path (framework #3371).
+   *
+   * Returns `{ query, hits }`. A backend without the search plugin installed
+   * answers `404`; we treat that as "no global search here" and return an empty
+   * hit set so callers can fall back to a per-object fanout rather than surface
+   * an error.
+   */
+  async searchAll(
+    query: string,
+    options?: { limit?: number; objects?: string[] },
+  ): Promise<GlobalSearchResult> {
+    const trimmed = (query ?? '').trim();
+    if (trimmed === '') return { query: '', hits: [] };
+
+    await this.connect();
+
+    const queryParams = new URLSearchParams();
+    queryParams.set('q', trimmed);
+    if (options?.limit != null && options.limit > 0) {
+      queryParams.set('limit', String(options.limit));
+    }
+    if (options?.objects && options.objects.length > 0) {
+      queryParams.set('objects', options.objects.join(','));
+    }
+
+    const baseUrl = (this.baseUrl || '').replace(/\/$/, '');
+    // Avoid doubling /api/v1 when baseUrl already carries the version suffix.
+    const hasApiVersionSuffix = /\/api\/v\d+$/i.test(baseUrl);
+    const searchPath = hasApiVersionSuffix ? '/search' : '/api/v1/search';
+    const url = `${baseUrl}${searchPath}?${queryParams.toString()}`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+
+    const res = await this.fetchImpl(url, { method: 'GET', headers });
+
+    if (!res.ok) {
+      // 404 → the search plugin isn't installed on this backend. Degrade to an
+      // empty result so the caller can fall back instead of hard-failing.
+      if (res.status === 404) return { query: trimmed, hits: [] };
+      const errorBody = await res.json().catch(() => ({ message: res.statusText }));
+      const err = new Error(
+        errorBody?.error?.message || errorBody?.message || res.statusText,
+      ) as Error & { status?: number };
+      err.status = res.status;
+      throw err;
+    }
+
+    const body = await res.json();
+    // Unwrap the standard `{ success, data }` envelope when present; the search
+    // endpoint itself returns `{ query, hits }`.
+    const payload =
+      body && typeof body === 'object' && typeof body.success === 'boolean' && 'data' in body
+        ? body.data
+        : body;
+
+    const rawHits: unknown[] = Array.isArray(payload?.hits)
+      ? payload.hits
+      : Array.isArray(payload)
+        ? payload
+        : [];
+
+    const hits: GlobalSearchHit[] = [];
+    for (const entry of rawHits) {
+      if (!entry || typeof entry !== 'object') continue;
+      const h = entry as Record<string, any>;
+      const object = h.object ?? h.objectName ?? h.object_name;
+      const id = h.id ?? h.record?.id ?? h.record?._id;
+      if (typeof object !== 'string' || id == null) continue;
+      hits.push({
+        object,
+        id: String(id),
+        title: typeof h.title === 'string' ? h.title : undefined,
+        snippet: typeof h.snippet === 'string' ? h.snippet : undefined,
+        record: h.record && typeof h.record === 'object' ? h.record : undefined,
+      });
+    }
+
+    return {
+      query: typeof payload?.query === 'string' ? payload.query : trimmed,
+      hits,
+    };
   }
 
   /**

--- a/packages/data-objectstack/src/searchAll.test.ts
+++ b/packages/data-objectstack/src/searchAll.test.ts
@@ -1,0 +1,120 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectStackAdapter, clearSharedDiscoveryCache } from './index';
+
+/** A fetch mock that answers discovery + records the global-search GET. */
+function makeFetch(searchResponse: { ok: boolean; status?: number; body: unknown }) {
+  const calls: Array<{ url: string; init?: any }> = [];
+  const fetchImpl = vi.fn(async (url: any, init?: any) => {
+    const u = String(url);
+    calls.push({ url: u, init });
+    if (u.includes('/api/v1/discovery')) {
+      return { ok: true, status: 200, statusText: 'OK', json: async () => ({ success: true, data: { version: 'v1', routes: {} } }) } as any;
+    }
+    if (u.includes('/api/v1/search')) {
+      return {
+        ok: searchResponse.ok,
+        status: searchResponse.status ?? (searchResponse.ok ? 200 : 400),
+        statusText: searchResponse.ok ? 'OK' : 'Error',
+        json: async () => searchResponse.body,
+      } as any;
+    }
+    return { ok: true, status: 200, statusText: 'OK', json: async () => ({}) } as any;
+  });
+  return { fetchImpl, calls };
+}
+
+const WAYNE_HITS = {
+  query: 'Wayne',
+  hits: [
+    { object: 'crm_account', id: 'a1', title: 'Wayne Enterprises', snippet: 'Wayne Enterprises', record: { id: 'a1', account_number: 'ACC-000005' } },
+    { object: 'crm_opportunity', id: 'o1', title: 'Wayne Q1 Expansion', record: { id: 'o1' } },
+  ],
+};
+
+describe('ObjectStackAdapter.searchAll', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('GETs /api/v1/search?q= and returns normalized ranked hits', async () => {
+    const { fetchImpl, calls } = makeFetch({ ok: true, body: WAYNE_HITS });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', token: 'tok_123', autoReconnect: false, fetch: fetchImpl as any });
+
+    const result = await adapter.searchAll('Wayne');
+
+    expect(result.query).toBe('Wayne');
+    expect(result.hits.map((h) => `${h.object}:${h.id}`)).toEqual(['crm_account:a1', 'crm_opportunity:o1']);
+    expect(result.hits[0].title).toBe('Wayne Enterprises');
+    expect(result.hits[0].record).toEqual({ id: 'a1', account_number: 'ACC-000005' });
+
+    const get = calls.find((c) => c.url.includes('/api/v1/search'))!;
+    const url = new URL(get.url);
+    expect(url.pathname).toBe('/api/v1/search');
+    expect(url.searchParams.get('q')).toBe('Wayne');
+    expect(get.init.method).toBe('GET');
+    expect(get.init.headers.Authorization).toBe('Bearer tok_123');
+  });
+
+  it('trims the query and forwards limit + objects scoping', async () => {
+    const { fetchImpl, calls } = makeFetch({ ok: true, body: { query: 'Wayne', hits: [] } });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+    await adapter.searchAll('  Wayne  ', { limit: 12, objects: ['crm_account', 'crm_opportunity'] });
+
+    const url = new URL(calls.find((c) => c.url.includes('/api/v1/search'))!.url);
+    expect(url.searchParams.get('q')).toBe('Wayne');
+    expect(url.searchParams.get('limit')).toBe('12');
+    expect(url.searchParams.get('objects')).toBe('crm_account,crm_opportunity');
+  });
+
+  it('short-circuits an empty query without hitting the network', async () => {
+    const { fetchImpl, calls } = makeFetch({ ok: true, body: { query: '', hits: [] } });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+    const result = await adapter.searchAll('   ');
+
+    expect(result).toEqual({ query: '', hits: [] });
+    expect(calls.some((c) => c.url.includes('/api/v1/search'))).toBe(false);
+  });
+
+  it('unwraps a { success, data } envelope', async () => {
+    const { fetchImpl } = makeFetch({ ok: true, body: { success: true, data: WAYNE_HITS } });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+    const result = await adapter.searchAll('Wayne');
+    expect(result.hits).toHaveLength(2);
+  });
+
+  it('treats a 404 (search plugin absent) as an empty result, not an error', async () => {
+    const { fetchImpl } = makeFetch({ ok: false, status: 404, body: { message: 'not found' } });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+    await expect(adapter.searchAll('Wayne')).resolves.toEqual({ query: 'Wayne', hits: [] });
+  });
+
+  it('throws with the server message on a non-404 error', async () => {
+    const { fetchImpl } = makeFetch({ ok: false, status: 500, body: { error: { message: 'index unavailable' } } });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+    await expect(adapter.searchAll('Wayne')).rejects.toThrow(/index unavailable/);
+  });
+
+  it('drops malformed hits (missing object or id)', async () => {
+    const { fetchImpl } = makeFetch({
+      ok: true,
+      body: { query: 'x', hits: [
+        { object: 'crm_account', id: 'a1', title: 'Keep' },
+        { id: 'no_object' },
+        { object: 'crm_lead' },
+        null,
+        { object: 'crm_contact', record: { id: 'c9' } },
+      ] },
+    });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+    const result = await adapter.searchAll('x');
+    expect(result.hits.map((h) => `${h.object}:${h.id}`)).toEqual(['crm_account:a1', 'crm_contact:c9']);
+  });
+});

--- a/packages/react/src/hooks/__tests__/useRecordSearch.test.ts
+++ b/packages/react/src/hooks/__tests__/useRecordSearch.test.ts
@@ -292,4 +292,121 @@ describe('useRecordSearch', () => {
       expect(ds.find).toHaveBeenCalledWith('account', { $search: 'acme', $top: 3 });
     });
   });
+
+  // ADR-0061 / framework #3371: when the data source exposes the unified global
+  // search endpoint (`searchAll` → GET /api/v1/search), the palette must use it
+  // instead of the per-object `find({ $search })` fanout — the fanout misses
+  // records that only the global index knows about.
+  describe('global searchAll endpoint', () => {
+    function makeSearchDataSource(hits: any[]) {
+      return {
+        find: vi.fn(async () => ({ data: [] })),
+        searchAll: vi.fn(async () => ({ query: 'wayne', hits })),
+      };
+    }
+
+    it('prefers searchAll and maps hits without fanning out to find', async () => {
+      const ds = makeSearchDataSource([
+        { object: 'account', id: 'a1', title: 'Wayne Enterprises', snippet: 'Wayne Enterprises' },
+        { object: 'contact', id: 'c1', title: 'Bruce Wayne', record: { id: 'c1' } },
+      ]);
+
+      const { result } = renderHook(() =>
+        useRecordSearch({ query: 'wayne', objects, dataSource: ds, debounceMs: 0 }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSearching).toBe(false);
+        expect(result.current.results.length).toBe(2);
+      });
+
+      expect(ds.searchAll).toHaveBeenCalledTimes(1);
+      expect(ds.find).not.toHaveBeenCalled();
+
+      const byId = Object.fromEntries(result.current.results.map((h) => [h.recordId, h]));
+      expect(byId.a1.display).toBe('Wayne Enterprises');
+      expect(byId.a1.objectName).toBe('account');
+      expect(byId.a1.objectLabel).toBe('Account');
+      expect(byId.c1.display).toBe('Bruce Wayne');
+    });
+
+    it('trims and forwards the whitelist as the objects scope', async () => {
+      const ds = makeSearchDataSource([]);
+      renderHook(() =>
+        useRecordSearch({
+          query: '  wayne  ',
+          objects,
+          dataSource: ds,
+          objectNames: ['account', 'contact'],
+          debounceMs: 0,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(ds.searchAll).toHaveBeenCalledTimes(1);
+      });
+      const [term, opts] = ds.searchAll.mock.calls[0];
+      expect(term).toBe('wayne');
+      expect(opts.objects).toEqual(['account', 'contact']);
+    });
+
+    it('drops hits for objects outside the candidate whitelist', async () => {
+      // Server ignored our `objects` filter and returned an out-of-scope object.
+      const ds = makeSearchDataSource([
+        { object: 'account', id: 'a1', title: 'Wayne Enterprises' },
+        { object: 'secret_object', id: 's1', title: 'Should be hidden' },
+      ]);
+
+      const { result } = renderHook(() =>
+        useRecordSearch({
+          query: 'wayne',
+          objects,
+          dataSource: ds,
+          objectNames: ['account'],
+          debounceMs: 0,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSearching).toBe(false);
+      });
+      expect(result.current.results.map((h) => h.objectName)).toEqual(['account']);
+    });
+
+    it('floats an exact-id paste above the server ranking', async () => {
+      const ds = makeSearchDataSource([
+        { object: 'account', id: 'a1', title: 'Alpha' },
+        { object: 'account', id: 'OPP-42', title: 'Unrelated name' },
+      ]);
+
+      const { result } = renderHook(() =>
+        useRecordSearch({ query: 'OPP-42', objects, dataSource: ds, debounceMs: 0 }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.results.length).toBe(2);
+      });
+      expect(result.current.results[0].recordId).toBe('OPP-42');
+    });
+
+    it('surfaces searchAll errors and clears results', async () => {
+      const ds = {
+        find: vi.fn(),
+        searchAll: vi.fn(async () => {
+          throw new Error('index unavailable');
+        }),
+      };
+
+      const { result } = renderHook(() =>
+        useRecordSearch({ query: 'wayne', objects, dataSource: ds, debounceMs: 0 }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSearching).toBe(false);
+        expect(result.current.error?.message).toBe('index unavailable');
+      });
+      expect(result.current.results).toEqual([]);
+      expect(ds.find).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react/src/hooks/useRecordSearch.ts
+++ b/packages/react/src/hooks/useRecordSearch.ts
@@ -208,6 +208,93 @@ export function useRecordSearch(opts: UseRecordSearchOptions): UseRecordSearchRe
       // Skip if a newer run started during the debounce window.
       if (runIdRef.current !== myRunId) return;
 
+      // Prefer the platform's unified global-search endpoint when the data
+      // source exposes it (ObjectStackAdapter → GET /api/v1/search?q=). The
+      // per-object `find({ $search })` fanout below only runs each object's
+      // metadata-driven search (ADR-0061) and can miss records the global
+      // search index knows about — the command-palette symptom in framework
+      // #3371, where `/api/v1/search` returned an account/opportunity the
+      // palette never showed. When `searchAll` is absent (mock/test adapters,
+      // non-ObjectStack backends) we fall back to the fanout.
+      const searchAll = (dataSource as { searchAll?: unknown }).searchAll;
+      if (typeof searchAll === 'function') {
+        // Scope to the candidate objects (the app's searchable nav objects) so
+        // the palette doesn't surface records from objects the current app
+        // can't route to. We both ask the server to scope (`objects`) and
+        // re-filter locally, guarding servers that ignore the param.
+        const byName = new Map<string, any>();
+        for (const obj of candidates) {
+          if (typeof obj?.name === 'string') byName.set(obj.name, obj);
+        }
+
+        Promise.resolve()
+          .then(() =>
+            (searchAll as (q: string, o?: any) => Promise<any>).call(dataSource, trimmed, {
+              limit: maxObjectsQueried * topPerObject,
+              objects: Array.from(byName.keys()),
+            }),
+          )
+          .then((res: any) => {
+            // Discard if a newer run started while we were waiting.
+            if (runIdRef.current !== myRunId) return;
+
+            const rawHits: any[] = Array.isArray(res?.hits)
+              ? res.hits
+              : Array.isArray(res)
+                ? res
+                : [];
+
+            const hits: RecordSearchHit[] = [];
+            for (const h of rawHits) {
+              const objectName = h?.object ?? h?.objectName;
+              if (typeof objectName !== 'string') continue;
+              // Keep only whitelisted objects (no-op when the server already
+              // honored `objects`).
+              if (byName.size > 0 && !byName.has(objectName)) continue;
+              const recordId = h?.id ?? h?.record?.id ?? h?.record?._id;
+              if (recordId == null) continue;
+
+              const objDef = byName.get(objectName) ?? { name: objectName };
+              const title =
+                typeof h?.title === 'string' && h.title.trim() !== '' ? h.title.trim() : '';
+              const display = title || getDisplayName(objDef, h?.record ?? {}) || `Record #${recordId}`;
+              const snippet = typeof h?.snippet === 'string' ? h.snippet.trim() : '';
+
+              hits.push({
+                objectName,
+                objectLabel:
+                  typeof objDef.label === 'string' && objDef.label.length > 0
+                    ? objDef.label
+                    : objectName,
+                recordId: String(recordId),
+                display,
+                // Only surface a snippet when it adds information beyond the title.
+                subtitle: snippet && snippet !== display ? snippet : undefined,
+                icon: objDef?.icon,
+                score: scoreHit(trimmed, display, String(recordId)),
+                raw: h?.record ?? h,
+              });
+            }
+
+            // The server already ranks hits across objects; preserve that order.
+            // Only float an exact-id paste to the very top (parity with the
+            // fanout path). Array.prototype.sort is stable, so every other hit
+            // keeps the server ordering.
+            hits.sort((a, b) => (b.score === 110 ? 1 : 0) - (a.score === 110 ? 1 : 0));
+
+            setResults(hits);
+            setIsSearching(false);
+            setError(undefined);
+          })
+          .catch((err: any) => {
+            if (runIdRef.current !== myRunId) return;
+            setResults([]);
+            setIsSearching(false);
+            setError(err instanceof Error ? err : new Error(String(err)));
+          });
+        return;
+      }
+
       const requests = candidates.map((obj) =>
         Promise.resolve()
           .then(() =>
@@ -281,6 +368,7 @@ export function useRecordSearch(opts: UseRecordSearchOptions): UseRecordSearchRe
     dataSource,
     candidateSignature,
     topPerObject,
+    maxObjectsQueried,
     minLength,
     debounceMs,
     getDisplayName,

--- a/packages/types/src/data.ts
+++ b/packages/types/src/data.ts
@@ -200,15 +200,69 @@ export interface BatchTransactionOperation {
  * }
  * ```
  */
+/**
+ * A single record hit returned by the platform's global search endpoint
+ * (`GET /api/v1/search`). The backend's registered search service ranks these
+ * across every searchable object the caller can see, so the returned ordering
+ * is authoritative (best match first).
+ */
+export interface GlobalSearchHit {
+  /** Object/table the record belongs to (e.g. `crm_account`). */
+  object: string;
+  /** Stable record identifier. */
+  id: string;
+  /** Server-resolved display title for the record, when provided. */
+  title?: string;
+  /** Optional highlighted/context snippet describing why it matched. */
+  snippet?: string;
+  /** The (partial) record payload, when the server includes it. */
+  record?: Record<string, any>;
+}
+
+/**
+ * Result of a {@link DataSource.searchAll} call — the query echoed back plus
+ * the ranked cross-object hits.
+ */
+export interface GlobalSearchResult {
+  /** The query string the server actually ran. */
+  query: string;
+  /** Ranked record hits across all searchable objects. */
+  hits: GlobalSearchHit[];
+}
+
 export interface DataSource<T = any> {
   /**
    * Fetch multiple records.
-   * 
+   *
    * @param resource - Resource name (e.g., 'users', 'posts')
    * @param params - Query parameters
    * @returns Promise resolving to query result
    */
   find(resource: string, params?: QueryParams): Promise<QueryResult<T>>;
+
+  /**
+   * Full-text search across every object the caller can see, in a single
+   * round-trip. Backed by the platform's global search endpoint
+   * (`GET /api/v1/search?q=`), which is served by the registered search
+   * service (e.g. the pinyin full-text plugin) and ranks hits across objects.
+   *
+   * This is intentionally distinct from `find(resource, { $search })`, which
+   * runs a *per-object* metadata-driven search: the global endpoint consults
+   * the search index and can surface records the per-object path misses. Global
+   * affordances — the ⌘K command palette, the search page — should prefer this
+   * and fall back to a per-object `find` fanout only when it is absent.
+   *
+   * Optional: adapters without a global search endpoint may omit it.
+   *
+   * @param query - Raw search term (the adapter trims/encodes it).
+   * @param options - Optional caps: `limit` (max total hits) and `objects`
+   *   (restrict the search to a whitelist of object names).
+   * @returns Ranked hits across objects.
+   */
+  searchAll?(
+    query: string,
+    options?: { limit?: number; objects?: string[] },
+  ): Promise<GlobalSearchResult>;
 
   /**
    * Fetch a single record by ID.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -269,6 +269,8 @@ export type {
   QueryParams,
   QueryResult,
   DataSource,
+  GlobalSearchHit,
+  GlobalSearchResult,
   BatchRef,
   BatchTransactionOperation,
   DataScope,


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#3371.

## Problem

In the Console command palette (⌘K), searching a well-known record name returned **no records** — e.g. typing `Wayne` (with a `Wayne Enterprises` account and a `Wayne Q1 Expansion` opportunity) surfaced only an unrelated report, never the account/opportunity. Meanwhile the backend was healthy: `GET /api/v1/search?q=Wayne` returned the records correctly.

## Root cause

The palette's record search (`useRecordSearch`) fanned out a **per-object** `find({ $search })` request to each nav object — the metadata-driven per-object search (ADR-0061). That path does **not** consult the platform's global search index (`PinyinSearchPlugin`, served at `/api/v1/search`), so records that only the global index resolves were silently missing. The palette never called the unified endpoint that actually works.

## Fix

Wire the palette to the platform's global search endpoint, preferring it over the fanout:

- **`@object-ui/types`** — add `GlobalSearchHit` / `GlobalSearchResult` and an optional `DataSource.searchAll(query, { limit, objects })`.
- **`@object-ui/data-objectstack`** — implement `searchAll` against `GET /api/v1/search?q=`. It trims/encodes the term, forwards `limit` + `objects` scoping, unwraps the `{ query, hits }` (and `{ success, data }`) envelope, normalizes hits, and degrades a `404` (search plugin absent on the backend) to an empty result instead of throwing.
- **`@object-ui/react`** — `useRecordSearch` now prefers `searchAll` when the data source exposes it: it maps the server-ranked hits, scopes them to the app's searchable (nav) objects, preserves the server ranking (floating an exact-id paste to the top), and keeps the existing debounce / stale-run guarding. When `searchAll` is absent (mock/test adapters, non-ObjectStack backends) it falls back to the original per-object fanout, so existing behavior is unchanged.
- **`@object-ui/app-shell`** — the palette renders the record hits **grouped by object** (per the issue's ask), alongside the existing metadata results, with the searching pulse on the leading group.

## Why not just fix the fanout?

The global endpoint is the authoritative, cross-object search the backend already ranks; the per-object `$search` route is a narrower, per-object matcher. Routing global affordances (⌘K, the search page) through `/api/v1/search` is what the issue requests and matches how the backend is designed to serve global search.

## Testing

- `packages/data-objectstack/src/searchAll.test.ts` (new) — URL/params, envelope unwrap, empty-query short-circuit, `404` → empty, non-404 error propagation, malformed-hit dropping.
- `packages/react/src/hooks/__tests__/useRecordSearch.test.ts` — new `global searchAll endpoint` suite: prefers `searchAll` over `find`, forwards the whitelist as `objects` scope, drops out-of-scope hits, floats exact-id paste, surfaces errors.
- Full `@object-ui/react` + `@object-ui/data-objectstack` suites and the ADR-0054 ratchet test pass (525 tests). `type-check` passes for `data-objectstack`, `react`, and `app-shell`; ESLint clean (no new errors).

A changeset is included (`patch` for the affected packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011s54R8tmaqmvj6xjLPfv7c

---
_Generated by [Claude Code](https://claude.ai/code/session_011s54R8tmaqmvj6xjLPfv7c)_