### PR TITLE
fix(console): make a paused screen flow completable, and stop the runner from tearing down its host (framework#3528)

### DIFF
--- a/.changeset/flow-runs-screen-flow-resume.md
+++ b/.changeset/flow-runs-screen-flow-resume.md
@@ -1,0 +1,38 @@
+---
+"@object-ui/console": patch
+"@object-ui/app-shell": patch
+---
+
+fix(console): let a screen flow be completed from the developer Flow Runs page (framework#3528)
+
+Developer → Flow Runs triggers a flow and renders the result. For a **screen**
+flow that result is not a result — it is `{ status: 'paused', runId, screen }`,
+and the run sits suspended until something posts to its resume endpoint. The
+panel dumped that envelope as JSON and stopped: no screen, no Submit, no resume
+call. Every test run of a screen flow left an orphaned `paused` row in Recent
+Runs, and there was no way to drive one to completion from this surface.
+
+- **console** — a paused test run now opens the same `FlowRunner` the record and
+  list surfaces use, so the screen renders for real (flat fields, multi-step
+  wizards, and `object-form` steps with their master-detail grids) and Submit
+  posts to `/automation/:flow/runs/:runId/resume`. Dismissing the runner no
+  longer strands the run: the pause is durable, so the panel keeps a "Continue
+  run" affordance to reopen the pending screen. `paused` also gets its own
+  status badge instead of falling through to the unknown-status style.
+- **app-shell** — `FlowRunner` (and its `ScreenFlowState` / `ScreenSpec` types)
+  is now exported from the package so surfaces outside `views/` can mount the
+  one screen-flow runner rather than reimplementing it.
+- **app-shell** — `FlowRunner` now wraps the screen body in its own `<Suspense>`
+  boundary. An `object-form` step mounts `ObjectForm`, whose field widgets are
+  lazy; that suspension used to unwind to the *host's* nearest boundary, and on
+  a surface whose nearest boundary is the route-level one, React swapped the
+  whole page for the fallback and remounted it — destroying the host's state
+  along with this dialog. The screen vanished before it could be filled in and
+  the run stayed paused with no resume call, which is exactly the "Submit does
+  nothing" shape. Reproduced on the Flow Runs page and fixed at the source, so
+  every host that mounts the runner is covered.
+- **app-shell** — a screen payload without `fields` no longer throws. `fields`
+  is optional on the wire (a message-only screen, or an `object-form` step from
+  a node executor that omits it), but `FlowRunner`/`ScreenView` read it
+  unguarded and blew up as the dialog mounted. Reads now go through a
+  `screenFields()` helper; the design-time builder keeps its exhaustive shape.

--- a/apps/console/src/pages/developer/FlowRunsPage.test.tsx
+++ b/apps/console/src/pages/developer/FlowRunsPage.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Flow Runs — a screen flow triggered from the Test Run panel must be
+ * completable, not left suspended.
+ *
+ * Regression for framework#3528: the panel triggered the flow, dumped the
+ * `{ status: 'paused', runId, screen }` envelope as JSON and stopped — the run
+ * stayed paused forever and the resume endpoint was never called from any
+ * developer surface. The panel now hands the pause to the shared FlowRunner.
+ *
+ * jsdom integration test — no backend; the automation client and the
+ * authenticated fetch the runner resumes through are both stubbed.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Hoisted so the vi.mock factories below can close over them, and so the
+// adapter is a STABLE singleton (a fresh object per render loops the page's
+// fetch effects).
+const { execute, ADAPTER, authFetch } = vi.hoisted(() => {
+  const flow = {
+    name: 'reassign_wizard',
+    label: 'Reassign',
+    variables: [{ name: 'recordId', type: 'text', isInput: true }],
+  };
+  // The trigger response for a screen flow: suspended at its `screen` node.
+  const execute = vi.fn(async () => ({
+    success: true,
+    status: 'paused',
+    runId: 'run_1',
+    durationMs: 3,
+    screen: {
+      nodeId: 'collect',
+      title: 'New Assignee',
+      fields: [{ name: 'new_assignee', label: 'New Assignee', type: 'text', required: true }],
+    },
+  }));
+  const ADAPTER = {
+    getClient: () => ({
+      meta: { getItems: async (type: string) => (type === 'flow' ? [{ spec: flow }] : []) },
+      automation: { execute, listRuns: async () => ({ runs: [] }) },
+    }),
+  };
+  const authFetch = vi.fn(async () =>
+    new Response(JSON.stringify({ success: true, data: { success: true, durationMs: 9 } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+  return { execute, ADAPTER, authFetch };
+});
+
+vi.mock('@object-ui/app-shell', async () => {
+  // The runner itself is the real component — this test asserts it is mounted
+  // AND that it resumes, so stubbing it would defeat the purpose.
+  const { FlowRunner } = await import('../../../../../packages/app-shell/src/views/FlowRunner');
+  return {
+    useAdapter: () => ADAPTER,
+    useMetadata: () => ({ objects: [] }),
+    FlowRunner,
+  };
+});
+
+vi.mock('@object-ui/auth', () => ({ createAuthenticatedFetch: () => authFetch }));
+
+// Imported AFTER the mocks so the page picks them up.
+import { FlowRunsPage } from './FlowRunsPage';
+
+beforeEach(() => {
+  execute.mockClear();
+  authFetch.mockClear();
+});
+afterEach(cleanup);
+
+describe('Flow Runs — screen flows are completable from the Test Run panel', () => {
+  it('renders the paused screen and resumes the run on Submit', async () => {
+    const user = userEvent.setup();
+    render(<FlowRunsPage />);
+
+    await screen.findByRole('button', { name: /Run Flow/i });
+    await user.click(screen.getByRole('button', { name: /Run Flow/i }));
+
+    // The pause opens the shared screen-flow runner instead of dead-ending.
+    await waitFor(() => expect(execute).toHaveBeenCalledWith('reassign_wizard', expect.any(Object)));
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveTextContent('New Assignee');
+
+    // The dialog's field is the last textbox on the page (the panel's own
+    // input-variable boxes render above it).
+    const textboxes = screen.getAllByRole('textbox');
+    await user.type(textboxes[textboxes.length - 1], 'ada@example.com');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(authFetch).toHaveBeenCalledWith(
+        '/api/v1/automation/reassign_wizard/runs/run_1/resume',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ inputs: { new_assignee: 'ada@example.com' } }),
+        }),
+      ),
+    );
+  });
+
+  it('offers a "Continue run" affordance after the runner is dismissed', async () => {
+    const user = userEvent.setup();
+    render(<FlowRunsPage />);
+
+    await screen.findByRole('button', { name: /Run Flow/i });
+    await user.click(screen.getByRole('button', { name: /Run Flow/i }));
+    await screen.findByRole('dialog');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+    // The suspension is durable — the tester can reopen the pending screen.
+    const resume = await screen.findByRole('button', { name: /Continue run/i });
+    await user.click(resume);
+    expect(await screen.findByRole('dialog')).toHaveTextContent('New Assignee');
+  });
+});

--- a/apps/console/src/pages/developer/FlowRunsPage.tsx
+++ b/apps/console/src/pages/developer/FlowRunsPage.tsx
@@ -5,10 +5,20 @@
  * Console is not project-scoped: there is no useScopedClient and no projectId
  * param. The client comes from `useAdapter().getClient()` (which exposes
  * `.automation` and `.meta`). Run output renders as a plain `<pre>` block.
+ *
+ * A *screen* flow pauses instead of completing: the trigger returns
+ * `{ status: 'paused', runId, screen }`. This page used to dump that envelope
+ * as JSON and stop — the run stayed suspended forever with no way to finish it
+ * from the UI, and every test run of a screen flow orphaned a `paused` row in
+ * the history (framework#3528). It now hands the pause to the SAME
+ * {@link FlowRunner} the record/list surfaces use, so a screen flow can be
+ * driven to completion (multi-step wizards and `object-form` steps included)
+ * from here too.
  */
 
 import { useEffect, useMemo, useState, useCallback } from 'react';
-import { useAdapter } from '@object-ui/app-shell';
+import { useAdapter, useMetadata, FlowRunner, type ScreenFlowState } from '@object-ui/app-shell';
+import { createAuthenticatedFetch } from '@object-ui/auth';
 import {
   Card,
   CardContent,
@@ -71,6 +81,9 @@ function StatusBadge({ status }: { status: string }) {
     error:     { icon: XCircle,      cls: 'text-red-600 border-red-300' },
     running:   { icon: Loader2,      cls: 'text-blue-600 border-blue-300 animate-pulse' },
     pending:   { icon: Clock,        cls: 'text-amber-600 border-amber-300' },
+    // A screen/approval node suspended the run — it is waiting for input, not
+    // stalled (ADR-0019 durable pause).
+    paused:    { icon: Clock,        cls: 'text-amber-600 border-amber-300' },
     skipped:   { icon: AlertCircle,  cls: 'text-muted-foreground' },
   };
   const cfg = map[status] ?? { icon: AlertCircle, cls: 'text-muted-foreground' };
@@ -247,15 +260,23 @@ function FlowTestRunner({
     [flow],
   );
 
+  const adapter = useAdapter();
+  const { objects } = useMetadata();
+  const authFetch = useMemo(() => createAuthenticatedFetch(), []);
+
   const [values, setValues] = useState<Record<string, string>>({});
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
+  // The paused screen a test run stopped at — driven to completion by
+  // <FlowRunner>, exactly as a `type: 'flow'` action would.
+  const [screenFlow, setScreenFlow] = useState<ScreenFlowState | null>(null);
 
   useEffect(() => {
     setValues({});
     setResult(null);
     setError(null);
+    setScreenFlow(null);
   }, [flow?.name]);
 
   const setVal = (k: string, v: string) => setValues(s => ({ ...s, [k]: v }));
@@ -268,6 +289,7 @@ function FlowTestRunner({
     setRunning(true);
     setError(null);
     setResult(null);
+    setScreenFlow(null);
     try {
       const params: Record<string, unknown> = {};
       for (const v of inputVars) {
@@ -277,6 +299,11 @@ function FlowTestRunner({
       }
       const res = await client.automation.execute(flow.name, { params });
       setResult(res);
+      // Screen flow: the run is suspended at a `screen` node. Open the runner
+      // so the tester can fill it in and the run can actually finish.
+      if (res?.status === 'paused' && res?.screen && res?.runId) {
+        setScreenFlow({ flowName: flow.name, runId: res.runId, screen: res.screen });
+      }
       onExecuted?.();
     } catch (e: any) {
       setError(e?.message ?? String(e));
@@ -342,6 +369,8 @@ function FlowTestRunner({
             <div className="flex items-center gap-2 text-sm font-medium">
               {error || result?.success === false ? (
                 <><XCircle className="h-4 w-4 text-red-500" /> Failed</>
+              ) : result?.status === 'paused' ? (
+                <><Clock className="h-4 w-4 text-amber-500" /> Waiting for input</>
               ) : (
                 <><CheckCircle2 className="h-4 w-4 text-emerald-500" /> Result</>
               )}
@@ -352,10 +381,38 @@ function FlowTestRunner({
               )}
             </div>
             {error && <p className="text-sm text-red-500 font-mono break-all">{error}</p>}
+            {/* A run left paused (the runner was dismissed) can be reopened —
+                the suspension is durable, so the screen is still waiting. */}
+            {result?.status === 'paused' && result?.screen && result?.runId && !screenFlow && (
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm text-muted-foreground">
+                  This run is paused at screen <span className="font-mono">{result.screen.nodeId}</span>.
+                </p>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setScreenFlow({ flowName: flow.name, runId: result.runId, screen: result.screen })}
+                >
+                  Continue run
+                </Button>
+              </div>
+            )}
             {result && <JsonBlock data={result} />}
           </div>
         )}
       </CardContent>
+
+      {/* The shared screen-flow runner — renders the paused screen and POSTs
+          the collected values to the run's resume endpoint. */}
+      <FlowRunner
+        state={screenFlow}
+        authFetch={authFetch}
+        baseUrl={import.meta.env.VITE_SERVER_URL || ''}
+        dataSource={adapter}
+        objects={objects}
+        onClose={() => { setScreenFlow(null); onExecuted?.(); }}
+        onComplete={() => { setScreenFlow(null); onExecuted?.(); }}
+      />
     </Card>
   );
 }

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -134,8 +134,16 @@ export {
   SearchResultsPage,
   ViewConfigPanel,
   DeclaredActionsBar,
+  FlowRunner,
 } from './views';
-export type { RecordFormPageProps, DeclaredActionsBarProps } from './views';
+export type {
+  RecordFormPageProps,
+  DeclaredActionsBarProps,
+  FlowRunnerProps,
+  ScreenFlowState,
+  ScreenSpec,
+  ScreenFieldSpec,
+} from './views';
 
 // Hooks
 export {

--- a/packages/app-shell/src/views/FlowRunner.tsx
+++ b/packages/app-shell/src/views/FlowRunner.tsx
@@ -14,7 +14,7 @@
  * {@link ScreenView} — the same renderer the Studio design preview reuses, so
  * the two can never drift (cf. #1927).
  */
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -25,7 +25,7 @@ import {
   Button,
 } from '@object-ui/components';
 import { toast } from 'sonner';
-import { ScreenView, isObjectFormScreen, initialScreenValues, type ScreenSpec } from './ScreenView';
+import { ScreenView, isObjectFormScreen, initialScreenValues, screenFields, type ScreenSpec } from './ScreenView';
 
 export type { ScreenSpec, ScreenFieldSpec } from './ScreenView';
 
@@ -120,7 +120,7 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
   };
 
   const submit = async () => {
-    const missing = screen.fields.filter(
+    const missing = screenFields(screen).filter(
       (f) => f.required && (values[f.name] === undefined || values[f.name] === '' || values[f.name] === null),
     );
     if (missing.length) {
@@ -164,21 +164,29 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
           {screen.description && <DialogDescription>{screen.description}</DialogDescription>}
         </DialogHeader>
 
-        <ScreenView
-          screen={screen}
-          values={values}
-          onValueChange={setVal}
-          dataSource={dataSource}
-          objects={objects}
-          objectForm={{
-            onSuccess: onObjectFormSaved,
-            onCancel: onClose,
-            showSubmit: true,
-            showCancel: true,
-            submitText: 'Save & Continue',
-            cancelText: 'Cancel',
-          }}
-        />
+        {/* The screen body pulls in lazily-loaded chunks (an `object-form` step
+            mounts ObjectForm, whose field widgets are lazy). Without a boundary
+            HERE, that suspension unwinds to the host's nearest <Suspense> — a
+            route-level one on some surfaces — which swaps the whole page for a
+            fallback and destroys the host's state, taking this dialog (and the
+            run it is driving) with it. */}
+        <Suspense fallback={<div className="py-6 text-sm text-muted-foreground">Loading…</div>}>
+          <ScreenView
+            screen={screen}
+            values={values}
+            onValueChange={setVal}
+            dataSource={dataSource}
+            objects={objects}
+            objectForm={{
+              onSuccess: onObjectFormSaved,
+              onCancel: onClose,
+              showSubmit: true,
+              showCancel: true,
+              submitText: 'Save & Continue',
+              cancelText: 'Cancel',
+            }}
+          />
+        </Suspense>
 
         {!isObjectForm && (
           <DialogFooter>

--- a/packages/app-shell/src/views/ScreenView.tsx
+++ b/packages/app-shell/src/views/ScreenView.tsx
@@ -42,7 +42,13 @@ export interface ScreenSpec {
   nodeId: string;
   title?: string;
   description?: string;
-  fields: ScreenFieldSpec[];
+  /**
+   * Optional on the wire: an `object-form` step (or a message-only screen from
+   * a third-party node executor) can legitimately omit it, so every read goes
+   * through {@link screenFields} rather than touching the array directly — an
+   * absent `fields` used to throw the moment the dialog opened.
+   */
+  fields?: ScreenFieldSpec[];
   /**
    * `'object-form'` renders the named object's FULL create/edit form — incl.
    * inline master-detail child grids — as a wizard step (vs. the flat `fields`
@@ -62,10 +68,15 @@ export function isObjectFormScreen(screen: ScreenSpec): boolean {
   return screen.kind === 'object-form' && !!screen.objectName;
 }
 
+/** The screen's input fields — always an array, even when the payload omits them. */
+export function screenFields(screen: ScreenSpec): ScreenFieldSpec[] {
+  return Array.isArray(screen.fields) ? screen.fields : [];
+}
+
 /** Seed flat-field values from each field's `defaultValue`. */
 export function initialScreenValues(screen: ScreenSpec): Record<string, unknown> {
   const v: Record<string, unknown> = {};
-  for (const f of screen.fields) if (f.defaultValue !== undefined) v[f.name] = f.defaultValue;
+  for (const f of screenFields(screen)) if (f.defaultValue !== undefined) v[f.name] = f.defaultValue;
   return v;
 }
 
@@ -143,7 +154,7 @@ export function ScreenView({ screen, values, onValueChange, dataSource, objects,
 
   return (
     <div className={cn('space-y-4 py-2', className)}>
-      {screen.fields.map((f) => (
+      {screenFields(screen).map((f) => (
         <div key={f.name} className="space-y-1.5">
           <Label htmlFor={`ff-${f.name}`} className="text-sm">
             {f.label || f.name}

--- a/packages/app-shell/src/views/__tests__/FlowRunner.test.tsx
+++ b/packages/app-shell/src/views/__tests__/FlowRunner.test.tsx
@@ -84,4 +84,48 @@ describe('FlowRunner resume outcomes', () => {
     await fillAndSubmit();
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
   });
+
+  it('renders and resumes a screen whose payload carries no `fields`', async () => {
+    // A message-only / object-form pause can omit `fields` entirely; reading it
+    // unguarded threw before the dialog could paint.
+    const authFetch = vi.fn(async () => jsonResponse({ success: true, data: { success: true } }));
+    const onClose = vi.fn();
+    const onComplete = vi.fn();
+    render(
+      <FlowRunner
+        state={{
+          flowName: 'convert_lead',
+          runId: 'run-9',
+          screen: { nodeId: 'notice', title: 'Already Converted' } as ScreenFlowState['screen'],
+        }}
+        authFetch={authFetch}
+        baseUrl=""
+        onClose={onClose}
+        onComplete={onComplete}
+      />,
+    );
+    expect(screen.getByText('Already Converted')).toBeInTheDocument();
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(authFetch).toHaveBeenCalledWith(
+      '/api/v1/automation/convert_lead/runs/run-9/resume',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ inputs: {} }) }),
+    );
+  });
+
+  it('posts the resume to the run endpoint with the collected values', async () => {
+    const authFetch = vi.fn(async () => jsonResponse({ success: true, data: { success: true } }));
+    setup(authFetch);
+    await fillAndSubmit();
+    await waitFor(() =>
+      expect(authFetch).toHaveBeenCalledWith(
+        '/api/v1/automation/reassign_wizard/runs/run-1/resume',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ inputs: { new_assignee: 'linus@example.com' } }),
+        }),
+      ),
+    );
+  });
 });

--- a/packages/app-shell/src/views/index.ts
+++ b/packages/app-shell/src/views/index.ts
@@ -13,3 +13,5 @@ export { MetadataToggle, MetadataPanel } from './MetadataInspector';
 export { ViewConfigPanel } from './ViewConfigPanel';
 export { CreateViewDialog } from './CreateViewDialog';
 export { DeclaredActionsBar, type DeclaredActionsBarProps } from './DeclaredActionsBar';
+export { FlowRunner } from './FlowRunner';
+export type { FlowRunnerProps, ScreenFlowState, ScreenSpec, ScreenFieldSpec } from './FlowRunner';

--- a/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
@@ -25,7 +25,7 @@ import * as React from 'react';
 import { Button, cn } from '@object-ui/components';
 import { useAdapter } from '../../../providers/AdapterProvider';
 import { useMetadata } from '../../../providers/MetadataProvider';
-import { ScreenView, isObjectFormScreen, initialScreenValues, type ScreenSpec } from '../../ScreenView';
+import { ScreenView, isObjectFormScreen, initialScreenValues, screenFields, type ScreenSpec } from '../../ScreenView';
 import { buildScreenSpec, interpolate, hiddenFieldCount, type ScreenPreviewNode } from './screen-spec';
 
 export type { ScreenPreviewNode } from './screen-spec';
@@ -63,9 +63,9 @@ export function ScreenPreview({ node, variables, className }: ScreenPreviewProps
   // label/title-only edit.
   const structKey = isObjectForm
     ? `obj:${spec.objectName}:${spec.mode ?? 'create'}`
-    : 'fields:' + spec.fields.map((f) => `${f.name}:${f.type ?? ''}:${f.required ? 1 : 0}`).join('|');
+    : 'fields:' + screenFields(spec).map((f) => `${f.name}:${f.type ?? ''}:${f.required ? 1 : 0}`).join('|');
 
-  const empty = !title && !description && !isObjectForm && spec.fields.length === 0 && hidden === 0;
+  const empty = !title && !description && !isObjectForm && screenFields(spec).length === 0 && hidden === 0;
 
   return (
     <div className={cn('overflow-hidden rounded-md border bg-background', className)}>
@@ -90,7 +90,7 @@ export function ScreenPreview({ node, variables, className }: ScreenPreviewProps
                 {' '}condition{hidden === 1 ? '' : 's'}.
               </p>
             )}
-            {!isObjectForm && spec.fields.length > 0 && (
+            {!isObjectForm && screenFields(spec).length > 0 && (
               <div className="mt-4 flex justify-end">
                 {/* Non-functional — the preview never resumes a real run. */}
                 <Button size="sm" disabled>Submit</Button>

--- a/packages/app-shell/src/views/metadata-admin/previews/screen-spec.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/screen-spec.ts
@@ -97,7 +97,14 @@ export function hiddenFieldCount(node: ScreenPreviewNode, variables: Record<stri
  * / objectName / mode / defaults / idVariable). `fields` are gated by their
  * `visibleWhen` against `variables` (omit `variables` to keep every field).
  */
-export function buildScreenSpec(node: ScreenPreviewNode, variables?: Record<string, unknown>): ScreenSpec {
+/**
+ * A designed screen always carries a (possibly empty) field list — `fields` is
+ * optional on the WIRE type only, where a message-only / object-form pause may
+ * omit it.
+ */
+export type DesignedScreenSpec = ScreenSpec & { fields: ScreenFieldSpec[] };
+
+export function buildScreenSpec(node: ScreenPreviewNode, variables?: Record<string, unknown>): DesignedScreenSpec {
   const c = (node.config && typeof node.config === 'object' ? node.config : {}) as Record<string, unknown>;
   const objectName = typeof c.objectName === 'string' && c.objectName ? c.objectName : undefined;
   const mode = c.mode === 'edit' ? 'edit' : c.mode === 'create' ? 'create' : undefined;


### PR DESCRIPTION
Console half of objectstack#3528 ("screen-flow Submit never calls the resume endpoint"). SDK half: objectstack#3552.

## What I found

I drove the reported path against a live server using the **published `@objectstack/console` 16.1.0 build** in Chromium. The record and list surfaces already resume correctly — trigger → screen → `POST .../runs/:runId/resume` → 200, including the two-step `object-form` lead-conversion wizard. But two real defects on the same path both end in "Submit never resumes":

**1. The Flow Runs test runner has no second half.** Developer → Flow Runs triggers a flow and renders the result. For a screen flow that result is not a result — it is `{ status: 'paused', runId, screen }`, and the run sits suspended until something posts to its resume endpoint. The panel dumped that envelope as JSON and stopped: no screen, no Submit, no resume call. Every test run of a screen flow orphaned a `paused` row in Recent Runs.

**2. `FlowRunner` tore down its host.** An `object-form` step mounts `ObjectForm`, whose field widgets are lazy. That suspension unwound to the *host's* nearest `<Suspense>`; where that is the route-level boundary, React swapped the whole page for the fallback and remounted it — destroying the host's state and this dialog with it. Traced live: the runner opened and was unmounted in the same tick.

```
[DBG] execute result {"success":true,"status":"paused","runId":"run_02a9…"}
[DBG] opening FlowRunner for run run_02a9…
[DBG] FlowTestRunner UNMOUNTED          ← dialog gone, run still paused
[DBG] FlowTestRunner MOUNTED
```

The screen vanished before it could be filled in and no resume was ever issued — the reported symptom exactly, from a cause that has nothing to do with the Submit handler.

## Changes

- **console** — a paused test run opens the same `FlowRunner` the record and list surfaces use, so the screen renders for real (flat fields, multi-step wizards, `object-form` steps with their master-detail grids) and Submit posts to `/automation/:flow/runs/:runId/resume`. Dismissing the runner no longer strands the run: the suspension is durable, so a "Continue run" affordance reopens the pending screen. `paused` gets its own status badge instead of the unknown-status style.
- **app-shell** — `FlowRunner` owns a `<Suspense>` boundary around its screen body, so a lazy screen body can never tear down its host. Fixed at the source rather than per-surface.
- **app-shell** — a screen payload without `fields` no longer throws. `fields` is optional on the wire (a message-only screen, or an executor that omits it) but was read unguarded as the dialog mounted; reads go through a `screenFields()` helper, and the design-time builder keeps its exhaustive shape via `DesignedScreenSpec`.
- **app-shell** — `FlowRunner` and its types are exported from the package so surfaces outside `views/` mount the one runner instead of reimplementing it.

## Test plan

- New `apps/console/src/pages/developer/FlowRunsPage.test.tsx` — asserts the pause opens the runner and that Submit posts to the run's resume endpoint, and that "Continue run" reopens a dismissed screen.
- `FlowRunner.test.tsx` — two new cases: a screen payload with no `fields` renders and resumes, and the resume body carries the collected values.
- Full affected suites: `FlowRunsPage`, `FlowRunner`, `ScreenPreview`, `FlowSimulatorPanel` — 26 passed.
- `pnpm --filter @object-ui/app-shell type-check` clean; eslint on all changed files: 0 errors.
- Browser, against a live `examples/app-crm` server: Flow Runs → Run Flow on `crm_convert_lead_wizard` → step 1 form renders → Save & Continue creates the account → **resume 200** → step 2 renders with the account prefilled.

## Not in this PR

Two adjacent launch-side gaps found while mapping every path that dispatches a `type: 'flow'` action: `DashboardRenderer` header actions never dispatch `flow` (they fall through to `console.warn("Unknown header actionType")`) and have no `ActionProvider` in their subtree; and the console-root `<ActionProvider>` in `ConsoleShell` is mounted with no `handlers` map, so any `action:button` outside ObjectView / RecordDetailView / PageView / DeclaredActionsBar hits a runner with no flow handler. Both deserve their own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX9ut3MK3KykE11S9bJmv5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX9ut3MK3KykE11S9bJmv5)_