### PR TITLE
fix(console): render the redaction notice on the enveloped resolve body (objectstack#3983)

### DIFF
--- a/.changeset/shared-record-redaction-notice.md
+++ b/.changeset/shared-record-redaction-notice.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/console': patch
+---
+
+**The shared-record page's redaction notice never rendered on the enveloped path.**
+
+`GET /api/v1/share-links/:token/resolve` has two producers — the framework's
+sharing plugin and the runtime dispatcher's `/share-links` domain, which is the
+designed primary surface for cloud's per-environment kernels. `SharedRecordPage`
+read both, but the wire spells the field `redactFields` while the render reads
+`redactedFields`, and only the BARE branch did that rename. The enveloped branch
+handed `body.data` straight through, so on the dispatcher path `redactedFields`
+was always `undefined` and "Some fields are hidden by the owner" never appeared —
+on exactly the pages where fields WERE being stripped. The record itself was
+correctly redacted throughout; what was missing is the visitor being told.
+
+The fold now lives in one place, `normalizeResolvedShare` in the new
+`pages/shared-record-shape.ts`, with both envelopes covered by tests. Extracting
+it out of the page module is also what lets those tests run without loading the
+chat renderer and the app-shell graph behind it.
+
+Prompted by objectstack#3983, which moves the plugin surface onto the same
+enveloped shape the dispatcher already used: without this fix that convergence
+would have spread the missing notice from the dispatcher path to every share
+page. No API change — the page reads a superset of what it read before, so it
+still works against a pre-#3983 framework.

--- a/apps/console/src/pages/SharedRecordPage.tsx
+++ b/apps/console/src/pages/SharedRecordPage.tsx
@@ -34,20 +34,7 @@ import {
 } from '@object-ui/app-shell';
 import { ChatbotEnhanced } from '@object-ui/plugin-chatbot';
 
-interface ResolvedShare {
-  link: {
-    id: string;
-    token: string;
-    object_name: string;
-    record_id: string;
-    permission: 'view' | 'comment' | 'edit';
-    audience: string;
-    expires_at?: string | null;
-    label?: string | null;
-  };
-  record: Record<string, unknown>;
-  redactedFields?: string[];
-}
+import { normalizeResolvedShare, type ResolvedShare } from './shared-record-shape';
 
 function resolveServerUrl(): string {
   const env = (import.meta as any).env ?? {};
@@ -102,18 +89,8 @@ export default function SharedRecordPage() {
           setLoading(false);
           return;
         }
-        const body = (await res.json()) as
-          | { data: ResolvedShare }
-          | { record: unknown; link: ResolvedShare['link']; redactFields?: string[] };
-        const resolved: ResolvedShare =
-          'data' in body
-            ? body.data
-            : {
-                record: body.record as Record<string, unknown>,
-                link: body.link,
-                redactedFields: (body as any).redactFields,
-              };
-        setData(resolved);
+        // Both envelopes fold to the same shape here — see `normalizeResolvedShare`.
+        setData(normalizeResolvedShare(await res.json()));
         setNeedsPassword(false);
       } catch (e: any) {
         setError(e?.message ?? 'Failed to load shared content.');

--- a/apps/console/src/pages/shared-record-shape.test.ts
+++ b/apps/console/src/pages/shared-record-shape.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `GET /api/v1/share-links/:token/resolve` has two producers, and the shared-record
+ * page has to read both: the sharing plugin's routes and the runtime dispatcher's
+ * `/share-links` domain (the designed primary surface for cloud's per-environment
+ * kernels). The dispatcher has always answered `{ success: true, data }`;
+ * objectstack#3983 moved the plugin onto the same shape, so the bare body is what a
+ * pre-#3983 server still sends.
+ *
+ * The page was already tolerant of both — but only the BARE branch renamed the
+ * wire's `redactFields` to the `redactedFields` the render reads. The enveloped
+ * branch handed `body.data` through verbatim, so on the dispatcher path
+ * `redactedFields` was `undefined` and the "Some fields are hidden by the owner"
+ * notice never rendered — on exactly the pages where fields WERE being stripped.
+ * Converting the plugin surface would have spread that to every share page, which
+ * is why the rename moved into one function with these tests on it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeResolvedShare,
+  type ResolveResponseBody,
+  type ShareLink,
+} from './shared-record-shape';
+
+const LINK: ShareLink = {
+  id: 'sl_1',
+  token: 'tok_abcdefgh',
+  object_name: 'crm_account',
+  record_id: 'acc_1',
+  permission: 'view',
+  audience: 'anyone',
+  expires_at: null,
+  label: 'For the auditor',
+};
+
+const RECORD = { id: 'acc_1', name: 'Acme' };
+
+/** The enveloped body, as both producers now send it. */
+const enveloped = (data: ResolveResponseBody['data']): ResolveResponseBody => ({ data });
+
+describe('normalizeResolvedShare — both producers fold to one shape', () => {
+  it('reads the ENVELOPED body (dispatcher, and the plugin after objectstack#3983)', () => {
+    const out = normalizeResolvedShare(
+      enveloped({ record: RECORD, link: LINK, redactFields: ['ssn'] }),
+    );
+    expect(out.record).toEqual(RECORD);
+    expect(out.link.token).toBe('tok_abcdefgh');
+    // The regression: this was `undefined` on the enveloped path, so the
+    // redaction notice silently disappeared.
+    expect(out.redactedFields).toEqual(['ssn']);
+  });
+
+  it('reads the BARE body (a pre-objectstack#3983 plugin surface)', () => {
+    const out = normalizeResolvedShare({ record: RECORD, link: LINK, redactFields: ['ssn'] });
+    expect(out.record).toEqual(RECORD);
+    expect(out.link.token).toBe('tok_abcdefgh');
+    expect(out.redactedFields).toEqual(['ssn']);
+  });
+
+  it('agrees on both shapes — the whole point of normalising in one place', () => {
+    const payload = { record: RECORD, link: LINK, redactFields: ['ssn', 'dob'] };
+    expect(normalizeResolvedShare(enveloped(payload))).toEqual(normalizeResolvedShare(payload));
+  });
+
+  it('leaves redactedFields undefined when the server redacted nothing', () => {
+    expect(normalizeResolvedShare(enveloped({ record: RECORD, link: LINK })).redactedFields)
+      .toBeUndefined();
+    // …and an EMPTY list stays empty rather than collapsing to undefined: the
+    // render guards on `.length > 0`, so both are correctly silent, but conflating
+    // them would hide a producer that started answering `[]` for "nothing stripped".
+    expect(normalizeResolvedShare(enveloped({ record: RECORD, link: LINK, redactFields: [] })).redactedFields)
+      .toEqual([]);
+  });
+
+  it('never hands the render a null record — it JSON.stringifies it unguarded', () => {
+    expect(normalizeResolvedShare(enveloped({ link: LINK })).record).toEqual({});
+  });
+});

--- a/apps/console/src/pages/shared-record-shape.ts
+++ b/apps/console/src/pages/shared-record-shape.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The wire shape of `GET /api/v1/share-links/:token/resolve`, and the one place
+ * that folds it into what {@link ../pages/SharedRecordPage} renders.
+ *
+ * Separate from the page because it is pure — the page's own module pulls in the
+ * chat renderer and the whole app-shell graph, which a shape test should not have
+ * to load.
+ */
+
+export interface ShareLink {
+  id: string;
+  token: string;
+  object_name: string;
+  record_id: string;
+  permission: 'view' | 'comment' | 'edit';
+  audience: string;
+  expires_at?: string | null;
+  label?: string | null;
+}
+
+/** What the page renders. Note `redactedFields` — see {@link normalizeResolvedShare}. */
+export interface ResolvedShare {
+  link: ShareLink;
+  record: Record<string, unknown>;
+  redactedFields?: string[];
+}
+
+/**
+ * The resolve payload AS IT ARRIVES — `redactFields`, the server's spelling.
+ * Keeping this named apart from {@link ResolvedShare} is what stops the enveloped
+ * branch from silently skipping the rename, which is what it did before
+ * objectstack#3983.
+ */
+export interface WireResolvedShare {
+  record?: unknown;
+  link: ShareLink;
+  redactFields?: string[];
+}
+
+/** Either producer's body: enveloped (`{ success, data }`) or bare. */
+export type ResolveResponseBody = { data?: WireResolvedShare } & Partial<WireResolvedShare>;
+
+/**
+ * Fold either producer's resolve body into {@link ResolvedShare}.
+ *
+ * Two producers serve this route: the sharing plugin's routes and the runtime
+ * dispatcher's `/share-links` domain (the designed primary surface for cloud's
+ * per-environment kernels). Both answer the same three fields; only the envelope
+ * differs, and the dispatcher has always enveloped them — objectstack#3983 moved
+ * the plugin onto the same shape, so the bare branch is what a pre-#3983 server
+ * still sends.
+ *
+ * The rename is the point. The wire spells it `redactFields`; the page reads
+ * `redactedFields`. Only the BARE branch used to do that mapping — the enveloped
+ * one handed `body.data` straight through — so on the dispatcher path
+ * `redactedFields` was always `undefined` and the "fields are hidden by the owner"
+ * notice never rendered, on exactly the pages where fields WERE being stripped.
+ */
+export function normalizeResolvedShare(body: ResolveResponseBody): ResolvedShare {
+  const wire = (body.data ?? body) as WireResolvedShare;
+  return {
+    record: (wire.record ?? {}) as Record<string, unknown>,
+    link: wire.link,
+    redactedFields: wire.redactFields,
+  };
+}


### PR DESCRIPTION
Consumer-side half of **objectstack#3983**. Merge this **before** the framework PR — see *Merge order*.

## The bug

`GET /api/v1/share-links/:token/resolve` has **two producers**: the framework's sharing plugin (`share-link-routes.ts`) and the runtime dispatcher's `/share-links` domain — and for cloud's per-environment kernels the dispatcher is the *designed primary* surface (`registerShareLinkRoutes: false`). `SharedRecordPage` was already tolerant of both bodies:

```ts
'data' in body
  ? body.data                                    // enveloped
  : { record: body.record, link: body.link,
      redactedFields: body.redactFields }        // bare — renames the field
```

The wire spells it **`redactFields`**; the render reads **`redactedFields`**. Only the *bare* branch did that rename — the enveloped branch handed `body.data` straight through. So on the dispatcher path:

```ts
{data.redactedFields && data.redactedFields.length > 0 && (
  <p>Some fields are hidden by the owner: …</p>
)}
```

…was gated on a field that was always `undefined`, and the notice **never rendered** — on exactly the pages where fields *were* being stripped.

To be precise about the severity: the record itself was redacted correctly the whole time. Nothing leaked. What was missing is the visitor being **told** that they are looking at a partial record.

## The fix

One fold, `normalizeResolvedShare`, in a new `pages/shared-record-shape.ts`, with both envelopes pinned by tests.

Extracting it out of the page module rather than exporting it from there is doing three things at once:

- the shape tests stop loading `ChatbotEnhanced` and the whole app-shell graph behind it — **import time 11.9s → 14ms**;
- it clears the `react-refresh/only-export-components` warning that exporting a plain function from a component module raises;
- `WireResolvedShare` (`redactFields`) and `ResolvedShare` (`redactedFields`) become two *named* types, which is what makes skipping the rename a type error rather than a silent `undefined`.

## Why now

objectstack#3983 moves the plugin surface onto the same enveloped shape the dispatcher already used. Without this fix, that convergence would have **spread** the missing notice from the dispatcher path to every share page — a user-visible regression caused by an otherwise-correct conformance change. Catching it is why #3983 got a consumer sweep instead of a shape swap.

## Merge order

This one is genuinely ordered, unlike the "not coupled" claim I got wrong on the last pair:

1. **this PR** → merge
2. framework bumps `.objectui-sha` to that commit and rebuilds `packages/console/dist`
3. framework PR (the envelope conversion) → merge

Framework-first would ship the enveloped bodies against a console `dist` built from a page that skips the rename — i.e. it would *cause* the regression above for one release window. The reverse order is safe: this page reads a superset of what it read before, so it works unchanged against a pre-#3983 framework.

## Verification

| gate | result |
|---|---|
| `vitest run shared-record-shape` | **5 passed** |
| `turbo run type-check --filter=@object-ui/console` | 35 tasks, clean |
| `eslint` on all three files | 0 errors, 0 new warnings (3 remain, all pre-existing) |

The test runs under the **root** `vitest run` that CI invokes, not just from `apps/console` — `apps/console/vitest.config.ts` is a registered project in `vitest.config.mts` while `apps/**` is excluded from the `unit` project, so I checked rather than assumed. That config carries a comment about objectui#2879, where ratchet rules shipped with tests that never ran; this is the same trap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYbS3kS8xzsHNXFTzp4e2z)_