### PR TITLE
feat(app-shell): approver values become record lookups (framework #3508)

### DIFF
--- a/.changeset/approval-approver-record-lookups.md
+++ b/.changeset/approval-approver-record-lookups.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/fields': patch
+---
+
+feat(app-shell): approval approver values become record lookups (framework #3508)
+
+- The flow designer's approver `Value` cell now sources directory kinds from DATA
+  records instead of the metadata registry: `user` / `team` / `department` / `position`
+  render a single-select record lookup (`LookupField` over `sys_user` / `sys_team` /
+  `sys_business_unit` / `sys_position` via the DataSource adapter), with a manual-entry
+  escape hatch and a plain free-text fallback when no adapter is available (offline
+  preview). `position` commits the machine name; the others commit the record id —
+  matching the approval engine's resolution semantics.
+- `org-membership-level` is now a strict select (owner/admin/member); a stored
+  out-of-enum value renders flagged instead of being blanked.
+- `manager` renders as an auto-resolved (disabled) cell; `queue` is no longer offered
+  for new approver rows and stored queue rows carry a "not supported by the runtime"
+  warning.
+- `@object-ui/fields`: `LookupField` hydrates the selected label through `id_field`
+  when it is not the primary id (e.g. `id_field: 'name'`), instead of always calling
+  `findOne` with the primary id.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx
@@ -267,6 +267,10 @@ export function FlowObjectListField({
                         value={typeof row.values[col.key] === 'string' ? (row.values[col.key] as string) : ''}
                         onCommit={(v) => setCell(row.id, col.key, typeof v === 'string' ? v : '')}
                         onBlur={() => flush(rows)}
+                        // Picker-style selections (record lookup, strict
+                        // select) have no blur to flush on — set-and-flush
+                        // atomically, like the checkbox/select cells.
+                        onSelect={(v) => commitCell(row.id, col.key, v)}
                         placeholder={col.placeholder}
                         disabled={disabled}
                         context={context}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.lookup.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.lookup.test.tsx
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * framework #3508 — the approver "Value" cell must source directory kinds
+ * (`user` / `team` / `department` / `position`) from DATA records, not the
+ * metadata registry: `GET /api/v1/meta/user` lists no `sys_user` rows, so the
+ * old datalist was always empty and the control silently degraded to a raw-id
+ * text box.
+ *
+ * Load-bearing behaviours:
+ *   1. the record-lookup bindings mirror the ENGINE's resolution semantics
+ *      (`plugin-approvals` resolveApproverSpec) — object names and the
+ *      committed field, incl. `position` storing the machine NAME;
+ *   2. with an adapter, a directory kind renders the record lookup (with the
+ *      manual-entry escape hatch — the author is never trapped);
+ *   3. without an adapter (offline preview gallery) it degrades to free text
+ *      and does NOT fall back to the metadata list;
+ *   4. `org-membership-level` is a STRICT select (free text is how
+ *      `sales_manager` got stored into a three-value enum);
+ *   5. `manager` is auto-resolved (disabled cell + explanation);
+ *   6. `queue` warns that the runtime resolves it to nobody.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+const state = vi.hoisted(() => {
+  const metaList = vi.fn(async () => [] as unknown[]);
+  return {
+    adapter: null as unknown,
+    metaList,
+    // STABLE identity, like the real memoized client: `useMetadataListOptions`
+    // keys its effect on the client object, so a fresh `{ list }` per render
+    // would setState → re-render → setState forever and hang the run.
+    metadataClient: { list: metaList },
+  };
+});
+
+// Static factories, matching AccessExplainPanel.test.tsx: app-shell tests stub
+// `@object-ui/fields` and `@object-ui/react` rather than load their real
+// graphs. LookupField's own behaviour (search, hydration through `id_field`,
+// commit-on-select) is covered in the fields package — this suite verifies
+// the WIRING: which cell renders per kind, and what binding it receives.
+vi.mock('@object-ui/react', () => ({
+  useAdapter: () => state.adapter,
+  // @object-ui/components wires this at module scope (related-count-store).
+  subscribeDataChanges: () => () => {},
+}));
+vi.mock('@object-ui/fields', () => ({
+  LookupField: (props: { field?: { reference_to?: string; id_field?: string; multiple?: boolean } }) => (
+    <div
+      data-testid="record-lookup"
+      data-object={props.field?.reference_to}
+      data-value-field={props.field?.id_field}
+      data-multiple={String(props.field?.multiple ?? false)}
+    />
+  ),
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+vi.mock('../previews/useObjectFields', () => ({
+  useObjectFields: () => ({ fields: [] }),
+}));
+
+import { ReferenceCombobox, KIND_TO_RECORD_LOOKUP } from './FlowReferenceField';
+
+afterEach(() => {
+  cleanup();
+  state.adapter = null;
+  state.metaList.mockClear();
+});
+
+function makeAdapter() {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(async () => null),
+    getObjectSchema: vi.fn(async () => undefined),
+  };
+}
+
+function renderRef(kind: string, props: Partial<React.ComponentProps<typeof ReferenceCombobox>> = {}) {
+  return render(
+    <ReferenceCombobox
+      resolved={{ kind: kind as never }}
+      value={props.value ?? ''}
+      onCommit={props.onCommit ?? vi.fn()}
+      onSelect={props.onSelect}
+      disabled={props.disabled}
+      placeholder={props.placeholder}
+    />,
+  );
+}
+
+describe('KIND_TO_RECORD_LOOKUP — engine contract (#3508)', () => {
+  it('mirrors resolveApproverSpec: objects and committed fields', () => {
+    // applyOooDelegation(String(value)) — a sys_user id.
+    expect(KIND_TO_RECORD_LOOKUP.user).toMatchObject({ object: 'sys_user', valueField: 'id' });
+    // find('sys_team_member', { team_id: value }) — a sys_team id.
+    expect(KIND_TO_RECORD_LOOKUP.team).toMatchObject({ object: 'sys_team', valueField: 'id' });
+    // find('sys_business_unit', { id: value }) — NOT a sys_department.
+    expect(KIND_TO_RECORD_LOOKUP.department).toMatchObject({ object: 'sys_business_unit', valueField: 'id' });
+    // find('sys_user_position', { position: value }) — the machine NAME.
+    expect(KIND_TO_RECORD_LOOKUP.position).toMatchObject({ object: 'sys_position', valueField: 'name' });
+  });
+
+  it('covers exactly the directory kinds — enum/auto/unsupported kinds stay off the record path', () => {
+    expect(Object.keys(KIND_TO_RECORD_LOOKUP).sort()).toEqual(['department', 'position', 'team', 'user']);
+  });
+});
+
+describe('ReferenceCombobox — directory kinds (#3508)', () => {
+  it('renders the record lookup with a manual-entry escape hatch when an adapter is present', () => {
+    state.adapter = makeAdapter();
+    renderRef('user');
+    const cell = screen.getByTestId('record-lookup');
+    expect(cell.getAttribute('data-object')).toBe('sys_user');
+    expect(cell.getAttribute('data-value-field')).toBe('id');
+    expect(cell.getAttribute('data-multiple')).toBe('false');
+    expect(screen.getByTitle('Enter value manually')).toBeInTheDocument();
+  });
+
+  it('position lookups commit the machine NAME, not the row id', () => {
+    state.adapter = makeAdapter();
+    renderRef('position');
+    const cell = screen.getByTestId('record-lookup');
+    expect(cell.getAttribute('data-object')).toBe('sys_position');
+    expect(cell.getAttribute('data-value-field')).toBe('name');
+  });
+
+  it('manual mode: typing commits the raw value and can return to the picker', () => {
+    state.adapter = makeAdapter();
+    const onCommit = vi.fn();
+    renderRef('user', { onCommit });
+    fireEvent.click(screen.getByTitle('Enter value manually'));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'usr_123' } });
+    expect(onCommit).toHaveBeenCalledWith('usr_123');
+    // The way back to the picker stays available.
+    expect(screen.getByTitle('Pick from records')).toBeInTheDocument();
+  });
+
+  it('degrades to plain free text offline (no adapter) and never queries the metadata list', () => {
+    renderRef('user');
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.queryByTitle('Enter value manually')).not.toBeInTheDocument();
+    // The old bug: user/team/department/queue mapped to client.list(kind) →
+    // GET /api/v1/meta/:kind, an endpoint that lists no records.
+    expect(state.metaList).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReferenceCombobox — org-membership-level is a strict select', () => {
+  it('renders the tier label, not a free-text box', () => {
+    renderRef('org-membership-level', { value: 'owner' });
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a stored out-of-enum value flagged instead of blanking it', () => {
+    renderRef('org-membership-level', { value: 'sales_manager' });
+    expect(screen.getByText('sales_manager (invalid)')).toBeInTheDocument();
+  });
+});
+
+describe('ReferenceCombobox — manager is auto-resolved', () => {
+  it('renders a disabled cell with the explanation', () => {
+    renderRef('manager');
+    const input = screen.getByPlaceholderText('Resolved automatically');
+    expect(input).toBeDisabled();
+    expect(screen.getByText(/submitter's manager/i)).toBeInTheDocument();
+  });
+
+  it('still displays a stored advanced override value', () => {
+    renderRef('manager', { value: 'requested_for' });
+    expect(screen.getByDisplayValue('requested_for')).toBeInTheDocument();
+  });
+});
+
+describe('ReferenceCombobox — queue warns (declared-but-unenforced)', () => {
+  it('keeps the stored value editable but warns that it resolves to nobody', () => {
+    const onCommit = vi.fn();
+    renderRef('queue', { value: 'q_west', onCommit });
+    expect(screen.getByText(/not supported by the runtime/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByDisplayValue('q_west'), { target: { value: 'q_east' } });
+    expect(onCommit).toHaveBeenCalledWith('q_east');
+    expect(state.metaList).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
@@ -8,11 +8,17 @@
  *
  * Why a combobox and not a strict dropdown: the designer must never trap the
  * author. The control suggests known values (fetched per {@link ReferenceKind})
- * but always accepts free text, so a field that doesn't exist yet, a role the
- * current tenant hasn't populated, or an empty catalog all still let the author
- * type a value. Implemented with a native `<datalist>` for exactly that
- * suggest-but-allow-anything behaviour, zero extra dependencies, and built-in
- * accessibility.
+ * but always accepts free text, so a field that doesn't exist yet or an empty
+ * catalog still let the author type a value. Implemented with a native
+ * `<datalist>` for exactly that suggest-but-allow-anything behaviour, zero
+ * extra dependencies, and built-in accessibility.
+ *
+ * Four kinds carry a stronger contract than suggest-and-allow-anything
+ * (framework #3508): the directory-backed kinds (`user`/`team`/`department`/
+ * `position`) render a record lookup against the data API (with a manual-entry
+ * escape hatch, so the never-trap rule still holds), `org-membership-level` is
+ * a strict select over a closed enum, `manager` is auto-resolved (disabled
+ * cell), and `queue` warns that the runtime doesn't resolve it.
  *
  * Two layers:
  *   • {@link ReferenceCombobox} — the bare control, given an already-resolved
@@ -28,7 +34,13 @@
  */
 
 import * as React from 'react';
-import { Input, Label } from '@object-ui/components';
+import {
+  Button, Input, Label,
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@object-ui/components';
+import { Pencil, Search } from 'lucide-react';
+import { useAdapter } from '@object-ui/react';
+import { LookupField } from '@object-ui/fields';
 import type { FlowReferenceSpec, ReferenceKind } from './flow-node-config';
 import { useMetadataClient } from '../useMetadata';
 import { useObjectFields } from '../previews/useObjectFields';
@@ -47,20 +59,52 @@ interface Option {
 }
 
 /**
- * Reference kinds backed by a flat metadata list (`client.list(type)`), mapped
+ * Reference kinds backed by a flat METADATA list (`client.list(type)`), mapped
  * to their metadata-type name. `object-field` and `node` are resolved
- * specially (not via a list) and are intentionally absent.
+ * specially (not via a list) and are intentionally absent — and so are the
+ * directory kinds (`user` / `team` / `department` / `position`), which are
+ * backed by DATA records, not the metadata registry: they used to map here,
+ * so the picker queried `GET /api/v1/meta/user` (which lists no `sys_user`
+ * rows), came back empty, and silently degraded to a free-text id box
+ * (framework #3508). They live in {@link KIND_TO_RECORD_LOOKUP} instead.
  */
 const KIND_TO_META_TYPE: Partial<Record<ReferenceKind, string>> = {
   object: 'object',
   flow: 'flow',
-  position: 'position',
-  user: 'user',
-  team: 'team',
-  queue: 'queue',
-  department: 'department',
   connector: 'connector',
   'email-template': 'email_template',
+};
+
+/**
+ * Reference kinds backed by DATA records in the system directory objects —
+ * mirrors `APPROVER_VALUE_BINDINGS` in `@objectstack/spec` (automation/
+ * approval.zod.ts, framework #3508; import it once a published ^16 release
+ * carries the export). The approval engine resolves these against records,
+ * so the designer offers a record lookup through the DataSource adapter.
+ *
+ * `valueField` is the committed value. `position` deliberately stores the
+ * machine NAME — the engine filters `sys_user_position.position` by name, and
+ * names stay portable across environments the way row ids do not. The others
+ * store the row id. `department` resolves against `sys_business_unit` (there
+ * is no `sys_department`).
+ */
+export interface RecordLookupBinding {
+  /** Directory object the picker queries via the data API. */
+  object: string;
+  /** Record field committed as the reference value. */
+  valueField: 'id' | 'name';
+  /** Record field shown as the row label. */
+  displayField: string;
+  /** `search` opts into the people picker (avatar rows) — users only. */
+  picker?: 'search';
+  /** Secondary-line fields for people rows. */
+  subtitle?: string[];
+}
+export const KIND_TO_RECORD_LOOKUP: Partial<Record<ReferenceKind, RecordLookupBinding>> = {
+  user: { object: 'sys_user', valueField: 'id', displayField: 'name', picker: 'search', subtitle: ['email'] },
+  team: { object: 'sys_team', valueField: 'id', displayField: 'name' },
+  department: { object: 'sys_business_unit', valueField: 'id', displayField: 'name' },
+  position: { object: 'sys_position', valueField: 'name', displayField: 'label' },
 };
 
 /**
@@ -69,7 +113,8 @@ const KIND_TO_META_TYPE: Partial<Record<ReferenceKind, string>> = {
  * ADR-0090 D3 removed the `role` metadata type, so that call returned nothing
  * and the picker silently degraded to a free-text box — which is how
  * `sales_manager` got typed into a field that only ever accepts these three.
- * The tier is a closed enum, so the options are supplied here instead.
+ * The tier is a closed enum, so it renders as a STRICT select over these
+ * options (framework #3508) — free text would re-open the same trap.
  */
 const ORG_MEMBERSHIP_LEVEL_OPTIONS: Option[] = [
   { value: 'owner', label: 'Owner' },
@@ -281,6 +326,101 @@ function useConnectorListOptions(enabled: boolean): { options: Option[] } {
   return state;
 }
 
+/**
+ * A single-select RECORD lookup cell for the directory-backed reference kinds
+ * (framework #3508). Wraps `@object-ui/fields` LookupField with the app-shell
+ * adapter as its DataSource — the same pattern `AccessExplainPanel` and
+ * `AssignedUsersSection` already use to pick `sys_user` rows inside metadata
+ * editing (ADR-0072: the picker only offers references that actually resolve).
+ *
+ * "Never trap the author" still holds: with no adapter (offline preview
+ * gallery, no backend) the cell degrades to plain free text, and even with an
+ * adapter a pencil toggle switches to manual entry — a value the directory
+ * can't resolve yet (fresh env, dangling id) stays typeable.
+ */
+function RecordLookupCell({ binding, value, onPick, onCommit, onBlur, disabled, placeholder }: {
+  binding: RecordLookupBinding;
+  value: unknown;
+  /** Immediate commit for picker selections (there is no blur to flush on). */
+  onPick: (value: string) => void;
+  /** Keystroke-level commit for the manual-entry input (flushed via onBlur). */
+  onCommit: (value: unknown) => void;
+  onBlur?: () => void;
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const adapter = useAdapter();
+  const [manual, setManual] = React.useState(false);
+  const current = value != null ? String(value) : '';
+
+  if (!adapter || manual) {
+    return (
+      <div className="flex w-full items-center gap-1">
+        <Input
+          value={current}
+          onChange={(e) => onCommit(e.target.value)}
+          onBlur={onBlur}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="h-8 flex-1 text-sm"
+        />
+        {adapter && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 shrink-0 p-0 text-muted-foreground"
+            onClick={() => setManual(false)}
+            disabled={disabled}
+            aria-label="Pick from records"
+            title="Pick from records"
+          >
+            <Search className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full items-center gap-1">
+      <div className="min-w-0 flex-1">
+        <LookupField
+          value={current || null}
+          onChange={(v: unknown) => onPick(v == null ? '' : String(v))}
+          readonly={disabled}
+          dataSource={adapter}
+          field={{
+            reference_to: binding.object,
+            display_field: binding.displayField,
+            id_field: binding.valueField,
+            multiple: false,
+            allow_create: false,
+            placeholder,
+            ...(binding.picker ? { picker: binding.picker } : {}),
+            ...(binding.subtitle ? { subtitle: binding.subtitle } : {}),
+          }}
+        />
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-8 w-8 shrink-0 p-0 text-muted-foreground"
+        onClick={() => setManual(true)}
+        disabled={disabled}
+        aria-label="Enter value manually"
+        title="Enter value manually"
+      >
+        <Pencil className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
 export interface ReferenceComboboxProps {
   /** The resolved concrete reference, or undefined → plain free text. */
   resolved: ResolvedRef | undefined;
@@ -288,6 +428,13 @@ export interface ReferenceComboboxProps {
   onCommit: (value: unknown) => void;
   /** Optional blur handler (the `objectList` repeater flushes rows on blur). */
   onBlur?: () => void;
+  /**
+   * Immediate-commit callback for picker-style selections (record lookup,
+   * strict select) — controls with no blur event to flush on. The `objectList`
+   * repeater passes its set-and-flush; when absent, falls back to
+   * `onCommit` + `onBlur`, which suits the standalone inspector field.
+   */
+  onSelect?: (value: string) => void;
   disabled?: boolean;
   placeholder?: string;
   context?: FlowReferenceContext;
@@ -297,13 +444,19 @@ export interface ReferenceComboboxProps {
 
 /**
  * The bare reference combobox — suggestions for `resolved.kind`, always
- * free-text editable. Hooks are called unconditionally (kind-gated args) so the
+ * free-text editable, except for the kinds with a stronger contract:
+ * directory-backed kinds render a record lookup ({@link RecordLookupCell}),
+ * `org-membership-level` a strict select (closed enum), `manager` a disabled
+ * auto-resolved cell, and `queue` free text with a not-supported warning
+ * (framework #3508). Hooks are called unconditionally (kind-gated args) so the
  * component is safe to use in a repeater where the kind changes per row.
  */
-export function ReferenceCombobox({ resolved, value, onCommit, onBlur, disabled, placeholder, context, showHint = true }: ReferenceComboboxProps) {
+export function ReferenceCombobox({ resolved, value, onCommit, onBlur, onSelect, disabled, placeholder, context, showHint = true }: ReferenceComboboxProps) {
   const listId = React.useId();
   const ctx: FlowReferenceContext = context ?? { draft: {}, node: null };
   const kind = resolved?.kind;
+  // Picker-style commits have no blur event; default to commit-then-flush.
+  const commitSelection = onSelect ?? ((v: string) => { onCommit(v); onBlur?.(); });
 
   // object-field: resolve the target object, then its field catalog.
   const objectName = resolved ? resolveObjectName(resolved.kind, resolved.objectSource, ctx) : undefined;
@@ -333,7 +486,6 @@ export function ReferenceCombobox({ resolved, value, onCommit, onBlur, disabled,
     }
     if (kind === 'connector-action') return connectorActionOptions;
     if (kind === 'connector') return connectorListOptions;
-    if (kind === 'org-membership-level') return ORG_MEMBERSHIP_LEVEL_OPTIONS;
     if (kind === 'node') {
       const nodes = Array.isArray(ctx.draft.nodes) ? (ctx.draft.nodes as Array<Record<string, unknown>>) : [];
       const currentId = typeof ctx.node?.id === 'string' ? ctx.node.id : undefined;
@@ -354,6 +506,92 @@ export function ReferenceCombobox({ resolved, value, onCommit, onBlur, disabled,
   const unresolvedObject = kind === 'object-field' && !objectName;
   // Same for a connector-action with no connector chosen yet.
   const unresolvedConnector = kind === 'connector-action' && !connectorName;
+
+  // ── Kinds with a stronger contract than suggest-and-allow-anything ──────
+  // (All hooks above have already run — the branches below only render.)
+
+  // Directory-backed kinds → single-select record lookup (framework #3508).
+  const lookup = kind ? KIND_TO_RECORD_LOOKUP[kind] : undefined;
+  if (lookup) {
+    return (
+      <RecordLookupCell
+        binding={lookup}
+        value={value}
+        onPick={commitSelection}
+        onCommit={onCommit}
+        onBlur={onBlur}
+        disabled={disabled}
+        placeholder={placeholder}
+      />
+    );
+  }
+
+  // Closed enum → strict select, never free text: `sales_manager` typed into
+  // a membership-tier box matches nobody at runtime. A stored value outside
+  // the enum (legacy dirty data) still renders, flagged, so editing an old
+  // row never silently blanks it — mirroring the repeater's select cells.
+  if (kind === 'org-membership-level') {
+    const current = value != null ? String(value) : '';
+    const shown = current && !ORG_MEMBERSHIP_LEVEL_OPTIONS.some((o) => o.value === current)
+      ? [...ORG_MEMBERSHIP_LEVEL_OPTIONS, { value: current, label: `${current} (invalid)` }]
+      : ORG_MEMBERSHIP_LEVEL_OPTIONS;
+    return (
+      <Select value={current || undefined} onValueChange={commitSelection} disabled={disabled}>
+        <SelectTrigger className="h-8 w-full text-sm">
+          <SelectValue placeholder={placeholder ?? '—'} />
+        </SelectTrigger>
+        <SelectContent>
+          {shown.map((o) => (
+            <SelectItem key={o.value} value={o.value}>
+              {o.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  // Auto-resolved at runtime (submitter's manager) — no value to author. A
+  // stored value (the advanced field-name override, authorable via API) still
+  // displays. The explanation renders regardless of `showHint`: it is the
+  // reason the input is disabled, not an optional nicety.
+  if (kind === 'manager') {
+    return (
+      <div className="w-full space-y-1">
+        <Input
+          value={value != null ? String(value) : ''}
+          disabled
+          placeholder="Resolved automatically"
+          className="h-8 text-sm"
+        />
+        <p className="text-[11px] leading-snug text-muted-foreground">
+          Resolved at runtime from the submitter&apos;s manager — no value needed.
+        </p>
+      </div>
+    );
+  }
+
+  // Declared-but-unenforced (framework #3508): the runtime has no queue
+  // resolution, so a stored value keeps its free-text cell but carries a
+  // warning — rendered regardless of `showHint` because the slot silently
+  // routes to nobody. New rows can no longer choose this type.
+  if (kind === 'queue') {
+    return (
+      <div className="w-full space-y-1">
+        <Input
+          value={value != null ? String(value) : ''}
+          onChange={(e) => onCommit(e.target.value)}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="h-8 text-sm"
+        />
+        <p className="text-[11px] leading-snug text-amber-600 dark:text-amber-400">
+          Queue approvers are not supported by the runtime yet — this slot resolves to nobody.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full space-y-1">

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
@@ -394,10 +394,17 @@ function RecordLookupCell({ binding, value, onPick, onCommit, onBlur, disabled, 
           readonly={disabled}
           dataSource={adapter}
           field={{
+            // `type` is the discriminator that selects LookupFieldMetadata —
+            // without it the literal is checked against the wrong union member
+            // and the lookup keys below are rejected.
+            type: 'lookup',
+            name: 'value',
             reference_to: binding.object,
             display_field: binding.displayField,
+            // `position` commits the machine name, the rest the row id.
             id_field: binding.valueField,
             multiple: false,
+            // A directory row is never created from a flow-authoring picker.
             allow_create: false,
             placeholder,
             ...(binding.picker ? { picker: binding.picker } : {}),

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -45,8 +45,8 @@ export type FlowConfigFieldKind =
   | 'reference';
 
 /**
- * What a `reference` field points at — the picker's data source. The control
- * is always an *editable* combobox (suggestions + free text), so an unknown /
+ * What a `reference` field points at — the picker's data source. Most kinds
+ * render an *editable* combobox (suggestions + free text), so an unknown /
  * not-yet-created value is never rejected and an empty catalog degrades to a
  * plain text box.
  *
@@ -56,20 +56,30 @@ export type FlowConfigFieldKind =
  *   • `flow`          → a flow, by name (`client.list('flow')`)
  *   • `org-membership-level`
  *                     → a better-auth org-membership tier. A FIXED three-value
- *                       enum (owner/admin/member), not a catalog: there is no
- *                       `role` metadata type to list (ADR-0090 D3 renamed
- *                       `sys_role` → `sys_position`), so this kind supplies its
- *                       own options rather than calling `client.list`.
- *   • `position`      → a position / 岗位 by machine name (`client.list('position')`);
- *                       holders resolve via `sys_user_position` (ADR-0090 D3)
+ *                       enum (owner/admin/member) rendered as a STRICT select
+ *                       (framework #3508): there is no `role` metadata type to
+ *                       list (ADR-0090 D3), and free text is how dirty values
+ *                       like `sales_manager` got stored.
+ *   • `user` / `team` / `department` / `position` → a DATA-record lookup on
+ *                       the matching directory object (`sys_user` / `sys_team`
+ *                       / `sys_business_unit` / `sys_position`) via the
+ *                       DataSource adapter — NOT the metadata registry, which
+ *                       lists no records (framework #3508). `position` commits
+ *                       the machine NAME (`sys_user_position` routes by name,
+ *                       ADR-0090 D3); the others commit the row id. See
+ *                       `KIND_TO_RECORD_LOOKUP`, which mirrors the spec's
+ *                       `APPROVER_VALUE_BINDINGS`.
+ *   • `manager`       → auto-resolved at runtime (submitter's manager) — a
+ *                       disabled cell, no value to author
+ *   • `queue`         → declared-but-unenforced in the runtime (framework
+ *                       #3508): free text + warning, not offered for new rows
  *   • `node`          → another node in *this* flow, by id (read from the draft)
- *   • `user` / `team` / `queue` / `department` → the matching metadata list
- *                       (`client.list(kind)`); empty in dev, populated per tenant
  *   • `connector`     → an installed connector (`client.list('connector')`)
  *   • `email-template`→ an email template (`client.list('email_template')`)
  *
  * Kinds that have no catalog in the current tenant simply degrade to a plain
- * text box — the control is always an editable combobox, never a hard dropdown.
+ * text box (record lookups also keep a manual-entry escape hatch) — the author
+ * is never trapped.
  */
 export type ReferenceKind =
   | 'object'
@@ -82,6 +92,7 @@ export type ReferenceKind =
   | 'team'
   | 'queue'
   | 'department'
+  | 'manager'
   | 'connector'
   | 'connector-action'
   | 'email-template';
@@ -526,36 +537,41 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
           key: 'type',
           label: 'Type',
           kind: 'select',
-          // `role` is deliberately absent: it is the deprecated spelling of
-          // `org_membership_level` (ADR-0090 D3) and reads as "the old name for
-          // position", which is the trap — a stored `role` row still renders
-          // and resolves, but the designer never authors a new one.
+          // Mirrors the spec's NON_AUTHORABLE_APPROVER_TYPES (approval.zod.ts):
+          // `role` is the deprecated spelling of `org_membership_level`
+          // (ADR-0090 D3), and `queue` is declared-but-unenforced — the runtime
+          // resolves it to nobody (framework #3508). A stored row of either
+          // still renders (the select surfaces it flagged "(deprecated)"), but
+          // the designer never authors a new one. Indirect bindings lead and
+          // the literal `user` binding comes last: binding a specific person is
+          // the least portable choice (env moves, people leave).
           options: [
-            { value: 'user', label: 'User' },
-            { value: 'position', label: 'Position' },
-            { value: 'org_membership_level', label: 'Organization membership (owner/admin/member)' },
-            { value: 'team', label: 'Team' },
-            { value: 'department', label: 'Department' },
             { value: 'manager', label: 'Manager' },
+            { value: 'position', label: 'Position' },
+            { value: 'department', label: 'Department' },
+            { value: 'team', label: 'Team' },
             { value: 'field', label: 'Field' },
-            { value: 'queue', label: 'Queue' },
+            { value: 'org_membership_level', label: 'Organization membership (owner/admin/member)' },
+            { value: 'user', label: 'User' },
           ],
         },
         {
-          // Polymorphic: the picker follows the row's `type`. `manager` takes no
-          // value (resolved from the submitter's manager_id) so it stays unmapped
-          // → free text; unmapped/empty types likewise fall back to free text.
+          // Polymorphic: the picker follows the row's `type` — record lookups
+          // for the directory kinds, a strict select for the membership tier,
+          // an auto-resolved cell for `manager`, an object-field picker for
+          // `field` (framework #3508). Unmapped/empty types fall back to free
+          // text.
           key: 'value',
           label: 'Value',
           kind: 'reference',
-          placeholder: 'user id / position / membership tier / field — per type',
+          placeholder: 'User id / membership tier / position / team / department / field — per `type`',
           ref: {
             kindFrom: 'type',
             objectSource: '$trigger',
-            // `role` maps to the same picker as `org_membership_level`: the
-            // designer no longer offers it, but a flow authored on 15.x still
-            // has stored rows, and they must keep rendering for the length of
-            // the deprecation window.
+            // `role` maps to the same picker as `org_membership_level`, and
+            // `queue` stays mapped (free text + warning): the designer no
+            // longer offers either, but stored rows must keep rendering for
+            // the length of the deprecation window.
             map: {
               user: 'user',
               position: 'position',
@@ -563,6 +579,7 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
               role: 'org-membership-level',
               team: 'team',
               department: 'department',
+              manager: 'manager',
               field: 'object-field',
               queue: 'queue',
             },

--- a/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.test.ts
@@ -21,20 +21,23 @@ const APPROVAL_CONFIG_SCHEMA = {
           type: {
             type: 'string',
             enum: ['user', 'org_membership_level', 'role', 'position', 'team', 'department', 'manager', 'field', 'queue'],
-            // `role` still parses (a 15.x flow must keep loading) but is not
-            // offered for new authoring — ADR-0090 D3.
-            xEnumDeprecated: ['role'],
+            // `role` (ADR-0090 D3) and `queue` (declared-but-unenforced,
+            // framework #3508) still parse — stored flows must keep loading —
+            // but are not offered for new authoring.
+            xEnumDeprecated: ['role', 'queue'],
           },
           value: {
-            description: 'User id / membership tier / position / team / department / field / queue — per `type`',
+            description: 'User id / membership tier / position / team / department / field — per `type`',
             type: 'string',
             xRef: {
               kindFrom: 'type',
               objectSource: '$trigger',
-              // Mirrors @objectstack/spec approval.zod.ts: both the canonical
-              // spelling and its deprecated `role` alias point at the same
-              // picker kind (ADR-0090 D3).
-              map: { user: 'user', org_membership_level: 'org-membership-level', role: 'org-membership-level', position: 'position', team: 'team', department: 'department', field: 'object-field', queue: 'queue' },
+              // Mirrors @objectstack/spec approval.zod.ts: the deprecated
+              // `role` alias points at the same picker kind as its canonical
+              // spelling (ADR-0090 D3); `manager` maps to the auto-resolved
+              // cell; `queue` stays mapped so stored rows keep rendering
+              // (framework #3508).
+              map: { user: 'user', org_membership_level: 'org-membership-level', role: 'org-membership-level', position: 'position', team: 'team', department: 'department', manager: 'manager', field: 'object-field', queue: 'queue' },
             },
           },
         },
@@ -112,23 +115,26 @@ describe('jsonSchemaToFlowFields', () => {
     expect(colKeys).toEqual(['type', 'value']);
     const typeCol = approvers.columns!.find((c) => c.key === 'type')!;
     expect(typeCol.kind).toBe('select');
-    // `role` is dropped from the OPTIONS (xEnumDeprecated) while staying in the
-    // enum: the designer must not hand an author the deprecated spelling, which
-    // reads as "the old name for position" and silently routes to nobody.
-    expect(typeCol.options!.map((o) => o.value)).toEqual(['user', 'org_membership_level', 'position', 'team', 'department', 'manager', 'field', 'queue']);
+    // `role` and `queue` are dropped from the OPTIONS (xEnumDeprecated) while
+    // staying in the enum: the designer must not hand an author a deprecated
+    // spelling (ADR-0090 D3) or a type the runtime resolves to nobody
+    // (framework #3508) — but stored rows keep rendering.
+    expect(typeCol.options!.map((o) => o.value)).toEqual(['user', 'org_membership_level', 'position', 'team', 'department', 'manager', 'field']);
     expect(typeCol.options!.map((o) => o.value)).not.toContain('role');
+    expect(typeCol.options!.map((o) => o.value)).not.toContain('queue');
     const valueCol = approvers.columns!.find((c) => c.key === 'value')!;
     // Polymorphic reference: the picker follows the row's `type`. The
     // deprecated `role` discriminator survives and resolves to the SAME picker
     // kind as the canonical spelling — a flow authored on 15.x must keep
-    // rendering for the length of its deprecation window (ADR-0090 D3).
+    // rendering for the length of its deprecation window (ADR-0090 D3) — and
+    // `queue`/`manager` map to their warning / auto-resolved cells (#3508).
     expect(valueCol.kind).toBe('reference');
     expect(valueCol.ref).toEqual({
       kindFrom: 'type',
       objectSource: '$trigger',
-      map: { user: 'user', org_membership_level: 'org-membership-level', role: 'org-membership-level', position: 'position', team: 'team', department: 'department', field: 'object-field', queue: 'queue' },
+      map: { user: 'user', org_membership_level: 'org-membership-level', role: 'org-membership-level', position: 'position', team: 'team', department: 'department', manager: 'manager', field: 'object-field', queue: 'queue' },
     });
-    expect(valueCol.placeholder).toBe('User id / membership tier / position / team / department / field / queue — per `type`');
+    expect(valueCol.placeholder).toBe('User id / membership tier / position / team / department / field — per `type`');
   });
 
   it('maps a static-kind xRef column into a reference column', () => {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/json-schema-to-fields.ts
@@ -102,6 +102,10 @@ const REFERENCE_KINDS: ReadonlySet<string> = new Set<ReferenceKind>([
   'team',
   'queue',
   'department',
+  // Auto-resolved approver (submitter's manager) — renders as a disabled
+  // cell, not a picker (framework #3508). Listed so the spec's xRef map entry
+  // survives validation; an older designer without it just degraded to text.
+  'manager',
   'connector',
   'email-template',
 ]);

--- a/packages/fields/src/widgets/LookupField.idField.test.tsx
+++ b/packages/fields/src/widgets/LookupField.idField.test.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Regression (objectstack #3508): a lookup whose committed value is NOT the
+ * primary id (`id_field: 'name'` — e.g. approval `position` approvers, which
+ * the engine routes by machine name) must hydrate its display label by
+ * FILTERING on that field. The old path always called `findOne(object, value)`
+ * — a primary-id GET — so a stored machine name never resolved and the field
+ * showed an empty placeholder over a real value.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { LookupField } from './LookupField';
+
+afterEach(cleanup);
+
+describe('LookupField — id_field hydration (#3508)', () => {
+  it('hydrates by filtering on id_field when it is not the primary id', async () => {
+    const find = vi.fn(async () => ({
+      data: [{ id: 'pos_1', name: 'sales_manager', label: 'Sales Manager' }],
+    }));
+    const findOne = vi.fn(async () => null);
+    render(
+      <LookupField
+        value="sales_manager"
+        onChange={() => {}}
+        dataSource={{ find, findOne } as never}
+        field={{
+          reference_to: 'sys_position',
+          id_field: 'name',
+          display_field: 'label',
+          multiple: false,
+        } as never}
+      />,
+    );
+    await waitFor(() => expect(find).toHaveBeenCalled());
+    // The stored machine name is not a primary id — findOne(object, name)
+    // would 404; hydration must go through $filter on the committed field.
+    expect(findOne).not.toHaveBeenCalled();
+    const hydration = find.mock.calls.find(
+      (c) => (c as unknown[])[1] && ((c as never[])[1] as { $filter?: Record<string, unknown> }).$filter?.name === 'sales_manager',
+    );
+    expect(hydration).toBeTruthy();
+  });
+
+  it('keeps findOne hydration for the default primary-id lookup', async () => {
+    const find = vi.fn(async () => ({ data: [] }));
+    const findOne = vi.fn(async () => ({ id: 'u1', name: 'Ada' }));
+    render(
+      <LookupField
+        value="u1"
+        onChange={() => {}}
+        dataSource={{ find, findOne } as never}
+        field={{ reference_to: 'sys_user', multiple: false } as never}
+      />,
+    );
+    await waitFor(() => expect(findOne).toHaveBeenCalledWith('sys_user', 'u1'));
+  });
+});

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -477,7 +477,11 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
       try {
         const fetched: LookupOption[] = [];
         for (const id of unresolved) {
-          if (typeof (dataSource as any).findOne === 'function') {
+          // `findOne` resolves by PRIMARY id only. When the field commits a
+          // different column (`id_field: 'name'` — e.g. position machine
+          // names, objectstack #3508), hydrate by filtering on that column or
+          // the stored value would never resolve to a label.
+          if (typeof (dataSource as any).findOne === 'function' && idField === 'id') {
             const rec = await (dataSource as any).findOne(referenceTo, id);
             if (rec) fetched.push(recordToOption(rec, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema));
           } else {

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -433,6 +433,31 @@ export interface LookupFieldMetadata extends BaseFieldMetadata {
   options?: SelectOptionMetadata[];
 
   /**
+   * Record field rendered as each candidate's label. Falls back to
+   * `reference_field`, then the referenced object's own display-name
+   * resolution, then the raw id.
+   * @example 'label' — a position's display name
+   */
+  display_field?: string;
+
+  /**
+   * Record field committed as this lookup's VALUE. Defaults to `'id'`; set it
+   * when the reference is stored by another column — e.g. an approval
+   * `position` approver stores `sys_position.name`, because the engine routes
+   * by machine name and names stay portable across environments
+   * (objectstack #3508).
+   */
+  id_field?: string;
+
+  /**
+   * Offer inline "create the referenced record" from an empty/zero-result
+   * picker. Defaults ON for user-facing relations and OFF for platform
+   * objects (`sys_`/`cloud_`/`ai_` and the user directory); set explicitly to
+   * override either way.
+   */
+  allow_create?: boolean;
+
+  /**
    * Secondary field shown as description in the quick-select popover.
    * @example 'industry' — shows customer industry below customer name
    */


### PR DESCRIPTION
设计器侧落地 framework #3508(spec/引擎侧在 objectstack#3536)。

## 问题

审批节点 Approvers → **Value** 是个 datalist 组合框,`user`/`team`/`department`/`position` 的候选接在 `client.list(kind)` → `GET /api/v1/meta/:kind`(**元数据注册表**)上。但这些处理人是 `sys_user`/`sys_team`/`sys_business_unit`/`sys_position` 里的**数据记录**,注册表列不出来 —— 候选恒空,控件退化成纯文本框,作者只能手敲 userid。

## 改动

**按「谁在背后支撑这个值」分流(`KIND_TO_RECORD_LOOKUP`,镜像 spec 的 `APPROVER_VALUE_BINDINGS`):**

| Type | 控件 | 存值 |
|---|---|---|
| `user` | 记录 lookup(`sys_user`,`picker: 'search'` → PeoplePicker,带邮箱副标题) | id |
| `team` | 记录 lookup(`sys_team`) | id |
| `department` | 记录 lookup(`sys_business_unit`,**非** sys_department) | id |
| `position` | 记录 lookup(`sys_position`) | **name(机器名)** |
| `org_membership_level` | **严格 Select**(owner/admin/member) | 枚举 |
| `manager` | 禁用单元格 +「由提交人上级自动解析」 | — |
| `field` | 维持对象字段选择器 | 字段名 |
| `expression` | #3447 的 CEL 表达式输入(合并 main 后保留) | CEL |
| `queue` | 从 Type 下拉移除;存量行保留可编辑 + 「运行时未支持」警告 | — |

`position` 存 name 是**故意**的:引擎按 `sys_user_position.position` 名字路由,机器名跨环境可移植而 id 不行。

**「永不困住作者」仍然成立**:记录 lookup 带铅笔切换的手工输入逃生口(目标记录尚不存在/悬空 id 仍可填);无 adapter 时(离线 preview gallery)整体退回纯文本。这一模式在 metadata-admin 内已有先例 —— `AccessExplainPanel` / `AssignedUsersSection` 早已用 `RecordPickerDialog` + `useAdapter()` 查 `sys_user`,也正是 ADR-0072「picker 只提供真正可解析的引用」的落实。

**其他:**
- Type 下拉顺序改为**间接绑定优先**(manager/position/department/team/field…,`user` 垫底):绑定具体某个人是可移植性最差的选择(环境迁移、人员离职),全球主流流程平台的最佳实践都是先引导到间接绑定。
- `ReferenceCombobox` 新增 `onSelect`:picker 类控件没有 blur 可依赖,repeater 传入 set-and-flush 原子提交(与 checkbox/select 单元格一致)。
- `@object-ui/fields` `LookupField`:当 `id_field` 不是主键时(如 `id_field: 'name'`)改用 `$filter` 回填显示标签 —— 否则 position 机器名永远 `findOne` 不到,已存的值显示为空。

## 测试

- 新增 `FlowReferenceField.lookup.test.tsx`(11 例):绑定与引擎语义对齐、各 kind 渲染哪种控件、手工输入逃生口、离线降级且**不再打 metadata 端点**、枚举严格 select 与脏值仍显示、manager 禁用、queue 警告。
- 新增 `LookupField.idField.test.tsx`(2 例):非主键 `id_field` 走 `$filter` 回填;默认主键路径仍走 `findOne`。
- `json-schema-to-fields.test.ts` 按新 spec 形状更新(xEnumDeprecated 含 `queue`、xRef map 含 `manager`)。
- 合并 main(含 #3447 expression approver)后回归:inspectors 目录 30 文件 / 346 用例通过;app-shell 全量 219 文件 / 1828 用例通过;fields 全量 30 文件 / 377 用例通过。

> 调试记录:新测试一度挂死,根因是测试里 `useMetadataClient` mock 每次返回新对象,而 `useMetadataListOptions` 的 effect 以 client 为依赖 → 无限重渲染。已改为稳定对象(产品代码用的是 memoized client,不受影响),`vitest.config.mts` 零改动。

## 依赖

需与 objectstack#3536 一起看:那边把 `queue` 标为不可授权(`xEnumDeprecated`)、声明 `APPROVER_VALUE_BINDINGS`。本 PR 的 `KIND_TO_RECORD_LOOKUP` 暂以本地常量镜像该契约,待 `@objectstack/spec ^16` 发布带该导出后可直接 import(已在代码注释中标注)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzRYYvxLHqzrqG2EceDKFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzRYYvxLHqzrqG2EceDKFm)_