### PR TITLE
fix(console): resolve a modal action's `target` as a page, not an object (#3530)

### DIFF
--- a/.changeset/modal-action-target-page-resolution.md
+++ b/.changeset/modal-action-target-page-resolution.md
@@ -1,0 +1,34 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(console): resolve a modal action's `target` as a page, not an object (#3530)
+
+Submitting a `type: 'modal'` action failed with "Error loading form — Bad
+Request". The console read the action's `target` as an OBJECT name and opened a
+create form for it, so a target naming a page issued `GET
+/meta/object/<page>` — which 400s — and the dialog rendered `<ModalForm>`'s
+error state instead of the page. Every modal action in an app hit this; the only
+workaround was re-authoring each one as a screen flow.
+
+The spec is explicit that for `type: 'modal'`, `target` is "the modal/page name
+to open".
+
+- `normalizeModalSchema` no longer guesses "object" for a string target. It
+  records the raw name and `useActionModal.resolveModalTarget` (new) resolves it
+  against metadata: **page first**, then object for back-compat. Resolution uses
+  `getItem(type, name)`, a single-item fetch, so it never eagerly loads the lazy
+  page/object lists — this hook is mounted at the console root.
+- The `create_x` / `edit_x` prefix convention still yields an object form, but
+  now only as a fallback: a page actually named `create_opportunity` wins over
+  the object `opportunity` the name would otherwise be parsed into.
+- A target that names neither reports what is wrong ("Modal target "x" matches
+  no page or object") instead of surfacing a downstream HTTP error.
+
+Modal dispatch is also now the same on every console surface. `type: 'modal'`
+was wired straight to the server-action POST in `useConsoleActionRuntime` (list
+pages, SDUI pages, the declared-actions bar) while `RecordDetailView` opened
+modals client-side — the same button did two different things depending on where
+it was mounted. Both now run one rule: render `target` when it names a page or
+object, otherwise complete the action through its server-side handler, so a
+modal action bound to `engine.registerAction(...)` keeps working.

--- a/packages/app-shell/src/hooks/__tests__/useActionModal.resolve.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useActionModal.resolve.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression (framework#3530 — "Console: modal-typed actions resolve `target` as
+ * an object"): a `type: 'modal'` action's `target` names the PAGE to open, but
+ * the console read it as an OBJECT name and opened a create form for it. That
+ * issued `GET /meta/object/<page>`, which 400s, so the modal body was replaced
+ * with ModalForm's "Error loading form — Bad Request" and the action never
+ * completed.
+ *
+ * These pin the resolution CONTRACT: page first (what the spec says the name
+ * means), object second (back-compat), `null` last so the console runtimes can
+ * fall through to the action's server-side handler. The pure normalization
+ * step is covered separately in `useActionModal.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { MetadataCtx } from '@object-ui/react';
+import { useActionModal } from '../useActionModal';
+
+const LOG_CALL_PAGE = { name: 'log_call', type: 'utility', label: 'Log a Call' };
+const CONTACT_OBJECT = { name: 'contact', label: 'Contact', fields: {} };
+
+/**
+ * Stand-in metadata context. `getItem(type, name)` is the ONLY lookup the
+ * resolver may use — reading the whole `pages` list would eagerly load a lazy
+ * metadata type at the console root, which is what `getItem` exists to avoid.
+ */
+function makeWrapper(items: Record<string, any[]>) {
+  const getItem = vi.fn(async (type: string, name: string) =>
+    (items[type] ?? []).find((i) => i.name === name) ?? null);
+  const value: any = {
+    apps: [], objects: items.object ?? [], dashboards: [], reports: [], pages: [],
+    loading: false, error: null,
+    refresh: async () => {}, invalidate: () => {}, ensureType: async () => [],
+    getItem,
+    getItemsByType: () => [],
+    getTypeStatus: () => 'ready',
+  };
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <MetadataCtx.Provider value={value}>{children}</MetadataCtx.Provider>
+  );
+  return { wrapper, getItem };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useActionModal — modal target resolution (framework#3530)', () => {
+  it('resolves a string target to the PAGE of that name, never GET /meta/object', async () => {
+    const { wrapper, getItem } = makeWrapper({ page: [LOG_CALL_PAGE] });
+    const { result } = renderHook(() => useActionModal(), { wrapper });
+
+    let d: any;
+    await act(async () => { d = await result.current.resolveModalTarget('log_call'); });
+
+    // Rendered as page CONTENT (same shape PageView feeds SchemaRenderer),
+    // not as an object form.
+    expect(d.content).toMatchObject({ name: 'log_call', type: 'utility' });
+    expect(d.objectName).toBeUndefined();
+    expect(d.title).toBe('Log a Call');
+
+    // The object lookup that produced the 400 must never happen.
+    expect(getItem).toHaveBeenCalledWith('page', 'log_call');
+    expect(getItem).not.toHaveBeenCalledWith('object', 'log_call');
+  });
+
+  it('falls back to an object create form when no page owns the name', async () => {
+    const { wrapper } = makeWrapper({ page: [], object: [CONTACT_OBJECT] });
+    const { result } = renderHook(() => useActionModal(), { wrapper });
+
+    let d: any;
+    await act(async () => { d = await result.current.resolveModalTarget('contact'); });
+
+    expect(d).toMatchObject({ objectName: 'contact', mode: 'create' });
+    expect(d.content).toBeUndefined();
+  });
+
+  it('prefers a page over the object a create_ prefix would parse into', async () => {
+    const { wrapper } = makeWrapper({
+      page: [{ name: 'create_opportunity', type: 'utility', label: 'New Opportunity' }],
+      object: [{ name: 'opportunity' }],
+    });
+    const { result } = renderHook(() => useActionModal(), { wrapper });
+
+    let d: any;
+    await act(async () => { d = await result.current.resolveModalTarget('create_opportunity'); });
+
+    expect(d.content).toMatchObject({ name: 'create_opportunity' });
+    expect(d.objectName).toBeUndefined();
+  });
+
+  it('still honors the create_ prefix when no page owns the name', async () => {
+    const { wrapper } = makeWrapper({ page: [], object: [{ name: 'opportunity' }] });
+    const { result } = renderHook(() => useActionModal(), { wrapper });
+
+    let d: any;
+    await act(async () => { d = await result.current.resolveModalTarget('create_opportunity'); });
+
+    expect(d).toMatchObject({ objectName: 'opportunity', mode: 'create' });
+  });
+
+  it('returns null when the target names neither a page nor an object', async () => {
+    // Not an error on its own — the console runtimes read null as "not a
+    // client-rendered modal" and run the action server-side instead.
+    const { wrapper } = makeWrapper({ page: [], object: [] });
+    const { result } = renderHook(() => useActionModal(), { wrapper });
+
+    let d: any;
+    await act(async () => { d = await result.current.resolveModalTarget('schedule_followup'); });
+    expect(d).toBeNull();
+  });
+
+  it('passes an explicit { objectName, mode } descriptor through without lookups', async () => {
+    // The lookup field's inline "create the referenced record" path.
+    const { wrapper, getItem } = makeWrapper({ page: [], object: [] });
+    const { result } = renderHook(() => useActionModal(), { wrapper });
+
+    let d: any;
+    await act(async () => {
+      d = await result.current.resolveModalTarget({ objectName: 'customers', mode: 'create' });
+    });
+
+    expect(d).toMatchObject({ objectName: 'customers', mode: 'create' });
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  it('modalHandler reports an unresolvable target instead of opening a broken form', async () => {
+    const { wrapper } = makeWrapper({ page: [], object: [] });
+    const { result } = renderHook(() => useActionModal(), { wrapper });
+
+    let r: any;
+    await act(async () => { r = await result.current.modalHandler('schedule_followup'); });
+
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('schedule_followup');
+  });
+});

--- a/packages/app-shell/src/hooks/__tests__/useActionModal.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/useActionModal.test.ts
@@ -2,19 +2,34 @@ import { describe, it, expect } from 'vitest';
 import { normalizeModalSchema } from '../useActionModal';
 
 describe('normalizeModalSchema', () => {
-  it('maps create_/new_/add_ string targets to a create object-form', () => {
-    expect(normalizeModalSchema('create_opportunity')).toEqual({ objectName: 'opportunity', mode: 'create' });
-    expect(normalizeModalSchema('new_task')).toEqual({ objectName: 'task', mode: 'create' });
-    expect(normalizeModalSchema('add_note')).toEqual({ objectName: 'note', mode: 'create' });
+  it('keeps a string target UNRESOLVED — page-vs-object is a metadata question', () => {
+    // framework#3530: assuming "object" here sent every page-targeting modal
+    // action to GET /meta/object/<page>, which 400s and rendered ModalForm's
+    // "Error loading form — Bad Request". `resolveModalTarget` asks the
+    // metadata service instead (see useActionModal.resolve.test.tsx).
+    expect(normalizeModalSchema('log_call')).toEqual({ targetName: 'log_call' });
+    expect(normalizeModalSchema('contact')).toEqual({ targetName: 'contact' });
   });
 
-  it('maps edit_/update_ string targets to an edit object-form', () => {
-    expect(normalizeModalSchema('edit_account')).toEqual({ objectName: 'account', mode: 'edit' });
-    expect(normalizeModalSchema('update_lead')).toEqual({ objectName: 'lead', mode: 'edit' });
+  it('carries a create_/new_/add_ prefix guess ALONGSIDE the raw target', () => {
+    expect(normalizeModalSchema('create_opportunity')).toEqual({
+      targetName: 'create_opportunity', objectName: 'opportunity', mode: 'create',
+    });
+    expect(normalizeModalSchema('new_task')).toEqual({
+      targetName: 'new_task', objectName: 'task', mode: 'create',
+    });
+    expect(normalizeModalSchema('add_note')).toEqual({
+      targetName: 'add_note', objectName: 'note', mode: 'create',
+    });
   });
 
-  it('treats a bare string as a create form for that object', () => {
-    expect(normalizeModalSchema('contact')).toEqual({ objectName: 'contact', mode: 'create' });
+  it('carries an edit_/update_ prefix guess as an edit form', () => {
+    expect(normalizeModalSchema('edit_account')).toEqual({
+      targetName: 'edit_account', objectName: 'account', mode: 'edit',
+    });
+    expect(normalizeModalSchema('update_lead')).toEqual({
+      targetName: 'update_lead', objectName: 'lead', mode: 'edit',
+    });
   });
 
   it('treats a bare SchemaNode (has type, no descriptor keys) as content', () => {

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -37,6 +37,22 @@ vi.mock('@object-ui/i18n', () => ({
   }),
 }));
 
+// The client modal transport is stubbed for the same reason — importing it for
+// real drags in <ModalForm> and the whole plugin-form graph. `resolveTargetSpy`
+// stands in for the page/object lookup so the modal-dispatch tests below can
+// choose whether a target resolves. Its real resolution rules are covered in
+// useActionModal.resolve.test.tsx.
+const modalHandlerSpy = vi.fn(async () => ({ success: true }));
+const resolveTargetSpy = vi.fn(async (_schema: any): Promise<any> => null);
+vi.mock('../useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: modalHandlerSpy,
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: resolveTargetSpy,
+  }),
+}));
+
 // The dialogs/flow-runner are not exercised here — keep them as inert stubs so
 // the hook module imports cheaply.
 vi.mock('../../views/ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
@@ -61,6 +77,9 @@ import { useAction, usePageVariables, PageVariablesProvider, PageVariableActionB
 beforeEach(() => {
   authFetchSpy.mockReset();
   navigateSpy.mockReset();
+  modalHandlerSpy.mockClear();
+  resolveTargetSpy.mockReset();
+  resolveTargetSpy.mockResolvedValue(null);
   (toast as any).mockClear?.();
   (toast as any).error.mockClear();
   (toast as any).success.mockClear();
@@ -295,6 +314,68 @@ describe('useConsoleActionRuntime — authenticated handlers', () => {
     expect(Object.keys(props.handlers).sort()).toEqual(['api', 'flow', 'modal', 'script']);
     expect(typeof props.onConfirm).toBe('function');
     expect(typeof props.onParamCollection).toBe('function');
+    expect(typeof props.onModal).toBe('function');
+  });
+});
+
+/**
+ * framework#3530 — `type: 'modal'` used to be wired straight to
+ * `serverActionHandler` here, while RecordDetailView opened modals client-side.
+ * The same button therefore did two different things depending on which surface
+ * mounted it. Both now run this rule: render `target` when it names a page (or
+ * object), else complete the action server-side.
+ */
+describe('modalActionHandler — open the target, else run it server-side', () => {
+  it('opens the resolved target client-side and never POSTs to /actions', async () => {
+    resolveTargetSpy.mockResolvedValue({ content: { name: 'log_call', type: 'utility' } });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'crm_call' }),
+    );
+
+    await act(async () => {
+      await result.current.modalActionHandler({ name: 'log_call', type: 'modal', target: 'log_call' } as any);
+    });
+
+    expect(resolveTargetSpy).toHaveBeenCalledWith('log_call');
+    expect(modalHandlerSpy).toHaveBeenCalledWith({ content: { name: 'log_call', type: 'utility' } });
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the server action when the target names no page or object', async () => {
+    // The modal was the param dialog the runner already collected — the action
+    // still has to run, so it goes to its registered server handler.
+    resolveTargetSpy.mockResolvedValue(null);
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: { ok: 1 } }) });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'crm_call' }),
+    );
+
+    let r: any;
+    await act(async () => {
+      r = await result.current.modalActionHandler({
+        name: 'log_call', type: 'modal', target: 'log_call', params: { subject: 'Intro' },
+      } as any);
+    });
+
+    expect(modalHandlerSpy).not.toHaveBeenCalled();
+    expect(authFetchSpy).toHaveBeenCalledTimes(1);
+    expect(authFetchSpy.mock.calls[0][0]).toContain('/api/v1/actions/crm_call/log_call');
+    expect(r.success).toBe(true);
+  });
+
+  it('prefers an inline `modal` descriptor over `target`', async () => {
+    resolveTargetSpy.mockResolvedValue({ objectName: 'customers', mode: 'create' });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'crm_call' }),
+    );
+
+    await act(async () => {
+      await result.current.modalActionHandler({
+        name: 'x', type: 'modal', target: 'ignored', modal: { objectName: 'customers', mode: 'create' },
+      } as any);
+    });
+
+    expect(resolveTargetSpy).toHaveBeenCalledWith({ objectName: 'customers', mode: 'create' });
   });
 });
 

--- a/packages/app-shell/src/hooks/useActionModal.tsx
+++ b/packages/app-shell/src/hooks/useActionModal.tsx
@@ -14,11 +14,18 @@
  *   placement: 'bottom'      → Drawer (bottom sheet)
  *
  * `content` is an arbitrary SchemaNode rendered via <SchemaRenderer>, so a
- * modal action can open any page/form/list. Back-compat: a string target
- * (e.g. "create_opportunity") or `{ objectName, mode }` opens a <ModalForm>.
+ * modal action can open any page/form/list. `{ objectName, mode }` opens a
+ * <ModalForm> (what a lookup field's inline "create the referenced record"
+ * passes).
  *
- * Returns `{ modalHandler, modalElement }`: pass `modalHandler` as the
- * ActionProvider `onModal`, and render `modalElement` once in the subtree.
+ * A STRING target — what `type: 'modal'` actions carry — is resolved through
+ * {@link resolveModalTarget}: page first, then object. See that function for
+ * why the order matters.
+ *
+ * Returns `{ modalHandler, modalElement, resolveModalTarget }`: pass
+ * `modalHandler` as the ActionProvider `onModal`, render `modalElement` once in
+ * the subtree, and use `resolveModalTarget` to ask — without opening anything —
+ * whether a target names something this hook can render.
  */
 import React, { useCallback, useState } from 'react';
 import {
@@ -60,6 +67,14 @@ export interface ModalDescriptor {
   mode?: string;
   recordId?: string;
   fields?: any;
+  /**
+   * An UNRESOLVED string target, straight off a `type: 'modal'` action. It
+   * names a page or an object; which one is only knowable by asking the
+   * metadata service, so `normalizeModalSchema` (pure) records the name here
+   * and {@link resolveModalTarget} (async) turns it into a renderable
+   * descriptor. Never rendered directly.
+   */
+  targetName?: string;
 }
 
 type ActionResult = { success: boolean; reload?: boolean; data?: any; [k: string]: any };
@@ -77,12 +92,33 @@ const SIDE_SIZE_CLASS: Partial<Record<ModalSize, string>> = {
   full: 'sm:max-w-[95vw]',
 };
 
-/** Normalize the opaque `schema` arg the ActionRunner passes into a descriptor. */
+/**
+ * Normalize the opaque `schema` arg the ActionRunner passes into a descriptor.
+ *
+ * A STRING is left UNRESOLVED (`targetName`) rather than assumed to be an
+ * object name. Per the spec, a `type: 'modal'` action's `target` is "the
+ * modal/page name to open" — so reading it as an object name sent every
+ * page-targeting modal action to `GET /meta/object/<page>`, which 400s, and the
+ * dialog rendered <ModalForm>'s "Error loading form — Bad Request" instead of
+ * the page (framework#3530). `resolveModalTarget` decides page-vs-object by
+ * asking the metadata service.
+ *
+ * The `create_`/`new_`/`add_`/`edit_`/`update_` prefix convention still yields
+ * an object-form guess, but it is now only a FALLBACK: it rides alongside
+ * `targetName` so a page actually named `create_opportunity` wins over the
+ * object `opportunity` it would otherwise be parsed into.
+ */
 export function normalizeModalSchema(schema: any): ModalDescriptor {
   if (typeof schema === 'string') {
     const m = schema.match(/^(create|new|add|edit|update)_(.+)$/);
-    if (m) return { objectName: m[2], mode: m[1] === 'edit' || m[1] === 'update' ? 'edit' : 'create' };
-    return { objectName: schema, mode: 'create' };
+    if (m) {
+      return {
+        targetName: schema,
+        objectName: m[2],
+        mode: m[1] === 'edit' || m[1] === 'update' ? 'edit' : 'create',
+      };
+    }
+    return { targetName: schema };
   }
   if (schema && typeof schema === 'object') {
     // A bare SchemaNode (has `type` but isn't a modal descriptor) → render as content.
@@ -99,7 +135,10 @@ export function useActionModal(dataSource?: any) {
   // Object metadata — degrades to an empty list outside a MetadataProvider
   // (see useMetadata). Used to resolve the object's default form view so the
   // create/edit modal honors its curated sections + field selection/order.
-  const { objects } = useMetadata();
+  // `getItem` fetches ONE named item on demand, so resolving a modal target
+  // never drags in the whole (lazily loaded) page or object list — this hook is
+  // mounted at the console root, where an eager list read would cost every page.
+  const { objects, getItem } = useMetadata();
 
   const close = useCallback((r: ActionResult) => {
     setState((s) => {
@@ -108,12 +147,73 @@ export function useActionModal(dataSource?: any) {
     });
   }, []);
 
+  /**
+   * Turn whatever the ActionRunner handed us into a descriptor this hook can
+   * actually render, or `null` when the target names nothing renderable.
+   *
+   * Resolution order for a string target is PAGE FIRST, then object, because
+   * that is what the spec says the name means — `type: 'modal'` documents
+   * `target` as "the modal/page name to open". Probing the object first would
+   * re-introduce framework#3530 in reverse for any app whose page and object
+   * share a name.
+   *
+   * A `null` return is not an error by itself: the console runtimes read it as
+   * "this isn't a client-rendered modal" and fall through to the action's
+   * server-side handler, which is how a modal action whose target names a
+   * registered `engine.registerAction` handler still completes.
+   */
+  const resolveModalTarget = useCallback(
+    async (schema: any): Promise<ModalDescriptor | null> => {
+      const d = normalizeModalSchema(schema);
+      const targetName = d.targetName;
+      if (!targetName) {
+        // Already renderable (content / objectName descriptor), or empty.
+        return d.content || d.objectName ? d : null;
+      }
+
+      const page = await getItem('page', targetName);
+      if (page) {
+        // Rendered exactly like PageView does it: the page item IS the schema
+        // node, with `type` naming the page kind ('record' | 'utility' | …).
+        return {
+          placement: d.placement ?? 'center',
+          size: d.size ?? 'xl',
+          title: d.title ?? (page as any).label ?? undefined,
+          description: d.description,
+          content: { ...(page as any), type: (page as any).type || 'page' },
+        };
+      }
+
+      // Object fallback: the `create_x`/`edit_x` prefix guess first (it names a
+      // different object than the raw target), then the raw target itself.
+      for (const objectName of [d.objectName, targetName]) {
+        if (!objectName) continue;
+        if (await getItem('object', objectName)) {
+          return { ...d, targetName: undefined, objectName, mode: d.mode ?? 'create' };
+        }
+      }
+      return null;
+    },
+    [getItem],
+  );
+
   const modalHandler = useCallback(
-    (schema: any) =>
-      new Promise<ActionResult>((resolve) => {
-        setState({ d: normalizeModalSchema(schema), resolve });
-      }),
-    [],
+    async (schema: any): Promise<ActionResult> => {
+      const d = await resolveModalTarget(schema);
+      if (!d) {
+        const name = normalizeModalSchema(schema).targetName;
+        return {
+          success: false,
+          error: name
+            ? `Modal target "${name}" matches no page or object — a modal action's \`target\` names the page to open.`
+            : 'Modal action has no target to open.',
+        };
+      }
+      return new Promise<ActionResult>((resolve) => {
+        setState({ d, resolve });
+      });
+    },
+    [resolveModalTarget],
   );
 
   let modalElement: React.ReactNode = null;
@@ -220,5 +320,5 @@ export function useActionModal(dataSource?: any) {
     }
   }
 
-  return { modalHandler, modalElement, closeModal: close };
+  return { modalHandler, modalElement, closeModal: close, resolveModalTarget };
 }

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -39,6 +39,7 @@ import type {
   ResultDialogHandler,
   ToastHandler,
 } from '@object-ui/core';
+import { useActionModal } from './useActionModal';
 import { ActionConfirmDialog, type ConfirmDialogState } from '../views/ActionConfirmDialog';
 import { ActionParamDialog, type ParamDialogState } from '../views/ActionParamDialog';
 import { ActionResultDialog, type ResultDialogState } from '../views/ActionResultDialog';
@@ -103,6 +104,8 @@ export interface ConsoleActionRuntime {
   apiHandler: (action: ActionDef) => Promise<ActionResult>;
   flowHandler: (action: ActionDef, context?: ActionContext) => Promise<ActionResult>;
   serverActionHandler: (action: ActionDef, context?: ActionContext) => Promise<ActionResult>;
+  /** `type: 'modal'` — opens `target` as a page/object form, else runs the action server-side. */
+  modalActionHandler: (action: ActionDef, context?: ActionContext) => Promise<ActionResult>;
   /** Authenticated fetch wrapper (Bearer + tenant + cookies). */
   authFetch: ReturnType<typeof createAuthenticatedFetch>;
   /** Open the shared environment entitlement (upgrade / limit) dialog. */
@@ -624,6 +627,30 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     }
   }, [authFetch, objApiName, refresh]);
 
+  // Client-side modal transport, shared with RecordDetailView so a
+  // `type: 'modal'` action behaves the SAME on a list page, an SDUI page, a
+  // declared-actions bar and a record page. Before this, only RecordDetailView
+  // opened modals client-side and every other console surface POSTed them to
+  // `/actions/...` — the same button did two different things depending on
+  // where it was mounted (framework#3530).
+  const { modalHandler, modalElement, resolveModalTarget } = useActionModal(dataSource);
+
+  /**
+   * `type: 'modal'` dispatch. The action's `target` names the page to open
+   * (spec: "the modal/page name to open"), so try to render it client-side
+   * first. When it names neither a page nor an object there is nothing to
+   * render — the modal was the param dialog the runner already collected — so
+   * complete the action through its server-side handler, which is how a modal
+   * action bound to `engine.registerAction(...)` (or an inline `body`) still
+   * runs.
+   */
+  const modalActionHandler = useCallback(async (action: ActionDef, context?: ActionContext): Promise<ActionResult> => {
+    const schema = (action as any).modal ?? action.target ?? (action as any).params?.schema;
+    const descriptor = schema != null ? await resolveModalTarget(schema) : null;
+    if (descriptor) return modalHandler(descriptor);
+    return serverActionHandler(action, context);
+  }, [resolveModalTarget, modalHandler, serverActionHandler]);
+
   const actionProviderProps = useMemo(() => ({
     context: {
       ...(objectName ? { objectName } : {}),
@@ -640,11 +667,12 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     onNavigate: navigateHandler,
     onParamCollection: paramCollectionHandler,
     onResultDialog: resultDialogHandler,
-    handlers: { api: apiHandler, flow: flowHandler, script: serverActionHandler, modal: serverActionHandler },
+    onModal: modalHandler,
+    handlers: { api: apiHandler, flow: flowHandler, script: serverActionHandler, modal: modalActionHandler },
   }), [
     objectName, currentUser, activeOrganization, confirmHandler, toastHandler,
     navigateHandler, paramCollectionHandler, resultDialogHandler, apiHandler,
-    flowHandler, serverActionHandler,
+    flowHandler, serverActionHandler, modalHandler, modalActionHandler,
   ]);
 
   const dialogs = (
@@ -676,6 +704,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
         apiBase={import.meta.env.VITE_SERVER_URL || ''}
         onOpenChange={(open) => { if (!open) setEntitlementDialog({ open: false }); }}
       />
+      {modalElement}
     </>
   );
 
@@ -688,6 +717,7 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     apiHandler,
     flowHandler,
     serverActionHandler,
+    modalActionHandler,
     authFetch,
     openEntitlementDialog,
     actionProviderProps,

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -578,7 +578,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
 
   // Client-side modal transport: `type:'modal'` actions open here (Dialog /
   // Sheet / Drawer by `placement`) and render arbitrary SchemaNode content.
-  const { modalHandler, modalElement } = useActionModal(dataSource);
+  const { modalHandler, modalElement, resolveModalTarget } = useActionModal(dataSource);
 
   // Flow action handler — POST to /api/v1/automation/{name}/trigger.
   // Triggered when an Action with `type: 'flow'` is invoked from a record-level
@@ -795,6 +795,22 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       serverActionInFlight.current.delete(inflightKey);
     }
   }, [authFetch, pureRecordId, objectName]);
+
+  /**
+   * `type: 'modal'` dispatch — same rule as the shared console runtime (see
+   * `useConsoleActionRuntime.modalActionHandler`): open `target` as a page (or
+   * an object form) when it names one, else fall through to the action's
+   * server-side handler. Registering it as a handler rather than relying on the
+   * runner's built-in `executeModal` is what gives the record page that server
+   * fallback, so a modal action bound to `engine.registerAction(...)` completes
+   * here exactly as it does on a list page.
+   */
+  const modalActionHandler = useCallback(async (action: ActionDef) => {
+    const schema = (action as any).modal ?? action.target ?? (action as any).params?.schema;
+    const descriptor = schema != null ? await resolveModalTarget(schema) : null;
+    if (descriptor) return modalHandler(descriptor);
+    return serverActionHandler(action);
+  }, [resolveModalTarget, modalHandler, serverActionHandler]);
 
   // ─── Approvals ─────────────────────────────────────────────────────
   // Since ADR-0019 an approval is a flow node: the flow opens the request,
@@ -1888,7 +1904,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           onParamCollection={paramCollectionHandler}
           onResultDialog={resultDialogHandler}
           onModal={modalHandler}
-          handlers={{ api: apiHandler, flow: flowHandler, script: serverActionHandler, approval: approvalHandler }}
+          handlers={{ api: apiHandler, flow: flowHandler, script: serverActionHandler, modal: modalActionHandler, approval: approvalHandler }}
         >
           <div className="flex-1 overflow-hidden flex flex-row">
             <div className="flex-1 overflow-auto p-3 sm:p-4 lg:p-6 scroll-pb-48">


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#3530.

## The bug

Submitting a `type: 'modal'` action failed with **"Error loading form — Bad Request"**. The console read the action's `target` as an **object** name and opened a create form for it, so a target naming a *page* issued `GET /api/v1/meta/object/<page>` — which 400s — and the dialog rendered `<ModalForm>`'s error state instead of the page. The action body never ran and nothing was written.

The spec is explicit about what the name means:

> `type: 'modal'` — `target` is **required** (the modal/page name to open).

The reporter hit this on every modal action in their app (`log_call`, `log_meeting`, `create_campaign`, …), including freshly authored ones, and the only workaround was re-authoring each as a screen flow.

## What was wrong

`normalizeModalSchema` mapped any bare string target straight to `{ objectName: <target>, mode: 'create' }`. That is a guess, and page-vs-object is not knowable without asking the metadata service.

The issue also notes "two code paths that disagree about what `target` means", which turned out to be broader than the param dialog: `type: 'modal'` was wired straight to the server-action POST in `useConsoleActionRuntime` (list pages, SDUI pages, the declared-actions bar) while `RecordDetailView` opened modals client-side. The same button did two different things depending on which surface mounted it.

## Changes

**Target resolution** (`useActionModal`)
- `normalizeModalSchema` no longer guesses "object" for a string target; it records the raw name under `targetName`.
- New `resolveModalTarget(schema)` resolves that name against metadata — **page first** (what the spec says it means), then object for back-compat, `null` when neither. It uses `getItem(type, name)`, a single-item fetch, so resolution never eagerly loads the lazy page/object lists; this hook is mounted at the console root, where a list read would cost every page.
- The `create_x` / `edit_x` prefix convention still yields an object form, but now only as a fallback — a page actually named `create_opportunity` wins over the object `opportunity` the name would otherwise be parsed into.
- A target naming neither reports what is actually wrong (`Modal target "x" matches no page or object …`) instead of surfacing a downstream HTTP error.

**One modal transport across the console** (`useConsoleActionRuntime`, `RecordDetailView`)
- Both now dispatch `type: 'modal'` through the same rule: render `target` when it names a page or object, otherwise complete the action through its server-side handler. That fallback is what keeps a modal action bound to `engine.registerAction(...)` working, and it is now available on the record page too (it previously had no server fallback at all).

An explicit `{ objectName, mode }` descriptor — what a lookup field's inline "create the referenced record" passes — is unchanged and resolves without any metadata lookup.

## Related

The reported action also declared a `body` on a `type: 'modal'` action, expecting it to run on submit. Per spec `body` is script-only, so it silently never runs; objectstack-ai/objectstack#3530 is paired with a spec-side change that rejects that combination at author time and points at `type: 'script'`.

## Testing

- New `useActionModal.resolve.test.tsx` pins the resolution contract: page wins, object fallback, prefix-vs-page precedence, `null` for unresolvable, descriptor pass-through, and — the regression itself — that a page target never issues the `object` lookup.
- `useActionModal.test.ts` updated to the corrected normalization semantics.
- New coverage in `useConsoleActionRuntime.test.tsx` for the open-vs-server-fallback dispatch rule.
- `packages/app-shell` build (`tsc`) clean; `vitest run` over `app-shell`, `core`, `react`, `fields` — 324 files / 3598 tests pass; eslint reports 0 errors on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYuc9N6YRbvoDMbCvJiX9f


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYuc9N6YRbvoDMbCvJiX9f)_