### PR TITLE
feat(app-shell): surface step warnings in the Flow Runs panel (#3407)

### DIFF
--- a/.changeset/flow-runs-step-warnings.md
+++ b/.changeset/flow-runs-step-warnings.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/app-shell": patch
+---
+
+feat(app-shell): surface step warnings in the Flow Runs panel (#3407)
+
+The automation engine now attaches advisory `warnings[]` to a step whose write
+was legally stripped by the data layer — an `update_record`/`create_record`
+targeting a `readonly` / `readonlyWhen` field. The step still reports
+`success` (the strip is legitimate semantics), so the run trace previously
+looked like a clean 3ms success while the intended write never landed; the
+only signal lived in the server WARN log.
+
+`FlowRunsPanel` now reads `step.warnings` and renders each one amber beneath
+its step — with a ⚠ marker on the step row — **without** recoloring the
+status. The dropped-write signal that #3407/#3413 plumbed from the data layer
+into the run's step log now reaches the Studio, closing the observability loop
+the author actually looks at.

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.render.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.render.test.tsx
@@ -77,4 +77,39 @@ describe('FlowRunsPanel (render)', () => {
     expect(screen.getByText('each_order')).toBeTruthy();
     expect(screen.getAllByText('charge')).toHaveLength(2);
   });
+
+  // #3407: a step that legally stripped a write (readonly / readonlyWhen) is
+  // reported by the engine as `success` + a step `warnings[]`. The panel must
+  // surface the warning text — the whole point of the fix is that the dropped
+  // write is no longer silent — without demoting the step out of `success`.
+  it('renders step warnings amber while the step stays success', async () => {
+    const WARN_RUN = {
+      id: 'run_warn_01',
+      status: 'completed',
+      startedAt: '2026-07-04T13:51:13.000Z',
+      durationMs: 8,
+      trigger: { type: 'manual' },
+      steps: [
+        {
+          nodeId: 'stamp_approval',
+          nodeType: 'update_record',
+          status: 'success',
+          warnings: ["update_record(crm_opportunity): field 'approval_status' is read-only — write ignored"],
+        },
+      ],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ success: true, data: { runs: [WARN_RUN] } }), { status: 200 })),
+    );
+
+    render(<FlowRunsPanel flowName="approval_flow" />);
+    fireEvent.click(await screen.findByRole('button', { expanded: false }));
+
+    // The warning text reaches the DOM (pre-fix it only existed in server logs).
+    expect(await screen.findByText(/approval_status.*read-only/)).toBeTruthy();
+    // The step keeps its success status — the strip is legal, not a failure.
+    expect(screen.getByText('success')).toBeTruthy();
+    expect(screen.queryByText('failure')).toBeNull();
+  });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
@@ -9,7 +9,9 @@
  * a `parallel` branch, or a `try`/`catch` handler — are nested under their
  * container node and grouped by iteration / branch (#1505), so authors can see
  * where a run paused or failed *and which iteration did it*, without leaving the
- * Studio.
+ * Studio. A step may also carry advisory `warnings` (#3407) — e.g. a write to a
+ * `readonly` field the data layer legally stripped — rendered amber beneath the
+ * step without demoting its `success` status.
  *
  * Degrades like the palette fetch: offline / plugin-absent / older backend →
  * a quiet "history unavailable" note, never an error state that blocks the
@@ -17,7 +19,7 @@
  */
 
 import * as React from 'react';
-import { AlertCircle, CheckCircle2, ChevronDown, ChevronRight, Clock, Loader2, PauseCircle, RefreshCw, SkipForward } from 'lucide-react';
+import { AlertCircle, AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Clock, Loader2, PauseCircle, RefreshCw, SkipForward } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import { apiBase } from './useFlowNodePalette';
 import { t as tr, tFormat } from '../i18n';
@@ -43,6 +45,12 @@ interface RunStep {
   iteration?: number;
   /** Region kind the step ran in: `loop-body` | `parallel-branch` | `try` | `catch`. */
   regionKind?: string;
+  // #3407: advisory warnings the engine attaches to an otherwise-successful step
+  // — e.g. an `update_record` whose write to a `readonly` / `readonlyWhen` field
+  // was legally stripped by the data layer. The step still `success`es (the strip
+  // is legitimate semantics); the warning is the only signal the intended write
+  // didn't land, which the server-side WARN log never surfaced in the run trace.
+  warnings?: string[];
 }
 
 /** A step plus the region body steps that ran under it — the execution tree the
@@ -220,20 +228,44 @@ function StepRow({ step, depth = 0 }: { step: RunStep; depth?: number }) {
         ? 'text-rose-600 dark:text-rose-400'
         : 'text-muted-foreground';
   const stepErr = errorText(step.error);
+  // #3407: advisory warnings are amber and never recolor the status — a step
+  // that legally stripped a write is still a `success`, just not silent. The
+  // status badge keeps its tone; the ⚠ marker and the amber sub-lines below
+  // carry the "your write didn't fully land" signal.
+  const warnings = Array.isArray(step.warnings)
+    ? step.warnings.filter((w): w is string => typeof w === 'string' && w.length > 0)
+    : [];
   return (
-    <li className="flex items-baseline gap-1.5 py-0.5" style={depth ? { paddingLeft: depth * 12 } : undefined}>
-      <span className={cn('shrink-0 text-[9px] font-semibold uppercase', cls)}>{step.status}</span>
-      <span className="truncate font-mono text-[10px]" title={step.nodeId}>{step.nodeId}</span>
-      {step.nodeType && <span className="shrink-0 text-[9px] uppercase text-muted-foreground">{step.nodeType}</span>}
-      {fmtDuration(step.durationMs) && (
-        <span className="ml-auto shrink-0 text-[9px] text-muted-foreground">{fmtDuration(step.durationMs)}</span>
-      )}
-      {stepErr && (
-        <span className="min-w-0 truncate text-[9px] text-rose-600" title={stepErr}>
-          {stepErr}
-        </span>
-      )}
-    </li>
+    <>
+      <li className="flex items-baseline gap-1.5 py-0.5" style={depth ? { paddingLeft: depth * 12 } : undefined}>
+        <span className={cn('shrink-0 text-[9px] font-semibold uppercase', cls)}>{step.status}</span>
+        <span className="truncate font-mono text-[10px]" title={step.nodeId}>{step.nodeId}</span>
+        {step.nodeType && <span className="shrink-0 text-[9px] uppercase text-muted-foreground">{step.nodeType}</span>}
+        {warnings.length > 0 && (
+          <AlertTriangle aria-hidden className="h-2.5 w-2.5 shrink-0 text-amber-600 dark:text-amber-400" />
+        )}
+        {fmtDuration(step.durationMs) && (
+          <span className="ml-auto shrink-0 text-[9px] text-muted-foreground">{fmtDuration(step.durationMs)}</span>
+        )}
+        {stepErr && (
+          <span className="min-w-0 truncate text-[9px] text-rose-600" title={stepErr}>
+            {stepErr}
+          </span>
+        )}
+      </li>
+      {warnings.map((w, i) => (
+        <li
+          key={i}
+          className="flex items-baseline gap-1 py-0.5 text-amber-700 dark:text-amber-400"
+          style={{ paddingLeft: (depth + 1) * 12 }}
+        >
+          <AlertTriangle aria-hidden className="h-2.5 w-2.5 shrink-0 self-center" />
+          <span className="min-w-0 break-words text-[9px]" title={w}>
+            {w}
+          </span>
+        </li>
+      ))}
+    </>
   );
 }
 


### PR DESCRIPTION
## 背景

后端可观测性闭环的最后一公里。framework 侧 [#3407](https://github.com/objectstack-ai/objectstack/issues/3407) / PR #3413(已合并)让自动化引擎在「请求写 N 个字段、因 `readonly`(#2948)/ `readonlyWhen`(#3042)被合法剥离后实际生效 < N」时,给步骤挂上 advisory `warnings[]` 并随 run history 持久化(`StepLogEntry.warnings`)——但 Studio 的 **Runs 面板还不会渲染它**,作者在 run trace 里依旧只看到一条干净的 `success`,真正的「写入没落」信号仍只躺在服务端 WARN 日志里。

本 PR 把这条已经流到步骤日志里的信号渲染出来。

## 改动(`packages/app-shell` · `FlowRunsPanel.tsx`)

- `RunStep` 接口新增 `warnings?: string[]`(对齐后端 `StepLogEntry.warnings`);
- `StepRow` 在步骤行渲染:
  - 行内一个琥珀色 ⚠ 标记(一眼可辨该步有 warning);
  - 每条 warning 作为琥珀色子行显示在步骤下方,带完整文本(点名字段与原因,如 `field 'approval_status' is read-only — write ignored`);
- **状态色不变** —— `success` 依旧是绿色。剥离是合法语义,warning 只是「不再沉默」,不降级为失败(与 #3407/#3413 的原则一致);
- 琥珀色在明/暗两套主题下都做了 `dark:` 适配;warning 文本沿用后端原文(与现有 `error` 文本同处理,不新增 i18n key)。

## 测试

- `FlowRunsPanel.render.test.tsx` 新增一例:带 `warnings` 的 `success` 步骤 —— 断言 warning 文本进入 DOM 且步骤仍为 `success`(不出现 `failure`);
- `pnpm exec vitest run FlowRunsPanel`:2 文件 / 21 例全过;
- `pnpm turbo run build --filter=@object-ui/app-shell`:29/29 成功(`tsc` 干净);
- eslint 两个改动文件:0 error(5 个 warning 均为改动前既有、非本次新增行)。

含 changeset(`@object-ui/app-shell` patch)。

## 关联

- framework #3407(缺口)/ #3413(数据层→步骤日志通道,已合并)
- framework #3431(REST 写路径同一缺口的 follow-up,已立案)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaofCZbsPTHE2oJedvKd77

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaofCZbsPTHE2oJedvKd77)_