### PR TITLE
fix(fields): a select no longer wipes itself when its value outruns its options (#2968)

### DIFF
--- a/.changeset/select-empty-writeback.md
+++ b/.changeset/select-empty-writeback.md
@@ -1,0 +1,29 @@
+---
+"@object-ui/components": patch
+---
+
+fix(fields): a `select` no longer wipes itself when its value outruns its options (#2968)
+
+Radix keeps a hidden native `<select>` mirror so a Select's value takes part in
+native form submission. Assigning a value that mirror has no `<option>` for is a
+no-op — the element stays on `''` — but Radix still dispatches the synthetic
+`change`, so `''` comes straight back out through `onValueChange` and lands in
+react-hook-form on top of the value the caller just set.
+
+The window is not theoretical: `SelectContent` registers its native options a
+commit AFTER the trigger mounts, so a record that lands after first paint — an
+edit modal whose `findOne` is still in flight — resets the form into exactly
+that gap. Every rendered select came back empty while RHF's `_defaultValues`
+still held the right value. When one of the wiped fields is the one a
+`visibleWhen` predicate reads, the predicate flips back to false, the
+conditional fields hide again and the form **latches** in the broken state:
+pressing Update then fails validation, or submits an empty enum, on a form the
+user never touched. The wipe is also recorded as a user edit, so Cancel prompts
+"discard changes?" on an untouched form.
+
+`SelectItem` rejects `value=""` outright, so `''` can never be a value the user
+actually picked — it is always the mirror talking. It is now dropped at the
+single `Select` chokepoint, which covers every surface that renders one (object
+form, inline grid editor, action param dialog). Clearing a select still goes
+through `undefined`, which is untouched — the `dependsOn` cascade-clear behaves
+exactly as before.

--- a/packages/components/src/renderers/form/__tests__/form-select-value-survives-rules.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-select-value-survives-rules.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * An edit form's `select` values must survive the record landing (#2968).
+ *
+ * The reported failure: a record loads after first paint, the form resets to
+ * the loaded defaults, and every rendered `select` comes back EMPTY — the
+ * hidden native mirror Radix keeps for form submission reported `''` for a
+ * value it had no `<option>` for yet, and that `''` was written into
+ * react-hook-form. When the wiped field is the one a `visibleWhen` predicate
+ * reads, the predicate flips back to false, the conditional fields hide again,
+ * and the form latches broken: Update then fails validation (or submits an
+ * empty enum) on a form the user never touched.
+ *
+ * The invariant these tests pin: nothing writes into a `select`-backed form
+ * value except the user. A value the option list does not (yet) offer is left
+ * alone rather than blanked.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+
+beforeAll(async () => {
+  await import('../../../renderers');
+}, 30000);
+
+const CATEGORY_OPTIONS = [
+  { label: '00 Production', value: 'production' },
+  { label: '01 Quality', value: 'quality' },
+];
+
+const fields = [
+  { name: 'category', label: 'Category', type: 'select', options: CATEGORY_OPTIONS },
+  {
+    name: 'status',
+    label: 'Status',
+    type: 'select',
+    options: [
+      { label: 'Pending', value: 'pending' },
+      { label: 'Done', value: 'done' },
+    ],
+  },
+  // Reads `category`, so a wipe of `category` is self-latching: the field hides
+  // again and never comes back.
+  {
+    name: 'need_quality',
+    label: 'Need quality check',
+    type: 'checkbox',
+    visibleWhen: 'record.category == "production"',
+  },
+];
+
+/**
+ * Build the form element. A plain factory (not a component) so the renderer is
+ * pulled from the registry once the `beforeAll` import has run, without
+ * resolving a component type during render.
+ */
+function formElement(
+  defaults: Record<string, unknown>,
+  onChange?: (data: Record<string, unknown>) => void,
+) {
+  const Form = ComponentRegistry.get('form')!;
+  return (
+    <Form
+      schema={{ type: 'form', showSubmit: false, showCancel: false, fields, defaultValues: defaults }}
+      onAction={(action: { type?: string; data?: Record<string, unknown> }) => {
+        if (action?.type === 'form_change') onChange?.(action.data ?? {});
+      }}
+    />
+  );
+}
+
+describe('form renderer — select values survive a late record (#2968)', () => {
+  it('keeps both selects and reveals the conditional field when the record lands', async () => {
+    const { rerender, container } = render(formElement({}));
+
+    // The record arrives after first paint (edit modal, findOne still in flight
+    // when the form first rendered).
+    rerender(formElement({ category: 'production', status: 'pending' }));
+
+    await waitFor(() => {
+      const mirrors = Array.from(container.querySelectorAll('select')) as HTMLSelectElement[];
+      const byName = Object.fromEntries(mirrors.map((s) => [s.name, s.value]));
+      expect(byName.category).toBe('production');
+      expect(byName.status).toBe('pending');
+    });
+
+    // The predicate now holds, so the conditional field is rendered.
+    expect(container.querySelector('[data-field="need_quality"]')).not.toBeNull();
+  });
+
+  it('never writes an empty string over a value the option list does not offer', async () => {
+    const changes: Array<Record<string, unknown>> = [];
+    const push = (d: Record<string, unknown>) => { changes.push(d); };
+    const { rerender } = render(formElement({}, push));
+
+    // A value outside the offered set is the deterministic form of the race:
+    // the mirror has no matching <option>, so Radix used to echo `''` back and
+    // react-hook-form recorded the wipe as a user edit.
+    rerender(formElement({ category: 'not-offered', status: 'pending' }, push));
+
+    await waitFor(() => {});
+
+    // No change event at all — the form is pristine, so the modal's dirty guard
+    // stays quiet and nothing was blanked behind the user's back.
+    expect(changes).toEqual([]);
+  });
+});

--- a/packages/components/src/ui/__tests__/select-empty-writeback.test.tsx
+++ b/packages/components/src/ui/__tests__/select-empty-writeback.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A `Select` must never echo an empty string back to its owner (#2968).
+ *
+ * Radix keeps a hidden native `<select>` mirror so the value participates in
+ * native form submission. Assigning a value the mirror has no `<option>` for is
+ * a no-op — the element stays on `''` — yet Radix still dispatches the
+ * synthetic `change`, which surfaces as `onValueChange('')`. Since the option
+ * set registers a commit AFTER the trigger mounts, any value that lands while a
+ * form is still hydrating hits that window and gets written back as `''`,
+ * wiping the field the caller just set.
+ *
+ * `SelectItem` rejects `value=""`, so `''` is never a value a user picked; the
+ * wrapper drops it and forwards every real selection unchanged.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { act } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../select';
+
+const OPTIONS = [
+  { label: '00 Production', value: 'production' },
+  { label: '01 Quality', value: 'quality' },
+];
+
+function Harness({
+  value,
+  options = OPTIONS,
+  onValueChange,
+}: {
+  value?: string;
+  options?: typeof OPTIONS;
+  onValueChange: (v: string) => void;
+}) {
+  return (
+    <form>
+      <Select name="category" value={value} onValueChange={onValueChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select an option" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((o) => (
+            <SelectItem key={o.value} value={o.value}>
+              {o.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </form>
+  );
+}
+
+describe('Select — empty-string write-back (#2968)', () => {
+  it('does not report a value when the controlled value is not among the options', () => {
+    const onValueChange = vi.fn();
+    const { rerender } = render(<Harness value={undefined} onValueChange={onValueChange} />);
+
+    // The owner sets a value the mirror carries no <option> for — exactly what
+    // a record landing before the option set registers looks like.
+    rerender(<Harness value="not-offered" onValueChange={onValueChange} />);
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('does not report a value while the option list is still empty', () => {
+    const onValueChange = vi.fn();
+    const { rerender } = render(<Harness value={undefined} options={[]} onValueChange={onValueChange} />);
+
+    rerender(<Harness value="production" options={[]} onValueChange={onValueChange} />);
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    // …and the value survives once the options do arrive.
+    rerender(<Harness value="production" options={OPTIONS} onValueChange={onValueChange} />);
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when a controlled value the options do carry is applied', () => {
+    const onValueChange = vi.fn();
+    const { rerender } = render(<Harness value={undefined} onValueChange={onValueChange} />);
+
+    rerender(<Harness value="production" onValueChange={onValueChange} />);
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('still forwards a real selection', () => {
+    const onValueChange = vi.fn();
+    const { container } = render(<Harness onValueChange={onValueChange} />);
+
+    // Drive the hidden native mirror the way Radix does when a user picks an
+    // option — the trigger/listbox itself needs pointer capture that jsdom
+    // cannot provide, but this is the same event path the value travels.
+    const mirror = container.querySelector('select') as HTMLSelectElement;
+    act(() => {
+      mirror.value = 'quality';
+      mirror.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith('quality');
+  });
+});

--- a/packages/components/src/ui/select.tsx
+++ b/packages/components/src/ui/select.tsx
@@ -14,7 +14,38 @@ import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
 import { cn } from "../lib/utils"
 
-const Select = SelectPrimitive.Root
+/**
+ * Radix mirrors a Select's value into a hidden native `<select>` so the value
+ * takes part in native form submission. Whenever the controlled `value` changes
+ * to one that mirror carries no `<option>` for, assigning it is a no-op — the
+ * element stays on `''` — and Radix still dispatches the synthetic `change`,
+ * which comes straight back out as `onValueChange('')`.
+ *
+ * That window is real, not theoretical: `SelectContent` mounts its items (and
+ * therefore registers the native options) a commit AFTER the trigger, so a
+ * value arriving while a form is still hydrating — an edit form whose record
+ * lands after first paint — is echoed back as an empty string and silently
+ * overwrites the field. When the wiped field is the one a `visibleWhen`
+ * predicate reads, the form latches in the broken state (#2968).
+ *
+ * `SelectItem` rejects `value=""` outright, so `''` can never be a value the
+ * user actually picked — it is always the mirror talking. Drop it. Clearing a
+ * select is done by writing `undefined`, which is untouched.
+ */
+const Select = ({
+  onValueChange,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root>) => {
+  const handleValueChange = React.useCallback(
+    (next: string) => {
+      if (next === "") return
+      onValueChange?.(next)
+    },
+    [onValueChange]
+  )
+  return <SelectPrimitive.Root {...props} onValueChange={handleValueChange} />
+}
+Select.displayName = SelectPrimitive.Root.displayName
 
 const SelectGroup = SelectPrimitive.Group
 


### PR DESCRIPTION
Closes #2968.

## Root cause

Not `visibleWhen`, and not the cascade-clear path — both of those write
`undefined`, which does not match the `''` the reporter measured. The writer is
Radix's hidden native `<select>` **mirror**.

Radix renders an `aria-hidden` `<select name=…>` alongside every Select so the
value takes part in native form submission. When the controlled `value` changes,
it assigns the mirror through `HTMLSelectElement.prototype.value` and dispatches
a synthetic `change`. If the mirror carries no `<option>` for that value the
assignment is a **no-op** — the element stays on `''` — but the `change` fires
anyway, so `''` comes straight back out through `onValueChange` and into
react-hook-form, on top of the value the caller just set.

The window is not theoretical: `SelectContent` returns `null` on its first
render (its `DocumentFragment` is created in a layout effect), so the native
options register a commit **after** the trigger mounts. A record landing after
first paint — an edit modal whose `findOne` is still in flight — resets the form
into exactly that gap.

That explains every detail of the report: the value is `''` and not `undefined`,
only `select` fields are hit, `_defaultValues` stays correct while `_formValues`
is blanked, and it is timing-dependent. And because one wiped field is usually
the one the `visibleWhen` predicate reads, the predicate flips back to false, the
conditional fields hide again, and the form **latches** broken.

Demonstrated directly against the `Select` wrapper (pre-fix):

| scenario | `onValueChange` received |
| --- | --- |
| `undefined` → value present in options | `[]` |
| `undefined` → value **not** in options | `[""]` |
| value lands **before** the options | `[""]` |
| option list changes, value unchanged | `[]` |

## Fix

`SelectItem` rejects `value=""` outright, so `''` can never be a value a user
picked — it is always the mirror talking. Drop it at the single `Select`
chokepoint (`packages/components/src/ui/select.tsx`), which covers every surface
that renders one: the object form, the inline grid editor, `ActionParamDialog`.
Clearing a select still goes through `undefined`, so the `dependsOn`
cascade-clear is untouched.

## Tests

Two regression files, red before the fix and green after (3 failed → 6 passed):

- `packages/components/src/ui/__tests__/select-empty-writeback.test.tsx` — the
  wrapper's invariant, including a positive assertion that a real selection is
  still forwarded.
- `packages/components/src/renderers/form/__tests__/form-select-value-survives-rules.test.tsx`
  — the form-level shape from the issue: a record landing late keeps both
  selects and reveals the `visibleWhen` field, and no `''` is ever recorded as a
  user edit.

Full DOM suite: **4113 passed / 24 skipped, 0 failed**. The 18 `unit`-project
failures on this branch are pre-existing (verified by re-running them with the
fix stashed): spec Theme schema parity, plugin-kanban, data-objectstack
`onMutation`, `DATEFORMAT`.

## Browser verification

Framework `examples/app-showcase` on a private port, driven through objectui's
own console dev server (so the running UI is this branch's `src`, not the
vendored bundle). Fixtures: `showcase_invoice` — two selects (`region`,
`status`) plus `paid_on` carrying `visibleWhen: record.status == 'paid'`, the
exact shape in the issue, and a master-detail line-item subform — and
`showcase_cascade` for the `dependsOn` / per-option `visibleWhen` paths.

- Edit modal on a paid invoice: both selects correct, `paid_on` rendered, and a
  fiber probe of RHF reports `lostKeys: []` with `_formValues` matching
  `_defaultValues`.
- Live predicate flip Paid → Sent → Paid: `paid_on` hides and comes back **with
  its value**, `readonlyWhen` on `tax_rate` follows, nothing else is touched.
- Master-detail save (the `batchTransaction` path): renaming the invoice and
  switching `region` APAC → EMEA both persist, with `status` / `paid_on` intact;
  the server's `readonlyWhen` notice for `tax_rate` fires as designed.
- Cascading select: the `dependsOn` gate ("Select country first") still holds,
  changing the parent still clears the child, the option list re-filters, and
  `cn/zj` → `us/ca` persists server-side.
- Create form: gate → country → filtered provinces → created and persisted.
- Escape on an untouched edit form closes with **no** "discard changes?" prompt.

A `this.client.data.batchTransaction is not a function` failure seen mid-run was
traced to a stale local `node_modules` (installed `@objectstack/client` had
drifted to 14.6.0 while `pnpm-lock.yaml` pins `17.0.0-rc.0`). `pnpm install`
resolved it; no lockfile or source change was needed, and the master-detail save
above was then verified on the correct client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
