### PR TITLE
fix(approvals): surface the admin override for a stuck request in the inbox (#3424)

### DIFF
--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -686,11 +686,14 @@ export function ApprovalsInboxPage() {
   // so the hint never contradicts the buttons — it already reflects position/
   // team approver resolution, which the client identity heuristic below can't.
   // The heuristic stays as a fallback for a backend that predates `viewer`.
-  // No actor-override branch: the admin "act as" escape hatch retired with the
-  // composer (cloud#861 enterprise act-as is the successor).
+  // framework#3424: a platform/tenant admin may OVERRIDE a stuck request (one
+  // routed to an unstaffed position) even holding no slot — `viewer.can_override`
+  // mirrors the server's decision authz, so the hint and the approve/reject/
+  // reassign buttons (which OR in `can_override`) stay consistent. This is a
+  // privileged recovery path, not the retired per-request "act as" composer.
   const canApproveReject = useMemo(() => {
     if (!selected || selected.status !== 'pending') return false;
-    if (selected.viewer) return selected.viewer.can_act;
+    if (selected.viewer) return selected.viewer.can_act || !!selected.viewer.can_override;
     const pending = new Set(selected.pending_approvers || []);
     return identities.some(id => pending.has(id));
   }, [selected, identities]);

--- a/apps/console/src/services/approvalsApi.ts
+++ b/apps/console/src/services/approvalsApi.ts
@@ -83,6 +83,14 @@ export interface ApprovalRequestRow {
     can_act: boolean;
     /** The caller submitted this request. */
     is_submitter: boolean;
+    /**
+     * framework#3424 — the caller is a platform/tenant admin who may OVERRIDE a
+     * stuck pending request (approve / reject / reassign it) despite holding no
+     * approver slot: the recovery path for an approval routed to an unstaffed
+     * position, which would otherwise lock the record forever. Optional so a
+     * response from an older backend (no `can_override`) reads as `false`.
+     */
+    can_override?: boolean;
   };
   /** ADR-0044 revision round on this (run, node): absent/1 = first round. */
   round?: number;


### PR DESCRIPTION
## Summary

Console companion to objectstack#3451 (framework#3424). The framework lets a platform/tenant admin act on a pending approval routed to an **unstaffed position** — otherwise undecidable, locking the record forever — via a new server-computed `viewer.can_override`. The `approve`/`reject`/`reassign` declared actions already OR `can_override` into their `visible` CEL server-side, so the drawer's action buttons show for an admin with no console change. This PR keeps the surrounding inbox affordances consistent.

## What changed

- `services/approvalsApi.ts` — add `can_override?: boolean` to the `viewer` type (optional, so a response from an older backend reads as `false`).
- `pages/system/ApprovalsInboxPage.tsx` — `canApproveReject` ORs in `viewer.can_override`, so the reply box shows for an admin and the "why disabled" hint no longer contradicts the now-visible approve/reject/reassign buttons. Normal approver/submitter gating and the retired "act as" composer are untouched.

## Testing

The change is a type addition plus a boolean OR. Bare `tsc` in the app can't resolve `@object-ui/*` without a full workspace build (pre-existing in this environment), but the two edited files introduce no new type errors, and the console's `visible`-CEL evaluator already fails closed on a missing key with `||` short-circuit, so there's no regression for normal approvers.

> Merge after objectstack#3451 so the backend attaches `viewer.can_override`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmQPXXbgomoqrXtoxr3CS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmQPXXbgomoqrXtoxr3CS2)_