### PR TITLE
fix(app-shell): i18n the "Switch Object" breadcrumb dropdown label

### DIFF
--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -748,7 +748,7 @@ export function AppHeader({
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="start" sideOffset={8} className="w-56 max-h-72 overflow-y-auto">
                         <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
-                          Switch Object
+                          {t('topbar.switchObject', { defaultValue: 'Switch Object' })}
                         </DropdownMenuLabel>
                         <DropdownMenuSeparator />
                         {seg.siblings.map((sibling) => (

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1894,6 +1894,7 @@ const en = {
     offline: 'Offline',
     usersOnline: 'Users currently online',
     switchView: 'Switch view',
+    switchObject: 'Switch Object',
     connection: {
       connected: 'Connected',
       connecting: 'Connecting...',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1977,6 +1977,7 @@ const zh = {
     offline: '离线',
     usersOnline: '当前在线用户',
     switchView: '切换视图',
+    switchObject: '切换对象',
     connection: {
       connected: '已连接',
       connecting: '连接中...',


### PR DESCRIPTION
## 问题

顶栏面包屑里的「对象切换」下拉,其标题标签硬编码为英文 `Switch Object`,在中文界面下不跟随本地化(见用户截图:zh UI 里仍显示英文 "Switch Object")。

## 修复

- `packages/app-shell/src/layout/AppHeader.tsx`:把硬编码字符串改为 `t('topbar.switchObject', { defaultValue: 'Switch Object' })`,复用同文件既有的 `useObjectTranslation()` 与 `topbar.*` 命名空间(与紧邻的 `topbar.switchView` 写法一致)。
- `packages/i18n/src/locales/en.ts`:新增 `topbar.switchObject: 'Switch Object'`。
- `packages/i18n/src/locales/zh.ts`:新增 `topbar.switchObject: '切换对象'`。

## 说明

只补 en/zh:其余语言(ar/de/es/fr/ja/ko/pt/ru)本就不带 `topbar.switchView` 等键,靠 en 兜底;en 为 `as const` 源,其他语言允许部分覆盖,无"所有语言必须齐全"的类型约束——与既有约定一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)