### PR TITLE
fix(form): a server rejection that names fields now marks those fields (objectstack#3896)

### DIFF
--- a/.changeset/server-field-errors-on-inputs.md
+++ b/.changeset/server-field-errors-on-inputs.md
@@ -1,0 +1,58 @@
+---
+"@object-ui/react": minor
+"@object-ui/data-objectstack": minor
+"@object-ui/components": minor
+---
+
+fix(form): a server rejection that names fields now marks those fields (objectstack#3896)
+
+The server has always said which field it rejected. `@objectstack/objectql`'s
+validators throw `VALIDATION_FAILED` with `fields[]` — one entry per offending
+field, each with a human `message` — and both the REST layer and the runtime
+dispatcher serve that as a 400 with the entries intact.
+
+Every form dropped them. The submit handler caught the rejection, ran the
+message through `extractWriteErrorMessage`, and showed **one undirected toast**:
+the user was told something was wrong but not *what*, on a surface that already
+knows how to mark an input — and already does exactly that for client-side
+validation. On a long form the offending field was often off-screen, so "创建"
+appeared to do nothing.
+
+**Now the two failures behave identically, because they share one
+implementation.** The per-field marking, the toast naming the fields, and the
+scroll-and-focus of the first offender (#2793) were extracted from the
+client-side invalid handler; the server path calls the same function. As far as
+the person filling in the form is concerned these are the same event — only the
+referee differs.
+
+Three layers, each of which was dropping the detail:
+
+- **`@object-ui/react`** — new `extractFieldErrors(err)` (exported alongside
+  `extractWriteErrorMessage` / `isPermissionError`) normalises the three shapes
+  the error can arrive in: a typed `ValidationError` from the ObjectStack
+  adapter, the raw `@objectstack/client` error (whose `details` falls back to the
+  whole response body, which is where `fields[]` lands), and a hand-rolled error
+  carrying `fields` directly — the server duck-types that shape identically, so
+  the client must not be pickier than the server. Entries with no usable `field`
+  are **dropped rather than guessed at**: marking an innocent input is worse than
+  the generic toast.
+- **`@object-ui/data-objectstack`** — `normaliseClientError` now maps a 400
+  `VALIDATION_FAILED` onto the `ValidationError` class that has sat in
+  `errors.ts` since the package was written, exported and **never once
+  constructed**. Its `validationErrors: Array<{ field, message }>` shape was
+  already exactly right. `create` also now normalises at all: only `update` did,
+  so a rejected insert reached callers as the raw client error — and a create is
+  the path that most often trips required-field validation.
+- **`@object-ui/components`** — the form renderer maps the entries onto
+  `form.setError` and takes over the failure, **but only when every rejected
+  field has a visible input to carry it**. If the server also rejected something
+  the form does not render, it falls through to the banner, whose top-level
+  message concatenates every field's reason — so the part the user cannot see
+  inline is still said out loud instead of silently dropped.
+
+This also removes the need for the client-side predicate mirroring added in
+#2962: a form no longer has to guess what the server will reject in order to
+warn about it beforehand, and mirrored predicates drift.
+
+Non-field failures (403 / permission denials / anything without `fields[]`) take
+exactly the path they took before.

--- a/packages/components/src/renderers/form/__tests__/form-server-field-errors.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-server-field-errors.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A server rejection that names fields must mark those fields.
+ *
+ * `@objectstack/objectql`'s validators throw `VALIDATION_FAILED` with
+ * `fields[]`, and both the REST layer and the runtime dispatcher serve it as a
+ * 400 with those entries intact. The form caught the rejection, showed one
+ * generic toast, and dropped `fields[]` — so a user told "Validation failed"
+ * had to guess WHICH input was wrong, on a surface that already knows how to
+ * mark it and already does exactly that for client-side validation.
+ *
+ * The sibling test `form-invalid-scroll.test.tsx` pins the client-side half;
+ * these two paths now share one implementation, so they must behave alike.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { toast } from '../../../ui/sonner';
+
+beforeAll(async () => {
+  await import('../../../renderers');
+}, 30000);
+
+let toastErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  toastErrorSpy = vi.spyOn(toast, 'error').mockImplementation(() => 'id' as any);
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** The wire shape the server sends, as `@objectstack/client` decorates it. */
+function validationFailure(fields: Array<{ field: string; code?: string; message?: string }>) {
+  const message = fields.map((f) => f.message ?? `${f.field} (${f.code})`).join('; ');
+  return Object.assign(new Error(message), {
+    code: 'VALIDATION_FAILED',
+    httpStatus: 400,
+    details: { error: message, code: 'VALIDATION_FAILED', fields, object: 'crm_opportunity' },
+  });
+}
+
+function renderForm(fields: any[], onSubmit: (data: any) => Promise<unknown>) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        fields,
+        onSubmit,
+      }}
+    />,
+  );
+}
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+const FIELDS = [
+  { name: 'title', label: 'Title', type: 'input' },
+  { name: 'stage', label: 'Stage', type: 'input' },
+];
+
+describe('form renderer — server-rejected fields', () => {
+  it("writes the server's reason under the offending input", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(
+      validationFailure([{ field: 'title', code: 'required', message: 'Title is required' }]),
+    );
+    renderForm(FIELDS, onSubmit);
+
+    submit();
+
+    await waitFor(() => expect(screen.getByText('Title is required')).toBeTruthy());
+  });
+
+  it('scrolls and focuses the first rejected field, as a client-side failure does', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(
+      validationFailure([{ field: 'stage', code: 'invalid_option', message: 'Stage is not a valid option' }]),
+    );
+    const { container } = renderForm(FIELDS, onSubmit);
+    const stageWrap = container.querySelector('[data-field="stage"]') as HTMLElement;
+    const scrollSpy = vi.fn();
+    stageWrap.scrollIntoView = scrollSpy;
+
+    submit();
+
+    await waitFor(() => expect(scrollSpy).toHaveBeenCalled());
+    await waitFor(() => expect(stageWrap.contains(document.activeElement)).toBe(true));
+  });
+
+  it('names the rejected fields in the toast', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(
+      validationFailure([{ field: 'title', message: 'Title is required' }]),
+    );
+    renderForm(FIELDS, onSubmit);
+
+    submit();
+
+    await waitFor(() => expect(toastErrorSpy).toHaveBeenCalled());
+    // The field LABEL, not its machine name.
+    expect(String(toastErrorSpy.mock.calls[0][0])).toMatch(/Title/);
+  });
+
+  it('marks every rejected field, not just the first', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(
+      validationFailure([
+        { field: 'title', message: 'Title is required' },
+        { field: 'stage', message: 'Stage is not a valid option' },
+      ]),
+    );
+    renderForm(FIELDS, onSubmit);
+
+    submit();
+
+    await waitFor(() => expect(screen.getByText('Title is required')).toBeTruthy());
+    expect(screen.getByText('Stage is not a valid option')).toBeTruthy();
+  });
+
+  it('falls back to the generic banner when a rejected field has no input to carry it', async () => {
+    // A field the form does not render cannot be marked inline. Taking over the
+    // failure anyway would silently drop the part the user cannot see, so the
+    // top-level message — which names every field — is shown instead.
+    const onSubmit = vi.fn().mockRejectedValue(
+      validationFailure([
+        { field: 'title', message: 'Title is required' },
+        { field: 'owner_id', message: 'Owner is required' },
+      ]),
+    );
+    renderForm(FIELDS, onSubmit);
+
+    submit();
+
+    await waitFor(() => expect(toastErrorSpy).toHaveBeenCalled());
+    expect(String(toastErrorSpy.mock.calls[0][0])).toMatch(/Owner is required/);
+  });
+
+  it('leaves a non-field failure on the generic path', async () => {
+    const forbidden = Object.assign(new Error('insufficient privileges'), {
+      code: 'FORBIDDEN',
+      httpStatus: 403,
+      details: { error: 'insufficient privileges', code: 'FORBIDDEN' },
+    });
+    const onSubmit = vi.fn().mockRejectedValue(forbidden);
+    const { container } = renderForm(FIELDS, onSubmit);
+    const titleWrap = container.querySelector('[data-field="title"]') as HTMLElement;
+    const scrollSpy = vi.fn();
+    titleWrap.scrollIntoView = scrollSpy;
+
+    submit();
+
+    await waitFor(() => expect(toastErrorSpy).toHaveBeenCalled());
+    // Nothing is attributable to a field, so no input is marked or scrolled to.
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -29,7 +29,7 @@ import { AlertCircle, ChevronDown, ChevronRight, Loader2, Maximize2, Check, X } 
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from '../../ui/dialog';
 import { cn } from '../../lib/utils';
 import React from 'react';
-import { SchemaRendererContext, usePredicateScope, isPermissionError, extractWriteErrorMessage } from '@object-ui/react';
+import { SchemaRendererContext, usePredicateScope, isPermissionError, extractWriteErrorMessage, extractFieldErrors } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
 
 /** Inline section header rendered as a virtual field inside a flat SchemaRenderer field list.
@@ -502,6 +502,45 @@ ComponentRegistry.register('form',
       return () => subscription.unsubscribe();
     }, [form, onDirtyChangeProp]);
 
+    /**
+     * Tell the user WHICH fields are wrong, wherever the verdict came from.
+     *
+     * Toast naming the offending fields, then scroll the FIRST of them into
+     * view (in declared/visual order, not the caller's key order) and focus a
+     * control inside it — the field wrapper carries `data-field` (FormItem), so
+     * this reaches custom widgets that RHF's own focus cannot (#2793).
+     *
+     * Extracted from the client-side invalid handler so the SERVER-rejection
+     * path gets identical treatment. The two failures are the same event as far
+     * as the person filling the form is concerned; only the referee differs.
+     */
+    const announceFieldErrors = (names: string[]) => {
+      if (names.length === 0) return;
+      const labels = names.map((n) => fieldLabelByName[n] || n);
+      const MAX = 3;
+      const fieldsText = labels.slice(0, MAX).join('、') + (labels.length > MAX ? '…' : '');
+      toast.error(t('validation.formInvalid', { fields: fieldsText }));
+
+      const errored = new Set(names);
+      const firstName =
+        (fields as FormFieldConfig[])
+          .map((f) => f?.name)
+          .find((n): n is string => Boolean(n) && errored.has(n as string)) ?? names[0];
+      const root: ParentNode = formRef.current ?? document;
+      const escaped =
+        typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+          ? CSS.escape(firstName)
+          : firstName.replace(/["\\]/g, '\\$&');
+      const target = root.querySelector<HTMLElement>(`[data-field="${escaped}"]`);
+      if (target) {
+        target.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+        const focusable = target.querySelector<HTMLElement>(
+          'input:not([type="hidden"]), select, textarea, button, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]',
+        );
+        focusable?.focus?.({ preventScroll: true });
+      }
+    };
+
     // Handle form submission
     const handleSubmit = form.handleSubmit(async (data) => {
       setIsSubmitting(true);
@@ -555,6 +594,37 @@ ComponentRegistry.register('form',
           form.reset();
         }
       } catch (error) {
+        // The server can reject field-by-field: `@objectstack/objectql`'s
+        // validators throw `VALIDATION_FAILED` with `fields[]`, and both the
+        // REST layer and the runtime dispatcher serve it as a 400 with those
+        // entries intact. Every form used to drop them and show one undirected
+        // toast — telling the user something was wrong, but not WHAT, on a
+        // surface that already knows how to mark the input. Mark them.
+        const fieldErrors = extractFieldErrors(error);
+        if (fieldErrors) {
+          const known = fieldErrors.filter((fe) =>
+            (fields as FormFieldConfig[]).some((f) => f?.name === fe.field),
+          );
+          for (const fe of known) {
+            form.setError(fe.field, {
+              type: 'server',
+              // Fall back to the envelope's top-level text rather than leaving
+              // a marked field with no reason next to it.
+              message: fe.message || extractWriteErrorMessage(error) || t('form.submitFailed'),
+            });
+          }
+          // Only take over the whole failure when EVERY rejected field has a
+          // visible input to carry it. If the server also rejected something
+          // this form does not render, fall through: the top-level message
+          // concatenates every field's reason, so the part the user cannot see
+          // inline is still said out loud instead of silently dropped.
+          if (known.length > 0 && known.length === fieldErrors.length) {
+            announceFieldErrors(known.map((fe) => fe.field));
+            // A fully-attributed rejection is not a form-level failure — the
+            // banner would just repeat what is now written under each input.
+            return;
+          }
+        }
         // A rejected write used to be rendered verbatim, which put raw server
         // diagnostics in front of end users — untranslated, and leaking the
         // object's machine name and the record id, e.g.
@@ -587,36 +657,7 @@ ComponentRegistry.register('form',
       // is often scrolled out of view — the user clicks 创建 and sees nothing
       // happen. Surface a toast naming the fields so the feedback is visible
       // regardless of scroll position (mirrors the server-error toast above).
-      const names = Object.keys(validationErrors || {});
-      if (names.length === 0) return;
-      const labels = names.map((n) => fieldLabelByName[n] || n);
-      const MAX = 3;
-      const fieldsText = labels.slice(0, MAX).join('、') + (labels.length > MAX ? '…' : '');
-      toast.error(t('validation.formInvalid', { fields: fieldsText }));
-
-      // #2793: the toast alone still leaves the user hunting — in a long form
-      // the offending field is off-screen. Scroll the FIRST errored field into
-      // view (in declared/visual order, not RHF's error-key order) and focus a
-      // focusable control inside it. The field wrapper carries `data-field`
-      // (FormItem); works for custom widgets that RHF's own focus can't reach.
-      const errored = new Set(names);
-      const firstName =
-        (fields as FormFieldConfig[])
-          .map((f) => f?.name)
-          .find((n): n is string => Boolean(n) && errored.has(n as string)) ?? names[0];
-      const root: ParentNode = formRef.current ?? document;
-      const escaped =
-        typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
-          ? CSS.escape(firstName)
-          : firstName.replace(/["\\]/g, '\\$&');
-      const target = root.querySelector<HTMLElement>(`[data-field="${escaped}"]`);
-      if (target) {
-        target.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
-        const focusable = target.querySelector<HTMLElement>(
-          'input:not([type="hidden"]), select, textarea, button, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]',
-        );
-        focusable?.focus?.({ preventScroll: true });
-      }
+      announceFieldErrors(Object.keys(validationErrors || {}));
     });
 
     // Handle cancel

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -38,6 +38,7 @@ import {
   MetadataNotFoundError,
   BulkOperationError,
   ConnectionError,
+  ValidationError,
   createErrorFromResponse,
 } from './errors';
 
@@ -281,17 +282,55 @@ export function isConcurrentUpdateError(error: unknown): error is ConcurrentUpda
 }
 
 /**
- * Convert any error thrown by the upstream client into a typed
- * `ConcurrentUpdateError` when it represents a 409 CONCURRENT_UPDATE.
- * Returns the original error untouched otherwise. Callers can simply
- * `throw normaliseClientError(err)` from their catch blocks.
+ * Convert any error thrown by the upstream client into a typed error when we
+ * recognise its shape. Returns the original error untouched otherwise, so
+ * callers can simply `throw normaliseClientError(err)` from their catch blocks.
+ *
+ * Two shapes are recognised:
+ *   - `409` + `CONCURRENT_UPDATE` → {@link ConcurrentUpdateError};
+ *   - `400` + `VALIDATION_FAILED` → {@link ValidationError}, carrying the
+ *     server's per-field entries so a form can mark the offending inputs
+ *     instead of showing one undirected toast.
  */
 export function normaliseClientError(error: unknown): unknown {
   if (!error || typeof error !== 'object') return error;
   const e = error as Record<string, unknown>;
+  // The client sets `details` to the parsed body's `details`, falling back to
+  // the WHOLE body — and the validation envelope has no `details` key, so this
+  // is where `fields[]` lands.
+  const details = (e.details ?? {}) as Record<string, unknown>;
+
+  if (e.code === 'VALIDATION_FAILED' || e.name === 'ValidationError') {
+    const rawFields = Array.isArray(details.fields)
+      ? details.fields
+      : Array.isArray((e as { fields?: unknown }).fields)
+        ? ((e as { fields: unknown[] }).fields)
+        : [];
+    const validationErrors = rawFields
+      .map((f) => {
+        const rec = (f ?? {}) as Record<string, unknown>;
+        const field = typeof rec.field === 'string' ? rec.field : undefined;
+        if (!field) return null;
+        const message =
+          typeof rec.message === 'string' && rec.message.trim()
+            ? rec.message
+            : typeof rec.code === 'string'
+              ? rec.code
+              : '';
+        return { field, message };
+      })
+      .filter((x): x is { field: string; message: string } => x !== null);
+
+    return new ValidationError(
+      typeof e.message === 'string' ? e.message : 'Validation failed',
+      validationErrors[0]?.field,
+      validationErrors,
+      { fields: rawFields },
+    );
+  }
+
   if (e.code !== 'CONCURRENT_UPDATE' && e.httpStatus !== 409) return error;
   if (e.code !== 'CONCURRENT_UPDATE') return error;
-  const details = (e.details ?? {}) as Record<string, unknown>;
   return new ConcurrentUpdateError({
     currentVersion: typeof details.currentVersion === 'string' ? details.currentVersion : null,
     currentRecord: details.currentRecord ?? null,
@@ -1022,10 +1061,18 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
 
   async create(resource: string, data: Partial<T>): Promise<T> {
     await this.connect();
-    const result = await this.client.data.create<T>(resource, data);
-    this.emitMutation({ type: 'create', resource, record: { ...result.record } });
-    this.notifyDroppedFields('create', resource, result, (result.record as { id?: string | number } | undefined)?.id);
-    return result.record;
+    try {
+      const result = await this.client.data.create<T>(resource, data);
+      this.emitMutation({ type: 'create', resource, record: { ...result.record } });
+      this.notifyDroppedFields('create', resource, result, (result.record as { id?: string | number } | undefined)?.id);
+      return result.record;
+    } catch (err) {
+      // `update` has always normalised; `create` did not, so a rejected insert
+      // reached callers as the raw client error — no typed shape to branch on,
+      // and its `fields[]` unreachable. A create is the path that most often
+      // trips required-field validation, so it needs this more, not less.
+      throw normaliseClientError(err);
+    }
   }
 
   /**

--- a/packages/data-objectstack/src/validation-error.test.ts
+++ b/packages/data-objectstack/src/validation-error.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { normaliseClientError } from './index';
+import { ValidationError } from './errors';
+
+/**
+ * The server has always sent per-field rejection detail; the adapter used to
+ * hand callers the raw client error, so `fields[]` had no typed home and every
+ * form fell back to one undirected toast.
+ */
+describe('normaliseClientError — VALIDATION_FAILED', () => {
+  // `@objectstack/rest` serves a thrown validation failure as 400 with `fields[]`
+  // verbatim; `@objectstack/client` sets `error.details` to the parsed body's
+  // `details` OR — as here, since the envelope has no such key — the whole body.
+  const upstream = () =>
+    Object.assign(new Error('Name is required; Stage is not a valid option'), {
+      code: 'VALIDATION_FAILED',
+      httpStatus: 400,
+      details: {
+        error: 'Name is required; Stage is not a valid option',
+        code: 'VALIDATION_FAILED',
+        fields: [
+          { field: 'name', code: 'required', message: 'Name is required' },
+          { field: 'stage', code: 'invalid_option', message: 'Stage is not a valid option' },
+        ],
+        object: 'crm_opportunity',
+      },
+    });
+
+  it('wraps it into a typed ValidationError', () => {
+    const normalised = normaliseClientError(upstream());
+    expect(normalised).toBeInstanceOf(ValidationError);
+  });
+
+  it('carries every field entry through', () => {
+    const normalised = normaliseClientError(upstream()) as ValidationError;
+    expect(normalised.validationErrors).toEqual([
+      { field: 'name', message: 'Name is required' },
+      { field: 'stage', message: 'Stage is not a valid option' },
+    ]);
+  });
+
+  it('keeps the server message verbatim — it names every field', () => {
+    const normalised = normaliseClientError(upstream()) as ValidationError;
+    expect(normalised.message).toBe('Name is required; Stage is not a valid option');
+  });
+
+  it('exposes the first offending field on `.field`', () => {
+    const normalised = normaliseClientError(upstream()) as ValidationError;
+    expect(normalised.field).toBe('name');
+  });
+
+  it('falls back to the machine code when an entry has no message', () => {
+    const err = Object.assign(new Error('Validation failed'), {
+      code: 'VALIDATION_FAILED',
+      details: { fields: [{ field: 'name', code: 'required' }] },
+    });
+    const normalised = normaliseClientError(err) as ValidationError;
+    expect(normalised.validationErrors).toEqual([{ field: 'name', message: 'required' }]);
+  });
+
+  it('drops entries with no field rather than inventing one', () => {
+    const err = Object.assign(new Error('Validation failed'), {
+      code: 'VALIDATION_FAILED',
+      details: { fields: [{ message: 'something is wrong' }] },
+    });
+    const normalised = normaliseClientError(err) as ValidationError;
+    expect(normalised.validationErrors).toEqual([]);
+  });
+
+  it('still wraps when the error carries `fields` directly (hand-rolled shape)', () => {
+    // The server duck-types on `code`/`name`, so a hook throwing the bare shape
+    // is served identically — the client must not be pickier than the server.
+    const err = Object.assign(new Error('nope'), {
+      name: 'ValidationError',
+      fields: [{ field: 'amount', message: 'Amount must be positive' }],
+    });
+    const normalised = normaliseClientError(err) as ValidationError;
+    expect(normalised.validationErrors).toEqual([{ field: 'amount', message: 'Amount must be positive' }]);
+  });
+
+  it('leaves an unrelated 400 untouched', () => {
+    const err = Object.assign(new Error('bad request'), { code: 'BAD_REQUEST', httpStatus: 400 });
+    expect(normaliseClientError(err)).toBe(err);
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -18,7 +18,8 @@ export { resolveI18nLabel } from './utils/i18n';
 
 // Write-error surfacing utilities (shared by drag-write plugins so a failed
 // PATCH — e.g. an RLS 403 — is never silently swallowed).
-export { extractWriteErrorMessage, isPermissionError } from './utils/error-message';
+export { extractWriteErrorMessage, isPermissionError, extractFieldErrors } from './utils/error-message';
+export type { WriteFieldError } from './utils/error-message';
 
 // Built-in i18n support
 export {

--- a/packages/react/src/utils/error-message.test.ts
+++ b/packages/react/src/utils/error-message.test.ts
@@ -1,0 +1,89 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { extractFieldErrors } from './error-message';
+
+describe('extractFieldErrors', () => {
+  // The wire shape the server actually sends: `@objectstack/rest` serves a
+  // thrown `VALIDATION_FAILED` as 400 with `fields[]` passed through verbatim,
+  // and `@objectstack/client` puts the whole body on `error.details` (the
+  // envelope has no `details` key of its own, so the fallback applies).
+  const serverEnvelope = {
+    error: 'Name is required; Stage is not a valid option',
+    code: 'VALIDATION_FAILED',
+    fields: [
+      { field: 'name', code: 'required', message: 'Name is required' },
+      { field: 'stage', code: 'invalid_option', message: 'Stage is not a valid option', options: ['won', 'lost'] },
+    ],
+    object: 'crm_opportunity',
+  };
+
+  it('reads the raw client error, whose details carry the response body', () => {
+    const err = Object.assign(new Error(serverEnvelope.error), {
+      code: 'VALIDATION_FAILED',
+      httpStatus: 400,
+      details: serverEnvelope,
+    });
+    expect(extractFieldErrors(err)).toEqual([
+      { field: 'name', message: 'Name is required' },
+      { field: 'stage', message: 'Stage is not a valid option' },
+    ]);
+  });
+
+  it('reads a normalised ValidationError from the ObjectStack adapter', () => {
+    const err = Object.assign(new Error('Name is required'), {
+      name: 'ValidationError',
+      validationErrors: [{ field: 'name', message: 'Name is required' }],
+    });
+    expect(extractFieldErrors(err)).toEqual([{ field: 'name', message: 'Name is required' }]);
+  });
+
+  it('reads a hand-rolled error carrying `fields` directly', () => {
+    // The server duck-types these identically (a hook may throw the shape
+    // without going through objectql's class), so the client does too.
+    const err = Object.assign(new Error('nope'), {
+      fields: [{ field: 'amount', message: 'Amount must be positive' }],
+    });
+    expect(extractFieldErrors(err)).toEqual([{ field: 'amount', message: 'Amount must be positive' }]);
+  });
+
+  it('falls back to the machine code when an entry carries no message', () => {
+    const err = { details: { fields: [{ field: 'name', code: 'required' }] } };
+    expect(extractFieldErrors(err)).toEqual([{ field: 'name', message: 'required' }]);
+  });
+
+  it('drops entries with no field rather than guessing which input to mark', () => {
+    const err = {
+      details: { fields: [{ message: 'something is wrong' }, { field: 'name', message: 'Name is required' }] },
+    };
+    // Marking an innocent input is worse than the generic toast we already show.
+    expect(extractFieldErrors(err)).toEqual([{ field: 'name', message: 'Name is required' }]);
+  });
+
+  it('returns null when the failure is not field-scoped', () => {
+    const forbidden = Object.assign(new Error('insufficient privileges'), {
+      code: 'FORBIDDEN',
+      httpStatus: 403,
+      details: { error: 'insufficient privileges', code: 'FORBIDDEN' },
+    });
+    expect(extractFieldErrors(forbidden)).toBeNull();
+  });
+
+  it('returns null for an empty fields array — a 400 with nothing to attribute', () => {
+    expect(extractFieldErrors({ code: 'VALIDATION_FAILED', details: { fields: [] } })).toBeNull();
+  });
+
+  it('returns null for junk input', () => {
+    expect(extractFieldErrors(null)).toBeNull();
+    expect(extractFieldErrors(undefined)).toBeNull();
+    expect(extractFieldErrors('a string')).toBeNull();
+    expect(extractFieldErrors(new Error('plain'))).toBeNull();
+  });
+});

--- a/packages/react/src/utils/error-message.ts
+++ b/packages/react/src/utils/error-message.ts
@@ -73,6 +73,63 @@ export function extractWriteErrorMessage(err: unknown): string | null {
   return clean || null;
 }
 
+/** One field the server rejected, normalised for `form.setError`. */
+export interface WriteFieldError {
+  /** Field name, matching the form control's `name`. */
+  field: string;
+  /** Human-readable reason, already localized by the server when it can be. */
+  message: string;
+}
+
+/**
+ * Per-field errors from a rejected write, or `null` when the failure was not
+ * field-scoped.
+ *
+ * The server has always sent these. `@objectstack/objectql`'s validators throw
+ * `{ code: 'VALIDATION_FAILED', fields: [{ field, code, message }] }`, and both
+ * the REST layer and the runtime dispatcher serve that as a 400 with `fields[]`
+ * intact. What was missing was the last hop: every form caught the rejection,
+ * showed one generic toast, and dropped `fields[]` on the floor — so a user told
+ * "Validation failed" had to guess WHICH input was wrong, on a surface that
+ * already knows how to mark it.
+ *
+ * Reads three shapes, because the error can arrive from either side of the
+ * adapter boundary:
+ *   - `validationErrors` — a `ValidationError` from `@object-ui/data-objectstack`;
+ *   - `details.fields` — the raw `@objectstack/client` error, whose `details`
+ *     falls back to the whole response body;
+ *   - `fields` — a hand-rolled error of the same shape (the server duck-types
+ *     these identically, so we do too).
+ *
+ * Entries without a usable `field` are dropped rather than guessed at: a wrong
+ * mark on an innocent input is worse than the generic toast we already show.
+ */
+export function extractFieldErrors(err: unknown): WriteFieldError[] | null {
+  const e = err as Record<string, any> | null | undefined;
+  if (!e || typeof e !== 'object') return null;
+
+  const raw: unknown =
+    (Array.isArray(e.validationErrors) && e.validationErrors) ||
+    (Array.isArray(e.details?.fields) && e.details.fields) ||
+    (Array.isArray(e.fields) && e.fields) ||
+    null;
+  if (!raw || !Array.isArray(raw)) return null;
+
+  const out: WriteFieldError[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const rec = entry as Record<string, unknown>;
+    const field = firstString(rec.field, rec.name, rec.path);
+    if (!field) continue;
+    // `code` is the machine enum (`required`, `invalid_option`, …). It is a
+    // last resort only: the server builds `message` to be shown verbatim, and
+    // an untranslated enum in the UI reads as a bug.
+    const message = firstString(rec.message, rec.error, rec.code) ?? '';
+    out.push({ field, message });
+  }
+  return out.length > 0 ? out : null;
+}
+
 /**
  * True when a failed write was rejected for authorization reasons (HTTP 403 /
  * `PERMISSION_DENIED` / `FORBIDDEN` / a row-level-security denial). Lets a


### PR DESCRIPTION
## The server always said which field

`@objectstack/objectql`'s validators throw `VALIDATION_FAILED` with `fields[]` — one entry per offending field, each carrying a human `message` — and both the REST layer and the runtime dispatcher serve that as a 400 with the entries intact.

**Every form dropped them.** The submit handler caught the rejection, ran the message through `extractWriteErrorMessage`, and showed one undirected toast. The user was told something was wrong but not *what* — on a surface that already knows how to mark an input, and already does exactly that for client-side validation. On a long form the offending field is usually off-screen, so the submit button appears to do nothing.

This is the general fix behind the specific one in #2962. That PR had to add a client-side hint precisely because the server's precise rejection only ever arrived as a toast, after Save.

## Now both failures share one implementation

The toast naming the fields and the scroll-and-focus of the first offender (#2793) were extracted from the client-side invalid handler into `announceFieldErrors`; the server path calls it. To the person filling in the form these are the same event — only the referee differs.

Three layers, each of which was dropping the detail:

**`@object-ui/react`** — new `extractFieldErrors(err)`, exported beside `extractWriteErrorMessage` / `isPermissionError`. Normalises the three shapes the error can arrive in:

| Shape | Where it comes from |
|---|---|
| `validationErrors` | a typed `ValidationError` from the ObjectStack adapter |
| `details.fields` | the raw `@objectstack/client` error — its `details` falls back to the **whole response body**, and the validation envelope has no `details` key, so this is where `fields[]` lands |
| `fields` | a hand-rolled error of the same shape; the server duck-types these identically, so the client must not be pickier than the server |

Entries with no usable `field` are **dropped rather than guessed at** — marking an innocent input is worse than the generic toast we already show.

**`@object-ui/data-objectstack`** — `normaliseClientError` maps a 400 `VALIDATION_FAILED` onto the `ValidationError` class that has sat in `errors.ts` since the package was written: **exported, and never once constructed.** Its `validationErrors: Array<{ field, message }>` shape was already exactly right for this.

`create` also now normalises *at all*. Only `update` did, so a rejected insert reached callers as the raw client error with no typed shape to branch on — and a create is the path that most often trips required-field validation.

**`@object-ui/components`** — the form renderer applies the entries via `form.setError` and takes over the failure, **but only when every rejected field has a visible input to carry it**. If the server also rejected something this form does not render, it falls through to the banner, whose top-level message concatenates every field's reason — so the part the user cannot see inline is still said out loud instead of silently dropped.

## Why this matters beyond one form

It removes the reason for the client-side predicate mirroring added in #2962. A form should not have to guess what the server will reject in order to warn about it beforehand — mirrored predicates drift, and the copy that drifts is the one users read.

## Verification

- **14 new unit tests** across the two helpers — the real wire envelope, the adapter's typed error, the hand-rolled shape, the message/code fallback, entries with no field, and the non-field failures that must stay on the old path.
- **6 form-renderer tests** driving a real rejected submit: the reason appears under the input, the first offender is scrolled to and focused, the toast names the field's *label*, every rejected field is marked, an unrenderable field falls through to the banner, and a 403 marks nothing.
- **107 files / 1073 tests green** across `components`, `plugin-form`, `react`, `data-objectstack`. `tsc --noEmit` clean on all three changed packages. eslint 0 errors (remaining warnings are the file's pre-existing `no-explicit-any` convention).

Non-field failures — 403, permission denials, anything without `fields[]` — take exactly the path they took before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuViRSR1j6GJjf9qGbnqFX)_