### PR TITLE
fix(sdui): a react page keeps its state; a source that exports nothing fails loudly

### DIFF
--- a/.changeset/react-page-state-and-docs.md
+++ b/.changeset/react-page-state-and-docs.md
@@ -1,0 +1,41 @@
+---
+"@object-ui/react": patch
+"@object-ui/react-runtime": minor
+"@object-ui/types": minor
+"@object-ui/components": patch
+---
+
+fix(sdui): a react page no longer loses its state to a memo that never held, and a source that exports nothing fails loudly
+
+Writing the regression guard for objectui#2954's "latent hazard" found it was
+already real.
+
+**`evaluatedSchema` was memoised on values rebuilt every render.**
+`SchemaRenderer` fell back to a fresh `{}` when no `SchemaRendererProvider` sat
+above it, and `usePageVariables()` returned a brand-new object literal outside a
+`PageVariablesProvider`. Both feed the `evaluatedSchema` memo's dependency list,
+so for any tree without those providers the memo never hit: the schema was
+re-cloned and the ExpressionEvaluator re-run on every render, and children got a
+new schema identity every time. A `kind:'react'` page memoises its compiled
+source on that identity, so the page was recompiled — a new page function, a new
+element type — and React remounted it, silently discarding the user's `useState`.
+Any registry notification (every lazy plugin's first load) triggered it. Both
+fallbacks are now module constants.
+
+**A source that exports nothing now throws instead of rendering blank.**
+`generateElement` inserts the implicit `export default` only when the source
+*starts with* JSX, a `function` declaration, `()` or `class` — so the very
+common `const Page = () => …` exported nothing, and the page rendered blank with
+no error reported anywhere. It now throws with a message naming the fix, which
+`ReactRunner`'s error panel surfaces. `export default null` still means "render
+nothing"; a default export that is not a component throws too.
+
+**`PageSchema['kind']` matches `@objectstack/spec`.** It declared
+`'full' | 'slotted'` while the renderer had shipped `'react'` and
+`'html'`/`'jsx'` since ADR-0080 and read the field through a cast. The union now
+spells all five and the cast is gone.
+
+Docs: new `content/docs/guide/react-pages.md` (choosing between the executed and
+parsed tiers, the capability gate, the injected scope, flat props, `Block`,
+`useAdapter`, source shapes, error handling) and a `@object-ui/react-runtime`
+README — the package had neither, while being the tier AI-authored pages target.

--- a/content/docs/guide/meta.json
+++ b/content/docs/guide/meta.json
@@ -23,6 +23,7 @@
     "record-edit-modes",
     "dashboard-filters",
     "slotted-pages",
+    "react-pages",
     "console",
     "console-architecture",
     "flow-designer",

--- a/content/docs/guide/react-pages.md
+++ b/content/docs/guide/react-pages.md
@@ -1,0 +1,188 @@
+---
+title: React Pages
+description: Author a page body as real React (kind:'react') or as constrained JSX that is parsed and never executed (kind:'html') — and how to choose between them.
+---
+
+# React Pages
+
+Most pages in ObjectUI are a **schema tree** — `regions[].components[]` of JSON
+nodes. Two page kinds let you write the body as **source** instead, for layouts
+that are awkward to express as nested JSON:
+
+| `kind` | Source is | Executed? | Author trust |
+|---|---|---|---|
+| `"html"` | Constrained JSX/HTML + Tailwind | **No** — parsed into a schema tree | Untrusted OK |
+| `"react"` | Real React (hooks, handlers, arbitrary JS) | **Yes** — in the main React tree | Trusted only |
+
+Both set `source` and leave `regions` unused. `"jsx"` is a deprecated alias for
+`"html"` and is still accepted.
+
+> Page `kind` also carries the record-page override values `"full"` (default)
+> and `"slotted"` — a different axis, covered in [Slotted Pages](./slotted-pages.md).
+
+## Choosing between them
+
+Reach for **`kind:'html'`** by default. It is parsed, whitelisted against the
+public block manifest, and never executed, so it is safe for AI-generated and
+customer-authored pages. It covers layout, blocks, and Tailwind styling.
+
+Reach for **`kind:'react'`** only when you need real behaviour the schema tree
+cannot express — local state, computed lists, event handlers wiring one block to
+another, custom data fetching. It runs **without a sandbox**.
+
+## `kind:'react'`
+
+```json
+{
+  "type": "home",
+  "name": "project_console",
+  "kind": "react",
+  "source": "function Page() {\n  const [selected, setSelected] = React.useState(null);\n  return (\n    <div className=\"grid grid-cols-2 gap-4\">\n      <ListView objectName=\"showcase_project\" fields={['name', 'status']} onRowClick={(r) => setSelected(r._id)} />\n      {selected && <ObjectForm objectName=\"showcase_project\" mode=\"edit\" recordId={selected} />}\n    </div>\n  );\n}"
+}
+```
+
+Written out, that `source` is:
+
+```jsx
+function Page() {
+  const [selected, setSelected] = React.useState(null);
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <ListView
+        objectName="showcase_project"
+        fields={['name', 'status']}
+        onRowClick={(r) => setSelected(r._id)}
+      />
+      {selected && <ObjectForm objectName="showcase_project" mode="edit" recordId={selected} />}
+    </div>
+  );
+}
+```
+
+### The security gate
+
+A react page's source is transpiled and evaluated directly in the application —
+no isolation, full access to the page's React tree. The platform assumes page
+authors are reviewed and draft-gated, so the host capability `react-pages`
+defaults **ON**.
+
+A deployment that does not trust its authors turns it off server-side with
+`OS_PAGE_REACT=off` (or `disableCapability('react-pages')` in the host). Pages
+then render an explanatory notice instead of executing. Existing `kind:'html'`
+pages are unaffected.
+
+### What is in scope
+
+Nothing is imported. These identifiers are injected as closure variables:
+
+| In scope | What it is |
+|---|---|
+| `React` | The host's React — call hooks with it (`React.useState`). |
+| The public data blocks | `<ObjectGrid>`, `<ListView>`, `<ObjectForm>`, `<ObjectKanban>`, `<ObjectChart>`, `<ObjectMetric>`, `<Markdown>`, … |
+| `Block` | Escape hatch for anything not injected. |
+| `useAdapter` | The live data source — query/create/update. |
+| `data`, `variables`, `page` | The page's own data, local variables, and schema. |
+
+The block tags come from the curated **public contract**
+(`PUBLIC_BLOCKS`), converted from kebab-case to PascalCase: `object-grid` →
+`<ObjectGrid>`, `record:details` → `<RecordDetails>`. Blocks registered lazily
+are in scope too — you never wait on a plugin chunk to reference one.
+
+**Layout containers are deliberately not injected.** In react mode you compose
+layout with real HTML and Tailwind, which React is better at than a schema-children
+renderer. `<flex>`, `<grid>`, `<card>` and friends have no injected wrapper — use
+`<div className="flex gap-4">`.
+
+### Blocks take flat props
+
+An injected block folds its JSX props into the block's schema, so you write
+flat props rather than a nested `schema` object:
+
+```jsx
+<ObjectGrid objectName="showcase_project" fields={['name', 'status']} pageSize={25} />
+```
+
+Function props (`onRowClick`, `onSelect`) are passed through as real callbacks —
+that is how you wire one block to another.
+
+One collision to know about: `type` is both the schema's component
+discriminator and a legitimate prop name on some blocks (a chart's family, for
+instance). The discriminator wins the `type` slot, and your value is preserved
+next to it as `specType` for the block to read.
+
+### `Block` — the escape hatch
+
+Any registered component, including ones outside the public contract:
+
+```jsx
+<Block type="object-tree" objectName="showcase_category" />
+```
+
+### Live data
+
+```jsx
+function Page() {
+  const adapter = useAdapter();
+  const [rows, setRows] = React.useState([]);
+
+  React.useEffect(() => {
+    adapter.find('showcase_project', { filters: [['status', '=', 'open']] }).then(setRows);
+  }, [adapter]);
+
+  return <ul>{rows.map((r) => <li key={r._id}>{r.name}</li>)}</ul>;
+}
+```
+
+### Source shapes
+
+The page renders the source's **default export**. An implicit `export default`
+is added when the source *starts with* JSX, a `function` declaration, `()`, or
+`class`:
+
+```jsx
+function Page() { return <p/>; }     // ✅
+<p>hi</p>                            // ✅
+() => <p>hi</p>                      // ✅
+
+const Page = () => <p/>;             // ❌ exports nothing
+const Page = () => <p/>;
+export default Page;                 // ✅
+```
+
+The `const Page = …` form does **not** get the implicit export — export it
+explicitly. Getting this wrong reports an error in the page error panel; it does
+not silently render blank.
+
+### When something throws
+
+Transpile errors, evaluation errors, and errors thrown while rendering all
+surface in a **React page error** panel with the message. The error is held
+until the page source or its data changes, so it does not flicker or escape to
+the generic renderer error.
+
+Referencing an identifier that is not in scope is the common case, and reads as
+`ReferenceError: <Name> is not defined` — usually a layout container (not
+injected — use HTML) or a block outside the public contract (use `Block`).
+
+### Page state
+
+A react page keeps its own `useState` across re-renders and across lazy plugin
+loads. Two things reset it, both intentional: a change to `source`, and a change
+to the page's data/variables — the page is genuinely a different page then.
+
+## `kind:'html'`
+
+The constrained tier. Same JSX-looking syntax, but the source is **parsed**
+into a schema tree and rendered through the normal renderer — never executed.
+Only tags in the public block manifest are allowed, props are validated against
+each block's declared inputs, and unknown tags are a hard error at save time.
+
+Use it for anything author- or AI-generated. Expressions are limited to what the
+schema supports (`${data.x}`), and there is no local state or event handling
+beyond the action system.
+
+## Related
+
+- [Slotted Pages](./slotted-pages.md) — `kind:'full'` / `kind:'slotted'` record pages.
+- [Schema Rendering](./schema-rendering.md) — the schema tree the other kinds compile to.
+- [Component Registry](./component-registry.md) — how blocks are registered and what makes one public.

--- a/packages/components/src/__tests__/react-page-state.test.tsx
+++ b/packages/components/src/__tests__/react-page-state.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * A `kind:'react'` page keeps its own state (objectui#2954).
+ *
+ * The page's `source` is evaluated into a fresh `Page` function on every
+ * compile — a new element TYPE, which React remounts. So the page's `useState`
+ * survives only as long as nothing recompiles it, and that holds only while
+ * BOTH links in the chain stay identity-stable: `ReactRunner` memoises on
+ * `(code, scope)`, and `ReactKindPage` memoises `scope` on `[schema, adapter]`.
+ *
+ * Break either link and nothing fails loudly. Types check, every scope-contract
+ * test still passes, the page still renders — it just silently drops whatever
+ * the user had typed, scrolled to, or selected, at a moment nobody can trace
+ * back to a scope object. These tests are the tripwire, written against the
+ * user-visible symptom rather than the memo internals.
+ *
+ * The lazy-load case is the one worth staring at. `react-page.tsx` deliberately
+ * does NOT subscribe to ComponentRegistry changes the way SchemaRenderer does —
+ * a reasonable-looking "fix" for load-order gaps, and the thing that would make
+ * every lazy plugin finishing its import wipe every react page on screen.
+ */
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer, AdapterCtx } from '@object-ui/react';
+
+const adapter = { find: async () => [], getObjectSchema: async () => ({ name: 'showcase_project', fields: {} }) } as any;
+
+/** A page that holds interactive state, plus an optional extra block. */
+const counterSource = (extra = '') => `
+function Page() {
+  const [n, setN] = React.useState(0);
+  return (
+    <div>
+      <button data-testid="counter" onClick={() => setN(n + 1)}>{n}</button>
+      ${extra}
+    </div>
+  );
+}`;
+
+/** Module-scope so the schema identity is stable across host re-renders. */
+const PLAIN_SCHEMA = { type: 'home', kind: 'react', name: 'test_page', source: counterSource() };
+
+beforeAll(async () => {
+  // Registers PageRenderer for `type:'home'`, which dispatches kind:'react'.
+  await import('../renderers');
+}, 30000);
+
+afterEach(() => {
+  ComponentRegistry.unregister('object-kanban', 'plugin-kanban');
+  ComponentRegistry.unregister('object-kanban');
+});
+
+function Host({ tick, schema }: { tick: number; schema: any }) {
+  return (
+    <AdapterCtx.Provider value={adapter}>
+      <span data-testid="tick">{tick}</span>
+      <SchemaRenderer schema={schema} />
+    </AdapterCtx.Provider>
+  );
+}
+
+describe('kind:\'react\' page state', () => {
+  it('survives a parent re-render', async () => {
+    const { findByTestId, getByTestId, rerender } = render(<Host tick={0} schema={PLAIN_SCHEMA} />);
+    fireEvent.click(await findByTestId('counter'));
+    expect(getByTestId('counter').textContent).toBe('1');
+
+    rerender(<Host tick={1} schema={PLAIN_SCHEMA} />);
+
+    expect(getByTestId('tick').textContent).toBe('1');
+    // '0' here means the page was remounted: something upstream handed
+    // ReactRunner a new `code` or a new `scope` identity.
+    expect(getByTestId('counter').textContent).toBe('1');
+  });
+
+  it('survives a lazy block finishing its load (objectui#2953 ∩ #2954)', async () => {
+    // The page renders a block whose plugin chunk has not been imported yet.
+    // Loading it calls register(), which notifies every registry subscriber.
+    let landPlugin!: () => void;
+    const loaded = new Promise<void>((resolve) => {
+      landPlugin = resolve;
+    });
+    ComponentRegistry.registerLazy(
+      'object-kanban',
+      async () => {
+        await loaded;
+        ComponentRegistry.register('object-kanban', () => <div data-testid="kanban-double" />, {
+          namespace: 'plugin-kanban',
+        });
+      },
+      { namespace: 'plugin-kanban', category: 'view' },
+    );
+
+    const schema = { type: 'home', kind: 'react', name: 'lazy_page', source: counterSource('<ObjectKanban objectName="showcase_project" />') };
+    const { findByTestId, getByTestId } = render(<Host tick={0} schema={schema} />);
+
+    // State the user has already produced, while the block is still loading.
+    fireEvent.click(await findByTestId('counter'));
+    expect(getByTestId('counter').textContent).toBe('1');
+
+    landPlugin();
+    expect(await findByTestId('kanban-double')).toBeTruthy();
+
+    // If ReactKindPage subscribed to the registry, this notify would rebuild
+    // the scope, hand ReactRunner a new identity, and reset the page — every
+    // interactive react page on screen, on any plugin's first use.
+    await waitFor(() => expect(getByTestId('counter').textContent).toBe('1'));
+  });
+
+  it('does recompile when the page source itself changes', async () => {
+    const { findByTestId, getByTestId, rerender } = render(<Host tick={0} schema={PLAIN_SCHEMA} />);
+    fireEvent.click(await findByTestId('counter'));
+    expect(getByTestId('counter').textContent).toBe('1');
+
+    // The negative control: stability must not mean staleness. A genuinely
+    // different page is a different page, state included.
+    rerender(<Host tick={0} schema={{ ...PLAIN_SCHEMA, source: counterSource('<i data-testid="marker" />') }} />);
+
+    expect(await findByTestId('marker')).toBeTruthy();
+    expect(getByTestId('counter').textContent).toBe('0');
+  });
+});

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -434,7 +434,9 @@ export const PageRenderer: React.FC<{
 
   // Select the layout variant based on template or page type
   const layoutElement = useMemo(() => {
-    const kind = (schema as { kind?: string }).kind;
+    // `PageSchema['kind']` now spells the source-authored values too, matching
+    // @objectstack/spec — no cast needed to read what the renderer dispatches on.
+    const kind = schema.kind;
     // `kind:'react'` — TRUSTED execution tier: real React, run (not parsed) by
     // @object-ui/react-runtime, gated behind the host CAP_REACT_PAGES flag.
     if (kind === 'react') {

--- a/packages/react-runtime/README.md
+++ b/packages/react-runtime/README.md
@@ -1,0 +1,133 @@
+# @object-ui/react-runtime
+
+Runs a JSX/TSX **source string** as real React, in the main React tree.
+
+This is the engine behind `kind:'react'` pages (ADR-0080). It transpiles the
+source with [Sucrase](https://github.com/alangpierce/sucrase), evaluates it
+against an injected scope, and renders the result behind a built-in error
+boundary. Vendored from [react-runner](https://github.com/nihgwu/react-runner)
+(MIT) rather than depended on, so we control the scope/imports surface and can
+lazy-load it behind a capability flag.
+
+> **⚠️ No sandbox — this is the trusted execution tier.**
+> The source is `new Function(...)`'d with full access to the page's React tree
+> and everything in scope. It is not isolated, not restricted, and not
+> validated. Only run source you would run as first-party code.
+>
+> For untrusted authors use **`kind:'html'`** instead: constrained JSX/HTML +
+> Tailwind, parsed into a schema tree and never executed. See
+> [React pages](../../content/docs/guide/react-pages.md).
+
+## Installation
+
+```bash
+npm install @object-ui/react-runtime
+```
+
+`react >= 18` is a peer dependency.
+
+## Usage
+
+```tsx
+import { ReactRunner } from '@object-ui/react-runtime';
+
+<ReactRunner
+  code={`
+    function Page() {
+      const [n, setN] = React.useState(0);
+      return <button onClick={() => setN(n + 1)}>clicked {n} times</button>;
+    }
+  `}
+  scope={{ ObjectGrid, useAdapter, data }}
+  fallback={(error) => <pre>{String(error)}</pre>}
+  onError={(error) => report(error)}
+/>
+```
+
+### Props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `code` | `string` | The JSX/TSX source. Required. |
+| `scope` | `Record<string, unknown>` | Values injected as closure variables. `React` is always present. **Keep the object identity stable** — see below. |
+| `fallback` | `(error: Error) => ReactNode` | Rendered when the source throws at transpile, eval, or render time. |
+| `onError` | `(error: Error) => void` | Called once per error, including errors caught at mount. |
+
+## Accepted source shapes
+
+`ReactRunner` renders the source's **default export**. An implicit
+`export default` is inserted when the source *starts with* JSX, a `function`
+declaration, `()`, or `class`:
+
+```tsx
+<p>hi</p>                              // ✅ bare JSX
+function Page() { return <p/>; }       // ✅ function declaration
+() => <p>hi</p>                        // ✅ arrow expression
+class Page extends React.Component {}  // ✅ class
+
+const Page = () => <p/>;               // ❌ exports nothing — see below
+const Page = () => <p/>;
+export default Page;                   // ✅ export it explicitly
+```
+
+The `const Page = …` form is the one authors reach for most, and it does **not**
+get the implicit export. It used to render a blank page with no error anywhere;
+it now throws with a message naming the fix, which `fallback` surfaces.
+`export default null` still means "render nothing".
+
+### Imports
+
+There is no module resolver. `import x from 'y'` compiles to a `require('y')`
+that reads `scope.import`:
+
+```tsx
+<ReactRunner code={code} scope={{ import: { 'date-fns': dateFns } }} />
+```
+
+Anything not provided there throws `Module not found`.
+
+## Stable scope identity matters
+
+Every evaluation produces a **new** component function — a new element *type* —
+which React unmounts and remounts. `ReactRunner` therefore memoises the
+transpile+eval on `(code, scope)` by identity and only recompiles when one of
+them actually changes.
+
+That means an inline `scope={{ ... }}` object literal recompiles and **remounts
+the rendered tree on every render**, silently discarding whatever state it held.
+Build the scope with `useMemo` (or hoist it to module scope) and keep its
+dependencies stable.
+
+```tsx
+// ❌ new object every render — the page remounts and loses its useState
+<ReactRunner code={src} scope={{ ObjectGrid, data }} />
+
+// ✅
+const scope = useMemo(() => ({ ObjectGrid, data }), [data]);
+<ReactRunner code={src} scope={scope} />
+```
+
+## Error handling
+
+`ReactRunner` is its own error boundary and holds the error until `code` or
+`scope` changes, so `fallback` is reached for render-phase errors too — not
+just transpile/eval failures. New inputs clear it and recompile.
+
+## Lower-level API
+
+```ts
+import { generateElement, transform, type Scope } from '@object-ui/react-runtime';
+
+transform(code)                  // JSX/TS → JS (classic runtime, imports → require)
+generateElement(code, scope)     // transpile + eval → ReactElement | null (throws, see above)
+```
+
+## Related
+
+- [React pages guide](../../content/docs/guide/react-pages.md) — authoring
+  `kind:'react'` pages, the injected block scope, and the capability gate.
+- `@object-ui/sdui-parser` — the `kind:'html'` tier: parse, never execute.
+
+## License
+
+MIT

--- a/packages/react-runtime/src/__tests__/ReactRunner.test.tsx
+++ b/packages/react-runtime/src/__tests__/ReactRunner.test.tsx
@@ -48,8 +48,33 @@ describe('generateElement', () => {
     expect(React.isValidElement(el)).toBe(true);
   });
 
+  it.each([
+    ['bare JSX', '<p>hi</p>'],
+    ['function declaration', 'function Page() { return <p>hi</p>; }'],
+    ['arrow IIFE form', '() => <p>hi</p>'],
+    ['explicit default export', 'const Page = () => <p>hi</p>;\nexport default Page;'],
+  ])('accepts the %s source shape', (_name, code) => {
+    expect(React.isValidElement(generateElement(code))).toBe(true);
+  });
+
   it('returns null for empty source', () => {
     expect(generateElement('   ')).toBeNull();
+  });
+
+  it('returns null for an explicit `export default null` — render nothing', () => {
+    expect(generateElement('export default null;')).toBeNull();
+  });
+
+  it('throws when the source exports nothing instead of rendering blank', () => {
+    // `normalizeCode` only auto-exports a source that STARTS with JSX /
+    // `function` / `()` / `class`. This shape is the one authors reach for
+    // most, and it used to produce a blank page with no error anywhere —
+    // nothing in the console, nothing in the page error panel.
+    expect(() => generateElement('const Page = () => <p>hi</p>;')).toThrow(/exported nothing/);
+  });
+
+  it('throws when the source exports something that is not a component', () => {
+    expect(() => generateElement('export default 42;')).toThrow(/default-exported a number/);
   });
 });
 

--- a/packages/react-runtime/src/index.tsx
+++ b/packages/react-runtime/src/index.tsx
@@ -37,16 +37,34 @@ const evalCode = (code: string, scope: Scope): unknown => {
   return new Function(...keys, code)(...keys.map((k) => finalScope[k]));
 };
 
-/** Transpile + eval a source string into a React element (or null). */
+/**
+ * Transpile + eval a source string into a React element.
+ *
+ * Returns null only for an empty source or an explicit `export default null`
+ * ("render nothing"). Anything else that fails to produce a component THROWS —
+ * `normalizeCode` only inserts the implicit `export default` when the source
+ * STARTS with JSX / `function` / `()` / `class`, so the extremely common
+ * `const Page = () => …` form exported nothing and used to render a blank page
+ * with no error reported anywhere. ReactRunner catches these and shows them.
+ */
 export function generateElement(code: string, scope: Scope = {}): ReactElement | null {
   if (!code.trim()) return null;
   const exports: Scope = {};
   evalCode(transform(normalizeCode(code)), { render: (v: unknown) => (exports.default = v), ...scope, exports });
   const result = exports.default;
-  if (!result) return null;
+  if (result === undefined) {
+    throw new Error(
+      'The source exported nothing, so there is no component to render. End it with ' +
+        '`export default <YourComponent>`, or start it with JSX, a `function` declaration, ' +
+        'or a `class` — those get an implicit default export.',
+    );
+  }
+  if (result === null) return null;
   if (isValidElement(result)) return result;
   if (typeof result === 'function') return createElement(result as React.ComponentType);
-  return null;
+  throw new Error(
+    `The source default-exported a ${typeof result}. Export a React component or an element.`,
+  );
 }
 
 export interface ReactRunnerProps {

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -189,9 +189,20 @@ export class SchemaErrorBoundary extends Component<
   }
 }
 
+/**
+ * Shared "no data source" fallback. MUST be a module constant: it feeds the
+ * `evaluatedSchema` memo below, and a fresh `{}` per render defeats that memo
+ * for every SchemaRenderer without a provider above it — re-cloning the schema
+ * and re-running the ExpressionEvaluator on each render, and handing a new
+ * schema identity to children that memoise on it. For a `kind:'react'` page
+ * that identity IS the compile key, so the page was silently remounted and its
+ * `useState` wiped (objectui#2954's latent hazard, made real by this line).
+ */
+const NO_DATA_SOURCE: Record<string, any> = {};
+
 export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<string, any>>(({ schema, ...props }, _ref) => {
   const context = useContext(SchemaRendererContext);
-  const dataSource = context?.dataSource || {};
+  const dataSource = context?.dataSource || NO_DATA_SOURCE;
   // Ambient host scope (user / app / features), fed by app-shell's
   // ExpressionProvider. Threaded into `visible`/expression evaluation so
   // component predicates can gate on the signed-in user & deployment flags.

--- a/packages/react/src/hooks/usePageVariables.tsx
+++ b/packages/react/src/hooks/usePageVariables.tsx
@@ -187,18 +187,31 @@ PageVariablesProvider.displayName = 'PageVariablesProvider';
  */
 export function usePageVariables(): PageVariablesContextValue {
   const ctx = useContext(PageVariablesContext);
-  if (!ctx) {
-    // Graceful fallback — allows components to work outside a Page
-    return {
-      variables: {},
-      definitions: [],
-      setVariable: () => {},
-      setVariables: () => {},
-      resetVariables: () => {},
-    };
-  }
-  return ctx;
+  return ctx ?? OUTSIDE_PAGE;
 }
+
+/**
+ * Graceful fallback — allows components to work outside a Page.
+ *
+ * MUST be a module constant, not a fresh literal per call. `SchemaRenderer`
+ * feeds `variables` into the `evaluatedSchema` memo's dependency list, so a new
+ * object each render defeats that memo for every component rendered outside a
+ * PageVariablesProvider — and hands children a new schema identity every time.
+ * A `kind:'react'` page memoises its compiled source on that identity, so the
+ * page was being remounted and its `useState` reset (objectui#2954).
+ *
+ * Frozen through, because sharing one instance means a stray write would no
+ * longer be scoped to one render — it would leak to every consumer outside a
+ * provider. There is no writer today (the setters are the API, and here they
+ * are no-ops); the freeze keeps it that way.
+ */
+const OUTSIDE_PAGE: PageVariablesContextValue = Object.freeze({
+  variables: Object.freeze({}),
+  definitions: Object.freeze([]) as never,
+  setVariable: () => {},
+  setVariables: () => {},
+  resetVariables: () => {},
+});
 
 /**
  * Hook to check if a PageVariablesProvider is available.

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -568,22 +568,30 @@ export interface PageSchema extends BaseSchema {
     role?: string;
   };
   /**
-   * Override semantics for record pages.
+   * How the page's body is authored. Mirrors `@objectstack/spec`'s page
+   * `kind` enum.
    *
+   * Schema-authored (the `regions[].components[]` tree):
    * - `"full"` (default): the schema fully describes the page; the
    *   default-page synthesizer is bypassed entirely.
    * - `"slotted"`: the schema only provides overrides for one or more
    *   named slots (see `slots`). The default-page synthesizer fills in
    *   every slot the author did NOT override. Use this when you want
    *   to customize just the header / actions / one tab without
-   *   re-authoring the rest of the page.
+   *   re-authoring the rest of the page. Only meaningful when
+   *   `pageType === 'record'`; ignored for other page types.
    *
-   * Only meaningful when `pageType === 'record'`. Ignored for full
-   * pages and for non-record page types.
+   * Source-authored (`source` carries the body; `regions` is unused) —
+   * ADR-0080, see `content/docs/guide/react-pages.md`:
+   * - `"html"`: constrained JSX/HTML + Tailwind, PARSED into a SchemaNode
+   *   tree and rendered. Never executed — safe for untrusted authors.
+   *   `"jsx"` is a deprecated alias, still accepted.
+   * - `"react"`: real React, transpiled and EVALUATED in the main tree.
+   *   No sandbox; gated behind the `react-pages` host capability.
    *
    * @default 'full'
    */
-  kind?: 'full' | 'slotted';
+  kind?: 'full' | 'slotted' | 'html' | 'jsx' | 'react';
   /**
    * Slotted override map. Each slot accepts a single SchemaNode or an
    * array (arrays are flattened into the slot position). Slots not


### PR DESCRIPTION
Follow-up to #2976 / #2979. Started as "write the regression guard for the state-loss hazard #2954 flagged" — the guard failed on first run, because the hazard was already real on the default path.

## 1. `evaluatedSchema` was memoised on values rebuilt every render

Two fallbacks minted a fresh object per call:

```ts
const dataSource = context?.dataSource || {};        // SchemaRenderer.tsx
return { variables: {}, definitions: [], ... };      // usePageVariables(), outside a provider
```

Both feed the `evaluatedSchema` `useMemo` dependency list. So for **any tree without a `SchemaRendererProvider` / `PageVariablesProvider` above it**, that memo never hit: the schema was re-cloned and the `ExpressionEvaluator` re-run on every render, and every child got a new schema identity each time.

For a `kind:'react'` page that identity **is** the compile key. New identity → recompile → a new page function → a new element *type* → React remounts the subtree and the user's `useState` is gone. And since `SchemaRenderer` subscribes to the registry, every lazy plugin's first load fired a notify that triggered it.

This is exactly the hazard #2954 described as "not yet observed":

> anything that makes the adapter identity unstable would turn this into user-visible state loss with no obvious cause

Both fallbacks are now module constants. The page-variables one is frozen through — sharing one instance means a stray write would leak to every consumer outside a provider instead of being scoped to one render. There is no writer today (the setters are the API, and there they are no-ops); the freeze keeps it that way.

Worth noting the win is not limited to react pages: **every** `SchemaRenderer` without those providers was re-cloning its schema and re-running expression evaluation on every single render.

## 2. The guard itself

`packages/components/src/__tests__/react-page-state.test.tsx` pins the invariant at the **symptom**, not the memo internals — the memo is an implementation detail, "the user's input survived" is the contract:

- state survives a parent re-render;
- state survives a lazy block finishing its load — the case a plausible-looking `ComponentRegistry.subscribe()` in `react-page.tsx` would break, which is precisely what the comment there warns against and nothing enforced;
- a genuinely changed `source` still recompiles (stability must not mean staleness).

## 3. A source that exports nothing now throws instead of rendering blank

`normalizeCode` inserts the implicit `export default` only when the source *starts with* JSX, a `function` declaration, `()` or `class`. So the form authors reach for most:

```jsx
const Page = () => <p>hi</p>;   // exports nothing
```

…evaluated fine, exported nothing, and `generateElement` returned `null` — a blank page, no error in the console, nothing in the page error panel. It now throws with a message naming the fix, which `ReactRunner`'s panel surfaces (reachable since #2976). `export default null` still means "render nothing"; a default export that is not a component throws too.

This was the open question I flagged before writing docs — documenting the tier required deciding whether that behaviour is contract or bug. It's a bug.

## 4. `PageSchema['kind']` matches `@objectstack/spec`

The spec has declared `full | slotted | html | jsx | react` since ADR-0080. `@object-ui/types` still said `'full' | 'slotted'`, and `page.tsx` read the field through `(schema as { kind?: string }).kind` to dispatch on values the type denied existed. Per AGENTS #0 the type follows the spec: the union now spells all five and the cast is gone.

## 5. Docs

`@object-ui/react-runtime` had **no README** and `content/docs` had **no page** on either source-authored kind — the injected block scope, `Block`, `useAdapter`, the capability gate and the accepted source shapes existed only in source comments. That is the tier AI-authored pages are written against.

- `content/docs/guide/react-pages.md` — choosing between the executed and parsed tiers, the security gate, what's in scope (and why layout containers deliberately are not), flat props and the `type`/`specType` collision, `Block`, `useAdapter`, source shapes, error handling. Added to the guide nav.
- `packages/react-runtime/README.md` — the API, the no-sandbox warning, and the stable-scope-identity requirement (an inline `scope={{...}}` literal remounts the tree every render — the same trap as #1, one layer up).

## Verification

- Full suite: `697 files passed | 1 skipped`, `8201 tests passed | 24 skipped`.
- `turbo run type-check` across the repo (76/76) — including after removing the `kind` cast.
- `lint` on the touched packages: 0 errors.
- `check-doc-links`: the new page's links resolve. (One pre-existing break remains in `content/docs/core/enhanced-actions.mdx`, untouched here and not gating — that workflow is `workflow_dispatch`-only.)
- `changeset:check`: clean. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4mrr1ihhwnfEHFSWmGoMp


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4mrr1ihhwnfEHFSWmGoMp)_