### PR TITLE
test: retire four raised hook timeouts by importing at module scope

### DIFF
--- a/apps/console/src/__tests__/public-contract.test.ts
+++ b/apps/console/src/__tests__/public-contract.test.ts
@@ -25,8 +25,23 @@
  * silently disappeared; an exact list makes both directions a deliberate edit.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ComponentRegistry, PUBLIC_BLOCKS, type PublicComponentConfig } from '@object-ui/core';
+// The two graphs whose registrations this file reads. At module scope, NOT
+// awaited inside a `beforeAll` — there their cold transform is billed to the
+// hook, against `hookTimeout`, which is why this needed a 60s budget. The import
+// phase has no test/hook timeout, so the raised timeout goes away rather than
+// getting raised again (objectui#3010). See AGENTS.md §9 (test discipline).
+//
+// Loading them here rather than in a hook does not change WHAT is loaded, so the
+// eager/lazy split the assertions below pin is untouched: static imports are
+// evaluated in order before the module body, and the shared setup still runs
+// before this module is imported at all.
+//
+// The layout/content primitives (Tier B) …
+import '@object-ui/components';
+// … and the console's own plugin layer, from the module main.tsx boots from.
+import '../register-plugins';
 
 /**
  * Every curated tag the console makes available, in `PUBLIC_BLOCKS` order.
@@ -109,15 +124,11 @@ const EXPECTED_LAZY = [
   'markdown',
 ];
 
-let contract: Map<string, PublicComponentConfig>;
-
-beforeAll(async () => {
-  // The layout/content primitives (Tier B) …
-  await import('@object-ui/components');
-  // … and the console's own plugin layer, from the module main.tsx boots from.
-  await import('../register-plugins');
-  contract = new Map(ComponentRegistry.getPublicConfigs().map((c) => [c.type, c]));
-}, 60000);
+// Safe at module scope: the two side-effect imports at the top of this file are
+// evaluated before the module body, so every registration is already in place.
+const contract: Map<string, PublicComponentConfig> = new Map(
+  ComponentRegistry.getPublicConfigs().map((c) => [c.type, c]),
+);
 
 describe('console ↔ PUBLIC_BLOCKS coverage', () => {
   it('exposes every curated block the console ships, eager or lazy', () => {

--- a/packages/plugin-charts/src/index.test.ts
+++ b/packages/plugin-charts/src/index.test.ts
@@ -6,15 +6,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
+// Imports all renderers to register them. Module scope, NOT awaited inside a
+// `beforeAll` — there the cold transform of the (recharts-backed) renderer graph
+// is billed to the hook, which is why this needed a 60s `hookTimeout` to begin
+// with. The import phase has no test/hook timeout, so the raised timeout goes
+// away rather than getting raised again (objectui#3010).
+// See AGENTS.md §9 (test discipline).
+import './index';
 
 describe('Plugin Charts', () => {
-  // Import all renderers to register them
-  beforeAll(async () => {
-    await import('./index');
-  }, 60000);
-
   describe('bar-chart component', () => {
     it('should be registered in ComponentRegistry', () => {
       const chartBarRenderer = ComponentRegistry.get('bar-chart');

--- a/packages/plugin-editor/src/index.test.ts
+++ b/packages/plugin-editor/src/index.test.ts
@@ -6,16 +6,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
+// Imports all renderers to register them. Module scope, NOT awaited inside a
+// `beforeAll` — Monaco is a heavy library, and loading it inside the hook billed
+// that cost against `hookTimeout`, which is why this needed a 30s budget. The
+// import phase has no test/hook timeout, so the raised timeout goes away rather
+// than getting raised again (objectui#3010).
+// See AGENTS.md §9 (test discipline).
+import './index';
 
 describe('Plugin Editor', () => {
-  // Import all renderers to register them
-  // Note: Monaco Editor is a heavy library that takes time to load
-  beforeAll(async () => {
-    await import('./index');
-  }, 30000); // 30 second timeout for Monaco Editor initialization
-
   describe('code-editor component', () => {
     it('should be registered in ComponentRegistry', () => {
       const editorRenderer = ComponentRegistry.get('code-editor');

--- a/packages/plugin-markdown/src/index.test.ts
+++ b/packages/plugin-markdown/src/index.test.ts
@@ -6,15 +6,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
+// Imports all renderers to register them. Module scope, NOT awaited inside a
+// `beforeAll` — there the cold transform of the renderer graph is billed to the
+// hook, against `hookTimeout`. That is what made the sibling plugin-kanban test
+// blow its raised 15s budget at 15021ms under full parallel load
+// (objectui#3010); this file's timed portion was already at 5.83s of the same
+// 15s. The import phase has no test/hook timeout, so no raised timeout is
+// needed. See AGENTS.md §9 (test discipline).
+import './index';
 
 describe('Plugin Markdown', () => {
-  // Import all renderers to register them
-  beforeAll(async () => {
-    await import('./index');
-  }, 15000); // Increase timeout to 15 seconds for async import
-
   describe('markdown component', () => {
     it('should be registered in ComponentRegistry', () => {
       const markdownRenderer = ComponentRegistry.get('markdown');


### PR DESCRIPTION
Follow-up to #3010 (the fix) and #3015 (the §9 rule). Sweeping for the same anti-pattern — `beforeAll(async () => { await import(…) })`, which bills a cold module transform to `hookTimeout` — turned up **36 more test files, every single one already carrying a raised timeout**, on an escalating ladder:

| Raised to | Files |
|---|---|
| 15s | 1 |
| 30s | 33 |
| 60s | 2 |

**That ladder is the finding.** Nobody raised a timeout once and moved on — the budgets went 15s → 30s → 60s, which is what "raising the timeout" looks like when it isn't actually fixing anything. One of the 30s files even leaves the escalation as advice: `// Increase timeout to 30 seconds for heavy renderer imports`.

This PR takes the four highest-risk ones. Each **drops** its raised timeout rather than raising it again — the import phase is subject to no test or hook timeout.

## The four

- **`plugin-markdown/src/index.test.ts`** (was 15s) — the twin of the file fixed in #3010: same shape, same budget, and the same comment *verbatim* (`// Increase timeout to 15 seconds for async import`). `plugin-kanban` proved that budget insufficient by blowing it at **15021ms**, and this file's timed portion was already **5.83s of the same 15s**. A live flake, not a theoretical one.
- **`plugin-charts/src/index.test.ts`** (was 60s) — recharts-backed graph.
- **`plugin-editor/src/index.test.ts`** (was 30s) — Monaco.
- **`apps/console/src/__tests__/public-contract.test.ts`** (was 60s) — also folds the `let contract` + hook assignment into a module-scope `const`, now that the two side-effect imports are evaluated before the module body.

## On the console file

This was the delicate one and worth being explicit about. Its assertions pin the **eager/lazy registration split** (#2953), so the real question was whether moving the imports changes *what is loaded when*. It does not:

- static imports are evaluated **in order, before the module body**, so `getPublicConfigs()` at module scope sees exactly the registrations the hook used to produce;
- the same two modules are loaded, so no extra plugin chunk resolves;
- the shared setup still runs before this module is imported at all.

Its order-sensitive test — *"reaches the lazily-registered blocks before their chunks load"* — passes unchanged.

## Results

Timed portion of each file, isolated:

| File | before | after |
|---|---|---|
| `plugin-markdown` | 5.83s | **2ms** |
| `plugin-charts` | 2.22s | **2ms** |
| `plugin-editor` | 1.78s | **4ms** |
| `public-contract` | 345ms | **3ms** |

**Full suite is 100% green: 731 files passed / 1 skipped, 8521 tests passed / 24 skipped, zero failures.** The `unit` project alone is 297/297 files and 4084/4084 tests — which also confirms no cross-file interference from the new module-scope registrations, despite that project running `isolate: false`.

Lint 0 errors (only pre-existing `no-explicit-any` warnings in untouched test bodies); `type-check` 38/38 successful. Test-only change, so no changeset.

## One note for anyone baselining locally

The ~19 failures this repo can show on a long-lived worktree are a **stale install**, not a regression: `node_modules/@objectstack/spec` was **14.6.0** against `^17.0.0-rc.0` declared in `package.json`. `pnpm install --prefer-offline` (9s) clears every one of them — which is why the run above is all-green where earlier local runs in this worktree showed 19 failures. Already documented in AGENTS.md §9; flagging it here because it is the single easiest way to misread this suite.

## Remaining

The 33-file `packages/components` cluster (all the same `await import('../../../renderers')` on 30s) is untouched here — mechanical, but a large diff that deserves its own PR. The durable fix is mechanical enforcement: the repo already has the `eslint-rules/` local-plugin infrastructure, and a rule flagging `await import(...)` inside `beforeAll`/`beforeEach` in test files would stop this regrowing. 36 files and a 15s→30s→60s ladder are the evidence that a prose convention alone does not hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)