### PR TITLE
test: fix five load-sensitive flaky tests by moving module loads out of timed windows

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/anchors.page-seed.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.page-seed.test.ts
@@ -1,6 +1,20 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+// `createSeed` reaches the page synthesizer through a dynamic
+// `await import('@object-ui/plugin-detail')` (anchors.ts), so the cold transform
+// of that whole package graph is billed to whichever test first awaits the hook
+// — inside the test body, against the 15s `testTimeout`. The `unit` project runs
+// `isolate: false`, so whether the module is already warm depends on what else
+// the worker happened to run first; when it wasn't, the seeding test blew the
+// budget. (It surfaced as a timeout rather than a wrong result because
+// `createSeed` swallows failures and returns `{}`.)
+//
+// Importing it here moves that cost into the file's import phase, which no test
+// or hook timeout applies to, so it can never land inside a timed window again.
+// Keep the specifier identical to the one in anchors.ts — ESM caches by resolved
+// specifier, so this makes the hook's own dynamic import resolve immediately.
+import '@object-ui/plugin-detail';
 import { registerBuiltinAnchors } from './anchors';
 import { resolveResourceConfig } from './registry';
 

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
@@ -1,8 +1,26 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import { DatasetPreview } from './DatasetPreview';
+
+// DatasetPreview renders its chart behind
+// `React.lazy(() => import('@object-ui/plugin-charts'))`, and the "use the right
+// axis" caption asserted on below lives *inside* that Suspense boundary — so it
+// only exists once the (recharts-backed) chunk resolves. Loading it is unbounded
+// work: under full-suite parallelism Vite's transform pipeline is saturated and
+// the first import of the package graph can outlast RTL's 1000ms
+// `waitFor`/`findBy` window. The earlier tests in this file assert on the table,
+// which renders *outside* the boundary, so they start the import but never wait
+// for it — leaving the ratio-measure test to race a load already in flight.
+//
+// Resolving the chunk once, up front, takes the module load out of every
+// assertion window instead of widening the windows. Keep this specifier
+// identical to DatasetPreview.tsx's: ESM caches by resolved specifier, so warming
+// it here makes the component's own `React.lazy` factory resolve immediately.
+beforeAll(async () => {
+  await import('@object-ui/plugin-charts');
+});
 
 // Mock the data adapter the preview pulls from AdapterProvider.
 const { queryDataset } = vi.hoisted(() => ({ queryDataset: vi.fn() }));

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
@@ -1,9 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
-import { DatasetPreview } from './DatasetPreview';
-
 // DatasetPreview renders its chart behind
 // `React.lazy(() => import('@object-ui/plugin-charts'))`, and the "use the right
 // axis" caption asserted on below lives *inside* that Suspense boundary — so it
@@ -14,13 +12,12 @@ import { DatasetPreview } from './DatasetPreview';
 // which renders *outside* the boundary, so they start the import but never wait
 // for it — leaving the ratio-measure test to race a load already in flight.
 //
-// Resolving the chunk once, up front, takes the module load out of every
-// assertion window instead of widening the windows. Keep this specifier
-// identical to DatasetPreview.tsx's: ESM caches by resolved specifier, so warming
-// it here makes the component's own `React.lazy` factory resolve immediately.
-beforeAll(async () => {
-  await import('@object-ui/plugin-charts');
-});
+// Importing it here moves that cost into the file's import phase, which no test
+// or hook timeout applies to, instead of widening any assertion window. Keep the
+// specifier identical to DatasetPreview.tsx's — ESM caches by resolved specifier,
+// so this makes the component's own `React.lazy` factory resolve immediately.
+import '@object-ui/plugin-charts';
+import { DatasetPreview } from './DatasetPreview';
 
 // Mock the data adapter the preview pulls from AdapterProvider.
 const { queryDataset } = vi.hoisted(() => ({ queryDataset: vi.fn() }));

--- a/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx
@@ -1,8 +1,27 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import { ReportPreview } from './ReportPreview';
+
+// ReportPreview renders the runtime report renderer behind
+// `React.lazy(() => import('@object-ui/plugin-report'))`, so nothing below the
+// Suspense boundary — including the `queryDataset` call the assertions wait on —
+// exists until that chunk resolves. Loading it is unbounded work: under
+// full-suite parallelism Vite's transform pipeline is saturated (the `dom-heavy`
+// project alone spends ~60s in transform) and the first import of the package
+// graph can outlast RTL's 1000ms `waitFor`/`findBy` window. The assertions then
+// raced the module loader and failed against the "Loading report renderer…"
+// fallback — only in the first tests of the file, because later ones find the
+// module warm.
+//
+// Resolving the chunk once, up front, takes the module load out of every
+// assertion window instead of widening the windows. Keep this specifier
+// identical to ReportPreview.tsx's: ESM caches by resolved specifier, so warming
+// it here makes the component's own `React.lazy` factory resolve immediately.
+beforeAll(async () => {
+  await import('@object-ui/plugin-report');
+});
 
 // Mock the data adapter the preview pulls from AdapterProvider.
 const { queryDataset } = vi.hoisted(() => ({ queryDataset: vi.fn() }));

--- a/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx
@@ -1,27 +1,25 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
-import { ReportPreview } from './ReportPreview';
-
 // ReportPreview renders the runtime report renderer behind
 // `React.lazy(() => import('@object-ui/plugin-report'))`, so nothing below the
 // Suspense boundary — including the `queryDataset` call the assertions wait on —
 // exists until that chunk resolves. Loading it is unbounded work: under
 // full-suite parallelism Vite's transform pipeline is saturated (the `dom-heavy`
 // project alone spends ~60s in transform) and the first import of the package
-// graph can outlast RTL's 1000ms `waitFor`/`findBy` window. The assertions then
-// raced the module loader and failed against the "Loading report renderer…"
-// fallback — only in the first tests of the file, because later ones find the
-// module warm.
+// graph can outlast RTL's 1000ms `waitFor`/`findBy` window. Measured under a real
+// full run, this import alone took 312/424/976ms across three runs — that last
+// one is 97.6% of the entire assertion budget. The assertions then raced the
+// module loader and failed against the "Loading report renderer…" fallback —
+// only in the first tests of the file, because later ones find the module warm.
 //
-// Resolving the chunk once, up front, takes the module load out of every
-// assertion window instead of widening the windows. Keep this specifier
-// identical to ReportPreview.tsx's: ESM caches by resolved specifier, so warming
-// it here makes the component's own `React.lazy` factory resolve immediately.
-beforeAll(async () => {
-  await import('@object-ui/plugin-report');
-});
+// Importing it here moves that cost into the file's import phase, which no test
+// or hook timeout applies to, instead of widening any assertion window. Keep the
+// specifier identical to ReportPreview.tsx's — ESM caches by resolved specifier,
+// so this makes the component's own `React.lazy` factory resolve immediately.
+import '@object-ui/plugin-report';
+import { ReportPreview } from './ReportPreview';
 
 // Mock the data adapter the preview pulls from AdapterProvider.
 const { queryDataset } = vi.hoisted(() => ({ queryDataset: vi.fn() }));

--- a/packages/i18n/src/__tests__/all-locales-key-parity.test.ts
+++ b/packages/i18n/src/__tests__/all-locales-key-parity.test.ts
@@ -61,7 +61,14 @@ describe('all locale packs are at full key parity with en (objectui#2872)', () =
   });
 
   it.each(OTHER_LOCALES)('%s defines every en key', (lang) => {
-    const missing = [...EN].filter((k) => !keysOf(builtInLocales[lang]).has(k)).sort();
+    // Build the pack's key set ONCE. Calling `keysOf` inside the predicate
+    // re-walks the whole locale tree per `en` key (~2.5k keys x a full
+    // recursive walk), which made this quadratic: ~850-2200ms per locale
+    // isolated, and >15s — a timeout, not a parity failure — once full-suite
+    // contention slowed each walk down. The sibling assertion below always
+    // hoisted it; this one didn't.
+    const packKeys = keysOf(builtInLocales[lang]);
+    const missing = [...EN].filter((k) => !packKeys.has(k)).sort();
     expect(missing, `${lang} is missing ${missing.length} key(s)`).toEqual([]);
   });
 

--- a/packages/plugin-kanban/src/index.test.ts
+++ b/packages/plugin-kanban/src/index.test.ts
@@ -6,15 +6,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
+// Import all renderers to register them. This was a `beforeAll(async () => {
+// await import('./index') }, 15000)` — the cold transform of the renderer graph
+// was billed to a hook, so it needed its timeout raised to 15s, and under full
+// parallel load it blew even that (observed: 15021ms, reported as 8 skipped tests
+// rather than a failed assertion). A static import puts the same cost in the
+// file's import phase, which no test or hook timeout applies to — so the raised
+// timeout is no longer needed at all.
+import './index';
 
 describe('Plugin Kanban', () => {
-  // Import all renderers to register them
-  beforeAll(async () => {
-    await import('./index');
-  }, 15000); // Increase timeout to 15 seconds for async import
-
   describe('kanban component', () => {
     it('should be registered in ComponentRegistry', () => {
       const kanbanRenderer = ComponentRegistry.get('kanban-ui');


### PR DESCRIPTION
## The race

Three `dom-heavy` tests failed intermittently under full-suite parallel load but passed in isolation. All of them turned out to be one root cause, and it is not in the code under test:

**An unbounded module load sitting inside a bounded assertion window.**

`DatasetPreview` and `ReportPreview` render their renderers behind `React.lazy(() => import('@object-ui/plugin-charts' | '@object-ui/plugin-report'))`. Everything the assertions wait on lives *behind* that Suspense boundary and does not exist until the chunk resolves. Under full parallelism Vite's transform pipeline is saturated — the `dom-heavy` project alone spends ~60s in transform — so the first import of the package graph can outlast RTL's **1000ms** default `waitFor`/`findBy` window.

### Evidence

A captured failure shows the DOM at timeout still rendering the Suspense fallback:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ 'sales', …(1) ]
Number of calls: 0
  <div class="flex items-center gap-2 p-4 text-xs text-muted-foreground">
    <svg class="lucide lucide-loader-circle h-4 w-4 animate-spin" …
     Loading report renderer…
```

`queryDataset` had 0 calls because `ReportRenderer` — the thing that calls it — had not loaded yet. The test duration was **1070ms**: the 1000ms window plus overhead.

Instrumenting the import under a real full `dom-heavy` run measured `import('@object-ui/plugin-report')` at **312ms / 424ms / 976ms** across three runs. That last one consumes **97.6% of the entire assertion budget** before a single render or query can happen.

This explains exactly *which* tests flaked:

| File | Flaky tests | Why those |
|---|---|---|
| `ReportPreview.dataset.test.tsx` | the **first two** | they run while the very first import is still in flight; tests 3–5 find the module warm |
| `DatasetPreview.test.tsx` | only the ratio-measure one | its "use the right axis" caption is the one assertion in the file that sits *inside* the Suspense boundary. Earlier tests assert on the table, which renders *outside* it — so they start the import but never wait for it, leaving the last test to race a load already in flight |

## The fix

Load each module at **module scope** in the test file, so the cost lands in the import phase — which no test or hook timeout applies to — instead of inside an assertion window. ESM caches by resolved specifier, so warming the same specifier makes the component's own `React.lazy` factory resolve immediately.

No timeout was raised and no file was moved to an allowlist.

> Note on the idiom: the first commit used `beforeAll`, then switched to a module-scope import because `beforeAll` is bounded by `hookTimeout` (10s) — *narrower* than the 15s `testTimeout` it replaces. The import phase is effectively unbounded (a full run logs `import 1523s` cumulative across 716 files with no import-phase failure).

## The two `unit`-project files

Both were reported as inconsistent. Verified: **timeouts, not genuine failures** — and one shares the exact root cause.

- **`anchors.page-seed.test.ts`** — same root cause. `createSeed` reaches the page synthesizer via `await import('@object-ui/plugin-detail')` ([anchors.ts:207](packages/app-shell/src/views/metadata-admin/anchors.ts:207)), so the cold transform is billed to the test body. `unit` runs `isolate: false`, so whether the module is already warm is scheduling-dependent — which is precisely the inconsistency. Confirmed it can only be a timeout: `createSeed` swallows failures and returns `{}`, so a genuine synth failure would read as `expected false to be true`, never observed.

- **`all-locales-key-parity.test.ts`** — *not* a load effect: a genuine quadratic. Line 64 called `keysOf(builtInLocales[lang])` **inside** the `.filter()` predicate, re-walking the whole locale tree once per `en` key (~2.5k keys × a full recursive walk). The sibling assertion immediately below it always hoisted the call; this one didn't. **Parity itself is clean** — all 9 non-`en` packs have 0 missing and 0 extra keys — so this was never a missing-translation failure.

## One more, found while verifying

`plugin-kanban/src/index.test.ts` surfaced during verification with the same root cause, and it is the anti-pattern's own cautionary tale:

```js
beforeAll(async () => { await import('./index'); }, 15000); // Increase timeout to 15 seconds
```

Already "fixed" once by raising the timeout — and it still timed out under full load (observed **15021ms**, surfacing as 8 skipped tests rather than a failed assertion). The raised timeout is **deleted**, not re-raised.

## Results

Timed portion of each file, isolated:

| File | Before | After |
|---|---|---|
| `all-locales-key-parity` | 7.51s | **25ms** (~300×) |
| `plugin-kanban/index` | 15021ms (hook timeout) | **2ms** |
| `anchors.page-seed` + i18n combined | ~9.6s | **48ms** |
| the two previews | 769ms | **397ms** |

Suite verification:

- **`--project dom-heavy`**: failed 1 run in 4 before; green **20/20 runs** after (14 on the `beforeAll` form, 6 on the final static-import form).
- **`--project unit`**: all four files above pass. The 7 files that still fail are a pre-existing broken baseline with real `AssertionError`s (`spec-subschema-parity`, `onMutation`, `filter-operator-ast-parity` ×2, `view-config-utils`, `view-operator-builder-parity`, `clientValidation.fieldRules`) — unchanged by this PR and unrelated to timing.
- **Full suite before vs after**: identical **19 genuine test failures**, no new failures, and no cross-file interference from the module-scope imports despite `isolate: false`.
- Lint clean on all five files (only pre-existing `no-explicit-any` warnings).

Test-only change, so no changeset per AGENTS.md.

## The durable takeaway

If a test asserts on content behind a `React.lazy` / dynamic-import boundary, load that module at module scope. Otherwise the module loader competes with the assertion timeout, and the test's reliability depends on machine load rather than on the code it covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)