### PR TITLE
fix(console): the API console lists the whole AI family, and the tool preview stops linking to a 404 (framework#3718)

### DIFF
--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
@@ -45,16 +45,33 @@ function buildAuthEndpoints(authBase: string): EndpointDef[] {
 }
 
 export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRoute: string; endpoints: ServiceEndpointEntry[] }> = {
-  // The twelve routes `buildAIRoutes()` mounts, in table order (framework#3718).
+  // The `/api/v1/ai/**` family, in ledger order (framework#3718).
+  //
   // `/nlq`, `/suggest` and `/insights` used to sit here with "try it" bodies and
   // always 404'd — they were declared in the framework's `DEFAULT_AI_ROUTES` and
   // never implemented anywhere, so this page offered three endpoints that had no
   // server. The audited table is cloud's `packages/service-ai/src/
   // ai-route-ledger.ts`; when a route is added or renamed there, mirror it here.
   //
-  // `/status` and `/effective-model` are deliberately NOT SDK surface (operator
-  // diagnostics) — which is exactly why they belong on this page: it explores raw
-  // HTTP, not `client.*`.
+  // That first fix listed one server-side builder, `buildAIRoutes()`. The family
+  // is SEVEN builders plus one route mounted by `objectos-runtime`, so this page
+  // still showed under half of it. All 26 are here now, grouped as the ledger
+  // groups them.
+  //
+  // TWO KINDS OF ENTRY LIVE HERE, and both belong:
+  //  - routes the SDK also expresses (`/chat`, `/conversations/*`) — this page is
+  //    where you check the wire shape behind `client.ai.*`;
+  //  - routes it deliberately does not (`/status`, `/effective-model`, `/tools/*`,
+  //    `/evals/runs`, `/usage`) — operator and console surfaces, which is exactly
+  //    why they belong on a page that explores raw HTTP rather than `client.*`.
+  //
+  // MOUNTING IS CONDITIONAL for four of the builders (see AI_ROUTE_MOUNT_GATES in
+  // the ledger): `/agents/*` and `/assistant/*` need a metadata service,
+  // `/evals/runs` also needs a data engine, `/conversations/:id/debug` needs one.
+  // A full Cloud deployment wires all of them; a stripped host may not, and there
+  // these 404 because they are not mounted — NOT because they do not exist. That
+  // is a different failure from the one above, and the only honest place to say so
+  // is here.
   ai: {
     group: 'AI',
     defaultRoute: '/api/v1/ai',
@@ -74,6 +91,39 @@ export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRo
       { method: 'PATCH', path: '/conversations/:id', desc: 'Update conversation (title, metadata)', bodyTemplate: { title: '' } },
       { method: 'DELETE', path: '/conversations/:id', desc: 'Delete conversation' },
       { method: 'POST', path: '/conversations/:id/messages', desc: 'Add message to conversation', bodyTemplate: { role: 'user', content: '' } },
+      { method: 'GET', path: '/conversations/:id/debug', desc: 'Reconcile a build conversation: agent-claimed vs live metadata' },
+
+      // Named agents. `/agents/:agentName/chat` is dual-mode on the same flag as
+      // `/chat` above — `stream: false` for the JSON reply this page can render.
+      { method: 'GET', path: '/agents', desc: 'List active agents' },
+      { method: 'POST', path: '/agents/:agentName/chat', desc: 'Chat with a named agent (JSON)', bodyTemplate: { messages: [{ role: 'user', content: '' }], stream: false } },
+
+      // Ambient assistant — resolves the agent and skills from context instead of
+      // being told. Same `stream: false` treatment on its chat route.
+      { method: 'GET', path: '/assistant', desc: 'Resolve the default assistant and its active skills' },
+      { method: 'GET', path: '/assistant/skills', desc: 'List active skills for a context' },
+      { method: 'POST', path: '/assistant/chat', desc: 'Ambient chat — auto-resolves agent and skills (JSON)', bodyTemplate: { messages: [{ role: 'user', content: '' }], stream: false } },
+
+      // Tools. `execute` is the mounted verb — the metadata-admin tool preview
+      // used to deep-link here with `/invoke`, which has never existed.
+      { method: 'GET', path: '/tools', desc: 'List registered AI tools' },
+      { method: 'POST', path: '/tools/:toolName/execute', desc: 'Execute one tool directly (playground)', bodyTemplate: { parameters: {} } },
+
+      // HITL approval queue. Reads take `ai:read`; approve/reject take the
+      // separate `ai:approve` — a token that lists the queue may not clear it.
+      { method: 'GET', path: '/pending-actions', desc: 'List pending actions awaiting approval' },
+      { method: 'GET', path: '/pending-actions/:id', desc: 'Get one pending action' },
+      { method: 'POST', path: '/pending-actions/:id/approve', desc: 'Approve a pending action and execute it', bodyTemplate: {} },
+      { method: 'POST', path: '/pending-actions/:id/reject', desc: 'Reject a pending action', bodyTemplate: { reason: '' } },
+
+      // Operator surfaces. A run here makes real (paid) LLM calls — hence
+      // `ai:admin`, and hence the warning in the description rather than a
+      // friendlier one-liner.
+      { method: 'POST', path: '/evals/runs', desc: 'Run an eval case — ai:admin, makes paid LLM calls', bodyTemplate: { caseId: '' } },
+
+      // Mounted by `objectos-runtime`, not `service-ai`: the console usage ring
+      // reads it. Reports a fraction of quota, never a token count.
+      { method: 'GET', path: '/usage', desc: 'AI quota headroom per meter (console usage indicator)' },
     ],
   },
   workflow: {

--- a/packages/app-shell/src/views/metadata-admin/previews/ToolPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ToolPreview.tsx
@@ -135,7 +135,11 @@ export function ToolPreview({ name, draft }: MetadataPreviewProps) {
       toolbar={
         toolName && (
           <a
-            href={`/developer/api-console?path=/api/v1/ai/tools/${encodeURIComponent(toolName)}/invoke`}
+            // `/execute` is the verb service-ai mounts (buildToolRoutes). This
+            // link said `/invoke`, which nothing has ever mounted, so "Open in
+            // API Console" landed on a path that could only 404 — the same
+            // shape as the three dead AI endpoints framework#3718 removed.
+            href={`/developer/api-console?path=/api/v1/ai/tools/${encodeURIComponent(toolName)}/execute`}
             target="_blank"
             rel="noreferrer"
             className="text-xs inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
Follow-up to #2921, which fixed this page for **one** server-side builder and listed what it deliberately left out. This is that list. The server-side audit is objectstack-ai/cloud#903.

## The finding

#2921 replaced three AI endpoints that had never existed with "the twelve routes `buildAIRoutes()` mounts". Correct as far as it went — and it went about half way. The `/api/v1/ai/**` family is **seven** builders in `service-ai` plus one route mounted by `objectos-runtime`. This page showed 12 of 26.

| | before | after |
|---|---|---|
| entries in the AI group | 12 | **26** |
| server-side builders represented | 1 of 7 | **7 of 7** |
| console links pointing at a path nothing mounts | **1** | 0 |

Fourteen entries added: `/agents` ×2, `/assistant` ×3, `/tools` ×2, `/pending-actions` ×4, `/evals/runs`, `/conversations/:id/debug`, and `/usage`.

## The deep link that could only 404

`ToolPreview`'s "Open in API Console" built:

```
/developer/api-console?path=/api/v1/ai/tools/<toolName>/invoke
```

`/invoke` has never been mounted. The route is `/execute` (`buildToolRoutes`). So the single first-party caller of the tool routes sent you to a guaranteed 404 — the same shape as the three dead endpoints #2921 removed from this very page, and it survived that pass because it lives in `packages/app-shell`, not in the catalog.

## Two behavioural details carried over rather than re-learned

**`stream: false` generalises.** #2921 found that `POST /chat` streams unless the body says otherwise, so a JSON-shaped "try it" came back as a wall of `data:` frames through `res.text()`. `POST /agents/:agentName/chat` and `POST /assistant/chat` are dual-mode on the **same** `stream !== false` flag — verified in `agent-routes.ts` and `assistant-routes.ts` — so both templates send it too.

**Bodies that are actually required.** `/tools/:toolName/execute` 400s without a `parameters` object; `/evals/runs` needs `caseId` and makes real, paid LLM calls under `ai:admin`, which its description now says rather than presenting it as an idle button.

## Mounting is conditional, and the page says so

Four of the seven builders are gated in `plugin.ts` — `/agents/*` and `/assistant/*` need a metadata service, `/evals/runs` also needs a data engine, `/conversations/:id/debug` needs one. A full Cloud deployment wires all of them; a stripped host may not, and there these 404 because they are **not mounted**, not because they do not exist.

That distinction is the whole point of #2921, so it is written down at the top of the group rather than left for whoever hits it.

## Worth knowing from the other side

The cloud PR's audit found `/assistant`, `/assistant/skills` and `/assistant/chat` have **no caller in either repo** — no SDK method and nothing in objectui. They are listed here because they are mounted and this page explores raw HTTP; but if the follow-up pass still finds no consumer, retiring the builder is the likelier outcome than three new SDK methods, and these three rows would go with it.

## Verification

- `pnpm vitest run apps/console/src/pages/developer` — **8/8** across 2 files.
- `turbo run type-check --filter=@object-ui/console --filter=@object-ui/app-shell` — **36/36 tasks**, clean.
- `eslint` on both changed files — **0 errors** (10 pre-existing warnings, none on touched lines).
- Data plus one string literal: no component, hook logic, or rendering path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJX6GnuNix7HisBc92THMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJX6GnuNix7HisBc92THMN)_