### PR TITLE
feat(report): carry a report's `order` into the dataset selection (framework#3916)

### DIFF
--- a/.changeset/report-order-reaches-the-selection.md
+++ b/.changeset/report-order-reaches-the-selection.md
@@ -1,0 +1,52 @@
+---
+"@object-ui/plugin-report": minor
+---
+
+feat(report): carry a report's `order` into the dataset selection (framework#3916)
+
+`@objectstack/spec` 17 gave reports an ordering declaration — `ReportSchema.order`
+(and `blocks[].order` for a joined report): a list of `{ by, direction }` keys,
+most significant first. The framework executor applies it. `DatasetReportRenderer`
+built the selection it posts and never carried the declaration into it, so an
+authored `order` reached no query and did nothing.
+
+`useDatasetRows` — the single fetch choke point behind every report path — now
+takes the lowered ordering, and all four call sites supply it: the grouped table,
+the embedded chart, the matrix cross-tab, and each joined block.
+
+- **Lowering.** `readOrder()` turns the authored list into
+  `DatasetSelection.order`, the array's element order becoming the object's key
+  insertion order (which is how sort significance is expressed on the wire). It
+  is permissive about its input, like the neighbouring `readNames()` — stored
+  report JSON crosses the repo boundary and may lag the schema, so an entry with
+  no usable `by` is dropped rather than thrown. An absent or entirely-unusable
+  list yields `undefined`, so the field is OMITTED and the server's own defaults
+  still apply: a selected time dimension comes back chronological with nothing
+  declared.
+
+  Kept local rather than importing spec's `reportSelectionOrder` — the pinned
+  `^17.0.0-rc.0` predates that export. Swap it for the import on the next bump.
+
+- **Scoped per sub-selection.** A report's `order` is validated against its
+  WHOLE selection, but this renderer issues narrower queries from it: the chart
+  plots one dimension × one measure, and the flat-table path drops the matrix
+  across-dimensions. The server rejects an order key naming nothing the
+  selection projects (a deliberate 400), so forwarding the full list would turn
+  a valid report into a failed chart. Keys outside a sub-selection are dropped
+  at the choke point instead. Nothing is masked: the schema already validated
+  every key against `rows` ∪ `columns` ∪ `values`, so the only keys that can be
+  lost are ones the narrower query genuinely has no column for.
+
+- **Part of the refetch key.** The ordering changes the ROWS the server returns,
+  not just their presentation, so it joins the `useDatasetRows` signature — an
+  ordering edited from asc to desc refetches instead of re-rendering the stale
+  grid.
+
+- **Matrix across-axis.** `colHeaders` are collected in row-arrival order, so
+  ordering the rows by the across dimension is what makes the columns read
+  left-to-right in that order. Ordering rides on the primary query only; the
+  server drops it for the totals sub-queries by design.
+
+Ordering stays server-side throughout — never a client-side re-sort, which would
+order the page rather than the query and could not sort by a derived measure at
+all.

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -32,6 +32,19 @@
  * the field's declared `currency` (`Intl` symbol) + numeral `format`, never
  * the raw field name or a misleading "$".
  *
+ * Ordering (framework#3916): a report's `order` — a list of `{ by, direction }`
+ * keys, most significant first — is lowered onto the dataset selection, so the
+ * SERVER orders the whole grid (after measure-scoped filters merge and derived
+ * measures evaluate) and this renderer only places the rows it is handed. It is
+ * never a client-side re-sort: sorting here would order the truncated page
+ * rather than the query, and could not sort by a derived measure at all.
+ *
+ * For a matrix that also decides the ACROSS axis: `colHeaders` are collected in
+ * row-arrival order, so ordering the rows by the across dimension is what makes
+ * the columns read left-to-right in that order. Declaring nothing still reads
+ * correctly — the server defaults a selected time dimension to ascending, which
+ * is what makes month/quarter columns chronological out of the box.
+ *
  * Drill-down (ADR-0021 D2): when the report's `drilldown` flag is not `false`
  * and the host supplies `onDrill`, every aggregated row / matrix cell is
  * clickable and emits `{ dataset, groupKey, runtimeFilter }`. The HOST owns
@@ -109,6 +122,13 @@ interface DatasetReportLike {
   values?: string[];
   runtimeFilter?: Record<string, unknown>;
   filter?: Record<string, unknown>;
+  /**
+   * Result ordering, most significant key first (framework#3916). Each `by`
+   * names a dimension the report groups by (`rows` / `columns`) or a measure it
+   * displays (`values`). A `joined` report carries this per BLOCK, never on the
+   * container.
+   */
+  order?: Array<{ by?: unknown; direction?: unknown }>;
   /** Click-through to underlying records (default true). */
   drilldown?: boolean;
   /** Embedded chart visualization (ADR-0021): type + xAxis/yAxis over the dataset. */
@@ -153,7 +173,78 @@ function readNames(value: unknown): string[] {
   return Array.isArray(value) ? (value as unknown[]).filter((v): v is string => typeof v === 'string' && !!v) : [];
 }
 
-/** Shared fetch for one dataset selection. */
+/** A lowered ordering, keyed in significance order (first key = primary sort). */
+type SelectionOrder = Record<string, 'asc' | 'desc'>;
+
+/**
+ * Lower a report's authored `order` list into the `DatasetSelection.order` the
+ * dataset query takes (framework#3916).
+ *
+ * The array's element order becomes the object's key insertion order, which is
+ * how `DatasetSelection.order` expresses sort significance. Returns `undefined`
+ * for an absent / empty / entirely-unusable list, so the caller OMITS the field
+ * and the server's own defaults still apply — a selected time dimension comes
+ * back chronological without the author declaring anything.
+ *
+ * Deliberately permissive about the input, like `readNames` above: this reads
+ * stored report JSON, which crosses the repo boundary and may predate (or lag)
+ * the schema. An entry with no usable `by` is dropped rather than throwing —
+ * the authoring-time schema is where a malformed `order` is meant to be caught.
+ *
+ * Mirrors `reportSelectionOrder` in `@objectstack/spec/ui`; kept local because
+ * the pinned spec (`^17.0.0-rc.0`) predates that export. Swap this for the
+ * import once the dependency bump lands.
+ */
+function readOrder(value: unknown): SelectionOrder | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: SelectionOrder = {};
+  for (const entry of value as Array<{ by?: unknown; direction?: unknown }>) {
+    const by = entry && typeof entry === 'object' ? entry.by : undefined;
+    if (typeof by !== 'string' || !by) continue;
+    out[by] = entry.direction === 'desc' ? 'desc' : 'asc';
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Narrow an ordering to the keys a given selection actually projects.
+ *
+ * The server REJECTS an order key that names nothing the selection selected
+ * (a deliberate 400 — a mistyped sort key that silently returns arbitrary rows
+ * is worse than a loud failure). But one report's `order` is validated against
+ * its WHOLE selection, while this renderer issues narrower sub-selections from
+ * it: the embedded chart queries only `chart.xAxis` × `chart.yAxis`, and the
+ * flat table path drops the matrix across-dimensions. Forwarding the full list
+ * to those would turn a perfectly valid report into a failed query.
+ *
+ * So keys outside a sub-selection are dropped HERE rather than sent and
+ * rejected. This cannot mask an authoring mistake: the report's own schema
+ * already validated every key against `rows` ∪ `columns` ∪ `values`, so the
+ * only keys that can be lost are ones the narrower query genuinely has no
+ * column for.
+ */
+function scopeOrder(
+  order: SelectionOrder | undefined,
+  dimensions: string[],
+  measures: string[],
+): SelectionOrder | undefined {
+  if (!order) return undefined;
+  const selectable = new Set<string>([...dimensions, ...measures]);
+  const out: SelectionOrder = {};
+  for (const [key, direction] of Object.entries(order)) {
+    if (selectable.has(key)) out[key] = direction;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Shared fetch for one dataset selection.
+ *
+ * `order` (framework#3916) is scoped to what THIS selection projects before it
+ * is sent — see {@link scopeOrder}. Every report path funnels through here, so
+ * scoping once is what keeps the chart's narrow x/y sub-selection from posting
+ * an order key it never selected.
+ */
 function useDatasetRows(
   dataset: string,
   dimensions: string[],
@@ -161,6 +252,7 @@ function useDatasetRows(
   runtimeFilter: Record<string, unknown> | undefined,
   dataSource: unknown,
   totalsGroupings?: string[][],
+  order?: SelectionOrder,
 ) {
   const [state, setState] = React.useState<{
     status: 'idle' | 'loading' | 'ok' | 'error';
@@ -177,9 +269,16 @@ function useDatasetRows(
     rows: [],
   });
 
+  const scopedOrder = scopeOrder(order, dimensions, measures);
   const rfKey = JSON.stringify(runtimeFilter ?? null);
   const totalsKey = JSON.stringify(totalsGroupings ?? null);
-  const signature = `${dataset}|${dimensions.join(',')}|${measures.join(',')}|${rfKey}|${totalsKey}`;
+  // The ordering is part of the signature: it changes the ROWS the server
+  // returns (and, for a matrix, the arrival order the pivot builds its column
+  // headers from), so a report edited from asc to desc must refetch, not
+  // re-render the previous grid. `JSON.stringify` preserves key order, which is
+  // exactly the sort significance that must invalidate the cache.
+  const orderKey = JSON.stringify(scopedOrder ?? null);
+  const signature = `${dataset}|${dimensions.join(',')}|${measures.join(',')}|${rfKey}|${totalsKey}|${orderKey}`;
   React.useEffect(() => {
     const src = dataSource as DatasetCapableSource | undefined;
     if (!src || typeof src.queryDataset !== 'function') {
@@ -198,6 +297,7 @@ function useDatasetRows(
         measures,
         ...(runtimeFilter && Object.keys(runtimeFilter).length > 0 ? { runtimeFilter } : {}),
         ...(totalsGroupings ? { totals: { groupings: totalsGroupings } } : {}),
+        ...(scopedOrder ? { order: scopedOrder } : {}),
       })
       .then((res) => {
         if (!cancelled) {
@@ -267,6 +367,7 @@ function DatasetReportTable({
   runtimeFilter,
   dataSource,
   onDrill,
+  order,
 }: {
   dataset: string;
   rows: string[];
@@ -274,8 +375,9 @@ function DatasetReportTable({
   runtimeFilter?: Record<string, unknown>;
   dataSource?: unknown;
   onDrill?: (args: DatasetDrillArgs) => void;
+  order?: SelectionOrder;
 }) {
-  const state = useDatasetRows(dataset, rows, values, runtimeFilter, dataSource);
+  const state = useDatasetRows(dataset, rows, values, runtimeFilter, dataSource, undefined, order);
   const { fieldLabel } = useSafeFieldLabel();
 
   if (values.length === 0) return <EmptyMeasures dataset={dataset} />;
@@ -420,20 +522,29 @@ function DatasetReportChart({
   chart,
   runtimeFilter,
   dataSource,
+  order,
 }: {
   dataset: string;
   chart: Record<string, unknown>;
   runtimeFilter?: Record<string, unknown>;
   dataSource?: unknown;
+  order?: SelectionOrder;
 }) {
   const xAxis = typeof chart.xAxis === 'string' ? chart.xAxis : '';
   const yAxis = typeof chart.yAxis === 'string' ? chart.yAxis : '';
+  // The chart plots a NARROWER selection than the table beneath it (one
+  // dimension × one measure), so `useDatasetRows` scopes the report's order to
+  // those two columns — a "biggest first" on the plotted measure still sorts
+  // the bars; a key naming some other row dimension is simply not applicable
+  // here and is dropped rather than posted and rejected.
   const state = useDatasetRows(
     dataset,
     xAxis ? [xAxis] : [],
     yAxis ? [yAxis] : [],
     runtimeFilter,
     dataSource,
+    undefined,
+    order,
   );
   const ChartComponent = useRegistryComponent('chart');
 
@@ -499,6 +610,7 @@ function DatasetMatrixTable({
   runtimeFilter,
   dataSource,
   onDrill,
+  order,
 }: {
   dataset: string;
   rows: string[];
@@ -507,13 +619,25 @@ function DatasetMatrixTable({
   runtimeFilter?: Record<string, unknown>;
   dataSource?: unknown;
   onDrill?: (args: DatasetDrillArgs) => void;
+  order?: SelectionOrder;
 }) {
   // Row subtotals, column subtotals, and the grand total ([]), in that order.
-  const state = useDatasetRows(dataset, [...rows, ...columnsAcross], values, runtimeFilter, dataSource, [
-    rows,
-    columnsAcross,
-    [],
-  ]);
+  //
+  // #3916: the ordering rides on the PRIMARY query only — the server drops it
+  // for the totals sub-queries by design (a total covers the whole selection,
+  // and an order key may name a dimension the totals grouping doesn't have).
+  // The across-axis header sequence follows from it: `pivot` below collects
+  // `colHeaders` in row-ARRIVAL order, so ordering the rows by the across
+  // dimension is what makes the columns read left-to-right in that order.
+  const state = useDatasetRows(
+    dataset,
+    [...rows, ...columnsAcross],
+    values,
+    runtimeFilter,
+    dataSource,
+    [rows, columnsAcross, []],
+    order,
+  );
   const tt = useSafeTranslate();
   const { fieldLabel } = useSafeFieldLabel();
 
@@ -708,6 +832,11 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
         {report.blocks.map((block, index) => {
           const blockFilter = mergeFilters(outerFilter, (block.runtimeFilter ?? block.filter) as Record<string, unknown> | undefined);
           const blockAcross = readNames(block.columns);
+          // #3916 — each block orders ITSELF. A joined container selects nothing
+          // of its own (the schema rejects `order` on it), and every block is an
+          // independent query over its own dataset, so there is no report-level
+          // ordering to inherit here.
+          const blockOrder = readOrder(block.order);
           const blockTable = block.type === 'matrix' && blockAcross.length > 0 ? (
             <DatasetMatrixTable
               dataset={String(block.dataset ?? '')}
@@ -717,6 +846,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
               runtimeFilter={blockFilter}
               dataSource={dataSource}
               onDrill={drillSink}
+              order={blockOrder}
             />
           ) : (
             <DatasetReportTable
@@ -726,6 +856,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
               runtimeFilter={blockFilter}
               dataSource={dataSource}
               onDrill={drillSink}
+              order={blockOrder}
             />
           );
           return (
@@ -750,6 +881,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
   }
 
   const across = readNames(report.columns);
+  const reportOrder = readOrder(report.order);
   // Matrix with an across dimension → true cross-tab; without one it
   // degrades to the flat grouped table (pre-`columns` stored JSON).
   if (report.type === 'matrix' && across.length > 0) {
@@ -763,6 +895,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
           runtimeFilter={outerFilter}
           dataSource={dataSource}
           onDrill={drillSink}
+          order={reportOrder}
         />
       </div>
     );
@@ -788,6 +921,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
           chart={chartCfg}
           runtimeFilter={outerFilter}
           dataSource={dataSource}
+          order={reportOrder}
         />
       ) : null}
       <DatasetReportTable
@@ -797,6 +931,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
         runtimeFilter={outerFilter}
         dataSource={dataSource}
         onDrill={drillSink}
+        order={reportOrder}
       />
     </div>
   );

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -12,6 +12,8 @@
  *    renders the SERVER-supplied subtotals/grand total; no totals in the
  *    response (older server) → no totals UI (never re-aggregated client-side)
  *  - drill-down: clickable rows/cells emit {dataset, groupKey, runtimeFilter}
+ *  - ordering (framework#3916): `report.order` / `blocks[].order` lowered onto
+ *    the selection, scoped per sub-selection, and part of the refetch key
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -597,6 +599,181 @@ describe('DatasetReportRenderer', () => {
     const args = onDrill.mock.calls[0][0];
     expect(args.groupKey).toEqual({ status: 'Backlog' });
     expect(args.objectFilter).toBeUndefined();
+  });
+
+  /**
+   * framework#3916 — a report's `order` must reach the SELECTION.
+   *
+   * The schema gained `order` on the framework side and the executor applies
+   * it, but this renderer built the selection it posts and never carried the
+   * declaration into it — so an authored ordering did nothing. These pin the
+   * lowering, its per-path scoping, and the cache key.
+   */
+  it('lowers report.order onto the selection, keys in declared order', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    render(
+      <DatasetReportRenderer
+        report={{
+          name: 'hours', type: 'summary', dataset: 'task_metrics',
+          rows: ['status'], values: ['est_hours'],
+          order: [{ by: 'est_hours', direction: 'desc' }, { by: 'status' }],
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    const order = src.calls[0].selection.order;
+    expect(order).toEqual({ est_hours: 'desc', status: 'asc' });
+    // Key ORDER is the contract — it is how sort significance survives the
+    // lowering from a list into a plain object.
+    expect(Object.keys(order)).toEqual(['est_hours', 'status']);
+  });
+
+  it('omits `order` entirely when the report declares none', async () => {
+    // Not `{}` — the field must be absent so the server's own default (a
+    // selected time dimension sorts ascending) still applies.
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'hours', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect('order' in src.calls[0].selection).toBe(false);
+  });
+
+  it('matrix sends the order alongside the totals groupings', async () => {
+    const src = makeSource({
+      task_metrics: [{ status: 'Backlog', closed_month: '2026-06', est_hours: 10 }],
+    });
+    render(
+      <DatasetReportRenderer
+        report={{
+          name: 'm', type: 'matrix', dataset: 'task_metrics',
+          rows: ['status'], columns: ['closed_month'], values: ['est_hours'],
+          order: [{ by: 'closed_month', direction: 'desc' }],
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    expect(src.calls[0].selection.order).toEqual({ closed_month: 'desc' });
+    expect(src.calls[0].selection.totals).toEqual({ groupings: [['status'], ['closed_month'], []] });
+  });
+
+  it('matrix column headers follow the row order the server returned', async () => {
+    // The pivot collects colHeaders in row-ARRIVAL order, so the server's
+    // ordering IS the across-axis order — the whole point of #3916.
+    const src = makeSource({
+      task_metrics: [
+        { status: 'Backlog', closed_month: '2026-08', est_hours: 1 },
+        { status: 'Backlog', closed_month: '2026-07', est_hours: 2 },
+        { status: 'Backlog', closed_month: '2026-06', est_hours: 3 },
+      ],
+    });
+    render(
+      <DatasetReportRenderer
+        report={{
+          name: 'm', type: 'matrix', dataset: 'task_metrics',
+          rows: ['status'], columns: ['closed_month'], values: ['est_hours'],
+          order: [{ by: 'closed_month', direction: 'desc' }],
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    const headers = screen.getAllByRole('columnheader').map((el) => el.textContent);
+    expect(headers).toEqual(expect.arrayContaining(['2026-08', '2026-07', '2026-06']));
+    expect(headers.indexOf('2026-08')).toBeLessThan(headers.indexOf('2026-07'));
+    expect(headers.indexOf('2026-07')).toBeLessThan(headers.indexOf('2026-06'));
+  });
+
+  it('scopes the order to each sub-selection — the chart drops keys it does not plot', async () => {
+    // The chart queries xAxis × yAxis only. Forwarding a key naming some other
+    // row dimension would have the server reject the query outright (an order
+    // key must name something the selection projects), turning a valid report
+    // into a broken chart.
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    render(
+      <DatasetReportRenderer
+        report={{
+          name: 'hours', type: 'summary', dataset: 'task_metrics',
+          rows: ['status', 'owner'], values: ['est_hours'],
+          chart: { type: 'bar', xAxis: 'status', yAxis: 'est_hours' },
+          order: [{ by: 'owner' }, { by: 'est_hours', direction: 'desc' }],
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(src.calls.length).toBeGreaterThan(1));
+    const chartCall = src.calls.find((c) => Array.isArray(c.selection.dimensions) && c.selection.dimensions.length === 1)!;
+    const tableCall = src.calls.find((c) => Array.isArray(c.selection.dimensions) && c.selection.dimensions.length === 2)!;
+    // Chart keeps only the measure it plots; `owner` is not in its selection.
+    expect(chartCall.selection.order).toEqual({ est_hours: 'desc' });
+    // The table selects both, so it keeps the full declaration.
+    expect(tableCall.selection.order).toEqual({ owner: 'asc', est_hours: 'desc' });
+  });
+
+  it('a joined report orders per block, never from the container', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', task_count: 2 }] });
+    render(
+      <DatasetReportRenderer
+        report={{
+          name: 'j', type: 'joined',
+          blocks: [
+            { name: 'a', dataset: 'task_metrics', rows: ['status'], values: ['task_count'], order: [{ by: 'task_count', direction: 'desc' }] },
+            { name: 'b', dataset: 'task_metrics', rows: ['status'], values: ['task_count'] },
+          ],
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getAllByTestId('dataset-report-block')).toHaveLength(2));
+    const withOrder = src.calls.filter((c) => 'order' in c.selection);
+    expect(withOrder).toHaveLength(1);
+    expect(withOrder[0].selection.order).toEqual({ task_count: 'desc' });
+  });
+
+  it('drops malformed order entries rather than failing the report', async () => {
+    // Stored report JSON crosses the repo boundary; the authoring-time schema
+    // is where a bad `order` is caught, not here. Deliberately violates the
+    // declared shape (that is the point), so it is built as `unknown` first.
+    const malformed: unknown = [
+      { by: 42 },                                 // non-string key
+      null,                                       // not an object at all
+      { direction: 'desc' },                      // no key
+      { by: 'status', direction: 'sideways' },    // unrecognised direction
+    ];
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    render(
+      <DatasetReportRenderer
+        report={{
+          name: 'hours', type: 'summary', dataset: 'task_metrics',
+          rows: ['status'], values: ['est_hours'],
+          order: malformed as Array<{ by?: unknown; direction?: unknown }>,
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    // Only the one usable key survives; an unrecognised direction falls to asc.
+    expect(src.calls[0].selection.order).toEqual({ status: 'asc' });
+  });
+
+  it('refetches when the order changes (it changes the rows, not just the view)', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    const report = (direction: string) => ({
+      name: 'hours', type: 'summary', dataset: 'task_metrics',
+      rows: ['status'], values: ['est_hours'],
+      order: [{ by: 'est_hours', direction }],
+    });
+    const { rerender } = render(<DatasetReportRenderer report={report('asc')} dataSource={src} />);
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect(src.calls).toHaveLength(1);
+    rerender(<DatasetReportRenderer report={report('desc')} dataSource={src} />);
+    await waitFor(() => expect(src.calls).toHaveLength(2));
+    expect(src.calls[1].selection.order).toEqual({ est_hours: 'desc' });
   });
 
   it('shows an error when the data source cannot run dataset queries', async () => {


### PR DESCRIPTION
跟进 framework#3916 / objectstack#3921 的 objectui 一半。

## 问题

`@objectstack/spec` 17 给报表加了排序声明 —— `ReportSchema.order`（joined 报表是 `blocks[].order`），一个 `{ by, direction }` 列表，最重要的键在前 —— 框架侧 executor 也已经会应用它。

但 `DatasetReportRenderer` 自己构造它 post 的 selection，从来没把这个声明带进去：

```ts
// DatasetReportRenderer.tsx — 改动前
src.queryDataset(dataset, {
  dimensions,
  measures,
  ...(runtimeFilter && ... ? { runtimeFilter } : {}),
  ...(totalsGroupings ? { totals: { groupings: totalsGroupings } } : {}),
})
```

所以作者写的 `order` 到不了任何查询，什么都不做。这正是 objectstack#3921 把 `report.order` 在 liveness ledger 里标成 `planned` + `authorWarn` 而不是 `live` 的原因。

## 改动

`useDatasetRows` 是所有报表路径背后唯一的取数收口，现在它接收降级后的排序，四个调用点全部供给：分组表、内嵌图表、matrix 交叉表、以及每个 joined block（joined 容器自己不选任何东西，schema 也禁止在容器上写 `order`，所以没有报表级排序可继承）。

**降级** —— `readOrder()` 把作者写的列表转成 `DatasetSelection.order`，数组元素顺序成为对象键插入顺序，这正是排序优先级在 wire 上的表达方式。它对输入保持宽容，和旁边的 `readNames()` 一致：存量报表 JSON 跨仓边界、可能落后于 schema，所以没有可用 `by` 的条目直接丢弃而不抛错 —— 作者期的 schema 才是校验 `order` 的地方。列表缺失或全不可用时返回 `undefined`，字段被**整个省略**，于是服务端自己的默认仍然生效：选中的时间维度不声明任何东西也会按时间顺序回来。

没有直接 import spec 的 `reportSelectionOrder`，因为本仓 pin 的 `^17.0.0-rc.0` 早于那个导出；依赖升版后可以换成 import（代码注释里标了）。

**按子选择收窄** —— 这是最容易踩的一点。报表的 `order` 是针对它**整个** selection 校验的，但这个渲染器会从中派生更窄的查询：图表只查 `chart.xAxis` × `chart.yAxis`，扁平表路径会丢掉 matrix 的 across 维度。服务端对「命名了 selection 未投影的列」的 order key 是**明确报错**的（故意的 400），所以把完整列表原样转发会把一个合法报表变成失败的图表查询。`scopeOrder()` 在收口处丢掉子选择之外的键。这不会掩盖作者错误：schema 已经把每个键对 `rows` ∪ `columns` ∪ `values` 校验过了，因此只可能丢掉那些更窄查询确实没有对应列的键。

**进入 refetch key** —— 排序改变的是服务端返回的**行**，不只是呈现，所以它加入了 `useDatasetRows` 的 signature：asc 改成 desc 会重新取数，而不是拿旧网格重渲染。

**matrix 的 across 轴** —— `colHeaders` 是按行到达顺序收集的，所以按 across 维度排序行，正是让列从左到右按该顺序排列的机制。排序只随主查询下发；totals 子查询由服务端按设计丢弃排序（total 覆盖整个 selection，而 order key 可能命名了该 grouping 没有的维度）。

排序全程留在服务端，不做客户端重排 —— 客户端排序只能排当前这一页而不是查询，而且根本无法按派生度量排序。

## 测试

新增 9 个用例（`DatasetReportRenderer.test.tsx`），覆盖：降级结果与键顺序、未声明时字段被省略（是 absent 而非 `{}`）、matrix 同时带 order 和 totals groupings、matrix 列头跟随服务端行序、按子选择收窄（图表丢掉它不绘制的键而表格保留完整声明）、joined 逐 block 排序、畸形输入、以及排序变化触发 refetch。

- `plugin-report` 全套件 53 passed（原 44 + 新 9）。
- `type-check` 通过；改动文件 eslint 0 error（仅剩文件里原有的 2 条 `no-explicit-any` warning）。

## 合并后

需要回到 objectstack 仓把 `report.order` 从 `planned` + `authorWarn` 翻成 `live`，并在 ledger 里附上本 PR 的证据路径。我会另开一个 PR 做这件事。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYJ5WSiCgd522s1zCWtmFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYJ5WSiCgd522s1zCWtmFT)_