### PR TITLE
feat(app-shell): localize the automations flow designer & inspector (en-US + zh-CN)

### DIFF
--- a/.changeset/automations-flow-i18n.md
+++ b/.changeset/automations-flow-i18n.md
@@ -1,0 +1,26 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(app-shell): localize the automations flow designer & inspector (en-US + zh-CN)
+
+Comprehensive zh-CN localization of the metadata-admin automations surfaces —
+the visual Flow designer, node/edge inspector, validation, and the shared editor
+panels shown on the flow screen. Client-side per the platform's
+`translateMetadataType` precedent; en-US is unchanged (every zh overlay falls
+back to English, so unknown/plugin values are never hidden).
+
+- Flow designer: node palette (labels/hints/categories + Chinese search), canvas
+  chrome & tooltips, header pills incl. enum values, preview panels, run-history
+  & debug simulator, nested-region tray, and localized default labels for
+  newly-created nodes.
+- Node & edge inspectors: config-field labels / help / options / column headers
+  for the full engine-published `configSchema` field set (loop
+  `indexVariable`/`maxIterations`, http `durable`/`signingSecret`, connector flat
+  ids, notify's config fields, …), keyed off the raw node type so aliased types
+  localize correctly.
+- Structural + unknown-reference validation messages (canvas banner, Problems
+  panel, debug simulator) and the Problems-panel chrome.
+- Generic `SchemaForm` enum-option / raw-field-label localization used on the
+  flow property form, plus the History / Audit / References / Layered-diff panels
+  and the force-save dialog shown on the flow screen.

--- a/apps/console/src/preview-gallery.tsx
+++ b/apps/console/src/preview-gallery.tsx
@@ -80,6 +80,18 @@ const ORDER = [
   'email_template',
 ];
 
+/**
+ * Dev-harness locale override — `?locale=zh-CN` (or `#locale=zh-CN`) renders the
+ * designers in that locale so i18n coverage can be eyeballed / browser-tested
+ * without wiring the full console LocaleSwitcher. Defaults to English.
+ */
+function galleryLocale(): string {
+  if (typeof window === 'undefined') return 'en-US';
+  const q = new URLSearchParams(window.location.search).get('locale');
+  const h = window.location.hash.match(/locale=([a-zA-Z-]+)/)?.[1];
+  return q ?? h ?? 'en-US';
+}
+
 function DesignerCard({ type }: { type: string }) {
   const Preview = getMetadataPreview(type);
   const [draft, setDraft] = React.useState<Record<string, unknown>>(
@@ -93,6 +105,7 @@ function DesignerCard({ type }: { type: string }) {
     setDraft((d) => ({ ...d, ...patch }));
 
   const Inspector = selection ? getMetadataInspector(type) : undefined;
+  const locale = galleryLocale();
 
   return (
     <section className="scroll-mt-4" id={`designer-${type}`}>
@@ -127,7 +140,7 @@ function DesignerCard({ type }: { type: string }) {
               selection,
               onSelectionChange: setSelection,
               onPatch,
-              locale: 'en',
+              locale,
             })}
           </div>
           {Inspector && selection && (
@@ -141,7 +154,7 @@ function DesignerCard({ type }: { type: string }) {
                 onClearSelection: () => setSelection(null),
                 onSelectionChange: setSelection,
                 readOnly: false,
-                locale: 'en-US',
+                locale,
               })}
             </div>
           )}

--- a/apps/console/src/preview-gallery.tsx
+++ b/apps/console/src/preview-gallery.tsx
@@ -85,11 +85,14 @@ const ORDER = [
  * designers in that locale so i18n coverage can be eyeballed / browser-tested
  * without wiring the full console LocaleSwitcher. Defaults to English.
  */
-function galleryLocale(): string {
+function galleryLocale(): 'en-US' | 'zh-CN' {
   if (typeof window === 'undefined') return 'en-US';
   const q = new URLSearchParams(window.location.search).get('locale');
   const h = window.location.hash.match(/locale=([a-zA-Z-]+)/)?.[1];
-  return q ?? h ?? 'en-US';
+  const raw = q ?? h ?? '';
+  // Normalize to the metadata-admin SupportedLocale union so it satisfies the
+  // typed `locale` prop on the previews/inspectors.
+  return /^zh/i.test(raw) ? 'zh-CN' : 'en-US';
 }
 
 function DesignerCard({ type }: { type: string }) {

--- a/packages/app-shell/src/views/metadata-admin/AuditPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/AuditPanel.tsx
@@ -28,7 +28,7 @@ import type {
   MetadataClient,
   MetadataAuditEntry,
 } from '@object-ui/data-objectstack';
-import { t, type SupportedLocale } from './i18n';
+import { t, translateConsoleValue, type SupportedLocale } from './i18n';
 
 export interface AuditPanelProps {
   type: string;
@@ -44,7 +44,7 @@ function fmtTime(iso: string): string {
   return d.toLocaleString();
 }
 
-function outcomeBadge(outcome: MetadataAuditEntry['outcome']) {
+function outcomeBadge(outcome: MetadataAuditEntry['outcome'], locale?: SupportedLocale | string) {
   const map: Record<MetadataAuditEntry['outcome'], {
     label: string;
     cls: string;
@@ -72,7 +72,7 @@ function outcomeBadge(outcome: MetadataAuditEntry['outcome']) {
       className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${v.cls}`}
     >
       <v.Icon className="h-3 w-3" />
-      {v.label}
+      {translateConsoleValue('outcome', v.label, locale)}
     </span>
   );
 }
@@ -183,14 +183,14 @@ export function AuditPanel({
                   <td className="px-2 py-1.5">{ev.actor}</td>
                   <td className="px-2 py-1.5">
                     <Badge variant="outline" className="text-[10px]">
-                      {ev.operation}
+                      {translateConsoleValue('op', ev.operation, locale)}
                     </Badge>
                   </td>
-                  <td className="px-2 py-1.5">{outcomeBadge(ev.outcome)}</td>
+                  <td className="px-2 py-1.5">{outcomeBadge(ev.outcome, locale)}</td>
                   <td className="px-2 py-1.5">
                     {ev.lockState && ev.lockState !== 'none' ? (
                       <span className="font-mono text-[11px]">
-                        {ev.lockState}
+                        {translateConsoleValue('lock', ev.lockState, locale)}
                         {ev.lockOverridden ? ' *' : ''}
                       </span>
                     ) : (

--- a/packages/app-shell/src/views/metadata-admin/LayeredDiff.tsx
+++ b/packages/app-shell/src/views/metadata-admin/LayeredDiff.tsx
@@ -29,7 +29,7 @@ import {
 import { Badge, Switch } from '@object-ui/components';
 import { cn } from '@object-ui/components';
 import type { MetadataLayered } from '@object-ui/data-objectstack';
-import { t, tFormat, type SupportedLocale } from './i18n';
+import { t, tFormat, translateConsoleValue, type SupportedLocale } from './i18n';
 
 export interface LayeredDiffProps {
   layered: MetadataLayered<Record<string, unknown>> | null;
@@ -186,25 +186,25 @@ export function LayeredDiff({ layered, loading, locale }: LayeredDiffProps) {
         <TabsTrigger value="code">
           {t('engine.layers.code', locale)}
           <Badge variant="outline" className="ml-1.5 text-[10px]">
-            artifact
+            {translateConsoleValue('layer', 'artifact', locale)}
           </Badge>
         </TabsTrigger>
         <TabsTrigger value="overlay">
           {t('engine.layers.overlay', locale)}
           {hasOverlay ? (
             <Badge className="ml-1.5 text-[10px] bg-emerald-600 text-emerald-50">
-              {layered.overlayScope ?? 'set'}
+              {layered.overlayScope ?? translateConsoleValue('layer', 'set', locale)}
             </Badge>
           ) : (
             <Badge variant="outline" className="ml-1.5 text-[10px] text-muted-foreground">
-              none
+              {translateConsoleValue('layer', 'none', locale)}
             </Badge>
           )}
         </TabsTrigger>
         <TabsTrigger value="effective">
           {t('engine.layers.effective', locale)}
           <Badge variant="outline" className="ml-1.5 text-[10px]">
-            merged
+            {translateConsoleValue('layer', 'merged', locale)}
           </Badge>
         </TabsTrigger>
       </TabsList>

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -2422,7 +2422,7 @@ function MetadataResourceEditPageImpl({
             </SheetDescription>
           </SheetHeader>
           <div className="flex-1 min-h-0 overflow-auto p-4">
-            <ReferencesPanel refs={refs} loading={refsLoading} />
+            <ReferencesPanel refs={refs} loading={refsLoading} locale={locale} />
           </div>
         </SheetContent>
       </Sheet>
@@ -2468,6 +2468,7 @@ function MetadataResourceEditPageImpl({
                 type={type}
                 name={name}
                 client={client}
+                locale={locale}
                 onRollback={() => setReloadKey((k) => k + 1)}
                 rollbackLabel={t('engine.edit.rollback', locale)}
                 rollbackConfirm={(version) =>
@@ -2526,11 +2527,10 @@ function MetadataResourceEditPageImpl({
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-amber-600" />
-              Destructive change detected
+              {t('engine.edit.destructiveTitle', locale)}
             </DialogTitle>
             <DialogDescription>
-              The framework refused this save because it would drop or narrow
-              data already in use. Review the issues and confirm to override.
+              {t('engine.edit.destructiveDesc', locale)}
             </DialogDescription>
           </DialogHeader>
           <div className="max-h-[300px] overflow-auto space-y-2 my-2">
@@ -2549,14 +2549,14 @@ function MetadataResourceEditPageImpl({
           </div>
           <DialogFooter>
             <Button variant="ghost" onClick={() => setDestructiveIssues(null)}>
-              Cancel
+              {t('engine.cancel', locale)}
             </Button>
             <Button
               variant="destructive"
               onClick={() => doSave(true)}
               disabled={saving}
             >
-              {saving ? 'Forcing…' : 'Force save'}
+              {saving ? t('engine.edit.forcing', locale) : t('engine.edit.forceSave', locale)}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -2568,23 +2568,25 @@ function MetadataResourceEditPageImpl({
 function ReferencesPanel({
   refs,
   loading,
+  locale,
 }: {
   refs: MetadataReference[] | null;
   loading: boolean;
+  locale?: string;
 }) {
   if (loading || refs == null) {
     return (
       <div className="text-sm text-muted-foreground flex items-center gap-2">
-        <Loader2 className="h-4 w-4 animate-spin" /> Scanning references…
+        <Loader2 className="h-4 w-4 animate-spin" /> {t('engine.edit.refsScanning', locale)}
       </div>
     );
   }
   if (refs.length === 0) {
     return (
       <Empty>
-        <EmptyTitle>No references found</EmptyTitle>
+        <EmptyTitle>{t('engine.edit.refsEmptyTitle', locale)}</EmptyTitle>
         <EmptyDescription>
-          Nothing in the metadata graph points at this item. Safe to delete.
+          {t('engine.edit.refsEmptyDesc', locale)}
         </EmptyDescription>
       </Empty>
     );

--- a/packages/app-shell/src/views/metadata-admin/ResourceHistoryPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceHistoryPage.tsx
@@ -21,6 +21,7 @@ import { ArrowLeft, RefreshCw, Loader2, RotateCcw } from 'lucide-react';
 import { Button } from '@object-ui/components';
 import { Badge } from '@object-ui/components';
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
+import { t, translateConsoleValue, useMetadataLocale } from './i18n';
 import { PageShell } from './PageShell';
 import {
   useMetadataClient,
@@ -59,6 +60,7 @@ export function MetadataResourceHistoryPage({
   const name = nameProp ?? params.name ?? '';
   const navigate = useNavigate();
   const client = useMetadataClient();
+  const locale = useMetadataLocale();
   const { entries } = useMetadataTypes(client);
   const entry: RichMetadataTypeEntry | undefined = entries.find((t) => t.type === type);
 
@@ -69,8 +71,8 @@ export function MetadataResourceHistoryPage({
     <PageShell
       entry={entry ?? { type, label: type }}
       itemName={name}
-      subtitle="Version history"
-      stats={[{ label: 'Events', value: eventCount }]}
+      subtitle={t('engine.edit.historySubtitle', locale)}
+      stats={[{ label: t('engine.edit.historyEvents', locale), value: eventCount }]}
       actions={
         <>
           <Button
@@ -98,6 +100,7 @@ export function MetadataResourceHistoryPage({
           refreshKey={refreshKey}
           onCount={setEventCount}
           client={client}
+          locale={locale}
           onRollback={() => setRefreshKey((k) => k + 1)}
         />
       </div>
@@ -123,12 +126,15 @@ export function HistoryPanel({
   onRollback,
   rollbackConfirm,
   rollbackLabel,
+  locale,
 }: {
   type: string;
   name: string;
   refreshKey?: number;
   onCount?: (n: number) => void;
   client: ReturnType<typeof useMetadataClient>;
+  /** UI locale for the operation badges. */
+  locale?: string;
   /** Called after a successful rollback so the parent can refresh. */
   onRollback?: (version: number) => void;
   /** Confirmation message — defaults to a literal English string. */
@@ -206,10 +212,9 @@ export function HistoryPanel({
       )}
       {!loading && !error && events.length === 0 && (
         <Empty>
-          <EmptyTitle>No history yet</EmptyTitle>
+          <EmptyTitle>{t('engine.edit.historyEmptyTitle', locale)}</EmptyTitle>
           <EmptyDescription>
-            This item has never been edited via an overlay. The first save
-            will create the initial history record.
+            {t('engine.edit.historyEmptyDesc', locale)}
           </EmptyDescription>
         </Empty>
       )}
@@ -261,7 +266,7 @@ export function HistoryPanel({
                                   : 'bg-emerald-100 text-emerald-800 hover:bg-emerald-100')
                         }
                       >
-                        {String(op)}
+                        {translateConsoleValue('op', String(op), locale)}
                       </Badge>
                     )}
                     {ev.actor && (

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -57,7 +57,7 @@ import {
 } from '@object-ui/components';
 import { evaluatePredicate } from './predicate';
 import { WIDGETS, type WidgetContext } from './widgets';
-import { useMetadataLocale, t, tFormat, translateValidationMessage } from './i18n';
+import { useMetadataLocale, t, tFormat, translateValidationMessage, translateEnumOption, translateSchemaFieldLabel, translateSchemaFieldHelp } from './i18n';
 
 type JsonSchema = Record<string, any>;
 
@@ -840,8 +840,17 @@ function FieldRow({
   formData?: Record<string, unknown>;
   onChange: (v: unknown) => void;
 }) {
-  const label = (fieldSpec?.label as string | undefined) || (schema?.title as string) || prettify(name);
-  const description = (fieldSpec?.helpText as string | undefined) || (schema?.description as string | undefined);
+  const locale = useMetadataLocale();
+  // A curated client `fieldSpec.label` always wins; otherwise localize the raw
+  // schema title/description for known generic field names (e.g. the flow
+  // edge/node sub-forms), falling back to the schema's own English text.
+  const label =
+    (fieldSpec?.label as string | undefined) ||
+    translateSchemaFieldLabel(name, schema?.title as string | undefined, locale) ||
+    prettify(name);
+  const description =
+    (fieldSpec?.helpText as string | undefined) ||
+    translateSchemaFieldHelp(name, schema?.description as string | undefined, locale);
   const id = `mdf-${name}`;
 
   // Auto-infer widget from fieldSpec.type or schema
@@ -899,6 +908,7 @@ function FieldRow({
         </div>
         <FieldControl
           id={id}
+          fieldName={name}
           schema={schema}
           value={value}
           onChange={onChange}
@@ -930,6 +940,7 @@ function FieldRow({
       </div>
       <FieldControl
         id={id}
+        fieldName={name}
         schema={schema}
         value={value}
         onChange={onChange}
@@ -953,6 +964,7 @@ function FieldRow({
 
 function FieldControl({
   id,
+  fieldName,
   schema,
   value,
   onChange,
@@ -963,6 +975,8 @@ function FieldControl({
   formData,
 }: {
   id: string;
+  /** Machine field name — keys enum-option localization (e.g. flow `type`). */
+  fieldName?: string;
   schema: JsonSchema;
   value: unknown;
   onChange: (v: unknown) => void;
@@ -1190,7 +1204,7 @@ function FieldControl({
         <SelectContent>
           {enumValues.map((opt) => (
             <SelectItem key={String(opt)} value={String(opt)}>
-              {String(opt)}
+              {translateEnumOption(fieldName ?? '', String(opt), locale)}
             </SelectItem>
           ))}
         </SelectContent>
@@ -1537,6 +1551,7 @@ function RepeaterField({
                       <td key={s.field} className="p-1.5">
                         <FieldControl
                           id={`rep-${idx}-${s.field}`}
+                          fieldName={s.field}
                           schema={sub}
                           value={row?.[s.field]}
                           readOnly={readOnly || s.readonly}

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -538,6 +538,128 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.flowPalette.category.human': 'Human',
   'engine.flowPalette.category.integration': 'Integration',
   'engine.flowPalette.category.flow': 'Flow',
+  // Flow canvas chrome — toolbar, node affordances, banner (FlowCanvas /
+  // flow-canvas-parts). Node-type labels/hints live in the strings table too
+  // (engine.flowNode.*) but are resolved via translateNodeLabel/Hint so the
+  // server descriptor stays the source of truth in English.
+  'engine.flowCanvas.zoomOut': 'Zoom out',
+  'engine.flowCanvas.zoomIn': 'Zoom in',
+  'engine.flowCanvas.fit': 'Fit to view',
+  'engine.flowCanvas.canvas': 'Flow canvas',
+  'engine.flowCanvas.reveal': 'Reveal on canvas',
+  'engine.flowCanvas.moreErrors': '+{count} more…',
+  'engine.flowCanvas.insertNode': 'Insert node here',
+  'engine.flowCanvas.addConnected': 'Add connected node',
+  'engine.flowCanvas.addReviseLoop': 'Add revision loop (send back for revision)',
+  'engine.flowCanvas.addReviseLoopShort': 'Add revision loop',
+  'engine.flowCanvas.awaitingRevision': 'Awaiting Revision',
+  'engine.flowCanvas.collapseRegions': 'Collapse nested regions',
+  'engine.flowCanvas.expandRegions': 'Expand nested regions',
+  // Nested structured-region tray headers (FlowRegionView / extractRegions).
+  'engine.flowRegion.branchN': 'Branch {n}',
+  'engine.flowRegion.try': 'Try',
+  'engine.flowRegion.catch': 'Catch',
+  // Flow preview header — pills, panel toggles, empty states (FlowPreview).
+  'engine.flowPreview.emptyHint': 'Add nodes in the Form tab to see the flow preview.',
+  'engine.flowPreview.malformed': 'One of the flow nodes or edges is malformed.',
+  'engine.flowPreview.pill.trigger': 'Trigger',
+  'engine.flowPreview.pill.status': 'Status',
+  'engine.flowPreview.pill.runAs': 'Run as',
+  'engine.flowPreview.pill.onError': 'On error',
+  'engine.flowPreview.showVars': 'Show variables panel',
+  'engine.flowPreview.hideVars': 'Hide variables panel',
+  'engine.flowPreview.variables': 'Variables',
+  'engine.flowPreview.noVars': 'No variables declared.',
+  'engine.flowPreview.runsTitle': 'Run history from the automation engine',
+  'engine.flowPreview.runs': 'Runs',
+  'engine.flowPreview.problemsTitle': 'Validation problems',
+  'engine.flowPreview.problems': 'Problems',
+  'engine.flowPreview.debug': 'Debug',
+  // Flow run-history panel (FlowRunsPanel).
+  'engine.flowRuns.title': 'Runs',
+  'engine.flowRuns.refresh': 'Refresh run history',
+  'engine.flowRuns.unavailable':
+    'Run history unavailable — the automation engine is offline or this flow hasn’t been published.',
+  'engine.flowRuns.empty': 'No runs yet.',
+  'engine.flowRuns.noSteps': 'No step log recorded.',
+  'engine.flowRuns.iteration': 'Iteration',
+  'engine.flowRuns.iterationN': 'Iteration {n}',
+  'engine.flowRuns.branch': 'Branch',
+  'engine.flowRuns.branchN': 'Branch {n}',
+  'engine.flowRuns.try': 'Try',
+  'engine.flowRuns.catch': 'Catch',
+  'engine.flowRuns.status.completed': 'Completed',
+  'engine.flowRuns.status.failed': 'Failed',
+  'engine.flowRuns.status.paused': 'Paused',
+  'engine.flowRuns.status.running': 'Running',
+  'engine.flowRuns.status.cancelled': 'Cancelled',
+  // Flow debug simulator (FlowSimulatorPanel).
+  'engine.flowSim.run': 'Run',
+  'engine.flowSim.step': 'Step',
+  'engine.flowSim.continue': 'Continue',
+  'engine.flowSim.reset': 'Reset',
+  'engine.flowSim.add': 'Add',
+  'engine.flowSim.resumeBranch': 'Resume down the “{branch}” branch',
+  'engine.flowSim.screen': 'Screen',
+  'engine.flowSim.inputs': 'Inputs',
+  'engine.flowSim.setVariables': 'Set variables',
+  'engine.flowSim.setVariablesHint': 'Override or inject any variable (wins over inputs and mocks at start).',
+  'engine.flowSim.mockOutputs': 'Mock outputs',
+  'engine.flowSim.mockPlaceholder': 'mocked result (JSON)',
+  'engine.flowSim.variables': 'Variables',
+  'engine.flowSim.noVars': 'No variables set.',
+  'engine.flowSim.timeline': 'Timeline',
+  'engine.flowSim.namePlaceholder': 'name',
+  'engine.flowSim.valuePlaceholder': 'value',
+  'engine.flowSim.removeVariable': 'Remove variable',
+  'engine.flowSim.idleHint':
+    'Press Run to simulate, or Step to walk node by node. Side effects are mocked — no backend is called.',
+  'engine.flowSim.status.idle': 'idle',
+  'engine.flowSim.status.running': 'running',
+  'engine.flowSim.status.paused': 'paused',
+  'engine.flowSim.status.done': 'done',
+  'engine.flowSim.status.error': 'error',
+  // Structural flow validation (flow-sim-validate) — canvas banner, Problems
+  // panel, and the debug simulator.
+  'engine.flowValidate.nodeMissingId': 'A node is missing an id.',
+  'engine.flowValidate.duplicateNodeId': 'Duplicate node id "{id}".',
+  'engine.flowValidate.edgeSourceMissing': 'Edge source "{source}" does not exist.',
+  'engine.flowValidate.edgeTargetMissing': 'Edge target "{target}" does not exist.',
+  'engine.flowValidate.startHasIncoming': 'Start node has an incoming edge.',
+  'engine.flowValidate.multipleStart': 'Flow has {count} start nodes; expected one.',
+  'engine.flowValidate.noStartUsingRoot': 'No "start" node; using the only root node as the entry.',
+  'engine.flowValidate.noEntry': 'No entry node (every node has an incoming edge — the graph is fully cyclic).',
+  'engine.flowValidate.ambiguousEntry': 'Cannot determine a single entry node ({count} candidates). Add a "start" node.',
+  'engine.flowValidate.decisionMultipleDefaults': 'Decision "{id}" has {count} default branches.',
+  'engine.flowValidate.decisionNoBranches': 'Decision "{id}" has no outgoing branches.',
+  'engine.flowValidate.decisionNoDefault': 'Decision "{id}" has no default branch; it may dead-end when no condition matches.',
+  'engine.flowValidate.nodeUnreachable': 'Node "{id}" is unreachable from the entry.',
+  'engine.flowValidate.cycleDetected': 'Cycle detected ({cycle}). Mark the connection that closes the loop as a back-edge (Connection type → Back-edge) to declare an intentional revise/rework loop.',
+  // Unknown-reference (scope) warnings (flow-ref-check) — Problems panel + the
+  // inline expression-field warnings.
+  'engine.flowRef.unknownWithSuggestion': 'Unknown reference `{token}` — did you mean `{suggestion}`?',
+  'engine.flowRef.notInScope': '`{token}` is not a reference in scope at this step.',
+  'engine.flowRef.notInScopeMulti': 'Not in scope: {tokens}.',
+  // Problems panel (ProblemsPanel).
+  'engine.flowProblems.title': 'Problems',
+  'engine.flowProblems.empty': 'No problems — this flow is structurally valid.',
+  'engine.flowProblems.sourceSchema': 'schema',
+  'engine.flowProblems.sourceExpression': 'expression',
+  // References side panel (ResourceEditPage) empty state.
+  'engine.edit.refsScanning': 'Scanning references…',
+  'engine.edit.refsEmptyTitle': 'No references found',
+  'engine.edit.refsEmptyDesc': 'Nothing in the metadata graph points at this item. Safe to delete.',
+  // Destructive-change (force save) dialog (ResourceEditPage).
+  'engine.edit.destructiveTitle': 'Destructive change detected',
+  'engine.edit.destructiveDesc':
+    'The framework refused this save because it would drop or narrow data already in use. Review the issues and confirm to override.',
+  'engine.edit.forcing': 'Forcing…',
+  // History page / panel (ResourceHistoryPage).
+  'engine.edit.historySubtitle': 'Version history',
+  'engine.edit.historyEvents': 'Events',
+  'engine.edit.historyEmptyTitle': 'No history yet',
+  'engine.edit.historyEmptyDesc':
+    'This item has never been edited via an overlay. The first save will create the initial history record.',
   // Reorder buttons (used in InspectorShell header)
   'engine.inspector.reorder.up': 'Move up',
   'engine.inspector.reorder.down': 'Move down',
@@ -1914,6 +2036,168 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.flowPalette.category.human': '人工',
   'engine.flowPalette.category.integration': '集成',
   'engine.flowPalette.category.flow': '流程',
+  // Flow node types — resolved by translateNodeLabel/Hint. Present only in the
+  // zh table: for English the palette falls back to the engine descriptor's
+  // own name/description (the server-authoritative label), so built-in nodes
+  // read Chinese under zh-CN while plugin/unknown nodes gracefully fall back.
+  'engine.flowNode.start.label': '开始',
+  'engine.flowNode.create_record.label': '创建记录',
+  'engine.flowNode.create_record.hint': '向对象中插入一条新记录',
+  'engine.flowNode.http_request.label': 'HTTP 请求',
+  'engine.flowNode.map.label': '逐项映射',
+  'engine.flowNode.map.hint': '对集合逐项运行子流程(可暂停)',
+  'engine.flowNode.update_record.label': '更新记录',
+  'engine.flowNode.update_record.hint': '更新匹配条件的记录',
+  'engine.flowNode.get_record.label': '查询记录',
+  'engine.flowNode.get_record.hint': '从对象中查询记录',
+  'engine.flowNode.delete_record.label': '删除记录',
+  'engine.flowNode.delete_record.hint': '删除匹配条件的记录',
+  'engine.flowNode.decision.label': '条件分支',
+  'engine.flowNode.decision.hint': '根据条件分支执行',
+  'engine.flowNode.loop.label': '循环',
+  'engine.flowNode.loop.hint': '遍历集合',
+  'engine.flowNode.assignment.label': '设置变量',
+  'engine.flowNode.assignment.hint': '为流程变量赋值',
+  'engine.flowNode.parallel.label': '并行',
+  'engine.flowNode.parallel.hint': '并发执行多个分支,结束时汇合',
+  'engine.flowNode.try_catch.label': '异常捕获',
+  'engine.flowNode.try_catch.hint': '用错误处理与重试保护步骤',
+  'engine.flowNode.approval.label': '审批',
+  'engine.flowNode.approval.hint': '暂停等待人工决策',
+  'engine.flowNode.screen.label': '交互页面',
+  'engine.flowNode.screen.hint': '收集用户输入',
+  'engine.flowNode.http.label': 'HTTP 请求',
+  'engine.flowNode.http.hint': '调用外部 API',
+  'engine.flowNode.connector_action.label': '连接器',
+  'engine.flowNode.connector_action.hint': '执行集成动作',
+  'engine.flowNode.notify.label': '通知',
+  'engine.flowNode.notify.hint': '向用户发送外发通知',
+  'engine.flowNode.script.label': '脚本',
+  'engine.flowNode.script.hint': '运行自定义代码',
+  'engine.flowNode.subflow.label': '子流程',
+  'engine.flowNode.subflow.hint': '调用其他流程',
+  'engine.flowNode.wait.label': '等待',
+  'engine.flowNode.wait.hint': '等待事件或定时器',
+  'engine.flowNode.end.label': '结束',
+  'engine.flowNode.end.hint': '终止流程',
+  // Flow canvas chrome — toolbar, node affordances, banner.
+  'engine.flowCanvas.zoomOut': '缩小',
+  'engine.flowCanvas.zoomIn': '放大',
+  'engine.flowCanvas.fit': '适应视图',
+  'engine.flowCanvas.canvas': '流程画布',
+  'engine.flowCanvas.reveal': '在画布中定位',
+  'engine.flowCanvas.moreErrors': '还有 {count} 项…',
+  'engine.flowCanvas.insertNode': '在此处插入节点',
+  'engine.flowCanvas.addConnected': '添加后继节点',
+  'engine.flowCanvas.addReviseLoop': '添加退回修订环(退回重新修订)',
+  'engine.flowCanvas.addReviseLoopShort': '添加退回修订环',
+  'engine.flowCanvas.awaitingRevision': '等待修订',
+  'engine.flowCanvas.collapseRegions': '折叠嵌套区域',
+  'engine.flowCanvas.expandRegions': '展开嵌套区域',
+  // Nested structured-region tray headers.
+  'engine.flowRegion.branchN': '分支 {n}',
+  'engine.flowRegion.try': '尝试',
+  'engine.flowRegion.catch': '捕获',
+  // Flow preview header — pills, panel toggles, empty states.
+  'engine.flowPreview.emptyHint': '在“表单”标签页中添加节点即可查看流程预览。',
+  'engine.flowPreview.malformed': '某个流程节点或连线的格式有误。',
+  'engine.flowPreview.pill.trigger': '触发',
+  'engine.flowPreview.pill.status': '状态',
+  'engine.flowPreview.pill.runAs': '运行身份',
+  'engine.flowPreview.pill.onError': '出错时',
+  'engine.flowPreview.showVars': '显示变量面板',
+  'engine.flowPreview.hideVars': '隐藏变量面板',
+  'engine.flowPreview.variables': '变量',
+  'engine.flowPreview.noVars': '未声明变量。',
+  'engine.flowPreview.runsTitle': '来自自动化引擎的运行历史',
+  'engine.flowPreview.runs': '运行',
+  'engine.flowPreview.problemsTitle': '校验问题',
+  'engine.flowPreview.problems': '问题',
+  'engine.flowPreview.debug': '调试',
+  // Flow run-history panel.
+  'engine.flowRuns.title': '运行',
+  'engine.flowRuns.refresh': '刷新运行历史',
+  'engine.flowRuns.unavailable': '运行历史不可用 —— 自动化引擎已离线,或此流程尚未发布。',
+  'engine.flowRuns.empty': '暂无运行记录。',
+  'engine.flowRuns.noSteps': '未记录步骤日志。',
+  'engine.flowRuns.iteration': '迭代',
+  'engine.flowRuns.iterationN': '第 {n} 次迭代',
+  'engine.flowRuns.branch': '分支',
+  'engine.flowRuns.branchN': '分支 {n}',
+  'engine.flowRuns.try': '尝试',
+  'engine.flowRuns.catch': '捕获',
+  'engine.flowRuns.status.completed': '已完成',
+  'engine.flowRuns.status.failed': '失败',
+  'engine.flowRuns.status.paused': '已暂停',
+  'engine.flowRuns.status.running': '运行中',
+  'engine.flowRuns.status.cancelled': '已取消',
+  // Flow debug simulator.
+  'engine.flowSim.run': '运行',
+  'engine.flowSim.step': '单步',
+  'engine.flowSim.continue': '继续',
+  'engine.flowSim.reset': '重置',
+  'engine.flowSim.add': '添加',
+  'engine.flowSim.resumeBranch': '沿“{branch}”分支继续',
+  'engine.flowSim.screen': '交互页面',
+  'engine.flowSim.inputs': '输入',
+  'engine.flowSim.setVariables': '设置变量',
+  'engine.flowSim.setVariablesHint': '覆盖或注入任意变量(启动时优先于输入与模拟值)。',
+  'engine.flowSim.mockOutputs': '模拟输出',
+  'engine.flowSim.mockPlaceholder': '模拟结果(JSON)',
+  'engine.flowSim.variables': '变量',
+  'engine.flowSim.noVars': '未设置变量。',
+  'engine.flowSim.timeline': '时间线',
+  'engine.flowSim.namePlaceholder': '名称',
+  'engine.flowSim.valuePlaceholder': '值',
+  'engine.flowSim.removeVariable': '删除变量',
+  'engine.flowSim.idleHint': '点击“运行”进行模拟,或用“单步”逐节点执行。副作用均为模拟 —— 不会调用后端。',
+  'engine.flowSim.status.idle': '空闲',
+  'engine.flowSim.status.running': '运行中',
+  'engine.flowSim.status.paused': '已暂停',
+  'engine.flowSim.status.done': '完成',
+  'engine.flowSim.status.error': '错误',
+  // 连线(edge)Type 枚举值 —— 属性表单里的 SchemaForm 下拉(与画布连线检查器一致)。
+  'engine.enum.type.default': '普通',
+  'engine.enum.type.conditional': '条件',
+  'engine.enum.type.fault': '故障(错误路径)',
+  'engine.enum.type.back': '回边(退回修改环)',
+  // 流程结构校验(flow-sim-validate)—— 画布横幅、问题面板、调试模拟器。
+  'engine.flowValidate.nodeMissingId': '有节点缺少 id。',
+  'engine.flowValidate.duplicateNodeId': '重复的节点 id “{id}”。',
+  'engine.flowValidate.edgeSourceMissing': '连线的源节点 “{source}” 不存在。',
+  'engine.flowValidate.edgeTargetMissing': '连线的目标节点 “{target}” 不存在。',
+  'engine.flowValidate.startHasIncoming': '开始节点存在入边。',
+  'engine.flowValidate.multipleStart': '流程有 {count} 个开始节点;应只有一个。',
+  'engine.flowValidate.noStartUsingRoot': '没有“开始”节点;以唯一的根节点作为入口。',
+  'engine.flowValidate.noEntry': '没有入口节点(每个节点都有入边 —— 整个图是全环状)。',
+  'engine.flowValidate.ambiguousEntry': '无法确定唯一入口节点(有 {count} 个候选)。请添加一个“开始”节点。',
+  'engine.flowValidate.decisionMultipleDefaults': '条件分支 “{id}” 有 {count} 个默认分支。',
+  'engine.flowValidate.decisionNoBranches': '条件分支 “{id}” 没有出向分支。',
+  'engine.flowValidate.decisionNoDefault': '条件分支 “{id}” 没有默认分支;当无条件匹配时可能走入死路。',
+  'engine.flowValidate.nodeUnreachable': '节点 “{id}” 从入口不可达。',
+  'engine.flowValidate.cycleDetected': '检测到环({cycle})。将闭合该环的连线标记为回边(连接类型 → 回边)以声明这是有意的退回 / 返工环。',
+  // 未知引用(作用域)告警(flow-ref-check)—— 问题面板 + 表达式字段内联提示。
+  'engine.flowRef.unknownWithSuggestion': '未知引用 `{token}` —— 是否想用 `{suggestion}`?',
+  'engine.flowRef.notInScope': '`{token}` 在当前步骤的作用域中不是有效引用。',
+  'engine.flowRef.notInScopeMulti': '不在作用域内:{tokens}。',
+  // 问题面板(ProblemsPanel)。
+  'engine.flowProblems.title': '问题',
+  'engine.flowProblems.empty': '没有问题 —— 该流程结构有效。',
+  'engine.flowProblems.sourceSchema': '架构',
+  'engine.flowProblems.sourceExpression': '表达式',
+  // 引用关系侧栏(ResourceEditPage)空态。
+  'engine.edit.refsScanning': '正在扫描引用…',
+  'engine.edit.refsEmptyTitle': '未找到引用',
+  'engine.edit.refsEmptyDesc': '元数据图中没有任何项指向它,可以安全删除。',
+  // 破坏性变更(强制保存)对话框(ResourceEditPage)。
+  'engine.edit.destructiveTitle': '检测到破坏性变更',
+  'engine.edit.destructiveDesc': '框架拒绝了本次保存,因为它会丢弃或收窄正在使用的数据。请检查这些问题并确认以强制覆盖。',
+  'engine.edit.forcing': '强制保存中…',
+  // 历史页 / 面板(ResourceHistoryPage)。
+  'engine.edit.historySubtitle': '版本历史',
+  'engine.edit.historyEvents': '事件',
+  'engine.edit.historyEmptyTitle': '暂无历史',
+  'engine.edit.historyEmptyDesc': '此项从未通过覆盖层编辑过。首次保存将创建初始历史记录。',
   // Reorder buttons
   'engine.inspector.reorder.up': '上移',
   'engine.inspector.reorder.down': '下移',
@@ -2888,6 +3172,288 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.appNav.itemOther': '项',
 };
 
+/** Whether a locale resolves to Chinese (the only non-English catalog). */
+export function isZhLocale(locale?: SupportedLocale | string): boolean {
+  return (locale ?? '').toLowerCase().startsWith('zh');
+}
+
+/** zh-CN overrides for one flow-node config field. English is the fallback. */
+interface FlowFieldZh {
+  label?: string;
+  help?: string;
+  /** select option value → zh label. */
+  opts?: Record<string, string>;
+  /** objectList column key → zh label (+ nested option labels). */
+  cols?: Record<string, { label?: string; opts?: Record<string, string> }>;
+}
+
+/**
+ * zh-CN translations for the flow node inspector's config fields, keyed by the
+ * canonical node type then the field `id`. Consumed by
+ * `localizeFlowFields` (flow-node-config) at render, which overlays these onto
+ * the English field table AND the engine-published `configSchema` fields (they
+ * share field ids for built-in nodes). Any field/option absent here falls back
+ * to its English label, so plugin nodes stay readable. Placeholders (example
+ * literals like cron strings / URLs) are intentionally left in English.
+ */
+const FLOW_FIELD_ZH: Record<string, Record<string, FlowFieldZh>> = {
+  start: {
+    triggerType: {
+      label: '触发方式',
+      help: '流程何时启动。记录触发在数据变更时触发;定时触发按 cron 触发。',
+      opts: {
+        'record-after-create': '记录创建后',
+        'record-after-update': '记录更新后',
+        'record-before-update': '记录更新前',
+        'record-after-delete': '记录删除后',
+        'record-change': '记录变更(任意)',
+        schedule: '定时(cron)',
+        time_relative: '相对时间(日期扫描)',
+        manual: '手动 / 自动启动',
+        webhook: 'Webhook / API',
+        event: '平台事件',
+      },
+    },
+    objectName: { label: '对象', help: '记录 / 定时扫描触发的目标对象。' },
+    condition: {
+      label: '进入条件',
+      help: 'CEL 表达式 —— 仅当其为 true 时流程才运行(相对时间扫描时对每条匹配记录做门控)。留空则每次事件都运行。',
+    },
+    'schedule.expression': {
+      label: 'Cron 表达式',
+      help: 'Cron 表达式 —— 流程运行的时刻。相对时间扫描留空默认每日。',
+    },
+    'timeRelative.object': { label: '扫描对象', help: '每次运行被扫描的对象。' },
+    'timeRelative.dateField': { label: '日期字段', help: '与今天比较的日期 / 日期时间字段。' },
+    'timeRelative.withinDays': {
+      label: '天数范围内',
+      help: '范围模式:当日期在今天前后 N 天内时触发(负值 = 逾期回溯)。若用偏移天数则留空。',
+    },
+    'timeRelative.offsetDays': {
+      label: '偏移天数',
+      help: '偏移模式:当日期恰好等于今天 + 各偏移量时触发(如 60、30、7)。若用天数范围则留空。',
+    },
+    'timeRelative.filter': { label: '附加筛选', help: '与日期窗口做 AND 的可选筛选(如 status = active)。' },
+    'timeRelative.maxRecords': { label: '每次最多记录数', help: '每次扫描启动的记录数上限(默认 1000)。' },
+    criteria: { label: '进入条件(旧)', help: '旧字段 —— 建议使用“进入条件”(condition)。' },
+  },
+  end: {
+    outcome: { label: '结果' },
+    outputVariable: { label: '输出变量' },
+  },
+  decision: {
+    conditions: {
+      label: '分支',
+      help: '每个分支包含标签、CEL 表达式和目标节点。表达式为 “true” 的分支即默认 / else 路径。选择目标会接线该分支的出边(创建或更新),清空则断开该边。',
+      cols: { label: { label: '标签' }, expression: { label: '表达式' }, target: { label: '目标节点' } },
+    },
+    condition: { label: '单一条件', help: '旧的单分支条件(CEL)。建议使用上方“分支”;每条边的条件也可写在出边上。' },
+  },
+  assignment: {
+    assignments: { label: '赋值', help: '设置变量:每个键为一个变量,值为表达式或字面量。' },
+  },
+  loop: {
+    collection: { label: '集合', help: '解析为待遍历项的表达式。' },
+    iteratorVariable: { label: '当前项变量', help: '存放当前项的循环变量。' },
+    indexVariable: { label: '索引变量', help: '存放当前索引的可选循环变量。' },
+    maxIterations: { label: '最大迭代次数' },
+  },
+  map: {
+    collection: { label: '集合', help: '解析为待逐项处理数组的表达式。' },
+    flowName: { label: '每项子流程', help: '为每一项运行的子流程 —— 它可以暂停(如审批)。' },
+    iteratorVariable: { label: '当前项变量' },
+    itemObject: { label: '项对象', help: '当项为记录时,它们所属的对象(将每项暴露为子流程的记录)。' },
+    outputVariable: { label: '输出变量', help: '各项子流程的输出,按顺序收集。' },
+  },
+  create_record: {
+    objectName: { label: '对象' },
+    fields: { label: '字段值', help: '写入新记录的字段值。' },
+    outputVariable: { label: '输出变量' },
+  },
+  update_record: {
+    objectName: { label: '对象' },
+    filter: { label: '筛选', help: '标识待更新记录的字段 / 值对(如 id → {recordId})。' },
+    fields: { label: '字段值', help: '要写入的字段值。' },
+  },
+  delete_record: {
+    objectName: { label: '对象' },
+    filter: { label: '筛选', help: '标识待删除记录的字段 / 值对。' },
+  },
+  get_record: {
+    objectName: { label: '对象' },
+    filter: { label: '筛选', help: '待匹配的字段 / 值对(如 status → active)。像 {"$ne": null} 这样的运算符值会被保留。' },
+    limit: { label: '数量上限' },
+    outputVariable: { label: '输出变量' },
+  },
+  http_request: {
+    method: { label: '方法' },
+    url: { label: 'URL' },
+    headers: { label: '请求头', help: '请求头(如 Authorization、Content-Type)。' },
+    body: { label: '请求体', help: '请求负载(JSON 或表达式)。' },
+    outputVariable: { label: '输出变量' },
+    durable: { label: '持久化(异步)', help: '通过持久化队列即发即忘(异步投递)。' },
+    signingSecret: { label: '签名密钥', help: 'HMAC-SHA256 密钥 → 写入 X-Objectstack 签名请求头。' },
+    timeoutMs: { label: '超时(毫秒)' },
+  },
+  script: {
+    actionType: {
+      label: '动作类型',
+      help: '本步骤如何运行。原始脚本保持为“代码”。',
+      opts: { code: '代码', email: '邮件', sms: '短信', notification: '通知' },
+    },
+    template: { label: '模板', help: '消息模板 id。' },
+    recipients: { label: '收件人', help: '每行一个收件人(用户 id、字段引用或地址)。' },
+    variables: { label: '模板变量', help: '注入模板的值。' },
+    script: { label: '代码', help: '脚本主体(JS/TS)。' },
+    outputVariables: { label: '输出变量', help: '此脚本写回的变量名。' },
+    timeoutMs: { label: '超时(毫秒)' },
+  },
+  screen: {
+    title: { label: '标题', help: '显示在页面上方的标题。' },
+    description: { label: '描述', help: '正文文本。会插值 {var} 引用(如 {approval_path})。' },
+    fields: {
+      label: '字段',
+      help: '此页面收集的输入字段。留空则为纯消息页面。',
+      cols: {
+        name: { label: '名称' },
+        label: { label: '标签' },
+        type: { label: '类型' },
+        required: { label: '必填' },
+        visibleWhen: { label: '显示条件' },
+      },
+    },
+    waitForInput: {
+      label: '等待输入',
+      help: '即使没有字段也暂停以展示此页面(消息 / 确认)。无字段且关闭此项则为服务端直通。',
+    },
+    objectName: { label: '对象表单', help: '渲染该对象完整的新建 / 编辑表单(含主从),而非扁平字段列表。' },
+    idVariable: { label: '保存记录变量', help: '仅对象表单:绑定到已保存记录 id 的变量,供后续步骤使用。' },
+    mode: { label: '表单模式', help: '仅对象表单。', opts: { create: '新建', edit: '编辑' } },
+    defaults: { label: '表单默认值', help: '仅对象表单:预填值(如 account → {account_id})。' },
+  },
+  approval: {
+    approvers: {
+      label: '审批人',
+      help: '谁可以处理此步骤。为节点的出边打上 “approve” 和 “reject” 标签。',
+      cols: {
+        type: {
+          label: '类型',
+          opts: {
+            user: '用户',
+            position: '岗位',
+            org_membership_level: '组织成员(所有者 / 管理员 / 成员)',
+            team: '团队',
+            department: '部门',
+            manager: '上级',
+            field: '字段',
+            queue: '队列',
+          },
+        },
+        value: { label: '值' },
+        group: { label: '分组' },
+      },
+    },
+    behavior: {
+      label: '审批方式',
+      help: '多个审批人如何组合。任何一个拒绝在所有模式下都是否决。',
+      opts: {
+        first_response: '首个响应生效',
+        unanimous: '全员通过',
+        quorum: '法定人数(N 选 M)',
+        per_group: '分组会签(每组签核)',
+      },
+    },
+    minApprovals: { label: '最少审批数', help: '所需审批数 —— quorum 为总数,per_group 为每组。服务端会做钳制以防死锁。' },
+    lockRecord: { label: '锁定记录', help: '此节点待处理期间锁定触发记录,禁止编辑。' },
+    approvalStatusField: {
+      label: '状态字段',
+      help: '将请求状态(待审 / 通过 / 拒绝)镜像到的业务对象字段。应为只读。',
+    },
+    'escalation.enabled': { label: 'SLA 升级', help: '在超时内未做决策时升级。' },
+    'escalation.timeoutHours': { label: '超时(小时)' },
+    'escalation.action': {
+      label: '超时动作',
+      opts: { notify: '通知', reassign: '改派', auto_approve: '自动通过', auto_reject: '自动拒绝' },
+    },
+    'escalation.escalateTo': { label: '升级至' },
+    'escalation.notifySubmitter': { label: '通知提交人' },
+    maxRevisions: {
+      label: '最多退回次数',
+      help: '请求自动拒绝前的最多退回修订次数(0 表示禁用退回)。需要一条 “revise” 出边才生效。',
+    },
+  },
+  wait: {
+    'waitEventConfig.eventType': {
+      label: '等待类型',
+      opts: { timer: '定时器', signal: '信号', webhook: 'Webhook', manual: '手动', condition: '条件' },
+    },
+    'waitEventConfig.timerDuration': { label: '时长', help: 'ISO 8601 时长(如 PT1H、P3D)。' },
+    'waitEventConfig.signalName': { label: '信号名称' },
+    'waitEventConfig.timeoutMs': { label: '超时(毫秒)' },
+    'waitEventConfig.onTimeout': { label: '超时时', opts: { fail: '失败', continue: '继续' } },
+  },
+  subflow: {
+    flowName: { label: '流程' },
+    input: { label: '输入映射', help: '传给子流程输入变量的值。' },
+    outputVariable: { label: '输出变量' },
+    timeoutMs: { label: '超时(毫秒)' },
+  },
+  connector_action: {
+    // Client field ids carry the `connectorConfig.` block prefix; the engine's
+    // published configSchema uses flat ids — cover both so on/offline match.
+    'connectorConfig.connectorId': { label: '连接器' },
+    'connectorConfig.actionId': { label: '动作' },
+    'connectorConfig.input': { label: '输入', help: '连接器动作的映射输入。' },
+    connectorId: { label: '连接器', help: '已注册的连接器名称。' },
+    actionId: { label: '动作', help: '连接器声明的动作标识。' },
+    input: { label: '输入', help: '连接器动作的映射输入。' },
+    timeoutMs: { label: '超时(毫秒)' },
+  },
+  try_catch: {
+    errorVariable: { label: '错误变量', help: '在 catch 区域内绑定所捕获错误的变量。' },
+    retry: { label: '重试' },
+  },
+  // notify has no client field table (offline → Advanced JSON); these localize
+  // the engine-published configSchema fields shown when online.
+  notify: {
+    recipients: { label: '收件人', help: '接收通知的用户 id / 受众。' },
+    title: { label: '标题', help: '通知标题(别名:subject)。' },
+    message: { label: '内容', help: '通知正文(别名:body)。' },
+    channels: { label: '渠道', help: '扇出投递的渠道(默认站内)。' },
+    topic: { label: '主题', help: '事件主题(默认 "notify")。' },
+    severity: { label: '级别', help: 'info | warning | critical' },
+    sourceObject: { label: '来源对象', help: '通知所关联记录的对象名。' },
+    sourceId: { label: '来源记录', help: '通知链接到的记录 id。' },
+    actorId: { label: '触发用户', help: '引发该事件的用户 id。' },
+    url: { label: '链接 URL', help: '显式的点击跳转 URL;覆盖默认值。' },
+    payload: { label: '附加数据', help: '合并进模板输入的额外数据。' },
+  },
+  boundary_event: {
+    'boundaryConfig.attachedToNodeId': { label: '附加到', help: '此边界事件所监视的宿主节点。' },
+    'boundaryConfig.eventType': {
+      label: '事件类型',
+      opts: { error: '错误', timer: '定时器', signal: '信号', cancel: '取消' },
+    },
+    'boundaryConfig.interrupting': { label: '中断', help: '此事件触发时取消宿主活动。' },
+    'boundaryConfig.errorCode': { label: '错误码' },
+    'boundaryConfig.timerDuration': { label: '时长' },
+    'boundaryConfig.signalName': { label: '信号名称' },
+  },
+  legacy_action: {
+    action: { label: '动作' },
+    objectName: { label: '对象' },
+    recordId: { label: '记录' },
+    params: { label: '参数', help: '动作输入。值会自动定型:3 → 数字,true → 布尔。' },
+    fields: { label: '字段值' },
+    outputVariable: { label: '输出变量' },
+  },
+};
+
+/** zh-CN overrides for a flow config field, or `undefined` for an unknown one. */
+export function flowFieldZh(type: string, id: string): FlowFieldZh | undefined {
+  return FLOW_FIELD_ZH[type]?.[id];
+}
+
 function pickTable(
   locale: SupportedLocale | string | undefined,
 ): { types: Record<string, string>; domains: Record<string, string>; strings: Record<string, string> } {
@@ -2918,6 +3484,196 @@ export function translateMetadataDomain(
   locale?: SupportedLocale | string,
 ): string {
   return pickTable(locale).domains[domain] ?? domain;
+}
+
+/**
+ * Localized display label for a flow node type (palette + node cards).
+ *
+ * Mirrors {@link translateMetadataType}: the locale table wins for built-in
+ * node types (so they read Chinese under zh-CN), while the caller-supplied
+ * `fallback` — typically the engine descriptor's server-authoritative `name`,
+ * or the hardcoded NODE_PALETTE label offline — covers plugin / unknown types
+ * and the English locale (whose table intentionally carries no `flowNode.*`
+ * keys, keeping the server descriptor authoritative in English).
+ */
+export function translateNodeLabel(
+  type: string,
+  locale?: SupportedLocale | string,
+  fallback?: string,
+): string {
+  const localized = pickTable(locale).strings[`engine.flowNode.${type}.label`];
+  if (localized) return localized;
+  return fallback ?? type;
+}
+
+/** Localized one-line hint for a flow node type. See {@link translateNodeLabel}. */
+export function translateNodeHint(
+  type: string,
+  locale?: SupportedLocale | string,
+  fallback?: string,
+): string | undefined {
+  const localized = pickTable(locale).strings[`engine.flowNode.${type}.hint`];
+  if (localized) return localized;
+  return fallback;
+}
+
+/**
+ * zh-CN labels for the flow-level meta values shown in the canvas header pills
+ * (trigger type / status / run-as / on-error). Keyed by pill kind → raw value.
+ * English is a no-op (raw value shown), and any value not listed here falls
+ * back to its raw form — so this never hides an unexpected value.
+ */
+const FLOW_META_ZH: Record<string, Record<string, string>> = {
+  type: {
+    autolaunched: '自动启动',
+    record_change: '记录变更',
+    schedule: '定时',
+    time_relative: '相对时间',
+    screen: '交互页面',
+    api: 'API',
+    manual: '手动',
+    webhook: 'Webhook',
+    event: '平台事件',
+  },
+  status: { active: '启用', draft: '草稿', inactive: '停用' },
+  runAs: { user: '用户', system: '系统', owner: '记录所有者' },
+  onError: { stop: '停止', continue: '继续', rollback: '回滚', retry: '重试', fail: '失败' },
+};
+
+/** Localized display for a flow-level meta value (header pills). English = raw. */
+export function translateFlowMeta(
+  kind: 'type' | 'status' | 'runAs' | 'onError',
+  value: string,
+  locale?: SupportedLocale | string,
+): string {
+  if (!isZhLocale(locale)) return value;
+  return FLOW_META_ZH[kind]?.[value] ?? value;
+}
+
+/**
+ * zh-CN labels for the metadata-editor side panels' raw enum-ish values —
+ * History operation badges, Audit operation/outcome/lock-state, and the Layered
+ * diff tab badges. Shared by every metadata type (not flow-specific). English
+ * (and any value not listed) shows the raw value, so unknown ops never break.
+ */
+const CONSOLE_VALUE_ZH: Record<string, Record<string, string>> = {
+  op: {
+    create: '创建',
+    update: '更新',
+    delete: '删除',
+    tombstone: '已删除',
+    publish: '发布',
+    revert: '回滚',
+    save: '保存',
+    restore: '恢复',
+    rollback: '回滚',
+  },
+  outcome: { allowed: '允许', denied: '拒绝', forced: '强制' },
+  lock: { draft: '草稿', locked: '已锁定', published: '已发布', none: '无' },
+  layer: { artifact: '工件', none: '无', merged: '合并', set: '已设', overlay: '覆盖' },
+};
+
+/** Localized label for a metadata-editor side-panel value (English = raw). */
+export function translateConsoleValue(
+  group: 'op' | 'outcome' | 'lock' | 'layer',
+  value: string,
+  locale?: SupportedLocale | string,
+): string {
+  if (!isZhLocale(locale)) return value;
+  return CONSOLE_VALUE_ZH[group]?.[value] ?? value;
+}
+
+/** Schema-form enum field names that reuse the flow header meta value maps. */
+const ENUM_FIELD_TO_META: Record<string, keyof typeof FLOW_META_ZH> = {
+  type: 'type',
+  status: 'status',
+  runAs: 'runAs',
+  run_as: 'runAs',
+};
+
+/**
+ * Localized label for a raw JSON-Schema enum option in the metadata SchemaForm
+ * (e.g. the flow `type` picker: `autolaunched` → 自动启动). Keyed by field name
+ * so it's unambiguous; English (and any value not translated) shows the raw
+ * value, so unknown enums across the 27 metadata types are never hidden. Reuses
+ * {@link FLOW_META_ZH} for type/status/runAs, plus an `engine.enum.<field>.<value>`
+ * strings-table extension point for anything else.
+ */
+export function translateEnumOption(
+  fieldName: string,
+  value: string,
+  locale?: SupportedLocale | string,
+): string {
+  if (!isZhLocale(locale)) return value;
+  const kind = ENUM_FIELD_TO_META[fieldName];
+  if (kind && FLOW_META_ZH[kind]?.[value]) return FLOW_META_ZH[kind][value];
+  const direct = pickTable(locale).strings[`engine.enum.${fieldName}.${value}`];
+  if (direct) return direct;
+  // A `type` field can also hold a flow-NODE type (the node sub-form's type
+  // picker) — reuse the node label table so create_record → 创建记录 etc.
+  if (fieldName === 'type') {
+    const nodeLabel = pickTable(locale).strings[`engine.flowNode.${value}.label`];
+    if (nodeLabel) return nodeLabel;
+  }
+  return value;
+}
+
+/**
+ * Generic zh-CN labels for raw JSON-Schema fields the metadata SchemaForm
+ * renders without a client `fieldSpec.label` — chiefly the flow edge/node
+ * sub-forms (Source / Target / Condition / …). Names here have one unambiguous
+ * meaning across metadata types, so the zh label is universally correct; English
+ * (and any name not listed) keeps the schema's own title. Applied only as a
+ * fallback UNDER `fieldSpec.label`, so curated top-level forms are untouched.
+ */
+const SCHEMA_FIELD_LABEL_ZH: Record<string, string> = {
+  id: 'ID',
+  name: '名称',
+  label: '标签',
+  type: '类型',
+  description: '描述',
+  source: '源节点',
+  target: '目标节点',
+  condition: '条件',
+  isDefault: '默认',
+  nodes: '节点',
+  edges: '连线',
+  config: '配置',
+  outputVariable: '输出变量',
+};
+
+/** zh-CN help text for the unambiguous (edge-specific) raw schema fields. */
+const SCHEMA_FIELD_HELP_ZH: Record<string, string> = {
+  source: '源节点 ID',
+  target: '目标节点 ID',
+  condition: '用于分支的 CEL 布尔表达式',
+  isDefault: '当没有其他条件匹配时,将此连线标记为默认路径',
+};
+
+/** Localized label for a raw schema field (falls back to the schema title). */
+export function translateSchemaFieldLabel(
+  name: string,
+  fallback: string | undefined,
+  locale?: SupportedLocale | string,
+): string | undefined {
+  if (isZhLocale(locale)) {
+    const v = SCHEMA_FIELD_LABEL_ZH[name];
+    if (v) return v;
+  }
+  return fallback;
+}
+
+/** Localized help for a raw schema field (falls back to the schema description). */
+export function translateSchemaFieldHelp(
+  name: string,
+  fallback: string | undefined,
+  locale?: SupportedLocale | string,
+): string | undefined {
+  if (isZhLocale(locale)) {
+    const v = SCHEMA_FIELD_HELP_ZH[name];
+    if (v) return v;
+  }
+  return fallback;
 }
 
 export function t(key: string, locale?: SupportedLocale | string): string {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
@@ -248,7 +248,7 @@ export function FlowEdgeInspector({ selection, draft, onPatch, onClearSelection,
           : findUnknownRefs(conditionText(edge.condition), 'predicate', scopeRoots(scopeGroups.flatMap((g) => g.refs)));
         return unknown.length > 0 ? (
           <p className="text-[11px] leading-snug text-amber-600 dark:text-amber-400" role="note">
-            {describeUnknownRefs(unknown)}
+            {describeUnknownRefs(unknown, locale)}
           </p>
         ) : null;
       })()}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
@@ -219,7 +219,7 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
       )}
       {!exprIssue && unknownRefs.length > 0 && (
         <p className="text-[11px] leading-snug text-amber-600 dark:text-amber-400" role="note">
-          {describeUnknownRefs(unknownRefs)}
+          {describeUnknownRefs(unknownRefs, locale)}
         </p>
       )}
       {field.help && !exprIssue && unknownRefs.length === 0 && (

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
@@ -32,12 +32,14 @@ import {
 } from './_shared';
 import {
   fieldsForNodeType,
+  localizeFlowFields,
   isFieldVisible,
   getFieldValue,
   configKeyOf,
   FLOW_NODE_TYPE_OPTIONS,
   type FlowConfigField,
 } from './flow-node-config';
+import { translateNodeLabel } from '../i18n';
 import { jsonSchemaToFlowFields } from './json-schema-to-fields';
 import { applyDecisionBranches, syncDecisionEdgesByOrder, withBranchTargets } from './flow-decision-edges';
 import { useActionConfigSchemas } from '../previews/useFlowNodePalette';
@@ -138,8 +140,11 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
   const fields = React.useMemo(() => {
     const schema = node?.type ? configSchemas[node.type] : undefined;
     const serverFields = schema !== undefined ? jsonSchemaToFlowFields(schema) : null;
-    return serverFields ?? fieldsForNodeType(node?.type);
-  }, [configSchemas, node?.type]);
+    const resolved = serverFields ?? fieldsForNodeType(node?.type);
+    // Localize both the hardcoded table and the engine-published configSchema
+    // fields (they share field ids for built-in nodes); no-op for English.
+    return localizeFlowFields(node?.type, resolved, locale);
+  }, [configSchemas, node?.type, locale]);
   const config = asConfig(node);
   const visibleFields = fields.filter((f) => isFieldVisible(f, node, fields));
 
@@ -304,7 +309,7 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
       <InspectorSelectField
         label={t('engine.inspector.flowNode.type', locale)}
         value={node.type}
-        options={typeOptions.map((v) => ({ value: v, label: v }))}
+        options={typeOptions.map((v) => ({ value: v, label: translateNodeLabel(v, locale, v) }))}
         onCommit={(v) => patchNode({ type: v })}
         disabled={readOnly}
       />

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -22,7 +22,14 @@
  * `textarea` (script code, request body) and `keyValue` for flat object maps
  * (e.g. record field values, connector input). Deeply nested / array values
  * still fall back to the optional Advanced block.
+ *
+ * The field labels/help/options here are English (the source of truth). A zh-CN
+ * overlay lives in `../i18n` (FLOW_FIELD_ZH) and is applied at render by
+ * {@link localizeFlowFields} — which also localizes the engine-published
+ * `configSchema` fields, since built-in nodes share the same field ids.
  */
+
+import { flowFieldZh, isZhLocale } from '../i18n';
 
 export type FlowConfigFieldKind =
   | 'text'
@@ -757,6 +764,57 @@ export function fieldsForNodeType(type?: string): FlowConfigField[] {
   if (!type) return [];
   const canonical = TYPE_ALIASES[type] ?? type;
   return FLOW_NODE_CONFIG[canonical] ?? [];
+}
+
+/** Overlay a column's zh label / option labels (English is the fallback). */
+function localizeColumn(
+  col: FlowConfigColumn,
+  cz: { label?: string; opts?: Record<string, string> } | undefined,
+): FlowConfigColumn {
+  if (!cz) return col;
+  const out: FlowConfigColumn = { ...col };
+  if (cz.label) out.label = cz.label;
+  if (col.options && cz.opts) {
+    out.options = col.options.map((o) => ({ ...o, label: cz.opts![o.value] ?? o.label }));
+  }
+  return out;
+}
+
+/** Overlay a field's zh label / help / option / column labels. The raw node
+ *  type wins over its alias, so a type with its OWN server field set (e.g.
+ *  `notify`, which aliases to `connector_action` for the offline client fields)
+ *  still gets its own translations. */
+function localizeField(rawType: string, canonicalType: string, field: FlowConfigField): FlowConfigField {
+  const z = flowFieldZh(rawType, field.id) ?? flowFieldZh(canonicalType, field.id);
+  if (!z) return field;
+  const out: FlowConfigField = { ...field };
+  if (z.label) out.label = z.label;
+  if (z.help) out.help = z.help;
+  if (field.options && z.opts) {
+    out.options = field.options.map((o) => ({ ...o, label: z.opts![o.value] ?? o.label }));
+  }
+  if (field.columns && z.cols) {
+    out.columns = field.columns.map((c) => localizeColumn(c, z.cols![c.key]));
+  }
+  return out;
+}
+
+/**
+ * Localize a resolved flow-field list for the active locale. English is a
+ * no-op (the table is authored in English); for zh-CN each field's label /
+ * help / options / column labels are overlaid from `FLOW_FIELD_ZH`, falling
+ * back to English for any field not covered (e.g. plugin nodes). Keyed by the
+ * canonical node type so it works for both the hardcoded table and the
+ * engine-published `configSchema` fields (which share field ids).
+ */
+export function localizeFlowFields(
+  type: string | undefined,
+  fields: FlowConfigField[],
+  locale?: string,
+): FlowConfigField[] {
+  if (!type || !isZhLocale(locale)) return fields;
+  const canonical = TYPE_ALIASES[type] ?? type;
+  return fields.map((f) => localizeField(type, canonical, f));
 }
 
 /** Read the current value at a field's node path, falling back to `fallbackPath`. */

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-ref-check.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-ref-check.ts
@@ -24,6 +24,7 @@
 
 import type { ExprFieldRole } from './expression-validate';
 import type { ScopeRef } from './flow-scope';
+import { tFormat } from '../i18n';
 
 /** CEL keywords / literals that are never flow references. */
 const CEL_RESERVED = new Set(['true', 'false', 'null', 'in']);
@@ -129,13 +130,13 @@ export function findUnknownRefs(source: unknown, role: ExprFieldRole, knownRoots
 }
 
 /** Build a one-line inspector warning from unknown refs (shared by the field
- *  and edge inspectors). */
-export function describeUnknownRefs(unknown: ReadonlyArray<UnknownRef>): string {
+ *  and edge inspectors). Localized; English (no locale) is the fallback. */
+export function describeUnknownRefs(unknown: ReadonlyArray<UnknownRef>, locale?: string): string {
   if (unknown.length === 1) {
     const u = unknown[0];
     return u.suggestion
-      ? `Unknown reference \`${u.token}\` — did you mean \`${u.suggestion}\`?`
-      : `\`${u.token}\` is not a reference in scope at this step.`;
+      ? tFormat('engine.flowRef.unknownWithSuggestion', locale, { token: u.token, suggestion: u.suggestion })
+      : tFormat('engine.flowRef.notInScope', locale, { token: u.token });
   }
-  return `Not in scope: ${unknown.map((u) => `\`${u.token}\``).join(', ')}.`;
+  return tFormat('engine.flowRef.notInScopeMulti', locale, { tokens: unknown.map((u) => `\`${u.token}\``).join(', ') });
 }

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -25,7 +25,7 @@ import * as React from 'react';
 import { AlertCircle, AlertTriangle, Maximize2, Plus, ZoomIn, ZoomOut } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import { uniqueId, appendArray, spliceArray } from '../inspectors/_shared';
-import { t as tr } from '../i18n';
+import { t as tr, tFormat } from '../i18n';
 import {
   computeLayoutWithGeometry,
   NODE_W,
@@ -254,7 +254,7 @@ export function FlowCanvas({
       if (!onPatch) return;
       const existing = nodes.map((n) => n.id).filter(Boolean) as string[];
       const id = uniqueId('node', existing);
-      const label = type === 'end' ? 'End' : defaultNodeLabel(type);
+      const label = defaultNodeLabel(type, locale);
       // Only an explicit `at` pins a manual position. A `from`-append is left
       // unpinned so the layered auto-layout slots it below its parent and
       // spaces it horizontally among siblings — pinning it directly under the
@@ -294,7 +294,7 @@ export function FlowCanvas({
       onSelect(newNode);
       setPaletteOpen(false);
     },
-    [edges, nodes, onPatch, onSelect, positionOf],
+    [edges, nodes, onPatch, onSelect, positionOf, locale],
   );
 
   /** Split edge A→B by inserting a new node N: A→N (keeps guard) + N→B. */
@@ -311,7 +311,7 @@ export function FlowCanvas({
       const newNode: FlowNode = {
         id,
         type,
-        label: defaultNodeLabel(type),
+        label: defaultNodeLabel(type, locale),
         ...defaultNodeExtras(type),
         ui: { x: at.x, y: at.y },
       };
@@ -326,7 +326,7 @@ export function FlowCanvas({
       onPatch({ nodes: appendArray(nodes, newNode), edges: appendArray(nextEdges, secondSegment) });
       onSelect(newNode);
     },
-    [edges, nodes, onPatch, onSelect, positionOf],
+    [edges, nodes, onPatch, onSelect, positionOf, locale],
   );
 
   /**
@@ -346,7 +346,7 @@ export function FlowCanvas({
       const waitNode: FlowNode = {
         id: waitId,
         type: 'wait',
-        label: 'Awaiting Revision',
+        label: tr('engine.flowCanvas.awaitingRevision', locale),
         // Signal-flavored wait: the submitter's resubmit signal resumes the run.
         waitEventConfig: { eventType: 'signal', signalName: 'revision', onTimeout: 'fail' },
       };
@@ -361,7 +361,7 @@ export function FlowCanvas({
       });
       onSelect(waitNode);
     },
-    [edges, nodes, onPatch, onSelect],
+    [edges, nodes, onPatch, onSelect, locale],
   );
 
   // Approval nodes that already declare a `revise` out-edge — used to hide the
@@ -556,7 +556,7 @@ export function FlowCanvas({
                 disabled={!clickable}
                 onPointerDown={(e) => e.stopPropagation()}
                 onClick={clickable ? (e) => { e.stopPropagation(); onRevealProblem!(p); } : undefined}
-                title={clickable ? 'Reveal on canvas' : undefined}
+                title={clickable ? tr('engine.flowCanvas.reveal', locale) : undefined}
                 className={cn(
                   'flex w-full items-start gap-1.5 rounded-lg border border-destructive/40 bg-destructive/10 px-2.5 py-1.5 text-left text-[11px] leading-snug text-destructive shadow-sm backdrop-blur-sm transition-colors',
                   clickable && 'cursor-pointer hover:border-destructive/60 hover:bg-destructive/20',
@@ -568,7 +568,7 @@ export function FlowCanvas({
             );
           })}
           {bannerErrors.length > 3 && (
-            <div className="px-2.5 text-[10px] text-destructive/80">+{bannerErrors.length - 3} more…</div>
+            <div className="px-2.5 text-[10px] text-destructive/80">{tFormat('engine.flowCanvas.moreErrors', locale, { count: bannerErrors.length - 3 })}</div>
           )}
         </div>
       )}
@@ -594,8 +594,8 @@ export function FlowCanvas({
         <div className="flex items-center rounded-lg border bg-background/90 shadow-sm backdrop-blur-sm">
           <button
             type="button"
-            title="Zoom out"
-            aria-label="Zoom out"
+            title={tr('engine.flowCanvas.zoomOut', locale)}
+            aria-label={tr('engine.flowCanvas.zoomOut', locale)}
             onClick={() => setZoom((z) => clampZoom(z - 0.15))}
             className="inline-flex h-7 w-7 items-center justify-center text-muted-foreground hover:text-foreground"
           >
@@ -606,8 +606,8 @@ export function FlowCanvas({
           </span>
           <button
             type="button"
-            title="Zoom in"
-            aria-label="Zoom in"
+            title={tr('engine.flowCanvas.zoomIn', locale)}
+            aria-label={tr('engine.flowCanvas.zoomIn', locale)}
             onClick={() => setZoom((z) => clampZoom(z + 0.15))}
             className="inline-flex h-7 w-7 items-center justify-center text-muted-foreground hover:text-foreground"
           >
@@ -615,8 +615,8 @@ export function FlowCanvas({
           </button>
           <button
             type="button"
-            title="Fit to view"
-            aria-label="Fit to view"
+            title={tr('engine.flowCanvas.fit', locale)}
+            aria-label={tr('engine.flowCanvas.fit', locale)}
             onClick={fitToView}
             className="inline-flex h-7 w-7 items-center justify-center border-l text-muted-foreground hover:text-foreground"
           >
@@ -630,7 +630,7 @@ export function FlowCanvas({
         ref={viewportRef}
         tabIndex={0}
         role="application"
-        aria-label="Flow canvas"
+        aria-label={tr('engine.flowCanvas.canvas', locale)}
         onKeyDown={onKeyDown}
         onPointerDown={onBgPointerDown}
         onPointerMove={(e) => {
@@ -843,8 +843,8 @@ export function FlowCanvas({
                     >
                       <button
                         type="button"
-                        title="Insert node here"
-                        aria-label="Insert node here"
+                        title={tr('engine.flowCanvas.insertNode', locale)}
+                        aria-label={tr('engine.flowCanvas.insertNode', locale)}
                         onPointerDown={(e) => e.stopPropagation()}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -868,6 +868,7 @@ export function FlowCanvas({
               <NodeCard
                 key={node.id}
                 id={node.id}
+                locale={locale}
                 type={node.type}
                 label={node.label || node.id}
                 summary={nodeSummary(node)}

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -34,8 +34,9 @@ import {
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell';
 import { uniqueId, appendArray } from '../inspectors/_shared';
-import { t as tr } from '../i18n';
+import { t as tr, translateFlowMeta } from '../i18n';
 import { FlowCanvas } from './FlowCanvas';
+import { defaultNodeLabel } from './flow-canvas-parts';
 import { edgeKey } from './flow-canvas-layout';
 import { NESTED_NODE_KIND, parseNestedNodeId, encodeNestedNodeId } from '../inspectors/flow-nested-selection';
 import { FlowSimulatorPanel } from './FlowSimulatorPanel';
@@ -108,8 +109,8 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
   // per-element badges, the red error ring/stroke, and the Problems panel.
   // Recomputed from the live draft so they all clear as the author fixes each issue.
   const problems = React.useMemo<FlowProblem[]>(
-    () => buildFlowProblems({ nodes, edges, serverDiagnostics: diagnostics, variables }),
-    [nodes, edges, diagnostics, d.variables],
+    () => buildFlowProblems({ nodes, edges, serverDiagnostics: diagnostics, variables, locale }),
+    [nodes, edges, diagnostics, d.variables, locale],
   );
   const errorCount = problems.filter((p) => p.level === 'error').length;
   // Red error ring/stroke derived from the same list (errors only; a cycle
@@ -144,11 +145,11 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
     // A flow's first node is its trigger — seed a `start` node (not a generic
     // `task`) so the canvas opens on the canonical entry point and the author
     // adds subsequent steps from there.
-    const newNode: FlowNode = { id: uniqueId('node', existingIds), type: 'start', label: 'Start' };
+    const newNode: FlowNode = { id: uniqueId('node', existingIds), type: 'start', label: defaultNodeLabel('start', locale) };
     const next = appendArray(nodes, newNode);
     onPatch!({ nodes: next });
     onSelectionChange?.({ kind: 'node', id: newNode.id, label: newNode.label || newNode.id });
-  }, [canEdit, nodes, onPatch, onSelectionChange]);
+  }, [canEdit, nodes, onPatch, onSelectionChange, locale]);
 
   // Run history needs the published flow name (the engine keys runs by it).
   const flowName = typeof d.name === 'string' && d.name ? d.name : '';
@@ -173,7 +174,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
             </button>
           </div>
         ) : (
-          <PreviewMessage>Add nodes in the Form tab to see the flow preview.</PreviewMessage>
+          <PreviewMessage>{tr('engine.flowPreview.emptyHint', locale)}</PreviewMessage>
         )}
       </PreviewShell>
     );
@@ -181,7 +182,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
 
   return (
     <PreviewShell hint={`flow · ${nodes.length} node${nodes.length === 1 ? '' : 's'}`}>
-      <PreviewErrorBoundary fallbackHint="One of the flow nodes or edges is malformed.">
+      <PreviewErrorBoundary fallbackHint={tr('engine.flowPreview.malformed', locale)}>
         <div className={
           'grid gap-0 h-full min-h-[440px] ' +
           (showDebug || showVars || showRuns || showProblems ? 'lg:grid-cols-[1fr_240px]' : 'grid-cols-1')
@@ -189,11 +190,11 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
           {/* Visual canvas */}
           <div className="flex flex-col min-w-0 min-h-0">
             <div className="rounded-none border-b bg-muted/30 px-3 py-2 text-xs flex flex-wrap items-center gap-x-4 gap-y-1">
-              <Pill icon={Zap} label="Trigger" value={flowType} />
-              <Pill icon={CircleDot} label="Status" value={status} tone={status === 'active' ? 'green' : status === 'draft' ? 'gray' : 'amber'} />
-              <Pill icon={Settings2} label="Run as" value={runAs} />
+              <Pill icon={Zap} label={tr('engine.flowPreview.pill.trigger', locale)} value={translateFlowMeta('type', flowType, locale)} />
+              <Pill icon={CircleDot} label={tr('engine.flowPreview.pill.status', locale)} value={translateFlowMeta('status', status, locale)} tone={status === 'active' ? 'green' : status === 'draft' ? 'gray' : 'amber'} />
+              <Pill icon={Settings2} label={tr('engine.flowPreview.pill.runAs', locale)} value={translateFlowMeta('runAs', runAs, locale)} />
               {version && <Pill label="v" value={version} />}
-              {errorStrategy && <Pill icon={GitBranch} label="On error" value={errorStrategy} />}
+              {errorStrategy && <Pill icon={GitBranch} label={tr('engine.flowPreview.pill.onError', locale)} value={translateFlowMeta('onError', errorStrategy, locale)} />}
               <div className="ml-auto flex items-center gap-1.5">
                 {!showDebug && !showRuns && !showProblems && (
                   <button
@@ -205,9 +206,9 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                         ? 'border-violet-500 bg-violet-50 text-violet-700'
                         : 'border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground')
                     }
-                    title={showVars ? 'Hide variables panel' : 'Show variables panel'}
+                    title={tr(showVars ? 'engine.flowPreview.hideVars' : 'engine.flowPreview.showVars', locale)}
                   >
-                    <PanelRight className="h-3 w-3" /> Variables
+                    <PanelRight className="h-3 w-3" /> {tr('engine.flowPreview.variables', locale)}
                   </button>
                 )}
                 {flowName && (
@@ -224,9 +225,9 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                         ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
                         : 'border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground')
                     }
-                    title="Run history from the automation engine"
+                    title={tr('engine.flowPreview.runsTitle', locale)}
                   >
-                    <History className="h-3 w-3" /> Runs
+                    <History className="h-3 w-3" /> {tr('engine.flowPreview.runs', locale)}
                   </button>
                 )}
                 <button
@@ -242,9 +243,9 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                       ? 'border-rose-500 bg-rose-50 text-rose-700'
                       : 'border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground')
                   }
-                  title="Validation problems"
+                  title={tr('engine.flowPreview.problemsTitle', locale)}
                 >
-                  <AlertCircle className="h-3 w-3" /> Problems
+                  <AlertCircle className="h-3 w-3" /> {tr('engine.flowPreview.problems', locale)}
                   {problems.length > 0 && (
                     <span
                       className={
@@ -270,7 +271,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                       : 'border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground')
                   }
                 >
-                  <Bug className="h-3 w-3" /> Debug
+                  <Bug className="h-3 w-3" /> {tr('engine.flowPreview.debug', locale)}
                 </button>
               </div>
             </div>
@@ -325,6 +326,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                 problems={problems}
                 selectedKey={selectedKey}
                 onSelectProblem={handleSelectProblem}
+                locale={locale}
               />
             </div>
           ) : showDebug ? (
@@ -333,20 +335,21 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
                 nodes={nodes}
                 edges={edges}
                 variables={variables}
+                locale={locale}
                 onRunStateChange={setRunHL}
               />
             </div>
           ) : showRuns && flowName ? (
             <div className="border-l bg-muted/20">
-              <FlowRunsPanel flowName={flowName} />
+              <FlowRunsPanel flowName={flowName} locale={locale} />
             </div>
           ) : showVars ? (
             <div className="border-l bg-muted/20 p-3 text-xs space-y-2">
             <div className="flex items-center gap-1.5 font-medium text-muted-foreground">
-              <Variable className="h-3 w-3" /> Variables
+              <Variable className="h-3 w-3" /> {tr('engine.flowPreview.variables', locale)}
             </div>
             {variables.length === 0 ? (
-              <div className="text-muted-foreground italic">No variables declared.</div>
+              <div className="text-muted-foreground italic">{tr('engine.flowPreview.noVars', locale)}</div>
             ) : (
               <ul className="space-y-1.5">
                 {variables.map((v, i) => (

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
@@ -20,6 +20,7 @@ import * as React from 'react';
 import { AlertCircle, CheckCircle2, ChevronDown, ChevronRight, Clock, Loader2, PauseCircle, RefreshCw, SkipForward } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import { apiBase } from './useFlowNodePalette';
+import { t as tr, tFormat } from '../i18n';
 
 /** An error on a run/step. The engine sends the run-level `error` as a plain
  *  string (`ExecutionLog.error`) while a step-level error is a `{code,message}`
@@ -120,18 +121,22 @@ export function buildStepTree(steps: RunStep[]): StepTreeNode[] {
  * carry a zero-based `iteration` surfaced 1-based; `try`/`catch` carry only the
  * region kind. Returns `null` for a top-level step (no region grouping).
  */
-export function regionLabel(step: RunStep): string | null {
+export function regionLabel(step: RunStep, locale?: string): string | null {
   const { regionKind, iteration } = step;
   if (!regionKind) return null;
   switch (regionKind) {
     case 'loop-body':
-      return iteration == null ? 'Iteration' : `Iteration ${iteration + 1}`;
+      return iteration == null
+        ? tr('engine.flowRuns.iteration', locale)
+        : tFormat('engine.flowRuns.iterationN', locale, { n: iteration + 1 });
     case 'parallel-branch':
-      return iteration == null ? 'Branch' : `Branch ${iteration + 1}`;
+      return iteration == null
+        ? tr('engine.flowRuns.branch', locale)
+        : tFormat('engine.flowRuns.branchN', locale, { n: iteration + 1 });
     case 'try':
-      return 'Try';
+      return tr('engine.flowRuns.try', locale);
     case 'catch':
-      return 'Catch';
+      return tr('engine.flowRuns.catch', locale);
     default:
       return iteration == null ? regionKind : `${regionKind} ${iteration + 1}`;
   }
@@ -145,13 +150,13 @@ function regionSignature(step: RunStep): string {
 
 /** Split a container's children into consecutive runs that share a region label
  *  (an iteration, a branch, a try/catch handler), so each gets one header. */
-function groupChildren(children: StepTreeNode[]): { label: string | null; items: StepTreeNode[] }[] {
+function groupChildren(children: StepTreeNode[], locale?: string): { label: string | null; items: StepTreeNode[] }[] {
   const groups: { label: string | null; items: StepTreeNode[] }[] = [];
   let sig: string | undefined;
   for (const child of children) {
     const s = regionSignature(child.step);
     if (groups.length === 0 || s !== sig) {
-      groups.push({ label: regionLabel(child.step), items: [child] });
+      groups.push({ label: regionLabel(child.step, locale), items: [child] });
       sig = s;
     } else {
       groups[groups.length - 1].items.push(child);
@@ -178,16 +183,20 @@ export async function fetchFlowRuns(flowName: string, signal?: AbortSignal): Pro
   }
 }
 
-const STATUS_META: Record<string, { icon: React.ComponentType<{ className?: string }>; cls: string; label: string }> = {
-  completed: { icon: CheckCircle2, cls: 'text-emerald-600 dark:text-emerald-400', label: 'Completed' },
-  failed: { icon: AlertCircle, cls: 'text-rose-600 dark:text-rose-400', label: 'Failed' },
-  paused: { icon: PauseCircle, cls: 'text-amber-600 dark:text-amber-400', label: 'Paused' },
-  running: { icon: Loader2, cls: 'text-sky-600 dark:text-sky-400', label: 'Running' },
-  cancelled: { icon: SkipForward, cls: 'text-muted-foreground', label: 'Cancelled' },
+const STATUS_META: Record<string, { icon: React.ComponentType<{ className?: string }>; cls: string; labelKey: string }> = {
+  completed: { icon: CheckCircle2, cls: 'text-emerald-600 dark:text-emerald-400', labelKey: 'engine.flowRuns.status.completed' },
+  failed: { icon: AlertCircle, cls: 'text-rose-600 dark:text-rose-400', labelKey: 'engine.flowRuns.status.failed' },
+  paused: { icon: PauseCircle, cls: 'text-amber-600 dark:text-amber-400', labelKey: 'engine.flowRuns.status.paused' },
+  running: { icon: Loader2, cls: 'text-sky-600 dark:text-sky-400', labelKey: 'engine.flowRuns.status.running' },
+  cancelled: { icon: SkipForward, cls: 'text-muted-foreground', labelKey: 'engine.flowRuns.status.cancelled' },
 };
 
-function statusMeta(status: string) {
-  return STATUS_META[status] ?? { icon: Clock, cls: 'text-muted-foreground', label: status };
+/** Resolve a run status to its icon, tone and localized label. Unknown statuses
+ *  fall back to the raw status string (no key). */
+function statusMeta(status: string, locale?: string) {
+  const meta = STATUS_META[status];
+  if (meta) return { icon: meta.icon, cls: meta.cls, label: tr(meta.labelKey, locale) };
+  return { icon: Clock, cls: 'text-muted-foreground', label: status };
 }
 
 function fmtTime(iso?: string): string {
@@ -245,8 +254,8 @@ function RegionHeader({ label, depth }: { label: string; depth: number }) {
 
 /** Render a step and, nested beneath it, its structured-region body steps —
  *  grouped by iteration / branch / handler (#1505). Recurses for nested regions. */
-function StepNode({ node, depth }: { node: StepTreeNode; depth: number }) {
-  const groups = node.children.length > 0 ? groupChildren(node.children) : [];
+function StepNode({ node, depth, locale }: { node: StepTreeNode; depth: number; locale?: string }) {
+  const groups = node.children.length > 0 ? groupChildren(node.children, locale) : [];
   return (
     <>
       <StepRow step={node.step} depth={depth} />
@@ -258,6 +267,7 @@ function StepNode({ node, depth }: { node: StepTreeNode; depth: number }) {
               key={`${child.step.nodeId}#${ci}`}
               node={child}
               depth={g.label != null ? depth + 2 : depth + 1}
+              locale={locale}
             />
           ))}
         </React.Fragment>
@@ -266,9 +276,9 @@ function StepNode({ node, depth }: { node: StepTreeNode; depth: number }) {
   );
 }
 
-function RunRow({ run }: { run: FlowRun }) {
+function RunRow({ run, locale }: { run: FlowRun; locale?: string }) {
   const [open, setOpen] = React.useState(false);
-  const meta = statusMeta(run.status);
+  const meta = statusMeta(run.status, locale);
   const Icon = meta.icon;
   const steps = Array.isArray(run.steps) ? run.steps : [];
   const runErr = errorText(run.error);
@@ -304,11 +314,11 @@ function RunRow({ run }: { run: FlowRun }) {
             <div className="pb-1 text-[10px] text-rose-600">{runErr}</div>
           )}
           {steps.length === 0 ? (
-            <div className="text-[10px] italic text-muted-foreground">No step log recorded.</div>
+            <div className="text-[10px] italic text-muted-foreground">{tr('engine.flowRuns.noSteps', locale)}</div>
           ) : (
             <ul>
               {buildStepTree(steps).map((node, i) => (
-                <StepNode key={`${node.step.nodeId}#${i}`} node={node} depth={0} />
+                <StepNode key={`${node.step.nodeId}#${i}`} node={node} depth={0} locale={locale} />
               ))}
             </ul>
           )}
@@ -318,7 +328,7 @@ function RunRow({ run }: { run: FlowRun }) {
   );
 }
 
-export function FlowRunsPanel({ flowName }: { flowName: string }) {
+export function FlowRunsPanel({ flowName, locale }: { flowName: string; locale?: string }) {
   const [runs, setRuns] = React.useState<FlowRun[]>([]);
   const [state, setState] = React.useState<LoadState>('loading');
   const [reloadKey, setReloadKey] = React.useState(0);
@@ -345,12 +355,12 @@ export function FlowRunsPanel({ flowName }: { flowName: string }) {
   return (
     <div className="flex h-full flex-col p-3 text-xs">
       <div className="flex items-center gap-1.5 pb-2 font-medium text-muted-foreground">
-        <Clock className="h-3 w-3" /> Runs
+        <Clock className="h-3 w-3" /> {tr('engine.flowRuns.title', locale)}
         <button
           type="button"
           onClick={() => setReloadKey((k) => k + 1)}
-          title="Refresh run history"
-          aria-label="Refresh run history"
+          title={tr('engine.flowRuns.refresh', locale)}
+          aria-label={tr('engine.flowRuns.refresh', locale)}
           className="ml-auto rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
         >
           <RefreshCw className={cn('h-3 w-3', state === 'loading' && 'animate-spin')} />
@@ -358,14 +368,14 @@ export function FlowRunsPanel({ flowName }: { flowName: string }) {
       </div>
       {state === 'unavailable' ? (
         <div className="italic text-muted-foreground">
-          Run history unavailable — the automation engine is offline or this flow hasn’t been published.
+          {tr('engine.flowRuns.unavailable', locale)}
         </div>
       ) : state === 'ready' && runs.length === 0 ? (
-        <div className="italic text-muted-foreground">No runs yet.</div>
+        <div className="italic text-muted-foreground">{tr('engine.flowRuns.empty', locale)}</div>
       ) : (
         <ul className="min-h-0 flex-1 space-y-1.5 overflow-y-auto">
           {runs.map((r) => (
-            <RunRow key={r.id} run={r} />
+            <RunRow key={r.id} run={r} locale={locale} />
           ))}
         </ul>
       )}

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.tsx
@@ -10,6 +10,7 @@
 import * as React from 'react';
 import { Play, StepForward, RotateCcw, ChevronRight, AlertTriangle, CircleAlert, Plus, Trash2 } from 'lucide-react';
 import { Button, Input, Label, cn } from '@object-ui/components';
+import { t as tr, tFormat } from '../i18n';
 import { FlowSimulator } from './simulator/flow-simulator';
 import { ScreenPreview } from './ScreenPreview';
 import type { FlowValidation, SimEdge, SimNode, SimState, SimStep } from './simulator/flow-sim-types';
@@ -25,6 +26,8 @@ export interface FlowSimulatorPanelProps {
   nodes: SimNode[];
   edges: SimEdge[];
   variables: FlowVariableDecl[];
+  /** UI locale for the panel's labels and hints. */
+  locale?: string;
   onRunStateChange?: (s: { activeNodeId: string | null; visitedNodeIds: string[]; traversedEdgeIds: string[] } | null) => void;
 }
 
@@ -88,7 +91,7 @@ const STATUS_TONE: Record<SimStep['status'], string> = {
   error: 'bg-rose-100 text-rose-700',
 };
 
-export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }: FlowSimulatorPanelProps) {
+export function FlowSimulatorPanel({ nodes, edges, variables, locale, onRunStateChange }: FlowSimulatorPanelProps) {
   const simRef = React.useRef<FlowSimulator | null>(null);
   const [snapshot, setSnapshot] = React.useState<SimState | null>(null);
   const [validation, setValidation] = React.useState<FlowValidation | null>(null);
@@ -144,11 +147,11 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
   }, [mocks]);
 
   const reset = React.useCallback(() => {
-    const sim = new FlowSimulator(nodes, edges);
+    const sim = new FlowSimulator(nodes, edges, locale);
     simRef.current = sim;
     setValidation(sim.reset(buildSeed(), buildMocks()));
     sync();
-  }, [nodes, edges, buildSeed, buildMocks, sync]);
+  }, [nodes, edges, buildSeed, buildMocks, sync, locale]);
 
   const ensure = React.useCallback(() => {
     if (!simRef.current) reset();
@@ -225,10 +228,10 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
     <div className="flex h-full flex-col text-xs">
       <div className="flex items-center gap-1.5 border-b bg-muted/30 px-3 py-2">
         <Button size="sm" className="h-7 gap-1 px-2" onClick={onRun} disabled={blocked}>
-          <Play className="h-3.5 w-3.5" /> Run
+          <Play className="h-3.5 w-3.5" /> {tr('engine.flowSim.run', locale)}
         </Button>
         <Button size="sm" variant="outline" className="h-7 gap-1 px-2" onClick={onStep} disabled={blocked || status === 'done' || status === 'error'}>
-          <StepForward className="h-3.5 w-3.5" /> Step
+          <StepForward className="h-3.5 w-3.5" /> {tr('engine.flowSim.step', locale)}
         </Button>
         {status === 'paused' &&
           (approvalPause && approvalPause.decisions.length > 0 ? (
@@ -240,7 +243,7 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
                   variant="outline"
                   className="h-7 gap-1 px-2 capitalize"
                   onClick={() => onDecision(d)}
-                  title={`Resume down the "${d}" branch`}
+                  title={tFormat('engine.flowSim.resumeBranch', locale, { branch: d })}
                 >
                   <ChevronRight className="h-3.5 w-3.5" /> {d}
                 </Button>
@@ -248,14 +251,14 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
             </div>
           ) : (
             <Button size="sm" variant="outline" className="h-7 gap-1 px-2" onClick={onResume}>
-              <ChevronRight className="h-3.5 w-3.5" /> Continue
+              <ChevronRight className="h-3.5 w-3.5" /> {tr('engine.flowSim.continue', locale)}
             </Button>
           ))}
         <Button size="sm" variant="ghost" className="h-7 gap-1 px-2 text-muted-foreground" onClick={onReset}>
-          <RotateCcw className="h-3.5 w-3.5" /> Reset
+          <RotateCcw className="h-3.5 w-3.5" /> {tr('engine.flowSim.reset', locale)}
         </Button>
         <span className={cn('ml-auto rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase', STATUS_TONE[status === 'idle' || status === 'running' ? 'ok' : (status as SimStep['status'])] ?? 'bg-muted')}>
-          {status}
+          {tr(`engine.flowSim.status.${status}`, locale)}
         </span>
       </div>
 
@@ -281,7 +284,7 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
         {/* Paused at a screen — render the end-user form the runtime would show. */}
         {screenPause && (
           <section className="space-y-1.5">
-            <div className="font-medium text-muted-foreground">Screen</div>
+            <div className="font-medium text-muted-foreground">{tr('engine.flowSim.screen', locale)}</div>
             <ScreenPreview node={screenPause.node} variables={screenPause.variables} />
           </section>
         )}
@@ -289,14 +292,14 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
         {/* Seed inputs */}
         {inputs.length > 0 && (
           <section className="space-y-1.5">
-            <div className="font-medium text-muted-foreground">Inputs</div>
+            <div className="font-medium text-muted-foreground">{tr('engine.flowSim.inputs', locale)}</div>
             {inputs.map((v) => (
               <div key={v.name} className="flex items-center gap-2">
                 <Label className="w-24 shrink-0 truncate font-mono text-[11px]" title={v.name}>{v.name}</Label>
                 <Input
                   value={seed[v.name] ?? (v.defaultValue != null ? String(v.defaultValue) : '')}
                   onChange={(e) => setSeed((p) => ({ ...p, [v.name]: e.target.value }))}
-                  placeholder={v.type ?? 'value'}
+                  placeholder={v.type ?? tr('engine.flowSim.valuePlaceholder', locale)}
                   className="h-7 flex-1 text-xs"
                 />
               </div>
@@ -308,38 +311,38 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
             declared input cannot reach (e.g. a computed value a decision reads). */}
         <section className="space-y-1.5">
           <div className="flex items-center gap-1.5 font-medium text-muted-foreground">
-            <span>Set variables</span>
+            <span>{tr('engine.flowSim.setVariables', locale)}</span>
             <button
               type="button"
               className="ml-auto inline-flex items-center gap-0.5 rounded border px-1.5 py-0.5 text-[10px] hover:bg-muted/50"
               onClick={() => setScratch((p) => [...p, { k: '', v: '' }])}
             >
-              <Plus className="h-3 w-3" /> Add
+              <Plus className="h-3 w-3" /> {tr('engine.flowSim.add', locale)}
             </button>
           </div>
           {scratch.length === 0 ? (
-            <div className="italic text-muted-foreground">Override or inject any variable (wins over inputs and mocks at start).</div>
+            <div className="italic text-muted-foreground">{tr('engine.flowSim.setVariablesHint', locale)}</div>
           ) : (
             scratch.map((row, i) => (
               <div key={i} className="flex items-center gap-1.5">
                 <Input
                   value={row.k}
                   onChange={(e) => setScratch((p) => p.map((r, j) => (j === i ? { ...r, k: e.target.value } : r)))}
-                  placeholder="name"
+                  placeholder={tr('engine.flowSim.namePlaceholder', locale)}
                   className="h-7 w-24 shrink-0 font-mono text-[11px]"
                 />
                 <span className="text-muted-foreground">=</span>
                 <Input
                   value={row.v}
                   onChange={(e) => setScratch((p) => p.map((r, j) => (j === i ? { ...r, v: e.target.value } : r)))}
-                  placeholder="value"
+                  placeholder={tr('engine.flowSim.valuePlaceholder', locale)}
                   className="h-7 flex-1 text-xs"
                 />
                 <button
                   type="button"
                   className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted/50 hover:text-rose-600"
                   onClick={() => setScratch((p) => p.filter((_, j) => j !== i))}
-                  aria-label="Remove variable"
+                  aria-label={tr('engine.flowSim.removeVariable', locale)}
                 >
                   <Trash2 className="h-3 w-3" />
                 </button>
@@ -351,7 +354,7 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
         {/* Per-node mock outputs — what each mocked side effect "returns". */}
         {mockNodes.length > 0 && (
           <section className="space-y-1.5">
-            <div className="font-medium text-muted-foreground">Mock outputs</div>
+            <div className="font-medium text-muted-foreground">{tr('engine.flowSim.mockOutputs', locale)}</div>
             {mockNodes.map((m) => (
               <div key={m.id} className="space-y-0.5">
                 <Label className="flex items-baseline gap-1.5 text-[11px]" title={m.id}>
@@ -364,7 +367,7 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
                 <Input
                   value={mocks[m.id] ?? ''}
                   onChange={(e) => setMocks((p) => ({ ...p, [m.id]: e.target.value }))}
-                  placeholder={m.type === 'script' && m.outputs.length ? `{ "${m.outputs[0]}": … }` : 'mocked result (JSON)'}
+                  placeholder={m.type === 'script' && m.outputs.length ? `{ "${m.outputs[0]}": … }` : tr('engine.flowSim.mockPlaceholder', locale)}
                   className="h-7 w-full font-mono text-[11px]"
                 />
               </div>
@@ -375,9 +378,9 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
         {/* Variable watch */}
         {snapshot && (
           <section className="space-y-1.5">
-            <div className="font-medium text-muted-foreground">Variables</div>
+            <div className="font-medium text-muted-foreground">{tr('engine.flowSim.variables', locale)}</div>
             {Object.keys(snapshot.variables).length === 0 ? (
-              <div className="italic text-muted-foreground">No variables set.</div>
+              <div className="italic text-muted-foreground">{tr('engine.flowSim.noVars', locale)}</div>
             ) : (
               <ul className="space-y-1">
                 {Object.entries(snapshot.variables).map(([k, val]) => (
@@ -396,7 +399,7 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
         {/* Step timeline */}
         {snapshot && snapshot.steps.length > 0 && (
           <section className="space-y-1.5">
-            <div className="font-medium text-muted-foreground">Timeline</div>
+            <div className="font-medium text-muted-foreground">{tr('engine.flowSim.timeline', locale)}</div>
             <ol className="space-y-1">
               {snapshot.steps.map((s) => (
                 <li key={s.seq} className="rounded border bg-background p-1.5">
@@ -436,7 +439,7 @@ export function FlowSimulatorPanel({ nodes, edges, variables, onRunStateChange }
         )}
 
         {!snapshot && !blocked && (
-          <p className="italic text-muted-foreground">Press Run to simulate, or Step to walk node by node. Side effects are mocked — no backend is called.</p>
+          <p className="italic text-muted-foreground">{tr('engine.flowSim.idleHint', locale)}</p>
         )}
       </div>
     </div>

--- a/packages/app-shell/src/views/metadata-admin/previews/NodePalette.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/NodePalette.test.tsx
@@ -85,8 +85,12 @@ describe('NodePalette search & filtering', () => {
     }
     expect(screen.queryByText('Data')).toBeNull();
     expect(screen.queryByText('Logic')).toBeNull();
-    // Item labels come from the (server-merged) items, not i18n — unchanged.
-    expect(screen.getByText('Create record')).toBeTruthy();
+    // Built-in node types are localized (the zh label wins over the English
+    // fixture label); plugin / unknown types fall back to their descriptor
+    // label so they stay readable.
+    expect(screen.getByText('创建记录')).toBeTruthy();
+    expect(screen.queryByText('Create record')).toBeNull();
+    expect(screen.getByText('HTTP Call')).toBeTruthy(); // plugin.http → fallback
   });
 
   it('filters across all categories and hides empty sections', async () => {

--- a/packages/app-shell/src/views/metadata-admin/previews/ProblemsPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ProblemsPanel.tsx
@@ -14,12 +14,15 @@ import * as React from 'react';
 import { AlertCircle, AlertTriangle, CheckCircle2, CircleDot, GitBranch } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import type { FlowProblem } from './flow-problems';
+import { t as tr } from '../i18n';
 
 export interface ProblemsPanelProps {
   problems: FlowProblem[];
   /** Selected element key (`node:<id>` or an edge's `edgeKey`) to highlight matching rows. */
   selectedKey?: string | null;
   onSelectProblem: (problem: FlowProblem) => void;
+  /** UI locale for the panel chrome. */
+  locale?: string;
 }
 
 function targetLabel(p: FlowProblem): string {
@@ -28,14 +31,14 @@ function targetLabel(p: FlowProblem): string {
   return 'flow';
 }
 
-export function ProblemsPanel({ problems, selectedKey, onSelectProblem }: ProblemsPanelProps) {
+export function ProblemsPanel({ problems, selectedKey, onSelectProblem, locale }: ProblemsPanelProps) {
   const errorCount = problems.filter((p) => p.level === 'error').length;
   const warningCount = problems.length - errorCount;
 
   return (
     <div className="flex h-full flex-col text-xs">
       <div className="flex items-center gap-2 border-b px-3 py-2 font-medium text-muted-foreground">
-        <span>Problems</span>
+        <span>{tr('engine.flowProblems.title', locale)}</span>
         {errorCount > 0 && (
           <span className="inline-flex items-center gap-1 text-destructive">
             <AlertCircle className="h-3 w-3" /> {errorCount}
@@ -50,7 +53,7 @@ export function ProblemsPanel({ problems, selectedKey, onSelectProblem }: Proble
       {problems.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-1.5 p-4 text-center text-muted-foreground">
           <CheckCircle2 className="h-5 w-5 text-emerald-500" />
-          <span>No problems — this flow is structurally valid.</span>
+          <span>{tr('engine.flowProblems.empty', locale)}</span>
         </div>
       ) : (
         <ul className="flex-1 overflow-auto p-1.5">
@@ -89,8 +92,8 @@ export function ProblemsPanel({ problems, selectedKey, onSelectProblem }: Proble
                     <span className="mt-0.5 flex items-center gap-1 text-[10px] text-muted-foreground">
                       <TargetIcon className="h-2.5 w-2.5 shrink-0" />
                       <span className="truncate font-mono">{targetLabel(p)}</span>
-                      {p.source === 'server' && <span className="uppercase tracking-wide">· schema</span>}
-                      {p.source === 'expression' && <span className="uppercase tracking-wide">· expression</span>}
+                      {p.source === 'server' && <span className="uppercase tracking-wide">· {tr('engine.flowProblems.sourceSchema', locale)}</span>}
+                      {p.source === 'expression' && <span className="uppercase tracking-wide">· {tr('engine.flowProblems.sourceExpression', locale)}</span>}
                     </span>
                   </span>
                 </button>

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -48,7 +48,7 @@ import {
   CommandItem,
   CommandList,
 } from '@object-ui/components';
-import { t as tr } from '../i18n';
+import { t as tr, translateNodeLabel, translateNodeHint } from '../i18n';
 import { NODE_W, NODE_H, type Point, type LabeledRegion, type FlowNode } from './flow-canvas-layout';
 import { FlowRegionView } from './flow-region-view';
 import { EXPANDED_REGION_MAX_W, NODE_REGION_GAP, REGION_PANEL_PAD } from './flow-region-metrics';
@@ -348,14 +348,22 @@ export const NODE_PALETTE: PaletteItem[] = [
   { type: 'end', label: 'End', hint: 'Terminate the flow', category: 'Flow' },
 ];
 
-/** Human-friendly default label for a newly created node of `type`. */
-export function defaultNodeLabel(type: string): string {
+/**
+ * Human-friendly default label for a newly created node of `type`. Localized
+ * for the active locale so a node added from the (localized) palette gets a
+ * matching default label — e.g. picking 创建记录 under zh-CN seeds the node
+ * label 创建记录, not "Create record". English (no locale) is unchanged, so
+ * programmatic / test callers keep the English default.
+ */
+export function defaultNodeLabel(type: string, locale?: string): string {
   const item = NODE_PALETTE.find((p) => p.type === type);
-  if (item) return item.label;
-  return type
-    .split('_')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
+  const english = item
+    ? item.label
+    : type
+        .split('_')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+  return translateNodeLabel(type, locale, english);
 }
 
 /**
@@ -389,6 +397,8 @@ export function defaultNodeExtras(type: string): Record<string, unknown> {
 
 export interface NodeCardProps {
   id: string;
+  /** UI locale for the card's affordance tooltips. */
+  locale?: string;
   type: string;
   label: string;
   summary?: string;
@@ -453,6 +463,7 @@ export interface NodeCardProps {
  */
 export function NodeCard({
   id,
+  locale,
   type,
   label,
   summary,
@@ -555,8 +566,8 @@ export function NodeCard({
         // layout can never disagree.
         <button
           type="button"
-          aria-label={expanded ? 'Collapse nested regions' : 'Expand nested regions'}
-          title={expanded ? 'Collapse nested regions' : 'Expand nested regions'}
+          aria-label={tr(expanded ? 'engine.flowCanvas.collapseRegions' : 'engine.flowCanvas.expandRegions', locale)}
+          title={tr(expanded ? 'engine.flowCanvas.collapseRegions' : 'engine.flowCanvas.expandRegions', locale)}
           aria-expanded={!!expanded}
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
@@ -581,6 +592,7 @@ export function NodeCard({
             maxWidth={EXPANDED_REGION_MAX_W}
             selected={selectedNestedNode}
             onSelectNode={onSelectNestedNode}
+            locale={locale}
           />
         </div>
       )}
@@ -605,8 +617,8 @@ export function NodeCard({
       {editable && type !== 'end' && (
         <button
           type="button"
-          title="Add connected node"
-          aria-label="Add connected node"
+          title={tr('engine.flowCanvas.addConnected', locale)}
+          aria-label={tr('engine.flowCanvas.addConnected', locale)}
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
@@ -623,8 +635,8 @@ export function NodeCard({
       {onAddReviseLoop && (
         <button
           type="button"
-          title="Add revision loop (send back for revision)"
-          aria-label="Add revision loop"
+          title={tr('engine.flowCanvas.addReviseLoop', locale)}
+          aria-label={tr('engine.flowCanvas.addReviseLoopShort', locale)}
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
@@ -701,9 +713,13 @@ export function NodePalette({ locale, items = NODE_PALETTE, onPick, open, onOpen
       (i) =>
         i.label.toLowerCase().includes(query) ||
         (i.hint ?? '').toLowerCase().includes(query) ||
-        i.type.toLowerCase().includes(query),
+        i.type.toLowerCase().includes(query) ||
+        // Also match the localized label/hint so a zh-CN author can search in
+        // Chinese (the display strings differ from the English `label`).
+        translateNodeLabel(i.type, locale, i.label).toLowerCase().includes(query) ||
+        (translateNodeHint(i.type, locale, i.hint) ?? '').toLowerCase().includes(query),
     );
-  }, [items, query]);
+  }, [items, query, locale]);
 
   // Bucket items by category (falling back to the type's inferred category, so
   // engine-only / plugin nodes still land in a sensible section), then render
@@ -736,6 +752,10 @@ export function NodePalette({ locale, items = NODE_PALETTE, onPick, open, onOpen
 
   const renderItem = (item: PaletteItem, recent?: boolean) => {
     const tone = nodeTone(item.type);
+    // Localize the built-in node types; server/plugin descriptors keep their
+    // own (server-authoritative) label/hint via the fallback.
+    const label = translateNodeLabel(item.type, locale, item.label);
+    const hint = translateNodeHint(item.type, locale, item.hint);
     return (
       <CommandItem
         key={recent ? `recent:${item.type}` : item.type}
@@ -748,8 +768,8 @@ export function NodePalette({ locale, items = NODE_PALETTE, onPick, open, onOpen
           <NodeTypeIcon type={item.type} className={cn('h-[15px] w-[15px]', tone.icon)} />
         </span>
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-medium">{item.label}</div>
-          {item.hint && <div className="truncate text-[11px] text-muted-foreground">{item.hint}</div>}
+          <div className="truncate text-[13px] font-medium">{label}</div>
+          {hint && <div className="truncate text-[11px] text-muted-foreground">{hint}</div>}
         </div>
       </CommandItem>
     );

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-expr-problems.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-expr-problems.ts
@@ -43,12 +43,12 @@ function str(v: unknown): string | undefined {
 }
 
 /** Brace error (error) else unknown-ref (warning, when `roots` given) for one CEL value. */
-function checkCel(value: unknown, roots: Set<string> | null): { level: DiagnosticLevel; message: string } | null {
+function checkCel(value: unknown, roots: Set<string> | null, locale?: string): { level: DiagnosticLevel; message: string } | null {
   const issue = validateExpressionClient('predicate', value);
   if (issue) return { level: 'error', message: issue.message };
   if (roots && roots.size > 0) {
     const unknown = findUnknownRefs(value, 'predicate', roots);
-    if (unknown.length > 0) return { level: 'warning', message: describeUnknownRefs(unknown) };
+    if (unknown.length > 0) return { level: 'warning', message: describeUnknownRefs(unknown, locale) };
   }
   return null;
 }
@@ -58,7 +58,7 @@ function checkCel(value: unknown, roots: Set<string> | null): { level: Diagnosti
  * Pure: no network — the trigger object's fields are not expanded (root-only
  * scope), which is why the start node is excluded from the ref check.
  */
-export function flowExpressionProblems(draft: Record<string, unknown>): ExprProblem[] {
+export function flowExpressionProblems(draft: Record<string, unknown>, locale?: string): ExprProblem[] {
   const nodes = asArray(draft.nodes).map(asRecord);
   const edges = asArray(draft.edges).map(asRecord);
   const startId = str(nodes.find((n) => str(n.type) === 'start')?.id);
@@ -74,7 +74,7 @@ export function flowExpressionProblems(draft: Record<string, unknown>): ExprProb
 
     for (const field of fieldsForNodeType(type)) {
       if (field.kind === 'expression' && field.refMode !== 'template') {
-        const hit = checkCel(getFieldValue(node, field), roots);
+        const hit = checkCel(getFieldValue(node, field), roots, locale);
         if (hit) out.push({ target: { kind: 'node', nodeId }, level: hit.level, message: hit.message });
       } else if (field.kind === 'objectList' && field.columns) {
         const exprCols = field.columns.filter((c) => c.kind === 'expression');
@@ -83,7 +83,7 @@ export function flowExpressionProblems(draft: Record<string, unknown>): ExprProb
           const r = asRecord(row);
           const rowLabel = str(r.label);
           for (const col of exprCols) {
-            const hit = checkCel(r[col.key], roots);
+            const hit = checkCel(r[col.key], roots, locale);
             if (hit) {
               const prefix = rowLabel || col.label;
               out.push({ target: { kind: 'node', nodeId }, level: hit.level, message: prefix ? `${prefix}: ${hit.message}` : hit.message });
@@ -99,7 +99,7 @@ export function flowExpressionProblems(draft: Record<string, unknown>): ExprProb
     const target = str(edge.target);
     if (!source || !target || edge.isDefault === true) continue;
     const roots = source === startId ? null : scopeRoots(resolveFlowScope(draft, source).refs);
-    const hit = checkCel(edge.condition, roots);
+    const hit = checkCel(edge.condition, roots, locale);
     if (hit) out.push({ target: { kind: 'edge', source, target }, level: hit.level, message: hit.message });
   }
 

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-problems.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-problems.ts
@@ -141,6 +141,8 @@ export interface BuildFlowProblemsArgs {
   serverDiagnostics?: ServerDiagnostic[];
   /** Declared flow variables — needed to resolve scope for the expression check. */
   variables?: unknown[];
+  /** UI locale for the structural-validation messages. */
+  locale?: string;
 }
 
 /**
@@ -148,10 +150,10 @@ export interface BuildFlowProblemsArgs {
  * diagnostics. Errors are listed before warnings; within a level each source
  * keeps its own emit order (structural before server).
  */
-export function buildFlowProblems({ nodes, edges, serverDiagnostics, variables }: BuildFlowProblemsArgs): FlowProblem[] {
+export function buildFlowProblems({ nodes, edges, serverDiagnostics, variables, locale }: BuildFlowProblemsArgs): FlowProblem[] {
   const problems: FlowProblem[] = [];
 
-  const v = validateFlowDraft(nodes as unknown as SimNode[], edges as unknown as SimEdge[]);
+  const v = validateFlowDraft(nodes as unknown as SimNode[], edges as unknown as SimEdge[], locale);
   const pushStructural = (level: DiagnosticLevel, list: Diagnostic[]) => {
     list.forEach((diag, i) => {
       const { target, highlight } = structuralMapping(diag, edges);
@@ -182,7 +184,7 @@ export function buildFlowProblems({ nodes, edges, serverDiagnostics, variables }
 
   // Client-side EXPRESSION issues (ADR-0032 braces + scope-aware unknown refs),
   // resolved onto node / edge targets — see flow-expr-problems.
-  flowExpressionProblems({ nodes, edges, variables: variables ?? [] }).forEach((ep, i) => {
+  flowExpressionProblems({ nodes, edges, variables: variables ?? [] }, locale).forEach((ep, i) => {
     const target: FlowProblemTarget =
       ep.target.kind === 'edge'
         ? {

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-region-view.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-region-view.tsx
@@ -32,6 +32,26 @@ import {
 } from './flow-canvas-layout';
 import { NodeTypeIcon, nodeTone } from './flow-canvas-parts';
 import { REGION_BLOCK_PAD, REGION_GAP, REGION_LABEL_H } from './flow-region-metrics';
+import { t as tr, tFormat } from '../i18n';
+
+/**
+ * Localized header for a nested region. `extractRegions` (a pure, i18n-free
+ * layout helper) bakes English structural fallbacks — so translate those here,
+ * at render, keyed off the stable region `key`. A user-supplied `parallel`
+ * branch name (anything other than the `Branch N` auto-label) is author content
+ * and passes through untouched.
+ */
+function displayRegionLabel(region: LabeledRegion, locale?: string): string | undefined {
+  const { key, label } = region;
+  if (key === 'try') return tr('engine.flowRegion.try', locale);
+  if (key === 'catch') return tr('engine.flowRegion.catch', locale);
+  const m = /^branch-(\d+)$/.exec(key);
+  if (m) {
+    const n = Number(m[1]) + 1;
+    if (label === `Branch ${n}`) return tFormat('engine.flowRegion.branchN', locale, { n });
+  }
+  return label;
+}
 
 /**
  * Node box inside a region — a compact echo of `NodeCard`. Read-only by default
@@ -167,6 +187,7 @@ export function FlowRegionView({
   maxWidth,
   selected,
   onSelectNode,
+  locale,
 }: {
   regions: LabeledRegion[];
   maxWidth: number;
@@ -174,24 +195,28 @@ export function FlowRegionView({
   selected?: { regionKey: string; nodeId: string } | null;
   /** Selecting a nested node, tagged with its region key (for the container path). */
   onSelectNode?: (regionKey: string, node: FlowNode) => void;
+  /** UI locale for the region header labels. */
+  locale?: string;
 }) {
   // #2670: every dimension in this height stack is an explicit px from
   // flow-region-metrics so the layout height PREDICTOR matches the DOM exactly
   // (rem-based Tailwind spacing and font-metric line-heights would drift).
   return (
     <div className="flex flex-col" style={{ gap: REGION_GAP }}>
-      {regions.map((region) => (
+      {regions.map((region) => {
+        const label = displayRegionLabel(region, locale);
+        return (
         <div
           key={region.key}
           className="rounded-md border border-dashed border-border/60 bg-muted/20"
           style={{ padding: REGION_BLOCK_PAD }}
         >
-          {region.label && (
+          {label && (
             <div
               className="text-[9px] font-semibold uppercase tracking-wide text-muted-foreground/80"
               style={{ height: REGION_LABEL_H, lineHeight: '12px', paddingBottom: 4 }}
             >
-              {region.label}
+              {label}
             </div>
           )}
           <RegionCanvas
@@ -201,7 +226,8 @@ export function FlowRegionView({
             onSelectNode={onSelectNode ? (node) => onSelectNode(region.key, node) : undefined}
           />
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-validate.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-validate.ts
@@ -13,6 +13,7 @@
 
 import { ExpressionEvaluator } from '@object-ui/core';
 import type { Diagnostic, FlowValidation, SimEdge, SimNode } from './flow-sim-types';
+import { t as tr, tFormat } from '../../i18n';
 
 const edgeCondString = (c: SimEdge['condition']): string | undefined =>
   typeof c === 'string' ? c : undefined;
@@ -93,7 +94,7 @@ export function findCycle(nodeIds: string[], edges: SimEdge[]): string[] | null 
 }
 
 /** Static structural checks; `errors` block Run, `warnings` are advisory. */
-export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValidation {
+export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[], locale?: string): FlowValidation {
   const errors: Diagnostic[] = [];
   const warnings: Diagnostic[] = [];
 
@@ -101,10 +102,10 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValid
   const idSet = new Set<string>();
   for (const id of ids) {
     if (!id) {
-      errors.push({ level: 'error', message: 'A node is missing an id.' });
+      errors.push({ level: 'error', message: tr('engine.flowValidate.nodeMissingId', locale) });
       continue;
     }
-    if (idSet.has(id)) errors.push({ level: 'error', nodeId: id, message: `Duplicate node id "${id}".` });
+    if (idSet.has(id)) errors.push({ level: 'error', nodeId: id, message: tFormat('engine.flowValidate.duplicateNodeId', locale, { id }) });
     idSet.add(id);
   }
 
@@ -112,9 +113,9 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValid
     // Attach the endpoints so a dangling-edge error can badge the offending
     // connection on the canvas (not just appear as a flow-level message).
     if (!idSet.has(e.source))
-      errors.push({ level: 'error', edge: { source: e.source, target: e.target }, message: `Edge source "${e.source}" does not exist.` });
+      errors.push({ level: 'error', edge: { source: e.source, target: e.target }, message: tFormat('engine.flowValidate.edgeSourceMissing', locale, { source: e.source }) });
     if (!idSet.has(e.target))
-      errors.push({ level: 'error', edge: { source: e.source, target: e.target }, message: `Edge target "${e.target}" does not exist.` });
+      errors.push({ level: 'error', edge: { source: e.source, target: e.target }, message: tFormat('engine.flowValidate.edgeTargetMissing', locale, { target: e.target }) });
   }
 
   // Entry resolution: prefer an explicit `start` node, else a node with no
@@ -127,17 +128,17 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValid
   if (startNodes.length === 1) {
     startNodeId = startNodes[0].id;
     if (incoming.has(startNodeId)) {
-      warnings.push({ level: 'warning', nodeId: startNodeId, message: 'Start node has an incoming edge.' });
+      warnings.push({ level: 'warning', nodeId: startNodeId, message: tr('engine.flowValidate.startHasIncoming', locale) });
     }
   } else if (startNodes.length > 1) {
-    errors.push({ level: 'error', message: `Flow has ${startNodes.length} start nodes; expected one.` });
+    errors.push({ level: 'error', message: tFormat('engine.flowValidate.multipleStart', locale, { count: startNodes.length }) });
   } else if (roots.length === 1) {
     startNodeId = roots[0].id;
-    warnings.push({ level: 'warning', nodeId: startNodeId, message: 'No "start" node; using the only root node as the entry.' });
+    warnings.push({ level: 'warning', nodeId: startNodeId, message: tr('engine.flowValidate.noStartUsingRoot', locale) });
   } else if (roots.length === 0) {
-    errors.push({ level: 'error', message: 'No entry node (every node has an incoming edge — the graph is fully cyclic).' });
+    errors.push({ level: 'error', message: tr('engine.flowValidate.noEntry', locale) });
   } else {
-    errors.push({ level: 'error', message: `Cannot determine a single entry node (${roots.length} candidates). Add a "start" node.` });
+    errors.push({ level: 'error', message: tFormat('engine.flowValidate.ambiguousEntry', locale, { count: roots.length }) });
   }
 
   // Per-decision: at most one default; warn on missing default (possible dead end).
@@ -146,12 +147,12 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValid
     const out = edges.filter((e) => e.source === n.id);
     const defaults = out.filter((e) => e.isDefault);
     if (defaults.length > 1) {
-      errors.push({ level: 'error', nodeId: n.id, message: `Decision "${n.id}" has ${defaults.length} default branches.` });
+      errors.push({ level: 'error', nodeId: n.id, message: tFormat('engine.flowValidate.decisionMultipleDefaults', locale, { id: n.id, count: defaults.length }) });
     }
     if (out.length === 0) {
-      warnings.push({ level: 'warning', nodeId: n.id, message: `Decision "${n.id}" has no outgoing branches.` });
+      warnings.push({ level: 'warning', nodeId: n.id, message: tFormat('engine.flowValidate.decisionNoBranches', locale, { id: n.id }) });
     } else if (defaults.length === 0 && out.every((e) => edgeCondString(e.condition))) {
-      warnings.push({ level: 'warning', nodeId: n.id, message: `Decision "${n.id}" has no default branch; it may dead-end when no condition matches.` });
+      warnings.push({ level: 'warning', nodeId: n.id, message: tFormat('engine.flowValidate.decisionNoDefault', locale, { id: n.id }) });
     }
   }
 
@@ -170,7 +171,7 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValid
     }
     for (const n of nodes) {
       if (!reachable.has(n.id)) {
-        warnings.push({ level: 'warning', nodeId: n.id, message: `Node "${n.id}" is unreachable from the entry.` });
+        warnings.push({ level: 'warning', nodeId: n.id, message: tFormat('engine.flowValidate.nodeUnreachable', locale, { id: n.id }) });
       }
     }
   }
@@ -187,7 +188,7 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[]): FlowValid
       level: 'error',
       nodeId: cycle[0],
       cycle,
-      message: `Cycle detected (${cycle.join(' → ')}). Mark the connection that closes the loop as a back-edge (Connection type → Back-edge) to declare an intentional revise/rework loop.`,
+      message: tFormat('engine.flowValidate.cycleDetected', locale, { cycle: cycle.join(' → ') }),
     });
   }
 

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-simulator.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-simulator.ts
@@ -62,14 +62,17 @@ export class FlowSimulator {
     traversedEdgeIds: [],
   };
 
-  constructor(nodes: SimNode[], edges: SimEdge[]) {
+  private readonly locale?: string;
+
+  constructor(nodes: SimNode[], edges: SimEdge[], locale?: string) {
     for (const n of nodes) this.nodes.set(n.id, n);
     this.edges = edges;
+    this.locale = locale;
   }
 
   /** Validate + seed variables and queue the entry node. Returns the validation. */
   reset(seedVariables: Record<string, unknown> = {}, mocks: MockResults = {}) {
-    const validation = validateFlowDraft([...this.nodes.values()], this.edges);
+    const validation = validateFlowDraft([...this.nodes.values()], this.edges, this.locale);
     this.mocks = mocks;
     this.seq = 0;
     this.state = {


### PR DESCRIPTION
## What

Comprehensive **zh-CN localization** of the metadata-admin **automations** surfaces (the visual Flow designer + node/edge inspector + the shared editor panels shown on the flow screen). Client-side, following the platform's existing `translateMetadataType` precedent — **framework is untouched**, and **en-US is unchanged** (every zh overlay falls back to English, so unknown/plugin values are never hidden).

## Scope

- **Flow designer**: node palette (labels/hints/categories + Chinese search), canvas chrome & tooltips, header pills incl. enum values (`autolaunched`→自动启动…), preview panels, run-history & debug simulator, nested-region tray, and localized **default labels for newly-created nodes**.
- **Node & edge inspectors**: config-field labels / help / options / column headers for the **full engine-published `configSchema` field set** (loop `indexVariable`/`maxIterations`, http `durable`/`signingSecret`, connector flat ids, notify's 11 fields, …). Keyed off the **raw** node type so aliased types (e.g. `notify`) localize correctly.
- **Validation**: structural + unknown-reference messages (canvas banner, Problems panel, debug simulator) and the Problems-panel chrome.
- **Shared editor chrome on the flow screen**: generic `SchemaForm` enum-option / raw-field-label localization used on the flow property form, plus the History / Audit / References / Layered-diff panels and the force-save dialog.

## Out of scope (deliberate)

The remaining hardcoded English is the **generic metadata console for OTHER types** (`ActionDefaultInspector`, `DatasetDefaultInspector`, `HookDefaultInspector`, PageShell/DirectoryPage chrome) — a separate, console-wide i18n effort across all 27 metadata types, not the automations module.

## Verification

Driven in the running console (`@object-ui/console`) against the **app-showcase** backend in **both locales** — the real `showcase_budget_approval` flow (palette, node/edge/config inspector incl. live server `configSchema`, validation, pills, new-node labels) reads fully zh-CN, and en-US shows no key leakage.

- ✅ `type-check` — 29/29 packages
- ✅ **909** metadata-admin tests pass
- ✅ `eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)