### PR TITLE
fix(detail): multi-value lookup is selectable in inline edit

### DIFF
--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -34,6 +34,7 @@ import { useSafeFieldLabel } from '@object-ui/react';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
 import { NON_EDITABLE_SYSTEM_FIELDS } from './systemFields';
 import { InlineFieldInput, TEXTUAL_REF_FALLBACK_TYPES } from './InlineFieldInput';
+import { enrichDetailField } from './fieldEnrichment';
 
 /**
  * Section-header icon. `fieldGroups[].icon` declares a Lucide name (spec),
@@ -212,28 +213,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     // like select options, currency code, lookup target, etc. are
     // available in either mode.
     const objectDefField = objectSchema?.fields?.[field.name];
-    const enrichedField: Record<string, any> = { ...field };
-    if (objectDefField) {
-      if (!field.type && objectDefField.type) enrichedField.type = objectDefField.type;
-      if (objectDefField.options && !enrichedField.options) enrichedField.options = objectDefField.options;
-      if (objectDefField.currency && !enrichedField.currency) enrichedField.currency = objectDefField.currency;
-      if (objectDefField.precision !== undefined && enrichedField.precision === undefined) enrichedField.precision = objectDefField.precision;
-      if ((objectDefField as any).scale !== undefined && (enrichedField as any).scale === undefined) (enrichedField as any).scale = (objectDefField as any).scale;
-      // Numeric range/step constraints (objectui#2572 item 3) — without these
-      // the metadata's `min: 0` never reaches the numeric edit widgets.
-      if ((objectDefField as any).min !== undefined && (enrichedField as any).min === undefined) (enrichedField as any).min = (objectDefField as any).min;
-      if ((objectDefField as any).max !== undefined && (enrichedField as any).max === undefined) (enrichedField as any).max = (objectDefField as any).max;
-      if ((objectDefField as any).step !== undefined && (enrichedField as any).step === undefined) (enrichedField as any).step = (objectDefField as any).step;
-      if (objectDefField.format && !enrichedField.format) enrichedField.format = objectDefField.format;
-      // Per-field widget override (ADR-0056 P2) — carry it from the object
-      // metadata so the inline-edit widget branch (and read cell) can honor a
-      // structured editor even when the synthesized section field didn't include it.
-      if ((objectDefField as any).widget && !enrichedField.widget) enrichedField.widget = (objectDefField as any).widget;
-      const refTarget = objectDefField.reference_to || objectDefField.reference;
-      if (refTarget && !enrichedField.reference_to) enrichedField.reference_to = refTarget;
-      if (objectDefField.reference_field && !enrichedField.reference_field) enrichedField.reference_field = objectDefField.reference_field;
-      if ((objectDefField as any).dueLike !== undefined && enrichedField.dueLike === undefined) enrichedField.dueLike = (objectDefField as any).dueLike;
-    }
+    const enrichedField = enrichDetailField(field as Record<string, any>, objectDefField);
     if (objectName && Array.isArray(enrichedField.options) && enrichedField.options.length > 0) {
       enrichedField.options = translateOptions(objectName, field.name, enrichedField.options as any);
     }

--- a/packages/plugin-detail/src/HeaderHighlight.tsx
+++ b/packages/plugin-detail/src/HeaderHighlight.tsx
@@ -20,6 +20,7 @@ import { getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
 import { useSafeFieldLabel, useInlineEdit } from '@object-ui/react';
 import { Check, X, Pencil } from 'lucide-react';
 import { InlineFieldInput, TEXTUAL_REF_FALLBACK_TYPES } from './InlineFieldInput';
+import { enrichDetailField } from './fieldEnrichment';
 import { NON_EDITABLE_SYSTEM_FIELDS } from './systemFields';
 import { useDetailTranslation } from './useDetailTranslation';
 
@@ -82,35 +83,15 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
             // Enrich field metadata from objectSchema
             const objectDefField = objectSchema?.fields?.[field.name];
             const resolvedType = field.type || objectDefField?.type;
-            // Backend object schemas use the ObjectStack-convention `reference`
-            // key (DetailSection normalizes the same pair) — without it the
-            // lookup editor has no target object to hydrate or search against.
-            const refTarget =
-              objectDefField?.reference_to || (objectDefField as any)?.reference;
-            const enrichedField = {
-              name: field.name,
-              label: field.label,
-              type: resolvedType || 'text',
-              ...(objectDefField?.options && { options: objectDefField.options }),
-              ...(objectDefField?.currency && { currency: objectDefField.currency }),
-              // The SPEC channel for a per-field currency (a bare `currency`
-              // key is designer/DB-only) — resolveFieldCurrency reads
-              // currencyConfig.defaultCurrency second (#2548).
-              ...(objectDefField?.currencyConfig && { currencyConfig: objectDefField.currencyConfig }),
-              ...(objectDefField?.precision !== undefined && { precision: objectDefField.precision }),
-              ...((objectDefField as any)?.scale !== undefined && { scale: (objectDefField as any).scale }),
-              // Numeric range/step constraints (objectui#2572 item 3) — keep in
-              // sync with DetailSection's enrichment so both editors honor them.
-              ...((objectDefField as any)?.min !== undefined && { min: (objectDefField as any).min }),
-              ...((objectDefField as any)?.max !== undefined && { max: (objectDefField as any).max }),
-              ...((objectDefField as any)?.step !== undefined && { step: (objectDefField as any).step }),
-              ...(objectDefField?.format && { format: objectDefField.format }),
-              ...(refTarget && { reference_to: refTarget }),
-              ...((objectDefField as any)?.reference_field && {
-                reference_field: (objectDefField as any).reference_field,
-              }),
-              ...((objectDefField as any)?.widget && { widget: (objectDefField as any).widget }),
-            };
+            // Shared with DetailSection (`enrichDetailField`) so the highlights
+            // strip and the details body resolve an identical field shape —
+            // including the relational keys a lookup picker needs (`multiple`,
+            // display/id fields, picker config), and the `reference` /
+            // `reference_to` spelling pair backend schemas use.
+            const enrichedField = enrichDetailField(
+              { name: field.name, label: field.label, type: resolvedType || 'text' },
+              objectDefField,
+            );
 
             // Live value = the user's draft edit for this field, else the record
             // value. Read as `draft[name] ?? data[name]` (objectui#2407 P2).

--- a/packages/plugin-detail/src/InlineFieldInput.tsx
+++ b/packages/plugin-detail/src/InlineFieldInput.tsx
@@ -113,9 +113,23 @@ export const InlineFieldInput: React.FC<InlineFieldInputProps> = ({
     );
   }
   // Picklist → real Select widget so users see localized option labels and
-  // can't free-type invalid values.
-  if (editType === 'select' && Array.isArray(field.options) && field.options.length > 0) {
-    return (
+  // can't free-type invalid values. A `multiple` picklist (spec canon: `select`
+  // + `multiple: true`; `multiselect` is the widget-level alias) selects
+  // zero-or-more values — `SelectField` delegates to the chip picker, so the
+  // value must stay an ARRAY here instead of being flattened by `String()`.
+  const isMultiSelect = editType === 'multiselect' || !!field.multiple;
+  if (
+    (editType === 'select' || editType === 'multiselect') &&
+    Array.isArray(field.options) &&
+    field.options.length > 0
+  ) {
+    return isMultiSelect ? (
+      <SelectField
+        field={{ ...(field as any), multiple: true }}
+        value={Array.isArray(value) ? value : value == null || value === '' ? [] : [value]}
+        onChange={(v) => onChange(v)}
+      />
+    ) : (
       <SelectField
         field={field as any}
         value={value == null ? '' : String(value)}

--- a/packages/plugin-detail/src/__tests__/DetailSection.multiValueInlineEdit.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.multiValueInlineEdit.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Multi-value fields in inline edit (the pencil affordance on a detail page).
+ *
+ * Regression: `DetailSection`'s field enrichment copied a hand-written key
+ * whitelist that never included `multiple`, so a lookup declared
+ * `multiple: true` reached the picker as a SINGLE-select field — picking a
+ * record replaced the value and closed the popover, making it impossible to
+ * select more than one. The read cell showed one chip for the same reason.
+ *
+ * The enrichment now goes through the shared `enrichDetailField`, which carries
+ * `multiple` (and the rest of the picker configuration) from the object schema.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { DetailSection } from '../DetailSection';
+import type { DetailViewSection } from '@object-ui/types';
+
+const tags = [
+  { id: 't1', name: 'Urgent' },
+  { id: 't2', name: 'Backlog' },
+];
+
+function makeDataSource() {
+  const find = vi.fn(async () => ({ data: tags, total: tags.length }));
+  return { find } as any;
+}
+
+const objectSchema = {
+  fields: {
+    tags: {
+      type: 'lookup',
+      reference_to: 'tags',
+      display_field: 'name',
+      multiple: true,
+    },
+    priority: {
+      type: 'select',
+      multiple: true,
+      options: [
+        { label: 'High', value: 'high' },
+        { label: 'Low', value: 'low' },
+      ],
+    },
+  },
+};
+
+const section = {
+  fields: [{ name: 'tags', label: 'Tags' }],
+} as DetailViewSection;
+
+/**
+ * Stand-in for `DetailView`'s inline-edit state: it merges the draft back into
+ * `data` on every change, exactly as `{ ...data, ...editedValues }` does, so a
+ * second pick sees the first one.
+ */
+function EditingHost({
+  onChange,
+  initial,
+  fields = section,
+}: {
+  onChange: (name: string, value: any) => void;
+  initial: Record<string, any>;
+  fields?: DetailViewSection;
+}) {
+  const [data, setData] = React.useState(initial);
+  return (
+    <DetailSection
+      section={fields}
+      data={data}
+      objectSchema={objectSchema}
+      dataSource={makeDataSource()}
+      isEditing
+      onFieldChange={(name, value) => {
+        setData((prev) => ({ ...prev, [name]: value }));
+        onChange(name, value);
+      }}
+    />
+  );
+}
+
+beforeEach(() => {
+  try {
+    localStorage.clear();
+  } catch {
+    /* happy-dom */
+  }
+});
+
+describe('DetailSection inline edit — multi-value lookup', () => {
+  it('accumulates picks instead of replacing the previous one', async () => {
+    const onChange = vi.fn();
+    render(<EditingHost onChange={onChange} initial={{ tags: [] }} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('lookup-trigger-tags'));
+    });
+
+    await waitFor(() => expect(screen.getByRole('option', { name: /Urgent/ })).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('option', { name: /Urgent/ }));
+    });
+    expect(onChange).toHaveBeenLastCalledWith('tags', ['t1']);
+
+    // The popover stays open in multi mode — the second pick must ADD to the
+    // value, which is the exact step that was impossible before the fix.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('option', { name: /Backlog/ }));
+    });
+    expect(onChange).toHaveBeenLastCalledWith('tags', ['t1', 't2']);
+  });
+
+  it('renders every selected record as a chip, including `$expand`-ed values', async () => {
+    render(
+      <EditingHost
+        onChange={vi.fn()}
+        initial={{ tags: [{ id: 't1', name: 'Urgent' }, { id: 't2', name: 'Backlog' }] }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Urgent')).toBeInTheDocument();
+      expect(screen.getByText('Backlog')).toBeInTheDocument();
+    });
+  });
+
+  it('renders a multi-value picklist as the chip picker, not a stringified value', async () => {
+    const onChange = vi.fn();
+    render(
+      <EditingHost
+        onChange={onChange}
+        initial={{ priority: ['high'] }}
+        fields={{ fields: [{ name: 'priority', label: 'Priority' }] } as DetailViewSection}
+      />,
+    );
+
+    // A single-select dropdown would have coerced the array through String();
+    // the multi picker offers every option as a toggleable chip.
+    const high = screen.getByTestId('multiselect-option-high');
+    expect(high).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('multiselect-option-low')).toHaveAttribute('aria-pressed', 'false');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('multiselect-option-low'));
+    });
+    expect(onChange).toHaveBeenLastCalledWith('priority', ['high', 'low']);
+  });
+});

--- a/packages/plugin-detail/src/__tests__/fieldEnrichment.test.ts
+++ b/packages/plugin-detail/src/__tests__/fieldEnrichment.test.ts
@@ -1,0 +1,64 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { enrichDetailField } from '../fieldEnrichment';
+
+describe('enrichDetailField', () => {
+  it('carries the relational picker configuration a lookup editor needs', () => {
+    const enriched = enrichDetailField(
+      { name: 'tags', label: 'Tags' },
+      {
+        type: 'lookup',
+        reference: 'tags',
+        multiple: true,
+        display_field: 'name',
+        id_field: 'code',
+        lookup_filters: [{ field: 'active', operator: 'eq', value: true }],
+        depends_on: ['category'],
+        picker: 'search',
+      },
+    );
+
+    expect(enriched).toMatchObject({
+      type: 'lookup',
+      // ObjectStack's `reference` spelling normalizes onto the canonical key.
+      reference_to: 'tags',
+      multiple: true,
+      display_field: 'name',
+      id_field: 'code',
+      picker: 'search',
+      depends_on: ['category'],
+    });
+    expect(enriched.lookup_filters).toEqual([{ field: 'active', operator: 'eq', value: true }]);
+  });
+
+  it('keeps the view field as the override — the schema only fills gaps', () => {
+    const enriched = enrichDetailField(
+      { name: 'amount', type: 'currency', currency: 'EUR' },
+      { type: 'number', currency: 'USD', scale: 2, min: 0 },
+    );
+
+    expect(enriched.type).toBe('currency');
+    expect(enriched.currency).toBe('EUR');
+    expect(enriched.scale).toBe(2);
+    expect(enriched.min).toBe(0);
+  });
+
+  it('never copies `readonly` (the hosts gate editability off the schema directly)', () => {
+    const enriched = enrichDetailField({ name: 'code' }, { type: 'text', readonly: true });
+    expect(enriched.readonly).toBeUndefined();
+  });
+
+  it('is a no-op passthrough when the field has no object metadata', () => {
+    expect(enrichDetailField({ name: 'ad_hoc', type: 'text' }, undefined)).toEqual({
+      name: 'ad_hoc',
+      type: 'text',
+    });
+  });
+});

--- a/packages/plugin-detail/src/fieldEnrichment.ts
+++ b/packages/plugin-detail/src/fieldEnrichment.ts
@@ -1,0 +1,104 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Object-metadata keys carried onto a detail-view field so the read cell and
+ * the inline editor see the SAME resolved field shape the object form does.
+ *
+ * A `DetailViewField` only declares presentation (name / label / span / …), so
+ * everything that configures a widget lives on the object schema. `DetailSection`
+ * and `HeaderHighlight` each used to hand-copy their own subset, which drifted
+ * repeatedly — numeric `min`/`max`/`step` were missing (objectui#2572), and the
+ * relational block below was missing entirely, so a `multiple: true` lookup
+ * rendered as a SINGLE-select picker in inline edit (picking one record replaced
+ * the value and closed the popover, making multi-select impossible).
+ *
+ * Ordering is documentation only; the copy is key-by-key.
+ */
+export const ENRICHED_FIELD_METADATA_KEYS = [
+  // Presentation / value formatting
+  'options',
+  'currency',
+  // The SPEC channel for a per-field currency (a bare `currency` key is
+  // designer/DB-only) — resolveFieldCurrency reads it second (#2548).
+  'currencyConfig',
+  'precision',
+  'scale',
+  // Numeric range/step constraints (objectui#2572 item 3).
+  'min',
+  'max',
+  'step',
+  'format',
+  // Per-field widget override (ADR-0056 P2) — a structured editor replaces the
+  // raw type in inline edit too, matching the form path.
+  'widget',
+  'dueLike',
+
+  // Relational / picker configuration. Every key the lookup + user pickers read
+  // off their field metadata (both the ObjectStack snake_case convention and the
+  // camelCase alias each reader accepts), so an inline-edit picker behaves
+  // exactly like the same field on the object form: multi-value selection,
+  // display/description/id fields, quick-create, the Level-2 record picker's
+  // columns / page size / base filters, the search-first people picker, and
+  // dependent-lookup gating.
+  'multiple',
+  'reference_field',
+  'display_field',
+  'displayField',
+  'description_field',
+  'descriptionField',
+  'id_field',
+  'allow_create',
+  'allowCreate',
+  'lookup_columns',
+  'lookupColumns',
+  'lookup_page_size',
+  'lookupPageSize',
+  'lookup_filters',
+  'lookupFilters',
+  'picker',
+  'subtitle',
+  'avatar_field',
+  'avatarField',
+  'depends_on',
+  'dependsOn',
+] as const;
+
+/**
+ * Merge a detail-view field with its object-schema metadata.
+ *
+ * The view field always wins — it is the author's explicit override; the object
+ * schema only fills the keys it left undefined. Shared by `DetailSection` (the
+ * details body) and `HeaderHighlight` (the highlights strip) so the two editors
+ * can't drift again.
+ *
+ * `readonly` is deliberately NOT copied: the hosts read it straight off the
+ * object metadata for their editability gate, and widgets take `readonly` as a
+ * prop rather than from field metadata.
+ */
+export function enrichDetailField(
+  viewField: Record<string, any>,
+  objectDefField: Record<string, any> | undefined | null,
+): Record<string, any> {
+  const enriched: Record<string, any> = { ...viewField };
+  if (!objectDefField) return enriched;
+
+  if (!enriched.type && objectDefField.type) enriched.type = objectDefField.type;
+
+  for (const key of ENRICHED_FIELD_METADATA_KEYS) {
+    const value = (objectDefField as Record<string, any>)[key];
+    if (value !== undefined && enriched[key] === undefined) enriched[key] = value;
+  }
+
+  // ObjectStack object metadata uses `reference` for the lookup target while the
+  // objectui types call it `reference_to` — accept both, stamp the canonical key.
+  const refTarget = objectDefField.reference_to || objectDefField.reference;
+  if (refTarget && enriched.reference_to === undefined) enriched.reference_to = refTarget;
+
+  return enriched;
+}


### PR DESCRIPTION
Fixes #2956

## 问题

详情页笔 icon 进入行内编辑后,多值 lookup 只能选中一个:选第一条即关闭浮层并**替换**值,再选只会顶掉前一个。同一字段在对象表单里多选正常。

## 根因

`DetailSection` 用**手写白名单**把 object schema 的字段元数据逐个拷到视图字段上,这份白名单没有 `multiple` —— `LookupField` 里 `fieldMeta?.multiple` 恒为 false,走单选分支。

同时漏掉的还有 lookup picker 的其余配置(display / description / id field、快捷新建、Level-2 记录选择器的列 / 分页 / 基础过滤、people picker、`depends_on` 联动),这些表单路径都是白拿的。`HeaderHighlight` 另抄了一份同类白名单,两份已互相漂移过两次(注释里还写着 "keep in sync with DetailSection")。

## 改动

- 新增 `packages/plugin-detail/src/fieldEnrichment.ts` → `enrichDetailField(viewField, objectDefField)`:一份带文档的 key 清单,视图字段永远优先,`readonly` 故意不拷(宿主自己从 object metadata 读来做可编辑性判定)。`DetailSection` 与 `HeaderHighlight` 共用,漂移这条路堵死。
- `InlineFieldInput`:`multiple` 真的传下来后,select 分支原来的 `String(value)` 会把数组拍扁,故多值 picklist(含 `multiselect` 别名)改走 chip 选择器、值保持数组。

## 测试

- `DetailSection.multiValueInlineEdit.test.tsx` — 驱动真实组件树(`DetailSection` + 真 `LookupField` + mock DataSource,真点 DOM):连点两个选项后 `onFieldChange` 依次收到 `['t1']` → `['t1','t2']`;`$expand` 数组渲染成多个 chip;多值 picklist 的 chip toggle。
- `fieldEnrichment.test.ts` — 关系配置透传、视图字段覆盖优先、不拷 `readonly`、无 schema 时原样返回。
- 反向验证:把 `multiple` 从 key 清单里临时摘掉,上述集成测试立刻红(2 条失败),装回即绿。
- `plugin-detail` 全量 **32 文件 / 281 用例通过**;eslint 0 error。
- `tsc` 有 3 条既有报错(`DetailView.tsx` / `record-details.tsx`),来自依赖包 dist 过期,与本 PR 无关。

## 真机验证(framework app-showcase)

本 worktree 构建 console dist 换入 `framework/packages/console/dist`,起 `objectstack dev --ui --seed-admin`,浏览器实测:

Field Zoo → `Specimen — Full` → 显示空字段 → `Users (multiple)` 笔 icon →
选 Dev Admin(浮层不关,「已选择 1 项」)→ 选 Mei Phone(「已选择 2 项」,两个都打勾)→ 选 Ada Auditor(3 项)→ 保存 → 详情页显示三个头像 → **整页重载后仍在**,接口返回干净的 id 数组
`f_users: ["Vbom68I0yoNTG9j5YGaKqZqDILHHnrIK","usr_showcase_phone_demo","usr_showcase_auditor_demo"]`,浏览器 console 无 error。

说明:showcase 里没有 `Field.lookup(..., { multiple: true })` 的样本,实测用的是多值 user 字段 —— `UserField` 直接委托 `LookupField`,`multiple` 也来自同一处富化,走的是同一条代码路径。

纯 bug 修复,按 AGENTS.md 不需要 changeset。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
