### PR TITLE
fix(plugin-form): a wizard that ends on a field-less review step can finish

### DIFF
--- a/packages/plugin-form/src/WizardForm.regression.test.tsx
+++ b/packages/plugin-form/src/WizardForm.regression.test.tsx
@@ -11,6 +11,18 @@
  *   2. the create-mode seeding effect reset `formData` to `{}` on re-render.
  * The buttons now submit the inner form natively (`type="submit"` + `form={id}`)
  * and the create seed is idempotent.
+ *
+ * What each case here actually pins down — the first two overlap less than they
+ * look, so don't read either as covering the whole merge:
+ *   - "submits the merged payload" is an END-TO-END outcome check. Two redundant
+ *     mechanisms carry values across steps (react-hook-form keeps unmounted
+ *     fields, since `shouldUnregister` is false; and the wizard merges
+ *     `{...formData, ...stepData}`), and breaking EITHER ONE ALONE still passes.
+ *     It catches a total failure to accumulate, not a broken merge.
+ *   - "carries earlier steps through a field-less review step" is what pins the
+ *     merge itself: a step with no inputs has no react-hook-form instance to
+ *     retain anything, so `formData` is the only carrier left.
+ *   - "wires the footer Next/Create buttons" pins the native-submit wiring.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
@@ -88,6 +100,39 @@ describe('WizardForm — multi-step create collects every step', () => {
     expect(obj).toBe('wiz_obj');
     // The regression was: payload === {} or { note } only. Must carry BOTH steps.
     expect(payload).toEqual(expect.objectContaining({ name: 'Alice', note: 'hello' }));
+  });
+
+  it('carries earlier steps through a field-less review step (and can finish it)', async () => {
+    const ds = makeDS();
+    // A final review/confirm step with no inputs — the shape this component's
+    // own usage example ends on. It renders no react-hook-form instance, so
+    // it is the one path where the wizard's own `formData` is the ONLY thing
+    // carrying the earlier steps.
+    const reviewSchema = {
+      ...schema,
+      sections: [{ label: 'Step 1', fields: ['name'] }, { label: 'Review', fields: [] }],
+    };
+    const { container } = render(<WizardForm schema={reviewSchema as any} dataSource={ds as any} />);
+
+    fireEvent.change(await settledStepInput(container, 'name'), { target: { value: 'Alice' } });
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement); // → review step
+
+    await waitFor(() => {
+      if (!screen.queryByText(/No fields configured/i)) throw new Error('not on the review step');
+    });
+    await act(async () => {});
+
+    // The review step must still expose a form for the footer button to submit;
+    // without one the button targets nothing and the wizard can never finish.
+    const createBtn = screen.getByRole('button', { name: /create/i });
+    const reviewForm = container.querySelector('form');
+    expect(reviewForm).not.toBeNull();
+    expect(createBtn.getAttribute('form')).toBe(reviewForm!.getAttribute('id'));
+
+    await act(async () => { fireEvent.click(createBtn); });
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+    // Step 1's value survives a step that contributed nothing of its own.
+    expect(ds.create.mock.calls[0][1]).toEqual(expect.objectContaining({ name: 'Alice' }));
   });
 
   it('wires the footer Next/Create buttons to the step form (cannot bypass it)', async () => {

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -537,9 +537,26 @@ export const WizardForm: React.FC<WizardFormProps> = ({
                 }}
               />
             ) : (
-              <div className="text-center py-8 text-muted-foreground">
-                No fields configured for this step
-              </div>
+              // A step can legitimately have NO inputs — a final "Review"/confirm
+              // step is the canonical case (this component's own usage example
+              // ends on `{ label: 'Step 3: Review', fields: [] }`). The footer
+              // Next/Create buttons submit the step form *natively* by id, so
+              // that form has to exist even when there is nothing to fill in:
+              // without it the buttons point at a missing target, the click does
+              // nothing at all, and a wizard that ends on a review step can never
+              // be completed. Submitting contributes no new values — the record
+              // is whatever the earlier steps accumulated in `formData`.
+              <form
+                id={stepFormId}
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  void handleStepSubmit({});
+                }}
+              >
+                <div className="text-center py-8 text-muted-foreground">
+                  No fields configured for this step
+                </div>
+              </form>
             )}
           </FormSection>
         )}


### PR DESCRIPTION
Follow-up to #2983. While auditing what that regression suite actually covers, I found a reachable product bug.

## The bug

A wizard step with no inputs — `{ label: 'Review', fields: [] }`, **the shape `WizardForm`'s own JSDoc example ends on** — rendered a bare hint div and **no `<form>`**. The footer Next/Create buttons submit the step form natively (`type="submit" form={stepFormId}`), so on that step they pointed at a target that does not exist.

Observed directly:

```
AUDIT form-on-review=ABSENT createBtn.form=_r_0_ createBtn.type=submit
AUDIT create-calls=0 payload=undefined
```

Clicking **Create** does nothing at all — no request, no error, no feedback. **A wizard that ends on a review step can never be completed.**

This is fallout from the very fix the regression suite guards: moving the buttons off `onClick={() => handleStepSubmit(formData)}` onto native submission is what made a missing form fatal. Fix renders a real form on the field-less step; it contributes no values of its own, so the record is whatever the earlier steps accumulated.

## The docblock was overstating its coverage

The suite claimed to guard "the MERGED payload from every step". It doesn't. Two **redundant** mechanisms carry values across steps:

1. react-hook-form retains unmounted fields (`shouldUnregister` is false)
2. the wizard merges `{...formData, ...stepData}`

Breaking **either one alone still passes** — I had to break both to make it fail. So `submits the merged payload` catches a total failure to accumulate, not a broken merge. I also confirmed RHF carries everything even across Back/Next navigation.

The new field-less-step case is what actually pins the merge down: that step has no react-hook-form instance, so `formData` is the only carrier left. Docblock rewritten to say what each case really covers.

## Verification

Mutation-tested, each reverted after:

| mutation | result |
|---|---|
| revert the field-less-step fix | ✗ `expected null not to be null` |
| break **only** the merge (`mergedData = {...stepData}`) | ✗ `expected {} to deeply equal {"name": "Alice"}` |

That second one is the point — the pre-existing test could not detect it.

Full `plugin-form` suite: 24 files / 218 tests pass. Product edit adds zero lint warnings; the 2 new ones are `no-explicit-any` on the new test's `as any` casts, matching the 14 pre-existing instances in that file. Pure bug fix, so no changeset per AGENTS.md §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)