### PR TITLE
refactor(fields): drop the retired `conditionalRequired` alias

### DIFF
--- a/.changeset/drop-conditional-required-alias.md
+++ b/.changeset/drop-conditional-required-alias.md
@@ -1,0 +1,53 @@
+---
+"@object-ui/types": minor
+"@object-ui/core": minor
+"@object-ui/components": minor
+"@object-ui/plugin-form": minor
+"@object-ui/app-shell": minor
+---
+
+refactor(fields): `requiredWhen` is the only required-predicate slot — drop the retired `conditionalRequired` alias
+
+`@objectstack/spec` 17 (objectstack#3855) **retired** `Field.conditionalRequired`,
+the long-deprecated alias of `requiredWhen`. ObjectUI carried a back-compat read
+for it in seven places; all of them are removed.
+
+The removal is safe because the spec did not merely *stop emitting* the key — it
+made authoring it **fail loudly**. `retiredKey()` declares the key as
+`z.never()`, so:
+
+- `z.input` types it as `never` — writing it is a `tsc` error at the authoring site;
+- the parse **rejects** it (verified against `17.0.0-rc.0`), at both `FieldSchema`
+  and `ObjectSchema`, with the prescription as the message:
+
+  > `conditionalRequired` was removed in @objectstack/spec 17 (#3855) — use
+  > `requiredWhen`. Rename the key; the value (a CEL predicate) is unchanged.
+  > Run `os migrate meta --from 16` to rewrite it automatically.
+
+So spec-parsed metadata cannot carry the key — an object declaring it fails to
+load rather than loading with the rule silently dropped. Keeping a renderer-side
+`requiredWhen ?? conditionalRequired` would have re-created exactly the second
+de-facto contract the tombstone exists to prevent: the key would have kept
+working in the UI while being rejected everywhere else, hiding the producer's bug
+(AGENTS.md #0.1). "Backend-agnostic" (#1) does not argue for keeping it either —
+`conditionalRequired` is an ObjectStack-spec-ism, so the only producers that ever
+emit it are ObjectStack producers on ≤16, and the spec ships them a converter.
+
+Removed from:
+
+| package | site |
+| :--- | :--- |
+| `@object-ui/types` | the `conditionalRequired?:` member on `FormField` |
+| `@object-ui/core` | the `??` fallback + rules-param member in `resolveFieldRuleState` |
+| `@object-ui/components` | three pass-throughs in the form renderer |
+| `@object-ui/plugin-form` | `ObjectForm`, `ModalForm`, `sectionFields`, `deriveMasterDetail` (×2) |
+| `@object-ui/app-shell` | the field inspector's legacy read/auto-migrate, and the key's entry in `clientValidation`'s CEL lint list |
+
+**Studio authors lose nothing.** The object designer's draft validation parses
+against the spec's own `ObjectSchema`, so a draft carrying the key now surfaces
+the tombstone's rename prescription under the same `fields.<name>.conditionalRequired`
+path the CEL lint used to report — a better message than the inspector's silent
+auto-migration, and one the server agrees with. That behavior is pinned by a test.
+
+**Migrating:** rename the key to `requiredWhen` (the CEL value is unchanged), or
+run `os migrate meta --from 16`.

--- a/content/docs/guide/metadata-diagnostics.md
+++ b/content/docs/guide/metadata-diagnostics.md
@@ -139,9 +139,9 @@ field disappears as soon as you start typing in it, then re-validates
 on save.
 
 For **object** drafts the live validation goes beyond the Zod shape check:
-every field conditional rule (`visibleWhen` / `readonlyWhen` / `requiredWhen`,
-plus the deprecated `conditionalRequired` alias) is linted as a CEL predicate
-with the same `@objectstack/formula` validators the server uses. A predicate
+every field conditional rule (`visibleWhen` / `readonlyWhen` / `requiredWhen`)
+is linted as a CEL predicate with the same `@objectstack/formula` validators
+the server uses. A predicate
 that parses but references an unknown field, or references a field bare
 instead of as `record.<field>`, surfaces under its `fields.<field>.<rule>`
 path in the banner. The field inspector's *Conditional rules* editors give

--- a/docs/adr/0036-field-conditional-rules.md
+++ b/docs/adr/0036-field-conditional-rules.md
@@ -23,7 +23,17 @@ We express them as three optional CEL predicates on `Field`:
 | `readonlyWhen` | the field is read-only                              | **client + server**|
 | `requiredWhen` | the field is required                               | **client + server**|
 
-`conditionalRequired` is a back-compat **alias of `requiredWhen`**.
+> **Amended (2026-07-29) — the `conditionalRequired` alias is gone.**
+> This ADR originally carried `conditionalRequired` as a back-compat **alias of
+> `requiredWhen`**. `@objectstack/spec` 17 (objectstack#3855) *retired* the key:
+> it is tombstoned via `retiredKey()`, so authoring it is both a `tsc` error and
+> a hard parse rejection whose message carries the rename (and
+> `os migrate meta --from 16` rewrites it automatically). Since the producer now
+> rejects the key outright, ObjectUI no longer reads it anywhere — keeping a
+> renderer-side `??` fallback would have re-created the second dialect the
+> tombstone exists to prevent (AGENTS.md #0.1). **`requiredWhen` is the only
+> required-predicate slot.** The paragraphs below are kept as the historical
+> record of the original decision.
 
 ## Why CEL, and why the *same* engine on both ends
 
@@ -47,7 +57,8 @@ import dragged into the bundle.
 - **`requiredWhen`** — `@objectstack/objectql`'s rule-validator evaluates the
   predicate over the *merged* record (`{ ...previous, ...patch }`) and pushes a
   `{ field, code: 'required' }` violation when it is TRUE and the value is
-  missing. `conditionalRequired` is treated identically.
+  missing. (Historical: `conditionalRequired` was treated identically until the
+  spec retired the key — see the amendment above.)
 - **`readonlyWhen`** — `stripReadonlyWhenFields` drops any field from an UPDATE
   payload whose predicate is TRUE for the merged record: the incoming change is
   **ignored** (the persisted value is kept), not rejected. Update paths fetch

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -248,9 +248,10 @@ The object designer's field inspector (`ObjectFieldInspector`, Advanced →
   typing `record.` / `previous.` completes the object's own field names.
 - Values round-trip both wire shapes: a bare CEL string or the
   `{ dialect, source }` Expression envelope (envelope extras such as
-  `meta.rationale` are preserved on edit). The deprecated
-  `conditionalRequired` alias is read into the *Required when* editor and
-  migrated to `requiredWhen` on the first edit.
+  `meta.rationale` are preserved on edit). `requiredWhen` is the only
+  required-predicate slot — the `conditionalRequired` alias was removed in
+  `@objectstack/spec` 17 (#3855), so a draft carrying it is rejected by the
+  spec parse itself, with the rename prescription, in the same issue banner.
 - The same lint also runs draft-wide in `clientValidation.ts`
   (`validateMetadataDraft('object', …)`), so an invalid predicate on any
   field — not just the selected one — surfaces in the editor's issue banner

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.fieldRules.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.fieldRules.test.ts
@@ -17,7 +17,7 @@ import { __setCelFormulaLoader } from './celAuthoring';
 
 afterEach(() => __setCelFormulaLoader(undefined));
 
-const RULE_PATH = /^fields\..+\.(visibleWhen|readonlyWhen|requiredWhen|conditionalRequired)$/;
+const RULE_PATH = /^fields\..+\.(visibleWhen|readonlyWhen|requiredWhen)$/;
 
 const draftWith = (fields: unknown) => ({ name: 'account', label: 'Account', fields });
 
@@ -59,12 +59,19 @@ describe('validateMetadataDraft — object field conditional rules (real engine)
     expect(res.issues.filter((i) => RULE_PATH.test(i.path))).toEqual([]);
   });
 
-  it('lints the legacy conditionalRequired alias too', async () => {
+  // `conditionalRequired` is no longer one of OUR lint keys — @objectstack/spec
+  // 17 (#3855) retired it, so the draft is rejected by the spec parse itself,
+  // and the rejection carries the rename prescription. We assert the author
+  // still gets told, and told by the spec (AGENTS.md #0.1 — one contract).
+  it('rejects the retired conditionalRequired alias via the spec tombstone', async () => {
     const res = await validateMetadataDraft(
       'object',
-      draftWith({ status: { type: 'text', conditionalRequired: '{status} == "x"' } }),
+      draftWith({ status: { type: 'text', conditionalRequired: 'record.x == 1' } }),
     );
-    expect(res.issues.some((i) => i.path === 'fields.status.conditionalRequired')).toBe(true);
+    expect(res.ok).toBe(false);
+    const issue = res.issues.find((i) => i.path === 'fields.status.conditionalRequired');
+    expect(issue).toBeTruthy();
+    expect(issue!.message).toMatch(/requiredWhen/);
   });
 
   it('uses index paths for the ARRAY fields shape', async () => {

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -133,7 +133,7 @@ function nodeTypeAt(draft: unknown, index: number): string | undefined {
  * fail-opens at runtime, so we lint the CEL here — the same
  * `@objectstack/formula` verdict the field inspector's editor shows live.
  */
-const FIELD_RULE_KEYS = ['visibleWhen', 'readonlyWhen', 'requiredWhen', 'conditionalRequired'] as const;
+const FIELD_RULE_KEYS = ['visibleWhen', 'readonlyWhen', 'requiredWhen'] as const;
 
 /** Extract a predicate's CEL source from either wire shape (string | envelope). */
 function predicateSource(v: unknown): string | null {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.test.tsx
@@ -257,17 +257,14 @@ describe('ObjectFieldInspector — conditional rules (CEL editors, #1582)', () =
     expect(onPatch.mock.calls.at(-1)![0].fields.note.visibleWhen).toBeUndefined();
   });
 
-  it('reads legacy conditionalRequired into Required when and migrates it on edit', () => {
+  // The retired `conditionalRequired` alias (@objectstack/spec 17, #3855) is no
+  // longer read into the editor: it is not a required-predicate slot, and a
+  // draft carrying it is rejected by the spec parse with the rename
+  // prescription (see clientValidation.fieldRules.test.ts).
+  it('does not read the retired conditionalRequired alias into Required when', () => {
     stubEngine();
-    const { onPatch } = renderField(
-      { note: { type: 'text', conditionalRequired: 'record.x == 1' } },
-      'note',
-    );
-    expect(controlFor('Required when')).toHaveValue('record.x == 1');
-    fireEvent.change(controlFor('Required when'), { target: { value: 'record.x == 2' } });
-    const field = onPatch.mock.calls.at(-1)![0].fields.note;
-    expect(field.requiredWhen).toBe('record.x == 2');
-    expect(field.conditionalRequired).toBeUndefined();
+    renderField({ note: { type: 'text', conditionalRequired: 'record.x == 1' } }, 'note');
+    expect(controlFor('Required when')).toHaveValue('');
   });
 });
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -641,15 +641,8 @@ export function ObjectFieldInspector({
           <CelPredicateField
             id={`field-rule-required-${entry.name}`}
             label={tr('designer.field.requiredWhen')}
-            // Legacy alias: `conditionalRequired` (spec @deprecated) reads into
-            // the same editor; the first edit migrates it to `requiredWhen`.
-            value={readPredicate(def.requiredWhen ?? def.conditionalRequired)}
-            onChange={(v) =>
-              patchDef({
-                requiredWhen: writePredicate(def.requiredWhen ?? def.conditionalRequired, v),
-                conditionalRequired: undefined,
-              })
-            }
+            value={readPredicate(def.requiredWhen)}
+            onChange={(v) => patchDef({ requiredWhen: writePredicate(def.requiredWhen, v) })}
             disabled={readOnly}
             placeholder="record.amount > 10000"
             objectName={typeof (draft as any).name === 'string' ? ((draft as any).name as string) : undefined}

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -374,7 +374,6 @@ ComponentRegistry.register('form',
             visibleWhen: (f as any).visibleWhen,
             readonlyWhen: (f as any).readonlyWhen,
             requiredWhen: (f as any).requiredWhen,
-            conditionalRequired: (f as any).conditionalRequired,
           },
           ruleRecord,
           { required: !!f.required, readonly: (f as any).readonly === true },
@@ -733,7 +732,6 @@ ComponentRegistry.register('form',
                   visibleWhen,
                   readonlyWhen,
                   requiredWhen,
-                  conditionalRequired,
                   ...fieldProps
                 } = field;
 
@@ -756,7 +754,7 @@ ComponentRegistry.register('form',
                 // the UX and the persisted verdict agree. A field with no rules
                 // resolves to its static flags unchanged.
                 const ruleState = resolveFieldRuleState(
-                  { visibleWhen, readonlyWhen, requiredWhen, conditionalRequired },
+                  { visibleWhen, readonlyWhen, requiredWhen },
                   ruleRecord,
                   { required: staticRequired, readonly: staticReadonly === true },
                 );

--- a/packages/core/src/evaluator/__tests__/fieldRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/fieldRules.test.ts
@@ -106,18 +106,17 @@ describe('resolveFieldRuleState', () => {
     expect(s.required).toBe(true);
   });
 
-  it('honors conditionalRequired as a requiredWhen alias', () => {
-    const s = resolveFieldRuleState({ conditionalRequired: "record.status == 'sent'" }, { status: 'sent' }, {});
-    expect(s.required).toBe(true);
-  });
-
-  it('prefers requiredWhen over conditionalRequired when both present', () => {
-    const s = resolveFieldRuleState(
-      { requiredWhen: "record.status == 'sent'", conditionalRequired: 'record.amount > 0' },
-      { status: 'draft', amount: 5 },
-      {},
-    );
-    // requiredWhen (status=='sent') is FALSE → not required; the alias is ignored.
+  // `conditionalRequired` was the pre-protocol-17 alias of `requiredWhen`.
+  // @objectstack/spec 17 (#3855) tombstoned it with `retiredKey`, so authoring
+  // it is now a `tsc` error AND a hard parse rejection carrying the rename
+  // prescription — it can never reach this evaluator from parsed metadata.
+  // `requiredWhen` is the only required-predicate slot (AGENTS.md #0.1).
+  it('ignores the retired conditionalRequired alias', () => {
+    // Deliberately a shape the parameter type no longer permits.
+    const legacyRules = { conditionalRequired: "record.status == 'sent'" } as unknown as Parameters<
+      typeof resolveFieldRuleState
+    >[0];
+    const s = resolveFieldRuleState(legacyRules, { status: 'sent' }, {});
     expect(s.required).toBe(false);
   });
 

--- a/packages/core/src/evaluator/fieldRules.ts
+++ b/packages/core/src/evaluator/fieldRules.ts
@@ -86,8 +86,6 @@ export function resolveFieldRuleState(
     visibleWhen?: FieldRulePredicate;
     readonlyWhen?: FieldRulePredicate;
     requiredWhen?: FieldRulePredicate;
-    /** Back-compat alias of `requiredWhen` (spec @deprecated). */
-    conditionalRequired?: FieldRulePredicate;
   },
   record: Record<string, unknown>,
   statics: { required?: boolean; readonly?: boolean },
@@ -105,10 +103,11 @@ export function resolveFieldRuleState(
       ? evalFieldPredicate(rules.readonlyWhen, record, false, previous, scope)
       : false);
 
-  const requiredPred = rules.requiredWhen ?? rules.conditionalRequired;
   const required =
     statics.required === true ||
-    (requiredPred != null ? evalFieldPredicate(requiredPred, record, false, previous, scope) : false);
+    (rules.requiredWhen != null
+      ? evalFieldPredicate(rules.requiredWhen, record, false, previous, scope)
+      : false);
 
   return { visible, readonly, required };
 }

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -377,7 +377,7 @@ export const ModalForm: React.FC<ModalFormProps> = ({
         // the form renderer via the canonical engine (#2212).
         visibleWhen: (field as any).visibleWhen,
         readonlyWhen: (field as any).readonlyWhen,
-        requiredWhen: (field as any).requiredWhen ?? (field as any).conditionalRequired,
+        requiredWhen: (field as any).requiredWhen,
         // Field-group membership (Field.group → object.fieldGroups[].key) —
         // read by deriveFieldGroupSections for the fieldGroups fallback.
         group: (field as any).group,

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -567,7 +567,7 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
           // engine (same dialect the server enforces). Undefined when absent.
           visibleWhen: field.visibleWhen,
           readonlyWhen: field.readonlyWhen,
-          requiredWhen: field.requiredWhen ?? field.conditionalRequired,
+          requiredWhen: field.requiredWhen,
           // Field-group membership (Field.group → object.fieldGroups[].key).
           // Carried through so the form can auto-derive sections from the
           // object's declared field groups when no explicit sections are given.

--- a/packages/plugin-form/src/deriveMasterDetail.test.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.test.ts
@@ -83,14 +83,16 @@ describe('deriveColumns', () => {
         parent: { type: 'master_detail', reference: 'order' },
         qty: { type: 'number', label: 'Qty', readonlyWhen: "parent.status == 'paid'" },
         note: { type: 'text', label: 'Note', requiredWhen: 'record.qty >= 100' },
+        // `conditionalRequired` was retired in @objectstack/spec 17 (#3855) and
+        // is no longer read as a `requiredWhen` alias — it is now a hard parse
+        // rejection upstream, so it must not silently gate a column here.
         memo: { type: 'text', label: 'Memo', conditionalRequired: 'record.qty >= 1' },
       },
     };
     const byName = Object.fromEntries(deriveColumns(schema, { relationshipField: 'parent' }).map((c) => [c.field, c]));
     expect(byName.qty.readonlyWhen).toBe("parent.status == 'paid'");
     expect(byName.note.requiredWhen).toBe('record.qty >= 100');
-    // conditionalRequired is carried as the requiredWhen alias.
-    expect(byName.memo.requiredWhen).toBe('record.qty >= 1');
+    expect(byName.memo.requiredWhen).toBeUndefined();
   });
 
   it('keeps file/image fields as upload columns instead of dropping them (#2360)', () => {

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -219,9 +219,9 @@ export function deriveColumns(
     if (col.type === 'file') applyFileColumnProps(col, d);
     // Field-level CEL conditional rules (B2 in grids). Carried through verbatim
     // so the grid cell evaluates them per row (against the row + `parent`
-    // header). requiredWhen falls back to the conditionalRequired alias.
+    // header).
     if (d?.readonlyWhen) col.readonlyWhen = d.readonlyWhen;
-    if (d?.requiredWhen ?? d?.conditionalRequired) col.requiredWhen = d.requiredWhen ?? d.conditionalRequired;
+    if (d?.requiredWhen) col.requiredWhen = d.requiredWhen;
     // A field carrying an arithmetic `expression` (e.g. amount = quantity *
     // unit_price) becomes a live read-only computed column. The expression may
     // be a bare string or the normalized CEL envelope `{ dialect, source }`.
@@ -272,8 +272,8 @@ export function hydrateColumns(
     }
     if (type === 'file') applyFileColumnProps(next, d);
     if (next.readonlyWhen == null && d?.readonlyWhen) next.readonlyWhen = d.readonlyWhen;
-    if (next.requiredWhen == null && (d?.requiredWhen ?? d?.conditionalRequired)) {
-      next.requiredWhen = d.requiredWhen ?? d.conditionalRequired;
+    if (next.requiredWhen == null && d?.requiredWhen) {
+      next.requiredWhen = d.requiredWhen;
     }
     const expr = typeof d?.expression === 'string' ? d.expression : d?.expression?.source;
     if (!next.computed && expr && typeof expr === 'string') {

--- a/packages/plugin-form/src/sectionFields.ts
+++ b/packages/plugin-form/src/sectionFields.ts
@@ -93,7 +93,6 @@ function fromObjectSchema(fieldName: string, ctx: SectionFieldsContext): FormFie
     visibleWhen: field.visibleWhen,
     readonlyWhen: field.readonlyWhen,
     requiredWhen: field.requiredWhen,
-    conditionalRequired: field.conditionalRequired,
   } as FormField;
 }
 

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -891,13 +891,6 @@ export interface FormField {
    */
   requiredWhen?: string | { dialect?: string; source: string };
   /**
-   * @deprecated Back-compat alias of {@link requiredWhen}. No longer a spec key:
-   * `@objectstack/spec` 17 (#3855) tombstoned `Field.conditionalRequired`, so
-   * spec-parsed metadata never carries it — only hand-authored or non-spec
-   * sources still can. Use {@link requiredWhen}.
-   */
-  conditionalRequired?: string | { dialect?: string; source: string };
-  /**
    * Additional field-specific props
    */
   [key: string]: any;

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -224,7 +224,11 @@ paid_on:   Field.date({
   prior persisted record, for transition rules like
   `"record.status == 'paid' && previous.status != 'paid'"`).
 - A predicate is `string` (treated as CEL) or `{ dialect: 'cel', source }`.
-- `conditionalRequired` is a **deprecated alias** of `requiredWhen`.
+- `requiredWhen` is the **only** required-predicate slot. The old
+  `conditionalRequired` alias was **removed** in `@objectstack/spec` 17
+  (#3855): authoring it is a `tsc` error and a parse rejection, and nothing in
+  ObjectUI reads it. Rename the key (the CEL value is unchanged), or run
+  `os migrate meta --from 16` to rewrite it automatically.
 - The form renderer re-evaluates these **reactively** as the user edits, via
   `resolveFieldRuleState` (`@object-ui/core`). Static `required: true` /
   `readonly: true` is a floor a FALSE predicate can't weaken.


### PR DESCRIPTION
## Decision: remove

`@objectstack/spec` 17 ([objectstack#3855](https://github.com/objectstack-ai/framework/issues/3855)) retired `Field.conditionalRequired`, the deprecated alias of `requiredWhen`. This drops ObjectUI's back-compat handling for it.

### Why removal, and not a comment at the fallback site

The premise worth correcting: the key is **not** "silently dropped from parsed output." It is tombstoned with `retiredKey()` — literally `z.never({ error: () => guidance }).optional()` — which makes the removal *audible* in two channels:

- **`tsc`** — `z.input` types the key as `never`, so authoring it fails to compile.
- **The parse** — it is **rejected**, with the prescription as the message.

Verified empirically against the `17.0.0-rc.0` now on `main`:

```
FieldSchema  → success: false
ObjectSchema → success: false
  fields.s.conditionalRequired: `conditionalRequired` was removed in
  @objectstack/spec 17 (#3855) — use `requiredWhen`. Rename the key; the value
  (a CEL predicate) is unchanged. Run `os migrate meta --from 16` to rewrite it
  automatically.
```

So spec-parsed metadata cannot carry the key — an object declaring it **fails to load**, loudly, rather than loading with the rule quietly dropped. Keeping `requiredWhen ?? conditionalRequired` in the renderer would have re-created exactly the second de-facto contract the tombstone exists to prevent: the key would keep working in the UI while being rejected everywhere else, hiding the producer's bug. That is AGENTS.md #0.1 verbatim.

**The backend-agnostic counter-argument (#1) doesn't hold here.** `conditionalRequired` is an ObjectStack-spec-ism — it only means anything because the spec once defined it. A non-ObjectStack backend has no reason to emit that exact key; the only producers that do are ObjectStack producers on ≤16, and the spec ships them a converter (`os migrate meta --from 16`) plus a load-time rejection. #0.1 is explicit that Postel's law doesn't apply when we own both ends.

### Scope — the original grep undercounted

The alias was live in **7 code sites across 5 packages**, not 4 in 3:

| package | site |
| :--- | :--- |
| `@object-ui/types` | the `conditionalRequired?:` member on `FormField` |
| `@object-ui/core` | the `??` fallback + rules-param member in `resolveFieldRuleState` |
| `@object-ui/components` | three pass-throughs in the form renderer |
| `@object-ui/plugin-form` | `ObjectForm`, `ModalForm`, `sectionFields`, `deriveMasterDetail` (×2) |
| `@object-ui/app-shell` | the field inspector's legacy read/auto-migrate, and the key's entry in `clientValidation`'s CEL lint list |

Leaving `plugin-form` behind would have been incoherent — `FormField` has an `[key: string]: any` index signature, so `tsc` would **not** have caught the leftovers.

### The app-shell call was the one real judgment

The Studio sites are a different class from a renderer fallback: the inspector *migrates* the key away rather than honoring it forever, which is the producer-side fix #0.1 actually endorses. They're removed anyway because the spec now shadows them with something strictly better — `validateMetadataDraft` parses drafts against the spec's own `ObjectSchema`, so a draft carrying the key surfaces the **tombstone's rename prescription** under the very same `fields.<name>.conditionalRequired` path the CEL lint used to report. The author gets a better message, from the spec, that the server agrees with. That behavior is now pinned by a test rather than left implicit.

Two tests are converted from "honors the alias" to negative assertions so a future re-introduction fails loudly, and ADR-0036 gets a dated amendment rather than a silent rewrite — it's the record of the original decision.

## Verification

- **395 test files / ~4,300 tests** green (`core`, `types`, `fields`, `components`, `plugin-form`, `app-shell`)
- `turbo type-check` — 43 tasks green
- `turbo lint` — **0 errors** on all 5 touched packages
- `pnpm changeset:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)