### PR TITLE
test(attachments): pin the both-dialects signed-URL readers (objectstack#3689)

### DIFF
--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -449,6 +449,9 @@ export function ApprovalsInboxPage() {
       const res = await authFetch(`${base}/api/v1/storage/files/${encodeURIComponent(att.id)}/url`);
       if (!res.ok) throw new Error(`HTTP_${res.status}`);
       const body = await res.json().catch(() => null);
+      // Both dialects: the declared `{ success: true, data: { url } }` envelope
+      // this route answers as of objectstack#3689, and the bare `{ url }` an
+      // older server still sends — the console deploys independently of it.
       const raw = body?.data?.url ?? body?.url;
       if (!raw) throw new Error('NO_URL');
       // Signed URLs from the local adapter are relative; S3/GCS are absolute.

--- a/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
+++ b/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
@@ -228,6 +228,10 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
           throw Object.assign(new Error(code ?? `Download failed (${res.status})`), { code });
         }
         const body = await res.json();
+        // Both URL dialects, for the same independent-deploy reason as the
+        // error branch above: the route answered a bare `{ url }` until
+        // objectstack#3689 moved it into the declared
+        // `{ success: true, data: { url } }` envelope.
         const url: string | undefined = body?.url ?? body?.data?.url;
         if (!url) throw new Error('Download URL missing from response');
         const target = /^https?:/i.test(url) ? url : `${baseUrl}${url}`;

--- a/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
@@ -97,11 +97,13 @@ describe('RecordAttachmentsPanel — server-denial error mapping (#2755)', () =>
 describe('RecordAttachmentsPanel — authenticated signed-URL download (#2970)', () => {
   it('fetches /files/:id/url with auth and opens the signed URL', async () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    // The declared envelope the route answers as of objectstack#3689 — the URL
+    // moved from the top level down under `data`.
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ url: '/api/v1/storage/_local/raw/tok123' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+      new Response(
+        JSON.stringify({ success: true, data: { url: '/api/v1/storage/_local/raw/tok123' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
     );
     setup(makeDataSource());
     await waitFor(() => expect(screen.getByText('report.pdf')).toBeInTheDocument());
@@ -189,5 +191,32 @@ describe('RecordAttachmentsPanel — authenticated signed-URL download (#2970)',
       ),
     );
     expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  // Same reasoning on the SUCCESS path (objectstack#3689): the route used to
+  // answer a bare `{ url }` with no envelope at all. The reader takes both, so
+  // whichever repo lands first, downloads keep working — and this pins that
+  // tolerance as deliberate rather than incidental.
+  it('still opens the legacy bare `{ url }` shape (older server)', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ url: '/api/v1/storage/_local/raw/legacy-tok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    setup(makeDataSource());
+    await waitFor(() => expect(screen.getByText('report.pdf')).toBeInTheDocument());
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Download' }));
+
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/storage/_local/raw/legacy-tok'),
+        '_blank',
+        'noopener,noreferrer',
+      ),
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The console half of **objectstack#3689** — the success-path twin of the error-path fix in objectstack#3675 / objectui#2869.

## What changed upstream

`GET /api/v1/storage/files/:fileId/url` answered a bare `{ url }` and now answers the declared `{ success: true, data: { url } }` envelope. It was the one storage success body carrying no envelope at all, against a `storage.zod.ts` schema that declared one.

## Why this PR is tests and comments only

Both console readers of that route already took either shape:

- `packages/app-shell/src/views/RecordAttachmentsPanel.tsx` — `body?.url ?? body?.data?.url`
- `apps/console/src/pages/system/ApprovalsInboxPage.tsx` — `body?.data?.url ?? body?.url`

That tolerance is what lets the two repos land in any order, and it is exactly the posture objectui#2869 took for the error path. So there is nothing to fix here — what was missing is any statement that reading two dialects is deliberate rather than incidental, and anything holding it in place.

## Changes

- `RecordAttachmentsPanel.test.tsx` — the main download case now drives the **enveloped** shape (what the server sends as of #3689); a new dedicated case drives the **legacy bare** `{ url }` (what an older server still sends). This mirrors how the same file already covers both *error* dialects, including its existing legacy-`code` case.
- Both readers gain a comment naming the two dialects and the independent-deploy reason, matching the comment already on the error branch.

No behaviour change. `RecordAttachmentsPanel.test.tsx` 8/8 green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmnSQC8KxxsoZQe3oDEHjG)_