### PR TITLE
fix(console): the API console's AI group lists the routes that exist (framework#3718)

### DIFF
--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
@@ -45,21 +45,35 @@ function buildAuthEndpoints(authBase: string): EndpointDef[] {
 }
 
 export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRoute: string; endpoints: ServiceEndpointEntry[] }> = {
+  // The twelve routes `buildAIRoutes()` mounts, in table order (framework#3718).
+  // `/nlq`, `/suggest` and `/insights` used to sit here with "try it" bodies and
+  // always 404'd — they were declared in the framework's `DEFAULT_AI_ROUTES` and
+  // never implemented anywhere, so this page offered three endpoints that had no
+  // server. The audited table is cloud's `packages/service-ai/src/
+  // ai-route-ledger.ts`; when a route is added or renamed there, mirror it here.
+  //
+  // `/status` and `/effective-model` are deliberately NOT SDK surface (operator
+  // diagnostics) — which is exactly why they belong on this page: it explores raw
+  // HTTP, not `client.*`.
   ai: {
     group: 'AI',
     defaultRoute: '/api/v1/ai',
     endpoints: [
-      { method: 'POST', path: '/chat', desc: 'Chat completion', bodyTemplate: { messages: [{ role: 'user', content: '' }] } },
+      // The endpoint STREAMS unless told otherwise, so the JSON template says so:
+      // without `stream: false` a "try it" here buffers an SSE body as text.
+      // `/chat/stream` below is the one that means to stream.
+      { method: 'POST', path: '/chat', desc: 'Chat completion (JSON)', bodyTemplate: { messages: [{ role: 'user', content: '' }], stream: false } },
       { method: 'POST', path: '/chat/stream', desc: 'Streaming chat (SSE)', bodyTemplate: { messages: [{ role: 'user', content: '' }] } },
       { method: 'POST', path: '/complete', desc: 'Text completion', bodyTemplate: { prompt: '' } },
       { method: 'GET', path: '/models', desc: 'List available models' },
-      { method: 'POST', path: '/nlq', desc: 'Natural language query', bodyTemplate: { query: '' } },
-      { method: 'POST', path: '/suggest', desc: 'AI-powered suggestions', bodyTemplate: { object: '', field: '', context: {} } },
-      { method: 'POST', path: '/insights', desc: 'AI-generated insights', bodyTemplate: { object: '', recordIds: [] } },
+      { method: 'GET', path: '/status', desc: 'Active LLM adapter provenance' },
+      { method: 'GET', path: '/effective-model', desc: 'Effective model ids and where they came from' },
       { method: 'POST', path: '/conversations', desc: 'Create conversation', bodyTemplate: {} },
       { method: 'GET', path: '/conversations', desc: 'List conversations' },
-      { method: 'POST', path: '/conversations/:id/messages', desc: 'Add message to conversation', bodyTemplate: { role: 'user', content: '' } },
+      { method: 'GET', path: '/conversations/:id', desc: 'Get conversation with message history' },
+      { method: 'PATCH', path: '/conversations/:id', desc: 'Update conversation (title, metadata)', bodyTemplate: { title: '' } },
       { method: 'DELETE', path: '/conversations/:id', desc: 'Delete conversation' },
+      { method: 'POST', path: '/conversations/:id/messages', desc: 'Add message to conversation', bodyTemplate: { role: 'user', content: '' } },
     ],
   },
   workflow: {


### PR DESCRIPTION
The last piece of objectstack-ai/objectstack#3718, and the only user-visible one. The framework half landed in objectstack-ai/objectstack#3840, the guard half in objectstack-ai/cloud#902.

## The finding

The developer API console offered three AI endpoints that have never existed:

```
POST /api/v1/ai/nlq        →  404
POST /api/v1/ai/suggest    →  404
POST /api/v1/ai/insights   →  404
```

Each came with a **"try it" body template**, so this page didn't merely document them — it invited you to send one. They were declared in the framework's `DEFAULT_AI_ROUTES` (a registration table with no runtime consumer) and typed as optional protocol methods nothing implemented; framework#3840 deleted the declarations and the three dead `client.ai.*` methods that built the same URLs. This removes the last surface a user could click them from.

## What the AI group is now

The twelve routes `buildAIRoutes()` actually mounts, in table order:

| | before | after |
|---|---|---|
| entries in the AI catalog | 11 | **12** |
| …that a mounted route answers | 8 | **12** |
| endpoints that always 404 | **3** | 0 |

Four were missing rather than wrong:

- `GET /conversations/:id` and `PATCH /conversations/:id` — mounted since the conversations family landed; the catalog listed create/list/addMessage/delete and skipped read and update.
- `GET /status` and `GET /effective-model` — deliberately **not** SDK surface (cloud's ledger marks both `server-only`: adapter provenance and per-env model resolution, operator diagnostics). That is exactly why they belong here: this page explores raw HTTP, not `client.*`, and the console is the audience those two were written for.

One behavioral fix: **`POST /chat` streams unless the body says otherwise.** Its template now sends `stream: false`, so "try it" gets the JSON reply the panel renders. Without it the request comes back `text/event-stream` and `ApiConsolePage` buffers the whole SSE body through `res.text()` — a JSON-shaped request producing a wall of `data:` frames. `/chat/stream` keeps the streaming template; it is the one that means it.

## Where truth lives

The audited table is cloud's `packages/service-ai/src/ai-route-ledger.ts`, next to the routes it describes, and cloud#902 drives every `ai.*` SDK method against it. A comment in this file points there and asks that a route added or renamed in that table be mirrored here.

**No test is added, deliberately.** This repo cannot verify an AI URL resolves — `service-ai` is mounted from another repo, and nothing in the console's test environment answers `/api/v1/ai/*`. A test pinning this list to a hardcoded copy of itself would assert only that the catalog equals the catalog. That is the same evidence-free shape as the framework client tests framework#3840 replaced — they mocked `fetch`, asserted the URL the client built, and passed for years against endpoints that did not exist. The three dead entries removed here sat directly under such coverage.

## Verification

- `pnpm vitest run apps/console/src/pages/developer` — 8/8 across 2 files.
- `eslint` on the changed file — 0 errors (8 pre-existing warnings, untouched by this diff).
- `pnpm type-check --filter=@object-ui/console` — green.
- Data-only change to one catalog: no component, no hook logic, no rendering path touched.

## Not in this PR

The other `/api/v1/ai/*` builders in `service-ai` — `agents`, `tools`, `assistant`, `pending-actions`, `evals`, `conversations/:id/debug` — are real mounted routes this catalog has never listed. They sit outside the `buildAIRoutes()` table that #3718 audited, and several are gated differently; adding them unaudited would be guessing rather than the opposite of guessing. Worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJX6GnuNix7HisBc92THMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJX6GnuNix7HisBc92THMN)_