### PR TITLE
fix(plugin-form): block page unload while a modal/drawer form has unsaved input

### DIFF
--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -363,6 +363,20 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
     }
   }, [confirmOnDiscard, isDirty, finalizeClose]);
 
+  // Browser-native "leave site?" prompt on tab close / reload while the form
+  // is dirty. The in-app guard above only covers Radix close paths (backdrop,
+  // Escape, the X) — a refresh bypasses them all and the input is gone.
+  useEffect(() => {
+    if (!isOpen || !isDirty || !confirmOnDiscard) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Required for Chrome to actually show the prompt.
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isOpen, isDirty, confirmOnDiscard]);
+
   // The explicit Cancel button is an *intentional* discard, so it closes
   // immediately — no "Discard changes?" prompt. The unsaved-changes guard only
   // intercepts *accidental* closes (backdrop click, Escape, the X), which Radix

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -456,6 +456,20 @@ export const ModalForm: React.FC<ModalFormProps> = ({
     }
   }, [confirmOnDiscard, isDirty, finalizeClose]);
 
+  // Browser-native "leave site?" prompt on tab close / reload while the form
+  // is dirty. The in-app guard above only covers Radix close paths (backdrop,
+  // Escape, the X) — a refresh bypasses them all and the input is gone.
+  useEffect(() => {
+    if (!isOpen || !isDirty || !confirmOnDiscard) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Required for Chrome to actually show the prompt.
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isOpen, isDirty, confirmOnDiscard]);
+
   // The explicit Cancel button is an *intentional* discard, so it closes
   // immediately — no "Discard changes?" prompt. The unsaved-changes guard only
   // intercepts *accidental* closes (backdrop click, Escape, the X), which Radix

--- a/packages/plugin-form/src/discardGuard.test.tsx
+++ b/packages/plugin-form/src/discardGuard.test.tsx
@@ -203,3 +203,58 @@ describe('DrawerForm unsaved-changes guard', () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Browser refresh / tab close while dirty. The Radix close guard above never
+ * sees an unload — only a `beforeunload` listener can intercept it, so a dirty
+ * overlay must register one (and a pristine one must not, or every navigation
+ * away from the app would prompt).
+ */
+function fireBeforeUnload(): Event {
+  const evt = new Event('beforeunload', { cancelable: true });
+  window.dispatchEvent(evt);
+  return evt;
+}
+
+describe.each([
+  ['ModalForm', ModalForm],
+  ['DrawerForm', DrawerForm],
+] as const)('%s beforeunload guard', (_name, Form) => {
+  it('does not block unload while the form is pristine', async () => {
+    render(
+      <Form
+        schema={{ objectName: 'task', mode: 'create', open: true, onOpenChange: vi.fn() } as any}
+        dataSource={ds}
+      />,
+    );
+    await waitFor(() => {
+      if (!document.querySelector('input')) throw new Error('form not ready');
+    });
+
+    expect(fireBeforeUnload().defaultPrevented).toBe(false);
+  });
+
+  it('blocks unload while the form is dirty', async () => {
+    render(
+      <Form
+        schema={{ objectName: 'task', mode: 'create', open: true, onOpenChange: vi.fn() } as any}
+        dataSource={ds}
+      />,
+    );
+    await dirtyTheForm();
+
+    await waitFor(() => expect(fireBeforeUnload().defaultPrevented).toBe(true));
+  });
+
+  it('does not block unload when confirmOnDiscard is false, even dirty', async () => {
+    render(
+      <Form
+        schema={{ objectName: 'task', mode: 'create', open: true, confirmOnDiscard: false, onOpenChange: vi.fn() } as any}
+        dataSource={ds}
+      />,
+    );
+    await dirtyTheForm();
+
+    expect(fireBeforeUnload().defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The in-app discard guard (#2028) only intercepts Radix close paths — backdrop click, Escape, the X. A browser refresh or tab close never reaches them: `beforeunload` fired with nobody calling `preventDefault()`, so a dirty create/edit overlay silently lost everything the user had typed. Worse, the overlay itself is restored afterwards via the `?recordId=` URL param — but empty, which reads as data loss with no warning at any point.

Verified live: dispatching `beforeunload` on a dirty edit modal returned `defaultPrevented === false`; a refresh dropped all entered values with zero confirmation.

## Fix

Register a `beforeunload` listener while the overlay is open **and** dirty (and `confirmOnDiscard` hasn't been opted out), in both `ModalForm` and `DrawerForm` — mirroring the existing StudioDesignSurface pillar guard (#2606). The listener is removed as soon as the form is pristine again, so normal navigation never prompts.

## Tests

6 new cases in `discardGuard.test.tsx` (`describe.each` over both overlays):
- pristine form → unload not blocked
- dirty form → unload blocked (`defaultPrevented`)
- dirty + `confirmOnDiscard: false` → unload not blocked

`pnpm vitest run packages/plugin-form`: 224 passed. `type-check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)