### PR TITLE
docs(plugin-grid): reflect audit-timeline preservation in the historical-import hint (#3493)

### DIFF
--- a/.changeset/import-historical-hint.md
+++ b/.changeset/import-historical-hint.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/plugin-grid": patch
+---
+
+docs(plugin-grid): the "Import as historical data" wizard hint now reflects audit-timeline preservation (#3493)
+
+`treatAsHistorical` gained a second half in framework #3493/#3497 — the import
+write context also carries `preserveAudit`, so a historical import keeps the
+original `updated_at`/`updated_by` and business `readonly` fields instead of
+stamping-now / stripping them. The checkbox hint only described the
+state-machine-skip half; it now also says the original timestamps & author are
+preserved. The `ImportRequest.treatAsHistorical` type doc (`@object-ui/types`)
+is updated to match. Copy-only — no behavior change (the checkbox already sent
+`treatAsHistorical`, so the server-side extension is reached without any wiring
+change).

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -121,7 +121,7 @@ const IMPORT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'grid.import.optCreateOptions': 'Keep unknown option values',
   'grid.import.optRunAutomations': 'Run automations & triggers',
   'grid.import.optTreatHistorical': 'Import as historical data',
-  'grid.import.optTreatHistoricalHint': '(skip state-machine checks so already-completed records import as-is)',
+  'grid.import.optTreatHistoricalHint': '(import completed records as-is — skip state-machine checks and keep their original timestamps & author instead of stamping now)',
   'grid.import.optSkipBlankKey': 'Skip rows with a blank match value',
   'grid.import.optBackground': 'Import in the background',
   'grid.import.optBackgroundHint': '(runs as an undoable job)',

--- a/packages/types/src/data.ts
+++ b/packages/types/src/data.ts
@@ -819,9 +819,11 @@ export interface ImportRequestOptions {
   matchFields?: string[];
   /** Fire triggers/hooks for each imported row (off by default for bulk). */
   runAutomations?: boolean;
-  /** Import as established historical facts: skip the `state_machine` rule so
+  /** Import as established historical facts. Skips the `state_machine` rule so
    *  mid-lifecycle rows (already-closed tickets, closed_won deals) aren't rejected
-   *  by `initialStates` (framework #3479). @default false */
+   *  by `initialStates` (framework #3479), AND preserves the original audit timeline:
+   *  a supplied `updated_at`/`updated_by` and business `readonly` fields are kept
+   *  instead of stamped-now / stripped (framework #3493). @default false */
   treatAsHistorical?: boolean;
   /** Trim leading/trailing whitespace from string cells. @default true */
   trimWhitespace?: boolean;


### PR DESCRIPTION
## What & why

Companion to framework #3497 (merged), which taught `treatAsHistorical` a second half (#3493).

**Verification first:** the import wizard already wires the historical option end-to-end — `ImportWizard.tsx` binds a checkbox to `treatAsHistorical` and `assembleImportRequest` sends `treatAsHistorical: true` (only when on) on both the regular and named-mapping paths, with `importDryRun.test.ts` pinning it. So the server-side `preserveAudit` extension is **already reachable from the wizard with no wiring change**. ✅

**The gap:** the checkbox's *hint copy* is now stale. It only described the state-machine-skip half:

> _(skip state-machine checks so already-completed records import as-is)_

...but checking the box now **also preserves the original audit timeline** — a supplied `updated_at`/`updated_by` and business `readonly` fields are kept instead of stamped-now / stripped. A user reading the hint wouldn't know that.

## Change (copy-only)

- `packages/plugin-grid/src/ImportWizard.tsx` — `optTreatHistoricalHint` now reads:
  > _(import completed records as-is — skip state-machine checks and keep their original timestamps & author instead of stamping now)_
- `packages/types/src/data.ts` — the `ImportRequest.treatAsHistorical` JSDoc now documents both halves (FSM skip #3479 + audit-timeline preservation #3493).

No behavior change; no test asserts the hint text (checked). These inline strings are the only copy — there's no separate locale file for the import-wizard hints. Patch changeset on `@object-ui/plugin-grid` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5rdfBKjkbcoEif4KUV6xE)_