### PR TITLE
docs(types): finish the ObjectTable -> ObjectGrid rename in two stale doc comments

### DIFF
--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -12,7 +12,7 @@ import type { ManagedByBucket } from './managed-by';
  * @object-ui/types - Field Type Definitions
  * 
  * Comprehensive field type system for ObjectQL protocol.
- * Defines all field types supported in ObjectTable and ObjectForm components.
+ * Defines all field types supported in ObjectGrid and ObjectForm components.
  * 
  * @module field-types
  * @packageDocumentation

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1227,7 +1227,7 @@ export interface ObjectFormSchema extends BaseSchema {
 
 /**
  * ObjectView Schema
- * A complete object management interface combining ObjectTable and ObjectForm.
+ * A complete object management interface combining ObjectGrid and ObjectForm.
  * Provides list view with search, filters, and integrated create/edit dialogs.
  */
 export interface ObjectViewSchema extends BaseSchema {


### PR DESCRIPTION
Follow-up to #2938.

## Context

While fixing #2938 I traced where `ObjectTable` came from. It is **not a typo** —
the component genuinely existed and was renamed to `ObjectGrid` long ago. The
original still sits in the package CHANGELOGs:

> `ObjectTable: Auto-generates tables from ObjectQL object schemas`
> — `packages/components/CHANGELOG.md:2321` (and 7 other packages)

Some prose never followed the rename.

## Why this PR is small

#2938 fixed the one occurrence that **actually bit authors**: the `kind:'react'`
page scope comment, where the prose *is* the API documentation for a scope that
is derived at runtime, so following it produced a `ReferenceError`.

These two are lower-stakes **descriptive prose on type definitions** — nobody
writes `<ObjectTable>` because of them. The value is retiring a dead name from
live code so the next reader doesn't go digging.

## Changes

| File | Note |
|---|---|
| [`field-types.ts:15`](packages/types/src/field-types.ts:15) | module doc for the field type system |
| [`objectql.ts:1230`](packages/types/src/objectql.ts:1230) | `ObjectViewSchema` — factually correct, not just mechanical: ObjectView renders an `object-grid` ([plugin-view/src/ObjectView.tsx:858](packages/plugin-view/src/ObjectView.tsx:858)) |

## After this

`ObjectTable` appears only in:

- package CHANGELOGs — immutable history, correctly left alone,
- gitignored `dist/` output — regenerates,
- `sdui-parser` synthetic compiler fixtures — these build their own inline
  manifests and never touch the real registry.

## Not done deliberately

I considered a test pinning `PUBLIC_BLOCKS` against actually-registered types to
stop this class of drift, and decided against it: "a component not yet registered
is simply skipped (the list is aspirational-safe)"
([public-blocks.ts:20](packages/core/src/registry/public-blocks.ts:20)) is
intentional design, since plugin packages may not be loaded. A hard assertion
would fight that.

Comment-only — no behavior change, no changeset (not a feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)