### PR TITLE
chore(type-check): `site` is not debt — its own `next build` type-checks it

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -30,7 +30,6 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 // peers already carry, so the TS6059 rootDir noise is excluded).
 const DEBT = {
   "@object-ui/plugin-form": { errors: 10, issue: 2919, note: "6x t() fallback-signature mismatch, 2x undefined index, 2x string|number" },
-  "@object-ui/site": { errors: 7, issue: 2919, note: "TS2304 on Next's generated LayoutProps/PageProps; needs .next/types from a prior next build" },
   "@object-ui/plugin-grid": { errors: 4, issue: 2919, note: "2x t() call signature + 2x TS2367 that are closure-mutation narrowing artifacts, NOT a logic bug" },
   "@object-ui/cli": { errors: 4, issue: 2919, note: "tsup dts:true does not fail on these" },
   "@object-ui/plugin-view": { errors: 3, issue: 2916, note: "Record<ViewType,...> missing the 'chart' key" },
@@ -44,6 +43,25 @@ const DEBT = {
 // on every run — the moment one gains a build script or a tsconfig it is a real
 // package, the exemption dies, and the guard fails.
 const NOT_COMPILED = ["@object-ui/example-hello-world"];
+
+// Packages whose own `build` type-checks them, so a separate `type-check` script
+// would only run the compiler twice. Unlike the `vite build` packages — which
+// transpile without checking, the hole that caused #2911 — `next build` runs a
+// full type-check unless `typescript.ignoreBuildErrors` is set.
+//
+// That escape hatch is exactly how this exemption could rot, so it is verified
+// on every run rather than trusted: setting `ignoreBuildErrors` fails the guard.
+const CHECKED_BY_OWN_BUILD = {
+  "@object-ui/site": {
+    build: "next build",
+    // Caveat worth knowing: the `docs` CI job runs this build only when
+    // `apps/site/` or `content/` changed (plus every push to main). A PR that
+    // only touches a workspace package in `transpilePackages` therefore does
+    // not re-check the site until it lands. Closing that would mean paying a
+    // Next build on many more PRs — a cost/coverage call, not a silent gap.
+    verifyNoIgnoreBuildErrors: "apps/site/next.config.mjs",
+  },
+};
 
 // ── Collect workspace packages ───────────────────────────────────────────────
 const GROUPS = ["packages", "apps", "examples"];
@@ -77,6 +95,7 @@ function collect() {
         name: pkg.name,
         dir,
         hasScript: Boolean(pkg.scripts?.["type-check"]),
+        build: pkg.scripts?.build,
         hasBuild: Boolean(pkg.scripts?.build),
         hasTsconfig,
       });
@@ -93,7 +112,7 @@ const errors = [];
 // 1. Undeclared gap — a package born without a type-check script.
 for (const pkg of packages) {
   if (pkg.hasScript) continue;
-  if (DEBT[pkg.name] || NOT_COMPILED.includes(pkg.name)) continue;
+  if (DEBT[pkg.name] || NOT_COMPILED.includes(pkg.name) || CHECKED_BY_OWN_BUILD[pkg.name]) continue;
   errors.push(
     `${pkg.name} (${pkg.dir}) has no "type-check" script, so \`pnpm type-check\` skips it entirely.\n` +
       `      Add  "type-check": "tsc --noEmit"  to its package.json. If its types do not compile\n` +
@@ -134,14 +153,58 @@ for (const name of NOT_COMPILED) {
   }
 }
 
+// 4. Ratchet — "its own build checks it" only holds while that stays true.
+for (const [name, spec] of Object.entries(CHECKED_BY_OWN_BUILD)) {
+  const pkg = byName.get(name);
+  if (!pkg) {
+    errors.push(`${name} is listed in CHECKED_BY_OWN_BUILD but is not a workspace package any more — delete the entry.`);
+    continue;
+  }
+  if (pkg.hasScript) {
+    errors.push(`${name} now has a "type-check" script — delete its CHECKED_BY_OWN_BUILD entry.`);
+    continue;
+  }
+  if (pkg.build !== spec.build) {
+    errors.push(
+      `${name} is exempt because its build is \`${spec.build}\`, which type-checks — but the build\n` +
+        `      script is now \`${pkg.build}\`. Re-confirm it still type-checks, then update or drop the entry.`
+    );
+    continue;
+  }
+  // `next build` type-checks by default; `ignoreBuildErrors` silently disables
+  // it, which would turn this exemption into exactly the hole #2911 was about.
+  if (spec.verifyNoIgnoreBuildErrors) {
+    const configPath = resolve(root, spec.verifyNoIgnoreBuildErrors);
+    let config;
+    try {
+      config = readFileSync(configPath, "utf8");
+    } catch {
+      errors.push(
+        `${name}: cannot read ${spec.verifyNoIgnoreBuildErrors}, so the exemption cannot be verified.\n` +
+          `      Point verifyNoIgnoreBuildErrors at the real config, or drop the exemption.`
+      );
+      continue;
+    }
+    if (/ignoreBuildErrors\s*:\s*true/.test(config)) {
+      errors.push(
+        `${name} sets \`ignoreBuildErrors: true\` in ${spec.verifyNoIgnoreBuildErrors}, so \`${spec.build}\`\n` +
+          `      no longer type-checks it and nothing else does either. Remove that flag, or add a\n` +
+          `      "type-check" script and delete this exemption.`
+      );
+    }
+  }
+}
+
 // ── Report ───────────────────────────────────────────────────────────────────
 const checked = packages.filter((p) => p.hasScript).length;
 const debtCount = Object.keys(DEBT).length;
 const debtErrors = Object.values(DEBT).reduce((sum, d) => sum + d.errors, 0);
+const byBuild = Object.keys(CHECKED_BY_OWN_BUILD).length;
 
 if (errors.length === 0) {
   console.log(
-    `✅  type-check coverage: ${checked}/${packages.length} packages checked, ` +
+    `✅  type-check coverage: ${checked}/${packages.length} via \`type-check\`, ` +
+      `${byBuild} via their own build, ` +
       `${debtCount} known-broken (${debtErrors} errors outstanding), ` +
       `${NOT_COMPILED.length} not compiled.`
   );


### PR DESCRIPTION
Follow-up off #2915 / #2919. Closes out the `@object-ui/site` entry by measuring it instead of assuming.

## It was miscategorised — zero errors, not 7

The #2911 sweep recorded `@object-ui/site` as **7 errors of debt**:

```
app/(home)/layout.tsx(4,46): error TS2304: Cannot find name 'LayoutProps'.
app/docs/[[...slug]]/page.tsx(9,43): error TS2304: Cannot find name 'PageProps'.
app/llms.mdx/docs/[[...slug]]/route.ts(6,54): error TS2304: Cannot find name 'RouteContext'.
...
```

Those are Next's **generated** types. `apps/site/tsconfig.json` includes them explicitly:

```json
"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"]
```

`.next/types` only exists after a build, and site is excluded from `pnpm build` (`--filter=!@object-ui/site`), so the sweep measured a package that had never been built. Build it and:

```
$ pnpm turbo run build --filter='@object-ui/site'   # generates .next/types
$ cd apps/site && tsc --noEmit
exit=0  errors=0
```

**Zero.** The phantom 7 were inflating the outstanding-error count by 28% (32 → 25), which matters because that number is meant to be read as a health signal.

## And it doesn't need a `type-check` script

`next build` runs a full type-check unless `typescript.ignoreBuildErrors` is set — and `apps/site/next.config.mjs` does not set it. The `docs` CI job already runs that build. Adding a `type-check` script would run the compiler twice and pull a Next build into the Type Check job for no new coverage.

So the honest classification isn't "debt" or "exempt" — it's **checked, by a different mechanism**. New `CHECKED_BY_OWN_BUILD` category records exactly that.

## The exemption is verified, not trusted

`ignoreBuildErrors: true` is a one-line flag that would silently turn this exemption into precisely the hole #2911 was about — a package that looks covered and isn't. So the guard checks it on every run. Three failure modes, each proven red before being trusted:

| tampering | result |
|---|---|
| `ignoreBuildErrors: true` added to `next.config.mjs` | exit 1 |
| site gains a `type-check` script (stale entry) | exit 1 |
| build script changes out from under the exemption | exit 1 |

Baseline restores green afterwards, with no residual diff (restored via `cp`, not `git checkout`).

## Recorded caveat

Noted in the code, because it's a genuine cost/coverage call rather than an oversight: the `docs` job runs the site build **only when `apps/site/` or `content/` changed** (plus every push to main). A PR that touches only a workspace package listed in `transpilePackages` therefore doesn't re-check the site until it lands. Closing that would mean paying a Next build on many more PRs — worth a deliberate decision, so I've left it visible rather than silently widening CI.

## Verification

```
✅  type-check coverage: 36/45 via `type-check`, 1 via their own build,
    7 known-broken (25 errors outstanding), 1 not compiled.
```

- `node scripts/check-type-check-coverage.mjs` — green, and red in all three tamper modes above
- `node scripts/check-changeset-fixed.mjs` — green
- No changeset: scripts-only change, no published package is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
