### PR TITLE
docs(readme): 副标题与简介加入 AI-writable 口径

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **The Universal Schema-Driven UI Engine**
 
-*From JSON to world-class UI in minutes*
+*AI writes the schema; Object UI renders it — production React, no component code*
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/objectstack-ai/objectui/workflows/CI/badge.svg)](https://github.com/objectstack-ai/objectui/actions/workflows/ci.yml)
@@ -21,7 +21,7 @@
 
 ## What is Object UI?
 
-**Object UI is the View layer of the [ObjectStack](https://github.com/objectstack-ai/objectstack) ecosystem** — a standalone, schema-driven renderer that turns a JSON schema (or ObjectStack metadata) into production-grade React UI. Use it on its own with any backend, like Amis or Formily — or let it render ObjectStack apps end to end.
+**Object UI is the View layer of the [ObjectStack](https://github.com/objectstack-ai/objectstack) ecosystem** — a standalone, schema-driven renderer that turns a JSON schema (or ObjectStack metadata) into production-grade React UI. Use it on its own with any backend, like Amis or Formily — or let it render ObjectStack apps end to end. Schema-driven is also what makes UI **AI-writable**: an agent that would drown hand-writing React across fifty screens can emit and refactor compact schemas instead — and every screen stays consistent by construction.
 
 ```
 Describe  →  ObjectStack   the open-source protocol, toolkit & production runtime


### PR DESCRIPTION
## 背景

配合 objectstack / objectos 拆分后的全新对外口径(objectstack#3390、objectos#55),Object UI 的简介补上 AI 时代的钩子:schema-driven 正是 UI 可被 AI 编写的原因。

## 改动

- 副标题由 *From JSON to world-class UI in minutes* 改为 *AI writes the schema; Object UI renders it — production React, no component code*。
- "What is Object UI?" 段落追加一句:智能体手写五十个页面的 React 会淹死,但可以输出并重构紧凑的 schema——且每个页面天然保持一致("consistent by construction")。
- 原有 Describe → Render → Operate 三层对照块保持不变(与主仓库口径互补)。

## 建议同步更新仓库 About(需管理员在 Settings 修改)

> The schema-driven UI engine for the AI era: agents (or you) write compact JSON; Object UI renders production React — grids, kanban, dashboards, Gantt, visual designers. Standalone with any backend, or the view layer of ObjectStack. MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk

---
_Generated by [Claude Code](https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk)_