### PR TITLE
fix(plugin-list,plugin-grid): drop undeliverable formats from the export menu

### DIFF
--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1233,6 +1233,30 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     return generatedColumns;
   }, [objectSchema, schemaFields, schemaColumns, dataConfig, hasInlineData, navigation.handleClick, executeAction, data, resolveFieldLabel, translateOptions, schema.objectName, perms]);
 
+  // Formats this grid can actually deliver (objectui#2942): the server stream
+  // handles csv/xlsx/json, the client fallback only csv/json, and pdf exists
+  // nowhere (declined platform-side — objectstack#1301). Declared-but-dead
+  // formats used to render as menu items whose click did nothing; now they're
+  // dropped from the menu (with a one-time warning for the app author).
+  // (Hoisted above the error/loading early returns to satisfy hooks rules.)
+  const exportableFormats = useMemo(() => {
+    const declared = schema.exportOptions?.formats || ['csv', 'json'];
+    const serverAvailable = typeof dataSource?.exportDownload === 'function'
+      && !!objectName
+      && !hasInlineData
+      && (schema.exportOptions as any)?.streaming !== false;
+    const supported = serverAvailable ? ['csv', 'xlsx', 'json'] : ['csv', 'json'];
+    return declared.filter((f: string) => supported.includes(f));
+  }, [schema.exportOptions, dataSource, objectName, hasInlineData]);
+  useEffect(() => {
+    const declared = schema.exportOptions?.formats;
+    if (!declared) return;
+    const dropped = declared.filter((f) => !exportableFormats.includes(f));
+    if (dropped.length > 0) {
+      console.warn(`[ObjectUI] ObjectGrid export: unsupported format(s) hidden from the menu: ${dropped.join(', ')}`);
+    }
+  }, [schema.exportOptions, exportableFormats]);
+
   const handleExport = useCallback((format: 'csv' | 'xlsx' | 'json' | 'pdf') => {
     // Object-level export permission gate. Default-allow: an explicit
     // `operations.export === false` blocks it, and — when the server hands down
@@ -2285,6 +2309,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // and it excludes `export`, the button is hidden. Missing set → unchanged.
   const exportEnabled =
     !!schema.exportOptions &&
+    exportableFormats.length > 0 &&
     schema.operations?.export !== false &&
     (effectiveApiOps ? effectiveApiOps.includes('export') : true);
   const hasToolbar = exportEnabled || showRowHeightToggle;
@@ -2319,7 +2344,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
           </PopoverTrigger>
           <PopoverContent align="end" className="w-48 p-2">
             <div className="space-y-1">
-              {(schema.exportOptions?.formats || ['csv', 'json']).map(format => (
+              {exportableFormats.map(format => (
                 <Button
                   key={format}
                   variant="ghost"

--- a/packages/plugin-grid/src/__tests__/exportGate.test.tsx
+++ b/packages/plugin-grid/src/__tests__/exportGate.test.tsx
@@ -5,7 +5,7 @@
  * is hidden; default-allow keeps it visible when the key is omitted.
  */
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 
@@ -50,5 +50,28 @@ describe('ObjectGrid export permission gate', () => {
   it('keeps the export button when operations is set but export is omitted (default-allow)', () => {
     renderGrid({ operations: { create: false } });
     expect(screen.getByRole('button', { name: /export/i })).toBeInTheDocument();
+  });
+});
+
+/**
+ * Dead-format gate (objectui#2942): declared formats the runtime cannot
+ * deliver must not render as menu items whose click silently does nothing.
+ * pdf is implemented nowhere; xlsx needs the server stream, which inline
+ * (provider: 'value') data never has.
+ */
+describe('ObjectGrid export dead formats', () => {
+  it('drops pdf and (with inline data) xlsx from the menu, keeping csv', async () => {
+    renderGrid({ exportOptions: { formats: ['csv', 'xlsx', 'pdf'] } });
+
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+
+    expect(await screen.findByRole('button', { name: /export as csv/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /export as pdf/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /export as xlsx/i })).toBeNull();
+  });
+
+  it('hides the export button entirely when no declared format is deliverable', () => {
+    renderGrid({ exportOptions: { formats: ['pdf'] } });
+    expect(screen.queryAllByRole('button', { name: /export/i }).length).toBe(0);
   });
 });

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -715,6 +715,28 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     return schema.exportOptions;
   }, [schema.exportOptions]);
 
+  // Formats this list can actually deliver (objectui#2942): the server stream
+  // handles csv/xlsx/json, the client fallback only csv/json, and pdf exists
+  // nowhere (declined platform-side — objectstack#1301). Declared-but-dead
+  // formats used to render as menu items whose click did nothing; now they're
+  // dropped from the menu (with a one-time warning for the app author).
+  const exportableFormats = React.useMemo(() => {
+    const declared = resolvedExportOptions?.formats || ['csv', 'json'];
+    const serverAvailable = typeof dataSource?.exportDownload === 'function'
+      && !!schema.objectName
+      && (resolvedExportOptions as any)?.streaming !== false;
+    const supported = serverAvailable ? ['csv', 'xlsx', 'json'] : ['csv', 'json'];
+    return declared.filter((f: string) => supported.includes(f));
+  }, [resolvedExportOptions, dataSource, schema.objectName]);
+  React.useEffect(() => {
+    const declared = resolvedExportOptions?.formats;
+    if (!declared) return;
+    const dropped = declared.filter((f: string) => !exportableFormats.includes(f));
+    if (dropped.length > 0) {
+      console.warn(`[ObjectUI] ListView export: unsupported format(s) hidden from the menu: ${dropped.join(', ')}`);
+    }
+  }, [resolvedExportOptions, exportableFormats]);
+
   // Toolbar density, resolved from the spec-canonical `rowHeight` (#2890). The
   // legacy `densityMode` is folded into it by `normalizeListViewSchema` above —
   // it used to be read FIRST here, so a view carrying both rendered the legacy
@@ -2207,7 +2229,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           )}
 
           {/* --- Separator: Appearance | Export --- */}
-          {(toolbarFlags.showColor || toolbarFlags.showDensity || toolbarFlags.compactToolbar) && resolvedExportOptions && exportPermitted && (
+          {(toolbarFlags.showColor || toolbarFlags.showDensity || toolbarFlags.compactToolbar) && resolvedExportOptions && exportPermitted && exportableFormats.length > 0 && (
             <div className="h-5 w-px bg-border/50 mx-1 shrink-0" />
           )}
 
@@ -2231,7 +2253,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           )}
 
           {/* Export */}
-          {resolvedExportOptions && exportPermitted && (
+          {resolvedExportOptions && exportPermitted && exportableFormats.length > 0 && (
             <Popover open={showExport} onOpenChange={setShowExport}>
               <PopoverTrigger asChild>
                 <Button
@@ -2245,7 +2267,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
               </PopoverTrigger>
               <PopoverContent align="start" className="w-48 p-2">
                 <div className="space-y-1">
-                  {(resolvedExportOptions.formats || ['csv', 'json']).map((format: any) => (
+                  {exportableFormats.map((format: any) => (
                     <Button
                       key={format}
                       variant="ghost"
@@ -2304,7 +2326,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
 
           {/* --- Separator: Print/Share/Export | Search --- */}
           {(() => {
-            const hasLeftSideItems = schema.allowPrinting || !!schema.sharing?.type || (resolvedExportOptions && exportPermitted);
+            const hasLeftSideItems = schema.allowPrinting || !!schema.sharing?.type || (resolvedExportOptions && exportPermitted && exportableFormats.length > 0);
             return toolbarFlags.showSearch && hasLeftSideItems ? (
               <div className="h-5 w-px bg-border/50 mx-1 shrink-0" />
             ) : null;

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -2164,6 +2164,70 @@ describe('ListView', () => {
     });
   });
 
+  // Declared formats the runtime cannot deliver (objectui#2942): pdf has no
+  // implementation anywhere, and xlsx only exists on the server stream. They
+  // must not render as menu items whose click silently does nothing.
+  describe('exportOptions dead formats', () => {
+    const serverDs: any = {
+      find: vi.fn().mockResolvedValue([]),
+      findOne: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      exportDownload: vi.fn(),
+    };
+
+    it('hides pdf from the export menu even when declared', async () => {
+      const schema: ListViewSchema = {
+        type: 'list-view',
+        objectName: 'contacts',
+        viewType: 'grid',
+        fields: ['name', 'email'],
+        exportOptions: { formats: ['xlsx', 'pdf'] as any },
+      };
+
+      render(
+        <SchemaRendererProvider dataSource={serverDs}>
+          <ListView schema={schema} dataSource={serverDs} />
+        </SchemaRendererProvider>
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /export/i }));
+      expect(await screen.findByRole('button', { name: /export as xlsx/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /export as pdf/i })).toBeNull();
+    });
+
+    it('hides xlsx when the data source has no server export stream', async () => {
+      const schema: ListViewSchema = {
+        type: 'list-view',
+        objectName: 'contacts',
+        viewType: 'grid',
+        fields: ['name', 'email'],
+        exportOptions: { formats: ['csv', 'xlsx'] },
+      };
+
+      renderWithProvider(<ListView schema={schema} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /export/i }));
+      expect(await screen.findByRole('button', { name: /export as csv/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /export as xlsx/i })).toBeNull();
+    });
+
+    it('hides the export button entirely when no declared format is deliverable', () => {
+      const schema: ListViewSchema = {
+        type: 'list-view',
+        objectName: 'contacts',
+        viewType: 'grid',
+        fields: ['name', 'email'],
+        exportOptions: { formats: ['pdf'] as any },
+      };
+
+      renderWithProvider(<ListView schema={schema} />);
+
+      expect(screen.queryAllByRole('button', { name: /export/i }).length).toBe(0);
+    });
+  });
+
   // ============================
   // conditionalFormatting spec format
   // ============================


### PR DESCRIPTION
## Problem

The export popover rendered whatever `exportOptions.formats` declared, but the runtime can only deliver a subset: the server stream (`dataSource.exportDownload`) handles csv/xlsx/json, the client fallback only csv/json. A declared `pdf` — implemented nowhere, and declined platform-side in objectstack-ai/objectstack#1301 (closed NOT_PLANNED) — rendered as a menu item whose click silently did nothing: no request, no file, the popover just closed. Same for `xlsx` whenever the server stream is unavailable (no `exportDownload`, inline `provider: 'value'` data, or `streaming: false`).

This is the export row of the #2942 dead-value audit (`ListView.tsx` / `ObjectGrid.tsx`).

## Fix

Both `ListView` and `ObjectGrid` now filter the menu to formats the current data source can actually produce:

- `pdf` never renders;
- `xlsx` renders only when the server stream is available;
- when nothing survives, the export button (and its toolbar separators) hides entirely;
- dropped declarations emit a `console.warn` so app authors find out at dev time instead of via a dead button.

## Tests

5 new cases (3 in `ListView.test.tsx`, 2 in `exportGate.test.tsx`): pdf hidden while xlsx stays on a server-capable source; xlsx hidden on a client-only source while csv stays; button fully hidden when only pdf is declared.

`pnpm vitest run packages/plugin-list packages/plugin-grid`: 535 passed. `type-check` on both packages: clean.

Closes the export row of #2942 (other rows remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)