### PR TITLE
test(charts): the chart-dialect guard fails on new dialect, not on the spec adopting one (#2945)

### DIFF
--- a/packages/plugin-charts/src/__tests__/chart-type-spec-parity.test.tsx
+++ b/packages/plugin-charts/src/__tests__/chart-type-spec-parity.test.tsx
@@ -52,12 +52,37 @@ describe('plugin-charts covers the spec chart-type vocabulary', () => {
     ).toEqual([]);
   });
 
-  it("the only renderer-local dialect is the documented 'combo'", () => {
+  it('carries no renderer-local dialect beyond the tracked exceptions', () => {
+    /**
+     * Dialect this renderer is knowingly ahead of the resolved spec on. Each
+     * entry needs a promote-or-delete decision (objectui#2945) — the set is an
+     * upper bound, not an expectation, so it shrinks silently as the spec
+     * adopts a name and only GROWING it fails.
+     *
+     * `combo`: promoted into `ChartTypeSchema` by framework#4070, which is not
+     * in a published spec version yet. When objectui bumps to a spec that
+     * includes it, this entry becomes dead weight — drop it then; nothing
+     * fails in the meantime.
+     */
+    const TRACKED_DIALECT = new Set(['combo']);
     const implemented = [...RENDERABLE, ...SINGLE_VALUE_CHART_TYPES, ...TABULAR_CHART_TYPES];
-    const dialect = implemented.filter((name) => !specNames.includes(name));
-    // `combo` is tracked in #2945 ("promote or delete"); anything else
-    // appearing here is NEW dialect and needs the same decision first.
-    expect(dialect).toEqual(['combo']);
+    const untracked = implemented.filter(
+      (name) => !specNames.includes(name) && !TRACKED_DIALECT.has(name),
+    );
+    expect(
+      untracked,
+      'new renderer-local chart dialect — promote it into @objectstack/spec or delete it (objectui#2945)',
+    ).toEqual([]);
+
+    // Report entries the spec has since adopted, so the list gets pruned
+    // instead of quietly accumulating stale exceptions.
+    const adopted = [...TRACKED_DIALECT].filter((name) => specNames.includes(name));
+    if (adopted.length > 0) {
+      // eslint-disable-next-line no-console
+      console.info(
+        `[chart-type parity] the spec now defines ${adopted.join(', ')} — remove them from TRACKED_DIALECT.`,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
A one-test follow-up to #3011, found while checking what remained of #2945.

## The problem

The chart-type parity guard I added in #3011 asserted an **exact match** against the one name objectui draws that the resolved spec doesn't define:

```js
expect(dialect).toEqual(['combo']);
```

That's the wrong shape for a drift guard. framework#4070 has **already promoted `combo` into `ChartTypeSchema`** (it isn't in a published spec version yet, so objectui still resolves the enum without it). The moment objectui bumps to a spec carrying `combo`, `dialect` becomes `[]` and the test fails with `expected [] to deeply equal ['combo']` — a cryptic red for the *good* outcome, landing on whoever does the version bump instead of on whoever introduces dialect.

## The fix

The tracked set becomes an upper bound rather than an expectation:

- only **untracked** dialect fails, with a message naming the promote-or-delete decision;
- the list shrinks silently as the spec adopts a name — a bump is green;
- an entry the spec has since defined is reported through `console.info` so it gets pruned rather than accumulating as a stale exception.

Coverage assertions (every spec chart type lands on a real branch; no silent bar collapse; single-value/tabular behavior) are untouched.

## Context on #2945

While verifying, I found **Track A and the additions-only work are both already done** framework-side, so #2945's "safe, ready now" section is stale:

- framework#4061 — retired the three orphan vocabularies (`AggregationFunctionEnum`, websocket `FilterOperator` + `EventFilterSchema`, `ODataFilterOperatorSchema`), each with a tombstone comment. I verified zero residue in framework, and zero consumers in objectui.
- framework#4070 — promoted `combo`, made `WidgetActionTypeSchema` *be* `ActionType`, derived `ListChartConfigSchema.chartType` via `.extract([...])`, and derived `@objectstack/lint`'s chart-family set from the taxonomy.
- framework#4107 — `saveMeta` now persists the normalized operator spellings, which was prerequisite #2 for Track C.

I've commented the same on #2945. Track C is still blocked on objectstack#3948 item 1 and shouldn't start.

## Verification

`vitest` 7/7 on the touched file, eslint clean. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)