### PR TITLE
feat: gate detail/form edit & delete on the server's effective operation set (#3546)

### DIFF
--- a/.changeset/detail-form-effective-ops.md
+++ b/.changeset/detail-form-effective-ops.md
@@ -1,0 +1,34 @@
+---
+"@object-ui/core": minor
+"@object-ui/app-shell": minor
+"@object-ui/plugin-detail": minor
+"@object-ui/plugin-form": minor
+---
+
+feat: gate detail/form edit & delete on the server's effective operation set (#3546)
+
+PR-4 (#3391) wired the **list/toolbar** surface (ObjectView Import, ListView /
+ObjectGrid Export) to the server-resolved effective API operation set
+(`/me/permissions` `apiOperations`, intersected via
+`resolveCrudAffordances(obj, effectiveApiOperations?)`). The **detail / form**
+surfaces still gated edit/delete on the bucket + `userActions` alone. This
+extends the same intersection to them, so the record page and its forms never
+offer an operation the server would 405.
+
+- **core** `isObjectInlineEditable(obj, effectiveApiOperations?)` gains the same
+  optional second argument as `resolveCrudAffordances` — inline-edit is now
+  additionally ANDed with the server allowing `update`.
+- **app-shell** `RecordDetailView` threads the object's effective operations into
+  the synthesized Edit/Delete header actions and the record-body inline-edit
+  gate (`canEdit`); `RelatedRecordActionsBridge` intersects each **child**
+  object's Create/Edit/Delete handlers with that child's own effective set.
+- **plugin-detail** `record:details` ANDs its inline-edit affordance with the
+  object's effective `update`.
+- **plugin-form** `ObjectForm`'s blanket managed-object field lock also engages
+  when the server denies `update` (edit mode) / `create` (create mode).
+
+Backward-compatible: a missing effective set (unrestricted object, older
+backend, or no `PermissionProvider`) leaves the resolved affordance untouched —
+the bucket/`userActions` decision wins, exactly as today. Layers on top of the
+existing per-object `check('edit')` / `check('delete')` permission gates
+(intersection, never union).

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -894,7 +894,18 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // are still loading (`isLoaded === false`, e.g. no PermissionProvider in a
   // standalone embed) the gate stays open — fail-open is safe because the
   // server enforces data access regardless; this is purely a UI/DX filter.
-  const { can: canOnObject, isLoaded: permissionsLoaded } = usePermissions();
+  const { can: canOnObject, isLoaded: permissionsLoaded, getObjectApiOperations } = usePermissions();
+  // [#3546] Server-resolved effective API operation set for this object
+  // (`/me/permissions` `apiOperations`). Threaded as the 2nd arg into
+  // `resolveCrudAffordances` for the detail header's Edit/Delete and the
+  // record-body inline-edit gate, so the detail surface never offers an
+  // operation the server would 405 — the same intersection the list/toolbar
+  // surface already applies (objectui#2823). `undefined` (unrestricted object
+  // / old backend) leaves the bucket affordances untouched (backward-compatible).
+  const effectiveApiOperations = useMemo(
+    () => (objectDef ? getObjectApiOperations(objectDef.name) : undefined),
+    [objectDef, getObjectApiOperations],
+  );
   const childRelations = useMemo(
     () => deriveRelatedLists(objectDef, objects, {
       canRead: permissionsLoaded ? (name) => canOnObject(name, 'read') : undefined,
@@ -1737,7 +1748,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // menu permanently — Delete must never surface as an inline red button
   // just because an object has few actions.
   const synthSystemActions: ActionDef[] = (() => {
-    const affordances = resolveCrudAffordances(objectDef as any);
+    const affordances = resolveCrudAffordances(objectDef as any, effectiveApiOperations);
     const items: ActionDef[] = [];
     if (affordances.edit) {
       // Single primary Edit CTA → opens the full record form. Inline editing
@@ -1882,7 +1893,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
             on backends that track the lock via approval requests only and
             never materialize an `approval_status` field (objectui#2618). */}
         <InlineEditProvider
-          canEdit={resolveCrudAffordances(objectDef as any).edit && !approvalLocked}
+          canEdit={resolveCrudAffordances(objectDef as any, effectiveApiOperations).edit && !approvalLocked}
           locked={approvalLocked}
           lockedReason={t('detail.lockedTooltip', {
             defaultValue: 'This record has a pending approval request; editing is locked',

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -49,6 +49,7 @@ import {
   type RelatedRowActionDef,
 } from '@object-ui/react';
 import type { ActionDef } from '@object-ui/core';
+import { usePermissions } from '@object-ui/permissions';
 import { resolveCrudAffordances } from '../utils/crudAffordances';
 import { RECORD_FORM_PARAM, RECORD_FORM_OBJECT_PARAM, RECORD_FORM_LINK_PARAM, RECORD_TRAIL_PARAM, appendRecordTrail } from '../urlParams';
 
@@ -122,6 +123,7 @@ export function RelatedRecordActionsBridge({
   const navigate = useNavigate();
   const { execute } = useAction();
   const [, setSearchParams] = useSearchParams();
+  const { getObjectApiOperations } = usePermissions();
   const base = appName ? `/apps/${appName}` : '';
 
   // #2604 D3 — open a child create/edit task as the console's global record
@@ -177,7 +179,12 @@ export function RelatedRecordActionsBridge({
       resolve: ({ objectName, relationshipField, parentId }) => {
         const childDef = objects.find((o: any) => o?.name === objectName);
         if (!childDef || !base) return {} as RelatedRecordHandlers;
-        const aff = resolveCrudAffordances(childDef);
+        // [#3546] Intersect the child object's bucket affordances with the
+        // server-resolved effective API operation set for THAT child
+        // (`/me/permissions` `apiOperations`), so a related list never offers
+        // Create/Edit/Delete on the child the server would 405. `undefined`
+        // (unrestricted / old backend) leaves the affordances untouched.
+        const aff = resolveCrudAffordances(childDef, getObjectApiOperations(objectName));
         const detailUrl = (id: string | number) => {
           const url = `${base}/${objectName}/record/${encodeURIComponent(String(id))}`;
           // Carry the parent record into the child's `?from=` trail so the
@@ -247,7 +254,7 @@ export function RelatedRecordActionsBridge({
         return handlers;
       },
     }),
-    [objects, base, navigate, dataSource, actionLabel, runRowAction, openChildForm, parentObjectName, parentRecordId, parentTitle],
+    [objects, base, navigate, dataSource, actionLabel, runRowAction, openChildForm, parentObjectName, parentRecordId, parentTitle, getObjectApiOperations],
   );
 
   return (

--- a/packages/app-shell/src/views/__tests__/RelatedRecordActionsBridge.effectiveOps.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RelatedRecordActionsBridge.effectiveOps.test.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * RelatedRecordActionsBridge — effective API operations (#3546).
+ *
+ * The related-list Create/Edit/Delete affordances for a CHILD object must be
+ * intersected with the server-resolved effective operation set for that child
+ * (`/me/permissions` `apiOperations`), so the list never offers an operation
+ * the server would 405. These pin the button-visibility outcome:
+ *   • full CRUD effective set → onCreate/onEdit/onDelete all present;
+ *   • read-only effective set → none present;
+ *   • update-only effective set → onEdit present, onCreate/onDelete absent;
+ *   • undefined (unrestricted / old backend) → bucket affordances win (all present).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import { vi } from 'vitest';
+
+// Controllable effective-operations map, keyed by child object name.
+let effectiveOps: Record<string, string[] | undefined> = {};
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({
+    getObjectApiOperations: (name: string) => effectiveOps[name],
+  }),
+}));
+
+import { RelatedRecordActionsBridge } from '../RelatedRecordActionsBridge';
+import { useRelatedRecordActions } from '@object-ui/react';
+
+const CHILD = 'invoice';
+// platform bucket → create/edit/delete all open by default.
+const objects = [{ name: CHILD, managedBy: 'platform' }];
+
+/** Probe: resolves the child's handlers and exposes which are present. */
+function Probe({ onResolve }: { onResolve: (present: Record<string, boolean>) => void }) {
+  const api = useRelatedRecordActions();
+  const handlers = api?.resolve({ objectName: CHILD }) ?? {};
+  onResolve({
+    onCreate: typeof handlers.onCreate === 'function',
+    onEdit: typeof handlers.onEdit === 'function',
+    onDelete: typeof handlers.onDelete === 'function',
+    onView: typeof handlers.onView === 'function',
+  });
+  return null;
+}
+
+function resolveHandlers(): Record<string, boolean> {
+  let captured: Record<string, boolean> = {};
+  render(
+    <MemoryRouter>
+      <RelatedRecordActionsBridge
+        appName="crm"
+        objects={objects}
+        dataSource={{ delete: vi.fn() }}
+        actionLabel={(_o, _n, fallback) => fallback}
+      >
+        <Probe onResolve={(p) => { captured = p; }} />
+      </RelatedRecordActionsBridge>
+    </MemoryRouter>,
+  );
+  return captured;
+}
+
+describe('RelatedRecordActionsBridge — effective API operations (#3546)', () => {
+  it('full-CRUD effective set → Create/Edit/Delete all offered', () => {
+    effectiveOps = { [CHILD]: ['get', 'list', 'create', 'update', 'delete'] };
+    const h = resolveHandlers();
+    expect(h.onCreate).toBe(true);
+    expect(h.onEdit).toBe(true);
+    expect(h.onDelete).toBe(true);
+    expect(h.onView).toBe(true); // view is always allowed when the list renders
+  });
+
+  it('read-only effective set → no Create/Edit/Delete (only View)', () => {
+    effectiveOps = { [CHILD]: ['get', 'list'] };
+    const h = resolveHandlers();
+    expect(h.onCreate).toBe(false);
+    expect(h.onEdit).toBe(false);
+    expect(h.onDelete).toBe(false);
+    expect(h.onView).toBe(true);
+  });
+
+  it('update-only effective set → Edit offered, Create/Delete hidden', () => {
+    effectiveOps = { [CHILD]: ['get', 'list', 'update'] };
+    const h = resolveHandlers();
+    expect(h.onEdit).toBe(true);
+    expect(h.onCreate).toBe(false);
+    expect(h.onDelete).toBe(false);
+  });
+
+  it('undefined effective set (unrestricted / old backend) → bucket wins, all offered', () => {
+    effectiveOps = { [CHILD]: undefined };
+    const h = resolveHandlers();
+    expect(h.onCreate).toBe(true);
+    expect(h.onEdit).toBe(true);
+    expect(h.onDelete).toBe(true);
+  });
+});

--- a/packages/core/src/utils/managedBy.test.ts
+++ b/packages/core/src/utils/managedBy.test.ts
@@ -186,3 +186,30 @@ describe('resolveCrudAffordances — effective API operations (#3391)', () => {
     expect(aff.exportCsv).toBe(true);
   });
 });
+
+describe('isObjectInlineEditable — effective API operations (#3546)', () => {
+  it('undefined effective set → bucket affordance decides (backward-compatible)', () => {
+    // platform is inline-editable by default; system is not.
+    expect(isObjectInlineEditable({ managedBy: 'platform' })).toBe(true);
+    expect(isObjectInlineEditable({ managedBy: 'platform' }, undefined)).toBe(true);
+    expect(isObjectInlineEditable({ managedBy: 'system' })).toBe(false);
+  });
+
+  it('effective set WITHOUT `update` closes inline-edit even on an editable bucket', () => {
+    // Server hands down a read-only effective set → no double-click/pencil.
+    expect(isObjectInlineEditable({ managedBy: 'platform' }, ['get', 'list'])).toBe(false);
+  });
+
+  it('effective set WITH `update` keeps inline-edit on an editable bucket', () => {
+    expect(isObjectInlineEditable({ managedBy: 'platform' }, ['get', 'update'])).toBe(true);
+  });
+
+  it('effective set never re-opens inline-edit the bucket already denied (intersection)', () => {
+    // system resolves edit=false; even a server `update` grant can't re-open it.
+    expect(isObjectInlineEditable({ managedBy: 'system' }, ['get', 'update'])).toBe(false);
+  });
+
+  it('empty effective set → not inline-editable (deny-all)', () => {
+    expect(isObjectInlineEditable({ managedBy: 'platform' }, [])).toBe(false);
+  });
+});

--- a/packages/core/src/utils/managedBy.ts
+++ b/packages/core/src/utils/managedBy.ts
@@ -192,7 +192,17 @@ export function isSystemWritable(obj: SchemaLike | null | undefined): boolean {
  * `append-only` / `better-auth` objects resolve to `false` unless they opened
  * `userActions.edit`. (Per-record predicates gate row action buttons, not
  * object-level editability, so only the resolved boolean matters here.)
+ *
+ * @param effectiveApiOperations OPTIONAL server-resolved effective API operation
+ *   set for this object (`/me/permissions` `apiOperations`, #3391/#3546). When
+ *   provided, inline-edit is additionally ANDed with the server allowing
+ *   `update`, so a record page never offers double-click/pencil editing the
+ *   server would 405. `undefined` (old backend / unrestricted) leaves the
+ *   bucket affordance untouched.
  */
-export function isObjectInlineEditable(obj: SchemaLike | null | undefined): boolean {
-  return resolveCrudAffordances(obj).edit;
+export function isObjectInlineEditable(
+  obj: SchemaLike | null | undefined,
+  effectiveApiOperations?: readonly string[] | null,
+): boolean {
+  return resolveCrudAffordances(obj, effectiveApiOperations).edit;
 }

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -229,7 +229,15 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   // source of truth — formerly a hand-mirrored `NON_EDITABLE_BUCKETS` set kept
   // in lockstep by hand because plugin-detail can't depend on app-shell.
   // Authors can still force-disable with `inlineEdit: false`.
-  const objectInlineEditable = isObjectInlineEditable(objSchema);
+  // [#3546] Also AND inline-editability with the server's effective API
+  // operation set for this object (`/me/permissions` `apiOperations`) — the
+  // record body must not offer double-click/pencil editing the server would
+  // 405. `undefined` (unrestricted / old backend) leaves the bucket affordance
+  // untouched (backward-compatible).
+  const objectInlineEditable = isObjectInlineEditable(
+    objSchema,
+    perms?.getObjectApiOperations?.(objectName),
+  );
   const inlineEditDefault = (schema.inlineEdit ?? true) && objectInlineEditable;
 
   const synthesized: any = {

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -506,7 +506,17 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     // (e.g. sys_user opens `edit` for its profile fields). When open, the lock
     // lifts and each field's own `readonly` flag decides. The server-side write
     // guard remains the real boundary; this is UX only.
-    const affordances = resolveCrudAffordances(objectSchema as any);
+    // [#3546] Intersect the bucket/userActions affordance with the server's
+    // effective API operation set for this object (`/me/permissions`
+    // `apiOperations`), so the form's blanket field lock also engages when the
+    // server denies `update` (edit mode) / `create` (create mode) — the same
+    // intersection the detail header and list/toolbar surfaces apply.
+    // `undefined` (unrestricted object / no PermissionProvider) leaves the
+    // resolved affordance untouched (backward-compatible).
+    const affordances = resolveCrudAffordances(
+      objectSchema as any,
+      perms?.getObjectApiOperations?.(schema.objectName),
+    );
     const modeAffordanceOpen =
       schema.mode === 'edit'
         ? affordances.edit
@@ -655,7 +665,7 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     if (!willFetchData) {
       setLoading(false);
     }
-  }, [objectSchema, schema.fields, schema.customFields, schema.readOnly, schema.mode, hasInlineFields, schema.recordId, dataSource]);
+  }, [objectSchema, schema.fields, schema.customFields, schema.readOnly, schema.mode, schema.objectName, hasInlineFields, schema.recordId, dataSource, perms]);
 
   // Handle form submission
   const handleSubmit = useCallback(async (formData: any, e?: any) => {


### PR DESCRIPTION
## 背景

框架 #3391 的独立 follow-up ③(前端,objectui 仓;对应 objectstack#3546)。

PR-4(objectui#2823)让**列表/工具栏**面(`ObjectView` Import、`ListView`/`ObjectGrid` Export)接入了服务端下发的 effective 操作集(`/me/permissions` 的 `apiOperations`,经 `resolveCrudAffordances(obj, effectiveApiOperations?)` 第二参交集)。**detail / form 面**的 edit/delete 此前仍只按 `resolveCrudAffordances(obj)`(bucket + `userActions`)判定,不与服务端 effective 集交集。本 PR 把同一交集扩展到 detail/form 面,使记录页及其表单**永不提供服务端会 405 的 edit/delete/create**。

## 改动

- **core** `isObjectInlineEditable(obj, effectiveApiOperations?)` 获得与 `resolveCrudAffordances` 相同的可选第二参 —— inline-edit 现在额外与服务端 `update` 取交集。
- **app-shell** `RecordDetailView` 把该对象的 effective 操作集传入 header 合成的 Edit/Delete 动作与记录体 inline-edit 门(`canEdit`);`RelatedRecordActionsBridge` 把每个**子对象**的 Create/Edit/Delete handler 与该子对象自身的 effective 集取交集。
- **plugin-detail** `record:details` 的 inline-edit 与 effective `update` 取交集。
- **plugin-form** `ObjectForm` 的托管对象整表字段锁,在服务端拒绝 `update`(edit 模式)/ `create`(create 模式)时同样生效。

## 契约 / 兼容

向后兼容:effective 集缺失(全开对象、旧后端、或未挂 `PermissionProvider`)时,保持 bucket + `userActions` 的判定不变(即今天的行为)。叠加在既有的 per-object `check('edit')` / `check('delete')` 权限门**之上**(取交集,永不取并集)。

## 测试

- **core** `isObjectInlineEditable` 的 effective-ops 用例:含/不含 `update`、空集、`undefined` 回退、bucket 已禁则服务端授权也不再开启。
- **app-shell** 新增 `RelatedRecordActionsBridge` 组件测试:在 full-CRUD / read-only / update-only / undefined 四种 effective 集下断言 Create/Edit/Delete 按钮的显隐。
- 既有 `record-details` / `ObjectForm.managedEdit` / `crudAffordances` 套件回归通过;core / plugin-detail / plugin-form / app-shell 构建(tsc + dts)全绿。

## 关联

- objectstack#3391(跟踪)/ objectstack#3546(本 follow-up)/ objectui#2823(PR-4,已铺路)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L8EfEa157Pe6C73qRnaJH

---
_Generated by [Claude Code](https://claude.ai/code/session_012L8EfEa157Pe6C73qRnaJH)_