### PR TITLE
fix(app-shell): stop the flow-node repeater from committing during render (#2838)

### DIFF
--- a/.changeset/flow-object-list-commit-in-render.md
+++ b/.changeset/flow-object-list-commit-in-render.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(app-shell): stop the flow-node repeater from committing during render (#2838)
+
+Operating any `commitCell`-backed control in a flow node's objectList repeater —
+checkbox, select cell, record lookup, nested list, remove-row — logged a React
+warning:
+
+```
+Cannot update a component (`MetadataResourceEditPageImpl`) while rendering a
+different component (`FlowObjectListField`).
+```
+
+`commitCell` and `removeRow` called `flush()` (which calls the parent's
+`onCommit`) from inside their `setRows` updater. React runs updaters during the
+render phase, so the parent's `setState` landed mid-render — the exact pattern
+React flags. React only warns once per component pair, so whichever control the
+author touched first "claimed" the warning and every other one looked innocent.
+
+The handler now raises a commit-intent flag and leaves the updater pure; an
+effect flushes after commit. Because the effect reads the rows React actually
+applied, a commit no longer risks publishing a stale snapshot when another
+update is already queued (typing in a cell and then hitting the row's ✕ in the
+same tick).
+
+The plain suites missed this because React computes an updater eagerly when the
+fiber has no pending work — that path runs it in the handler and hides the
+warning — and because an `onCommit: vi.fn()` parent takes no update at all. The
+new regression test reproduces both conditions.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.commit.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.commit.test.tsx
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Regression (objectui#2838): the repeater must never publish upward from inside
+ * a `setRows` updater.
+ *
+ * React runs updater functions during the RENDER phase. `commitCell` / `removeRow`
+ * used to call `flush()` — which calls the parent's `onCommit` — in there, so a
+ * parent that stores the committed value took a `setState` mid-render:
+ *
+ *   Cannot update a component (`MetadataResourceEditPageImpl`) while rendering a
+ *   different component (`FlowObjectListField`).
+ *
+ * Two things kept this hidden from the existing suites, and both are encoded in
+ * the setup below:
+ *
+ *   • **The parent must hold state.** `ResourceEditPage` does (`FlowNodeInspector`
+ *     → `setField` → `onPatch`); an `onCommit: vi.fn()` takes no update, so there
+ *     is nothing for React to complain about.
+ *   • **The component must already have a queued update.** React computes an
+ *     updater eagerly inside `dispatchSetState` when the fiber has no pending
+ *     work, which runs it in the handler and hides the bug. Queue one first —
+ *     type in a cell, then hit the row's ✕ in the same tick — and the updater is
+ *     deferred to the render pass, where the warning fires. In the real designer
+ *     the inspector is never that quiescent, which is why every commit warned
+ *     there while a lone `fireEvent.click` here stays silent.
+ *
+ * The commit BEHAVIOUR is asserted alongside the warning: publishing nothing at
+ * all would silence React just as effectively and would be the wrong fix.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import * as React from 'react';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { FlowObjectListField } from './FlowObjectListField';
+import type { FlowConfigColumn } from './flow-node-config';
+
+afterEach(cleanup);
+
+const COLUMNS: FlowConfigColumn[] = [
+  { key: 'type', label: 'Type', kind: 'text' },
+  { key: 'value', label: 'Value', kind: 'text' },
+];
+
+/** Set a controlled input's value the way the browser does, so React's onChange runs. */
+function typeInto(input: HTMLInputElement, text: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(input, text);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function StatefulHost({ initial, onCommitted }: {
+  initial: Array<Record<string, unknown>>;
+  onCommitted: (v: Array<Record<string, unknown>> | undefined) => void;
+}) {
+  const [list, setList] = React.useState<Array<Record<string, unknown>> | undefined>(initial);
+  return (
+    <FlowObjectListField
+      label="Approvers"
+      columns={COLUMNS}
+      value={list}
+      onCommit={(v) => {
+        setList(v);
+        onCommitted(v);
+      }}
+      addLabel="Add"
+      removeLabel="Remove"
+      emptyLabel="None"
+    />
+  );
+}
+
+describe('FlowObjectListField — upward commit (objectui#2838)', () => {
+  let errors: string[];
+  let spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errors = [];
+    spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map((a) => String(a)).join(' '));
+    });
+  });
+
+  afterEach(() => spy.mockRestore());
+
+  const setStateInRender = () => errors.filter((e) => /Cannot update a component/.test(e));
+
+  it('commits with a pending update in flight, without a setState-in-render warning', () => {
+    const onCommitted = vi.fn();
+    render(
+      <StatefulHost
+        initial={[
+          { type: 'user', value: 'u1' },
+          { type: 'position', value: 'finance' },
+        ]}
+        onCommitted={onCommitted}
+      />,
+    );
+
+    // Type into the second row's Value (queues a `setCell` update), then remove
+    // the first row — both in one tick, so the remove cannot be computed eagerly.
+    act(() => {
+      const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+      typeInto(inputs[3], 'legal');
+      // `.click()` rather than `fireEvent.click`: fireEvent wraps each call in
+      // its own `act`, which would flush the typed update before the remove and
+      // hand the remove an idle fiber — the eager-updater path that hides the bug.
+      (screen.getAllByLabelText('Remove')[0] as HTMLElement).click();
+    });
+
+    expect(setStateInRender()).toEqual([]);
+    // The surviving row is published — and it carries the character typed in the
+    // same tick, so the flush read the rows that were actually applied rather
+    // than a stale snapshot.
+    expect(onCommitted).toHaveBeenCalledWith([{ type: 'position', value: 'legal' }]);
+  });
+
+  it('removing the last row commits `undefined`, still without the warning', () => {
+    const onCommitted = vi.fn();
+    render(<StatefulHost initial={[{ type: 'user', value: 'u1' }]} onCommitted={onCommitted} />);
+
+    fireEvent.click(screen.getByLabelText('Remove'));
+
+    // An empty list commits `undefined` so the key drops out of the node config
+    // rather than persisting as `[]`.
+    expect(onCommitted).toHaveBeenCalledWith(undefined);
+    expect(setStateInRender()).toEqual([]);
+  });
+
+  it('a pure re-render never republishes — only an interaction commits', () => {
+    const onCommitted = vi.fn();
+    const { rerender } = render(
+      <StatefulHost initial={[{ type: 'user', value: 'u1' }]} onCommitted={onCommitted} />,
+    );
+    rerender(<StatefulHost initial={[{ type: 'user', value: 'u1' }]} onCommitted={onCommitted} />);
+
+    // The commit effect is gated on an intent flag, not on `rows` changing, so
+    // re-renders and external value syncs stay silent.
+    expect(onCommitted).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx
@@ -155,16 +155,38 @@ export function FlowObjectListField({
   };
 
   // Set a cell AND flush — used by controls with no blur to flush on (checkbox,
-  // select) and by the nested-list editors, which each commit a whole array on
-  // their own blur/add/remove. The flush stays inside the `setRows` updater
-  // (the accepted idiom for the sibling scalar controls) so the `lastCommitted`
-  // ref is touched only there, never in the render body.
+  // select, record lookup) and by the nested-list editors, which each commit a
+  // whole array on their own blur/add/remove.
+  //
+  // The flush must NOT happen inside the `setRows` updater (objectui#2838):
+  // React runs updaters during the RENDER phase, so calling `onCommit` there
+  // reaches the parent's setState mid-render —
+  //   Cannot update a component (`MetadataResourceEditPageImpl`) while rendering
+  //   a different component (`FlowObjectListField`).
+  // React usually computes an updater eagerly inside the dispatch, which hides
+  // the warning; it surfaces as soon as the component already has a queued
+  // update (type in a cell, then hit the row's ✕), which is why the plain suites
+  // never caught it and the real designer warns on every commit.
+  //
+  // So: the handler bumps a commit token alongside the row update, the updater
+  // stays pure, and the effect below flushes AFTER commit — publishing the rows
+  // React actually applied rather than a stale closure read.
+  const [commitToken, setCommitToken] = React.useState(0);
+
+  React.useEffect(() => {
+    if (commitToken === 0) return; // mount, not a commit
+    flush(rows);
+    // Keyed on the token ALONE. `rows` also changes when the external value
+    // syncs down (the effect above), and flushing then would echo the parent's
+    // own value back at it; the token only moves on a real interaction. `rows`
+    // is still read fresh here — both setStates batch into the render this
+    // effect belongs to.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [commitToken]);
+
   const commitCell = (id: string, key: string, v: Cell) => {
-    setRows((rs) => {
-      const next = rs.map((r) => (r.id === id ? { ...r, values: { ...r.values, [key]: v } } : r));
-      flush(next);
-      return next;
-    });
+    setRows((rs) => rs.map((r) => (r.id === id ? { ...r, values: { ...r.values, [key]: v } } : r)));
+    setCommitToken((t) => t + 1);
   };
 
   const addRow = () => {
@@ -173,12 +195,11 @@ export function FlowObjectListField({
     setRows((rs) => [...rs, { id: uniqueId('ol', rs.map((r) => r.id)), values }]);
   };
 
+  // Same shape as `commitCell`: bump the token, let the effect publish
+  // (objectui#2838).
   const removeRow = (id: string) => {
-    setRows((rs) => {
-      const next = rs.filter((r) => r.id !== id);
-      flush(next);
-      return next;
-    });
+    setRows((rs) => rs.filter((r) => r.id !== id));
+    setCommitToken((t) => t + 1);
   };
 
   return (


### PR DESCRIPTION
Closes #2838。

## 问题

流程设计器节点 inspector 里,操作 `FlowObjectListField`(objectList repeater)中任意一个 `commitCell` 型控件——checkbox、select 单元格、记录 lookup、嵌套 list、删除行——控制台都会打:

```
Cannot update a component (`MetadataResourceEditPageImpl`) while rendering a
different component (`FlowObjectListField`).
```

`commitCell` / `removeRow` 把 `flush()`(→ 父组件 `onCommit`)放在 `setRows` 的 **updater 内部**执行,而 React 的 updater 跑在 **render 阶段**,于是父组件的 setState 落在了渲染中途——正是 React 要拦的写法。

React 对同一组件对只告警一次,所以先被操作的控件「认领」了告警,其余看起来都干净。真机验证时把**本次未改动**的 `Resolve As`(普通 enum select cell)放在第一步操作,告警由它认领、随后的记录 lookup 选取就静默了,确认是共用写法而非某个控件的问题。

## 改动

`packages/app-shell/src/views/metadata-admin/inspectors/FlowObjectListField.tsx`

事件处理器在更新行的同时 bump 一个 commit token,updater 保持纯函数;新增的 effect 在 **commit 之后**执行 flush:

```tsx
const [commitToken, setCommitToken] = React.useState(0);

React.useEffect(() => {
  if (commitToken === 0) return;   // mount,不是一次提交
  flush(rows);
}, [commitToken]);

const commitCell = (id, key, v) => {
  setRows((rs) => rs.map(...));
  setCommitToken((t) => t + 1);
};
```

两个要点:

- **effect 只以 token 为依赖**。`rows` 在外部值同步下来时也会变(上面那个 effect),若把它列进依赖就会把父组件自己的值原样回吐给它;token 只在真实交互时前进。
- **读到的是 React 真正应用后的 rows**。两次 setState 在同一个 handler 里批处理,effect 属于它们落地后的那次 render。相比「在 handler 里用闭包 `rows` 算出 `next` 再 flush」,这样在已有排队更新时(在单元格里打字、紧接着点该行的 ✕)不会提交到过期快照。

`removeRow` 同样改法。`addRow` / `setCell` 不提交,保持不变。

## 测试

新增 `FlowObjectListField.commit.test.tsx`(3 例)。这条 bug 能躲过既有用例有两个原因,新测试把两者都复现了:

1. **父组件必须持有 state**。`ResourceEditPage` 是这样(`FlowNodeInspector.setField` → `onPatch`),而 `onCommit: vi.fn()` 根本不产生更新,React 无从告警。
2. **组件必须已有排队更新**。fiber 空闲时 React 会在 `dispatchSetState` 里**提前**求值 updater,那条路径在 handler 里跑、告警被掩盖;先在单元格里打字再点 ✕(同一 tick)就会走到 render 阶段。这也解释了为什么真机上每次提交都告警、而单独一个 `fireEvent.click` 在 jsdom 里始终安静。

用 `.click()` 而非 `fireEvent.click`:后者每次调用各自裹一层 `act`,会在删除前把打字的更新冲掉,又回到那条掩盖 bug 的提前求值路径。

回归验证(在改动上 stash 掉源文件跑一遍):

```
× commits with a pending update in flight, without a setState-in-render warning
+ "Cannot update a component (`%s`) while rendering a different component (`%s`)… StatefulHost FlowObjectListField"
```

带改动则 3 例全过。

- `packages/app-shell` 全量:**223 文件 / 1848 用例通过**
- inspectors 目录:30 文件 / 347 用例通过
- `tsc --noEmit` 干净;改动文件 ESLint 干净(`FlowObjectListField.tsx` 上那条 `react-hooks/refs` warning 在 `origin/main` 上就存在,来自 `lastCommitted.current`,不在本次范围内)

## 影响

此前提交本身是生效的、值也正确落库,所以这是纯粹的正确性/噪音修复:去掉 React 明确点名的写法(并发渲染下行为不保证),并让控制台不再被这条告警淹没。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzRYYvxLHqzrqG2EceDKFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzRYYvxLHqzrqG2EceDKFm)_