### PR TITLE
feat(react)!: trim dead device/preference delegates from useClientNotifications (objectstack#3612 companion)

### DIFF
--- a/.changeset/trim-dead-notification-delegates.md
+++ b/.changeset/trim-dead-notification-delegates.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/react": minor
+---
+
+feat(react)!: trim the dead device/preference delegates from
+`useClientNotifications` (objectstack#3612 companion)
+
+`registerDevice`, `getPreferences`, and `updatePreferences` delegated to
+`@objectstack/client` methods that were deleted in objectstack#3612 — the
+`/notifications/devices` and `/notifications/preferences` server routes they
+targeted were never built, so every call already surfaced an error at
+runtime. The hook keeps `fetchNotifications` and `markAsRead` (both
+dispatcher-served and route-ledgered). Breaking only for code destructuring
+the removed functions from the hook result; nothing in this repo did.

--- a/packages/react/src/hooks/useClientNotifications.ts
+++ b/packages/react/src/hooks/useClientNotifications.ts
@@ -18,8 +18,13 @@
  * `sys_inbox_message` materialization and the `sys_notification_receipt`
  * read-state spine (the re-modeled `sys_notification` L2 event carries no
  * recipient/read columns). This hook only needs to call the SDK with its
- * current signatures: `list(options)`, `markRead(ids[])`, `markAllRead()`,
- * and `registerDevice(request)`.
+ * current signatures: `list(options)`, `markRead(ids[])`, `markAllRead()`.
+ *
+ * The former registerDevice/getPreferences/updatePreferences delegates were
+ * removed (objectstack#3612): the SDK deleted those methods because the
+ * /notifications/devices and /notifications/preferences server routes were
+ * never built — every call was a guaranteed error. They return when the
+ * server side exists.
  */
 
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
@@ -43,12 +48,6 @@ export interface UseClientNotificationsOptions {
 export interface UseClientNotificationsResult {
   /** Fetch notifications from server */
   fetchNotifications: () => Promise<void>;
-  /** Register device for push notifications */
-  registerDevice: (token: string, platform: string) => Promise<void>;
-  /** Get notification preferences */
-  getPreferences: () => Promise<any>;
-  /** Update notification preferences */
-  updatePreferences: (prefs: any) => Promise<void>;
   /** Mark a notification as read on the server */
   markAsRead: (id: string) => Promise<void>;
   /** Loading state */
@@ -159,60 +158,6 @@ export function useClientNotifications(
     }
   }, [client, notify]);
 
-  /* ---- registerDevice ---- */
-
-  const registerDevice = useCallback(
-    async (token: string, platform: string) => {
-      if (!client?.notifications) return;
-      setError(null);
-      try {
-        // ADR-0030 / @objectstack/client v7+: registerDevice takes a single
-        // RegisterDeviceRequest object (`{ token, platform }`), not positional
-        // args. `platform` is the device platform enum.
-        await client.notifications.registerDevice({
-          token,
-          platform: platform as 'ios' | 'android' | 'web',
-        });
-      } catch (err) {
-        const wrapped = err instanceof Error ? err : new Error('Failed to register device');
-        setError(wrapped);
-        throw wrapped;
-      }
-    },
-    [client],
-  );
-
-  /* ---- getPreferences ---- */
-
-  const getPreferences = useCallback(async () => {
-    if (!client?.notifications) return null;
-    setError(null);
-    try {
-      return await client.notifications.getPreferences();
-    } catch (err) {
-      const wrapped = err instanceof Error ? err : new Error('Failed to get preferences');
-      setError(wrapped);
-      throw wrapped;
-    }
-  }, [client]);
-
-  /* ---- updatePreferences ---- */
-
-  const updatePreferences = useCallback(
-    async (prefs: any) => {
-      if (!client?.notifications) return;
-      setError(null);
-      try {
-        await client.notifications.updatePreferences(prefs);
-      } catch (err) {
-        const wrapped = err instanceof Error ? err : new Error('Failed to update preferences');
-        setError(wrapped);
-        throw wrapped;
-      }
-    },
-    [client],
-  );
-
   /* ---- markAsRead (server + local) ---- */
 
   const markAsRead = useCallback(
@@ -259,9 +204,6 @@ export function useClientNotifications(
 
   return {
     fetchNotifications,
-    registerDevice,
-    getPreferences,
-    updatePreferences,
     markAsRead,
     loading,
     error,


### PR DESCRIPTION
Companion to objectstack-ai/objectstack#3616 (closes objectstack#3612 there).

## What

`useClientNotifications` exposed three delegates — `registerDevice`, `getPreferences`, `updatePreferences` — that forwarded to `@objectstack/client` methods deleted in objectstack#3612: the `/notifications/devices` and `/notifications/preferences` server routes they targeted were **never built** (ADR-0012's device-registry section was aspirational), so every call already surfaced an error at runtime today. This trims the delegates, their `UseClientNotificationsResult` entries, and the stale JSDoc.

Kept: `fetchNotifications` and `markAsRead` — both delegate to dispatcher-served, route-ledgered SDK methods (`notifications.list` / `markRead`).

Breaking only for code destructuring the removed functions from the hook result; a repo-wide sweep found no consumer (the hook is barrel-exported only). Changeset: `@object-ui/react` minor with `feat(react)!` marker, matching the launch-window convention.

## Verification

- `@object-ui/react`: 12 test files / 91 tests pass; `tsc -p` clean (after rebuilding the stale local `@object-ui/core` dist — the one error seen was pre-existing staleness, not from this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX9ut3MK3KykE11S9bJmv5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX9ut3MK3KykE11S9bJmv5)_