### PR TITLE
feat(setup): the datasource list shows the real connect verdict, with the operator-facing reason (framework#3827)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/datasource/DatasourceResourcePage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/datasource/DatasourceResourcePage.tsx
@@ -70,9 +70,52 @@ interface DatasourceRow {
   name: string;
   label?: string;
   driver?: string;
+  /**
+   * Last connect verdict, from the framework's retained connection state
+   * (framework#3827): `ok` (live driver registered) | `error` (connect
+   * attempted and failed — see statusReason) | `blocked` (the host's connect
+   * policy refused it; a decision, not a fault) | `unvalidated` (no connect
+   * attempted — e.g. a managed datasource the auto-connect gate leaves
+   * metadata-only).
+   */
   status?: string;
+  /**
+   * Operator-facing detail behind `error` / `blocked` — the raw connect error
+   * or the policy's reason. This surface is admin-gated, so showing it here is
+   * intended; end users never see it (framework#3828).
+   */
+  statusReason?: string;
   origin?: string;
   active?: boolean;
+}
+
+/**
+ * Status chip per verdict. `unvalidated` stays visually quiet — it means
+ * "nothing is known", not "something is wrong" — while `error`/`blocked` carry
+ * the operator-facing reason as a native tooltip (the file's existing idiom).
+ */
+function StatusChip({ status, reason }: { status?: string; reason?: string }) {
+  if (!status) return null;
+  const chip = (cls: string, label: string) => (
+    <span
+      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium ${cls}`}
+      title={reason || undefined}
+    >
+      {label}
+    </span>
+  );
+  switch (status) {
+    case 'ok':
+      return chip('bg-emerald-500/10 text-emerald-600 dark:text-emerald-400', 'connected');
+    case 'error':
+      return chip('bg-destructive/10 text-destructive', 'connect failed');
+    case 'blocked':
+      return chip('bg-amber-500/10 text-amber-600 dark:text-amber-400', 'blocked by policy');
+    case 'unvalidated':
+      return chip('bg-muted text-muted-foreground', 'not connected');
+    default:
+      return chip('bg-muted text-muted-foreground', status);
+  }
 }
 interface RemoteTable { name: string; schema?: string; columnCount?: number }
 
@@ -456,9 +499,14 @@ export function DatasourceResourcePage(_props: { type?: string }): React.ReactEl
                   </div>
                   <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground">
                     <span className="rounded bg-muted px-1.5 py-0.5 font-mono">{ds.driver}</span>
-                    {ds.status && <span>· {ds.status}</span>}
+                    <StatusChip status={ds.status} reason={ds.statusReason} />
                     {ds.origin && <span>· {ds.origin}</span>}
                   </div>
+                  {ds.statusReason && (ds.status === 'error' || ds.status === 'blocked') && (
+                    <div className="mt-0.5 truncate text-[11px] text-muted-foreground" title={ds.statusReason}>
+                      {ds.statusReason}
+                    </div>
+                  )}
                 </div>
                 <Button variant="ghost" size="sm" disabled={busy === `test:${ds.name}`} onClick={() => void test(ds.name)}>
                   {busy === `test:${ds.name}` ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Plug className="mr-1.5 h-4 w-4" />} Test


### PR DESCRIPTION
framework 侧 #3827/#3869 之后,datasource-admin 列表返回四态 `status`(留存的连接判决)+ 面向运维的 `statusReason`,且主库 `default` 也进入列表。本页此前把 `status` 渲染成无区分的裸文本(`· error`),死掉的 datasource 和没测过的看起来一模一样,reason 从不显示 —— 后端说了真话、界面不显示,framework#3827 的价值只兑现了一半。

## 改动(单文件:`DatasourceResourcePage.tsx`)

- **四态 status chip**:`connected`(emerald)/ `connect failed`(destructive)/ `blocked by policy`(amber)/ `not connected`(muted)。未知值降级为 muted chip 显示原始字符串 —— framework 未来加状态时页面可读地降级,而不是消失。
- **`statusReason` 在 error / blocked 行下方显示**(截断,完整文本走原生 `title` tooltip —— 本文件既有惯例,不引新依赖)。该表面已有 admin 门禁,展示原始原因是设计意图;终端用户永远看不到这些字符串(framework#3828 的 privileged/public 分离)。
- `unvalidated` 保持视觉安静 —— 它的含义是「一无所知」,不是「有问题」。

## 验证

- `@object-ui/app-shell` type-check 0 错、测试 91/91、lint 0 错(1986 条 warning 为仓库既有基线)。
- `pnpm build` 全 workspace 43/43 通过。

合并后需要在 framework 仓库跑 `pnpm objectui:refresh` 把构建拉进 `packages/console/`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQVM3A9Yd6N2eZS8ZcdnMk)_