### PR TITLE
fix(list): show real match total in record-count bar under server pagination

### DIFF
--- a/.changeset/listview-record-count-total.md
+++ b/.changeset/listview-record-count-total.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/plugin-list": patch
+---
+
+fix(list): show the real match total in the record-count status bar under server pagination
+
+The Airtable-style record-count bar read `data.length`, but under server-side
+pagination (#2212) `data` is only the current page window — so a 158-row result
+paginated 100/page reported "100 条记录" on page 1 and "58 条记录" on page 2,
+never the true total. There was no other place to see how many records the
+query matched.
+
+The bar now shows the server's grand total (`serverTotal`) when known, falling
+back to `data.length` when the whole result set is in memory (non-paginated,
+grouped and non-grid views are unchanged — `serverTotal` is null there, so the
+count is identical to before). Browser-verified against the showcase contacts
+list: the bar reads "158 条记录" and stays stable across pages, and switching to
+grouped/other views correctly resets to the loaded count.

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -2523,7 +2523,16 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           data-testid="record-count-bar"
         >
           <span className="font-medium text-foreground/80">
-            {data.length === 1 ? t('list.recordCountOne', { count: data.length }) : t('list.recordCount', { count: data.length })}
+            {/* Under server pagination `data` is only the current page, so the
+                honest record count is the server's grand total (#586). When the
+                whole result set is in memory, serverTotal is null and data.length
+                already IS the total. */}
+            {(() => {
+              const totalCount = serverTotal ?? data.length;
+              return totalCount === 1
+                ? t('list.recordCountOne', { count: totalCount })
+                : t('list.recordCount', { count: totalCount });
+            })()}
           </span>
           {dataLimitReached && (
             <span className="text-amber-600" data-testid="data-limit-warning">

--- a/packages/plugin-list/src/__tests__/ListView.serverPagination.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.serverPagination.test.tsx
@@ -124,6 +124,18 @@ describe('ListView — server-side pagination drives the child grid (#2212)', ()
     expect(lastGridProps.data.length).toBe(PAGE_SIZE);
   });
 
+  it('shows the real match total in the record-count bar, not the current window length (#586)', async () => {
+    const ds = makeDataSource();
+    const { findByTestId } = renderList(ds);
+    // Wait until server pagination has engaged (the window is the first batch).
+    await waitFor(() => expect(lastGridProps?.rowCount).toBe(TOTAL));
+    const bar = await findByTestId('record-count-bar');
+    // The bar must report the grand total (3125), NOT the page window (50) that
+    // `data.length` would give under server pagination.
+    expect(bar.textContent).toContain(String(TOTAL));
+    expect(bar.textContent).not.toContain(String(PAGE_SIZE));
+  });
+
   it('REFETCHES with $skip when the grid turns the page (reaches records past batch 1)', async () => {
     const ds = makeDataSource();
     renderList(ds);


### PR DESCRIPTION
## 问题
列表底部的记录数状态栏读的是 `data.length`。服务端分页（#2212）下 `data` 只有当前页，所以 158 行按 100/页分页时第 1 页显示「100 条记录」、第 2 页「58 条记录」，看不到真实总数——用户没有任何地方能看到查询命中的总条数。

## 修复
状态栏改为有服务端总数（`serverTotal`）时显示总数，否则回退 `data.length`（内存态/分组/非 grid 视图 `serverTotal` 为 null，行为不变）。

## 验证
- 单测：`ListView.serverPagination` 5/5、`ListView` 126/126
- 浏览器实测 showcase 联系人列表（158 行）：状态栏显示「158 条记录」跨页稳定；切分组/清除分组正确重置，无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)