### PR TITLE
fix(i18n): 补齐记录详情审批按钮与弹窗的国际化文案

### DIFF
--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1947,6 +1947,14 @@ const ar = {
       yearsAgo: "منذ {{count}} سنة(سنوات)",
     },
   },
+  approvals: {
+    approve: 'الموافقة',
+    reject: 'رفض',
+    comment: 'تعليق (اختياري)',
+    approveSuccess: 'تمت الموافقة',
+    rejectSuccess: 'تم الرفض',
+    rejectConfirm: 'هل تريد رفض طلب الموافقة هذا؟',
+  },
   approvalsInbox: {
     loadMore: 'تحميل المزيد',
     loadingMore: 'جارٍ التحميل…',

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1949,6 +1949,14 @@ const de = {
       yearsAgo: "vor {{count}} Jahren",
     },
   },
+  approvals: {
+    approve: 'Genehmigen',
+    reject: 'Ablehnen',
+    comment: 'Kommentar (optional)',
+    approveSuccess: 'Genehmigt',
+    rejectSuccess: 'Abgelehnt',
+    rejectConfirm: 'Diese Genehmigungsanfrage ablehnen?',
+  },
   approvalsInbox: {
     loadMore: 'Mehr laden',
     loadingMore: 'Lädt…',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -2488,6 +2488,14 @@ const en = {
         yearsAgo: '{{count}}y ago',
       },
     },
+  approvals: {
+    approve: 'Approve',
+    reject: 'Reject',
+    comment: 'Comment (optional)',
+    approveSuccess: 'Approved',
+    rejectSuccess: 'Rejected',
+    rejectConfirm: 'Reject this approval request?',
+  },
   approvalsInbox: {
     loadMore: 'Load more',
     loadingMore: 'Loading…',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1949,6 +1949,14 @@ const es = {
       yearsAgo: "hace {{count}} años",
     },
   },
+  approvals: {
+    approve: 'Aprobar',
+    reject: 'Rechazar',
+    comment: 'Comentario (opcional)',
+    approveSuccess: 'Aprobado',
+    rejectSuccess: 'Rechazado',
+    rejectConfirm: '¿Rechazar esta solicitud de aprobación?',
+  },
   approvalsInbox: {
     loadMore: 'Cargar más',
     loadingMore: 'Cargando…',

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1947,6 +1947,14 @@ const fr = {
       yearsAgo: "il y a {{count}} ans",
     },
   },
+  approvals: {
+    approve: 'Approuver',
+    reject: 'Rejeter',
+    comment: 'Commentaire (facultatif)',
+    approveSuccess: 'Approuvé',
+    rejectSuccess: 'Rejeté',
+    rejectConfirm: 'Rejeter cette demande d’approbation ?',
+  },
   approvalsInbox: {
     loadMore: 'Charger plus',
     loadingMore: 'Chargement…',

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1949,6 +1949,14 @@ const ja = {
       yearsAgo: "{{count}}年前",
     },
   },
+  approvals: {
+    approve: '承認',
+    reject: '却下',
+    comment: 'コメント(任意)',
+    approveSuccess: '承認しました',
+    rejectSuccess: '却下しました',
+    rejectConfirm: 'この承認リクエストを却下しますか?',
+  },
   approvalsInbox: {
     loadMore: 'さらに読み込む',
     loadingMore: '読み込み中…',

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1949,6 +1949,14 @@ const ko = {
       yearsAgo: "{{count}}년 전",
     },
   },
+  approvals: {
+    approve: '승인',
+    reject: '반려',
+    comment: '의견(선택 사항)',
+    approveSuccess: '승인됨',
+    rejectSuccess: '반려됨',
+    rejectConfirm: '이 승인 요청을 반려하시겠습니까?',
+  },
   approvalsInbox: {
     loadMore: '더 보기',
     loadingMore: '불러오는 중…',

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1947,6 +1947,14 @@ const pt = {
       yearsAgo: "há {{count}} anos",
     },
   },
+  approvals: {
+    approve: 'Aprovar',
+    reject: 'Rejeitar',
+    comment: 'Comentário (opcional)',
+    approveSuccess: 'Aprovado',
+    rejectSuccess: 'Rejeitado',
+    rejectConfirm: 'Rejeitar esta solicitação de aprovação?',
+  },
   approvalsInbox: {
     loadMore: 'Carregar mais',
     loadingMore: 'Carregando…',

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1947,6 +1947,14 @@ const ru = {
       yearsAgo: "{{count}} лет назад",
     },
   },
+  approvals: {
+    approve: 'Утвердить',
+    reject: 'Отклонить',
+    comment: 'Комментарий (необязательно)',
+    approveSuccess: 'Утверждено',
+    rejectSuccess: 'Отклонено',
+    rejectConfirm: 'Отклонить этот запрос на согласование?',
+  },
   approvalsInbox: {
     loadMore: 'Загрузить ещё',
     loadingMore: 'Загрузка…',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -2562,6 +2562,14 @@ const zh = {
         yearsAgo: '{{count}} 年前',
       },
     },
+  approvals: {
+    approve: '批准',
+    reject: '驳回',
+    comment: '审批意见(可选)',
+    approveSuccess: '已批准',
+    rejectSuccess: '已驳回',
+    rejectConfirm: '确定驳回该审批请求吗?',
+  },
   approvalsInbox: {
     loadMore: '加载更多',
     loadingMore: '加载中…',


### PR DESCRIPTION
## 问题
记录详情页在当前用户是待审批人时,会注入 **Approve / Reject** 两个操作按钮(`RecordDetailView.tsx`)。按钮及相关弹窗的文案取自 `t('approvals.*')` key,但这些 key **在所有语言包里都不存在**,i18n 回退到英文 `defaultValue` —— 中文界面因此显示成英文 "Approve" / "Reject"。

## 改动
在全部 10 个内置语言包(`packages/i18n/src/locales`)新增顶层 `approvals` 命名空间,补齐 6 个 key:

| Key | 用途 | 中文 |
|---|---|---|
| `approve` | 批准按钮 | 批准 |
| `reject` | 驳回按钮 | 驳回 |
| `comment` | 弹窗意见输入框 label | 审批意见(可选) |
| `rejectConfirm` | 驳回确认弹窗 | 确定驳回该审批请求吗? |
| `approveSuccess` | 批准成功 toast | 已批准 |
| `rejectSuccess` | 驳回成功 toast | 已驳回 |

中文用词与状态阶段("02 已批准""03 已驳回")保持一致。

## 影响面
- 纯语言包数据新增,无逻辑/组件改动;无破坏性变更。
- 锁定条("审批中已锁定""撤回审批")本就走 `t('detail.*')`,已正常国际化,未改动。

## 验证
- `@object-ui/i18n` 测试全绿(89 passed),含 "all locales have the same top-level keys" 对齐校验。
- `tsc` 构建通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)