### PR TITLE
fix(fls): wire real per-caller FLS into import targets and grid columns, drop dead field.permissions shape

### DIFF
--- a/.changeset/remove-dead-field-permissions-wire-fls.md
+++ b/.changeset/remove-dead-field-permissions-wire-fls.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/types": major
+"@object-ui/app-shell": patch
+"@object-ui/plugin-form": patch
+"@object-ui/plugin-grid": patch
+---
+
+fix(fls): wire the real per-caller FLS channel into import targets and grid
+columns; remove the never-populated `field.permissions` shape (objectstack#3661)
+
+The `permissions?: { read?, write?, edit? }` key on `@object-ui/types` field
+definitions (Phase 3.2.6) was declared-but-never-enforced: no producer in the
+stack ever populated it, so every guard reading it short-circuited to "allow".
+Per ADR-0049 enforce-or-remove, the shape is deleted and the three consumers
+now use the server-resolved `/auth/me/permissions` channel
+(`usePermissions().checkField`) — the same channel ObjectForm/ModalForm/ListView
+already enforce:
+
+- **ImportWizard target fields (app-shell `ObjectView`)**: the importable
+  field set (and thus the downloadable CSV template's columns) now drops
+  fields the caller cannot edit, instead of offering columns the server's
+  FLS write gate would 403.
+- **ObjectGrid auto-derived columns**: columns the caller cannot read are
+  dropped (same gate ListView applies), instead of a dead schema-shape check.
+- **ObjectForm**: the redundant dead guard in field generation is removed;
+  the existing `applyFieldPerms` gate remains the real enforcement point.
+
+BREAKING CHANGE: `@object-ui/types` field definitions no longer accept a
+`permissions` key. It never carried data at runtime; consumers needing
+per-caller field-level permissions must use `@object-ui/permissions`
+(`MePermissionsProvider` + `useFieldPermissions`/`checkField`).

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -362,7 +362,8 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     // Admin users automatically get design tools (no toggle needed)
     const { user, activeOrganization } = useAuth();
     const isAdmin = useIsWorkspaceAdmin();
-    const { can, getObjectApiOperations } = usePermissions();
+    const perms = usePermissions();
+    const { can, getObjectApiOperations } = perms;
     
     // Get Object Definition. The outer ObjectView wrapper already guards the
     // missing-object case, so this always resolves while this component is
@@ -1790,14 +1791,19 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                      ? identityImportFields(objectDef.fields)
                      : Object.entries(objectDef.fields || {})
                      // Only writable fields are importable targets. Computed
-                     // types (formula/summary/autonumber) and fields flagged
-                     // readonly / write:false are server-rejected, so we omit
-                     // them from the mapping step rather than let a user map to
-                     // a column the import will silently drop.
-                     .filter(([, def]: [string, any]) =>
+                     // types (formula/summary/autonumber) and readonly fields
+                     // are server-rejected, and FLS-restricted fields get a
+                     // 403 from the write path — so we omit them from the
+                     // mapping step (and the downloadable template) rather
+                     // than let a user map to a column the import will
+                     // reject. The FLS bit comes from the server-resolved
+                     // /me/permissions channel (checkField), not from the
+                     // schema, which carries no per-caller permission bits
+                     // (objectstack#3661).
+                     .filter(([name, def]: [string, any]) =>
                        !['formula', 'summary', 'autonumber'].includes(def?.type) &&
                        !def?.readonly &&
-                       def?.permissions?.write !== false,
+                       (!perms?.isLoaded || perms.checkField(objectDef.name, name, 'write')),
                      )
                      .map(([name, def]: [string, any]) => ({
                        name,

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -542,9 +542,9 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
       const field = objectSchema.fields?.[name];
       if (!field && !hasInlineFields) return; // Skip if not found in object definition unless inline
 
-      // Check field-level permissions for create/edit modes
-      const hasWritePermission = !field?.permissions || field?.permissions.write !== false;
-      if (schema.mode !== 'view' && !hasWritePermission) return; // Skip fields without write permission
+      // Field-level permissions are enforced downstream by `applyFieldPerms`
+      // (the real per-caller gate via `perms.checkField`); the schema itself
+      // carries no per-caller permission bits (objectstack#3661).
 
       // Check if there's a custom field configuration
       const customField = schema.customFields?.find(f => f.name === name);

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -417,7 +417,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // gate with this — a missing set (unrestricted object / old backend / no
   // provider) keeps the current behavior. The frontend consumes the effective
   // set the server resolved; it never reads the raw `apiMethods`.
-  const { getObjectApiOperations } = usePermissions();
+  const perms = usePermissions();
+  const { getObjectApiOperations } = perms;
   const effectiveApiOps = objectName ? getObjectApiOperations(objectName) : undefined;
   const schemaFields = schema.fields;
   const schemaColumns = schema.columns;
@@ -1229,7 +1230,12 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       const field = objectSchema.fields?.[fieldName];
       if (!field) return;
 
-      if (field.permissions && field.permissions.read === false) return;
+      // FLS: drop columns the current user cannot read (server-resolved
+      // /me/permissions via checkField — the schema itself carries no
+      // per-caller permission bits, objectstack#3661). Same gate ListView
+      // applies to its auto-derived columns.
+      if (perms?.isLoaded && schema.objectName
+        && !perms.checkField(schema.objectName, fieldName, 'read')) return;
 
       const CellRenderer = getCellRenderer(field.type);
       const numericTypes = ['number', 'currency', 'percent'];
@@ -1249,7 +1255,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     });
 
     return generatedColumns;
-  }, [objectSchema, schemaFields, schemaColumns, dataConfig, hasInlineData, navigation.handleClick, executeAction, data, resolveFieldLabel, translateOptions, schema.objectName]);
+  }, [objectSchema, schemaFields, schemaColumns, dataConfig, hasInlineData, navigation.handleClick, executeAction, data, resolveFieldLabel, translateOptions, schema.objectName, perms]);
 
   const handleExport = useCallback((format: 'csv' | 'xlsx' | 'json' | 'pdf') => {
     // Object-level export permission gate. Default-allow: an explicit

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -78,15 +78,6 @@ export interface BaseFieldMetadata {
   defaultValue?: any;
   
   /**
-   * Field permissions (Phase 3.2.6)
-   */
-  permissions?: {
-    read?: boolean;
-    write?: boolean;
-    edit?: boolean;
-  };
-  
-  /**
    * Whether field is sortable
    */
   sortable?: boolean;


### PR DESCRIPTION
Implements steps ① and ② of objectstack-ai/objectstack#3661 (metadata-plane FLS: dead `field.permissions` guards).

## What changed

**① Wire the real per-caller FLS channel (`/auth/me/permissions` via `usePermissions().checkField`) into the two surfaces that had none:**

- **ImportWizard target fields** (`app-shell/ObjectView.tsx`): the importable field set — and therefore the downloadable CSV template's columns — now drops fields the caller cannot edit (`checkField(object, field, 'write')`), instead of offering columns the server-side FLS write gate rejects with an explicit 403 (`security-plugin.ts` step 2.5). Permissive when no permission provider is mounted (`!perms?.isLoaded`), matching the ListView precedent.
- **ObjectGrid auto-derived columns** (`plugin-grid/ObjectGrid.tsx`): columns the caller cannot read are dropped via `checkField(object, field, 'read')` — the same gate ListView already applies to its auto-derived columns (`ListView.tsx:961`).
- **ObjectForm** (`plugin-form/ObjectForm.tsx`): the dead guard in field generation is deleted outright — its output already flows through the real `applyFieldPerms` gate (`checkField` read/write), so the dead check was redundant there rather than a gap.

**② Remove the never-populated `permissions?: { read?, write?, edit? }` shape from `@object-ui/types` (BREAKING):**

The shape was Phase 3.2.6 legacy: it exists in no `@objectstack/spec` schema, has zero producers in either repo, and every guard reading it permanently short-circuited to "allow" — declared ≠ enforced (ADR-0049 enforce-or-remove). Deleting the key makes any future guard written against it a compile error. Rides the major release currently being prepared (a `major` changeset for the fixed group is already pending).

## What this is NOT

- Not a write-path vulnerability fix — the server already 403s forbidden field writes (ObjectQL security middleware step 2.5). This closes the metadata-disclosure path (template column headers) and the UX trap (template offers columns the import then rejects).
- Step ③ of the issue (per-caller masking of `/meta` object schemas) is intentionally **not** included: per the maintainer, target deployments have no untrusted authenticated callers, so the metadata plane stays unmasked with `/auth/me/permissions` as the authoritative per-caller channel (to be recorded in an ADR).

## Verification

- `turbo run build` for the 4 touched packages + dependents: 29/29 green.
- `vitest --project unit`: 429 + 1010 tests green; `--project dom --project dom-heavy` for plugin-form / plugin-grid / app-shell / permissions: 1103 tests green.
- `changeset:check` and `turbo run lint` for touched packages: green.
- Grep sweep: zero remaining references to the removed shape in code, tests, or docs.

Closes nothing by itself — tracked by objectstack-ai/objectstack#3661 (steps ①②).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEb4XCVb7iLEBVe9HghjTt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEb4XCVb7iLEBVe9HghjTt)_