### PR TITLE
feat(types)!: drop the ObjectStack/ObjectOS/ObjectQL/ObjectUI Capabilities re-exports

### DIFF
--- a/.changeset/drop-capabilities-descriptor-reexports.md
+++ b/.changeset/drop-capabilities-descriptor-reexports.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/types": minor
+---
+
+feat(types)!: drop the `ObjectStack/ObjectOS/ObjectQL/ObjectUI Capabilities` re-exports (framework capabilities-descriptor prune)
+
+Upstream `@objectstack/spec` removed the dead static capability-descriptor
+cluster (`ObjectStackCapabilitiesSchema` / `ObjectOSCapabilitiesSchema` /
+`ObjectQLCapabilitiesSchema` / `ObjectUICapabilitiesSchema` + their types) —
+a never-wired fixed-boolean self-portrait whose defaults contradicted the
+live platform (FLS/RLS/audit all `default(false)` while actually enforced).
+This drops the `@object-ui/types` re-exports of those symbols.
+
+**Migration**: discover real runtime capabilities at runtime, not from a
+static schema — `GET /api/v1/discovery` (dynamic `capabilities` record with
+declared === enforced discipline) and the `/.well-known` contract
+(`WellKnownCapabilitiesSchema` from `@objectstack/spec/api`). No replacement
+re-export.

--- a/packages/types/src/__tests__/namespace-exports.test.ts
+++ b/packages/types/src/__tests__/namespace-exports.test.ts
@@ -19,13 +19,8 @@ describe('ObjectStack Spec v3.0.0 Namespace Exports', () => {
 
   it('should export ObjectStack schemas', async () => {
     const types = await import('../index');
-    // ObjectStack capability schemas should be exported
     expect(types.ObjectStackSchema).toBeDefined();
     expect(types.ObjectStackDefinitionSchema).toBeDefined();
-    expect(types.ObjectStackCapabilitiesSchema).toBeDefined();
-    expect(types.ObjectOSCapabilitiesSchema).toBeDefined();
-    expect(types.ObjectQLCapabilitiesSchema).toBeDefined();
-    expect(types.ObjectUICapabilitiesSchema).toBeDefined();
   });
 
   it('should export VERSION constant', async () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -943,20 +943,12 @@ export {
   defineStack,
   ObjectStackSchema,
   ObjectStackDefinitionSchema,
-  ObjectStackCapabilitiesSchema,
-  ObjectOSCapabilitiesSchema,
-  ObjectQLCapabilitiesSchema,
-  ObjectUICapabilitiesSchema,
 } from '@objectstack/spec';
 
 export type {
   PluginContext,
   ObjectStack,
   ObjectStackDefinition,
-  ObjectStackCapabilities,
-  ObjectOSCapabilities,
-  ObjectQLCapabilities,
-  ObjectUICapabilities,
 } from '@objectstack/spec';
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Companion to the framework capabilities-descriptor prune (objectstack-ai/objectstack — `chore/prune-dead-capabilities-descriptor`). Upstream removed the dead static capability-descriptor cluster: a never-wired fixed-boolean platform self-portrait whose defaults contradicted the live platform (FLS/RLS/audit `default(false)` while enforced).

- Drop the `ObjectStackCapabilitiesSchema` / `ObjectOSCapabilitiesSchema` / `ObjectQLCapabilitiesSchema` / `ObjectUICapabilitiesSchema` value re-exports + the four type re-exports from `@object-ui/types`.
- Drop the two `namespace-exports.test.ts` assertions.
- Independent of the spec bump (objectui keeps compiling against published 16.x); must land before the next spec version alignment.

**Migration**: discover capabilities at runtime — `GET /api/v1/discovery` (dynamic record, declared === enforced) and the `/.well-known` `WellKnownCapabilitiesSchema` contract. No replacement re-export.

Verified: `@object-ui/types` build green; `namespace-exports` + `spec-ui-schema-reexports` tests pass (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)