### PR TITLE
fix(grid): a legacy string row action runs instead of green-toasting a no-op (#2960)

### DIFF
--- a/.changeset/legacy-row-actions-dead-end.md
+++ b/.changeset/legacy-row-actions-dead-end.md
@@ -1,0 +1,37 @@
+---
+"@object-ui/plugin-grid": patch
+"@object-ui/core": patch
+---
+
+fix(grid): a legacy string row action runs instead of green-toasting a no-op — objectui#2960
+
+A list view declaring `rowActions: ['convert_lead']` rendered a menu item that
+performed **zero network requests** and reported success. Where the object also
+declared the same action with `locations: ['list_item']`, the row menu showed a
+working entry and a dead duplicate of it side by side.
+
+**The name never became an action.** `ObjectGrid` dispatched the legacy form as
+`{ type: <action name>, params: { record } }` — the action *name* landing in the
+runner's `type` slot, never resolved against the object's action defs. It
+matches no built-in type and (absent a handler registered under that exact name)
+no handler either, so it fell through to `ActionRunner.executeActionSchema`,
+which returned `{success: true, reload: true, close: true}` for a schema with
+nothing in it. `handlePostExecution` then fired the green "Action completed
+successfully" toast.
+
+Two changes, either of which would have surfaced the bug:
+
+**① `ObjectGrid` resolves legacy names against `objectDef.actions`.** A name
+that matches a declared action is promoted to that def and dispatched through
+the same path as a `list_item` action — so it actually runs, and it picks up the
+def's label, `visible`/`disabled` predicates, param dialog and capability gate,
+none of which the string form could carry. A name that matches an action already
+rendered as a def is dropped, which is what removes the dead twin. Names that
+resolve to nothing are still dispatched by name, since a consumer may have
+registered a runner handler under exactly that name.
+
+**② `ActionRunner`'s empty-schema fallthrough fails loudly.** It no longer
+reports success for an action it never ran: a dispatch with no registered
+handler and no `api`/`endpoint`/`navigate`/`redirect`/`onClick` returns a
+failure naming the action. Schema-only shapes that *do* declare something — a
+bare `redirect`, an explicit `reload`/`close` — run exactly as before.

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -884,10 +884,40 @@ export class ActionRunner {
     };
   }
 
+  /**
+   * Terminal fallback for a dispatch the switch above did not recognize: no
+   * known `type`, no registered handler, no `navigate` / `api` / `endpoint` /
+   * `onClick`. Some schema-only shapes are still runnable here — an action
+   * whose whole payload is a `redirect`, or an explicit `reload` / `close`
+   * directive — so this stays a real execution path.
+   *
+   * What it must never do is report success for an action it did not run. It
+   * used to return `{ success: true, reload: true, close: true }` for a
+   * COMPLETELY EMPTY schema, which is how a legacy string row action —
+   * dispatched as `{ type: '<action name>' }`, the name landing in the `type`
+   * slot — reached the user as a green "Action completed successfully" toast
+   * having issued zero requests (objectui#2960). An unresolvable dispatch is a
+   * wiring bug; surface it instead of laundering it into a success.
+   */
   private async executeActionSchema(action: ActionDef): Promise<ActionResult> {
+    const hasApi = !!(action.api || action.endpoint);
+    // `reload`/`close` default to true downstream, so only an EXPLICIT `true`
+    // counts as declared intent — otherwise every empty schema would look like
+    // it asked for a reload and slip back through this guard.
+    const declaresBehavior =
+      hasApi || !!action.onClick || !!action.redirect
+      || action.reload === true || action.close === true;
+    if (!declaresBehavior) {
+      const label = action.name || action.type || action.actionType || 'action';
+      return {
+        success: false,
+        error: `Action "${label}" is not executable: no handler is registered under that name and it declares no api, endpoint, navigate, redirect or onClick.`,
+      };
+    }
+
     const result: ActionResult = { success: true };
 
-    if (action.api || action.endpoint) {
+    if (hasApi) {
       const apiResult = await this.executeAPI(action);
       if (!apiResult.success) return apiResult;
       result.data = apiResult.data;

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -56,6 +56,57 @@ describe('ActionRunner', () => {
   });
 
   // ==========================================================================
+  // Unresolvable dispatch (objectui#2960)
+  // ==========================================================================
+
+  describe('unresolvable dispatch', () => {
+    it('fails loudly when the schema declares nothing executable', async () => {
+      // A legacy string row action reaches the runner as `{ type: <name> }` —
+      // the NAME in the `type` slot. It matches no built-in type and no
+      // registered handler, so there is nothing to run. This used to return
+      // `{ success: true, reload: true, close: true }` after issuing zero
+      // requests.
+      const result = await runner.execute({ type: 'convert_lead', params: { record: { id: 1 } } });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('convert_lead');
+      expect(result.reload).toBeUndefined();
+    });
+
+    it('does not toast success for an action it never ran', async () => {
+      const toastHandler = vi.fn();
+      runner.setToastHandler(toastHandler);
+
+      await runner.execute({ type: 'convert_lead' });
+
+      expect(toastHandler).toHaveBeenCalledTimes(1);
+      expect(toastHandler).toHaveBeenCalledWith(
+        expect.stringContaining('convert_lead'),
+        expect.objectContaining({ type: 'error' }),
+      );
+    });
+
+    it('still runs a handler registered under the action name', async () => {
+      // The by-name dispatch path is how consumers wire custom row actions;
+      // the guard must not close it.
+      const handler = vi.fn().mockResolvedValue({ success: true });
+      runner.registerHandler('convert_lead', handler);
+
+      const result = await runner.execute({ type: 'convert_lead' });
+
+      expect(result.success).toBe(true);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('still runs a typeless action that only declares a redirect', async () => {
+      const result = await runner.execute({ redirect: '/leads/1' });
+
+      expect(result.success).toBe(true);
+      expect(result.redirect).toBe('/leads/1');
+    });
+  });
+
+  // ==========================================================================
   // Conditions and disabled
   // ==========================================================================
 

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -44,6 +44,7 @@ import { useGroupedData } from './useGroupedData';
 import { GroupRow } from './GroupRow';
 import { useColumnSummary } from './useColumnSummary';
 import { resolveRowCrudAffordances } from './rowCrudAffordances';
+import { resolveLegacyRowActions } from './resolveLegacyRowActions';
 import { RowActionMenu, formatActionLabel } from './components/RowActionMenu';
 import { BulkActionBar } from './components/BulkActionBar';
 import { BulkActionDialog } from './components/BulkActionDialog';
@@ -1446,7 +1447,16 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const rowActionDefsList: any[] = Array.isArray((schema as any).rowActionDefs) ? (schema as any).rowActionDefs : [];
   const wantEditAction = rowActionsList.includes('edit');
   const wantDeleteAction = rowActionsList.includes('delete');
-  const customRowActions = rowActionsList.filter(a => a !== 'edit' && a !== 'delete');
+  // Legacy `rowActions` carry a bare action NAME, which the runner cannot
+  // execute on its own — resolve each against the object's declared actions so
+  // it dispatches as a real def (and so a name that duplicates an existing
+  // `list_item` def stops rendering a dead twin of it). See
+  // `resolveLegacyRowActions` for the full rationale (objectui#2960).
+  const { defs: resolvedRowActionDefs, unresolved: customRowActions } = resolveLegacyRowActions({
+    rowActions: rowActionsList.filter(a => a !== 'edit' && a !== 'delete'),
+    rowActionDefs: rowActionDefsList,
+    objectActions: (objectSchema as any)?.actions,
+  });
   // Honor the object's resolved CRUD affordance: the ADR-0103 lifecycle bucket
   // (`managedBy`), the `userActions.edit`/`delete` override — explicit `false`
   // opts out of the generic row Edit/Delete (e.g. sys_environment ships a
@@ -1468,7 +1478,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     effectiveApiOperations: effectiveApiOps,
   });
   const hasActions = !!(operations && (operations.update || operations.delete));
-  const hasRowActions = customRowActions.length > 0 || rowActionDefsList.length > 0 || wantEditAction || wantDeleteAction;
+  const hasRowActions = customRowActions.length > 0 || resolvedRowActionDefs.length > 0 || wantEditAction || wantDeleteAction;
 
   const columnsWithActions = (hasActions || hasRowActions) ? [
     ...persistedColumns,
@@ -1489,7 +1499,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
         <RowActionMenu
           row={row}
           rowActions={customRowActions}
-          rowActionDefs={rowActionDefsList}
+          rowActionDefs={resolvedRowActionDefs as any[]}
           maxInlineActions={(schema as any).maxInlineRowActions ?? 1}
           canEdit={canEdit}
           canDelete={canDelete}

--- a/packages/plugin-grid/src/__tests__/legacyRowActionDispatch.test.tsx
+++ b/packages/plugin-grid/src/__tests__/legacyRowActionDispatch.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Legacy string `rowActions` must reach the ActionRunner as a real action DEF
+ * (objectui#2960).
+ *
+ * A view declaring `rowActions: ['convert_lead']` used to dispatch the action
+ * NAME in the runner's `type` slot — `{ type: 'convert_lead' }`. That matches
+ * no built-in type and no registered handler, so it fell through the runner's
+ * schema fallback: zero requests, then a green "Action completed successfully"
+ * toast. And because an object action declaring `locations: ['list_item']`
+ * also injects its own (working) entry, the same action could render twice —
+ * one live, one dead.
+ *
+ * These drive the REAL ObjectGrid through a real ActionProvider and assert the
+ * user-visible outcome: the click issues the action's request, and the menu
+ * carries one entry per action rather than a working/dead pair.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({ isLoaded: false, checkField: () => true, getObjectApiOperations: () => undefined }),
+}));
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+
+registerAllFields();
+
+const OBJECT = 'lead';
+const ROWS = [{ id: '1', name: 'Alice' }];
+
+/**
+ * The object's own `convert_lead` action — an api call to a custom route. The
+ * label is deliberately NOT the humanization of the name ("Convert Lead"), so
+ * an assertion on it can tell the resolved def apart from the legacy path,
+ * which could only ever render `formatActionLabel(name)`.
+ */
+const CONVERT_LEAD = {
+  name: 'convert_lead',
+  label: 'Convert to Account',
+  type: 'api',
+  target: '/api/v1/leads/convert',
+  locations: ['record_header'],
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function renderGrid(opts: { objectActions?: unknown[]; schema?: Record<string, unknown> }) {
+  const dataSource: any = {
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: { id: { type: 'text' }, name: { type: 'text', label: 'Name' } },
+      ...(opts.objectActions ? { actions: opts.objectActions } : {}),
+    }),
+  };
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    columns: [{ field: 'name', label: 'Name' }],
+    data: { provider: 'value', items: ROWS },
+    ...opts.schema,
+  };
+  return render(
+    <ActionProvider>
+      <SchemaRendererProvider dataSource={dataSource}>
+        <ObjectGrid schema={schema} dataSource={dataSource} />
+      </SchemaRendererProvider>
+    </ActionProvider>,
+  );
+}
+
+/** Render, wait for the async schema fetch to settle, then open the row kebab. */
+async function openRowMenu(opts: Parameters<typeof renderGrid>[0]) {
+  renderGrid(opts);
+  await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+  // The promotion depends on `getObjectSchema`, so an assertion taken before
+  // it lands would read the pre-fetch (unresolved) state.
+  await waitFor(() => expect(screen.getByTestId('row-action-trigger')).toBeInTheDocument());
+  await userEvent.click(screen.getByTestId('row-action-trigger'));
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => 'application/json' },
+    json: async () => ({ success: true }),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('legacy string rowActions dispatch (objectui#2960)', () => {
+  it('issues the resolved action request instead of no-opping', async () => {
+    await openRowMenu({
+      objectActions: [CONVERT_LEAD],
+      schema: { rowActions: ['convert_lead'] },
+    });
+
+    await userEvent.click(screen.getByTestId('row-action-convert_lead'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/leads/convert');
+  });
+
+  it('renders the object action label, not the humanized name', async () => {
+    await openRowMenu({
+      objectActions: [CONVERT_LEAD],
+      schema: { rowActions: ['convert_lead'] },
+    });
+
+    const item = screen.getByTestId('row-action-convert_lead');
+    expect(item).toHaveTextContent('Convert to Account');
+    expect(item).not.toHaveTextContent('Convert Lead');
+  });
+
+  it('does not render a dead duplicate of a list_item action', async () => {
+    const listItemDef = { ...CONVERT_LEAD, locations: ['list_item'], label: 'Convert' };
+    await openRowMenu({
+      objectActions: [listItemDef],
+      // The app-shell derives `rowActionDefs` from `locations: ['list_item']`;
+      // a view that ALSO names the action in legacy `rowActions` used to get
+      // both a working entry and a dead twin.
+      schema: { rowActions: ['convert_lead'], rowActionDefs: [listItemDef] },
+    });
+
+    expect(screen.getAllByTestId('row-action-convert_lead')).toHaveLength(1);
+  });
+
+  it('leaves a name with no declared action to the by-name handler path', async () => {
+    // Consumers may register a runner handler under exactly this name, so the
+    // entry must still render and still dispatch.
+    await openRowMenu({
+      objectActions: [CONVERT_LEAD],
+      schema: { rowActions: ['crm_only_handler'] },
+    });
+
+    expect(screen.getByTestId('row-action-crm_only_handler')).toBeInTheDocument();
+    // Nothing resolvable to call — and with the runner's fallback now failing
+    // loudly, no request and no success are reported.
+    await userEvent.click(screen.getByTestId('row-action-crm_only_handler'));
+    await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+  });
+});

--- a/packages/plugin-grid/src/__tests__/resolveLegacyRowActions.test.ts
+++ b/packages/plugin-grid/src/__tests__/resolveLegacyRowActions.test.ts
@@ -1,0 +1,110 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveLegacyRowActions } from '../resolveLegacyRowActions';
+
+const CONVERT_LEAD = {
+  name: 'convert_lead',
+  label: 'Convert Lead',
+  type: 'api',
+  target: '/leads/convert',
+  locations: ['record_header'],
+};
+
+describe('resolveLegacyRowActions', () => {
+  it('promotes a legacy name to the object action it names', () => {
+    const { defs, unresolved } = resolveLegacyRowActions({
+      rowActions: ['convert_lead'],
+      rowActionDefs: [],
+      objectActions: [CONVERT_LEAD],
+    });
+
+    // The dead `{ type: 'convert_lead' }` dispatch is gone: the row now
+    // carries the real def, so it routes through the api branch (objectui#2960).
+    expect(defs).toEqual([CONVERT_LEAD]);
+    expect(unresolved).toEqual([]);
+  });
+
+  it('drops a legacy name that duplicates an existing list_item def', () => {
+    const listItemDef = { ...CONVERT_LEAD, locations: ['list_item'], label: '转换线索' };
+    const { defs, unresolved } = resolveLegacyRowActions({
+      rowActions: ['convert_lead'],
+      rowActionDefs: [listItemDef],
+      objectActions: [listItemDef],
+    });
+
+    // One working entry, not a working entry plus a dead twin — and the
+    // already-localized def wins over the raw object action.
+    expect(defs).toEqual([listItemDef]);
+    expect(unresolved).toEqual([]);
+  });
+
+  it('keeps a name that matches no declared action for by-name dispatch', () => {
+    // Consumers may register a runner handler under exactly this name; that
+    // path stays intact.
+    const { defs, unresolved } = resolveLegacyRowActions({
+      rowActions: ['crm_only_handler'],
+      rowActionDefs: [],
+      objectActions: [CONVERT_LEAD],
+    });
+
+    expect(defs).toEqual([]);
+    expect(unresolved).toEqual(['crm_only_handler']);
+  });
+
+  it('appends promotions after the declared defs and preserves order', () => {
+    const archive = { name: 'archive', locations: ['list_item'] };
+    const merge = { name: 'merge', locations: ['record_header'] };
+    const { defs, unresolved } = resolveLegacyRowActions({
+      rowActions: ['merge', 'unknown_one', 'convert_lead'],
+      rowActionDefs: [archive],
+      objectActions: [CONVERT_LEAD, merge],
+    });
+
+    expect(defs).toEqual([archive, merge, CONVERT_LEAD]);
+    expect(unresolved).toEqual(['unknown_one']);
+  });
+
+  it('promotes a repeated legacy name only once', () => {
+    const { defs } = resolveLegacyRowActions({
+      rowActions: ['convert_lead', 'convert_lead'],
+      rowActionDefs: [],
+      objectActions: [CONVERT_LEAD],
+    });
+
+    expect(defs).toEqual([CONVERT_LEAD]);
+  });
+
+  it('returns the defs array by reference when nothing is promoted', () => {
+    const rowActionDefs = [{ name: 'archive' }];
+
+    // No legacy names at all — the common case; the row menu memoizes over
+    // this list, so a fresh array here would bust it on every render.
+    expect(
+      resolveLegacyRowActions({ rowActions: [], rowActionDefs }).defs,
+    ).toBe(rowActionDefs);
+
+    // Legacy names present but none resolvable — still no new defs array.
+    expect(
+      resolveLegacyRowActions({ rowActions: ['nope'], rowActionDefs, objectActions: [] }).defs,
+    ).toBe(rowActionDefs);
+  });
+
+  it('tolerates a missing object schema and malformed entries', () => {
+    // `objectSchema` is fetched async, so the first paint has no actions.
+    const { defs, unresolved } = resolveLegacyRowActions({
+      rowActions: ['convert_lead', '', null as unknown as string],
+      rowActionDefs: null,
+      objectActions: undefined,
+    });
+
+    expect(defs).toEqual([]);
+    expect(unresolved).toEqual(['convert_lead']);
+  });
+});

--- a/packages/plugin-grid/src/resolveLegacyRowActions.ts
+++ b/packages/plugin-grid/src/resolveLegacyRowActions.ts
@@ -1,0 +1,99 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Fold a list view's legacy `rowActions: string[]` into the row-context action
+ * DEFS before the row kebab renders them.
+ *
+ * Two vocabularies reach the row menu:
+ *
+ *  1. `rowActionDefs` — full `ActionDef` records the view already derived from
+ *     `objectDef.actions` filtered by `locations.includes('list_item')`. These
+ *     dispatch through the action runner with their own type/target/params, so
+ *     they actually run.
+ *
+ *  2. `rowActions` — the legacy bare-name form (`rowActions: ['convert_lead']`).
+ *     A name is not an action: dispatching it put the NAME in the runner's
+ *     `type` slot, which matches no built-in type and (absent a handler
+ *     registered under that name) fell through to the runner's schema fallback
+ *     — zero requests, then a green "Action completed successfully" toast
+ *     (objectui#2960). Worse, when the same action ALSO declared
+ *     `locations: ['list_item']`, the menu showed a working entry and a dead
+ *     duplicate of it side by side.
+ *
+ * Resolving each legacy name against the object's declared actions collapses
+ * both problems: a name that matches an existing def is dropped (the def
+ * already renders the working entry), and a name that matches an action
+ * declared elsewhere on the object — the case the legacy form exists to serve —
+ * is PROMOTED to that def so it dispatches for real.
+ *
+ * Names that resolve to nothing stay in `unresolved` and are still dispatched
+ * by name: consumers may have registered a runner handler under exactly that
+ * name (`runner.registerHandler('my_action', …)`), and that path must keep
+ * working. When no such handler exists the runner now reports the dead end
+ * rather than toasting success.
+ */
+
+/** The subset of an `ActionDef` this fold needs: everything is passed through. */
+export interface NamedActionDef {
+  name?: string;
+  [key: string]: unknown;
+}
+
+export function resolveLegacyRowActions(opts: {
+  /**
+   * Legacy `rowActions` names, already stripped of the canonical `'edit'` /
+   * `'delete'` entries (those route to `onEdit` / `onDelete`, not the runner).
+   */
+  rowActions?: readonly string[] | null;
+  /** Row-context defs the view resolved from `locations: ['list_item']`. */
+  rowActionDefs?: readonly NamedActionDef[] | null;
+  /** Every action declared on the object (`objectDef.actions`). */
+  objectActions?: readonly NamedActionDef[] | null;
+}): {
+  /**
+   * `rowActionDefs` plus any promoted legacy names, in declaration order
+   * (defs first, promotions after). Returned by REFERENCE when nothing was
+   * promoted, so the row menu's `useMemo` over this list is not busted on
+   * every render of a view that has no legacy names to fold.
+   */
+  defs: readonly NamedActionDef[];
+  /** Legacy names that matched no declared action; dispatched by name. */
+  unresolved: string[];
+} {
+  const defs = Array.isArray(opts.rowActionDefs) ? opts.rowActionDefs : [];
+  const names = Array.isArray(opts.rowActions) ? opts.rowActions : [];
+  if (names.length === 0) return { defs, unresolved: [] };
+
+  const objectActions = Array.isArray(opts.objectActions) ? opts.objectActions : [];
+  const claimed = new Set(
+    defs.map(d => d?.name).filter((n): n is string => typeof n === 'string' && n !== ''),
+  );
+
+  const promoted: NamedActionDef[] = [];
+  const unresolved: string[] = [];
+
+  for (const name of names) {
+    if (typeof name !== 'string' || name === '') continue;
+    // Already rendered as a def (either a `list_item` action of the same name,
+    // or an earlier promotion of a repeated legacy entry) — drop the duplicate.
+    if (claimed.has(name)) continue;
+    const match = objectActions.find(a => a?.name === name);
+    if (match) {
+      claimed.add(name);
+      promoted.push(match);
+    } else {
+      unresolved.push(name);
+    }
+  }
+
+  return {
+    defs: promoted.length > 0 ? [...defs, ...promoted] : defs,
+    unresolved,
+  };
+}


### PR DESCRIPTION
Fixes #2960.

## 症状

列表视图声明 `rowActions: ['convert_lead']` 时，行菜单里的这一项点下去**零网络请求**却报成功。如果同一个 action 还声明了 `locations: ['list_item']`，菜单里会并排出现**一个能用、一个是死的**同名项。

## 根因

名字从来没变成 action。`ObjectGrid` 把 legacy 形式派发成 `{ type: <action 名>, params: { record } }` —— action 的**名字**落进了 runner 的 `type` 槽位，从未拿去和对象的 action def 做解析。它匹配不到任何内建类型，也匹配不到 handler（除非恰好有人用这个名字注册过），于是落到 `ActionRunner.executeActionSchema`：对一个什么都没声明的 schema，它返回 `{success: true, reload: true, close: true}`，接着 `handlePostExecution` 弹出绿色的 "Action completed successfully"。

## 改动

两处，任意一处都能让这个 bug 暴露出来：

**① `ObjectGrid` 把 legacy 名字解析到 `objectDef.actions`**（新增纯函数 `resolveLegacyRowActions`）：

- 命中已声明的 action → **提升**为该 def，走和 `list_item` action 完全相同的派发路径。于是它真的会执行，并且拿到 def 的 label、`visible`/`disabled` 谓词、参数弹窗和 capability gate —— 这些字符串形式一个都带不了。
- 命中一个已经作为 def 渲染的 action → **丢弃**，死的那个副本就此消失。
- 解析不到 → 仍按名字派发，因为消费方可能正好用这个名字注册了 runner handler。

`ObjectGrid` 是三个调用方（app-shell `ObjectView`、plugin-view `ObjectView`、plugin-list `ListView`）的唯一收敛点，改一处即可覆盖。没有提升发生时该函数按引用返回原数组，`RowActionMenu` 的 `useMemo` 不会被打散。

**② `ActionRunner` 的空 schema 兜底改为响亮失败**：不再为一个从未执行过的 action 报成功——没有注册 handler、也没有 `api`/`endpoint`/`navigate`/`redirect`/`onClick` 的派发，返回一条点名该 action 的失败。仅声明 schema 但**确实有内容**的形态（裸 `redirect`、显式 `reload`/`close`）行为完全不变，已注册 handler 的路径也未触碰。

## 未处理（有意）

同一文件里的批量 action 路径是同样的 `{type: <name>}` 形状，但 `bulkActionDefs` 从来不是由 `objectDef.actions` 推导出来的，没有可解析的对象；给它加推导是新功能而不是修这个 bug。改动 ② 让这条路径至少诚实地失败，而不是弹绿 toast。

## 验证

- **反向对照**：只 stash 掉两个源文件后，4 条新增的行为断言全部失败 —— `success: true`（应为 false）、绿色 toast 触发、`fetch` 调用 0 次、菜单里出现 2 项（应为 1 项）。
- **受影响包**：`packages/core/src/actions/` + `packages/plugin-grid/src/` → 50 文件 / 506 测试全通过。
- **全量套件**：干净 stash 树上同样有 8 文件 / 22 测试失败（`types`、`data-objectstack`、`i18n`、`plugin-kanban`、`plugin-markdown`、`plugin-list`、`metadata-admin` 的 `@objectstack/spec` dist 陈旧问题）。加不加本改动，失败**文件集合完全一致**，且都不在 `core/actions` 或 `plugin-grid`。

新增测试：`resolveLegacyRowActions.test.ts`（7 条纯函数）、`legacyRowActionDispatch.test.tsx`（4 条，驱动真实 grid + runner）、`ActionRunner.test.ts`（4 条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)