### PR TITLE
feat(fields): 采纳 file-as-reference 值形态 — ObjectStack ADR-0104 D3 wave 2 (PR-7)

### DIFF
--- a/.changeset/file-as-reference-adoption.md
+++ b/.changeset/file-as-reference-adoption.md
@@ -1,0 +1,36 @@
+---
+"@object-ui/fields": minor
+"@object-ui/app-shell": patch
+---
+
+feat(fields): adopt the file-as-reference value shape (ObjectStack ADR-0104 D3 wave 2)
+
+A `file`/`image` field value now reaches the UI in one of three forms, and the
+rules for reading them live in one place — `@object-ui/fields`' new
+`file-value` module — instead of being re-derived in each widget:
+
+1. **Reference** — a bare `sys_file` id string, what the backend stores once
+   file-as-reference is adopted.
+2. **Expanded** — `{ id, name, size, mimeType, url }`, what the read path
+   returns after resolving a reference.
+3. **Legacy inline blob** — `{ file_id?, name, original_name, size, mime_type,
+   url }`, the pre-reference shape this package used to build itself.
+
+**The casing split is the bug this fixes.** The expanded form carries
+`mimeType`; the legacy blob carries `mime_type`. `FileField`, `FileCell` and
+`ImageField` all read only `mime_type`, so the moment a backend starts returning
+the expanded form they stop recognising images — thumbnails silently degrade to
+a generic file icon, with nothing pointing at a value shape as the cause.
+`readFileValue()` accepts both.
+
+**Uploads now submit the reference form** — the bare `sys_file` id — when the
+upload adapter surfaced one, falling back to the legacy blob when it did not
+(the object-URL fallback adapter, or a backend predating file-as-reference). The
+same build therefore works against both. Action params already POSTed a bare
+fileId; record field values now use the same contract, and
+`serializeParamValues` shares the `fileIdOf()` extractor so the two surfaces
+cannot drift on what counts as an id.
+
+Because a bare id carries no name or URL, each widget remembers the display
+details of files it just uploaded, keyed by id, so an upload renders immediately
+rather than showing a bare token until the next read enriches it.

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -32,7 +32,7 @@ import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionParamDef } from '@object-ui/core';
 import { ExpressionEvaluator } from '@object-ui/core';
 import { usePredicateScope } from '@object-ui/react';
-import { getLazyFieldWidget } from '@object-ui/fields';
+import { getLazyFieldWidget, fileIdOf } from '@object-ui/fields';
 import { paramToField } from '../utils/paramToField';
 
 export interface ParamDialogState {
@@ -75,12 +75,15 @@ export function filterVisibleParams(
 
 /**
  * Serialize collected values for the request body. Upload widgets (`file` /
- * `image`) hold a rich `{ file_id, name, url, … }` object — or an array of them
- * when `multiple` — but the portable API contract is the storage id(s). Map each
- * upload param to its `file_id` (a bare string passes through unchanged, and an
- * object missing `file_id` is left intact so the failure is visible rather than
- * silently POSTing `undefined`). Every non-upload value is returned as-is. Pure
- * + exported so the mapping is unit-testable without the dialog render tree.
+ * `image`) may hold a bare `sys_file` id — the reference form they now submit
+ * when the adapter surfaces one — or a rich `{ file_id, name, url, … }` object,
+ * or an array of either when `multiple`. The portable API contract is the
+ * storage id(s), so each upload param is reduced to its id via `fileIdOf`, the
+ * same extractor the field widgets use, so the two surfaces cannot drift on
+ * what counts as an id. An object carrying no id is left intact, so the failure
+ * is visible rather than silently POSTing `undefined`. Every non-upload value is
+ * returned as-is. Pure + exported so the mapping is unit-testable without the
+ * dialog render tree.
  */
 export function serializeParamValues(
   params: ActionParamDef[],
@@ -95,8 +98,7 @@ export function serializeParamValues(
       .map((p) => p.name),
   );
   if (uploadNames.size === 0) return values;
-  const toId = (item: any) =>
-    item && typeof item === 'object' ? (item.file_id ?? item.id ?? item) : item;
+  const toId = (item: any) => fileIdOf(item) ?? item;
   const out: Record<string, any> = { ...values };
   for (const name of uploadNames) {
     const v = out[name];

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -2443,6 +2443,10 @@ export function registerFields() {
 }
 
 export * from './widgets/types';
+// File field value shapes (ObjectStack ADR-0104 D3 wave 2) — the single
+// arbiter of reference vs expanded vs legacy-blob form, shared by the upload
+// widgets and by action-param serialization.
+export * from './widgets/file-value';
 export * from './FieldEditWidget';
 export * from './widgets/TextField';
 export * from './widgets/NumberField';

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -5,6 +5,14 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { Upload, X, File as FileIcon, ImageIcon, Camera, Loader2 } from 'lucide-react';
 import { FieldWidgetProps } from './types';
 import { useUploadingSignal } from './useUploadingSignal';
+import {
+  fileValueForSubmit,
+  readFileValues,
+  uploadResultView,
+  withRecentUploads,
+  isImageValue,
+  type FileValueView,
+} from './file-value';
 
 /**
  * Shared upload pipeline for the file widgets: validates size, uploads through
@@ -12,6 +20,13 @@ import { useUploadingSignal } from './useUploadingSignal';
  * into the field value — append for `multiple`, replace otherwise. Extracted so
  * the full-size FileField and the compact grid-cell {@link FileCell} stay
  * behaviourally identical (same value shape, same error handling).
+ *
+ * Stores the **reference form** — a bare `sys_file` id — when the upload
+ * adapter surfaced one, and the legacy inline blob when it did not, so the same
+ * build works against a backend that has adopted file-as-reference and one that
+ * has not (see `file-value`). Because a bare id carries no name or URL, each
+ * completed upload's display details are kept in `recent`, keyed by id, so the
+ * file renders immediately instead of as a bare token until a read enriches it.
  */
 function useFileUploads(opts: {
   files: any[];
@@ -25,6 +40,7 @@ function useFileUploads(opts: {
   const [errors, setErrors] = useState<string[]>([]);
   const [uploadProgress, setUploadProgress] = useState<Record<string, number>>({});
   const [uploading, setUploading] = useState(false);
+  const [recent, setRecent] = useState<Record<string, FileValueView>>({});
 
   const processFiles = useCallback(async (selectedFiles: File[]) => {
     if (selectedFiles.length === 0) return;
@@ -47,26 +63,14 @@ function useFileUploads(opts: {
 
     setUploading(true);
     try {
-      const fileObjects = await Promise.all(
+      const uploaded = await Promise.all(
         validFiles.map(async (file) => {
           try {
             const result = await upload(file, {
               onProgress: (ratio) =>
                 setUploadProgress((prev) => ({ ...prev, [file.name]: ratio })),
             });
-            return {
-              // `file_id` is the storage id the backend keys attachments by
-              // (the adapter returns it as `meta.fileId`); surfacing it here
-              // lets callers that need the id — e.g. an action param POSTing
-              // `attachments: string[]` — recover it without a second lookup.
-              // Extra key; the record file-field value shape is unchanged.
-              file_id: (result.meta as { fileId?: string } | undefined)?.fileId,
-              name: result.name,
-              original_name: file.name,
-              size: result.size,
-              mime_type: result.mimeType,
-              url: result.url,
-            };
+            return { result, originalName: file.name };
           } catch (err) {
             newErrors.push(t('fields.file.uploadFailed', {
               defaultValue: `Failed to upload "${file.name}": ${(err as Error).message}`,
@@ -77,13 +81,25 @@ function useFileUploads(opts: {
           }
         }),
       );
-      const successful = fileObjects.filter(Boolean) as any[];
+      const successful = uploaded.filter(Boolean) as Array<{ result: any; originalName: string }>;
       if (successful.length === 0) return;
 
+      // Remember what each new id looks like so it can render before the next
+      // read expands it back into `{ id, name, size, mimeType, url }`.
+      const views: Record<string, FileValueView> = {};
+      for (const { result, originalName } of successful) {
+        const view = uploadResultView(result, originalName);
+        if (view.id) views[view.id] = view;
+      }
+      if (Object.keys(views).length > 0) setRecent((prev) => ({ ...prev, ...views }));
+
+      const nextValues = successful.map(({ result, originalName }) =>
+        fileValueForSubmit(result, originalName),
+      );
       if (multiple) {
-        onChange([...files, ...successful]);
+        onChange([...files, ...nextValues]);
       } else {
-        onChange(successful[0]);
+        onChange(nextValues[0]);
       }
     } finally {
       setUploading(false);
@@ -91,7 +107,7 @@ function useFileUploads(opts: {
     }
   }, [files, multiple, onChange, maxSize, upload, t]);
 
-  return { processFiles, errors, uploading, uploadProgress };
+  return { processFiles, errors, uploading, uploadProgress, recent };
 }
 
 /**
@@ -124,9 +140,13 @@ export function FileField({ value, onChange, field, readonly, onUploadingChange,
   const [isDragOver, setIsDragOver] = useState(false);
 
   const files = value ? (Array.isArray(value) ? value : [value]) : [];
-  const { processFiles, errors, uploading, uploadProgress } = useFileUploads({
+  const { processFiles, errors, uploading, uploadProgress, recent } = useFileUploads({
     files, multiple, maxSize, onChange,
   });
+  const fallbackName = t('fields.file.fileFallback', { defaultValue: 'File' });
+  // Normalised for display: accepts a bare reference id, the expanded
+  // `{ id, name, size, mimeType, url }`, or a legacy inline blob.
+  const views = withRecentUploads(readFileValues(value, fallbackName), recent);
   useUploadingSignal(uploading, onUploadingChange);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -164,13 +184,12 @@ export function FileField({ value, onChange, field, readonly, onUploadingChange,
 
   if (readonly) {
     if (!value) return <EmptyValue />;
-    
-    const readonlyFiles = Array.isArray(value) ? value : [value];
+
     return (
       <div className="flex flex-wrap gap-2">
-        {readonlyFiles.map((file: any, idx: number) => (
+        {views.map((file, idx) => (
           <span key={idx} className="text-sm truncate max-w-xs">
-            {file.name || file.original_name || t('fields.file.fileFallback', { defaultValue: 'File' })}
+            {file.name}
           </span>
         ))}
       </div>
@@ -188,11 +207,6 @@ export function FileField({ value, onChange, field, readonly, onUploadingChange,
     } else {
       onChange(null);
     }
-  };
-
-  const isImage = (file: any) => {
-    const mime = file.mime_type || '';
-    return mime.startsWith('image/');
   };
 
   return (
@@ -303,23 +317,23 @@ export function FileField({ value, onChange, field, readonly, onUploadingChange,
         )}
 
         {/* File list */}
-        {files.length > 0 && (
+        {views.length > 0 && (
           <div className="space-y-1">
-            {files.map((file: any, idx: number) => (
+            {views.map((file, idx) => (
               <div
                 key={idx}
                 className="flex items-center justify-between gap-2 p-2 bg-muted/50 rounded-md border"
               >
                 <div className="flex items-center gap-2 flex-1 min-w-0">
-                  {isImage(file) && file.url ? (
+                  {isImageValue(file) && file.url ? (
                     <img src={file.url} alt={file.name} className="size-8 object-cover rounded shrink-0" />
-                  ) : isImage(file) ? (
+                  ) : isImageValue(file) ? (
                     <ImageIcon className="size-4 text-muted-foreground shrink-0" />
                   ) : (
                     <FileIcon className="size-4 text-muted-foreground shrink-0" />
                   )}
                   <span className="text-sm truncate">
-                    {file.name || file.original_name || t('fields.file.fileFallback', { defaultValue: 'File' })}
+                    {file.name}
                   </span>
                   {file.size && (
                     <span className="text-xs text-muted-foreground">
@@ -382,9 +396,11 @@ export function FileCell({
   const { t } = useObjectTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
   const files = value ? (Array.isArray(value) ? value : [value]) : [];
-  const { processFiles, errors, uploading } = useFileUploads({
+  const { processFiles, errors, uploading, recent } = useFileUploads({
     files, multiple: !!multiple, maxSize, onChange,
   });
+  const fallbackName = t('fields.file.fileFallback', { defaultValue: 'File' });
+  const views = withRecentUploads(readFileValues(value, fallbackName), recent);
 
   const removeAt = (index: number) => {
     if (multiple) {
@@ -395,11 +411,6 @@ export function FileCell({
     }
   };
 
-  const isImage = (file: any) => String(file?.mime_type || '').startsWith('image/');
-  const nameOf = (file: any) =>
-    typeof file === 'string'
-      ? file
-      : file?.name || file?.original_name || t('fields.file.fileFallback', { defaultValue: 'File' });
   const showUpload = !disabled && !uploading && (multiple || files.length === 0);
 
   return (
@@ -415,24 +426,24 @@ export function FileCell({
         }}
         className="hidden"
       />
-      {files.map((file: any, idx: number) => (
+      {views.map((file, idx) => (
         <span
           key={idx}
           className="inline-flex max-w-40 items-center gap-1 rounded border bg-muted/50 px-1 py-0.5 text-xs"
-          title={nameOf(file)}
+          title={file.name}
           data-testid="file-cell-chip"
         >
-          {isImage(file) && file.url ? (
-            <img src={file.url} alt={nameOf(file)} className="size-5 shrink-0 rounded object-cover" />
+          {isImageValue(file) && file.url ? (
+            <img src={file.url} alt={file.name} className="size-5 shrink-0 rounded object-cover" />
           ) : (
             <FileIcon className="size-3 shrink-0 text-muted-foreground" />
           )}
-          <span className="truncate">{nameOf(file)}</span>
+          <span className="truncate">{file.name}</span>
           {!disabled && (
             <button
               type="button"
               className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
-              aria-label={t('fields.file.remove', { defaultValue: `Remove ${nameOf(file)}`, name: nameOf(file) })}
+              aria-label={t('fields.file.remove', { defaultValue: `Remove ${file.name}`, name: file.name })}
               onClick={() => removeAt(idx)}
             >
               <X className="size-3" />

--- a/packages/fields/src/widgets/ImageField.tsx
+++ b/packages/fields/src/widgets/ImageField.tsx
@@ -4,6 +4,13 @@ import { useUpload } from '@object-ui/providers';
 import { Upload, X, Image as ImageIcon, Crop as CropIcon, Loader2 } from 'lucide-react';
 import { FieldWidgetProps } from './types';
 import { useUploadingSignal } from './useUploadingSignal';
+import {
+  fileValueForSubmit,
+  readFileValues,
+  uploadResultView,
+  withRecentUploads,
+  type FileValueView,
+} from './file-value';
 
 // Lazy-load the cropper so the dialog (canvas + crop logic) is not in the initial
 // ImageField bundle. Consumers that never crop pay zero cost.
@@ -27,11 +34,22 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
   const [cropTarget, setCropTarget] = useState<{ index: number; src: string; name: string } | null>(null);
   const { upload } = useUpload();
   const [uploading, setUploading] = useState(false);
+  // Display details of just-uploaded images, keyed by their new `sys_file` id.
+  // Submitting the reference form means the field value no longer carries the
+  // URL a thumbnail needs; these keep the preview visible until the next read
+  // returns the expanded form. See `file-value`.
+  const [recent, setRecent] = useState<Record<string, FileValueView>>({});
   useUploadingSignal(uploading, onUploadingChange);
 
   // Derived value + memoized handlers must run before the readonly early return
   // so hook order stays stable across renders.
   const images = value ? (Array.isArray(value) ? value : [value]) : [];
+  const views = withRecentUploads(readFileValues(value, 'Image'), recent);
+
+  const remember = useCallback((result: any, originalName: string) => {
+    const view = uploadResultView(result, originalName);
+    if (view.id) setRecent((prev) => ({ ...prev, [view.id as string]: view }));
+  }, []);
 
   const handleCropConfirm = useCallback(
     async (blob: Blob, name: string) => {
@@ -39,13 +57,8 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
       setUploading(true);
       try {
         const result = await upload(blob);
-        const next = {
-          name: result.name || name,
-          original_name: name,
-          size: result.size,
-          mime_type: result.mimeType,
-          url: result.url,
-        };
+        remember(result, name);
+        const next = fileValueForSubmit(result, name);
         if (multiple) {
           const updated = [...images];
           updated[cropTarget.index] = next;
@@ -58,16 +71,16 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
         setCropTarget(null);
       }
     },
-    [cropTarget, images, multiple, onChange, upload],
+    [cropTarget, images, multiple, onChange, upload, remember],
   );
 
   const openCropper = useCallback(
     (index: number) => {
-      const img = images[index];
+      const img = views[index];
       if (!img?.url) return;
       setCropTarget({ index, src: img.url, name: img.name || `image-${index}.png` });
     },
-    [images],
+    [views],
   );
 
   if (readonly) {
@@ -75,7 +88,7 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
 
     return (
       <div className="flex flex-wrap gap-2">
-        {images.map((img: any, idx: number) => (
+        {views.map((img, idx) => (
           <img
             key={idx}
             src={img.url || ''}
@@ -96,13 +109,8 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
       const imageObjects = await Promise.all(
         selectedFiles.map(async (file) => {
           const result = await upload(file);
-          return {
-            name: result.name,
-            original_name: file.name,
-            size: result.size,
-            mime_type: result.mimeType,
-            url: result.url,
-          };
+          remember(result, file.name);
+          return fileValueForSubmit(result, file.name);
         }),
       );
 
@@ -139,9 +147,9 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
       />
       
       <div className="space-y-2">
-        {images.length > 0 && (
+        {views.length > 0 && (
           <div className="grid grid-cols-4 gap-2">
-            {images.map((img: any, idx: number) => (
+            {views.map((img, idx) => (
               <div key={idx} className="relative group">
                 <img
                   src={img.url || ''}

--- a/packages/fields/src/widgets/file-value.test.ts
+++ b/packages/fields/src/widgets/file-value.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isFileIdToken,
+  fileIdOf,
+  readFileValue,
+  readFileValues,
+  isImageValue,
+  fileValueForSubmit,
+  uploadResultView,
+  withRecentUploads,
+} from './file-value';
+
+const uploadResult = (over: Record<string, unknown> = {}) => ({
+  url: 'https://app.example.com/api/v1/storage/files/file_a',
+  name: 'a.png',
+  size: 1024,
+  mimeType: 'image/png',
+  ...over,
+});
+
+describe('isFileIdToken', () => {
+  it.each(['file_a', 'abc123', '0e2f4c1a-9b7d-4e3f-8a1b-2c3d4e5f6a7b', 'A-_9'])(
+    'accepts the minted id %s',
+    (v) => expect(isFileIdToken(v)).toBe(true),
+  );
+
+  it.each([
+    'https://cdn.example.com/a.png',
+    '/api/v1/storage/files/file_a',
+    'data:image/png;base64,aGk=',
+    'blob:http://localhost/abc',
+    'a.png',
+    '',
+  ])('rejects the URL-shaped or dotted value %s', (v) => expect(isFileIdToken(v)).toBe(false));
+
+  it('rejects non-strings and over-long values', () => {
+    expect(isFileIdToken(null)).toBe(false);
+    expect(isFileIdToken(42)).toBe(false);
+    expect(isFileIdToken('a'.repeat(65))).toBe(false);
+  });
+});
+
+describe('fileIdOf', () => {
+  it('reads a bare reference', () => {
+    expect(fileIdOf('file_a')).toBe('file_a');
+  });
+
+  it('prefers file_id, then id', () => {
+    expect(fileIdOf({ file_id: 'legacy', id: 'expanded' })).toBe('legacy');
+    expect(fileIdOf({ id: 'expanded' })).toBe('expanded');
+  });
+
+  it('returns undefined when there is no id to read', () => {
+    expect(fileIdOf({ url: 'https://cdn.example.com/a.png', name: 'a.png' })).toBeUndefined();
+    expect(fileIdOf('https://cdn.example.com/a.png')).toBeUndefined();
+    expect(fileIdOf(null)).toBeUndefined();
+  });
+});
+
+describe('readFileValue', () => {
+  /**
+   * The casing split is the reason this module exists: the platform's expanded
+   * form is camelCase `mimeType`, the legacy inline blob is snake_case
+   * `mime_type`. A widget reading only one silently stops recognising images
+   * the moment the backend switches form.
+   */
+  it('reads the expanded form (camelCase mimeType)', () => {
+    const view = readFileValue({
+      id: 'file_a',
+      name: 'a.png',
+      size: 1024,
+      mimeType: 'image/png',
+      url: '/api/v1/storage/files/file_a',
+    });
+
+    expect(view).toMatchObject({
+      id: 'file_a',
+      name: 'a.png',
+      size: 1024,
+      mimeType: 'image/png',
+      url: '/api/v1/storage/files/file_a',
+    });
+    expect(isImageValue(view)).toBe(true);
+  });
+
+  it('reads the legacy inline blob (snake_case mime_type)', () => {
+    const view = readFileValue({
+      file_id: 'file_a',
+      name: 'a.png',
+      original_name: 'original.png',
+      size: 1024,
+      mime_type: 'image/png',
+      url: 'https://cdn.example.com/a.png',
+    });
+
+    expect(view).toMatchObject({ id: 'file_a', name: 'a.png', mimeType: 'image/png' });
+    expect(isImageValue(view)).toBe(true);
+  });
+
+  it('falls back to original_name when name is absent', () => {
+    expect(readFileValue({ original_name: 'orig.pdf' }).name).toBe('orig.pdf');
+  });
+
+  it('derives a name from the URL when the value carries none', () => {
+    expect(readFileValue({ url: 'https://cdn.example.com/docs/report%20v2.pdf' }).name).toBe(
+      'report v2.pdf',
+    );
+    expect(readFileValue('https://cdn.example.com/a.png').name).toBe('a.png');
+  });
+
+  it('reads a bare reference as an id with no URL of its own', () => {
+    const view = readFileValue('file_a', 'File');
+
+    // Honest: an unexpanded reference genuinely has nothing to render from.
+    expect(view).toMatchObject({ id: 'file_a', name: 'File' });
+    expect(view.url).toBeUndefined();
+  });
+
+  it('treats a URL string as a URL, never as a reference', () => {
+    const view = readFileValue('/api/v1/storage/files/file_a');
+    expect(view.id).toBeUndefined();
+    expect(view.url).toBe('/api/v1/storage/files/file_a');
+  });
+
+  it('uses the supplied fallback name so widgets stay localised', () => {
+    expect(readFileValue({}, '文件').name).toBe('文件');
+    expect(readFileValue(null, '文件').name).toBe('文件');
+  });
+
+  it('is not an image when the MIME type says otherwise or is missing', () => {
+    expect(isImageValue(readFileValue({ mimeType: 'application/pdf' }))).toBe(false);
+    expect(isImageValue(readFileValue({ name: 'a.png' }))).toBe(false);
+  });
+});
+
+describe('readFileValues', () => {
+  it('normalises single, array and empty values', () => {
+    expect(readFileValues(null)).toEqual([]);
+    expect(readFileValues([])).toEqual([]);
+    expect(readFileValues('file_a')).toHaveLength(1);
+    expect(readFileValues(['file_a', 'file_b'])).toHaveLength(2);
+  });
+
+  it('drops null entries inside an array', () => {
+    expect(readFileValues(['file_a', null, 'file_b'])).toHaveLength(2);
+  });
+
+  it('handles a mixed-form array during the transition', () => {
+    const views = readFileValues([
+      'file_a',
+      { id: 'file_b', name: 'b.png', mimeType: 'image/png' },
+      { name: 'c.png', mime_type: 'image/png', url: 'https://cdn.example.com/c.png' },
+    ]);
+
+    expect(views.map((v) => v.id)).toEqual(['file_a', 'file_b', undefined]);
+    expect(views.map(isImageValue)).toEqual([false, true, true]);
+  });
+});
+
+describe('fileValueForSubmit', () => {
+  it('submits the bare reference when the adapter surfaced a fileId', () => {
+    expect(fileValueForSubmit(uploadResult({ meta: { fileId: 'file_a' } }), 'orig.png')).toBe(
+      'file_a',
+    );
+  });
+
+  /**
+   * Back-compat: the object-URL fallback adapter, or a backend predating
+   * file-as-reference, surfaces no fileId. The same build must keep working
+   * there, so it submits the legacy blob unchanged.
+   */
+  it('falls back to the legacy inline blob when there is no fileId', () => {
+    expect(fileValueForSubmit(uploadResult(), 'orig.png')).toEqual({
+      name: 'a.png',
+      original_name: 'orig.png',
+      size: 1024,
+      mime_type: 'image/png',
+      url: 'https://app.example.com/api/v1/storage/files/file_a',
+    });
+  });
+
+  it('ignores a meta.fileId that is not id-shaped', () => {
+    const v = fileValueForSubmit(uploadResult({ meta: { fileId: 'https://evil.example/x' } }));
+    expect(typeof v).toBe('object');
+  });
+
+  it('round-trips through readFileValue in both modes', () => {
+    const asRef = fileValueForSubmit(uploadResult({ meta: { fileId: 'file_a' } }));
+    const asBlob = fileValueForSubmit(uploadResult(), 'orig.png');
+
+    expect(readFileValue(asRef).id).toBe('file_a');
+    expect(readFileValue(asBlob).mimeType).toBe('image/png');
+  });
+});
+
+describe('withRecentUploads', () => {
+  it('fills in display details for a bare reference just uploaded', () => {
+    const view = uploadResultView(uploadResult({ meta: { fileId: 'file_a' } }), 'orig.png');
+    const merged = withRecentUploads(readFileValues('file_a'), { file_a: view });
+
+    expect(merged[0]).toMatchObject({
+      id: 'file_a',
+      name: 'a.png',
+      mimeType: 'image/png',
+      url: 'https://app.example.com/api/v1/storage/files/file_a',
+    });
+    // The raw value stays the reference — display enrichment must not change
+    // what the field submits.
+    expect(merged[0].raw).toBe('file_a');
+  });
+
+  it('leaves a value the backend already expanded alone', () => {
+    const stale = uploadResultView(uploadResult({ name: 'stale.png', meta: { fileId: 'file_a' } }));
+    const expanded = readFileValues([{ id: 'file_a', name: 'fresh.png', url: '/u', mimeType: 'image/png' }]);
+
+    expect(withRecentUploads(expanded, { file_a: stale })[0].name).toBe('fresh.png');
+  });
+
+  it('is a no-op with nothing remembered', () => {
+    const views = readFileValues('file_a');
+    expect(withRecentUploads(views, {})).toBe(views);
+  });
+});

--- a/packages/fields/src/widgets/file-value.ts
+++ b/packages/fields/src/widgets/file-value.ts
@@ -1,0 +1,197 @@
+/**
+ * File field value shapes (ObjectStack ADR-0104 D3 wave 2).
+ *
+ * A `file`/`image`/`avatar`/`video`/`audio` field value reaches the UI in one
+ * of three forms, and every widget that renders one has to cope with all
+ * three — so the rules live here once rather than being re-derived per widget.
+ *
+ *  1. **Reference** — a bare `sys_file` id string. The form the backend stores
+ *     once file-as-reference is adopted.
+ *  2. **Expanded** — `{ id, name, size, mimeType, url }`, what the read path
+ *     returns after resolving a stored reference. Note `mimeType`: this comes
+ *     from the platform's spec-owned `FileValueSchema` and is **camelCase**.
+ *  3. **Legacy inline blob** — `{ file_id?, name, original_name, size,
+ *     mime_type, url }`, the pre-reference shape this package used to build
+ *     itself, with **snake_case** `mime_type`.
+ *
+ * That casing split is the whole reason this module exists: a widget reading
+ * only `mime_type` silently stops recognising images the moment the backend
+ * starts returning the expanded form, and the failure looks like "thumbnails
+ * disappeared" rather than anything pointing at a value shape.
+ *
+ * ## Submitting
+ *
+ * When the upload adapter surfaced a `fileId`, the widget submits the **bare
+ * id** — the reference form. When it did not (the object-URL fallback adapter,
+ * an older backend), it submits the legacy blob unchanged. So the same build
+ * works against a backend that has adopted references and one that has not.
+ * Action params already POST a bare fileId; this brings record field values
+ * onto the same contract.
+ */
+
+/** A file value normalised for rendering, whatever form it arrived in. */
+export interface FileValueView {
+  /** `sys_file` id, when the value carries one. */
+  id?: string;
+  /** Best available display name. Never empty. */
+  name: string;
+  /** Resolvable URL, when the value carries one. A bare reference does not. */
+  url?: string;
+  size?: number;
+  mimeType?: string;
+  /** The value as it arrived, so callers can pass it through untouched. */
+  raw: unknown;
+}
+
+/**
+ * A minted file id: uuid/nanoid-shaped, and crucially not a URL — a URL always
+ * carries `:`, `/` or `.`, so it can never match. Mirrors the platform's
+ * `isFileIdToken`, which is the arbiter on the server side of the same question.
+ */
+export function isFileIdToken(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Za-z0-9_-]{1,64}$/.test(value);
+}
+
+/**
+ * The `sys_file` id a value refers to, or `undefined`.
+ *
+ * `file_id ?? id` matches the rule `serializeParamValues` already applies to
+ * action params — one extraction rule for both surfaces.
+ */
+export function fileIdOf(value: unknown): string | undefined {
+  if (isFileIdToken(value)) return value;
+  if (value && typeof value === 'object') {
+    const o = value as Record<string, unknown>;
+    const id = o.file_id ?? o.id;
+    if (typeof id === 'string' && id) return id;
+  }
+  return undefined;
+}
+
+/** Last path segment of a URL, used as a display name of last resort. */
+function nameFromUrl(url: string): string {
+  const path = url.split(/[?#]/)[0] ?? url;
+  const seg = path.split('/').filter(Boolean).pop();
+  return seg ? decodeURIComponent(seg) : url;
+}
+
+/**
+ * Normalise one file value for display.
+ *
+ * @param fallbackName shown when the value carries no usable name — pass a
+ *   translated string so the widget stays localised.
+ */
+export function readFileValue(value: unknown, fallbackName = 'File'): FileValueView {
+  if (value == null) return { name: fallbackName, raw: value };
+
+  if (typeof value === 'string') {
+    // A bare id has no name or URL of its own — the backend expands it on read.
+    if (isFileIdToken(value)) return { id: value, name: fallbackName, raw: value };
+    // Otherwise it is a URL (legacy external link, data:, blob:).
+    return { url: value, name: nameFromUrl(value), raw: value };
+  }
+
+  if (typeof value === 'object') {
+    const o = value as Record<string, unknown>;
+    const str = (v: unknown) => (typeof v === 'string' && v ? v : undefined);
+    const url = str(o.url);
+    const name =
+      str(o.name) ??
+      str(o.original_name) ??
+      (url ? nameFromUrl(url) : undefined) ??
+      fallbackName;
+    return {
+      id: fileIdOf(o),
+      name,
+      url,
+      size: typeof o.size === 'number' ? o.size : undefined,
+      // Expanded form is camelCase, legacy blob is snake_case — accept both.
+      mimeType: str(o.mimeType) ?? str(o.mime_type),
+      raw: value,
+    };
+  }
+
+  return { name: fallbackName, raw: value };
+}
+
+/** Normalise a field value (single or `multiple`) to an array of views. */
+export function readFileValues(value: unknown, fallbackName = 'File'): FileValueView[] {
+  if (value == null) return [];
+  const items = Array.isArray(value) ? value : [value];
+  return items.filter((v) => v != null).map((v) => readFileValue(v, fallbackName));
+}
+
+/** Does this value look like an image, by MIME type? */
+export function isImageValue(view: FileValueView): boolean {
+  return (view.mimeType ?? '').startsWith('image/');
+}
+
+/** The subset of an upload result these helpers read. */
+export interface UploadResultLike {
+  url: string;
+  name: string;
+  size: number;
+  mimeType: string;
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * What to store in the field for a completed upload.
+ *
+ * Returns the bare `sys_file` id when the adapter surfaced one — the reference
+ * form — and the legacy inline blob when it did not, so a deployment whose
+ * upload adapter or backend predates file-as-reference keeps working unchanged.
+ */
+export function fileValueForSubmit(
+  result: UploadResultLike,
+  originalName?: string,
+): string | Record<string, unknown> {
+  const fileId = (result.meta as { fileId?: unknown } | undefined)?.fileId;
+  if (isFileIdToken(fileId)) return fileId;
+  return {
+    name: result.name,
+    original_name: originalName ?? result.name,
+    size: result.size,
+    mime_type: result.mimeType,
+    url: result.url,
+  };
+}
+
+/**
+ * The display view of a just-completed upload.
+ *
+ * Submitting a bare id means the field value no longer carries the name, size
+ * or URL needed to render it, and the enriched form only comes back on the next
+ * read. Widgets keep these views keyed by id so an upload appears immediately
+ * instead of showing a bare token until a refetch.
+ */
+export function uploadResultView(result: UploadResultLike, originalName?: string): FileValueView {
+  const id = isFileIdToken((result.meta as { fileId?: unknown } | undefined)?.fileId)
+    ? ((result.meta as { fileId?: string }).fileId as string)
+    : undefined;
+  return {
+    id,
+    name: result.name || originalName || 'File',
+    url: result.url,
+    size: result.size,
+    mimeType: result.mimeType,
+    raw: result,
+  };
+}
+
+/**
+ * Merge locally-known upload views over a field value's own views, matched by
+ * id. A value that is still a bare reference picks up the name/URL captured at
+ * upload time; anything already enriched by the backend is left alone.
+ */
+export function withRecentUploads(
+  views: FileValueView[],
+  recent: Record<string, FileValueView>,
+): FileValueView[] {
+  if (Object.keys(recent).length === 0) return views;
+  return views.map((v) => {
+    if (!v.id || v.url) return v;
+    const known = recent[v.id];
+    return known ? { ...known, raw: v.raw } : v;
+  });
+}


### PR DESCRIPTION
配对 framework 侧的 ADR-0104 D3 wave 2（objectstack#3527 / #3534 / #3535,均已合并）。

## 三种形态,一处规则

`file`/`image` 字段值现在会以三种形态之一到达 UI。读取规则收敛到 `@object-ui/fields` 新增的 `file-value` 模块,不再由每个 widget 各自重新推导:

| 形态 | 样子 | 何时出现 |
|---|---|---|
| **引用** | 裸 `sys_file` id 字符串 | 后端采纳 file-as-reference 后的存储形态 |
| **展开** | `{ id, name, size, **mimeType**, url }` | 读路径解析引用后返回的形态 |
| **遗留 blob** | `{ file_id?, name, original_name, size, **mime_type**, url }` | 本包此前自己构造的形态 |

## 这个 PR 修掉的真实 bug:大小写分裂

展开形态带的是 **`mimeType`**（camelCase,来自平台 spec 拥有的 `FileValueSchema`）,遗留 blob 带的是 **`mime_type`**（snake_case）。而 `FileField`、`FileCell`、`ImageField` **只读 `mime_type`**。

后果:后端一旦开始返回展开形态,这三个 widget 立刻**认不出图片**——缩略图静默退化成通用文件图标,而症状里没有任何东西指向"值形态"这个原因。`readFileValue()` 两种都接受,所有 widget 都走它。

## 提交侧:上传后存引用

上传适配器给出 fileId 时,widget 提交**裸 id**（引用形态）;没给出时（object-URL 兜底适配器、或早于 file-as-reference 的后端）提交遗留 blob。**同一份构建对两种后端都工作**。

action param 本来就已经 POST 裸 fileId（#2698/#2710）——这个 PR 让**记录字段值走上同一份契约**,并且让 `serializeParamValues` 共用 `fileIdOf()` 提取器,两个面就不会在"什么算 id"上漂移。

## UX:刚上传的文件立即可见

裸 id 本身不带 name 和 url,而丰富形态要等下一次读取才回来。所以每个 widget 会按 id 记住自己刚上传的文件的展示信息(`withRecentUploads`),上传完立刻正常渲染,而不是先显示一个裸 token 直到刷新。

## 测试

- `file-value.test.ts` 新增 **32 项**:id token 的接受/拒绝矩阵(含 4 种 URL 形态)、`fileIdOf` 的 `file_id → id` 优先级、展开形态与遗留 blob **两种大小写都识别成图片**、name 回退链(`name → original_name → URL 末段 → 本地化兜底`)、裸引用诚实地不带 url、混合形态数组、提交两种模式并与 `readFileValue` 往返、`meta.fileId` 不是 id 形态时拒绝、`withRecentUploads` 只补裸引用且不改 `raw`(展示增强绝不改变提交内容)。
- 全量回归:**7418 passed / 0 failed**(622 个测试文件) · `type-check` ✅ · `build` ✅ · `lint` exit 0

## 依赖与顺序

需要 framework 侧已合并的 PR-2(读路径解析 id)+ PR-3(写路径认领所有权)。因为提交侧带 fallback、读取侧三形态都认,**这个 PR 可以先于 framework 的写切换(PR-5a)合并**——合并后 PR-5a 就只是把已经在发生的事情正式收窄,而不是一次行为切换。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHpGw3GBA9aFpfwVArRWfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHpGw3GBA9aFpfwVArRWfd)_