### PR TITLE
feat(lint): run ESLint on PRs, and cover every package (#2923)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,30 @@
 name: Lint
 
+# Until #2923 this workflow was `workflow_dispatch`-only, so ESLint had never
+# gated a PR. That mattered more than it looked: `eslint.config.js` sets three
+# `object-ui/*` rules to `error` *specifically* so a new violation fails CI
+# (ADR-0054 Phase 5, #2879, and the objectql.ts ratchet), and each author
+# pre-cleaned the existing sites so the rule would lint clean. All three
+# ratchets were inert because nothing ran them.
+#
+# `--max-warnings` is deliberately not set: the 7,724 warnings repo-wide are 81%
+# `no-explicit-any`, plus React Compiler rules the config downgrades on purpose.
+# This gate is about errors.
 on:
+  push:
+    branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'content/**'
+      - 'docs/**'
+      - '.changeset/**'
+  pull_request:
+    branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'content/**'
+      - 'docs/**'
+      - '.changeset/**'
   workflow_dispatch:
 
 concurrency:
@@ -32,6 +56,12 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'pnpm'
+
+      # Every package must run ESLint or be declared a known gap. turbo skips
+      # scriptless packages silently, so without this a package reads as clean
+      # because nothing linted it. Runs before install: only reads package.json.
+      - name: Verify lint coverage
+        run: node scripts/check-lint-coverage.mjs
 
       - name: Turbo Cache
         uses: actions/cache@v6

--- a/apps/site/app/(home)/page.tsx
+++ b/apps/site/app/(home)/page.tsx
@@ -88,7 +88,8 @@ export default function HomePage() {
                     rel="noopener noreferrer"
                     className="inline-block transition hover:opacity-80"
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    {/* Plain <img>, not next/image: these are third-party badge
+                        endpoints that render their own SVG and need no optimisation. */}
                     <img
                       src={b.src}
                       alt={b.alt}

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prebuild": "pnpm --filter @object-ui/example-schema-catalog build",
     "build": "next build",
+    "lint": "eslint .",
     "dev": "next dev",
     "start": "next start",
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,21 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import objectUi from './eslint-rules/index.js'
 
-export default tseslint.config({ ignores: ['**/dist', '**/.next', '**/node_modules', '**/public'] }, {
+export default tseslint.config({
+  ignores: [
+    '**/dist',
+    '**/.next',
+    '**/node_modules',
+    '**/public',
+    // fumadocs-mdx codegen for apps/site (gitignored — see apps/site/.gitignore).
+    // Linting generated output only reports on the generator's choices.
+    '**/.source',
+    // Tailwind configs are authored in TypeScript despite the `.js` extension,
+    // and the TS parser below is scoped to `.ts`/`.tsx`, so the base JS parser
+    // would fail on `import type`. Build config, not app code.
+    '**/tailwind.config.js',
+  ],
+}, {
   extends: [js.configs.recommended, ...tseslint.configs.recommended],
   files: ['**/*.{ts,tsx}'],
   languageOptions: {

--- a/examples/byo-backend-console/package.json
+++ b/examples/byo-backend-console/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "preview": "vite preview"
   },

--- a/examples/console-starter/package.json
+++ b/examples/console-starter/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "preview": "vite preview"
   },

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -9,5 +9,8 @@
     "@object-ui/react": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
+  },
+  "scripts": {
+    "lint": "eslint ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "lint": "turbo run lint",
+    "lint:coverage": "node scripts/check-lint-coverage.mjs",
     "type-check": "turbo run type-check",
     "type-check:coverage": "node scripts/check-type-check-coverage.mjs",
     "cli": "node packages/cli/dist/cli.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -192,6 +192,7 @@
   "scripts": {
     "vscode:prepublish": "pnpm run build",
     "build": "tsup",
+    "lint": "eslint .",
     "dev": "tsup --watch",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",

--- a/scripts/check-lint-coverage.mjs
+++ b/scripts/check-lint-coverage.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Validates that every workspace package is actually linted by CI.
+ *
+ * The sibling of scripts/check-type-check-coverage.mjs, for the same reason:
+ * `pnpm lint` runs `turbo run lint`, and turbo silently skips any package with
+ * no `lint` script — so a package without one is not "clean", it is unlinted.
+ * That is how `apps/console`, the largest surface in the repo, went unlinted
+ * while carrying 14 ESLint errors that nobody had ever seen (#2923).
+ *
+ * The stakes are concrete: `eslint.config.js` sets three `object-ui/*` rules to
+ * `error` specifically so a new violation fails CI (ADR-0054 Phase 5, #2879,
+ * and the objectql.ts type-discipline ratchet). Those ratchets are worthless in
+ * a package that never runs ESLint.
+ *
+ * Run:  node scripts/check-lint-coverage.mjs
+ * Exit: 0 = OK, 1 = coverage regressed or the list is stale
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { resolve, dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ── Known gaps ───────────────────────────────────────────────────────────────
+// Packages with outstanding ESLint *errors*, so they cannot carry a `lint`
+// script without turning CI red. Warnings do not matter here — ESLint only
+// fails on errors unless `--max-warnings` is set, and it deliberately is not
+// (7,724 warnings repo-wide are dominated by `no-explicit-any`; see #2923).
+//
+// Every entry is real debt: fix the errors, add `"lint": "eslint ."`, then
+// delete the entry.
+const DEBT = {
+  "@object-ui/console": {
+    errors: 14,
+    issue: 2927,
+    note: "8x react-hooks/purity (Date.now during render) + 4x react-hooks/static-components (components created during render reset state) + no-useless-assignment + prefer-const",
+  },
+  "@object-ui/runner": {
+    errors: 3,
+    issue: 2927,
+    note: "3x react-hooks/static-components in LayoutRenderer",
+  },
+};
+
+// ── Collect workspace packages ───────────────────────────────────────────────
+const GROUPS = ["packages", "apps", "examples"];
+
+function collect() {
+  const out = [];
+  for (const group of GROUPS) {
+    let entries;
+    try {
+      entries = readdirSync(resolve(root, group));
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const dir = join(group, entry);
+      const manifest = resolve(root, dir, "package.json");
+      try {
+        statSync(manifest);
+      } catch {
+        continue;
+      }
+      const pkg = JSON.parse(readFileSync(manifest, "utf8"));
+      if (!pkg.name) continue;
+      out.push({
+        name: pkg.name,
+        dir,
+        hasScript: Boolean(pkg.scripts?.lint),
+      });
+    }
+  }
+  return out;
+}
+
+const packages = collect();
+const byName = new Map(packages.map((p) => [p.name, p]));
+
+const errors = [];
+
+// 1. Undeclared gap — a package that never runs ESLint.
+for (const pkg of packages) {
+  if (pkg.hasScript) continue;
+  if (DEBT[pkg.name]) continue;
+  errors.push(
+    `${pkg.name} (${pkg.dir}) has no "lint" script, so \`pnpm lint\` skips it entirely.\n` +
+      `      Add  "lint": "eslint ."  to its package.json. If it still has ESLint errors,\n` +
+      `      add it to DEBT in scripts/check-lint-coverage.mjs with an error count.`
+  );
+}
+
+// 2. Ratchet — a declared gap that has been closed must leave the list.
+for (const name of Object.keys(DEBT)) {
+  const pkg = byName.get(name);
+  if (!pkg) {
+    errors.push(`${name} is listed in DEBT but is not a workspace package any more — delete the entry.`);
+  } else if (pkg.hasScript) {
+    errors.push(
+      `${name} now has a "lint" script — delete its DEBT entry so the gap cannot reopen` +
+        `${DEBT[name].issue ? ` (and close #${DEBT[name].issue} if it is done)` : ""}.`
+    );
+  }
+}
+
+// ── Report ───────────────────────────────────────────────────────────────────
+const linted = packages.filter((p) => p.hasScript).length;
+const debtCount = Object.keys(DEBT).length;
+const debtErrors = Object.values(DEBT).reduce((sum, d) => sum + d.errors, 0);
+
+if (errors.length === 0) {
+  console.log(
+    `✅  lint coverage: ${linted}/${packages.length} packages linted, ` +
+      `${debtCount} with outstanding errors (${debtErrors} total).`
+  );
+  process.exit(0);
+}
+
+console.error("❌  lint coverage regressed:\n");
+for (const message of errors) {
+  console.error(`    • ${message}`);
+}
+console.error(
+  "\nA package with no `lint` script is not clean — turbo skips it and CI sees nothing.\n" +
+    "See https://github.com/objectstack-ai/objectui/issues/2923 for why this guard exists."
+);
+process.exit(1);


### PR DESCRIPTION
Closes #2923. Follow-up: #2927 for the errors this declares.

## The thing I got wrong in #2923, and why this PR exists

I originally filed #2923 recommending **against** wiring `lint.yml`, on the grounds that it would be a no-op gate: `pnpm lint` reports 7,724 problems but **0 errors**, and ESLint only fails on errors unless `--max-warnings` is set.

The arithmetic was right; I had missed the bottom of `eslint.config.js`. It sets **three `object-ui/*` rules to `error` specifically so a new violation fails CI**:

```js
// ADR-0054 Phase 5 ratchet — ban synthetic-event triggers (C1). Error so a
// new violation fails CI; the existing surfaces were converted to direct
// idempotent commands first, so this lints clean today.
'object-ui/no-synthetic-event-trigger': 'error',

// objectui#2879 ratchet — ... Error so a tenth copy fails CI; all known
// sites were converted first, so this lints clean today.
'object-ui/no-try-catch-around-hook': 'error',

// ... Error so a new inline mirror fails CI; ...
'object-ui/no-inline-spec-config': 'error',   // scoped to packages/types/src/objectql.ts
```

Three separate deliberate efforts, each written assuming CI enforces it, each with its existing violations pre-cleaned so the rule would "lint clean today". **The enforcement they were built against did not exist.** Same shape as #2911, one layer up: the rule is authored, nothing runs it.

## And the same second layer, again

`turbo run lint` **silently skips packages with no `lint` script** — identical to the type-check hole. **7 of 45 packages had none**, including **`apps/console`**, the largest surface in the repo. So even once wired, the three ratchets would have been blind to console.

| | before | after |
|---|---:|---:|
| packages linted | 38 / 45 | **43 / 45** |
| workflow runs on PRs | no | **yes** |
| ratchets actually enforced | 0 of 3 | **3 of 3** |

## Two config fixes, not code debt

Measuring the unlinted packages first turned up 25 "errors" — most of which were not real:

**`apps/site`: 7 errors → 0.** Six were in `apps/site/.source/`, which is **fumadocs-mdx generated output and already gitignored** (`apps/site/.gitignore:5`). Linting codegen only reports on the generator's choices. The seventh was a stale `eslint-disable-next-line @next/next/no-img-element` — the Next plugin isn't in the flat config, so the *directive itself* errored as an unknown rule. Replaced with a comment saying why a plain `<img>` is right for third-party badge endpoints.

**`apps/console`: 15 → 14.** One was `tailwind.config.js`, authored in TypeScript (`import type { Config }`) despite the `.js` extension; the TS parser block is scoped to `.ts`/`.tsx`, so the base JS parser choked on it. Now ignored as build config.

This is the second time `apps/site` has looked like debt purely because of generated artifacts — cf. #2924, where its 7 phantom type errors were missing `.next/types`.

## What is genuinely broken, and is not fixed here

Per the plan agreed for this PR, the real errors are **declared, not fixed** — they touch runtime behaviour and deserve their own review. Tracked in #2927:

- **`apps/console` — 14 errors.** 8x `react-hooks/purity` (`Date.now()` during render in `ApprovalsInboxPage`), 4x `react-hooks/static-components` (components created during render — *"will reset"*, i.e. state loss / focus loss, and three of the four are Settings pages), plus a dead assignment on an auth path and a `prefer-const`.
- **`packages/runner` — 3 errors.** `react-hooks/static-components` in `LayoutRenderer` at 70/106/168, same class.

Note both `purity` and `static-components` are at **error** severity because `eslint.config.js` downgrades five other React Compiler rules but deliberately not these two.

These are **pre-existing and were simply invisible**. This PR does not turn them red — it records them in `DEBT` so they cannot stay invisible.

## Why no `--max-warnings`

Measured composition of the 7,724 warnings:

| rule | count | share |
|---|---:|---:|
| `@typescript-eslint/no-explicit-any` | **6,262** | 81% |
| `react-refresh/only-export-components` | 486 | 6% |
| `@typescript-eslint/no-unused-vars` | 322 | 4% |
| `react-hooks/set-state-in-effect` | 252 | 3% |
| `react-hooks/exhaustive-deps` | 177 | 2% |
| `react-hooks/refs` | 111 | 1% |
| four more `react-hooks/*` | 79 | |

One stylistic rule is 81% of it, and five of the `react-hooks/*` rules are downgraded on purpose (*"codebase predates these rules"*). A blanket cap of 7,724 would read as a health signal while tracking `no-explicit-any`. This gate is about errors; the warning question is left open in #2923's history rather than answered badly.

## Verification

**The ratchets now actually bite.** Planted a hook inside try/catch in `packages/i18n` (a package that was already linted):

```
4:12  error  Do not call the hook 'useMemo' inside try/catch — a caught throw
             desyncs hook order on the next render (objectui#2879)
             object-ui/no-try-catch-around-hook

pnpm lint exit=1
Failed:    @object-ui/i18n#lint
```

Impossible before this PR, in two independent ways: the workflow never ran, and had it run, console still would not have been linted.

**Coverage guard red in all three modes:**

| tampering | result |
|---|---|
| new package with no `lint` script | exit 1 |
| a DEBT entry outliving its gap (package gains the script) | exit 1 |
| `lint` script removed from a covered package | exit 1 |

Baseline restores green after each; restored via `cp`, no residual diff.

**Green state:**

```
✅  lint coverage: 43/45 packages linted, 2 with outstanding errors (17 total)
✅  type-check coverage: 36/45 via `type-check`, 1 via their own build, 7 known-broken (25 errors outstanding), 1 not compiled
✅  All workspace packages are in the changeset fixed group
$ pnpm lint   →  43/43 successful, exit 0
```

No changeset: all five packages that gained a `lint` script are `private: true`, so no published package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
