### PR TITLE
fix(actions): apply the ADR-0066 D4 capability gate on every action surface (framework#3923)

### DIFF
--- a/.changeset/action-required-permissions-ui-gate.md
+++ b/.changeset/action-required-permissions-ui-gate.md
@@ -1,0 +1,45 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/components": patch
+"@object-ui/plugin-detail": patch
+"@object-ui/plugin-grid": patch
+"@object-ui/react": patch
+---
+
+fix(actions): apply the ADR-0066 D4 capability gate on every action surface (framework#3923)
+
+An action declaring `requiredPermissions` is supposed to be one declaration with
+two enforcement surfaces: 403 on the server, hidden button in the UI. The UI half
+only ever ran inside `ActionEngine.getActionsForLocation` — and the surfaces
+`record_header`, `record_more`, `list_item` and `list_toolbar` actually render on
+do not go through the engine. They filter their own action lists. So a button
+declaring a capability nobody holds rendered, live and clickable, on the record
+header, in every grid row menu, and on the list toolbar. For a `type: 'api'`
+action pointed at a self-authored endpoint, nothing else was checking either: the
+platform's action route (which is where the 403 comes from) never sees that
+request.
+
+`page:header`, `action:bar` (business *and* `systemActions`) and the grid's
+`RowActionMenu` now apply the same gate, via a shared `useCapabilityGate()` so
+the surfaces cannot drift apart. The rule is the engine's, unchanged: hide unless
+the caller holds **all** declared capabilities; an empty held set is "holds
+nothing" and gates; **unknown** — no action runtime, no resolved capabilities —
+fails OPEN, because the server is the authority and hiding a permitted user's
+button on missing client data is the worse failure.
+
+The record surface was also feeding the gate nothing to work with.
+`RecordDetailView` mounts its own `<ActionProvider>`, which shadows the shell's
+for every action on that page, and seeded it with identity only — no
+`systemPermissions`. Since unknown fails open, that alone un-gated every
+`record_header` / `record_more` / `record_section` action on the one page those
+locations exist on. It now forwards the caller's resolved capabilities (and only
+once they have actually resolved, so a standalone embed without a
+`PermissionProvider` keeps failing open rather than hiding everything).
+
+`useRecordEditable`'s record-level explain probe went out on a bare
+`fetch(..., { credentials: 'include' })`. A bearer-token session carries its
+credential in the `Authorization` header, not a cookie, so the probe came back
+401 on a perfectly valid admin session and the verdict silently failed open —
+the hook was inert in exactly the deployments it was written for. It now rides
+the host's authenticated fetch (`SchemaRendererProvider`'s `apiFetch`), falling
+back to the global one for standalone embeds.

--- a/packages/app-shell/src/views/RecordDetailView.actionUser.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.actionUser.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RecordDetailView — the `user` seeded into the record surface's own
+ * `<ActionProvider>` (ADR-0066 D4 / framework#3923).
+ *
+ * The record page mounts an ActionProvider that SHADOWS the shell-level one, so
+ * the capability gate the engine reads (`user.systemPermissions`) is whatever
+ * this object carries. It used to carry identity only — `{id, name, avatar}` —
+ * and since `ActionEngine.getActionsForLocation` fails OPEN on `undefined`, every
+ * `record_header` / `record_more` action's `requiredPermissions` was silently
+ * unenforced on the one surface those locations exist on.
+ *
+ * Two properties are pinned here, and they pull in opposite directions:
+ *   • loaded permissions MUST reach the engine (otherwise: no gate at all);
+ *   • unloaded permissions MUST NOT be forwarded as `[]` (otherwise: every gated
+ *     action hides in a standalone embed that never mounts a PermissionProvider).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveActionUser } from './RecordDetailView';
+
+const user = { id: 'u1', name: 'Ada', image: 'https://cdn/a.png' };
+
+describe('resolveActionUser — ADR-0066 D4 capability gate seeding (#3923)', () => {
+  it('forwards loaded systemPermissions so the action gate can enforce', () => {
+    expect(resolveActionUser(user, true, ['manage_platform_settings'])).toEqual({
+      id: 'u1',
+      name: 'Ada',
+      avatar: 'https://cdn/a.png',
+      systemPermissions: ['manage_platform_settings'],
+    });
+  });
+
+  it('forwards an EMPTY loaded set — "holds nothing" must gate, not fail open', () => {
+    const resolved = resolveActionUser(user, true, []);
+    expect(resolved.systemPermissions).toEqual([]);
+    // The distinction the engine keys off: present-but-empty ≠ absent.
+    expect(Array.isArray(resolved.systemPermissions)).toBe(true);
+  });
+
+  it('omits systemPermissions while permissions are still loading (fail-open)', () => {
+    const resolved = resolveActionUser(user, false, []);
+    expect(resolved).toEqual({ id: 'u1', name: 'Ada', avatar: 'https://cdn/a.png' });
+    expect('systemPermissions' in resolved).toBe(false);
+  });
+
+  it('treats a loaded-but-undefined set as "holds nothing", not as unknown', () => {
+    expect(resolveActionUser(user, true, undefined).systemPermissions).toEqual([]);
+  });
+
+  it('keeps the anonymous fallback identity and still carries the gate', () => {
+    const resolved = resolveActionUser(null, true, ['setup.access']);
+    expect(resolved.id).toBe('current-user');
+    expect(resolved.systemPermissions).toEqual(['setup.access']);
+  });
+
+  it('never mutates the shared FALLBACK_USER constant', () => {
+    resolveActionUser(undefined, true, ['a']);
+    const second = resolveActionUser(undefined, false, undefined);
+    expect('systemPermissions' in second).toBe(false);
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -73,6 +73,38 @@ interface RecordDetailViewProps {
 const FALLBACK_USER = { id: 'current-user', name: 'Demo User' };
 
 /**
+ * The `user` seeded into this view's own `<ActionProvider>` — identity plus, once
+ * resolved, the caller's system capabilities.
+ *
+ * [ADR-0066 D4 / framework#3923] `systemPermissions` is not decoration here: this
+ * provider SHADOWS the shell-level one (`useConsoleActionRuntime`) for every
+ * action on the record surface, and `ActionEngine.getActionsForLocation` reads the
+ * capability gate off `runner.getContext().user.systemPermissions`. The engine
+ * fails OPEN on `undefined` (unknown ≠ denied), so shipping identity alone
+ * silently un-gated every `record_header` / `record_more` action that declared
+ * `requiredPermissions` — the button rendered, and only the server's 403 stopped
+ * it (and only for platform action routes at that).
+ *
+ * The `permissionsLoaded` gate keeps the two states apart: `usePermissions()`
+ * returns `[]` both for "holds no capabilities" and for "no PermissionProvider /
+ * still resolving". Forwarding the latter as `[]` would flip the gate fail-CLOSED
+ * and hide gated actions in a standalone embed, so it stays `undefined` until the
+ * answer is real.
+ */
+export function resolveActionUser(
+  user: { id: string; name: string; image?: string } | null | undefined,
+  permissionsLoaded: boolean,
+  systemPermissions: string[] | undefined,
+): { id: string; name: string; avatar?: string; systemPermissions?: string[] } {
+  const identity = user
+    ? { id: user.id, name: user.name, avatar: user.image }
+    : FALLBACK_USER;
+  return permissionsLoaded
+    ? { ...identity, systemPermissions: systemPermissions ?? [] }
+    : identity;
+}
+
+/**
  * Audit field names auto-injected by the framework's `applySystemFields`.
  * Filtered out of the auto-generated body sections — they are rendered
  * separately as a single subtle one-line `<RecordMetaFooter>` (see
@@ -940,7 +972,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // are still loading (`isLoaded === false`, e.g. no PermissionProvider in a
   // standalone embed) the gate stays open — fail-open is safe because the
   // server enforces data access regardless; this is purely a UI/DX filter.
-  const { can: canOnObject, isLoaded: permissionsLoaded, getObjectApiOperations } = usePermissions();
+  const { can: canOnObject, isLoaded: permissionsLoaded, getObjectApiOperations, systemPermissions } = usePermissions();
   // [#3546] Server-resolved effective API operation set for this object
   // (`/me/permissions` `apiOperations`). Threaded as the 2nd arg into
   // `resolveRecordHeaderActionGates` for the detail header's Edit/Delete and
@@ -1208,9 +1240,12 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // Memoize so the object identity is stable across renders — otherwise
   // any effect that depends on it (e.g. the feed loader below) would
   // re-fire every render and create an infinite request loop.
+  //
+  // Carries the ADR-0066 D4 capability gate into this view's ActionProvider —
+  // see `resolveActionUser` for why that matters (framework#3923).
   const currentUser = useMemo(
-    () => (user ? { id: user.id, name: user.name, avatar: user.image } : FALLBACK_USER),
-    [user?.id, user?.name, user?.image],
+    () => resolveActionUser(user, permissionsLoaded, systemPermissions),
+    [user?.id, user?.name, user?.image, permissionsLoaded, systemPermissions],
   );
 
   // Fetch comments from API.

--- a/packages/components/src/__tests__/action-bar.test.tsx
+++ b/packages/components/src/__tests__/action-bar.test.tsx
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider } from '@object-ui/react';
 import { renderComponent, validateComponentRegistration } from './test-utils';
 
 // Ensure action renderers are loaded (side-effect imports via vitest.setup.tsx)
@@ -379,6 +380,56 @@ describe('ActionBar (action:bar)', () => {
       });
       const toolbar = container.querySelector('[role="toolbar"]');
       expect(toolbar?.className).toContain('flex-row');
+    });
+  });
+
+  /**
+   * [ADR-0066 D4 / framework#3923] The bar filters its own action list instead
+   * of going through `ActionEngine.getActionsForLocation`, so the engine's
+   * capability gate never reached `list_toolbar`: an action declaring a
+   * capability nobody holds rendered as a live button, with nothing behind it
+   * for a `type: 'api'` action pointed at a custom endpoint (the platform's
+   * action route — the source of the 403 — never sees that request).
+   */
+  describe('requiredPermissions capability gate', () => {
+    const Bar = ({ actions, systemActions }: { actions?: any[]; systemActions?: any[] }) => {
+      const Component = ComponentRegistry.get('action:bar')!;
+      // eslint-disable-next-line react-hooks/static-components -- registry component is stable
+      return <Component schema={{ type: 'action:bar', location: 'list_toolbar', actions, systemActions }} />;
+    };
+    const withUser = (user: unknown, props: { actions?: any[]; systemActions?: any[] }) =>
+      render(<ActionProvider context={{ user } as any}><Bar {...props} /></ActionProvider>);
+
+    const gated = { name: 'gated', label: 'Bulk Reassign', type: 'api', requiredPermissions: ['manage_users'] };
+    const plain = { name: 'plain', label: 'Export', type: 'api' };
+
+    it('hides an action whose capability the caller lacks', () => {
+      const { container } = withUser({ id: 'u1', systemPermissions: ['setup.access'] }, { actions: [gated, plain] });
+      expect(container.textContent).not.toContain('Bulk Reassign');
+      expect(container.textContent).toContain('Export');
+    });
+
+    it('shows it when the capability is held', () => {
+      const { container } = withUser({ id: 'u1', systemPermissions: ['manage_users'] }, { actions: [gated] });
+      expect(container.textContent).toContain('Bulk Reassign');
+    });
+
+    it('gates on an EMPTY held set — "holds nothing" is known, not unknown', () => {
+      const { container } = withUser({ id: 'u1', systemPermissions: [] }, { actions: [gated] });
+      expect(container.textContent).not.toContain('Bulk Reassign');
+    });
+
+    it('fails OPEN when the host never resolved capabilities', () => {
+      const { container } = withUser({ id: 'u1' }, { actions: [gated] });
+      expect(container.textContent).toContain('Bulk Reassign');
+    });
+
+    it('gates systemActions too — the overflow slot is not a bypass', () => {
+      const { container } = withUser(
+        { id: 'u1', systemPermissions: [] },
+        { actions: [plain], systemActions: [{ ...gated, label: 'Purge All' }] },
+      );
+      expect(container.textContent).not.toContain('Purge All');
     });
   });
 });

--- a/packages/components/src/__tests__/page-header-capability-gate.test.tsx
+++ b/packages/components/src/__tests__/page-header-capability-gate.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `page:header` — ADR-0066 D4 `requiredPermissions` gate (framework#3923).
+ *
+ * `record_header` / `record_more` actions render through THIS component, which
+ * filters its own action list rather than calling
+ * `ActionEngine.getActionsForLocation`. So the engine's capability gate never
+ * ran on the one surface those locations exist on: an action declaring a
+ * capability nobody holds rendered as a live button, and the only thing behind
+ * it was the server's 403 — which covers platform action routes only, never a
+ * `type: 'api'` action pointed at a custom endpoint.
+ *
+ * The gate reads the ActionProvider's runner user (the same object the engine
+ * reads), falls back to the ambient predicate scope, and fails OPEN when
+ * neither knows — unknown is not denied.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider, PredicateScopeProvider } from '@object-ui/react';
+
+function PageHeader({ schema }: { schema: any }) {
+  const Component = ComponentRegistry.get('page:header');
+  if (!Component) throw new Error('page:header not registered');
+  // eslint-disable-next-line react-hooks/static-components -- registry component is stable
+  return <Component schema={schema} />;
+}
+
+const schema = {
+  type: 'page:header',
+  title: 'Invoice',
+  actions: [
+    { name: 'gated', label: 'Set Parallel Reviewers', type: 'api', requiredPermissions: ['ehr_probe_capability'] },
+    { name: 'plain', label: 'Print', type: 'api' },
+  ],
+};
+
+const renderWithUser = (user: unknown, scope?: Record<string, any>) => {
+  const tree = <ActionProvider context={{ user } as any}><PageHeader schema={schema} /></ActionProvider>;
+  return render(scope ? <PredicateScopeProvider scope={scope}>{tree}</PredicateScopeProvider> : tree);
+};
+
+const gatedShown = () => !!screen.queryByRole('button', { name: /Set Parallel Reviewers/i });
+
+describe('page:header — ADR-0066 D4 capability gate (#3923)', () => {
+  it('hides an action whose requiredPermissions the caller lacks', () => {
+    renderWithUser({ id: 'u1', systemPermissions: ['setup.access'] });
+    expect(gatedShown()).toBe(false);
+    // The ungated action is untouched — this filters, it does not blank the bar.
+    expect(screen.getByRole('button', { name: /Print/i })).toBeTruthy();
+  });
+
+  it('shows the action when every declared capability is held', () => {
+    renderWithUser({ id: 'u1', systemPermissions: ['ehr_probe_capability', 'setup.access'] });
+    expect(gatedShown()).toBe(true);
+  });
+
+  it('requires ALL declared capabilities (AND, not OR)', () => {
+    render(
+      <ActionProvider context={{ user: { id: 'u1', systemPermissions: ['a'] } } as any}>
+        <PageHeader
+          schema={{
+            type: 'page:header',
+            title: 'Invoice',
+            actions: [{ name: 'both', label: 'Needs Both', type: 'api', requiredPermissions: ['a', 'b'] }],
+          }}
+        />
+      </ActionProvider>,
+    );
+    expect(screen.queryByRole('button', { name: /Needs Both/i })).toBeNull();
+  });
+
+  it('gates on an EMPTY held set — "holds nothing" is known, not unknown', () => {
+    renderWithUser({ id: 'u1', systemPermissions: [] });
+    expect(gatedShown()).toBe(false);
+  });
+
+  it('fails OPEN when the host never resolved capabilities', () => {
+    renderWithUser({ id: 'u1' });
+    expect(gatedShown()).toBe(true);
+  });
+
+  it('falls back to the ambient predicate scope when there is no runner user', () => {
+    renderWithUser(undefined, { user: { id: 'u1', systemPermissions: ['setup.access'] } });
+    expect(gatedShown()).toBe(false);
+  });
+});

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -35,7 +35,7 @@ import React, { forwardRef, useMemo } from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import type { ActionSchema, ActionLocation, ActionComponent } from '@object-ui/types';
 import { ACTION_LOCATIONS } from '@object-ui/types';
-import { useCondition, toPredicateInput } from '@object-ui/react';
+import { useCondition, toPredicateInput, useCapabilityGate } from '@object-ui/react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { cn } from '../../lib/utils';
 import { useIsMobile } from '../../hooks/use-mobile';
@@ -119,13 +119,21 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
       label: `action:bar${schema.location ? ` (${schema.location})` : ''} (visible)`,
     });
     const isMobile = useIsMobile();
+    // [ADR-0066 D4 / framework#3923] Shared capability gate — see below.
+    const mayInvoke = useCapabilityGate();
 
     // Filter business actions by location and deduplicate by name
     const filteredActions = useMemo(() => {
       const actions = schema.actions || [];
+      // [ADR-0066 D4 / framework#3923] Capability gate — this bar filters its
+      // own set instead of going through `ActionEngine.getActionsForLocation`,
+      // so without this a `list_toolbar` action declaring a capability nobody
+      // holds rendered as a live button. Same rule as the engine; unknown
+      // capabilities fail OPEN (see `useCapabilityGate`).
+      const permitted = actions.filter(a => mayInvoke((a as any)?.requiredPermissions));
       const located = !schema.location
-        ? actions
-        : actions.filter(
+        ? permitted
+        : permitted.filter(
             a => !a.locations || a.locations.length === 0 || a.locations.includes(schema.location!),
           );
       // Deduplicate by action name — keep first occurrence
@@ -163,20 +171,23 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
         });
       }
       return deduped;
-    }, [schema.actions, schema.location]);
+    }, [schema.actions, schema.location, mayInvoke]);
 
     // System actions: always go into the overflow menu, deduped by name,
     // never filtered by location (they're chrome, not business logic).
     const systemActions = useMemo(() => {
       const actions = schema.systemActions || [];
       const seen = new Set<string>();
+      // Chrome or not, a declared capability gates it (ADR-0066 D4) — a host
+      // that puts a gated action in this slot means the same thing by it.
       return actions.filter(a => {
+        if (!mayInvoke((a as any)?.requiredPermissions)) return false;
         if (!a.name) return true;
         if (seen.has(a.name)) return false;
         seen.add(a.name);
         return true;
       });
-    }, [schema.systemActions]);
+    }, [schema.systemActions, mayInvoke]);
 
     // Split business actions into visible inline and overflow.
     // On mobile, show fewer actions inline (default: 1).

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { ComponentRegistry, ExpressionEvaluator, getRecordDisplayName } from '@object-ui/core';
-import { useRecordContext, useAction, usePredicateScope, usePageVariables, useInlineEdit } from '@object-ui/react';
+import { useRecordContext, useAction, useCapabilityGate, usePredicateScope, usePageVariables, useInlineEdit } from '@object-ui/react';
 import { renderChildren, cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { RelatedCountStore, useRelatedCountVersion } from '../../hooks/related-count-store';
@@ -807,6 +807,8 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   // action was silently filtered out.
   const predicateScope = usePredicateScope();
   const { execute } = useAction();
+  // [ADR-0066 D4 / framework#3923] Shared capability gate — see filterAction.
+  const mayInvoke = useCapabilityGate();
   const isMobile = useIsMobile();
   const { objectLabel: tObjectLabel, actionLabel: tActionLabel } = useObjectLabel();
   const { fieldOptionLabel } = useSafeFieldLabel();
@@ -897,6 +899,22 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       }
     };
     const filterAction = (a: any): boolean => {
+      // [ADR-0066 D4 / framework#3923] Capability gate — the UI half of the
+      // dual-surface `requiredPermissions` contract.
+      //
+      // `page:header` filters its own actions rather than going through
+      // `ActionEngine.getActionsForLocation`, so the engine's gate never ran on
+      // the ONE surface `record_header` / `record_more` actions live on: a
+      // button declaring a capability nobody holds rendered, and only the
+      // server's 403 stopped it — and only for platform action routes, never
+      // for a `type: 'api'` action pointed at a custom endpoint. Same rule as
+      // the engine, so the two surfaces can't disagree: hide unless the caller
+      // holds ALL declared capabilities.
+      //
+      // Fail-OPEN when the caller's capabilities are unknown (no
+      // ActionProvider user, no host predicate scope) — unknown is not denied,
+      // and hiding on missing data is the worse regression.
+      if (!mayInvoke(a?.requiredPermissions)) return false;
       // Location filter — when `locations` is declared, require record_header
       // or record_more (the latter renders in the header's ⋯ overflow menu —
       // see renderHeaderActions; #2358 trap 2). Missing/empty `locations`

--- a/packages/plugin-detail/src/useRecordEditable.test.tsx
+++ b/packages/plugin-detail/src/useRecordEditable.test.tsx
@@ -18,8 +18,10 @@
  * Every uncertainty must fail OPEN — a courtesy hint may never be the reason a
  * permitted user cannot act. The server is the authority (ADR-0057 D10).
  */
+import * as React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
+import { SchemaRendererProvider } from '@object-ui/react';
 import { useRecordEditable, __clearRecordEditableCache } from './useRecordEditable';
 
 function mockExplain(body: unknown, ok = true) {
@@ -87,6 +89,39 @@ describe('useRecordEditable', () => {
     renderHook(() => useRecordEditable(undefined, 'r1'));
     renderHook(() => useRecordEditable('note', undefined));
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // ── framework#3923 ② — the probe must be AUTHENTICATED ──────────────────
+  //
+  // It shipped as a bare `fetch(..., {credentials:'include'})`. A bearer-token
+  // session keeps its credential in the `Authorization` header, not a cookie, so
+  // every probe came back 401 on a perfectly valid admin session and the verdict
+  // always failed open — the hook was inert in exactly the deployments it was
+  // written for. Route it through the host's authenticated fetch instead.
+  it('uses the host apiFetch when a SchemaRendererProvider supplies one', async () => {
+    const hostFetch = mockExplain({ record: { recordId: 'r1', visible: false } });
+    const globalFetch = mockExplain({ record: { recordId: 'r1', visible: true } });
+    vi.stubGlobal('fetch', globalFetch);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <SchemaRendererProvider dataSource={{}} apiFetch={hostFetch}>
+        {children}
+      </SchemaRendererProvider>
+    );
+    const { result } = renderHook(() => useRecordEditable('note', 'r1'), { wrapper });
+
+    await waitFor(() => expect(result.current).toBe(false));
+    expect(hostFetch).toHaveBeenCalledTimes(1);
+    expect(globalFetch).not.toHaveBeenCalled();
+    expect(hostFetch.mock.calls[0][0]).toBe('/api/v1/security/explain');
+  });
+
+  it('falls back to the global fetch in a standalone embed (no provider)', async () => {
+    const globalFetch = mockExplain({ record: { recordId: 'r1', visible: false } });
+    vi.stubGlobal('fetch', globalFetch);
+    const { result } = renderHook(() => useRecordEditable('note', 'r1'));
+    await waitFor(() => expect(result.current).toBe(false));
+    expect(globalFetch).toHaveBeenCalledTimes(1);
   });
 
   it('memoises the verdict so revisiting a record costs nothing', async () => {

--- a/packages/plugin-detail/src/useRecordEditable.ts
+++ b/packages/plugin-detail/src/useRecordEditable.ts
@@ -27,8 +27,17 @@
  * where the cookie doesn't reach the API: the button stays enabled and the
  * server does its job. A permission hint must never be the reason a permitted
  * user cannot act.
+ *
+ * The probe rides the host's AUTHENTICATED fetch (`SchemaRendererProvider`'s
+ * `apiFetch`, the same channel `provider: 'api'` view sources use), not the bare
+ * global one. A bearer-token session carries its credential in the
+ * `Authorization` header, not a cookie, so `credentials: 'include'` alone made
+ * every probe 401 on a perfectly valid admin session — the verdict then always
+ * failed open and this hook was dead weight in exactly the deployments it was
+ * written for (framework#3923 ②). Cookies stay on for cookie-session hosts.
  */
 import * as React from 'react';
+import { SchemaRendererContext } from '@object-ui/react';
 
 /** Cache keyed by `object:recordId:operation` so revisiting a record is free. */
 const verdictCache = new Map<string, boolean>();
@@ -45,6 +54,10 @@ export function useRecordEditable(
   const [allowed, setAllowed] = React.useState<boolean>(() =>
     key && verdictCache.has(key) ? verdictCache.get(key)! : true,
   );
+  // Read the context directly (not `useSchemaContext`, which throws when no
+  // provider is mounted): a standalone `detail:view` embed has no host fetch
+  // and must still degrade to the global one rather than crash the render.
+  const apiFetch = React.useContext(SchemaRendererContext)?.apiFetch;
 
   React.useEffect(() => {
     if (!enabled || !key) {
@@ -58,7 +71,8 @@ export function useRecordEditable(
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch('/api/v1/security/explain', {
+        const doFetch = apiFetch ?? fetch;
+        const res = await doFetch('/api/v1/security/explain', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -77,7 +91,7 @@ export function useRecordEditable(
     return () => {
       cancelled = true;
     };
-  }, [key, objectName, recordId, operation, enabled]);
+  }, [key, objectName, recordId, operation, enabled, apiFetch]);
 
   return allowed;
 }

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuTrigger,
 } from '@object-ui/components';
 import { Edit, Trash2, MoreVertical } from 'lucide-react';
-import { useObjectTranslation, useRowPredicate } from '@object-ui/react';
+import { useObjectTranslation, useRowPredicate, useCapabilityGate } from '@object-ui/react';
 
 const ROW_ACTION_FALLBACKS: Record<string, string> = {
   'grid.openMenu': 'Open menu',
@@ -232,17 +232,29 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
   maxInlineActions = 1,
 }) => {
   const t = useRowActionTranslation();
+  // [ADR-0066 D4 / framework#3923] Capability gate, applied ONCE to the whole
+  // declared set so the inline CTA, the overflow menu and `hasMenu` all agree.
+  // This surface filters its own actions instead of going through
+  // `ActionEngine.getActionsForLocation`, so the engine's gate never reached
+  // `list_item` — a row action declaring a capability nobody holds still
+  // rendered. Unknown capabilities fail OPEN (see `useCapabilityGate`); the
+  // server remains the authority.
+  const mayInvoke = useCapabilityGate();
+  const gatedActionDefs = React.useMemo(
+    () => (rowActionDefs ?? []).filter(d => mayInvoke((d as any)?.requiredPermissions)),
+    [rowActionDefs, mayInvoke],
+  );
   // Surface `variant: 'primary'` row actions inline (as the row's main CTA);
   // everything else stays in the "⋮" overflow menu. Only the first
   // `maxInlineActions` primaries render inline — any extra primaries fold into
   // the menu (kept above secondary actions) so a row never renders more inline
   // buttons than the actions column can show, which previously clipped the
   // leftmost button (e.g. "Open" hidden behind "Upgrade Plan").
-  const primaryDefs = (rowActionDefs ?? []).filter(d => d.variant === 'primary');
+  const primaryDefs = gatedActionDefs.filter(d => d.variant === 'primary');
   const inlineDefs = primaryDefs.slice(0, Math.max(0, maxInlineActions));
   const menuDefs = [
     ...primaryDefs.slice(Math.max(0, maxInlineActions)),
-    ...(rowActionDefs ?? []).filter(d => d.variant !== 'primary'),
+    ...gatedActionDefs.filter(d => d.variant !== 'primary'),
   ];
   const hasMenu = Boolean(
     (canEdit && onEdit) ||

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.capabilityGate.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.capabilityGate.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RowActionMenu — ADR-0066 D4 `requiredPermissions` gate (framework#3923).
+ *
+ * `list_item` actions render here, and this component filters its own set
+ * instead of going through `ActionEngine.getActionsForLocation` — so the
+ * engine's capability gate never reached the row surface. A row action
+ * declaring a capability nobody holds showed up in the "⋮" menu (and, for a
+ * primary, as the row's inline CTA) and clicking it just produced whatever the
+ * server said — or nothing at all when the action targets a custom endpoint the
+ * platform's action route never sees.
+ *
+ * The gate is applied ONCE to the declared set, so the inline slot, the
+ * overflow menu, and the "is there a menu at all?" decision can't disagree.
+ * Assertions use `variant: 'primary'` (always-mounted inline buttons) plus the
+ * overflow trigger, mirroring the sibling suite — dropdown items only mount
+ * once the menu opens.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ActionProvider, PredicateScopeProvider } from '@object-ui/react';
+import { RowActionMenu } from '../RowActionMenu';
+
+const GATED = {
+  name: 'gated',
+  label: 'Set Reviewers',
+  variant: 'primary' as const,
+  requiredPermissions: ['ehr_probe_capability'],
+} as any;
+const PLAIN = { name: 'plain', label: 'Print', variant: 'primary' as const } as any;
+
+function renderMenu(user: unknown, defs: any[], maxInlineActions = 2) {
+  return render(
+    <PredicateScopeProvider scope={{}}>
+      <ActionProvider context={{ user } as any}>
+        <RowActionMenu
+          row={{ id: 'e1' }}
+          onActionDef={() => {}}
+          rowActionDefs={defs}
+          maxInlineActions={maxInlineActions}
+        />
+      </ActionProvider>
+    </PredicateScopeProvider>,
+  );
+}
+
+const inline = (name: string) => screen.queryByTestId(`row-action-inline-${name}`);
+
+describe('RowActionMenu — ADR-0066 D4 capability gate (#3923)', () => {
+  it('hides a row action whose capability the caller lacks', () => {
+    renderMenu({ id: 'u1', systemPermissions: ['setup.access'] }, [GATED, PLAIN]);
+    expect(inline('gated')).not.toBeInTheDocument();
+    // Filtering, not blanking — the ungated action is untouched.
+    expect(inline('plain')).toBeInTheDocument();
+  });
+
+  it('shows it when the capability is held', () => {
+    renderMenu({ id: 'u1', systemPermissions: ['ehr_probe_capability'] }, [GATED, PLAIN]);
+    expect(inline('gated')).toBeInTheDocument();
+  });
+
+  it('requires ALL declared capabilities (AND, not OR)', () => {
+    const both = { ...GATED, name: 'both', requiredPermissions: ['a', 'b'] };
+    renderMenu({ id: 'u1', systemPermissions: ['a'] }, [both]);
+    expect(inline('both')).not.toBeInTheDocument();
+  });
+
+  it('gates on an EMPTY held set — "holds nothing" is known, not unknown', () => {
+    renderMenu({ id: 'u1', systemPermissions: [] }, [GATED]);
+    expect(inline('gated')).not.toBeInTheDocument();
+  });
+
+  it('renders no overflow trigger when the gate empties the whole set', () => {
+    // `hasMenu` must see the GATED set — otherwise the row grows a "⋮" button
+    // that opens an empty menu.
+    renderMenu({ id: 'u1', systemPermissions: [] }, [{ ...GATED, variant: 'secondary' }]);
+    expect(screen.queryByTestId('row-action-trigger')).not.toBeInTheDocument();
+  });
+
+  it('still renders the overflow trigger for a gated action the caller holds', () => {
+    renderMenu({ id: 'u1', systemPermissions: ['ehr_probe_capability'] }, [
+      { ...GATED, variant: 'secondary' },
+    ]);
+    expect(screen.getByTestId('row-action-trigger')).toBeInTheDocument();
+  });
+
+  it('fails OPEN when the host never resolved capabilities', () => {
+    renderMenu({ id: 'u1' }, [GATED]);
+    expect(inline('gated')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/__tests__/useActionEngine.capabilityGate.test.tsx
+++ b/packages/react/src/__tests__/useActionEngine.capabilityGate.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ADR-0066 D4 capability gate — end to end through the PROVIDER, not just the
+ * engine (framework#3923).
+ *
+ * `ActionEngine.getActionsForLocation` has its own unit coverage, but every real
+ * surface reaches it the long way round: a host seeds `<ActionProvider>` with
+ * `context.user`, a renderer (`record:quick_actions`, `action:bar`) then calls
+ * `useActionEngine({ actions, context: { record, recordId, objectName } })` with
+ * a per-render context of its own, and the hook merges that into the SHARED
+ * runner. That merge is where the gate died in #3923's sibling failure mode: a
+ * caller context without `user` must not erase the provider's, or every gated
+ * action silently reappears (`undefined` systemPermissions → fail open).
+ *
+ * These pin the composed contract: what the host seeds is what the gate sees.
+ */
+
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ActionProvider } from '../context/ActionContext';
+import { useActionEngine } from '../hooks/useActionEngine';
+
+const gated = {
+  name: 'set_parallel_positions',
+  label: 'Set parallel reviewers',
+  type: 'api' as const,
+  locations: ['record_header'],
+  requiredPermissions: ['ehr_probe_capability'],
+};
+const ungated = { name: 'print', label: 'Print', type: 'api' as const, locations: ['record_header'] };
+
+/** The shape a record surface really mounts: provider seeds the user, the
+ *  renderer passes only record-scoped keys. */
+function wrapperFor(user: unknown) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <ActionProvider context={{ record: { id: 'r1' }, objectName: 'ehr_case', user } as any}>
+      {children}
+    </ActionProvider>
+  );
+}
+
+const renderInProvider = (user: unknown) =>
+  renderHook(
+    () =>
+      useActionEngine({
+        actions: [gated, ungated] as any,
+        context: { record: { id: 'r1' }, recordId: 'r1', objectName: 'ehr_case' } as any,
+      }),
+    { wrapper: wrapperFor(user) },
+  );
+
+const names = (r: ReturnType<typeof renderInProvider>) =>
+  r.result.current.getActionsForLocation('record_header' as any).map((a: any) => a.name);
+
+describe('useActionEngine + ActionProvider — ADR-0066 D4 capability gate (#3923)', () => {
+  it('hides a gated action when the seeded user lacks the capability', () => {
+    expect(names(renderInProvider({ id: 'u1', systemPermissions: [] }))).toEqual(['print']);
+  });
+
+  it('shows a gated action when the seeded user holds the capability', () => {
+    const held = renderInProvider({ id: 'u1', systemPermissions: ['ehr_probe_capability'] });
+    expect(names(held)).toEqual(['set_parallel_positions', 'print']);
+  });
+
+  it('does not let the renderer-supplied context erase the provider user', () => {
+    // The regression itself: the hook merges `{record, recordId, objectName}`
+    // into the shared runner. If that merge replaced the context wholesale, the
+    // gate would read `undefined` and fail open.
+    const r = renderInProvider({ id: 'u1', systemPermissions: [] });
+    const ctx = r.result.current.engine.getRunner().getContext() as any;
+    expect(ctx.user?.systemPermissions).toEqual([]);
+    expect(names(r)).not.toContain('set_parallel_positions');
+  });
+
+  it('fails OPEN when the host seeds a user with no systemPermissions at all', () => {
+    // Unknown ≠ denied — the documented contract for hosts that never resolved
+    // permissions. The server still rejects the invocation with 403.
+    expect(names(renderInProvider({ id: 'u1' }))).toContain('set_parallel_positions');
+  });
+});

--- a/packages/react/src/__tests__/useCapabilityGate.test.tsx
+++ b/packages/react/src/__tests__/useCapabilityGate.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * useCapabilityGate — the single ADR-0066 D4 rule shared by every surface that
+ * filters its own actions (`page:header`, the grid row menu) instead of going
+ * through `ActionEngine.getActionsForLocation` (framework#3923).
+ *
+ * The precedence and the fail-open boundary are the whole contract, so they are
+ * pinned here rather than re-tested per consumer.
+ */
+
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ActionProvider } from '../context/ActionContext';
+import { PredicateScopeProvider } from '../hooks/useExpression';
+import { useCapabilityGate, useHeldCapabilities } from '../hooks/useCapabilityGate';
+
+const wrap = (opts: { user?: unknown; scope?: Record<string, any> }) =>
+  ({ children }: { children: React.ReactNode }) => {
+    const inner =
+      opts.user === undefined && !('user' in opts)
+        ? <>{children}</>
+        : <ActionProvider context={{ user: opts.user } as any}>{children}</ActionProvider>;
+    return opts.scope
+      ? <PredicateScopeProvider scope={opts.scope}>{inner}</PredicateScopeProvider>
+      : inner;
+  };
+
+const gateWith = (opts: { user?: unknown; scope?: Record<string, any> }) =>
+  renderHook(() => useCapabilityGate(), { wrapper: wrap(opts) }).result.current;
+
+describe('useCapabilityGate', () => {
+  it('passes actions that declare nothing', () => {
+    const may = gateWith({ user: { id: 'u1', systemPermissions: [] } });
+    expect(may(undefined)).toBe(true);
+    expect(may([])).toBe(true);
+  });
+
+  it('requires every declared capability', () => {
+    const may = gateWith({ user: { id: 'u1', systemPermissions: ['a'] } });
+    expect(may(['a'])).toBe(true);
+    expect(may(['a', 'b'])).toBe(false);
+    expect(may(['b'])).toBe(false);
+  });
+
+  it('treats an empty held set as "holds nothing", not unknown', () => {
+    expect(gateWith({ user: { id: 'u1', systemPermissions: [] } })(['a'])).toBe(false);
+  });
+
+  it('fails OPEN when nothing supplied capabilities', () => {
+    expect(gateWith({ user: { id: 'u1' } })(['a'])).toBe(true);
+    expect(gateWith({})(['a'])).toBe(true);
+  });
+
+  it('prefers the action runner user over the ambient predicate scope', () => {
+    // The runner is what ActionEngine reads — the two must not diverge.
+    const may = gateWith({
+      user: { id: 'u1', systemPermissions: [] },
+      scope: { user: { id: 'u1', systemPermissions: ['a'] } },
+    });
+    expect(may(['a'])).toBe(false);
+  });
+
+  it('falls back to the predicate scope when the runner user has none', () => {
+    const may = gateWith({ user: { id: 'u1' }, scope: { user: { id: 'u1', systemPermissions: ['a'] } } });
+    expect(may(['a'])).toBe(true);
+    expect(may(['b'])).toBe(false);
+  });
+
+  it('exposes the resolved set (undefined when unknown)', () => {
+    const held = renderHook(() => useHeldCapabilities(), {
+      wrapper: wrap({ user: { id: 'u1', systemPermissions: ['a'] } }),
+    }).result.current;
+    expect(held).toEqual(['a']);
+    const unknown = renderHook(() => useHeldCapabilities(), {
+      wrapper: wrap({ user: { id: 'u1' } }),
+    }).result.current;
+    expect(unknown).toBeUndefined();
+  });
+});

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -35,6 +35,7 @@ export * from './useSchemaPersistence';
 export * from './useGlobalUndo';
 export * from './useDebugMode';
 export * from './useActionEngine';
+export * from './useCapabilityGate';
 export * from './useDataRefresh';
 export * from './usePageAssignment';
 export * from './useRecordSearch';

--- a/packages/react/src/hooks/useCapabilityGate.ts
+++ b/packages/react/src/hooks/useCapabilityGate.ts
@@ -1,0 +1,63 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * useCapabilityGate — the UI half of ADR-0066 D4's `requiredPermissions`
+ * contract, for surfaces that filter actions THEMSELVES.
+ *
+ * `ActionEngine.getActionsForLocation` applies this gate for everything routed
+ * through the engine. But several renderers filter their own action lists —
+ * `page:header` (record_header / record_more) and the grid's row-action menu
+ * (list_item) — and each of those bypassed the engine entirely, so a button
+ * declaring a capability nobody holds still rendered (framework#3923). One hook
+ * so all three surfaces gate identically and can't drift apart.
+ *
+ * Source of truth for what the caller holds: the ActionProvider's runner
+ * context (`user.systemPermissions`) — the same object the engine reads — with
+ * the ambient predicate scope as fallback for hosts that mount an
+ * ExpressionProvider but no action runtime.
+ *
+ * **Fail-OPEN when unknown.** No runner, no user, no `systemPermissions` array:
+ * the action shows. Unknown is not denied, the server is the authority
+ * (ADR-0057 D10), and hiding a permitted user's button on missing client data
+ * is the worse failure. An EMPTY array is not unknown — it means "holds
+ * nothing" and gates normally.
+ */
+
+import { useCallback, useContext } from 'react';
+import { ActionCtxReact } from '../context/ActionContext';
+import { usePredicateScope } from './useExpression';
+
+/**
+ * The caller's system capabilities, or `undefined` when the host never supplied
+ * them (→ callers must fail open).
+ */
+export function useHeldCapabilities(): string[] | undefined {
+  const actionCtx = useContext(ActionCtxReact);
+  const predicateScope = usePredicateScope();
+  const runnerUser = (actionCtx?.runner?.getContext?.() as any)?.user;
+  if (Array.isArray(runnerUser?.systemPermissions)) return runnerUser.systemPermissions;
+  const scopeUser = (predicateScope as any)?.user;
+  if (Array.isArray(scopeUser?.systemPermissions)) return scopeUser.systemPermissions;
+  return undefined;
+}
+
+/**
+ * `(requiredPermissions) => mayInvoke`. Actions declaring nothing always pass.
+ */
+export function useCapabilityGate(): (required: unknown) => boolean {
+  const held = useHeldCapabilities();
+  return useCallback(
+    (required: unknown) => {
+      if (!Array.isArray(required) || required.length === 0) return true;
+      if (!Array.isArray(held)) return true; // unknown → fail open
+      return required.every((p) => typeof p === 'string' && held.includes(p));
+    },
+    [held],
+  );
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -85,6 +85,7 @@ const heavyDomTests = [
   'packages/components/src/__tests__/action-bar.test.tsx',
   'packages/components/src/__tests__/page-card-i18n-title.test.tsx',
   'packages/components/src/__tests__/page-header-actions.test.tsx',
+  'packages/components/src/__tests__/page-header-capability-gate.test.tsx',
   'packages/components/src/__tests__/page-header-title.test.tsx',
   'packages/plugin-calendar/src/registration.test.tsx',
   'packages/plugin-dashboard/src/__tests__/DashboardRenderer.designMode.test.tsx',


### PR DESCRIPTION
Fixes the UI half of the `requiredPermissions` contract reported in [objectstack#3923](https://github.com/objectstack-ai/objectstack/issues/3923).

## The bug

`requiredPermissions` is meant to be one declaration with two enforcement surfaces: 403 on the server, hidden button in the UI. The UI half only ever ran inside `ActionEngine.getActionsForLocation` — and **none of the surfaces those locations actually render on go through the engine**. Each filters its own action list:

| Surface | Location | Renderer | Before |
|---|---|---|---|
| Record header | `record_header` / `record_more` | `page:header` | no gate |
| List toolbar | `list_toolbar` | `action:bar` | no gate |
| Row ⋯ menu | `list_item` | `RowActionMenu` | no gate |
| Record section | `record_section` | engine — but fed a user with no `systemPermissions` | fail-open |

So a button declaring a capability nobody holds rendered live and clickable. For a `type: 'api'` action pointed at a self-authored endpoint nothing else was checking either: the platform action route, which is where the 403 comes from, never sees that request.

## The fix

- **`useCapabilityGate()`** (new, `@object-ui/react`) — one rule the three self-filtering surfaces share, so they cannot drift from the engine or from each other. Hide unless the caller holds **all** declared capabilities; an empty held set means "holds nothing" and gates; **unknown** (no action runtime, nothing resolved) fails OPEN — the server is the authority, and hiding a permitted user's button on missing client data is the worse failure. Source is the ActionProvider runner user (what the engine reads), falling back to the ambient predicate scope.
- **`page:header`**, **`action:bar`** (business *and* `systemActions`) and **`RowActionMenu`** now apply it.
- **`RecordDetailView`** forwards the caller's resolved `systemPermissions` into its own `<ActionProvider>` — the one that shadows the shell's for every action on that page. It seeded identity alone, and since unknown fails open that by itself un-gated every `record_header` / `record_more` / `record_section` action on the one page those locations exist on. Only forwarded once permissions have actually resolved, so a standalone embed with no `PermissionProvider` keeps failing open instead of hiding everything.
- **`useRecordEditable`** rides the host's authenticated fetch. Its record-level explain probe went out on a bare `fetch(..., { credentials: 'include' })`; a bearer-token session carries its credential in the `Authorization` header, not a cookie, so the probe came back 401 on a valid admin session and the verdict silently failed open — inert in exactly the deployments it was written for.

## Verification

Real showcase app (`objectstack dev --seed-admin`) driven through this branch's console. Two probe actions: one requiring a capability nobody holds, one requiring `setup.access` (which the admin does hold). **Both sides checked on all four surfaces** — denied hidden, allowed shown. Plus a live A/B: reverting the `RecordDetailView` seed made `PROBE Section Denied` reappear immediately, restoring it made it vanish.

The explain probe now carries `Authorization: Bearer …` + `X-Tenant-ID` + `Accept-Language` (captured at runtime), where it previously sent cookies only — on a session that has no auth cookie at all. Note the local dev server answers the bare probe with 200, so the reporter's 401 was not reproduced locally; the cause was identified and is covered by unit tests.

**Tests** — 5 new files, 31 cases, each reverse-verified (reverting the fix turns them red). Touched packages: 134 files / 1235 tests green; app-shell 233 / 1921 green; full suite 8038 tests with 2 pre-existing flakes unrelated to this change (`FormulaFunctions > DATEFORMAT` fails identically on clean `main`; `ReportPreview.dataset` passes in isolation). `pnpm build` 43/43 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)