### PR TITLE
fix(app-shell): map raw sys_activity rows in the inbox Activity tab (#2781)

### DIFF
--- a/.changeset/activity-popover-field-mapping.md
+++ b/.changeset/activity-popover-field-mapping.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(app-shell): map raw `sys_activity` rows before rendering the inbox Activity tab
+
+The top-bar inbox bell's Activity tab (`InboxPopover`) rendered blank rows —
+only the relative time showed (`47m ·`), with the actor, summary, and object
+name all missing. `AppHeader.fetchPresenceAndActivities` cast the raw
+`sys_activity` rows straight to `ActivityItem` without renaming their fields,
+so the popover read `a.user` / `a.description` / `a.objectName` while the rows
+only carry plugin-audit's `actor_name` / `summary` / `object_name`.
+
+The rows are now mapped onto `ActivityItem` (with `type` normalization, a
+`timestamp` fallback, and an empty-`summary` filter), mirroring the mapping in
+`useHomeInbox` so the bell and the Home dashboard stay in sync.

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -274,9 +274,35 @@ export function AppHeader({
           return { data: [] as Record<string, unknown>[] };
         });
       if (activityResult.data?.length) {
-        const items = (activityResult.data as Record<string, unknown>[]).filter(
-          (a): a is ActivityItem & Record<string, unknown> => typeof a.type === 'string'
-        );
+        // Raw sys_activity rows use plugin-audit's column names
+        // (summary / actor_name / object_name / timestamp). Map them onto
+        // ActivityItem's shape (description / user / objectName) — casting the
+        // raw row straight through left every field undefined, so the popover
+        // Activity tab rendered blank rows (only the relative time showed).
+        // Mirrors the mapping in `useHomeInbox` so the bell and Home never diverge.
+        const items: ActivityItem[] = (activityResult.data as Record<string, unknown>[])
+          .filter((r) => typeof r.type === 'string' && String(r.summary ?? '').trim())
+          .map((r) => {
+            let when = r.timestamp as string | undefined;
+            if (!when || when === 'NOW()' || Number.isNaN(Date.parse(when))) {
+              when = r.created_at as string | undefined;
+            }
+            const raw = String(r.type);
+            const type: ActivityItem['type'] =
+              raw === 'commented' || raw === 'mentioned' ? 'comment'
+                : raw === 'deleted' ? 'delete'
+                  : raw === 'created' ? 'create'
+                    : 'update';
+            return {
+              id: String(r.id),
+              type,
+              objectName: (r.object_name as string) ?? '',
+              recordId: (r.record_id as string) ?? undefined,
+              user: (r.actor_name as string) ?? '',
+              description: (r.summary as string) ?? '',
+              timestamp: when ?? '',
+            };
+          });
         if (items.length) setApiActivities(items);
       }
     } catch { /* fallback below */ } finally {


### PR DESCRIPTION
## 问题
顶栏消息中心的**「活动动态」** tab 每条只显示相对时间(`47m ·`),操作人/摘要/对象名全空白。

## 根因
`packages/app-shell/src/layout/AppHeader.tsx` 的 `fetchPresenceAndActivities` 把 `sys_activity` 原始行直接 cast 成 `ActivityItem`,没做字段改名:

| 原始行 (plugin-audit) | ActivityItem |
|---|---|
| `summary` | `description` |
| `actor_name` | `user` |
| `object_name` | `objectName` |

`InboxPopover` 渲染 `{a.user} {a.description}` 与 `{timeAgo(a.timestamp)} · {a.objectName}`,除 `timestamp` 外全 `undefined` → `47m ·`。`hooks/useHomeInbox.ts` 做了正确映射,两者本应一致。

## 修复
在 AppHeader 里按 `useHomeInbox` 的方式映射:字段改名 + `type` 归一化 + `timestamp` 兜底 + 过滤空 `summary`。单文件,+29 −3。

## 验证
- framework showcase 后端 REST 确认 `sys_activity` 数据完整非空(响应 `records` 键)。
- console 连该后端:修复前「活动动态」一堆 `1m ·`/`7m ·` 空条目;打补丁后正常显示 `Created Semantic Zoo "activity probe row" · 7m showcase_semantic_zoo`、`Updated User "Dev Admin" · 7m sys_user` 等。
- 列表页(活动/站内消息)在 `main` 本就正常,不在本 PR 范围。

Closes #2781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)