### PR TITLE
feat(app-shell): toast when a save silently dropped read-only fields (framework #3431/#3455)

### DIFF
--- a/.changeset/surface-dropped-fields-warnings.md
+++ b/.changeset/surface-dropped-fields-warnings.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/data-objectstack": minor
+"@object-ui/app-shell": patch
+---
+
+feat(app-shell): toast when a save silently dropped read-only fields (framework #3431/#3455)
+
+The framework now reports fields it LEGALLY stripped from a write (a non-system
+caller can't seed a `readonly` field, a `readonlyWhen` predicate locked it, …)
+via a `droppedFields` payload on the create/update response. Previously the
+console discarded it: a value the user typed into a locked field just vanished on
+save with a success toast and no explanation.
+
+- **data-objectstack:** `ObjectStackAdapter` now emits a `WriteWarningEvent`
+  after a create/update whose response carried `droppedFields`, exposed through a
+  new `onWriteWarning(cb)` subscription (mirrors the existing `onMutation` bus).
+  Reads the field structurally, so an older client or a backend that never drops
+  is a no-op. New exported types: `WriteWarningEvent`, `WriteWarningListener`,
+  `DroppedFieldsEvent`.
+- **app-shell:** `AdapterProvider` subscribes and raises a `toast.warning`
+  ("Some fields were not saved — the read-only field … could not be changed"),
+  so the strip is visible instead of silent. The write itself still succeeded;
+  status/behaviour are unchanged.

--- a/packages/app-shell/src/providers/AdapterProvider.tsx
+++ b/packages/app-shell/src/providers/AdapterProvider.tsx
@@ -8,12 +8,29 @@
  */
 
 import { useState, useEffect, type ReactNode } from 'react';
-import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { toast } from 'sonner';
+import { ObjectStackAdapter, type WriteWarningEvent } from '@object-ui/data-objectstack';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import { AdapterCtx } from '@object-ui/react';
 import { installSettleSignalGlobal, withSettleSignal } from '../observability/settleSignal';
 
 export { useAdapter } from '@object-ui/react';
+
+/**
+ * Turn a write-warning (framework #3431/#3455) into a human toast. The write
+ * SUCCEEDED — some caller-supplied fields were legally stripped (read-only /
+ * locked by state), so we tell the user rather than let it pass silently.
+ */
+function toastWriteWarning(ev: WriteWarningEvent): void {
+  const fields = Array.from(new Set(ev.droppedFields.flatMap((d) => d.fields)));
+  if (fields.length === 0) return;
+  const list = fields.join(', ');
+  const description =
+    fields.length === 1
+      ? `The read-only field “${list}” could not be changed and was not saved.`
+      : `${fields.length} read-only fields could not be changed and were not saved: ${list}.`;
+  toast.warning('Some fields were not saved', { description });
+}
 
 interface AdapterProviderProps {
   children: ReactNode;
@@ -35,6 +52,7 @@ export function AdapterProvider({ children, adapter: externalAdapter }: AdapterP
     }
 
     let cancelled = false;
+    let unsubscribeWriteWarning: (() => void) | undefined;
 
     // Expose window.__objectui.{pendingRequests,idle,whenIdle} so an automated
     // (AI) browser driver has one "is the app settled?" predicate (ADR-0054 C5).
@@ -52,6 +70,10 @@ export function AdapterProvider({ children, adapter: externalAdapter }: AdapterP
           cache: { maxSize: 50, ttl: 300_000 },
         });
 
+        // Surface silently-stripped write fields (#3431/#3455) as a toast so a
+        // read-only value the user typed doesn't just vanish on save.
+        unsubscribeWriteWarning = a.onWriteWarning(toastWriteWarning);
+
         await a.connect();
 
         if (!cancelled) {
@@ -65,7 +87,10 @@ export function AdapterProvider({ children, adapter: externalAdapter }: AdapterP
     }
 
     init();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      unsubscribeWriteWarning?.();
+    };
   }, [externalAdapter]);
 
   return (

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -379,6 +379,36 @@ export type ConnectionStateListener = (event: ConnectionStateEvent) => void;
  */
 export type BatchProgressListener = (event: BatchProgressEvent) => void;
 
+/**
+ * One server-reported write-strip: caller-supplied fields the backend LEGALLY
+ * removed from a write before persisting (a non-system caller cannot seed a
+ * `readonly` field, a `readonlyWhen` predicate locked it, etc.). Mirrors the
+ * framework `DroppedFieldsEvent` (spec `DroppedFieldsEventSchema`) structurally
+ * so we don't pin a client type version — `reason` is kept as a widened string
+ * for forward-compatibility with reasons added server-side.
+ */
+export interface DroppedFieldsEvent {
+  object: string;
+  fields: string[];
+  reason: string;
+}
+
+/**
+ * Emitted after a create/update whose response carried `droppedFields`
+ * (framework #3431/#3455). The write SUCCEEDED — this is a warning that some
+ * supplied fields never landed, so the UI can tell the user rather than let it
+ * pass silently. Subscribe via {@link ObjectStackAdapter.onWriteWarning}.
+ */
+export interface WriteWarningEvent {
+  operation: 'create' | 'update';
+  resource: string;
+  id?: string | number;
+  droppedFields: DroppedFieldsEvent[];
+}
+
+/** Event listener type for write-warning (dropped-fields) events. */
+export type WriteWarningListener = (event: WriteWarningEvent) => void;
+
 // Re-export FileUploadResult from types for consumers
 export type { FileUploadResult } from '@object-ui/types';
 
@@ -470,6 +500,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   // calendar) auto-refresh — the interface ListView relies on to reflect
   // inline-edit "Save All" writes without a manual reload.
   private mutationListeners = new Set<(event: MutationEvent<T>) => void>();
+
+  // Subscribers registered via onWriteWarning(). Emitted after a create/update
+  // whose response carried `droppedFields` (framework #3431/#3455) so the app
+  // shell can surface a toast instead of the strip passing silently.
+  private writeWarningListeners = new Set<WriteWarningListener>();
 
   constructor(config: {
     baseUrl: string;
@@ -902,10 +937,59 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     };
   }
 
+  /**
+   * Notify all write-warning subscribers. Isolated like {@link emitMutation}: a
+   * throwing listener must not break the write or starve the others.
+   */
+  private emitWriteWarning(event: WriteWarningEvent): void {
+    for (const listener of this.writeWarningListeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        console.warn('ObjectStackAdapter: write-warning listener error', err);
+      }
+    }
+  }
+
+  /**
+   * Read `droppedFields` off a create/update response (framework #3431/#3455)
+   * and, when present, notify write-warning subscribers. Tolerant of a client
+   * whose response type predates `droppedFields`: the field is read structurally
+   * and validated, so an older client (or a backend that never drops) is a no-op.
+   */
+  private notifyDroppedFields(
+    operation: 'create' | 'update',
+    resource: string,
+    result: unknown,
+    id?: string | number,
+  ): void {
+    const dropped = (result as { droppedFields?: unknown } | null | undefined)?.droppedFields;
+    if (!Array.isArray(dropped) || dropped.length === 0) return;
+    const droppedFields = dropped.filter(
+      (e): e is DroppedFieldsEvent =>
+        !!e && typeof e === 'object' && Array.isArray((e as DroppedFieldsEvent).fields) && (e as DroppedFieldsEvent).fields.length > 0,
+    );
+    if (droppedFields.length === 0) return;
+    this.emitWriteWarning({ operation, resource, ...(id !== undefined ? { id } : {}), droppedFields });
+  }
+
+  /**
+   * Subscribe to write-warning events (a create/update dropped caller-supplied
+   * fields — #3431/#3455). Returns an unsubscribe function. The app shell uses
+   * this to toast the user; the write itself already succeeded.
+   */
+  onWriteWarning(callback: WriteWarningListener): () => void {
+    this.writeWarningListeners.add(callback);
+    return () => {
+      this.writeWarningListeners.delete(callback);
+    };
+  }
+
   async create(resource: string, data: Partial<T>): Promise<T> {
     await this.connect();
     const result = await this.client.data.create<T>(resource, data);
     this.emitMutation({ type: 'create', resource, record: { ...result.record } });
+    this.notifyDroppedFields('create', resource, result, (result.record as { id?: string | number } | undefined)?.id);
     return result.record;
   }
 
@@ -935,6 +1019,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         opts?.ifMatch ? { ifMatch: opts.ifMatch } : undefined,
       );
       this.emitMutation({ type: 'update', resource, id, record: { ...result.record } });
+      this.notifyDroppedFields('update', resource, result, id);
       return result.record;
     } catch (err) {
       throw normaliseClientError(err);

--- a/packages/data-objectstack/src/onWriteWarning.test.ts
+++ b/packages/data-objectstack/src/onWriteWarning.test.ts
@@ -1,0 +1,122 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ObjectStackAdapter must surface the framework's write-observability channel
+ * (#3431/#3455): when a create/update response carries `droppedFields` — fields
+ * the backend LEGALLY stripped (read-only / locked-by-state) — the adapter emits
+ * a WriteWarningEvent so the app shell can toast the user instead of letting the
+ * dropped value vanish silently. The write itself still succeeded.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackAdapter } from './index';
+import type { WriteWarningEvent } from './index';
+
+function makeDS(stub: Record<string, any>) {
+  const ds: any = new ObjectStackAdapter({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () =>
+      new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+  });
+  ds.connected = true;
+  ds.connectionState = 'connected';
+  ds.client = { data: stub };
+  return ds;
+}
+
+const ONE_DROP = [{ object: 'approval_case', fields: ['approval_status'], reason: 'readonly' }];
+
+describe('ObjectStackAdapter.onWriteWarning', () => {
+  it('emits a create write-warning carrying the dropped fields and the new id', async () => {
+    const create = vi.fn().mockResolvedValue({ record: { id: 'r1', title: 'A' }, droppedFields: ONE_DROP });
+    const ds = makeDS({ create });
+    const events: WriteWarningEvent[] = [];
+    ds.onWriteWarning((e: WriteWarningEvent) => events.push(e));
+
+    const rec = await ds.create('approval_case', { title: 'A', approval_status: 'approved' });
+
+    // The write still returns the plain record (unchanged behaviour).
+    expect(rec).toEqual({ id: 'r1', title: 'A' });
+    expect(events).toEqual([
+      { operation: 'create', resource: 'approval_case', id: 'r1', droppedFields: ONE_DROP },
+    ]);
+  });
+
+  it('emits an update write-warning carrying the target id', async () => {
+    const update = vi.fn().mockResolvedValue({ record: { id: 'r1' }, droppedFields: ONE_DROP });
+    const ds = makeDS({ update });
+    const events: WriteWarningEvent[] = [];
+    ds.onWriteWarning((e: WriteWarningEvent) => events.push(e));
+
+    await ds.update('approval_case', 'r1', { approval_status: 'approved' });
+
+    expect(events).toEqual([
+      { operation: 'update', resource: 'approval_case', id: 'r1', droppedFields: ONE_DROP },
+    ]);
+  });
+
+  it('does NOT emit when the response carries no droppedFields (the common case)', async () => {
+    const create = vi.fn().mockResolvedValue({ record: { id: 'r1', title: 'A' } });
+    const update = vi.fn().mockResolvedValue({ record: { id: 'r1' } });
+    const ds = makeDS({ create, update });
+    const events: WriteWarningEvent[] = [];
+    ds.onWriteWarning((e: WriteWarningEvent) => events.push(e));
+
+    await ds.create('approval_case', { title: 'A' });
+    await ds.update('approval_case', 'r1', { title: 'B' });
+
+    expect(events).toEqual([]);
+  });
+
+  it('does NOT emit for an empty or malformed droppedFields payload', async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({ record: { id: 'r1' }, droppedFields: [] })
+      .mockResolvedValueOnce({ record: { id: 'r2' }, droppedFields: 'nope' })
+      .mockResolvedValueOnce({ record: { id: 'r3' }, droppedFields: [{ object: 'x', fields: [] }] });
+    const ds = makeDS({ create });
+    const events: WriteWarningEvent[] = [];
+    ds.onWriteWarning((e: WriteWarningEvent) => events.push(e));
+
+    await ds.create('x', {});
+    await ds.create('x', {});
+    await ds.create('x', {}); // event present but its fields[] is empty → filtered out
+
+    expect(events).toEqual([]);
+  });
+
+  it('stops delivering after unsubscribe', async () => {
+    const create = vi.fn().mockResolvedValue({ record: { id: 'r1' }, droppedFields: ONE_DROP });
+    const ds = makeDS({ create });
+    const events: WriteWarningEvent[] = [];
+    const unsub = ds.onWriteWarning((e: WriteWarningEvent) => events.push(e));
+
+    await ds.create('approval_case', {});
+    unsub();
+    await ds.create('approval_case', {});
+
+    expect(events).toHaveLength(1);
+  });
+
+  it('isolates a throwing listener so the write still resolves and other listeners fire', async () => {
+    const update = vi.fn().mockResolvedValue({ record: { id: 'r1' }, droppedFields: ONE_DROP });
+    const ds = makeDS({ update });
+    const good = vi.fn();
+    ds.onWriteWarning(() => { throw new Error('boom'); });
+    ds.onWriteWarning(good);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(ds.update('approval_case', 'r1', { approval_status: 'x' })).resolves.toBeTruthy();
+    expect(good).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
Consumes the framework write-observability channel (framework #3431 / #3455): the backend now reports fields it LEGALLY stripped from a write — a non-system caller can't seed a `readonly` field, a `readonlyWhen` predicate locked it, the #3043 create-ingress strip removed it — as a `droppedFields` payload on the create/update response (and the `X-ObjectStack-Dropped-Fields` header). The console **discarded** it: a value the user typed into a locked field just vanished on save under a success toast, with no explanation. This surfaces it.

## Changes

**`@object-ui/data-objectstack` — central adapter seam.**
`ObjectStackAdapter` gains a write-warning bus mirroring the existing `onMutation` one:
- `onWriteWarning(cb): () => void` — subscribe; returns an unsubscribe.
- After a `create`/`update` whose client response carried `droppedFields`, the adapter emits a `WriteWarningEvent { operation, resource, id?, droppedFields }`.
- The payload is read **structurally** and validated (`notifyDroppedFields`), so an older `@objectstack/client` whose type predates `droppedFields`, or a backend that never drops, is a silent no-op — no version pin.
- New exported types: `WriteWarningEvent`, `WriteWarningListener`, `DroppedFieldsEvent`.

**`@object-ui/app-shell` — wiring.**
`AdapterProvider` subscribes on adapter creation and raises a `toast.warning` (“Some fields were not saved — the read-only field … could not be changed and was not saved”), cleaning the subscription up on unmount. The write itself still succeeded — this is a warning, status/behaviour unchanged.

Central by design: the single `onWriteWarning` seam on the shared adapter covers every create/update consumer (ObjectView form save, inline edit, …) without touching each call site.

## Verification

- **Unit** (`packages/data-objectstack/src/onWriteWarning.test.ts`, 6 cases): emits on create/update with the dropped fields + id; **no** emit when `droppedFields` is absent / empty / malformed; unsubscribe stops delivery; a throwing listener is isolated (write still resolves). `onMutation` regression suite still green (36 tests total).
- **Types:** `data-objectstack` (`tsc -b`) and `app-shell` (`tsc --noEmit`) both clean.
- **Browser:** rendered the toast through the **real** ConsoleToaster in the running console — both the singular (“The read-only field “approval_status” …”) and plural (“2 read-only fields … : approval_status, locked_at”) grammar. Screenshot on request.

## Notes

Depends on the backend returning `droppedFields`, which lands with framework #3468 (merged). Until a deployment includes it, this is inert (no event, no toast) — safe to ship ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)