### PR TITLE
fix(components,app-shell): the last two `direction` props follow v4's rename to `orientation`

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -117,11 +117,6 @@ import { describeIssuePath } from './issuePath';
 import { buildCreateModeBody } from './createBody';
 import { errorCodeIs, errorCodeIsAnyOf } from '@object-ui/types';
 
-// react-resizable-panels' `direction` prop type does not always narrow
-// cleanly in our TS config; cast at the boundary (precedent:
-// packages/components/src/custom/navigation-overlay.tsx).
-const PanelGroup = ResizablePanelGroup as React.FC<any>;
-
 /**
  * Metadata types whose canvas IS the primary create-time authoring
  * surface, so we render the preview/inspector split during create
@@ -2060,8 +2055,8 @@ function MetadataResourceEditPageImpl({
                     : 'relative flex-1 min-h-0 flex'
                 }
               >
-                <PanelGroup
-                  direction="horizontal"
+                <ResizablePanelGroup
+                  orientation="horizontal"
                   className="flex-1 min-h-0 rounded-md border bg-background overflow-hidden"
                   id={`metadata-edit-${type}`}
                 >
@@ -2336,7 +2331,7 @@ function MetadataResourceEditPageImpl({
                       </div>
                     </div>
                   </ResizablePanel>
-                </PanelGroup>
+                </ResizablePanelGroup>
                 {/* The floating reopen pill that used to live here was
                     removed: the canvas toolbar already hosts a permanent
                     VSCode-style inspector toggle next to the fullscreen

--- a/packages/components/src/custom/navigation-overlay.tsx
+++ b/packages/components/src/custom/navigation-overlay.tsx
@@ -460,12 +460,8 @@ export const NavigationOverlay: React.FC<NavigationOverlayProps> = ({
       : 40;
     const mainPercent = 100 - detailPercent;
 
-    // Cast needed: ResizablePanelGroup has correct runtime behavior but
-    // vite-plugin-dts may not resolve the direction prop type correctly
-    const PanelGroup = ResizablePanelGroup as React.FC<any>;
-
     return (
-      <PanelGroup direction="horizontal" className={cn('h-full', className)}>
+      <ResizablePanelGroup orientation="horizontal" className={cn('h-full', className)}>
         <ResizablePanel defaultSize={mainPercent} minSize={30}>
           {mainContent}
         </ResizablePanel>
@@ -501,7 +497,7 @@ export const NavigationOverlay: React.FC<NavigationOverlayProps> = ({
             {renderContent(selectedRecord)}
           </div>
         </ResizablePanel>
-      </PanelGroup>
+      </ResizablePanelGroup>
     );
   }
 


### PR DESCRIPTION
Finishes the `react-resizable-panels` v3→v4 prop migration whose visible half landed in #3024.

## The dead prop

v4 renamed `PanelGroup`'s `direction` prop to `orientation`. Two call sites were still passing the v3 name, so v4 ignored it and React forwarded the unknown prop straight to the DOM as a stray `direction="horizontal"` attribute on the group div:

- [navigation-overlay.tsx:466](packages/components/src/custom/navigation-overlay.tsx)
- [ResourceEditPage.tsx:2064](packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx)

Both groups are horizontal-only and `horizontal` is v4's default, so nothing rendered wrong. **No visual change** — this is dead-prop cleanup.

## Why it survived the v4 bump

Each site also carried a cast:

```ts
const PanelGroup = ResizablePanelGroup as React.FC<any>;
```

That cast is the reason the rename went unnoticed: it erased the props to `any`, so `direction` type-checked against nothing. Both comments blamed the toolchain — vite-plugin-dts "not resolving the direction prop type correctly", and a prop that "does not always narrow cleanly in our TS config" — but neither was a narrowing problem. `GroupProps` in v4.12.2 simply has no `direction` key; it has `orientation?: "horizontal" | "vertical"`.

Casts removed, `ResizablePanelGroup` used directly. The rename is now self-enforcing — reintroducing `direction` on the un-cast component fails:

```
src/custom/navigation-overlay.tsx(464,28): error TS2322: Type '{ children: Element[]; direction: string; className: string; }'
is not assignable to type 'IntrinsicAttributes & HTMLAttributes<HTMLDivElement> & { … }'.
```

## `ResizablePanel` props: all valid v4, no workaround needed

`ResourceEditPage` also passes `panelRef`, `collapsible`, `collapsedSize` and `onResize`. All four are valid v4 `PanelProps` and all four type-check with no cast — they were never covered by it in the first place, since the cast only ever wrapped the *group*, not the panel. `ResizablePanel` is a bare re-export of the library's `Panel`, so those props were already being checked strictly on `main`. No narrowly-typed workaround is required.

Verified against `react-resizable-panels@4.12.2`'s own `PanelProps`: `collapsedSize?: number | string`, `collapsible?: boolean`, `onResize?: (panelSize: PanelSize, id, prevPanelSize) => void`, `panelRef?: Ref<PanelImperativeHandle | null>`.

## Verification

- `pnpm --filter @object-ui/components type-check` — clean
- `pnpm --filter @object-ui/app-shell type-check` — clean (0 errors)
- Negative control: reintroducing `direction` produces the TS2322 above, then reverted
- `resizable-orientation` + `form-field-panes` tests — 15 passed
- `ObjectView` + `FlowObjectListField.commit` tests — 35 passed

No changeset — not a feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)