### PR TITLE
test(sdui): check the contract in the direction that would have caught #3006

### DIFF
--- a/.changeset/reverse-contract-check.md
+++ b/.changeset/reverse-contract-check.md
@@ -1,0 +1,36 @@
+---
+"@object-ui/console": patch
+---
+
+test(sdui): check the contract in the direction that would have caught #3006
+
+The console contract guard only looked one way: every tag in `PUBLIC_BLOCKS`
+must resolve. That direction cannot tell "not built yet" from "built, but the
+contract spells it wrong" — so `record:line_items` was filed as a known gap for
+a release while its renderer shipped, fully configured, in plugin-form.
+
+Two checks close the other direction:
+
+- **Every shipped `record:*` block is curated, or listed with a reason.** Seven
+  are deliberately out, each declaring zero `inputs` — nothing for an author or
+  a model to configure. A new `record:*` registration now fails until someone
+  decides which side it belongs on, so the vocabulary cannot quietly drift from
+  what the platform can render. A companion assertion pins those seven at zero
+  inputs, so one growing a configurable surface re-opens the decision instead of
+  inheriting the exclusion.
+
+- **A curated tag that near-misses a registered block.** `line_items` vs
+  `record:line_items` differ only by namespace; one of the two spellings is
+  always a typo. The check reports the candidate ("also try
+  `record:line_items`") rather than just "not covered".
+
+Both were verified against the real bug: reverting the tag to `line_items`
+fails them with exactly that diagnosis.
+
+Grouping the registry by canonical `type` surfaced a second, latent issue —
+eleven `record:*` blocks in plugin-detail are registered as
+`register('record:x', …, { namespace: 'record' })`, prefixing an already-
+prefixed name and yielding doubled `record:record:x` keys. It does not reach
+the contract (`getPublicConfigs()` rewrites `type` to the curated tag), so this
+changeset only documents it where the grouping happens; the registrations are
+left for a separate change.

--- a/apps/console/src/__tests__/public-contract.test.ts
+++ b/apps/console/src/__tests__/public-contract.test.ts
@@ -147,3 +147,88 @@ describe('console ↔ PUBLIC_BLOCKS coverage', () => {
     }
   });
 });
+
+/**
+ * `record:*` blocks that ship but are deliberately NOT in the AI vocabulary,
+ * each with the reason it stays out. Every one of these currently declares
+ * ZERO `inputs` — there is nothing for an author or a model to configure, so
+ * putting them in the contract would advertise a block that can only be
+ * emitted bare.
+ *
+ * This list exists to force a decision, not to park problems: registering a
+ * new `record:*` block fails the test below until it is either curated or
+ * added here with a reason. That is the property objectui#3006 needed and did
+ * not have — `record:line_items` shipped fully configurable (5 inputs) and
+ * simply never reached the contract, because nothing looked in this direction.
+ */
+const DELIBERATELY_UNCURATED: Record<string, string> = {
+  'record:activity': 'no declared inputs — feed is derived from the record, nothing to author',
+  'record:alert': 'no declared inputs — banner content comes from record state',
+  'record:chatter': 'no declared inputs — feed is derived from the record',
+  'record:discussion': 'no declared inputs — shares the chatter renderer',
+  'record:history': 'no declared inputs — audit trail is derived from the record',
+  'record:quick_actions': 'no declared inputs — actions come from object metadata',
+  'record:reference_rail': 'no declared inputs — rail is derived from the record',
+};
+
+describe('PUBLIC_BLOCKS ↔ console coverage (reverse direction)', () => {
+  const NS = 'record';
+
+  /**
+   * Eleven of these blocks are registered as
+   * `register('record:x', …, { namespace: 'record' })` — an already-prefixed
+   * name that gets prefixed again — so the registry holds both `record:x` and a
+   * doubled `record:record:x` for the same component. The doubling never
+   * reaches the contract (`getPublicConfigs()` rewrites `type` to the curated
+   * tag), but it is real in the registry, and counting raw keys would report
+   * those components twice. Collapsing the repeated prefix is what makes the
+   * set below one entry per block.
+   */
+  const undouble = (key: string): string => {
+    let k = key;
+    while (k.startsWith(`${NS}:${NS}:`)) k = k.slice(NS.length + 1);
+    return k;
+  };
+
+  const shippedRecordBlocks = (): string[] => {
+    const keys = ComponentRegistry.getKnownTypes().filter(
+      (k) => ComponentRegistry.getMeta(k)?.namespace === NS,
+    );
+    return [...new Set(keys.map(undouble))].sort();
+  };
+
+  it('curates every shipped record:* block, or records why not', () => {
+    const curated = new Set<string>(PUBLIC_BLOCKS);
+    const uncurated = shippedRecordBlocks().filter((tag) => !curated.has(tag));
+
+    expect(uncurated).toEqual(Object.keys(DELIBERATELY_UNCURATED).sort());
+  });
+
+  it('keeps the deliberately-uncurated blocks unconfigurable', () => {
+    // The stated reason for every exclusion is "nothing to author". If one of
+    // these grows `inputs`, it became authorable and the exclusion needs
+    // re-deciding rather than inheriting.
+    for (const tag of Object.keys(DELIBERATELY_UNCURATED)) {
+      // A pending lazy stub reports `inputs: undefined` meaning "not known
+      // yet", which would make the assertion below vacuous. These are eager
+      // registrations in plugin-detail; pin that, so the day one goes lazy this
+      // fails loudly instead of silently passing.
+      expect(ComponentRegistry.getConfig(tag)).toBeDefined();
+      expect(ComponentRegistry.getMeta(tag)?.inputs ?? []).toEqual([]);
+    }
+  });
+
+  it('catches a curated tag that misses a registered block by its namespace', () => {
+    // The objectui#3006 shape: PUBLIC_BLOCKS said `line_items`, the registry
+    // said `record:line_items`, and the forward check could only report "not
+    // covered" — which reads as "not built yet" and got filed as a known gap.
+    // A near-miss is never intentional: one of the two spellings is a typo.
+    const known = new Set(ComponentRegistry.getKnownTypes());
+    const nearMisses = PUBLIC_BLOCKS.filter((tag) => !known.has(tag)).map((tag) => {
+      const bare = tag.slice(tag.indexOf(':') + 1);
+      return { tag, alsoTry: [...known].filter((k) => k === bare || k.endsWith(`:${bare}`)) };
+    });
+
+    expect(nearMisses.filter((m) => m.alsoTry.length > 0)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up to #3006. The guard there only looked one way: every tag in `PUBLIC_BLOCKS` must resolve. That direction cannot distinguish **"not built yet"** from **"built, but the contract spells it wrong"** — so `record:line_items` sat in `EXPECTED_UNIMPLEMENTED` for a release while its renderer shipped, fully configured, in plugin-form.

## What I found before writing the check

The obvious reverse check — *every registered block must be curated* — is wrong, and the data says so. The console registers **525 keys / ~274 components**; `PUBLIC_BLOCKS` curates **36**. The rest are `ui:*` primitives, `field:*` types, and plugin internals. Curation is the point; asserting against the full registry would be pure noise.

Narrowing to the `record:` family doesn't trivially work either — **12 blocks ship, 5 are curated**. The 7 uncurated ones aren't mistakes:

| block | label | inputs | curated |
|---|---|---|---|
| `record:details` | Record Details | 4 | ✅ |
| `record:highlights` | Highlights Panel | 2 | ✅ |
| `record:related_list` | Related List | 9 | ✅ |
| `record:path` | Path / Stepper | 2 | ✅ |
| `record:line_items` | Line Items | 5 | ✅ (as of #3006) |
| `record:activity` | Activity Timeline | **0** | — |
| `record:alert` | Alert Banner | **0** | — |
| `record:chatter` | Chatter Feed | **0** | — |
| `record:discussion` | Discussion | **0** | — |
| `record:history` | History Timeline | **0** | — |
| `record:quick_actions` | Quick Actions | **0** | — |
| `record:reference_rail` | Reference Rail | **0** | — |

The split is exactly `inputs > 0`. Curated blocks are configurable; the excluded ones have nothing an author or a model can set.

## The two checks

**1. Every shipped `record:*` block is curated, or listed with a reason.** The seven live in a `DELIBERATELY_UNCURATED` map with a one-line rationale each. This is an allowlist of *decisions*, not of *defects* — registering a new `record:*` block fails the test until someone picks a side, so the vocabulary can't drift from what the platform renders. A companion assertion pins those seven at zero inputs, so one that grows a configurable surface re-opens the decision instead of inheriting the exclusion.

That assertion also guards its own premise: `getMeta()` reports `inputs: undefined` for a pending lazy stub, meaning *"not known yet"*, not *"declares none"*. The test asserts these are eager registrations first, so going lazy fails loudly rather than passing vacuously.

**2. A curated tag that near-misses a registered block.** `line_items` vs `record:line_items` differ only by namespace — one of the two spellings is always a typo, never a design. The check reports the candidate rather than just "not covered".

## Verified against the real bug

Reverting the tag to `line_items` fails both with exactly the right diagnosis:

```
- "record:line_items"          ← reverse check: shipped but uncurated
+ "alsoTry": ["record:line_items"]   ← near-miss: did you mean this?
```

That second line is the sentence I needed and didn't have on #3006 — I read "not covered", concluded "not built yet", and filed it.

Full suite `726 passed | 1 skipped`, type-check 35/35, lint 0 errors, changeset included.

## Latent issue found, not fixed here

Deduping the registry surfaced eleven `record:*` blocks in plugin-detail registered as:

```ts
register('record:details', …, { namespace: 'record' })   // already prefixed, prefixed again
```

which yields doubled `record:record:details` keys. It does **not** reach the contract — `getPublicConfigs()` rewrites `type` to the curated tag (`Registry.ts:477`) — so it's internal dirt, not a live bug. `record:line_items` is the one registered correctly (`'line_items'` + `namespace` + `skipFallback`). Documented where the deduping happens; the registrations want their own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4mrr1ihhwnfEHFSWmGoMp


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4mrr1ihhwnfEHFSWmGoMp)_