### PR TITLE
fix(hooks): stop calling translation hooks inside try/catch (#2879)

### DIFF
--- a/.changeset/no-try-catch-around-hook.md
+++ b/.changeset/no-try-catch-around-hook.md
@@ -1,0 +1,51 @@
+---
+"@object-ui/i18n": patch
+"@object-ui/plugin-detail": patch
+"@object-ui/plugin-timeline": patch
+"@object-ui/plugin-list": patch
+"@object-ui/plugin-calendar": patch
+"@object-ui/plugin-grid": patch
+"@object-ui/plugin-designer": patch
+"@object-ui/plugin-gantt": patch
+"@object-ui/plugin-view": patch
+"@object-ui/components": patch
+---
+
+fix(hooks): stop calling translation hooks inside try/catch (objectui#2879)
+
+Eleven call sites wrapped a React hook in `try`/`catch` to make it
+"provider-safe". `useObjectTranslation` and `useObjectLabel` already are — they
+read context optionally and fall back to react-i18next's global instance, and
+never throw. The `catch` bought nothing and cost correctness: a throw *after*
+the hook ran desyncs hook order on the next render, because React matches hooks
+positionally. objectui#2595/#2596 fixed exactly this in `@object-ui/i18n`'s
+`createSafeTranslation`; nine plugin-local re-implementations kept their own
+copy of the bug, and two more (`ObjectTimeline`, `ObjectView`) were found by the
+new lint rule below — `ObjectView` had even suppressed
+`react-hooks/rules-of-hooks` inline to keep it.
+
+- Six exact re-implementations now delegate to `createSafeTranslation`:
+  `plugin-detail`, `plugin-timeline`, `plugin-list`, `plugin-calendar`,
+  `plugin-grid`'s `ObjectGrid`, `plugin-designer`.
+- `components`' `data-table` also delegates; `createSafeTranslation` now
+  returns `language` alongside `t` so consumers that localize dates don't need
+  a second hook call. Purely additive.
+- `plugin-gantt` and `plugin-grid`'s `ImportWizard` keep their local hooks —
+  they fall back *per key*, which a single-probe factory cannot express and
+  which their comments justify (a host dictionary that covers common keys but
+  lags on newer ones). Only the `try`/`catch` is removed.
+- `ObjectTimeline` and `ObjectView` call the hook directly and probe the
+  returned value, mirroring `useSafeFieldLabel`.
+
+Adds `object-ui/no-try-catch-around-hook` (error) so a twelfth copy fails CI.
+It only matches `use*` names, accepts member calls solely on `React` (so
+`vi.useRealTimers()` is not a hook), and resets its try-depth inside nested
+functions (so `renderHook(() => useThing())` inside a `try` is fine) — both
+false positives were real code in this repo and are pinned in the rule's tests.
+
+`eslint-rules/**/*.test.js` matched no vitest project glob, so the local
+plugin's specs had never run in CI. They are now included; all three pass.
+
+`ObjectTimeline`'s test mock of `@object-ui/react` omitted `useObjectLabel` —
+the removed `try`/`catch` had been silently absorbing that gap. The mock is now
+complete.

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -3,10 +3,12 @@
  */
 import noSyntheticEventTrigger from './no-synthetic-event-trigger.js';
 import noInlineSpecConfig from './no-inline-spec-config.js';
+import noTryCatchAroundHook from './no-try-catch-around-hook.js';
 
 export default {
   rules: {
     'no-synthetic-event-trigger': noSyntheticEventTrigger,
     'no-inline-spec-config': noInlineSpecConfig,
+    'no-try-catch-around-hook': noTryCatchAroundHook,
   },
 };

--- a/eslint-rules/no-try-catch-around-hook.js
+++ b/eslint-rules/no-try-catch-around-hook.js
@@ -1,0 +1,99 @@
+/**
+ * ObjectUI ESLint rule: no-try-catch-around-hook
+ *
+ * Bans wrapping a React hook call in `try`/`catch`.
+ *
+ * A `catch` that swallows a throw from a hook desyncs hook order on the next
+ * render: the hooks that already ran before the throw were registered, the
+ * ones after it were not, and React matches hooks positionally. The result is
+ * the classic "Rendered fewer hooks than expected" crash, or silently reading
+ * another hook's state.
+ *
+ * This exists because the pattern kept getting copy-pasted. objectui#2595 /
+ * #2596 fixed it in `@object-ui/i18n`'s `createSafeTranslation`, but nine
+ * plugin-local re-implementations kept their own `try { useObjectTranslation() }
+ * catch {}` (objectui#2879) — every one of them written to make a hook
+ * "provider-safe", which the hook already is.
+ *
+ * The correct pattern for "no provider mounted" is a VALUE probe after the
+ * hook has run (e.g. `t(testKey) === testKey` → use English defaults), not a
+ * `catch`. See `packages/i18n/src/useSafeTranslation.ts`.
+ *
+ * Scope, deliberately narrow to stay false-positive free:
+ *  - Only `use*` names, per React's own convention.
+ *  - Bare identifiers and `React.useX` only. `vi.useRealTimers()` and
+ *    `jest.useFakeTimers()` are test utilities, not hooks.
+ *  - The try-depth RESETS inside a nested function. A hook called in a
+ *    callback that merely happens to be written inside a try —
+ *    `renderHook(() => useCondition(...))` — runs during React's render of
+ *    that component, not in the try's synchronous flow, and is fine.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+
+/** React's own convention: a hook is `use` followed by a non-lowercase char. */
+function isHookName(name) {
+  return typeof name === 'string' && /^use[A-Z0-9]/.test(name);
+}
+
+/**
+ * Resolve the called name, but only for shapes that can be a React hook.
+ * `vi.useRealTimers()` / `jest.useFakeTimers()` are namespaced test helpers
+ * that match the `use*` spelling by coincidence, so member calls are accepted
+ * only on `React`.
+ */
+function hookCalleeName(callee) {
+  if (callee.type === 'Identifier') return callee.name;
+  if (
+    callee.type === 'MemberExpression' &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'React' &&
+    callee.property.type === 'Identifier'
+  ) {
+    return callee.property.name;
+  }
+  return undefined;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow calling a React hook inside try/catch — a caught throw desyncs hook order on the next render (objectui#2595/#2596/#2879).',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      banned:
+        "Do not call the hook '{{name}}' inside try/catch — a caught throw desyncs hook order on the next render (objectui#2879). Call the hook unconditionally and probe its RETURN VALUE for the degraded case; see createSafeTranslation in packages/i18n/src/useSafeTranslation.ts.",
+    },
+  },
+  create(context) {
+    // Stack of try-depths, one frame per enclosing function. Entering a
+    // function pushes a fresh 0 so a callback written inside a try starts
+    // clean; leaving pops back to the outer count.
+    const frames = [0];
+    const bump = (n) => { frames[frames.length - 1] += n; };
+
+    const enterFn = () => { frames.push(0); };
+    const exitFn = () => { frames.pop(); };
+
+    return {
+      ':function': enterFn,
+      ':function:exit': exitFn,
+
+      'TryStatement > BlockStatement': () => bump(1),
+      'TryStatement > BlockStatement:exit': () => bump(-1),
+      'CatchClause > BlockStatement': () => bump(1),
+      'CatchClause > BlockStatement:exit': () => bump(-1),
+
+      CallExpression(node) {
+        if (frames[frames.length - 1] === 0) return;
+        const name = hookCalleeName(node.callee);
+        if (!isHookName(name)) return;
+        context.report({ node, messageId: 'banned', data: { name } });
+      },
+    };
+  },
+};

--- a/eslint-rules/no-try-catch-around-hook.test.js
+++ b/eslint-rules/no-try-catch-around-hook.test.js
@@ -1,0 +1,67 @@
+/**
+ * Pins `no-try-catch-around-hook` against the two false positives that the
+ * first draft of the rule produced when it was run across the repo:
+ *
+ *  - `vi.useRealTimers()` / `jest.useFakeTimers()` — test helpers that match
+ *    the `use*` spelling by coincidence and are not React hooks.
+ *  - `renderHook(() => useThing())` inside a try — the hook runs during
+ *    React's render of the harness component, not in the try's synchronous
+ *    flow, so hook order is unaffected.
+ *
+ * Both were real code in this repo (packages/auth/.../createAuthClient.test.ts
+ * and packages/react/.../useExpression.test.ts), which is why they are pinned
+ * rather than left to judgement.
+ */
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from './no-try-catch-around-hook.js';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-try-catch-around-hook', rule, {
+  valid: [
+    // The correct shape: hook first, probe its return value.
+    `function useThing() {
+       const r = useObjectTranslation();
+       return r.t('k') === 'k' ? FALLBACK : r.t;
+     }`,
+    // Namespaced test helpers are not hooks.
+    `function t() { try { vi.useRealTimers(); } finally { done(); } }`,
+    `function t() { try { jest.useFakeTimers(); } catch { /* noop */ } }`,
+    // Hook inside a nested callback: runs under React's render, not the try.
+    `function t() {
+       try { renderHook(() => useCondition(SRC)); } finally { cleanup(); }
+     }`,
+    // try/catch with no hook at all.
+    `function t() { try { JSON.parse(s); } catch { return null; } }`,
+    // Lowercase `user*` must not be mistaken for a hook.
+    `function t() { try { username(); } catch { return null; } }`,
+  ],
+  invalid: [
+    {
+      code: `function useBad() {
+        try { const r = useObjectTranslation(); return { t: r.t }; }
+        catch { return { t: (k) => k }; }
+      }`,
+      errors: [{ messageId: 'banned' }],
+    },
+    {
+      code: `function useBad() { try { return useObjectLabel(); } catch { return null; } }`,
+      errors: [{ messageId: 'banned' }],
+    },
+    // `React.useX` member form is still a hook.
+    {
+      code: `function useBad() { try { return React.useMemo(f, []); } catch { return null; } }`,
+      errors: [{ messageId: 'banned' }],
+    },
+    // A hook in the catch body is equally order-desyncing.
+    {
+      code: `function useBad() { try { f(); } catch { return useObjectTranslation(); } }`,
+      errors: [{ messageId: 'banned' }],
+    },
+  ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,12 @@ export default tseslint.config({ ignores: ['**/dist', '**/.next', '**/node_modul
     // new violation fails CI; the existing surfaces were converted to direct
     // idempotent commands first, so this lints clean today.
     'object-ui/no-synthetic-event-trigger': 'error',
+    // objectui#2879 ratchet — a hook called inside try/catch desyncs hook order
+    // when the catch swallows a throw. #2595/#2596 fixed this in the canonical
+    // createSafeTranslation; nine plugin-local copies kept it until #2879.
+    // Error so a tenth copy fails CI; all known sites were converted first, so
+    // this lints clean today.
+    'object-ui/no-try-catch-around-hook': 'error',
   },
 }, {
   // Type-discipline ratchet, scoped to the canonical view-schema file: a

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -13,7 +13,8 @@ import { resolveIcon } from '../action/resolve-icon';
 import { useGridFieldAuthoring } from '../../context/gridFieldAuthoring';
 import { ComponentRegistry } from '@object-ui/core';
 import type { DataTableSchema } from '@object-ui/types';
-import { useObjectTranslation, useRowPredicate } from '@object-ui/react';
+import { useRowPredicate } from '@object-ui/react';
+import { createSafeTranslation } from '@object-ui/i18n';
 import { 
   Table, 
   TableHeader, 
@@ -155,41 +156,12 @@ const TABLE_DEFAULT_TRANSLATIONS: Record<string, string> = {
 /**
  * Safe wrapper for useObjectTranslation that falls back to English defaults
  * when I18nProvider is not available (e.g., standalone usage).
+ *
+ * Delegates to `@object-ui/i18n`'s `createSafeTranslation` (which also
+ * surfaces `language` for the date/number formatting below); the local copy
+ * this replaced wrapped the hook in try/catch (rules-of-hooks, objectui#2879).
  */
-function useTableTranslation() {
-  try {
-    const result = useObjectTranslation();
-    const testValue = result.t('table.rowsPerPage');
-    if (testValue === 'table.rowsPerPage') {
-      return {
-        t: (key: string, options?: Record<string, unknown>) => {
-          let value = TABLE_DEFAULT_TRANSLATIONS[key] || key;
-          if (options) {
-            for (const [k, v] of Object.entries(options)) {
-              value = value.replace(`{{${k}}}`, String(v));
-            }
-          }
-          return value;
-        },
-        language: result.language || 'en',
-      };
-    }
-    return { t: result.t, language: result.language || 'en' };
-  } catch {
-    return {
-      t: (key: string, options?: Record<string, unknown>) => {
-        let value = TABLE_DEFAULT_TRANSLATIONS[key] || key;
-        if (options) {
-          for (const [k, v] of Object.entries(options)) {
-            value = value.replace(`{{${k}}}`, String(v));
-          }
-        }
-        return value;
-      },
-      language: 'en',
-    };
-  }
-}
+const useTableTranslation = createSafeTranslation(TABLE_DEFAULT_TRANSLATIONS, 'table.rowsPerPage');
 
 /**
  * Pull the most useful human-readable message out of whatever the save path

--- a/packages/i18n/src/useSafeTranslation.ts
+++ b/packages/i18n/src/useSafeTranslation.ts
@@ -37,10 +37,15 @@ export function createSafeTranslation(
     // "translations not configured" fallback.
     const result = useObjectTranslation();
     const testValue = result.t(testKey);
+    // `language` is surfaced so consumers that localize dates/numbers
+    // alongside their copy (data-table, gantt) don't have to call
+    // `useObjectTranslation` a second time just to read it. With no provider
+    // it is whatever react-i18next reports, which callers may treat as
+    // "follow the runtime default".
     if (testValue === testKey) {
-      return { t: fallbackT };
+      return { t: fallbackT, language: result.language };
     }
-    return { t: result.t };
+    return { t: result.t, language: result.language };
   };
 }
 

--- a/packages/plugin-calendar/src/CalendarView.tsx
+++ b/packages/plugin-calendar/src/CalendarView.tsx
@@ -23,7 +23,7 @@ import {
   PopoverContent,
   PopoverTrigger
 } from "@object-ui/components"
-import { useObjectTranslation } from "@object-ui/i18n"
+import { createSafeTranslation } from "@object-ui/i18n"
 
 const DEFAULT_EVENT_COLOR = "bg-blue-100 text-blue-900 border border-blue-200"
 const STABLE_DEFAULT_DATE = new Date()
@@ -87,43 +87,11 @@ const DEFAULT_TRANSLATIONS: Record<string, string> = {
 /**
  * Safe wrapper for useObjectTranslation that falls back to English defaults
  * when I18nProvider is not available (e.g., standalone usage outside console).
+ *
+ * Delegates to `@object-ui/i18n`'s `createSafeTranslation`; the local copy this
+ * replaced wrapped the hook in try/catch (rules-of-hooks, objectui#2879).
  */
-function useCalendarTranslation() {
-  try {
-    const result = useObjectTranslation()
-    // Check if i18n is properly initialized by testing a known key
-    const testValue = result.t('calendar.today')
-    if (testValue === 'calendar.today') {
-      // i18n returned the key itself — not initialized
-      return {
-        t: (key: string, options?: Record<string, unknown>) => {
-          let value = DEFAULT_TRANSLATIONS[key] || key
-          if (options) {
-            for (const [k, v] of Object.entries(options)) {
-              value = value.replace(`{{${k}}}`, String(v))
-            }
-          }
-          return value
-        },
-        language: 'en',
-      }
-    }
-    return { t: result.t, language: result.language }
-  } catch {
-    return {
-      t: (key: string, options?: Record<string, unknown>) => {
-        let value = DEFAULT_TRANSLATIONS[key] || key
-        if (options) {
-          for (const [k, v] of Object.entries(options)) {
-            value = value.replace(`{{${k}}}`, String(v))
-          }
-        }
-        return value
-      },
-      language: 'en',
-    }
-  }
-}
+const useCalendarTranslation = createSafeTranslation(DEFAULT_TRANSLATIONS, 'calendar.today')
 
 export interface CalendarEvent {
   id: string | number

--- a/packages/plugin-designer/src/hooks/useDesignerTranslation.ts
+++ b/packages/plugin-designer/src/hooks/useDesignerTranslation.ts
@@ -11,7 +11,7 @@
  * when I18nProvider is not available (e.g., standalone usage outside console).
  */
 
-import { useObjectTranslation } from '@object-ui/i18n';
+import { createSafeTranslation } from '@object-ui/i18n';
 
 const DESIGNER_DEFAULT_TRANSLATIONS: Record<string, string> = {
   // Step labels & descriptions
@@ -193,28 +193,11 @@ const DESIGNER_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'common.edit': 'Edit',
 };
 
-function createFallbackTranslator(defaults: Record<string, string>) {
-  return (key: string, options?: Record<string, unknown>): string => {
-    let value = defaults[key] || key;
-    if (options) {
-      for (const [k, v] of Object.entries(options)) {
-        value = value.replace(`{{${k}}}`, String(v));
-      }
-    }
-    return value;
-  };
-}
-
-export function useDesignerTranslation() {
-  try {
-    const result = useObjectTranslation();
-    const testValue = result.t('appDesigner.basicInfo');
-    if (testValue === 'appDesigner.basicInfo') {
-      // i18n returned the key itself — not initialized
-      return { t: createFallbackTranslator(DESIGNER_DEFAULT_TRANSLATIONS) };
-    }
-    return { t: result.t };
-  } catch {
-    return { t: createFallbackTranslator(DESIGNER_DEFAULT_TRANSLATIONS) };
-  }
-}
+/**
+ * Delegates to `@object-ui/i18n`'s `createSafeTranslation`; the local copy this
+ * replaced wrapped the hook in try/catch (rules-of-hooks, objectui#2879).
+ */
+export const useDesignerTranslation = createSafeTranslation(
+  DESIGNER_DEFAULT_TRANSLATIONS,
+  'appDesigner.basicInfo',
+);

--- a/packages/plugin-detail/src/useDetailTranslation.ts
+++ b/packages/plugin-detail/src/useDetailTranslation.ts
@@ -6,52 +6,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useObjectTranslation } from '@object-ui/react';
+import { createSafeTranslation } from '@object-ui/i18n';
 
 /**
  * Create a safe translation hook with fallback to defaults.
- * Follows the same pattern as useGridTranslation / useListViewTranslation.
+ *
+ * Thin alias over `@object-ui/i18n`'s `createSafeTranslation` — this used to
+ * be a local re-implementation that wrapped the hook call in try/catch, which
+ * violates rules-of-hooks (objectui#2879, same class as #2595/#2596).
+ * `useObjectTranslation` is provider-safe and never throws, so the testKey
+ * probe alone carries the "translations not configured" fallback.
  *
  * @param defaults - Fallback English translations keyed by i18n key
  * @param testKey - A key to test if i18n is properly configured
  */
-export function createSafeTranslationHook(
-  defaults: Record<string, string>,
-  testKey: string,
-) {
-  return function useSafeTranslation() {
-    try {
-      const result = useObjectTranslation();
-      const testValue = result.t(testKey);
-      if (testValue === testKey) {
-        return {
-          t: (key: string, options?: Record<string, unknown>) => {
-            let value = defaults[key] || key;
-            if (options) {
-              for (const [k, v] of Object.entries(options)) {
-                value = value.replace(`{{${k}}}`, String(v));
-              }
-            }
-            return value;
-          },
-        };
-      }
-      return { t: result.t };
-    } catch {
-      return {
-        t: (key: string, options?: Record<string, unknown>) => {
-          let value = defaults[key] || key;
-          if (options) {
-            for (const [k, v] of Object.entries(options)) {
-              value = value.replace(`{{${k}}}`, String(v));
-            }
-          }
-          return value;
-        },
-      };
-    }
-  };
-}
+export const createSafeTranslationHook = createSafeTranslation;
 
 /**
  * Default English translations for detail view components.

--- a/packages/plugin-gantt/src/useGanttTranslation.ts
+++ b/packages/plugin-gantt/src/useGanttTranslation.ts
@@ -100,31 +100,31 @@ function fallback(key: string, options?: Record<string, unknown>): string {
 }
 
 export function useGanttTranslation() {
-  try {
-    const result = useObjectTranslation();
-    // `language` is a BCP-47 tag (e.g. 'zh', 'en'). We thread it into the
-    // date formatters so the calendar headers/tooltips localize to the SAME
-    // language as the chrome, instead of silently following the browser
-    // locale (which can diverge — English UI but Chinese dates).
-    const language = result.language as string | undefined;
-    // Per-key fallback. A consuming app's i18n dictionary commonly translates
-    // the *common* gantt keys (column headers, toolbar) but lags behind on
-    // newer ones (link types, dependency context-menu). i18next returns the
-    // raw key string for a miss, which would surface untranslated keys like
-    // `gantt.linkType.fs` in the UI. So for every key we let the host resolve
-    // it first and fall back to our bundled English default ONLY when the host
-    // returns the key unchanged (a miss). An all-or-nothing probe on a single
-    // key can't catch a partially-translated host dictionary.
-    const t = (key: string, options?: Record<string, unknown>): string => {
-      const hostValue = result.t(key, options as never) as unknown;
-      if (typeof hostValue === 'string' && hostValue !== key) return hostValue;
-      return fallback(key, options);
-    };
-    return { t, language };
-  } catch {
-    // No I18nProvider on the tree (standalone embed / unit tests): keep the
-    // English fallback and let dates follow the browser locale (language
-    // undefined → toLocaleDateString uses the runtime default).
-    return { t: fallback, language: undefined as string | undefined };
-  }
+  // Deliberately NOT `createSafeTranslation`: that probes a single testKey and
+  // then serves defaults for everything, which can't handle a host dictionary
+  // that translates the common gantt keys but lags on newer ones (see the
+  // per-key rationale below). No try/catch either — `useObjectTranslation` is
+  // provider-safe and wrapping a hook in try/catch violates rules-of-hooks
+  // (objectui#2879, same class as #2595/#2596).
+  const result = useObjectTranslation();
+  // `language` is a BCP-47 tag (e.g. 'zh', 'en'). We thread it into the
+  // date formatters so the calendar headers/tooltips localize to the SAME
+  // language as the chrome, instead of silently following the browser
+  // locale (which can diverge — English UI but Chinese dates).
+  const language = result.language as string | undefined;
+  // Per-key fallback. A consuming app's i18n dictionary commonly translates
+  // the *common* gantt keys (column headers, toolbar) but lags behind on
+  // newer ones (link types, dependency context-menu). i18next returns the
+  // raw key string for a miss, which would surface untranslated keys like
+  // `gantt.linkType.fs` in the UI. So for every key we let the host resolve
+  // it first and fall back to our bundled English default ONLY when the host
+  // returns the key unchanged (a miss). An all-or-nothing probe on a single
+  // key can't catch a partially-translated host dictionary.
+  const t = (key: string, options?: Record<string, unknown>): string => {
+    const hostValue = result.t(key, options as never) as unknown;
+    if (typeof hostValue === 'string' && hostValue !== key) return hostValue;
+    return fallback(key, options);
+  };
+  return { t, language };
 }
+

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -205,25 +205,26 @@ function interpolate(template: string, vars?: Record<string, unknown>): string {
 }
 
 /** Translation hook with safe English fallback for standalone usage.
- *  Mirrors the pattern in ObjectGrid.tsx — when no I18nProvider is mounted
- *  (e.g. unit tests) the hook still resolves `grid.import.*`
- *  keys via the embedded defaults so the wizard stays usable. */
+ *  When no I18nProvider is mounted (e.g. unit tests) the hook still resolves
+ *  `grid.import.*` keys via the embedded defaults so the wizard stays usable. */
 function useImportTranslation(): { t: (key: string, vars?: Record<string, unknown>) => string } {
   const fallback = (key: string, vars?: Record<string, unknown>) =>
     interpolate(IMPORT_DEFAULT_TRANSLATIONS[key] ?? key, vars);
-  try {
-    const result = useObjectTranslation();
-    const probe = result.t('grid.import.title');
-    if (probe === 'grid.import.title') return { t: fallback };
-    return {
-      t: (key, vars) => {
-        const v = result.t(key, vars as Record<string, unknown> | undefined);
-        return v === key ? fallback(key, vars) : v;
-      },
-    };
-  } catch {
-    return { t: fallback };
-  }
+  // Deliberately NOT `createSafeTranslation`: that probes one testKey and then
+  // serves defaults for everything, whereas the wizard falls back per key so a
+  // host dictionary that covers the common keys but lags on newer ones still
+  // resolves what it has. No try/catch either — `useObjectTranslation` is
+  // provider-safe, and wrapping a hook in try/catch violates rules-of-hooks
+  // (objectui#2879, same class as #2595/#2596).
+  const result = useObjectTranslation();
+  const probe = result.t('grid.import.title');
+  if (probe === 'grid.import.title') return { t: fallback };
+  return {
+    t: (key, vars) => {
+      const v = result.t(key, vars as Record<string, unknown> | undefined);
+      return v === key ? fallback(key, vars) : v;
+    },
+  };
 }
 
 /** @internal — exported solely for unit tests. */

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -25,7 +25,8 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { ObjectGridSchema, DataSource, ListColumn, ViewData } from '@object-ui/types';
 import { isSystemManagedField } from '@object-ui/types';
 import type { I18nLabel } from '@objectstack/spec/ui';
-import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useObjectTranslation, useSafeFieldLabel, usePredicateScope } from '@object-ui/react';
+import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useSafeFieldLabel, usePredicateScope } from '@object-ui/react';
+import { createSafeTranslation } from '@object-ui/i18n';
 import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses, FieldEditWidget, hasFieldEditWidget, DISCRETE_EDIT_TYPES, coerceToSafeValue } from '@object-ui/fields';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import { stateMachineNextValues, isFieldInlineEditable } from './inline-edit-options';
@@ -105,39 +106,11 @@ const GRID_DEFAULT_TRANSLATIONS: Record<string, string> = {
 /**
  * Safe wrapper for useObjectTranslation that falls back to English defaults
  * when I18nProvider is not available (e.g., standalone usage).
+ *
+ * Delegates to `@object-ui/i18n`'s `createSafeTranslation`; the local copy this
+ * replaced wrapped the hook in try/catch (rules-of-hooks, objectui#2879).
  */
-function useGridTranslation() {
-  try {
-    const result = useObjectTranslation();
-    const testValue = result.t('grid.actions');
-    if (testValue === 'grid.actions') {
-      return {
-        t: (key: string, options?: Record<string, unknown>) => {
-          let value = GRID_DEFAULT_TRANSLATIONS[key] || key;
-          if (options) {
-            for (const [k, v] of Object.entries(options)) {
-              value = value.replace(`{{${k}}}`, String(v));
-            }
-          }
-          return value;
-        },
-      };
-    }
-    return { t: result.t };
-  } catch {
-    return {
-      t: (key: string, options?: Record<string, unknown>) => {
-        let value = GRID_DEFAULT_TRANSLATIONS[key] || key;
-        if (options) {
-          for (const [k, v] of Object.entries(options)) {
-            value = value.replace(`{{${k}}}`, String(v));
-          }
-        }
-        return value;
-      },
-    };
-  }
-}
+const useGridTranslation = createSafeTranslation(GRID_DEFAULT_TRANSLATIONS, 'grid.actions');
 
 /** Resolve an I18nLabel (string) to a plain string. */
 function resolveColumnLabel(label: string | I18nLabel | undefined): string | undefined {

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -20,7 +20,7 @@ import type { ListViewSchema } from '@object-ui/types';
 import { detectStatusField } from '@object-ui/types';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { resolveConditionalFormatting, buildExpandFields, buildExportFileName } from '@object-ui/core';
-import { useObjectTranslation, useObjectLabel, useSafeFieldLabel } from '@object-ui/i18n';
+import { useObjectTranslation, useObjectLabel, useSafeFieldLabel, createSafeTranslation } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
 
 export interface ListViewProps {
@@ -266,33 +266,18 @@ const LIST_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'list.viewSettingsHint': 'Grouping, color, density, and visible fields.',
 };
 
-const fallbackListT = (key: string, options?: Record<string, unknown>) => {
-  let value = LIST_DEFAULT_TRANSLATIONS[key] || key;
-  if (options) {
-    for (const [k, v] of Object.entries(options)) {
-      value = value.replace(`{{${k}}}`, String(v));
-    }
-  }
-  return value;
-};
-
 /**
  * Safe wrapper for useObjectTranslation that falls back to English defaults
  * when I18nProvider is not available (e.g., standalone usage outside console).
+ *
+ * Delegates to `@object-ui/i18n`'s `createSafeTranslation`. The local copy
+ * this replaced wrapped the hook in try/catch — the very thing the comment on
+ * `useListViewObjectLabel` below warns against (objectui#2879).
  */
-function useListViewTranslation() {
-  try {
-    const result = useObjectTranslation();
-    const testValue = result.t('list.recordCount');
-    if (testValue === 'list.recordCount') {
-      // i18n returned the key itself — not initialized
-      return { t: fallbackListT };
-    }
-    return { t: result.t };
-  } catch {
-    return { t: fallbackListT };
-  }
-}
+const useListViewTranslation = createSafeTranslation(
+  LIST_DEFAULT_TRANSLATIONS,
+  'list.recordCount',
+);
 
 /**
  * Thin selector over useObjectLabel. The underlying hook is provider-safe

--- a/packages/plugin-timeline/package.json
+++ b/packages/plugin-timeline/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
+    "@object-ui/i18n": "workspace:*",
     "@object-ui/mobile": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",

--- a/packages/plugin-timeline/src/ObjectTimeline.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.test.tsx
@@ -19,6 +19,15 @@ vi.mock('@object-ui/react', async () => {
       mode: 'overlay',
       view: undefined,
     }),
+    // `useObjectLabel` was missing here. It used to be masked by a try/catch
+    // around the hook inside ObjectTimeline — which meant this mock's gap was
+    // silently absorbed by production code that had a rules-of-hooks bug
+    // (objectui#2879). With that removed, the mock has to be complete.
+    useObjectLabel: () => ({
+      fieldOptionLabel: (_o: string, _f: string, _v: string, fallback: string) => fallback,
+      translateOptions: (_o: string, _f: string, opts: unknown[]) => opts,
+      fieldLabel: (_o: string, _f: string, fallback: string) => fallback,
+    }),
     SchemaRendererContext: React.createContext(null),
   };
 });

--- a/packages/plugin-timeline/src/ObjectTimeline.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.tsx
@@ -19,17 +19,22 @@ import { useTimelineTranslation } from './useTimelineTranslation';
 /**
  * Wrap `useObjectLabel` so the timeline keeps rendering when no
  * I18nProvider is mounted (standalone usage / unit tests).
+ *
+ * No try/catch: `useObjectLabel` delegates to the provider-safe
+ * `useObjectTranslation` and never throws, and wrapping a hook call in
+ * try/catch violates rules-of-hooks — a throw after other hooks ran would
+ * desync hook order on the next render (objectui#2879, same class as
+ * #2595/#2596). The nullish guard is the defensive default, mirroring
+ * `useSafeFieldLabel` in `@object-ui/i18n`.
  */
+const OBJECT_LABEL_FALLBACK = {
+  fieldOptionLabel: (_o: string, _f: string, _v: string, fallback: string) => fallback,
+  translateOptions: <T extends { value: string; label: string }>(_o: string, _f: string, opts: T[]) => opts,
+  fieldLabel: (_o: string, _f: string, fallback: string) => fallback,
+} as any;
+
 function useSafeObjectLabel() {
-  try {
-    return useObjectLabel();
-  } catch {
-    return {
-      fieldOptionLabel: (_o: string, _f: string, _v: string, fallback: string) => fallback,
-      translateOptions: <T extends { value: string; label: string }>(_o: string, _f: string, opts: T[]) => opts,
-      fieldLabel: (_o: string, _f: string, fallback: string) => fallback,
-    } as any;
-  }
+  return useObjectLabel() ?? OBJECT_LABEL_FALLBACK;
 }
 
 const TimelineMappingSchema = z.object({

--- a/packages/plugin-timeline/src/useTimelineTranslation.ts
+++ b/packages/plugin-timeline/src/useTimelineTranslation.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useObjectTranslation } from '@object-ui/react';
+import { createSafeTranslation } from '@object-ui/i18n';
 
 /**
  * Default English translations for ObjectTimeline. Mirrors the
@@ -32,25 +32,12 @@ export const TIMELINE_DEFAULT_TRANSLATIONS: Record<string, string> = {
 
 const TEST_KEY = 'timeline.bucket.today';
 
-function fallback(key: string, options?: Record<string, unknown>): string {
-  let v = TIMELINE_DEFAULT_TRANSLATIONS[key] || key;
-  if (options) {
-    for (const [k, val] of Object.entries(options)) {
-      v = v.replace(`{{${k}}}`, String(val));
-    }
-  }
-  return v;
-}
-
-export function useTimelineTranslation() {
-  try {
-    const result = useObjectTranslation();
-    const testValue = result.t(TEST_KEY);
-    if (testValue === TEST_KEY) {
-      return { t: fallback };
-    }
-    return { t: result.t };
-  } catch {
-    return { t: fallback };
-  }
-}
+/**
+ * Was a local re-implementation that wrapped the hook in try/catch — a
+ * rules-of-hooks violation (objectui#2879, same class as #2595/#2596).
+ * `useObjectTranslation` is provider-safe, so the probe alone is enough.
+ */
+export const useTimelineTranslation = createSafeTranslation(
+  TIMELINE_DEFAULT_TRANSLATIONS,
+  TEST_KEY,
+);

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -72,19 +72,18 @@ const SchemaRendererComponent: React.FC<any> = ImportedSchemaRenderer;
  * Record-create verb, shared with the runtime object pages: both surfaces
  * resolve `console.objectView.new` ("New" / 新建) so the Studio grid toolbar
  * and the running app never disagree (framework#2615 P3). Falls back to
- * English when no I18nProvider is mounted (standalone usage). The try/catch
- * mirrors plugin-grid's useGridTranslation — the hook is always attempted
- * first thing, so call order is stable.
+ * English when no I18nProvider is mounted (standalone usage) — via the
+ * key-identity probe, not a caught throw.
  */
 function useCreateVerb(): string {
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks -- always the first call; catch only guards a missing provider
-    const { t } = useObjectTranslation();
-    const value = t('console.objectView.new');
-    return value === 'console.objectView.new' ? 'New' : value;
-  } catch {
-    return 'New';
-  }
+  // No try/catch: `useObjectTranslation` is provider-safe (optional context
+  // read + react-i18next global-instance fallback) and never throws, so the
+  // key-identity probe below is the whole "no provider" path. Wrapping a hook
+  // in try/catch violates rules-of-hooks — a throw after it ran would desync
+  // hook order on the next render (objectui#2879, same class as #2595/#2596).
+  const { t } = useObjectTranslation();
+  const value = t('console.objectView.new');
+  return value === 'console.objectView.new' ? 'New' : value;
 }
 
 export interface ObjectViewProps {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2307,6 +2307,9 @@ importers:
       '@object-ui/core':
         specifier: workspace:*
         version: link:../core
+      '@object-ui/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@object-ui/mobile':
         specifier: workspace:*
         version: link:../mobile

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -139,7 +139,10 @@ export default defineConfig({
           // separately.
           isolate: false,
           setupFiles: [path.resolve(__dirname, 'vitest.setup.base.ts')],
-          include: ['packages/**/*.test.ts', 'examples/**/*.test.ts'],
+          // `eslint-rules/**` holds the local ESLint plugin's RuleTester specs.
+          // They were previously matched by no project glob, so the ratchet
+          // rules shipped with tests that never ran (objectui#2879).
+          include: ['packages/**/*.test.ts', 'examples/**/*.test.ts', 'eslint-rules/**/*.test.js'],
           exclude: [...sharedExclude, ...domTsTests],
         },
       },


### PR DESCRIPTION
Closes #2879.

## The bug

Eleven call sites wrapped a React hook in `try`/`catch` to make it "provider-safe". `useObjectTranslation` and `useObjectLabel` already are — they read context optionally (`context?.language || i18n.language || 'en'`) and fall back to react-i18next's global instance. They never throw. Compare `useI18nContext` immediately below, which *does* throw.

So the `catch` bought nothing and cost correctness: a throw **after** the hook ran desyncs hook order on the next render, because React matches hooks positionally.

This is not a new discovery — #2595/#2596 fixed exactly this in `@object-ui/i18n`'s `createSafeTranslation`, and its test file says so explicitly:

> Locks the fallback semantics of the safe-translation hooks **AFTER the try/catch-around-hook removal** … via the testKey probe / per-key detection, **not via a caught throw**.

Nine plugin-local re-implementations kept their own copy of the bug. `plugin-detail`'s was even named `useSafeTranslation` — the canonical name, minus the fix.

## What changed

| Treatment | Files |
|---|---|
| Delegate to `createSafeTranslation` | `plugin-detail`, `plugin-timeline`, `plugin-list`, `plugin-calendar`, `plugin-grid`/`ObjectGrid`, `plugin-designer`, `components`/`data-table` |
| Keep local hook, drop only the `try`/`catch` | `plugin-gantt`, `plugin-grid`/`ImportWizard` |
| Call hook directly + probe return value | `plugin-timeline`/`ObjectTimeline`, `plugin-view`/`ObjectView` |

**Gantt and ImportWizard are deliberately not consolidated.** They fall back **per key**, not on a single probe — so a host dictionary that translates the common keys but lags on newer ones still resolves what it has. A single-probe factory can't express that, and both files document the reasoning. Consolidating them would have been a silent behaviour regression.

`createSafeTranslation` now returns `language` alongside `t` (purely additive) so `data-table`'s `Intl.DateTimeFormat` consumer doesn't need a second hook call.

## Two things this surfaced that a grep could not

**1. Two more violations I'd missed.** My initial grep found 9; the lint rule found 11. `ObjectView` had an inline `eslint-disable-next-line react-hooks/rules-of-hooks` with the rationale *"always the first call; catch only guards a missing provider"* — which is the exact misconception the canonical comment refutes.

**2. The `try`/`catch` was masking a broken test mock.** With it removed, `ObjectTimeline.test.tsx` failed: its `vi.mock('@object-ui/react')` omits `useObjectLabel`. The catch had been absorbing that — which is precisely the class of real breakage a swallowed throw hides. Mock completed.

## The lint rule

`object-ui/no-try-catch-around-hook`, error-level, so a twelfth copy fails CI.

My first draft was too broad and I only found out by running it repo-wide — it flagged `vi.useRealTimers()` (a vitest helper matching `use*` by coincidence) and `renderHook(() => useCondition(…))` inside a `try` (the hook runs during React's render of the harness, not in the try's flow). Both were **real code in this repo**. The rule now matches only `use*` names, accepts member calls solely on `React`, and resets its try-depth inside nested functions. Both false positives are pinned as `valid` cases in its tests.

**`eslint-rules/**/*.test.js` matched no vitest project glob**, so the local plugin's specs — including the pre-existing `no-synthetic-event-trigger` and `no-inline-spec-config` ones — had never run in CI. Now included; all three files pass (25 tests).

## Verification

- Full suite: **7604 passed**, 1 skipped, 0 failed
- ESLint: repo-wide error count **identical to baseline** (25, all pre-existing); 0 hits for the new rule
- `turbo type-check`: clean except a pre-existing `maplibre-gl` default-export error in `plugin-map`, **verified identical on a stashed baseline**
- Rule verified by construction: fails on the bad pattern, passes on the good one, and on both false-positive shapes

One nuance worth flagging: imports go to `@object-ui/i18n` **directly**, not via `@object-ui/react`. I initially routed them through the `react` barrel, which tripped a module-init cycle — `data-table` threw at import time in the combined suite while passing in isolation. Importing directly matches what the three existing `components` consumers already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TubWYdWquVkS9dj733sDmC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TubWYdWquVkS9dj733sDmC)_