### PR TITLE
fix(errors): error-code branches survive the framework's ADR-0112 rename (objectstack#3841)

### DIFF
--- a/.changeset/error-code-vocabulary-tolerant-read.md
+++ b/.changeset/error-code-vocabulary-tolerant-read.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/types": minor
+"@object-ui/app-shell": patch
+"@object-ui/react": patch
+"@object-ui/data-objectstack": patch
+---
+
+fix(errors): error-code branches survive the framework's ADR-0112 rename — objectstack#3841
+
+Framework ADR-0112 renamed the whole `error.code` vocabulary from lowercase
+`snake_case` to `SCREAMING_SNAKE` (`destructive_change` → `DESTRUCTIVE_CHANGE`).
+Eleven places compared `err.code` against the old spelling with `===`, so against
+a swept server they simply stopped matching — and nothing threw. The affordance
+each branch guards just vanished and the user got the generic error toast instead:
+
+- the destructive-change confirm dialog (resource editor, permission matrix)
+- the "create a writable package first" hint
+- field-scoped validation issues on embedded item saves
+- the all-or-nothing publish summary naming the causal item
+- unknown-object tolerance in the app header and in record search
+- the marketplace's local-install messages for conflict / auth / unavailable
+- `isNotFoundError` in the data layer
+
+`RECORD_NOT_FOUND` had already been renamed a release earlier, so that branch was
+already dead before this fix.
+
+New `errorCodeIs` / `errorCodeIsAnyOf` in `@object-ui/types` compare
+case-insensitively, so the console keeps working against servers on either side
+of the rename — the console ships separately from the server it talks to. Every
+call site now passes the catalog (SCREAMING) spelling, and `error-code.ts` is the
+single file to delete once no supported server emits the old vocabulary.

--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -65,6 +65,7 @@ import { emitMetadataRefresh } from '../../assistant/assistantBus';
 import { useMetadata } from '../../providers/MetadataProvider';
 import { SuggestedBindingsPanel, type SuggestedBindingsStrings } from '../../components/SuggestedBindingsPanel';
 import type { SuggestedBinding } from '../../services/suggestedBindingsApi';
+import { errorCodeIs } from '@object-ui/types';
 
 export function MarketplacePackagePage() {
   const navigate = useNavigate();
@@ -332,11 +333,11 @@ export function MarketplacePackagePage() {
     } catch (e: any) {
       const code = e?.code;
       let msg = e?.message ?? String(e);
-      if (code === 'manifest_conflict') {
+      if (errorCodeIs(e, 'MANIFEST_CONFLICT')) {
         msg = t('marketplace.install.localManifestConflict', { message: msg });
-      } else if (code === 'unauthorized') {
+      } else if (errorCodeIs(e, 'UNAUTHENTICATED')) {
         msg = t('marketplace.install.localUnauthorized');
-      } else if (code === 'marketplace_unavailable') {
+      } else if (errorCodeIs(e, 'MARKETPLACE_UNAVAILABLE')) {
         msg = t('marketplace.install.localMarketplaceUnavailable');
       }
       setLocalResult({ ok: false, message: msg });

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -78,6 +78,7 @@ import { useAiSurfaceEnabled } from '../hooks/useAiSurface';
 import { getProductName, getLogoUrl } from '../runtime-config';
 import { LocalizedSidebarTrigger } from './LocalizedSidebarTrigger';
 import { PreviewBadge } from './PreviewBadge';
+import { errorCodeIs } from '@object-ui/types';
 
 function humanizeSlug(slug: string): string {
   return slug.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
@@ -253,7 +254,7 @@ export function AppHeader({
     // registered on the server. Either signal means the feature is
     // unavailable — disable it for the rest of the page.
     const isMissingResource = (err: any): boolean =>
-      err?.httpStatus === 404 || err?.status === 404 || err?.code === 'object_not_found';
+      err?.httpStatus === 404 || err?.status === 404 || errorCodeIs(err, 'OBJECT_NOT_FOUND');
 
     // Tenant-wide presence ("who else is online?") is intentionally NOT
     // probed here. Presence is real-time ephemeral state that does not
@@ -343,7 +344,7 @@ export function AppHeader({
     const MAX_BACKOFF_MS = 120_000;
     let backoffMs = ACTIVE_INTERVAL_MS;
     const isMissingResource = (err: any): boolean =>
-      err?.httpStatus === 404 || err?.status === 404 || err?.code === 'object_not_found';
+      err?.httpStatus === 404 || err?.status === 404 || errorCodeIs(err, 'OBJECT_NOT_FOUND');
     const READ_STATES = new Set(['read', 'clicked', 'dismissed']);
     const fetchOnce = async () => {
       if (notifInFlightRef.current) return;

--- a/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx
@@ -22,6 +22,7 @@ import { Button } from '@object-ui/components';
 import { SchemaForm, type SchemaFormIssue } from './SchemaForm';
 import { useMetadataClient, useMetadataTypes } from './useMetadata';
 import { useMetadataLocale, t, tFormat, translateValidationMessage } from './i18n';
+import { errorCodeIsAnyOf } from '@object-ui/types';
 
 export interface EmbeddedItemEditorProps {
   parentType: string;
@@ -104,7 +105,7 @@ export function EmbeddedItemEditor({
     } catch (err: any) {
       // Validation issues from the parent save apply to the embedded
       // path. Try to scope them back to this item.
-      if (err?.status === 422 || err?.code === 'invalid_metadata' || err?.code === 'invalid_payload') {
+      if (err?.status === 422 || errorCodeIsAnyOf(err, ['INVALID_METADATA', 'INVALID_PAYLOAD'])) {
         const raw = err?.body?.issues ?? [];
         const mapped: SchemaFormIssue[] = (Array.isArray(raw) ? raw : []).map((x: any) => {
           const fullPath = Array.isArray(x.path) ? x.path.join('.') : String(x.path ?? '');

--- a/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PackagesPage.tsx
@@ -62,6 +62,7 @@ import {
 } from '@object-ui/components';
 import { useMetadataLocale, t, tFormat } from './i18n';
 import { PackageFormDialog } from './PackageFormDialog';
+import { errorCodeIs } from '@object-ui/types';
 
 /* -------------------------------------------------------------------------- */
 /* Types + API                                                                 */
@@ -346,8 +347,8 @@ export function PackageDetailSheet({
             // error. Say "rolled back because X", not "{n} failed" (which reads
             // as a partial publish that no longer exists).
             const failedList = Array.isArray(r.failed) ? r.failed : [];
-            const causal = failedList.find((f) => f?.code !== 'batch_aborted' && f?.error);
-            if (failedList.some((f) => f?.code === 'batch_aborted')) {
+            const causal = failedList.find((f) => !errorCodeIs(f, 'BATCH_ABORTED') && f?.error);
+            if (failedList.some((f) => errorCodeIs(f, 'BATCH_ABORTED'))) {
               throw new Error(tFormat('engine.packages.detail.publishDraftsRolledBack', locale, {
                 cause: causal ? `${causal.type ?? '?'}/${causal.name ?? '?'}: ${causal.error}` : String(r.failedCount),
               }));

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -76,6 +76,7 @@ import { useMetadataClient, useMetadataTypes, type RichMetadataTypeEntry } from 
 import { resolveResourceConfig } from './registry';
 import { t as translate, useMetadataLocale } from './i18n';
 import { PermissionAdvancedFacets } from './PermissionAdvancedFacets';
+import { errorCodeIs } from '@object-ui/types';
 import {
   mergePermissionSlice,
   scopePermissionSet,
@@ -578,7 +579,7 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
       }
       setDestructive(null);
     } catch (err: any) {
-      if (err?.status === 409 && err?.code === 'destructive_change') {
+      if (err?.status === 409 && errorCodeIs(err, 'DESTRUCTIVE_CHANGE')) {
         const issues = err?.body?.issues ?? [];
         setDestructive({ issues: Array.isArray(issues) ? issues : [], pending: payload });
       } else {

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -115,6 +115,7 @@ import { JsonSourceEditor } from './JsonSourceEditor';
 import { validateMetadataDraft, hasClientValidator } from './clientValidation';
 import { describeIssuePath } from './issuePath';
 import { buildCreateModeBody } from './createBody';
+import { errorCodeIs, errorCodeIsAnyOf } from '@object-ui/types';
 
 // react-resizable-panels' `direction` prop type does not always narrow
 // cleanly in our TS config; cast at the boundary (precedent:
@@ -1133,7 +1134,7 @@ function MetadataResourceEditPageImpl({
       }
     } catch (err: any) {
       // Map destructive change → confirmation dialog.
-      if (err?.status === 409 && err?.code === 'destructive_change') {
+      if (err?.status === 409 && errorCodeIs(err, 'DESTRUCTIVE_CHANGE')) {
         const i = err?.body?.issues ?? [];
         setDestructiveIssues(Array.isArray(i) ? i : []);
         setPendingItem(draft);
@@ -1143,11 +1144,11 @@ function MetadataResourceEditPageImpl({
       // so this MUST precede the generic invalid_metadata branch below).
       // Surface an actionable message guiding the author to pick or create a
       // writable base rather than mangling it into phantom field issues.
-      else if (err?.code === 'writable_package_required') {
+      else if (errorCodeIs(err, 'WRITABLE_PACKAGE_REQUIRED')) {
         setError(t('engine.package.writableRequired', locale));
       }
       // Map schema validation → inline field errors.
-      else if (err?.status === 422 || err?.code === 'invalid_metadata' || err?.code === 'invalid_payload') {
+      else if (err?.status === 422 || errorCodeIsAnyOf(err, ['INVALID_METADATA', 'INVALID_PAYLOAD'])) {
         const i = err?.body?.issues ?? [];
         let mapped: SchemaFormIssue[] = (Array.isArray(i) ? i : []).map((x: any) => ({
           path: Array.isArray(x.path) ? x.path.join('.') : String(x.path ?? ''),

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -26,6 +26,7 @@ import type {
   ImportJobUndoResult,
   ListImportJobsOptions,
 } from '@object-ui/types';
+import { errorCodeIsAnyOf } from '@object-ui/types';
 import {
   convertFiltersToAST,
   emulateBatchTransaction,
@@ -236,7 +237,7 @@ export function is404Error(error: unknown): boolean {
     return true;
   }
   const code = typeof err.code === 'string' ? err.code : '';
-  return code === 'object_not_found' || code === 'record_not_found';
+  return errorCodeIsAnyOf({ code }, ['OBJECT_NOT_FOUND', 'RECORD_NOT_FOUND']);
 }
 
 /**
@@ -356,7 +357,7 @@ function createQuietHttpLogger(): any {
     const errBody = meta.error;
     if (errBody && typeof errBody === 'object') {
       const code = (errBody as Record<string, unknown>).code;
-      if (code === 'object_not_found' || code === 'record_not_found') return true;
+      if (errorCodeIsAnyOf({ code }, ['OBJECT_NOT_FOUND', 'RECORD_NOT_FOUND'])) return true;
     }
     return false;
   };

--- a/packages/react/src/hooks/useRecordSearch.ts
+++ b/packages/react/src/hooks/useRecordSearch.ts
@@ -8,6 +8,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getRecordDisplayName as defaultDisplayName } from '@object-ui/core';
+import { errorCodeIs } from '@object-ui/types';
 
 // ADR-0079: the global-search default display-name resolver is now the ONE
 // shared `getRecordDisplayName` from `@object-ui/core` (honors titleFormat →
@@ -321,7 +322,7 @@ export function useRecordSearch(opts: UseRecordSearchOptions): UseRecordSearchRe
             // last real error so the UI can show a non-blocking hint.
             const status = err?.httpStatus ?? err?.status;
             const code = err?.code;
-            if (status === 404 || code === 'object_not_found') continue;
+            if (status === 404 || errorCodeIs(err, 'OBJECT_NOT_FOUND')) continue;
             lastError = err instanceof Error ? err : new Error(String(err));
             continue;
           }

--- a/packages/types/src/__tests__/error-code.test.ts
+++ b/packages/types/src/__tests__/error-code.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { errorCodeIs, errorCodeIsAnyOf } from '../error-code';
+
+describe('errorCodeIs', () => {
+  it('matches the catalog spelling', () => {
+    expect(errorCodeIs({ code: 'DESTRUCTIVE_CHANGE' }, 'DESTRUCTIVE_CHANGE')).toBe(true);
+  });
+
+  // The reason this helper exists: a console build outlives the server rename,
+  // and the pre-ADR-0112 server is still a supported peer.
+  it('matches a pre-ADR-0112 server still sending the lowercase spelling', () => {
+    expect(errorCodeIs({ code: 'destructive_change' }, 'DESTRUCTIVE_CHANGE')).toBe(true);
+  });
+
+  it('does not match a different code', () => {
+    expect(errorCodeIs({ code: 'INVALID_METADATA' }, 'DESTRUCTIVE_CHANGE')).toBe(false);
+    expect(errorCodeIs({ code: 'invalid_metadata' }, 'DESTRUCTIVE_CHANGE')).toBe(false);
+  });
+
+  it('tolerates anything as the error', () => {
+    for (const junk of [null, undefined, {}, 'DESTRUCTIVE_CHANGE', 42, { code: '' }, { code: 7 }]) {
+      expect(errorCodeIs(junk, 'DESTRUCTIVE_CHANGE')).toBe(false);
+    }
+  });
+
+  it('errorCodeIsAnyOf matches on any listed code, in either spelling', () => {
+    const codes = ['INVALID_METADATA', 'INVALID_PAYLOAD'] as const;
+    expect(errorCodeIsAnyOf({ code: 'invalid_payload' }, codes)).toBe(true);
+    expect(errorCodeIsAnyOf({ code: 'INVALID_METADATA' }, codes)).toBe(true);
+    expect(errorCodeIsAnyOf({ code: 'ITEM_LOCKED' }, codes)).toBe(false);
+    expect(errorCodeIsAnyOf(null, codes)).toBe(false);
+  });
+});

--- a/packages/types/src/error-code.ts
+++ b/packages/types/src/error-code.ts
@@ -1,0 +1,31 @@
+/**
+ * Does an ObjectStack error carry this semantic code?
+ *
+ * Compare with this instead of `err.code === 'x'`. The console is versioned
+ * separately from the server it talks to, so at any moment it may be pointed at
+ * a build from either side of framework ADR-0112 — which renamed the whole
+ * `error.code` vocabulary from lowercase `snake_case` to `SCREAMING_SNAKE`
+ * (`destructive_change` → `DESTRUCTIVE_CHANGE`). A strict equality check against
+ * one spelling silently stops matching against the other half of that split, and
+ * silently is the bad part: the affordance the branch guards — a confirm dialog,
+ * a targeted hint, a "create the package first" prompt — just disappears, and
+ * the user gets the generic error toast instead. Nothing throws, so no test that
+ * doesn't assert the affordance would notice.
+ *
+ * Pass the SCREAMING spelling (the catalog's, post-ADR-0112). Matching is
+ * case-insensitive, so both spellings resolve, and this file is the one place to
+ * delete when no supported server emits the old vocabulary.
+ *
+ * @param err   Anything caught — the shape is not trusted.
+ * @param code  The catalog code, SCREAMING_SNAKE (e.g. `'DESTRUCTIVE_CHANGE'`).
+ */
+export function errorCodeIs(err: unknown, code: string): boolean {
+  const raw = (err as { code?: unknown } | null | undefined)?.code;
+  if (typeof raw !== 'string' || raw.length === 0) return false;
+  return raw.toUpperCase() === code.toUpperCase();
+}
+
+/** `errorCodeIs` for any of several codes. True if the error matches one. */
+export function errorCodeIsAnyOf(err: unknown, codes: readonly string[]): boolean {
+  return codes.some((c) => errorCodeIs(err, c));
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1184,3 +1184,5 @@ export type {
   WidgetRegistryEvent,
   WidgetRegistryListener,
 } from './widget';
+
+export { errorCodeIs, errorCodeIsAnyOf } from './error-code';


### PR DESCRIPTION
Console side of framework [ADR-0112](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0112-error-code-vocabulary-and-ledger.md), which renamed the whole `error.code` vocabulary from lowercase `snake_case` to `SCREAMING_SNAKE`. Framework batch 2 is objectstack#4021.

## The bug

Eleven places compared `err.code` against the old spelling with `===`. Against a swept server they stop matching, and **nothing throws** — the affordance each branch guards just disappears and the user gets the generic error toast:

| Where | Branch | What silently stops working |
|:---|:---|:---|
| `ResourceEditPage`, `PermissionMatrixEditor` | `destructive_change` | the confirm dialog before a data-dropping change |
| `ResourceEditPage` | `writable_package_required` | the "create a writable package first" hint |
| `ResourceEditPage`, `EmbeddedItemEditor` | `invalid_metadata` / `invalid_payload` | field-scoped validation issues; they fall back to a flat message |
| `PackagesPage` | `batch_aborted` | the all-or-nothing publish summary naming the causal item |
| `AppHeader`, `useRecordSearch` | `object_not_found` | unknown-object tolerance — a 404 becomes a hard error |
| `MarketplacePackagePage` | `manifest_conflict`, `unauthorized`, `marketplace_unavailable` | the three specific local-install messages |
| `data-objectstack` `isNotFoundError` | `object_not_found`, `record_not_found` | not-found detection in the data layer |

`RECORD_NOT_FOUND` was renamed in framework batch 1 (objectstack#3988), so that branch has been dead since before this PR — it just never announced itself.

## The fix

`errorCodeIs` / `errorCodeIsAnyOf` in `@object-ui/types` (the one package all three affected packages already depend on) compare case-insensitively, so the console works against servers on **either** side of the rename. That tolerance is the point rather than a nicety: the console ships separately from the server it talks to, so both spellings are live peers for as long as older servers are supported.

Call sites pass the catalog (SCREAMING) spelling. `packages/types/src/error-code.ts` is the single file to delete once no supported server emits the old vocabulary.

## Why a helper instead of just updating the strings

Updating the literals would have swapped one silent failure for its mirror image — the console would break against every server that hasn't upgraded yet. This is the tolerant dual-read pattern the framework ADR's rollout prescribes for the console (objectui#2869's shape).

## Test evidence

`packages/types/src/__tests__/error-code.test.ts` — 5 tests, green: catalog spelling, pre-ADR-0112 lowercase spelling, non-matches in both spellings, junk-tolerance (`null`, a bare string, a numeric `code`), and the any-of variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaSQn77TT5fUgHK9CesaDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaSQn77TT5fUgHK9CesaDK)_