### PR TITLE
docs(components): react-page scope comment says ObjectGrid, not the unregistered ObjectTable

### DIFF
--- a/packages/components/src/renderers/layout/react-page.tsx
+++ b/packages/components/src/renderers/layout/react-page.tsx
@@ -19,11 +19,11 @@
  *
  * Scope injected into the source:
  *   - `React`                — so authors can call hooks.
- *   - the PUBLIC data blocks — `<ObjectTable>`, `<ObjectForm>`, charts, metrics…
+ *   - the PUBLIC data blocks — `<ObjectGrid>`, `<ObjectForm>`, charts, metrics…
  *     each as a prop-driven wrapper that renders via SchemaRenderer. Layout is
  *     left to plain HTML + Tailwind (React's strength); only the data blocks
  *     that can't be expressed in HTML are injected.
- *   - `Block`                — escape hatch: `<Block type="object-table" .../>`.
+ *   - `Block`                — escape hatch: `<Block type="object-grid" .../>`.
  *   - `useAdapter`            — live data hook: query/create/update objects.
  *   - `data` / `variables`   — page data + local variables, for convenience.
  */


### PR DESCRIPTION
## Problem

The `kind:'react'` page renderer's header comment in
[`react-page.tsx`](packages/components/src/renderers/layout/react-page.tsx)
advertised two identifiers that **do not exist**. An author following the
comment hit a wall either way:

| Comment said | What actually happens |
|---|---|
| `<ObjectTable>` (line 22) | `ReferenceError` — surfaced as the red **"React page error"** panel |
| `<Block type="object-table" />` (line 26) | **"Unknown component type"** |

## Why

`buildComponentScope` (react-page.tsx:50-86) builds the injected scope by
PascalCasing each **public, non-container** tag from the curated
`PUBLIC_BLOCKS` contract. That list
([public-blocks.ts:26-66](packages/core/src/registry/public-blocks.ts:26))
carries `object-grid` — **never** `object-table` — so the real injected
identifier has always been `ObjectGrid`.

`object-grid` is genuinely registered, and without `isContainer`, so it
survives the container filter and lands in the scope:

- [`plugin-grid/src/index.tsx:55`](packages/plugin-grid/src/index.tsx:55) — `ComponentRegistry.register('object-grid', ObjectGridRenderer, {...})`

## Verification that `object-table` has no registration

`grep -rn "object-table" packages apps docs` returns only:

- this doc comment (now fixed),
- `packages/components/dist/...d.ts` — stale build output, regenerates,
- `packages/sdui-parser` compiler fixtures (`__tests__/*`, `verify.ts`) — these
  build their **own inline synthetic manifests** and a fake in-test
  `ComponentRegistry.register`, and never touch the real product registry.

So nothing in the product registers `object-table`.

## Change

Comment-only — two lines, no behavior change, no changeset (not a feature).

```diff
- *   - the PUBLIC data blocks — `<ObjectTable>`, `<ObjectForm>`, charts, metrics…
+ *   - the PUBLIC data blocks — `<ObjectGrid>`, `<ObjectForm>`, charts, metrics…
...
- *   - `Block`                — escape hatch: `<Block type="object-table" .../>`.
+ *   - `Block`                — escape hatch: `<Block type="object-grid" .../>`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)