### PR TITLE
refactor(app-shell): action-location 与目录查找两处手抄清单改为从 spec 派生 (#3017)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
@@ -30,6 +30,7 @@
 
 import * as React from 'react';
 import { Plus, Trash2 } from 'lucide-react';
+import type { ActionLocation } from '@objectstack/spec/ui';
 import {
   Button, Label, Textarea,
 } from '@object-ui/components';
@@ -107,16 +108,32 @@ const PARAM_TYPE_OPTS = [
   { value: 'lookup', label: 'Lookup' },
 ];
 
-/** Canonical action locations (mirrors spec ACTION_LOCATIONS) with friendly labels. */
-const LOCATIONS: Array<{ value: string; label: string }> = [
-  { value: 'record_header', label: 'Record header' },
-  { value: 'record_more', label: 'Record · more menu' },
-  { value: 'record_section', label: 'Record · section' },
-  { value: 'record_related', label: 'Record · related list' },
-  { value: 'list_toolbar', label: 'List toolbar' },
-  { value: 'list_item', label: 'List · row' },
-  { value: 'global_nav', label: 'Global nav / command palette' },
-];
+/**
+ * Friendly labels for the spec's action locations.
+ *
+ * The vocabulary belongs to `ActionLocation` (spec `ACTION_LOCATIONS`). This
+ * used to restate all seven values under a "mirrors spec ACTION_LOCATIONS"
+ * comment with nothing enforcing it (objectui#3017). Typing the map as a TOTAL
+ * `Record<ActionLocation, string>` makes the compiler the mechanism: a location
+ * the spec ADDS is a missing-key error here rather than a silently absent
+ * dropdown entry, and one it REMOVES is an excess-property error.
+ *
+ * Insertion order is the display order — an authoring-friendly grouping
+ * (record → list → global), deliberately not the spec's declaration order.
+ */
+const LOCATION_LABELS: Record<ActionLocation, string> = {
+  record_header: 'Record header',
+  record_more: 'Record · more menu',
+  record_section: 'Record · section',
+  record_related: 'Record · related list',
+  list_toolbar: 'List toolbar',
+  list_item: 'List · row',
+  global_nav: 'Global nav / command palette',
+};
+
+const LOCATIONS: Array<{ value: ActionLocation; label: string }> = (
+  Object.keys(LOCATION_LABELS) as ActionLocation[]
+).map((value) => ({ value, label: LOCATION_LABELS[value] }));
 
 /** Per-type binding hints for the single `target` field. */
 const TARGET_FIELD: Record<string, { label: string; placeholder: string; hint: string }> = {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.specDerivation.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.specDerivation.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * **The directory-lookup table is derived from the spec, not restated** (objectui#3017).
+ *
+ * `KIND_TO_RECORD_LOOKUP` used to hard-code `object` / `valueField` for the four
+ * directory-backed kinds under a comment saying it mirrored the spec's
+ * `APPROVER_VALUE_BINDINGS`. It now composes objectui's presentation on top of
+ * the published `APPROVER_VALUE_SOURCES`, so those two fields cannot drift by
+ * construction.
+ *
+ * What is still worth asserting is that the composition stays WIRED. Two ways it
+ * could quietly stop being: the derivation could yield an empty table (every
+ * kind skipped because the spec changed shape), or a kind could lose its
+ * `data` source and vanish from the picker. Both would degrade a resolvable
+ * reference back to a free-text box — exactly the framework #3508 failure that
+ * publishing the binding existed to end, and exactly the kind of regression a
+ * comment cannot catch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { APPROVER_VALUE_SOURCES } from '@objectstack/spec/automation';
+
+import { KIND_TO_RECORD_LOOKUP } from './FlowReferenceField';
+
+/** The directory-backed kinds this package renders a record lookup for. */
+const EXPECTED_KINDS = ['user', 'team', 'department', 'position'] as const;
+
+describe('KIND_TO_RECORD_LOOKUP is derived from APPROVER_VALUE_SOURCES (objectui#3017)', () => {
+  it('is not vacuous — the derivation still produces every expected kind', () => {
+    // If the spec renamed these keys or changed their `source`, the flatMap
+    // would skip them and the table would silently shrink.
+    expect(Object.keys(KIND_TO_RECORD_LOOKUP).sort()).toEqual([...EXPECTED_KINDS].sort());
+  });
+
+  it.each(EXPECTED_KINDS)('%s: object + valueField come from the spec, not a local literal', (kind) => {
+    const source = APPROVER_VALUE_SOURCES[kind as keyof typeof APPROVER_VALUE_SOURCES];
+    expect(source, `spec no longer declares an approver binding for '${kind}'`).toBeDefined();
+    expect(
+      source.source,
+      `spec changed '${kind}' away from a record lookup — the picker needs rethinking, not just re-deriving`,
+    ).toBe('data');
+
+    const binding = KIND_TO_RECORD_LOOKUP[kind];
+    expect(binding).toBeDefined();
+    expect(binding!.object).toBe((source as { object: string }).object);
+    expect(binding!.valueField).toBe((source as { valueField: string }).valueField);
+  });
+
+  it('keeps presentation local — the spec publishes no display hints', () => {
+    // The split is the point: the spec owns WHERE candidates come from and WHAT
+    // is committed; this package owns what the row looks like. A spec that
+    // started publishing display hints would make this assertion fail and force
+    // the boundary to be re-drawn deliberately.
+    for (const kind of EXPECTED_KINDS) {
+      const source = APPROVER_VALUE_SOURCES[kind as keyof typeof APPROVER_VALUE_SOURCES] as Record<string, unknown>;
+      expect(Object.keys(source).sort()).toEqual(['object', 'source', 'valueField']);
+      expect(KIND_TO_RECORD_LOOKUP[kind]!.displayField).toBeTruthy();
+    }
+  });
+
+  it('the people picker stays on `user` only', () => {
+    // `picker: 'search'` opts into avatar rows; it is presentation, so it must
+    // survive the derivation rather than be lost when the binding is composed.
+    expect(KIND_TO_RECORD_LOOKUP.user?.picker).toBe('search');
+    expect(KIND_TO_RECORD_LOOKUP.user?.subtitle).toEqual(['email']);
+    for (const kind of ['team', 'department', 'position'] as const) {
+      expect(KIND_TO_RECORD_LOOKUP[kind]?.picker).toBeUndefined();
+    }
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.tsx
@@ -39,6 +39,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from '@object-ui/components';
 import { Pencil, Search } from 'lucide-react';
+import { APPROVER_VALUE_SOURCES } from '@objectstack/spec/automation';
 import { useAdapter } from '@object-ui/react';
 import { LookupField } from '@object-ui/fields';
 import type { FlowReferenceSpec, ReferenceKind, RefValueSource } from './flow-node-config';
@@ -100,12 +101,61 @@ export interface RecordLookupBinding {
   /** Secondary-line fields for people rows. */
   subtitle?: string[];
 }
-export const KIND_TO_RECORD_LOOKUP: Partial<Record<ReferenceKind, RecordLookupBinding>> = {
-  user: { object: 'sys_user', valueField: 'id', displayField: 'name', picker: 'search', subtitle: ['email'] },
-  team: { object: 'sys_team', valueField: 'id', displayField: 'name' },
-  department: { object: 'sys_business_unit', valueField: 'id', displayField: 'name' },
-  position: { object: 'sys_position', valueField: 'name', displayField: 'label' },
-};
+/**
+ * PRESENTATION for the directory-backed kinds — which column to show, whether
+ * to open the people picker, what subtitle to put under a row.
+ *
+ * Deliberately local: the spec publishes the data contract only and says so.
+ * Everything below this line is objectui's call; everything above it (which
+ * object, which column is committed) now comes from the spec.
+ */
+const RECORD_LOOKUP_PRESENTATION = {
+  user: { displayField: 'name', picker: 'search', subtitle: ['email'] },
+  team: { displayField: 'name' },
+  department: { displayField: 'name' },
+  position: { displayField: 'label' },
+} as const satisfies Partial<
+  Record<ReferenceKind, Omit<RecordLookupBinding, 'object' | 'valueField'>>
+>;
+
+/**
+ * The older-server fallback, DERIVED from the spec's published binding.
+ *
+ * `object` / `valueField` used to be hand-written here, under a comment saying
+ * this table "mirrors `APPROVER_VALUE_BINDINGS` … import it once a published
+ * release carries the export". `@objectstack/spec@17` carries it, so this now
+ * reads `APPROVER_VALUE_SOURCES` and composes objectui's presentation on top
+ * (objectui#3017).
+ *
+ * That matters more here than anywhere else in the designer: the FIRST copy of
+ * this data contract was wrong — every directory kind was wired to the metadata
+ * registry, which holds no `sys_user` / `sys_team` / `sys_business_unit` /
+ * `sys_position` ROWS, so candidates came back empty, the control degraded to
+ * free text, and `sales_manager` got typed into a field that accepts three
+ * values (framework #3508). Spec answered by publishing the binding with a
+ * `satisfies` that makes an undeclared `ApproverType` a compile error; reading
+ * it here is what finally carries that guarantee across the repo boundary.
+ *
+ * A kind whose spec source is not `data` is skipped rather than thrown on — a
+ * module-level throw would white-screen the designer over a vocabulary change.
+ * `FlowReferenceField.specDerivation.test.ts` asserts the table is non-vacuous
+ * and still covers every kind with presentation.
+ */
+export const KIND_TO_RECORD_LOOKUP: Partial<Record<ReferenceKind, RecordLookupBinding>> =
+  Object.fromEntries(
+    Object.entries(RECORD_LOOKUP_PRESENTATION).flatMap(([kind, presentation]) => {
+      const source = APPROVER_VALUE_SOURCES[kind as keyof typeof APPROVER_VALUE_SOURCES];
+      if (!source || source.source !== 'data') return [];
+      return [[
+        kind,
+        {
+          object: source.object,
+          valueField: source.valueField as RecordLookupBinding['valueField'],
+          ...presentation,
+        },
+      ]];
+    }),
+  );
 
 /**
  * better-auth org-membership tiers. `org-membership-level` is intentionally NOT


### PR DESCRIPTION
承 #3017(源自 framework#3786 的模式排查)。metadata-admin inspector 里两处手抄 spec 词表,各配一句「保持同步」注释、零机制。**两处目前都与 spec 一致 —— 这不是 bug 修复,是把「碰巧一致」换成「不可能不一致」。**

对应 framework 侧:[objectstack#4120](https://github.com/objectstack-ai/objectstack/pull/4120)(那边同一模式已查出四份**真的漂移过**的表单,全部静默失效)。

## 1. `ActionDefaultInspector.LOCATIONS` → 编译期保证

原先重述了 `ACTION_LOCATIONS` 的七个值。label 留在本地(那是 presentation),但词表改由 `Record<ActionLocation, string>` 承担 —— **让编译器当机制**:

| spec 侧变化 | 改前 | 改后 |
|:---|:---|:---|
| 新增一个 location | 下拉框里**静默缺一项** | `TS2741: Property 'x' is missing` |
| 删除一个 location | 下拉框里**多一个死选项** | `TS2353: 'x' does not exist in type` |

两个方向都对着实际安装的 `@objectstack/spec@17.0.0-rc.0` 验证过(构造最小样例跑 `tsc`,确认 good 编译通过、missing/extra 各自报上表的错)。

展示顺序仍是对象的插入顺序,所以 record → list → global 这个便于作者理解的分组没变 —— 没有被 spec 的声明顺序带跑。

## 2. `FlowReferenceField.KIND_TO_RECORD_LOOKUP` → 运行期派生 + 测试闸门

原先为四个目录类 kind 硬编码了 `object` / `valueField`。**它自己的注释就写着**「import it once a published release carries the export」—— `@objectstack/spec@17` 已经带上了 `APPROVER_VALUE_SOURCES`,所以现在真的 import 了,并把 objectui 的 presentation 组合在上面。

这张表是本模式**已经让我们付过一次代价**的地方:第一份数据契约抄错,把每个目录类 kind 都接到元数据注册表上,而那里根本不存放 `sys_user`/`sys_team`/`sys_business_unit`/`sys_position` 的**行** —— 候选返回空、控件退化成自由文本框,于是 `sales_manager` 被打进只接受三个值的字段(framework#3508)。spec 当时的回应就是把 binding 发布出来,并用 `satisfies` 保证新增 `ApproverType` 不声明 binding 即编译错误。**在这里读它,才是把那层保证跨仓传导过来。**

spec 要求的分工被完整保留:**spec 管候选从哪来、提交什么值;本包管 `displayField` / `picker` / `subtitle`**。source 不是 `data` 的 kind 走跳过而非抛错 —— 模块级 throw 会因为一次词表变更把设计器整个白屏。

## 行为零变化

派生出来的表与它替换掉的字面量**逐字段完全相同**(已跑脚本比对)。`recordLookupFor` 的优先级不变:服务端发布的 binding 仍然优先,这张表仍是旧服务端的 fallback —— 只不过 fallback 的值现在来自编译进来的 spec,而不是一份手抄。

## 测试

新增 `FlowReferenceField.specDerivation.test.ts`(7 个用例),盯的是「派生有没有**悄悄断掉**」:表非空、四个 kind 都在、`object`/`valueField` 确实来自 spec、presentation 没在组合过程中丢失(尤其 `user` 的 people picker)。若 spec 把某个 kind 从 `data` 改走,测试会指名道姓地说「这个 picker 需要重新设计,不是重新派生一下就行」。

## 验证

- `pnpm --filter @object-ui/app-shell type-check` —— 通过(先做了完整 workspace build,否则 `@object-ui/*` 解析不到会报一堆假错)
- inspector 全量测试 **33 files / 368 tests 全绿**
- `lint` **0 errors**(包内 2054 条 warning 均为既有,我改的文件未新增)

## 未处理

#3017 里另外四处(`object-fields-bridge` ↔ `FieldDesigner`、`RecordMetaFooter` ↔ `RecordDetailView`、`ImportWizard` 的两处 ↔ 服务端 `import-coerce`)本 PR 未动 —— 它们要么是 objectui 内部的两份清单(需要本地断言当闸门),要么需要 framework 先导出常量才能派生。留在 issue 里跟踪。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXGj3Z5TmwSV6RK2oGc3cb)_