### PR TITLE
feat(form): consume spec-aligned FormView buttons/defaults in ObjectForm

### DIFF
--- a/.changeset/formview-buttons-defaults-fold.md
+++ b/.changeset/formview-buttons-defaults-fold.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/plugin-form": patch
+"@object-ui/plugin-view": patch
+"@object-ui/app-shell": patch
+"@object-ui/types": patch
+---
+
+feat(form): consume spec-aligned FormView buttons/defaults in ObjectForm
+
+The authored `@objectstack/spec` FormViewSchema carries structured
+`buttons.{submit,cancel,reset}.{show,label}` and `defaults`, but the form
+renderer only read the flat renderer-invented `showSubmit`/`submitText`/
+`showCancel`/`cancelText`/`showReset`/`initialValues`. That left the two spec
+keys parsed-but-inert (ADR-0078) and stuck at `experimental` in the spec
+liveness ledger.
+
+`ObjectForm` now folds the structured shape down onto those flat props inside
+its existing normalization pass, so every entry path (ObjectView
+drawer/modal/page, RecordFormPage) honors it. An explicitly-set flat key still
+wins, so metadata authored against the deprecated flat keys is unchanged.
+`ObjectView` and `RecordFormPage` forward `buttons`/`defaults` from the spec
+form view. `ObjectFormSchema` gains the optional `buttons`/`defaults` fields.
+
+Refs objectstack-ai/objectstack#1894, objectstack-ai/objectstack#2998.

--- a/packages/app-shell/src/views/RecordFormPage.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.tsx
@@ -311,6 +311,12 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
                 mode,
                 recordId: mode === 'edit' ? recordId : undefined,
                 ...(prefillValues && { initialValues: prefillValues }),
+                // framework#1894 / #2998: honor the spec-aligned structured
+                // `buttons`/`defaults` from the object's form view. ObjectForm
+                // folds them onto its flat props; an explicit `initialValues`
+                // (URL prefill above) still wins over `defaults`.
+                ...(formDef.buttons && { buttons: formDef.buttons }),
+                ...(formDef.defaults && { defaults: formDef.defaults }),
                 title: pageTitle,
                 description:
                   mode === 'create'

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -57,10 +57,39 @@ export interface ObjectFormProps {
 }
 
 /**
+/**
+ * Fold the structured, spec-aligned `buttons`/`defaults` surface
+ * (`@objectstack/spec` FormViewSchema; framework#1894 / #2998) down onto the
+ * flat renderer props ObjectForm and its variants read
+ * (`showSubmit`/`submitText`/`showCancel`/`cancelText`/`showReset`/
+ * `initialValues`). This is the objectui-side consumer of those spec keys — it
+ * is what lets them flip `experimental → live` in the spec liveness ledger.
+ *
+ * Spec is the authored surface, but an explicitly-set flat key still wins so
+ * existing metadata that authored the deprecated flat keys is unchanged.
+ * Returns the input untouched when neither structured key is present (the
+ * common case), so there is no allocation on the hot path.
+ */
+function foldFormButtons(schema: ObjectFormProps['schema']): ObjectFormProps['schema'] {
+  const buttons = (schema as { buttons?: ObjectFormSchema['buttons'] }).buttons;
+  const defaults = (schema as { defaults?: Record<string, any> }).defaults;
+  if (!buttons && !defaults) return schema;
+  const s = schema as Record<string, any>;
+  const out: Record<string, any> = { ...s };
+  if (buttons?.submit?.show !== undefined && s.showSubmit === undefined) out.showSubmit = buttons.submit.show;
+  if (buttons?.submit?.label != null && s.submitText === undefined) out.submitText = buttons.submit.label;
+  if (buttons?.cancel?.show !== undefined && s.showCancel === undefined) out.showCancel = buttons.cancel.show;
+  if (buttons?.cancel?.label != null && s.cancelText === undefined) out.cancelText = buttons.cancel.label;
+  if (buttons?.reset?.show !== undefined && s.showReset === undefined) out.showReset = buttons.reset.show;
+  if (defaults && s.initialValues === undefined) out.initialValues = defaults;
+  return out as ObjectFormProps['schema'];
+}
+
+/**
  * ObjectForm Component
- * 
+ *
  * Renders a form for an ObjectQL object with automatic schema integration.
- * 
+ *
  * @example
  * ```tsx
  * <ObjectForm
@@ -84,15 +113,23 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
   // (Tabbed/Wizard/Split/Drawer/Modal/Simple) transparently honour FLS.
   // Fail-open when no provider mounted (perms.isLoaded false).
   const schema = useMemo<ObjectFormProps['schema']>(() => {
+    // framework#1894 / #2998 (ADR-0078): the authored @objectstack/spec
+    // FormViewSchema carries the structured `buttons.{submit,cancel,reset}.
+    // {show,label}` + `defaults` surface, but this renderer historically read
+    // only the flat `showSubmit`/`submitText`/…/`initialValues`. Fold the
+    // structured shape down onto those flat props FIRST so every downstream
+    // read (and every variant we dispatch `schema` into) sees it. An
+    // explicitly-set flat key still wins (deprecated back-compat).
+    const folded = foldFormButtons(rawSchema);
     // #2545: spec FormViewSchema defines `groups` as a legacy alias of
     // `sections`, and this renderer only ever consumes `sections` — normalize
-    // FIRST so groups-only metadata actually renders (it used to be silently
+    // so groups-only metadata actually renders (it used to be silently
     // ignored). Legacy shape maps `title`→`label`, `defaultCollapsed`→`collapsed`.
-    const legacyGroups = (rawSchema as any).groups;
+    const legacyGroups = (folded as any).groups;
     const base: ObjectFormProps['schema'] =
-      !rawSchema.sections?.length && Array.isArray(legacyGroups) && legacyGroups.length
+      !folded.sections?.length && Array.isArray(legacyGroups) && legacyGroups.length
         ? {
-            ...rawSchema,
+            ...folded,
             sections: legacyGroups.map((g: any) => ({
               label: g.title ?? g.label,
               description: g.description,
@@ -101,7 +138,7 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
               fields: g.fields ?? [],
             })),
           }
-        : rawSchema;
+        : folded;
     if (!perms?.isLoaded) return base;
     const gateField = (f: any) => {
       if (!f?.name) return f;

--- a/packages/plugin-form/src/__tests__/formButtonsDefaults.test.tsx
+++ b/packages/plugin-form/src/__tests__/formButtonsDefaults.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * ObjectForm structured `buttons` / `defaults` fold (framework#1894 / #2998).
+ *
+ * `@objectstack/spec` FormViewSchema declares the structured
+ * `buttons.{submit,cancel,reset}.{show,label}` + `defaults` authoring surface,
+ * but ObjectForm reads flat `showSubmit`/`submitText`/…/`initialValues`. These
+ * tests lock in the fold that reconciles the two — the objectui-side consumer
+ * that lets the two spec keys flip `experimental → live` in the liveness ledger
+ * — and its precedence (an explicitly-set flat key still wins).
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectForm } from '../ObjectForm';
+
+registerAllFields();
+
+function buildMockDataSource() {
+  return {
+    create: vi.fn(async (_obj: string, data: Record<string, unknown>) => ({ id: '1', ...data })),
+    update: vi.fn(),
+    delete: vi.fn(),
+    findOne: vi.fn(),
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    getObjectSchema: vi.fn(async (name: string) => ({
+      name,
+      label: name,
+      fields: {
+        name: { type: 'text', label: 'Name' },
+        status: { type: 'text', label: 'Status' },
+      },
+    })),
+  } as any;
+}
+
+describe('ObjectForm buttons/defaults fold (framework#1894 / #2998)', () => {
+  it('uses buttons.submit.label as the submit button text', async () => {
+    render(
+      <ObjectForm
+        schema={{
+          type: 'object-form',
+          objectName: 'lead',
+          mode: 'create',
+          fields: ['name'],
+          buttons: { submit: { label: 'Save it' } },
+        } as any}
+        dataSource={buildMockDataSource()}
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Save it' })).toBeTruthy();
+  });
+
+  it('applies defaults as create-mode initial values', async () => {
+    render(
+      <ObjectForm
+        schema={{
+          type: 'object-form',
+          objectName: 'lead',
+          mode: 'create',
+          fields: ['name', 'status'],
+          defaults: { status: 'open' },
+        } as any}
+        dataSource={buildMockDataSource()}
+      />,
+    );
+
+    expect(await screen.findByDisplayValue('open')).toBeTruthy();
+  });
+
+  it('lets an explicitly-set flat key win over the structured buttons block', async () => {
+    render(
+      <ObjectForm
+        schema={{
+          type: 'object-form',
+          objectName: 'lead',
+          mode: 'create',
+          fields: ['name'],
+          submitText: 'Flat Wins',
+          buttons: { submit: { label: 'Structured' } },
+        } as any}
+        dataSource={buildMockDataSource()}
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Flat Wins' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Structured' })).toBeNull();
+  });
+});

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -901,6 +901,11 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
       cancelText: schema.form?.cancelText,
       showReset: schema.form?.showReset,
       initialValues: schema.form?.initialValues,
+      // framework#1894 / #2998: forward the spec-aligned structured
+      // `buttons`/`defaults`; ObjectForm folds them onto the flat props above
+      // (an explicitly-set flat key still wins).
+      buttons: schema.form?.buttons,
+      defaults: schema.form?.defaults,
       readOnly: schema.form?.readOnly || formMode === 'view',
       className: schema.form?.className,
       // Master-detail by config: a form view can declare inline child

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1046,9 +1046,35 @@ export interface ObjectFormSchema extends BaseSchema {
   
   /**
    * Initial values (for create mode)
+   *
+   * @deprecated Prefer the spec-aligned {@link defaults}. Kept as back-compat:
+   * ObjectForm folds `defaults` into this at render, and an explicitly-set
+   * `initialValues` still wins.
    */
   initialValues?: Record<string, any>;
-  
+
+  /**
+   * Structured, spec-aligned form action-button config — the authoring surface
+   * for submit/cancel/reset visibility + labels, mirroring `@objectstack/spec`
+   * `FormViewSchema.buttons` (framework#1894 / #2998). ObjectForm normalizes
+   * this down onto the flat `showSubmit`/`submitText`/`showCancel`/`cancelText`/
+   * `showReset` props at render, so prefer this over those flat keys (which
+   * remain only as deprecated back-compat). An explicitly-set flat key wins.
+   */
+  buttons?: {
+    submit?: { show?: boolean; label?: string };
+    cancel?: { show?: boolean; label?: string };
+    reset?: { show?: boolean; label?: string };
+  };
+
+  /**
+   * Create-mode initial field values, keyed by field machine name — the
+   * spec-aligned alias of the deprecated flat {@link initialValues}, mirroring
+   * `@objectstack/spec` `FormViewSchema.defaults` (framework#1894 / #2998).
+   * ObjectForm folds this into `initialValues` at render.
+   */
+  defaults?: Record<string, any>;
+
   /**
    * Callback on successful submission
    */


### PR DESCRIPTION
## What

Teaches the form renderer to consume the structured, spec-aligned
`FormViewSchema.buttons` / `FormViewSchema.defaults` surface from `@objectstack/spec`.

The authored spec carries `buttons.{submit,cancel,reset}.{show,label}` and
`defaults` (create-mode initial values), but `ObjectForm` only ever read the
flat renderer-invented `showSubmit`/`submitText`/`showCancel`/`cancelText`/
`showReset`/`initialValues`. That left the two spec keys parsed-but-inert
(ADR-0078) and stuck at `experimental` in the spec liveness ledger.

## How

- **`@object-ui/types`** — add optional `buttons` / `defaults` to
  `ObjectFormSchema`; mark the flat `initialValues` deprecated in favor of `defaults`.
- **`ObjectForm`** — a new `foldFormButtons()` runs inside the existing schema
  normalization pass and folds the structured shape down onto the flat props the
  component (and every variant it dispatches into) already read. Returns the
  input untouched when neither key is present (no hot-path allocation). An
  explicitly-set flat key still wins, so metadata authored against the deprecated
  flat keys is unchanged.
- **`ObjectView` + `RecordFormPage`** — forward `buttons`/`defaults` from the
  spec form view so both entry paths honor them.

This is the objectui-side consumer that lets the framework flip the two ledger
entries `experimental → live` (paired PR: objectstack-ai/objectstack — closes
the `view` item of objectstack-ai/objectstack#1894).

## Testing

- New `formButtonsDefaults.test.tsx` (3 cases): `buttons.submit.label` becomes
  the submit text; `defaults` seed create-mode initial values; an explicit flat
  key wins over the structured block.
- `type-check` green across `@object-ui/types`, `plugin-form`, `plugin-view`,
  `app-shell` (turbo, deps built).
- Full `plugin-form` + `plugin-view` DOM suite green (118 tests, no regression).

Refs objectstack-ai/objectstack#1894, objectstack-ai/objectstack#2998, #2545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMaDBhnZEUu1fcw8Rvo6Yq)_