### PR TITLE
fix(page,field): consume the spec's type/label/maxLength keys (framework#1878 §3 recheck)

### DIFF
--- a/.changeset/naming-drift-page-and-maxlength.md
+++ b/.changeset/naming-drift-page-and-maxlength.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/components": patch
+"@object-ui/plugin-form": patch
+"@object-ui/fields": patch
+---
+
+fix(page,field): consume the spec's `type`/`label`/`maxLength` keys (framework#1878 §3 naming-drift recheck)
+
+Three forward-drifts where objectui read a different key than the spec
+declares, so authoring the documented key silently no-oped:
+
+- **page `type` → `pageType`** (app-shell + components): `PageSchema` declares
+  the page KIND as `type`, but `PageRenderer` reads `schema.pageType` and fell
+  back to `'record'` — and nothing mapped between them. Every non-record page
+  (`home`/`app`/`list`/`utility`) rendered with the record max-width, a wrong
+  `data-page-type` attribute, and a suppressed header. `PageView` now passes
+  `pageType` alongside the SchemaNode discriminator `type`.
+- **page `label` → `title`** (components): `PageSchema.label` is required but the
+  region renderer read only `title`. Now dual-reads `title ?? label`, mirroring
+  the fallback `DashboardRenderer` already uses. Coupled with the above — the
+  header is gated on `pageType !== 'record'`, so both were needed for a title to
+  appear.
+- **field `maxLength`/`minLength`** (plugin-form + fields): validation already
+  dual-read these, but `ObjectForm`'s HTML-attribute pass and `TextAreaField`
+  read `max_length` only, so a spec-authored `maxLength` gave no browser cap and
+  no character counter. Both now dual-read, matching `buildValidationRules`.
+
+Verified in the browser against the showcase: `capability_map` (`type: 'home'`)
+now renders `data-page-type="home"`, the `home` max-width and its page title;
+record pages are unchanged.

--- a/packages/app-shell/src/views/PageView.tsx
+++ b/packages/app-shell/src/views/PageView.tsx
@@ -120,7 +120,15 @@ export function PageView() {
               key={refreshKey}
               schema={{
                 ...page,
+                // `type` stays the SchemaNode discriminator ComponentRegistry
+                // dispatches on. The spec's page KIND (`record|home|app|utility|
+                // list`) rides `pageType`, which PageRenderer reads — without
+                // this mapping every page fell back to `pageType: 'record'`,
+                // so non-record pages got the record max-width, a wrong
+                // `data-page-type` and a suppressed header (framework#1878 §3
+                // naming-drift recheck).
                 type: (page as any).type || 'page',
+                pageType: (page as any).type,
                 context: { ...(page as any).context, params, refreshKey },
               }}
             />

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -389,6 +389,10 @@ export const PageRenderer: React.FC<{
   [key: string]: any;
 }> = ({ schema, className, ...props }) => {
   const pageType = schema.pageType || 'record';
+  // Spec PageSchema declares `label` (required); `title` is the objectui
+  // spelling. Dual-read so a spec-authored page still renders its header
+  // (framework#1878 §3 naming-drift recheck).
+  const pageTitle = schema.title ?? (schema as any).label;
 
   // Extract designer-related props and strip schema-only metadata that
   // would otherwise leak onto the wrapper <div> as invalid HTML attributes
@@ -499,12 +503,15 @@ export const PageRenderer: React.FC<{
     >
       <div className={cn(fullBleed ? 'space-y-6' : 'mx-auto space-y-6', maxWidthClass)}>
         {/* Page header — suppressed on record pages (the page:header component
-            in the header region renders the record-bound title instead). */}
-        {pageType !== 'record' && (schema.title || schema.description) && (
+            in the header region renders the record-bound title instead).
+            `title` is the objectui spelling; the spec's PageSchema declares
+            `label` (required), so dual-read it — mirrors the fallback
+            DashboardRenderer already uses (framework#1878 §3 recheck). */}
+        {pageType !== 'record' && (pageTitle || schema.description) && (
           <div className="space-y-2">
-            {schema.title && (
+            {pageTitle && (
               <h1 className="text-3xl font-bold tracking-tight text-foreground">
-                {schema.title}
+                {pageTitle}
               </h1>
             )}
             {schema.description && (

--- a/packages/fields/src/widgets/TextAreaField.tsx
+++ b/packages/fields/src/widgets/TextAreaField.tsx
@@ -36,7 +36,10 @@ export function TextAreaField({ value, onChange, field, readonly, errorMessage, 
 
   const textareaField = (field || (props as any).schema) as any;
   const rows = textareaField?.rows || 4;
-  const maxLength = textareaField?.max_length;
+  // Spec FieldSchema declares camelCase `maxLength`; `max_length` is the legacy
+  // objectui spelling. Dual-read (framework#1878 §3 recheck) — without this a
+  // spec-authored maxLength gave neither the textarea cap nor the counter.
+  const maxLength = textareaField?.maxLength ?? textareaField?.max_length;
   // Mobile fullscreen flag may arrive on the field metadata, on the form-field
   // schema (when called via the form renderer where `field` is the ObjectQL
   // metadata sub-object), or as an explicit widget prop.

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -604,8 +604,12 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
         }
 
         if (field.type === 'text' || field.type === 'textarea' || field.type === 'markdown' || field.type === 'html') {
-          formField.maxLength = field.max_length;
-          formField.minLength = field.min_length;
+          // Spec FieldSchema declares camelCase; `max_length`/`min_length` is
+          // the legacy objectui spelling. Dual-read like buildValidationRules
+          // already does (framework#1878 §3 recheck) — without this a
+          // spec-authored `maxLength` never reached the HTML maxlength cap.
+          formField.maxLength = (field as any).maxLength ?? field.max_length;
+          formField.minLength = (field as any).minLength ?? field.min_length;
         }
 
         if (field.type === 'file' || field.type === 'image') {


### PR DESCRIPTION
Companion to objectstack-ai/objectstack `docs/naming-drift-recheck`. Three FORWARD-DRIFTs found by rechecking the 2026-06 audit's §3 list — cases where objectui reads a different key than the spec declares, so **the author does everything right and nothing happens**.

## 1 + 2. The page pair (coupled — must land together)

`PageSchema` declares the page KIND as **`type`** (`record|home|app|utility|list`) and requires **`label`**. But:
- `PageRenderer` reads `schema.pageType` with a `'record'` fallback (`page.tsx:391`) — and **nothing mapped `type` → `pageType`**. The boundary passed `type` only (`PageView.tsx:123`).
- the region renderer reads only `schema.title`, never `label` (`page.tsx:503-507`).

Coupled because the header is gated on `pageType !== 'record'` — pinned false by drift #1, so wiring `label` alone would still render no title.

**Observable today in the showcase**: `capability_map` (`type:'home'`), `active_projects` (`type:'list'`) and `command_center_jsx` (`type:'home'`) all rendered as record pages — record max-width, `data-page-type="record"`, no title.

**Why it hid for a year**: the spec's `type` defaults to `'record'` *and* the renderer's fallback is `'record'`, so the most common page kind looked correct by coincidence.

Fix: `PageView` passes `pageType` alongside `type` (which must stay — `ComponentRegistry` dispatches on it), and `PageRenderer` dual-reads `title ?? label`, mirroring the fallback `DashboardRenderer` already uses.

## 3. field `maxLength` / `minLength`

Validation already dual-reads these (`fields/src/index.tsx:2013,2022`, citing the same #1878 closeout), but two readers were missed: `ObjectForm`'s HTML-attribute pass (`:607-608`) and `TextAreaField` (`:39`) read `max_length` only — so a spec-authored `maxLength` produced **no browser cap and no character counter**. Both now dual-read.

## Verification

- **Browser-verified** against the showcase: `capability_map` now reports `data-page-type="home"`, `max-w-screen-2xl` and renders its `<h1>Capability Map` (screenshot in the framework PR thread). Record pages re-checked unchanged — still `data-page-type="record"`, no duplicate title.
- 625 tests green across components / app-shell / plugin-form / fields; all four packages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)