### PR TITLE
fix(actions): one precedence for `target`/`execute`, and stop mislabeling server-side `body`

### DIFF
--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -701,7 +701,13 @@ export class ActionRunner {
    * Supports ${} template expressions referencing data, record, user context.
    */
   private async executeScript(action: ActionDef): Promise<ActionResult> {
-    const script = action.execute || action.target;
+    // `target` is the canonical binding; `execute` is its deprecated alias
+    // (@objectstack/spec ActionSchema). Canonical wins when both are present,
+    // matching the spec's own fold and ActionPreview's `target ?? execute`.
+    // Spec >=16.1 folds `execute` into `target` and drops it at parse, so this
+    // only bites on raw, unparsed metadata — where the two readers used to
+    // disagree. Alias-only authoring still works via the fallback.
+    const script = action.target || action.execute;
     if (!script) {
       return { success: false, error: 'No script provided for script action' };
     }

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -132,6 +132,23 @@ export interface ActionDef {
   execute?: string;
   /** Target URL or identifier (for type: 'url', 'modal', 'flow') */
   target?: string;
+  /**
+   * Action body (spec `ActionSchema.body` — `HookBodySchema`). Opaque here:
+   * bodies are a SERVER-side execution surface and this runner never
+   * interprets one.
+   *
+   * L2 (`language: 'js'`) is defined as a function body run inside an isolated
+   * VM enforcing declared capabilities, `timeoutMs` and `memoryMb`. A browser
+   * has no such isolate, so "enforcing" those client-side would be decoration.
+   * L1 (`language: 'expression'`) is formula-engine (CEL) source, a different
+   * dialect from this package's `${…}` ExpressionEvaluator — running it here
+   * would diverge silently rather than fail.
+   *
+   * Consumers dispatch bodies by registering a `script` handler that POSTs to
+   * `/api/v1/actions/{object}/{action}` (see app-shell's
+   * `useConsoleActionRuntime`); the server runs the body through its sandbox.
+   */
+  body?: unknown;
   /** For type: 'url' — where to open `target`. `'new-tab'` forces a new
    *  browser tab/window, `'self'` forces same-page navigation. When omitted,
    *  external URLs open in a new tab and relative URLs navigate in place.
@@ -709,6 +726,19 @@ export class ActionRunner {
     // disagree. Alias-only authoring still works via the fallback.
     const script = action.target || action.execute;
     if (!script) {
+      // A spec `body` IS a script — this runner just cannot run one (see the
+      // `body` field docs). Saying "no script provided" would send the author
+      // hunting for a missing field they actually wrote, so name the real
+      // cause and the remedy instead.
+      if (action.body != null) {
+        return {
+          success: false,
+          error:
+            'Action body must be executed server-side — this client runner does not interpret ' +
+            '`body` (sandboxed JS needs an isolated VM; expression bodies use the formula engine). ' +
+            'Register a `script` handler that POSTs to /api/v1/actions/{object}/{action}.',
+        };
+      }
       return { success: false, error: 'No script provided for script action' };
     }
 

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -228,6 +228,39 @@ describe('ActionRunner', () => {
       expect(result.error).toContain('No script provided');
     });
 
+    it('should report a server-side body rather than claiming no script was provided', async () => {
+      // Spec-valid action: `body` IS the script, but bodies run server-side.
+      // The old message sent authors hunting for a field they had written.
+      const result = await runner.execute({
+        type: 'script',
+        body: { language: 'expression', source: 'input.amount > 1000' },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('server-side');
+      expect(result.error).not.toContain('No script provided');
+    });
+
+    it('should not interpret a js body client-side', async () => {
+      // L2 needs an isolated VM enforcing capabilities/timeout/memory — the
+      // browser has none, so this must refuse rather than approximate.
+      const result = await runner.execute({
+        type: 'script',
+        body: { language: 'js', source: 'return 1 + 1;', capabilities: [] },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('server-side');
+    });
+
+    it('should still evaluate a client-side target when a body is also present', async () => {
+      const result = await runner.execute({
+        type: 'script',
+        target: 'data.name',
+        body: { language: 'expression', source: 'input.amount > 1000' },
+      });
+      expect(result.success).toBe(true);
+      expect(result.data).toBe('Test');
+    });
+
     it('should return data as undefined for expressions referencing missing vars', async () => {
       const result = await runner.execute({
         type: 'script',

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -200,10 +200,23 @@ describe('ActionRunner', () => {
       expect(result.data).toBe(101);
     });
 
-    it('should evaluate script with string target fallback', async () => {
+    it('should evaluate script from the canonical target field', async () => {
       const result = await runner.execute({
         type: 'script',
         target: 'data.name',
+      });
+      expect(result.success).toBe(true);
+      expect(result.data).toBe('Test');
+    });
+
+    it('should prefer canonical target over the deprecated execute alias', async () => {
+      // Spec >=16.1 folds `execute` into `target` at parse, so the two keys only
+      // coexist on raw metadata. When they do, canonical wins — the same
+      // precedence ActionPreview and the spec's own fold already use.
+      const result = await runner.execute({
+        type: 'script',
+        target: 'data.name',
+        execute: 'record.id + 100',
       });
       expect(result.success).toBe(true);
       expect(result.data).toBe('Test');


### PR DESCRIPTION
Two fixes in `ActionRunner.executeScript`, both about the same question — *what source does a script action actually run?* Completes the cross-repo half of objectstack#3713 / objectstack#3742, and closes #2896.

## 1. `target` vs `execute` precedence

`executeScript` picked the deprecated alias first:

```ts
const script = action.execute || action.target;                    // ActionRunner.ts:704
```

`ActionPreview` already picked the canonical key first:

```ts
const target = (d.target as string | undefined) ?? (d.execute as string | undefined);   // ActionPreview.tsx:154
```

Two readers in this repo, two precedences — the drift shape objectstack#3713 fixed one field over. `@objectstack/spec` `ActionSchema` declares `target` canonical for **every** action type (including `script`) and `execute` deprecated.

**This is hardening, not a live bug fix**, and that's worth knowing before you review it: spec >= 16.1 (objectstack#3742) folds `execute` into `target` and drops the alias at parse, so parsed metadata never carries both keys, and the old `||` fell through to the right value anyway. The divergence only bites on **raw, unparsed** metadata — reachable, since this repo's `ActionDef` is hand-written rather than imported from the spec, but I could not produce it on a live path. What was wrong is that nothing *made* the two readers agree.

Now `target || execute`. Alias-only authoring is unaffected — with `target` absent the fallback still picks up `execute`, which is how this repo's own script-action tests are written. Behavior differs **only** when both keys are set.

## 2. A `body` is a script — say so

`ActionSchema.body` (`HookBodySchema`) is the spec's *preferred* binding for script actions:

```ts
// spec packages/spec/src/ui/action.zod.ts:306
// For `script` type: prefer `body` over `target`.
```

`executeScript` reads neither key of it, so a spec-valid action:

```json
{ "type": "script", "body": { "language": "expression", "source": "input.amount > 1000" } }
```

failed with **"No script provided for script action"** — false, and it sends the author hunting for a field they had written.

**Scope check:** this is *not* broken in the console. `useConsoleActionRuntime` registers `script: serverActionHandler`, registered handlers beat built-ins (ActionRunner.ts:493), and the server runs the body through its sandbox (`runtime/src/sandbox/*` → `engine.executeAction`). Only consumers registering **no** `script` handler — standalone core, SDUI, embedded renderers — hit the built-in.

**The fix is deliberately not a client-side body evaluator:**

- **L2 (`js`) must never run in the browser.** The contract is an isolated VM enforcing declared capabilities (`api.read`/`api.write`/`api.transaction`/…), `timeoutMs` and `memoryMb`. There is no isolate in a page, so "checking" capabilities client-side is decoration — and `api.write` from an unsandboxed page is strictly worse than no support.
- **L1 (`expression`) is a different dialect here.** The spec evaluates L1 with the formula engine (CEL). This package's `ExpressionEvaluator` is a `${…}` template evaluator. They agree on simple comparisons and diverge on the rest — silently wrong beats loudly unsupported only in the wrong direction.

So `body` is declared **opaque** on `ActionDef` (documented as server-executed) and the error now names the cause and the remedy: register a `script` handler POSTing to `/api/v1/actions/{object}/{action}`. Actions carrying no source at all keep the original message.

## Verification

- The precedence test fails on the old line and is the **only** failure under the old code (62 passed / 1 failed) — nothing else depended on alias-first order.
- 4 new tests: canonical-wins; body reported as server-side; `js` body refused, not approximated; a client-side `target` still wins when a body is also present.
- `pnpm type-check --filter @object-ui/core` — clean.
- Full `unit` project: **270 files / 3703 tests, all passing**.

## Out of scope

Wiring a *default* server dispatcher into `@object-ui/core`, so standalone consumers get body support without registering a handler. Core has no opinion about auth, base URL, or object resolution today — all of which `serverActionHandler` needs. Noted in #2896.

Also unchanged: the four renderers (`action-button`, `action-group`, `action-icon`, `action-menu`) forward both `target` and `execute` faithfully — pure plumbing, no precedence decision. And `execute` stays accepted on input; removing it is a separate breaking change to coordinate with the spec's own eventual removal.

Refs objectstack#3713, objectstack#3742
Closes #2896