### PR TITLE
feat: render the server's effective API operation set (#3391 PR-4)

### DIFF
--- a/.changeset/effective-api-operations-ui.md
+++ b/.changeset/effective-api-operations-ui.md
@@ -1,0 +1,41 @@
+---
+"@object-ui/core": minor
+"@object-ui/permissions": minor
+"@object-ui/plugin-grid": minor
+"@object-ui/plugin-list": minor
+"@object-ui/app-shell": minor
+"@object-ui/i18n": minor
+---
+
+feat: render the server's effective API operation set (#3391 PR-4)
+
+The frontend now consumes the per-object **effective API operation set** the
+server resolves (from `/me/permissions` `apiOperations`, framework #3391) —
+never the raw `apiMethods` — so Import/Export/New/Edit/Delete buttons match what
+the server will actually admit, and a 405 import refusal shows a dedicated
+message instead of silently falling back.
+
+- **core** `resolveCrudAffordances(obj, effectiveApiOperations?)` — new optional
+  second argument intersects each affordance bit with its API operation
+  (create/import→create/import, edit→update, delete→delete, exportCsv→export).
+  Omitting it (old backend / no effective set) leaves affordances unchanged.
+- **permissions** — `/me/permissions` response carries per-object
+  `apiOperations`; `PermissionContextValue.getObjectApiOperations(object)`
+  exposes it (undefined when absent → callers keep current behavior); `check()`
+  maps `import→allowCreate`, `export→allowRead`.
+- **app-shell** `ObjectView` intersects its toolbar affordances with the object's
+  effective operations (Import); the platform-admin identity-import bypass is
+  unaffected.
+- **plugin-list** `ListView` / **plugin-grid** `ObjectGrid` gate the Export
+  button (and export handler) on effective `export`; `plugin-grid` gains the
+  `@object-ui/permissions` workspace dependency.
+- **plugin-grid** `ImportWizard` — a 405 / `OBJECT_API_METHOD_NOT_ALLOWED`
+  import refusal is detected by a new `isImportNotAllowed` predicate at every
+  catch site (async, sync, dry-run) and STOPS with a dedicated
+  `grid.import.notAllowed` message (10 locales + fallback dict) — it never falls
+  back to the sync/legacy path (which 405s too), distinct from the 404
+  route-absent fallback.
+
+Backward-compatible: a missing effective set (unrestricted object, older
+backend, or no permission provider) preserves the current default-allow
+behavior everywhere.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -350,7 +350,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     // Admin users automatically get design tools (no toggle needed)
     const { user, activeOrganization } = useAuth();
     const isAdmin = useIsWorkspaceAdmin();
-    const { can } = usePermissions();
+    const { can, getObjectApiOperations } = usePermissions();
     
     // Get Object Definition. The outer ObjectView wrapper already guards the
     // missing-object case, so this always resolves while this component is
@@ -405,9 +405,14 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     // hide the lot — those flows go through purpose-built actions on the
     // source record (e.g. "Submit for Approval" on an Opportunity creates
     // an `sys_approval_request`).  Permissions still gate the buttons.
+    // [#3391] Intersect the bucket affordances with the server's effective API
+    // operation set for this object (from /me/permissions apiOperations), so the
+    // toolbar never offers Import/Export/New/Edit/Delete the server would 405.
+    // `undefined` (unrestricted object / old backend) leaves affordances as-is.
+    // The identity-import bypass below is independent of `affordances.import`.
     const affordances = useMemo(
-      () => resolveCrudAffordances(objectDef as any),
-      [objectDef],
+      () => resolveCrudAffordances(objectDef as any, getObjectApiOperations(objectDef.name)),
+      [objectDef, getObjectApiOperations],
     );
 
     // Propagate externally-triggered refreshes (e.g. global ModalForm submit)

--- a/packages/core/src/utils/managedBy.test.ts
+++ b/packages/core/src/utils/managedBy.test.ts
@@ -143,3 +143,46 @@ describe('MANAGED_BY_BUCKETS', () => {
     expect(MANAGED_BY_BUCKETS).toEqual(['platform', 'config', 'system', 'engine-owned', 'append-only', 'better-auth']);
   });
 });
+
+describe('resolveCrudAffordances — effective API operations (#3391)', () => {
+  it('undefined effective set → affordances unchanged (backward-compatible)', () => {
+    const platform = { managedBy: 'platform' };
+    expect(resolveCrudAffordances(platform)).toEqual(resolveCrudAffordances(platform, undefined));
+    expect(resolveCrudAffordances(platform, undefined)).toEqual({
+      create: true, import: true, edit: true, delete: true, exportCsv: true,
+    });
+  });
+
+  it('ANDs each affordance bit with its API operation (create/import→create/import, edit→update, delete→delete, exportCsv→export)', () => {
+    // A full-CRUD platform object whose server effective set is read-only + list-derived.
+    const aff = resolveCrudAffordances({ managedBy: 'platform' }, ['get', 'list', 'export']);
+    expect(aff).toMatchObject({
+      create: false, import: false, edit: false, delete: false, exportCsv: true,
+    });
+  });
+
+  it('keeps a bit only when BOTH the affordance and the effective op allow it', () => {
+    // create+update present → create/import/edit survive; no delete/list → delete/export drop.
+    const aff = resolveCrudAffordances({ managedBy: 'platform' }, ['create', 'update', 'import']);
+    expect(aff.create).toBe(true);
+    expect(aff.edit).toBe(true);
+    expect(aff.import).toBe(true);
+    expect(aff.delete).toBe(false);
+    expect(aff.exportCsv).toBe(false);
+  });
+
+  it('empty effective set → all bits off (deny-all)', () => {
+    expect(resolveCrudAffordances({ managedBy: 'platform' }, [])).toMatchObject({
+      create: false, import: false, edit: false, delete: false, exportCsv: false,
+    });
+  });
+
+  it('never re-enables a bit the bucket/userActions already denied', () => {
+    // config bucket has no import; even if the server would allow import, the
+    // UI-intent axis keeps it off (intersection, never union).
+    const aff = resolveCrudAffordances({ managedBy: 'config' }, ['create', 'update', 'delete', 'import', 'export']);
+    expect(aff.import).toBe(false); // config never imports
+    expect(aff.create).toBe(true);
+    expect(aff.exportCsv).toBe(true);
+  });
+});

--- a/packages/core/src/utils/managedBy.ts
+++ b/packages/core/src/utils/managedBy.ts
@@ -112,8 +112,36 @@ export function userActionPredicates(
   return normalizeUserAction(v, false).predicates;
 }
 
-/** Resolve the effective CRUD affordances for an object schema. */
-export function resolveCrudAffordances(obj: SchemaLike | null | undefined): CrudAffordances {
+/**
+ * The affordance-bit → server API-operation mapping used to intersect the
+ * UI-intent affordances with the server's effective API operation set (#3391).
+ * This is the objectui end of the framework's `API_METHOD_DERIVATION` contract:
+ * the button predicate is `affordance(op) ∧ effective.api(op)`.
+ */
+const AFFORDANCE_TO_API_OPERATION = {
+  create: 'create',
+  import: 'import',
+  edit: 'update',
+  delete: 'delete',
+  exportCsv: 'export',
+} as const;
+
+/**
+ * Resolve the effective CRUD affordances for an object schema.
+ *
+ * @param obj The object schema (managedBy bucket + userActions overrides).
+ * @param effectiveApiOperations OPTIONAL server-resolved effective API operation
+ *   set for this object (from `/me/permissions` `apiOperations`, #3391). When
+ *   provided, each affordance bit is ANDed with the corresponding API operation
+ *   (create/import→create/import, edit→update, delete→delete, exportCsv→export),
+ *   so the UI never shows a button the server would 405. Passing `undefined`
+ *   (old backend / no effective set) leaves the affordances untouched —
+ *   backward-compatible. An empty array means "expose nothing" → all bits off.
+ */
+export function resolveCrudAffordances(
+  obj: SchemaLike | null | undefined,
+  effectiveApiOperations?: readonly string[] | null,
+): CrudAffordances {
   const bucket = (obj?.managedBy as ManagedByBucket | undefined) ?? 'platform';
   const base = DEFAULTS[bucket] ?? DEFAULTS.platform;
   const o = obj?.userActions ?? {};
@@ -128,6 +156,17 @@ export function resolveCrudAffordances(obj: SchemaLike | null | undefined): Crud
   };
   if (edit.predicates) out.editPredicates = edit.predicates;
   if (del.predicates) out.deletePredicates = del.predicates;
+  // [#3391] Intersect with the server's effective API operations when present.
+  // The frontend consumes the effective set the server hands down; it never
+  // reads the raw `apiMethods` nor re-derives.
+  if (Array.isArray(effectiveApiOperations)) {
+    const eff = new Set(effectiveApiOperations);
+    for (const [bit, op] of Object.entries(AFFORDANCE_TO_API_OPERATION) as Array<
+      [keyof typeof AFFORDANCE_TO_API_OPERATION, string]
+    >) {
+      if (out[bit] && !eff.has(op)) out[bit] = false;
+    }
+  }
   return out;
 }
 

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -182,6 +182,7 @@ const ar = {
     },
     import: {
       title: "استيراد {{object}}",
+      notAllowed: "هذا الكائن غير متاح للاستيراد.",
       stepUpload: "رفع",
       stepMapping: "تعيين",
       stepPreview: "معاينة",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -182,6 +182,7 @@ const de = {
     },
     import: {
       title: "{{object}} importieren",
+      notAllowed: "Dieses Objekt ist nicht für den Import freigegeben.",
       stepUpload: "Hochladen",
       stepMapping: "Zuordnung",
       stepPreview: "Vorschau",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -207,6 +207,7 @@ const en = {
     },
     import: {
       title: 'Import {{object}}',
+      notAllowed: 'This object is not open for import.',
       stepUpload: 'Upload',
       stepMapping: 'Mapping',
       stepPreview: 'Preview',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -182,6 +182,7 @@ const es = {
     },
     import: {
       title: "Importar {{object}}",
+      notAllowed: "Este objeto no está habilitado para la importación.",
       stepUpload: "Cargar",
       stepMapping: "Asignación",
       stepPreview: "Vista previa",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -182,6 +182,7 @@ const fr = {
     },
     import: {
       title: "Importer {{object}}",
+      notAllowed: "Cet objet n'est pas ouvert à l'import.",
       stepUpload: "Télécharger",
       stepMapping: "Correspondance",
       stepPreview: "Aperçu",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -182,6 +182,7 @@ const ja = {
     },
     import: {
       title: "{{object}}をインポート",
+      notAllowed: "このオブジェクトはインポートに対応していません。",
       stepUpload: "アップロード",
       stepMapping: "マッピング",
       stepPreview: "プレビュー",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -182,6 +182,7 @@ const ko = {
     },
     import: {
       title: "{{object}} 가져오기",
+      notAllowed: "이 객체는 가져오기가 허용되지 않습니다.",
       stepUpload: "업로드",
       stepMapping: "매핑",
       stepPreview: "미리보기",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -182,6 +182,7 @@ const pt = {
     },
     import: {
       title: "Importar {{object}}",
+      notAllowed: "Este objeto não está aberto para importação.",
       stepUpload: "Enviar",
       stepMapping: "Mapeamento",
       stepPreview: "Pré-visualização",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -182,6 +182,7 @@ const ru = {
     },
     import: {
       title: "Импорт {{object}}",
+      notAllowed: "Этот объект не открыт для импорта.",
       stepUpload: "Загрузка",
       stepMapping: "Сопоставление",
       stepPreview: "Предпросмотр",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -206,6 +206,7 @@ const zh = {
     },
     import: {
       title: '导入{{object}}',
+      notAllowed: '该对象未开放导入。',
       stepUpload: '上传',
       stepMapping: '字段映射',
       stepPreview: '预览',

--- a/packages/permissions/src/MePermissionsProvider.tsx
+++ b/packages/permissions/src/MePermissionsProvider.tsx
@@ -34,6 +34,13 @@ export interface MePermissionsResponse {
     allowDelete?: boolean;
     viewAllRecords?: boolean;
     modifyAllRecords?: boolean;
+    /**
+     * [#3391] Server-resolved effective API operation set for this object
+     * (enum-ordered). Present only when the object tightens exposure via
+     * `apiMethods`; absent = unrestricted (client default-allow). The frontend
+     * consumes THIS, never a raw `apiMethods` whitelist.
+     */
+    apiOperations?: string[];
     [k: string]: unknown;
   }>;
   /** field-level perms keyed `"object.field"` */
@@ -156,6 +163,12 @@ export function MePermissionsProvider({
         update: 'allowEdit',
         edit: 'allowEdit',
         delete: 'allowDelete',
+        // [#3391] import derives from create∨update, export from list(read) —
+        // gate them on the base write/read permission bit (the per-object
+        // effective API operation set adds the finer apiMethods layer on top,
+        // consumed via getObjectApiOperations + resolveCrudAffordances).
+        import: 'allowCreate',
+        export: 'allowRead',
       };
       const k = map[action as string] ?? 'allowRead';
       // Same authentication-gated default as checkField (#2926 ④).
@@ -186,12 +199,26 @@ export function MePermissionsProvider({
 
   const getRowFilter = useCallback(() => undefined, []);
 
+  const getObjectApiOperations = useCallback(
+    (object: string): string[] | undefined => {
+      if (!data) return undefined;
+      const objKey = (object ?? '').toLowerCase();
+      // Per-object only — the `*` wildcard carries no apiOperations. Absent →
+      // undefined so consumers fall back to their current (default-allow) path.
+      const objPerm = data.objects?.[objKey] ?? data.objects?.[object];
+      const ops = objPerm?.apiOperations;
+      return Array.isArray(ops) ? ops : undefined;
+    },
+    [data],
+  );
+
   const value = useMemo<PermissionContextValue>(
     () => ({
       check,
       checkField,
       getFieldPermissions,
       getRowFilter,
+      getObjectApiOperations,
       roles: data?.roles ?? [],
       systemPermissions: data?.systemPermissions ?? [],
       hasCapabilities: (required: string[]) => {
@@ -200,7 +227,7 @@ export function MePermissionsProvider({
       },
       isLoaded: !loading && !error && data !== null,
     }),
-    [check, checkField, getFieldPermissions, getRowFilter, data, loading, error],
+    [check, checkField, getFieldPermissions, getRowFilter, getObjectApiOperations, data, loading, error],
   );
 
   if (loading && !data) return <>{loadingFallback}</>;

--- a/packages/permissions/src/PermissionContext.ts
+++ b/packages/permissions/src/PermissionContext.ts
@@ -18,6 +18,14 @@ export interface PermissionContextValue {
   getFieldPermissions: (object: string) => FieldLevelPermission[];
   /** Get row filter for an object */
   getRowFilter: (object: string) => string | undefined;
+  /**
+   * [#3391] Server-resolved effective API operation set for an object (from
+   * `/me/permissions` `apiOperations`), or `undefined` when the object carries
+   * no effective set (unrestricted object / old backend / no provider). The UI
+   * intersects this with its CRUD affordances (`resolveCrudAffordances`), never
+   * reading the raw `apiMethods`. `undefined` → callers keep current behavior.
+   */
+  getObjectApiOperations: (object: string) => string[] | undefined;
   /** Current user roles */
   roles: string[];
   /** [ADR-0066] System capabilities held by the user (union of permission-set systemPermissions). */

--- a/packages/permissions/src/PermissionProvider.tsx
+++ b/packages/permissions/src/PermissionProvider.tsx
@@ -119,6 +119,9 @@ export function PermissionProvider({
       checkField,
       getFieldPermissions,
       getRowFilter,
+      // [#3391] Role-based provider does not model the server's effective API
+      // operation set — return undefined so consumers keep current behavior.
+      getObjectApiOperations: () => undefined,
       roles: userRoles,
       // This role-based provider does not model ADR-0066 system capabilities;
       // expose an empty set + a fail-open capability check to satisfy the

--- a/packages/permissions/src/__tests__/MePermissionsProvider.test.tsx
+++ b/packages/permissions/src/__tests__/MePermissionsProvider.test.tsx
@@ -192,4 +192,63 @@ describe('MePermissionsProvider', () => {
     expect(screen.getByTestId('loaded').textContent).toBe('true');
     expect(screen.getByTestId('read').textContent).toBe('false');
   });
+
+  // [#3391] The provider exposes the server's per-object effective API operation
+  // set and maps import/export onto the base write/read permission bit.
+  it('exposes per-object effective apiOperations; undefined when absent', () => {
+    function ApiOpsProbe() {
+      const { getObjectApiOperations } = usePermissions();
+      return (
+        <div>
+          <span data-testid="acct">{JSON.stringify(getObjectApiOperations('account'))}</span>
+          <span data-testid="widget">{String(getObjectApiOperations('widget'))}</span>
+          <span data-testid="missing">{String(getObjectApiOperations('nope'))}</span>
+        </div>
+      );
+    }
+    render(
+      <MePermissionsProvider
+        endpoint="/x"
+        initialPermissions={{
+          authenticated: true, userId: 'u', tenantId: 't', roles: [], permissionSets: [],
+          objects: {
+            account: { allowRead: true, apiOperations: ['get', 'list', 'export'] },
+            widget: { allowRead: true }, // no apiOperations → undefined
+          },
+          fields: {},
+        }}
+      >
+        <ApiOpsProbe />
+      </MePermissionsProvider>,
+    );
+    expect(screen.getByTestId('acct').textContent).toBe(JSON.stringify(['get', 'list', 'export']));
+    expect(screen.getByTestId('widget').textContent).toBe('undefined');
+    expect(screen.getByTestId('missing').textContent).toBe('undefined');
+  });
+
+  it('check(import)→allowCreate and check(export)→allowRead', () => {
+    function ActionProbe() {
+      const { can } = usePermissions();
+      return (
+        <div>
+          <span data-testid="import">{String(can('account', 'import'))}</span>
+          <span data-testid="export">{String(can('account', 'export'))}</span>
+        </div>
+      );
+    }
+    render(
+      <MePermissionsProvider
+        endpoint="/x"
+        initialPermissions={{
+          authenticated: true, userId: 'u', tenantId: 't', roles: [], permissionSets: [],
+          objects: { account: { allowRead: true, allowCreate: false } },
+          fields: {},
+        }}
+      >
+        <ActionProbe />
+      </MePermissionsProvider>,
+    );
+    expect(screen.getByTestId('import').textContent).toBe('false'); // gated on allowCreate:false
+    expect(screen.getByTestId('export').textContent).toBe('true');  // gated on allowRead:true
+  });
 });

--- a/packages/permissions/src/usePermissions.ts
+++ b/packages/permissions/src/usePermissions.ts
@@ -34,6 +34,7 @@ export function usePermissions(): PermissionContextValue & {
         checkField: () => true,
         getFieldPermissions: () => [],
         getRowFilter: () => undefined,
+        getObjectApiOperations: () => undefined,
         roles: [],
         systemPermissions: [],
         hasCapabilities: () => true,

--- a/packages/plugin-grid/package.json
+++ b/packages/plugin-grid/package.json
@@ -25,6 +25,7 @@
     "@object-ui/fields": "workspace:*",
     "@object-ui/i18n": "workspace:*",
     "@object-ui/mobile": "workspace:*",
+    "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@tanstack/react-virtual": "^3.14.6",

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -174,6 +174,9 @@ const IMPORT_DEFAULT_TRANSLATIONS: Record<string, string> = {
   // Shown on the completion screen when the import ran via the legacy per-row
   // fallback (server `/import` route unavailable) — no server-side coercion.
   'grid.import.legacyFallbackNotice': 'Imported via a compatibility fallback: this connection doesn’t support the server import route, so values were saved as text without server-side type coercion. Upgrade the backend/client for full import support (type coercion and relation lookups).',
+  // Shown when the server refuses import with 405 because the object does not
+  // expose the import operation (#3391) — distinct from "route not found".
+  'grid.import.notAllowed': 'This object is not open for import.',
 };
 
 /** Apply `{{var}}` interpolation to a translation template. */
@@ -219,6 +222,7 @@ export const __testables = {
   get mappedReferenceFields() { return mappedReferenceFields; },
   get formatDryRunError() { return formatDryRunError; },
   get isUnsupportedImportJob() { return isUnsupportedImportJob; },
+  get isImportNotAllowed() { return isImportNotAllowed; },
   get jobResultToImportResult() { return jobResultToImportResult; },
   get buildFailedRowsCsv() { return buildFailedRowsCsv; },
   get buildImportTemplateCsv() { return buildImportTemplateCsv; },
@@ -568,6 +572,25 @@ function isUnsupportedImportJob(err: unknown): boolean {
   if (code === 'UNSUPPORTED_OPERATION') return true;
   const msg = err instanceof Error ? err.message : '';
   return /does not support async import|createImportJob is not a function|import\/jobs|404/i.test(msg);
+}
+
+/** True when the SERVER refused the import because the object does not expose
+ *  the import operation (405 / `OBJECT_API_METHOD_NOT_ALLOWED`, #3391).
+ *
+ *  The opposite of {@link isUnsupportedImportJob} (404 = the async-job ROUTE is
+ *  absent → fall back to sync) and {@link isUnsupportedImport} (adapter can't
+ *  speak `/import` → fall back to per-row create): a **405** means "this object
+ *  is not open for import at all", so every fallback would 405 too. The wizard
+ *  must STOP and show a dedicated message — never fall back. Checked BEFORE the
+ *  unsupported predicates at every catch site so 405 wins over the 404/regex
+ *  fall-back paths. */
+function isImportNotAllowed(err: unknown): boolean {
+  const code = (err as { code?: unknown })?.code;
+  if (code === 'OBJECT_API_METHOD_NOT_ALLOWED') return true;
+  const e = err as { status?: unknown; statusCode?: unknown; httpStatus?: unknown };
+  if (e?.status === 405 || e?.statusCode === 405 || e?.httpStatus === 405) return true;
+  const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  return /\b405\b|method not allowed/i.test(msg);
 }
 
 /** Map an async import-job's final results payload onto the wizard's
@@ -1830,6 +1853,10 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
     try {
       created = await ds.createImportJob(objectName, request);
     } catch (err) {
+      // [#3391] A 405 (object not open for import) must NOT fall back to the
+      // sync route (which 405s too) — rethrow so handleImport surfaces the
+      // dedicated message. Checked BEFORE the 404-based unsupported fallback.
+      if (isImportNotAllowed(err)) throw err;
       if (isUnsupportedImportJob(err)) return false;
       throw err;
     }
@@ -1918,6 +1945,16 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
         const handled = await runAsyncImport(request);
         if (handled) return;
       } catch (err) {
+        // [#3391] Object not open for import (405) → stop with the dedicated
+        // message; never fall back to the sync route (it 405s too).
+        if (isImportNotAllowed(err)) {
+          const importResult: ImportResult = {
+            totalRows: rows.length, importedRows: 0, skippedRows: rows.length,
+            errors: [{ row: 0, field: '', message: t('grid.import.notAllowed') }],
+          };
+          setResult(importResult); setImporting(false); onComplete?.(importResult);
+          return;
+        }
         if (!isUnsupportedImportJob(err)) {
           const msg = err instanceof Error ? err.message : 'Import failed';
           const importResult: ImportResult = {
@@ -1956,6 +1993,16 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
         setResult(importResult); setImporting(false); onComplete?.(importResult);
         return;
       } catch (err) {
+        // [#3391] Object not open for import (405) → stop with the dedicated
+        // message; never fall back to the legacy per-row loop (it 405s too).
+        if (isImportNotAllowed(err)) {
+          const importResult: ImportResult = {
+            totalRows: rows.length, importedRows: 0, skippedRows: rows.length,
+            errors: [{ row: 0, field: '', message: t('grid.import.notAllowed') }],
+          };
+          setResult(importResult); setImporting(false); onComplete?.(importResult);
+          return;
+        }
         if (!isUnsupportedImport(err)) {
           // A real server failure — surface it rather than silently retrying
           // via the legacy loop (which could double-import partial successes).
@@ -1974,7 +2021,7 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
     await legacyImport();
   }, [
     dataSource, objectName, buildImportRequest, onComplete, rows.length, legacyImport, runAsyncImport,
-    backgroundImport,
+    backgroundImport, t,
   ]);
 
   // Small-file server dry-run pre-check: validate + coerce every row without
@@ -1990,6 +2037,17 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
       const res = await serverImport.call(dataSource, objectName, buildImportRequest(true));
       setDryRunResult(res);
     } catch (err) {
+      // [#3391] Object not open for import (405) → surface the dedicated
+      // message in the dry-run summary; checked before the /import unsupported
+      // fall-back (which would silently hide the refusal).
+      if (isImportNotAllowed(err)) {
+        setDryRunResult({
+          object: objectName, dryRun: true, writeMode, total: rows.length,
+          ok: 0, errors: rows.length, created: 0, updated: 0, skipped: 0,
+          results: [{ row: 0, ok: false, error: t('grid.import.notAllowed') }],
+        });
+        return;
+      }
       // Older adapter/client without /import — silently fall back to the
       // client-side cell validation that StepPreview already shows.
       if (!isUnsupportedImport(err)) {
@@ -2003,7 +2061,7 @@ export const ImportWizard: React.FC<ImportWizardProps> = ({
     } finally {
       setValidating(false);
     }
-  }, [dataSource, objectName, buildImportRequest, writeMode, rows.length]);
+  }, [dataSource, objectName, buildImportRequest, writeMode, rows.length, t]);
 
   // A prior dry-run becomes stale the moment the payload changes (mapping,
   // write-mode, options, or an inline cell correction) — drop it so the summary

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -36,6 +36,7 @@ import {
 } from '@object-ui/components';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { resolveConditionalFormatting, buildExpandFields, buildExportFileName } from '@object-ui/core';
+import { usePermissions } from '@object-ui/permissions';
 import { ChevronRight, ChevronDown, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock, Loader2 } from 'lucide-react';
 import { useRowColor } from './useRowColor';
 import { useGroupedData } from './useGroupedData';
@@ -411,6 +412,13 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const objectName = dataConfig?.provider === 'object' && dataConfig && 'object' in dataConfig
     ? (dataConfig as any).object
     : schema.objectName;
+  // [#3391] Server-resolved effective API operation set for this object
+  // (/me/permissions `apiOperations`). The Export button and handler AND their
+  // gate with this — a missing set (unrestricted object / old backend / no
+  // provider) keeps the current behavior. The frontend consumes the effective
+  // set the server resolved; it never reads the raw `apiMethods`.
+  const { getObjectApiOperations } = usePermissions();
+  const effectiveApiOps = objectName ? getObjectApiOperations(objectName) : undefined;
   const schemaFields = schema.fields;
   const schemaColumns = schema.columns;
   const schemaFilter = schema.filter;
@@ -1244,9 +1252,12 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   }, [objectSchema, schemaFields, schemaColumns, dataConfig, hasInlineData, navigation.handleClick, executeAction, data, resolveFieldLabel, translateOptions, schema.objectName]);
 
   const handleExport = useCallback((format: 'csv' | 'xlsx' | 'json' | 'pdf') => {
-    // Object-level export permission gate. Default-allow: only an explicit
-    // `operations.export === false` blocks the export.
+    // Object-level export permission gate. Default-allow: an explicit
+    // `operations.export === false` blocks it, and — when the server hands down
+    // an effective API operation set for this object (#3391) — so does its
+    // exclusion of `export`. Missing effective set keeps current behavior.
     if (schema.operations?.export === false) return;
+    if (effectiveApiOps && !effectiveApiOps.includes('export')) return;
     const exportConfig = schema.exportOptions;
     const maxRecords = exportConfig?.maxRecords || 0;
     const includeHeaders = exportConfig?.includeHeaders !== false;
@@ -1352,7 +1363,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       downloadFile(new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' }), fileNameFor('json'));
     }
     setShowExport(false);
-  }, [data, schema.exportOptions, schema.operations?.export, schema.objectName, objectName, objectSchema, generateColumns, dataSource, hasInlineData, schemaFilter, schemaSort]);
+  }, [data, schema.exportOptions, schema.operations?.export, effectiveApiOps, schema.objectName, objectName, objectSchema, generateColumns, dataSource, hasInlineData, schemaFilter, schemaSort]);
 
   if (error) {
     return (
@@ -2269,8 +2280,13 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // Hide row-height toggle when parent (e.g., ListView) controls density externally,
   // signaled by `hideRowHeightToggle` prop on schema.
   const showRowHeightToggle = schema.rowHeight !== undefined && !(schema as any).hideRowHeightToggle;
-  // Export is offered only when configured AND not blocked by object-level perms.
-  const exportEnabled = !!schema.exportOptions && schema.operations?.export !== false;
+  // Export is offered only when configured AND not blocked by object-level perms
+  // — including the server's effective API operation set (#3391): when present
+  // and it excludes `export`, the button is hidden. Missing set → unchanged.
+  const exportEnabled =
+    !!schema.exportOptions &&
+    schema.operations?.export !== false &&
+    (effectiveApiOps ? effectiveApiOps.includes('export') : true);
   const hasToolbar = exportEnabled || showRowHeightToggle;
   const gridToolbar = hasToolbar ? (
     <div className="flex items-center justify-end gap-1 px-2 py-1">

--- a/packages/plugin-grid/src/importAsyncPath.test.ts
+++ b/packages/plugin-grid/src/importAsyncPath.test.ts
@@ -2,7 +2,44 @@ import { describe, it, expect } from 'vitest';
 import { __testables } from './ImportWizard';
 import type { ImportJobResultsInfo } from '@object-ui/types';
 
-const { isUnsupportedImportJob, jobResultToImportResult } = __testables;
+const { isUnsupportedImportJob, isImportNotAllowed, jobResultToImportResult } = __testables;
+
+describe('isImportNotAllowed (#3391)', () => {
+  it('matches the framework OBJECT_API_METHOD_NOT_ALLOWED code', () => {
+    expect(isImportNotAllowed({ code: 'OBJECT_API_METHOD_NOT_ALLOWED' })).toBe(true);
+  });
+
+  it('matches a 405 on status / statusCode / httpStatus', () => {
+    expect(isImportNotAllowed({ status: 405 })).toBe(true);
+    expect(isImportNotAllowed({ statusCode: 405 })).toBe(true);
+    expect(isImportNotAllowed({ httpStatus: 405 })).toBe(true);
+  });
+
+  it('matches a bare 405 / "method not allowed" message', () => {
+    expect(isImportNotAllowed(new Error('Request failed with status 405'))).toBe(true);
+    expect(isImportNotAllowed(new Error('405 Method Not Allowed'))).toBe(true);
+    expect(isImportNotAllowed('Method Not Allowed')).toBe(true);
+  });
+
+  it('does NOT match a 404 (route absent → sync fallback) or UNSUPPORTED_OPERATION', () => {
+    expect(isImportNotAllowed(new Error('POST /data/task/import/jobs 404 Not Found'))).toBe(false);
+    expect(isImportNotAllowed({ code: 'UNSUPPORTED_OPERATION' })).toBe(false);
+    expect(isImportNotAllowed(new Error('Row 3: value out of range'))).toBe(false);
+    expect(isImportNotAllowed(null)).toBe(false);
+    expect(isImportNotAllowed(undefined)).toBe(false);
+  });
+
+  it('405 wins over the 404/regex fall-back predicates (checked first at every catch site)', () => {
+    // A 405 must be classified as "not allowed", never as "unsupported job route".
+    const err405 = { code: 'OBJECT_API_METHOD_NOT_ALLOWED', status: 405 };
+    expect(isImportNotAllowed(err405)).toBe(true);
+    expect(isUnsupportedImportJob(err405)).toBe(false);
+    // Conversely a 404 is "unsupported" and NOT "not allowed".
+    const err404 = new Error('import/jobs 404');
+    expect(isUnsupportedImportJob(err404)).toBe(true);
+    expect(isImportNotAllowed(err404)).toBe(false);
+  });
+});
 
 describe('isUnsupportedImportJob', () => {
   it('matches the adapter UNSUPPORTED_OPERATION code', () => {

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -658,8 +658,18 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   const [exportError, setExportError] = React.useState<string | null>(null);
 
   // Object-level export permission gate. Default-allow: export stays enabled
-  // unless `allowExport === false` or `operations.export === false`.
-  const exportPermitted = schema.allowExport !== false && schema.operations?.export !== false;
+  // unless `allowExport === false` or `operations.export === false`, AND — when
+  // the server hands down an effective API operation set for this object
+  // (/me/permissions `apiOperations`, #3391) — unless it excludes `export`.
+  // Missing effective set (unrestricted object / old backend / no provider)
+  // keeps the current behavior. The frontend consumes the effective set the
+  // server resolved; it never reads the raw `apiMethods`.
+  const { getObjectApiOperations } = usePermissions();
+  const effectiveApiOps = schema.objectName ? getObjectApiOperations(schema.objectName) : undefined;
+  const exportPermitted =
+    schema.allowExport !== false &&
+    schema.operations?.export !== false &&
+    (effectiveApiOps ? effectiveApiOps.includes('export') : true);
 
   // Normalize exportOptions: support both ObjectUI object format and spec string[] format
   const resolvedExportOptions = React.useMemo(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1944,6 +1944,9 @@ importers:
       '@object-ui/mobile':
         specifier: workspace:*
         version: link:../mobile
+      '@object-ui/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react


### PR DESCRIPTION
## 背景

#3391 的前端配套(方案里的 **PR-4**,objectui 侧)。框架侧 P1(spec/runtime/rest/hono)已合并(objectstack#3498),`/me/permissions` 现下发 per-object `apiOperations`(服务端解析的有效操作集)。本 PR 让前端**消费下发的 effective 结果**——不读原始 `apiMethods`、不自行派生——使按钮与服务端实际放行一致,并让导入 405 出独立文案而非静默回退。

## 改动

- **core** `resolveCrudAffordances(obj, effectiveApiOperations?)` —— 新增可选第二参,逐位与 API 操作交集(`create/import→create/import`、`edit→update`、`delete→delete`、`exportCsv→export`)。省略即不变(向后兼容);空数组 = 全禁。
- **permissions** —— `/me/permissions` 响应补 per-object `apiOperations`;`PermissionContextValue.getObjectApiOperations(object)` 暴露之(缺失→`undefined`→回退现行为);`check()` 补 `import→allowCreate`、`export→allowRead`;角色 provider 与无 provider 路径返回 `undefined`。
- **app-shell `ObjectView`** —— 工具栏 affordances 与对象 effective 操作交集(Import);平台管理员 identity-import 旁路不受影响。
- **plugin-list `ListView` / plugin-grid `ObjectGrid`** —— Export 按钮与 handler 门控在 effective `export`;plugin-grid 补 `@object-ui/permissions` workspace 依赖(现缺)。
- **plugin-grid `ImportWizard`** —— 新增 `isImportNotAllowed`(405 / `OBJECT_API_METHOD_NOT_ALLOWED`)谓词,在**四个 catch 点**(async / handleImport / sync / dry-run)**先于** unsupported 判定;命中即终止并出独立文案 `grid.import.notAllowed`(10 locale + fallback 字典),**决不回退同步/legacy**(它们同样 405),与 404「路由不存在→回退」语义相反。

## 向后兼容

effective 缺失(unrestricted 对象 / 旧后端 / 无 permission provider)处处回退现行为;新旧前后端任意组合可用。

## 测试

- core:`resolveCrudAffordances` 第二参矩阵(缺失零变化 / 逐位 AND / 空数组全禁 / 不越权重开)。
- permissions:`getObjectApiOperations` 读取与缺失、`check('import')→allowCreate`、`check('export')→allowRead`。
- plugin-grid:`isImportNotAllowed` 矩阵(code/status/statusCode/httpStatus/裸 405 命中;404、UNSUPPORTED_OPERATION 不命中;405 优先于 unsupported 判定)。
- 涉及包全量测试通过:core 89 / permissions 89 / plugin-list 163 / plugin-grid 237 / app-shell 89;`type-check` 全绿;`lint` 0 errors。

## 关联

- objectstack#3391(跟踪)/ objectstack#3498(框架侧 P1,已合并)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L8EfEa157Pe6C73qRnaJH

---
_Generated by [Claude Code](https://claude.ai/code/session_012L8EfEa157Pe6C73qRnaJH)_