### PR TITLE
test(plugin-form): settle each wizard step before typing (#2982)

### DIFF
--- a/packages/plugin-form/src/WizardForm.regression.test.tsx
+++ b/packages/plugin-form/src/WizardForm.regression.test.tsx
@@ -13,7 +13,7 @@
  * and the create seed is idempotent.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import { WizardForm } from './WizardForm';
 import { registerAllFields } from '@object-ui/fields';
@@ -46,24 +46,40 @@ const schema = {
   ],
 };
 
+/**
+ * A step's input being in the DOM does NOT mean the step is ready to type into.
+ * The inner step form is reused across steps (one react-hook-form instance) and
+ * the wizard feeds it `defaultValues={formData}`; when that value changes the
+ * form applies it with a `reset()` in a PASSIVE EFFECT — i.e. one commit after
+ * the new step's inputs have already been painted. `waitFor` can resolve inside
+ * that window, and a value typed there is lost: the pending reset replaces the
+ * whole RHF record with the earlier steps' data, dropping the field just filled,
+ * so the final create posts a body missing the last step. That is a test-harness
+ * race, not the product regression this file guards, and it made CI flaky
+ * (#2982). Drain the pending effects before typing so each step is settled.
+ */
+const settledStepInput = async (container: HTMLElement, name: string) => {
+  const el = await waitFor(() => {
+    const found = container.querySelector(`input[name="${name}"]`) as HTMLInputElement | null;
+    if (!found) throw new Error(`step input "${name}" not rendered`);
+    return found;
+  });
+  // Flush the step form's pending `defaultValues` reset so it cannot land
+  // *after* the change below and clobber it.
+  await act(async () => {});
+  return el;
+};
+
 describe('WizardForm — multi-step create collects every step', () => {
   it('submits the merged payload (both steps), not an empty/last-only body', async () => {
     const ds = makeDS();
     const { container } = render(<WizardForm schema={schema as any} dataSource={ds as any} />);
 
-    const nameInput = await waitFor(() => {
-      const el = container.querySelector('input[name="name"]') as HTMLInputElement | null;
-      if (!el) throw new Error('step-1 name input not rendered');
-      return el;
-    });
+    const nameInput = await settledStepInput(container, 'name');
     fireEvent.change(nameInput, { target: { value: 'Alice' } });
     fireEvent.submit(container.querySelector('form') as HTMLFormElement); // advance to step 2
 
-    const noteInput = await waitFor(() => {
-      const el = container.querySelector('input[name="note"]') as HTMLInputElement | null;
-      if (!el) throw new Error('step-2 note input not rendered');
-      return el;
-    });
+    const noteInput = await settledStepInput(container, 'note');
     fireEvent.change(noteInput, { target: { value: 'hello' } });
     fireEvent.submit(container.querySelector('form') as HTMLFormElement); // final create
 


### PR DESCRIPTION
Fixes #2982.

## The flake

`WizardForm.regression` → *"submits the merged payload"* occasionally saw the create POST carry `{ name: 'Alice' }` only, dropping the last step's `note`.

The inner step form is **reused across steps** (one `react-hook-form` instance), and `WizardForm` feeds it `defaultValues={formData}`. When that value changes, the form applies it with `reset()` **in a passive effect** — i.e. one commit *after* the new step's inputs are already in the DOM. `waitFor(input)` can resolve inside that window, and a value typed there is lost: the pending reset replaces the whole RHF record with the earlier steps' data.

Captured interleaving (instrumented run):

```
test: waitFor(note) RESOLVED
form: RESET to {"name":"Alice"} (values before: {"name":"Alice","note":"hello"})   ← wipes note
test: change note done
→ payload {"name":"Alice"}
```

**The issue title's diagnosis is slightly off, and it matters:** the value is lost *before* the submit, during the `change`. Waiting *after* `fireEvent.change` — the fix the title suggests — would not have helped. The step has to be settled **before** typing.

## The fix

A `settledStepInput()` helper that waits for the step's input **and** drains the pending effects, so the `defaultValues` reset cannot land after the change. Applied to both steps (step 1 has the same window against the initial mount reset).

## Why this doesn't weaken the guard

Harness-only — nothing asserted changed. Verified by mutation: breaking **both** value carriers (RHF cross-step retention + the wizard's `{...formData, ...stepData}` merge) fails the old and the new test *identically*, with the exact `{ note: 'hello' }` "last-only body" the file's docblock names.

Worth noting the two carriers are redundant on their own — breaking either one alone still passes.

## Verification

Scenario replayed 1500× per arm in-process, under 10 competing CPU hogs:

| arm | failures / 1500 |
|---|---|
| before | **7** (~0.5%) |
| after | **0** |

Full `plugin-form` suite: 24 files / 217 tests pass. No new `tsc` or `eslint` findings in the changed file.

## Follow-up (not in this PR)

The same window exists in the product, narrowly: `form.tsx` commits new `defaultValues` one frame before its `reset()` runs, so input typed in that gap is silently discarded. In a browser it takes a busy main thread plus typing on the very first frame of a step, so it is far less likely than in tests — but it is the same defect, and it lives in a shared renderer every form uses. Deliberately left alone here to keep this change harness-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)