### PR TITLE
fix: read spec-canonical keys for dashboard header title and field length rules

### DIFF
--- a/.changeset/naming-drift-dashboard-label-field-length.md
+++ b/.changeset/naming-drift-dashboard-label-field-length.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/plugin-dashboard": patch
+"@object-ui/fields": patch
+---
+
+fix: read spec-canonical keys for dashboard header title and field length rules
+
+Two naming-drift closeouts (framework#1878 / framework#1891):
+
+- `DashboardRenderer` header now falls back to the spec-canonical `label` when
+  the legacy `title` is absent (mirrors the `DashboardGridLayout` fallback from
+  #2666) — a spec-compliant dashboard gets its header title.
+- Field validation rules now read the spec-canonical camelCase
+  `minLength`/`maxLength` (what the server record-validator enforces) with the
+  legacy snake_case `min_length`/`max_length` kept as fallback — authored
+  length constraints reach the client form.

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1966,18 +1966,23 @@ export function buildValidationRules(field: any): any {
   // vars); a field-authored `*_message` is a string and passes through as-is,
   // still winning over the localized default. See form.tsx `localizeRule`.
 
-  // Length validation for text fields
-  if (field.min_length) {
+  // Length validation for text fields. The spec-canonical keys are camelCase
+  // (`minLength`/`maxLength`, @objectstack/spec FieldSchema — what the server
+  // record-validator enforces); the snake_case pair is the legacy objectui
+  // spelling, kept as fallback (framework#1878/#1891 naming-drift closeout).
+  const minLength = (field as any).minLength ?? field.min_length;
+  if (minLength) {
     rules.minLength = {
-      value: field.min_length,
+      value: minLength,
       message: typeof field.min_length_message === 'string' ? field.min_length_message : undefined,
       messageKey: 'validation.minLength',
     };
   }
 
-  if (field.max_length) {
+  const maxLength = (field as any).maxLength ?? field.max_length;
+  if (maxLength) {
     rules.maxLength = {
-      value: field.max_length,
+      value: maxLength,
       message: typeof field.max_length_message === 'string' ? field.max_length_message : undefined,
       messageKey: 'validation.maxLength',
     };

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -775,13 +775,18 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
         return <Fragment key={widgetKey}>{renderedNode}</Fragment>;
     };
 
+    // The spec-canonical dashboard display name is `label` (@objectstack/spec
+    // DashboardSchema); `title` is the legacy objectui spelling. Read both so
+    // spec-compliant dashboards get their header title (framework#1878/#1891;
+    // mirrors the DashboardGridLayout fallback from #2666).
+    const headerTitle = schema.title || schema.label;
     const headerSection = schema.header && (
       <div className="col-span-full mb-4">
-        {!hideHeaderText && schema.header.showTitle !== false && schema.title && (
+        {!hideHeaderText && schema.header.showTitle !== false && headerTitle && (
           <h2 className="text-lg font-semibold tracking-tight">
             {dashName
-              ? dashboardLabel({ name: dashName, label: resolveLabel(schema.title) })
-              : resolveLabel(schema.title)}
+              ? dashboardLabel({ name: dashName, label: resolveLabel(headerTitle) })
+              : resolveLabel(headerTitle)}
           </h2>
         )}
         {!hideHeaderText && schema.header.showDescription !== false && schema.description && (


### PR DESCRIPTION
## What

Closes the two remaining objectui-side naming-drift items of
objectstack-ai/objectstack#1891 (umbrella objectstack-ai/objectstack#1878):
spec key ≠ consumed key, so the authored property silently did nothing.

## Changes

- **`DashboardRenderer`** — the header title now falls back to the
  spec-canonical `label` (`@objectstack/spec` `DashboardSchema`) when the
  legacy `title` is absent, mirroring the `DashboardGridLayout` fallback from
  #2666. A spec-compliant dashboard arriving via the spec bridge gets its
  header title.
- **`@object-ui/fields`** — auto-generated length validation rules now read
  the spec-canonical camelCase `minLength`/`maxLength` (what the server
  record-validator enforces), keeping the legacy snake_case
  `min_length`/`max_length` as fallback — authored length constraints reach
  the client form instead of only failing server-side.

Changeset: `@object-ui/plugin-dashboard` + `@object-ui/fields` patch.

## Testing

- `type-check` green (fields, plugin-dashboard + deps).
- DOM suites green: plugin-dashboard 80 tests, fields 375 tests.

Pairs with the framework PR folding agent `knowledge.topics` → `sources` and
marking unenforced AI config experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMaDBhnZEUu1fcw8Rvo6Yq)_