### PR TITLE
test: pin the detail/form edit/delete gate to the server's effective operation set (#3546)

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.headerActionGates.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.headerActionGates.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RecordDetailView — the detail header's Edit/Delete gate vs the server's
+ * effective API operation set (#3546).
+ *
+ * PR-4 (objectui#2823) intersected the LIST/TOOLBAR affordances with the
+ * server-resolved effective operation set (`/me/permissions` `apiOperations`).
+ * #3546 extends that intersection to the DETAIL surface: the synthesized
+ * `sys_edit` CTA (which also gates the record-body inline-edit session) and the
+ * `sys_delete` overflow item must never be offered for an operation the server
+ * would 405.
+ *
+ * These pin the resulting show/hide matrix, including the two properties that
+ * make this an INTERSECTION and not a union:
+ *   • a server grant never re-opens an affordance the lifecycle bucket closed;
+ *   • a permissive bucket default never survives a server denial.
+ * ...and the backward-compatible fallback: a missing effective set (unrestricted
+ * object / old backend / no PermissionProvider) leaves today's bucket +
+ * `userActions` decision untouched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveRecordHeaderActionGates } from './RecordDetailView';
+
+// `platform` is the permissive bucket — edit + delete both default open, so it
+// isolates the effective-set intersection as the only variable.
+const platform = { name: 'crm_lead', managedBy: 'platform' };
+
+describe('resolveRecordHeaderActionGates — effective API operations (#3546)', () => {
+  it('full-CRUD effective set → Edit and Delete both offered', () => {
+    expect(
+      resolveRecordHeaderActionGates(platform, ['get', 'list', 'create', 'update', 'delete']),
+    ).toEqual({ edit: true, delete: true });
+  });
+
+  it('read-only effective set → neither Edit nor Delete', () => {
+    expect(resolveRecordHeaderActionGates(platform, ['get', 'list'])).toEqual({
+      edit: false,
+      delete: false,
+    });
+  });
+
+  it('update-only effective set → Edit offered, Delete hidden', () => {
+    expect(resolveRecordHeaderActionGates(platform, ['get', 'list', 'update'])).toEqual({
+      edit: true,
+      delete: false,
+    });
+  });
+
+  it('delete-only effective set → Delete offered, Edit hidden', () => {
+    expect(resolveRecordHeaderActionGates(platform, ['get', 'list', 'delete'])).toEqual({
+      edit: false,
+      delete: true,
+    });
+  });
+
+  it('empty effective set ("expose nothing") → neither', () => {
+    expect(resolveRecordHeaderActionGates(platform, [])).toEqual({ edit: false, delete: false });
+  });
+
+  it('undefined effective set (unrestricted / old backend) → bucket wins, both offered', () => {
+    expect(resolveRecordHeaderActionGates(platform, undefined)).toEqual({
+      edit: true,
+      delete: true,
+    });
+    // Omitting the argument entirely must behave identically — this is the
+    // pre-#3546 call shape every non-permission-aware caller still uses.
+    expect(resolveRecordHeaderActionGates(platform)).toEqual({ edit: true, delete: true });
+  });
+
+  it('null effective set is treated as absent, not as an empty set', () => {
+    expect(resolveRecordHeaderActionGates(platform, null)).toEqual({ edit: true, delete: true });
+  });
+
+  // ── Intersection, never union ────────────────────────────────────────────
+  it('bucket-locked object stays locked even when the server allows update/delete', () => {
+    // `system` (engine-owned) closes edit + delete by default. A permissive
+    // server set must NOT re-open them — the server governs what it will
+    // accept, the bucket governs what the product offers.
+    expect(
+      resolveRecordHeaderActionGates({ name: 'sys_automation_run', managedBy: 'system' }, [
+        'get',
+        'list',
+        'create',
+        'update',
+        'delete',
+      ]),
+    ).toEqual({ edit: false, delete: false });
+  });
+
+  it('userActions opt-in still loses to a server denial', () => {
+    // sys_user opens `edit` via userActions (ADR-0103), but a caller whose
+    // effective set lacks `update` must not see the Edit CTA.
+    const sysUser = { name: 'sys_user', managedBy: 'better-auth', userActions: { edit: true } };
+    expect(resolveRecordHeaderActionGates(sysUser, ['get', 'list', 'update'])).toEqual({
+      edit: true,
+      delete: false,
+    });
+    expect(resolveRecordHeaderActionGates(sysUser, ['get', 'list'])).toEqual({
+      edit: false,
+      delete: false,
+    });
+  });
+
+  it('admin-editable `config` bucket intersects the same way', () => {
+    const webhook = { name: 'sys_webhook', managedBy: 'config' };
+    expect(resolveRecordHeaderActionGates(webhook, ['get', 'list', 'update', 'delete'])).toEqual({
+      edit: true,
+      delete: true,
+    });
+    expect(resolveRecordHeaderActionGates(webhook, ['get', 'list', 'update'])).toEqual({
+      edit: true,
+      delete: false,
+    });
+  });
+
+  it('a missing objectDef falls back to the platform default (no crash)', () => {
+    expect(resolveRecordHeaderActionGates(undefined, ['get', 'list', 'update'])).toEqual({
+      edit: true,
+      delete: false,
+    });
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -112,6 +112,34 @@ function isSecondaryField(fieldName: string, fieldDef: any): boolean {
   return SECONDARY_FIELD_NAME_HINTS.some((hint) => lc === hint || lc.endsWith(`_${hint}`));
 }
 
+/**
+ * Which system record-header affordances the record page may offer for this
+ * object — the primary `sys_edit` CTA (which also gates the record-body
+ * inline-edit session) and the `sys_delete` overflow item.
+ *
+ * [#3546] Each bit is the object's resolved CRUD affordance (lifecycle bucket +
+ * `userActions`) INTERSECTED with the server-resolved effective API operation
+ * set (`/me/permissions` `apiOperations`) — never a union. So a server grant can
+ * never re-open an affordance the object's bucket closed, and a permissive
+ * bucket default never survives the server denying `update` / `delete`. This is
+ * the detail-surface end of the same intersection the list/toolbar surface
+ * applies (objectui#2823). Passing `undefined` for `effectiveApiOperations`
+ * (unrestricted object / old backend / no `PermissionProvider`) leaves the
+ * bucket + `userActions` decision untouched — backward-compatible.
+ *
+ * Exported so the gate can be unit-tested directly: the record page itself is
+ * wired into routing, auth, presence and data fetching too deeply to render in
+ * a unit test, and this matrix is the part that must not regress. Same pattern
+ * as `defaultListColumnsFromObject` in `ObjectView`.
+ */
+export function resolveRecordHeaderActionGates(
+  objectDef: unknown,
+  effectiveApiOperations?: readonly string[] | null,
+): { edit: boolean; delete: boolean } {
+  const affordances = resolveCrudAffordances(objectDef as any, effectiveApiOperations);
+  return { edit: affordances.edit, delete: affordances.delete };
+}
+
 export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverride, recordIdOverride, embedded }: RecordDetailViewProps) {
 
   const params = useParams<{
@@ -897,8 +925,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   const { can: canOnObject, isLoaded: permissionsLoaded, getObjectApiOperations } = usePermissions();
   // [#3546] Server-resolved effective API operation set for this object
   // (`/me/permissions` `apiOperations`). Threaded as the 2nd arg into
-  // `resolveCrudAffordances` for the detail header's Edit/Delete and the
-  // record-body inline-edit gate, so the detail surface never offers an
+  // `resolveRecordHeaderActionGates` for the detail header's Edit/Delete and
+  // the record-body inline-edit gate, so the detail surface never offers an
   // operation the server would 405 — the same intersection the list/toolbar
   // surface already applies (objectui#2823). `undefined` (unrestricted object
   // / old backend) leaves the bucket affordances untouched (backward-compatible).
@@ -1748,7 +1776,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // menu permanently — Delete must never surface as an inline red button
   // just because an object has few actions.
   const synthSystemActions: ActionDef[] = (() => {
-    const affordances = resolveCrudAffordances(objectDef as any, effectiveApiOperations);
+    const affordances = resolveRecordHeaderActionGates(objectDef, effectiveApiOperations);
     const items: ActionDef[] = [];
     if (affordances.edit) {
       // Single primary Edit CTA → opens the full record form. Inline editing
@@ -1893,7 +1921,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
             on backends that track the lock via approval requests only and
             never materialize an `approval_status` field (objectui#2618). */}
         <InlineEditProvider
-          canEdit={resolveCrudAffordances(objectDef as any, effectiveApiOperations).edit && !approvalLocked}
+          canEdit={resolveRecordHeaderActionGates(objectDef, effectiveApiOperations).edit && !approvalLocked}
           locked={approvalLocked}
           lockedReason={t('detail.lockedTooltip', {
             defaultValue: 'This record has a pending approval request; editing is locked',

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.effectiveOps.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.effectiveOps.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `record:details` — inline-edit vs the server's effective API operation set
+ * (#3546).
+ *
+ * The record BODY offers per-field editing through a double-click / hover
+ * pencil, gated by `isObjectInlineEditable`. #3546 intersects that gate with the
+ * server-resolved effective operation set (`/me/permissions` `apiOperations`),
+ * so a record page never offers inline editing the server would 405 on save.
+ *
+ * The renderer hands the resolved verdict to `<DetailView>` as
+ * `schema.inlineEdit`; these stub DetailView and assert that flag across the
+ * effective-set matrix — including that the intersection never becomes a union
+ * (a server `update` grant can't re-open a bucket-locked object) and that a
+ * missing effective set preserves today's behavior.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+const stub = {
+  /** Server-resolved effective API operations for the bound object. */
+  effectiveOps: undefined as string[] | undefined,
+  /** The bound object's schema (lifecycle bucket + userActions). */
+  objectSchema: { managedBy: 'platform' } as any,
+};
+
+vi.mock('@object-ui/react', () => ({
+  useRecordContext: () => ({
+    objectName: 'crm_lead',
+    recordId: 'rec_1',
+    data: { id: 'rec_1', name: 'Acme' },
+    dataSource: { update: async () => ({}) },
+    refresh: async () => {},
+    objectSchema: stub.objectSchema,
+  }),
+  useHighlightFieldNames: () => [] as string[],
+  useSafeFieldLabel: () => ({
+    sectionLabel: (_obj: string, _name: string, fallback: string) => fallback,
+  }),
+}));
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({
+    can: () => true,
+    getObjectApiOperations: () => stub.effectiveOps,
+  }),
+  useFieldPermissions: () => ({ readableFields: (names: string[]) => names }),
+}));
+
+// Capture the schema the renderer synthesizes — `inlineEdit` is the gate under
+// test. Stubbing DetailView also keeps the suite off the heavy field/registry
+// graph, which this behavior does not depend on.
+let captured: any = null;
+vi.mock('../../DetailView', () => ({
+  DetailView: (props: any) => {
+    captured = props?.schema;
+    return <div data-testid="detail-view" />;
+  },
+}));
+
+import { RecordDetailsRenderer } from '../record-details';
+
+/** Render the renderer and return the `inlineEdit` flag it resolved. */
+function inlineEditFor(schema: any = { fields: ['name'] }): boolean {
+  captured = null;
+  render(<RecordDetailsRenderer schema={schema} />);
+  return captured?.inlineEdit;
+}
+
+beforeEach(() => {
+  stub.effectiveOps = undefined;
+  stub.objectSchema = { managedBy: 'platform' };
+  captured = null;
+  cleanup();
+});
+
+describe('record:details — inline-edit vs effective API operations (#3546)', () => {
+  it('effective set WITH `update` → inline-edit offered', () => {
+    stub.effectiveOps = ['get', 'list', 'update'];
+    expect(inlineEditFor()).toBe(true);
+  });
+
+  it('effective set WITHOUT `update` → inline-edit withheld', () => {
+    // The #3546 behavior change: pre-fix this stayed `true` on a platform
+    // object and the body offered a pencil the server would 405 on save.
+    stub.effectiveOps = ['get', 'list'];
+    expect(inlineEditFor()).toBe(false);
+  });
+
+  it('empty effective set ("expose nothing") → inline-edit withheld', () => {
+    stub.effectiveOps = [];
+    expect(inlineEditFor()).toBe(false);
+  });
+
+  it('undefined effective set (unrestricted / old backend) → bucket wins, offered', () => {
+    stub.effectiveOps = undefined;
+    expect(inlineEditFor()).toBe(true);
+  });
+
+  it('bucket-locked object stays locked even when the server allows `update`', () => {
+    // Intersection, never union: an engine-owned object is not user-editable
+    // regardless of what the caller's effective set permits.
+    stub.objectSchema = { managedBy: 'system' };
+    stub.effectiveOps = ['get', 'list', 'create', 'update', 'delete'];
+    expect(inlineEditFor()).toBe(false);
+  });
+
+  it('userActions.edit opt-in still loses to a server denial', () => {
+    stub.objectSchema = { managedBy: 'better-auth', userActions: { edit: true } };
+    stub.effectiveOps = ['get', 'list', 'update'];
+    expect(inlineEditFor()).toBe(true);
+
+    stub.effectiveOps = ['get', 'list'];
+    expect(inlineEditFor()).toBe(false);
+  });
+
+  it('author opt-out (`inlineEdit: false`) still wins over a permissive server set', () => {
+    stub.effectiveOps = ['get', 'list', 'update'];
+    expect(inlineEditFor({ fields: ['name'], inlineEdit: false })).toBe(false);
+  });
+});

--- a/packages/plugin-form/src/ObjectForm.effectiveOps.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.effectiveOps.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ObjectForm — the managed-object blanket field lock vs the server's effective
+ * API operation set (#3546).
+ *
+ * The form's blanket lock resolves the object's CRUD affordance for the CURRENT
+ * mode (`edit` → `update`, `create` → `create`). #3546 intersects that with the
+ * server-resolved effective operation set (`/me/permissions` `apiOperations`),
+ * so the form never presents writable inputs for an operation the server would
+ * 405 on submit.
+ *
+ * These assert the rendered input's `disabled` state — the user-visible outcome
+ * — across the effective-set matrix, and pin the two invariants that make this
+ * an intersection: a server grant never re-opens a bucket-locked object, and a
+ * `userActions` opt-in never survives a server denial. A missing effective set
+ * (unrestricted object / old backend / no PermissionProvider) preserves the
+ * pre-#3546 behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+
+// The stub must keep a STABLE identity across renders: ObjectForm carries
+// `perms` in several `useMemo` dependency arrays, and the real `usePermissions`
+// memoizes its return value for exactly that reason. Handing back a fresh
+// object literal per call makes those memos churn every render and the form
+// spins in an infinite update loop. `vi.hoisted` builds it before the hoisted
+// `vi.mock` factory runs, and the accessor reads mutable state so tests can
+// swap the effective set without changing the object's identity.
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { effectiveOps: string[] | undefined } = { effectiveOps: undefined };
+  return {
+    state,
+    // `isLoaded: false` keeps the FIELD-level permission filter out of the way
+    // (ObjectForm fails open on it) so the blanket mode lock is the only variable.
+    permsStub: {
+      isLoaded: false,
+      checkField: () => true,
+      getObjectApiOperations: () => state.effectiveOps,
+    },
+  };
+});
+
+// `usePermissions` is the only binding this module graph takes from the package.
+vi.mock('@object-ui/permissions', () => ({ usePermissions: () => permsStub }));
+
+import { ObjectForm } from './ObjectForm';
+import { registerAllFields } from '@object-ui/fields';
+
+registerAllFields();
+
+const textField = { name: { type: 'text', label: 'Name', readonly: false } };
+const record = { id: 'u1', name: 'Acme' };
+
+const dsFor = (schema: any): any => ({
+  getObjectSchema: vi.fn().mockResolvedValue(schema),
+  findOne: vi.fn().mockResolvedValue(record),
+  getRecord: vi.fn().mockResolvedValue(record),
+  createRecord: vi.fn(),
+  updateRecord: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  query: vi.fn(),
+});
+
+/** Render the object form in `mode` and report whether its input is locked. */
+async function nameInputDisabled(schema: any, mode: 'edit' | 'create'): Promise<boolean> {
+  const { container } = render(
+    <ObjectForm
+      schema={
+        {
+          type: 'object-form',
+          objectName: schema.name,
+          mode,
+          ...(mode === 'edit' ? { recordId: 'u1' } : {}),
+        } as any
+      }
+      dataSource={dsFor(schema)}
+    />,
+  );
+  const el = await waitFor(() => {
+    const found = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+    if (!found) throw new Error('name input not yet rendered');
+    return found;
+  });
+  return el.disabled;
+}
+
+const platform = { name: 'crm_lead', managedBy: 'platform', fields: textField };
+
+beforeEach(() => {
+  state.effectiveOps = undefined;
+  cleanup();
+});
+
+describe('ObjectForm — blanket lock vs effective API operations (#3546)', () => {
+  it('edit mode, effective set WITH `update` → fields editable', async () => {
+    state.effectiveOps = ['get', 'list', 'update'];
+    expect(await nameInputDisabled(platform, 'edit')).toBe(false);
+  });
+
+  it('edit mode, effective set WITHOUT `update` → blanket lock engages', async () => {
+    // The #3546 behavior change: pre-fix a platform object rendered enabled
+    // inputs that the server would have rejected on submit.
+    state.effectiveOps = ['get', 'list'];
+    expect(await nameInputDisabled(platform, 'edit')).toBe(true);
+  });
+
+  it('edit mode, empty effective set ("expose nothing") → locked', async () => {
+    state.effectiveOps = [];
+    expect(await nameInputDisabled(platform, 'edit')).toBe(true);
+  });
+
+  it('edit mode, undefined effective set (unrestricted / old backend) → unchanged, editable', async () => {
+    state.effectiveOps = undefined;
+    expect(await nameInputDisabled(platform, 'edit')).toBe(false);
+  });
+
+  it('create mode keys off `create`, not `update`', async () => {
+    // Server allows update but NOT create → the create form must lock, even
+    // though the edit form on the same object would not.
+    state.effectiveOps = ['get', 'list', 'update'];
+    expect(await nameInputDisabled(platform, 'create')).toBe(true);
+
+    cleanup();
+    state.effectiveOps = ['get', 'list', 'create'];
+    expect(await nameInputDisabled(platform, 'create')).toBe(false);
+  });
+
+  it('bucket-locked object stays locked even when the server allows `update`', async () => {
+    // Intersection, never union.
+    const engineOwned = { name: 'sys_automation_run', managedBy: 'system', fields: textField };
+    state.effectiveOps = ['get', 'list', 'create', 'update', 'delete'];
+    expect(await nameInputDisabled(engineOwned, 'edit')).toBe(true);
+  });
+
+  it('userActions.edit opt-in still loses to a server denial', async () => {
+    const sysUser = {
+      name: 'sys_user',
+      managedBy: 'better-auth',
+      userActions: { edit: true },
+      fields: textField,
+    };
+    state.effectiveOps = ['get', 'list', 'update'];
+    expect(await nameInputDisabled(sysUser, 'edit')).toBe(false);
+
+    cleanup();
+    state.effectiveOps = ['get', 'list'];
+    expect(await nameInputDisabled(sysUser, 'edit')).toBe(true);
+  });
+});


### PR DESCRIPTION
## 背景

objectstack#3546 的实现已由 objectui#2832 合入 main —— detail/form 面的 edit/delete 确实已经与服务端 effective 操作集(`/me/permissions` 的 `apiOperations`)取交集。但该 issue 的**第三条勾选项**(「测试:effective 含/不含 update·delete 时按钮显隐」)只完成了一半:

- 已有:`@object-ui/core` 的 `isObjectInlineEditable` 单测 + `RelatedRecordActionsBridge` 组件测试(**子对象**相关列表)。
- 缺失:issue 标题点名的**三个面本身**—— detail header 的 Edit/Delete、记录体 inline-edit 门、form 的整表字段锁 —— 只靠「既有套件回归通过」兜底,没有任何测试真正钉住这三处的接线。

也就是说:在这三处任一处把 `resolveCrudAffordances` / `isObjectInlineEditable` 的第二参删掉,合入前的测试**全绿**。本 PR 补齐这部分覆盖,不改变任何行为。

## 改动

### 新增测试(25 例)

- **app-shell** `RecordDetailView.headerActionGates.test.tsx`(11 例)—— 合成的 `sys_edit` / `sys_delete` 门,覆盖 full-CRUD / read-only / update-only / delete-only / 空集 / `undefined` / `null` 七种 effective 集。
- **plugin-detail** `record-details.effectiveOps.test.tsx`(7 例)—— 交给 `<DetailView>` 的 `schema.inlineEdit`,含作者 `inlineEdit: false` opt-out 优先级。
- **plugin-form** `ObjectForm.effectiveOps.test.tsx`(7 例)—— 渲染出的 input `disabled` 实际状态,含 create 模式按 `create`(而非 `update`)判定。

三个套件都额外钉住使其成为**交集而非并集**的两条性质:

- 服务端授权**永不**重新打开 bucket 已关闭的 affordance(engine-owned `system` 即使 effective 全开仍锁);
- `userActions` opt-in **永不**盖过服务端拒绝(`sys_user` 开了 `edit`,但 effective 无 `update` 时仍锁)。

以及向后兼容:effective 缺失(全开对象 / 旧后端 / 未挂 `PermissionProvider`)保持 #3546 之前的行为。

### 生产代码(行为不变)

detail header 的门原本内联在 `RecordDetailView` 函数体里,而该组件深度耦合 routing / auth / presence / 数据拉取,无法在单测中渲染。故把这一处判定抽成导出的纯函数 `resolveRecordHeaderActionGates(objectDef, effectiveApiOperations)`——与 `ObjectView` 的 `defaultListColumnsFromObject` 同一套路。

行为等价:返回的就是它所替换的那次 `resolveCrudAffordances(objectDef, effectiveApiOperations)` 的 `edit` / `delete` 两位;两个调用点(header 合成 + `InlineEditProvider` 的 `canEdit`)原样改调。该函数**未**加入包的 public export 列表,不构成公开 API 变化。

## 验证

- **变异验证**:在三个调用点分别删掉 effective 操作集实参后,新测试 **14 例失败**(三个文件全红)—— 证明这些用例钉的是接线本身,而不是在复述 core 的单测。恢复后全绿。
- 触及包全量套件绿:**212 文件 / 1953 用例**。
- `tsc` 构建绿(app-shell / plugin-detail / plugin-form 及其依赖,29 个 task)。
- eslint **0 error**(仅既有 `no-explicit-any` warning)。

## 无 changeset

无行为变化、无公开 API 变化,按 AGENTS.md §9(feature 才需要 changeset)不写 changeset。CI 的 `changeset-check` 只校验 fixed group 配置,不要求每个 PR 带 changeset。

## 关联

objectstack#3546(本 issue,实现已由 objectui#2832 合入,本 PR 补其测试项)、objectstack#3391(跟踪)、objectui#2823(PR-4)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEcwUzbuzU8LM5dk4pYQQA)_