### PR TITLE
feat(console): group tenancy posture affordances — org switcher as write context + org attribution (ADR-0105 Phase 1)

### DIFF
--- a/.changeset/adr-0105-group-posture-console.md
+++ b/.changeset/adr-0105-group-posture-console.md
@@ -1,0 +1,35 @@
+---
+"@object-ui/auth": minor
+"@object-ui/app-shell": minor
+---
+
+feat(console): group tenancy posture affordances — org switcher as write
+context + org attribution in read views (framework ADR-0105 Phase 1)
+
+Under the new `group` tenancy posture the server widens reads to every
+organization the member belongs to (`organization_id IN accessible_org_ids`)
+while writes land in the ACTIVE organization — so the console's existing
+"which org am I in = which org's data I see" presentation becomes wrong the
+moment a deployment switches postures. The ADR requires these affordances to
+land WITH Phase 1, not after.
+
+- `@object-ui/auth`: `AuthPublicConfig.features.tenancyPosture`
+  (`'single' | 'group' | 'isolated'`, exported as `TenancyPosture`) mirrors
+  the server's public auth config key. It gates nothing — `multiOrgEnabled`
+  stays the capability flag; this only tells the console how to render org
+  context.
+- `useTenancyPosture()` (app-shell): reads the posture from the cached auth
+  config fetch; `undefined` (older server, unrecognized value, fetch failure)
+  keeps every group affordance off, so non-group deployments render
+  pixel-identical to today.
+- `WorkspaceSwitcher`: under `group` the dropdown labels the active org
+  "Working organization" and explains the split — new records are created
+  here, views show data from all your organizations.
+- `RecordFormPage` (create mode): org-walled objects show a "Creates in
+  <active org>" badge naming the engine's write target (ADR-0105 D5 stamps
+  `organization_id` from the active org).
+- Default list columns (`ObjectView`, `InterfaceListPage`, `ObjectDataPage`):
+  under `group`, org-walled objects get a TRAILING `organization_id`
+  attribution column so cross-org rows are attributable at a glance.
+  Render-time only — never persisted into saved view/page metadata, and
+  business fields still lead.

--- a/packages/app-shell/src/hooks/index.ts
+++ b/packages/app-shell/src/hooks/index.ts
@@ -31,6 +31,7 @@ export {
   type UseUrlOverlayOptions,
   type UrlOverlayControls,
 } from './useUrlOverlay';
+export { useTenancyPosture } from './useTenancyPosture';
 export { useTrackRouteAsRecent, type UseTrackRouteAsRecentOptions } from './useTrackRouteAsRecent';
 export {
   sanitizeChatMessagesForCache,

--- a/packages/app-shell/src/hooks/useTenancyPosture.ts
+++ b/packages/app-shell/src/hooks/useTenancyPosture.ts
@@ -1,0 +1,48 @@
+/**
+ * useTenancyPosture — the deployment's tenancy posture (framework ADR-0105 D1),
+ * read from the public auth config's `features.tenancyPosture`.
+ *
+ * Under `group` posture the active organization is only the WRITE target —
+ * reads span every organization the member belongs to (the server enforces
+ * `organization_id IN accessible_org_ids`; the client never filters for
+ * security). Components use this hook to key the group-only affordances:
+ * write-context labeling on the org switcher, the create-form target-org
+ * badge, and org attribution columns in default list views.
+ *
+ * Returns `undefined` until the config resolves, and stays `undefined` when
+ * the server doesn't report a posture (older server) or reports an
+ * unrecognized value — so every group affordance fails toward today's
+ * rendering. The auth client caches the config fetch behind one promise, so
+ * concurrent mounts share a single request.
+ */
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@object-ui/auth';
+import type { TenancyPosture } from '@object-ui/auth';
+
+const POSTURES: readonly TenancyPosture[] = ['single', 'group', 'isolated'];
+
+export function useTenancyPosture(): TenancyPosture | undefined {
+  const { getAuthConfig } = useAuth();
+  const [posture, setPosture] = useState<TenancyPosture | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAuthConfig?.()
+      .then((cfg) => {
+        if (cancelled) return;
+        const reported = cfg?.features?.tenancyPosture;
+        if (reported && (POSTURES as readonly string[]).includes(reported)) {
+          setPosture(reported);
+        }
+      })
+      .catch(() => {
+        /* config unavailable — leave undefined, group affordances stay off */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [getAuthConfig]);
+
+  return posture;
+}

--- a/packages/app-shell/src/layout/WorkspaceSwitcher.tsx
+++ b/packages/app-shell/src/layout/WorkspaceSwitcher.tsx
@@ -12,6 +12,11 @@
  *   (full-page reload so the active-org context refreshes app-wide, mirroring
  *   OrganizationsPage), plus shortcuts to manage members / create a workspace.
  * - No org context at all: renders nothing.
+ *
+ * Under `group` tenancy posture (ADR-0105) the switcher's meaning changes:
+ * the active organization is only the WRITE target — reads span every
+ * organization the member belongs to — so the dropdown labels it as the
+ * working organization instead of implying it bounds what the user sees.
  */
 
 import { useEffect, useState } from 'react';
@@ -29,6 +34,7 @@ import {
 } from '@object-ui/components';
 import { ChevronsUpDown, Check, Plus, Users } from 'lucide-react';
 import { resolveRootUrl } from '../console/organizations/resolveHomeUrl';
+import { useTenancyPosture } from '../hooks/useTenancyPosture';
 
 function getOrgInitials(name: string): string {
   return name
@@ -52,6 +58,7 @@ export function WorkspaceSwitcher() {
   const navigate = useNavigate();
   const { organizations, activeOrganization, switchOrganization, getAuthConfig } = useAuth();
   const [multiOrgDisabled, setMultiOrgDisabled] = useState(false);
+  const isGroupPosture = useTenancyPosture() === 'group';
 
   useEffect(() => {
     let cancelled = false;
@@ -105,8 +112,21 @@ export function WorkspaceSwitcher() {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-60">
         <DropdownMenuLabel className="text-xs text-muted-foreground">
-          {t('organization.switcher.label', { defaultValue: 'Switch organization' })}
+          {isGroupPosture
+            ? t('organization.switcher.groupLabel', { defaultValue: 'Working organization' })
+            : t('organization.switcher.label', { defaultValue: 'Switch organization' })}
         </DropdownMenuLabel>
+        {isGroupPosture && (
+          <p
+            className="px-2 pb-1.5 text-xs font-normal leading-snug text-muted-foreground"
+            data-testid="workspace-switcher-group-hint"
+          >
+            {t('organization.switcher.groupHint', {
+              defaultValue:
+                'New records are created here. Views show data from all your organizations.',
+            })}
+          </p>
+        )}
         {orgList.map((org) => (
           <DropdownMenuItem
             key={org.id}

--- a/packages/app-shell/src/layout/__tests__/WorkspaceSwitcher.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * WorkspaceSwitcher — ADR-0105 group-posture semantics.
+ *
+ * Under `group` tenancy posture the active organization is only the WRITE
+ * target (reads span every organization the member belongs to), so the
+ * dropdown must label it "Working organization" and explain the split.
+ * Every other posture — isolated, single, absent, or an unrecognized value
+ * from a newer server — keeps today's "Switch organization" rendering.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@object-ui/i18n', () => ({
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
+let authState: Record<string, unknown>;
+vi.mock('@object-ui/auth', () => ({ useAuth: () => authState }));
+
+vi.mock('../../console/organizations/resolveHomeUrl', () => ({ resolveRootUrl: () => '/root' }));
+
+// Passthrough dropdown primitives so label/hint render without interaction.
+vi.mock('@object-ui/components', () => ({
+  DropdownMenu: (p: any) => <div>{p.children}</div>,
+  DropdownMenuTrigger: (p: any) => <button {...p} />,
+  DropdownMenuContent: (p: any) => <div>{p.children}</div>,
+  DropdownMenuItem: ({ onClick, children }: any) => <div onClick={onClick}>{children}</div>,
+  DropdownMenuLabel: (p: any) => <div {...p} />,
+  DropdownMenuSeparator: () => <hr />,
+}));
+vi.mock('lucide-react', () => ({
+  ChevronsUpDown: () => <span />,
+  Check: () => <span />,
+  Plus: () => <span />,
+  Users: () => <span />,
+}));
+
+import { WorkspaceSwitcher } from '../WorkspaceSwitcher';
+
+const ORGS = [
+  { id: 'org_a', name: 'Plant A', slug: 'plant-a' },
+  { id: 'org_b', name: 'Plant B', slug: 'plant-b' },
+];
+
+function setAuthConfig(features: Record<string, unknown>) {
+  authState = {
+    organizations: ORGS,
+    activeOrganization: ORGS[0],
+    switchOrganization: vi.fn(),
+    getAuthConfig: vi.fn().mockResolvedValue({ features }),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('WorkspaceSwitcher (ADR-0105 tenancy posture)', () => {
+  it('group posture: labels the active org as the working organization and explains the read/write split', async () => {
+    setAuthConfig({ multiOrgEnabled: true, tenancyPosture: 'group' });
+    render(<WorkspaceSwitcher />);
+    await waitFor(() => {
+      expect(screen.getByText('Working organization')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('workspace-switcher-group-hint')).toHaveTextContent(
+      'New records are created here. Views show data from all your organizations.',
+    );
+    expect(screen.queryByText('Switch organization')).not.toBeInTheDocument();
+  });
+
+  it('isolated posture: keeps the plain switch label with no group hint', async () => {
+    setAuthConfig({ multiOrgEnabled: true, tenancyPosture: 'isolated' });
+    render(<WorkspaceSwitcher />);
+    // The posture fetch resolves async — assert the steady state.
+    await waitFor(() => {
+      expect((authState.getAuthConfig as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText('Switch organization')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-switcher-group-hint')).not.toBeInTheDocument();
+  });
+
+  it('absent or unrecognized posture fails toward today\'s rendering', async () => {
+    setAuthConfig({ multiOrgEnabled: true, tenancyPosture: 'weird-future-value' });
+    render(<WorkspaceSwitcher />);
+    await waitFor(() => {
+      expect((authState.getAuthConfig as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText('Switch organization')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-switcher-group-hint')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/InterfaceListPage.defaults.test.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.defaults.test.tsx
@@ -104,4 +104,27 @@ describe('defaultColumnsFromObject', () => {
     expect(cols).not.toContain('owner_id');
     expect(cols[0]).toBe('b_0');
   });
+
+  // ADR-0105 group posture: organization_id is appended as a TRAILING
+  // attribution column for org-walled objects; business fields still lead.
+  describe('orgAttribution (ADR-0105 group posture)', () => {
+    it('appends organization_id last for an org-walled object', () => {
+      const cols = defaultColumnsFromObject(fieldZooLike, { orgAttribution: true });
+      expect(cols).toEqual(['name', 'f_email', 'f_number', 'organization_id']);
+    });
+
+    it('does not append for an object without organization_id', () => {
+      const cols = defaultColumnsFromObject(
+        { fields: { title: { type: 'text' } } },
+        { orgAttribution: true },
+      );
+      expect(cols).toEqual(['title']);
+    });
+
+    it('is a no-op when the flag is off (non-group postures unchanged)', () => {
+      expect(defaultColumnsFromObject(fieldZooLike, { orgAttribution: false })).toEqual(
+        defaultColumnsFromObject(fieldZooLike),
+      );
+    });
+  });
 });

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -24,6 +24,7 @@ import { Database } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { isSystemManagedField } from '@object-ui/types';
 import { useMetadata } from '../providers/MetadataProvider';
+import { useTenancyPosture } from '../hooks/useTenancyPosture';
 import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState';
 import { RecordDetailView } from './RecordDetailView';
 
@@ -74,18 +75,32 @@ function resolveSourceView(objectDef: any, sourceView?: string): any | undefined
  * (ADR-0085), else the first business fields — framework-managed
  * system/audit/ownership columns (including the injected, editable `owner_id`)
  * are excluded via the shared `isSystemManagedField` classifier.
+ *
+ * `opts.orgAttribution` (ADR-0105 group posture): reads span every
+ * organization the member belongs to, so cross-org rows need attribution —
+ * append `organization_id` as a TRAILING column when the object carries the
+ * field. Render-time only; never persisted into page/view metadata.
  */
-export function defaultColumnsFromObject(objectDef: any): string[] {
+export function defaultColumnsFromObject(
+  objectDef: any,
+  opts?: { orgAttribution?: boolean },
+): string[] {
+  const withOrgAttribution = (cols: string[]): string[] =>
+    opts?.orgAttribution && objectDef?.fields?.organization_id && !cols.includes('organization_id')
+      ? [...cols, 'organization_id']
+      : cols;
   const curated = objectDef?.highlightFields;
   if (Array.isArray(curated) && curated.length > 0) {
-    return curated.filter((n: string) => objectDef.fields?.[n]);
+    return withOrgAttribution(curated.filter((n: string) => objectDef.fields?.[n]));
   }
   const fields = objectDef?.fields;
   if (fields && typeof fields === 'object') {
-    return Object.entries(fields)
-      .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
-      .map(([name]) => name)
-      .slice(0, 6);
+    return withOrgAttribution(
+      Object.entries(fields)
+        .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
+        .map(([name]) => name)
+        .slice(0, 6),
+    );
   }
   return [];
 }
@@ -176,6 +191,9 @@ export function InterfaceListPage({ page, className, onConfigChange, reserveEdit
   const dataSource = useAdapter();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  // ADR-0105: group posture appends a trailing organization_id attribution
+  // column to the object-derived default column set (reads span all orgs).
+  const orgAttribution = useTenancyPosture() === 'group';
 
   // ADR-0047 filter persistence: restore `uf_*` URL params once at mount,
   // mirror every selection change back (replace — no history spam).
@@ -337,7 +355,7 @@ export function InterfaceListPage({ page, className, onConfigChange, reserveEdit
       ? (cfg.columns as any)
       : hasColumns(view)
         ? view.columns
-        : defaultColumnsFromObject(objectDef);
+        : defaultColumnsFromObject(objectDef, { orgAttribution });
 
     // Sort: the page's own first, then the legacy view's.
     const sort = Array.isArray(cfg.sort) && cfg.sort.length ? cfg.sort : view.sort;
@@ -388,7 +406,7 @@ export function InterfaceListPage({ page, className, onConfigChange, reserveEdit
       inlineEdit: userActions.editInline === true,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [objectDefName, viewDefJson, cfg]);
+  }, [objectDefName, viewDefJson, cfg, orgAttribution]);
 
   if (!objectDef || !schema) {
     return (

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -65,6 +65,7 @@ import {
   PREVIEW_QUERY_FLAG,
   PREVIEW_QUERY_VALUE,
 } from '../preview/PreviewModeContext';
+import { useTenancyPosture } from '../hooks/useTenancyPosture';
 
 /** Field types the auto-derived user-filter bar offers as dropdowns. */
 const USER_FILTER_TYPES = new Set(['select', 'multiselect', 'radio', 'enum', 'boolean']);
@@ -81,6 +82,9 @@ export function ObjectDataPage({ dataSource, objects }: any) {
   const { user } = useAuth();
   const isAdmin = useIsWorkspaceAdmin();
   const metadataClient = useMetadataClient();
+  // ADR-0105: group posture appends a trailing organization_id attribution
+  // column to the auto-derived columns (reads span all the user's orgs).
+  const orgAttribution = useTenancyPosture() === 'group';
   // ADR-0037: enter draft-preview after "Save as view" so the fresh draft is
   // visible; if already previewing, keep the flag off the suffix (it's sticky).
   const previewDrafts = usePreviewDrafts();
@@ -141,8 +145,8 @@ export function ObjectDataPage({ dataSource, objects }: any) {
 
   // Auto-derived columns + filter bar, both trimmed by field-level security.
   const columns = React.useMemo(
-    () => defaultColumnsFromObject(objectDef).filter((f: string) => canRead(f)),
-    [objectDef, canRead],
+    () => defaultColumnsFromObject(objectDef, { orgAttribution }).filter((f: string) => canRead(f)),
+    [objectDef, canRead, orgAttribution],
   );
   const userFilters = React.useMemo(() => {
     const fields = objectDef?.fields;

--- a/packages/app-shell/src/views/ObjectView.defaultColumns.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.defaultColumns.test.tsx
@@ -69,4 +69,47 @@ describe('defaultListColumnsFromObject', () => {
     expect(defaultListColumnsFromObject({})).toEqual([]);
     expect(defaultListColumnsFromObject(undefined)).toEqual([]);
   });
+
+  // ADR-0105 group posture: reads span every organization the member belongs
+  // to, so org-walled rows need attribution — organization_id is appended as a
+  // TRAILING column, business fields still lead.
+  describe('orgAttribution (ADR-0105 group posture)', () => {
+    it('appends organization_id last for an org-walled object', () => {
+      const cols = defaultListColumnsFromObject(invoiceLike, 5, { orgAttribution: true });
+      expect(cols).toEqual(['invoice_no', 'account', 'contact', 'owner', 'organization_id']);
+    });
+
+    it('appends after a curated highlightFields set too', () => {
+      const cols = defaultListColumnsFromObject(
+        { highlightFields: ['invoice_no'], fields: invoiceLike.fields },
+        5,
+        { orgAttribution: true },
+      );
+      expect(cols).toEqual(['invoice_no', 'organization_id']);
+    });
+
+    it('does not append for an object without organization_id (not org-walled)', () => {
+      const cols = defaultListColumnsFromObject(
+        { fields: { title: { type: 'text' } } },
+        5,
+        { orgAttribution: true },
+      );
+      expect(cols).toEqual(['title']);
+    });
+
+    it('does not duplicate when the curated set already lists organization_id', () => {
+      const cols = defaultListColumnsFromObject(
+        { highlightFields: ['invoice_no', 'organization_id'], fields: invoiceLike.fields },
+        5,
+        { orgAttribution: true },
+      );
+      expect(cols).toEqual(['invoice_no', 'organization_id']);
+    });
+
+    it('is a no-op when the flag is off or absent (non-group postures unchanged)', () => {
+      expect(defaultListColumnsFromObject(invoiceLike, 5, { orgAttribution: false })).toEqual(
+        defaultListColumnsFromObject(invoiceLike, 5),
+      );
+    });
+  });
 });

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -35,6 +35,7 @@ import {
 } from '@object-ui/components';
 import { Plus, Upload, Star, StarOff, Table as TableIcon, KanbanSquare, Calendar, LayoutGrid, Activity, GanttChart, MapPin, BarChart3 } from 'lucide-react';
 import { useFavorites } from '../hooks/useFavorites';
+import { useTenancyPosture } from '../hooks/useTenancyPosture';
 import { getIcon } from '../utils/getIcon';
 import type { ListViewSchema, ViewNavigationConfig, FeedItem } from '@object-ui/types';
 import { detectStatusField, isSystemManagedField } from '@object-ui/types';
@@ -128,18 +129,35 @@ function substituteFilterTokens(filter: any, currentUserId: string | undefined):
  * non-hidden / non-readonly `owner_id` and `organization_id`. Without this,
  * `applySystemFields` (which spreads injected fields to the FRONT of the field
  * map) would surface `owner_id` as a leading raw-id column (#2702, #2777).
+ *
+ * `opts.orgAttribution` (ADR-0105 group posture): reads span every
+ * organization the member belongs to, so cross-org rows need attribution —
+ * append `organization_id` as a TRAILING column when the object carries the
+ * field. Trailing keeps business fields leading; render-time only, never
+ * persisted into saved view metadata (a saved view must not fossilize a
+ * posture-dependent column set).
  */
-export function defaultListColumnsFromObject(objectDef: any, limit = 5): string[] {
+export function defaultListColumnsFromObject(
+    objectDef: any,
+    limit = 5,
+    opts?: { orgAttribution?: boolean },
+): string[] {
+    const withOrgAttribution = (cols: string[]): string[] =>
+        opts?.orgAttribution && objectDef?.fields?.organization_id && !cols.includes('organization_id')
+            ? [...cols, 'organization_id']
+            : cols;
     const curated = objectDef?.highlightFields;
     if (Array.isArray(curated) && curated.length > 0) {
-        return curated.filter((n: string) => objectDef?.fields?.[n]);
+        return withOrgAttribution(curated.filter((n: string) => objectDef?.fields?.[n]));
     }
     const fields = objectDef?.fields;
     if (fields && typeof fields === 'object') {
-        return Object.entries(fields)
-            .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
-            .map(([name]) => name)
-            .slice(0, limit);
+        return withOrgAttribution(
+            Object.entries(fields)
+                .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
+                .map(([name]) => name)
+                .slice(0, limit),
+        );
     }
     return [];
 }
@@ -198,6 +216,9 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     const { t } = useObjectTranslation();
     const { objectLabel, objectDescription: objectDesc, viewLabel, viewEmptyState, actionLabel, actionConfirm, actionSuccess, actionParamText, fieldLabel, fieldOptionLabel } = useObjectLabel();
     const { isFavorite, toggleFavorite } = useFavorites();
+    // ADR-0105: under group posture default list columns get a trailing
+    // organization_id attribution column (reads span all the user's orgs).
+    const orgAttribution = useTenancyPosture() === 'group';
     // ADR-0034: runtime view edits persist via the metadata draft/publish
     // model (the `sys_view` table is retired).
     const metadataClient = useMetadataClient();
@@ -571,7 +592,8 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         // / ownership columns (notably the non-readonly `owner_id`) are excluded
         // by the shared classifier. #2702 applied this to ObjectGrid /
         // InterfaceListPage; this view resolves its columns here (#2777).
-        const resolveDefaultColumns = (): string[] => defaultListColumnsFromObject(objectDef, 5);
+        const resolveDefaultColumns = (): string[] =>
+            defaultListColumnsFromObject(objectDef, 5, { orgAttribution });
 
         const definedViews = objectDef.listViews || objectDef.list_views || {};
         const viewList = Object.entries(definedViews).map(([key, value]: [string, any]) => {
@@ -707,7 +729,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         });
 
         return viewList;
-    }, [objectDef, savedViews, viewOverrides, t]);
+    }, [objectDef, savedViews, viewOverrides, t, orgAttribution]);
 
     // Active View State — merge saved draft if available for this view.
     // Resolution priority: URL viewId → ?view= → user-marked default → first.

--- a/packages/app-shell/src/views/RecordFormPage.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.tsx
@@ -32,7 +32,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { ObjectForm } from '@object-ui/plugin-form';
 import { Button, Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
-import { ArrowLeft, Database } from 'lucide-react';
+import { ArrowLeft, Building2, Database } from 'lucide-react';
 import { toast } from 'sonner';
 import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import { useMetadata } from '../providers/MetadataProvider';
@@ -68,7 +68,7 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
   const { objects, loading: metadataLoading } = useMetadata();
   const { t } = useObjectTranslation();
   const { objectLabel } = useObjectLabel();
-  const { user, getAuthConfig } = useAuth();
+  const { user, getAuthConfig, activeOrganization } = useAuth();
 
   // Pull deployment-level feature flags so action visibility predicates
   // (e.g. `features.multiOrgEnabled != false` on sys_organization's create
@@ -297,6 +297,25 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
               className="ml-1"
             />
           </nav>
+          {/* ADR-0105 group posture: reads span all the user's organizations
+              but a new record lands in the ACTIVE one (engine-stamped), so
+              create mode names the write target where the user commits. Only
+              rendered for org-walled objects (they carry organization_id). */}
+          {mode === 'create' &&
+            features?.tenancyPosture === 'group' &&
+            activeOrganization &&
+            (objectDef as any)?.fields?.organization_id && (
+              <span
+                className="ml-auto inline-flex items-center gap-1.5 rounded-md border bg-muted/50 px-2 py-1 text-xs text-muted-foreground"
+                data-testid="record-form-write-target-org"
+              >
+                <Building2 className="h-3.5 w-3.5 shrink-0" />
+                {t('form.createTargetOrg', {
+                  org: activeOrganization.name,
+                  defaultValue: `Creates in ${activeOrganization.name}`,
+                })}
+              </span>
+            )}
         </header>
 
         <div className="flex-1 overflow-auto p-4 sm:p-6">

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -71,6 +71,7 @@ export type {
   AuthSocialProvider,
   AuthPublicConfig,
   SignInWithProviderOptions,
+  TenancyPosture,
 } from './types';
 
 export type { AuthContextValue } from './AuthContext';

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -106,6 +106,17 @@ export interface AuthSocialProvider {
   type?: 'social' | 'oidc';
 }
 
+/**
+ * Deployment tenancy posture (framework ADR-0105 D1).
+ *
+ * - `single` — one organization, no wall.
+ * - `group` — one shared database, organization as membership boundary:
+ *   reads span every organization the caller belongs to, writes land in the
+ *   ACTIVE organization.
+ * - `isolated` — hard per-organization walls (the pre-ADR-0105 `multi`).
+ */
+export type TenancyPosture = 'single' | 'group' | 'isolated';
+
 /** Public auth configuration returned by the server */
 export interface AuthPublicConfig {
   emailPassword?: {
@@ -172,6 +183,17 @@ export interface AuthPublicConfig {
      * (framework#2874 / objectui#2513).
      */
     deviceAuthorization?: boolean;
+    /**
+     * Which tenancy posture the deployment runs (framework ADR-0105 D1).
+     * Non-boolean by design: `multiOrgEnabled` stays the capability gate
+     * ("is an organization wall enforced at all?"), while this key only tells
+     * the console HOW to render organization context. Under `group` the org
+     * switcher picks the WRITE target and reads span every organization the
+     * member belongs to, so group-only affordances (write-context labeling,
+     * org attribution in list views) key off `tenancyPosture === 'group'`.
+     * Absent (older server / config not yet fetched) ⇒ no group affordances.
+     */
+    tenancyPosture?: TenancyPosture;
   };
 }
 


### PR DESCRIPTION
Closes the remaining Phase 1 console item of [framework ADR-0105](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0105-group-tenancy-posture-and-first-class-org-scope.md) (tracking: objectstack-ai/objectstack#3541; engine side landed in objectstack-ai/objectstack#3559).

## Why

Under the new `group` tenancy posture the server widens **reads** to every organization the member belongs to (`organization_id IN accessible_org_ids`) while **writes** land in the ACTIVE organization (engine-stamped, D5). The console's existing presentation — "which org am I in = which org's data I see" — becomes wrong the moment a deployment switches postures, which is why the ADR's Risks section requires these affordances to land **with Phase 1, not after**.

The switching *mechanism* is untouched: better-auth `organization.setActive` → session `activeOrganizationId` → engine write stamping is already the single channel, client and server agree on it. This PR only changes what the console *communicates*.

## What

- **`@object-ui/auth`** — `AuthPublicConfig.features.tenancyPosture` (`'single' | 'group' | 'isolated'`, exported as `TenancyPosture`) mirrors the server's public auth config key (`public-auth-features.ts`, non-flag by design: `multiOrgEnabled` stays the capability gate; this only tells the console how to render org context).
- **`useTenancyPosture()`** (app-shell) — reads the posture from the promise-cached auth config fetch. `undefined` (older server, unrecognized value, fetch failure) keeps every group affordance off — **non-group deployments render pixel-identical to today**.
- **`WorkspaceSwitcher`** — under `group` the dropdown labels the active org "Working organization" with the hint "New records are created here. Views show data from all your organizations."
- **`RecordFormPage`** (create mode) — org-walled objects (they carry `organization_id`) show a "Creates in *&lt;active org&gt;*" badge naming the engine's write target.
- **Default list columns** (`ObjectView`, `InterfaceListPage`, `ObjectDataPage`) — under `group`, org-walled objects get a TRAILING `organization_id` attribution column so cross-org rows are attributable at a glance. Render-time only — never persisted into saved view/page metadata (a saved view must not fossilize a posture-dependent column set); the view-creation prefill path is deliberately left untouched.

## Verification

- `turbo build` (29 tasks) and `turbo lint` clean for `@object-ui/auth` + `@object-ui/app-shell` and dependents.
- `vitest run packages/app-shell packages/auth` — 231 files, 1950 tests, all passing.
- New coverage: `WorkspaceSwitcher.test.tsx` (group label + hint; isolated/unknown postures keep today's rendering), `ObjectView.defaultColumns.test.tsx` + `InterfaceListPage.defaults.test.tsx` org-attribution cases (append-last, non-walled objects untouched, no dupes, off-flag is a no-op).
- Changeset included (minor, feature).

## Not in this PR

Deeper "all my organizations" console affordances (aggregated cross-org views, org quick-filters) are tracked as Phase 2 in objectstack-ai/objectstack#3541. The three-plants-one-group dogfood acceptance runs against a `group`-posture backend once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FebXPaaGrLhGKw1LHPbpL

---
_Generated by [Claude Code](https://claude.ai/code/session_015FebXPaaGrLhGKw1LHPbpL)_