### PR TITLE
fix(spec-parity): render the six Tier-1 spec values right instead of silently wrong (#2941)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -90,6 +90,7 @@
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
+    "@objectstack/spec": "^17.0.0-rc.0",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
@@ -100,7 +101,8 @@
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3",
     "vite": "^8.1.5",
-    "vite-plugin-dts": "^5.0.3"
+    "vite-plugin-dts": "^5.0.3",
+    "zod": "^4.4.3"
   },
   "keywords": [
     "objectui",

--- a/packages/components/src/__tests__/data-table-selection-mode.test.tsx
+++ b/packages/components/src/__tests__/data-table-selection-mode.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Selection mode ↔ spec vocabulary parity + behavior (#2941).
+ *
+ * `SelectionConfigSchema.type` (`ui/view.zod.ts`) publishes three names:
+ * `none | single | multiple`. The table used to treat `selectable` as a bare
+ * truthy, so a view authored with `selection.type: 'single'` rendered the full
+ * multi-select UX — per-row checkboxes that accumulate AND a select-all
+ * header. The output looked right and wasn't: `single` was never
+ * distinguished from `multiple`.
+ *
+ * Contract under test:
+ * - parity: the table's declared mode set equals the spec enum, both ways;
+ * - `single` offers no select-all and replaces the selection on each pick;
+ * - `multiple` (and legacy `true`) keeps the accumulate + select-all UX.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SelectionConfigSchema } from '@objectstack/spec/ui';
+import { renderComponent } from './test-utils';
+import { SUPPORTED_SELECTION_MODES } from '../renderers/complex/data-table';
+
+beforeAll(async () => {
+  await import('../renderers');
+}, 30000);
+
+/** The spec's selection vocabulary, read through the `.default()` wrapper. */
+function specSelectionModes(): string[] {
+  const typeSchema = (SelectionConfigSchema as unknown as { shape?: Record<string, unknown> })
+    .shape?.type as { def?: { innerType?: { options?: readonly string[] } } } | undefined;
+  const options = typeSchema?.def?.innerType?.options;
+  return Array.isArray(options) ? [...options] : [];
+}
+
+const baseSchema = {
+  type: 'data-table' as const,
+  columns: [{ header: 'Name', accessorKey: 'name' }],
+  data: [
+    { id: '1', name: 'Alice' },
+    { id: '2', name: 'Bob' },
+    { id: '3', name: 'Carol' },
+  ],
+  pagination: false,
+  searchable: false,
+};
+
+describe('data-table selection mode covers the spec selection vocabulary', () => {
+  const specNames = specSelectionModes();
+
+  it('reads a non-empty enum from the spec', () => {
+    expect(specNames, 'could not read SelectionConfigSchema.shape.type options from the spec').not.toEqual([]);
+  });
+
+  it('implements every selection mode the spec accepts', () => {
+    const unimplemented = specNames.filter((name) => !SUPPORTED_SELECTION_MODES.has(name));
+    expect(
+      unimplemented,
+      'these pass schema validation but render an undistinguished selection UX — implement them in data-table',
+    ).toEqual([]);
+  });
+
+  it('does not accept selection modes the spec rejects', () => {
+    const extra = [...SUPPORTED_SELECTION_MODES].filter((name) => !specNames.includes(name));
+    expect(
+      extra,
+      'these are renderer-local dialect — promote them into @objectstack/spec instead',
+    ).toEqual([]);
+  });
+});
+
+describe('data-table selection behavior per mode', () => {
+  it("'single' renders no select-all header and replaces the selection on each pick", () => {
+    const onSelectionChange = vi.fn();
+    const { getAllByRole } = renderComponent({
+      ...baseSchema,
+      selectable: 'single',
+      onSelectionChange,
+    } as any);
+
+    // 3 rows → exactly 3 checkboxes; a select-all header would make it 4.
+    const checkboxes = getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(3);
+
+    fireEvent.click(checkboxes[0]);
+    expect(onSelectionChange).toHaveBeenLastCalledWith([expect.objectContaining({ name: 'Alice' })]);
+
+    // Picking Bob must REPLACE Alice, never accumulate to two rows.
+    fireEvent.click(checkboxes[1]);
+    expect(onSelectionChange).toHaveBeenLastCalledWith([expect.objectContaining({ name: 'Bob' })]);
+  });
+
+  it("'single' allows deselecting the picked row", () => {
+    const onSelectionChange = vi.fn();
+    const { getAllByRole } = renderComponent({
+      ...baseSchema,
+      selectable: 'single',
+      onSelectionChange,
+    } as any);
+
+    const checkboxes = getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[0]);
+    expect(onSelectionChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it("'multiple' keeps the select-all header and accumulates picks", () => {
+    const onSelectionChange = vi.fn();
+    const { getAllByRole } = renderComponent({
+      ...baseSchema,
+      selectable: 'multiple',
+      onSelectionChange,
+    } as any);
+
+    // 3 rows + the select-all header.
+    const checkboxes = getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(4);
+
+    // First checkbox is the header select-all; rows follow.
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(checkboxes[2]);
+    expect(onSelectionChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ name: 'Alice' }),
+      expect.objectContaining({ name: 'Bob' }),
+    ]);
+  });
+
+  it('legacy `selectable: true` still means multi-select', () => {
+    const { getAllByRole } = renderComponent({
+      ...baseSchema,
+      selectable: true,
+    } as any);
+    expect(getAllByRole('checkbox')).toHaveLength(4);
+  });
+
+  it("'none' renders no selection column", () => {
+    const { queryAllByRole } = renderComponent({
+      ...baseSchema,
+      selectable: 'none',
+    } as any);
+    expect(queryAllByRole('checkbox')).toHaveLength(0);
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -289,13 +289,38 @@ export const DataTableBuiltinRowActionItem: React.FC<{
 };
 
 /**
+ * The selection modes this table implements — the renderer half of the spec's
+ * `SelectionConfigSchema.type` vocabulary (`ui/view.zod.ts`). Kept as an
+ * explicit export so a parity test can fail the moment either side moves
+ * (#2941; template: plugin-grid `summary-spec-parity.test.ts`).
+ */
+export const SUPPORTED_SELECTION_MODES: ReadonlySet<string> = new Set(['none', 'single', 'multiple']);
+
+type SelectionMode = 'none' | 'single' | 'multiple';
+
+/**
+ * Resolve the `selectable` prop — `boolean | 'single' | 'multiple'` (plus
+ * `'none'` arriving verbatim from raw SDUI JSON) — to a selection mode.
+ * `'single'` is a real mode (replace-on-select, no select-all), not a truthy
+ * alias for `'multiple'`; collapsing the two rendered per-row checkboxes AND
+ * a select-all header for `selection.type: 'single'` (#2941). Legacy `true`
+ * and unrecognized truthy strings keep their historical multi-select meaning.
+ */
+function resolveSelectionMode(selectable: DataTableSchema['selectable'] | 'none'): SelectionMode {
+  if (selectable === 'single') return 'single';
+  if (selectable === 'none' || !selectable) return 'none';
+  return 'multiple';
+}
+
+/**
  * Enterprise-level data table component with Airtable-like features.
  *
  * Provides comprehensive table functionality including:
  * - Multi-column sorting (ascending/descending/none)
  * - Real-time search across all columns
  * - Pagination with configurable page sizes
- * - Row selection with persistence across pages
+ * - Row selection with persistence across pages (multi-select), or
+ *   replace-on-select when the view declares `selection.type: 'single'`
  * - CSV export of filtered/sorted data
  * - Row action buttons (edit/delete)
  * 
@@ -337,7 +362,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     onPageChange,
     onPageSizeChange,
     searchable = true,
-    selectable = false,
+    selectable: selectableProp = false,
     showSelectionCount = true,
     selectionResetKey,
     sortable = true,
@@ -358,6 +383,11 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     borderless = false,
     disableInnerScroll = false,
   } = schema;
+
+  // 'single' caps the selection at one row (replace-on-select) and drops the
+  // select-all header; every truthy legacy value keeps meaning 'multiple'.
+  const selectionMode = resolveSelectionMode(selectableProp);
+  const selectable = selectionMode !== 'none';
 
   // Ambient design-surface affordance: when a host (Studio) provides it, render
   // a trailing "+ add field" column header. `null` for every runtime table, so
@@ -699,7 +729,9 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   };
 
   const handleSelectRow = (rowId: any, checked: boolean) => {
-    const newSelected = new Set(selectedRowIds);
+    // Single mode replaces the previous selection instead of accumulating —
+    // the spec's 'single' must never hold two rows (#2941).
+    const newSelected = new Set(selectionMode === 'single' ? [] : selectedRowIds);
     if (checked) {
       newSelected.add(rowId);
     } else {
@@ -1283,10 +1315,15 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
             <TableRow ref={headerRowRef}>
               {selectable && (
                 <TableHead className={cn("w-10 bg-background px-3", frozenColumns > 0 && "sticky left-0 z-20")}>
-                  <Checkbox
-                    checked={allPageRowsSelected ? true : somePageRowsSelected ? 'indeterminate' : false}
-                    onCheckedChange={handleSelectAll}
-                  />
+                  {/* Select-all is a multi-select affordance; a 'single' view
+                      keeps the column (alignment) but offers no way to select
+                      more than one row (#2941). */}
+                  {selectionMode === 'multiple' && (
+                    <Checkbox
+                      checked={allPageRowsSelected ? true : somePageRowsSelected ? 'indeterminate' : false}
+                      onCheckedChange={handleSelectAll}
+                    />
+                  )}
                 </TableHead>
               )}
               {showRowNumbers && (

--- a/packages/plugin-dashboard/package.json
+++ b/packages/plugin-dashboard/package.json
@@ -42,6 +42,7 @@
     "react-grid-layout": "^2.2.0 || ^1.4.0"
   },
   "devDependencies": {
+    "@objectstack/spec": "^17.0.0-rc.0",
     "@types/react-grid-layout": "^2.1.0",
     "@vitejs/plugin-react": "^6.0.4",
     "react-grid-layout": "^2.2.3",

--- a/packages/plugin-dashboard/src/PivotTable.tsx
+++ b/packages/plugin-dashboard/src/PivotTable.tsx
@@ -97,6 +97,17 @@ function displayKey(key: string, labels?: Record<string, string>): string {
   return labels?.[key] ?? key;
 }
 
+/**
+ * The aggregations this pivot computes — the renderer half of the spec's
+ * `ChartAggregateFunctionSchema` (`ui/chart.zod.ts`), the UI-side subset the
+ * spec deliberately carved out of the engine's 8-name `AggregationFunction`.
+ * Engine-level names (`count_distinct`, `array_agg`, `string_agg`) used to
+ * fall into a `default:` branch that returned a SUM — a plausible wrong total
+ * with no signal (#2941). They now short-circuit to a visible notice before
+ * any cell is computed. Exported for the spec-parity test.
+ */
+export const PIVOT_AGGREGATIONS: ReadonlySet<string> = new Set(['sum', 'count', 'avg', 'min', 'max']);
+
 /** Aggregate an array of numbers with the given function. */
 function aggregate(values: number[], fn: PivotAggregation): number {
   if (values.length === 0) return 0;
@@ -112,7 +123,10 @@ function aggregate(values: number[], fn: PivotAggregation): number {
     case 'max':
       return Math.max(...values);
     default:
-      return values.reduce((a, b) => a + b, 0);
+      // Unreachable: the component refuses to render out-of-vocabulary
+      // aggregations. NaN (never a silent sum) is the tripwire if a new call
+      // site skips that gate.
+      return Number.NaN;
   }
 }
 
@@ -227,6 +241,26 @@ export const PivotTable: React.FC<PivotTableProps> = ({ schema, className, rowLa
   }, [data, rowField, columnField, valueField, aggregation]);
 
   const fmt = (v: number) => formatValue(v, format);
+
+  // Out-of-vocabulary aggregation (e.g. the engine-level `count_distinct`
+  // arriving through untyped SDUI JSON): refuse loudly instead of quietly
+  // summing every cell (#2941). Placed after the hooks so their order stays
+  // stable across renders.
+  if (!PIVOT_AGGREGATIONS.has(aggregation)) {
+    return (
+      <div className={cn('overflow-auto', className)} data-testid="pivot-unsupported-aggregation">
+        {title && (
+          <h3 className="text-sm font-semibold mb-2">{title}</h3>
+        )}
+        <div role="alert" className="flex flex-col items-center justify-center py-8 text-destructive">
+          <p className="text-xs">
+            Unsupported aggregation &ldquo;{String(aggregation)}&rdquo; — this pivot table renders{' '}
+            {[...PIVOT_AGGREGATIONS].join(', ')}.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (data.length === 0) {
     return (

--- a/packages/plugin-dashboard/src/__tests__/pivot-aggregation-spec-parity.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/pivot-aggregation-spec-parity.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pivot aggregation ↔ spec vocabulary parity + behavior (#2941).
+ *
+ * `ChartAggregateFunctionSchema` (`ui/chart.zod.ts`) is the UI-side
+ * aggregation vocabulary — the five names the spec deliberately carved out of
+ * the engine's 8-name `AggregationFunction` because client renderers
+ * implement exactly these. The pivot's `default:` branch used to return a
+ * SUM for anything else, so `aggregation: 'count_distinct'` (an engine name
+ * that validates on engine surfaces) produced a plausible wrong total with
+ * no signal anywhere.
+ *
+ * Contract under test:
+ * - parity: the pivot's implemented set equals the spec enum, both ways;
+ * - an out-of-vocabulary aggregation renders a visible notice, never numbers.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ChartAggregateFunctionSchema } from '@objectstack/spec/ui';
+import { PivotTable, PIVOT_AGGREGATIONS } from '../PivotTable';
+
+const baseSchema = {
+  type: 'pivot' as const,
+  rowField: 'region',
+  columnField: 'quarter',
+  valueField: 'amount',
+  data: [
+    { region: 'East', quarter: 'Q1', amount: 10 },
+    { region: 'East', quarter: 'Q1', amount: 10 },
+    { region: 'West', quarter: 'Q1', amount: 5 },
+  ],
+};
+
+describe('PivotTable covers the spec UI aggregation vocabulary', () => {
+  const rawOptions = (ChartAggregateFunctionSchema as unknown as { options?: readonly string[] }).options;
+  const specNames: string[] = Array.isArray(rawOptions) ? [...rawOptions] : [];
+
+  it('reads a non-empty enum from the spec', () => {
+    expect(specNames, 'could not read ChartAggregateFunctionSchema.options from the spec').not.toEqual([]);
+  });
+
+  it('implements every aggregation the spec accepts', () => {
+    const unimplemented = specNames.filter((name) => !PIVOT_AGGREGATIONS.has(name));
+    expect(
+      unimplemented,
+      'these pass schema validation but refuse to render — implement them in PivotTable.aggregate',
+    ).toEqual([]);
+  });
+
+  it('does not accept aggregations the spec rejects', () => {
+    const extra = [...PIVOT_AGGREGATIONS].filter((name) => !specNames.includes(name));
+    expect(
+      extra,
+      'these are renderer-local dialect — promote them into @objectstack/spec instead',
+    ).toEqual([]);
+  });
+});
+
+describe('PivotTable refuses out-of-vocabulary aggregations', () => {
+  it("renders a visible notice for 'count_distinct' instead of silently summing", () => {
+    render(<PivotTable schema={{ ...baseSchema, aggregation: 'count_distinct' as any }} />);
+
+    expect(screen.getByTestId('pivot-unsupported-aggregation')).toBeInTheDocument();
+    expect(screen.getByRole('alert').textContent).toContain('count_distinct');
+    // The wrong-total failure mode: 2×10 rows would sum to "20".
+    expect(screen.queryByText('20')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('still renders every supported aggregation as a table', () => {
+    for (const aggregation of PIVOT_AGGREGATIONS) {
+      const { unmount, container } = render(
+        <PivotTable schema={{ ...baseSchema, aggregation: aggregation as any }} />,
+      );
+      expect(container.querySelector('table'), `aggregation '${aggregation}' should render a table`).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it('defaults to sum when no aggregation is authored', () => {
+    render(<PivotTable schema={{ ...baseSchema }} />);
+    expect(screen.getByText('20')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1620,6 +1620,10 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     // Auto-enable multi-select when bulk actions exist
     selectionMode = 'multiple';
   }
+  // `selection.type: 'single'` caps the selection at one row (the data-table
+  // enforces replace-on-select, #2941), so the cross-page "select all N
+  // matching" escalation must never be offered.
+  const singleSelection = selectionMode === 'single';
 
   // Resolve the rows the bulk action should actually operate on. When
   // "select all N matching" is active, fan out a paged find against the
@@ -2522,9 +2526,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
                 onActionDef={dispatchBulkActionDef}
                 onClearSelection={() => { setSelectedRows([]); setSelectAllMatching(false); }}
                 pageSize={data.length}
-                totalMatching={totalMatching}
+                totalMatching={singleSelection ? undefined : totalMatching}
                 allMatchingSelected={selectAllMatching}
-                onSelectAllMatching={() => setSelectAllMatching(true)}
+                onSelectAllMatching={singleSelection ? undefined : () => setSelectAllMatching(true)}
               />
             </div>
           }
@@ -2559,9 +2563,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
         onActionDef={dispatchBulkActionDef}
         onClearSelection={() => { setSelectedRows([]); setSelectAllMatching(false); }}
         pageSize={data.length}
-        totalMatching={totalMatching}
+        totalMatching={singleSelection ? undefined : totalMatching}
         allMatchingSelected={selectAllMatching}
-        onSelectAllMatching={() => setSelectAllMatching(true)}
+        onSelectAllMatching={singleSelection ? undefined : () => setSelectAllMatching(true)}
       />
       {navigation.isOverlay && (
         <NavigationOverlay

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -183,6 +183,31 @@ function formatActionLabel(action: string): string {
 }
 
 /**
+ * Resolve the spec `AddRecordConfigSchema.position` (`ui/view.zod.ts`:
+ * `top | bottom | both`) to the two render slots. A binary ternary used to
+ * collapse `both` to `top`, so the bottom button never rendered (#2941).
+ *
+ * An absent or unrecognized value keeps this renderer's historical `top`
+ * placement. (The spec's own default is `bottom`; spec-parsed metadata
+ * arrives with it materialized, but raw stored JSON predating the spec
+ * default relied on `top` — moving it is a UX change out of scope here.)
+ *
+ * Exported for the spec-parity test, which fails the moment the spec's
+ * position vocabulary and this mapping drift in either direction.
+ */
+export function resolveAddRecordPlacement(position: unknown): { top: boolean; bottom: boolean } {
+  switch (position) {
+    case 'bottom':
+      return { top: false, bottom: true };
+    case 'both':
+      return { top: true, bottom: true };
+    case 'top':
+    default:
+      return { top: true, bottom: false };
+  }
+}
+
+/**
  * Normalize an array of filter conditions, expanding `in`/`not in` operators
  * and ensuring consistent AST structure.
  */
@@ -414,6 +439,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     // buttons on every existing view.)
     const ua = schema.userActions as Record<string, boolean | undefined> | undefined;
     const addRecordEnabled = schema.addRecord?.enabled === true && ua?.addRecordForm !== false;
+    const addRecordPlacement = resolveAddRecordPlacement(schema.addRecord?.position);
     return {
       showSearch: ua?.search !== false,
       showSort: ua?.sort !== false,
@@ -424,8 +450,12 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       showHideFields: ua?.hideFields === true,
       showColor: ua?.rowColor === true,
       compactToolbar: schema.compactToolbar === true,
+      // Position-independent switch (empty-state CTA) + the two placement
+      // slots. `position: 'both'` renders both buttons — it used to collapse
+      // to `top` through a binary ternary (#2941).
       showAddRecord: addRecordEnabled,
-      addRecordPosition: (schema.addRecord?.position === 'bottom' ? 'bottom' : 'top') as 'top' | 'bottom',
+      showAddRecordTop: addRecordEnabled && addRecordPlacement.top,
+      showAddRecordBottom: addRecordEnabled && addRecordPlacement.bottom,
     };
   }, [schema.userActions, schema.compactToolbar, schema.addRecord]);
 
@@ -2367,7 +2397,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           )}
 
           {/* Add Record (top position) */}
-          {toolbarFlags.showAddRecord && toolbarFlags.addRecordPosition === 'top' && (
+          {toolbarFlags.showAddRecordTop && (
             <Button
               variant="ghost"
               size="sm"
@@ -2504,7 +2534,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       </div>
 
       {/* Add Record (bottom position) */}
-      {toolbarFlags.showAddRecord && toolbarFlags.addRecordPosition === 'bottom' && (
+      {toolbarFlags.showAddRecordBottom && (
         <div className="border-t px-2 sm:px-4 py-1 bg-background shrink-0">
           <Button
             variant="ghost"

--- a/packages/plugin-list/src/UserFilters.tsx
+++ b/packages/plugin-list/src/UserFilters.tsx
@@ -47,6 +47,28 @@ interface ResolvedField {
 
 const LOOKUP_LIKE_TYPES = new Set(['lookup', 'master_detail', 'user', 'owner']);
 
+/**
+ * Selection arity for every filter control type the spec's
+ * `UserFilterFieldSchema.type` (`ui/view.zod.ts`) publishes. The enum names
+ * BOTH `select` and `multi-select`, so `select` necessarily means
+ * single-choice — rendering it as accumulating checkboxes made a single-choice
+ * filter silently accept many values (#2941).
+ *
+ * Applies to the AUTHORED `type` only: when the author omits it, the control
+ * is inferred from the field definition and keeps the historical multi-check
+ * UX. Exported for the spec-parity test, which fails the moment the spec's
+ * vocabulary and this table drift in either direction.
+ */
+export const FILTER_CONTROL_ARITY: Record<string, 'single' | 'multiple'> = {
+  select: 'single',
+  'multi-select': 'multiple',
+  boolean: 'multiple',
+  // Dead controls today (their popovers render "No options" — #2942); their
+  // arity is still declared so the vocabulary stays fully mapped.
+  'date-range': 'single',
+  text: 'single',
+};
+
 export interface UserFiltersProps {
   config: NonNullable<ListViewSchema['userFilters']>;
   /** Object definition for auto-deriving field options */
@@ -289,6 +311,14 @@ function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, 
   const { fieldLabel, translateOptions } = useSafeFieldLabel();
   const moreLabel = useMoreLabel();
   const objectName: string | undefined = objectDef?.name;
+  // Fields whose AUTHORED control type is single-choice (`type: 'select'`).
+  // Keyed off the raw config, not the resolved field: `resolveFields` back-fills
+  // `type` from the object definition, and an inferred type must keep the
+  // historical multi-check UX (#2941).
+  const singleChoiceFields = React.useMemo(
+    () => new Set(fields.filter(f => FILTER_CONTROL_ARITY[f.type ?? ''] === 'single').map(f => f.field)),
+    [fields],
+  );
   const [selectedValues, setSelectedValues] = React.useState<
     Record<string, (string | number | boolean)[]>
   >(() => {
@@ -301,6 +331,11 @@ function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, 
       const restored = initialSelections?.[f.field];
       if (restored && restored.length > 0) {
         init[f.field] = restored;
+      }
+      // A single-choice control can never hold more than one value, whatever
+      // an author default or a hand-edited URL claims.
+      if (singleChoiceFields.has(f.field) && (init[f.field]?.length ?? 0) > 1) {
+        init[f.field] = init[f.field].slice(0, 1);
       }
     });
     return init;
@@ -389,6 +424,7 @@ function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, 
   const renderBadge = (f: ResolvedField) => {
     const selected = selectedValues[f.field] || [];
     const hasSelection = selected.length > 0;
+    const singleChoice = singleChoiceFields.has(f.field);
     const isLookupLike =
       LOOKUP_LIKE_TYPES.has(f.type || '') &&
       f.options.length === 0 &&
@@ -467,15 +503,21 @@ function DropdownFilters({ fields, objectDef, data, onFilterChange, maxVisible, 
                     )}
                   >
                     <input
-                      type="checkbox"
+                      type={singleChoice ? 'radio' : 'checkbox'}
+                      name={singleChoice ? `user-filter-${f.field}` : undefined}
                       checked={selected.includes(opt.value)}
                       onChange={() => {
-                        const next = selected.includes(opt.value)
-                          ? selected.filter(v => v !== opt.value)
-                          : [...selected, opt.value];
+                        // Single-choice replaces the selection; multi toggles
+                        // the clicked value in place (#2941). Clearing a
+                        // single-choice pick is the badge ×.
+                        const next = singleChoice
+                          ? [opt.value]
+                          : selected.includes(opt.value)
+                            ? selected.filter(v => v !== opt.value)
+                            : [...selected, opt.value];
                         handleChange(f.field, next);
                       }}
-                      className="rounded border-input"
+                      className={singleChoice ? 'border-input' : 'rounded border-input'}
                     />
                     {opt.color && (
                       <span

--- a/packages/plugin-list/src/__tests__/add-record-position-spec-parity.test.tsx
+++ b/packages/plugin-list/src/__tests__/add-record-position-spec-parity.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Add-record placement ↔ spec vocabulary parity + behavior (#2941).
+ *
+ * `AddRecordConfigSchema.position` (`ui/view.zod.ts`) publishes
+ * `top | bottom | both`. The toolbar used a binary ternary
+ * (`position === 'bottom' ? 'bottom' : 'top'`), so `both` validated and then
+ * silently rendered only the top button — the bottom one never existed.
+ *
+ * Contract under test:
+ * - parity: every spec position resolves to a distinct placement, and the
+ *   resolver is exactly the spec vocabulary plus the documented fallback;
+ * - behavior: `both` renders two add-record buttons, `top`/`bottom` one each.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { AddRecordConfigSchema } from '@objectstack/spec/ui';
+import { ListView, resolveAddRecordPlacement } from '../ListView';
+import type { ListViewSchema } from '@object-ui/types';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: (() => {
+      let store: Record<string, string> = {};
+      return {
+        getItem: (k: string) => store[k] ?? null,
+        setItem: (k: string, v: string) => { store[k] = v; },
+        clear: () => { store = {}; },
+        removeItem: (k: string) => { delete store[k]; },
+      };
+    })(),
+    configurable: true,
+  });
+});
+
+/** The spec's position vocabulary, read through the `.default()` wrapper. */
+function specPositions(): string[] {
+  const positionSchema = (AddRecordConfigSchema as unknown as { shape?: Record<string, unknown> })
+    .shape?.position as { def?: { innerType?: { options?: readonly string[] } } } | undefined;
+  const options = positionSchema?.def?.innerType?.options;
+  return Array.isArray(options) ? [...options] : [];
+}
+
+describe('resolveAddRecordPlacement covers the spec position vocabulary', () => {
+  const specNames = specPositions();
+
+  it('reads a non-empty enum from the spec', () => {
+    expect(specNames, 'could not read AddRecordConfigSchema.shape.position options from the spec').not.toEqual([]);
+  });
+
+  it('gives every spec position a placement that matches its name', () => {
+    const placements = Object.fromEntries(specNames.map((name) => [name, resolveAddRecordPlacement(name)]));
+    expect(placements).toEqual({
+      top: { top: true, bottom: false },
+      bottom: { top: false, bottom: true },
+      both: { top: true, bottom: true },
+    });
+  });
+
+  it('keeps the historical top placement for absent/unknown values', () => {
+    expect(resolveAddRecordPlacement(undefined)).toEqual({ top: true, bottom: false });
+    expect(resolveAddRecordPlacement('sideways')).toEqual({ top: true, bottom: false });
+  });
+});
+
+function makeDataSource() {
+  const find = vi.fn().mockResolvedValue({ data: [{ id: '1', name: 'A' }], total: 1 });
+  return {
+    find,
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  } as any;
+}
+
+function renderList(schema: Partial<ListViewSchema>, ds: any) {
+  return render(
+    <SchemaRendererProvider dataSource={ds}>
+      <ListView
+        schema={{ type: 'list-view', objectName: 'proj', fields: ['name'], ...schema } as any}
+        dataSource={ds}
+      />
+    </SchemaRendererProvider>,
+  );
+}
+
+describe("addRecord.position 'both' renders both buttons", () => {
+  it("renders two add-record buttons for position 'both'", async () => {
+    const ds = makeDataSource();
+    renderList({ addRecord: { enabled: true, position: 'both' } as any }, ds);
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getAllByTestId('add-record-button')).toHaveLength(2));
+  });
+
+  it("renders one button for 'top' and one for 'bottom'", async () => {
+    const ds = makeDataSource();
+    const { unmount } = renderList({ addRecord: { enabled: true, position: 'top' } as any }, ds);
+    await waitFor(() => expect(screen.getAllByTestId('add-record-button')).toHaveLength(1));
+    unmount();
+
+    const ds2 = makeDataSource();
+    renderList({ addRecord: { enabled: true, position: 'bottom' } as any }, ds2);
+    await waitFor(() => expect(screen.getAllByTestId('add-record-button')).toHaveLength(1));
+  });
+});

--- a/packages/plugin-list/src/__tests__/user-filter-arity-spec-parity.test.tsx
+++ b/packages/plugin-list/src/__tests__/user-filter-arity-spec-parity.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * User-filter control arity ↔ spec vocabulary parity + behavior (#2941).
+ *
+ * `UserFilterFieldSchema.type` (`ui/view.zod.ts`) names both `select` and
+ * `multi-select`, so `select` necessarily means single-choice. The dropdown
+ * filter used to render accumulating checkboxes for every control type — a
+ * single-choice filter silently accepted many values, and the emitted
+ * condition looked plausible (`['status', 'in', [a, b]]`) while contradicting
+ * the authored contract.
+ *
+ * Contract under test:
+ * - parity: `FILTER_CONTROL_ARITY` maps exactly the spec's vocabulary;
+ * - authored `type: 'select'` renders radios and replaces the pick;
+ * - authored `type: 'multi-select'` (and an omitted, inferred type) keeps
+ *   accumulating checkboxes;
+ * - restored/default selections for a single-choice control clamp to one.
+ */
+import * as React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UserFilterFieldSchema } from '@objectstack/spec/ui';
+import { UserFilters, FILTER_CONTROL_ARITY } from '../UserFilters';
+
+const objectDef = {
+  name: 'tasks',
+  fields: {
+    status: {
+      type: 'select',
+      label: 'Status',
+      options: [
+        { label: 'To Do', value: 'todo' },
+        { label: 'Doing', value: 'doing' },
+        { label: 'Done', value: 'done' },
+      ],
+    },
+  },
+};
+
+/** The spec's control-type vocabulary, read through the `.optional()` wrapper. */
+function specControlTypes(): string[] {
+  const typeSchema = (UserFilterFieldSchema as unknown as { shape?: Record<string, unknown> })
+    .shape?.type as { def?: { innerType?: { options?: readonly string[] } } } | undefined;
+  const options = typeSchema?.def?.innerType?.options;
+  return Array.isArray(options) ? [...options] : [];
+}
+
+describe('FILTER_CONTROL_ARITY covers the spec user-filter control vocabulary', () => {
+  const specNames = specControlTypes();
+
+  it('reads a non-empty enum from the spec', () => {
+    expect(specNames, 'could not read UserFilterFieldSchema.shape.type options from the spec').not.toEqual([]);
+  });
+
+  it('declares an arity for every control type the spec accepts', () => {
+    const undeclared = specNames.filter((name) => !(name in FILTER_CONTROL_ARITY));
+    expect(
+      undeclared,
+      'these pass schema validation with no declared selection arity — add them to FILTER_CONTROL_ARITY',
+    ).toEqual([]);
+  });
+
+  it('does not declare control types the spec rejects', () => {
+    const extra = Object.keys(FILTER_CONTROL_ARITY).filter((name) => !specNames.includes(name));
+    expect(
+      extra,
+      'these are renderer-local dialect — promote them into @objectstack/spec instead',
+    ).toEqual([]);
+  });
+});
+
+describe("filter type 'select' is single-choice", () => {
+  it('renders radios and replaces the pick instead of accumulating', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'status', type: 'select' }] } as any}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-badge-status'));
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+
+    fireEvent.click(screen.getByText('To Do'));
+    expect(onFilterChange).toHaveBeenLastCalledWith([['status', 'in', ['todo']]]);
+
+    // Picking a second option REPLACES the first — never two values at once.
+    fireEvent.click(screen.getByText('Done'));
+    expect(onFilterChange).toHaveBeenLastCalledWith([['status', 'in', ['done']]]);
+  });
+
+  it("authored 'multi-select' keeps accumulating checkboxes", () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'status', type: 'multi-select' }] } as any}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-badge-status'));
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+
+    fireEvent.click(screen.getByText('To Do'));
+    fireEvent.click(screen.getByText('Done'));
+    expect(onFilterChange).toHaveBeenLastCalledWith([['status', 'in', ['todo', 'done']]]);
+  });
+
+  it('an omitted (inferred) type keeps the historical multi-check UX', () => {
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'status' }] } as any}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-badge-status'));
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  });
+
+  it('clamps a multi-value restored selection to one value', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ element: 'dropdown', fields: [{ field: 'status', type: 'select' }] } as any}
+        objectDef={objectDef}
+        data={[]}
+        onFilterChange={onFilterChange}
+        initialSelections={{ status: ['todo', 'done'] }}
+      />,
+    );
+
+    expect(onFilterChange).toHaveBeenLastCalledWith([['status', 'in', ['todo']]]);
+  });
+});

--- a/packages/plugin-report/package.json
+++ b/packages/plugin-report/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
+    "@objectstack/spec": "^17.0.0-rc.0",
     "@types/node": "^26.1.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -11,7 +11,10 @@
  * use, so the numbers (and the server-resolved dimension display labels)
  * match everywhere.
  *
- * - `summary` / `tabular` → one grouped table (`rows` + `values`).
+ * - `tabular` → the selection as a simple list (`rows` + `values`), no totals.
+ * - `summary` → the same table plus a SERVER-computed grand-total footer
+ *   (`totals: { groupings: [[]] }`) — the declared type picks the branch
+ *   (#2941), the data shape never does.
  * - `matrix` → a true cross-tab (ADR-0021 D2): `rows` down × `columns`
  *   across, measures in the cells. One dataset query over all dimensions,
  *   pivoted client-side. Totals (per-row subtotals, per-column subtotals,
@@ -359,7 +362,18 @@ function NoRows() {
 
 const DRILL_CLASS = 'cursor-pointer hover:bg-accent/40';
 
-/** One dataset-bound table: fetch via `queryDataset`, render `rows` + `values`. */
+/**
+ * One dataset-bound table: fetch via `queryDataset`, render `rows` + `values`.
+ *
+ * `withTotals` is what tells a `summary` report ("grouped by row") apart from
+ * a `tabular` one ("simple list") at the same selection (#2941): a summary
+ * additionally asks the SAME query for its grand total
+ * (`totals: { groupings: [[]] }`) and renders it as a footer row. The total is
+ * server-aggregated — never recombined from the bucket rows here, which the
+ * ADR-0021 governance red line forbids (an `avg` cannot be recombined) — so an
+ * older server that returns no `totals` renders the plain table, exactly like
+ * the matrix path.
+ */
 function DatasetReportTable({
   dataset,
   rows,
@@ -368,6 +382,7 @@ function DatasetReportTable({
   dataSource,
   onDrill,
   order,
+  withTotals,
 }: {
   dataset: string;
   rows: string[];
@@ -376,9 +391,21 @@ function DatasetReportTable({
   dataSource?: unknown;
   onDrill?: (args: DatasetDrillArgs) => void;
   order?: SelectionOrder;
+  withTotals?: boolean;
 }) {
-  const state = useDatasetRows(dataset, rows, values, runtimeFilter, dataSource, undefined, order);
+  // With no grouping dimensions the single result row already IS the grand
+  // total — requesting totals would only duplicate it.
+  const state = useDatasetRows(
+    dataset,
+    rows,
+    values,
+    runtimeFilter,
+    dataSource,
+    withTotals && rows.length > 0 ? [[]] : undefined,
+    order,
+  );
   const { fieldLabel } = useSafeFieldLabel();
+  const tt = useSafeTranslate();
 
   if (values.length === 0) return <EmptyMeasures dataset={dataset} />;
   if (state.status === 'loading' || state.status === 'idle') return <FetchStates status={state.status} />;
@@ -410,6 +437,11 @@ function DatasetReportTable({
 
   const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
   const columns = [...rows, ...values];
+  // Server-supplied grand total (`dimensions: []`); absent → no totals row.
+  const grandTotal = withTotals
+    ? state.totals?.find((t) => Array.isArray(t.dimensions) && t.dimensions.length === 0)?.rows?.[0]
+    : undefined;
+  const totalText = tt('report.total', 'Total');
   return (
     <div className="overflow-auto max-h-[70vh] rounded-md border">
       <table className="w-full text-xs">
@@ -439,6 +471,20 @@ function DatasetReportTable({
               ))}
             </tr>
           ))}
+          {grandTotal && (
+            <tr className="border-t bg-muted/30 font-medium" data-testid="dataset-report-total-row">
+              {rows.length > 0 && (
+                <td colSpan={rows.length} className="px-2 py-1 whitespace-nowrap">
+                  {totalText}
+                </td>
+              )}
+              {values.map((measure) => (
+                <td key={measure} className="px-2 py-1 tabular-nums whitespace-nowrap">
+                  {formatMeasure(grandTotal[measure], measureField(measure)?.format, measureField(measure)?.currency)}
+                </td>
+              ))}
+            </tr>
+          )}
         </tbody>
       </table>
     </div>
@@ -446,31 +492,88 @@ function DatasetReportTable({
 }
 
 /**
- * Report chart type → the generic chart component's `chartType`. Families that
- * aren't a cartesian/categorical series (gauge / kpi / metric / funnel /
- * treemap / sankey / bullet / table / pivot) fall back to a bar so the
- * visualization still renders; the grouped table beneath always carries the
- * exact numbers, so the fallback never hides data.
+ * Resolve a report's declared `type` — the spec's `ReportType`
+ * (`ui/report.zod.ts`: `tabular | summary | matrix | joined`) — to the
+ * presentation it renders. The DECLARED type picks the branch; it is never
+ * inferred from the data shape. Before this, `tabular` and `summary` shared
+ * one branch and the visual difference was read off whether `rows` happened
+ * to be non-empty — a `tabular` report that declared `rows` silently rendered
+ * exactly like a `summary` (#2941). An absent/out-of-spec value falls back to
+ * `tabular`, the spec's own declared default.
+ *
+ * Exported for the spec-parity test, which fails the moment `ReportType` and
+ * this dispatch drift in either direction.
  */
-function mapReportChartType(t: unknown): string {
+export function resolveReportPresentation(type: unknown): 'tabular' | 'summary' | 'matrix' | 'joined' {
+  switch (type) {
+    case 'summary':
+      return 'summary';
+    case 'matrix':
+      return 'matrix';
+    case 'joined':
+      return 'joined';
+    case 'tabular':
+    default:
+      return 'tabular';
+  }
+}
+
+/** How a report renders its embedded chart for one spec `ChartTypeSchema` value. */
+export type ReportChartPlan =
+  /** A categorical series the generic chart component draws distinctly. */
+  | { kind: 'series'; chartType: string }
+  /** Single-value family — one dimensionless dataset query, shown as a number. */
+  | { kind: 'single_value' }
+  /** Tabular family — the grouped table beneath IS the rendering; no duplicate chart. */
+  | { kind: 'tabular' }
+  /** Out-of-spec value (stored dialect / typo) — surfaced, never a silent bar. */
+  | { kind: 'unsupported'; type: string };
+
+/**
+ * Classify a report chart type into its rendering plan — every value of the
+ * spec's `ChartTypeSchema` (`ui/chart.zod.ts`, 19 names), each on the branch
+ * its family demands. The old mapping collapsed 10 of the 19 to a BAR — a
+ * plausible wrong picture with no warning (#2941). Now:
+ *
+ * - the 12 series families reach the generic chart component verbatim
+ *   (`column` is its documented vertical-bar alias; `horizontal-bar` stays
+ *   horizontal instead of silently flipping vertical);
+ * - the single-value families (`gauge` / `solid-gauge` / `metric` / `kpi` /
+ *   `bullet`) render the measure as a number — the spec's own comment calls
+ *   them "honest single-value variants pending a real dial/target renderer";
+ * - `table` / `pivot` add no duplicate chart: the grouped table that always
+ *   renders beneath the chart slot is exactly the tabular presentation;
+ * - anything else is out-of-spec and gets a visible notice.
+ *
+ * Exported for the spec-parity test, which fails the moment `ChartTypeSchema`
+ * and this classification drift in either direction.
+ */
+export function planReportChart(t: unknown): ReportChartPlan {
   switch (t) {
-    case 'line':
-      return 'line';
-    case 'area':
-      return 'area';
-    case 'pie':
-      return 'pie';
-    case 'donut':
-      return 'donut';
-    case 'radar':
-      return 'radar';
-    case 'scatter':
-      return 'scatter';
     case 'bar':
     case 'column':
     case 'horizontal-bar':
+    case 'line':
+    case 'area':
+    case 'pie':
+    case 'donut':
+    case 'funnel':
+    case 'scatter':
+    case 'treemap':
+    case 'sankey':
+    case 'radar':
+      return { kind: 'series', chartType: t };
+    case 'gauge':
+    case 'solid-gauge':
+    case 'metric':
+    case 'kpi':
+    case 'bullet':
+      return { kind: 'single_value' };
+    case 'table':
+    case 'pivot':
+      return { kind: 'tabular' };
     default:
-      return 'bar';
+      return { kind: 'unsupported', type: String(t) };
   }
 }
 
@@ -532,24 +635,52 @@ function DatasetReportChart({
 }) {
   const xAxis = typeof chart.xAxis === 'string' ? chart.xAxis : '';
   const yAxis = typeof chart.yAxis === 'string' ? chart.yAxis : '';
+  const plan = planReportChart(chart.type);
   // The chart plots a NARROWER selection than the table beneath it (one
   // dimension × one measure), so `useDatasetRows` scopes the report's order to
   // those two columns — a "biggest first" on the plotted measure still sorts
   // the bars; a key naming some other row dimension is simply not applicable
   // here and is dropped rather than posted and rejected.
+  //
+  // A single-value chart (metric / kpi / gauge…) instead queries the measure
+  // with NO dimension: the server hands back its one pre-aggregated grand
+  // total, so the number shown is governed by the semantic layer, never a
+  // client-side recombination (the ADR-0021 red line). Plans that render no
+  // chart at all select no measures, which parks the hook in `idle`.
+  const wantsQuery = plan.kind === 'series' || plan.kind === 'single_value';
   const state = useDatasetRows(
     dataset,
-    xAxis ? [xAxis] : [],
-    yAxis ? [yAxis] : [],
+    plan.kind === 'series' && xAxis ? [xAxis] : [],
+    wantsQuery && yAxis ? [yAxis] : [],
     runtimeFilter,
     dataSource,
     undefined,
     order,
   );
   const ChartComponent = useRegistryComponent('chart');
+  const { fieldLabel } = useSafeFieldLabel();
 
-  // A chart needs both an x (dimension) and y (measure); without them, skip.
-  if (!xAxis || !yAxis) return null;
+  const title = typeof chart.title === 'string' ? chart.title : undefined;
+
+  // `table` / `pivot`: the grouped table rendered beneath this slot IS the
+  // tabular presentation — a duplicate chart would say nothing new.
+  if (plan.kind === 'tabular') return null;
+  if (plan.kind === 'unsupported') {
+    // Out-of-spec chart type in stored metadata: say so instead of drawing a
+    // silently wrong bar (#2941). The table beneath still carries the numbers.
+    return (
+      <div
+        className="rounded-md border border-dashed bg-muted/20 px-3 py-2 text-xs text-muted-foreground"
+        data-testid="dataset-report-chart-unsupported"
+      >
+        Chart type &ldquo;{plan.type}&rdquo; is not a spec chart type — the grouped table below carries this report&rsquo;s numbers.
+      </div>
+    );
+  }
+
+  // A series chart needs both an x (dimension) and y (measure); a
+  // single-value chart needs only the measure. Without them, skip.
+  if (plan.kind === 'series' ? !xAxis || !yAxis : !yAxis) return null;
   if (state.status === 'loading' || state.status === 'idle') {
     return (
       <div className="flex items-center gap-2 p-4 text-xs text-muted-foreground">
@@ -559,18 +690,34 @@ function DatasetReportChart({
   }
   // On error or empty, fall back silently to the table beneath.
   if (state.status === 'error' || state.rows.length === 0) return null;
+
+  if (plan.kind === 'single_value') {
+    const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
+    const mf = measureField(yAxis);
+    return (
+      <div className="rounded-md border bg-card p-3" data-testid="dataset-report-metric">
+        {title ? <h3 className="mb-2 text-sm font-semibold">{title}</h3> : null}
+        <div className="flex flex-col gap-0.5 py-2">
+          <span className="text-2xl font-semibold tabular-nums">
+            {formatMeasure(state.rows[0]?.[yAxis], mf?.format, mf?.currency)}
+          </span>
+          <span className="text-xs text-muted-foreground">{headerLabel(yAxis)}</span>
+        </div>
+      </div>
+    );
+  }
+
   // The chart component is registered lazily; until it resolves render nothing
   // (the grouped table beneath still shows the exact numbers).
   if (!ChartComponent) return null;
 
-  const title = typeof chart.title === 'string' ? chart.title : undefined;
   return (
     <div className="rounded-md border bg-card p-3" data-testid="dataset-report-chart">
       {title ? <h3 className="mb-2 text-sm font-semibold">{title}</h3> : null}
       {/* eslint-disable-next-line react-hooks/static-components -- ChartComponent is a stable registry lookup (useRegistryComponent), not a component created during render */}
       <ChartComponent
         schema={{
-          chartType: mapReportChartType(chart.type),
+          chartType: plan.chartType,
           data: state.rows,
           xAxisKey: xAxis,
           series: [{ dataKey: yAxis }],
@@ -819,9 +966,11 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
   );
   // ADR-0021 D2: `drilldown` defaults on; the host must still supply a sink.
   const drillSink = report.drilldown === false ? undefined : onDrill;
+  // The DECLARED type drives the branch (#2941) — never the data shape.
+  const presentation = resolveReportPresentation(report.type);
 
   // Joined → a vertical stack of dataset-bound blocks.
-  if (report.type === 'joined' && Array.isArray(report.blocks)) {
+  if (presentation === 'joined' && Array.isArray(report.blocks)) {
     return (
       <div
         className={className}
@@ -837,7 +986,12 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
           // independent query over its own dataset, so there is no report-level
           // ordering to inherit here.
           const blockOrder = readOrder(block.order);
-          const blockTable = block.type === 'matrix' && blockAcross.length > 0 ? (
+          // Same type-driven dispatch as the top level: a block's declared
+          // type picks its presentation (`JoinedReportBlockSchema.type`
+          // defaults to `tabular`). A grouped block (summary, or a matrix
+          // without across-dimensions) carries the totals footer.
+          const blockPresentation = resolveReportPresentation(block.type);
+          const blockTable = blockPresentation === 'matrix' && blockAcross.length > 0 ? (
             <DatasetMatrixTable
               dataset={String(block.dataset ?? '')}
               rows={readNames(block.rows)}
@@ -857,6 +1011,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
               dataSource={dataSource}
               onDrill={drillSink}
               order={blockOrder}
+              withTotals={blockPresentation === 'summary' || blockPresentation === 'matrix'}
             />
           );
           return (
@@ -883,8 +1038,8 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
   const across = readNames(report.columns);
   const reportOrder = readOrder(report.order);
   // Matrix with an across dimension → true cross-tab; without one it
-  // degrades to the flat grouped table (pre-`columns` stored JSON).
-  if (report.type === 'matrix' && across.length > 0) {
+  // degrades to the grouped (summary) table (pre-`columns` stored JSON).
+  if (presentation === 'matrix' && across.length > 0) {
     return (
       <div className={className} data-testid="dataset-report" data-report-name={report.name}>
         <DatasetMatrixTable
@@ -901,10 +1056,13 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
     );
   }
 
-  // summary / tabular (and matrix without `columns`) → a grouped table,
-  // preceded by the embedded chart visualization when the report declares one
-  // (ADR-0021: the chart plots the dataset's yAxis measure across the xAxis
-  // dimension; the table beneath always carries the exact numbers).
+  // summary → grouped table with the server-computed totals footer;
+  // tabular → the same selection as a simple list, no totals (the declared
+  // type is what separates them, #2941). A matrix without `columns` degrades
+  // to the summary presentation — it is a grouped type. Either is preceded by
+  // the embedded chart visualization when the report declares one (ADR-0021:
+  // the chart plots the dataset's yAxis measure across the xAxis dimension;
+  // the table beneath always carries the exact numbers).
   const chartCfg =
     report.chart && typeof report.chart === 'object' && (report.chart as { type?: unknown }).type
       ? (report.chart as Record<string, unknown>)
@@ -914,6 +1072,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
       className={`${className ?? ''} flex flex-col gap-3`}
       data-testid="dataset-report"
       data-report-name={report.name}
+      data-report-presentation={presentation}
     >
       {chartCfg ? (
         <DatasetReportChart
@@ -932,6 +1091,7 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
         dataSource={dataSource}
         onDrill={drillSink}
         order={reportOrder}
+        withTotals={presentation === 'summary' || presentation === 'matrix'}
       />
     </div>
   );

--- a/packages/plugin-report/src/__tests__/report-spec-parity.test.tsx
+++ b/packages/plugin-report/src/__tests__/report-spec-parity.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Report type & chart type ↔ spec vocabulary parity + behavior (#2941).
+ *
+ * Two Tier-1 findings lived in this renderer:
+ *
+ * 1. `mapReportChartType` collapsed 10 of the 19 `ChartTypeSchema` values to
+ *    a BAR — an author who declared `funnel` or `treemap` got a plausible
+ *    wrong picture with no warning anywhere.
+ * 2. `tabular` vs `summary` was resolved from the DATA (whether `rows` was
+ *    non-empty), never from the declared type — the two types shared one
+ *    branch and the type dropdown did nothing.
+ *
+ * Contract under test:
+ * - parity: `planReportChart` classifies exactly the spec's 19 chart names
+ *   (none fall through to `unsupported`), and `resolveReportPresentation`
+ *   maps exactly the spec's 4 report types;
+ * - behavior: the classifier's families reach distinct renderings — series
+ *   types keep their name (no bar collapse), single-value types render a
+ *   number, tabular types add no duplicate chart, out-of-spec values get a
+ *   visible notice;
+ * - behavior: `summary` renders the server-computed totals footer, `tabular`
+ *   does not — same selection, distinct presentation, driven by the type.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ChartTypeSchema, ReportType } from '@objectstack/spec/ui';
+import {
+  DatasetReportRenderer,
+  planReportChart,
+  resolveReportPresentation,
+} from '../DatasetReportRenderer';
+
+const specChartTypes: string[] = (() => {
+  const raw = (ChartTypeSchema as unknown as { options?: readonly string[] }).options;
+  return Array.isArray(raw) ? [...raw] : [];
+})();
+
+const specReportTypes: string[] = (() => {
+  const raw = (ReportType as unknown as { options?: readonly string[] }).options;
+  return Array.isArray(raw) ? [...raw] : [];
+})();
+
+describe('planReportChart covers the spec chart vocabulary', () => {
+  it('reads a non-empty enum from the spec', () => {
+    expect(specChartTypes, 'could not read ChartTypeSchema.options from the spec').not.toEqual([]);
+  });
+
+  it('classifies every spec chart type onto a real branch', () => {
+    const unsupported = specChartTypes.filter((name) => planReportChart(name).kind === 'unsupported');
+    expect(
+      unsupported,
+      'these validate against ChartTypeSchema but hit the out-of-spec branch — classify them in planReportChart',
+    ).toEqual([]);
+  });
+
+  it('never collapses a non-bar series family to bar', () => {
+    const collapsed = specChartTypes.filter((name) => {
+      const plan = planReportChart(name);
+      // `column` IS the spec's vertical-bar alias — the generic chart draws
+      // it as a bar by definition, so it is exempt.
+      return plan.kind === 'series' && plan.chartType === 'bar' && name !== 'bar' && name !== 'column';
+    });
+    expect(collapsed, 'these silently drew a bar chart before #2941').toEqual([]);
+  });
+
+  it('flags an out-of-spec value instead of guessing', () => {
+    expect(planReportChart('sunburst')).toEqual({ kind: 'unsupported', type: 'sunburst' });
+  });
+});
+
+describe('resolveReportPresentation covers the spec report-type vocabulary', () => {
+  it('reads a non-empty enum from the spec', () => {
+    expect(specReportTypes, 'could not read ReportType.options from the spec').not.toEqual([]);
+  });
+
+  it('maps every spec report type onto its own presentation', () => {
+    const mapped = Object.fromEntries(specReportTypes.map((name) => [name, resolveReportPresentation(name)]));
+    expect(mapped).toEqual({
+      tabular: 'tabular',
+      summary: 'summary',
+      matrix: 'matrix',
+      joined: 'joined',
+    });
+  });
+
+  it("falls back to the spec's declared default ('tabular') for absent values", () => {
+    expect(resolveReportPresentation(undefined)).toBe('tabular');
+  });
+});
+
+type MockRows = Array<Record<string, unknown>>;
+type MockResult = { rows: MockRows; totals?: Array<{ dimensions: string[]; rows: MockRows }> };
+
+function makeSource(byDataset: Record<string, MockRows | MockResult>) {
+  const calls: Array<{ dataset: string; selection: any }> = [];
+  return {
+    calls,
+    queryDataset: vi.fn(async (dataset: string, selection: unknown) => {
+      calls.push({ dataset, selection: selection as any });
+      const entry = byDataset[dataset];
+      if (Array.isArray(entry)) return { rows: entry };
+      return { rows: entry?.rows ?? [], ...(entry?.totals ? { totals: entry.totals } : {}) };
+    }),
+  };
+}
+
+const bucketRows = [
+  { status: 'Backlog', est_hours: 30 },
+  { status: 'Done', est_hours: 24 },
+];
+
+describe('summary vs tabular is driven by the declared type', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('summary requests the grand total and renders the totals footer', async () => {
+    const src = makeSource({
+      task_metrics: { rows: bucketRows, totals: [{ dimensions: [], rows: [{ est_hours: 54 }] }] },
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-report-total-row')).toBeInTheDocument());
+    expect(src.calls[0].selection.totals).toEqual({ groupings: [[]] });
+    expect(screen.getByTestId('dataset-report-total-row').textContent).toContain('54');
+  });
+
+  it('tabular renders the same selection with no totals request and no footer', async () => {
+    const src = makeSource({
+      task_metrics: { rows: bucketRows, totals: [{ dimensions: [], rows: [{ est_hours: 54 }] }] },
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'tabular', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect(src.calls[0].selection.totals).toBeUndefined();
+    expect(screen.queryByTestId('dataset-report-total-row')).not.toBeInTheDocument();
+  });
+
+  it('an older server returning no totals renders the summary table without a footer', async () => {
+    const src = makeSource({ task_metrics: bucketRows });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect(screen.queryByTestId('dataset-report-total-row')).not.toBeInTheDocument();
+  });
+});
+
+describe('embedded chart families render per plan', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const reportWithChart = (type: string) => ({
+    name: 'r',
+    type: 'summary',
+    dataset: 'task_metrics',
+    rows: ['status'],
+    values: ['est_hours'],
+    chart: { type, xAxis: 'status', yAxis: 'est_hours' },
+  });
+
+  it('a single-value chart (kpi) queries the measure with NO dimension and renders the number', async () => {
+    const src = makeSource({ task_metrics: { rows: [{ est_hours: 54 }] } });
+    render(<DatasetReportRenderer report={reportWithChart('kpi')} dataSource={src} />);
+    await waitFor(() => expect(screen.getByTestId('dataset-report-metric')).toBeInTheDocument());
+    // The metric card's own query: measures only, no grouping dimension.
+    const metricCall = src.calls.find((c) => Array.isArray(c.selection.dimensions) && c.selection.dimensions.length === 0);
+    expect(metricCall, 'expected a dimensionless dataset query for the single-value chart').toBeTruthy();
+    expect(metricCall!.selection.measures).toEqual(['est_hours']);
+    expect(screen.getByTestId('dataset-report-metric').textContent).toContain('54');
+  });
+
+  it("a tabular chart type ('table') adds no duplicate chart", async () => {
+    const src = makeSource({ task_metrics: bucketRows });
+    render(<DatasetReportRenderer report={reportWithChart('table')} dataSource={src} />);
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect(screen.queryByTestId('dataset-report-chart')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dataset-report-metric')).not.toBeInTheDocument();
+  });
+
+  it('an out-of-spec chart type renders a visible notice, not a silent bar', async () => {
+    const src = makeSource({ task_metrics: bucketRows });
+    render(<DatasetReportRenderer report={reportWithChart('sunburst')} dataSource={src} />);
+    await waitFor(() => expect(screen.getByTestId('dataset-report-chart-unsupported')).toBeInTheDocument());
+    expect(screen.getByTestId('dataset-report-chart-unsupported').textContent).toContain('sunburst');
+    expect(screen.queryByTestId('dataset-report-chart')).not.toBeInTheDocument();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1032,6 +1032,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
+      '@objectstack/spec':
+        specifier: ^17.0.0-rc.0
+        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -1065,6 +1068,9 @@ importers:
       vite-plugin-dts:
         specifier: ^5.0.3
         version: 5.0.3(@microsoft/api-extractor@7.58.2(@types/node@26.1.1))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/core:
     dependencies:
@@ -1618,6 +1624,9 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
+      '@objectstack/spec':
+        specifier: ^17.0.0-rc.0
+        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
       '@types/react-grid-layout':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2289,6 +2298,9 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
+      '@objectstack/spec':
+        specifier: ^17.0.0-rc.0
+        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1


### PR DESCRIPTION
Closes #2941 (Tier 1 of the #2901 audit — spec values that validate and then render **silently wrong** output; [audit doc](https://github.com/objectstack-ai/objectui/pull/2937)).

Every finding below produced output that looked correct and wasn't. Each fix lands with a spec-parity guard per the #2897 template (`summary-spec-parity.test.ts`) plus behavior tests, so the pair fails the moment either side moves again.

## The six fixes

| Finding | Before | Now |
|---|---|---|
| Pivot aggregation fell back to **sum** (`PivotTable.tsx`) | `count_distinct` / `array_agg` / `string_agg` (engine-level names with no client renderer) returned a sum — a plausible wrong total, no signal | Out-of-vocabulary aggregations refuse loudly with a `role="alert"` notice; the implemented set is pinned to the spec's 5-name `ChartAggregateFunctionSchema` (the UI-side subset the spec carved out for exactly this reason). The `default:` branch now returns `NaN` as a tripwire, unreachable behind the gate |
| Report chart fell back to **bar** (`DatasetReportRenderer.tsx`) | 10 of 19 `ChartTypeSchema` values silently drew a bar chart | `planReportChart` classifies all 19: the 12 series families reach the generic chart **verbatim** (`horizontal-bar` stays horizontal, `funnel`/`treemap`/`sankey` draw their real shapes — the renderer grew them since the audit); the 5 single-value families (`gauge`/`solid-gauge`/`metric`/`kpi`/`bullet`) render the measure as a number from a **dimensionless dataset query** (server-aggregated; the spec's own comment calls them "honest single-value variants pending a real dial renderer"); `table`/`pivot` add no duplicate chart (the grouped table beneath *is* that rendering); out-of-spec values get a visible notice instead of a guessed bar |
| `selection.type: 'single'` rendered **multi-select** (`data-table.tsx` ← `ObjectGrid.tsx`) | `selectable` was consumed as a bare truthy: per-row checkboxes *and* select-all, `single` never distinguished | `single` is a real mode: replace-on-select (never two rows), no select-all header, and ObjectGrid stops offering the cross-page "select all N matching" escalation. Legacy `true` keeps meaning multi-select |
| Filter `type: 'select'` rendered multi-check (`UserFilters.tsx`) | A single-choice filter accepted many values | The spec names both `select` and `multi-select`, which settles the semantic question: `select` is single-choice. It renders radios, picking replaces (badge × clears), and restored/default multi-value selections clamp to one. **Authored types only** — an omitted type is inferred from the field and keeps the historical multi-check UX |
| `addRecord.position: 'both'` collapsed to `top` (`ListView.tsx`) | Binary ternary; the bottom button never rendered | `resolveAddRecordPlacement` maps all three spec values; `both` renders both buttons. (Discovered adjacent, left alone: the renderer's implicit default is `top` while the spec's declared default is `bottom` — moving stored views' button is a UX change beyond this PR; noted in the resolver's doc comment) |
| `tabular` vs `summary` resolved from **data, not type** (`DatasetReportRenderer.tsx`) | Identical branch; the difference was whether `report.rows` happened to be non-empty | `resolveReportPresentation` makes the DECLARED type pick the branch. `summary` ("grouped by row") now carries a **server-computed** grand-total footer — `totals: { groupings: [[]] }`, same machinery as the matrix path, never recombined client-side (ADR-0021 red line), older servers degrade to no footer. `tabular` ("simple list") is the same selection as a plain list with no totals. Joined blocks get the same per-block dispatch |

## Semantic decisions the issue asked for

- **`selection.type: 'single'`** — replace-on-select radio semantics *and* a hard cap at one (they coincide: selecting row B deselects row A; unchecking clears). The spec's `single | multiple` contrast pair plus every mainstream grid's behavior settle this.
- **`filter type: 'select'` vs `'multi-select'`** — the enum contains both names, so `select` must mean the thing `multi-select` isn't: one value at a time.

## Guard prerequisite

`components`, `plugin-dashboard`, `plugin-report` gain the `@objectstack/spec` devDependency (the issue's noted prerequisite; `plugin-list`/`plugin-grid` already had it). `components` also pins `zod@^4.4.3` — without it, shadcn's MCP SDK leaks `zod@3` into the importer context and pnpm forks a **second store instance** of the spec (`spec@17.0.0-rc.0(ai@7.0.37(zod@3.25.76))`), the exact two-instances failure mode the audit's method note warns about. The lockfile now resolves one variant repo-wide.

## Verification

- New guards: 5 parity suites + behavior tests (39 new tests), all green.
- Full suites of the five touched packages: plugin-report + plugin-dashboard 211 ✓, plugin-grid 310 ✓, plugin-list 232 ✓, components 288 ✓ (+4 files that hit the known-heavy `import('../renderers')` 30 s hook timeout under a contended machine; all 73 tests pass re-run in isolation).
- `tsc --noEmit` clean on all five packages; eslint 0 errors on every touched file.

Refs #2901. Tier 2 (#2942), Tier 3 (#2943), forks (#2944) and vocabulary consolidation (#2945) stay separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)