### PR TITLE
feat(sdui): guard the public contract against silent drift (follow-up to #2953)

### DIFF
--- a/.changeset/public-contract-drift-guards.md
+++ b/.changeset/public-contract-drift-guards.md
@@ -1,0 +1,35 @@
+---
+"@object-ui/sdui-parser": minor
+"@object-ui/console": patch
+---
+
+feat(sdui): guard the public contract against silent drift — coverage test + manifest lazy-stub assertion
+
+Follow-up to objectui#2953. That bug — every lazily-registered public block
+missing from the contract, and so from every `kind:'react'` page's scope —
+survived because nothing compared `PUBLIC_BLOCKS` against what an app actually
+registers. Type-check, lint, build and the whole suite stayed green while seven
+curated blocks were unusable. Two guards close that class.
+
+**Console ↔ contract coverage.** `apps/console/src/register-plugins.ts` extracts
+the plugin registration out of `main.tsx` so it can be imported without booting
+the app. A new `apps/console/src/__tests__/public-contract.test.ts` reads that
+real list and pins, as exact lists, which curated tags the console exposes (35),
+which are still unimplemented (`line_items`), and which reach the contract
+through a pending lazy stub. Exact lists rather than `toContain`, because the
+failure mode is a *shrinking* contract. Reverting the #2953 fix drops coverage
+from 35 to 28 and fails all four assertions.
+
+**Manifests must be generated from loaded registrations.** New exported
+`assertFullyLoaded(configs)` in `@object-ui/sdui-parser`, plus `lazy?: boolean`
+on `RegistryConfigLike`. A lazy stub carries metadata but no `inputs`, so it
+would be written into `sdui.manifest.json` as a block that takes no props —
+making every prop an author passes it an `unknown-prop` diagnostic in the save
+gate. Both generators now assert instead: `gen-manifest.ts` throws, and
+`dev/manifest-dump.tsx` also imports the console's real registration list, so a
+plugin the console lazy-registers but the dump forgets to import eagerly is
+caught rather than silently emitted propless. `scripts/dump-public-manifest.mjs`
+surfaces that failure instead of timing out for 120s with no message.
+
+Also documents `object-chart` as a seventh block affected by objectui#2953 —
+the issue listed six.

--- a/apps/console/dev/manifest-dump.tsx
+++ b/apps/console/dev/manifest-dump.tsx
@@ -1,5 +1,20 @@
 /* ADR-0080: headless dump of the public-tier component manifest.
- * Registers everything the console does, then serializes getPublicConfigs(). */
+ * Registers everything the console does, then serializes getPublicConfigs().
+ *
+ * Two lists have to agree here, and nothing used to check them:
+ *   - `src/register-plugins.ts` — what the console actually ships, most of it
+ *     registered LAZILY (the chunk loads on first use).
+ *   - the eager imports below — what this dump loads so the manifest carries
+ *     each block's real `inputs`.
+ *
+ * Importing the former means a plugin the console lazy-registers but this file
+ * forgets to import eagerly survives as a `lazy: true` stub and
+ * `assertFullyLoaded` fails the build — instead of that block landing in the
+ * manifest with no props, which would make every prop an author writes on it
+ * an `unknown-prop` diagnostic downstream. Eager registration wins over a stub,
+ * so the manifest itself is unchanged; this only makes the drift detectable. */
+import '../src/register-plugins';
+
 import '@object-ui/components';
 import '@object-ui/plugin-grid';
 import '@object-ui/plugin-form';
@@ -17,9 +32,21 @@ import '@object-ui/plugin-markdown';
 import '@object-ui/plugin-report';
 import '@object-ui/plugin-tree';
 import { ComponentRegistry } from '@object-ui/core';
-import { manifestFromConfigs } from '@object-ui/sdui-parser';
+import { assertFullyLoaded, manifestFromConfigs } from '@object-ui/sdui-parser';
 
-const manifest = manifestFromConfigs(ComponentRegistry.getPublicConfigs() as never);
-const json = JSON.stringify(manifest, null, 2);
-document.getElementById('out')!.textContent = json;
-(window as unknown as { __MANIFEST: string }).__MANIFEST = json;
+const out = document.getElementById('out')!;
+const win = window as unknown as { __MANIFEST?: string; __MANIFEST_ERROR?: string };
+
+try {
+  const configs = ComponentRegistry.getPublicConfigs() as never;
+  assertFullyLoaded(configs);
+  const json = JSON.stringify(manifestFromConfigs(configs), null, 2);
+  out.textContent = json;
+  win.__MANIFEST = json;
+} catch (err) {
+  // Surface the failure instead of leaving `__MANIFEST` unset — the dump script
+  // waits for one of these two, and would otherwise just time out with no clue.
+  const message = err instanceof Error ? err.message : String(err);
+  out.textContent = message;
+  win.__MANIFEST_ERROR = message;
+}

--- a/apps/console/src/__tests__/public-contract.test.ts
+++ b/apps/console/src/__tests__/public-contract.test.ts
@@ -1,0 +1,142 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Console ↔ public contract coverage (ADR-0080, objectui#2953).
+ *
+ * `PUBLIC_BLOCKS` is the curated contract and AI-authoring vocabulary. What an
+ * author (or a model) can actually write is the intersection of that list with
+ * what THIS APP registers — and nothing was checking the two against each
+ * other. objectui#2953 is what that costs: `getPublicConfigs()` resolved each
+ * curated tag through `getConfig()`, which reads loaded registrations only, so
+ * every block the console registers via `registerLazy()` fell out of the
+ * contract — and out of every `kind:'react'` page's scope — while type-check,
+ * lint, build and the whole test suite stayed green.
+ *
+ * This reads the REAL registration list (`src/register-plugins.ts`, the same
+ * module `main.tsx` boots from). A hand-copied list here would reproduce the
+ * original failure: it would agree with itself and tell us nothing.
+ *
+ * The assertions are exact lists rather than "contains", because the failure
+ * mode is a SHRINKING contract. `toContain` would sail past a block that
+ * silently disappeared; an exact list makes both directions a deliberate edit.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ComponentRegistry, PUBLIC_BLOCKS, type PublicComponentConfig } from '@object-ui/core';
+
+/**
+ * Every curated tag the console makes available, in `PUBLIC_BLOCKS` order.
+ * Update this only alongside a deliberate change to what the console ships.
+ */
+const EXPECTED_COVERED = [
+  'object-grid',
+  'list-view',
+  'object-form',
+  'embeddable-form',
+  'object-master-detail-form',
+  'object-kanban',
+  'object-calendar',
+  'object-gantt',
+  'object-timeline',
+  'object-map',
+  'object-metric',
+  'object-chart',
+  'dashboard',
+  'object-pivot',
+  'record:details',
+  'record:highlights',
+  'record:related_list',
+  'record:path',
+  'flex',
+  'grid',
+  'stack',
+  'card',
+  'tabs',
+  'accordion',
+  'container',
+  'page:header',
+  'text',
+  'image',
+  'icon',
+  'markdown',
+  'element:divider',
+  'badge',
+  'alert',
+  'button',
+  'html',
+];
+
+/**
+ * Curated tags with no renderer behind them yet. `PUBLIC_BLOCKS` is documented
+ * as aspirational-safe (an unregistered tag is skipped), so a gap is allowed —
+ * but it should be a listed, reviewable gap rather than a silent one, since
+ * "advertised in the contract, absent at runtime" is what an AI-authored page
+ * trips over.
+ */
+const EXPECTED_UNIMPLEMENTED = ['line_items'];
+
+/**
+ * The curated tags that reach the contract through a PENDING lazy stub in this
+ * environment — i.e. the exact code path objectui#2953 broke. Nothing here is
+ * eagerly imported by `register-plugins.ts` or by `vitest.setup.dom.tsx`.
+ *
+ * `dashboard` / `object-metric` / `object-pivot` are lazy in the real console
+ * too, but the shared DOM setup imports `@object-ui/plugin-dashboard` eagerly,
+ * so they arrive loaded here. That skew is precisely why the coverage
+ * assertion above pins AVAILABILITY and not tier: whether a given block is
+ * eager or lazy is a bundling decision that varies by host, while "the author
+ * can write this tag" must not. If the shared setup ever imports one of the
+ * plugins below, move that tag out of this list — it is still covered.
+ */
+const EXPECTED_LAZY = [
+  'object-kanban',
+  'object-calendar',
+  'object-gantt',
+  'object-timeline',
+  'object-map',
+  'object-chart',
+  'markdown',
+];
+
+let contract: Map<string, PublicComponentConfig>;
+
+beforeAll(async () => {
+  // The layout/content primitives (Tier B) …
+  await import('@object-ui/components');
+  // … and the console's own plugin layer, from the module main.tsx boots from.
+  await import('../register-plugins');
+  contract = new Map(ComponentRegistry.getPublicConfigs().map((c) => [c.type, c]));
+}, 60000);
+
+describe('console ↔ PUBLIC_BLOCKS coverage', () => {
+  it('exposes every curated block the console ships, eager or lazy', () => {
+    expect(PUBLIC_BLOCKS.filter((tag) => contract.has(tag))).toEqual(EXPECTED_COVERED);
+  });
+
+  it('leaves exactly the known-unimplemented curated tags uncovered', () => {
+    expect(PUBLIC_BLOCKS.filter((tag) => !contract.has(tag))).toEqual(EXPECTED_UNIMPLEMENTED);
+  });
+
+  it('reaches the lazily-registered blocks before their chunks load (objectui#2953)', () => {
+    // If `getPublicConfigs()` ever goes back to resolving through `getConfig()`,
+    // these seven vanish from the contract — silently, since the plugin chunk
+    // that would prove them present is exactly the thing that hasn't loaded.
+    const lazy = EXPECTED_COVERED.filter((tag) => contract.get(tag)!.lazy);
+    expect(lazy).toEqual(EXPECTED_LAZY);
+    // A pending stub carries metadata but no renderer — consumers must go
+    // through SchemaRenderer, which triggers the loader.
+    for (const tag of EXPECTED_LAZY) {
+      expect(contract.get(tag)!.component).toBeUndefined();
+    }
+  });
+
+  it('keeps the contract keyed by the bare tag authors write', () => {
+    for (const tag of EXPECTED_COVERED) {
+      expect(contract.get(tag)!.type).toBe(tag);
+    }
+  });
+});

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -10,7 +10,6 @@ import './index.css';
 import { App } from './App';
 import { I18nProvider } from '@object-ui/i18n';
 import { MobileProvider, generatePWAManifest } from '@object-ui/mobile';
-import { ComponentRegistry } from '@object-ui/core';
 import { registerPlaceholders } from '@object-ui/components';
 import { initSentry, initRuntimeConfig, getProductName, getProductShortName, getFaviconUrl, getPwaDescription, getPwaThemeColor } from '@object-ui/app-shell';
 import { loadLanguage } from './loadLanguage';
@@ -26,121 +25,11 @@ void initSentry();
 // Plugin registration
 // ────────────────────────────────────────────────────────────────────────────
 //
-// Eager imports — core views needed on most pages.  These are cheap (no heavy
-// 3rd-party deps) so paying their cost upfront is the right tradeoff.
-import '@object-ui/plugin-grid';
-import '@object-ui/plugin-form';
-import '@object-ui/plugin-view';
-import '@object-ui/plugin-list';
-import '@object-ui/plugin-detail';
-
-// Lazy plugins — registered as deferred loaders.  The first time the
-// SchemaRenderer encounters one of these `type` values, the plugin module is
-// imported on-demand (and its top-level `ComponentRegistry.register()` calls
-// run as a side-effect).  This keeps maplibre-gl, recharts, frappe-gantt,
-// markdown renderers, etc. out of the initial bundle.
-ComponentRegistry.registerLazy('object-map', () => import('@object-ui/plugin-map'), {
-  namespace: 'plugin-map',
-  category: 'view',
-});
-ComponentRegistry.registerLazy('map', () => import('@object-ui/plugin-map'), {
-  namespace: 'view',
-  category: 'view',
-});
-
-ComponentRegistry.registerLazy('object-tree', () => import('@object-ui/plugin-tree'), {
-  namespace: 'plugin-tree',
-  category: 'view',
-});
-ComponentRegistry.registerLazy('tree', () => import('@object-ui/plugin-tree'), {
-  namespace: 'view',
-  category: 'view',
-});
-
-// Dashboard plugin — only used on dashboard / home pages. Lazy-load all 8
-// component types so the ~150 KB widget/pivot/metric tree stays out of the
-// initial bundle for users who never visit a dashboard.
-for (const variant of ['dashboard', 'metric', 'metric-card', 'object-metric', 'pivot', 'object-pivot', 'dashboard-grid', 'object-data-table']) {
-  ComponentRegistry.registerLazy(variant, () => import('@object-ui/plugin-dashboard'), {
-    namespace: 'plugin-dashboard',
-    category: 'view',
-  });
-}
-
-ComponentRegistry.registerLazy('chart', () => import('@object-ui/plugin-charts'), {
-  namespace: 'plugin-charts',
-  category: 'chart',
-});
-// Additional chart variants registered by @object-ui/plugin-charts so the
-// renderer can lazy-load when any chart type appears in a schema.
-for (const variant of ['object-chart', 'bar-chart', 'pie-chart', 'donut-chart', 'radar-chart', 'scatter-chart', 'line-chart', 'area-chart', 'advanced-chart', 'chart:bar']) {
-  ComponentRegistry.registerLazy(variant, () => import('@object-ui/plugin-charts'), {
-    namespace: 'plugin-charts',
-    category: 'chart',
-  });
-}
-
-ComponentRegistry.registerLazy('object-gantt', () => import('@object-ui/plugin-gantt'), {
-  namespace: 'plugin-gantt',
-  category: 'view',
-});
-ComponentRegistry.registerLazy('gantt', () => import('@object-ui/plugin-gantt'), {
-  namespace: 'view',
-  category: 'view',
-});
-
-ComponentRegistry.registerLazy('markdown', () => import('@object-ui/plugin-markdown'), {
-  namespace: 'plugin-markdown',
-  category: 'display',
-});
-
-ComponentRegistry.registerLazy('object-timeline', () => import('@object-ui/plugin-timeline'), {
-  namespace: 'plugin-timeline',
-  category: 'view',
-});
-ComponentRegistry.registerLazy('timeline', () => import('@object-ui/plugin-timeline'), {
-  namespace: 'view',
-  category: 'view',
-});
-
-ComponentRegistry.registerLazy('object-calendar', () => import('@object-ui/plugin-calendar'), {
-  namespace: 'plugin-calendar',
-  category: 'view',
-});
-ComponentRegistry.registerLazy('calendar', () => import('@object-ui/plugin-calendar'), {
-  namespace: 'view',
-  category: 'view',
-});
-ComponentRegistry.registerLazy('calendar-view', () => import('@object-ui/plugin-calendar'), {
-  namespace: 'plugin-calendar',
-  category: 'view',
-});
-
-ComponentRegistry.registerLazy('object-kanban', () => import('@object-ui/plugin-kanban'), {
-  namespace: 'plugin-kanban',
-  category: 'view',
-});
-ComponentRegistry.registerLazy('kanban', () => import('@object-ui/plugin-kanban'), {
-  namespace: 'view',
-  category: 'view',
-});
-for (const variant of ['kanban-ui', 'kanban-enhanced']) {
-  ComponentRegistry.registerLazy(variant, () => import('@object-ui/plugin-kanban'), {
-    namespace: 'plugin-kanban',
-    category: 'view',
-  });
-}
-
-ComponentRegistry.registerLazy('report', () => import('@object-ui/plugin-report'), {
-  namespace: 'plugin-report',
-  category: 'view',
-});
-for (const variant of ['report-viewer', 'spec-report']) {
-  ComponentRegistry.registerLazy(variant, () => import('@object-ui/plugin-report'), {
-    namespace: 'plugin-report',
-    category: 'view',
-  });
-}
+// The SDUI block layer (eager core views + lazy heavy plugins) lives in its own
+// module so it can be imported without booting the app — the public-contract
+// test and the manifest dump both read the REAL list from there rather than
+// keeping a copy that can drift (objectui#2953).
+import './register-plugins';
 
 // Register console-specific schema widgets (object detail page sections)
 import './components/schema/registerObjectDetailWidgets';

--- a/apps/console/src/register-plugins.ts
+++ b/apps/console/src/register-plugins.ts
@@ -1,0 +1,144 @@
+/**
+ * Console plugin registration — the SDUI block layer.
+ *
+ * Extracted from `main.tsx` so it can be imported WITHOUT booting the app
+ * (which mounts React, resolves runtime config and inits Sentry). Two consumers
+ * need exactly this and nothing else:
+ *
+ *   - `src/__tests__/public-contract.test.ts` — pins which curated
+ *     `PUBLIC_BLOCKS` tags the console actually makes available. That guard is
+ *     only meaningful if it reads the REAL registration list rather than a
+ *     hand-copied one (objectui#2953 was a public block silently missing from
+ *     the contract; a duplicated list would have hidden it just as well).
+ *   - `dev/manifest-dump.tsx` — imports this alongside its own eager plugin
+ *     imports, so a plugin the console lazy-registers but the dump forgets to
+ *     load eagerly shows up as a `lazy: true` stub and fails the build.
+ *
+ * Import order note: this module's own imports are hoisted, so the eager
+ * plugins below register during import and the `registerLazy` calls run in this
+ * module's body — the same relative order they had inline in `main.tsx`.
+ * `registerPlaceholders()` still runs in `main.tsx`, after this module, because
+ * it must only fill gaps left by every real registration.
+ */
+
+import { ComponentRegistry } from '@object-ui/core';
+
+// Eager imports — core views needed on most pages.  These are cheap (no heavy
+// 3rd-party deps) so paying their cost upfront is the right tradeoff.
+import '@object-ui/plugin-grid';
+import '@object-ui/plugin-form';
+import '@object-ui/plugin-view';
+import '@object-ui/plugin-list';
+import '@object-ui/plugin-detail';
+
+// Lazy plugins — registered as deferred loaders.  The first time the
+// SchemaRenderer encounters one of these `type` values, the plugin module is
+// imported on-demand (and its top-level `ComponentRegistry.register()` calls
+// run as a side-effect).  This keeps maplibre-gl, recharts, frappe-gantt,
+// markdown renderers, etc. out of the initial bundle.
+//
+// A lazily-registered tag is still a full member of the public contract:
+// `getPublicConfigs()` resolves these stubs, so `kind:'react'` pages get them
+// in scope before the chunk loads (objectui#2953).
+ComponentRegistry.registerLazy('object-map', () => import('@object-ui/plugin-map'), {
+  namespace: 'plugin-map',
+  category: 'view',
+});
+ComponentRegistry.registerLazy('map', () => import('@object-ui/plugin-map'), {
+  namespace: 'view',
+  category: 'view',
+});
+
+ComponentRegistry.registerLazy('object-tree', () => import('@object-ui/plugin-tree'), {
+  namespace: 'plugin-tree',
+  category: 'view',
+});
+ComponentRegistry.registerLazy('tree', () => import('@object-ui/plugin-tree'), {
+  namespace: 'view',
+  category: 'view',
+});
+
+// Dashboard plugin — only used on dashboard / home pages. Lazy-load all 8
+// component types so the ~150 KB widget/pivot/metric tree stays out of the
+// initial bundle for users who never visit a dashboard.
+for (const variant of ['dashboard', 'metric', 'metric-card', 'object-metric', 'pivot', 'object-pivot', 'dashboard-grid', 'object-data-table']) {
+  ComponentRegistry.registerLazy(variant, () => import('@object-ui/plugin-dashboard'), {
+    namespace: 'plugin-dashboard',
+    category: 'view',
+  });
+}
+
+ComponentRegistry.registerLazy('chart', () => import('@object-ui/plugin-charts'), {
+  namespace: 'plugin-charts',
+  category: 'chart',
+});
+// Additional chart variants registered by @object-ui/plugin-charts so the
+// renderer can lazy-load when any chart type appears in a schema.
+for (const variant of ['object-chart', 'bar-chart', 'pie-chart', 'donut-chart', 'radar-chart', 'scatter-chart', 'line-chart', 'area-chart', 'advanced-chart', 'chart:bar']) {
+  ComponentRegistry.registerLazy(variant, () => import('@object-ui/plugin-charts'), {
+    namespace: 'plugin-charts',
+    category: 'chart',
+  });
+}
+
+ComponentRegistry.registerLazy('object-gantt', () => import('@object-ui/plugin-gantt'), {
+  namespace: 'plugin-gantt',
+  category: 'view',
+});
+ComponentRegistry.registerLazy('gantt', () => import('@object-ui/plugin-gantt'), {
+  namespace: 'view',
+  category: 'view',
+});
+
+ComponentRegistry.registerLazy('markdown', () => import('@object-ui/plugin-markdown'), {
+  namespace: 'plugin-markdown',
+  category: 'display',
+});
+
+ComponentRegistry.registerLazy('object-timeline', () => import('@object-ui/plugin-timeline'), {
+  namespace: 'plugin-timeline',
+  category: 'view',
+});
+ComponentRegistry.registerLazy('timeline', () => import('@object-ui/plugin-timeline'), {
+  namespace: 'view',
+  category: 'view',
+});
+
+ComponentRegistry.registerLazy('object-calendar', () => import('@object-ui/plugin-calendar'), {
+  namespace: 'plugin-calendar',
+  category: 'view',
+});
+ComponentRegistry.registerLazy('calendar', () => import('@object-ui/plugin-calendar'), {
+  namespace: 'view',
+  category: 'view',
+});
+ComponentRegistry.registerLazy('calendar-view', () => import('@object-ui/plugin-calendar'), {
+  namespace: 'plugin-calendar',
+  category: 'view',
+});
+
+ComponentRegistry.registerLazy('object-kanban', () => import('@object-ui/plugin-kanban'), {
+  namespace: 'plugin-kanban',
+  category: 'view',
+});
+ComponentRegistry.registerLazy('kanban', () => import('@object-ui/plugin-kanban'), {
+  namespace: 'view',
+  category: 'view',
+});
+for (const variant of ['kanban-ui', 'kanban-enhanced']) {
+  ComponentRegistry.registerLazy(variant, () => import('@object-ui/plugin-kanban'), {
+    namespace: 'plugin-kanban',
+    category: 'view',
+  });
+}
+
+ComponentRegistry.registerLazy('report', () => import('@object-ui/plugin-report'), {
+  namespace: 'plugin-report',
+  category: 'view',
+});
+for (const variant of ['report-viewer', 'spec-report']) {
+  ComponentRegistry.registerLazy(variant, () => import('@object-ui/plugin-report'), {
+    namespace: 'plugin-report',
+    category: 'view',
+  });
+}

--- a/packages/sdui-parser/scripts/gen-manifest.ts
+++ b/packages/sdui-parser/scripts/gen-manifest.ts
@@ -4,17 +4,21 @@
  *   - sdui-intrinsics.d.ts (the JSX type surface for authoring)
  *   - sdui-blocks.md       (the human 清单)
  *
- * PREREQUISITE: all plugins must be registered before this runs — import the
- * app's plugin barrel first so getPublicConfigs() sees the full set, e.g.:
- *   import '@object-ui/console/register-all';   // side-effectful registration
- * Then run with tsx. Mirrors the build-skill-docs pattern.
+ * PREREQUISITE: all plugins must be EAGERLY registered before this runs —
+ * import the app's plugin modules first so getPublicConfigs() sees the full
+ * set with its `inputs`, e.g.:
+ *   import '@object-ui/plugin-kanban';   // side-effectful registration
+ * A plugin that is only lazily registered has no renderer and no `inputs` yet;
+ * `assertFullyLoaded` fails the build rather than emitting it as a propless
+ * block. Then run with tsx. Mirrors the build-skill-docs pattern.
  */
 import { writeFileSync } from 'node:fs';
 import { ComponentRegistry } from '@object-ui/core';
-import { generateBlockList, generateDts, manifestFromConfigs, type RegistryConfigLike } from '../src/index.js';
+import { assertFullyLoaded, generateBlockList, generateDts, manifestFromConfigs, type RegistryConfigLike } from '../src/index.js';
 
 export function buildArtifacts(outDir: string): void {
   const configs = ComponentRegistry.getPublicConfigs() as unknown as RegistryConfigLike[];
+  assertFullyLoaded(configs);
   const manifest = manifestFromConfigs(configs);
   writeFileSync(`${outDir}/sdui.manifest.json`, JSON.stringify(manifest, null, 2));
   writeFileSync(`${outDir}/sdui-intrinsics.d.ts`, generateDts(manifest));

--- a/packages/sdui-parser/src/__tests__/tier.test.ts
+++ b/packages/sdui-parser/src/__tests__/tier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateBlockList, generateDts, manifestFromConfigs } from '../index.js';
+import { assertFullyLoaded, generateBlockList, generateDts, manifestFromConfigs } from '../index.js';
 
 const configs = [
   { type: 'object-table', namespace: 'plugin-grid', tier: 'public' as const, inputs: [
@@ -25,5 +25,25 @@ describe('M4: capability vs contract (tier)', () => {
   it('codegen stays consistent with the public manifest', () => {
     expect(generateDts(manifestFromConfigs(configs, { publicOnly: true })))
       .toContain('"object-table": ObjectTableProps;');
+  });
+});
+
+describe('assertFullyLoaded — generators must not emit lazy stubs (objectui#2953)', () => {
+  it('passes when every config is a loaded registration', () => {
+    expect(() => assertFullyLoaded(configs)).not.toThrow();
+  });
+
+  it('names every stub, so the fix is "import these plugins"', () => {
+    const withStubs = [
+      ...configs,
+      { type: 'object-kanban', namespace: 'plugin-kanban', lazy: true },
+      { type: 'object-map', namespace: 'plugin-map', lazy: true },
+    ];
+    // The silent alternative is what this exists to prevent: both blocks reach
+    // the manifest with `inputs: []`, which reads as "takes no props" and turns
+    // every prop an author writes into an unknown-prop diagnostic.
+    expect(manifestFromConfigs(withStubs).components['object-kanban'].inputs).toEqual([]);
+    expect(() => assertFullyLoaded(withStubs)).toThrow(/object-kanban, object-map/);
+    expect(() => assertFullyLoaded(withStubs)).toThrow(/2 not-yet-loaded lazy block/);
   });
 });

--- a/packages/sdui-parser/src/index.ts
+++ b/packages/sdui-parser/src/index.ts
@@ -66,6 +66,38 @@ export interface RegistryConfigLike {
     binding?: 'object' | 'field';
     description?: string;
   }>;
+  /**
+   * True when the registry entry is a pending lazy stub — registered, but its
+   * plugin module has not been imported, so it carries metadata and no
+   * `inputs`. See {@link assertFullyLoaded}.
+   */
+  lazy?: boolean;
+}
+
+/**
+ * Build-time guard for the manifest generators.
+ *
+ * A manifest is the contract's frozen form: the parser's tag whitelist and the
+ * save gate's prop validator both read it. So it has to be generated from
+ * FULLY LOADED registrations. A `lazy: true` entry means the generator never
+ * imported that plugin, and the block would be written out with empty
+ * `inputs` — indistinguishable from a block that legitimately takes no props,
+ * which turns every prop an author writes on it into an `unknown-prop`
+ * diagnostic. Wrong quietly, in the artifact everything downstream trusts.
+ *
+ * The generators keep their own eager import list, so this is what catches it
+ * drifting behind the app's registration list (objectui#2953 was the same
+ * class of bug one layer down).
+ */
+export function assertFullyLoaded(configs: RegistryConfigLike[]): void {
+  const stubs = configs.filter((c) => c.lazy).map((c) => c.type).sort();
+  if (stubs.length === 0) return;
+  throw new Error(
+    `Manifest generation saw ${stubs.length} not-yet-loaded lazy block(s): ${stubs.join(', ')}.\n` +
+      `A manifest must describe loaded registrations — these would be written out with no \`inputs\`, ` +
+      `so every prop an author passes them would be reported as unknown.\n` +
+      `Add an eager \`import\` of each block's plugin to the generator entry.`,
+  );
 }
 
 const INPUT_TYPES = new Set([

--- a/scripts/dump-public-manifest.mjs
+++ b/scripts/dump-public-manifest.mjs
@@ -18,8 +18,13 @@ const browser = await chromium.launch();
 try {
   const page = await browser.newPage();
   await page.goto(`${BASE}/dev/manifest-dump.html`, { waitUntil: 'networkidle', timeout: 120_000 });
-  const json = await page.waitForFunction(() => globalThis.__MANIFEST, null, { timeout: 120_000 })
+  // The page sets exactly one of these. Waiting only on __MANIFEST would turn
+  // any generation failure into a silent 120s timeout instead of its message.
+  const json = await page
+    .waitForFunction(() => globalThis.__MANIFEST ?? globalThis.__MANIFEST_ERROR, null, { timeout: 120_000 })
     .then((h) => h.jsonValue());
+  const failure = await page.evaluate(() => globalThis.__MANIFEST_ERROR);
+  if (failure) throw new Error(`manifest generation failed in the browser:\n${failure}`);
   const manifest = JSON.parse(json);
   const n = Object.keys(manifest.components ?? {}).length;
   if (n === 0) throw new Error('empty manifest — registry not populated');


### PR DESCRIPTION
Follow-up to #2953 (merged in #2976). No behaviour change — two guards against the class of bug that one was.

## Why

#2953 survived because nothing compared `PUBLIC_BLOCKS` against what an app actually registers. Type-check, lint, build and the whole suite stayed green while **seven** curated blocks were unusable in every `kind:'react'` page. Both guards below fail loudly on exactly that.

(Seven, not six — the issue listed `object-kanban`, `object-calendar`, `object-gantt`, `object-timeline`, `object-map`, `markdown`. Building the coverage test surfaced `object-chart` as an eighth… seventh. It is now recorded.)

## 1. Console ↔ contract coverage

`apps/console/src/register-plugins.ts` extracts the plugin registration out of `main.tsx` so it can be imported without booting the app (which mounts React, resolves runtime config and inits Sentry). `main.tsx` now just `import './register-plugins'` where the block was; `registerPlaceholders()` still runs after it, in `main.tsx`, since it must only fill gaps left by real registrations.

`apps/console/src/__tests__/public-contract.test.ts` reads that **real** list — a hand-copied one here would reproduce the original failure by agreeing with itself — and pins, as exact lists:

- the 35 curated tags the console exposes, eager or lazy;
- the one still unimplemented (`line_items`), so an advertised-but-absent tag is a listed, reviewable gap rather than a silent one;
- the 7 that reach the contract through a *pending lazy stub* — the exact code path #2953 broke — asserting `lazy: true` and no `component`.

Exact lists rather than `toContain`, because the failure mode is a **shrinking** contract: `toContain` sails right past a block that silently disappeared.

Verified meaningful: patching `getContractConfig` back to loaded-only drops coverage from 35 to 28 and fails all four assertions.

```
AssertionError: expected [ 'object-grid', 'list-view', …(26) ] to deeply equal [ 'object-grid', 'list-view', …(33) ]
AssertionError: expected [ 'object-kanban', …(7) ] to deeply equal [ 'line_items' ]
```

The coverage assertion pins **availability, not tier** deliberately: whether a block is eager or lazy is a bundling decision that varies by host (and by test setup — the shared DOM setup imports `plugin-dashboard`, so `dashboard`/`object-metric`/`object-pivot` arrive loaded here though they are lazy in the real console). "The author can write this tag" must not vary.

## 2. Manifests must be generated from loaded registrations

New exported `assertFullyLoaded(configs)` in `@object-ui/sdui-parser`, plus `lazy?: boolean` on `RegistryConfigLike`.

A lazy stub carries metadata but no `inputs`. Written into `sdui.manifest.json` it becomes a block that *takes no props* — so every prop an author passes it turns into an `unknown-prop` diagnostic in the save gate. Wrong quietly, in the artifact everything downstream trusts. The test pins that shape explicitly before asserting the throw:

```ts
expect(manifestFromConfigs(withStubs).components['object-kanban'].inputs).toEqual([]);
expect(() => assertFullyLoaded(withStubs)).toThrow(/object-kanban, object-map/);
```

- `packages/sdui-parser/scripts/gen-manifest.ts` calls it, and its doc comment no longer points at `@object-ui/console/register-all` (never a real export path).
- `apps/console/dev/manifest-dump.tsx` calls it **and** imports the console's real registration list. Its 15 hand-maintained eager imports had no relationship to what the console ships; now a plugin the console lazy-registers but the dump forgets to import eagerly survives as a stub and fails the build. Eager registration wins over a stub, so **the manifest output itself is unchanged** — this only makes the drift detectable.
- `scripts/dump-public-manifest.mjs` waits for `__MANIFEST ?? __MANIFEST_ERROR` and rethrows the message, instead of turning any generation failure into a silent 120s timeout.

## Verification

- Full suite: `696 files passed | 1 skipped`, `8191 tests passed | 24 skipped`.
- `pnpm --filter @object-ui/console build` (tsc + vite + plugin): clean.
- `type-check` for `@object-ui/console` + `@object-ui/sdui-parser`: clean.
- `lint`: 0 errors.
- `changeset:check`: clean. Changeset included (`@object-ui/sdui-parser` minor — new export; `@object-ui/console` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4mrr1ihhwnfEHFSWmGoMp


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4mrr1ihhwnfEHFSWmGoMp)_