### PR TITLE
fix(app-shell): keep list-origin back link when switching detail tabs

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -132,13 +132,16 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // overlay contract where Back closes `?form=…`).
   const [tabSearchParams, setTabSearchParams] = useSearchParams();
   const activeTabParam = tabSearchParams.get(RECORD_DETAIL_TAB_PARAM) ?? undefined;
+  const location = useLocation();
   const handleTabChange = useCallback((value: string) => {
     const sp = new URLSearchParams(window.location.search);
     if (sp.get(RECORD_DETAIL_TAB_PARAM) === value) return;
     sp.set(RECORD_DETAIL_TAB_PARAM, value);
-    setTabSearchParams(sp, { replace: true });
-  }, [setTabSearchParams]);
-  const location = useLocation();
+    // `setSearchParams` is a navigation: without an explicit `state` it drops
+    // the entry's history state, losing the list-origin `state.from` that
+    // renders the "← All <object>" back link — switching tabs must keep it.
+    setTabSearchParams(sp, { replace: true, state: location.state });
+  }, [setTabSearchParams, location.state]);
   // Inline "← back to parent" link shown above the record body. Prefers an
   // explicit history-state `from` (legacy, in-session only), then falls back
   // to the last ancestor in the `?from=` URL trail — which, unlike history


### PR DESCRIPTION
Closes #2774

## 问题

从对象列表点开一条记录,详情页顶部显示「← 全部<对象>」返回链接。切「相关」/「历史」Tab 后该链接消失,无法一键回列表。

## 根因

返回链接的数据来自列表行点击写入的 history state（`state.from`，见 `ObjectView.tsx`）。切 Tab 时 `handleTabChange` 用 `setSearchParams` 写 `?tab=` —— 这是一次导航,默认不携带 history state,`state.from` 被清空,链接随之消失。

## 修改

`RecordDetailView.tsx` 的 `handleTabChange`：切 Tab 导航时显式透传当前 `location.state`,使 `state.from` 在 Tab 切换后保留。单文件、6+/3-。

## 验证

- `pageTabsUrlSync` 单测 6/6 通过；`@object-ui/app-shell` type-check 干净。
- 真机实测（showcase 后端 + 本仓 console dev）：列表 → 打开 QD-00043 → 切「相关」→ 切「历史」,返回链接全程保留且可点击回到列表。修复前正是复现丢失现象。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
