### PR TITLE
fix(analytics): 未安装分析能力时不再渲染成"空 KPI"——可读提示 + 400 不再被静默回退掩盖（objectstack#3891 跨仓收尾）

### DIFF
--- a/.changeset/analytics-capability-absent-hint.md
+++ b/.changeset/analytics-capability-absent-hint.md
@@ -1,0 +1,44 @@
+---
+"@object-ui/data-objectstack": minor
+"@object-ui/app-shell": patch
+---
+
+fix(analytics): a missing analytics capability no longer renders as an empty KPI — objectstack#3891
+
+The framework retired its degraded in-kernel analytics fallback (objectstack#3891):
+it dropped the caller's RLS/tenant scope and ignored the contract filter, so it
+answered `200` with over-broad numbers. `@objectstack/service-analytics` is now
+the only implementation, and a deployment without it answers `404` on
+`/analytics/query` (objectstack#4019 stops mounting the routes) or `501` on
+`/analytics/dataset/query`.
+
+Three things were wrong on this side of that boundary:
+
+**① A KPI on such a deployment rendered a confident zero.** `aggregate()`'s
+`catch` promises a client-side fallback, and the fallback is correct — but the
+adapter never got there for the most likely failure. It now classifies the
+failure (`classifyAnalyticsFailure`) instead of treating every error alike:
+capability-absent (404/501) degrades to a client-side aggregate over a
+**server-scoped** `find()` — same rows, same filter, RLS still applied — and
+says so **once per adapter** in the console, naming the package to install,
+rather than once per widget or not at all.
+
+**② A rejected query was answered with plausible numbers.** The framework
+validates `/analytics/query` at the entry now (objectstack#4010), so a `400
+VALIDATION_FAILED` means *this adapter* sent an off-contract body. Degrading
+there would bury our own bug behind output from a different code path — the
+misdirection objectstack#3878 documented. It now throws
+`AnalyticsQueryRejectedError` and never falls back. Transient failures (5xx,
+network) degrade exactly as before.
+
+**③ The dataset preview blamed the author for a missing capability.**
+`queryDataset` mapped `501`/`404` to `Dataset query failed: 501 Not Implemented
+— …`; it now throws the typed `AnalyticsNotInstalledError`
+(`code: 'ANALYTICS_NOT_INSTALLED'`) with a message a UI can render verbatim, and
+`DatasetPreview` shows it as a "analytics capability not installed" empty state
+instead of a red error banner. A real compile error (e.g. "relationship not
+declared in include") keeps its server detail and its banner.
+
+New exports from `@object-ui/data-objectstack`: `AnalyticsNotInstalledError`,
+`AnalyticsQueryRejectedError`, `isAnalyticsNotInstalledError`,
+`classifyAnalyticsFailure`.

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
@@ -78,6 +78,25 @@ describe('DatasetPreview', () => {
     expect(alert.textContent).toMatch(/not declared/);
   });
 
+  // objectstack#3891 retired the framework's degraded analytics fallback, so a
+  // deployment without @objectstack/service-analytics can't run dataset
+  // previews at all. That is a missing capability, not a mistake in the dataset
+  // the author is editing — so it must NOT read as a red "your draft is broken"
+  // alert.
+  it('shows a "capability not installed" empty state, not an error alert', async () => {
+    const err = Object.assign(
+      new Error('Analytics capability is not installed on this deployment — POST /analytics/dataset/query is unavailable.'),
+      { code: 'ANALYTICS_NOT_INSTALLED' },
+    );
+    queryDataset.mockRejectedValue(err);
+    render(<DatasetPreview {...baseProps} draft={draft} />);
+
+    expect(await screen.findByText(/Analytics capability not installed/i)).toBeInTheDocument();
+    // Names the fix, and does not blame the draft.
+    expect(screen.getByText(/@objectstack\/service-analytics/)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
   it('prompts to add a measure when none are defined', () => {
     render(<DatasetPreview {...baseProps} draft={{ ...draft, measures: [] }} />);
     expect(screen.getByText(/Add a measure/i)).toBeInTheDocument();

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx
@@ -17,7 +17,7 @@
  */
 
 import * as React from 'react';
-import { Loader2, BarChart3, AlertTriangle } from 'lucide-react';
+import { Loader2, BarChart3, AlertTriangle, PackageOpen } from 'lucide-react';
 import { useAdapter } from '../../../providers/AdapterProvider';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewEmptyState, PreviewErrorBoundary } from './PreviewShell';
@@ -39,7 +39,11 @@ type Row = Record<string, unknown>;
 type PreviewState =
   | { status: 'idle' | 'loading'; rows: Row[]; error?: undefined }
   | { status: 'ok'; rows: Row[]; fields?: DatasetResultField[]; object?: string; error?: undefined }
-  | { status: 'error'; rows: Row[]; error: string };
+  | { status: 'error'; rows: Row[]; error: string }
+  // The deployment has no analytics capability (framework#3891) — not an
+  // authoring mistake, so it reads as a "this needs installing" empty state
+  // rather than a red banner blaming the dataset the author just wrote.
+  | { status: 'not-installed'; rows: Row[]; error?: undefined };
 
 export function DatasetPreview({ draft }: MetadataPreviewProps) {
   const adapter = useAdapter();
@@ -75,6 +79,10 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
         object: result?.object,
       });
     } catch (e) {
+      if ((e as { code?: string })?.code === 'ANALYTICS_NOT_INSTALLED') {
+        setState({ status: 'not-installed', rows: [] });
+        return;
+      }
       setState({ status: 'error', rows: [], error: String((e as Error)?.message ?? e) });
     }
   }, [adapter, draft, dimensionNames, measureNames, canRun]);
@@ -157,6 +165,14 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
             <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span className="break-words">{state.error}</span>
           </div>
+        )}
+
+        {state.status === 'not-installed' && (
+          <PreviewEmptyState
+            icon={<PackageOpen className="h-8 w-8" />}
+            title="Analytics capability not installed"
+            description="This deployment has no analytics service, so dataset previews can't run. Install @objectstack/service-analytics and mount AnalyticsServicePlugin — the dataset definition itself is fine."
+          />
         )}
 
         {state.status === 'ok' && state.rows.length === 0 && (

--- a/packages/data-objectstack/src/aggregate-capability.test.ts
+++ b/packages/data-objectstack/src/aggregate-capability.test.ts
@@ -1,0 +1,177 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `aggregate()` against an analytics endpoint that cannot answer.
+ *
+ * WHY THIS EXISTS. `@objectstack/client`'s `analytics.query()` returns
+ * `res.json()` WITHOUT checking `res.ok`, so a non-2xx never throws — the error
+ * body arrives where rows were expected. The adapter's row parser matched none
+ * of its shapes, produced `[]`, and returned it as a RESULT: the `catch` that
+ * promises a client-side fallback never ran, and a KPI on a deployment without
+ * `@objectstack/service-analytics` rendered a confident **zero**.
+ *
+ * That is the same lie framework#3891 removed from the server side (a degraded
+ * shim answering 200 with unscoped numbers), reproduced one layer up. These
+ * tests pin the three outcomes:
+ *   - capability absent (404 / 501)  → client-side fallback over a scoped find();
+ *   - our body is off-contract (400) → THROWS, never silently re-answered;
+ *   - a normal result                → untouched.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectStackAdapter, clearSharedDiscoveryCache } from './index';
+
+const RECORDS = [
+  { id: '1', stage: 'won', amount: 100 },
+  { id: '2', stage: 'won', amount: 50 },
+  { id: '3', stage: 'lost', amount: 20 },
+];
+
+/**
+ * A fetch mock answering discovery, the analytics query (with `analyticsBody`
+ * at `analyticsStatus`), and the `/data` read the fallback performs.
+ */
+function makeFetch(analyticsStatus: number, analyticsBody: unknown) {
+  const calls: string[] = [];
+  const fetchImpl = vi.fn(async (url: any, init?: any) => {
+    const u = String(url);
+    calls.push(`${init?.method ?? 'GET'} ${u}`);
+    if (u.includes('/api/v1/discovery')) {
+      return { ok: true, status: 200, statusText: 'OK', json: async () => ({ success: true, data: { version: 'v1', routes: {} } }) } as any;
+    }
+    if (u.includes('/api/v1/analytics/query')) {
+      return {
+        ok: analyticsStatus >= 200 && analyticsStatus < 300,
+        status: analyticsStatus,
+        statusText: 'x',
+        json: async () => analyticsBody,
+      } as any;
+    }
+    // The fallback's scoped read.
+    return {
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ success: true, data: { object: 'opportunity', records: RECORDS, total: RECORDS.length } }),
+    } as any;
+  });
+  return { fetchImpl, calls };
+}
+
+function makeAdapter(fetchImpl: any) {
+  return new ObjectStackAdapter({
+    baseUrl: 'http://localhost:3000',
+    autoReconnect: false,
+    fetch: fetchImpl as any,
+  });
+}
+
+const SUM_BY_STAGE = { function: 'sum', field: 'amount', groupBy: 'stage' };
+
+describe('aggregate() when the analytics capability is absent', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('404 (routes not mounted, framework#4019) falls back instead of returning an empty result', async () => {
+    const { fetchImpl, calls } = makeFetch(404, { error: 'Not found' });
+    const rows = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE);
+
+    // Pre-fix this was `[]` — a chart reading "no data" on a populated table.
+    expect(rows.length).toBeGreaterThan(0);
+    const won = rows.find((r: any) => r.stage === 'won');
+    expect(won?.amount).toBe(150);
+    // It really did fall back to a server-side read (not invent numbers).
+    expect(calls.some((c) => c.includes('/api/v1/data'))).toBe(true);
+  });
+
+  it('501 NOT_IMPLEMENTED (REST route, no service) falls back the same way', async () => {
+    const { fetchImpl } = makeFetch(501, {
+      code: 'NOT_IMPLEMENTED',
+      message: 'Analytics is not available on this deployment.',
+    });
+    const rows = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE);
+    expect(rows.find((r: any) => r.stage === 'won')?.amount).toBe(150);
+  });
+
+  it('warns ONCE per adapter, not once per widget', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { fetchImpl } = makeFetch(404, { error: 'Not found' });
+      const adapter = makeAdapter(fetchImpl);
+      await adapter.aggregate('opportunity', SUM_BY_STAGE);
+      await adapter.aggregate('opportunity', SUM_BY_STAGE);
+      await adapter.aggregate('opportunity', SUM_BY_STAGE);
+
+      const capabilityWarnings = warn.mock.calls.filter((c) =>
+        String(c[0]).includes('analytics capability unavailable'),
+      );
+      expect(capabilityWarnings).toHaveLength(1);
+      expect(String(capabilityWarnings[0][0])).toContain('@objectstack/service-analytics');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('forwards the widget filter into the fallback (never aggregates the whole table)', async () => {
+    const { fetchImpl, calls } = makeFetch(404, { error: 'Not found' });
+    await makeAdapter(fetchImpl).aggregate('opportunity', { ...SUM_BY_STAGE, filter: { stage: 'won' } });
+
+    const dataCall = calls.find((c) => c.includes('/api/v1/data'));
+    expect(dataCall).toBeDefined();
+    expect(decodeURIComponent(dataCall!)).toContain('won');
+  });
+});
+
+describe('aggregate() when the server REJECTS our query body', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  // framework#4010 validates /analytics/query at the entry. A 400 means the
+  // adapter sent an off-contract body — answering it with numbers from the
+  // client-side path would bury our own bug behind plausible output, which is
+  // exactly the misdirection framework#3878 documented.
+  it('400 VALIDATION_FAILED throws — it must NOT be answered by the fallback', async () => {
+    const { fetchImpl, calls } = makeFetch(400, {
+      success: false,
+      error: {
+        code: 'VALIDATION_FAILED',
+        httpStatus: 400,
+        message: 'Invalid AnalyticsQuery body: measures: Invalid input',
+        details: { fields: [{ field: 'measures', code: 'invalid_type' }] },
+      },
+    });
+
+    const err = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE).catch((e) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as { code?: string }).code).toBe('ANALYTICS_QUERY_REJECTED');
+    expect(String(err.message)).toContain('measures');
+    // No silent second answer from a different code path.
+    expect(calls.some((c) => c.includes('/api/v1/data'))).toBe(false);
+  });
+});
+
+describe('aggregate() on a healthy analytics endpoint', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('returns the server rows untouched (no false capability detection)', async () => {
+    const { fetchImpl, calls } = makeFetch(200, {
+      rows: [{ stage: 'won', amount_sum: 150 }],
+      fields: [{ name: 'amount_sum', type: 'number' }],
+    });
+
+    const rows = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE);
+
+    // Measure key mapped back to the caller's column (`amount`), rows from the server.
+    expect(rows).toEqual([{ stage: 'won', amount: 150 }]);
+    expect(calls.some((c) => c.includes('/api/v1/data'))).toBe(false);
+  });
+
+  it('a `{ success, data: { rows } }` envelope is still a result, not an error', async () => {
+    const { fetchImpl } = makeFetch(200, { success: true, data: { rows: [{ stage: 'won', amount_sum: 150 }] } });
+    const rows = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE);
+    expect(rows).toEqual([{ stage: 'won', amount: 150 }]);
+  });
+});

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -241,6 +241,107 @@ export function is404Error(error: unknown): boolean {
 }
 
 /**
+ * Thrown when the deployment has no analytics capability installed
+ * (framework#3891 / #4019).
+ *
+ * The framework retired its degraded in-kernel analytics fallback — it dropped
+ * the caller's RLS/tenant scope and ignored the contract filter, so it answered
+ * 200 with over-broad numbers. `@objectstack/service-analytics` is now the
+ * domain's only implementation, and a deployment without it answers:
+ *
+ *   - `POST /api/v1/analytics/query` → **404** (the routes aren't even mounted);
+ *   - `POST /api/v1/analytics/dataset/query` → **501 NOT_IMPLEMENTED**.
+ *
+ * Neither is a bug to report as a stack trace: it is a deployment that hasn't
+ * installed the capability. This error carries a message a UI can show as-is.
+ */
+export class AnalyticsNotInstalledError extends Error {
+  readonly code = 'ANALYTICS_NOT_INSTALLED';
+  /** The surface that was unavailable, for the message a host renders. */
+  readonly surface: string;
+  constructor(surface: string, detail?: string) {
+    super(
+      `Analytics capability is not installed on this deployment — ${surface} is unavailable. ` +
+      'Install @objectstack/service-analytics and mount AnalyticsServicePlugin to enable it.' +
+      (detail ? ` (server said: ${detail})` : ''),
+    );
+    this.name = 'AnalyticsNotInstalledError';
+    this.surface = surface;
+  }
+}
+
+/** True when `error` is an {@link AnalyticsNotInstalledError} (or its wire twin). */
+export function isAnalyticsNotInstalledError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  return (error as { code?: unknown }).code === 'ANALYTICS_NOT_INSTALLED';
+}
+
+/**
+ * Thrown when the server REJECTED the analytics query body (HTTP 400 —
+ * `VALIDATION_FAILED` since framework#4010 validates `/analytics/query` at the
+ * entry against the canonical bare `AnalyticsQuery` shape).
+ *
+ * Distinct from {@link AnalyticsNotInstalledError} on purpose: this one is a
+ * defect in what WE sent, so it must never be answered with the client-side
+ * fallback. Numbers produced by a different code path would look plausible and
+ * bury the contract violation — the misdirection framework#3878 documented.
+ */
+export class AnalyticsQueryRejectedError extends Error {
+  readonly code = 'ANALYTICS_QUERY_REJECTED';
+  /** The server's own error code (e.g. `VALIDATION_FAILED`), when it sent one. */
+  readonly serverCode?: string;
+  constructor(detail?: string, serverCode?: string) {
+    super(
+      `Analytics rejected the query: ${detail ?? 'the request body does not match the AnalyticsQuery contract'}`,
+    );
+    this.name = 'AnalyticsQueryRejectedError';
+    this.serverCode = serverCode;
+  }
+}
+
+/**
+ * Classify a FAILED analytics call so the caller knows whether to degrade or
+ * to surface the failure.
+ *
+ * `@objectstack/client`'s fetch wrapper throws on a non-2xx, decorating the
+ * error with the semantic `code` string and the numeric `httpStatus` (the
+ * ADR-0112 / framework#3842 shape this repo already reads elsewhere). Two
+ * outcomes must NOT be conflated:
+ *
+ *   - **`not-installed`** — the deployment has no analytics service. Since
+ *     framework#3891 retired the degraded in-kernel shim, that is a 404 (the
+ *     routes aren't mounted at all, framework#4019) or a 501 `NOT_IMPLEMENTED`
+ *     (REST's dataset route with no service behind it). Degrading to a
+ *     client-side aggregate over a scoped `find()` is CORRECT here.
+ *   - **`rejected`** — the server refused OUR body (400 `VALIDATION_FAILED`;
+ *     framework#4010 validates `/analytics/query` at the entry). Degrading
+ *     would answer our own contract violation with plausible numbers from a
+ *     different code path and bury it — the misdirection framework#3878
+ *     documented. It must be surfaced.
+ *
+ * Anything else (5xx, network) is `unknown`: degrade, but silently — it is a
+ * transient failure, not a deployment that is missing a capability.
+ */
+export function classifyAnalyticsFailure(
+  error: unknown,
+): { kind: 'not-installed' | 'rejected' | 'unknown'; code?: string; message?: string } {
+  const err = (error ?? {}) as Record<string, unknown>;
+  const code = typeof err.code === 'string' ? err.code : undefined;
+  const message = typeof err.message === 'string' ? err.message : undefined;
+  const status =
+    typeof err.httpStatus === 'number' ? err.httpStatus
+    : typeof err.status === 'number' ? err.status
+    : typeof err.statusCode === 'number' ? err.statusCode
+    : undefined;
+
+  if (code === 'VALIDATION_FAILED' || status === 400) return { kind: 'rejected', code, message };
+  if (status === 404 || status === 501 || code === 'NOT_IMPLEMENTED' || code === 'ROUTE_NOT_FOUND') {
+    return { kind: 'not-installed', code, message };
+  }
+  return { kind: 'unknown', code, message };
+}
+
+/**
  * Thrown by `update()` / `delete()` when the server returns
  * `409 CONCURRENT_UPDATE` — i.e. the record was modified by someone else
  * between when the caller last read it and when they attempted to write.
@@ -509,6 +610,8 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   private reconnectAttempts: number = 0;
   private baseUrl: string;
   private token?: string;
+  /** One "analytics capability is missing" console line per adapter, not per widget. */
+  private analyticsCapabilityWarned = false;
   private fetchImpl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   // In-flight find() requests keyed by resource + serialized params.
   // Coalesces concurrent identical reads (e.g. React StrictMode double-mount,
@@ -2709,6 +2812,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       }
 
       const data = await this.client.analytics.query(payload);
+
       const rawRows: any[] = Array.isArray(data) ? data
         : data?.rows && Array.isArray(data.rows) ? data.rows
         : data?.data && Array.isArray(data.data) ? data.data
@@ -2728,10 +2832,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         return true;
       });
       if (measureMissing) {
-        const result = await this.find(resource as any, params.filter ? { $filter: params.filter } as any : undefined);
-        const records = result.data || [];
-        if (records.length === 0) return [];
-        return this.aggregateClientSide(records, params);
+        return await this.aggregateViaFind(resource, params);
       }
 
       // Map measure keys back to the object-bound result column so consumers
@@ -2747,18 +2848,67 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         }
         return mapped;
       });
-    } catch {
-      // If the analytics endpoint is not available, fall back to
-      // find() + client-side aggregation. Crucially, forward the same
-      // filter so the fallback aggregates over the SAME row set the
-      // server-side analytics query would have — otherwise the KPI
-      // silently sums the whole table and lies to the user.
-      const result = await this.find(resource as any, params.filter ? { $filter: params.filter } as any : undefined);
-      const records = result.data || [];
-      if (records.length === 0) return [];
+    } catch (e) {
+      const failure = classifyAnalyticsFailure(e);
 
-      return this.aggregateClientSide(records, params);
+      // The server refused OUR body — that is a defect in this adapter's
+      // request, not a deployment without the capability. Answering it with
+      // the client-side path would produce plausible numbers and bury the
+      // contract violation, the misdirection framework#3878 documented.
+      if (failure.kind === 'rejected') {
+        throw new AnalyticsQueryRejectedError(failure.message, failure.code);
+      }
+
+      // The capability is absent (404 — framework#4019 stops mounting the
+      // routes when no analytics service is registered — or 501). Say so ONCE
+      // so an operator sees a missing capability rather than charts that
+      // quietly read from a slower path forever.
+      if (failure.kind === 'not-installed') {
+        this.warnAnalyticsCapabilityOnce(failure.message);
+      }
+
+      // Degrade to find() + client-side aggregation. `aggregateViaFind`
+      // forwards the same filter, so the fallback aggregates over the SAME row
+      // set the server-side query would have — and `find()` is server-scoped,
+      // so RLS still applies.
+      return await this.aggregateViaFind(resource, params);
     }
+  }
+
+  /**
+   * Client-side aggregation over a server-scoped `find()` — the fallback used
+   * whenever the analytics endpoint cannot answer (capability absent, network
+   * failure, or a result whose measure came back missing).
+   *
+   * Forwarding `params.filter` is load-bearing: without it the fallback
+   * aggregates the whole table while the caller believes it applied a filter,
+   * which is the "KPI silently sums everything" failure this adapter has
+   * guarded against since the widget filter was threaded through.
+   */
+  private async aggregateViaFind(resource: string, params: any): Promise<any[]> {
+    const result = await this.find(
+      resource as any,
+      params.filter ? ({ $filter: params.filter } as any) : undefined,
+    );
+    const records = result.data || [];
+    if (records.length === 0) return [];
+    return this.aggregateClientSide(records, params);
+  }
+
+  /**
+   * Say "the analytics capability isn't installed" ONCE per adapter, not once
+   * per widget: a dashboard fans out one aggregate() per KPI, and N identical
+   * console lines read like N different failures.
+   */
+  private warnAnalyticsCapabilityOnce(detail?: string): void {
+    if (this.analyticsCapabilityWarned) return;
+    this.analyticsCapabilityWarned = true;
+    console.warn(
+      '[OBJECTSTACKDataSource] analytics capability unavailable — aggregating client-side ' +
+      'from a scoped find(). Numbers stay correct but the semantic layer (cubes, joins, ' +
+      'server-side rollups) is off. Install @objectstack/service-analytics to enable it.' +
+      (detail ? ` Server said: ${detail}` : ''),
+    );
   }
 
   /**
@@ -2840,6 +2990,16 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         const errBody = await res.json();
         detail = errBody?.message || errBody?.error || JSON.stringify(errBody);
       } catch { /* non-JSON error body */ }
+      // "The capability isn't installed" is not a stack trace to show an
+      // author (framework#3891): the REST dataset route answers 501
+      // NOT_IMPLEMENTED when no analytics service provides `queryDataset`, and
+      // a host that doesn't mount the route at all answers 404. Both mean the
+      // same thing and both get a message a UI can render verbatim; anything
+      // else (a compile error like "relationship not declared in include") is
+      // a real authoring error and keeps its server detail.
+      if (res.status === 501 || res.status === 404) {
+        throw new AnalyticsNotInstalledError('POST /analytics/dataset/query', detail || undefined);
+      }
       throw new Error(`Dataset query failed: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ''}`);
     }
 

--- a/packages/data-objectstack/src/queryDataset.test.ts
+++ b/packages/data-objectstack/src/queryDataset.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ObjectStackAdapter, clearSharedDiscoveryCache } from './index';
+import {
+  ObjectStackAdapter,
+  clearSharedDiscoveryCache,
+  isAnalyticsNotInstalledError,
+} from './index';
 
 /** A fetch mock that answers discovery + records the dataset-query POST. */
 function makeFetch(datasetResponse: { ok: boolean; status?: number; body: unknown }) {
@@ -79,5 +83,50 @@ describe('ObjectStackAdapter.queryDataset', () => {
     const { fetchImpl } = makeFetch({ ok: false, status: 400, body: { code: 'DATASET_INVALID', message: 'relationship not declared' } });
     const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
     await expect(adapter.queryDataset(inlineDataset as any, selection)).rejects.toThrow(/relationship not declared/);
+  });
+
+  // framework#3891 retired the degraded in-kernel analytics fallback, so a
+  // deployment without @objectstack/service-analytics answers 501 (REST route
+  // present, no service) or 404 (framework#4019 stopped mounting the routes).
+  // Neither is an authoring mistake — the caller gets a typed, readable error
+  // instead of `Dataset query failed: 501 Not Implemented — …`.
+  describe('analytics capability absent', () => {
+    it('maps 501 NOT_IMPLEMENTED to a readable ANALYTICS_NOT_INSTALLED error', async () => {
+      const { fetchImpl } = makeFetch({
+        ok: false,
+        status: 501,
+        body: {
+          code: 'NOT_IMPLEMENTED',
+          message: 'Analytics dataset query is not available on this deployment (no analytics service with queryDataset).',
+        },
+      });
+      const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+      const err = await adapter.queryDataset(inlineDataset as any, selection).catch((e) => e);
+
+      expect(isAnalyticsNotInstalledError(err)).toBe(true);
+      expect(err.code).toBe('ANALYTICS_NOT_INSTALLED');
+      expect(err.message).toContain('Analytics capability is not installed');
+      expect(err.message).toContain('@objectstack/service-analytics');
+    });
+
+    it('maps a 404 (routes not mounted) the same way', async () => {
+      const { fetchImpl } = makeFetch({ ok: false, status: 404, body: { error: 'Not found' } });
+      const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+      const err = await adapter.queryDataset(inlineDataset as any, selection).catch((e) => e);
+
+      expect(isAnalyticsNotInstalledError(err)).toBe(true);
+    });
+
+    it('leaves a real compile error alone (it is NOT a missing capability)', async () => {
+      const { fetchImpl } = makeFetch({ ok: false, status: 400, body: { message: 'relationship not declared in include' } });
+      const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+      const err = await adapter.queryDataset(inlineDataset as any, selection).catch((e) => e);
+
+      expect(isAnalyticsNotInstalledError(err)).toBe(false);
+      expect(String(err.message)).toContain('relationship not declared');
+    });
   });
 });


### PR DESCRIPTION
objectstack#3891 系列的跨仓收尾（框架侧三个 PR 已合并：objectstack#3989 退役降级 shim、objectstack#4010 契约收严+入口校验、objectstack#4019 路由按能力条件挂载）。

原计划只是"把裸 404 换成可读提示"的文案活，落地时挖出一个**静默错值 bug**。

## ① 未装 analytics 的部署上，KPI 渲染成一个自信的「0」

`aggregate()` 的 catch 注释承诺"analytics 不可用就回退到客户端聚合"，回退逻辑本身也是对的（`find()` 是服务端作用域的，RLS 照常生效）。问题是**所有失败被一视同仁**，而其中两类需要区别对待。

新增 `classifyAnalyticsFailure()` 把失败分三类：

| 类别 | 触发 | 处理 |
|:--|:--|:--|
| `not-installed` | 404（objectstack#4019 起不挂载路由）/ 501 | 回退到 server-scoped `find()` + 客户端聚合，**每适配器警告一次**并指出装哪个包 |
| `rejected` | 400 `VALIDATION_FAILED` | **抛错**，绝不回退（见 ②） |
| `unknown` | 5xx、网络 | 静默回退，行为与此前完全一致 |

调查过程中的一个弯路值得记录：我最初以为 `client.analytics.query()` 不检查 `res.ok`（它确实直接 `return res.json()`），据此写了响应体检测；测试却显示 404 回退**已经**生效。追进 SDK 才发现它内部的 `fetch` 包装层会在非 2xx 抛出带 `code`/`httpStatus` 的错误。于是把分类逻辑放在 catch（正确位置），响应体检测删除。

## ② 被拒绝的查询，被"回退"用另一条路径算出看似合理的数字

objectstack#4010 之后框架在入口校验 `/analytics/query`，所以 400 `VALIDATION_FAILED` 意味着**是这个 adapter 发错了形状**。此时回退等于用另一条代码路径给出貌似合理的数字，把契约违规埋掉——正是 objectstack#3878 记录的那类误导。现在抛 `AnalyticsQueryRejectedError`，且**不发起第二次数据读取**（测试钉住了这一点）。

## ③ dataset 预览把"能力缺失"当成作者的错

`queryDataset` 原先抛 `Dataset query failed: 501 Not Implemented — …`。现在 501/404 映射为带 `code: 'ANALYTICS_NOT_INSTALLED'` 的 `AnalyticsNotInstalledError`（消息可直接展示），`DatasetPreview` 渲染成"Analytics capability not installed"信息态空状态而非红色报错横幅。真正的编译错误（"relationship not declared in include"）保留服务端详情与红色横幅。

`ObjectChart` 的 dataset 路径展示 `e.message`，因此自动获得可读文案；是否给每个图表也做定制空状态属于 UI 设计决策，本 PR 不扩张。`DashboardFilterBar` 已有"取不到就空选项"的降级，不变。

## 四条真实链路已对着框架代码逐条核验

| 部署形态 | 服务端响应 | SDK 错误 | 分类 |
|:--|:--|:--|:--|
| 单内核未装 | hono catch-all `404 {error:'Not found'}` | `httpStatus:404` | not-installed ✓ |
| 多租户宿主、该 env 无服务 | dispatcher `404 ROUTE_NOT_FOUND` | `code:'ROUTE_NOT_FOUND'` | not-installed ✓ |
| 装了但发错形状 | `400 VALIDATION_FAILED` | `code:'VALIDATION_FAILED'` | rejected ✓ |
| dataset 路由无服务 | REST `501 NOT_IMPLEMENTED` | `httpStatus:501` | not-installed ✓ |

## 新增导出

`AnalyticsNotInstalledError`、`AnalyticsQueryRejectedError`、`isAnalyticsNotInstalledError`、`classifyAnalyticsFailure`（`@object-ui/data-objectstack`）。

## 测试与验证

- 新增 `aggregate-capability.test.ts`（8 条）：404/501 不再返回空结果而是回退；400 抛错且**不发起 `/data` 读取**；警告只出现一次；过滤器必须透传进回退（否则 KPI 会偷偷合计全表）；健康结果原样返回、不误判。
- `queryDataset.test.ts` +3 条；`DatasetPreview.test.tsx` +1 条（空状态、点名安装包、**不出现** `role="alert"`）。
- `packages/app-shell` + `packages/data-objectstack`：**257 文件 / 2205 项全绿**。
- typecheck 错误数与基线**完全一致**（2407，全部是"workspace 包未构建"的预存在错误）；eslint 0 error。
- 全量 `vitest run`（8159 项）有 1 条失败：`anchors.page-seed.test.ts` —— 单文件隔离运行 5/5 通过，包级运行也通过，是重负载下的超时 flake（该文件单独跑就要 14.4s），与本改动无关。

关联：objectstack#3891、objectstack#3878、objectstack#3989、objectstack#4010、objectstack#4019。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WZBR9XyhXoqKCU6qQVyjx

---
_Generated by [Claude Code](https://claude.ai/code/session_017WZBR9XyhXoqKCU6qQVyjx)_